### PR TITLE
Add TimelinePlot support

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1739,7 +1739,7 @@ Application,Application wrapper,,unevaluated,12.2,1766
 FindFile,Find file,✅,unevaluated,7.0,1766
 DistanceTransform,Distance transform,,unevaluated,7.0,1768
 DialogInput,Dialog input,,unevaluated,6.0,1770
-TimelinePlot,Timeline plot,,unevaluated,10.1,1770
+TimelinePlot,Plots dates and date intervals as events on a horizontal timeline,✅,pure,10.1,1770
 PassEventsDown,Pass events down option,,unevaluated,6.0,1771
 AssociateTo,Adds one or more key-value pairs to an association variable in-place,✅,stateful,10.0,1776
 CircleDot,Symbolic circle dot operator with Unicode display,✅,pure,3.0,1776

--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -252,7 +252,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "Cyclotomic" => Some((2, 2)),
     "D" => Some((2, usize::MAX)),
     "DateDifference" => Some((2, usize::MAX)),
-    "DateInterval" => Some((1, 1)),
+    "DateInterval" => Some((1, 4)),
     "DatePlus" => Some((2, 2)),
     "DateRange" => Some((2, 3)),
     "TimeObject" => Some((0, usize::MAX)),

--- a/src/evaluator/dispatch/datetime_functions.rs
+++ b/src/evaluator/dispatch/datetime_functions.rs
@@ -60,6 +60,14 @@ pub fn dispatch_datetime_functions(
     "DayRound" if args.len() == 1 || args.len() == 2 => {
       return Some(crate::functions::datetime_ast::day_round_ast(args));
     }
+    // The canonical form DateInterval[{{d1, d2}, ...}, granularity, calendar,
+    // timezone] evaluates to itself, like wolframscript.
+    "DateInterval" if args.len() == 4 => {
+      return Some(Ok(Expr::FunctionCall {
+        name: "DateInterval".to_string(),
+        args: args.to_vec().into(),
+      }));
+    }
     // DateInterval[{date1, date2}] — create a date interval
     "DateInterval" if args.len() == 1 => {
       if let Expr::List(dates) = &args[0]

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -510,6 +510,9 @@ pub fn dispatch_plotting(
     "NumberLinePlot" if !args.is_empty() => Some(
       crate::functions::number_line_plot::number_line_plot_ast(args),
     ),
+    "TimelinePlot" if !args.is_empty() => {
+      Some(crate::functions::timeline_plot::timeline_plot_ast(args))
+    }
     "WordCloud" if !args.is_empty() => {
       Some(crate::functions::chart::word_cloud_ast(args))
     }

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -2039,8 +2039,7 @@ pub fn bubble_histogram_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::List(items) => items,
     _ => {
       return Err(InterpreterError::EvaluationError(
-        "BubbleHistogram: first argument must be a list of {x, y} pairs"
-          .into(),
+        "BubbleHistogram: first argument must be a list of {x, y} pairs".into(),
       ));
     }
   };

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -8206,6 +8206,7 @@ fn is_graphics_producing_head(name: &str) -> bool {
       | "VectorPlot"
       | "VectorPlot3D"
       | "NumberLinePlot"
+      | "TimelinePlot"
       | "ComplexPlot"
       | "ComplexPlot3D"
       | "ComplexListPlot"

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -51,6 +51,7 @@ pub mod sound;
 pub mod string_ast;
 pub mod sum_convergence_ast;
 pub mod tabular_ast;
+pub mod timeline_plot;
 pub mod timeseries_ast;
 pub mod tree_form;
 pub mod trig_factor_ast;

--- a/src/functions/timeline_plot.rs
+++ b/src/functions/timeline_plot.rs
@@ -1,0 +1,482 @@
+use crate::InterpreterError;
+use crate::evaluator::evaluate_expr_to_expr;
+use crate::functions::interval_ast::is_interval;
+use crate::functions::math_ast::try_eval_to_f64;
+use crate::functions::plot::{
+  DEFAULT_HEIGHT, DEFAULT_WIDTH, PLOT_COLORS, RESOLUTION_SCALE,
+  format_date_tick, generate_date_ticks, parse_image_size,
+};
+use crate::syntax::Expr;
+
+/// Default display width of a TimelinePlot in pixels.
+const DEFAULT_TLP_WIDTH: u32 = 360;
+/// Height allotted to each stacked event row (display pixels).
+const ROW_HEIGHT: u32 = 26;
+/// Padding above the first row.
+const PADDING_TOP: u32 = 15;
+/// Padding below the axis (space for the date tick labels).
+const PADDING_BOTTOM: u32 = 30;
+/// Extra vertical space between the lowest row and the axis line.
+const AXIS_GAP: u32 = 12;
+
+/// A single timeline event: either an instant (a point) or a span (interval).
+struct TimelineEvent {
+  /// Start of the event in AbsoluteTime seconds (since 1900-01-01).
+  start: f64,
+  /// End of the event for intervals; `None` for point events.
+  end: Option<f64>,
+  /// Text label rendered next to the event marker.
+  label: String,
+}
+
+/// `TimelinePlot[{date, ...}]` — render events on a horizontal timeline.
+pub fn timeline_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  let mut svg_width = DEFAULT_TLP_WIDTH;
+  let mut full_width = false;
+
+  // Parse options (Rules at the end), e.g. ImageSize.
+  for opt in &args[1..] {
+    if let Expr::Rule {
+      pattern,
+      replacement,
+    } = opt
+      && let Expr::Identifier(name) = pattern.as_ref()
+      && name == "ImageSize"
+      && let Some((w, _h, fw)) =
+        parse_image_size(replacement, DEFAULT_WIDTH, DEFAULT_HEIGHT)
+    {
+      svg_width = w;
+      full_width = fw;
+    }
+  }
+
+  let events = parse_events(&args[0]);
+  if events.is_empty() {
+    // Mirror Wolfram: return unevaluated for data we cannot interpret.
+    return Ok(Expr::FunctionCall {
+      name: "TimelinePlot".to_string(),
+      args: args.to_vec().into(),
+    });
+  }
+
+  let svg = render_timeline_svg(&events, svg_width, full_width);
+  Ok(crate::graphics_result(svg))
+}
+
+/// Parse the first argument into a flat list of timeline events.
+fn parse_events(arg: &Expr) -> Vec<TimelineEvent> {
+  let evaluated = evaluate_expr_to_expr(arg).unwrap_or_else(|_| arg.clone());
+
+  let mut events = Vec::new();
+  match &evaluated {
+    // Association: each key -> value pair is a labelled event.
+    Expr::Association(pairs) => {
+      for (key, val) in pairs {
+        if let Some(mut ev) = event_from_date(val) {
+          ev.label = expr_to_label(key);
+          events.push(ev);
+        }
+      }
+    }
+    Expr::List(items) => {
+      for item in items {
+        if let Some(ev) = parse_one_event(item) {
+          events.push(ev);
+        }
+      }
+    }
+    // A single date given directly.
+    other => {
+      if let Some(ev) = parse_one_event(other) {
+        events.push(ev);
+      }
+    }
+  }
+  events
+}
+
+/// Parse a single event specification (a list element).
+fn parse_one_event(item: &Expr) -> Option<TimelineEvent> {
+  let evaluated = evaluate_expr_to_expr(item).unwrap_or_else(|_| item.clone());
+
+  match &evaluated {
+    // Labeled[date, label] — explicit label wrapper.
+    Expr::FunctionCall { name, args }
+      if name == "Labeled" && args.len() == 2 =>
+    {
+      let mut ev = event_from_date(&args[0])?;
+      ev.label = expr_to_label(&args[1]);
+      Some(ev)
+    }
+    // Style[date, ...] — ignore styling, keep the underlying date.
+    Expr::FunctionCall { name, args }
+      if name == "Style" && !args.is_empty() =>
+    {
+      event_from_date(&args[0])
+    }
+    // Tooltip[date, label] — treat the tooltip text as the label.
+    Expr::FunctionCall { name, args }
+      if name == "Tooltip" && args.len() == 2 =>
+    {
+      let mut ev = event_from_date(&args[0])?;
+      ev.label = expr_to_label(&args[1]);
+      Some(ev)
+    }
+    // label -> date (an association entry written as a Rule).
+    Expr::Rule {
+      pattern,
+      replacement,
+    } => {
+      let mut ev = event_from_date(replacement)?;
+      ev.label = expr_to_label(pattern);
+      Some(ev)
+    }
+    _ => event_from_date(&evaluated),
+  }
+}
+
+/// Build an event from a date-like expression, defaulting the label to the
+/// formatted date (or date range for intervals).
+fn event_from_date(expr: &Expr) -> Option<TimelineEvent> {
+  let evaluated = evaluate_expr_to_expr(expr).unwrap_or_else(|_| expr.clone());
+
+  // DateInterval[{d1, d2}] — an explicit time span.
+  if let Expr::FunctionCall { name, args } = &evaluated
+    && name == "DateInterval"
+    && args.len() == 1
+    && let Expr::List(pair) = &args[0]
+    && pair.len() == 2
+    && let (Some(lo), Some(hi)) =
+      (date_to_absolute_time(&pair[0]), date_to_absolute_time(&pair[1]))
+  {
+    let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+    return Some(TimelineEvent {
+      start: lo,
+      end: Some(hi),
+      label: format!("{} – {}", format_date_tick(lo), format_date_tick(hi)),
+    });
+  }
+
+  // Interval[{d1, d2}] — also treated as a time span.
+  if let Some(spans) = is_interval(&evaluated)
+    && let Some((lo_e, hi_e)) = spans.first()
+    && let (Some(lo), Some(hi)) =
+      (date_to_absolute_time(lo_e), date_to_absolute_time(hi_e))
+  {
+    let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+    return Some(TimelineEvent {
+      start: lo,
+      end: Some(hi),
+      label: format!("{} – {}", format_date_tick(lo), format_date_tick(hi)),
+    });
+  }
+
+  // A single instant.
+  let t = date_to_absolute_time(&evaluated)?;
+  Some(TimelineEvent {
+    start: t,
+    end: None,
+    label: format_date_tick(t),
+  })
+}
+
+/// Convert a date expression to AbsoluteTime seconds (since 1900-01-01).
+/// Handles raw numbers (already AbsoluteTime), date lists `{y,m,d,...}` and
+/// `DateObject[...]`.
+fn date_to_absolute_time(expr: &Expr) -> Option<f64> {
+  let evaluated = evaluate_expr_to_expr(expr).unwrap_or_else(|_| expr.clone());
+
+  if let Some(t) = try_eval_to_f64(&evaluated) {
+    return Some(t);
+  }
+
+  let components =
+    crate::functions::datetime_ast::extract_date_components(&evaluated)?;
+  if components.is_empty() {
+    return None;
+  }
+  let year = components[0] as i64;
+  let month = components.get(1).map(|v| *v as i64).unwrap_or(1);
+  let day = components.get(2).map(|v| *v as i64).unwrap_or(1);
+  let hour = components.get(3).map(|v| *v as i64).unwrap_or(0);
+  let minute = components.get(4).map(|v| *v as i64).unwrap_or(0);
+  let second = components.get(5).copied().unwrap_or(0.0);
+  Some(crate::functions::datetime_ast::date_to_absolute_seconds(
+    year, month, day, hour, minute, second,
+  ))
+}
+
+/// Render a label expression to display text (strings without their quotes).
+fn expr_to_label(expr: &Expr) -> String {
+  let evaluated = evaluate_expr_to_expr(expr).unwrap_or_else(|_| expr.clone());
+  match &evaluated {
+    Expr::String(s) => s.clone(),
+    other => crate::syntax::expr_to_output(other),
+  }
+}
+
+/// Greedily pack events into as few rows as possible so their markers and
+/// labels do not overlap horizontally. Returns the row index per event.
+fn pack_rows(
+  events: &[TimelineEvent],
+  x_to_px: impl Fn(f64) -> f64,
+  label_px_width: impl Fn(&str) -> f64,
+  marker_gap: f64,
+  row_gap: f64,
+) -> Vec<usize> {
+  // Process events left-to-right by start position for tidy packing.
+  let mut order: Vec<usize> = (0..events.len()).collect();
+  order.sort_by(|&a, &b| {
+    events[a]
+      .start
+      .partial_cmp(&events[b].start)
+      .unwrap_or(std::cmp::Ordering::Equal)
+  });
+
+  let mut row_end: Vec<f64> = Vec::new();
+  let mut assignment = vec![0usize; events.len()];
+
+  for &idx in &order {
+    let ev = &events[idx];
+    let left = x_to_px(ev.start);
+    let marker_right = match ev.end {
+      Some(end) => x_to_px(end),
+      None => left,
+    };
+    let occupied_end =
+      marker_right + marker_gap + label_px_width(&ev.label) + row_gap;
+
+    // Find the first row whose content ends before this event starts.
+    let mut placed = None;
+    for (row, end) in row_end.iter_mut().enumerate() {
+      if left >= *end {
+        *end = occupied_end;
+        placed = Some(row);
+        break;
+      }
+    }
+    let row = placed.unwrap_or_else(|| {
+      row_end.push(occupied_end);
+      row_end.len() - 1
+    });
+    assignment[idx] = row;
+  }
+
+  assignment
+}
+
+/// Estimate the pixel width of a text label at the given font size.
+fn est_text_width(label: &str, font_size: f64) -> f64 {
+  label.chars().count() as f64 * font_size * 0.6
+}
+
+/// Render the complete TimelinePlot SVG.
+fn render_timeline_svg(
+  events: &[TimelineEvent],
+  svg_width: u32,
+  full_width: bool,
+) -> String {
+  let sf = RESOLUTION_SCALE as f64;
+  let render_width = svg_width * RESOLUTION_SCALE;
+
+  let (bg_color, axis_color, label_fill, event_color) = theme_colors();
+
+  let font_size = 13.0 * sf;
+  let marker_gap = 6.0 * sf;
+  let row_gap = 10.0 * sf;
+
+  // Compute the x range across all events, with a little padding.
+  let (mut x_min, mut x_max) = (f64::INFINITY, f64::NEG_INFINITY);
+  for ev in events {
+    x_min = x_min.min(ev.start);
+    x_max = x_max.max(ev.end.unwrap_or(ev.start));
+  }
+  if !x_min.is_finite() || !x_max.is_finite() {
+    x_min = 0.0;
+    x_max = 86400.0;
+  }
+  let range = x_max - x_min;
+  let pad = if range.abs() < f64::EPSILON {
+    // All events at the same instant: default to a one-year window.
+    365.25 * 86400.0
+  } else {
+    range * 0.08
+  };
+  x_min -= pad;
+  x_max += pad;
+
+  // Reserve right margin large enough for the longest label so nothing clips.
+  let longest_label = events
+    .iter()
+    .map(|e| est_text_width(&e.label, font_size))
+    .fold(0.0_f64, f64::max);
+  let margin_left = 10.0 * sf;
+  let margin_right = (longest_label + marker_gap + 10.0 * sf)
+    .min(render_width as f64 * 0.5)
+    .max(20.0 * sf);
+  let plot_width = (render_width as f64 - margin_left - margin_right).max(1.0);
+
+  let x_to_px =
+    |x: f64| -> f64 { margin_left + (x - x_min) / (x_max - x_min) * plot_width };
+
+  // Pack events into rows.
+  let rows = pack_rows(
+    events,
+    |x| x_to_px(x),
+    |lbl| est_text_width(lbl, font_size),
+    marker_gap,
+    row_gap,
+  );
+  let num_rows = rows.iter().copied().max().map(|m| m + 1).unwrap_or(1);
+
+  let svg_height = PADDING_TOP
+    + num_rows as u32 * ROW_HEIGHT
+    + AXIS_GAP
+    + PADDING_BOTTOM;
+  let render_height = svg_height * RESOLUTION_SCALE;
+
+  let top = PADDING_TOP as f64 * sf;
+  let axis_y = top + num_rows as f64 * ROW_HEIGHT as f64 * sf + AXIS_GAP as f64 * sf;
+  let row_y = |row: usize| -> f64 {
+    top + (row as f64 + 0.5) * ROW_HEIGHT as f64 * sf
+  };
+
+  let mut body = String::new();
+
+  // Background.
+  body.push_str(&format!(
+    "<rect width=\"{}\" height=\"{}\" fill=\"{}\"/>\n",
+    render_width, render_height, bg_color
+  ));
+
+  let axis_x0 = margin_left;
+  let axis_x1 = margin_left + plot_width;
+
+  // Draw events (in original order for stable colors/z-order).
+  let marker_r = 4.0 * sf;
+  let bar_half = 3.0 * sf;
+  for (idx, ev) in events.iter().enumerate() {
+    let y = row_y(rows[idx]);
+    let x_start = x_to_px(ev.start);
+
+    // Light vertical guide from the marker down to the axis.
+    body.push_str(&format!(
+      "<line x1=\"{:.1}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" \
+       stroke=\"{}\" stroke-width=\"{:.1}\" stroke-dasharray=\"{:.0},{:.0}\"/>\n",
+      x_start,
+      y,
+      x_start,
+      axis_y,
+      axis_color,
+      sf * 0.5,
+      sf * 2.0,
+      sf * 2.0,
+    ));
+
+    let label_x = match ev.end {
+      Some(end) => {
+        // Interval: draw a rounded bar from start to end.
+        let x_end = x_to_px(end);
+        body.push_str(&format!(
+          "<rect x=\"{:.1}\" y=\"{:.1}\" width=\"{:.1}\" height=\"{:.1}\" \
+           rx=\"{:.1}\" fill=\"{}\"/>\n",
+          x_start,
+          y - bar_half,
+          (x_end - x_start).max(sf),
+          bar_half * 2.0,
+          bar_half,
+          event_color,
+        ));
+        x_end + marker_gap
+      }
+      None => {
+        // Point: draw a filled circle marker.
+        body.push_str(&format!(
+          "<circle cx=\"{:.1}\" cy=\"{:.1}\" r=\"{:.1}\" fill=\"{}\"/>\n",
+          x_start, y, marker_r, event_color
+        ));
+        x_start + marker_r + marker_gap
+      }
+    };
+
+    // Event label to the right of the marker, vertically centered.
+    body.push_str(&format!(
+      "<text x=\"{:.1}\" y=\"{:.1}\" dy=\"0.32em\" text-anchor=\"start\" \
+       font-family=\"sans-serif\" font-size=\"{:.0}\" fill=\"{}\">{}</text>\n",
+      label_x,
+      y,
+      font_size,
+      label_fill,
+      html_escape(&ev.label),
+    ));
+  }
+
+  // Bottom axis line.
+  body.push_str(&format!(
+    "<line x1=\"{:.1}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" \
+     stroke=\"{}\" stroke-width=\"{:.0}\"/>\n",
+    axis_x0, axis_y, axis_x1, axis_y, axis_color, sf
+  ));
+
+  // Date ticks and labels on the axis.
+  let ticks = generate_date_ticks(x_min, x_max);
+  let tick_len = 5.0 * sf;
+  let tick_font = 12.0 * sf;
+  for &t in &ticks {
+    if t < x_min || t > x_max {
+      continue;
+    }
+    let px = x_to_px(t);
+    body.push_str(&format!(
+      "<line x1=\"{:.1}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" \
+       stroke=\"{}\" stroke-width=\"{:.0}\"/>\n",
+      px,
+      axis_y,
+      px,
+      axis_y + tick_len,
+      axis_color,
+      sf
+    ));
+    body.push_str(&format!(
+      "<text x=\"{:.1}\" y=\"{:.1}\" text-anchor=\"middle\" \
+       font-family=\"sans-serif\" font-size=\"{:.0}\" fill=\"{}\">{}</text>\n",
+      px,
+      axis_y + tick_len + tick_font * 1.1,
+      tick_font,
+      label_fill,
+      html_escape(&format_date_tick(t)),
+    ));
+  }
+
+  let mut buf = format!(
+    "<svg width=\"{}\" height=\"{}\" viewBox=\"0 0 {} {}\" \
+     xmlns=\"http://www.w3.org/2000/svg\">\n{}</svg>",
+    svg_width, svg_height, render_width, render_height, body
+  );
+
+  if full_width {
+    let old = format!("width=\"{}\" height=\"{}\"", svg_width, svg_height);
+    buf = buf.replacen(&old, "width=\"100%\"", 1);
+  }
+
+  buf
+}
+
+/// Escape special HTML characters in text content.
+fn html_escape(s: &str) -> String {
+  s.replace('&', "&amp;")
+    .replace('<', "&lt;")
+    .replace('>', "&gt;")
+    .replace('"', "&quot;")
+}
+
+/// Theme colors: `(background, axis, label, event)`.
+fn theme_colors() -> (&'static str, &'static str, String, String) {
+  let (r, g, b) = PLOT_COLORS[0];
+  let event = format!("rgb({},{},{})", r, g, b);
+  if crate::is_dark_mode() {
+    ("#1a1a1a", "#999999", "#999".to_string(), event)
+  } else {
+    ("#ffffff", "#666666", "#666".to_string(), event)
+  }
+}

--- a/src/functions/timeline_plot.rs
+++ b/src/functions/timeline_plot.rs
@@ -140,14 +140,22 @@ fn parse_one_event(item: &Expr) -> Option<TimelineEvent> {
 fn event_from_date(expr: &Expr) -> Option<TimelineEvent> {
   let evaluated = evaluate_expr_to_expr(expr).unwrap_or_else(|_| expr.clone());
 
-  // DateInterval[{d1, d2}] — an explicit time span.
+  // DateInterval[{d1, d2}] — an explicit time span. Also matches the
+  // canonical form DateInterval[{{d1, d2}}, granularity, calendar, timezone]
+  // that evaluating DateInterval produces.
   if let Expr::FunctionCall { name, args } = &evaluated
     && name == "DateInterval"
-    && args.len() == 1
-    && let Expr::List(pair) = &args[0]
-    && pair.len() == 2
-    && let (Some(lo), Some(hi)) =
-      (date_to_absolute_time(&pair[0]), date_to_absolute_time(&pair[1]))
+    && !args.is_empty()
+    && let Expr::List(spec) = &args[0]
+    && let Some(pair) = match spec.as_slice() {
+      [d1, d2] => Some([d1, d2]),
+      [Expr::List(span)] if span.len() == 2 => Some([&span[0], &span[1]]),
+      _ => None,
+    }
+    && let (Some(lo), Some(hi)) = (
+      date_to_absolute_time(pair[0]),
+      date_to_absolute_time(pair[1]),
+    )
   {
     let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
     return Some(TimelineEvent {
@@ -316,30 +324,29 @@ fn render_timeline_svg(
     .max(20.0 * sf);
   let plot_width = (render_width as f64 - margin_left - margin_right).max(1.0);
 
-  let x_to_px =
-    |x: f64| -> f64 { margin_left + (x - x_min) / (x_max - x_min) * plot_width };
+  let x_to_px = |x: f64| -> f64 {
+    margin_left + (x - x_min) / (x_max - x_min) * plot_width
+  };
 
   // Pack events into rows.
   let rows = pack_rows(
     events,
-    |x| x_to_px(x),
+    x_to_px,
     |lbl| est_text_width(lbl, font_size),
     marker_gap,
     row_gap,
   );
   let num_rows = rows.iter().copied().max().map(|m| m + 1).unwrap_or(1);
 
-  let svg_height = PADDING_TOP
-    + num_rows as u32 * ROW_HEIGHT
-    + AXIS_GAP
-    + PADDING_BOTTOM;
+  let svg_height =
+    PADDING_TOP + num_rows as u32 * ROW_HEIGHT + AXIS_GAP + PADDING_BOTTOM;
   let render_height = svg_height * RESOLUTION_SCALE;
 
   let top = PADDING_TOP as f64 * sf;
-  let axis_y = top + num_rows as f64 * ROW_HEIGHT as f64 * sf + AXIS_GAP as f64 * sf;
-  let row_y = |row: usize| -> f64 {
-    top + (row as f64 + 0.5) * ROW_HEIGHT as f64 * sf
-  };
+  let axis_y =
+    top + num_rows as f64 * ROW_HEIGHT as f64 * sf + AXIS_GAP as f64 * sf;
+  let row_y =
+    |row: usize| -> f64 { top + (row as f64 + 0.5) * ROW_HEIGHT as f64 * sf };
 
   let mut body = String::new();
 

--- a/tests/cli/plotting.md
+++ b/tests/cli/plotting.md
@@ -84,6 +84,7 @@ SVG images.
 - [`SphericalPlot3D`](plotting/SphericalPlot3D.md)
 - [`StreamDensityPlot`](plotting/StreamDensityPlot.md)
 - [`StreamPlot`](plotting/StreamPlot.md)
+- [`TimelinePlot`](plotting/TimelinePlot.md)
 - [`TreeForm`](plotting/TreeForm.md)
 - [`TreeGraph`](plotting/TreeGraph.md)
 - [`VectorPlot`](plotting/VectorPlot.md)

--- a/tests/cli/plotting/TimelinePlot.md
+++ b/tests/cli/plotting/TimelinePlot.md
@@ -1,0 +1,44 @@
+# `TimelinePlot`
+
+Plots dates and date intervals as events along a horizontal timeline.
+
+Each date becomes a point marker; each `DateInterval` becomes a bar. Events
+are automatically stacked into rows so their labels don't overlap, and a date
+axis is drawn along the bottom.
+
+```scrut
+$ wo 'Head[TimelinePlot[{DateObject[{2000}], DateObject[{2005}], DateObject[{2010}]}]]'
+Graphics
+```
+
+Date lists (`{y, m, d}`) are accepted directly.
+
+```scrut
+$ wo 'Head[TimelinePlot[{{2001, 1, 1}, {2003, 6, 15}}]]'
+Graphics
+```
+
+Events can be labeled with `Labeled`, `label -> date` rules, or an
+association keyed by label.
+
+```scrut
+$ wo 'Head[TimelinePlot[{Labeled[DateObject[{2000}], "Start"], Labeled[DateObject[{2010}], "End"]}]]'
+Graphics
+```
+
+```scrut
+$ wo 'Head[TimelinePlot[<|"One" -> DateObject[{2000}], "Two" -> DateObject[{2004}]|>]]'
+Graphics
+```
+
+A `DateInterval` is drawn as a bar spanning its start and end dates.
+
+```scrut
+$ wo 'Head[TimelinePlot[{DateInterval[{DateObject[{2000}], DateObject[{2005}]}]}]]'
+Graphics
+```
+
+### Options
+
+- **`ImageSize`** — overall width in pixels (height grows with the number of
+  stacked rows).

--- a/tests/interpreter_tests/functions.rs
+++ b/tests/interpreter_tests/functions.rs
@@ -3536,6 +3536,20 @@ mod date_interval {
   fn invalid_arg() {
     assert_eq!(interpret("DateInterval[0]").unwrap(), "DateInterval[0]");
   }
+
+  // Regression: re-evaluating the canonical form must be a fixed point and
+  // not emit DateInterval::argx.
+  #[test]
+  fn canonical_form_is_fixed_point() {
+    assert_eq!(
+      interpret(
+        "DateInterval[{{{2020, 1, 1, 0, 0, 0.}, {2020, 12, 31, 0, 0, 0.}}}, \
+         \"Day\", \"Gregorian\", None]"
+      )
+      .unwrap(),
+      "DateInterval[{{{2020, 1, 1, 0, 0, 0.}, {2020, 12, 31, 0, 0, 0.}}}, Day, Gregorian, None]"
+    );
+  }
 }
 
 mod xml_template {

--- a/tests/zensical.toml
+++ b/tests/zensical.toml
@@ -1462,6 +1462,7 @@ nav = [
     { "SphericalPlot3D" = "plotting/SphericalPlot3D.md" },
     { "StreamDensityPlot" = "plotting/StreamDensityPlot.md" },
     { "StreamPlot" = "plotting/StreamPlot.md" },
+    { "TimelinePlot" = "plotting/TimelinePlot.md" },
     { "TreeForm" = "plotting/TreeForm.md" },
     { "TreeGraph" = "plotting/TreeGraph.md" },
     { "VectorPlot" = "plotting/VectorPlot.md" },


### PR DESCRIPTION
Implement TimelinePlot, which renders dates and date intervals as events
along a horizontal timeline with an automatic date axis.

- Point events (dates, DateObject, date lists, absolute times) draw as
  markers; DateInterval/Interval events draw as bars.
- Events are labeled via Labeled[...], label -> date rules, or an
  association keyed by label; unlabeled events fall back to their formatted
  date.
- Events are greedily packed into stacked rows so labels don't overlap.
- Supports the ImageSize option.

Wire up dispatch, the graphics-producing-head list, and module export.
Add unit tests, a CLI doc with scrut tests, register the doc in the nav,
and mark the function implemented in functions.csv.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016WzG1S59rQMaexMuERuWEq