### PR TITLE
Initial Windows build support

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,6 +2,12 @@
 # .bin/ contains wolframscript and wo wrappers for Docker environments.
 export PATH := $(CURDIR)/.bin:$(HOME)/.cargo/bin:$(PATH)
 
+ifeq ($(OS),Windows_NT)
+DEV_NULL = NUL:
+else
+DEV_NULL = /dev/null
+endif
+
 .PHONY: help
 help: makefile
 	@tail -n +4 makefile | grep ".PHONY"
@@ -110,9 +116,9 @@ test-docker:
 
 .PHONY: format
 format:
-	cargo clippy --fix --allow-dirty > /dev/null 2>&1
+	cargo clippy --fix --allow-dirty > $(DEV_NULL) 2>&1
 	cargo fmt
-	# nix fmt
+#	nix fmt
 
 
 .PHONY: install-cli

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -202,13 +202,15 @@ fn run_notebook_notebook_directory_resolves_to_file_dir() {
   let _ = std::fs::remove_file(&path);
   assert!(ok, "woxi run notebook failed: stderr={}", stderr);
   // The canonical temp dir, with a trailing separator (WL convention).
-  let expected = format!("{}/", dir.to_string_lossy().trim_end_matches('/'));
+  let sep = std::path::MAIN_SEPARATOR;
+  let expected =
+    format!("{}{}", dir.to_string_lossy().trim_end_matches(sep), sep);
   assert!(
     !stderr.contains("nosv"),
     "NotebookDirectory emitted nosv message: stderr={}",
     stderr
   );
-  assert_eq!(stdout.trim(), expected.trim_end_matches('/'));
+  assert_eq!(stdout.trim(), expected.trim_end_matches(sep));
 }
 
 /// Pipe a REPL session's input via stdin and capture (stdout, stderr, ok).


### PR DESCRIPTION
These are some minor changes to get make format and make test (kinda) working on Windows.

First I needed a compatible environment.

1. I installed Rust using the Windows installer, and accepted the defaults.
2. GNU tools are mostly provided by my Git install.  I had to tweak the PATH so that GNU find.exe was used, not the Windows native version.
3. I added version 3.81 of make.exe from GnuWin32, which is quite old.
4. I installed cargo-binstall manually by downloading and copying the exe into .cargo/bin.
5. nextest was missing, cargo binstall cargo-nextest --secure installed it.

make format then reminds us that /dev/null is not a device on Windows.  Replacing it with NUL: resolves this issue.  It also shows that in old versions of make the # comment start must be the first character.  Rather than track down a newer version of make I just patched out one case of this for now.

make test fails of course.  I fixed one test, and will start fixing/skipping more tests, but I wanted to push this to see if the changes thus far are acceptable.