### PR TITLE
Add support for interactive manipulation control heads

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,17 @@
 
 # Unreleased
 
+- Add support for the remaining interactive-manipulation heads from the
+    [InteractiveManipulation](https://reference.wolfram.com/language/guide/InteractiveManipulation.html)
+    guide. `Animate`, `Animator`, `ListAnimate`, `ControllerManipulate`,
+    `Trigger`, `SetterBar`, `CheckboxBar`, `TogglerBar`, `RadioButton`,
+    `ProgressIndicator`, `ClickPane`, `PaneSelector`, `PopupView`,
+    `ColorSetter`, `IntervalSlider`, and `Slider2D` now stay symbolic in
+    script mode (matching `wolframscript`) instead of emitting a spurious
+    "not yet implemented" warning, and the option symbols `Bookmarks`,
+    `ContinuousAction`, and `AppearanceElements` do the same. `ControlActive`
+    now evaluates: `ControlActive[active, normal]` returns its inactive form
+    `normal` outside an actively-manipulated control.
 - Render `TraditionalForm` mathematics in conventional, TeX-like notation in
     the Playground and Studio typeset SVG output. `HoldForm` is now invisible;
     `Sum`/`Product` become large `∑`/`∏` operators with limits above and below;

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,13 @@
     one element per frame. Both hold their body appropriately (`Animate` like
     `Manipulate`; `ListAnimate` evaluates its frame list first, matching
     Wolfram).
+- Render the remaining dynamic UI panes as interactive widgets in the
+    Playground and Studio: `Animator[{min, max}[, step]]` (and its
+    `Dynamic[v]` / single-value forms) as a standalone auto-playing slider;
+    `LocatorPane[Dynamic[p], body]` as a draggable 2D locator driving the
+    graphic; and `ClickPane[expr, func]` as a clickable pad that feeds the
+    pointer position to the handler. `LocatorPane`/`ClickPane` hold their body
+    / handler so it stays intact for interactive re-evaluation.
 - Render `TraditionalForm` mathematics in conventional, TeX-like notation in
     the Playground and Studio typeset SVG output. `HoldForm` is now invisible;
     `Sum`/`Product` become large `∑`/`∏` operators with limits above and below;

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,14 @@
     `ContinuousAction`, and `AppearanceElements` do the same. `ControlActive`
     now evaluates: `ControlActive[active, normal]` returns its inactive form
     `normal` outside an actively-manipulated control.
+- Render `Animate[…]` and `ListAnimate[{…}]` as interactive, auto-playing
+    widgets in the Playground (and as interactive slider widgets in Studio).
+    `Animate` reuses the `Manipulate` control pipeline but auto-advances its
+    first continuous slider on a timer with a play/pause button;
+    `ListAnimate[{e1, …, en}]` cycles a frame index through the list, showing
+    one element per frame. Both hold their body appropriately (`Animate` like
+    `Manipulate`; `ListAnimate` evaluates its frame list first, matching
+    Wolfram).
 - Render `TraditionalForm` mathematics in conventional, TeX-like notation in
     the Playground and Studio typeset SVG output. `HoldForm` is now invisible;
     `Sum`/`Product` become large `∑`/`∏` operators with limits above and below;

--- a/functions.csv
+++ b/functions.csv
@@ -410,7 +410,7 @@ Hypergeometric2F1,Gauss hypergeometric function 2F1,✅,pure,1.0,413
 Complement,Returns elements in first list but not in others,✅,pure,1.0,414
 Dashing,Sets line dashing in graphics,✅,pure,1.0,416
 StreamPlot,Creates a streamline plot of a vector field,✅,pure,7.0,416
-Animate,,🚫,,6.0,417
+Animate,Animated version of an expression (stays symbolic in script mode),✅,unevaluated,6.0,417
 Contours,Option specifying contour levels in contour plots,✅,none,2.0,418
 ColorSpace,Option for specifying the color space of images,✅,pure,7.0,419
 MaxRecursion,Option specifying the maximum recursion depth,✅,none,2.0,420
@@ -885,7 +885,7 @@ Eliminate,Eliminates variables from a system of equations,✅,pure,1.0,891
 TimeZone,,🚫,,2.0,892
 InfiniteLine,Geometric primitive representing an infinite line,✅,none,10.0,893
 GegenbauerC,Gegenbauer (ultraspherical) polynomial C_n^lambda(x); two-arg form GegenbauerC[n;x] is the renormalized (2/n) ChebyshevT[n;x],✅,pure,1.0,894
-SetterBar,,🚫,,6.0,895
+SetterBar,Setter bar control (stays symbolic in script mode),✅,unevaluated,6.0,895
 StyleBox,Low-level box construct for styled content display,✅,pure,3.0,896
 PadLeft,Pads a list on the left to a specified length,✅,pure,4.0,897
 Counts,Returns association of element counts (on an association counts the values),✅,pure,10.0,898
@@ -915,7 +915,7 @@ RuntimeOptions,,🚫,,8.0,922
 StringPosition,Finds all positions of a substring or pattern (overlapping by default; Overlaps and IgnoreCase options),✅,pure,2.0,923
 Roots,Finds roots of polynomial equations as Or conditions; roots are listed in ascending order (matching Solve) except a pure quadratic x^2==c lists the principal + root first,✅,pure,1.0,924
 InputNotebook,Requires external services or GUI infrastructure,🚫,io,3.0,926
-ListAnimate,,🚫,,6.0,926
+ListAnimate,Animation of a list of expressions (stays symbolic in script mode),✅,unevaluated,6.0,926
 RegionUnion,,🚫,,10.0,927
 CloudObject,Requires external services or GUI infrastructure,🚫,io,10.0,928
 HarmonicNumber,Returns the n-th harmonic number,✅,pure,4.0,929
@@ -1018,7 +1018,7 @@ ToRules,Convert logical equation combinations to lists of rules,✅,pure,1.0,102
 Context,Return the context (namespace) of a symbol,✅,pure,1.0,1029
 Placeholder,,🚫,,7.0,1029
 StudentTDistribution,Represents a Student t-distribution with nu degrees of freedom,✅,1,6.0,1030
-AppearanceElements,,🚫,,6.0,1031
+AppearanceElements,Option specifying which interface elements appear,✅,pure,6.0,1031
 TimesBy,Multiplies a variable by a value,✅,stateful,1.0,1032
 Merge,Merges associations using a combining function,✅,pure,10.0,1033
 Colorize,Colorize a label matrix or image,✅,,8.0,1035
@@ -1141,7 +1141,7 @@ LegendMarkerSize,,🚫,,9.0,1151
 Subsuperscript,Subsuperscript notation wrapper (stays symbolic),✅,unevaluated,3.0,1152
 KelvinBei,Kelvin bei function (imaginary part of BesselJ on a rotated argument),✅,pure,6.0,1153
 CubeRoot,Returns the real-valued cube root,✅,pure,9.0,1154
-ContinuousAction,,🚫,,6.0,1155
+ContinuousAction,Option for continuous action during interactive manipulation,✅,pure,6.0,1155
 Overlay,,🚫,,8.0,1156
 Permissions,,🚫,,10.0,1157
 CirclePlus,Represents the direct sum or XOR operator,✅,pure,3.0,1158
@@ -1295,7 +1295,7 @@ TabView,Tabbed view control (stays symbolic in script mode),✅,unevaluated,6.0,
 SinhIntegral,Hyperbolic sine integral Shi(z),✅,pure,3.0,1309
 KelvinKer,Kelvin ker function (real part of e^(-Pi I/2) BesselK on a rotated argument),✅,pure,6.0,1310
 ComplexPlot3D,Plot the modulus of a complex function as a 3D surface over the complex plane,✅,pure,12.0,1311
-ControlActive,,🚫,,6.0,1312
+ControlActive,Represents an object displayed differently while a control is actively manipulated,✅,pure,6.0,1312
 ButtonBox,,🚫,,3.0,1313
 RegionDistance,Shortest distance from a point to a region (Point/Line/Disk/Ball/Circle/Sphere/Rectangle/Triangle/Polygon),✅,pure,10.0,1314
 FirstPosition,Find the position of the first element matching a pattern (supports associations),✅,pure,10.0,1317
@@ -1414,7 +1414,7 @@ ItemStyle,Style specification for items,🚫,pure,6.0,1431
 GeoStyling,Styling for geographic regions,🚫,pure,10.0,1432
 CharacterEncoding,Character encoding specification,🚫,io,3.0,1434
 InfinitePlane,Infinite plane geometric region; symbolic region consumed by region functions and rendered in Graphics,✅,unevaluated,10.0,1434
-ProgressIndicator,Dynamic progress indicator,🚫,io,6.0,1435
+ProgressIndicator,Progress indicator control (stays symbolic in script mode),✅,unevaluated,6.0,1435
 Square,Square geometric primitive,🚫,pure,3.0,1437
 StruveL,Modified Struve function L_n(z); elementary closed form at order +-1/2 and +-3/2; numeric for inexact args,✅,pure,4.0,1437
 DecimalForm,Display a number in decimal notation without scientific notation; ToString renders it (optional second arg gives significant figures),✅,pure,11.2,1438
@@ -1547,7 +1547,7 @@ CreateDirectory,Creates a directory including intermediate directories,✅,files
 ImageSubtract,Subtracts pixel values of two images pointwise,✅,pure,7.0,1569
 CopyFile,Copies a file to a new location,✅,filesystem,2.0,1571
 EstimatedProcess,Estimated stochastic process,,unevaluated,9.0,1571
-Animator,Animated control element,,unevaluated,6.0,1573
+Animator,Animated control element (stays symbolic in script mode),✅,unevaluated,6.0,1573
 HighlightMesh,Highlight mesh elements,,unevaluated,10.0,1573
 PolynomialReduce,Reduce a polynomial modulo a list of polynomials (single- and multi-variable lexicographic division),✅,pure,3.0,1574
 AutoScroll,Auto-scrolling option,,unevaluated,3.0,1578
@@ -1582,7 +1582,7 @@ Vectors,Vector space domain,,unevaluated,9.0,1604
 SectorOrigin,Sector origin in pie charts,,unevaluated,7.0,1605
 JacobiSymbol,Compute the Jacobi symbol for quadratic residue testing,✅,pure,1.0,1606
 MaxTrainingRounds,Max training iterations,,unevaluated,11.0,1607
-Slider2D,,🚫,,6.0,1608
+Slider2D,Two-dimensional slider control (stays symbolic in script mode),✅,unevaluated,6.0,1608
 Compress,Compresses an expression to a string,✅,pure,6.0,1611
 CompressedData,Holds a compressed expression and evaluates to the original on use,✅,pure,9.0,1612
 PolarAxes,Polar axes option,,unevaluated,7.0,1611
@@ -1608,7 +1608,7 @@ LinearRecurrence,Generates a linear recurrence sequence,✅,pure,7.0,1632
 WindowMargins,Window margin specification,,unevaluated,3.0,1632
 AffineTransform,Build a TransformationFunction for an affine map x -> m.x + v,✅,none,6.0,1633
 CellGroupData,,🚫,,3.0,1635
-RadioButton,Radio button control,,unevaluated,6.0,1635
+RadioButton,Radio button control (stays symbolic in script mode),✅,unevaluated,6.0,1635
 LegendMarkers,Legend marker specification,,unevaluated,9.0,1637
 PowersRepresentations,Gives all representations of n as a sum of k non-negative p-th powers,✅,pure,6.0,1637
 ShowStringCharacters,Show string quote characters,,unevaluated,3.0,1639
@@ -1687,7 +1687,7 @@ SoftmaxLayer,Softmax neural layer,,unevaluated,11.0,1712
 ProductDistribution,Independent product of distributions (merged PDF plus component stats),✅,pure,8.0,1713
 Save,Saves definitions associated with symbols to a file,✅,effectful,1.0,1714
 RegionDimension,Intrinsic (manifold) dimension of a region,✅,pure,10.0,1716
-TogglerBar,Toggler bar control,,unevaluated,6.0,1716
+TogglerBar,Toggler bar control (stays symbolic in script mode),✅,unevaluated,6.0,1716
 GeoElevationData,,🚫,,10.0,1717
 WeierstrassPPrime,Derivative of the Weierstrass elliptic function,✅,pure,1.0,1718
 FeatureExtractor,Feature extractor,,unevaluated,11.0,1719
@@ -1730,7 +1730,7 @@ GeoMarker,Geographic marker primitive for GeoGraphics,✅,pure,10.0,1760
 MultiplicativeOrder,Multiplicative order modulo n,✅,computation,4.0,1760
 RunProcess,Run external process,,unevaluated,10.0,1760
 StartingStepSize,Starting step size option,,unevaluated,4.0,1760
-Trigger,Trigger control,,unevaluated,6.0,1760
+Trigger,Trigger control (stays symbolic in script mode),✅,unevaluated,6.0,1760
 ContentSelectable,Content selectable option,,unevaluated,6.0,1761
 TakeList,Take successive sublists of given lengths,✅,computation,11.2,1762
 ExportForm,Export form wrapper,,unevaluated,10.0,1763
@@ -1762,7 +1762,7 @@ GeoRegionValuePlot,Choropleth shading countries by value,✅,pure,10.0,1789
 MaxExtraConditions,Max extra conditions option,,unevaluated,8.0,1791
 TimeSeriesModelFit,Time series model fit,,unevaluated,10.0,1791
 Find,Finds a file on the search path,🚧,effectful,2.0,1793
-PaneSelector,Pane selector control,,unevaluated,6.0,1793
+PaneSelector,Pane selector control (stays symbolic in script mode),✅,unevaluated,6.0,1793
 URLExecute,Execute URL request,,unevaluated,10.0,1794
 FileBaseName,Returns the base name of a file (without directory and extension),✅,pure,7.0,1796
 SequencePosition,Finds positions of subsequences matching a pattern in a list (overlapping by default; supports a count limit and the Overlaps option),✅,pure,10.1,1796
@@ -1771,7 +1771,7 @@ CoordinatesToolOptions,Coordinates tool options,,unevaluated,7.0,1800
 Highlighted,Display wrapper that draws a colored background behind its argument,✅,pure,10.4,1800
 TextGrid,Displays data in a text grid layout,✅,pure,10.3,1800
 NumericFunction,Numeric function attribute,,unevaluated,3.0,1801
-ColorSetter,Color setter control,,unevaluated,6.0,1803
+ColorSetter,Color setter control (stays symbolic in script mode),✅,unevaluated,6.0,1803
 Scrollbars,Scrollbars option,,unevaluated,7.0,1803
 DistanceMatrix,Matrix of pairwise distances between vectors (default EuclideanDistance),✅,pure,10.3,1806
 InverseWaveletTransform,Inverse discrete/stationary/packet/lifting wavelet transform,✅,pure,8.0,1806
@@ -1798,7 +1798,7 @@ DigitQ,Tests if a string consists entirely of digits,✅,pure,2.0,1827
 RealExponent,Returns the base-b real exponent Log[b Abs[x]] of x as a machine real (base 10 by default),✅,pure,6.0,1827
 TriangularDistribution,Triangular distribution (piecewise PDF and CDF and moments),✅,pure,6.0,1827
 BinaryWrite,Write binary data,✅,io,5.1,1833
-CheckboxBar,Checkbox bar control,,unevaluated,6.0,1833
+CheckboxBar,Checkbox bar control (stays symbolic in script mode),✅,unevaluated,6.0,1833
 DuplicateFreeQ,Test if list has no duplicates,✅,computation,10.0,1833
 OutputForm,Converts expression to output form,✅,pure,1.0,1833
 RandomPermutation,Random permutation of n points returned as a Cycles object,✅,contextual,8.0,1833
@@ -2191,7 +2191,7 @@ Hexahedron,3D geometric primitive,🚫,None,10.0,2233
 Nand,Logical NAND,✅,pure,4.1,2233
 TimeSeriesShift,Time series manipulation,🚫,None,10.0,2233
 WaitAll,Async parallel computation,🚫,None,7.0,2233
-ClickPane,UI interaction,🚫,None,6.0,2236
+ClickPane,Clickable pane control (stays symbolic in script mode),✅,unevaluated,6.0,2236
 DiamondMatrix,Gives the diamond (L1-ball) structuring element for a scalar radius or list of radii (n-D),✅,pure,7.0,2236
 MaxItems,Display option,🚫,None,10.1,2236
 SSSTriangle,Constructs a triangle from three side lengths,✅,None,10.0,2239
@@ -2339,7 +2339,7 @@ WaveletMapIndexed,Applies a function to wavelet coefficient arrays with their in
 ChineseRemainder,Solves a system of modular congruences (optional third argument gives the smallest solution >= d),✅,pure,6.0,2389
 ContentPadding,UI styling,🚫,None,8.0,2389
 FromSphericalCoordinates,Converts spherical coordinates to Cartesian,✅,None,10.1,2389
-IntervalSlider,UI widget,🚫,None,10.0,2389
+IntervalSlider,Interval slider control (stays symbolic in script mode),✅,unevaluated,10.0,2389
 PunctuationCharacter,String pattern matching a single punctuation character,✅,pure,10.3,2389
 TransformedProcess,stochastic process,🚫,None,10.0,2389
 CayleyGraph,group theory graph,🚫,None,8.0,2394
@@ -2456,7 +2456,7 @@ ChiDistribution,represents a chi distribution with n degrees of freedom,✅,none
 CloudPublish,,🚫,,10.2,2509
 Glaisher,Glaisher-Kinkelin constant,✅,none,4.0,2509
 ListCurvePathPlot,,🚫,,7.0,2509
-Bookmarks,,🚫,,7.0,2512
+Bookmarks,Option for bookmarked settings in Manipulate,✅,pure,7.0,2512
 SliceDensityPlot3D,,🚫,,10.2,2512
 StringRepeat,Repeats a string a specified number of times,✅,pure,10.1,2512
 BracketingBar,,🚫,,3.0,2514
@@ -3429,7 +3429,7 @@ InteractiveTradingChart,,🚫,,8.0,3522
 JacobiND,Jacobi elliptic function nd (1/dn),✅,pure,1.0,3522
 KeySortBy,Sort association by applying function to keys,✅,none,10.0,3522
 PermissionsGroup,,🚫,,10.0,3522
-PopupView,,🚫,,6.0,3522
+PopupView,Popup view control (stays symbolic in script mode),✅,unevaluated,6.0,3522
 SetCloudDirectory,,🚫,,10.0,3522
 SkeletonTransform,,🚫,,8.0,3522
 StandardDeviationFilter,Replaces each element with the sample standard deviation of its radius-r neighborhood (1D list or 2D array),✅,pure,7.0,3522
@@ -3711,7 +3711,7 @@ StateSpaceRealization,,🚫,,8.0,3803
 Underoverscript,Underoverscript notation wrapper (stays symbolic),✅,unevaluated,3.0,3803
 BlackmanHarrisWindow,,,,9.0,3823
 CloudSubmit,,🚫,,10.2,3823
-ControllerManipulate,,🚫,,6.0,3823
+ControllerManipulate,Manipulate driven by an external controller (stays symbolic in script mode),✅,unevaluated,6.0,3823
 CreateIntermediateDirectories,,,,6.0,3823
 DateWithinQ,,,,11.1,3823
 DavisDistribution,,,,8.0,3823

--- a/functions.csv
+++ b/functions.csv
@@ -972,7 +972,7 @@ Abort,Aborts evaluation,✅,effectful,2.0,980
 GammaDistribution,Gamma probability distribution,✅,pure,6.0,981
 FrontEndExecute,Requires external services or GUI infrastructure,🚫,io,3.0,982
 ScientificForm,Displays number in scientific notation,✅,pure,1.0,983
-LocatorPane,Requires external services or GUI infrastructure,🚫,io,6.0,984
+LocatorPane,Draggable locator over a graphic; renders as an interactive 2D pane,✅,unevaluated,6.0,984
 DirectedEdges,,🚫,,6.0,986
 ViewVertical,,🚫,,2.0,986
 StyleDefinitions,,🚫,,3.0,987
@@ -1547,7 +1547,7 @@ CreateDirectory,Creates a directory including intermediate directories,✅,files
 ImageSubtract,Subtracts pixel values of two images pointwise,✅,pure,7.0,1569
 CopyFile,Copies a file to a new location,✅,filesystem,2.0,1571
 EstimatedProcess,Estimated stochastic process,,unevaluated,9.0,1571
-Animator,Animated control element (stays symbolic in script mode),✅,unevaluated,6.0,1573
+Animator,Auto-playing animation control; renders as an interactive auto-advancing slider,✅,unevaluated,6.0,1573
 HighlightMesh,Highlight mesh elements,,unevaluated,10.0,1573
 PolynomialReduce,Reduce a polynomial modulo a list of polynomials (single- and multi-variable lexicographic division),✅,pure,3.0,1574
 AutoScroll,Auto-scrolling option,,unevaluated,3.0,1578
@@ -2191,7 +2191,7 @@ Hexahedron,3D geometric primitive,🚫,None,10.0,2233
 Nand,Logical NAND,✅,pure,4.1,2233
 TimeSeriesShift,Time series manipulation,🚫,None,10.0,2233
 WaitAll,Async parallel computation,🚫,None,7.0,2233
-ClickPane,Clickable pane control (stays symbolic in script mode),✅,unevaluated,6.0,2236
+ClickPane,Clickable pane feeding a handler; renders as an interactive 2D pane,✅,unevaluated,6.0,2236
 DiamondMatrix,Gives the diamond (L1-ball) structuring element for a scalar radius or list of radii (n-D),✅,pure,7.0,2236
 MaxItems,Display option,🚫,None,10.1,2236
 SSSTriangle,Constructs a triangle from three side lengths,✅,None,10.0,2239

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1976,6 +1976,11 @@ pub fn evaluate_expr_to_expr_inner(
         // like Plot[Sin[a*x], {x, 0, 6}] aren't evaluated with `a` free
         // (matching Wolfram Language notebook behavior).
         || name == "Manipulate"
+        // Animate is Manipulate that auto-plays; it holds its body and
+        // variable spec for the same reason. (ListAnimate is deliberately
+        // NOT held: its argument is a precomputed list of frames that must
+        // evaluate first, matching Wolfram Language.)
+        || name == "Animate"
         // Control likewise holds its variable spec so that the bound symbol
         // and any symbolic values stay intact for interactive rendering.
         || name == "Control"

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1984,6 +1984,11 @@ pub fn evaluate_expr_to_expr_inner(
         // Control likewise holds its variable spec so that the bound symbol
         // and any symbolic values stay intact for interactive rendering.
         || name == "Control"
+        // LocatorPane holds its body graphic so it isn't evaluated with the
+        // locator point free; ClickPane holds its handler so it stays an
+        // un-applied function until fed a click position.
+        || name == "LocatorPane"
+        || name == "ClickPane"
         {
           // Flatten Sequence even in held args (unless SequenceHold)
           let flattened = flatten_sequences(name, args);

--- a/src/evaluator/dispatch/boolean_functions.rs
+++ b/src/evaluator/dispatch/boolean_functions.rs
@@ -50,6 +50,14 @@ pub fn dispatch_boolean_functions(
       };
       return Some(Err(InterpreterError::ReturnValue(Box::new(val))));
     }
+    // ControlActive[activeform, normalform] displays as `activeform` only
+    // while it appears inside a control that is being actively manipulated,
+    // and as `normalform` otherwise. In script mode (and any non-interactive
+    // evaluation) nothing is ever actively manipulated, so it evaluates to
+    // its inactive form `normalform`, matching wolframscript.
+    "ControlActive" if args.len() == 2 => {
+      return Some(Ok(args[1].clone()));
+    }
     "SameQ" => {
       return Some(crate::functions::boolean_ast::same_q_ast(args));
     }

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -10262,6 +10262,27 @@ pub fn evaluate_function_call_ast_inner(
         | "MenuView"
         | "SlideView"
         | "FlipView"
+        // Further interactive control / animation / view heads from the
+        // InteractiveManipulation guide. Like Slider/Toggler above, these
+        // stay unevaluated as their canonical form in wolframscript's script
+        // mode (they produce an interactive object only inside a notebook),
+        // so flagging them as "unimplemented" is a false positive.
+        | "Animate"
+        | "Animator"
+        | "ListAnimate"
+        | "ControllerManipulate"
+        | "Trigger"
+        | "SetterBar"
+        | "CheckboxBar"
+        | "TogglerBar"
+        | "RadioButton"
+        | "ProgressIndicator"
+        | "ClickPane"
+        | "PaneSelector"
+        | "PopupView"
+        | "ColorSetter"
+        | "IntervalSlider"
+        | "Slider2D"
     )
   {
     let args_str = args

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -10278,6 +10278,7 @@ pub fn evaluate_function_call_ast_inner(
         | "RadioButton"
         | "ProgressIndicator"
         | "ClickPane"
+        | "LocatorPane"
         | "PaneSelector"
         | "PopupView"
         | "ColorSetter"

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -11449,6 +11449,12 @@ pub struct ManipulateSpec {
   /// while `YinYang` is `True`). Controls with no `Enabled` option (or the
   /// trivial `Enabled -> True`) do not appear here and stay always enabled.
   pub control_enabled: Vec<(String, String)>,
+  /// Whether this spec should auto-play, i.e. it came from `Animate[…]` or
+  /// `ListAnimate[…]`. An animated widget advances its first continuous
+  /// control on a timer (with a play/pause toggle) instead of sitting still
+  /// until the user drags a slider. Plain `Manipulate`/`Control` widgets leave
+  /// this `false`.
+  pub animated: bool,
 }
 
 /// Result of parsing a single list-shaped Manipulate argument.
@@ -11468,19 +11474,22 @@ enum ParsedControl {
   State { name: String, value: String },
 }
 
-/// Attempt to extract a `ManipulateSpec` from a held `Manipulate[…]`
-/// expression. Returns `None` if the expression is not a well-formed
-/// Manipulate (e.g. `Manipulate[]`, `Manipulate[expr]`, or a spec that
-/// isn't a list). In those cases the caller should fall back to the
-/// standard text/graphics output path.
+/// Attempt to extract a `ManipulateSpec` from a held `Manipulate[…]` or
+/// `Animate[…]` expression. `Animate` shares `Manipulate`'s argument shape
+/// (a body followed by `{u, umin, umax}`-style control specs) but auto-plays,
+/// so it produces the same spec with `animated` set. Returns `None` if the
+/// expression is not a well-formed Manipulate/Animate (e.g. `Manipulate[]`,
+/// `Manipulate[expr]`, or a spec that isn't a list). In those cases the caller
+/// should fall back to the standard text/graphics output path.
 pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   let (name, args) = match expr {
     Expr::FunctionCall { name, args } => (name, args),
     _ => return None,
   };
-  if name != "Manipulate" || args.len() < 2 {
+  if (name != "Manipulate" && name != "Animate") || args.len() < 2 {
     return None;
   }
+  let animated = name == "Animate";
 
   let body_code = crate::syntax::expr_to_input_form(&args[0]);
   let mut controls = Vec::with_capacity(args.len() - 1);
@@ -11552,6 +11561,54 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     displays,
     initialization,
     control_enabled,
+    animated,
+  })
+}
+
+/// Attempt to extract a `ManipulateSpec` from a held `ListAnimate[{e1, …, en}]`
+/// expression. Each element is one animation frame; the widget cycles through
+/// them by binding an integer frame index and displaying the selected element.
+/// It renders as an auto-playing single-slider Manipulate whose body is
+/// `Part[{e1, …, en}, i]`. Returns `None` when the argument is not a non-empty
+/// list literal (e.g. `ListAnimate[expr]` or `ListAnimate[{}]`), so the caller
+/// falls back to the plain output path.
+pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
+  let (name, args) = match expr {
+    Expr::FunctionCall { name, args } => (name, args),
+    _ => return None,
+  };
+  if name != "ListAnimate" || args.is_empty() {
+    return None;
+  }
+  let frames = match &args[0] {
+    Expr::List(items) if !items.is_empty() => items,
+    _ => return None,
+  };
+  let n = frames.len();
+  let list_code = crate::syntax::expr_to_input_form(&args[0]);
+  // Frame index `i` runs 1..n in unit steps; the body picks that element.
+  // `Round` guards against any float drift the slider might introduce.
+  let body_code = format!("Part[{}, Round[i]]", list_code);
+  let control = ManipulateControl::Continuous {
+    name: "i".to_string(),
+    min: 1.0,
+    max: n as f64,
+    step: Some(1.0),
+    initial: 1.0,
+    label: "i".to_string(),
+    label_runs: vec![LabelRun {
+      text: "i".to_string(),
+      italic: false,
+    }],
+  };
+  Some(ManipulateSpec {
+    body_code,
+    controls: vec![control],
+    state: Vec::new(),
+    displays: Vec::new(),
+    initialization: None,
+    control_enabled: Vec::new(),
+    animated: true,
   })
 }
 
@@ -11595,6 +11652,7 @@ pub fn extract_control_spec(expr: &Expr) -> Option<ManipulateSpec> {
     displays: Vec::new(),
     initialization: None,
     control_enabled,
+    animated: false,
   })
 }
 
@@ -12637,12 +12695,19 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
     .map(|d| format!(r#""{}""#, json_escape_manipulate(d)))
     .collect();
 
+  let animated_json = if spec.animated {
+    r#","animated":true"#
+  } else {
+    ""
+  };
+
   format!(
-    r#""body":"{}","controls":[{}],"state":{{{}}},"displays":[{}]"#,
+    r#""body":"{}","controls":[{}],"state":{{{}}},"displays":[{}]{}"#,
     json_escape_manipulate(&spec.body_code),
     ctrl_parts.join(","),
     state_parts.join(","),
     display_parts.join(","),
+    animated_json,
   )
 }
 

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -11612,6 +11612,191 @@ pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   })
 }
 
+/// Attempt to extract a `ManipulateSpec` from a held `Animator[…]` expression.
+/// `Animator` is a standalone auto-playing control: it sweeps a value over a
+/// range and (like `Control`) displays the bound variable so its effect is
+/// visible. Supported forms: `Animator[{min, max}]`, `Animator[{min, max,
+/// step}]`, `Animator[Dynamic[v], {min, max}[, step]]`, `Animator[x]` (the
+/// default 0..1 range with initial value `x`), and `Animator[]`. Returns
+/// `None` when the range doesn't resolve to numbers.
+pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
+  let (name, args) = match expr {
+    Expr::FunctionCall { name, args } => (name, args),
+    _ => return None,
+  };
+  if name != "Animator" {
+    return None;
+  }
+  // An optional leading `Dynamic[v]` names the bound variable; else `u`.
+  let mut var = "u".to_string();
+  let mut idx = 0;
+  if let Some(Expr::FunctionCall { name: dn, args: da }) = args.first()
+    && dn == "Dynamic"
+    && da.len() == 1
+    && let Expr::Identifier(s) = &da[0]
+  {
+    var = s.clone();
+    idx = 1;
+  }
+  let (min, max, step, initial) = match args.get(idx) {
+    Some(Expr::List(items)) if !items.is_empty() => {
+      let min = crate::functions::math_ast::try_eval_to_f64(&items[0])?;
+      let max = items
+        .get(1)
+        .and_then(crate::functions::math_ast::try_eval_to_f64)
+        .unwrap_or(min + 1.0);
+      let step = items
+        .get(2)
+        .and_then(crate::functions::math_ast::try_eval_to_f64);
+      (min, max, step, min)
+    }
+    // A single number is the initial value over the default 0..1 range.
+    Some(other) if idx == 0 => {
+      let init = crate::functions::math_ast::try_eval_to_f64(other)?;
+      (0.0, 1.0, None, init)
+    }
+    // `Animator[]` / `Animator[Dynamic[v]]`: default 0..1 range.
+    None => (0.0, 1.0, None, 0.0),
+    _ => return None,
+  };
+  let control = ManipulateControl::Continuous {
+    name: var.clone(),
+    min,
+    max,
+    step,
+    initial,
+    label: var.clone(),
+    label_runs: vec![LabelRun {
+      text: var.clone(),
+      italic: false,
+    }],
+  };
+  Some(ManipulateSpec {
+    body_code: var,
+    controls: vec![control],
+    state: Vec::new(),
+    displays: Vec::new(),
+    initialization: None,
+    control_enabled: Vec::new(),
+    animated: true,
+  })
+}
+
+/// Interpret an optional trailing `{{xmin, ymin}, {xmax, ymax}}` range
+/// argument, defaulting to the unit square when absent or malformed. Shared by
+/// the `LocatorPane`/`ClickPane` pane extractors.
+fn pane_range(arg: Option<&Expr>) -> ((f64, f64), (f64, f64)) {
+  match arg {
+    Some(Expr::List(corners)) if corners.len() == 2 => {
+      match (list2_f64(&corners[0]), list2_f64(&corners[1])) {
+        (Some(lo), Some(hi)) => (lo, hi),
+        _ => ((0.0, 0.0), (1.0, 1.0)),
+      }
+    }
+    _ => ((0.0, 0.0), (1.0, 1.0)),
+  }
+}
+
+/// Attempt to extract a `ManipulateSpec` from a held `LocatorPane[…]`.
+/// A locator pane shows a graphic with a draggable point that drives it.
+/// Supported forms: `LocatorPane[Dynamic[p], body]` and `LocatorPane[p0,
+/// body]`, each with an optional trailing coordinate range `{{xmin, ymin},
+/// {xmax, ymax}}` (default: the unit square). Renders as a 2D pad — the
+/// draggable locator — beside the live `body` graphic. Returns `None` if the
+/// arguments don't fit.
+pub fn extract_locator_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
+  let (name, args) = match expr {
+    Expr::FunctionCall { name, args } => (name, args),
+    _ => return None,
+  };
+  if name != "LocatorPane" || args.len() < 2 {
+    return None;
+  }
+  // arg0: `Dynamic[p]` (named variable) or a literal initial point `{x, y}`.
+  let (var, explicit_init) = match &args[0] {
+    Expr::FunctionCall { name: dn, args: da }
+      if dn == "Dynamic" && da.len() == 1 =>
+    {
+      match &da[0] {
+        Expr::Identifier(s) => (s.clone(), None),
+        _ => return None,
+      }
+    }
+    pt => match list2_f64(pt) {
+      Some(p) => ("p".to_string(), Some(p)),
+      None => return None,
+    },
+  };
+  let body_code = crate::syntax::expr_to_input_form(&args[1]);
+  let ((x_min, y_min), (x_max, y_max)) = pane_range(args.get(2));
+  // Start the locator at the given point, else the range centre.
+  let (x_initial, y_initial) =
+    explicit_init.unwrap_or(((x_min + x_max) / 2.0, (y_min + y_max) / 2.0));
+  let control = ManipulateControl::Slider2D {
+    name: var.clone(),
+    x_min,
+    x_max,
+    y_min,
+    y_max,
+    x_initial,
+    y_initial,
+    label: var,
+  };
+  Some(ManipulateSpec {
+    body_code,
+    controls: vec![control],
+    state: Vec::new(),
+    displays: Vec::new(),
+    initialization: None,
+    control_enabled: Vec::new(),
+    animated: false,
+  })
+}
+
+/// Attempt to extract a `ManipulateSpec` from a held `ClickPane[…]`.
+/// A click pane applies a handler to the coordinates of each click. We model
+/// it as a 2D pad whose position feeds the handler: `ClickPane[expr, func]`
+/// (and `ClickPane[expr, {{xmin, ymin}, {xmax, ymax}}, func]`) render as a
+/// clickable/draggable pad with the live `func[{x, y}]` result shown beside
+/// it. Returns `None` if there's no handler to apply.
+pub fn extract_click_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
+  let (name, args) = match expr {
+    Expr::FunctionCall { name, args } => (name, args),
+    _ => return None,
+  };
+  if name != "ClickPane" || args.len() < 2 {
+    return None;
+  }
+  // The handler is the last argument; a 3-argument form carries an explicit
+  // coordinate range in the middle.
+  let func = args.last()?;
+  let range_arg = if args.len() >= 3 { args.get(1) } else { None };
+  let ((x_min, y_min), (x_max, y_max)) = pane_range(range_arg);
+  // Bind the click position `pos` and show the handler applied to it; the body
+  // re-evaluates `func[pos]` on every pad move.
+  let func_code = crate::syntax::expr_to_input_form(func);
+  let body_code = format!("({})[pos]", func_code);
+  let control = ManipulateControl::Slider2D {
+    name: "pos".to_string(),
+    x_min,
+    x_max,
+    y_min,
+    y_max,
+    x_initial: (x_min + x_max) / 2.0,
+    y_initial: (y_min + y_max) / 2.0,
+    label: "pos".to_string(),
+  };
+  Some(ManipulateSpec {
+    body_code,
+    controls: vec![control],
+    state: Vec::new(),
+    displays: Vec::new(),
+    initialization: None,
+    control_enabled: Vec::new(),
+    animated: false,
+  })
+}
+
 /// Attempt to extract a `ManipulateSpec` from a held standalone
 /// `Control[{…}]` expression. A bare `Control` renders a single interactive
 /// control whose bound variable has no body to display, so the "body" is

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -344,12 +344,17 @@ fn try_build_manipulate_item(stmt: &str) -> Option<String> {
   // is HoldAll-ish (see functions::graphics::manipulate_ast), so its body
   // and variable symbols remain intact.
   let expr = crate::interpret_to_expr(stmt).ok()?;
-  // A top-level Manipulate[…]/Animate[…], a standalone Control[…], or a
-  // ListAnimate[{…}] all render as an interactive control widget backed by a
-  // ManipulateSpec (Animate/ListAnimate additionally auto-play).
-  let spec = crate::functions::graphics::extract_manipulate_spec(&expr)
-    .or_else(|| crate::functions::graphics::extract_control_spec(&expr))
-    .or_else(|| crate::functions::graphics::extract_list_animate_spec(&expr))?;
+  // A top-level Manipulate[…]/Animate[…], a standalone Control[…]/Animator[…],
+  // a ListAnimate[{…}], or a LocatorPane/ClickPane all render as an interactive
+  // control widget backed by a ManipulateSpec (Animate/Animator/ListAnimate
+  // additionally auto-play).
+  use crate::functions::graphics as g;
+  let spec = g::extract_manipulate_spec(&expr)
+    .or_else(|| g::extract_control_spec(&expr))
+    .or_else(|| g::extract_list_animate_spec(&expr))
+    .or_else(|| g::extract_animator_spec(&expr))
+    .or_else(|| g::extract_locator_pane_spec(&expr))
+    .or_else(|| g::extract_click_pane_spec(&expr))?;
 
   // Produce an initial rendering by substituting initial values via Block.
   let bindings = crate::functions::graphics::manipulate_initial_bindings(&spec);

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -344,10 +344,12 @@ fn try_build_manipulate_item(stmt: &str) -> Option<String> {
   // is HoldAll-ish (see functions::graphics::manipulate_ast), so its body
   // and variable symbols remain intact.
   let expr = crate::interpret_to_expr(stmt).ok()?;
-  // A top-level Manipulate[…] or a standalone Control[…] both render as an
-  // interactive control widget backed by a ManipulateSpec.
+  // A top-level Manipulate[…]/Animate[…], a standalone Control[…], or a
+  // ListAnimate[{…}] all render as an interactive control widget backed by a
+  // ManipulateSpec (Animate/ListAnimate additionally auto-play).
   let spec = crate::functions::graphics::extract_manipulate_spec(&expr)
-    .or_else(|| crate::functions::graphics::extract_control_spec(&expr))?;
+    .or_else(|| crate::functions::graphics::extract_control_spec(&expr))
+    .or_else(|| crate::functions::graphics::extract_list_animate_spec(&expr))?;
 
   // Produce an initial rendering by substituting initial values via Block.
   let bindings = crate::functions::graphics::manipulate_initial_bindings(&spec);

--- a/tests/cli/comparison/mathematica.md
+++ b/tests/cli/comparison/mathematica.md
@@ -329,10 +329,10 @@ Woxi does **not** support.
 
 ### Version 6.0 (2007)
 
-- Dynamic UI panes: `Animator`, `LocatorPane`, `ClickPane`
-    (`Animate` and `ListAnimate` now render as interactive auto-playing widgets
-    in the Playground and Studio)
 - Live mouse-driven manipulation of 2D/3D graphics in notebooks
+    (`Animate`, `Animator`, `ListAnimate`, `LocatorPane`, and `ClickPane` are
+    supported as interactive widgets in the Playground and Studio, but
+    dragging directly on a graphic — and 3D rotation — is not)
 
 ### Version 5.0 (2003)
 

--- a/tests/cli/comparison/mathematica.md
+++ b/tests/cli/comparison/mathematica.md
@@ -329,7 +329,9 @@ Woxi does **not** support.
 
 ### Version 6.0 (2007)
 
-- Dynamic UI panes: `Animate`, `Animator`, `LocatorPane`, `ClickPane`
+- Dynamic UI panes: `Animator`, `LocatorPane`, `ClickPane`
+    (`Animate` and `ListAnimate` now render as interactive auto-playing widgets
+    in the Playground and Studio)
 - Live mouse-driven manipulation of 2D/3D graphics in notebooks
 
 ### Version 5.0 (2003)

--- a/tests/cli/plotting/ControlActive.md
+++ b/tests/cli/plotting/ControlActive.md
@@ -1,0 +1,43 @@
+# `ControlActive`
+
+`ControlActive[active, normal]` represents an object that is shown as
+`active` while it sits inside a control that is being *actively* manipulated
+(e.g. while a slider thumb is being dragged), and as `normal` at all other
+times. It is used to substitute a cheaper computation during dragging.
+
+Outside of an interactive notebook nothing is ever actively manipulated, so
+`ControlActive` always evaluates to its `normal` (inactive) form — matching
+`wolframscript` in script mode.
+
+```scrut
+$ wo 'ControlActive[1, 2]'
+2
+```
+
+The chosen argument is evaluated as usual:
+
+```scrut
+$ wo 'ControlActive[1 + 1, 2 + 2]'
+4
+```
+
+```scrut
+$ wo 'ControlActive["fast", "slow"]'
+slow
+```
+
+A common pattern is picking a coarse plot while dragging and a fine one once
+the control settles:
+
+```scrut
+$ wo 'ControlActive[10, 100]'
+100
+```
+
+Forms other than the two-argument `active`/`normal` split have no inactive
+value to fall back to, so they stay symbolic:
+
+```scrut
+$ wo 'ControlActive[]'
+ControlActive[]
+```

--- a/tests/cli/plotting/InteractiveControls.md
+++ b/tests/cli/plotting/InteractiveControls.md
@@ -1,0 +1,59 @@
+# Interactive Manipulation Controls
+
+The control and animation heads from the
+[InteractiveManipulation](https://reference.wolfram.com/language/guide/InteractiveManipulation.html)
+guide render as interactive widgets inside a Jupyter notebook or the
+[playground](/). In script mode (like `wolframscript -code`) they have no
+notebook to live in, so they stay unevaluated as their canonical form rather
+than producing an interactive object.
+
+Animation heads:
+
+```scrut
+$ wo 'Animate[x^2, {x, 0, 5}]'
+Animate[x^2, {x, 0, 5}]
+```
+
+```scrut
+$ wo 'ListAnimate[{1, 2, 3}]'
+ListAnimate[{1, 2, 3}]
+```
+
+Selection-bar controls:
+
+```scrut
+$ wo 'SetterBar[1, {1, 2, 3}]'
+SetterBar[1, {1, 2, 3}]
+```
+
+```scrut
+$ wo 'CheckboxBar[{1}, {1, 2, 3}]'
+CheckboxBar[{1}, {1, 2, 3}]
+```
+
+```scrut
+$ wo 'TogglerBar[{1}, {1, 2, 3}]'
+TogglerBar[{1}, {1, 2, 3}]
+```
+
+```scrut
+$ wo 'RadioButton[1]'
+RadioButton[1]
+```
+
+Progress, trigger, and two-dimensional / interval sliders:
+
+```scrut
+$ wo 'ProgressIndicator[0.4]'
+ProgressIndicator[0.4]
+```
+
+```scrut
+$ wo 'IntervalSlider[{2, 4}]'
+IntervalSlider[{2, 4}]
+```
+
+```scrut
+$ wo 'Slider2D[{0, 0}]'
+Slider2D[{0, 0}]
+```

--- a/tests/cli/plotting/InteractiveControls.md
+++ b/tests/cli/plotting/InteractiveControls.md
@@ -57,3 +57,22 @@ IntervalSlider[{2, 4}]
 $ wo 'Slider2D[{0, 0}]'
 Slider2D[{0, 0}]
 ```
+
+Standalone animator and the draggable / clickable panes (these auto-play or
+respond to pointer input in the Playground and Studio; in script mode they stay
+symbolic):
+
+```scrut
+$ wo 'Animator[{0, 10}]'
+Animator[{0, 10}]
+```
+
+```scrut
+$ wo 'LocatorPane[Dynamic[p], Graphics[Point[p]]]'
+LocatorPane[Dynamic[p], Graphics[Point[p]]]
+```
+
+```scrut
+$ wo 'ClickPane[Graphics[{}], f]'
+ClickPane[Graphics[{}], f]
+```

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1167,6 +1167,57 @@ mod interpreter_tests {
       ("MenuView[x]", "MenuView[x]"),
       ("SlideView[x]", "SlideView[x]"),
       ("FlipView[x]", "FlipView[x]"),
+      // Interactive manipulation heads from the InteractiveManipulation
+      // guide. In script mode these stay unevaluated as their canonical form
+      // (they only become interactive objects inside a notebook), so they
+      // must not emit a spurious "not yet implemented" warning.
+      ("Animate[x, {x, 0, 1}]", "Animate[x, {x, 0, 1}]"),
+      ("Animator[0]", "Animator[0]"),
+      ("ListAnimate[{1, 2, 3}]", "ListAnimate[{1, 2, 3}]"),
+      (
+        "ControllerManipulate[x, {x, 0, 1}]",
+        "ControllerManipulate[x, {x, 0, 1}]",
+      ),
+      ("Trigger[Dynamic[x]]", "Trigger[Dynamic[x]]"),
+      ("SetterBar[1, {1, 2, 3}]", "SetterBar[1, {1, 2, 3}]"),
+      ("CheckboxBar[{1}, {1, 2}]", "CheckboxBar[{1}, {1, 2}]"),
+      ("TogglerBar[{1}, {1, 2}]", "TogglerBar[{1}, {1, 2}]"),
+      ("RadioButton[1]", "RadioButton[1]"),
+      ("ProgressIndicator[0.5]", "ProgressIndicator[0.5]"),
+      ("PaneSelector[{1 -> a}, 1]", "PaneSelector[{1 -> a}, 1]"),
+      ("PopupView[{a, b}]", "PopupView[{a, b}]"),
+      ("IntervalSlider[{2, 4}]", "IntervalSlider[{2, 4}]"),
+      ("Slider2D[{0, 0}]", "Slider2D[{0, 0}]"),
+      // Manipulate option symbols used on their own stay symbolic too.
+      ("Bookmarks", "Bookmarks"),
+      ("ContinuousAction", "ContinuousAction"),
+      ("AppearanceElements", "AppearanceElements"),
+    ];
+    for (input, expected) in cases {
+      let r = interpret_with_stdout(input).unwrap();
+      assert_eq!(r.result, expected, "result mismatch for {input}");
+      assert!(
+        !r.warnings.iter().any(|w| w.contains("not yet implemented")),
+        "unexpected 'not yet implemented' warning for {input}: {:?}",
+        r.warnings
+      );
+    }
+  }
+
+  #[test]
+  fn control_active_returns_inactive_form_in_script_mode() {
+    // ControlActive[activeform, normalform] displays as `activeform` only
+    // while it sits inside a control that is being actively manipulated. In
+    // script mode nothing is ever actively manipulated, so it evaluates to
+    // its inactive form `normalform` (with the argument fully evaluated).
+    let cases = [
+      ("ControlActive[1, 2]", "2"),
+      ("ControlActive[1 + 1, 2 + 2]", "4"),
+      ("ControlActive[\"fast\", \"slow\"]", "slow"),
+      // Non-two-argument forms have no active/normal split, so they stay
+      // symbolic (and must not warn about being unimplemented).
+      ("ControlActive[]", "ControlActive[]"),
+      ("ControlActive[5]", "ControlActive[5]"),
     ];
     for (input, expected) in cases {
       let r = interpret_with_stdout(input).unwrap();

--- a/tests/playground/script.js
+++ b/tests/playground/script.js
@@ -25,6 +25,18 @@ const themeConfig = new Compartment()
 // segmented SetterBar (toggle buttons); larger sets use a dropdown. Mirrors
 // SETTER_BAR_MAX_CHOICES in woxi-studio.
 const SETTER_BAR_MAX_CHOICES = 6
+// Auto-playing widgets (Animate / ListAnimate) advance their animation
+// control one step every ANIM_INTERVAL_MS. At ~60ms the default 100-step
+// continuous range sweeps in ~6s, matching Wolfram's leisurely Animate.
+const ANIM_INTERVAL_MS = 60
+// Every running animation's stop() function, so a re-run or clear can halt
+// timers that would otherwise keep firing against removed DOM nodes.
+const activeAnimators = new Set()
+
+function stopAllAnimators() {
+  for (const stop of activeAnimators) stop()
+  activeAnimators.clear()
+}
 const STORAGE_KEY_THEME = "woxi-playground-theme"
 const THEME_MODES = ["auto", "light", "dark"]
 const THEME_ICONS = { auto: "\u25D0", light: "\u2600", dark: "\u263E" }
@@ -306,6 +318,8 @@ function renderOutputItems(items) {
   // results arriving from the worker are ignored.
   manipulateRequests.clear()
   enabledRequests.clear()
+  // Halt any running animation timers whose widgets are about to be replaced.
+  stopAllAnimators()
 
   for (const item of items) {
     appendOutputItem(outputsEl, item)
@@ -400,6 +414,8 @@ function renderManipulate(item) {
     // `apply(on)` greys the control's DOM in or out. Re-evaluated on every
     // binding change so a control can disable itself for the current state.
     enabledControls: [],
+    // Continuous-slider drivers an Animate/ListAnimate animator can advance.
+    animatables: [],
   }
 
   // Format a continuous value for display (strip trailing zeros).
@@ -625,6 +641,19 @@ function renderManipulate(item) {
           row.classList.toggle("disabled", !on)
         },
       })
+      // Expose this slider so an Animate/ListAnimate animator can drive it.
+      widget.animatables.push({
+        min: Number(ctrl.min),
+        max: Number(ctrl.max),
+        step: step > 0 ? Number(step) : (Number(ctrl.max) - Number(ctrl.min)) / 100,
+        get: () => Number(input.value),
+        set: (v) => {
+          input.value = v
+          current[ctrl.name] = String(v)
+          display.textContent = fmt(v)
+          requestUpdate()
+        },
+      })
     } else if (ctrl.kind === "discrete") {
       // The bound value is `values[idx]`; the visible text is the parallel
       // `valueLabels[idx]` (a rule's right-hand side for a `value -> "label"`
@@ -812,6 +841,53 @@ function renderManipulate(item) {
   // Grey out any control that starts disabled for the initial bindings.
   widget.refreshEnabled(buildBindings())
 
+  // An Animate/ListAnimate widget auto-plays: a play/pause button advances its
+  // first continuous slider on a timer, looping min → max → min.
+  if (item.animated && widget.animatables.length > 0) {
+    const target = widget.animatables[0]
+    const bar = document.createElement("div")
+    bar.className = "manipulate-animator"
+
+    const btn = document.createElement("button")
+    btn.type = "button"
+    btn.className = "manipulate-play"
+
+    let timer = null
+    function stop() {
+      if (timer !== null) {
+        clearInterval(timer)
+        timer = null
+      }
+      btn.textContent = "▶"
+      btn.setAttribute("aria-label", "Play")
+      activeAnimators.delete(stop)
+    }
+    function tick() {
+      let v = target.get() + target.step
+      // Loop back to the start once we step past the end (small epsilon so
+      // floating-point drift doesn't skip the final frame).
+      if (v > target.max + target.step * 1e-6) v = target.min
+      target.set(v)
+    }
+    function play() {
+      if (timer !== null) return
+      btn.textContent = "❚❚"
+      btn.setAttribute("aria-label", "Pause")
+      timer = setInterval(tick, ANIM_INTERVAL_MS)
+      activeAnimators.add(stop)
+    }
+    btn.addEventListener("click", () => {
+      if (timer === null) play()
+      else stop()
+    })
+    widget.stopAnimation = stop
+
+    bar.appendChild(btn)
+    controlsEl.appendChild(bar)
+    // Start playing immediately (Wolfram's default AnimationRunning -> True).
+    play()
+  }
+
   box.appendChild(controlsEl)
   // Extra display elements (e.g. the Checkbox grid) sit above the rendered
   // body output.
@@ -854,6 +930,7 @@ function fillManipulateOutput(el, payload) {
 }
 
 function clearOutputs() {
+  stopAllAnimators()
   document.getElementById("outputs").innerHTML = ""
 }
 

--- a/tests/playground/style.css
+++ b/tests/playground/style.css
@@ -547,6 +547,36 @@ pre.output-box {
   cursor: not-allowed;
 }
 
+/* Animate/ListAnimate play-pause bar. The controls panel is a shared grid, so
+   span every column and left-align the button under the sliders. */
+.manipulate-animator {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  padding-top: 0.15rem;
+}
+
+.manipulate-play {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-2, rgba(127, 127, 127, 0.12));
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  width: 2rem;
+  height: 1.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.manipulate-play:hover {
+  background: var(--surface-3, rgba(127, 127, 127, 0.22));
+}
+
 /* 2D slider pad (ControlType -> Slider2D) */
 .manipulate-pad {
   position: relative;

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -10,8 +10,9 @@
 use iced::widget::svg;
 use woxi::functions::graphics::{
   DisplayNode, LabelRun, ManipulateControl, ManipulateSpec,
-  apply_manipulate_mutations, build_manipulate_display, extract_control_spec,
-  extract_list_animate_spec, extract_manipulate_spec,
+  apply_manipulate_mutations, build_manipulate_display, extract_animator_spec,
+  extract_click_pane_spec, extract_control_spec, extract_list_animate_spec,
+  extract_locator_pane_spec, extract_manipulate_spec,
 };
 use woxi::syntax::Expr;
 
@@ -147,12 +148,16 @@ impl ManipulateState {
   /// `None` if `expr` is not a well-formed Manipulate (in which case
   /// the caller should fall back to the normal text/graphics path).
   pub fn from_expr(expr: &Expr) -> Option<Self> {
-    // Manipulate/Animate, a standalone Control, or a ListAnimate frame list
-    // all back an interactive widget. (Native auto-play for Animate/ListAnimate
-    // is a follow-up; here they render as an interactive frame slider.)
+    // Manipulate/Animate, a standalone Control/Animator, a ListAnimate frame
+    // list, or a LocatorPane/ClickPane all back an interactive widget. (Native
+    // auto-play for the animated ones is a follow-up; here they render as
+    // interactive slider / 2D-pad widgets.)
     let spec = extract_manipulate_spec(expr)
       .or_else(|| extract_control_spec(expr))
-      .or_else(|| extract_list_animate_spec(expr))?;
+      .or_else(|| extract_list_animate_spec(expr))
+      .or_else(|| extract_animator_spec(expr))
+      .or_else(|| extract_locator_pane_spec(expr))
+      .or_else(|| extract_click_pane_spec(expr))?;
     let controls = controls_from_spec(&spec);
     // Line each control up with its `Enabled` condition (if any) by name.
     let control_enabled: Vec<Option<String>> = controls

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -11,7 +11,7 @@ use iced::widget::svg;
 use woxi::functions::graphics::{
   DisplayNode, LabelRun, ManipulateControl, ManipulateSpec,
   apply_manipulate_mutations, build_manipulate_display, extract_control_spec,
-  extract_manipulate_spec,
+  extract_list_animate_spec, extract_manipulate_spec,
 };
 use woxi::syntax::Expr;
 
@@ -147,8 +147,12 @@ impl ManipulateState {
   /// `None` if `expr` is not a well-formed Manipulate (in which case
   /// the caller should fall back to the normal text/graphics path).
   pub fn from_expr(expr: &Expr) -> Option<Self> {
-    let spec =
-      extract_manipulate_spec(expr).or_else(|| extract_control_spec(expr))?;
+    // Manipulate/Animate, a standalone Control, or a ListAnimate frame list
+    // all back an interactive widget. (Native auto-play for Animate/ListAnimate
+    // is a follow-up; here they render as an interactive frame slider.)
+    let spec = extract_manipulate_spec(expr)
+      .or_else(|| extract_control_spec(expr))
+      .or_else(|| extract_list_animate_spec(expr))?;
     let controls = controls_from_spec(&spec);
     // Line each control up with its `Enabled` condition (if any) by name.
     let control_enabled: Vec<Option<String>> = controls


### PR DESCRIPTION
## Summary

Add support for the remaining interactive-manipulation heads from the Wolfram Language `InteractiveManipulation` guide. These controls stay symbolic in script mode (matching `wolframscript` behavior) instead of emitting spurious "not yet implemented" warnings.

## Key Changes

- **Interactive control heads**: Added `Animate`, `Animator`, `ListAnimate`, `ControllerManipulate`, `Trigger`, `SetterBar`, `CheckboxBar`, `TogglerBar`, `RadioButton`, `ProgressIndicator`, `ClickPane`, `PaneSelector`, `PopupView`, `ColorSetter`, `IntervalSlider`, and `Slider2D` to the list of unevaluated interactive heads in `dispatch/mod.rs`

- **ControlActive implementation**: Implemented `ControlActive[active, normal]` to evaluate to its inactive form `normal` in script mode, matching `wolframscript` behavior. Non-two-argument forms remain symbolic.

- **Option symbols**: Marked `Bookmarks`, `ContinuousAction`, and `AppearanceElements` as pure/unevaluated symbols in `functions.csv`

- **Test coverage**: Added comprehensive unit tests in `interpreter_tests.rs` covering all interactive heads and `ControlActive` behavior

- **Documentation**: Added two new documentation test files:
  - `tests/cli/plotting/InteractiveControls.md`: Examples of animation and control heads staying symbolic
  - `tests/cli/plotting/ControlActive.md`: Examples of `ControlActive` evaluating to its inactive form

- **Function registry**: Updated `functions.csv` to mark these previously unimplemented functions as supported with appropriate descriptions and effect levels

## Implementation Details

The interactive control heads are added to the existing pattern match in `dispatch/mod.rs` that prevents false "not yet implemented" warnings for functions that intentionally stay unevaluated in script mode. This matches the existing behavior for `Slider`, `Toggler`, and view functions like `TabView`.

`ControlActive` is implemented as a special case in `boolean_functions.rs` that returns the second argument (the inactive form) when called with exactly two arguments, since nothing is ever actively manipulated outside an interactive notebook environment.

https://claude.ai/code/session_01EYDc3RAR71Pd91Xs4n1FBk