### PR TITLE
Remove Tree family from Mathematica 12.3 unsupported features

### DIFF
--- a/tests/cli/comparison/mathematica.md
+++ b/tests/cli/comparison/mathematica.md
@@ -201,7 +201,6 @@ Woxi does **not** support.
 ### Version 12.3 (2021)
 
 - Multivariate transcendental equation solving; symbolic PDE solutions
-- Tree family: `Tree`, `TreeMap`, `TreeFold`
 - Data structures: `ByteTrie`, `KDTree`, `ImmutableVector`
 - `GeometricTest`; region dilation/erosion
 - `StreamPlot3D`, `ListStreamPlot3D`


### PR DESCRIPTION
## Summary
Updates the Mathematica 12.3 (2021) feature comparison documentation to remove the Tree family (`Tree`, `TreeMap`, `TreeFold`) from the list of unsupported features in Woxi.

## Changes
- Removed the line documenting `Tree`, `TreeMap`, `TreeFold` as unsupported features from the Mathematica 12.3 section in `tests/cli/comparison/mathematica.md`

## Details
This change indicates that Woxi now supports the Tree family of functions, which were previously listed as unsupported in the version 12.3 feature comparison documentation.

https://claude.ai/code/session_01NCREs7SnM5js9zMx8jUfLw