### PR TITLE
Fix Map to work on arbitrary expressions, not just lists (#68)

### DIFF
--- a/src/functions/list_helpers_ast/mapping.rs
+++ b/src/functions/list_helpers_ast/mapping.rs
@@ -27,11 +27,26 @@ pub fn map_ast(func: &Expr, list: &Expr) -> Result<Expr, InterpreterError> {
       Ok(Expr::Association(results?))
     }
     _ => {
-      // Not a list or association, return unevaluated
-      Ok(Expr::FunctionCall {
-        name: "Map".to_string(),
-        args: vec![func.clone(), list.clone()],
-      })
+      // For any compound expression, decompose into head + children,
+      // apply func to each child, and reconstruct.
+      // E.g. Map[f, Power[x, 2]] -> Power[f[x], f[2]]
+      use crate::functions::expr_form::{ExprForm, decompose_expr};
+      match decompose_expr(list) {
+        ExprForm::Composite { head, children } => {
+          let mapped: Result<Vec<Expr>, _> = children
+            .iter()
+            .map(|child| apply_func_ast(func, child))
+            .collect();
+          crate::evaluator::evaluate_function_call_ast(&head, &mapped?)
+        }
+        ExprForm::Atom(_) => {
+          // Atomic expression, return unevaluated
+          Ok(Expr::FunctionCall {
+            name: "Map".to_string(),
+            args: vec![func.clone(), list.clone()],
+          })
+        }
+      }
     }
   }
 }

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -3024,6 +3024,48 @@ mod join_non_list {
   }
 
   #[test]
+  fn map_on_power_expression() {
+    // Map[f, x^2] applies f to each part of Power[x, 2]
+    assert_eq!(interpret("Map[f, x^2]").unwrap(), "f[x]^f[2]");
+  }
+
+  #[test]
+  fn map_on_function_call() {
+    // Map[f, g[a, b, c]] applies f to each argument of g
+    assert_eq!(
+      interpret("Map[f, g[a, b, c]]").unwrap(),
+      "g[f[a], f[b], f[c]]"
+    );
+  }
+
+  #[test]
+  fn map_on_plus_expression() {
+    // Map[f, x + y] applies f to each summand
+    assert_eq!(interpret("Map[f, x + y]").unwrap(), "f[x] + f[y]");
+  }
+
+  #[test]
+  fn map_on_atom_unevaluated() {
+    // Map on an atom should return unevaluated
+    assert_eq!(interpret("Map[f, x]").unwrap(), "Map[f, x]");
+  }
+
+  #[test]
+  fn map_recursive_user_function() {
+    // Regression test for issue #68: Map with user-defined recursive function
+    assert_eq!(
+      interpret(
+        "TrigSimplify[expr_] := expr /; AtomQ[expr]\n\
+         TrigSimplify[expr_] := expr /; Head[expr] === If\n\
+         TrigSimplify[expr_] := Map[TrigSimplify, expr]\n\
+         TrigSimplify[x^2]"
+      )
+      .unwrap(),
+      "x^2"
+    );
+  }
+
+  #[test]
   fn map_at_operator_form() {
     assert_eq!(
       interpret("MapAt[f, -1][{a, b, c}]").unwrap(),


### PR DESCRIPTION
Map now decomposes any compound expression (e.g. Power, Plus, Times, FunctionCall) into its head and children, applies the function to each child, and reconstructs. This matches Wolfram Language behavior where Map[f, x^2] returns f[x]^f[2] rather than returning unevaluated.

https://claude.ai/code/session_016RHF2Qq42c438Ccj6LAsPz