### PR TITLE
Support asymmetric uncertainties in Around values

### DIFF
--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -70,7 +70,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "ArgMax" => Some((2, 4)),
     "ArgMin" => Some((2, 4)),
     "ArithmeticGeometricMean" => Some((2, 2)),
-    "Around" => Some((2, usize::MAX)),
+    "Around" => Some((1, usize::MAX)),
     "Array" => Some((2, 4)),
     "ArrayComponents" => Some((1, 3)),
     "ArrayDepth" => Some((1, 1)),

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -2333,6 +2333,73 @@ pub fn dispatch_complex_and_special(
       }
     }
 
+    // Around[dist] — an approximate number from a distribution:
+    // Around[N[Mean[dist]], N[StandardDeviation[dist]]].
+    // Around[Interval[{a, b}]] treats the interval as a uniform distribution:
+    // Around[(a+b)/2, (b-a)/(2 Sqrt[3])].
+    "Around" if args.len() == 1 => {
+      let unevaluated = || {
+        Some(Ok(Expr::FunctionCall {
+          name: "Around".to_string(),
+          args: args.to_vec().into(),
+        }))
+      };
+      return match &args[0] {
+        Expr::FunctionCall {
+          name: iname,
+          args: iargs,
+        } if iname == "Interval" && iargs.len() == 1 => {
+          if let Expr::List(bounds) = &iargs[0]
+            && bounds.len() == 2
+            && let (Some(a), Some(b)) = (
+              crate::functions::math_ast::try_eval_to_f64(&bounds[0]),
+              crate::functions::math_ast::try_eval_to_f64(&bounds[1]),
+            )
+          {
+            let value = (a + b) / 2.0;
+            let uncertainty = (b - a).abs() / (2.0 * 3f64.sqrt());
+            if uncertainty == 0.0 {
+              return Some(Ok(Expr::Real(value)));
+            }
+            return Some(Ok(Expr::FunctionCall {
+              name: "Around".to_string(),
+              args: vec![Expr::Real(value), Expr::Real(uncertainty)].into(),
+            }));
+          }
+          unevaluated()
+        }
+        Expr::FunctionCall { name: dname, .. }
+          if dname.ends_with("Distribution") =>
+        {
+          let numeric_of = |stat: &str| -> Option<f64> {
+            let expr = Expr::FunctionCall {
+              name: "N".to_string(),
+              args: vec![Expr::FunctionCall {
+                name: stat.to_string(),
+                args: vec![args[0].clone()].into(),
+              }]
+              .into(),
+            };
+            let value = crate::evaluator::evaluate_expr_to_expr(&expr).ok()?;
+            crate::functions::math_ast::try_eval_to_f64(&value)
+          };
+          if let (Some(mean), Some(sd)) =
+            (numeric_of("Mean"), numeric_of("StandardDeviation"))
+          {
+            if sd == 0.0 {
+              return Some(Ok(Expr::Real(mean)));
+            }
+            return Some(Ok(Expr::FunctionCall {
+              name: "Around".to_string(),
+              args: vec![Expr::Real(mean), Expr::Real(sd)].into(),
+            }));
+          }
+          unevaluated()
+        }
+        _ => unevaluated(),
+      };
+    }
+
     // Around[value, uncertainty] — convert integer value to real when uncertainty is real
     // Around[{v1, v2, …}, u] threads over the list of central values, giving
     // each the same uncertainty: {Around[v1, u], Around[v2, u], …}.
@@ -2375,22 +2442,52 @@ pub fn dispatch_complex_and_special(
         }
       }
       // A zero uncertainty collapses to the bare value (Around[5, 0] -> 5,
-      // Around[5., 0.] -> 5.), matching wolframscript.
+      // Around[5., 0.] -> 5.), matching wolframscript. The asymmetric
+      // Around[x, {0, 0}] collapses the same way.
+      fn is_zero_num(e: &Expr) -> bool {
+        matches!(e, Expr::Integer(0)) || matches!(e, Expr::Real(z) if *z == 0.0)
+      }
       let zero_uncertainty = new_args.len() == 2
         && match &new_args[1] {
-          Expr::Integer(0) => true,
-          Expr::Real(z) => *z == 0.0,
-          _ => false,
+          Expr::List(items) => {
+            items.len() == 2 && items.iter().all(is_zero_num)
+          }
+          other => is_zero_num(other),
         };
       if zero_uncertainty {
         return Some(Ok(new_args[0].clone()));
       }
       // Around stores its central value and uncertainty as machine reals, so
-      // integer arguments are promoted to Real: Around[5, 1] -> Around[5., 1.]
-      // (matching wolframscript). Symbolic arguments are left untouched.
+      // exact arguments are promoted to Real: Around[5, 1] -> Around[5., 1.],
+      // Around[3/4, 1/8] -> Around[0.75, 0.125] (matching wolframscript). The
+      // components of an asymmetric {δ₋, δ₊} uncertainty are promoted the same
+      // way. Symbolic arguments are left untouched.
+      fn promote_to_real(a: &mut Expr) {
+        match a {
+          Expr::Integer(n) => *a = Expr::Real(*n as f64),
+          Expr::FunctionCall { name, args }
+            if name == "Rational" && args.len() == 2 =>
+          {
+            if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1])
+              && *d != 0
+            {
+              *a = Expr::Real(*n as f64 / *d as f64);
+            }
+          }
+          _ => {}
+        }
+      }
       for a in new_args.iter_mut() {
-        if let Expr::Integer(n) = a {
-          *a = Expr::Real(*n as f64);
+        if let Expr::List(items) = a {
+          if items.len() == 2 {
+            let mut promoted = items.to_vec();
+            for item in promoted.iter_mut() {
+              promote_to_real(item);
+            }
+            *a = Expr::List(promoted.into());
+          }
+        } else {
+          promote_to_real(a);
         }
       }
       return Some(Ok(Expr::FunctionCall {

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -857,6 +857,28 @@ pub fn apply_curried_call(
       // Entity["type", "name"]["property"] — property access on entities
       crate::functions::entity_ast::entity_property_access(func_args, args)
     }
+    // Around[x, δ]["Value"] / ["Uncertainty"] — property extraction on an
+    // uncertain value. Unknown properties keep the curried form unevaluated.
+    Expr::FunctionCall {
+      name,
+      args: func_args,
+    } if name == "Around"
+      && func_args.len() == 2
+      && args.len() == 1
+      && matches!(&args[0], Expr::String(_)) =>
+    {
+      let Expr::String(prop) = &args[0] else {
+        unreachable!();
+      };
+      match prop.as_str() {
+        "Value" => Ok(func_args[0].clone()),
+        "Uncertainty" => Ok(func_args[1].clone()),
+        _ => Ok(Expr::CurriedCall {
+          func: Box::new(func.clone()),
+          args: args.to_vec(),
+        }),
+      }
+    }
     // DateObject[...]["property"] — extract a date component (e.g. "Day",
     // "DayName", "Week"). Delegates to DateValue, which already resolves every
     // such property; if it cannot, the curried form is kept unevaluated.

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -8692,18 +8692,45 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
   }
 }
 
-/// Check if an expression contains any `Expr::Real` (float) value.
-/// (value, uncertainty) of an `Around[v, d]` with numeric components.
-fn as_around(e: &Expr) -> Option<(f64, f64)> {
-  if let Expr::FunctionCall { name, args } = e
-    && name == "Around"
-    && args.len() == 2
-    && let (Some(v), Some(d)) =
-      (around_literal(&args[0]), around_literal(&args[1]))
-  {
-    Some((v, d))
-  } else {
-    None
+/// Numeric payload of an `Around`: the central value together with the
+/// downward/upward uncertainties. A symmetric `Around[v, d]` has
+/// `minus == plus`; the asymmetric `Around[v, {δ₋, δ₊}]` form sets `asym` so
+/// propagated results stay in list form.
+struct AroundNum {
+  value: f64,
+  minus: f64,
+  plus: f64,
+  asym: bool,
+}
+
+fn as_around(e: &Expr) -> Option<AroundNum> {
+  let Expr::FunctionCall { name, args } = e else {
+    return None;
+  };
+  if name != "Around" || args.len() != 2 {
+    return None;
+  }
+  let value = around_literal(&args[0])?;
+  match &args[1] {
+    Expr::List(items) if items.len() == 2 => {
+      let minus = around_literal(&items[0])?;
+      let plus = around_literal(&items[1])?;
+      Some(AroundNum {
+        value,
+        minus,
+        plus,
+        asym: true,
+      })
+    }
+    d => {
+      let d = around_literal(d)?;
+      Some(AroundNum {
+        value,
+        minus: d,
+        plus: d,
+        asym: false,
+      })
+    }
   }
 }
 
@@ -8739,6 +8766,37 @@ fn make_around(value: f64, uncertainty: f64) -> Expr {
   }
 }
 
+/// Assemble a propagated result: list-form uncertainty iff any input was
+/// asymmetric, and a vanishing uncertainty collapses to the bare value.
+fn make_around_general(value: f64, minus: f64, plus: f64, asym: bool) -> Expr {
+  if !asym {
+    return make_around(value, minus);
+  }
+  if minus == 0.0 && plus == 0.0 {
+    return Expr::Real(value);
+  }
+  Expr::FunctionCall {
+    name: "Around".to_string(),
+    args: vec![
+      Expr::Real(value),
+      Expr::List(vec![Expr::Real(minus), Expr::Real(plus)].into()),
+    ]
+    .into(),
+  }
+}
+
+/// Contribution of one argument to the (minus, plus) sides of a result,
+/// through the partial derivative `c`: a positive coefficient keeps the
+/// sides aligned, a negative one swaps them (the value's downward excursion
+/// pushes the result upward).
+fn side_contributions(c: f64, a: &AroundNum) -> (f64, f64) {
+  if c >= 0.0 {
+    (c * a.minus, c * a.plus)
+  } else {
+    (-c * a.plus, -c * a.minus)
+  }
+}
+
 /// Around[a, δa] + Around[b, δb] + c = Around[a+b+c, Sqrt[δa²+δb²]] —
 /// first-order error propagation treating each Around as independent. Returns
 /// None unless at least one argument is an Around and every other argument is a
@@ -8748,18 +8806,27 @@ pub fn try_around_plus(args: &[Expr]) -> Option<Expr> {
     return None;
   }
   let mut value = 0.0;
-  let mut var = 0.0;
+  let mut var_minus = 0.0;
+  let mut var_plus = 0.0;
+  let mut asym = false;
   for a in args {
-    if let Some((v, d)) = as_around(a) {
-      value += v;
-      var += d * d;
+    if let Some(ar) = as_around(a) {
+      value += ar.value;
+      var_minus += ar.minus * ar.minus;
+      var_plus += ar.plus * ar.plus;
+      asym |= ar.asym;
     } else if let Some(c) = around_literal(a) {
       value += c;
     } else {
       return None;
     }
   }
-  Some(make_around(value, var.sqrt()))
+  Some(make_around_general(
+    value,
+    var_minus.sqrt(),
+    var_plus.sqrt(),
+    asym,
+  ))
 }
 
 /// Product of Around values and literal scalars, with the absolute partial
@@ -8772,35 +8839,47 @@ pub fn try_around_times(args: &[Expr]) -> Option<Expr> {
     return None;
   }
   let mut value = 1.0;
-  let mut arounds: Vec<(f64, f64)> = Vec::new();
+  let mut arounds: Vec<AroundNum> = Vec::new();
+  let mut asym = false;
   for a in args {
-    if let Some((v, d)) = as_around(a) {
-      if v == 0.0 {
+    if let Some(ar) = as_around(a) {
+      if ar.value == 0.0 {
         return None; // partial (Π/a_i) undefined at 0
       }
-      value *= v;
-      arounds.push((v, d));
+      value *= ar.value;
+      asym |= ar.asym;
+      arounds.push(ar);
     } else if let Some(c) = around_literal(a) {
       value *= c;
     } else {
       return None;
     }
   }
-  let mut var = 0.0;
-  for (v, d) in arounds {
-    let partial = (value / v) * d;
-    var += partial * partial;
+  let mut var_minus = 0.0;
+  let mut var_plus = 0.0;
+  for ar in &arounds {
+    let (m, p) = side_contributions(value / ar.value, ar);
+    var_minus += m * m;
+    var_plus += p * p;
   }
-  Some(make_around(value, var.sqrt()))
+  Some(make_around_general(
+    value,
+    var_minus.sqrt(),
+    var_plus.sqrt(),
+    asym,
+  ))
 }
 
 /// Around[a, δ]^n = Around[a^n, |n·a^(n-1)|·δ] for a literal exponent n.
 pub fn try_around_power(base: &Expr, exp: &Expr) -> Option<Expr> {
-  let (a, d) = as_around(base)?;
+  let ar = as_around(base)?;
   let n = around_literal(exp)?;
-  let value = a.powf(n);
-  let uncertainty = (n * a.powf(n - 1.0)).abs() * d;
-  Some(make_around(value, uncertainty))
+  let value = ar.value.powf(n);
+  let (m, p) = side_contributions(n * ar.value.powf(n - 1.0), &ar);
+  if !value.is_finite() || !m.is_finite() || !p.is_finite() {
+    return None;
+  }
+  Some(make_around_general(value, m, p, ar.asym))
 }
 
 /// (f(a), f'(a)) for an elementary unary function, used to propagate an
@@ -8838,12 +8917,13 @@ pub fn try_around_unary(
   if args.len() != 1 {
     return None;
   }
-  let (a, d) = as_around(&args[0])?;
-  let (fa, fpa) = around_func_and_deriv(name, a)?;
+  let ar = as_around(&args[0])?;
+  let (fa, fpa) = around_func_and_deriv(name, ar.value)?;
   if !fa.is_finite() || !fpa.is_finite() {
     return None;
   }
-  Some(Ok(make_around(fa, fpa.abs() * d)))
+  let (m, p) = side_contributions(fpa, &ar);
+  Some(Ok(make_around_general(fa, m, p, ar.asym)))
 }
 
 fn contains_real(expr: &Expr) -> bool {

--- a/tests/cli/comparison/mathematica.md
+++ b/tests/cli/comparison/mathematica.md
@@ -90,7 +90,6 @@ Woxi does **not** support.
 - `ModelFit` superfunction with `ExponentialModel`, `PowerModel`,
     `LogModel`, `PolynomialModel`, `PeriodicModel`, `DecisionTreeModel`
 - Big-data `Tabular` enhancements, `TabularSummary`
-- `Around` data type
 - Exception handling: `ThrowException`, `CatchExceptions`,
     `RegisterExceptionType`
 - Lazy sequences via `IncrementalObject` and incremental

--- a/tests/cli/math/utility/Around.md
+++ b/tests/cli/math/utility/Around.md
@@ -7,6 +7,34 @@ $ wo 'Around[5, 0.3]'
 Around[5., 0.3]
 ```
 
+Exact numbers are converted to machine reals.
+
+```scrut
+$ wo 'Around[3/4, 1/8]'
+Around[0.75, 0.125]
+```
+
+`Around[x, {δminus, δplus}]` represents a value with asymmetric uncertainties.
+
+```scrut
+$ wo 'Around[5, {0.1, 0.2}]'
+Around[5., {0.1, 0.2}]
+```
+
+`Around[dist]` represents an approximate number from a distribution.
+
+```scrut
+$ wo 'Around[NormalDistribution[3, 2]]'
+Around[3., 2.]
+```
+
+`Around[interval]` treats the interval as a uniform distribution.
+
+```scrut
+$ wo 'Around[Interval[{2, 4}]]'
+Around[3., 0.5773502691896258]
+```
+
 Arithmetic propagates the uncertainty, treating each `Around` as independent.
 
 ```scrut
@@ -17,6 +45,14 @@ Around[8., 1.4142135623730951]
 ```scrut
 $ wo 'Around[5, 1]^2'
 Around[25., 10.]
+```
+
+Asymmetric uncertainties are propagated per side; a negative coefficient
+swaps the two sides.
+
+```scrut
+$ wo '-Around[5, {0.1, 0.2}]'
+Around[-5., {0.2, 0.1}]
 ```
 
 Elementary functions propagate the uncertainty through their derivative.
@@ -31,4 +67,11 @@ A vanishing uncertainty collapses to the bare value.
 ```scrut
 $ wo 'Around[5, 0]'
 5
+```
+
+`around["Value"]` and `around["Uncertainty"]` extract the stored components.
+
+```scrut
+$ wo 'Around[5, 0.3]["Uncertainty"]'
+0.3
 ```

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -6655,6 +6655,144 @@ mod batch_inert_symbols_2 {
     assert_eq!(interpret("Around[5, 0.3]").unwrap(), "Around[5., 0.3]");
   }
 
+  // Exact numbers are promoted to machine reals, rationals included.
+  #[test]
+  fn around_promotes_rationals() {
+    assert_eq!(
+      interpret("Around[3/4, 1/8]").unwrap(),
+      "Around[0.75, 0.125]"
+    );
+    assert_eq!(interpret("Around[1/2, 0.1]").unwrap(), "Around[0.5, 0.1]");
+  }
+
+  // Around[x, {δ₋, δ₊}] holds asymmetric uncertainties; exact components are
+  // promoted to reals and a vanishing {0, 0} collapses to the bare value.
+  #[test]
+  fn around_asymmetric_construction() {
+    assert_eq!(
+      interpret("Around[5, {0.1, 0.2}]").unwrap(),
+      "Around[5., {0.1, 0.2}]"
+    );
+    assert_eq!(
+      interpret("Around[5, {1, 2}]").unwrap(),
+      "Around[5., {1., 2.}]"
+    );
+    assert_eq!(
+      interpret("Around[5, {1/4, 1/2}]").unwrap(),
+      "Around[5., {0.25, 0.5}]"
+    );
+    assert_eq!(interpret("Around[5, {0, 0}]").unwrap(), "5");
+  }
+
+  // Asymmetric uncertainties propagate per side, in quadrature.
+  #[test]
+  fn around_asymmetric_plus() {
+    assert_eq!(
+      interpret("Around[5, {0.3, 0.4}] + Around[3, {0.4, 0.3}]").unwrap(),
+      "Around[8., {0.5, 0.5}]"
+    );
+    // A constant shifts the value but not the uncertainties.
+    assert_eq!(
+      interpret("Around[5, {0.1, 0.2}] + 1").unwrap(),
+      "Around[6., {0.1, 0.2}]"
+    );
+    // Mixing with a symmetric Around keeps the result asymmetric.
+    assert_eq!(
+      interpret("Around[5, {3, 4}] + Around[3, 0]").unwrap(),
+      "Around[8., {3., 4.}]"
+    );
+  }
+
+  // A negative coefficient swaps the two sides: the value's downward
+  // excursion pushes the result upward.
+  #[test]
+  fn around_asymmetric_negation_swaps_sides() {
+    assert_eq!(
+      interpret("-Around[5, {0.1, 0.2}]").unwrap(),
+      "Around[-5., {0.2, 0.1}]"
+    );
+    assert_eq!(
+      interpret("2 * Around[5, {0.1, 0.2}]").unwrap(),
+      "Around[10., {0.2, 0.4}]"
+    );
+    assert_eq!(
+      interpret("Around[10, 0] - Around[5, {0.1, 0.2}]").unwrap(),
+      "Around[5., {0.2, 0.1}]"
+    );
+  }
+
+  #[test]
+  fn around_asymmetric_power() {
+    assert_eq!(
+      interpret("Around[2, {0.1, 0.2}]^2").unwrap(),
+      "Around[4., {0.4, 0.8}]"
+    );
+    // Negative derivative (d(1/x)/dx < 0) swaps the sides.
+    assert_eq!(
+      interpret("Around[2, {0.1, 0.2}]^-1").unwrap(),
+      "Around[0.5, {0.05, 0.025}]"
+    );
+  }
+
+  #[test]
+  fn around_asymmetric_unary_functions() {
+    assert_eq!(
+      interpret("Sqrt[Around[4, {1, 2}]]").unwrap(),
+      "Around[2., {0.25, 0.5}]"
+    );
+    // Exp'(0) = 1 keeps the sides aligned.
+    assert_eq!(
+      interpret("Exp[Around[0, {0.1, 0.2}]]").unwrap(),
+      "Around[1., {0.1, 0.2}]"
+    );
+  }
+
+  // Around[dist] gives Around[N[Mean[dist]], N[StandardDeviation[dist]]].
+  #[test]
+  fn around_from_distribution() {
+    assert_eq!(
+      interpret("Around[NormalDistribution[3, 2]]").unwrap(),
+      "Around[3., 2.]"
+    );
+    assert_eq!(
+      interpret("Around[UniformDistribution[{0, 1}]]").unwrap(),
+      "Around[0.5, 0.28867513459481287]"
+    );
+    assert_eq!(
+      interpret("Around[PoissonDistribution[4]]").unwrap(),
+      "Around[4., 2.]"
+    );
+  }
+
+  // Around[Interval[{a, b}]] treats the interval as a uniform distribution:
+  // Around[(a+b)/2, (b-a)/(2 Sqrt[3])].
+  #[test]
+  fn around_from_interval() {
+    assert_eq!(
+      interpret("Around[Interval[{2, 4}]]").unwrap(),
+      "Around[3., 0.5773502691896258]"
+    );
+    // A degenerate interval collapses to its point value.
+    assert_eq!(interpret("Around[Interval[{3, 3}]]").unwrap(), "3.");
+  }
+
+  // A non-distribution argument leaves the 1-argument form unevaluated.
+  #[test]
+  fn around_one_arg_symbolic_stays() {
+    assert_eq!(interpret("Around[x]").unwrap(), "Around[x]");
+  }
+
+  // around["Value"] / around["Uncertainty"] extract the stored components.
+  #[test]
+  fn around_properties() {
+    assert_eq!(interpret("Around[5, 0.3][\"Value\"]").unwrap(), "5.");
+    assert_eq!(interpret("Around[5, 0.3][\"Uncertainty\"]").unwrap(), "0.3");
+    assert_eq!(
+      interpret("Around[5, {0.1, 0.2}][\"Uncertainty\"]").unwrap(),
+      "{0.1, 0.2}"
+    );
+  }
+
   // Around[{v1, …}, u] threads over the central values, giving each the same
   // uncertainty.
   #[test]


### PR DESCRIPTION
## Summary

Extends the `Around` function to support asymmetric uncertainties in the form `Around[value, {δ₋, δ₊}]`, enabling proper error propagation for measurements with different downward and upward error bounds. Also adds support for constructing `Around` values from distributions and intervals.

## Key Changes

- **Refactored `as_around` function**: Changed return type from `Option<(f64, f64)>` to `Option<AroundNum>` struct that tracks separate minus/plus uncertainties and whether the value is asymmetric
- **Added `AroundNum` struct**: Stores central value, downward uncertainty (`minus`), upward uncertainty (`plus`), and an `asym` flag to preserve asymmetry through propagation
- **Implemented asymmetric error propagation**:
  - `make_around_general`: Assembles results with proper handling of asymmetric uncertainties, collapsing to bare values when both sides are zero
  - `side_contributions`: Correctly handles how partial derivatives affect uncertainty sides (negative coefficients swap the sides)
  - Updated `try_around_plus`, `try_around_times`, `try_around_power`, and `try_around_unary` to propagate uncertainties per side in quadrature
- **Added distribution and interval support**: `Around[dist]` now evaluates to `Around[Mean[dist], StandardDeviation[dist]]` for distributions, and `Around[Interval[{a,b}]]` treats intervals as uniform distributions
- **Added property extraction**: `Around[x, δ]["Value"]` and `Around[x, δ]["Uncertainty"]` extract stored components
- **Promoted exact numbers to reals**: Integer and rational arguments are converted to machine reals (e.g., `Around[3/4, 1/8]` → `Around[0.75, 0.125]`)
- **Updated argument count**: `Around` now accepts 1-2 arguments instead of 2+

## Notable Implementation Details

- Asymmetric uncertainties are preserved through arithmetic operations only when at least one input is asymmetric
- A negative partial derivative (e.g., in `x^-1`) correctly swaps the uncertainty sides since the value's downward excursion pushes the result upward
- Zero uncertainties (both symmetric and asymmetric `{0, 0}`) collapse to bare numeric values
- Comprehensive test coverage added for all asymmetric propagation scenarios

https://claude.ai/code/session_01XwTfN5P4tV9iCmuy8Rccnj