### PR TITLE
Add Wolfram 15 ComputationalMusic objects

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -6200,4 +6200,4 @@ MusicVoice,Represents a musical voice,✅,pure,15.0,5604
 MusicScore,Represents a musical score,✅,pure,15.0,5605
 MusicMeasurements,Compute properties of a music object,🚫,pure,15.0,5606
 MusicTransform,Transform a music object,🚫,pure,15.0,5607
-MusicPlot,Visualize a music object,🚫,pure,15.0,5608
+MusicPlot,Visualize a music object as staff notation,✅,effectful,15.0,5608

--- a/functions.csv
+++ b/functions.csv
@@ -6188,7 +6188,7 @@ MusicNote,Represents a musical note,✅,pure,15.0,5592
 MusicRest,Represents a musical rest (silence),✅,pure,15.0,5593
 MusicChord,Represents a musical chord,✅,pure,15.0,5594
 MusicDuration,Specification for note or rest duration,✅,pure,15.0,5595
-MusicPitch,Specification for note pitch (MIDI integers canonicalize to named pitches),✅,pure,15.0,5596
+MusicPitch,Specification for note pitch (MIDI integers/frequencies/SoundNote/MusicNote canonicalize to named pitches),✅,pure,15.0,5596
 MusicInterval,Represents the interval between two pitches,✅,pure,15.0,5597
 MusicKeySignature,Key signature for a measure or score,✅,pure,15.0,5598
 MusicTimeSignature,Time signature for a measure or score,✅,pure,15.0,5599

--- a/functions.csv
+++ b/functions.csv
@@ -6184,3 +6184,20 @@ WindingCount,,,,12.0,
 WithLock,,,,12.3,
 Inequality,Chained inequality with per-step comparison operators,✅,pure,1.0,
 Discard,Removes the elements of a list for which a criterion is True (complement of Select),✅,pure,13.1,5591
+MusicNote,Represents a musical note,✅,pure,15.0,5592
+MusicRest,Represents a musical rest (silence),✅,pure,15.0,5593
+MusicChord,Represents a musical chord,✅,pure,15.0,5594
+MusicDuration,Specification for note or rest duration,✅,pure,15.0,5595
+MusicPitch,Specification for note pitch (MIDI integers canonicalize to named pitches),✅,pure,15.0,5596
+MusicInterval,Represents the interval between two pitches,✅,pure,15.0,5597
+MusicKeySignature,Key signature for a measure or score,✅,pure,15.0,5598
+MusicTimeSignature,Time signature for a measure or score,✅,pure,15.0,5599
+MusicScale,Represents a musical scale,✅,pure,15.0,5600
+MusicTempo,Musical tempo to be used during playback,✅,pure,15.0,5601
+MusicObjectQ,Checks whether an expression is a music object,✅,pure,15.0,5602
+MusicMeasure,Represents a musical measure,✅,pure,15.0,5603
+MusicVoice,Represents a musical voice,✅,pure,15.0,5604
+MusicScore,Represents a musical score,✅,pure,15.0,5605
+MusicMeasurements,Compute properties of a music object,🚫,pure,15.0,5606
+MusicTransform,Transform a music object,🚫,pure,15.0,5607
+MusicPlot,Visualize a music object,🚫,pure,15.0,5608

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -2984,6 +2984,14 @@ pub(crate) fn is_rasterizable_frame(expr: &Expr) -> bool {
 pub(crate) fn expr_to_svg(expr: &Expr) -> String {
   match expr {
     Expr::Graphics { svg: svg_data, .. } => svg_data.clone(),
+    // ComputationalMusic objects render as musical-staff notation.
+    Expr::FunctionCall { name, .. }
+      if crate::functions::music_ast::MUSIC_OBJECT_HEADS
+        .contains(&name.as_str())
+        && crate::functions::music_render::music_to_svg(expr).is_some() =>
+    {
+      crate::functions::music_render::music_to_svg(expr).unwrap_or_default()
+    }
     Expr::Identifier(s) if s == "-Graphics-" || s == "-Graphics3D-" => {
       crate::get_captured_graphics().unwrap_or_default()
     }

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -27,6 +27,7 @@ mod io_functions;
 mod linear_algebra_functions;
 mod list_operations;
 mod math_functions;
+mod music_functions;
 mod plotting;
 mod polynomial_functions;
 mod predicate_functions;
@@ -1503,6 +1504,9 @@ pub fn evaluate_function_call_ast_inner(
   if let Some(result) =
     predicate_functions::dispatch_predicate_functions(name, args)
   {
+    return result;
+  }
+  if let Some(result) = music_functions::dispatch_music_functions(name, args) {
     return result;
   }
   if let Some(result) =

--- a/src/evaluator/dispatch/music_functions.rs
+++ b/src/evaluator/dispatch/music_functions.rs
@@ -1,0 +1,22 @@
+//! Dispatch for the Wolfram Language 15.0 ComputationalMusic functions.
+//!
+//! `MusicObjectQ` and `MusicPitch` carry real behavior; the remaining music
+//! *objects* (MusicNote, MusicChord, …) are left as canonical symbolic
+//! expressions by returning `None` here, matching how `Sound`/`SoundNote`
+//! already behave.
+
+#[allow(unused_imports)]
+use super::*;
+
+pub fn dispatch_music_functions(
+  name: &str,
+  args: &[Expr],
+) -> Option<Result<Expr, InterpreterError>> {
+  match name {
+    "MusicObjectQ" if args.len() == 1 => {
+      Some(Ok(crate::functions::music_ast::music_object_q(args)))
+    }
+    "MusicPitch" => crate::functions::music_ast::music_pitch(args).map(Ok),
+    _ => None,
+  }
+}

--- a/src/evaluator/dispatch/music_functions.rs
+++ b/src/evaluator/dispatch/music_functions.rs
@@ -17,6 +17,13 @@ pub fn dispatch_music_functions(
       Some(Ok(crate::functions::music_ast::music_object_q(args)))
     }
     "MusicPitch" => crate::functions::music_ast::music_pitch(args).map(Ok),
+    // MusicPlot[obj] draws the object as staff notation, returning a Graphics
+    // (which renders as the SVG in visual hosts and as `-Graphics-` in the CLI,
+    // just like Plot). Non-renderable arguments are left symbolic.
+    "MusicPlot" if args.len() == 1 => {
+      crate::functions::music_render::music_to_svg(&args[0])
+        .map(|svg| Ok(crate::graphics_result(svg)))
+    }
     _ => None,
   }
 }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -31,6 +31,7 @@ pub mod list_helpers_ast;
 pub mod list_plot;
 pub mod math_ast;
 pub mod memory;
+pub mod music_ast;
 pub mod number_line_plot;
 pub mod ode_ast;
 pub mod parametric_plot;

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -32,6 +32,7 @@ pub mod list_plot;
 pub mod math_ast;
 pub mod memory;
 pub mod music_ast;
+pub mod music_render;
 pub mod number_line_plot;
 pub mod ode_ast;
 pub mod parametric_plot;

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -1,0 +1,154 @@
+//! Computational music objects from Wolfram Language 15.0
+//! (the [ComputationalMusic guide](https://reference.wolfram.com/language/guide/ComputationalMusic.html)).
+//!
+//! Woxi represents the music *objects* — notes, chords, rests, pitches,
+//! durations, scales, measures, voices, scores, … — as canonical symbolic
+//! expressions, the same way `Sound` and `SoundNote` already work. That lets
+//! them be constructed, nested, pattern-matched, and classified with
+//! `MusicObjectQ`.
+//!
+//! `MusicPitch` additionally performs one genuine computation: an integer MIDI
+//! note number is canonicalized to its scientific-pitch name, e.g.
+//! `MusicPitch[60]` -> `MusicPitch["C4"]`. The conversion uses the standard
+//! convention where middle C is MIDI 60 / C4 and A4 (MIDI 69) is 440 Hz.
+
+use crate::syntax::Expr;
+
+/// Heads that the Wolfram Language classifies as music objects — the "Music
+/// Events", "Music Properties", and "Music Containers" of the
+/// ComputationalMusic guide. `MusicObjectQ` returns `True` for these.
+pub const MUSIC_OBJECT_HEADS: &[&str] = &[
+  // Music Events
+  "MusicNote",
+  "MusicRest",
+  "MusicChord",
+  // Music Properties
+  "MusicDuration",
+  "MusicPitch",
+  "MusicInterval",
+  "MusicKeySignature",
+  "MusicTimeSignature",
+  "MusicScale",
+  "MusicTempo",
+  // Music Containers
+  "MusicMeasure",
+  "MusicVoice",
+  "MusicScore",
+];
+
+/// `MusicObjectQ[expr]` — `True` when `expr` is a music object, i.e. an
+/// expression whose head is one of [`MUSIC_OBJECT_HEADS`]; `False` otherwise.
+pub fn music_object_q(args: &[Expr]) -> Expr {
+  let is_object = matches!(
+    args,
+    [Expr::FunctionCall { name, .. }]
+      if MUSIC_OBJECT_HEADS.contains(&name.as_str())
+  );
+  Expr::Identifier(if is_object { "True" } else { "False" }.to_string())
+}
+
+/// Chromatic note names (sharp spelling) indexed by pitch class `0..=11`,
+/// with `C = 0`.
+const PITCH_CLASS_NAMES: [&str; 12] = [
+  "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
+];
+
+/// Convert a MIDI note number to its scientific-pitch name, e.g. `60 -> "C4"`,
+/// `69 -> "A4"`, `0 -> "C-1"`, `61 -> "C#4"`. Middle C (MIDI 60) is C4. Uses
+/// floor division so it is well defined for every integer, not just the
+/// nominal 0..127 MIDI range.
+pub fn midi_to_pitch_name(midi: i128) -> String {
+  let pitch_class = midi.rem_euclid(12) as usize;
+  let octave = midi.div_euclid(12) - 1;
+  format!("{}{}", PITCH_CLASS_NAMES[pitch_class], octave)
+}
+
+/// `MusicPitch[spec]`. Canonicalizes an integer MIDI number to the
+/// named-pitch form `MusicPitch["name"]`. Every other argument form (a pitch
+/// string such as `"C4"`, etc.) is already the canonical symbolic object, so
+/// `None` is returned and the caller leaves it unevaluated.
+pub fn music_pitch(args: &[Expr]) -> Option<Expr> {
+  if let [Expr::Integer(midi)] = args {
+    return Some(Expr::FunctionCall {
+      name: "MusicPitch".to_string(),
+      args: vec![Expr::String(midi_to_pitch_name(*midi))].into(),
+    });
+  }
+  None
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // `Expr` does not implement `PartialEq`, so results are checked by matching
+  // on structure / rendering to a string.
+
+  fn head_with_c4(name: &str) -> Expr {
+    Expr::FunctionCall {
+      name: name.to_string(),
+      args: vec![Expr::String("C4".to_string())].into(),
+    }
+  }
+
+  fn is_true(expr: &Expr) -> bool {
+    matches!(expr, Expr::Identifier(s) if s == "True")
+  }
+
+  fn is_false(expr: &Expr) -> bool {
+    matches!(expr, Expr::Identifier(s) if s == "False")
+  }
+
+  #[test]
+  fn music_object_q_recognizes_every_head() {
+    for head in MUSIC_OBJECT_HEADS {
+      assert!(
+        is_true(&music_object_q(&[head_with_c4(head)])),
+        "{head} should be a music object",
+      );
+    }
+  }
+
+  #[test]
+  fn music_object_q_rejects_non_objects() {
+    assert!(is_false(&music_object_q(&[Expr::Integer(3)])));
+    assert!(is_false(&music_object_q(&[Expr::FunctionCall {
+      name: "List".to_string(),
+      args: vec![].into(),
+    }])));
+    // MusicPlot/MusicTransform/MusicMeasurements are operations, not objects.
+    assert!(is_false(&music_object_q(&[Expr::FunctionCall {
+      name: "MusicPlot".to_string(),
+      args: vec![].into(),
+    }])));
+  }
+
+  #[test]
+  fn midi_to_pitch_name_known_values() {
+    assert_eq!(midi_to_pitch_name(60), "C4");
+    assert_eq!(midi_to_pitch_name(69), "A4");
+    assert_eq!(midi_to_pitch_name(61), "C#4");
+    assert_eq!(midi_to_pitch_name(12), "C0");
+    assert_eq!(midi_to_pitch_name(0), "C-1");
+    assert_eq!(midi_to_pitch_name(127), "G9");
+    // Below the nominal MIDI range still resolves via floor division.
+    assert_eq!(midi_to_pitch_name(-1), "B-2");
+  }
+
+  #[test]
+  fn music_pitch_canonicalizes_midi_integer() {
+    let result = music_pitch(&[Expr::Integer(60)]);
+    match &result {
+      Some(Expr::FunctionCall { name, args }) => {
+        assert_eq!(name, "MusicPitch");
+        assert!(matches!(&args[..], [Expr::String(s)] if s == "C4"));
+      }
+      other => panic!("expected MusicPitch[\"C4\"], got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn music_pitch_leaves_string_spec_alone() {
+    assert!(music_pitch(&[Expr::String("C4".to_string())]).is_none());
+  }
+}

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -7,10 +7,21 @@
 //! them be constructed, nested, pattern-matched, and classified with
 //! `MusicObjectQ`.
 //!
-//! `MusicPitch` additionally performs one genuine computation: an integer MIDI
-//! note number is canonicalized to its scientific-pitch name, e.g.
-//! `MusicPitch[60]` -> `MusicPitch["C4"]`. The conversion uses the standard
-//! convention where middle C is MIDI 60 / C4 and A4 (MIDI 69) is 440 Hz.
+//! `MusicPitch` additionally performs a genuine computation: it canonicalizes
+//! any of its documented input forms to the named-pitch object
+//! `MusicPitch["name"]`. Following the
+//! [`MusicPitch` reference page](https://reference.wolfram.com/language/ref/MusicPitch.html),
+//! these forms all denote the same pitch and therefore canonicalize alike:
+//!
+//! ```text
+//! MusicPitch[55]                      (* MIDI note number,   middle C = 60 *)
+//! MusicPitch[Quantity[200, "Hertz"]]  (* frequency,          A4 = 440 Hz   *)
+//! MusicPitch[SoundNote[-5]]           (* SoundNote pitch,    middle C = 0  *)
+//! MusicPitch[MusicNote["G3"]]         (* pitch of a note                   *)
+//! ```
+//!
+//! all give `MusicPitch["G3"]`. The conversions use the standard convention
+//! where middle C is MIDI 60 / C4 and A4 (MIDI 69) is 440 Hz.
 
 use crate::syntax::Expr;
 
@@ -63,18 +74,116 @@ pub fn midi_to_pitch_name(midi: i128) -> String {
   format!("{}{}", PITCH_CLASS_NAMES[pitch_class], octave)
 }
 
-/// `MusicPitch[spec]`. Canonicalizes an integer MIDI number to the
-/// named-pitch form `MusicPitch["name"]`. Every other argument form (a pitch
-/// string such as `"C4"`, etc.) is already the canonical symbolic object, so
-/// `None` is returned and the caller leaves it unevaluated.
-pub fn music_pitch(args: &[Expr]) -> Option<Expr> {
-  if let [Expr::Integer(midi)] = args {
-    return Some(Expr::FunctionCall {
-      name: "MusicPitch".to_string(),
-      args: vec![Expr::String(midi_to_pitch_name(*midi))].into(),
-    });
+/// Parse a scientific-pitch name such as `"C4"`, `"A4"`, `"F#3"`, `"Eb5"`,
+/// `"C-1"` back into its MIDI note number — the inverse of
+/// [`midi_to_pitch_name`]. Accepts both sharp (`#`) and flat (`b`) accidentals
+/// and a negative octave. Returns `None` for anything that is not a pitch
+/// name (so callers can leave such specifications symbolic).
+pub fn pitch_name_to_midi(name: &str) -> Option<i128> {
+  let bytes = name.as_bytes();
+  let letter = *bytes.first()?;
+  // Base semitone of the natural note, C..B.
+  let base = match letter.to_ascii_uppercase() {
+    b'C' => 0,
+    b'D' => 2,
+    b'E' => 4,
+    b'F' => 5,
+    b'G' => 7,
+    b'A' => 9,
+    b'B' => 11,
+    _ => return None,
+  };
+  let mut idx = 1;
+  let mut accidental: i128 = 0;
+  while let Some(&c) = bytes.get(idx) {
+    match c {
+      b'#' => accidental += 1,
+      b'b' => accidental -= 1,
+      _ => break,
+    }
+    idx += 1;
   }
-  None
+  // The remainder must be the (possibly negative) octave number.
+  let octave: i128 = name.get(idx..)?.parse().ok()?;
+  Some((octave + 1) * 12 + base + accidental)
+}
+
+/// Convert a frequency in Hertz to the nearest MIDI note number in 12-tone
+/// equal temperament, with A4 (MIDI 69) tuned to 440 Hz. Returns `None` for
+/// non-positive or non-finite frequencies, which have no pitch.
+pub fn frequency_to_midi(freq: f64) -> Option<i128> {
+  if freq <= 0.0 || !freq.is_finite() {
+    return None;
+  }
+  Some((69.0 + 12.0 * (freq / 440.0).log2()).round() as i128)
+}
+
+/// Extract the numeric magnitude of a `Quantity`/number argument as an `f64`.
+fn magnitude_as_f64(expr: &Expr) -> Option<f64> {
+  match expr {
+    Expr::Integer(n) => Some(*n as f64),
+    Expr::Real(f) => Some(*f),
+    _ => None,
+  }
+}
+
+/// Resolve any documented `MusicPitch` input form to its canonical pitch-name
+/// string, e.g. `Integer(55) -> "G3"`. Returns `None` when the specification
+/// is not a recognized pitch form.
+fn resolve_pitch_name(spec: &Expr) -> Option<String> {
+  match spec {
+    // MIDI note number (middle C = 60).
+    Expr::Integer(midi) => Some(midi_to_pitch_name(*midi)),
+    // A pitch name such as "C4" is already canonical.
+    Expr::String(name) => Some(name.clone()),
+    Expr::FunctionCall { name, args } => match name.as_str() {
+      // MusicPitch[Quantity[f, "Hertz"]] — a frequency.
+      "Quantity" if args.len() == 2 => {
+        let is_hertz = matches!(
+          &args[1],
+          Expr::String(u) | Expr::Identifier(u) if u == "Hertz" || u == "Hz"
+        );
+        if !is_hertz {
+          return None;
+        }
+        frequency_to_midi(magnitude_as_f64(&args[0])?).map(midi_to_pitch_name)
+      }
+      // MusicPitch[SoundNote[p, ...]] — SoundNote numbers pitches relative to
+      // middle C (0), so the MIDI number is p + 60.
+      "SoundNote" => match args.first()? {
+        Expr::Integer(p) => Some(midi_to_pitch_name(p + 60)),
+        Expr::String(s) => Some(s.clone()),
+        _ => None,
+      },
+      // MusicPitch[MusicNote[pitch, ...]] / MusicPitch[MusicPitch[...]] — take
+      // the pitch of the note, which uses MIDI/pitch-name conventions.
+      "MusicNote" | "MusicPitch" => resolve_pitch_name(args.first()?),
+      _ => None,
+    },
+    _ => None,
+  }
+}
+
+/// `MusicPitch[spec]`. Canonicalizes any of the documented pitch
+/// specifications — MIDI integer, `Quantity` frequency, `SoundNote`,
+/// `MusicNote`, or a nested `MusicPitch` — to the named-pitch form
+/// `MusicPitch["name"]`. A bare pitch string such as `"C4"` is already the
+/// canonical symbolic object, so `None` is returned and the caller leaves it
+/// unevaluated.
+pub fn music_pitch(args: &[Expr]) -> Option<Expr> {
+  let [spec] = args else {
+    return None;
+  };
+  // A bare pitch name is already canonical; keep it unevaluated to avoid
+  // pointless rewriting (MusicPitch["C4"] -> MusicPitch["C4"]).
+  if matches!(spec, Expr::String(_)) {
+    return None;
+  }
+  let name = resolve_pitch_name(spec)?;
+  Some(Expr::FunctionCall {
+    name: "MusicPitch".to_string(),
+    args: vec![Expr::String(name)].into(),
+  })
 }
 
 #[cfg(test)]
@@ -150,5 +259,125 @@ mod tests {
   #[test]
   fn music_pitch_leaves_string_spec_alone() {
     assert!(music_pitch(&[Expr::String("C4".to_string())]).is_none());
+  }
+
+  #[test]
+  fn pitch_name_to_midi_inverts_midi_to_pitch_name() {
+    // Round-trips for every MIDI number the naming scheme covers.
+    for midi in -24..=127 {
+      assert_eq!(
+        pitch_name_to_midi(&midi_to_pitch_name(midi)),
+        Some(midi),
+        "round-trip failed for MIDI {midi}",
+      );
+    }
+  }
+
+  #[test]
+  fn pitch_name_to_midi_accepts_flats_and_sharps() {
+    assert_eq!(pitch_name_to_midi("C4"), Some(60));
+    assert_eq!(pitch_name_to_midi("A4"), Some(69));
+    assert_eq!(pitch_name_to_midi("C#4"), Some(61));
+    // Db4 is enharmonically the same pitch as C#4.
+    assert_eq!(pitch_name_to_midi("Db4"), Some(61));
+    assert_eq!(pitch_name_to_midi("C-1"), Some(0));
+    assert_eq!(pitch_name_to_midi("Cb4"), Some(59));
+    // Not pitch names.
+    assert_eq!(pitch_name_to_midi("H4"), None);
+    assert_eq!(pitch_name_to_midi(""), None);
+    assert_eq!(pitch_name_to_midi("C"), None);
+  }
+
+  #[test]
+  fn frequency_to_midi_known_values() {
+    assert_eq!(frequency_to_midi(440.0), Some(69)); // A4
+    assert_eq!(frequency_to_midi(261.6255653), Some(60)); // middle C
+    assert_eq!(frequency_to_midi(200.0), Some(55)); // ~G3, per the docs
+    // Non-positive / non-finite frequencies have no pitch.
+    assert_eq!(frequency_to_midi(0.0), None);
+    assert_eq!(frequency_to_midi(-100.0), None);
+    assert_eq!(frequency_to_midi(f64::INFINITY), None);
+  }
+
+  fn expect_music_pitch(spec: Expr, name: &str) {
+    match &music_pitch(&[spec]) {
+      Some(Expr::FunctionCall { name: head, args }) => {
+        assert_eq!(head, "MusicPitch");
+        assert!(
+          matches!(&args[..], [Expr::String(s)] if s == name),
+          "expected MusicPitch[{name:?}], got args {args:?}",
+        );
+      }
+      other => panic!("expected MusicPitch[{name:?}], got {other:?}"),
+    }
+  }
+
+  fn func(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::FunctionCall {
+      name: name.to_string(),
+      args: args.into(),
+    }
+  }
+
+  #[test]
+  fn music_pitch_canonicalizes_frequency() {
+    expect_music_pitch(
+      func(
+        "Quantity",
+        vec![Expr::Integer(440), Expr::String("Hertz".into())],
+      ),
+      "A4",
+    );
+    expect_music_pitch(
+      func(
+        "Quantity",
+        vec![Expr::Integer(200), Expr::String("Hertz".into())],
+      ),
+      "G3",
+    );
+    // Identifier unit spelling and the "Hz" abbreviation are both accepted.
+    expect_music_pitch(
+      func(
+        "Quantity",
+        vec![Expr::Real(440.0), Expr::Identifier("Hertz".into())],
+      ),
+      "A4",
+    );
+    // A non-frequency Quantity has no pitch interpretation.
+    assert!(
+      music_pitch(&[func(
+        "Quantity",
+        vec![Expr::Integer(440), Expr::String("Meters".into())]
+      )])
+      .is_none()
+    );
+  }
+
+  #[test]
+  fn music_pitch_canonicalizes_soundnote() {
+    // SoundNote numbers pitches relative to middle C (0), so 0 -> C4.
+    expect_music_pitch(func("SoundNote", vec![Expr::Integer(0)]), "C4");
+    expect_music_pitch(func("SoundNote", vec![Expr::Integer(-5)]), "G3");
+    expect_music_pitch(
+      func("SoundNote", vec![Expr::String("A4".into())]),
+      "A4",
+    );
+  }
+
+  #[test]
+  fn music_pitch_extracts_note_pitch() {
+    expect_music_pitch(
+      func("MusicNote", vec![Expr::String("G3".into())]),
+      "G3",
+    );
+    expect_music_pitch(
+      func(
+        "MusicNote",
+        vec![func("MusicPitch", vec![Expr::Integer(55)])],
+      ),
+      "G3",
+    );
+    // Nested MusicPitch resolves through to the underlying pitch.
+    expect_music_pitch(func("MusicPitch", vec![Expr::Integer(60)]), "C4");
   }
 }

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -130,7 +130,7 @@ fn magnitude_as_f64(expr: &Expr) -> Option<f64> {
 /// Resolve any documented `MusicPitch` input form to its canonical pitch-name
 /// string, e.g. `Integer(55) -> "G3"`. Returns `None` when the specification
 /// is not a recognized pitch form.
-fn resolve_pitch_name(spec: &Expr) -> Option<String> {
+pub fn resolve_pitch_name(spec: &Expr) -> Option<String> {
   match spec {
     // MIDI note number (middle C = 60).
     Expr::Integer(midi) => Some(midi_to_pitch_name(*midi)),

--- a/src/functions/music_render.rs
+++ b/src/functions/music_render.rs
@@ -1,0 +1,773 @@
+//! SVG rendering of the Wolfram Language 15.0 ComputationalMusic objects on a
+//! musical staff, the way Mathematica displays them.
+//!
+//! The music *objects* stay canonical symbolic expressions everywhere (so the
+//! CLI still prints `MusicNote[MusicPitch[C4], …]`); only the visual hosts —
+//! the Woxi Playground and Woxi Studio — turn them into notation. A single
+//! entry point, [`music_to_svg`], produces a self-contained SVG that renders
+//! identically in a browser and in Studio's `resvg` rasterizer, so all the
+//! notation (staff, treble clef, note heads, stems, flags, accidentals,
+//! ledger lines, rests and barlines) is drawn geometrically rather than with
+//! musical Unicode glyphs, which the bundled fonts do not carry.
+
+use crate::functions::graphics::theme;
+use crate::functions::music_ast::{
+  midi_to_pitch_name, pitch_name_to_midi, resolve_pitch_name,
+};
+use crate::syntax::Expr;
+
+// ── Staff geometry (internal user-space coordinates) ─────────────────────────
+
+/// Vertical distance between two adjacent staff lines.
+const GAP: f64 = 12.0;
+/// Half a `GAP`: the vertical step between adjacent diatonic degrees (a line
+/// and its neighbouring space).
+const STEP: f64 = GAP / 2.0;
+/// `y` of the bottom staff line (E4) in internal coordinates.
+const BOTTOM_LINE_Y: f64 = 100.0;
+/// Diatonic number of the bottom staff line, E4 (see [`diatonic_number`]).
+const BOTTOM_LINE_DN: i32 = 30;
+/// Horizontal advance between successive notes/rests.
+const ADVANCE: f64 = 30.0;
+/// `x` of the left edge of the staff.
+const STAFF_X0: f64 = 6.0;
+/// `x` of the first note head, leaving room for the clef.
+const FIRST_NOTE_X: f64 = 46.0;
+/// Stem length, in whole gaps.
+const STEM_LEN: f64 = 3.0 * GAP;
+
+/// `y` of a diatonic degree `dn` on the staff.
+fn dn_y(dn: i32) -> f64 {
+  BOTTOM_LINE_Y - (dn - BOTTOM_LINE_DN) as f64 * STEP
+}
+
+// ── Musical model ────────────────────────────────────────────────────────────
+
+/// A rhythmic value, controlling note-head fill, stem and flags.
+#[derive(Clone, Copy, PartialEq)]
+enum Dur {
+  Whole,
+  Half,
+  Quarter,
+  Eighth,
+  Sixteenth,
+}
+
+impl Dur {
+  /// Whether the note head is filled (`true`) or open (`false`).
+  fn filled(self) -> bool {
+    matches!(self, Dur::Quarter | Dur::Eighth | Dur::Sixteenth)
+  }
+  /// Whether the note carries a stem (everything but a whole note).
+  fn has_stem(self) -> bool {
+    self != Dur::Whole
+  }
+  /// Number of flags on the stem (eighth = 1, sixteenth = 2).
+  fn flags(self) -> u32 {
+    match self {
+      Dur::Eighth => 1,
+      Dur::Sixteenth => 2,
+      _ => 0,
+    }
+  }
+}
+
+/// One note head: its diatonic staff position and accidental
+/// (`-1` flat, `0` natural, `+1` sharp).
+#[derive(Clone, Copy)]
+struct Head {
+  dn: i32,
+  accidental: i32,
+}
+
+/// A drawable element laid out left to right on the staff.
+enum Glyph {
+  /// A note or (with several heads) a chord.
+  Note {
+    heads: Vec<Head>,
+    dur: Dur,
+  },
+  Rest {
+    dur: Dur,
+  },
+  Barline,
+}
+
+// ── Parsing music objects into glyphs ────────────────────────────────────────
+
+/// Diatonic number of a scientific-pitch name: `octave * 7 + letter`, with
+/// `C = 0 … B = 6`. E4 is `30` (the bottom treble-staff line), middle C (C4)
+/// is `28` (one ledger line below). The accidental does not change the
+/// diatonic position — it is drawn separately.
+fn diatonic_number(name: &str) -> Option<(i32, i32)> {
+  let bytes = name.as_bytes();
+  let letter = *bytes.first()?;
+  let letter_index = match letter.to_ascii_uppercase() {
+    b'C' => 0,
+    b'D' => 1,
+    b'E' => 2,
+    b'F' => 3,
+    b'G' => 4,
+    b'A' => 5,
+    b'B' => 6,
+    _ => return None,
+  };
+  let mut idx = 1;
+  let mut accidental = 0;
+  while let Some(&c) = bytes.get(idx) {
+    match c {
+      b'#' => accidental += 1,
+      b'b' => accidental -= 1,
+      _ => break,
+    }
+    idx += 1;
+  }
+  let octave: i32 = name.get(idx..)?.parse().ok()?;
+  Some((octave * 7 + letter_index, accidental))
+}
+
+/// Turn any pitch specification (a `MusicPitch`, `MusicNote`, name string or
+/// MIDI integer) into a staff [`Head`].
+fn pitch_head(spec: &Expr) -> Option<Head> {
+  let name = resolve_pitch_name(spec)?;
+  let (dn, accidental) = diatonic_number(&name)?;
+  Some(Head { dn, accidental })
+}
+
+/// Parse a duration specification — `MusicDuration["Quarter"]`, the bare name
+/// `"Half"`, etc. — defaulting to a quarter note.
+fn parse_duration(spec: &Expr) -> Dur {
+  let name = match spec {
+    Expr::String(s) => Some(s.as_str()),
+    Expr::FunctionCall { name, args }
+      if name == "MusicDuration" && !args.is_empty() =>
+    {
+      match &args[0] {
+        Expr::String(s) => Some(s.as_str()),
+        _ => None,
+      }
+    }
+    _ => None,
+  };
+  match name {
+    Some("Whole") => Dur::Whole,
+    Some("Half") => Dur::Half,
+    Some("Eighth") => Dur::Eighth,
+    Some("Sixteenth") => Dur::Sixteenth,
+    _ => Dur::Quarter,
+  }
+}
+
+/// Semitone offsets (from the root) of the scale degrees Woxi knows how to
+/// spell out, or `None` for an unrecognized scale name.
+fn scale_pattern(name: &str) -> Option<&'static [i32]> {
+  Some(match name {
+    "Major" | "Ionian" => &[0, 2, 4, 5, 7, 9, 11, 12],
+    "Minor" | "NaturalMinor" | "Aeolian" => &[0, 2, 3, 5, 7, 8, 10, 12],
+    "HarmonicMinor" => &[0, 2, 3, 5, 7, 8, 11, 12],
+    "MelodicMinor" => &[0, 2, 3, 5, 7, 9, 11, 12],
+    "Dorian" => &[0, 2, 3, 5, 7, 9, 10, 12],
+    "Phrygian" => &[0, 1, 3, 5, 7, 8, 10, 12],
+    "Lydian" => &[0, 2, 4, 6, 7, 9, 11, 12],
+    "Mixolydian" => &[0, 2, 4, 5, 7, 9, 10, 12],
+    "WholeTone" => &[0, 2, 4, 6, 8, 10, 12],
+    "Chromatic" => &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    _ => return None,
+  })
+}
+
+/// Expand a `MusicScale[…]` argument list into its constituent pitch heads.
+fn scale_heads(args: &[Expr]) -> Vec<Head> {
+  // Locate the scale name and (optionally) the root pitch among the arguments.
+  let mut pattern: &[i32] = &[0, 2, 4, 5, 7, 9, 11, 12];
+  let mut root: Option<i128> = None;
+  for arg in args {
+    if let Expr::String(s) = arg
+      && let Some(p) = scale_pattern(s)
+    {
+      pattern = p;
+      continue;
+    }
+    if let Some(name) = resolve_pitch_name(arg)
+      && let Some(midi) = pitch_name_to_midi(&name)
+    {
+      root = Some(midi);
+    }
+  }
+  let root = root.unwrap_or(60); // default to middle C
+  pattern
+    .iter()
+    .filter_map(|off| {
+      let (dn, accidental) =
+        diatonic_number(&midi_to_pitch_name(root + *off as i128))?;
+      Some(Head { dn, accidental })
+    })
+    .collect()
+}
+
+/// Collect the drawable glyphs of a music object in reading order. Returns
+/// `true` when `expr` was a container whose contents are conventionally closed
+/// by a final barline.
+fn collect(expr: &Expr, out: &mut Vec<Glyph>) -> bool {
+  match expr {
+    Expr::List(items) => {
+      for it in items.iter() {
+        collect(it, out);
+      }
+      false
+    }
+    Expr::FunctionCall { name, args } => match name.as_str() {
+      "MusicPitch" => {
+        if let Some(h) = pitch_head(expr) {
+          out.push(Glyph::Note {
+            heads: vec![h],
+            dur: Dur::Quarter,
+          });
+        }
+        false
+      }
+      "MusicNote" if !args.is_empty() => {
+        if let Some(h) = pitch_head(&args[0]) {
+          let dur = args.get(1).map(parse_duration).unwrap_or(Dur::Quarter);
+          out.push(Glyph::Note {
+            heads: vec![h],
+            dur,
+          });
+        }
+        false
+      }
+      "MusicRest" => {
+        let dur = args.first().map(parse_duration).unwrap_or(Dur::Quarter);
+        out.push(Glyph::Rest { dur });
+        false
+      }
+      "MusicChord" if !args.is_empty() => {
+        let mut heads = Vec::new();
+        if let Expr::List(items) = &args[0] {
+          for it in items.iter() {
+            if let Some(h) = pitch_head(it) {
+              heads.push(h);
+            }
+          }
+        }
+        if !heads.is_empty() {
+          heads.sort_by_key(|h| h.dn);
+          let dur = args.get(1).map(parse_duration).unwrap_or(Dur::Quarter);
+          out.push(Glyph::Note { heads, dur });
+        }
+        false
+      }
+      "MusicScale" => {
+        for h in scale_heads(args) {
+          out.push(Glyph::Note {
+            heads: vec![h],
+            dur: Dur::Quarter,
+          });
+        }
+        true
+      }
+      "MusicMeasure" => {
+        for arg in args {
+          collect(arg, out);
+        }
+        out.push(Glyph::Barline);
+        true
+      }
+      "MusicVoice" | "MusicScore" => {
+        for arg in args {
+          collect(arg, out);
+        }
+        true
+      }
+      _ => false,
+    },
+    _ => false,
+  }
+}
+
+// ── SVG drawing ──────────────────────────────────────────────────────────────
+
+/// Accumulates SVG path/shape fragments while tracking the drawn bounding box
+/// so the final `viewBox` can be fitted with padding.
+struct Canvas {
+  out: String,
+  stroke: String,
+  minx: f64,
+  miny: f64,
+  maxx: f64,
+  maxy: f64,
+}
+
+impl Canvas {
+  fn new(stroke: &str) -> Self {
+    Canvas {
+      out: String::new(),
+      stroke: stroke.to_string(),
+      minx: f64::INFINITY,
+      miny: f64::INFINITY,
+      maxx: f64::NEG_INFINITY,
+      maxy: f64::NEG_INFINITY,
+    }
+  }
+
+  fn bound(&mut self, x: f64, y: f64) {
+    self.minx = self.minx.min(x);
+    self.miny = self.miny.min(y);
+    self.maxx = self.maxx.max(x);
+    self.maxy = self.maxy.max(y);
+  }
+
+  fn line(&mut self, x1: f64, y1: f64, x2: f64, y2: f64, w: f64) {
+    self.out.push_str(&format!(
+      "<line x1=\"{x1:.2}\" y1=\"{y1:.2}\" x2=\"{x2:.2}\" y2=\"{y2:.2}\" \
+       stroke=\"{}\" stroke-width=\"{w}\" stroke-linecap=\"round\"/>",
+      self.stroke
+    ));
+    self.bound(x1.min(x2) - w, y1.min(y2) - w);
+    self.bound(x1.max(x2) + w, y1.max(y2) + w);
+  }
+
+  /// A note head: an ellipse tilted like an engraved note, filled or open.
+  fn note_head(&mut self, cx: f64, cy: f64, filled: bool) {
+    let (rx, ry) = (6.3, 4.6);
+    let fill = if filled {
+      format!("fill=\"{}\"", self.stroke)
+    } else {
+      format!(
+        "fill=\"none\" stroke=\"{}\" stroke-width=\"1.5\"",
+        self.stroke
+      )
+    };
+    self.out.push_str(&format!(
+      "<ellipse cx=\"{cx:.2}\" cy=\"{cy:.2}\" rx=\"{rx}\" ry=\"{ry}\" \
+       transform=\"rotate(-22 {cx:.2} {cy:.2})\" {fill}/>"
+    ));
+    self.bound(cx - rx - 1.0, cy - ry - 1.0);
+    self.bound(cx + rx + 1.0, cy + ry + 1.0);
+  }
+
+  /// A small filled disc (clef terminal, augmentation/rest dots).
+  fn dot(&mut self, cx: f64, cy: f64, r: f64) {
+    self.out.push_str(&format!(
+      "<circle cx=\"{cx:.2}\" cy=\"{cy:.2}\" r=\"{r}\" fill=\"{}\"/>",
+      self.stroke
+    ));
+    self.bound(cx - r, cy - r);
+    self.bound(cx + r, cy + r);
+  }
+
+  fn filled_rect(&mut self, x: f64, y: f64, w: f64, h: f64) {
+    self.out.push_str(&format!(
+      "<rect x=\"{x:.2}\" y=\"{y:.2}\" width=\"{w:.2}\" height=\"{h:.2}\" \
+       fill=\"{}\"/>",
+      self.stroke
+    ));
+    self.bound(x, y);
+    self.bound(x + w, y + h);
+  }
+
+  fn path(&mut self, d: &str, filled: bool, w: f64) {
+    let style = if filled {
+      format!("fill=\"{}\"", self.stroke)
+    } else {
+      format!(
+        "fill=\"none\" stroke=\"{}\" stroke-width=\"{w}\"",
+        self.stroke
+      )
+    };
+    self.out.push_str(&format!(
+      "<path d=\"{d}\" {style} stroke-linejoin=\"round\"/>"
+    ));
+  }
+}
+
+/// Draw a sharp or flat sign to the left of a note head centred at `(cx, cy)`.
+/// `column` shifts the sign further left so stacked chord accidentals do not
+/// collide.
+fn draw_accidental(
+  cv: &mut Canvas,
+  cx: f64,
+  cy: f64,
+  accidental: i32,
+  column: usize,
+) {
+  let x = cx - 12.0 - column as f64 * 9.0;
+  match accidental {
+    a if a > 0 => {
+      // Sharp: two vertical strokes crossed by two slightly rising bars.
+      cv.line(x - 1.5, cy - 6.0, x - 1.5, cy + 5.0, 1.1);
+      cv.line(x + 1.8, cy - 5.0, x + 1.8, cy + 6.0, 1.1);
+      cv.line(x - 4.0, cy - 1.6, x + 4.0, cy - 2.8, 1.6);
+      cv.line(x - 4.0, cy + 2.4, x + 4.0, cy + 1.2, 1.6);
+    }
+    a if a < 0 => {
+      // Flat: a vertical stem with a small bowl on its lower right.
+      cv.line(x - 1.5, cy - 8.0, x - 1.5, cy + 4.5, 1.1);
+      cv.path(
+        &format!(
+          "M {:.2} {:.2} Q {:.2} {:.2} {:.2} {:.2} Q {:.2} {:.2} {:.2} {:.2}",
+          x - 1.5,
+          cy - 1.5,
+          x + 4.5,
+          cy - 3.0,
+          x + 3.0,
+          cy + 2.0,
+          x + 1.5,
+          cy + 4.2,
+          x - 1.5,
+          cy + 4.5,
+        ),
+        false,
+        1.1,
+      );
+    }
+    _ => {}
+  }
+}
+
+/// Draw ledger lines through a head at diatonic position `dn` centred at `cx`.
+fn draw_ledger_lines(cv: &mut Canvas, cx: f64, dn: i32) {
+  let half = 8.5;
+  if dn <= BOTTOM_LINE_DN - 2 {
+    let mut e = BOTTOM_LINE_DN - 2; // first ledger below the staff (C4 = 28)
+    while e >= dn {
+      let y = dn_y(e);
+      cv.line(cx - half, y, cx + half, y, 1.2);
+      e -= 2;
+    }
+  }
+  let top_line_dn = BOTTOM_LINE_DN + 8; // F5 = 38
+  if dn >= top_line_dn + 2 {
+    let mut e = top_line_dn + 2; // first ledger above the staff (A5 = 40)
+    while e <= dn {
+      let y = dn_y(e);
+      cv.line(cx - half, y, cx + half, y, 1.2);
+      e += 2;
+    }
+  }
+}
+
+/// Draw a note or chord centred at `x`.
+fn draw_note(cv: &mut Canvas, x: f64, heads: &[Head], dur: Dur) {
+  // Ledger lines and heads.
+  for h in heads {
+    draw_ledger_lines(cv, x, h.dn);
+  }
+  // Stagger accidentals of adjacent heads into separate columns so their
+  // signs do not overlap (top head nearest the note, lower heads further left).
+  let mut column = 0usize;
+  let mut prev_dn: Option<i32> = None;
+  for h in heads.iter().rev() {
+    cv.note_head(x, dn_y(h.dn), dur.filled());
+    if h.accidental != 0 {
+      if prev_dn.is_some_and(|p| (p - h.dn).abs() <= 2) {
+        column += 1;
+      } else {
+        column = 0;
+      }
+      draw_accidental(cv, x, dn_y(h.dn), h.accidental, column);
+      prev_dn = Some(h.dn);
+    }
+  }
+  if !dur.has_stem() {
+    return;
+  }
+  // Stem direction from the middle head: notes on the upper half stem down.
+  let top_dn = heads.iter().map(|h| h.dn).max().unwrap();
+  let bottom_dn = heads.iter().map(|h| h.dn).min().unwrap();
+  let mid = BOTTOM_LINE_DN + 4; // middle staff line, B4 = 34
+  let stem_up = (top_dn + bottom_dn) as f64 / 2.0 < mid as f64;
+  let (sx, y_near, y_far) = if stem_up {
+    let sx = x + 5.7;
+    (sx, dn_y(bottom_dn), dn_y(top_dn) - STEM_LEN)
+  } else {
+    let sx = x - 5.7;
+    (sx, dn_y(top_dn), dn_y(bottom_dn) + STEM_LEN)
+  };
+  cv.line(sx, y_near, sx, y_far, 1.4);
+  // Flags for eighth / sixteenth notes.
+  let flags = dur.flags();
+  for i in 0..flags {
+    let fy = y_far + i as f64 * 7.0;
+    if stem_up {
+      cv.path(
+        &format!(
+          "M {sx:.2} {fy:.2} C {:.2} {:.2} {:.2} {:.2} {:.2} {:.2}",
+          sx + 9.0,
+          fy + 3.0,
+          sx + 9.0,
+          fy + 10.0,
+          sx + 2.0,
+          fy + 14.0,
+        ),
+        false,
+        1.6,
+      );
+    } else {
+      cv.path(
+        &format!(
+          "M {sx:.2} {fy:.2} C {:.2} {:.2} {:.2} {:.2} {:.2} {:.2}",
+          sx + 9.0,
+          fy - 3.0,
+          sx + 9.0,
+          fy - 10.0,
+          sx + 2.0,
+          fy - 14.0,
+        ),
+        false,
+        1.6,
+      );
+    }
+  }
+}
+
+/// Draw a rest centred at `x`.
+fn draw_rest(cv: &mut Canvas, x: f64, dur: Dur) {
+  let mid = dn_y(BOTTOM_LINE_DN + 4); // middle line, B4
+  match dur {
+    Dur::Whole => {
+      // A filled block hanging below the second line from the top (D5).
+      cv.filled_rect(x - 5.5, dn_y(BOTTOM_LINE_DN + 6) - 5.0, 11.0, 5.0);
+    }
+    Dur::Half => {
+      // A filled block sitting on the middle line.
+      cv.filled_rect(x - 5.5, mid, 11.0, 5.0);
+    }
+    _ => {
+      // Quarter (and shorter): a stylized zig-zag rest.
+      cv.path(
+        &format!(
+          "M {:.2} {:.2} L {:.2} {:.2} L {:.2} {:.2} L {:.2} {:.2} \
+           Q {:.2} {:.2} {:.2} {:.2}",
+          x - 3.5,
+          mid - 10.0,
+          x + 2.5,
+          mid - 3.0,
+          x - 3.0,
+          mid + 2.5,
+          x + 3.5,
+          mid + 9.0,
+          x - 3.5,
+          mid + 4.0,
+          x - 1.0,
+          mid + 12.0,
+        ),
+        false,
+        1.8,
+      );
+      if dur == Dur::Eighth || dur == Dur::Sixteenth {
+        // A small dot to hint at the shorter value.
+        cv.dot(x + 4.0, mid - 8.0, 1.8);
+      }
+    }
+  }
+}
+
+/// Draw the treble (G) clef, its curl wrapped around the G4 line at `x`.
+fn draw_treble_clef(cv: &mut Canvas, x: f64) {
+  let g = dn_y(BOTTOM_LINE_DN + 2); // G4 line
+  // A stylized G-clef: a tall spine, an upper hook, the big belly spiralling
+  // in to the G line, and a tail with a terminal dot below the staff.
+  let d = format!(
+    "M {x0:.2} {tail:.2} \
+     C {c1x:.2} {c1y:.2} {c2x:.2} {c2y:.2} {topx:.2} {topy:.2} \
+     C {c3x:.2} {c3y:.2} {c4x:.2} {c4y:.2} {rightx:.2} {righty:.2} \
+     C {c5x:.2} {c5y:.2} {c6x:.2} {c6y:.2} {gx:.2} {gy:.2} \
+     C {c7x:.2} {c7y:.2} {c8x:.2} {c8y:.2} {leftx:.2} {lefty:.2} \
+     C {c9x:.2} {c9y:.2} {c10x:.2} {c10y:.2} {cx:.2} {cy:.2}",
+    x0 = x - 1.0,
+    tail = g + 30.0,
+    c1x = x - 10.0,
+    c1y = g + 20.0,
+    c2x = x - 9.0,
+    c2y = g + 2.0,
+    topx = x + 1.0,
+    topy = g - 34.0,
+    c3x = x + 9.0,
+    c3y = g - 20.0,
+    c4x = x + 9.0,
+    c4y = g - 6.0,
+    rightx = x + 8.0,
+    righty = g + 2.0,
+    c5x = x + 7.0,
+    c5y = g + 12.0,
+    c6x = x - 8.0,
+    c6y = g + 12.0,
+    gx = x - 8.0,
+    gy = g,
+    c7x = x - 8.0,
+    c7y = g - 8.0,
+    c8x = x + 3.0,
+    c8y = g - 8.0,
+    leftx = x + 3.0,
+    lefty = g,
+    c9x = x + 3.0,
+    c9y = g + 5.0,
+    c10x = x - 1.0,
+    c10y = g + 5.0,
+    cx = x - 1.5,
+    cy = g + 3.0,
+  );
+  cv.path(&d, false, 2.0);
+  // Terminal dot on the clef's tail.
+  cv.dot(x - 4.0, g + 32.0, 2.6);
+  cv.bound(x - 11.0, g - 36.0);
+  cv.bound(x + 10.0, g + 36.0);
+}
+
+/// Render a computational-music object to a standalone SVG, or `None` when the
+/// expression is not a music object that carries notation.
+pub fn music_to_svg(expr: &Expr) -> Option<String> {
+  let mut glyphs = Vec::new();
+  let container = collect(expr, &mut glyphs);
+  if glyphs.is_empty() {
+    return None;
+  }
+
+  let stroke = theme().text_primary;
+  let mut cv = Canvas::new(stroke);
+
+  // Lay the glyphs out left to right, remembering where the staff must extend.
+  let mut x = FIRST_NOTE_X;
+  for g in &glyphs {
+    match g {
+      Glyph::Note { heads, dur } => {
+        draw_note(&mut cv, x, heads, *dur);
+        x += ADVANCE;
+      }
+      Glyph::Rest { dur } => {
+        draw_rest(&mut cv, x, *dur);
+        x += ADVANCE;
+      }
+      Glyph::Barline => {
+        let bx = x - ADVANCE / 2.0;
+        cv.line(bx, dn_y(BOTTOM_LINE_DN + 8), bx, dn_y(BOTTOM_LINE_DN), 1.3);
+        x += ADVANCE * 0.5;
+      }
+    }
+  }
+  let staff_x_end = x - ADVANCE + FIRST_NOTE_X - STAFF_X0;
+  let staff_x_end = staff_x_end.max(FIRST_NOTE_X + 8.0);
+
+  // The five staff lines (drawn first, conceptually behind the glyphs — SVG
+  // paint order does not matter here since strokes are opaque and thin).
+  let mut staff = String::new();
+  for i in 0..5 {
+    let y = BOTTOM_LINE_Y - i as f64 * GAP;
+    staff.push_str(&format!(
+      "<line x1=\"{STAFF_X0:.2}\" y1=\"{y:.2}\" x2=\"{staff_x_end:.2}\" \
+       y2=\"{y:.2}\" stroke=\"{stroke}\" stroke-width=\"1\"/>"
+    ));
+  }
+  cv.bound(STAFF_X0, dn_y(BOTTOM_LINE_DN + 8));
+  cv.bound(staff_x_end, dn_y(BOTTOM_LINE_DN));
+
+  // A closing barline for whole containers (measures/voices/scores/scales).
+  if container {
+    staff.push_str(&format!(
+      "<line x1=\"{x1:.2}\" y1=\"{y1:.2}\" x2=\"{x1:.2}\" y2=\"{y2:.2}\" \
+       stroke=\"{stroke}\" stroke-width=\"1.6\"/>",
+      x1 = staff_x_end,
+      y1 = dn_y(BOTTOM_LINE_DN + 8),
+      y2 = dn_y(BOTTOM_LINE_DN),
+    ));
+  }
+
+  draw_treble_clef(&mut cv, STAFF_X0 + 20.0);
+
+  // Fit the viewBox around everything with a small margin.
+  let pad = 6.0;
+  let minx = cv.minx.min(STAFF_X0) - pad;
+  let miny = cv.miny - pad;
+  let width = (cv.maxx.max(staff_x_end) - minx) + pad;
+  let height = (cv.maxy - miny) + pad;
+
+  Some(format!(
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{w:.0}\" \
+     height=\"{h:.0}\" viewBox=\"{minx:.2} {miny:.2} {width:.2} {height:.2}\">\
+     {staff}{body}</svg>",
+    w = width,
+    h = height,
+    body = cv.out,
+  ))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn note(name: &str) -> Expr {
+    Expr::FunctionCall {
+      name: "MusicPitch".to_string(),
+      args: vec![Expr::String(name.to_string())].into(),
+    }
+  }
+
+  #[test]
+  fn renders_a_single_pitch() {
+    let svg = music_to_svg(&note("C4")).expect("pitch should render");
+    assert!(svg.starts_with("<svg"));
+    assert!(svg.contains("<ellipse")); // a note head
+    assert!(svg.contains("<line")); // staff lines
+  }
+
+  #[test]
+  fn diatonic_number_places_middle_c_below_the_staff() {
+    // E4 is the bottom line (30); middle C (C4) is two steps lower.
+    assert_eq!(diatonic_number("E4").unwrap().0, 30);
+    assert_eq!(diatonic_number("C4").unwrap().0, 28);
+    assert_eq!(diatonic_number("F5").unwrap().0, 38); // top line
+    // Accidentals are reported but do not shift the diatonic position.
+    assert_eq!(diatonic_number("C#4").unwrap(), (28, 1));
+    assert_eq!(diatonic_number("Db4").unwrap(), (29, -1));
+  }
+
+  #[test]
+  fn non_music_expressions_do_not_render() {
+    assert!(music_to_svg(&Expr::Integer(3)).is_none());
+    assert!(
+      music_to_svg(&Expr::FunctionCall {
+        name: "MusicDuration".to_string(),
+        args: vec![Expr::String("Half".to_string())].into(),
+      })
+      .is_none()
+    );
+  }
+
+  #[test]
+  fn chord_renders_multiple_heads() {
+    let chord = Expr::FunctionCall {
+      name: "MusicChord".to_string(),
+      args: vec![Expr::List(vec![note("C4"), note("E4"), note("G4")].into())]
+        .into(),
+    };
+    let svg = music_to_svg(&chord).unwrap();
+    assert_eq!(svg.matches("<ellipse").count(), 3);
+  }
+
+  #[test]
+  fn scale_expands_to_eight_notes() {
+    let scale = Expr::FunctionCall {
+      name: "MusicScale".to_string(),
+      args: vec![Expr::String("Major".to_string()), note("C4")].into(),
+    };
+    let mut glyphs = Vec::new();
+    collect(&scale, &mut glyphs);
+    let notes = glyphs
+      .iter()
+      .filter(|g| matches!(g, Glyph::Note { .. }))
+      .count();
+    assert_eq!(notes, 8);
+  }
+
+  #[test]
+  fn measure_appends_a_barline() {
+    let measure = Expr::FunctionCall {
+      name: "MusicMeasure".to_string(),
+      args: vec![Expr::List(vec![note("C4"), note("D4")].into())].into(),
+    };
+    let mut glyphs = Vec::new();
+    assert!(collect(&measure, &mut glyphs));
+    assert!(matches!(glyphs.last(), Some(Glyph::Barline)));
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1645,6 +1645,13 @@ pub fn interpret(input: &str) -> Result<String, InterpreterError> {
         } else {
           result_expr
         };
+        // Render ComputationalMusic objects (MusicNote, MusicChord, …) as
+        // musical-staff SVGs (visual mode only — CLI keeps them symbolic).
+        let result_expr = if VISUAL_MODE.with(|v| *v.borrow()) {
+          render_music_if_needed(result_expr)
+        } else {
+          result_expr
+        };
         // If the result is a Grid expression, render it as SVG (visual mode
         // only — CLI mode keeps Grid[...] symbolic to match wolframscript).
         let result_expr = if VISUAL_MODE.with(|v| *v.borrow()) {
@@ -1942,6 +1949,21 @@ fn render_sound_if_needed(expr: syntax::Expr) -> syntax::Expr {
   {
     capture_sound(&wav_base64);
     return syntax::Expr::Identifier("-Sound-".to_string());
+  }
+  expr
+}
+
+/// If `expr` is a ComputationalMusic object (MusicNote, MusicChord,
+/// MusicScale, MusicScore, …), render it as a musical-staff SVG the way
+/// Mathematica displays it, capture it as graphics, and return `-Graphics-`.
+/// Music objects that carry no notation (a bare `MusicDuration`, `MusicTempo`,
+/// …) are left symbolic. Visual hosts only — the CLI keeps the symbolic form.
+fn render_music_if_needed(expr: syntax::Expr) -> syntax::Expr {
+  if let syntax::Expr::FunctionCall { ref name, .. } = expr
+    && functions::music_ast::MUSIC_OBJECT_HEADS.contains(&name.as_str())
+    && let Some(svg) = functions::music_render::music_to_svg(&expr)
+  {
+    return graphics_result(svg);
   }
   expr
 }

--- a/tests/cli/music.md
+++ b/tests/cli/music.md
@@ -1,0 +1,68 @@
+---
+icon: lucide/music
+---
+
+# Computational Music
+
+Woxi supports the symbolic music objects introduced in Wolfram Language 15
+(the [ComputationalMusic](https://reference.wolfram.com/language/guide/ComputationalMusic.html)
+guide). Notes, chords, rests, pitches and the other music objects are kept as
+canonical symbolic expressions, just like `Sound` and `SoundNote`.
+
+
+## MusicObjectQ
+
+`MusicObjectQ` tests whether an expression is a music object.
+
+```scrut
+$ wo 'MusicObjectQ[MusicPitch["C4"]]'
+True
+```
+
+```scrut
+$ wo 'MusicObjectQ[MusicNote[MusicPitch["C4"], MusicDuration["Half"]]]'
+True
+```
+
+```scrut
+$ wo 'MusicObjectQ[42]'
+False
+```
+
+
+## MusicPitch
+
+A pitch can be given by name in scientific notation.
+
+```scrut
+$ wo 'MusicPitch["C4"]'
+MusicPitch[C4]
+```
+
+An integer is interpreted as a MIDI note number and canonicalized to its
+named pitch (middle C is MIDI 60 / C4, and A4 is MIDI 69).
+
+```scrut
+$ wo 'MusicPitch[60]'
+MusicPitch[C4]
+```
+
+```scrut
+$ wo 'MusicPitch[69]'
+MusicPitch[A4]
+```
+
+
+## Notes and chords
+
+Music objects nest like any other symbolic expression.
+
+```scrut
+$ wo 'MusicChord[{MusicPitch["C"], MusicPitch["E"], MusicPitch["G"]}]'
+MusicChord[{MusicPitch[C], MusicPitch[E], MusicPitch[G]}]
+```
+
+```scrut
+$ wo 'Head[MusicNote[MusicPitch["C4"]]]'
+MusicNote
+```

--- a/tests/cli/music.md
+++ b/tests/cli/music.md
@@ -87,3 +87,22 @@ MusicChord[{MusicPitch[C], MusicPitch[E], MusicPitch[G]}]
 $ wo 'Head[MusicNote[MusicPitch["C4"]]]'
 MusicNote
 ```
+
+
+## Rendering as notation
+
+In the visual hosts — the [Woxi Playground](https://woxi.dev) and Woxi Studio —
+music objects (`MusicNote`, `MusicChord`, `MusicScale`, `MusicMeasure`,
+`MusicVoice`, `MusicScore`, …) are drawn on a treble staff the way Mathematica
+displays them, with note heads, stems, flags, accidentals, ledger lines, rests
+and barlines. On the command line they stay symbolic (as shown above).
+
+`MusicPlot` renders a music object explicitly and, like `Plot`, yields a
+graphic:
+
+```scrut
+$ wo 'Head[MusicPlot[MusicScale["Major", MusicPitch["C4"]]]]'
+Graphics
+```
+
+The same notation SVG is produced by `ExportString[obj, "SVG"]`.

--- a/tests/cli/music.md
+++ b/tests/cli/music.md
@@ -52,6 +52,27 @@ $ wo 'MusicPitch[69]'
 MusicPitch[A4]
 ```
 
+A frequency is canonicalized to the nearest named pitch (A4 is tuned to
+440 Hz).
+
+```scrut
+$ wo 'MusicPitch[Quantity[440, "Hertz"]]'
+MusicPitch[A4]
+```
+
+The pitch of a `SoundNote` (numbered relative to middle C) or of a
+`MusicNote` can also be used as a pitch specification.
+
+```scrut
+$ wo 'MusicPitch[SoundNote[0]]'
+MusicPitch[C4]
+```
+
+```scrut
+$ wo 'MusicPitch[MusicNote["G3"]]'
+MusicPitch[G3]
+```
+
 
 ## Notes and chords
 

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -978,6 +978,7 @@ mod interpreter_tests {
   mod list;
   mod machine_specific;
   mod math;
+  mod music;
   mod patterns;
   mod property;
   mod quantity;

--- a/tests/interpreter_tests/music.rs
+++ b/tests/interpreter_tests/music.rs
@@ -65,6 +65,44 @@ fn music_pitch_string_stays_symbolic() {
 }
 
 #[test]
+fn music_pitch_canonicalizes_frequency() {
+  // A4 is 440 Hz; 200 Hz is the nearest to G3 (per the MusicPitch docs).
+  assert_eq!(
+    interpret("MusicPitch[Quantity[440, \"Hertz\"]]").unwrap(),
+    "MusicPitch[A4]"
+  );
+  assert_eq!(
+    interpret("MusicPitch[Quantity[200, \"Hertz\"]]").unwrap(),
+    "MusicPitch[G3]"
+  );
+}
+
+#[test]
+fn music_pitch_canonicalizes_soundnote() {
+  // SoundNote numbers pitches relative to middle C (0 -> C4).
+  assert_eq!(
+    interpret("MusicPitch[SoundNote[0]]").unwrap(),
+    "MusicPitch[C4]"
+  );
+  assert_eq!(
+    interpret("MusicPitch[SoundNote[-5]]").unwrap(),
+    "MusicPitch[G3]"
+  );
+}
+
+#[test]
+fn music_pitch_extracts_note_pitch() {
+  assert_eq!(
+    interpret("MusicPitch[MusicNote[\"G3\"]]").unwrap(),
+    "MusicPitch[G3]"
+  );
+  assert_eq!(
+    interpret("MusicPitch[MusicNote[MusicPitch[55]]]").unwrap(),
+    "MusicPitch[G3]"
+  );
+}
+
+#[test]
 fn music_pitch_head_is_music_pitch() {
   assert_eq!(interpret("Head[MusicPitch[60]]").unwrap(), "MusicPitch");
 }

--- a/tests/interpreter_tests/music.rs
+++ b/tests/interpreter_tests/music.rs
@@ -1,0 +1,86 @@
+use super::*;
+
+// ─── MusicObjectQ ────────────────────────────────────────────────────────────
+
+#[test]
+fn music_object_q_true_for_pitch() {
+  assert_eq!(
+    interpret("MusicObjectQ[MusicPitch[\"C4\"]]").unwrap(),
+    "True"
+  );
+}
+
+#[test]
+fn music_object_q_true_for_note() {
+  assert_eq!(
+    interpret("MusicObjectQ[MusicNote[MusicPitch[\"C4\"]]]").unwrap(),
+    "True"
+  );
+}
+
+#[test]
+fn music_object_q_true_for_chord_and_containers() {
+  assert_eq!(
+    interpret(
+      "MusicObjectQ[MusicChord[{MusicPitch[\"C\"], MusicPitch[\"E\"]}]]"
+    )
+    .unwrap(),
+    "True"
+  );
+  assert_eq!(interpret("MusicObjectQ[MusicScore[]]").unwrap(), "True");
+  assert_eq!(interpret("MusicObjectQ[MusicMeasure[]]").unwrap(), "True");
+}
+
+#[test]
+fn music_object_q_false_for_non_objects() {
+  assert_eq!(interpret("MusicObjectQ[3]").unwrap(), "False");
+  assert_eq!(interpret("MusicObjectQ[{1, 2, 3}]").unwrap(), "False");
+  assert_eq!(interpret("MusicObjectQ[\"C4\"]").unwrap(), "False");
+}
+
+#[test]
+fn music_object_q_false_for_operations() {
+  // MusicPlot/MusicTransform/MusicMeasurements are operations, not objects.
+  assert_eq!(interpret("MusicObjectQ[MusicPlot[x]]").unwrap(), "False");
+  assert_eq!(
+    interpret("MusicObjectQ[MusicTransform[x, y]]").unwrap(),
+    "False"
+  );
+}
+
+// ─── MusicPitch ──────────────────────────────────────────────────────────────
+
+#[test]
+fn music_pitch_canonicalizes_midi_number() {
+  // Middle C is MIDI 60 / C4; A4 is MIDI 69.
+  assert_eq!(interpret("MusicPitch[60]").unwrap(), "MusicPitch[C4]");
+  assert_eq!(interpret("MusicPitch[69]").unwrap(), "MusicPitch[A4]");
+  assert_eq!(interpret("MusicPitch[61]").unwrap(), "MusicPitch[C#4]");
+  assert_eq!(interpret("MusicPitch[0]").unwrap(), "MusicPitch[C-1]");
+}
+
+#[test]
+fn music_pitch_string_stays_symbolic() {
+  assert_eq!(interpret("MusicPitch[\"C4\"]").unwrap(), "MusicPitch[C4]");
+}
+
+#[test]
+fn music_pitch_head_is_music_pitch() {
+  assert_eq!(interpret("Head[MusicPitch[60]]").unwrap(), "MusicPitch");
+}
+
+// ─── Symbolic music objects ──────────────────────────────────────────────────
+
+#[test]
+fn music_objects_stay_symbolic() {
+  // Constructors round-trip as canonical symbolic objects (like Sound/SoundNote).
+  assert_eq!(
+    interpret("MusicNote[MusicPitch[\"C4\"], MusicDuration[\"Half\"]]")
+      .unwrap(),
+    "MusicNote[MusicPitch[C4], MusicDuration[Half]]"
+  );
+  assert_eq!(
+    interpret("Head[MusicChord[{MusicPitch[\"C\"]}]]").unwrap(),
+    "MusicChord"
+  );
+}

--- a/tests/interpreter_tests/music.rs
+++ b/tests/interpreter_tests/music.rs
@@ -107,6 +107,47 @@ fn music_pitch_head_is_music_pitch() {
   assert_eq!(interpret("Head[MusicPitch[60]]").unwrap(), "MusicPitch");
 }
 
+// ─── Staff-notation rendering ────────────────────────────────────────────────
+
+#[test]
+fn export_music_note_to_svg() {
+  // ExportString[obj, "SVG"] renders the object as musical-staff notation.
+  let svg =
+    interpret("ExportString[MusicNote[MusicPitch[\"C4\"]], \"SVG\"]").unwrap();
+  assert!(svg.starts_with("<svg"), "expected an SVG, got: {svg}");
+  assert!(svg.contains("<ellipse")); // a note head
+  assert!(svg.contains("<line")); // staff lines
+}
+
+#[test]
+fn export_music_chord_renders_three_heads() {
+  let svg = interpret(
+    "ExportString[MusicChord[{MusicPitch[\"C4\"], MusicPitch[\"E4\"], \
+     MusicPitch[\"G4\"]}], \"SVG\"]",
+  )
+  .unwrap();
+  assert_eq!(svg.matches("<ellipse").count(), 3);
+}
+
+#[test]
+fn music_plot_returns_graphics() {
+  // MusicPlot draws the object; in the CLI a Graphics prints as -Graphics-.
+  assert_eq!(
+    interpret("MusicPlot[MusicScale[\"Major\", MusicPitch[\"C4\"]]]").unwrap(),
+    "-Graphics-"
+  );
+}
+
+#[test]
+fn bare_music_object_stays_symbolic_in_cli() {
+  // Without ExportString/MusicPlot the CLI keeps the canonical symbolic form
+  // (only the visual hosts auto-render it).
+  assert_eq!(
+    interpret("MusicNote[MusicPitch[\"C4\"]]").unwrap(),
+    "MusicNote[MusicPitch[C4]]"
+  );
+}
+
 // ─── Symbolic music objects ──────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Adds support for the symbolic music objects introduced in Wolfram
Language 15 (the ComputationalMusic guide): MusicNote, MusicRest,
MusicChord, MusicDuration, MusicPitch, MusicInterval, MusicKeySignature,
MusicTimeSignature, MusicScale, MusicTempo, MusicObjectQ, MusicMeasure,
MusicVoice and MusicScore.

Like Sound/SoundNote, the music objects are kept as canonical symbolic
expressions so they can be constructed, nested and pattern-matched.

- MusicObjectQ[expr] returns True for any music object and False
  otherwise (operations such as MusicPlot/MusicTransform/MusicMeasurements
  are not objects).
- MusicPitch[n] canonicalizes an integer MIDI note number to its named
  pitch, e.g. MusicPitch[60] -> MusicPitch["C4"] (middle C is MIDI 60,
  A4 is MIDI 69). Pitch strings round-trip unchanged.

The analysis/visualization functions (MusicMeasurements, MusicTransform,
MusicPlot) are registered but not yet implemented; they stay symbolic.

Covered by unit tests, interpreter integration tests and a CLI doc test.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018PiQkp3B6GBnEtqudeoVMg