### PR TITLE
Implement TraditionalForm typesetting for conventional math notation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@
 
 # Unreleased
 
+- Render `TraditionalForm` mathematics in conventional, TeX-like notation in
+    the Playground and Studio typeset SVG output. `HoldForm` is now invisible;
+    `Sum`/`Product` become large `∑`/`∏` operators with limits above and below;
+    `Integrate` uses a `∫` sign with bounds and a `ⅆx` differential; `D` renders
+    as a Leibniz `∂ⁿ/∂xᵐ` fraction; `Det` and matrices get stretchy bars and
+    parentheses; `Sqrt` is drawn as one connected radical-and-vinculum object
+    that scales to its content; `Sin[x]^2` becomes `sin²(x)`; constants map to
+    glyphs (`Pi`→`π`, `Infinity`→`∞`, `Exp[x]`→`ⅇˣ`); `Gamma`/`Zeta`/`BesselJ`,
+    `Grad`/`Div`/`Curl`/`Laplacian` (`∇`), and `Limit` use their standard
+    notation; binary operators and relations get proper spacing; and single
+    Latin-letter variables are italicized. The parser now also accepts a
+    named-character symbol as a function head (e.g. `\[Psi][x, t]`).
 - Add support for the standalone `Control[…]` control expression in the
     Playground and Studio. `Control[{x, 0, 1}]` renders a slider,
     `Control[{x, {a, b, c}}]` a popup menu, `Control[{x, {0, 0}, {1, 1}}]`

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -4963,30 +4963,751 @@ fn trim_bigfloat_to_precision_for_output(expr: &Expr) -> Expr {
   }
 }
 
-/// Like `expr_to_box_form` but renders function calls with `(` / `)`
-/// instead of `[` / `]` for TraditionalForm (e.g. `F[x]` → `F(x)`).
-/// Only function-call brackets are swapped; List `{…}` braces and all
-/// other syntax stay as in StandardForm.
-pub fn expr_to_box_form_traditional(expr: &Expr) -> Expr {
-  match expr {
-    Expr::FunctionCall { name, args } => {
-      let mut row_args: Vec<Expr> = Vec::with_capacity(args.len() * 2 + 2);
-      row_args.push(Expr::String(name.clone()));
-      row_args.push(Expr::String("(".to_string()));
-      for (i, arg) in args.iter().enumerate() {
-        if i > 0 {
-          row_args.push(Expr::String(",".to_string()));
+// ── TraditionalForm typesetting helpers ───────────────────────────────
+//
+// These build the 2D box tree that the Playground/Studio SVG renderer
+// consumes so held mathematical expressions display in conventional
+// notation: `∑`/`∫`/`∏` operators with limits, invisible HoldForm, `π`/`∞`
+// glyphs, `sin(x)` instead of `Sin[x]`, stacked fractions, radicals, and
+// bracketed matrices. Only the *display* shape is produced here — no
+// evaluation happens.
+
+fn tf_string(s: &str) -> Expr {
+  Expr::String(s.to_string())
+}
+
+fn tf_row(items: Vec<Expr>) -> Expr {
+  if items.len() == 1 {
+    return items.into_iter().next().unwrap();
+  }
+  Expr::FunctionCall {
+    name: "RowBox".to_string(),
+    args: vec![Expr::List(items.into())].into(),
+  }
+}
+
+fn tf_box(name: &str, args: Vec<Expr>) -> Expr {
+  Expr::FunctionCall {
+    name: name.to_string(),
+    args: args.into(),
+  }
+}
+
+/// Thin space used between implicitly-multiplied factors (`2 a`, `n x`).
+/// The SVG text renderer draws a standalone U+2009 as a narrow gap.
+fn tf_thin_space() -> Expr {
+  Expr::String("\u{2009}".to_string())
+}
+
+fn tf_parens(inner: Expr) -> Expr {
+  tf_row(vec![tf_string("("), inner, tf_string(")")])
+}
+
+/// Map a symbol/constant name to its TraditionalForm glyph. Greek letters
+/// entered as `\[Mu]` etc. already arrive as their Unicode character, so
+/// only the named mathematical constants need translating here.
+fn tf_symbol(name: &str) -> String {
+  match name {
+    "Pi" => "\u{03C0}".to_string(),                    // π
+    "Infinity" => "\u{221E}".to_string(),              // ∞
+    "E" | "ExponentialE" => "\u{2147}".to_string(),    // ⅇ
+    "I" | "ImaginaryI" => "\u{2148}".to_string(),      // ⅈ
+    "Degree" => "\u{00B0}".to_string(),                // °
+    "EulerGamma" => "\u{03B3}".to_string(),            // γ
+    "GoldenRatio" => "\u{03C6}".to_string(),           // φ
+    "ComplexInfinity" => "\u{221E}".to_string(),       // ∞
+    _ => name.to_string(),
+  }
+}
+
+/// TraditionalForm display name for a well-known function (lowercase roman),
+/// or `None` if the head should be shown verbatim.
+fn tf_known_func(name: &str) -> Option<&'static str> {
+  Some(match name {
+    "Sin" => "sin",
+    "Cos" => "cos",
+    "Tan" => "tan",
+    "Cot" => "cot",
+    "Sec" => "sec",
+    "Csc" => "csc",
+    "Sinh" => "sinh",
+    "Cosh" => "cosh",
+    "Tanh" => "tanh",
+    "ArcSin" => "arcsin",
+    "ArcCos" => "arccos",
+    "ArcTan" => "arctan",
+    "Log" => "log",
+    "Log10" => "log",
+    "Ln" => "ln",
+    "Max" => "max",
+    "Min" => "min",
+    "Sign" => "sgn",
+    "Mod" => "mod",
+    "Gcd" => "gcd",
+    "Lcm" => "lcm",
+    "Gamma" => "\u{0393}", // Γ
+    "Zeta" => "\u{03B6}",  // ζ
+    _ => return None,
+  })
+}
+
+/// True for a trig/hyperbolic function whose power is written on the name
+/// (`sin²(x)`) rather than around the whole call.
+fn tf_is_trig(name: &str) -> bool {
+  matches!(
+    name,
+    "Sin" | "Cos" | "Tan" | "Cot" | "Sec" | "Csc" | "Sinh" | "Cosh" | "Tanh"
+  )
+}
+
+/// Whether a List is a matrix (a non-empty list whose every element is a
+/// list of equal length ≥ 1).
+fn tf_is_matrix(items: &[Expr]) -> bool {
+  if items.is_empty() {
+    return false;
+  }
+  let mut cols = None;
+  for it in items {
+    match it {
+      Expr::List(row) if !row.is_empty() => {
+        if *cols.get_or_insert(row.len()) != row.len() {
+          return false;
         }
-        row_args.push(expr_to_box_form_traditional(arg));
       }
-      row_args.push(Expr::String(")".to_string()));
-      Expr::FunctionCall {
-        name: "RowBox".to_string(),
-        args: vec![Expr::List(row_args.into())].into(),
+      _ => return false,
+    }
+  }
+  true
+}
+
+/// True if `expr` is the literal integer 0 (used to strip the spurious
+/// `0 -` the parser emits for a leading unary minus like `-x`).
+fn tf_is_zero(expr: &Expr) -> bool {
+  matches!(expr, Expr::Integer(0))
+}
+
+/// Collect the signed terms of an additive expression, flattening nested
+/// Plus/Minus and unary minus and dropping literal `0` terms. Each entry is
+/// `(is_negative, term)`.
+fn tf_flatten_additive(expr: &Expr, neg: bool, out: &mut Vec<(bool, Expr)>) {
+  use crate::syntax::{BinaryOperator, UnaryOperator};
+  match expr {
+    Expr::BinaryOp {
+      op: BinaryOperator::Plus,
+      left,
+      right,
+    } => {
+      tf_flatten_additive(left, neg, out);
+      tf_flatten_additive(right, neg, out);
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Minus,
+      left,
+      right,
+    } => {
+      tf_flatten_additive(left, neg, out);
+      tf_flatten_additive(right, !neg, out);
+    }
+    Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      operand,
+    } => tf_flatten_additive(operand, !neg, out),
+    Expr::FunctionCall { name, args } if name == "Plus" => {
+      for a in args.iter() {
+        tf_flatten_additive(a, neg, out);
       }
     }
+    _ if tf_is_zero(expr) => {}
+    _ => out.push((neg, expr.clone())),
+  }
+}
+
+/// Flatten a multiplicative expression into its factors.
+fn tf_flatten_times(expr: &Expr, out: &mut Vec<Expr>) {
+  use crate::syntax::BinaryOperator;
+  match expr {
+    Expr::BinaryOp {
+      op: BinaryOperator::Times,
+      left,
+      right,
+    } => {
+      tf_flatten_times(left, out);
+      tf_flatten_times(right, out);
+    }
+    Expr::FunctionCall { name, args } if name == "Times" => {
+      for a in args.iter() {
+        tf_flatten_times(a, out);
+      }
+    }
+    _ => out.push(expr.clone()),
+  }
+}
+
+/// Does this term need parentheses when placed as a factor in a product or
+/// as the base of a power?
+fn tf_needs_paren_factor(expr: &Expr) -> bool {
+  use crate::syntax::BinaryOperator;
+  match expr {
+    Expr::BinaryOp {
+      op: BinaryOperator::Plus | BinaryOperator::Minus,
+      ..
+    } => true,
+    Expr::UnaryOp {
+      op: crate::syntax::UnaryOperator::Minus,
+      ..
+    } => true,
+    Expr::Comparison { .. } => true,
+    Expr::FunctionCall { name, args } => {
+      (name == "Plus" && args.len() >= 2)
+        || (name == "Times"
+          && matches!(args.first(), Some(Expr::Integer(n)) if *n < 0))
+    }
+    _ => false,
+  }
+}
+
+fn tf_factor_boxed(expr: &Expr) -> Expr {
+  let boxed = tf(expr);
+  if tf_needs_paren_factor(expr) {
+    tf_parens(boxed)
+  } else {
+    boxed
+  }
+}
+
+/// TraditionalForm box of `base^exp`, with trig special-casing (`sin²(x)`)
+/// and half-integer exponents rendered as radicals.
+fn tf_power(base: &Expr, exp: &Expr) -> Expr {
+  // sin[x]^2 → sin²(x)
+  if let Expr::FunctionCall { name, args } = base
+    && tf_is_trig(name)
+    && args.len() == 1
+    && matches!(exp, Expr::Integer(n) if *n > 0)
+  {
+    let disp = tf_known_func(name).unwrap_or(name.as_str());
+    return tf_row(vec![
+      tf_box("SuperscriptBox", vec![tf_string(disp), tf(exp)]),
+      tf_string("("),
+      tf(&args[0]),
+      tf_string(")"),
+    ]);
+  }
+  // x^(1/2) → √x
+  let is_half = matches!(exp, Expr::FunctionCall { name, args }
+      if name == "Rational" && args.len() == 2
+      && matches!(&args[0], Expr::Integer(1))
+      && matches!(&args[1], Expr::Integer(2)))
+    || matches!(exp, Expr::Real(f) if (*f - 0.5).abs() < f64::EPSILON);
+  if is_half {
+    return tf_box("SqrtBox", vec![tf(base)]);
+  }
+  let negative_number = matches!(base, Expr::Integer(n) if *n < 0)
+    || matches!(base, Expr::Real(f) if *f < 0.0);
+  let base_box = if tf_needs_paren_factor(base)
+    || negative_number
+    || matches!(base, Expr::BinaryOp { op: crate::syntax::BinaryOperator::Power | crate::syntax::BinaryOperator::Divide, .. })
+    || matches!(base, Expr::FunctionCall { name, .. } if name == "Power" || name == "Rational")
+  {
+    tf_parens(tf(base))
+  } else {
+    tf(base)
+  };
+  tf_box("SuperscriptBox", vec![base_box, tf(exp)])
+}
+
+fn tf_fraction(num: &Expr, den: &Expr) -> Expr {
+  tf_box("FractionBox", vec![tf(num), tf(den)])
+}
+
+/// TraditionalForm box of a product (already flattened factor list).
+fn tf_times(expr: &Expr) -> Expr {
+  let mut factors = Vec::new();
+  tf_flatten_times(expr, &mut factors);
+  // Pull a leading -1 / negative numeric coefficient into a sign.
+  let mut negative = false;
+  if let Some(Expr::Integer(n)) = factors.first()
+    && *n < 0
+  {
+    negative = true;
+    if *n == -1 {
+      factors.remove(0);
+    } else {
+      factors[0] = Expr::Integer(-*n);
+    }
+  }
+  let mut items: Vec<Expr> = Vec::new();
+  for (i, f) in factors.iter().enumerate() {
+    if i > 0 {
+      items.push(tf_thin_space());
+    }
+    items.push(tf_factor_boxed(f));
+  }
+  let body = tf_row(items);
+  if negative {
+    tf_row(vec![tf_string("-"), body])
+  } else {
+    body
+  }
+}
+
+/// TraditionalForm box of an additive expression.
+fn tf_plus(expr: &Expr) -> Expr {
+  let mut terms = Vec::new();
+  tf_flatten_additive(expr, false, &mut terms);
+  if terms.is_empty() {
+    return tf_string("0");
+  }
+  let mut items: Vec<Expr> = Vec::new();
+  for (i, (neg, term)) in terms.iter().enumerate() {
+    if i == 0 {
+      if *neg {
+        items.push(tf_string("-"));
+      }
+    } else {
+      items.push(tf_string(if *neg { "-" } else { "+" }));
+    }
+    items.push(tf(term));
+  }
+  tf_row(items)
+}
+
+/// Render the iterator body of Sum/Product with the given large operator.
+fn tf_big_operator(glyph: &str, args: &[Expr]) -> Expr {
+  // Build one Underoverscript operator per iterator spec.
+  let mut ops: Vec<Expr> = Vec::new();
+  for spec in &args[1..] {
+    if let Expr::List(parts) = spec {
+      match parts.as_slice() {
+        [var, lo, hi] => {
+          let under =
+            tf_row(vec![tf(var), tf_string("="), tf(lo)]);
+          ops.push(tf_box(
+            "UnderoverscriptBox",
+            vec![tf_string(glyph), under, tf(hi)],
+          ));
+        }
+        [var, hi] => {
+          ops.push(tf_box(
+            "UnderoverscriptBox",
+            vec![tf_string(glyph), tf(var), tf(hi)],
+          ));
+        }
+        _ => ops.push(tf_string(glyph)),
+      }
+    } else {
+      ops.push(tf_string(glyph));
+    }
+  }
+  if ops.is_empty() {
+    ops.push(tf_string(glyph));
+  }
+  let mut items = ops;
+  items.push(tf_thin_space());
+  items.push(tf(&args[0]));
+  tf_row(items)
+}
+
+/// Render `Integrate[body, {x, a, b}, …]` with ∫ operators and ⅆx factors.
+fn tf_integrate(args: &[Expr]) -> Expr {
+  let mut ops: Vec<Expr> = Vec::new();
+  let mut diffs: Vec<Expr> = Vec::new();
+  for spec in &args[1..] {
+    match spec {
+      Expr::List(parts) if parts.len() == 3 => {
+        ops.push(tf_box(
+          "SubsuperscriptBox",
+          vec![tf_string("\u{222B}"), tf(&parts[1]), tf(&parts[2])],
+        ));
+        diffs.push(tf_string("\u{2146}")); // ⅆ
+        diffs.push(tf(&parts[0]));
+      }
+      Expr::List(parts) if parts.len() == 1 => {
+        ops.push(tf_string("\u{222B}"));
+        diffs.push(tf_string("\u{2146}"));
+        diffs.push(tf(&parts[0]));
+      }
+      other => {
+        ops.push(tf_string("\u{222B}"));
+        diffs.push(tf_string("\u{2146}"));
+        diffs.push(tf(other));
+      }
+    }
+  }
+  if ops.is_empty() {
+    return tf_generic_call("Integrate", args);
+  }
+  let mut items = ops;
+  items.push(tf_thin_space());
+  let body_needs_paren = matches!(&args[0],
+    Expr::BinaryOp { op: crate::syntax::BinaryOperator::Plus | crate::syntax::BinaryOperator::Minus, .. })
+    || matches!(&args[0], Expr::FunctionCall { name, .. } if name == "Plus");
+  if body_needs_paren {
+    items.push(tf_parens(tf(&args[0])));
+  } else {
+    items.push(tf(&args[0]));
+  }
+  items.push(tf_thin_space());
+  items.extend(diffs);
+  tf_row(items)
+}
+
+/// Render `D[body, x]`, `D[body, {x, n}]`, `D[body, s1, s2, …]` as a
+/// Leibniz-style derivative `∂ⁿ/(∂x^a ∂y^b) body`.
+fn tf_derivative(args: &[Expr]) -> Expr {
+  // Parse each spec into (var, order).
+  let mut specs: Vec<(Expr, i128)> = Vec::new();
+  for spec in &args[1..] {
+    match spec {
+      Expr::List(parts) if parts.len() == 2 => {
+        let order = match &parts[1] {
+          Expr::Integer(n) => *n,
+          _ => 1,
+        };
+        specs.push((parts[0].clone(), order));
+      }
+      other => specs.push((other.clone(), 1)),
+    }
+  }
+  if specs.is_empty() {
+    return tf_generic_call("D", args);
+  }
+  let total: i128 = specs.iter().map(|(_, n)| *n).sum();
+  let partial = "\u{2202}"; // ∂
+  let num = if total > 1 {
+    tf_box(
+      "SuperscriptBox",
+      vec![tf_string(partial), tf(&Expr::Integer(total))],
+    )
+  } else {
+    tf_string(partial)
+  };
+  let mut den_items: Vec<Expr> = Vec::new();
+  for (var, order) in &specs {
+    den_items.push(tf_string(partial));
+    if *order > 1 {
+      den_items.push(tf_box(
+        "SuperscriptBox",
+        vec![tf(var), tf(&Expr::Integer(*order))],
+      ));
+    } else {
+      den_items.push(tf(var));
+    }
+  }
+  let frac = tf_box("FractionBox", vec![num, tf_row(den_items)]);
+  let body = &args[0];
+  let body_box = if tf_needs_paren_factor(body)
+    || matches!(body, Expr::BinaryOp { op: crate::syntax::BinaryOperator::Times, .. })
+    || matches!(body, Expr::FunctionCall { name, .. } if name == "Times")
+  {
+    tf_parens(tf(body))
+  } else {
+    tf(body)
+  };
+  tf_row(vec![frac, tf_thin_space(), body_box])
+}
+
+/// Build a GridBox from a matrix (list of row-lists), boxing each cell.
+fn tf_matrix_grid(rows: &[Expr]) -> Expr {
+  let grid_rows: Vec<Expr> = rows
+    .iter()
+    .map(|row| {
+      if let Expr::List(cells) = row {
+        Expr::List(cells.iter().map(tf).collect::<Vec<_>>().into())
+      } else {
+        Expr::List(vec![tf(row)].into())
+      }
+    })
+    .collect();
+  tf_box("GridBox", vec![Expr::List(grid_rows.into())])
+}
+
+/// Generic `head(arg, …)` rendering (unknown functions). The head is shown
+/// verbatim — the constant glyph map (E→ⅇ, I→ⅈ, …) is deliberately *not*
+/// applied here, so a symbol used as a function head (e.g. the field `E` in
+/// `E[x, y, z]`) stays `E(x, y, z)` rather than becoming `ⅇ(x, y, z)`.
+fn tf_generic_call(name: &str, args: &[Expr]) -> Expr {
+  let mut items: Vec<Expr> = Vec::with_capacity(args.len() * 2 + 3);
+  items.push(tf_string(name));
+  items.push(tf_string("("));
+  for (i, arg) in args.iter().enumerate() {
+    if i > 0 {
+      items.push(tf_string(","));
+    }
+    items.push(tf(arg));
+  }
+  items.push(tf_string(")"));
+  tf_row(items)
+}
+
+/// Dispatch a function call to its TraditionalForm rendering.
+fn tf_call(name: &str, args: &[Expr]) -> Expr {
+  match name {
+    "HoldForm" | "HoldComplete" | "Defer" | "Identity" if args.len() == 1 => {
+      tf(&args[0])
+    }
+    "Sqrt" if args.len() == 1 => tf_box("SqrtBox", vec![tf(&args[0])]),
+    "Power" if args.len() == 2 => tf_power(&args[0], &args[1]),
+    "Rational" if args.len() == 2 => tf_fraction(&args[0], &args[1]),
+    "Times" if args.len() >= 2 => tf_times(&Expr::FunctionCall {
+      name: "Times".to_string(),
+      args: args.to_vec().into(),
+    }),
+    "Plus" if args.len() >= 2 => tf_plus(&Expr::FunctionCall {
+      name: "Plus".to_string(),
+      args: args.to_vec().into(),
+    }),
+    "Divide" if args.len() == 2 => tf_fraction(&args[0], &args[1]),
+    "Exp" if args.len() == 1 => {
+      tf_box("SuperscriptBox", vec![tf_string("\u{2147}"), tf(&args[0])])
+    }
+    "Sum" if args.len() >= 2 => tf_big_operator("\u{2211}", args), // ∑
+    "Product" if args.len() >= 2 => tf_big_operator("\u{220F}", args), // ∏
+    "Integrate" if args.len() >= 2 => tf_integrate(args),
+    "D" if args.len() >= 2 => tf_derivative(args),
+    "Abs" if args.len() == 1 => {
+      tf_row(vec![tf_string("|"), tf(&args[0]), tf_string("|")])
+    }
+    "Det" if args.len() == 1 => {
+      if let Expr::List(rows) = &args[0]
+        && tf_is_matrix(rows)
+      {
+        tf_row(vec![
+          tf_string("|"),
+          tf_matrix_grid(rows),
+          tf_string("|"),
+        ])
+      } else {
+        tf_row(vec![tf_string("det"), tf_parens(tf(&args[0]))])
+      }
+    }
+    "MatrixForm" | "TableForm" if args.len() == 1 => {
+      if let Expr::List(rows) = &args[0]
+        && tf_is_matrix(rows)
+      {
+        tf_row(vec![
+          tf_string("("),
+          tf_matrix_grid(rows),
+          tf_string(")"),
+        ])
+      } else {
+        tf(&args[0])
+      }
+    }
+    // Vector-calculus operators drop their coordinate-list argument and use
+    // ∇ notation: Grad → ∇f, Div → ∇·f, Curl → ∇×f, Laplacian → ∇²f.
+    "Grad" if args.len() == 2 && matches!(&args[1], Expr::List(_)) => {
+      tf_row(vec![tf_string("\u{2207}"), tf(&args[0])])
+    }
+    "Div" if args.len() == 2 && matches!(&args[1], Expr::List(_)) => {
+      tf_row(vec![
+        tf_string("\u{2207}"),
+        tf_string("\u{22C5}"),
+        tf(&args[0]),
+      ])
+    }
+    "Curl" if args.len() == 2 && matches!(&args[1], Expr::List(_)) => {
+      tf_row(vec![
+        tf_string("\u{2207}"),
+        tf_string("\u{00D7}"),
+        tf(&args[0]),
+      ])
+    }
+    "Laplacian" if args.len() == 2 && matches!(&args[1], Expr::List(_)) => {
+      tf_row(vec![
+        tf_box(
+          "SuperscriptBox",
+          vec![tf_string("\u{2207}"), tf_string("2")],
+        ),
+        tf(&args[0]),
+      ])
+    }
+    // Limit[body, x -> x0] → lim_{x→x0} body
+    "Limit" if args.len() >= 2 => {
+      let sub = match &args[1] {
+        Expr::Rule {
+          pattern,
+          replacement,
+        } => tf_row(vec![
+          tf(pattern),
+          tf_string("\u{2192}"),
+          tf(replacement),
+        ]),
+        Expr::FunctionCall { name, args: ra }
+          if name == "Rule" && ra.len() == 2 =>
+        {
+          tf_row(vec![
+            tf(&ra[0]),
+            tf_string("\u{2192}"),
+            tf(&ra[1]),
+          ])
+        }
+        other => tf(other),
+      };
+      let op = tf_box("UnderscriptBox", vec![tf_string("lim"), sub]);
+      let body_box = if tf_needs_paren_factor(&args[0]) {
+        tf_parens(tf(&args[0]))
+      } else {
+        tf(&args[0])
+      };
+      tf_row(vec![op, tf_thin_space(), body_box])
+    }
+    // Bessel functions render with a subscript order: BesselJ[n, x] → Jₙ(x).
+    "BesselJ" | "BesselY" | "BesselI" | "BesselK" if args.len() == 2 => {
+      let letter = match name {
+        "BesselJ" => "J",
+        "BesselY" => "Y",
+        "BesselI" => "I",
+        _ => "K",
+      };
+      tf_row(vec![
+        tf_box("SubscriptBox", vec![tf_string(letter), tf(&args[0])]),
+        tf_string("("),
+        tf(&args[1]),
+        tf_string(")"),
+      ])
+    }
+    "Subscript" if args.len() >= 2 => {
+      let sub = if args.len() == 2 {
+        tf(&args[1])
+      } else {
+        let mut parts: Vec<Expr> = Vec::new();
+        for (i, a) in args[1..].iter().enumerate() {
+          if i > 0 {
+            parts.push(tf_string(","));
+          }
+          parts.push(tf(a));
+        }
+        tf_row(parts)
+      };
+      tf_box("SubscriptBox", vec![tf(&args[0]), sub])
+    }
+    "Superscript" if args.len() == 2 => {
+      tf_box("SuperscriptBox", vec![tf(&args[0]), tf(&args[1])])
+    }
+    _ => {
+      if let Some(disp) = tf_known_func(name) {
+        let mut items: Vec<Expr> = vec![tf_string(disp), tf_string("(")];
+        for (i, arg) in args.iter().enumerate() {
+          if i > 0 {
+            items.push(tf_string(","));
+          }
+          items.push(tf(arg));
+        }
+        items.push(tf_string(")"));
+        tf_row(items)
+      } else {
+        tf_generic_call(name, args)
+      }
+    }
+  }
+}
+
+/// Core TraditionalForm typesetter: expression → 2D box tree.
+fn tf(expr: &Expr) -> Expr {
+  use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
+  match expr {
+    Expr::Identifier(s) | Expr::Constant(s) => tf_string(&tf_symbol(s)),
+    Expr::FunctionCall { name, args } => tf_call(name, args),
+    Expr::List(items) => {
+      if tf_is_matrix(items) {
+        tf_row(vec![tf_string("("), tf_matrix_grid(items), tf_string(")")])
+      } else {
+        let mut parts: Vec<Expr> = vec![tf_string("{")];
+        for (i, it) in items.iter().enumerate() {
+          if i > 0 {
+            parts.push(tf_string(","));
+          }
+          parts.push(tf(it));
+        }
+        parts.push(tf_string("}"));
+        tf_row(parts)
+      }
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Power,
+      left,
+      right,
+    } => tf_power(left, right),
+    Expr::BinaryOp {
+      op: BinaryOperator::Divide,
+      left,
+      right,
+    } => tf_fraction(left, right),
+    Expr::BinaryOp {
+      op: BinaryOperator::Times,
+      ..
+    } => tf_times(expr),
+    Expr::BinaryOp {
+      op: BinaryOperator::Minus,
+      left,
+      right,
+    } if tf_is_zero(left) => {
+      // Parser artifact: leading unary minus `-x` becomes `0 - x`.
+      tf_row(vec![tf_string("-"), tf_factor_boxed(right)])
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Plus | BinaryOperator::Minus,
+      ..
+    } => tf_plus(expr),
+    Expr::BinaryOp {
+      op: BinaryOperator::And,
+      left,
+      right,
+    } => tf_row(vec![tf(left), tf_string("\u{2227}"), tf(right)]),
+    Expr::BinaryOp {
+      op: BinaryOperator::Or,
+      left,
+      right,
+    } => tf_row(vec![tf(left), tf_string("\u{2228}"), tf(right)]),
+    Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      operand,
+    } => tf_row(vec![tf_string("-"), tf_factor_boxed(operand)]),
+    Expr::UnaryOp {
+      op: UnaryOperator::Not,
+      operand,
+    } => tf_row(vec![tf_string("\u{00AC}"), tf(operand)]),
+    Expr::Comparison {
+      operands,
+      operators,
+    } => {
+      let mut parts = vec![tf(&operands[0])];
+      for (i, op) in operators.iter().enumerate() {
+        let sym = match op {
+          ComparisonOp::Equal => "=",
+          ComparisonOp::NotEqual => "\u{2260}",     // ≠
+          ComparisonOp::Less => "<",
+          ComparisonOp::LessEqual => "\u{2264}",    // ≤
+          ComparisonOp::Greater => ">",
+          ComparisonOp::GreaterEqual => "\u{2265}", // ≥
+          ComparisonOp::SameQ => "\u{2261}",        // ≡
+          ComparisonOp::UnsameQ => "\u{2262}",      // ≢
+        };
+        parts.push(tf_string(sym));
+        parts.push(tf(&operands[i + 1]));
+      }
+      tf_row(parts)
+    }
+    Expr::Rule {
+      pattern,
+      replacement,
+    } => tf_row(vec![
+      tf(pattern),
+      tf_string("\u{2192}"),
+      tf(replacement),
+    ]),
     _ => expr_to_box_form(expr),
   }
+}
+
+/// Convert an expression to its TraditionalForm box tree for typeset SVG
+/// display (Playground / Studio) and for `MakeBoxes[…, TraditionalForm]`.
+/// Produces conventional mathematical notation: `∑`/`∫`/`∏` operators with
+/// limits, invisible HoldForm, `π`/`∞`/`ⅇ` glyphs, `sin(x)` for `Sin[x]`,
+/// stacked fractions, radicals, and bracketed matrices. Unknown functions
+/// render as `head(args)`.
+pub fn expr_to_box_form_traditional(expr: &Expr) -> Expr {
+  tf(expr)
 }
 
 /// Convert a Quantity unit expression to box form with proper abbreviations.

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -4393,6 +4393,184 @@ pub struct BoxLayout {
 /// opening `[`) overlap.
 pub(crate) const MONO_ADVANCE: f64 = 0.632;
 
+/// If `s` is a single n-ary/large operator glyph (∑ ∏ ∫ …), return the font
+/// scale factor at which it should be drawn so it reads as a display-size
+/// operator. Returns `None` for ordinary atoms.
+fn large_operator_scale(s: &str) -> Option<f64> {
+  match s {
+    "\u{2211}" | "\u{220F}" | "\u{2210}" => Some(1.9), // ∑ ∏ ∐
+    "\u{22C3}" | "\u{22C2}" | "\u{2A01}" | "\u{2A02}" | "\u{2A00}" => Some(1.8), // ⋃ ⋂ ⨁ ⨂ ⨀
+    "\u{222B}" | "\u{222C}" | "\u{222D}" | "\u{222E}" => Some(1.8), // ∫ ∬ ∭ ∮
+    _ => None,
+  }
+}
+
+/// True if `s` is a single Latin letter, which TraditionalForm renders as an
+/// italic math variable.
+fn is_math_italic_atom(s: &str) -> bool {
+  let mut chars = s.chars();
+  match (chars.next(), chars.next()) {
+    (Some(c), None) => c.is_ascii_alphabetic(),
+    _ => false,
+  }
+}
+
+/// The set of single-character bracket/bar glyphs that can be vertically
+/// stretched to enclose tall content.
+fn stretchy_delim_kind(s: &str) -> Option<char> {
+  match s {
+    "(" | ")" | "[" | "]" | "|" | "{" | "}" => s.chars().next(),
+    _ => None,
+  }
+}
+
+/// Whether `open`/`close` form a matching stretchy-delimiter pair. Braces
+/// are intentionally excluded: lists keep ordinary `{`/`}` glyphs.
+fn delim_pair_matches(open: char, close: char) -> bool {
+  matches!((open, close), ('(', ')') | ('[', ']') | ('|', '|'))
+}
+
+/// Horizontal space (in character advances) placed on each side of a binary
+/// operator or relation token; `0.0` for non-operators.
+fn operator_space(s: &str) -> f64 {
+  match s {
+    "=" | "\u{2260}" | "<" | ">" | "\u{2264}" | "\u{2265}" | "\u{2261}"
+    | "\u{2262}" | "\u{2192}" | "\u{29F4}" | "\u{2248}" | "\u{221D}"
+    | "\u{21D2}" | "\u{27F9}" => 0.44,
+    "+" | "-" | "\u{00B1}" | "\u{2213}" => 0.36,
+    "\u{2227}" | "\u{2228}" | "\u{22C5}" => 0.34,
+    _ => 0.0,
+  }
+}
+
+/// Draw a bracket/bar/paren glyph as a vector path stretched vertically to
+/// enclose content of the given ascent/descent. The delimiter's baseline is
+/// aligned to the inner content's baseline so the surrounding row stays on the
+/// math axis.
+fn render_stretchy_delim(
+  kind: char,
+  inner_ascent: f64,
+  inner_descent: f64,
+  font_size: f64,
+) -> BoxLayout {
+  let pad = font_size * 0.14;
+  let h = inner_ascent + inner_descent + pad * 2.0;
+  let baseline = inner_ascent + pad;
+  let sw = (font_size * 0.055).max(0.7);
+  // Width reserved for the delimiter, plus a hair of side bearing.
+  let (body_w, bearing) = match kind {
+    '|' => (font_size * 0.10, font_size * 0.10),
+    '[' | ']' => (font_size * 0.22, font_size * 0.08),
+    '{' | '}' => (font_size * 0.28, font_size * 0.08),
+    _ => (font_size * 0.30, font_size * 0.08), // ( )
+  };
+  let w = body_w + bearing * 2.0;
+  let x0 = bearing;
+  let x1 = bearing + body_w;
+  let path = match kind {
+    '|' => {
+      let cx = (x0 + x1) / 2.0;
+      format!(
+        "<line x1=\"{cx:.2}\" y1=\"0\" x2=\"{cx:.2}\" y2=\"{h:.2}\" stroke=\"currentColor\" stroke-width=\"{sw:.2}\"/>"
+      )
+    }
+    '[' => format!(
+      "<path d=\"M {x1:.2} 0 L {x0:.2} 0 L {x0:.2} {h:.2} L {x1:.2} {h:.2}\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"{sw:.2}\"/>"
+    ),
+    ']' => format!(
+      "<path d=\"M {x0:.2} 0 L {x1:.2} 0 L {x1:.2} {h:.2} L {x0:.2} {h:.2}\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"{sw:.2}\"/>"
+    ),
+    '{' => {
+      let midy = h / 2.0;
+      let xm = (x0 + x1) / 2.0;
+      format!(
+        "<path d=\"M {x1:.2} 0 Q {x0:.2} 0 {x0:.2} {q:.2} L {x0:.2} {a:.2} Q {x0:.2} {midy:.2} {xm:.2} {midy:.2} Q {x0:.2} {midy:.2} {x0:.2} {b:.2} L {x0:.2} {c:.2} Q {x0:.2} {h:.2} {x1:.2} {h:.2}\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"{sw:.2}\"/>",
+        q = h * 0.12,
+        a = midy - h * 0.06,
+        b = midy + h * 0.06,
+        c = h * 0.88,
+      )
+    }
+    '}' => {
+      let midy = h / 2.0;
+      let xm = (x0 + x1) / 2.0;
+      format!(
+        "<path d=\"M {x0:.2} 0 Q {x1:.2} 0 {x1:.2} {q:.2} L {x1:.2} {a:.2} Q {x1:.2} {midy:.2} {xm:.2} {midy:.2} Q {x1:.2} {midy:.2} {x1:.2} {b:.2} L {x1:.2} {c:.2} Q {x1:.2} {h:.2} {x0:.2} {h:.2}\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"{sw:.2}\"/>",
+        q = h * 0.12,
+        a = midy - h * 0.06,
+        b = midy + h * 0.06,
+        c = h * 0.88,
+      )
+    }
+    '(' => {
+      let cx = x1 + body_w * 0.15;
+      format!(
+        "<path d=\"M {cx:.2} 0 Q {x0:.2} {midy:.2} {cx:.2} {h:.2}\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"{sw:.2}\"/>",
+        midy = h / 2.0,
+      )
+    }
+    ')' => {
+      let cx = x0 - body_w * 0.15;
+      format!(
+        "<path d=\"M {cx:.2} 0 Q {x1:.2} {midy:.2} {cx:.2} {h:.2}\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"{sw:.2}\"/>",
+        midy = h / 2.0,
+      )
+    }
+    _ => String::new(),
+  };
+  BoxLayout {
+    width: w,
+    height: h,
+    baseline,
+    elements: path,
+  }
+}
+
+/// Lay out a square-root: the radical hook and the vinculum over `content`
+/// are emitted as one connected polyline that scales to the content height,
+/// so the sign and overbar read as a single object. `left_offset` reserves
+/// space to the left of the hook (used by RadicalBox for its index). Returns
+/// the hook width and the composed layout.
+fn sqrt_radical(
+  content: &BoxLayout,
+  left_offset: f64,
+  font_size: f64,
+) -> (f64, BoxLayout) {
+  let ch = content.height;
+  let sw = (font_size * 0.06).max(0.9);
+  let gap_top = font_size * 0.18;
+  let hook_w = font_size * 0.55;
+  let line_y = sw; // keep the vinculum fully inside the viewport
+  let content_x = left_offset + hook_w;
+  let content_top = line_y + gap_top;
+  let bottom = content_top + ch;
+  let h = bottom + sw;
+  let w = content_x + content.width + font_size * 0.10;
+
+  // Radical polyline: enter mid-left, dip to the bottom vertex, rise along
+  // the long diagonal to the top-left corner, then run across as the vinculum.
+  let x0 = left_offset;
+  let p0 = (x0 + hook_w * 0.04, content_top + ch * 0.55);
+  let p1 = (x0 + hook_w * 0.30, content_top + ch * 0.72);
+  let p2 = (x0 + hook_w * 0.52, h - sw * 0.5);
+  let p3 = (content_x, line_y);
+  let p4 = (w, line_y);
+  let path = format!(
+    "<path d=\"M {:.2} {:.2} L {:.2} {:.2} L {:.2} {:.2} L {:.2} {:.2} L {:.2} {:.2}\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"{sw:.2}\" stroke-linejoin=\"round\" stroke-linecap=\"round\"/>",
+    p0.0, p0.1, p1.0, p1.1, p2.0, p2.1, p3.0, p3.1, p4.0, p4.1,
+  );
+  let elements = format!("{}{}", path, content.translate(content_x, content_top));
+  (
+    hook_w,
+    BoxLayout {
+      width: w,
+      height: h,
+      baseline: content_top + content.baseline,
+      elements,
+    },
+  )
+}
+
 impl BoxLayout {
   /// Create a layout for a simple text atom.
   fn text(s: &str, font_size: f64) -> Self {
@@ -4400,6 +4578,26 @@ impl BoxLayout {
     let ascent = font_size * 0.8; // approximate ascent
     let descent = font_size * 0.25; // approximate descent
     let height = ascent + descent;
+    // Large (n-ary) operators — ∑ ∏ ∫ … — are drawn oversized and vertically
+    // centered on the math axis so they read as display-size operators with
+    // limits stacked above/below (Sum, Product) or as scripts (Integrate),
+    // matching conventional math typesetting.
+    if let Some(scale) = large_operator_scale(s) {
+      let fs = font_size * scale;
+      let glyph_ascent = fs * 0.72;
+      let glyph_descent = fs * 0.28;
+      let w = fs * 0.62;
+      let escaped = svg_escape(s);
+      return BoxLayout {
+        width: w,
+        height: glyph_ascent + glyph_descent,
+        baseline: glyph_ascent,
+        elements: format!(
+          "<text x=\"{cx:.2}\" y=\"{glyph_ascent:.2}\" font-family=\"serif\" font-size=\"{fs:.2}\" stroke=\"none\" text-anchor=\"middle\">{escaped}</text>",
+          cx = w / 2.0,
+        ),
+      };
+    }
     // The multiplication separator " × " reserves a full monospace space on
     // each side of the small sign, which reads as too wide. Render it in a
     // tighter slot (~half a space per side) with the sign centered, without
@@ -4467,6 +4665,14 @@ impl BoxLayout {
     let s = mapped.as_str();
     let w = s.chars().count() as f64 * ch;
     let escaped = svg_escape(s);
+    // Single Latin letters are math variables — render them italic for a
+    // conventional TeX-like look. The advance width is unchanged (same font,
+    // slanted), so surrounding layout is unaffected.
+    let style_attr = if is_math_italic_atom(s) {
+      " font-style=\"italic\""
+    } else {
+      ""
+    };
     BoxLayout {
       width: w,
       height,
@@ -4476,7 +4682,7 @@ impl BoxLayout {
       // their allocated width rather than the glyph sticking to the previous
       // token. The width above already counts those spaces.
       elements: format!(
-        "<text x=\"0\" y=\"{ascent:.1}\" font-family=\"monospace\" font-size=\"{font_size:.1}\" stroke=\"none\" xml:space=\"preserve\">{escaped}</text>"
+        "<text x=\"0\" y=\"{ascent:.1}\" font-family=\"monospace\" font-size=\"{font_size:.1}\" stroke=\"none\"{style_attr} xml:space=\"preserve\">{escaped}</text>"
       ),
     }
   }
@@ -4515,8 +4721,48 @@ pub fn layout_box(expr: &Expr, font_size: f64) -> BoxLayout {
         if items.is_empty() {
           return BoxLayout::text("", font_size);
         }
-        let children: Vec<BoxLayout> =
+        let mut children: Vec<BoxLayout> =
           items.iter().map(|e| layout_box(e, font_size)).collect();
+
+        // Stretchy delimiters: when the row is bracketed — its first child is
+        // an opening (or bar) delimiter and its last child is the matching
+        // closing (or bar) delimiter — grow both to enclose the inner content
+        // (matrices, determinants, tall fractions). Function-call parens are
+        // unaffected because the head token precedes the `(`.
+        if items.len() >= 3 {
+          let open = match &items[0] {
+            Expr::String(s) => stretchy_delim_kind(s),
+            _ => None,
+          };
+          let close = match items.last() {
+            Some(Expr::String(s)) => stretchy_delim_kind(s),
+            _ => None,
+          };
+          if let (Some(o), Some(c)) = (open, close)
+            && delim_pair_matches(o, c)
+          {
+            let inner_ascent = children[1..children.len() - 1]
+              .iter()
+              .map(|c| c.baseline)
+              .fold(0.0_f64, f64::max);
+            let inner_descent = children[1..children.len() - 1]
+              .iter()
+              .map(|c| c.height - c.baseline)
+              .fold(0.0_f64, f64::max);
+            let natural = children[0].height;
+            // Only stretch for genuinely tall content (fractions, grids,
+            // nested radicals) — a lone superscript (~1.3×) stays with plain
+            // glyphs so ordinary parenthesized expressions are unaffected.
+            if inner_ascent + inner_descent > natural * 1.5 {
+              let last = children.len() - 1;
+              children[0] =
+                render_stretchy_delim(o, inner_ascent, inner_descent, font_size);
+              children[last] =
+                render_stretchy_delim(c, inner_ascent, inner_descent, font_size);
+            }
+          }
+        }
+
         // Find the maximum baseline and maximum below-baseline
         let max_baseline =
           children.iter().map(|c| c.baseline).fold(0.0_f64, f64::max);
@@ -4528,19 +4774,29 @@ pub fn layout_box(expr: &Expr, font_size: f64) -> BoxLayout {
         let mut elements = String::new();
         let mut x = 0.0_f64;
         for (i, child) in children.iter().enumerate() {
+          // Medium space around binary operators / relations (but not around a
+          // leading unary sign, which has no left operand).
+          let op_space = match &items[i] {
+            Expr::String(s) if i > 0 && i + 1 < items.len() => {
+              operator_space(s) * ch
+            }
+            _ => 0.0,
+          };
           // A small space before a bare comma so it does not crowd the
           // preceding token (e.g. the trailing digit of a list element).
           if i > 0 && matches!(&items[i], Expr::String(s) if s == ",") {
-            x += ch * 0.35;
+            x += ch * 0.2;
           }
+          x += op_space;
           let dy = max_baseline - child.baseline;
           elements.push_str(&child.translate(x, dy));
           x += child.width;
+          x += op_space;
           // Add space after bare comma
           if matches!(&items[i], Expr::String(s) if s == ",")
             && i + 1 < items.len()
           {
-            x += ch * 0.5;
+            x += ch * 0.4;
           }
         }
         BoxLayout {
@@ -4649,54 +4905,29 @@ pub fn layout_box(expr: &Expr, font_size: f64) -> BoxLayout {
         }
       }
 
-      // SqrtBox: √ symbol + overline (vinculum) above content
+      // SqrtBox: the radical hook and its vinculum (overline) are drawn as a
+      // single connected stroke that scales to the content height, so the
+      // sign and bar read as one object instead of a fixed glyph butted
+      // against a separate line.
       "SqrtBox" if args.len() == 1 => {
         let content = layout_box(&args[0], font_size);
-        let radical = BoxLayout::text("\u{221A}", font_size);
-        let pad = 2.0; // space above content for the vinculum
-        let line_y = pad * 0.5;
-        let content_x = radical.width;
-        let w = radical.width + content.width;
-        let h = content.height + pad;
-        let elements = format!(
-          "{}\
-           <line x1=\"{content_x:.1}\" y1=\"{line_y:.1}\" x2=\"{w:.1}\" y2=\"{line_y:.1}\" stroke=\"currentColor\" stroke-width=\"0.8\"/>\
-           {}",
-          radical.translate(0.0, pad),
-          content.translate(content_x, pad),
-        );
-        BoxLayout {
-          width: w,
-          height: h,
-          baseline: pad + content.baseline,
-          elements,
-        }
+        sqrt_radical(&content, 0.0, font_size).1
       }
 
-      // RadicalBox: index + √ symbol + overline above content
+      // RadicalBox: like SqrtBox but with a small index tucked into the hook.
       "RadicalBox" if args.len() == 2 => {
         let content = layout_box(&args[0], font_size);
-        let index = layout_box(&args[1], font_size * 0.7);
-        let radical = BoxLayout::text("\u{221A}", font_size);
-        let pad = 2.0;
-        let index_dy = 0.0;
-        let body_dy = index.height * 0.3 + pad;
-        let content_x = index.width + radical.width;
-        let w = content_x + content.width;
-        let line_y = body_dy - pad * 0.5;
-        let elements = format!(
-          "{}{}\
-           <line x1=\"{content_x:.1}\" y1=\"{line_y:.1}\" x2=\"{w:.1}\" y2=\"{line_y:.1}\" stroke=\"currentColor\" stroke-width=\"0.8\"/>\
-           {}",
-          index.translate(0.0, index_dy),
-          radical.translate(index.width, body_dy),
-          content.translate(content_x, body_dy),
-        );
+        let index = layout_box(&args[1], font_size * 0.6);
+        let index_w = index.width + font_size * 0.05;
+        let (hook_w, body) = sqrt_radical(&content, index_w, font_size);
+        // Place the index over the low part of the hook.
+        let index_x = (index_w + hook_w - index.width).max(0.0) * 0.4;
+        let index_y = body.height * 0.18;
+        let elements =
+          format!("{}{}", index.translate(index_x, index_y), body.elements);
         BoxLayout {
-          width: w,
-          height: body_dy + content.height,
-          baseline: body_dy + content.baseline,
           elements,
+          ..body
         }
       }
 

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -4894,14 +4894,20 @@ pub fn layout_box(expr: &Expr, font_size: f64) -> BoxLayout {
         let large_op = matches!(&args[0],
           Expr::String(s) if large_operator_scale(s).is_some());
         if large_op {
-          let sup_x = base.width * 0.66;
+          // Set the limits beside the sign, clear of its ink: the upper bound
+          // at the top-right tip and the lower bound at the bottom, a little
+          // left of the upper (following the sign's slant). Both start at (or
+          // past) the sign's right edge so neither overlaps the stroke.
+          let gap = font_size * 0.08;
+          let sup_x = base.width + gap;
           let sup_y = 0.0;
-          let sub_x = base.width * 0.28;
+          let sub_x = base.width * 0.72 + gap;
           let sub_y = (base.height - sub.height).max(base.baseline);
           let width = base
             .width
             .max(sup_x + sup.width)
-            .max(sub_x + sub.width);
+            .max(sub_x + sub.width)
+            + gap;
           let elements = format!(
             "{}{}{}",
             base.translate(0.0, 0.0),

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -4886,6 +4886,35 @@ pub fn layout_box(expr: &Expr, font_size: f64) -> BoxLayout {
         let base = layout_box(&args[0], font_size);
         let sub = layout_box(&args[1], font_size * 0.7);
         let sup = layout_box(&args[2], font_size * 0.7);
+        // A large-operator base (∫) carries its limits like a display
+        // integral: the upper bound at the top-right tip and the lower bound
+        // at the bottom, nudged left to sit under the slanted stem (the sign's
+        // lower hook is on the left). Other bases use ordinary tight
+        // sub/superscripts to the right.
+        let large_op = matches!(&args[0],
+          Expr::String(s) if large_operator_scale(s).is_some());
+        if large_op {
+          let sup_x = base.width * 0.66;
+          let sup_y = 0.0;
+          let sub_x = base.width * 0.28;
+          let sub_y = (base.height - sub.height).max(base.baseline);
+          let width = base
+            .width
+            .max(sup_x + sup.width)
+            .max(sub_x + sub.width);
+          let elements = format!(
+            "{}{}{}",
+            base.translate(0.0, 0.0),
+            sup.translate(sup_x, sup_y),
+            sub.translate(sub_x, sub_y),
+          );
+          return BoxLayout {
+            width,
+            height: (sub_y + sub.height).max(base.height),
+            baseline: base.baseline,
+            elements,
+          };
+        }
         let sup_y = 0.0;
         let base_y = sup.height * 0.4;
         let sub_y = base_y + base.height * 0.4;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2907,10 +2907,16 @@ fn generate_output_svg(expr: &syntax::Expr) {
   {
     return;
   }
-  // Unwrap StandardForm/TraditionalForm — render SVG for the inner expression
+  // Unwrap StandardForm/TraditionalForm — render SVG for the inner expression.
+  // TraditionalForm routes through the dedicated traditional typesetter so
+  // math renders in conventional notation (∑/∫ operators, invisible HoldForm,
+  // π/∞ glyphs, `sin(x)` instead of `Sin[x]`, …) rather than the literal
+  // StandardForm box tree.
+  let mut traditional = false;
   let expr = if let syntax::Expr::FunctionCall { name, args } = expr {
     if (name == "StandardForm" || name == "TraditionalForm") && args.len() == 1
     {
+      traditional = name == "TraditionalForm";
       &args[0]
     } else {
       expr
@@ -2923,9 +2929,15 @@ fn generate_output_svg(expr: &syntax::Expr) {
   let boxes = if let syntax::Expr::FunctionCall { name, args } = expr {
     if (name == "RawBoxes" || name == "DisplayForm") && args.len() == 1 {
       args[0].clone()
+    } else if traditional {
+      evaluator::dispatch::complex_and_special::expr_to_box_form_traditional(
+        expr,
+      )
     } else {
       evaluator::dispatch::complex_and_special::expr_to_box_form(expr)
     }
+  } else if traditional {
+    evaluator::dispatch::complex_and_special::expr_to_box_form_traditional(expr)
   } else {
     evaluator::dispatch::complex_and_special::expr_to_box_form(expr)
   };

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2566,7 +2566,7 @@ pub fn pair_to_expr(pair: Pair<Rule>) -> Expr {
     Rule::BaseFunctionCall => {
       let inner_pairs: Vec<_> = pair.into_inner().collect();
       let name_pair = &inner_pairs[0];
-      let name = name_pair.as_str().to_string();
+      let name = resolve_head_name(name_pair);
       let derivative_order = inner_pairs
         .iter()
         .find(|p| matches!(p.as_rule(), Rule::DerivativePrime))
@@ -3508,7 +3508,7 @@ fn parse_function_call_extended(pair: Pair<Rule>) -> Expr {
       result
     } else if let Some(order) = derivative_order {
       // f'[x] → Derivative[1][f][x], f''[x] → Derivative[2][f][x], etc.
-      let name = name_pair.as_str().to_string();
+      let name = resolve_head_name(name_pair);
       // Derivative[n][f]
       let mut result = Expr::CurriedCall {
         func: Box::new(Expr::FunctionCall {
@@ -3526,7 +3526,7 @@ fn parse_function_call_extended(pair: Pair<Rule>) -> Expr {
       }
       result
     } else {
-      let name = name_pair.as_str().to_string();
+      let name = resolve_head_name(name_pair);
       if fc_bracket_args.len() == 1 {
         Expr::FunctionCall {
           name,
@@ -3707,6 +3707,20 @@ fn parse_function_call_extended(pair: Pair<Rule>) -> Expr {
   }
 }
 
+/// Resolve the display name of a function-call head pair. A plain
+/// `Identifier` head uses its raw text; a `NamedCharIdentifier` head (e.g.
+/// `\[Psi]`) is decoded to its Unicode symbol (`ψ`) so `\[Psi][x, t]` calls
+/// the same symbol that `\[Psi]` denotes on its own.
+fn resolve_head_name(name_pair: &Pair<Rule>) -> String {
+  if matches!(name_pair.as_rule(), Rule::NamedCharIdentifier) {
+    let decoded = pair_to_expr(name_pair.clone());
+    if let Expr::Identifier(s) | Expr::Constant(s) = &decoded {
+      return s.clone();
+    }
+  }
+  name_pair.as_str().to_string()
+}
+
 fn parse_function_call(pair: Pair<Rule>) -> Expr {
   let inner_pairs: Vec<_> = pair.into_inner().collect();
   let name_pair = &inner_pairs[0];
@@ -3771,7 +3785,7 @@ fn parse_function_call(pair: Pair<Rule>) -> Expr {
     result
   } else if let Some(order) = derivative_order {
     // f'[x] → Derivative[1][f][x]
-    let name = name_pair.as_str().to_string();
+    let name = resolve_head_name(name_pair);
     let mut result = Expr::CurriedCall {
       func: Box::new(Expr::FunctionCall {
         name: "Derivative".to_string(),
@@ -3787,7 +3801,7 @@ fn parse_function_call(pair: Pair<Rule>) -> Expr {
     }
     result
   } else {
-    let name = name_pair.as_str().to_string();
+    let name = resolve_head_name(name_pair);
     // Build chained calls: f[a][b] becomes Apply(f[a], b)
     let result = if bracket_sequences.len() == 1 {
       Expr::FunctionCall {

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -156,7 +156,7 @@ ParenExtended = {
 // RuleAnonymousFunction handles ReplacementRule& - for expressions like {#, First@#2} -> "Q" &
 RuleAnonymousFunction = { ReplacementRule ~ "&" ~ !"&" }
 // BaseFunctionCall is a function call that doesn't include anonymous functions to avoid recursion
-BaseFunctionCall = { Identifier ~ DerivativePrime? ~ ("[" ~ (FunctionArg ~ ("," ~ FunctionArg)*)? ~ "]")+ }
+BaseFunctionCall = { (Identifier | NamedCharIdentifier) ~ DerivativePrime? ~ ("[" ~ (FunctionArg ~ ("," ~ FunctionArg)*)? ~ "]")+ }
 
 // Atomic so that WHITESPACE/COMMENT tokens are not consumed within
 // the operator span — otherwise as_str() would include e.g. comments
@@ -412,7 +412,7 @@ GetPathChar = _{ ASCII_ALPHANUMERIC | LETTER | "~" | "/" | "." | "\\" | "-" | "_
 // `Function[Equal[Mod[#1,3], Mod[#2,3]]]`.
 FunctionCallImplicitSuffix = { ImplicitTimesFactor+ }
 FunctionCallExtended = {
-    Identifier ~ DerivativePrime? ~ BracketArgs+
+    (Identifier | NamedCharIdentifier) ~ DerivativePrime? ~ BracketArgs+
     ~ DerivativePrime?
     ~ (
         PartIndexSuffix ~ (ImplicitPowerSuffix? ~ FunctionCallImplicitSuffix)?
@@ -709,7 +709,7 @@ FunctionArgRule = { ReplacementRule ~ RuleAnonSuffix? }
 FunctionArg = _{ &HasRuleOperator ~ FunctionArgRule | &HasSemicolon ~ CompoundExpression | &HasSpanSep ~ SpanExpr | Expression }
 // BracketArgs groups arguments within a single bracket pair, allowing proper chained call parsing
 BracketArgs = { "[" ~ (FunctionArg ~ ("," ~ FunctionArg)*)? ~ "]" }
-FunctionCall = { (Identifier | SimpleAnonymousFunction) ~ DerivativePrime? ~ BracketArgs+ ~ DerivativePrime? }
+FunctionCall = { (Identifier | NamedCharIdentifier | SimpleAnonymousFunction) ~ DerivativePrime? ~ BracketArgs+ ~ DerivativePrime? }
 
 // FunctionDefinition supports multiple pattern arguments: f[a_, b_] := ...
 FunctionDefinitionPattern = _{ PatternCondition | PatternTest | PatternOptionalNamedBlank | PatternOptionalWithHead | PatternOptionalSimple | PatternOptionalAnonBlank | PatternOptionalDefaultSimple | PatternWithHead | PatternSimple }

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -143,4 +143,20 @@ mod tests {
       assert_eq!(pair.as_rule(), Rule::Program, "Failed to parse: {}", input);
     }
   }
+
+  #[test]
+  fn test_parse_named_character_function_head() {
+    // Regression: a named-character symbol used as a function head — e.g. the
+    // wavefunction `\[Psi][x, t]` — must parse as a call on the decoded symbol
+    // `ψ`, not fail at the trailing `[`.
+    for input in ["\\[Psi][x, t]", "\\[Phi][r]", "\\[CapitalGamma][z]"] {
+      let pair = parse(input).unwrap().next().unwrap();
+      assert_eq!(pair.as_rule(), Rule::Program, "Failed to parse: {}", input);
+    }
+    assert_eq!(
+      woxi::interpret("\\[Psi][x, t]").unwrap(),
+      "\u{03C8}[x, t]",
+      "named-char head resolves to ψ"
+    );
+  }
 }

--- a/tests/svg_rendering_tests.rs
+++ b/tests/svg_rendering_tests.rs
@@ -2523,3 +2523,169 @@ mod triangle_rendering {
     assert!(svg.contains("<polygon"), "expected voxel polygons: {svg}");
   }
 }
+
+// ── TraditionalForm typesetting ──────────────────────────────────────
+//
+// These verify the 2D box tree produced for `TraditionalForm` math so held
+// expressions render in conventional notation (∑/∫/∏ operators, invisible
+// HoldForm, π/∞/ⅇ glyphs, `sin(x)`, stacked fractions, radicals, bracketed
+// matrices) rather than as literal `Sum[…]`/`Integrate[…]` function calls.
+mod traditional_form_boxes {
+  use woxi::evaluator::dispatch::complex_and_special::expr_to_box_form_traditional;
+  use woxi::interpret_with_stdout;
+  use woxi::syntax::string_to_expr;
+
+  /// TraditionalForm box tree of `code`, as a debug string for substring
+  /// assertions.
+  fn tf(code: &str) -> String {
+    let expr = string_to_expr(code).expect("parse");
+    format!("{:?}", expr_to_box_form_traditional(&expr))
+  }
+
+  /// Typeset SVG the Playground/Studio produce for `code`.
+  fn tf_svg(code: &str) -> String {
+    interpret_with_stdout(code)
+      .expect("eval")
+      .output_svg
+      .expect("output_svg")
+  }
+
+  #[test]
+  fn hold_form_is_invisible() {
+    let boxes = tf("HoldForm[a + b]");
+    assert!(!boxes.contains("HoldForm"), "HoldForm should vanish: {boxes}");
+  }
+
+  #[test]
+  fn constants_map_to_glyphs() {
+    // Go through the full parser (bare `string_to_expr("Infinity")` would hit
+    // an f64 fast-path and yield a Real, not the symbol).
+    let svg = tf_svg("TraditionalForm @ HoldForm[Pi + Infinity + Exp[x]]");
+    assert!(svg.contains('\u{03C0}'), "Pi → π: {svg}");
+    assert!(svg.contains('\u{221E}'), "Infinity → ∞: {svg}");
+    assert!(svg.contains('\u{2147}'), "Exp base → ⅇ: {svg}");
+  }
+
+  #[test]
+  fn equal_renders_as_single_equals() {
+    let boxes = tf("a == b");
+    assert!(boxes.contains("\"=\""), "== → = : {boxes}");
+    assert!(!boxes.contains("\"==\""), "no literal == : {boxes}");
+  }
+
+  #[test]
+  fn known_function_lowercased_with_parens() {
+    let boxes = tf("Sin[x]");
+    assert!(boxes.contains("\"sin\""), "Sin → sin: {boxes}");
+    assert!(boxes.contains("\"(\""), "uses parentheses: {boxes}");
+  }
+
+  #[test]
+  fn trig_power_sits_on_the_name() {
+    // Sin[x]^2 → sin²(x): the exponent goes on the function name.
+    let boxes = tf("Sin[x]^2");
+    let sup = boxes.find("SuperscriptBox").expect("has superscript");
+    let sin = boxes.find("\"sin\"").expect("has sin");
+    assert!(sup < sin, "exponent precedes the name: {boxes}");
+  }
+
+  #[test]
+  fn unknown_function_uses_parentheses() {
+    // Preserves the MakeBoxes contract: F[x] → RowBox[{F, (, x, )}].
+    let boxes = tf("F[x]");
+    assert!(boxes.contains("\"F\""), "head kept: {boxes}");
+    assert!(boxes.contains("\"(\"") && boxes.contains("\")\""), "parens: {boxes}");
+    assert!(!boxes.contains("\"[\""), "no square brackets: {boxes}");
+  }
+
+  #[test]
+  fn sum_becomes_underoverscript_operator() {
+    let boxes = tf("Sum[1/n^2, {n, 1, Infinity}]");
+    assert!(
+      boxes.contains("UnderoverscriptBox"),
+      "Sum uses a large operator with limits: {boxes}"
+    );
+    assert!(boxes.contains('\u{2211}'), "∑ glyph present: {boxes}");
+    assert!(!boxes.contains("\"Sum\""), "no literal Sum head: {boxes}");
+  }
+
+  #[test]
+  fn product_becomes_large_operator() {
+    let boxes = tf("Product[k, {k, 1, Infinity}]");
+    assert!(boxes.contains('\u{220F}'), "∏ glyph present: {boxes}");
+  }
+
+  #[test]
+  fn integrate_uses_integral_sign_and_differential() {
+    let boxes = tf("Integrate[Exp[-x^2], {x, 0, Infinity}]");
+    assert!(boxes.contains('\u{222B}'), "∫ present: {boxes}");
+    assert!(boxes.contains('\u{2146}'), "ⅆ differential present: {boxes}");
+    assert!(
+      boxes.contains("SubsuperscriptBox"),
+      "integral carries limits: {boxes}"
+    );
+  }
+
+  #[test]
+  fn derivative_renders_as_leibniz_fraction() {
+    let boxes = tf("D[f[x], {x, 2}]");
+    assert!(boxes.contains("FractionBox"), "∂/∂ fraction: {boxes}");
+    assert!(boxes.contains('\u{2202}'), "∂ glyph present: {boxes}");
+  }
+
+  #[test]
+  fn determinant_uses_bars_and_grid() {
+    let boxes = tf("Det[{{a, b}, {c, d}}]");
+    assert!(boxes.contains("GridBox"), "matrix laid out as a grid: {boxes}");
+    assert!(boxes.contains("\"|\""), "determinant bars: {boxes}");
+  }
+
+  #[test]
+  fn leading_unary_minus_has_no_zero_artifact() {
+    // The parser stores `-x^2` as `0 - x^2`; the display must drop the 0.
+    let boxes = tf("-x^2");
+    assert!(boxes.starts_with("FunctionCall") || boxes.contains("\"-\""));
+    assert!(!boxes.contains("\"0\""), "no spurious 0 term: {boxes}");
+  }
+
+  #[test]
+  fn negative_power_base_is_parenthesized() {
+    // (-1)^n must keep its parentheses.
+    let boxes = tf("(-1)^n");
+    let sup = boxes.find("SuperscriptBox").expect("superscript");
+    let paren = boxes.find("\"(\"").expect("open paren");
+    assert!(paren > sup, "parens wrap the base: {boxes}");
+  }
+
+  #[test]
+  fn symbol_used_as_head_is_not_glyph_mapped() {
+    // `E[x, y, z]` is a field, not Euler's number — keep the head as `E`.
+    let boxes = tf("Div[E[x, y, z], {x, y, z}]");
+    assert!(boxes.contains("\"E\""), "E head preserved: {boxes}");
+    assert!(!boxes.contains('\u{2147}'), "not turned into ⅇ: {boxes}");
+  }
+
+  #[test]
+  fn vector_operators_use_nabla() {
+    assert!(tf("Grad[f[x], {x}]").contains('\u{2207}'), "Grad → ∇");
+    assert!(tf("Laplacian[f[x], {x}]").contains('\u{2207}'), "Laplacian → ∇²");
+  }
+
+  #[test]
+  fn end_to_end_svg_carries_operator_glyphs() {
+    let svg = tf_svg("TraditionalForm @ HoldForm[Sum[1/n^2, {n, 1, Infinity}] == Pi^2/6]");
+    assert!(svg.contains('\u{2211}'), "∑ rendered: {svg}");
+    assert!(svg.contains('\u{03C0}'), "π rendered: {svg}");
+    assert!(svg.contains('\u{221E}'), "∞ rendered: {svg}");
+    assert!(!svg.contains("HoldForm"), "HoldForm invisible: {svg}");
+    assert!(!svg.contains("Sum["), "no literal Sum call: {svg}");
+  }
+
+  #[test]
+  fn end_to_end_svg_draws_stretchy_determinant_bars() {
+    let svg = tf_svg("TraditionalForm @ HoldForm[Det[{{a, b, c}, {d, e, f}, {g, h, i}}]]");
+    // Bars stretch into vertical <line>s spanning the grid.
+    assert!(svg.contains("<line"), "stretchy bars drawn as lines: {svg}");
+    assert!(svg.contains(">a<") && svg.contains(">i<"), "cells present: {svg}");
+  }
+}


### PR DESCRIPTION
## Summary

Implement comprehensive TraditionalForm typesetting that renders mathematical expressions in conventional TeX-like notation for SVG output in the Playground and Studio. This includes support for large operators (∑/∏/∫), invisible HoldForm, Unicode glyphs for constants (π/∞/ⅇ), lowercase function names with parentheses, stacked fractions, radicals, and bracketed matrices.

## Key Changes

- **New TraditionalForm typesetter** (`src/evaluator/dispatch/complex_and_special.rs`):
  - Complete rewrite of `expr_to_box_form_traditional()` with dedicated helper functions for building 2D box trees
  - Symbol mapping (`tf_symbol()`) converts named constants to Unicode glyphs (Pi→π, Infinity→∞, E→ⅇ, I→ⅈ, etc.)
  - Function name mapping (`tf_known_func()`) renders known functions in lowercase with parentheses (Sin→sin, Cos→cos, etc.)
  - Special handling for trig functions where exponents sit on the name (sin²(x) instead of (sin(x))²)
  - Additive/multiplicative flattening (`tf_flatten_additive()`, `tf_flatten_times()`) for proper term/factor layout
  - Large operator rendering (`tf_big_operator()`) for Sum/Product with UnderoverscriptBox limits
  - Integral rendering (`tf_integrate()`) with ∫ signs, bounds, and ⅆx differentials
  - Derivative rendering (`tf_derivative()`) as Leibniz-style ∂ⁿ/∂xᵐ fractions
  - Matrix detection and GridBox rendering for Det, MatrixForm, and bracketed lists
  - Vector calculus operators (Grad, Div, Curl, Laplacian) using ∇ notation
  - Limit rendering with arrow notation (x→x₀)
  - Bessel function subscript notation (Jₙ(x))

- **SVG rendering enhancements** (`src/functions/graphics.rs`):
  - Large operator scaling (`large_operator_scale()`) for display-size ∑/∏/∫ glyphs
  - Math italic rendering for single Latin letters (conventional variable styling)
  - Stretchy delimiter support (`render_stretchy_delim()`) for parentheses/brackets/braces that grow to enclose tall content (fractions, matrices, nested radicals)
  - Radical rendering (`sqrt_radical()`) with connected polyline hook and vinculum
  - Operator spacing (`operator_space()`) for binary operators and relations
  - Delimiter pair matching and height-based stretching logic

- **Parser fix** (`src/syntax.rs`):
  - Add `resolve_head_name()` call in function call parsing to properly handle named-character symbols (e.g., `\[Psi][x, t]`) as function heads

- **Integration** (`src/lib.rs`):
  - Route TraditionalForm through the new dedicated typesetter instead of StandardForm

- **Comprehensive test coverage** (`tests/svg_rendering_tests.rs`):
  - 15 new tests covering HoldForm invisibility, constant glyphs, operator rendering, trig powers, matrix layout, unary minus handling, symbol-as-head preservation, and end-to-end SVG output

## Notable Implementation Details

- The typesetter produces a 2D box tree (RowBox, SuperscriptBox, FractionBox, GridBox, etc.) that the SVG renderer consumes, enabling proper layout of complex mathematical structures
- Leading unary minus (`-x`) is handled by detecting the parser artifact `0 - x` and stripping the zero term
- Negative numeric coefficients are extracted from products to render as a leading sign
- Stretchy delimiters only activate for genuinely tall content (>1.5× natural height) to avoid over-stretching ordinary parenthesized expressions
- Unknown functions preserve their head name verbatim (not glyph-mapped) to distinguish field names from constants
- Trig function powers are specially positioned on the function name rather

https://claude.ai/code/session_012EvvxyQ4AgHUrFKACCspWG