### PR TITLE
Fix Head[1/(2*x - 3)] returning Times instead of Power (fixes #83)

### DIFF
--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -991,13 +991,20 @@ pub fn head_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     Expr::Rule { .. } => "Rule",
     Expr::RuleDelayed { .. } => "RuleDelayed",
-    Expr::BinaryOp { op, .. } => {
+    Expr::BinaryOp { op, left, .. } => {
       use crate::syntax::BinaryOperator;
       match op {
         BinaryOperator::Plus => "Plus",
         BinaryOperator::Minus => "Plus", // Minus is represented as Plus internally
         BinaryOperator::Times => "Times",
-        BinaryOperator::Divide => "Times", // Divide is represented as Times internally
+        // In Wolfram, a/b is Times[a, Power[b, -1]], but 1/b is Power[b, -1]
+        BinaryOperator::Divide => {
+          if matches!(left.as_ref(), Expr::Integer(1)) {
+            "Power"
+          } else {
+            "Times"
+          }
+        }
         BinaryOperator::Power => "Power",
         BinaryOperator::And => "And",
         BinaryOperator::Or => "Or",

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -2277,6 +2277,28 @@ mod rational_symbol {
     assert_eq!(interpret("MatchQ[1/2, _Rational]").unwrap(), "True");
     assert_eq!(interpret("MatchQ[5, _Rational]").unwrap(), "False");
   }
+
+  // Regression tests for https://github.com/ad-si/Woxi/issues/83
+  #[test]
+  fn head_of_reciprocal_is_power() {
+    assert_eq!(interpret("Head[1/x]").unwrap(), "Power");
+    assert_eq!(interpret("Head[1/(2*x - 3)]").unwrap(), "Power");
+  }
+
+  #[test]
+  fn head_of_reciprocal_via_variable() {
+    clear_state();
+    assert_eq!(
+      interpret("y = 1/(2*x - 3); Head[y]").unwrap(),
+      "Power"
+    );
+  }
+
+  #[test]
+  fn head_of_symbolic_division_is_times() {
+    assert_eq!(interpret("Head[2/x]").unwrap(), "Times");
+    assert_eq!(interpret("Head[x/(2*y)]").unwrap(), "Times");
+  }
 }
 
 mod mesh_symbol {


### PR DESCRIPTION
In Wolfram Language, 1/expr is canonically Power[expr, -1], so Head[1/expr] should return Power. The head_ast function was unconditionally mapping BinaryOp::Divide to "Times", but now correctly checks if the numerator is 1 to return "Power" instead.