### PR TITLE
Reduce stack needed for parse_expression

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3927,6 +3927,22 @@ fn parse_expression(pair: Pair<Rule>) -> Expr {
     return result;
   }
 
+  parse_expression_inner(
+    inner,
+    replace_rules,
+    postfix_funcs,
+    anon_func_suffix,
+    post_anon_pairs,
+  )
+}
+
+fn parse_expression_inner(
+  inner: Vec<Pair<Rule>>,
+  replace_rules: Option<(Pair<Rule>, bool)>,
+  postfix_funcs: Vec<Pair<Rule>>,
+  anon_func_suffix: Option<Vec<Vec<Expr>>>,
+  post_anon_pairs: Vec<Pair<Rule>>,
+) -> Expr {
   // Parse operators: Term (Operator Term)*
   // Build expression with proper precedence
   let mut terms: Vec<Expr> = Vec::new();


### PR DESCRIPTION
pair_to_expr, when expanding expressions, consumes 16k of stack for each invocation of parse_expression.  Most of the stack is needed for complex expression evaluation, so splitting the function after the single term case code drops the common stack usage down to about 1k, and the stack needed for my canonical test case of

  N[Round[QuantityMagnitude[Longitude[GeoDestination[{40, -100}, {100000, 45}]]], 10^-9]]

drops from 224k to 132k.