### PR TITLE
Implement Molecule chemistry functions with SMILES parsing

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1978,7 +1978,7 @@ DeleteStopwords,Remove stopwords from text (NLP),🚫,,10.1,2012
 Downsample,Take every n-th element from a list,✅,none,9.0,2012
 SliceContourPlot3D,3D contour slice plot (plotting),🚫,,10.2,2012
 FieldHint,Input field hint text option (GUI),🚫,,8.0,2015
-Molecule,Chemical molecule representation (chemistry),🚫,,12.0,2015
+Molecule,Chemical molecule representation (chemistry),✅,pure,12.0,2015
 ShowCellBracket,Notebook cell bracket display option (GUI),🚫,,3.0,2015
 FileByteCount,Count bytes in file (file I/O),✅,,2.0,2018
 NegativeBinomialDistribution,Discrete distribution for number of failures before n successes,✅,none,6.0,2018
@@ -2024,7 +2024,7 @@ MachineNumberQ,Test whether an expression is a machine-precision real number,✅
 TextString,Convert any expression to a human-readable string,✅,1,10.0,2059
 ContainsAny,Test if any elements of the second list appear in the first,✅,none,10.2,2061
 ImagePerspectiveTransformation,Perspective transform on image,🚫,,8.0,2061
-Atom,Basic building block,🚫,,12.0,2065
+Atom,Represents an atom in a molecule (chemistry),✅,pure,12.0,2065
 InverseSeries,Computes the reversion (inverse) of a power series,✅,pure,1.0,2065
 RootMeanSquare,Returns the root mean square of a list,✅,pure,6.0,2065
 SquareMatrixQ,Test if an expression is a square matrix,✅,none,10.0,2065
@@ -3978,7 +3978,7 @@ URLDownloadSubmit,,🚫,,11.2,4081
 UpperRightArrow,,,,3.0,4081
 AskDisplay,,🚫,,10.4,4104
 AsymptoticEqual,,,,11.3,4104
-AtomList,,,,12.0,4104
+AtomList,List of atoms in a molecule,✅,pure,12.0,4104
 AutoItalicWords,,,,3.0,4104
 CircularOrthogonalMatrixDistribution,,,,10.3,4104
 DayHemisphere,,,,10.0,4104
@@ -4107,7 +4107,7 @@ GaussianWindow,Gaussian window function E^(-x^2/(2 sigma^2)) on [-1/2 1/2] (defa
 ImageCapture,,🚫,,8.0,4225
 MaxDuration,,,,11.2,4225
 MaxMixtureKernels,,,,8.0,4225
-MoleculeValue,,🚫,,12.0,4225
+MoleculeValue,Computes properties of a molecule,✅,pure,12.0,4225
 NumberDecompose,Greedy decomposition of a number into unit multiples,✅,pure,10.2,4225
 ReferenceLineStyle,,,,8.0,4225
 SequenceFold,Fold over a list keeping an n-element history at each step and returning the last result,✅,pure,10.2,4225
@@ -4747,7 +4747,7 @@ MassTransferValue,,,,12.2,4947
 MathieuGroupM23,,,,8.0,4947
 MeanDegreeConnectivity,Mean neighbor degree of vertices indexed by degree,✅,pure,9.0,4947
 MoleculeProperty,,🚫,,12.0,4947
-MoleculeQ,,🚫,,12.0,4947
+MoleculeQ,Tests whether an expression is a valid molecule,✅,pure,12.0,4947
 OutputPorts,,,,12.2,4947
 ParticleAcceleratorData,,🚫,,10.0,4947
 PersistenceTime,,🚫,,11.1,4947
@@ -4998,7 +4998,7 @@ AutocompletionFunction,,🚫,,10.2,5390
 BaseDecode,Base64-decode a string to a ByteArray,✅,pure,11.3,5390
 BinomialPointProcess,,🚫,,12.2,5390
 BlockchainContractValue,,🚫,,12.0,5390
-BondList,,,,12.0,5390
+BondList,List of bonds in a molecule,✅,pure,12.0,5390
 ByteArrayFormatQ,,,,12.2,5390
 CTCLossLayer,,🚫,,11.3,5390
 CaptureRunning,,🚫,,11.2,5390

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -1558,6 +1558,26 @@ pub fn evaluate_function_call_ast_inner(
     return crate::functions::element_data::element_data_ast(args);
   }
 
+  // Chemistry: molecules and their properties
+  match name {
+    "Molecule" => {
+      return crate::functions::molecule_ast::molecule_ast(args);
+    }
+    "MoleculeQ" => {
+      return crate::functions::molecule_ast::molecule_q_ast(args);
+    }
+    "AtomList" => {
+      return crate::functions::molecule_ast::atom_list_ast(args);
+    }
+    "BondList" => {
+      return crate::functions::molecule_ast::bond_list_ast(args);
+    }
+    "MoleculeValue" => {
+      return crate::functions::molecule_ast::molecule_value_ast(args);
+    }
+    _ => {}
+  }
+
   // Entity store functions
   match name {
     "EntityStore" => {
@@ -2029,6 +2049,7 @@ pub fn evaluate_function_call_ast_inner(
     | "Offset"
     | "RowBox"
     | "Bond"
+    | "Atom"
     | "Colon"
     | "Cap"
     | "Cup"

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -922,6 +922,28 @@ pub fn apply_curried_call(
         }),
       }
     }
+    // Molecule[…]["property"] — property access on a molecule object
+    // (e.g. "AtomCount", "MolecularFormula"). Unsupported properties and
+    // invalid molecules keep the curried form unevaluated.
+    Expr::FunctionCall {
+      name,
+      args: func_args,
+    } if name == "Molecule"
+      && args.len() == 1
+      && matches!(&args[0], Expr::String(_)) =>
+    {
+      let Expr::String(prop) = &args[0] else {
+        unreachable!()
+      };
+      match crate::functions::molecule_ast::molecule_property(func_args, prop)
+      {
+        Some(result) => Ok(result),
+        None => Ok(Expr::CurriedCall {
+          func: Box::new(func.clone()),
+          args: args.to_vec(),
+        }),
+      }
+    }
     // TimeSeries[…][t] — value lookup at time `t` (a date or number) or, for a
     // string argument, a path-property accessor (e.g. ts["Values"], ts["Path"]).
     Expr::FunctionCall { name, .. }

--- a/src/functions/element_data.rs
+++ b/src/functions/element_data.rs
@@ -2251,6 +2251,22 @@ pub fn resolve_atomic_number(identifier: &Expr) -> Option<i128> {
   find_element(identifier).map(|e| e.atomic_number)
 }
 
+/// Exact-match check that `sym` is a chemical element abbreviation
+/// ("C", "Cl", …). Case-sensitive: molecule atom symbols must use the
+/// canonical capitalization.
+pub fn is_element_abbreviation(sym: &str) -> bool {
+  ELEMENTS.iter().any(|e| e.abbreviation == sym)
+}
+
+/// Abbreviation ("C", "Cl", …) of the element with the given atomic number.
+pub fn abbreviation_for_atomic_number(z: i128) -> Option<&'static str> {
+  if (1..=118).contains(&z) {
+    Some(ELEMENTS[(z - 1) as usize].abbreviation)
+  } else {
+    None
+  }
+}
+
 /// Look up an element by name (case-insensitive), abbreviation, or atomic number
 fn find_element(identifier: &Expr) -> Option<&'static Element> {
   match identifier {

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -36,6 +36,7 @@ pub mod list_helpers_ast;
 pub mod list_plot;
 pub mod math_ast;
 pub mod memory;
+pub mod molecule_ast;
 pub mod music_ast;
 pub mod music_font;
 pub mod music_midi;

--- a/src/functions/molecule_ast.rs
+++ b/src/functions/molecule_ast.rs
@@ -1,0 +1,951 @@
+//! AST-native chemistry functions.
+//!
+//! Implements Molecule, MoleculeQ, AtomList, BondList, MoleculeValue, and
+//! molecule property access (`mol["AtomCount"]`).
+//!
+//! A molecule's canonical form is
+//! `Molecule[{Atom["sym", opts…], …}, {Bond[{i, j}, "type"], …}]`,
+//! matching the evaluated form wolframscript produces. Strings are
+//! interpreted first as chemical names (via a built-in name → SMILES table)
+//! and then as SMILES structure specifications. Hydrogen atoms are added
+//! explicitly to fill the normal valences, as wolframscript does.
+
+use crate::InterpreterError;
+use crate::functions::element_data::{
+  abbreviation_for_atomic_number, is_element_abbreviation,
+};
+use crate::syntax::Expr;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum BondKind {
+  Single,
+  Double,
+  Triple,
+  Aromatic,
+}
+
+impl BondKind {
+  fn as_str(self) -> &'static str {
+    match self {
+      BondKind::Single => "Single",
+      BondKind::Double => "Double",
+      BondKind::Triple => "Triple",
+      BondKind::Aromatic => "Aromatic",
+    }
+  }
+
+  fn from_str(s: &str) -> Option<Self> {
+    match s {
+      "Single" => Some(BondKind::Single),
+      "Double" => Some(BondKind::Double),
+      "Triple" => Some(BondKind::Triple),
+      "Aromatic" => Some(BondKind::Aromatic),
+      _ => None,
+    }
+  }
+
+  /// Integer bond order used for valence bookkeeping. Aromatic bonds count
+  /// as one σ-bond; the delocalized π-system is accounted for separately.
+  fn order(self) -> u32 {
+    match self {
+      BondKind::Single | BondKind::Aromatic => 1,
+      BondKind::Double => 2,
+      BondKind::Triple => 3,
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+struct AtomData {
+  symbol: String,
+  formal_charge: i64,
+  mass_number: Option<i64>,
+  /// Lowercase (aromatic) atom in SMILES input.
+  aromatic: bool,
+  /// Hydrogen count given explicitly in a SMILES bracket atom. `None` means
+  /// "fill the normal valence"; bracket atoms always specify it (default 0).
+  explicit_h: Option<u32>,
+}
+
+impl AtomData {
+  fn plain(symbol: &str) -> Self {
+    AtomData {
+      symbol: symbol.to_string(),
+      formal_charge: 0,
+      mass_number: None,
+      aromatic: false,
+      explicit_h: None,
+    }
+  }
+}
+
+/// A molecular graph with 0-based atom indices.
+struct MolGraph {
+  atoms: Vec<AtomData>,
+  bonds: Vec<(usize, usize, BondKind)>,
+}
+
+// ---------------------------------------------------------------------------
+// Chemical name database
+// ---------------------------------------------------------------------------
+
+/// Common chemical names resolvable without the Wolfram curated data
+/// service. Keys are lowercase; lookup normalizes case and whitespace.
+static NAME_TO_SMILES: &[(&str, &str)] = &[
+  ("acetaldehyde", "CC=O"),
+  ("acetaminophen", "CC(=O)Nc1ccc(O)cc1"),
+  ("acetic acid", "CC(=O)O"),
+  ("acetone", "CC(=O)C"),
+  ("acetylene", "C#C"),
+  ("alanine", "CC(N)C(=O)O"),
+  ("ammonia", "N"),
+  ("aniline", "Nc1ccccc1"),
+  ("aspirin", "CC(=O)Oc1ccccc1C(=O)O"),
+  ("benzene", "c1ccccc1"),
+  ("benzoic acid", "OC(=O)c1ccccc1"),
+  ("butane", "CCCC"),
+  ("caffeine", "CN1C=NC2=C1C(=O)N(C)C(=O)N2C"),
+  ("carbon dioxide", "O=C=O"),
+  ("carbon monoxide", "[C-]#[O+]"),
+  ("carbon tetrachloride", "ClC(Cl)(Cl)Cl"),
+  ("chloroform", "ClC(Cl)Cl"),
+  ("chloromethane", "CCl"),
+  ("cyclohexane", "C1CCCCC1"),
+  ("cyclopropane", "C1CC1"),
+  ("dichloromethane", "ClCCl"),
+  ("diethyl ether", "CCOCC"),
+  ("dimethyl ether", "COC"),
+  ("ethane", "CC"),
+  ("ethanol", "CCO"),
+  ("ethylene", "C=C"),
+  ("ethylene glycol", "OCCO"),
+  ("formaldehyde", "C=O"),
+  ("formic acid", "OC=O"),
+  ("furan", "c1ccoc1"),
+  ("glucose", "OCC1OC(O)C(O)C(O)C1O"),
+  ("glycerol", "OCC(O)CO"),
+  ("glycine", "NCC(=O)O"),
+  ("hexane", "CCCCCC"),
+  ("hydrochloric acid", "Cl"),
+  ("hydrogen", "[H][H]"),
+  ("hydrogen chloride", "Cl"),
+  ("hydrogen peroxide", "OO"),
+  ("hydrogen sulfide", "S"),
+  ("ibuprofen", "CC(C)Cc1ccc(cc1)C(C)C(=O)O"),
+  ("imidazole", "c1c[nH]cn1"),
+  ("isopropanol", "CC(C)O"),
+  ("methane", "C"),
+  ("methanol", "CO"),
+  ("methylamine", "CN"),
+  ("naphthalene", "c1ccc2ccccc2c1"),
+  ("nicotine", "CN1CCCC1c1cccnc1"),
+  ("nitric acid", "O[N+](=O)[O-]"),
+  ("nitrogen", "N#N"),
+  ("nitrous oxide", "[N-]=[N+]=O"),
+  ("oxygen", "O=O"),
+  ("ozone", "[O-][O+]=O"),
+  ("paracetamol", "CC(=O)Nc1ccc(O)cc1"),
+  ("pentane", "CCCCC"),
+  ("phenol", "Oc1ccccc1"),
+  ("phosphoric acid", "OP(=O)(O)O"),
+  ("propane", "CCC"),
+  ("pyridine", "c1ccncc1"),
+  ("pyrrole", "c1cc[nH]c1"),
+  ("sodium chloride", "[Na+].[Cl-]"),
+  ("styrene", "C=Cc1ccccc1"),
+  ("sulfur dioxide", "O=S=O"),
+  ("sulfuric acid", "OS(=O)(=O)O"),
+  ("tetrahydrofuran", "C1CCOC1"),
+  ("toluene", "Cc1ccccc1"),
+  ("urea", "NC(N)=O"),
+  ("water", "O"),
+];
+
+fn smiles_for_name(name: &str) -> Option<&'static str> {
+  let normalized = name
+    .to_lowercase()
+    .split_whitespace()
+    .collect::<Vec<_>>()
+    .join(" ");
+  NAME_TO_SMILES
+    .iter()
+    .find(|(n, _)| *n == normalized)
+    .map(|(_, s)| *s)
+}
+
+// ---------------------------------------------------------------------------
+// SMILES parsing
+// ---------------------------------------------------------------------------
+
+/// Elements of the SMILES "organic subset", writable without brackets and
+/// eligible for implicit hydrogen filling.
+fn organic_subset_valences(symbol: &str) -> Option<&'static [u32]> {
+  match symbol {
+    "B" => Some(&[3]),
+    "C" => Some(&[4]),
+    "N" => Some(&[3, 5]),
+    "O" => Some(&[2]),
+    "P" => Some(&[3, 5]),
+    "S" => Some(&[2, 4, 6]),
+    "F" | "Cl" | "Br" | "I" => Some(&[1]),
+    _ => None,
+  }
+}
+
+/// Charge-adjusted valence: `B` gains a bond per negative charge, `C` loses
+/// a bond per unit of charge of either sign, and the more electronegative
+/// elements (N, O, P, S, halogens) gain a bond per positive charge.
+fn adjust_valence(symbol: &str, valence: u32, charge: i64) -> u32 {
+  let v = valence as i64;
+  let adjusted = match symbol {
+    "B" => v - charge,
+    "C" => v - charge.abs(),
+    _ => v + charge,
+  };
+  adjusted.max(0) as u32
+}
+
+struct SmilesParser<'a> {
+  bytes: &'a [u8],
+  pos: usize,
+  graph: MolGraph,
+  /// Atom the next bond attaches to.
+  prev: Option<usize>,
+  /// Open branch atoms.
+  stack: Vec<usize>,
+  /// Explicit bond symbol waiting for the next atom or ring closure.
+  pending: Option<BondKind>,
+  /// Open ring closures: number → (atom index, explicit bond at opening).
+  rings: Vec<(u32, usize, Option<BondKind>)>,
+}
+
+impl<'a> SmilesParser<'a> {
+  fn new(input: &'a str) -> Self {
+    SmilesParser {
+      bytes: input.as_bytes(),
+      pos: 0,
+      graph: MolGraph {
+        atoms: Vec::new(),
+        bonds: Vec::new(),
+      },
+      prev: None,
+      stack: Vec::new(),
+      pending: None,
+      rings: Vec::new(),
+    }
+  }
+
+  fn peek(&self) -> Option<u8> {
+    self.bytes.get(self.pos).copied()
+  }
+
+  /// Default bond kind between two atoms without an explicit bond symbol.
+  fn implied_bond(&self, a: usize, b: usize) -> BondKind {
+    if self.graph.atoms[a].aromatic && self.graph.atoms[b].aromatic {
+      BondKind::Aromatic
+    } else {
+      BondKind::Single
+    }
+  }
+
+  fn add_atom(&mut self, atom: AtomData) {
+    self.graph.atoms.push(atom);
+    let idx = self.graph.atoms.len() - 1;
+    if let Some(p) = self.prev {
+      let kind = self
+        .pending
+        .take()
+        .unwrap_or_else(|| self.implied_bond(p, idx));
+      self.graph.bonds.push((p, idx, kind));
+    } else {
+      self.pending = None;
+    }
+    self.prev = Some(idx);
+  }
+
+  fn ring_closure(&mut self, number: u32) -> Option<()> {
+    let cur = self.prev?;
+    let here = self.pending.take();
+    if let Some(open_pos) =
+      self.rings.iter().position(|(n, _, _)| *n == number)
+    {
+      let (_, open_atom, open_bond) = self.rings.remove(open_pos);
+      if open_atom == cur {
+        return None; // ring bond to itself
+      }
+      // The bond symbol may be written at either end; they must agree.
+      let kind = match (open_bond, here) {
+        (Some(a), Some(b)) if a != b => return None,
+        (Some(k), _) | (_, Some(k)) => k,
+        (None, None) => self.implied_bond(open_atom, cur),
+      };
+      self.graph.bonds.push((open_atom, cur, kind));
+    } else {
+      self.rings.push((number, cur, here));
+    }
+    Some(())
+  }
+
+  /// Parse a bracket atom starting after `[`. Grammar:
+  /// `[` isotope? symbol chiral? hcount? charge? class? `]`
+  fn parse_bracket_atom(&mut self) -> Option<AtomData> {
+    // isotope
+    let mut mass: Option<i64> = None;
+    while let Some(c) = self.peek() {
+      if c.is_ascii_digit() {
+        mass = Some(mass.unwrap_or(0) * 10 + (c - b'0') as i64);
+        self.pos += 1;
+      } else {
+        break;
+      }
+    }
+    // element symbol: uppercase (+ optional lowercase), or a lowercase
+    // aromatic symbol
+    let first = self.peek()?;
+    let (symbol, aromatic) = if first.is_ascii_uppercase() {
+      self.pos += 1;
+      let mut sym = (first as char).to_string();
+      if let Some(c) = self.peek()
+        && c.is_ascii_lowercase()
+        && is_element_abbreviation(&format!("{}{}", sym, c as char))
+      {
+        sym.push(c as char);
+        self.pos += 1;
+      }
+      (sym, false)
+    } else if first.is_ascii_lowercase() {
+      // aromatic symbols allowed in brackets: b, c, n, o, p, s, se, as, te, si
+      let two = self.bytes.get(self.pos..self.pos + 2).map(|w| {
+        std::str::from_utf8(w).unwrap_or_default().to_string()
+      });
+      match two.as_deref() {
+        Some("se") | Some("as") | Some("te") | Some("si") => {
+          self.pos += 2;
+          let s = two.unwrap();
+          let mut chars = s.chars();
+          let cap: String = chars
+            .next()
+            .map(|c| c.to_ascii_uppercase())
+            .into_iter()
+            .chain(chars)
+            .collect();
+          (cap, true)
+        }
+        _ => {
+          if !matches!(first, b'b' | b'c' | b'n' | b'o' | b'p' | b's') {
+            return None;
+          }
+          self.pos += 1;
+          ((first as char).to_ascii_uppercase().to_string(), true)
+        }
+      }
+    } else {
+      return None;
+    };
+    if !is_element_abbreviation(&symbol) {
+      return None;
+    }
+    // chirality (ignored: stereochemistry is not represented)
+    while self.peek() == Some(b'@') {
+      self.pos += 1;
+    }
+    // hydrogen count
+    let mut hcount: u32 = 0;
+    if self.peek() == Some(b'H') {
+      self.pos += 1;
+      hcount = 1;
+      let mut digits = 0u32;
+      while let Some(c) = self.peek() {
+        if c.is_ascii_digit() {
+          if digits == 0 {
+            hcount = 0;
+          }
+          hcount = hcount * 10 + (c - b'0') as u32;
+          digits += 1;
+          self.pos += 1;
+        } else {
+          break;
+        }
+      }
+    }
+    // charge: +, -, ++, --, +2, -3, …
+    let mut charge: i64 = 0;
+    if let Some(sign @ (b'+' | b'-')) = self.peek() {
+      let unit: i64 = if sign == b'+' { 1 } else { -1 };
+      self.pos += 1;
+      charge = unit;
+      if let Some(c) = self.peek()
+        && c.is_ascii_digit()
+      {
+        let mut magnitude: i64 = 0;
+        while let Some(c) = self.peek() {
+          if c.is_ascii_digit() {
+            magnitude = magnitude * 10 + (c - b'0') as i64;
+            self.pos += 1;
+          } else {
+            break;
+          }
+        }
+        charge = unit * magnitude;
+      } else {
+        while self.peek() == Some(sign) {
+          charge += unit;
+          self.pos += 1;
+        }
+      }
+    }
+    // atom class (ignored)
+    if self.peek() == Some(b':') {
+      self.pos += 1;
+      let mut saw_digit = false;
+      while let Some(c) = self.peek() {
+        if c.is_ascii_digit() {
+          saw_digit = true;
+          self.pos += 1;
+        } else {
+          break;
+        }
+      }
+      if !saw_digit {
+        return None;
+      }
+    }
+    if self.peek() != Some(b']') {
+      return None;
+    }
+    self.pos += 1;
+    Some(AtomData {
+      symbol,
+      formal_charge: charge,
+      mass_number: mass,
+      aromatic,
+      explicit_h: Some(hcount),
+    })
+  }
+
+  fn parse(mut self) -> Option<MolGraph> {
+    while let Some(c) = self.peek() {
+      match c {
+        b'(' => {
+          self.stack.push(self.prev?);
+          self.pos += 1;
+        }
+        b')' => {
+          if self.pending.is_some() {
+            return None;
+          }
+          self.prev = Some(self.stack.pop()?);
+          self.pos += 1;
+        }
+        b'-' => {
+          self.pending = Some(BondKind::Single);
+          self.pos += 1;
+        }
+        b'=' => {
+          self.pending = Some(BondKind::Double);
+          self.pos += 1;
+        }
+        b'#' => {
+          self.pending = Some(BondKind::Triple);
+          self.pos += 1;
+        }
+        b':' => {
+          self.pending = Some(BondKind::Aromatic);
+          self.pos += 1;
+        }
+        // Directional (stereo) bonds are treated as plain single bonds.
+        b'/' | b'\\' => {
+          self.pending = Some(BondKind::Single);
+          self.pos += 1;
+        }
+        b'.' => {
+          if self.pending.is_some() {
+            return None;
+          }
+          self.prev = None;
+          self.pos += 1;
+        }
+        b'%' => {
+          self.pos += 1;
+          let d1 = self.peek()?;
+          self.pos += 1;
+          let d2 = self.peek()?;
+          self.pos += 1;
+          if !d1.is_ascii_digit() || !d2.is_ascii_digit() {
+            return None;
+          }
+          let number = ((d1 - b'0') as u32) * 10 + (d2 - b'0') as u32;
+          self.ring_closure(number)?;
+        }
+        b'0'..=b'9' => {
+          self.pos += 1;
+          self.ring_closure((c - b'0') as u32)?;
+        }
+        b'[' => {
+          self.pos += 1;
+          let atom = self.parse_bracket_atom()?;
+          self.add_atom(atom);
+        }
+        b'B' | b'C' | b'N' | b'O' | b'P' | b'S' | b'F' | b'I' => {
+          self.pos += 1;
+          let mut sym = (c as char).to_string();
+          // two-letter organic-subset symbols: Cl, Br
+          if let Some(next) = self.peek()
+            && ((c == b'C' && next == b'l') || (c == b'B' && next == b'r'))
+          {
+            sym.push(next as char);
+            self.pos += 1;
+          }
+          self.add_atom(AtomData::plain(&sym));
+        }
+        b'b' | b'c' | b'n' | b'o' | b'p' | b's' => {
+          self.pos += 1;
+          let mut atom =
+            AtomData::plain(&(c as char).to_ascii_uppercase().to_string());
+          atom.aromatic = true;
+          self.add_atom(atom);
+        }
+        _ => return None,
+      }
+    }
+    if !self.rings.is_empty()
+      || !self.stack.is_empty()
+      || self.pending.is_some()
+      || self.graph.atoms.is_empty()
+    {
+      return None;
+    }
+    Some(self.graph)
+  }
+}
+
+fn parse_smiles(input: &str) -> Option<MolGraph> {
+  SmilesParser::new(input).parse()
+}
+
+// ---------------------------------------------------------------------------
+// Hydrogen filling
+// ---------------------------------------------------------------------------
+
+/// Append explicit hydrogen atoms filling each atom's normal valence, the
+/// way wolframscript canonicalizes molecules. Bracket SMILES atoms carry
+/// their hydrogen count explicitly; other atoms of the organic subset are
+/// filled up to the smallest charge-adjusted valence that fits the existing
+/// bonds. Atoms that already take part in an aromatic bond but were not
+/// parsed from SMILES (no aromatic flag) are left untouched: their hydrogen
+/// count is not deducible without kekulization.
+fn add_explicit_hydrogens(graph: &mut MolGraph) {
+  let heavy_count = graph.atoms.len();
+  let mut h_counts: Vec<u32> = vec![0; heavy_count];
+  for (i, atom) in graph.atoms.iter().enumerate() {
+    if let Some(h) = atom.explicit_h {
+      h_counts[i] = h;
+      continue;
+    }
+    if atom.symbol == "H" {
+      continue;
+    }
+    let Some(valences) = organic_subset_valences(&atom.symbol) else {
+      continue;
+    };
+    let mut bond_sum: u32 = 0;
+    let mut has_aromatic_bond = false;
+    for (a, b, kind) in &graph.bonds {
+      if *a == i || *b == i {
+        bond_sum += kind.order();
+        if *kind == BondKind::Aromatic {
+          has_aromatic_bond = true;
+        }
+      }
+    }
+    if atom.aromatic || has_aromatic_bond {
+      if !atom.aromatic {
+        continue;
+      }
+      // One valence slot is consumed by the delocalized π-system.
+      bond_sum += 1;
+    }
+    let h = valences
+      .iter()
+      .map(|v| adjust_valence(&atom.symbol, *v, atom.formal_charge))
+      .filter(|v| *v >= bond_sum)
+      .map(|v| v - bond_sum)
+      .next()
+      .unwrap_or(0);
+    h_counts[i] = h;
+  }
+  for (i, count) in h_counts.iter().enumerate() {
+    for _ in 0..*count {
+      graph.atoms.push(AtomData::plain("H"));
+      let h_idx = graph.atoms.len() - 1;
+      graph.bonds.push((i, h_idx, BondKind::Single));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Conversion between MolGraph and Expr
+// ---------------------------------------------------------------------------
+
+fn rule(key: &str, value: Expr) -> Expr {
+  Expr::Rule {
+    pattern: Box::new(Expr::String(key.to_string())),
+    replacement: Box::new(value),
+  }
+}
+
+fn atom_to_expr(atom: &AtomData) -> Expr {
+  let mut args = vec![Expr::String(atom.symbol.clone())];
+  if atom.formal_charge != 0 {
+    args.push(rule(
+      "FormalCharge",
+      Expr::Integer(atom.formal_charge as i128),
+    ));
+  }
+  if let Some(mass) = atom.mass_number {
+    args.push(rule("MassNumber", Expr::Integer(mass as i128)));
+  }
+  Expr::FunctionCall {
+    name: "Atom".to_string(),
+    args: args.into(),
+  }
+}
+
+fn bond_to_expr(bond: &(usize, usize, BondKind)) -> Expr {
+  Expr::FunctionCall {
+    name: "Bond".to_string(),
+    args: vec![
+      Expr::List(
+        vec![
+          Expr::Integer((bond.0 + 1) as i128),
+          Expr::Integer((bond.1 + 1) as i128),
+        ]
+        .into(),
+      ),
+      Expr::String(bond.2.as_str().to_string()),
+    ]
+    .into(),
+  }
+}
+
+fn graph_to_expr(graph: &MolGraph) -> Expr {
+  Expr::FunctionCall {
+    name: "Molecule".to_string(),
+    args: vec![
+      Expr::List(graph.atoms.iter().map(atom_to_expr).collect::<Vec<_>>().into()),
+      Expr::List(graph.bonds.iter().map(bond_to_expr).collect::<Vec<_>>().into()),
+    ]
+    .into(),
+  }
+}
+
+/// Parse one atom specification: `"C"`, an atomic number, or
+/// `Atom["C", "FormalCharge" -> -1, "MassNumber" -> 13]`.
+fn atom_from_expr(expr: &Expr) -> Option<AtomData> {
+  match expr {
+    Expr::String(sym) => {
+      if is_element_abbreviation(sym) {
+        Some(AtomData::plain(sym))
+      } else {
+        None
+      }
+    }
+    Expr::Integer(z) => {
+      abbreviation_for_atomic_number(*z).map(AtomData::plain)
+    }
+    Expr::FunctionCall { name, args } if name == "Atom" && !args.is_empty() => {
+      let Expr::String(sym) = &args[0] else {
+        return None;
+      };
+      if !is_element_abbreviation(sym) {
+        return None;
+      }
+      let mut atom = AtomData::plain(sym);
+      for opt in &args[1..] {
+        let Expr::Rule {
+          pattern,
+          replacement,
+        } = opt
+        else {
+          return None;
+        };
+        let Expr::String(key) = pattern.as_ref() else {
+          return None;
+        };
+        let Expr::Integer(value) = replacement.as_ref() else {
+          return None;
+        };
+        match key.as_str() {
+          "FormalCharge" => atom.formal_charge = *value as i64,
+          "MassNumber" => atom.mass_number = Some(*value as i64),
+          _ => return None,
+        }
+      }
+      Some(atom)
+    }
+    _ => None,
+  }
+}
+
+/// Parse one bond specification: `Bond[{i, j}]` or `Bond[{i, j}, "type"]`,
+/// with 1-based indices into an atom list of length `atom_count`.
+fn bond_from_expr(
+  expr: &Expr,
+  atom_count: usize,
+) -> Option<(usize, usize, BondKind)> {
+  let Expr::FunctionCall { name, args } = expr else {
+    return None;
+  };
+  if name != "Bond" || args.is_empty() || args.len() > 2 {
+    return None;
+  }
+  let Expr::List(pair) = &args[0] else {
+    return None;
+  };
+  if pair.len() != 2 {
+    return None;
+  }
+  let (Expr::Integer(i), Expr::Integer(j)) = (&pair[0], &pair[1]) else {
+    return None;
+  };
+  let kind = match args.get(1) {
+    None => BondKind::Single,
+    Some(Expr::String(s)) => BondKind::from_str(s)?,
+    Some(_) => return None,
+  };
+  let (i, j) = (*i, *j);
+  let n = atom_count as i128;
+  if i < 1 || j < 1 || i > n || j > n || i == j {
+    return None;
+  }
+  Some(((i - 1) as usize, (j - 1) as usize, kind))
+}
+
+/// Build a molecular graph from explicit atom and bond lists. Returns None
+/// if any specification is invalid.
+fn graph_from_lists(atoms: &[Expr], bonds: &[Expr]) -> Option<MolGraph> {
+  let atom_data: Vec<AtomData> = atoms
+    .iter()
+    .map(atom_from_expr)
+    .collect::<Option<Vec<_>>>()?;
+  let bond_data: Vec<(usize, usize, BondKind)> = bonds
+    .iter()
+    .map(|b| bond_from_expr(b, atom_data.len()))
+    .collect::<Option<Vec<_>>>()?;
+  Some(MolGraph {
+    atoms: atom_data,
+    bonds: bond_data,
+  })
+}
+
+/// Extract the validated graph from an already-evaluated
+/// `Molecule[{atoms…}, {bonds…}]` expression.
+fn graph_from_molecule_expr(expr: &Expr) -> Option<MolGraph> {
+  let Expr::FunctionCall { name, args } = expr else {
+    return None;
+  };
+  if name != "Molecule" || args.len() != 2 {
+    return None;
+  }
+  let (Expr::List(atoms), Expr::List(bonds)) = (&args[0], &args[1]) else {
+    return None;
+  };
+  graph_from_lists(atoms, bonds)
+}
+
+// ---------------------------------------------------------------------------
+// Molecular formula (Hill order)
+// ---------------------------------------------------------------------------
+
+fn molecular_formula(graph: &MolGraph) -> String {
+  let mut counts: Vec<(String, usize)> = Vec::new();
+  for atom in &graph.atoms {
+    match counts.iter_mut().find(|(s, _)| *s == atom.symbol) {
+      Some((_, c)) => *c += 1,
+      None => counts.push((atom.symbol.clone(), 1)),
+    }
+  }
+  let has_carbon = counts.iter().any(|(s, _)| s == "C");
+  counts.sort_by(|(a, _), (b, _)| {
+    let rank = |s: &str| -> (u8, String) {
+      if has_carbon {
+        match s {
+          "C" => (0, String::new()),
+          "H" => (1, String::new()),
+          _ => (2, s.to_string()),
+        }
+      } else {
+        (2, s.to_string())
+      }
+    };
+    rank(a).cmp(&rank(b))
+  });
+  let mut formula = String::new();
+  for (symbol, count) in &counts {
+    formula.push_str(symbol);
+    if *count > 1 {
+      formula.push_str(&count.to_string());
+    }
+  }
+  let net_charge: i64 = graph.atoms.iter().map(|a| a.formal_charge).sum();
+  match net_charge {
+    0 => {}
+    1 => formula.push('+'),
+    -1 => formula.push('-'),
+    c if c > 1 => formula.push_str(&format!("+{}", c)),
+    c => formula.push_str(&format!("-{}", -c)),
+  }
+  formula
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+fn unevaluated(name: &str, args: &[Expr]) -> Expr {
+  Expr::FunctionCall {
+    name: name.to_string(),
+    args: args.to_vec().into(),
+  }
+}
+
+/// Molecule[spec] / Molecule[{atoms…}, {bonds…}] — build the canonical
+/// molecule expression.
+pub fn molecule_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  match args {
+    [Expr::String(spec)] => {
+      let graph = match smiles_for_name(spec) {
+        Some(smiles) => parse_smiles(smiles),
+        None => parse_smiles(spec),
+      };
+      match graph {
+        Some(mut graph) => {
+          add_explicit_hydrogens(&mut graph);
+          Ok(graph_to_expr(&graph))
+        }
+        None => {
+          crate::emit_message(&format!(
+            "Molecule::nointerp: Unable to interpret the input \"{}\" as a molecule.",
+            spec
+          ));
+          Ok(unevaluated("Molecule", args))
+        }
+      }
+    }
+    [Expr::List(atoms), Expr::List(bonds)] => {
+      match graph_from_lists(atoms, bonds) {
+        Some(mut graph) => {
+          add_explicit_hydrogens(&mut graph);
+          Ok(graph_to_expr(&graph))
+        }
+        None => Ok(unevaluated("Molecule", args)),
+      }
+    }
+    _ => Ok(unevaluated("Molecule", args)),
+  }
+}
+
+/// MoleculeQ[expr] — True for a valid canonical molecule expression.
+pub fn molecule_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  if args.len() != 1 {
+    return Ok(unevaluated("MoleculeQ", args));
+  }
+  let valid = graph_from_molecule_expr(&args[0]).is_some();
+  Ok(Expr::Identifier(if valid { "True" } else { "False" }.to_string()))
+}
+
+/// AtomList[mol] — the list of atoms.
+pub fn atom_list_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  if args.len() == 1
+    && let Some(result) = molecule_property_from_expr(&args[0], "AtomList")
+  {
+    return Ok(result);
+  }
+  Ok(unevaluated("AtomList", args))
+}
+
+/// BondList[mol] — the list of bonds.
+pub fn bond_list_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  if args.len() == 1
+    && let Some(result) = molecule_property_from_expr(&args[0], "BondList")
+  {
+    return Ok(result);
+  }
+  Ok(unevaluated("BondList", args))
+}
+
+/// MoleculeValue[mol, "prop"] / MoleculeValue[mol, {props…}].
+pub fn molecule_value_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  if args.len() == 2 {
+    match &args[1] {
+      Expr::String(prop) => {
+        if let Some(result) = molecule_property_from_expr(&args[0], prop) {
+          return Ok(result);
+        }
+      }
+      Expr::List(props) => {
+        let results: Option<Vec<Expr>> = props
+          .iter()
+          .map(|p| match p {
+            Expr::String(prop) => {
+              molecule_property_from_expr(&args[0], prop)
+            }
+            _ => None,
+          })
+          .collect();
+        if let Some(results) = results {
+          return Ok(Expr::List(results.into()));
+        }
+      }
+      _ => {}
+    }
+  }
+  Ok(unevaluated("MoleculeValue", args))
+}
+
+/// Property access on a molecule expression. Returns None when the
+/// expression is not a valid molecule or the property is unsupported,
+/// leaving the call unevaluated.
+fn molecule_property_from_expr(mol: &Expr, prop: &str) -> Option<Expr> {
+  let Expr::FunctionCall { name, args } = mol else {
+    return None;
+  };
+  if name != "Molecule" || args.len() != 2 {
+    return None;
+  }
+  molecule_property(args, prop)
+}
+
+/// Property access on the argument list of a valid canonical molecule.
+/// Used both by MoleculeValue and by subvalue application
+/// (`Molecule[…]["AtomCount"]`).
+pub fn molecule_property(mol_args: &[Expr], prop: &str) -> Option<Expr> {
+  if mol_args.len() != 2 {
+    return None;
+  }
+  let graph = graph_from_lists(
+    match &mol_args[0] {
+      Expr::List(atoms) => atoms,
+      _ => return None,
+    },
+    match &mol_args[1] {
+      Expr::List(bonds) => bonds,
+      _ => return None,
+    },
+  )?;
+  match prop {
+    "AtomCount" => Some(Expr::Integer(graph.atoms.len() as i128)),
+    "BondCount" => Some(Expr::Integer(graph.bonds.len() as i128)),
+    "AtomList" => Some(Expr::List(
+      graph.atoms.iter().map(atom_to_expr).collect::<Vec<_>>().into(),
+    )),
+    "BondList" => Some(Expr::List(
+      graph.bonds.iter().map(bond_to_expr).collect::<Vec<_>>().into(),
+    )),
+    "MolecularFormula" => Some(Expr::String(molecular_formula(&graph))),
+    "NetCharge" => Some(Expr::Integer(
+      graph.atoms.iter().map(|a| a.formal_charge as i128).sum(),
+    )),
+    _ => None,
+  }
+}

--- a/tests/cli/expressions.md
+++ b/tests/cli/expressions.md
@@ -54,6 +54,7 @@ Output is always in [FullForm].
 - [`Level`](expressions/Level.md)
 - [`LightDarkSwitched`](expressions/LightDarkSwitched.md)
 - [`MatrixForm`](expressions/MatrixForm.md)
+- [`Molecule`](expressions/Molecule.md)
 - [`Opening`](expressions/Opening.md)
 - [`OrthogonalMatrixQ`](expressions/OrthogonalMatrixQ.md)
 - [`ParallelMap`](expressions/ParallelMap.md)

--- a/tests/cli/expressions/Molecule.md
+++ b/tests/cli/expressions/Molecule.md
@@ -1,0 +1,77 @@
+# `Molecule`
+
+Represents a chemical molecule as a symbolic expression of atoms and bonds.
+A molecule can be constructed from a chemical name:
+
+```scrut
+$ wo 'Molecule["water"]'
+Molecule[{Atom[O], Atom[H], Atom[H]}, {Bond[{1, 2}, Single], Bond[{1, 3}, Single]}]
+```
+
+… from a [SMILES](https://en.wikipedia.org/wiki/SMILES) string
+(hydrogen atoms are added to fill the normal valences):
+
+```scrut
+$ wo 'Molecule["C=O"]'
+Molecule[{Atom[C], Atom[O], Atom[H], Atom[H]}, {Bond[{1, 2}, Double], Bond[{1, 3}, Single], Bond[{1, 4}, Single]}]
+```
+
+… or from explicit atom and bond lists:
+
+```scrut
+$ wo 'Molecule[{"C", "O"}, {Bond[{1, 2}, "Single"]}]'
+Molecule[{Atom[C], Atom[O], Atom[H], Atom[H], Atom[H], Atom[H]}, {Bond[{1, 2}, Single], Bond[{1, 3}, Single], Bond[{1, 4}, Single], Bond[{1, 5}, Single], Bond[{2, 6}, Single]}]
+```
+
+Aromatic rings, formal charges, and isotopes are supported:
+
+```scrut
+$ wo 'Molecule["[NH4+]"]'
+Molecule[{Atom[N, FormalCharge -> 1], Atom[H], Atom[H], Atom[H], Atom[H]}, {Bond[{1, 2}, Single], Bond[{1, 3}, Single], Bond[{1, 4}, Single], Bond[{1, 5}, Single]}]
+```
+
+## `MoleculeQ`
+
+Tests whether an expression is a valid molecule:
+
+```scrut
+$ wo 'MoleculeQ[Molecule["ethanol"]]'
+True
+```
+
+```scrut
+$ wo 'MoleculeQ[5]'
+False
+```
+
+## `AtomList` and `BondList`
+
+Return the atoms and bonds of a molecule:
+
+```scrut
+$ wo 'AtomList[Molecule["methane"]]'
+{Atom[C], Atom[H], Atom[H], Atom[H], Atom[H]}
+```
+
+```scrut
+$ wo 'BondList[Molecule["ammonia"]]'
+{Bond[{1, 2}, Single], Bond[{1, 3}, Single], Bond[{1, 4}, Single]}
+```
+
+## `MoleculeValue`
+
+Computes properties of a molecule
+(`"AtomCount"`, `"BondCount"`, `"AtomList"`, `"BondList"`,
+`"MolecularFormula"`, and `"NetCharge"`):
+
+```scrut
+$ wo 'MoleculeValue[Molecule["caffeine"], "MolecularFormula"]'
+C8H10N4O2
+```
+
+Properties can also be accessed by applying the molecule to a property name:
+
+```scrut
+$ wo 'Molecule["benzene"]["AtomCount"]'
+12
+```

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1079,6 +1079,7 @@ mod interpreter_tests {
   mod list;
   mod machine_specific;
   mod math;
+  mod molecule;
   mod music;
   mod patterns;
   mod property;

--- a/tests/interpreter_tests/molecule.rs
+++ b/tests/interpreter_tests/molecule.rs
@@ -1,0 +1,428 @@
+use super::*;
+
+mod molecule_tests {
+  use super::*;
+
+  // --- Construction from chemical names ---------------------------------
+
+  #[test]
+  fn molecule_from_name_water() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["water"]"#).unwrap(),
+      "Molecule[{Atom[O], Atom[H], Atom[H]}, \
+       {Bond[{1, 2}, Single], Bond[{1, 3}, Single]}]"
+    );
+  }
+
+  #[test]
+  fn molecule_name_lookup_is_case_insensitive() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["Water"]"#).unwrap(),
+      interpret(r#"Molecule["water"]"#).unwrap()
+    );
+  }
+
+  #[test]
+  fn molecule_from_name_methane() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["methane"]"#).unwrap(),
+      "Molecule[{Atom[C], Atom[H], Atom[H], Atom[H], Atom[H]}, \
+       {Bond[{1, 2}, Single], Bond[{1, 3}, Single], Bond[{1, 4}, Single], \
+       Bond[{1, 5}, Single]}]"
+    );
+  }
+
+  // --- Construction from SMILES strings ---------------------------------
+
+  #[test]
+  fn molecule_from_smiles_ethanol() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["CCO"]"#).unwrap(),
+      "Molecule[{Atom[C], Atom[C], Atom[O], Atom[H], Atom[H], Atom[H], \
+       Atom[H], Atom[H], Atom[H]}, \
+       {Bond[{1, 2}, Single], Bond[{2, 3}, Single], Bond[{1, 4}, Single], \
+       Bond[{1, 5}, Single], Bond[{1, 6}, Single], Bond[{2, 7}, Single], \
+       Bond[{2, 8}, Single], Bond[{3, 9}, Single]}]"
+    );
+  }
+
+  #[test]
+  fn molecule_from_smiles_double_bond() {
+    clear_state();
+    // formaldehyde
+    assert_eq!(
+      interpret(r#"Molecule["C=O"]"#).unwrap(),
+      "Molecule[{Atom[C], Atom[O], Atom[H], Atom[H]}, \
+       {Bond[{1, 2}, Double], Bond[{1, 3}, Single], Bond[{1, 4}, Single]}]"
+    );
+  }
+
+  #[test]
+  fn molecule_from_smiles_triple_bond() {
+    clear_state();
+    // hydrogen cyanide
+    assert_eq!(
+      interpret(r#"Molecule["C#N"]"#).unwrap(),
+      "Molecule[{Atom[C], Atom[N], Atom[H]}, \
+       {Bond[{1, 2}, Triple], Bond[{1, 3}, Single]}]"
+    );
+  }
+
+  #[test]
+  fn molecule_from_smiles_branches() {
+    clear_state();
+    // isobutane: central carbon with three methyl groups
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["CC(C)C"], "MolecularFormula"]"#)
+        .unwrap(),
+      "C4H10"
+    );
+  }
+
+  #[test]
+  fn molecule_from_smiles_ring() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["C1CCCCC1"], "MolecularFormula"]"#)
+        .unwrap(),
+      "C6H12"
+    );
+  }
+
+  #[test]
+  fn molecule_from_smiles_percent_ring_closure() {
+    clear_state();
+    // cyclododecane written with a two-digit ring bond number
+    assert_eq!(
+      interpret(
+        r#"MoleculeValue[Molecule["C%12CCCCCCCCCCC%12"], "MolecularFormula"]"#
+      )
+      .unwrap(),
+      "C12H24"
+    );
+  }
+
+  #[test]
+  fn molecule_from_aromatic_smiles() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["c1ccccc1"]"#).unwrap(),
+      "Molecule[{Atom[C], Atom[C], Atom[C], Atom[C], Atom[C], Atom[C], \
+       Atom[H], Atom[H], Atom[H], Atom[H], Atom[H], Atom[H]}, \
+       {Bond[{1, 2}, Aromatic], Bond[{2, 3}, Aromatic], \
+       Bond[{3, 4}, Aromatic], Bond[{4, 5}, Aromatic], \
+       Bond[{5, 6}, Aromatic], Bond[{1, 6}, Aromatic], \
+       Bond[{1, 7}, Single], Bond[{2, 8}, Single], Bond[{3, 9}, Single], \
+       Bond[{4, 10}, Single], Bond[{5, 11}, Single], \
+       Bond[{6, 12}, Single]}]"
+    );
+  }
+
+  #[test]
+  fn aromatic_nitrogen_gets_no_hydrogen() {
+    clear_state();
+    // pyridine: C5H5N — the ring nitrogen carries no hydrogen
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["c1ccncc1"], "MolecularFormula"]"#)
+        .unwrap(),
+      "C5H5N"
+    );
+  }
+
+  #[test]
+  fn bracket_hydrogen_count_is_respected() {
+    clear_state();
+    // pyrrole: the [nH] nitrogen carries exactly one hydrogen
+    assert_eq!(
+      interpret(
+        r#"MoleculeValue[Molecule["c1cc[nH]c1"], "MolecularFormula"]"#
+      )
+      .unwrap(),
+      "C4H5N"
+    );
+  }
+
+  #[test]
+  fn molecule_from_smiles_formal_charge() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["[NH4+]"]"#).unwrap(),
+      "Molecule[{Atom[N, FormalCharge -> 1], Atom[H], Atom[H], Atom[H], \
+       Atom[H]}, \
+       {Bond[{1, 2}, Single], Bond[{1, 3}, Single], Bond[{1, 4}, Single], \
+       Bond[{1, 5}, Single]}]"
+    );
+  }
+
+  #[test]
+  fn molecule_from_smiles_mass_number() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["[13C]"]"#).unwrap(),
+      "Molecule[{Atom[C, MassNumber -> 13]}, {}]"
+    );
+  }
+
+  #[test]
+  fn molecule_from_smiles_disconnected_components() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["[Na+].[Cl-]"]"#).unwrap(),
+      "Molecule[{Atom[Na, FormalCharge -> 1], \
+       Atom[Cl, FormalCharge -> -1]}, {}]"
+    );
+  }
+
+  #[test]
+  fn multi_character_charge_forms() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["[Fe+2]"]"#).unwrap(),
+      "Molecule[{Atom[Fe, FormalCharge -> 2]}, {}]"
+    );
+    assert_eq!(
+      interpret(r#"Molecule["[Fe++]"]"#).unwrap(),
+      "Molecule[{Atom[Fe, FormalCharge -> 2]}, {}]"
+    );
+  }
+
+  // --- Construction from explicit atom and bond lists -------------------
+
+  #[test]
+  fn molecule_from_atom_and_bond_lists_fills_valences() {
+    clear_state();
+    // methanol: hydrogens are added to fill the normal valences
+    assert_eq!(
+      interpret(r#"Molecule[{"C", "O"}, {Bond[{1, 2}, "Single"]}]"#).unwrap(),
+      "Molecule[{Atom[C], Atom[O], Atom[H], Atom[H], Atom[H], Atom[H]}, \
+       {Bond[{1, 2}, Single], Bond[{1, 3}, Single], Bond[{1, 4}, Single], \
+       Bond[{1, 5}, Single], Bond[{2, 6}, Single]}]"
+    );
+  }
+
+  #[test]
+  fn molecule_accepts_atomic_numbers() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule[{6, 8}, {Bond[{1, 2}, "Single"]}]"#).unwrap(),
+      interpret(r#"Molecule[{"C", "O"}, {Bond[{1, 2}, "Single"]}]"#).unwrap()
+    );
+  }
+
+  #[test]
+  fn bond_without_type_defaults_to_single() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule[{"C", "O"}, {Bond[{1, 2}]}]"#).unwrap(),
+      interpret(r#"Molecule[{"C", "O"}, {Bond[{1, 2}, "Single"]}]"#).unwrap()
+    );
+  }
+
+  #[test]
+  fn molecule_evaluation_is_idempotent() {
+    clear_state();
+    let canonical = interpret(r#"Molecule["water"]"#).unwrap();
+    assert_eq!(interpret(&canonical).unwrap(), canonical);
+  }
+
+  // --- Invalid input stays unevaluated -----------------------------------
+
+  #[test]
+  fn uninterpretable_string_stays_unevaluated() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["gibberish"]"#).unwrap(),
+      "Molecule[gibberish]"
+    );
+  }
+
+  #[test]
+  fn unclosed_ring_bond_stays_unevaluated() {
+    clear_state();
+    assert_eq!(interpret(r#"Molecule["C1CC"]"#).unwrap(), "Molecule[C1CC]");
+  }
+
+  #[test]
+  fn out_of_range_bond_index_stays_unevaluated() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule[{"C"}, {Bond[{1, 5}, "Single"]}]"#).unwrap(),
+      "Molecule[{C}, {Bond[{1, 5}, Single]}]"
+    );
+  }
+
+  #[test]
+  fn unknown_element_symbol_stays_unevaluated() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule[{"Xx"}, {}]"#).unwrap(),
+      "Molecule[{Xx}, {}]"
+    );
+  }
+
+  // --- MoleculeQ ---------------------------------------------------------
+
+  #[test]
+  fn molecule_q_true_for_valid_molecule() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"MoleculeQ[Molecule["ethanol"]]"#).unwrap(),
+      "True"
+    );
+  }
+
+  #[test]
+  fn molecule_q_false_for_non_molecule() {
+    clear_state();
+    assert_eq!(interpret("MoleculeQ[5]").unwrap(), "False");
+    assert_eq!(interpret(r#"MoleculeQ["water"]"#).unwrap(), "False");
+  }
+
+  #[test]
+  fn molecule_q_false_for_invalid_molecule() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"MoleculeQ[Molecule["gibberish"]]"#).unwrap(),
+      "False"
+    );
+    assert_eq!(
+      interpret(r#"MoleculeQ[Molecule[{Atom["O"]}, {Bond[{1, 2}]}]]"#)
+        .unwrap(),
+      "False"
+    );
+  }
+
+  // --- AtomList and BondList ---------------------------------------------
+
+  #[test]
+  fn atom_list_returns_atoms() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"AtomList[Molecule["methane"]]"#).unwrap(),
+      "{Atom[C], Atom[H], Atom[H], Atom[H], Atom[H]}"
+    );
+  }
+
+  #[test]
+  fn bond_list_returns_bonds() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"BondList[Molecule["ammonia"]]"#).unwrap(),
+      "{Bond[{1, 2}, Single], Bond[{1, 3}, Single], Bond[{1, 4}, Single]}"
+    );
+  }
+
+  #[test]
+  fn atom_list_of_non_molecule_stays_unevaluated() {
+    clear_state();
+    assert_eq!(interpret("AtomList[5]").unwrap(), "AtomList[5]");
+  }
+
+  // --- MoleculeValue and property access ---------------------------------
+
+  #[test]
+  fn molecule_value_atom_count() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["ethanol"], "AtomCount"]"#)
+        .unwrap(),
+      "9"
+    );
+  }
+
+  #[test]
+  fn molecule_value_bond_count() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["water"], "BondCount"]"#).unwrap(),
+      "2"
+    );
+  }
+
+  #[test]
+  fn molecule_value_molecular_formula() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["caffeine"], "MolecularFormula"]"#)
+        .unwrap(),
+      "C8H10N4O2"
+    );
+  }
+
+  #[test]
+  fn molecule_value_net_charge() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["[NH4+]"], "NetCharge"]"#).unwrap(),
+      "1"
+    );
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["water"], "NetCharge"]"#).unwrap(),
+      "0"
+    );
+  }
+
+  #[test]
+  fn molecule_value_list_of_properties() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        r#"MoleculeValue[Molecule["glucose"], {"AtomCount", "MolecularFormula"}]"#
+      )
+      .unwrap(),
+      "{24, C6H12O6}"
+    );
+  }
+
+  #[test]
+  fn molecule_subvalue_property_access() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Molecule["water"]["AtomCount"]"#).unwrap(),
+      "3"
+    );
+    assert_eq!(
+      interpret(r#"Molecule["benzene"]["MolecularFormula"]"#).unwrap(),
+      "C6H6"
+    );
+  }
+
+  #[test]
+  fn unknown_property_stays_unevaluated() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["water"], "Bogus"]"#).unwrap(),
+      "MoleculeValue[Molecule[{Atom[O], Atom[H], Atom[H]}, \
+       {Bond[{1, 2}, Single], Bond[{1, 3}, Single]}], Bogus]"
+    );
+  }
+
+  // --- Formula edge cases --------------------------------------------------
+
+  #[test]
+  fn formula_without_carbon_is_alphabetical() {
+    clear_state();
+    // Hill order without carbon: strictly alphabetical (H before N and O)
+    assert_eq!(
+      interpret(
+        r#"MoleculeValue[Molecule["nitric acid"], "MolecularFormula"]"#
+      )
+      .unwrap(),
+      "HNO3"
+    );
+  }
+
+  #[test]
+  fn formula_of_charged_molecule_shows_net_charge() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"MoleculeValue[Molecule["[NH4+]"], "MolecularFormula"]"#)
+        .unwrap(),
+      "H4N+"
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive support for chemical molecule representation and manipulation through the `Molecule` function family, including SMILES parsing, chemical name lookup, hydrogen filling, and molecular property computation.

## Key Changes

- **New module `src/functions/molecule_ast.rs`** (951 lines)
  - Implements `Molecule`, `MoleculeQ`, `AtomList`, `BondList`, and `MoleculeValue` functions
  - Full SMILES parser supporting organic subset atoms, bracket atoms, bonds (single/double/triple/aromatic), branches, and ring closures
  - Chemical name database with ~60 common compounds (acetone, benzene, caffeine, glucose, etc.)
  - Automatic hydrogen filling to match Wolfram Language's canonical form
  - Molecular property computation: AtomCount, BondCount, MolecularFormula (Hill order), NetCharge
  - Support for formal charges, isotopes (mass numbers), and aromatic systems

- **Molecule construction methods**
  - From chemical names: `Molecule["water"]` → canonical form with explicit hydrogens
  - From SMILES strings: `Molecule["CCO"]` (ethanol)
  - From explicit lists: `Molecule[{"C", "O"}, {Bond[{1, 2}, "Single"]}]`
  - Accepts atomic numbers as atom specifications: `Molecule[{6, 8}, ...]`

- **Property access**
  - `MoleculeValue[mol, "AtomCount"]` and similar property queries
  - Subvalue syntax: `Molecule["water"]["AtomCount"]`
  - Multiple properties at once: `MoleculeValue[mol, {"AtomCount", "MolecularFormula"}]`

- **Integration**
  - Added dispatch in `src/evaluator/dispatch/mod.rs` for all molecule functions
  - Added curried function application support in `src/evaluator/function_application.rs` for property access
  - Added helper functions to `src/functions/element_data.rs`: `is_element_abbreviation()` and `abbreviation_for_atomic_number()`
  - Updated `functions.csv` to mark Molecule as implemented (✅)

- **Comprehensive test coverage** (428 lines in `tests/interpreter_tests/molecule.rs`)
  - Construction from names, SMILES, and explicit lists
  - Hydrogen filling and valence handling
  - Aromatic systems and bracket atom specifications
  - Formal charges and isotopes
  - All property accessors
  - Invalid input handling (stays unevaluated)
  - Edge cases (Hill order, charged molecules)

- **Documentation** (`tests/cli/expressions/Molecule.md`)
  - Usage examples for all construction methods
  - Property access patterns
  - Supported properties reference

## Notable Implementation Details

- **Hydrogen filling algorithm**: Respects explicit hydrogen counts in bracket atoms, fills organic subset atoms to smallest charge-adjusted valence, handles aromatic systems correctly
- **SMILES parsing**: Hand-written recursive descent parser supporting full organic subset syntax, ring closures with both single-digit and two-digit numbers, directional bonds (treated as single)
- **Canonical form**: Always produces `Molecule[{atoms…}, {bonds…}]` with explicit hydrogens, matching wolframscript output exactly
- **Aromatic handling**: Distinguishes between aromatic atoms (lowercase in SMILES) and regular atoms in aromatic bonds; aromatic bonds count as 1 σ-bond for valence purposes
- **Hill order formula**: Carbon first (if present), then hydrogen, then alphabetical; includes net charge notation

https://claude.ai/code/session_01BcNQMtRXzy46bK1azHUNR6