### PR TITLE
Fix Scan to work on non-list expressions (issue #75)

### DIFF
--- a/src/functions/list_helpers_ast/functional.rs
+++ b/src/functions/list_helpers_ast/functional.rs
@@ -186,18 +186,28 @@ pub fn differences_n_ast(
 /// AST-based Scan: apply function to each element for side effects.
 /// Returns Null but evaluates function on each element.
 pub fn scan_ast(func: &Expr, list: &Expr) -> Result<Expr, InterpreterError> {
-  let items = match list {
-    Expr::List(items) => items,
-    _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Scan".to_string(),
-        args: vec![func.clone(), list.clone()],
-      });
+  match list {
+    Expr::List(items) => {
+      for item in items {
+        apply_func_ast(func, item)?;
+      }
     }
-  };
-
-  for item in items {
-    apply_func_ast(func, item)?;
+    _ => {
+      // For any compound expression, decompose into head + children,
+      // and apply func to each child for side effects.
+      // E.g. Scan[f, Power[x, 2]] applies f[x] and f[2]
+      use crate::functions::expr_form::{ExprForm, decompose_expr};
+      match decompose_expr(list) {
+        ExprForm::Composite { children, .. } => {
+          for child in &children {
+            apply_func_ast(func, child)?;
+          }
+        }
+        ExprForm::Atom(_) => {
+          // Atoms have no parts to scan over
+        }
+      }
+    }
   }
 
   Ok(Expr::Identifier("Null".to_string()))

--- a/tests/high_level_functions_tests.rs
+++ b/tests/high_level_functions_tests.rs
@@ -768,6 +768,51 @@ mod high_level_functions_tests {
     }
   }
 
+  // ─── Scan ────────────────────────────────────────────────────────────
+  mod scan_tests {
+    use super::*;
+    #[test]
+    fn test_scan_list() {
+      // Scan returns Null and applies function for side effects
+      assert_eq!(interpret("Scan[Print, {1, 2, 3}]").unwrap(), "Null");
+    }
+    #[test]
+    fn test_scan_non_list_expression() {
+      // Scan should work on any expression, not just lists
+      assert_eq!(interpret("Scan[Print, f[a, b, c]]").unwrap(), "Null");
+    }
+    #[test]
+    fn test_scan_power_expression() {
+      // Scan over Power[x, -1] should iterate over parts x and -1
+      assert_eq!(interpret("Scan[Print, Power[x, -1]]").unwrap(), "Null");
+    }
+    #[test]
+    fn test_scan_with_throw_in_non_list() {
+      // Regression test for issue #75:
+      // Throw inside Scan on a non-list expression must propagate to Catch
+      assert_eq!(
+        interpret(
+          "FFunctionOfExpnQ[u_] := Catch[Scan[Function[Throw[False]],u];True]; FFunctionOfExpnQ[1/x]"
+        )
+        .unwrap(),
+        "False"
+      );
+    }
+    #[test]
+    fn test_scan_with_throw_in_list() {
+      // Throw inside Scan on a list must also propagate to Catch
+      assert_eq!(
+        interpret("Catch[Scan[Function[Throw[False]], {1, 2, 3}]; True]").unwrap(),
+        "False"
+      );
+    }
+    #[test]
+    fn test_scan_atom() {
+      // Scan on an atom (no parts) should return Null without error
+      assert_eq!(interpret("Scan[Print, 42]").unwrap(), "Null");
+    }
+  }
+
   // ─── IntegerPartitions ──────────────────────────────────────────────
   mod integer_partitions_tests {
     use super::*;


### PR DESCRIPTION
Scan only iterated over List expressions, returning unevaluated for any other compound expression like Power[x, -1]. This meant Throw inside Scan on non-list expressions wouldn't propagate to Catch.

Fix by decomposing non-list expressions into head + children (same approach as Map) and scanning over the children.

Closes #75