### PR TITLE
Add support for QuestionObject and AssessmentFunction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 # 2025-05-08 - 0.1.0
 
+- Add support for `QuestionObject`, `AssessmentFunction`, and `AssessmentResultObject`
 - Implement `DateString` and `Now`
 - Implement `StringStartsQ` and `StringEndsQ`
 - Support executing Woxi as a shebang script

--- a/functions.csv
+++ b/functions.csv
@@ -3566,7 +3566,7 @@ SpectrogramArray,,🚫,,9.0,3656
 TravelDirections,,🚫,,10.3,3656
 AirPressureData,,🚫,,10.0,3678
 AroundReplace,,,,12.0,3678
-AssessmentFunction,,🚫,,12.2,3678
+AssessmentFunction,Symbolic assessment object; AssessmentFunction[spec][answer] grades the answer against the answer key and returns an AssessmentResultObject,✅,pure,12.2,3678
 DEigenvalues,,,,10.3,3678
 DeviceReadBuffer,,🚫,,10.0,3678
 DirichletWindow,Compute DirichletWindow value,✅,pure,9.0,3678
@@ -5369,7 +5369,7 @@ ArcSinDegrees,Compute inverse sine returning degrees,✅,pure,14.1,
 ArcTanDegrees,Compute inverse tangent returning degrees,✅,pure,14.1,
 ArrayDot,,,,14.1,
 ArraySymbol,,,,14.1,
-AssessmentResultObject,,🚫,,12.2,
+AssessmentResultObject,Graded result of an assessment; supports property access such as result[Score] and result[AnswerCorrect],✅,pure,12.2,
 AstroAngularSeparation,,🚫,,13.2,
 AstroBackground,,🚫,,13.2,
 AstroCenter,,🚫,,13.2,
@@ -5874,7 +5874,7 @@ PropagateAborts,,,,13.2,
 PublisherID,,🚫,,11.2,
 QuestionGenerator,,🚫,,13.1,
 QuestionInterface,,🚫,,13.0,
-QuestionObject,,🚫,,12.3,
+QuestionObject,Pairs a prompt with an assessment; QuestionObject[q assess][answer] grades the answer through the embedded assessment,✅,pure,12.3,
 QuestionSelector,,🚫,,13.1,
 QuietEcho,,,,12.2,
 RFixedPoints,,,,14.1,

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -9893,6 +9893,14 @@ pub fn evaluate_function_call_ast_inner(
         // consumed by the quantum framework, so they are not "unimplemented".
         | "Ket"
         | "Bra"
+        // Quiz/assessment objects. AssessmentFunction[spec] and
+        // QuestionObject[q, assess] are symbolic constructor objects that stay
+        // unevaluated until applied to a candidate answer (handled in
+        // apply_curried_call), and AssessmentResultObject[<|…|>] is the graded
+        // result they produce, so none of these are "unimplemented".
+        | "AssessmentFunction"
+        | "QuestionObject"
+        | "AssessmentResultObject"
         // More notation/display wrapper heads. Like Subscript/Framed, these
         // describe layout rather than a value to compute, so wolframscript
         // leaves them unevaluated as their canonical form.

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -893,6 +893,34 @@ pub fn apply_curried_call(
       // Interpreter["Country"][input] — resolve input to an Entity.
       crate::functions::country_data::apply_interpreter(&func_args[0], args)
     }
+    // AssessmentFunction[spec][answer] — grade the answer, returning an
+    // AssessmentResultObject.
+    Expr::FunctionCall {
+      name,
+      args: func_args,
+    } if name == "AssessmentFunction" && args.len() == 1 => {
+      crate::functions::assessment_ast::apply_assessment_function(
+        func_args, &args[0],
+      )
+    }
+    // QuestionObject[q, assess][answer] — grade the answer through the
+    // embedded assessment.
+    Expr::FunctionCall {
+      name,
+      args: func_args,
+    } if name == "QuestionObject" && args.len() == 1 => {
+      crate::functions::assessment_ast::apply_question_object(
+        func_args, &args[0],
+      )
+    }
+    // AssessmentResultObject[<|…|>]["property"] — property access
+    // (e.g. "Score", "AnswerCorrect", or All for the whole association).
+    Expr::FunctionCall {
+      name,
+      args: func_args,
+    } if name == "AssessmentResultObject" && args.len() == 1 => {
+      crate::functions::assessment_ast::apply_result_object(func_args, &args[0])
+    }
     // BooleanFunction[n, k][b1, …, bk] — the integer-indexed boolean function.
     // The result is bit `v` of `n`, where `v` is the k arguments read as a
     // binary number (first argument most significant, True/1 → 1, False/0 → 0).

--- a/src/functions/assessment_ast.rs
+++ b/src/functions/assessment_ast.rs
@@ -1,0 +1,193 @@
+//! `QuestionObject`, `AssessmentFunction`, and `AssessmentResultObject`.
+//!
+//! These implement the Wolfram Language quiz/assessment primitives.
+//!
+//! * `AssessmentFunction[spec]` is a symbolic object that, when applied to a
+//!   candidate answer, grades it and returns an `AssessmentResultObject`.
+//! * `QuestionObject[q, assess]` (or `QuestionObject[assess]`) pairs a prompt
+//!   with an assessment; applying it to an answer grades the answer through the
+//!   embedded assessment.
+//! * `AssessmentResultObject[<|…|>]` holds the grade of a single answer and
+//!   supports property access such as `result["Score"]` /
+//!   `result["AnswerCorrect"]`.
+//!
+//! The grading follows the documented convention: *True and positive numeric
+//! scores denote correct answers, while False, zero and negative scores are
+//! incorrect.* A spec entry given as a plain value (not a rule) denotes a
+//! correct answer with a score of `1`.
+
+use crate::InterpreterError;
+use crate::evaluator::pattern_matching::expr_equal;
+use crate::syntax::Expr;
+
+/// Turn a numeric-or-boolean grade expression into a `(score, correct)` pair.
+/// Returns `None` when the expression is not a recognized grade value.
+fn grade_value(v: &Expr) -> Option<(f64, bool)> {
+  match v {
+    Expr::Identifier(s) if s == "True" => Some((1.0, true)),
+    Expr::Identifier(s) if s == "False" => Some((0.0, false)),
+    Expr::Integer(n) => Some((*n as f64, *n > 0)),
+    Expr::Real(r) => Some((*r, *r > 0.0)),
+    // Full specification `<|"Score" -> s, …|>`: read the "Score" key.
+    Expr::Association(pairs) => {
+      for (k, val) in pairs {
+        if matches!(k, Expr::String(s) if s == "Score") {
+          return grade_value(val);
+        }
+      }
+      // An association without an explicit score counts as correct.
+      Some((1.0, true))
+    }
+    _ => None,
+  }
+}
+
+/// Normalize an `AssessmentFunction` specification into `(key, score, correct)`
+/// entries. A bare (non-list) spec is treated as a single-entry answer key.
+fn spec_entries(spec: &Expr) -> Vec<(Expr, f64, bool)> {
+  let elems: Vec<Expr> = match spec {
+    Expr::List(items) => items.iter().cloned().collect(),
+    other => vec![other.clone()],
+  };
+  let mut entries = Vec::with_capacity(elems.len());
+  for e in elems {
+    match &e {
+      // `answer -> grade`: the answer is correct according to the grade value.
+      Expr::Rule {
+        pattern,
+        replacement,
+      } => {
+        if let Some((score, correct)) = grade_value(replacement) {
+          entries.push(((**pattern).clone(), score, correct));
+        }
+      }
+      // A bare value is itself a correct answer (score 1).
+      _ => entries.push((e.clone(), 1.0, true)),
+    }
+  }
+  entries
+}
+
+/// Grade `answer` against a normalized set of spec entries, returning
+/// `(score, correct)`. An answer matching no entry scores `0` (incorrect).
+fn grade(spec: &Expr, answer: &Expr) -> (f64, bool) {
+  for (key, score, correct) in spec_entries(spec) {
+    if expr_equal(&key, answer) {
+      return (score, correct);
+    }
+  }
+  (0.0, false)
+}
+
+/// Render a score as an integer expression when it is whole, else as a real.
+fn score_expr(score: f64) -> Expr {
+  if score.fract() == 0.0 && score.abs() < 1e15 {
+    Expr::Integer(score as i128)
+  } else {
+    Expr::Real(score)
+  }
+}
+
+fn bool_expr(b: bool) -> Expr {
+  Expr::Identifier(if b { "True" } else { "False" }.to_string())
+}
+
+/// Build an `AssessmentResultObject[<|"AnswerCorrect" -> …, "Score" -> …|>]`.
+fn result_object(score: f64, correct: bool) -> Expr {
+  let assoc = Expr::Association(vec![
+    (
+      Expr::String("AnswerCorrect".to_string()),
+      bool_expr(correct),
+    ),
+    (Expr::String("Score".to_string()), score_expr(score)),
+  ]);
+  Expr::FunctionCall {
+    name: "AssessmentResultObject".to_string(),
+    args: vec![assoc].into(),
+  }
+}
+
+/// Extract the assessment specification embedded in an `AssessmentFunction`.
+/// Returns `None` when `expr` is not an `AssessmentFunction[spec]`.
+fn assessment_function_spec(expr: &Expr) -> Option<&Expr> {
+  match expr {
+    Expr::FunctionCall { name, args }
+      if name == "AssessmentFunction" && args.len() == 1 =>
+    {
+      Some(&args[0])
+    }
+    _ => None,
+  }
+}
+
+/// Apply `AssessmentFunction[spec]` to `answer`, producing an
+/// `AssessmentResultObject`.
+pub fn apply_assessment_function(
+  func_args: &[Expr],
+  answer: &Expr,
+) -> Result<Expr, InterpreterError> {
+  if func_args.len() != 1 {
+    return Ok(keep_curried("AssessmentFunction", func_args, answer));
+  }
+  let (score, correct) = grade(&func_args[0], answer);
+  Ok(result_object(score, correct))
+}
+
+/// Apply `QuestionObject[q, assess]` (or `QuestionObject[assess]`) to `answer`.
+/// The embedded assessment does the grading; a `QuestionObject` whose
+/// assessment is an `AssessmentFunction` is graded through it.
+pub fn apply_question_object(
+  func_args: &[Expr],
+  answer: &Expr,
+) -> Result<Expr, InterpreterError> {
+  // The assessment is the last argument (`QuestionObject[q, assess]`) or the
+  // sole argument (`QuestionObject[assess]`).
+  let assess = match func_args.len() {
+    1 => &func_args[0],
+    2 => &func_args[1],
+    _ => return Ok(keep_curried("QuestionObject", func_args, answer)),
+  };
+  if let Some(spec) = assessment_function_spec(assess) {
+    let (score, correct) = grade(spec, answer);
+    return Ok(result_object(score, correct));
+  }
+  // A bare assessment specification (list/rule/value) is graded directly.
+  let (score, correct) = grade(assess, answer);
+  Ok(result_object(score, correct))
+}
+
+/// Access a property of an `AssessmentResultObject[<|…|>]`, e.g.
+/// `result["Score"]` or `result["AnswerCorrect"]`. Returns the stored
+/// association for `result[All]`. Leaves the call unevaluated (curried) when
+/// the property is unknown.
+pub fn apply_result_object(
+  func_args: &[Expr],
+  key: &Expr,
+) -> Result<Expr, InterpreterError> {
+  if let Some(Expr::Association(pairs)) = func_args.first() {
+    // `result[All]` returns the whole association.
+    if matches!(key, Expr::Identifier(s) if s == "All") {
+      return Ok(Expr::Association(pairs.clone()));
+    }
+    if let Expr::String(wanted) = key {
+      for (k, v) in pairs {
+        if matches!(k, Expr::String(s) if s == wanted) {
+          return Ok(v.clone());
+        }
+      }
+    }
+  }
+  Ok(keep_curried("AssessmentResultObject", func_args, key))
+}
+
+/// Reconstruct an inert curried call `head[func_args][arg]` for cases that
+/// cannot be reduced.
+fn keep_curried(head: &str, func_args: &[Expr], arg: &Expr) -> Expr {
+  Expr::CurriedCall {
+    func: Box::new(Expr::FunctionCall {
+      name: head.to_string(),
+      args: func_args.to_vec().into(),
+    }),
+    args: vec![arg.clone()],
+  }
+}

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,4 +1,5 @@
 // Functions are organized by categories
+pub mod assessment_ast;
 pub mod association_ast;
 pub mod boolean_ast;
 pub mod calculus_ast;

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -952,6 +952,7 @@ mod interpreter_tests {
   mod algebra;
   mod arg_count;
   mod arithmetic;
+  mod assessment;
   mod association;
   mod attributes;
   mod batch_wrappers;

--- a/tests/interpreter_tests/assessment.rs
+++ b/tests/interpreter_tests/assessment.rs
@@ -1,0 +1,218 @@
+//! Tests for the quiz/assessment primitives: `QuestionObject`,
+//! `AssessmentFunction`, and `AssessmentResultObject`.
+
+use super::*;
+
+// ─── Symbolic objects stay symbolic ─────────────────────────────────────────
+
+#[test]
+fn assessment_function_stays_symbolic() {
+  assert_eq!(
+    interpret("AssessmentFunction[{True}]").unwrap(),
+    "AssessmentFunction[{True}]"
+  );
+}
+
+#[test]
+fn question_object_stays_symbolic() {
+  assert_eq!(
+    interpret(
+      r#"QuestionObject["Is a whale a mammal?", AssessmentFunction[{True}]]"#
+    )
+    .unwrap(),
+    "QuestionObject[Is a whale a mammal?, AssessmentFunction[{True}]]"
+  );
+}
+
+#[test]
+fn question_object_head() {
+  assert_eq!(
+    interpret(r#"Head[QuestionObject["q", AssessmentFunction[{True}]]]"#)
+      .unwrap(),
+    "QuestionObject"
+  );
+}
+
+#[test]
+fn assessment_function_head() {
+  assert_eq!(
+    interpret("Head[AssessmentFunction[{True}]]").unwrap(),
+    "AssessmentFunction"
+  );
+}
+
+#[test]
+fn assessment_objects_emit_no_unimplemented_warning() {
+  clear_state();
+  let _ = interpret("AssessmentFunction[{True}]").unwrap();
+  let warnings = woxi::get_captured_warnings();
+  assert!(
+    !warnings.iter().any(|w| w.contains("not yet implemented")),
+    "unexpected unimplemented warning: {:?}",
+    warnings
+  );
+}
+
+// ─── Grading with a rule-based answer key ────────────────────────────────────
+
+#[test]
+fn assessment_grades_correct_answer() {
+  assert_eq!(
+    interpret(
+      "AssessmentFunction[{714 -> False, 755 -> True, 868 -> False}][755]"
+    )
+    .unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> True, Score -> 1|>]"
+  );
+}
+
+#[test]
+fn assessment_grades_incorrect_answer() {
+  assert_eq!(
+    interpret(
+      "AssessmentFunction[{714 -> False, 755 -> True, 868 -> False}][714]"
+    )
+    .unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> False, Score -> 0|>]"
+  );
+}
+
+#[test]
+fn assessment_grades_unlisted_answer_as_incorrect() {
+  assert_eq!(
+    interpret(
+      "AssessmentFunction[{714 -> False, 755 -> True, 868 -> False}][999]"
+    )
+    .unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> False, Score -> 0|>]"
+  );
+}
+
+// ─── Grading with a plain-value answer key ───────────────────────────────────
+
+#[test]
+fn assessment_plain_value_key_matches() {
+  assert_eq!(
+    interpret("AssessmentFunction[{1, 2, 3}][2]").unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> True, Score -> 1|>]"
+  );
+}
+
+#[test]
+fn assessment_plain_value_key_no_match() {
+  assert_eq!(
+    interpret("AssessmentFunction[{1, 2, 3}][5]").unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> False, Score -> 0|>]"
+  );
+}
+
+#[test]
+fn assessment_true_false_question() {
+  assert_eq!(
+    interpret("AssessmentFunction[{True}][True]").unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> True, Score -> 1|>]"
+  );
+  assert_eq!(
+    interpret("AssessmentFunction[{True}][False]").unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> False, Score -> 0|>]"
+  );
+}
+
+// ─── Numeric scores ──────────────────────────────────────────────────────────
+
+#[test]
+fn assessment_positive_score_is_correct() {
+  assert_eq!(
+    interpret(r#"AssessmentFunction[{"cat" -> 10, "dog" -> 0}]["cat"]"#)
+      .unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> True, Score -> 10|>]"
+  );
+}
+
+#[test]
+fn assessment_zero_score_is_incorrect() {
+  assert_eq!(
+    interpret(r#"AssessmentFunction[{"cat" -> 10, "dog" -> 0}]["dog"]"#)
+      .unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> False, Score -> 0|>]"
+  );
+}
+
+// ─── AssessmentResultObject property access ──────────────────────────────────
+
+#[test]
+fn result_object_score_property() {
+  assert_eq!(
+    interpret(
+      "AssessmentFunction[{714 -> False, 755 -> True}][755][\"Score\"]"
+    )
+    .unwrap(),
+    "1"
+  );
+}
+
+#[test]
+fn result_object_answer_correct_property() {
+  assert_eq!(
+    interpret(
+      "AssessmentFunction[{714 -> False, 755 -> True}][755][\"AnswerCorrect\"]"
+    )
+    .unwrap(),
+    "True"
+  );
+}
+
+#[test]
+fn result_object_all_property() {
+  assert_eq!(
+    interpret(r#"AssessmentFunction[{"cat" -> 10}]["cat"][All]"#).unwrap(),
+    "<|AnswerCorrect -> True, Score -> 10|>"
+  );
+}
+
+// ─── QuestionObject delegates grading to its assessment ──────────────────────
+
+#[test]
+fn question_object_grades_through_assessment() {
+  assert_eq!(
+    interpret(
+      r#"QuestionObject["Is a whale a mammal?", AssessmentFunction[{True}]][True]"#
+    )
+    .unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> True, Score -> 1|>]"
+  );
+}
+
+#[test]
+fn question_object_incorrect_answer() {
+  assert_eq!(
+    interpret(
+      r#"QuestionObject["Is a whale a mammal?", AssessmentFunction[{True}]][False]"#
+    )
+    .unwrap(),
+    "AssessmentResultObject[<|AnswerCorrect -> False, Score -> 0|>]"
+  );
+}
+
+#[test]
+fn question_object_single_argument_form() {
+  // QuestionObject[assess] derives the question from the assessment alone.
+  assert_eq!(
+    interpret(
+      "QuestionObject[AssessmentFunction[{42 -> True}]][42][\"AnswerCorrect\"]"
+    )
+    .unwrap(),
+    "True"
+  );
+}
+
+#[test]
+fn question_object_property_chain() {
+  assert_eq!(
+    interpret(
+      r#"QuestionObject["q", AssessmentFunction[{True}]][True]["AnswerCorrect"]"#
+    )
+    .unwrap(),
+    "True"
+  );
+}


### PR DESCRIPTION
Implement the Wolfram Language quiz/assessment primitives:

- `AssessmentFunction[spec]` is a symbolic object that grades a candidate
  answer against its answer key when applied, returning an
  `AssessmentResultObject`. The key can be given as rules
  (`{answer -> grade}`), plain correct answers (`{a1, a2, ...}`), or a single
  value. True and positive numeric scores denote correct answers; False,
  zero, and negative scores are incorrect.
- `QuestionObject[q, assess]` (and `QuestionObject[assess]`) pairs a prompt
  with an assessment and grades an answer through the embedded assessment.
- `AssessmentResultObject[<|...|>]` holds the grade and supports property
  access such as `result["Score"]`, `result["AnswerCorrect"]`, and
  `result[All]`.

All three heads now stay symbolic in their canonical form instead of
emitting the "not yet implemented" warning. Adds a dedicated unit-test
module, updates functions.csv, and notes the change in the changelog.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013B5n62EYjHQHX667ohVDHH