### PR TITLE
Cap pest parser calls to reject pathological nesting fast

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,14 @@ impl WolframParser {
     input: &str,
   ) -> Result<pest::iterators::Pairs<'_, Rule>, Box<pest::error::Error<Rule>>>
   {
+    // Deeply nested invalid input (e.g. `f[f[f[...` without closing
+    // brackets) makes pest backtrack exponentially, so rejecting it would
+    // take hours. The call limit turns that into a "call limit reached"
+    // parse error within seconds. The worst script in tests/scripts needs
+    // ~5,700 calls per byte, so 20,000 per byte (with a floor for tiny
+    // inputs) leaves ample headroom for legitimate code of any size.
+    let limit = 50_000_000.max(input.len().saturating_mul(20_000));
+    pest::set_call_limit(std::num::NonZeroUsize::new(limit));
     Self::parse(Rule::Program, input).map_err(Box::new)
   }
 }

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -159,4 +159,26 @@ mod tests {
       "named-char head resolves to ψ"
     );
   }
+
+  #[test]
+  fn test_parse_pathological_nesting_rejected_quickly() {
+    // Regression (fuzz finding): deeply nested invalid input made pest
+    // backtrack exponentially — depth 20 previously took hours to reject.
+    // The call limit in parse_wolfram must turn these into prompt errors.
+    let cases = [
+      // unclosed nested brackets
+      format!("{}x", "f[".repeat(30)),
+      // balanced nesting around a token that is invalid everywhere
+      format!("{}\u{0}{}", "f[".repeat(30), "]".repeat(30)),
+    ];
+    for input in &cases {
+      let start = std::time::Instant::now();
+      assert!(parse(input).is_err(), "should not parse: {:?}", input);
+      assert!(
+        start.elapsed() < std::time::Duration::from_secs(60),
+        "rejection took too long for: {:?}",
+        input
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Problem

`make fuzz-parse` found a libFuzzer timeout: a 2KB input took 19+ seconds to parse. Root cause: deeply nested invalid input — unclosed `f[f[f[...` brackets, or balanced nesting around an invalid token — makes pest backtrack exponentially through the nested grammar alternatives. Depth 12 takes ~63s (debug); depth 20 would take hours.

## Fix

Set `pest::set_call_limit` in `parse_wolfram`, scaled to input size (20,000 calls/byte with a 50M floor). Pathological input now fails with a "call limit reached" parse error within seconds instead of hanging.

The per-byte factor was calibrated by binary-searching the minimum limit for every script in `tests/scripts`: the worst one needs ~4.5M calls (~5,700 calls/byte), so legitimate code of any size has >3x headroom per byte and the floor alone covers scripts 10x larger than the worst current one.

This is a mitigation, not a grammar fix — the proper fix is left-factoring the `FunctionDefinition`/`FunctionCall` alternatives so nested bracket structures aren't re-parsed per alternative.

## Testing

- New regression test `test_parse_pathological_nesting_rejected_quickly` covering both the unclosed and the balanced-invalid variants
- `make test`: 23,116 tests pass
- Re-ran `make fuzz-parse` with the fix: the original timeout artifact executes in 2.7s (under the 10s limit); no new findings during the run
