### PR TITLE
Add Erfi (imaginary error function) support

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1738,7 +1738,7 @@ EquirippleFilterKernel,,,,9,4225
 Equivalent,Logical equivalence,✅,pure,7,1298
 Erf,Returns the error function value,✅,pure,1,554
 Erfc,Returns the complementary error function value,✅,pure,2,784
-Erfi,,,,3,995
+Erfi,Returns the imaginary error function value,✅,pure,1,995
 ErlangB,,,,9,4387
 ErlangC,,,,9,4262
 ErlangDistribution,,,,8,2190

--- a/src/evaluator/attributes.rs
+++ b/src/evaluator/attributes.rs
@@ -67,6 +67,7 @@ pub fn get_builtin_attributes(name: &str) -> Vec<&'static str> {
     | "Pochhammer"
     | "Erf"
     | "Erfc"
+    | "Erfi"
     | "Beta"
     | "Zeta"
     | "PolyGamma"

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -584,6 +584,9 @@ pub fn dispatch_math_functions(
     "Erfc" if args.len() == 1 => {
       return Some(crate::functions::math_ast::erfc_ast(args));
     }
+    "Erfi" if args.len() == 1 => {
+      return Some(crate::functions::math_ast::erfi_ast(args));
+    }
     "Log" if !args.is_empty() && args.len() <= 2 => {
       return Some(crate::functions::math_ast::log_ast(args));
     }

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -45,6 +45,7 @@ pub fn is_builtin_listable(name: &str) -> bool {
       | "Gamma"
       | "Erf"
       | "Erfc"
+      | "Erfi"
       | "Prime"
       | "Power"
       | "Plus"

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -1354,6 +1354,45 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             }))
           }
         }
+        // Erfi[z]: D[Erfi[z], z] = 2*E^(z^2)/Sqrt[Pi]
+        "Erfi" if args.len() == 1 => {
+          let dz = differentiate(&args[0], var)?;
+          if matches!(dz, Expr::Integer(0)) {
+            return Ok(Expr::Integer(0));
+          }
+          let z_sq = Expr::BinaryOp {
+            op: crate::syntax::BinaryOperator::Power,
+            left: Box::new(args[0].clone()),
+            right: Box::new(Expr::Integer(2)),
+          };
+          let exp_z2 = Expr::BinaryOp {
+            op: crate::syntax::BinaryOperator::Power,
+            left: Box::new(Expr::Constant("E".to_string())),
+            right: Box::new(z_sq),
+          };
+          let two_over_sqrt_pi = Expr::BinaryOp {
+            op: crate::syntax::BinaryOperator::Divide,
+            left: Box::new(Expr::Integer(2)),
+            right: Box::new(Expr::FunctionCall {
+              name: "Sqrt".to_string(),
+              args: vec![Expr::Constant("Pi".to_string())],
+            }),
+          };
+          let result = simplify(Expr::BinaryOp {
+            op: crate::syntax::BinaryOperator::Times,
+            left: Box::new(two_over_sqrt_pi),
+            right: Box::new(exp_z2),
+          });
+          if matches!(dz, Expr::Integer(1)) {
+            Ok(result)
+          } else {
+            Ok(simplify(Expr::BinaryOp {
+              op: crate::syntax::BinaryOperator::Times,
+              left: Box::new(dz),
+              right: Box::new(result),
+            }))
+          }
+        }
         // Handle Rational[n, d] as constant
         "Rational" if args.len() == 2 => Ok(Expr::Integer(0)),
         // Handle Integrate[f, {t, a, b}] via Leibniz integral rule

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -91,6 +91,29 @@ pub fn erfc_cf(x: f64) -> f64 {
   (-x * x).exp() / (f * std::f64::consts::PI.sqrt())
 }
 
+/// Compute the imaginary error function erfi(x) using the Taylor series.
+/// erfi(x) = (2/sqrt(pi)) * sum_{n=0}^{inf} x^(2n+1) / (n! * (2n+1))
+pub fn erfi_f64(x: f64) -> f64 {
+  // erfi is an odd function
+  let sign = if x < 0.0 { -1.0 } else { 1.0 };
+  let x = x.abs();
+
+  // Taylor series: erfi(x) = (2/sqrt(pi)) * sum_{n=0}^inf x^(2n+1) / (n! * (2n+1))
+  // Note: unlike erf, there is no (-1)^n factor, so all terms are positive for x > 0
+  let mut sum = 0.0;
+  let mut term = x; // first term: x
+  sum += term;
+  for n in 1..200 {
+    term *= x * x / (n as f64);
+    let contribution = term / (2 * n + 1) as f64;
+    sum += contribution;
+    if contribution.abs() < 1e-16 * sum.abs() {
+      break;
+    }
+  }
+  sign * sum * 2.0 / std::f64::consts::PI.sqrt()
+}
+
 /// Recursively try to evaluate any expression to f64.
 /// This handles constants (Pi, E, Degree), arithmetic operations, and known functions.
 /// Used by N[], comparisons, and anywhere a numeric value is needed from a symbolic expression.
@@ -202,6 +225,7 @@ pub fn try_eval_to_f64(expr: &Expr) -> Option<f64> {
       "Erfc" if args.len() == 1 => {
         try_eval_to_f64(&args[0]).map(|v| 1.0 - erf_f64(v))
       }
+      "Erfi" if args.len() == 1 => try_eval_to_f64(&args[0]).map(erfi_f64),
       "Log" if args.len() == 1 => try_eval_to_f64(&args[0])
         .and_then(|v| if v > 0.0 { Some(v.ln()) } else { None }),
       "Log" if args.len() == 2 => {

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -532,6 +532,10 @@ pub fn expr_to_bigfloat(
           let x = expr_to_bigfloat(&args[0], bits, rm, cc)?;
           Ok(bigfloat_erfc(&x, bits, rm, cc))
         }
+        "Erfi" if args.len() == 1 => {
+          let x = expr_to_bigfloat(&args[0], bits, rm, cc)?;
+          Ok(bigfloat_erfi(&x, bits, rm, cc))
+        }
         "ExpIntegralEi" if args.len() == 1 => {
           let x = expr_to_bigfloat(&args[0], bits, rm, cc)?;
           Ok(bigfloat_exp_integral_ei(&x, bits, rm, cc))
@@ -2811,6 +2815,65 @@ fn bigfloat_erfc(
   } else {
     result
   }
+}
+
+/// Compute erfi(x) with arbitrary precision.
+/// erfi(x) = (2/sqrt(pi)) * sum_{n=0}^{inf} x^(2n+1) / (n! * (2n+1))
+/// Unlike erf, the terms do NOT alternate in sign.
+fn bigfloat_erfi(
+  x: &astro_float::BigFloat,
+  bits: usize,
+  rm: astro_float::RoundingMode,
+  cc: &mut astro_float::Consts,
+) -> astro_float::BigFloat {
+  use astro_float::BigFloat;
+
+  if x.is_zero() {
+    return BigFloat::from_i32(0, bits);
+  }
+
+  // erfi is odd: erfi(-x) = -erfi(x)
+  let is_negative = x.is_negative();
+  let x_abs = x.abs();
+
+  let work_bits = bits + 64;
+
+  // Taylor series: term_0 = x, term_n = term_{n-1} * x^2 / n
+  // contribution_n = term_n / (2n+1), all terms positive (no alternating sign)
+  let x2 = x_abs.mul(&x_abs, work_bits, rm);
+  let mut term = x_abs.clone();
+  let mut sum = x_abs.clone();
+
+  let max_iterations = work_bits * 2 + 100;
+  for n in 1..max_iterations {
+    term = term.mul(&x2, work_bits, rm);
+    let n_bf = BigFloat::from_i32(n as i32, work_bits);
+    term = term.div(&n_bf, work_bits, rm);
+
+    let denom = BigFloat::from_i32((2 * n + 1) as i32, work_bits);
+    let contribution = term.div(&denom, work_bits, rm);
+
+    sum = sum.add(&contribution, work_bits, rm);
+
+    if contribution.is_zero() {
+      break;
+    }
+    if let (Some(c_exp), Some(s_exp)) =
+      (contribution.exponent(), sum.exponent())
+      && s_exp - c_exp > (work_bits as i32)
+    {
+      break;
+    }
+  }
+
+  // Multiply by 2/sqrt(π), round to final precision
+  let two = BigFloat::from_i32(2, work_bits);
+  let pi = cc.pi(work_bits, rm);
+  let sqrt_pi = pi.sqrt(work_bits, rm);
+  let factor = two.div(&sqrt_pi, work_bits, rm);
+  let result = sum.mul(&factor, bits, rm);
+
+  if is_negative { result.neg() } else { result }
 }
 
 /// Compute the exponential integral Ei(x) using BigFloat arithmetic.

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1147,6 +1147,96 @@ pub fn erfc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 }
 
+pub fn erfi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  if args.len() != 1 {
+    return Err(InterpreterError::EvaluationError(
+      "Erfi expects 1 argument".into(),
+    ));
+  }
+  // Helper: compute -Erfi[inner] by evaluating Erfi[inner] first, then negating
+  let negate_erfi = |inner: Expr| -> Result<Expr, InterpreterError> {
+    let inner_result = erfi_ast(&[inner])?;
+    Ok(Expr::UnaryOp {
+      op: crate::syntax::UnaryOperator::Minus,
+      operand: Box::new(inner_result),
+    })
+  };
+  match &args[0] {
+    // Erfi[0] = 0
+    Expr::Integer(0) => Ok(Expr::Integer(0)),
+    // Erfi[Infinity] = Infinity
+    Expr::Identifier(s) if s == "Infinity" => {
+      Ok(Expr::Identifier("Infinity".to_string()))
+    }
+    // Erfi[-x] = -Erfi[x] (UnaryOp form)
+    Expr::UnaryOp {
+      op: crate::syntax::UnaryOperator::Minus,
+      operand,
+    } => negate_erfi(*operand.clone()),
+    // Erfi[Times[-1, x]] = -Erfi[x] (evaluated form of -x)
+    Expr::FunctionCall { name, args: fargs }
+      if name == "Times" && fargs.len() == 2 =>
+    {
+      if matches!(&fargs[0], Expr::Integer(-1)) {
+        return negate_erfi(fargs[1].clone());
+      }
+      if matches!(&fargs[1], Expr::Integer(-1)) {
+        return negate_erfi(fargs[0].clone());
+      }
+      // Negative integer coefficient: Times[-n, x] -> -Erfi[Times[n, x]]
+      if let Expr::Integer(n) = &fargs[0]
+        && *n < 0
+      {
+        let pos_arg = Expr::FunctionCall {
+          name: "Times".to_string(),
+          args: vec![Expr::Integer(-*n), fargs[1].clone()],
+        };
+        return negate_erfi(pos_arg);
+      }
+      Ok(Expr::FunctionCall {
+        name: "Erfi".to_string(),
+        args: args.to_vec(),
+      })
+    }
+    // BinaryOp::Times form: -1 * x
+    Expr::BinaryOp {
+      op: crate::syntax::BinaryOperator::Times,
+      left,
+      right,
+    } => {
+      if matches!(left.as_ref(), Expr::Integer(-1)) {
+        return negate_erfi(*right.clone());
+      }
+      if matches!(right.as_ref(), Expr::Integer(-1)) {
+        return negate_erfi(*left.clone());
+      }
+      if let Expr::Integer(n) = left.as_ref()
+        && *n < 0
+      {
+        let pos_arg = Expr::BinaryOp {
+          op: crate::syntax::BinaryOperator::Times,
+          left: Box::new(Expr::Integer(-*n)),
+          right: right.clone(),
+        };
+        return negate_erfi(pos_arg);
+      }
+      Ok(Expr::FunctionCall {
+        name: "Erfi".to_string(),
+        args: args.to_vec(),
+      })
+    }
+    // Erfi[-n] for negative integer
+    Expr::Integer(n) if *n < 0 => negate_erfi(Expr::Integer(-*n)),
+    // Numeric evaluation for Real arguments
+    Expr::Real(f) => Ok(Expr::Real(erfi_f64(*f))),
+    // Otherwise symbolic
+    _ => Ok(Expr::FunctionCall {
+      name: "Erfi".to_string(),
+      args: args.to_vec(),
+    }),
+  }
+}
+
 pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !args.is_empty()
     && matches!(&args[0], Expr::Identifier(s) if s == "Indeterminate")

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -893,6 +893,101 @@ mod integrate_gaussian {
   }
 }
 
+mod erfi {
+  use super::*;
+
+  #[test]
+  fn erfi_zero() {
+    assert_eq!(interpret("Erfi[0]").unwrap(), "0");
+  }
+
+  #[test]
+  fn erfi_symbolic() {
+    assert_eq!(interpret("Erfi[x]").unwrap(), "Erfi[x]");
+  }
+
+  #[test]
+  fn erfi_negative_arg() {
+    // Erfi[-x] = -Erfi[x] (odd function)
+    assert_eq!(interpret("Erfi[-x]").unwrap(), "-Erfi[x]");
+  }
+
+  #[test]
+  fn erfi_negative_integer() {
+    // Erfi[-1] = -Erfi[1]
+    assert_eq!(interpret("Erfi[-1]").unwrap(), "-Erfi[1]");
+  }
+
+  #[test]
+  fn erfi_infinity() {
+    assert_eq!(interpret("Erfi[Infinity]").unwrap(), "Infinity");
+  }
+
+  #[test]
+  fn erfi_neg_infinity() {
+    assert_eq!(interpret("Erfi[-Infinity]").unwrap(), "-Infinity");
+  }
+
+  #[test]
+  fn erfi_real() {
+    // Erfi[1.0] ≈ 1.6504257587975429
+    let result = interpret("Erfi[1.0]").unwrap();
+    let val: f64 = result.parse().unwrap();
+    assert!((val - 1.6504257587975429).abs() < 1e-10, "Erfi[1.0] = {result}");
+  }
+
+  #[test]
+  fn erfi_real_negative() {
+    // Erfi[-1.0] = -Erfi[1.0]
+    let result = interpret("Erfi[-1.0]").unwrap();
+    let val: f64 = result.parse().unwrap();
+    assert!((val + 1.6504257587975429).abs() < 1e-10, "Erfi[-1.0] = {result}");
+  }
+
+  #[test]
+  fn erfi_listable() {
+    assert_eq!(
+      interpret("Erfi[{0, x}]").unwrap(),
+      "{0, Erfi[x]}"
+    );
+  }
+
+  #[test]
+  fn d_erfi_x() {
+    // D[Erfi[x], x] = 2*E^(x^2)/Sqrt[Pi]
+    assert_eq!(interpret("D[Erfi[x],x]").unwrap(), "(2*E^x^2)/Sqrt[Pi]");
+  }
+
+  #[test]
+  fn n_erfi_1() {
+    // N[Erfi[1], 20] — small argument, Taylor series
+    let result = interpret("N[Erfi[1], 20]").unwrap();
+    assert!(
+      result.starts_with("1.65042575879754287602"),
+      "N[Erfi[1], 20] = {result}"
+    );
+  }
+
+  #[test]
+  fn n_erfi_0() {
+    let result = interpret("N[Erfi[0], 20]").unwrap();
+    assert!(
+      result.starts_with("0"),
+      "N[Erfi[0], 20] = {result}"
+    );
+  }
+
+  #[test]
+  fn n_erfi_half() {
+    // N[Erfi[1/2], 20] ≈ 0.61427...
+    let result = interpret("N[Erfi[1/2], 20]").unwrap();
+    assert!(
+      result.starts_with("0.61495209469651"),
+      "N[Erfi[1/2], 20] = {result}"
+    );
+  }
+}
+
 mod big_o {
   use super::*;
 


### PR DESCRIPTION
Implement Erfi[z] = -I * Erf[I * z] with:
- Symbolic evaluation: Erfi[0]=0, Erfi[-x]=-Erfi[x], Erfi[Infinity]=Infinity
- Numeric evaluation (f64 and arbitrary precision BigFloat)
- Derivative rule: D[Erfi[z],z] = 2*E^(z^2)/Sqrt[Pi]
- Listable attribute and function registration
- 13 unit tests covering symbolic, numeric, derivative, and edge cases