### PR TITLE
Implement StackedListPlot for cumulative stacked area charts

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -2763,7 +2763,7 @@ HistogramTransform,,🚫,,9.0,2821
 Image3DSlices,,🚫,,9.0,2821
 ImageDistance,,🚫,,9.0,2821
 Modal,,🚫,,6.0,2821
-StackedListPlot,,🚫,,11.2,2821
+StackedListPlot,Plots datasets with their values stacked cumulatively,✅,pure,11.2,2821
 AlphabeticSort,Sorts strings in case-insensitive alphabetical order,✅,pure,10.3,2828
 AlternatingGroup,Symbolic alternating group A_n of degree n; stays unevaluated and is consumed by GroupOrder/GroupGenerators/GroupElements,✅,unevaluated,8.0,2828
 BoundedRegionQ,,🚫,,10.0,2828

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -220,6 +220,9 @@ pub fn dispatch_plotting(
     "ListStepPlot" if !args.is_empty() => Some(quiet_plot(|| {
       crate::functions::list_plot::list_step_plot_ast(args)
     })),
+    "StackedListPlot" if !args.is_empty() => Some(quiet_plot(|| {
+      crate::functions::list_plot::stacked_list_plot_ast(args)
+    })),
     "LogLogPlot" if args.len() >= 2 => Some(quiet_plot(|| {
       crate::functions::plot::log_log_plot_ast(args)
     })),

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -8221,6 +8221,7 @@ fn is_graphics_producing_head(name: &str) -> bool {
       | "ListLogLogPlot"
       | "ListLogLinearPlot"
       | "ListStepPlot"
+      | "StackedListPlot"
       | "ListContourPlot"
       | "ListDensityPlot"
       | "ListPolarPlot"

--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -382,6 +382,45 @@ pub fn list_line_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(crate::graphics_result(svg))
 }
 
+/// StackedListPlot[{list1, list2, ...}]: plot several datasets with their
+/// y-values accumulated, so each successive dataset is stacked on top of the
+/// running total of the preceding ones. The regions between consecutive
+/// cumulative curves are filled by default.
+pub fn stacked_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  let all_series = parse_list_data(&args[0])?;
+  let mut parsed = parse_plot_options(args);
+  parsed.opts.stacked = true;
+  // Default to filled bands unless the user explicitly overrode Filling.
+  if parsed.opts.filling == crate::functions::plot::Filling::None {
+    parsed.opts.filling = crate::functions::plot::Filling::Axis;
+  }
+
+  // Accumulate y-values by index position across the series so that each
+  // curve is the running total up to and including that dataset.
+  let mut cumulative: Vec<Vec<(f64, f64)>> =
+    Vec::with_capacity(all_series.len());
+  let mut running: Vec<f64> = Vec::new();
+  for series in &all_series {
+    let mut curve = Vec::with_capacity(series.len());
+    for (j, &(x, y)) in series.iter().enumerate() {
+      if j >= running.len() {
+        running.push(0.0);
+      }
+      running[j] += y;
+      curve.push((x, running[j]));
+    }
+    cumulative.push(curve);
+  }
+
+  let (x_range, mut y_range) = compute_ranges(&cumulative);
+  y_range = adjust_y_range_for_filling(parsed.opts.filling, y_range);
+  let (x_range, y_range) = apply_plot_range_override(&parsed, x_range, y_range);
+
+  let svg =
+    generate_svg_with_filling(&cumulative, x_range, y_range, &parsed.opts)?;
+  Ok(crate::graphics_result(svg))
+}
+
 /// ListStepPlot[{y1, y2, ...}]
 pub fn list_step_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let all_series = parse_list_data(&args[0])?;

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -1058,6 +1058,10 @@ pub(crate) struct PlotOptions {
   pub log_y: bool,
   /// Callout labels for each series (None = no callout for that series)
   pub callout_labels: Vec<Option<String>>,
+  /// Stacked mode (StackedListPlot): fill each series down to the previous
+  /// series' curve instead of to a constant baseline, producing opaque
+  /// stacked bands. The `all_points` passed in are the cumulative curves.
+  pub stacked: bool,
 }
 
 impl Default for PlotOptions {
@@ -1087,6 +1091,7 @@ impl Default for PlotOptions {
       callout_labels: Vec::new(),
       log_x: false,
       log_y: false,
+      stacked: false,
     }
   }
 }
@@ -1638,8 +1643,31 @@ fn generate_svg_with_options(
             y_max,
           );
 
-          // Draw filled area before the line so the line renders on top
-          if let Some(ref_y) = filling.reference_y(y_min, y_max) {
+          // Draw filled area before the line so the line renders on top.
+          // In stacked mode each band is bounded below by the previous
+          // cumulative curve (or the axis for the first series) and above by
+          // the current one; the bands are disjoint so an opaque polygon fill
+          // renders cleanly. Otherwise fill each segment down to the constant
+          // reference level given by the Filling option.
+          if opts.stacked {
+            let baseline: Vec<(f64, f64)> = if series_idx == 0 {
+              points.iter().map(|&(x, _)| (x, 0.0)).collect()
+            } else {
+              all_points[series_idx - 1].clone()
+            };
+            let mut polygon: Vec<(f64, f64)> = points.to_vec();
+            polygon.extend(baseline.iter().rev().copied());
+            if polygon.len() >= 3 {
+              chart
+                .draw_series(std::iter::once(Polygon::new(
+                  polygon,
+                  RGBColor(r, g, b).mix(0.6),
+                )))
+                .map_err(|e| {
+                  InterpreterError::EvaluationError(format!("Plot: {e}"))
+                })?;
+            }
+          } else if let Some(ref_y) = filling.reference_y(y_min, y_max) {
             for segment in &segments {
               if segment.len() < 2 {
                 continue;

--- a/tests/SUMMARY.md
+++ b/tests/SUMMARY.md
@@ -1365,6 +1365,7 @@
   - [`SectorChart`](plotting/SectorChart.md)
   - [`Show`](plotting/Show.md)
   - [`SphericalPlot3D`](plotting/SphericalPlot3D.md)
+  - [`StackedListPlot`](plotting/StackedListPlot.md)
   - [`StreamDensityPlot`](plotting/StreamDensityPlot.md)
   - [`StreamPlot`](plotting/StreamPlot.md)
   - [`TreeForm`](plotting/TreeForm.md)

--- a/tests/cli/plotting.md
+++ b/tests/cli/plotting.md
@@ -82,6 +82,7 @@ SVG images.
 - [`RevolutionPlot3D`](plotting/RevolutionPlot3D.md)
 - [`SectorChart`](plotting/SectorChart.md)
 - [`SphericalPlot3D`](plotting/SphericalPlot3D.md)
+- [`StackedListPlot`](plotting/StackedListPlot.md)
 - [`StreamDensityPlot`](plotting/StreamDensityPlot.md)
 - [`StreamPlot`](plotting/StreamPlot.md)
 - [`TreeForm`](plotting/TreeForm.md)

--- a/tests/cli/plotting/StackedListPlot.md
+++ b/tests/cli/plotting/StackedListPlot.md
@@ -1,0 +1,17 @@
+# `StackedListPlot`
+
+Plots several datasets with their `y`-values accumulated, so each successive
+dataset is stacked on top of the running total of the preceding ones. The
+regions between consecutive cumulative curves are filled by default.
+
+```scrut
+$ wo 'Head[StackedListPlot[{{1, 2, 3, 4}, {2, 3, 4, 5}}]]'
+Graphics
+```
+
+A single dataset stacks against the axis, like a filled line plot:
+
+```scrut
+$ wo 'Head[StackedListPlot[{1, 2, 3, 4}]]'
+Graphics
+```

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__stacked_list_plot_multiple_series.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__stacked_list_plot_multiple_series.snap
@@ -1,0 +1,159 @@
+---
+source: tests/interpreter_tests/graphics.rs
+expression: "export_svg(\"StackedListPlot[{{1, 2, 3, 4}, {2, 3, 4, 5}}]\")"
+---
+<svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1686" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1686 749,1686 "/>
+<text x="670" y="1601" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1601 749,1601 "/>
+<text x="670" y="1516" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1516 749,1516 "/>
+<text x="670" y="1431" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1431 749,1431 "/>
+<text x="670" y="1346" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1346 749,1346 "/>
+<text x="670" y="1261" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1261 749,1261 "/>
+<text x="670" y="1176" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1176 749,1176 "/>
+<text x="670" y="1091" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1091 749,1091 "/>
+<text x="670" y="1006" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+4
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1006 749,1006 "/>
+<text x="670" y="921" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,921 749,921 "/>
+<text x="670" y="835" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,835 749,835 "/>
+<text x="670" y="750" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,750 749,750 "/>
+<text x="670" y="665" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+6
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,665 749,665 "/>
+<text x="670" y="580" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,580 749,580 "/>
+<text x="670" y="495" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,495 749,495 "/>
+<text x="670" y="410" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,410 749,410 "/>
+<text x="670" y="325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+8
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,325 749,325 "/>
+<text x="670" y="240" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,240 749,240 "/>
+<text x="670" y="155" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,155 749,155 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
+<text x="851" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+1
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="851,1750 851,1790 "/>
+<text x="1021" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1021,1750 1021,1790 "/>
+<text x="1191" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1191,1750 1191,1790 "/>
+<text x="1360" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1360,1750 1360,1790 "/>
+<text x="1530" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1530,1750 1530,1790 "/>
+<text x="1700" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1700,1750 1700,1790 "/>
+<text x="1869" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1869,1750 1869,1790 "/>
+<text x="2039" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2039,1750 2039,1790 "/>
+<text x="2209" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2209,1750 2209,1790 "/>
+<text x="2379" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2379,1750 2379,1790 "/>
+<text x="2548" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+3
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2548,1750 2548,1790 "/>
+<text x="2718" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2718,1750 2718,1790 "/>
+<text x="2888" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2888,1750 2888,1790 "/>
+<text x="3057" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3057,1750 3057,1790 "/>
+<text x="3227" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3227,1750 3227,1790 "/>
+<polyline fill="none" opacity="1" stroke="#CCCCCC" stroke-width="10" points="750,1686 3499,1686 "/>
+<polygon opacity="0.6" fill="#5E81B5" points="851,1516 1700,1346 2548,1176 3397,1006 3397,1686 2548,1686 1700,1686 851,1686 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1516 1700,1346 2548,1176 3397,1006 "/>
+<polygon opacity="0.6" fill="#E0932C" points="851,1176 1700,835 2548,495 3397,155 3397,1006 2548,1176 1700,1346 851,1516 "/>
+<polyline fill="none" opacity="1" stroke="#E0932C" stroke-width="15" points="851,1176 1700,835 2548,495 3397,155 "/>
+<line x1="851.9" y1="1790.0" x2="851.9" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="1700.6" y1="1790.0" x2="1700.6" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2549.4" y1="1790.0" x2="2549.4" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="3398.1" y1="1790.0" x2="3398.1" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1686.5" x2="680.0" y2="1686.5" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1346.1" x2="680.0" y2="1346.1" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1005.6" x2="680.0" y2="1005.6" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="665.2" x2="680.0" y2="665.2" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="324.7" x2="680.0" y2="324.7" stroke="#666" stroke-width="10"/>
+</svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__stacked_list_plot_plot_style.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__stacked_list_plot_plot_style.snap
@@ -1,0 +1,146 @@
+---
+source: tests/interpreter_tests/graphics.rs
+expression: "export_svg(\"StackedListPlot[{{1, 2, 3}, {2, 1, 2}}, PlotStyle -> {Red, Green}]\")"
+---
+<svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1686" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1686 749,1686 "/>
+<text x="670" y="1532" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1532 749,1532 "/>
+<text x="670" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1379 749,1379 "/>
+<text x="670" y="1225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1225 749,1225 "/>
+<text x="670" y="1072" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1072 749,1072 "/>
+<text x="670" y="918" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,918 749,918 "/>
+<text x="670" y="764" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,764 749,764 "/>
+<text x="670" y="611" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,611 749,611 "/>
+<text x="670" y="457" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+4
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,457 749,457 "/>
+<text x="670" y="303" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,303 749,303 "/>
+<text x="670" y="150" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,150 749,150 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
+<text x="851" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+1
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="851,1750 851,1790 "/>
+<text x="979" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="979,1750 979,1790 "/>
+<text x="1106" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1106,1750 1106,1790 "/>
+<text x="1233" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1233,1750 1233,1790 "/>
+<text x="1360" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1360,1750 1360,1790 "/>
+<text x="1488" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+1.5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1488,1750 1488,1790 "/>
+<text x="1615" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1615,1750 1615,1790 "/>
+<text x="1742" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1742,1750 1742,1790 "/>
+<text x="1869" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1869,1750 1869,1790 "/>
+<text x="1997" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1997,1750 1997,1790 "/>
+<text x="2124" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2124,1750 2124,1790 "/>
+<text x="2251" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2251,1750 2251,1790 "/>
+<text x="2379" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2379,1750 2379,1790 "/>
+<text x="2506" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2506,1750 2506,1790 "/>
+<text x="2633" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2633,1750 2633,1790 "/>
+<text x="2760" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+2.5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2760,1750 2760,1790 "/>
+<text x="2888" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2888,1750 2888,1790 "/>
+<text x="3015" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3015,1750 3015,1790 "/>
+<text x="3142" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3142,1750 3142,1790 "/>
+<text x="3269" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3269,1750 3269,1790 "/>
+<polyline fill="none" opacity="1" stroke="#CCCCCC" stroke-width="10" points="750,1686 3499,1686 "/>
+<polygon opacity="0.6" fill="#FF0000" points="851,1379 2124,1072 3397,764 3397,1686 2124,1686 851,1686 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="15" points="851,1379 2124,1072 3397,764 "/>
+<polygon opacity="0.6" fill="#00FF00" points="851,764 2124,764 3397,150 3397,764 2124,1072 851,1379 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="15" points="851,764 2124,764 3397,150 "/>
+<line x1="851.9" y1="1790.0" x2="851.9" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="1488.4" y1="1790.0" x2="1488.4" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2125.0" y1="1790.0" x2="2125.0" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2761.6" y1="1790.0" x2="2761.6" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="3398.1" y1="1790.0" x2="3398.1" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1686.5" x2="680.0" y2="1686.5" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1071.6" x2="680.0" y2="1071.6" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="456.7" x2="680.0" y2="456.7" stroke="#666" stroke-width="10"/>
+</svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__stacked_list_plot_single_series.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__stacked_list_plot_single_series.snap
@@ -1,0 +1,161 @@
+---
+source: tests/interpreter_tests/graphics.rs
+expression: "export_svg(\"StackedListPlot[{1, 2, 3, 4}]\")"
+---
+<svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1686" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1686 749,1686 "/>
+<text x="670" y="1609" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1609 749,1609 "/>
+<text x="670" y="1532" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1532 749,1532 "/>
+<text x="670" y="1455" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1455 749,1455 "/>
+<text x="670" y="1378" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1378 749,1378 "/>
+<text x="670" y="1301" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+1
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1301 749,1301 "/>
+<text x="670" y="1224" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1224 749,1224 "/>
+<text x="670" y="1147" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1147 749,1147 "/>
+<text x="670" y="1070" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1070 749,1070 "/>
+<text x="670" y="993" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,993 749,993 "/>
+<text x="670" y="916" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,916 749,916 "/>
+<text x="670" y="839" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,839 749,839 "/>
+<text x="670" y="762" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,762 749,762 "/>
+<text x="670" y="685" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,685 749,685 "/>
+<text x="670" y="608" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,608 749,608 "/>
+<text x="670" y="532" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+3
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,532 749,532 "/>
+<text x="670" y="455" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,455 749,455 "/>
+<text x="670" y="378" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,378 749,378 "/>
+<text x="670" y="301" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,301 749,301 "/>
+<text x="670" y="224" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,224 749,224 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
+<text x="851" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+1
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="851,1750 851,1790 "/>
+<text x="1021" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1021,1750 1021,1790 "/>
+<text x="1191" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1191,1750 1191,1790 "/>
+<text x="1360" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1360,1750 1360,1790 "/>
+<text x="1530" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1530,1750 1530,1790 "/>
+<text x="1700" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1700,1750 1700,1790 "/>
+<text x="1869" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1869,1750 1869,1790 "/>
+<text x="2039" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2039,1750 2039,1790 "/>
+<text x="2209" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2209,1750 2209,1790 "/>
+<text x="2379" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2379,1750 2379,1790 "/>
+<text x="2548" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+3
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2548,1750 2548,1790 "/>
+<text x="2718" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2718,1750 2718,1790 "/>
+<text x="2888" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2888,1750 2888,1790 "/>
+<text x="3057" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3057,1750 3057,1790 "/>
+<text x="3227" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3227,1750 3227,1790 "/>
+<polyline fill="none" opacity="1" stroke="#CCCCCC" stroke-width="10" points="750,1686 3499,1686 "/>
+<polygon opacity="0.6" fill="#5E81B5" points="851,1301 1700,916 2548,532 3397,147 3397,1686 2548,1686 1700,1686 851,1686 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1301 1700,916 2548,532 3397,147 "/>
+<line x1="851.9" y1="1790.0" x2="851.9" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="1700.6" y1="1790.0" x2="1700.6" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2549.4" y1="1790.0" x2="2549.4" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="3398.1" y1="1790.0" x2="3398.1" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1686.5" x2="680.0" y2="1686.5" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1301.5" x2="680.0" y2="1301.5" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="916.4" x2="680.0" y2="916.4" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="531.3" x2="680.0" y2="531.3" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="146.2" x2="680.0" y2="146.2" stroke="#666" stroke-width="10"/>
+</svg>

--- a/tests/zensical.toml
+++ b/tests/zensical.toml
@@ -1460,6 +1460,7 @@ nav = [
     { "SectorChart" = "plotting/SectorChart.md" },
     { "Show" = "plotting/Show.md" },
     { "SphericalPlot3D" = "plotting/SphericalPlot3D.md" },
+    { "StackedListPlot" = "plotting/StackedListPlot.md" },
     { "StreamDensityPlot" = "plotting/StreamDensityPlot.md" },
     { "StreamPlot" = "plotting/StreamPlot.md" },
     { "TreeForm" = "plotting/TreeForm.md" },


### PR DESCRIPTION
## Summary

Implements `StackedListPlot`, a plotting function that displays multiple datasets with their y-values accumulated cumulatively. Each successive dataset is stacked on top of the running total of preceding ones, with filled regions between consecutive cumulative curves.

## Key Changes

- **New function `stacked_list_plot_ast`** in `src/functions/list_plot.rs`: Parses list data, accumulates y-values across series to create cumulative curves, and generates SVG output with filled stacked bands.

- **Extended `PlotOptions`** in `src/functions/plot.rs`: Added `stacked` boolean flag to indicate stacked mode, which changes how filled areas are rendered. In stacked mode, each band is bounded below by the previous cumulative curve (or the axis for the first series) and above by the current one.

- **Updated SVG generation logic** in `src/functions/plot.rs`: Modified `generate_svg_with_options` to handle stacked mode by drawing opaque polygons between consecutive cumulative curves instead of filling to a constant reference level.

- **Dispatcher integration** in `src/evaluator/dispatch/plotting.rs`: Added routing for `StackedListPlot` function calls.

- **Graphics recognition** in `src/functions/graphics.rs`: Added `StackedListPlot` to the list of graphics-producing functions.

- **Comprehensive test coverage**: Added three snapshot tests covering single series, multiple series, and custom plot styles (colors).

- **Documentation**: Added CLI documentation file and updated function registry (`functions.csv`) with description and implementation status.

## Implementation Details

- The function accumulates y-values by index position across all series, creating cumulative curves where each point's y-value is the sum of all preceding series' y-values at that position.
- Filling defaults to `Axis` (filled bands) unless explicitly overridden by the user.
- Stacked bands are rendered as opaque polygons (60% opacity) with the polygon vertices defined by the current cumulative curve and the previous cumulative curve (or axis for the first series) in reverse order.
- Supports all standard plot options including custom `PlotStyle` for individual series colors.

https://claude.ai/code/session_018mArT1qHZyErvvhB2vaya8