### PR TITLE
Add PolyhedronData and graphics object regions support

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -594,7 +594,7 @@ PlotLabels,Option for labeling plot curves,✅,none,10.4,597
 Scale,Scales a graphics object,✅,pure,6.0,597
 Log10,Returns the base-10 logarithm of a number,✅,pure,7.0,598
 EndPackage,Ends a package context (no-op in Woxi),✅,effectful,1.0,599
-PolyhedronData,,🚫,,6.0,601
+PolyhedronData,Properties of named polyhedra (Platonic solids),🚧,pure,6.0,601
 Nearest,Find the nearest elements in a list to a given value (numbers/vectors by Euclidean distance; strings by edit distance),✅,pure,6.0,602
 RegionPlot3D,plots the 3D region where a condition is true,✅,pure,6.0,603
 IntervalMemberQ,Tests if a point or sub-interval is contained in an interval,✅,pure,3.0,605
@@ -1413,7 +1413,7 @@ GeoBackground,Background for geographic plots,🚫,pure,10.0,1430
 ItemStyle,Style specification for items,🚫,pure,6.0,1431
 GeoStyling,Styling for geographic regions,🚫,pure,10.0,1432
 CharacterEncoding,Character encoding specification,🚫,io,3.0,1434
-InfinitePlane,Infinite plane geometric region,🚫,pure,10.0,1434
+InfinitePlane,Infinite plane geometric region; symbolic region consumed by region functions and rendered in Graphics,✅,unevaluated,10.0,1434
 ProgressIndicator,Dynamic progress indicator,🚫,io,6.0,1435
 Square,Square geometric primitive,🚫,pure,3.0,1437
 StruveL,Modified Struve function L_n(z); elementary closed form at order +-1/2 and +-3/2; numeric for inexact args,✅,pure,4.0,1437
@@ -1724,7 +1724,7 @@ SequenceCases,Finds matching subsequences in a list (supports a count limit and 
 TimeConstraint,Time constraint option,,unevaluated,3.0,1751
 DoubleRightTee,Inert operator displayed with the ⊨ symbol,✅,pure,3.0,1752
 Matrices,Matrix domain,,unevaluated,9.0,1753
-JoinedCurve,Joined curve primitive,,unevaluated,8.0,1754
+JoinedCurve,Joined curve graphics primitive,✅,unevaluated,8.0,1754
 DefaultButton,Default button control,,unevaluated,6.0,1760
 GeoMarker,Geographic marker primitive for GeoGraphics,✅,pure,10.0,1760
 MultiplicativeOrder,Multiplicative order modulo n,✅,computation,4.0,1760
@@ -1858,7 +1858,7 @@ CovarianceFunction,Sample autocovariance of a numeric time series at a lag; or t
 XYZColor,XYZ color specification,,unevaluated,10.0,1887
 GraphHighlightStyle,Graph highlight style,,unevaluated,8.0,1889
 ImageTrim,Trims an image to a specified coordinate region,✅,pure,8.0,1889
-BSplineSurface,B-spline surface,,unevaluated,7.0,1891
+BSplineSurface,B-spline surface 3D graphics primitive,✅,unevaluated,7.0,1891
 Setting,Setting wrapper,,unevaluated,6.0,1891
 SingularValueList,Returns the nonzero singular values of a matrix in decreasing order,✅,pure,5.0,1892
 Gudermannian,Returns the Gudermannian function value,✅,pure,7.0,1895
@@ -2096,7 +2096,7 @@ MatrixFunction,Apply a scalar function to a square matrix via its eigenvalues,�
 QuantityUnit,Returns the unit of a quantity,✅,pure,9.0,2134
 Delayed,Delayed evaluation wrapper,🚫,,10.0,2138
 PacletInstall,Install Wolfram paclet,🚫,,12.1,2138
-Parallelogram,Parallelogram geometric region,🚫,,10.0,2138
+Parallelogram,Parallelogram geometric region; symbolic region consumed by region functions and rendered in Graphics,✅,unevaluated,10.0,2138
 SectorChart,Creates a sector chart from data,✅,pure,7.0,2138
 InexactNumberQ,Tests if an expression is an inexact real number,✅,pure,4.0,2141
 RootSum,Sum of form[r] over the roots r of a polynomial; numeric-coefficient polynomial f with polynomial form gives an exact power-sum value via Newton identities; other shapes stay symbolic,✅,pure,3.0,2141
@@ -2271,7 +2271,7 @@ FindClique,Finds maximal cliques (largest by default; size spec and count/All fo
 GraphHighlight,graph visualization,🚫,None,8.0,2317
 MissingQ,Test whether an expression is a Missing value,✅,1,10.2,2317
 PlanckRadiationLaw,physics formula (external data),🚫,None,10.0,2317
-Raster3D,3D graphics primitive,🚫,None,9.0,2317
+Raster3D,3D raster (voxel) graphics primitive,✅,unevaluated,9.0,2317
 GeoGridLines,Graticule option for GeoGraphics,✅,pure,10.0,2320
 NArgMax,numeric optimization,✅,None,7.0,2320
 PrimePowerQ,Tests if a number is a prime power,✅,pure,6.0,2320
@@ -2415,7 +2415,7 @@ VerticalGauge,,🚫,,9.0,2462
 Algebraics,,🚫,,4.0,2468
 Beep,,🚫,,6.0,2468
 GaussianIntegers,,🚫,,2.0,2468
-HalfPlane,,🚫,,10.0,2468
+HalfPlane,Half-plane geometric region; symbolic region consumed by region functions and rendered in Graphics,✅,unevaluated,10.0,2468
 MantissaExponent,Decompose a number into mantissa and exponent,✅,pure,2.0,2468
 SelectedCells,,🚫,,10.0,2468
 CellID,,🚫,,6.0,2469
@@ -5399,7 +5399,7 @@ AudioReverse,,🚫,,12.1,
 AudioTrackSelection,,🚫,,12.2,
 AutoOperatorRenderings,,,,12.3,
 AxisLabel,,,,12.3,
-AxisObject,,,,12.3,
+AxisObject,Symbolic axis object; contained primitives render in Graphics,✅,unevaluated,12.3,
 AxisStyle,,,,12.3,
 BeginDialogPacket,,🚫,,3.0,
 BilateralHypergeometricPFQ,,,,14.0,
@@ -5579,7 +5579,7 @@ FileFormatProperties,,,,13.0,
 FileNameToFormatList,,,,13.0,
 FileSystemTree,,,,13.2,
 FilledPolarCurve,"Filled region enclosed by a polar curve: FilledPolarCurve[PolarCurve[r; {t; t0; t1}]] or FilledPolarCurve[r; t] (full period)",✅,pure,14.1,
-FilledTorus,,,,13.0,
+FilledTorus,Solid torus graphics and region primitive,✅,unevaluated,13.0,
 FindEdgeColoring,,,,13.0,
 FindExternalEvaluators,,,,11.2,
 FindImageShapes,,,,13.3,
@@ -6062,7 +6062,7 @@ ToFiniteField,,,,14.0,
 ToRawPointer,,,,13.1,
 ToTabular,Converts data into a Tabular object with specified orientation,✅,pure,14.2,
 ToonShading,,🚫,,12.1,
-Torus,,,,13.0,
+Torus,Torus surface graphics and region primitive,✅,unevaluated,13.0,
 TorusGraph,,,,13.1,
 Tour3DVideo,,🚫,,14.0,
 TourVideo,,🚫,,13.0,

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -6743,6 +6743,97 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
       "Disk" | "Rectangle" | "Triangle" | "Polygon" => {
         return or_unevaluated(compute_area(expr));
       }
+      // Unbounded regions have infinite measure in their intrinsic dimension.
+      "HalfPlane" | "InfinitePlane" | "HalfLine" | "InfiniteLine"
+      | "HalfSpace" | "ConicHullRegion" => {
+        return Ok(Expr::Identifier("Infinity".to_string()));
+      }
+      // Parallelogram[p, {v1, v2}] — the area spanned by v1 and v2 is
+      // Sqrt[Det of the Gram matrix] = Sqrt[(v1.v1)(v2.v2) - (v1.v2)^2],
+      // which reduces to |Det[{v1, v2}]| in the plane but also covers
+      // parallelograms embedded in higher-dimensional space.
+      // Parallelogram[] is the unit square {0,0} + {{0,1},{1,0}}.
+      "Parallelogram" => {
+        let Some((_, v1, v2)) = parallelogram_parts(args) else {
+          return unevaluated();
+        };
+        if v1.len() == 2 {
+          return det_measure(
+            vec![Expr::List(v1.into()), Expr::List(v2.into())],
+            1,
+          );
+        }
+        let dot = |a: &[Expr], b: &[Expr]| Expr::FunctionCall {
+          name: "Dot".to_string(),
+          args: vec![
+            Expr::List(a.to_vec().into()),
+            Expr::List(b.to_vec().into()),
+          ]
+          .into(),
+        };
+        let gram_det = Expr::FunctionCall {
+          name: "Subtract".to_string(),
+          args: vec![
+            Expr::FunctionCall {
+              name: "Times".to_string(),
+              args: vec![dot(&v1, &v1), dot(&v2, &v2)].into(),
+            },
+            Expr::FunctionCall {
+              name: "Power".to_string(),
+              args: vec![dot(&v1, &v2), Expr::Integer(2)].into(),
+            },
+          ]
+          .into(),
+        };
+        let area = Expr::FunctionCall {
+          name: "Sqrt".to_string(),
+          args: vec![gram_det].into(),
+        };
+        return crate::evaluator::evaluate_expr_to_expr(&area);
+      }
+      // Torus[{x,y,z}, {r1, r2}] is the surface with inner radius r1 and
+      // outer radius r2: tube radius a = (r2-r1)/2 around a circle of
+      // radius c = (r1+r2)/2, so the area is 4 Pi^2 a c = Pi^2 (r2^2 - r1^2).
+      // FilledTorus is the enclosed solid: 2 Pi^2 a^2 c.
+      "Torus" | "FilledTorus" => {
+        let Some((_, r1, r2)) = torus_parts(args) else {
+          return unevaluated();
+        };
+        let half = |e: Expr| Expr::BinaryOp {
+          op: crate::syntax::BinaryOperator::Divide,
+          left: Box::new(e),
+          right: Box::new(Expr::Integer(2)),
+        };
+        let tube = half(Expr::FunctionCall {
+          name: "Subtract".to_string(),
+          args: vec![r2.clone(), r1.clone()].into(),
+        });
+        let ring = half(Expr::FunctionCall {
+          name: "Plus".to_string(),
+          args: vec![r1, r2].into(),
+        });
+        let pi_sq = Expr::FunctionCall {
+          name: "Power".to_string(),
+          args: vec![Expr::Constant("Pi".to_string()), Expr::Integer(2)]
+            .into(),
+        };
+        let measure = if name == "Torus" {
+          Expr::FunctionCall {
+            name: "Times".to_string(),
+            args: vec![Expr::Integer(4), pi_sq, tube, ring].into(),
+          }
+        } else {
+          let tube_sq = Expr::FunctionCall {
+            name: "Power".to_string(),
+            args: vec![tube, Expr::Integer(2)].into(),
+          };
+          Expr::FunctionCall {
+            name: "Times".to_string(),
+            args: vec![Expr::Integer(2), pi_sq, tube_sq, ring].into(),
+          }
+        };
+        return crate::evaluator::evaluate_expr_to_expr(&measure);
+      }
       // A Sphere is a 2-dimensional surface embedded in 3-space, so its
       // measure is the surface area (Area already returns 4 Pi r^2).
       "Sphere" => {
@@ -6868,11 +6959,14 @@ fn compute_region_dimension(expr: &Expr) -> Result<Expr, InterpreterError> {
     match name.as_str() {
       // Regions of fixed intrinsic dimension.
       "Disk" | "Rectangle" | "Triangle" | "Polygon" | "RegularPolygon"
-      | "Annulus" => return Ok(Expr::Integer(2)),
+      | "Annulus" | "Parallelogram" | "HalfPlane" | "InfinitePlane"
+      | "Torus" => return Ok(Expr::Integer(2)),
       "Circle" | "Line" | "HalfLine" | "InfiniteLine" => {
         return Ok(Expr::Integer(1));
       }
-      "Cylinder" | "Cone" | "Tetrahedron" => return Ok(Expr::Integer(3)),
+      "Cylinder" | "Cone" | "Tetrahedron" | "FilledTorus" => {
+        return Ok(Expr::Integer(3));
+      }
       "Point" => return Ok(Expr::Integer(0)),
       // Ball / Ellipsoid are solid: their dimension is the length of the
       // center vector (default unit ball / sphere lives in 3-space).
@@ -6938,6 +7032,41 @@ fn compute_region_dimension(expr: &Expr) -> Result<Expr, InterpreterError> {
 fn compute_region_embedding_dimension(
   expr: &Expr,
 ) -> Result<Expr, InterpreterError> {
+  if let Expr::FunctionCall { name, args } = expr {
+    match name.as_str() {
+      "Torus" | "FilledTorus" => {
+        if torus_parts(args).is_some() {
+          return Ok(Expr::Integer(3));
+        }
+      }
+      "Parallelogram" => {
+        if let Some((p, _, _)) = parallelogram_parts(args) {
+          return Ok(Expr::Integer(p.len() as i128));
+        }
+      }
+      // HalfPlane[{p1, p2}, w] / HalfPlane[p, v, w] — ambient space of the
+      // defining points. InfinitePlane[{p1, p2, p3}] / InfinitePlane[p,
+      // {v1, v2}] likewise.
+      "HalfPlane" | "InfinitePlane" => {
+        let first_coord = match args.first() {
+          Some(Expr::List(items)) if !items.is_empty() => {
+            if let Expr::List(p) = &items[0] {
+              // A list of defining points: use one point's length.
+              Some(p.len())
+            } else {
+              // A single coordinate vector.
+              Some(items.len())
+            }
+          }
+          _ => None,
+        };
+        if let Some(n) = first_coord {
+          return Ok(Expr::Integer(n as i128));
+        }
+      }
+      _ => {}
+    }
+  }
   match compute_region_bounds(expr)? {
     Expr::List(ref bounds) => Ok(Expr::Integer(bounds.len() as i128)),
     _ => Ok(Expr::FunctionCall {
@@ -7059,6 +7188,49 @@ fn compute_region_bounds(expr: &Expr) -> Result<Expr, InterpreterError> {
         bounds.push(Expr::List(vec![lo, hi].into()));
       }
       return Ok(Expr::List(bounds.into()));
+    }
+    // Torus/FilledTorus — x and y span center ± outer radius r2, z spans
+    // center ± tube radius (r2 - r1)/2.
+    if matches!(name.as_str(), "Torus" | "FilledTorus")
+      && let Some((center, r1, r2)) = torus_parts(args)
+    {
+      let tube = Expr::BinaryOp {
+        op: crate::syntax::BinaryOperator::Divide,
+        left: Box::new(Expr::FunctionCall {
+          name: "Subtract".to_string(),
+          args: vec![r2.clone(), r1].into(),
+        }),
+        right: Box::new(Expr::Integer(2)),
+      };
+      let extents = [r2.clone(), r2, tube];
+      let bounds: Vec<Expr> = center
+        .iter()
+        .zip(extents.iter())
+        .map(|(c, e)| {
+          let lo = eval_binop("Subtract", c.clone(), e.clone());
+          let hi = eval_binop("Plus", c.clone(), e.clone());
+          Expr::List(vec![lo, hi].into())
+        })
+        .collect();
+      return Ok(Expr::List(bounds.into()));
+    }
+    // Parallelogram — min/max over the four corners p, p+v1, p+v2, p+v1+v2.
+    if name == "Parallelogram"
+      && let Some((p, v1, v2)) = parallelogram_parts(args)
+    {
+      let add = |a: &[Expr], b: &[Expr]| -> Vec<Expr> {
+        a.iter()
+          .zip(b.iter())
+          .map(|(x, y)| eval_binop("Plus", x.clone(), y.clone()))
+          .collect()
+      };
+      let corners: Vec<Expr> = vec![
+        Expr::List(p.clone().into()),
+        Expr::List(add(&p, &v1).into()),
+        Expr::List(add(&p, &v2).into()),
+        Expr::List(add(&add(&p, &v1), &v2).into()),
+      ];
+      return Ok(points_bounds(&corners).unwrap_or_else(unevaluated));
     }
     // Rectangle/Cuboid[c1, c2] — per-dimension sorted corners.
     if matches!(name.as_str(), "Rectangle" | "Cuboid") {
@@ -7222,6 +7394,79 @@ fn simplex_edges(pts: &[Expr]) -> Option<Vec<Expr>> {
 /// `n!` as an `i128` for small `n`.
 fn factorial_small(n: usize) -> i128 {
   (1..=n as i128).product::<i128>().max(1)
+}
+
+/// Decompose Parallelogram arguments into (base point, v1, v2), applying the
+/// default Parallelogram[] == Parallelogram[{0, 0}, {{0, 1}, {1, 0}}].
+/// Returns None for malformed argument lists.
+fn parallelogram_parts(
+  args: &[Expr],
+) -> Option<(Vec<Expr>, Vec<Expr>, Vec<Expr>)> {
+  match args.len() {
+    0 => Some((
+      vec![Expr::Integer(0), Expr::Integer(0)],
+      vec![Expr::Integer(0), Expr::Integer(1)],
+      vec![Expr::Integer(1), Expr::Integer(0)],
+    )),
+    2 => {
+      let Expr::List(p) = &args[0] else {
+        return None;
+      };
+      let Expr::List(vecs) = &args[1] else {
+        return None;
+      };
+      if vecs.len() != 2 {
+        return None;
+      }
+      let (Expr::List(v1), Expr::List(v2)) = (&vecs[0], &vecs[1]) else {
+        return None;
+      };
+      if v1.len() != p.len() || v2.len() != p.len() || p.is_empty() {
+        return None;
+      }
+      Some((p.to_vec(), v1.to_vec(), v2.to_vec()))
+    }
+    _ => None,
+  }
+}
+
+/// Decompose Torus/FilledTorus arguments into (center, r1, r2), applying the
+/// defaults Torus[] == Torus[{0, 0, 0}, {1/2, 1}]. Returns None for
+/// malformed argument lists.
+fn torus_parts(args: &[Expr]) -> Option<(Vec<Expr>, Expr, Expr)> {
+  let default_center = || vec![Expr::Integer(0); 3];
+  let default_radii = || {
+    (
+      Expr::FunctionCall {
+        name: "Rational".to_string(),
+        args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
+      },
+      Expr::Integer(1),
+    )
+  };
+  match args.len() {
+    0 => {
+      let (r1, r2) = default_radii();
+      Some((default_center(), r1, r2))
+    }
+    1 | 2 => {
+      let Expr::List(center) = &args[0] else {
+        return None;
+      };
+      if center.len() != 3 {
+        return None;
+      }
+      let (r1, r2) = match args.get(1) {
+        None => default_radii(),
+        Some(Expr::List(radii)) if radii.len() == 2 => {
+          (radii[0].clone(), radii[1].clone())
+        }
+        Some(_) => return None,
+      };
+      Some((center.to_vec(), r1, r2))
+    }
+    _ => None,
+  }
 }
 
 fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
@@ -8150,6 +8395,41 @@ fn compute_region_centroid(expr: &Expr) -> Result<Expr, InterpreterError> {
           return compute_triangle_centroid(pts);
         }
         unevaluated()
+      }
+      // Torus / FilledTorus — symmetric about the center.
+      "Torus" | "FilledTorus" => {
+        if let Some((center, _, _)) = torus_parts(args) {
+          Ok(Expr::List(center.into()))
+        } else {
+          unevaluated()
+        }
+      }
+      // Parallelogram[p, {v1, v2}] — centroid is p + (v1 + v2)/2.
+      "Parallelogram" => {
+        let (p, v1, v2) = match parallelogram_parts(args) {
+          Some(parts) => parts,
+          None => return unevaluated(),
+        };
+        let coords: Vec<Expr> = (0..p.len())
+          .map(|d| {
+            Expr::FunctionCall {
+              name: "Plus".to_string(),
+              args: vec![
+                p[d].clone(),
+                Expr::BinaryOp {
+                  op: crate::syntax::BinaryOperator::Divide,
+                  left: Box::new(Expr::FunctionCall {
+                    name: "Plus".to_string(),
+                    args: vec![v1[d].clone(), v2[d].clone()].into(),
+                  }),
+                  right: Box::new(Expr::Integer(2)),
+                },
+              ]
+              .into(),
+            }
+          })
+          .collect();
+        crate::evaluator::evaluate_expr_to_expr(&Expr::List(coords.into()))
       }
       // Tetrahedron / Simplex — the centroid is the mean of the vertices.
       "Tetrahedron" | "Simplex" => {

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -1564,6 +1564,11 @@ pub fn evaluate_function_call_ast_inner(
     return crate::functions::element_data::element_data_ast(args);
   }
 
+  // Polyhedron data function
+  if name == "PolyhedronData" && !args.is_empty() {
+    return crate::functions::polyhedron_data::polyhedron_data_ast(args);
+  }
+
   // Chemistry: molecules and their properties
   match name {
     "Molecule" => {
@@ -7861,7 +7866,8 @@ pub fn evaluate_function_call_ast_inner(
       | "Ellipsoid" | "Cone" | "Cylinder" | "Tetrahedron" | "Hexahedron"
       | "Prism" | "Pyramid" | "Point" | "Interval" | "Simplex"
       | "Parallelepiped" | "Annulus" | "StadiumShape" | "DiskSegment"
-      | "SphericalShell" | "CapsuleShape" => Some(true),
+      | "SphericalShell" | "CapsuleShape" | "Torus" | "FilledTorus"
+      | "Parallelogram" => Some(true),
       // Unbounded regions
       "HalfPlane" | "HalfSpace" | "InfiniteLine" | "InfinitePlane"
       | "HalfLine" | "ConicHullRegion" | "AffineHalfSpace" | "AffineSpace" => {
@@ -9901,6 +9907,20 @@ pub fn evaluate_function_call_ast_inner(
         | "Simplex"
         | "Annulus"
         | "Parallelepiped"
+        // Torus/FilledTorus/Parallelogram/HalfPlane/InfinitePlane are likewise
+        // symbolic geometric regions consumed by the region functions.
+        | "Torus"
+        | "FilledTorus"
+        | "Parallelogram"
+        | "HalfPlane"
+        | "InfinitePlane"
+        // JoinedCurve/BSplineSurface/Raster3D/AxisObject are graphics
+        // primitives: they stay unevaluated as their canonical form and are
+        // consumed by the Graphics/Graphics3D renderers.
+        | "JoinedCurve"
+        | "BSplineSurface"
+        | "Raster3D"
+        | "AxisObject"
         // OperatorApplied[f, …] is a symbolic operator object that stays
         // unevaluated until applied to arguments via the curried form
         // OperatorApplied[f][x][y] (handled in parse_curry_form), so it is

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -534,6 +534,17 @@ enum Primitive {
     x_max: f64,
     y_max: f64,
   },
+  /// HalfPlane (fill on the `w` side of the line through `p` along `v`) or,
+  /// with `full`, InfinitePlane covering the whole viewport. The actual fill
+  /// polygon is built at render time so it always reaches past the visible
+  /// plot range.
+  HalfPlanePrim {
+    p: (f64, f64),
+    v: (f64, f64),
+    w: (f64, f64),
+    full: bool,
+    style: StyleState,
+  },
 }
 
 impl Primitive {
@@ -551,7 +562,8 @@ impl Primitive {
       | Primitive::PolygonPrim { style, .. }
       | Primitive::ArrowPrim { style, .. }
       | Primitive::TextPrim { style, .. }
-      | Primitive::BezierCurvePrim { style, .. } => Some(style),
+      | Primitive::BezierCurvePrim { style, .. }
+      | Primitive::HalfPlanePrim { style, .. } => Some(style),
       Primitive::RasterPrim { .. } => None,
     }
   }
@@ -1334,6 +1346,20 @@ fn collect_primitives(
         "RegularPolygon" if !args.is_empty() => {
           parse_regular_polygon(args, style, prims);
         }
+        "Parallelogram" => {
+          parse_parallelogram(args, style, prims);
+        }
+        // JoinedCurve[{c1, c2, …}] draws its curve components as one path;
+        // stroke-rendering each component in order is visually equivalent.
+        "JoinedCurve" if !args.is_empty() => {
+          collect_primitives(&args[0], style, prims, errors);
+        }
+        "HalfPlane" => {
+          parse_half_plane(args, style, prims);
+        }
+        "InfinitePlane" => {
+          parse_infinite_plane(args, style, prims);
+        }
 
         _ => {
           // Try as directive first
@@ -1642,6 +1668,135 @@ fn parse_polygon(
   }
 }
 
+/// Parallelogram[p, {v1, v2}] (default: unit square {0,0} + {{0,1},{1,0}})
+/// — a filled quadrilateral with corners p, p+v1, p+v1+v2, p+v2.
+fn parse_parallelogram(
+  args: &[Expr],
+  style: &StyleState,
+  prims: &mut Vec<Primitive>,
+) {
+  let (p, v1, v2) = if args.is_empty() {
+    ((0.0, 0.0), (0.0, 1.0), (1.0, 0.0))
+  } else if args.len() == 2 {
+    let Some(p) = expr_to_point(&args[0]) else {
+      return;
+    };
+    let Expr::List(vecs) = &args[1] else {
+      return;
+    };
+    if vecs.len() != 2 {
+      return;
+    }
+    let (Some(v1), Some(v2)) =
+      (expr_to_point(&vecs[0]), expr_to_point(&vecs[1]))
+    else {
+      return;
+    };
+    (p, v1, v2)
+  } else {
+    return;
+  };
+  let points = vec![
+    p,
+    (p.0 + v1.0, p.1 + v1.1),
+    (p.0 + v1.0 + v2.0, p.1 + v1.1 + v2.1),
+    (p.0 + v2.0, p.1 + v2.1),
+  ];
+  prims.push(Primitive::PolygonPrim {
+    points,
+    style: style.clone(),
+  });
+}
+
+/// HalfPlane[{p1, p2}, w] — the half plane swept by translating the line
+/// through p1 and p2 along w. HalfPlane[p, v, w] — the same with the line
+/// given as point p and direction v.
+fn parse_half_plane(
+  args: &[Expr],
+  style: &StyleState,
+  prims: &mut Vec<Primitive>,
+) {
+  let (p, v, w) = match args.len() {
+    2 => {
+      let Expr::List(pts) = &args[0] else {
+        return;
+      };
+      if pts.len() != 2 {
+        return;
+      }
+      let (Some(p1), Some(p2)) = (expr_to_point(&pts[0]), expr_to_point(&pts[1]))
+      else {
+        return;
+      };
+      let Some(w) = expr_to_point(&args[1]) else {
+        return;
+      };
+      (p1, (p2.0 - p1.0, p2.1 - p1.1), w)
+    }
+    3 => {
+      let (Some(p), Some(v), Some(w)) = (
+        expr_to_point(&args[0]),
+        expr_to_point(&args[1]),
+        expr_to_point(&args[2]),
+      ) else {
+        return;
+      };
+      (p, v, w)
+    }
+    _ => return,
+  };
+  if (v.0 == 0.0 && v.1 == 0.0) || (w.0 == 0.0 && w.1 == 0.0) {
+    return;
+  }
+  prims.push(Primitive::HalfPlanePrim {
+    p,
+    v,
+    w,
+    full: false,
+    style: style.clone(),
+  });
+}
+
+/// InfinitePlane[{p1, p2, p3}] / InfinitePlane[p, {v1, v2}] — with 2D
+/// coordinates the plane covers the entire viewport.
+fn parse_infinite_plane(
+  args: &[Expr],
+  style: &StyleState,
+  prims: &mut Vec<Primitive>,
+) {
+  let p = match args.len() {
+    1 => {
+      let Expr::List(pts) = &args[0] else {
+        return;
+      };
+      if pts.len() != 3 {
+        return;
+      }
+      let Some(p1) = expr_to_point(&pts[0]) else {
+        return;
+      };
+      if expr_to_point(&pts[1]).is_none() || expr_to_point(&pts[2]).is_none() {
+        return;
+      }
+      p1
+    }
+    2 => {
+      let Some(p) = expr_to_point(&args[0]) else {
+        return;
+      };
+      p
+    }
+    _ => return,
+  };
+  prims.push(Primitive::HalfPlanePrim {
+    p,
+    v: (1.0, 0.0),
+    w: (0.0, 1.0),
+    full: true,
+    style: style.clone(),
+  });
+}
+
 fn parse_regular_polygon(
   args: &[Expr],
   style: &StyleState,
@@ -1936,7 +2091,7 @@ fn evaluate_bspline(
 }
 
 /// Cox-de Boor recursion for B-spline basis function.
-fn bspline_basis(i: usize, k: usize, t: f64, knots: &[f64]) -> f64 {
+pub(crate) fn bspline_basis(i: usize, k: usize, t: f64, knots: &[f64]) -> f64 {
   if k == 0 {
     return if knots[i] <= t && t < knots[i + 1] {
       1.0
@@ -2132,6 +2287,13 @@ fn primitive_bbox(prim: &Primitive) -> BBox {
     } => {
       bb.include_point(*x_min, *y_min);
       bb.include_point(*x_max, *y_max);
+    }
+    // An unbounded fill only anchors the plot range at its defining
+    // points; the fill itself extends past whatever range results.
+    Primitive::HalfPlanePrim { p, v, w, .. } => {
+      bb.include_point(p.0, p.1);
+      bb.include_point(p.0 + v.0, p.1 + v.1);
+      bb.include_point(p.0 + w.0, p.1 + w.1);
     }
   }
   bb
@@ -3046,6 +3208,56 @@ fn render_primitive(
         stroke_attr,
       ));
     }
+    Primitive::HalfPlanePrim {
+      p,
+      v,
+      w,
+      full,
+      style,
+    } => {
+      // Build a parallelogram that extends far past the visible plot range
+      // in every relevant direction; the SVG viewport clips it.
+      let ext = 10.0 * (bb.width() + bb.height());
+      let corners: Vec<(f64, f64)> = if *full {
+        vec![
+          (bb.x_min - ext, bb.y_min - ext),
+          (bb.x_max + ext, bb.y_min - ext),
+          (bb.x_max + ext, bb.y_max + ext),
+          (bb.x_min - ext, bb.y_max + ext),
+        ]
+      } else {
+        let norm = |(x, y): (f64, f64)| {
+          let len = (x * x + y * y).sqrt();
+          (x / len * ext, y / len * ext)
+        };
+        let (vx, vy) = norm(*v);
+        let (wx, wy) = norm(*w);
+        vec![
+          (p.0 - vx, p.1 - vy),
+          (p.0 + vx, p.1 + vy),
+          (p.0 + vx + wx, p.1 + vy + wy),
+          (p.0 - vx + wx, p.1 - vy + wy),
+        ]
+      };
+      let color = style.effective_color();
+      let pts: Vec<String> = corners
+        .iter()
+        .map(|&(x, y)| {
+          format!("{:.2},{:.2}", coord_x(x, bb, svg_w), coord_y(y, bb, svg_h))
+        })
+        .collect();
+      let fill_opacity = if color.a < 1.0 {
+        format!(" fill-opacity=\"{}\"", color.a)
+      } else {
+        String::new()
+      };
+      out.push_str(&format!(
+        "<polygon points=\"{}\" fill=\"{}\"{}/>\n",
+        pts.join(" "),
+        color.to_svg_rgb(),
+        fill_opacity,
+      ));
+    }
     Primitive::ArrowPrim {
       points,
       setback,
@@ -3533,6 +3745,9 @@ fn primitives_to_box_elements(primitives: &[Primitive]) -> Vec<String> {
       }
       Primitive::RasterPrim { .. } => {
         // RasterBox is not yet supported in .nb export; skip
+      }
+      Primitive::HalfPlanePrim { .. } => {
+        // Unbounded fills have no fixed-coordinate box form; skip
       }
     }
   }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -47,6 +47,7 @@ pub mod parametric_plot;
 pub mod periodic_table_plot;
 pub mod plot;
 pub mod plot3d;
+pub mod polyhedron_data;
 pub mod polynomial_ast;
 pub mod predicate_ast;
 pub mod quantity_ast;

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -1564,6 +1564,12 @@ enum Primitive3D {
     radius: f64,
     style: StyleState3D,
   },
+  /// A pre-tessellated triangle surface (Torus, FilledTorus, BSplineSurface,
+  /// Raster3D voxels, …).
+  Surface3D {
+    tris: Vec<(Point3D, Point3D, Point3D)>,
+    style: StyleState3D,
+  },
 }
 
 /// Try to apply a 3D style directive (color or Opacity). Returns true if consumed.
@@ -1914,6 +1920,45 @@ fn collect_3d_primitives(
             style: style.clone(),
           });
         }
+        "Torus" | "FilledTorus" => {
+          let center = if !args.is_empty() {
+            parse_point3d(&args[0]).unwrap_or(Point3D {
+              x: 0.0,
+              y: 0.0,
+              z: 0.0,
+            })
+          } else {
+            Point3D {
+              x: 0.0,
+              y: 0.0,
+              z: 0.0,
+            }
+          };
+          let (r1, r2) = match args.get(1) {
+            Some(Expr::List(radii)) if radii.len() == 2 => {
+              let num = |e: &Expr| {
+                try_eval_to_f64(&evaluate_expr_to_expr(e).unwrap_or(e.clone()))
+              };
+              (num(&radii[0]).unwrap_or(0.5), num(&radii[1]).unwrap_or(1.0))
+            }
+            _ => (0.5, 1.0),
+          };
+          prims.push(Primitive3D::Surface3D {
+            tris: tessellate_torus(&center, r1, r2),
+            style: style.clone(),
+          });
+        }
+        "BSplineSurface" if !args.is_empty() => {
+          if let Some(grid) = parse_point3d_grid(&args[0]) {
+            prims.push(Primitive3D::Surface3D {
+              tris: tessellate_bspline_surface(&grid),
+              style: style.clone(),
+            });
+          }
+        }
+        "Raster3D" if !args.is_empty() => {
+          collect_raster3d(&args[0], style, prims);
+        }
         _ => {
           // Try as directive first
           if !apply_3d_directive(expr, style) {
@@ -1964,6 +2009,217 @@ fn tessellate_sphere(
     }
   }
   tris
+}
+
+/// Tessellate a torus with inner radius r1 and outer radius r2 (so the tube
+/// of radius (r2 - r1)/2 follows a circle of radius (r1 + r2)/2 in the
+/// z = center.z plane).
+fn tessellate_torus(
+  center: &Point3D,
+  r1: f64,
+  r2: f64,
+) -> Vec<(Point3D, Point3D, Point3D)> {
+  let ring = (r1 + r2) / 2.0;
+  let tube = (r2 - r1) / 2.0;
+  let n_u = 32;
+  let n_v = 16;
+  let pi = std::f64::consts::PI;
+  let p = |u: f64, v: f64| -> Point3D {
+    Point3D {
+      x: center.x + (ring + tube * v.cos()) * u.cos(),
+      y: center.y + (ring + tube * v.cos()) * u.sin(),
+      z: center.z + tube * v.sin(),
+    }
+  };
+  let mut tris = Vec::new();
+  for i in 0..n_u {
+    let u1 = 2.0 * pi * i as f64 / n_u as f64;
+    let u2 = 2.0 * pi * (i + 1) as f64 / n_u as f64;
+    for j in 0..n_v {
+      let v1 = 2.0 * pi * j as f64 / n_v as f64;
+      let v2 = 2.0 * pi * (j + 1) as f64 / n_v as f64;
+      let a = p(u1, v1);
+      let b = p(u2, v1);
+      let c = p(u2, v2);
+      let d = p(u1, v2);
+      tris.push((a, b, c));
+      tris.push((a, c, d));
+    }
+  }
+  tris
+}
+
+/// Parse a rectangular grid of 3D control points (a list of equal-length
+/// rows with at least 2 rows and 2 columns).
+fn parse_point3d_grid(expr: &Expr) -> Option<Vec<Vec<Point3D>>> {
+  let Expr::List(rows) = expr else {
+    return None;
+  };
+  let mut grid = Vec::with_capacity(rows.len());
+  for row in rows {
+    grid.push(parse_point3d_list(row)?);
+  }
+  if grid.len() >= 2
+    && grid[0].len() >= 2
+    && grid.iter().all(|r| r.len() == grid[0].len())
+  {
+    Some(grid)
+  } else {
+    None
+  }
+}
+
+/// B-spline basis weights for `n` control points sampled at `num_samples`
+/// evenly spaced parameter values (degree min(3, n-1), clamped uniform
+/// knots): one weight row per sample.
+fn bspline_sample_weights(n: usize, num_samples: usize) -> Vec<Vec<f64>> {
+  let degree = 3usize.min(n - 1);
+  let num_knots = n + degree + 1;
+  let mut knots = Vec::with_capacity(num_knots);
+  for _ in 0..=degree {
+    knots.push(0.0);
+  }
+  let num_internal = num_knots - 2 * (degree + 1);
+  for i in 1..=num_internal {
+    knots.push(i as f64);
+  }
+  let max_knot = (num_internal + 1) as f64;
+  for _ in 0..=degree {
+    knots.push(max_knot);
+  }
+  let t_min = knots[degree];
+  let t_max = knots[n];
+  (0..num_samples)
+    .map(|s| {
+      let t =
+        t_min + (t_max - t_min) * s as f64 / (num_samples - 1) as f64;
+      (0..n)
+        .map(|j| {
+          crate::functions::graphics::bspline_basis(j, degree, t, &knots)
+        })
+        .collect()
+    })
+    .collect()
+}
+
+/// Tessellate a B-spline surface from its control-point grid by sampling
+/// the tensor-product spline on a fixed grid.
+fn tessellate_bspline_surface(
+  grid: &[Vec<Point3D>],
+) -> Vec<(Point3D, Point3D, Point3D)> {
+  let n_rows = grid.len();
+  let n_cols = grid[0].len();
+  let samples = 24;
+  let wu = bspline_sample_weights(n_rows, samples);
+  let wv = bspline_sample_weights(n_cols, samples);
+  let surface: Vec<Vec<Point3D>> = wu
+    .iter()
+    .map(|row_w| {
+      wv.iter()
+        .map(|col_w| {
+          let mut acc = Point3D {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+          };
+          for (r, &rw) in row_w.iter().enumerate() {
+            if rw == 0.0 {
+              continue;
+            }
+            for (c, &cw) in col_w.iter().enumerate() {
+              let w = rw * cw;
+              if w == 0.0 {
+                continue;
+              }
+              acc.x += w * grid[r][c].x;
+              acc.y += w * grid[r][c].y;
+              acc.z += w * grid[r][c].z;
+            }
+          }
+          acc
+        })
+        .collect()
+    })
+    .collect();
+  let mut tris = Vec::new();
+  for i in 0..samples - 1 {
+    for j in 0..samples - 1 {
+      let a = surface[i][j];
+      let b = surface[i + 1][j];
+      let c = surface[i + 1][j + 1];
+      let d = surface[i][j + 1];
+      tris.push((a, b, c));
+      tris.push((a, c, d));
+    }
+  }
+  tris
+}
+
+/// Raster3D[data] — data is a nested list of layers (z), rows (y), and
+/// cells (x); each cell is a grayscale value in [0, 1] or an {r, g, b} /
+/// {r, g, b, a} list. Every cell becomes a unit voxel cuboid.
+fn collect_raster3d(
+  data: &Expr,
+  style: &StyleState3D,
+  prims: &mut Vec<Primitive3D>,
+) {
+  let num = |e: &Expr| {
+    try_eval_to_f64(&evaluate_expr_to_expr(e).unwrap_or(e.clone()))
+  };
+  let Expr::List(layers) = data else {
+    return;
+  };
+  for (k, layer) in layers.iter().enumerate() {
+    let Expr::List(rows) = layer else {
+      return;
+    };
+    for (j, row) in rows.iter().enumerate() {
+      let Expr::List(cells) = row else {
+        return;
+      };
+      for (i, cell) in cells.iter().enumerate() {
+        let (r, g, b, a) = match cell {
+          Expr::List(channels) => {
+            let vals: Vec<f64> =
+              match channels.iter().map(num).collect::<Option<Vec<_>>>() {
+                Some(v) => v,
+                None => return,
+              };
+            match vals.len() {
+              3 => (vals[0], vals[1], vals[2], 1.0),
+              4 => (vals[0], vals[1], vals[2], vals[3]),
+              _ => return,
+            }
+          }
+          other => match num(other) {
+            Some(v) => (v, v, v, 1.0),
+            None => return,
+          },
+        };
+        let mut voxel_style = style.clone();
+        voxel_style.color = Some((
+          (r.clamp(0.0, 1.0) * 255.0).round() as u8,
+          (g.clamp(0.0, 1.0) * 255.0).round() as u8,
+          (b.clamp(0.0, 1.0) * 255.0).round() as u8,
+        ));
+        voxel_style.opacity = a.clamp(0.0, 1.0) * style.opacity;
+        let p_min = Point3D {
+          x: i as f64,
+          y: j as f64,
+          z: k as f64,
+        };
+        let p_max = Point3D {
+          x: i as f64 + 1.0,
+          y: j as f64 + 1.0,
+          z: k as f64 + 1.0,
+        };
+        prims.push(Primitive3D::Surface3D {
+          tris: tessellate_cuboid(&p_min, &p_max),
+          style: voxel_style,
+        });
+      }
+    }
+  }
 }
 
 /// Tessellate a cuboid into 12 triangles (2 per face).
@@ -2302,6 +2558,7 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           };
           (t, style)
         }
+        Primitive3D::Surface3D { tris, style } => (tris.clone(), style),
         // Line and Point are handled separately below
         _ => (
           vec![],
@@ -2478,6 +2735,21 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Primitive3D::Line3D { segments, .. } => {
         for seg in segments {
           for pt in seg {
+            extend_3d(
+              pt,
+              &mut x3_min,
+              &mut x3_max,
+              &mut y3_min,
+              &mut y3_max,
+              &mut z3_min,
+              &mut z3_max,
+            );
+          }
+        }
+      }
+      Primitive3D::Surface3D { tris, .. } => {
+        for (a, b, c) in tris {
+          for pt in [a, b, c] {
             extend_3d(
               pt,
               &mut x3_min,

--- a/src/functions/polyhedron_data.rs
+++ b/src/functions/polyhedron_data.rs
@@ -1,0 +1,326 @@
+//! PolyhedronData[name] and PolyhedronData[name, property] for the Platonic
+//! solids. All metric properties refer to unit edge length and are stored as
+//! exact Wolfram Language expressions so results stay symbolic.
+
+use crate::InterpreterError;
+use crate::syntax::Expr;
+
+struct PolyhedronInfo {
+  name: &'static str,
+  vertex_count: i128,
+  edge_count: i128,
+  face_count: i128,
+  /// Exact metric properties (unit edge length) as WL source.
+  volume: &'static str,
+  surface_area: &'static str,
+  circumradius: &'static str,
+  inradius: &'static str,
+  /// Vertex coordinates for unit edge length (used for rendering).
+  vertices: fn() -> Vec<[f64; 3]>,
+}
+
+const PHI: f64 = 1.618_033_988_749_895; // golden ratio (1 + Sqrt[5])/2
+
+fn tetrahedron_vertices() -> Vec<[f64; 3]> {
+  // Edge length of {±1, ±1, ±1} alternated corners is 2 Sqrt[2].
+  let s = 1.0 / (2.0 * std::f64::consts::SQRT_2);
+  vec![
+    [s, s, s],
+    [s, -s, -s],
+    [-s, s, -s],
+    [-s, -s, s],
+  ]
+}
+
+fn cube_vertices() -> Vec<[f64; 3]> {
+  let mut v = Vec::with_capacity(8);
+  for &x in &[-0.5, 0.5] {
+    for &y in &[-0.5, 0.5] {
+      for &z in &[-0.5, 0.5] {
+        v.push([x, y, z]);
+      }
+    }
+  }
+  v
+}
+
+fn octahedron_vertices() -> Vec<[f64; 3]> {
+  let s = 1.0 / std::f64::consts::SQRT_2;
+  vec![
+    [s, 0.0, 0.0],
+    [-s, 0.0, 0.0],
+    [0.0, s, 0.0],
+    [0.0, -s, 0.0],
+    [0.0, 0.0, s],
+    [0.0, 0.0, -s],
+  ]
+}
+
+fn dodecahedron_vertices() -> Vec<[f64; 3]> {
+  // The classic (±1, ±1, ±1) / (0, ±1/φ, ±φ) / … coordinates have edge
+  // length 2/φ; scale by φ/2 for a unit edge.
+  let s = PHI / 2.0;
+  let a = 1.0 / PHI;
+  let mut v = Vec::with_capacity(20);
+  for &x in &[-1.0, 1.0] {
+    for &y in &[-1.0, 1.0] {
+      for &z in &[-1.0, 1.0] {
+        v.push([s * x, s * y, s * z]);
+      }
+    }
+  }
+  for &p in &[-1.0f64, 1.0] {
+    for &q in &[-1.0f64, 1.0] {
+      v.push([0.0, s * p * a, s * q * PHI]);
+      v.push([s * p * a, s * q * PHI, 0.0]);
+      v.push([s * p * PHI, 0.0, s * q * a]);
+    }
+  }
+  v
+}
+
+fn icosahedron_vertices() -> Vec<[f64; 3]> {
+  // Cyclic permutations of (0, ±1, ±φ) have edge length 2; halve for unit.
+  let mut v = Vec::with_capacity(12);
+  for &p in &[-0.5f64, 0.5] {
+    for &q in &[-0.5f64, 0.5] {
+      v.push([0.0, p, q * PHI]);
+      v.push([p, q * PHI, 0.0]);
+      v.push([q * PHI, 0.0, p]);
+    }
+  }
+  v
+}
+
+static POLYHEDRA: &[PolyhedronInfo] = &[
+  PolyhedronInfo {
+    name: "Tetrahedron",
+    vertex_count: 4,
+    edge_count: 6,
+    face_count: 4,
+    volume: "1/(6*Sqrt[2])",
+    surface_area: "Sqrt[3]",
+    circumradius: "Sqrt[3/8]",
+    inradius: "1/(2*Sqrt[6])",
+    vertices: tetrahedron_vertices,
+  },
+  PolyhedronInfo {
+    name: "Cube",
+    vertex_count: 8,
+    edge_count: 12,
+    face_count: 6,
+    volume: "1",
+    surface_area: "6",
+    circumradius: "Sqrt[3]/2",
+    inradius: "1/2",
+    vertices: cube_vertices,
+  },
+  PolyhedronInfo {
+    name: "Octahedron",
+    vertex_count: 6,
+    edge_count: 12,
+    face_count: 8,
+    volume: "Sqrt[2]/3",
+    surface_area: "2*Sqrt[3]",
+    circumradius: "1/Sqrt[2]",
+    inradius: "1/Sqrt[6]",
+    vertices: octahedron_vertices,
+  },
+  PolyhedronInfo {
+    name: "Dodecahedron",
+    vertex_count: 20,
+    edge_count: 30,
+    face_count: 12,
+    volume: "(15 + 7*Sqrt[5])/4",
+    surface_area: "3*Sqrt[25 + 10*Sqrt[5]]",
+    circumradius: "(Sqrt[15] + Sqrt[3])/4",
+    inradius: "Sqrt[250 + 110*Sqrt[5]]/20",
+    vertices: dodecahedron_vertices,
+  },
+  PolyhedronInfo {
+    name: "Icosahedron",
+    vertex_count: 12,
+    edge_count: 30,
+    face_count: 20,
+    volume: "(5*(3 + Sqrt[5]))/12",
+    surface_area: "5*Sqrt[3]",
+    circumradius: "Sqrt[10 + 2*Sqrt[5]]/4",
+    inradius: "(Sqrt[3]*(3 + Sqrt[5]))/12",
+    vertices: icosahedron_vertices,
+  },
+];
+
+fn find_polyhedron(name: &str) -> Option<&'static PolyhedronInfo> {
+  // "Hexahedron" is the standard alternative name for the cube.
+  let name = if name == "Hexahedron" { "Cube" } else { name };
+  POLYHEDRA.iter().find(|p| p.name == name)
+}
+
+/// Compute the faces of a convex polyhedron from its vertices: every plane
+/// through three vertices that has all remaining vertices strictly on one
+/// side is a supporting plane, and the vertices lying on it (ordered by
+/// angle around the face centroid) form a face.
+fn convex_faces(vertices: &[[f64; 3]]) -> Vec<Vec<usize>> {
+  const EPS: f64 = 1e-9;
+  let sub = |a: [f64; 3], b: [f64; 3]| [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+  let cross = |a: [f64; 3], b: [f64; 3]| {
+    [
+      a[1] * b[2] - a[2] * b[1],
+      a[2] * b[0] - a[0] * b[2],
+      a[0] * b[1] - a[1] * b[0],
+    ]
+  };
+  let dot =
+    |a: [f64; 3], b: [f64; 3]| a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+  let norm = |a: [f64; 3]| dot(a, a).sqrt();
+
+  let n = vertices.len();
+  let mut seen: std::collections::HashSet<Vec<usize>> =
+    std::collections::HashSet::new();
+  let mut faces: Vec<Vec<usize>> = Vec::new();
+  for i in 0..n {
+    for j in i + 1..n {
+      for k in j + 1..n {
+        let mut normal =
+          cross(sub(vertices[j], vertices[i]), sub(vertices[k], vertices[i]));
+        let len = norm(normal);
+        if len < EPS {
+          continue;
+        }
+        normal = [normal[0] / len, normal[1] / len, normal[2] / len];
+        let d = dot(normal, vertices[i]);
+        let mut above = false;
+        let mut below = false;
+        let mut on_plane = Vec::new();
+        for (idx, v) in vertices.iter().enumerate() {
+          let s = dot(normal, *v) - d;
+          if s > EPS {
+            above = true;
+          } else if s < -EPS {
+            below = true;
+          } else {
+            on_plane.push(idx);
+          }
+        }
+        if above && below {
+          continue;
+        }
+        // Orient the normal outward so face winding is consistent.
+        let outward = if above {
+          [-normal[0], -normal[1], -normal[2]]
+        } else {
+          normal
+        };
+        // Order face vertices by angle around the face centroid.
+        let centroid = on_plane.iter().fold([0.0; 3], |acc, &idx| {
+          [
+            acc[0] + vertices[idx][0] / on_plane.len() as f64,
+            acc[1] + vertices[idx][1] / on_plane.len() as f64,
+            acc[2] + vertices[idx][2] / on_plane.len() as f64,
+          ]
+        });
+        let x_axis = {
+          let v = sub(vertices[on_plane[0]], centroid);
+          let len = norm(v);
+          [v[0] / len, v[1] / len, v[2] / len]
+        };
+        let y_axis = cross(outward, x_axis);
+        let mut ordered = on_plane.clone();
+        ordered.sort_by(|&a, &b| {
+          let angle = |idx: usize| {
+            let v = sub(vertices[idx], centroid);
+            dot(v, y_axis).atan2(dot(v, x_axis))
+          };
+          angle(a)
+            .partial_cmp(&angle(b))
+            .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        // Many vertex triples describe the same plane; deduplicate faces
+        // by their sorted index set.
+        let mut key = ordered.clone();
+        key.sort_unstable();
+        if seen.insert(key) {
+          faces.push(ordered);
+        }
+      }
+    }
+  }
+  faces
+}
+
+/// Build the Graphics3D expression for a polyhedron and evaluate it into
+/// the rendered graphics object.
+fn polyhedron_graphics(
+  info: &PolyhedronInfo,
+) -> Result<Expr, InterpreterError> {
+  let vertices = (info.vertices)();
+  let faces = convex_faces(&vertices);
+  let polygons: Vec<Expr> = faces
+    .iter()
+    .map(|face| {
+      let pts: Vec<Expr> = face
+        .iter()
+        .map(|&idx| {
+          Expr::List(
+            vertices[idx].iter().map(|&c| Expr::Real(c)).collect::<Vec<_>>()
+              .into(),
+          )
+        })
+        .collect();
+      Expr::FunctionCall {
+        name: "Polygon".to_string(),
+        args: vec![Expr::List(pts.into())].into(),
+      }
+    })
+    .collect();
+  let graphics = Expr::FunctionCall {
+    name: "Graphics3D".to_string(),
+    args: vec![Expr::List(polygons.into())].into(),
+  };
+  crate::evaluator::evaluate_expr_to_expr(&graphics)
+}
+
+/// Evaluate a stored exact WL value.
+fn eval_wl(src: &str) -> Result<Expr, InterpreterError> {
+  let parsed = crate::functions::string_ast::parse_program_to_expr(src)?;
+  crate::evaluator::evaluate_expr_to_expr(&parsed)
+}
+
+pub fn polyhedron_data_ast(
+  args: &[Expr],
+) -> Result<Expr, InterpreterError> {
+  let unevaluated = || {
+    Ok(Expr::FunctionCall {
+      name: "PolyhedronData".to_string(),
+      args: args.to_vec().into(),
+    })
+  };
+  let Some(Expr::String(name)) = args.first() else {
+    return unevaluated();
+  };
+  let Some(info) = find_polyhedron(name) else {
+    crate::emit_message(&format!(
+      "PolyhedronData::notent: {name} is not a known entity, class, or tag for PolyhedronData. Use PolyhedronData[] for a list of entities."
+    ));
+    return Ok(Expr::Identifier("$Failed".to_string()));
+  };
+  match args.len() {
+    1 => polyhedron_graphics(info),
+    2 => {
+      let Expr::String(property) = &args[1] else {
+        return unevaluated();
+      };
+      match property.as_str() {
+        "VertexCount" => Ok(Expr::Integer(info.vertex_count)),
+        "EdgeCount" => Ok(Expr::Integer(info.edge_count)),
+        "FaceCount" => Ok(Expr::Integer(info.face_count)),
+        "Volume" => eval_wl(info.volume),
+        "SurfaceArea" => eval_wl(info.surface_area),
+        "Circumradius" => eval_wl(info.circumradius),
+        "Inradius" => eval_wl(info.inradius),
+        _ => unevaluated(),
+      }
+    }
+    _ => unevaluated(),
+  }
+}

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -6861,7 +6861,9 @@ pub fn to_expression_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// for its single top-level statement. Multiple `;`-separated statements
 /// become a `CompoundExpression`. Used by the three-argument ToExpression
 /// form so a holding head receives the unevaluated parse.
-fn parse_program_to_expr(src: &str) -> Result<Expr, InterpreterError> {
+pub(crate) fn parse_program_to_expr(
+  src: &str,
+) -> Result<Expr, InterpreterError> {
   use crate::Rule;
   use crate::syntax::pair_to_expr;
   let normalized = if src.contains('\r') {

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1208,6 +1208,7 @@ mod interpreter_tests {
   mod molecule;
   mod music;
   mod patterns;
+  mod polyhedron_data;
   mod property;
   mod quantity;
   mod rosetta_script_fixes;

--- a/tests/interpreter_tests/geometry.rs
+++ b/tests/interpreter_tests/geometry.rs
@@ -3416,3 +3416,200 @@ mod region {
     );
   }
 }
+
+// Graphics-object regions from the GraphicsObjects guide: Torus, FilledTorus,
+// Parallelogram, HalfPlane, InfinitePlane.
+mod graphics_object_regions {
+  use super::*;
+
+  #[test]
+  fn torus_stays_symbolic() {
+    assert_eq!(interpret("Torus[]").unwrap(), "Torus[]");
+    assert_eq!(
+      interpret("FilledTorus[{0, 0, 0}, {1, 2}]").unwrap(),
+      "FilledTorus[{0, 0, 0}, {1, 2}]"
+    );
+  }
+
+  // Torus[{x,y,z}, {r1, r2}] is a surface: area = Pi^2 (r2^2 - r1^2).
+  // The default is Torus[{0, 0, 0}, {1/2, 1}].
+  #[test]
+  fn torus_region_functions() {
+    assert_eq!(interpret("RegionMeasure[Torus[]]").unwrap(), "(3*Pi^2)/4");
+    assert_eq!(
+      interpret("RegionMeasure[Torus[{0, 0, 0}, {1, 3}]]").unwrap(),
+      "8*Pi^2"
+    );
+    assert_eq!(interpret("RegionDimension[Torus[]]").unwrap(), "2");
+    assert_eq!(interpret("RegionEmbeddingDimension[Torus[]]").unwrap(), "3");
+    assert_eq!(
+      interpret("RegionCentroid[Torus[{1, 2, 3}, {1, 2}]]").unwrap(),
+      "{1, 2, 3}"
+    );
+    assert_eq!(interpret("BoundedRegionQ[Torus[]]").unwrap(), "True");
+    assert_eq!(
+      interpret("RegionBounds[Torus[]]").unwrap(),
+      "{{-1, 1}, {-1, 1}, {-1/4, 1/4}}"
+    );
+  }
+
+  // FilledTorus is the solid: volume = Pi^2 (r2 - r1)^2 (r1 + r2) / 4.
+  #[test]
+  fn filled_torus_region_functions() {
+    assert_eq!(
+      interpret("RegionMeasure[FilledTorus[]]").unwrap(),
+      "(3*Pi^2)/32"
+    );
+    assert_eq!(
+      interpret("RegionMeasure[FilledTorus[{0, 0, 0}, {1, 3}]]").unwrap(),
+      "4*Pi^2"
+    );
+    assert_eq!(interpret("RegionDimension[FilledTorus[]]").unwrap(), "3");
+    assert_eq!(
+      interpret("RegionCentroid[FilledTorus[]]").unwrap(),
+      "{0, 0, 0}"
+    );
+    assert_eq!(interpret("BoundedRegionQ[FilledTorus[]]").unwrap(), "True");
+  }
+
+  #[test]
+  fn parallelogram_region_functions() {
+    // Area is |Det[{v1, v2}]| in the plane…
+    assert_eq!(
+      interpret("RegionMeasure[Parallelogram[{0, 0}, {{2, 0}, {1, 3}}]]")
+        .unwrap(),
+      "6"
+    );
+    // …and Sqrt of the Gram determinant in higher-dimensional space.
+    assert_eq!(
+      interpret(
+        "RegionMeasure[Parallelogram[{0, 0, 0}, {{1, 0, 0}, {0, 2, 0}}]]"
+      )
+      .unwrap(),
+      "2"
+    );
+    // Parallelogram[] is the unit square.
+    assert_eq!(interpret("RegionMeasure[Parallelogram[]]").unwrap(), "1");
+    assert_eq!(interpret("RegionDimension[Parallelogram[]]").unwrap(), "2");
+    assert_eq!(
+      interpret("RegionEmbeddingDimension[Parallelogram[]]").unwrap(),
+      "2"
+    );
+    assert_eq!(
+      interpret("RegionCentroid[Parallelogram[{0, 0}, {{2, 0}, {1, 3}}]]")
+        .unwrap(),
+      "{3/2, 3/2}"
+    );
+    assert_eq!(
+      interpret("RegionBounds[Parallelogram[{0, 0}, {{2, 0}, {1, 3}}]]")
+        .unwrap(),
+      "{{0, 3}, {0, 3}}"
+    );
+    assert_eq!(interpret("BoundedRegionQ[Parallelogram[]]").unwrap(), "True");
+  }
+
+  #[test]
+  fn half_plane_region_functions() {
+    assert_eq!(
+      interpret("RegionMeasure[HalfPlane[{{0, 0}, {1, 0}}, {0, 1}]]").unwrap(),
+      "Infinity"
+    );
+    assert_eq!(
+      interpret("RegionDimension[HalfPlane[{{0, 0}, {1, 0}}, {0, 1}]]")
+        .unwrap(),
+      "2"
+    );
+    assert_eq!(
+      interpret(
+        "RegionEmbeddingDimension[HalfPlane[{{0, 0}, {1, 0}}, {0, 1}]]"
+      )
+      .unwrap(),
+      "2"
+    );
+    assert_eq!(
+      interpret("BoundedRegionQ[HalfPlane[{{0, 0}, {1, 0}}, {0, 1}]]")
+        .unwrap(),
+      "False"
+    );
+    // HalfPlane[p, v, w] form stays symbolic.
+    assert_eq!(
+      interpret("HalfPlane[{0, 0}, {1, 0}, {0, 1}]").unwrap(),
+      "HalfPlane[{0, 0}, {1, 0}, {0, 1}]"
+    );
+  }
+
+  #[test]
+  fn infinite_plane_region_functions() {
+    assert_eq!(
+      interpret(
+        "RegionMeasure[InfinitePlane[{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}}]]"
+      )
+      .unwrap(),
+      "Infinity"
+    );
+    assert_eq!(
+      interpret(
+        "RegionDimension[InfinitePlane[{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}}]]"
+      )
+      .unwrap(),
+      "2"
+    );
+    assert_eq!(
+      interpret(
+        "RegionEmbeddingDimension[InfinitePlane[{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}}]]"
+      )
+      .unwrap(),
+      "3"
+    );
+    assert_eq!(
+      interpret(
+        "RegionEmbeddingDimension[InfinitePlane[{0, 0}, {{1, 0}, {0, 1}}]]"
+      )
+      .unwrap(),
+      "2"
+    );
+    assert_eq!(
+      interpret(
+        "BoundedRegionQ[InfinitePlane[{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}}]]"
+      )
+      .unwrap(),
+      "False"
+    );
+  }
+
+  // Unbounded curves also have infinite measure.
+  #[test]
+  fn unbounded_curve_measures() {
+    assert_eq!(
+      interpret("RegionMeasure[InfiniteLine[{{0, 0}, {1, 1}}]]").unwrap(),
+      "Infinity"
+    );
+    assert_eq!(
+      interpret("RegionMeasure[HalfLine[{{0, 0}, {1, 1}}]]").unwrap(),
+      "Infinity"
+    );
+  }
+
+  // JoinedCurve / BSplineSurface / Raster3D / AxisObject stay symbolic
+  // (they are consumed by the Graphics/Graphics3D renderers).
+  #[test]
+  fn graphics_primitives_stay_symbolic() {
+    assert_eq!(
+      interpret("JoinedCurve[{Line[{{0, 0}, {1, 1}}]}]").unwrap(),
+      "JoinedCurve[{Line[{{0, 0}, {1, 1}}]}]"
+    );
+    assert_eq!(
+      interpret("BSplineSurface[{{{0, 0, 0}, {1, 0, 1}}, {{0, 1, 1}, {1, 1, 0}}}]")
+        .unwrap(),
+      "BSplineSurface[{{{0, 0, 0}, {1, 0, 1}}, {{0, 1, 1}, {1, 1, 0}}}]"
+    );
+    assert_eq!(
+      interpret("Raster3D[{{{0, 1}, {1, 0}}, {{1, 0}, {0, 1}}}]").unwrap(),
+      "Raster3D[{{{0, 1}, {1, 0}}, {{1, 0}, {0, 1}}}]"
+    );
+    assert_eq!(
+      interpret("AxisObject[Line[{{0, 0}, {1, 0}}]]").unwrap(),
+      "AxisObject[Line[{{0, 0}, {1, 0}}]]"
+    );
+  }
+}

--- a/tests/interpreter_tests/polyhedron_data.rs
+++ b/tests/interpreter_tests/polyhedron_data.rs
@@ -1,0 +1,127 @@
+use super::*;
+
+mod polyhedron_data_tests {
+  use super::*;
+
+  // Counts for the five Platonic solids.
+  #[test]
+  fn polyhedron_data_counts() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Tetrahedron", "FaceCount"]"#).unwrap(),
+      "4"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube", "EdgeCount"]"#).unwrap(),
+      "12"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Octahedron", "VertexCount"]"#).unwrap(),
+      "6"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Dodecahedron", "FaceCount"]"#).unwrap(),
+      "12"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Icosahedron", "FaceCount"]"#).unwrap(),
+      "20"
+    );
+  }
+
+  // Exact metric properties for unit edge length.
+  #[test]
+  fn polyhedron_data_volumes() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Tetrahedron", "Volume"]"#).unwrap(),
+      "1/(6*Sqrt[2])"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube", "Volume"]"#).unwrap(),
+      "1"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Octahedron", "Volume"]"#).unwrap(),
+      "Sqrt[2]/3"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Dodecahedron", "Volume"]"#).unwrap(),
+      "(15 + 7*Sqrt[5])/4"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Icosahedron", "Volume"]"#).unwrap(),
+      "(5*(3 + Sqrt[5]))/12"
+    );
+  }
+
+  #[test]
+  fn polyhedron_data_surface_areas() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Tetrahedron", "SurfaceArea"]"#).unwrap(),
+      "Sqrt[3]"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube", "SurfaceArea"]"#).unwrap(),
+      "6"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Icosahedron", "SurfaceArea"]"#).unwrap(),
+      "5*Sqrt[3]"
+    );
+  }
+
+  #[test]
+  fn polyhedron_data_radii() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube", "Circumradius"]"#).unwrap(),
+      "Sqrt[3]/2"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube", "Inradius"]"#).unwrap(),
+      "1/2"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Octahedron", "Circumradius"]"#).unwrap(),
+      "1/Sqrt[2]"
+    );
+  }
+
+  // "Hexahedron" is an alternative name for the cube.
+  #[test]
+  fn polyhedron_data_hexahedron_alias() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Hexahedron", "Volume"]"#).unwrap(),
+      "1"
+    );
+  }
+
+  // PolyhedronData[name] renders the solid as a Graphics3D object.
+  #[test]
+  fn polyhedron_data_renders_graphics3d() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube"]"#).unwrap(),
+      "-Graphics3D-"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Dodecahedron"]"#).unwrap(),
+      "-Graphics3D-"
+    );
+  }
+
+  // Unknown polyhedra yield $Failed (with a notent message).
+  #[test]
+  fn polyhedron_data_unknown_name() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["NoSuchSolid", "Volume"]"#).unwrap(),
+      "$Failed"
+    );
+  }
+
+  // Unknown properties stay unevaluated.
+  #[test]
+  fn polyhedron_data_unknown_property() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube", "NoSuchProperty"]"#).unwrap(),
+      "PolyhedronData[Cube, NoSuchProperty]"
+    );
+  }
+}

--- a/tests/svg_rendering_tests.rs
+++ b/tests/svg_rendering_tests.rs
@@ -2404,4 +2404,80 @@ mod triangle_rendering {
     let direct = svg_of("Graphics[Triangle[{{0, 0}, {1, 0}, {0, 1}}]]");
     assert_eq!(complex, direct);
   }
+
+  // ── Graphics objects: Parallelogram, HalfPlane, InfinitePlane,
+  //    JoinedCurve, Torus, FilledTorus, BSplineSurface, Raster3D ──
+
+  #[test]
+  fn parallelogram_renders_as_polygon() {
+    let svg = svg_of("Graphics[Parallelogram[{0, 0}, {{2, 0}, {1, 1}}]]");
+    assert!(svg.contains("<polygon"), "expected a polygon: {svg}");
+  }
+
+  #[test]
+  fn half_plane_renders_clipped_fill() {
+    let svg =
+      svg_of("Graphics[{Blue, HalfPlane[{{0, 0}, {1, 0}}, {0, 1}]}]");
+    assert!(
+      svg.contains("<polygon") && svg.contains("fill=\"rgb(0,0,255)\""),
+      "expected a blue fill polygon: {svg}"
+    );
+  }
+
+  #[test]
+  fn infinite_plane_renders_full_fill() {
+    let svg =
+      svg_of("Graphics[{Red, InfinitePlane[{{0, 0}, {1, 0}, {0, 1}}]}]");
+    assert!(
+      svg.contains("<polygon") && svg.contains("fill=\"rgb(255,0,0)\""),
+      "expected a red fill polygon: {svg}"
+    );
+  }
+
+  #[test]
+  fn joined_curve_renders_components() {
+    let svg = svg_of(
+      "Graphics[JoinedCurve[{Line[{{0, 0}, {1, 1}}], \
+       BezierCurve[{{1, 1}, {2, 0}, {3, 1}}]}]]",
+    );
+    assert!(svg.contains("<polyline"), "expected the line part: {svg}");
+    assert!(svg.contains("<path"), "expected the bezier part: {svg}");
+  }
+
+  #[test]
+  fn torus_renders_in_graphics3d() {
+    let svg = svg_of("Graphics3D[Torus[]]");
+    assert!(
+      svg.matches("<polygon").count() > 100,
+      "expected a tessellated torus surface: {svg}"
+    );
+    let filled = svg_of("Graphics3D[FilledTorus[{0, 0, 0}, {1, 2}]]");
+    assert!(
+      filled.matches("<polygon").count() > 100,
+      "expected a tessellated filled torus surface"
+    );
+  }
+
+  #[test]
+  fn bspline_surface_renders_in_graphics3d() {
+    let svg = svg_of(
+      "Graphics3D[BSplineSurface[Table[{i, j, Sin[i j]}, {i, 5}, {j, 5}]]]",
+    );
+    assert!(
+      svg.matches("<polygon").count() > 100,
+      "expected a tessellated spline surface"
+    );
+  }
+
+  #[test]
+  fn raster3d_renders_voxels() {
+    let svg =
+      svg_of("Graphics3D[Raster3D[{{{0, 1}, {1, 0}}, {{1, 0}, {0, 1}}}]]");
+    // 8 voxel cuboids, 12 triangles each.
+    assert_eq!(svg.matches("<polygon").count(), 96);
+    // Voxels with value 0 are black, voxels with value 1 are white; both
+    // shades must appear (modulated by lighting, so just check some
+    // polygons exist with distinct fills).
+    assert!(svg.contains("<polygon"), "expected voxel polygons: {svg}");
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds support for `PolyhedronData` function for the five Platonic solids and implements region support for graphics objects including `Torus`, `FilledTorus`, `Parallelogram`, `HalfPlane`, and `InfinitePlane`. It also adds rendering support for `BSplineSurface` and `Raster3D` in 3D graphics.

## Key Changes

### PolyhedronData Implementation
- New module `src/functions/polyhedron_data.rs` providing exact metric properties (volume, surface area, circumradius, inradius) for Tetrahedron, Cube, Octahedron, Dodecahedron, and Icosahedron
- Stores metric properties as exact Wolfram Language expressions for symbolic computation
- Generates vertex coordinates for unit edge length and computes faces via convex hull algorithm
- Renders polyhedra as `Graphics3D` objects with tessellated polygon surfaces
- Supports "Hexahedron" as an alias for "Cube"

### Region Support for Graphics Objects
- Extended `RegionMeasure`, `RegionDimension`, `RegionEmbeddingDimension`, and `RegionBounds` to handle:
  - `Torus` and `FilledTorus`: Surface area and volume calculations with proper bounds
  - `Parallelogram`: Area computation using determinant (2D) or Gram matrix (higher dimensions)
  - `HalfPlane` and `InfinitePlane`: Infinite measure with proper dimension tracking
- Added helper functions `torus_parts()` and `parallelogram_parts()` for argument decomposition

### Graphics Rendering Enhancements
- **2D Graphics**: Added `Parallelogram`, `HalfPlane`, and `InfinitePlane` rendering with proper SVG polygon generation
- **3D Graphics**: 
  - New `Surface3D` primitive type for tessellated surfaces
  - `tessellate_torus()`: Generates triangle mesh for torus surfaces (32×16 grid)
  - `tessellate_bspline_surface()`: Evaluates tensor-product B-spline surfaces on 24×24 sample grid
  - `collect_raster3d()`: Converts voxel data to unit cuboid meshes with per-voxel color/opacity
  - `JoinedCurve` support for combining multiple curve components

### Test Coverage
- Added comprehensive test suite in `tests/interpreter_tests/polyhedron_data.rs` covering:
  - Vertex/edge/face counts for all Platonic solids
  - Exact metric properties (volumes, surface areas, radii)
  - Hexahedron alias
  - Graphics3D rendering
  - Error handling for unknown polyhedra/properties
- Extended geometry tests in `tests/interpreter_tests/geometry.rs` for graphics object regions
- Added SVG rendering tests for all new graphics primitives

### Notable Implementation Details
- Vertex coordinates use golden ratio (φ ≈ 1.618) for dodecahedron and icosahedron
- Convex hull face detection uses epsilon-based floating-point comparisons (1e-9)
- Face vertices are ordered by angle around centroid for consistent winding
- B-spline basis uses Cox-de Boor recursion with clamped uniform knots
- Unbounded regions (HalfPlane, InfinitePlane) extend 10× the plot range for proper clipping
- Updated `functions.csv` to mark `PolyhedronData` as partially implemented (🚧)

https://claude.ai/code/session_012gkhUwpLSfMU2mNxpYmfja