### PR TITLE
Fix pattern matching for expressions with division and power

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -186,6 +186,12 @@ fn normalize_structural_pattern(pattern: &Expr) -> Expr {
   let with_placeholders = replace_patterns_with_placeholders(pattern, &vars);
   match evaluate_expr_to_expr(&with_placeholders) {
     Ok(evaluated) => {
+      // Convert BinaryOp::Divide to canonical Times[..., Power[..., -1]] form
+      // so that patterns match regardless of how the expression was written
+      // (e.g., 1/(a*b) vs (a*b)^-1 should both match the same pattern).
+      // This is done before replacing placeholders back, since the arithmetic
+      // functions (power_two, times_ast) need plain symbols, not pattern nodes.
+      let evaluated = canonicalize_divide_in_expr(&evaluated);
       let result = replace_placeholders_with_patterns(&evaluated, &vars);
       // For Orderless functions (Times, Plus), reorder top-level args so
       // PatternOptional args come last. This ensures non-optional patterns
@@ -194,6 +200,61 @@ fn normalize_structural_pattern(pattern: &Expr) -> Expr {
       reorder_orderless_pattern_args(result)
     }
     Err(_) => pattern.clone(), // fallback to raw pattern
+  }
+}
+
+/// Recursively convert BinaryOp::Divide to canonical Times[num, Power[den, -1]]
+/// form. Uses power_two/times_ast so nested structures are properly distributed
+/// (e.g., 1/(a*Sqrt[b]) → Times[Power[a,-1], Power[b,-1/2]]).
+pub fn canonicalize_divide_in_expr(expr: &Expr) -> Expr {
+  match expr {
+    Expr::BinaryOp {
+      op: crate::syntax::BinaryOperator::Divide,
+      left,
+      right,
+    } => {
+      let left = canonicalize_divide_in_expr(left);
+      let right = canonicalize_divide_in_expr(right);
+      match crate::functions::math_ast::power_two(
+        &right,
+        &Expr::Integer(-1),
+      ) {
+        Ok(den_inv) => {
+          if matches!(left, Expr::Integer(1)) {
+            den_inv
+          } else {
+            crate::functions::math_ast::times_ast(&[left.clone(), den_inv])
+              .unwrap_or_else(|_| Expr::BinaryOp {
+                op: crate::syntax::BinaryOperator::Divide,
+                left: Box::new(left),
+                right: Box::new(right),
+              })
+          }
+        }
+        Err(_) => Expr::BinaryOp {
+          op: crate::syntax::BinaryOperator::Divide,
+          left: Box::new(left),
+          right: Box::new(right),
+        },
+      }
+    }
+    Expr::FunctionCall { name, args } => Expr::FunctionCall {
+      name: name.clone(),
+      args: args.iter().map(canonicalize_divide_in_expr).collect(),
+    },
+    Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
+      op: *op,
+      left: Box::new(canonicalize_divide_in_expr(left)),
+      right: Box::new(canonicalize_divide_in_expr(right)),
+    },
+    Expr::UnaryOp { op, operand } => Expr::UnaryOp {
+      op: *op,
+      operand: Box::new(canonicalize_divide_in_expr(operand)),
+    },
+    Expr::List(items) => {
+      Expr::List(items.iter().map(canonicalize_divide_in_expr).collect())
+    }
+    other => other.clone(),
   }
 }
 

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -527,9 +527,11 @@ pub fn evaluate_function_call_ast_inner(
             let pattern = &marker_args[1];
             if let Some(idx) = params.iter().position(|p| p == param_name) {
               if idx < effective_args.len() {
+                // Canonicalize the expression to match the canonical pattern form
+                let canonical_arg = crate::evaluator::assignment::canonicalize_divide_in_expr(&effective_args[idx]);
                 if let Some(bindings) =
                   crate::evaluator::pattern_matching::match_pattern(
-                    &effective_args[idx],
+                    &canonical_arg,
                     pattern,
                   )
                 {
@@ -755,9 +757,12 @@ pub fn evaluate_function_call_ast_inner(
             // Find the effective arg for this structural param
             if let Some(idx) = params.iter().position(|p| p == param_name) {
               if idx < effective_args.len() {
+                // Canonicalize the expression to match the canonical pattern form
+                // (e.g., BinaryOp::Divide → Times[..., Power[..., -1]])
+                let canonical_arg = crate::evaluator::assignment::canonicalize_divide_in_expr(&effective_args[idx]);
                 if let Some(bindings) =
                   crate::evaluator::pattern_matching::match_pattern(
-                    &effective_args[idx],
+                    &canonical_arg,
                     pattern,
                   )
                 {

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -1663,17 +1663,44 @@ pub fn match_pattern(
           if pat_args.len() != expr_args.len() {
             return None;
           }
-          let mut bindings = Vec::new();
-          for (p, e) in pat_args.iter().zip(expr_args.iter()) {
-            if let Some(b) = match_pattern(e, p) {
-              if !merge_bindings(&mut bindings, b) {
+          // For Orderless functions (Times, Plus), try all permutations
+          let is_orderless =
+            crate::evaluator::listable::is_builtin_orderless(pat_name);
+          if is_orderless && pat_args.len() >= 2 {
+            // Try all permutations of expression args against pattern args
+            let perms = permutations(expr_args);
+            for perm in perms {
+              let mut bindings = Vec::new();
+              let mut matched = true;
+              for (p, e) in pat_args.iter().zip(perm.iter()) {
+                if let Some(b) = match_pattern(e, p) {
+                  if !merge_bindings(&mut bindings, b) {
+                    matched = false;
+                    break;
+                  }
+                } else {
+                  matched = false;
+                  break;
+                }
+              }
+              if matched {
+                return Some(bindings);
+              }
+            }
+            None
+          } else {
+            let mut bindings = Vec::new();
+            for (p, e) in pat_args.iter().zip(expr_args.iter()) {
+              if let Some(b) = match_pattern(e, p) {
+                if !merge_bindings(&mut bindings, b) {
+                  return None;
+                }
+              } else {
                 return None;
               }
-            } else {
-              return None;
             }
+            Some(bindings)
           }
-          Some(bindings)
         }
       } else {
         // Expression is not a FunctionCall with the same name;

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -2540,15 +2540,11 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
       _ => None,
     };
     if let Some(factors) = factors {
-      let inv_factors: Vec<Expr> = factors
+      let inv_factors: Result<Vec<Expr>, InterpreterError> = factors
         .into_iter()
-        .map(|f| Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
-          left: Box::new(f.clone()),
-          right: Box::new(Expr::Integer(-1)),
-        })
+        .map(|f| power_two(f, &Expr::Integer(-1)))
         .collect();
-      return times_ast(&inv_factors);
+      return times_ast(&inv_factors?);
     }
   }
 

--- a/tests/high_level_functions_tests.rs
+++ b/tests/high_level_functions_tests.rs
@@ -1831,4 +1831,67 @@ mod high_level_functions_tests {
       );
     }
   }
+
+  // Regression tests for issue #76:
+  // Pattern matching with structural patterns involving Power and Sqrt
+  mod structural_pattern_matching_tests {
+    use super::*;
+
+    #[test]
+    fn test_inverted_times_sqrt_matches_pattern() {
+      // (Sqrt[x]*(a + b*x))^-1 should match 1/((a_.+b_.*x_)*Sqrt[c_.+d_.*x_])
+      assert_eq!(
+        interpret(
+          "Int[1/((a_.+b_.*x_)*Sqrt[c_.+d_.*x_]),x_Symbol] := False; \
+           Int[(Sqrt[x]*(a + b*x))^-1, x]"
+        )
+        .unwrap(),
+        "False"
+      );
+    }
+
+    #[test]
+    fn test_direct_form_matches_pattern() {
+      // 1/((a+b*x)*Sqrt[x]) should also match the same pattern
+      assert_eq!(
+        interpret(
+          "f76a[1/((a_.+b_.*x_)*Sqrt[c_.+d_.*x_]),x_Symbol] := {a,b,c,d,x}; \
+           f76a[1/((p+q*r)*Sqrt[r]), r]"
+        )
+        .unwrap(),
+        "{p, q, 0, 1, r}"
+      );
+    }
+
+    #[test]
+    fn test_inverted_form_extracts_bindings() {
+      // (Sqrt[r]*(p+q*r))^-1 should match and extract correct bindings
+      assert_eq!(
+        interpret(
+          "f76b[1/((a_.+b_.*x_)*Sqrt[c_.+d_.*x_]), x_Symbol] := {a,b,c,d,x}; \
+           f76b[(Sqrt[r]*(p+q*r))^-1, r]"
+        )
+        .unwrap(),
+        "{p, q, 0, 1, r}"
+      );
+    }
+
+    #[test]
+    fn test_power_times_distribution() {
+      // Power[Times[a, b], -1] should distribute to Times[Power[a,-1], Power[b,-1]]
+      assert_eq!(
+        interpret("FullForm[(a*Sqrt[x])^-1]").unwrap(),
+        "Times[Power[a, -1], Power[x, Rational[-1, 2]]]"
+      );
+    }
+
+    #[test]
+    fn test_divide_canonical_form() {
+      // 1/(a*b) should produce canonical Times[Power[...]] form matching (a*b)^-1
+      assert_eq!(
+        interpret("(a*b)^-1 === 1/(a*b)").unwrap(),
+        "True"
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
This PR fixes pattern matching for structural patterns involving division and power operations (issue #76). The core issue was that expressions written in different but mathematically equivalent forms (e.g., `1/(a*b)` vs `(a*b)^-1`) were not matching the same patterns.

## Key Changes

- **Canonicalize division in pattern matching**: Added `canonicalize_divide_in_expr()` function that recursively converts `BinaryOp::Divide` to the canonical `Times[num, Power[den, -1]]` form. This ensures patterns match regardless of how the expression was written.

- **Apply canonicalization in pattern normalization**: Modified `normalize_structural_pattern()` to canonicalize division operations before pattern matching, ensuring both the pattern and the expression being matched are in the same canonical form.

- **Apply canonicalization at dispatch points**: Updated `evaluate_function_call_ast_inner()` to canonicalize expressions before pattern matching at two key locations where structural parameters are evaluated.

- **Fix power distribution for division**: Modified `power_two()` to properly distribute power operations over factors when inverting a product (e.g., `(a*Sqrt[b])^-1` correctly becomes `Times[Power[a,-1], Power[b,-1/2]]`).

- **Add orderless permutation matching**: Enhanced pattern matching for orderless functions (Times, Plus) to try all permutations of expression arguments against pattern arguments, improving matching robustness.

## Notable Implementation Details

- The canonicalization is performed before placeholder replacement in pattern normalization, since arithmetic functions (`power_two`, `times_ast`) require plain symbols rather than pattern nodes.
- The `power_two()` function now recursively applies itself when distributing inverses, ensuring nested structures are properly simplified.
- Comprehensive regression tests were added covering various forms of division and power patterns to prevent future regressions.

https://claude.ai/code/session_01BAga2LVXerQ4hEwW7vLVZ8