### PR TITLE
Fix fuzzing with ASan by targeting host triple explicitly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,10 @@ jobs:
       # Runs even when the parse target already found a crash, so one
       # night reports both.
       if: '!cancelled()'
-      run: cargo fuzz run interpret --target "$HOST_TARGET" -- -timeout=20 -max_len=2048 -max_total_time=300
+      # -rss_limit_mb is raised above the 2048 default because some corpus
+      # seeds (tests/scripts/*.wls) are legitimately memory-hungry
+      # computations, and ASan roughly triples their footprint.
+      run: cargo fuzz run interpret --target "$HOST_TARGET" -- -timeout=20 -max_len=2048 -max_total_time=300 -rss_limit_mb=8192
     - name: Upload crashing inputs
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,13 +44,20 @@ jobs:
         tool: cargo-fuzz
     - name: Seed corpora from the test scripts
       run: make fuzz-corpus
+    # The prebuilt cargo-fuzz binary is a static musl build and defaults to
+    # its own compile-time triple (x86_64-unknown-linux-musl), which cannot
+    # link ASan ("sanitizer is incompatible with statically linked libc").
+    # Pass the host triple explicitly so the fuzz targets build against glibc.
+    - name: Determine host target triple
+      run: |
+        echo "HOST_TARGET=$(rustc -vV | sed -n 's/host: //p')" >> "$GITHUB_ENV"
     - name: Fuzz the parser
-      run: cargo fuzz run parse -- -timeout=10 -max_len=4096 -max_total_time=300
+      run: cargo fuzz run parse --target "$HOST_TARGET" -- -timeout=10 -max_len=4096 -max_total_time=300
     - name: Fuzz the interpreter
       # Runs even when the parse target already found a crash, so one
       # night reports both.
       if: '!cancelled()'
-      run: cargo fuzz run interpret -- -timeout=20 -max_len=2048 -max_total_time=300
+      run: cargo fuzz run interpret --target "$HOST_TARGET" -- -timeout=20 -max_len=2048 -max_total_time=300
     - name: Upload crashing inputs
       if: failure()
       uses: actions/upload-artifact@v4

--- a/makefile
+++ b/makefile
@@ -128,7 +128,7 @@ fuzz-interpret: fuzz-corpus
 	@if ! command -v cargo-fuzz &> /dev/null; \
 		then cargo install cargo-fuzz; \
 		fi
-	cargo +nightly fuzz run interpret -- -timeout=20 -max_len=2048
+	cargo +nightly fuzz run interpret -- -timeout=20 -max_len=2048 -rss_limit_mb=8192
 
 # Differential fuzzing against wolframscript (local binary or the
 # cmd-server.js Docker bridge — auto-detected). Reports and shrinks any


### PR DESCRIPTION
## Summary

This PR fixes fuzzing issues when using AddressSanitizer (ASan) by explicitly passing the host target triple to cargo-fuzz commands. The prebuilt cargo-fuzz binary is a static musl build that defaults to `x86_64-unknown-linux-musl`, which cannot link with ASan. By targeting the host triple explicitly, the fuzz targets build against glibc instead, allowing ASan to work correctly.

## Key Changes

- **Nightly workflow**: Added a step to determine the host target triple and pass it to both `cargo fuzz run parse` and `cargo fuzz run interpret` commands
- **Memory limit adjustment**: Increased the RSS limit for the interpret fuzzer from the default 2048 MB to 8192 MB, as ASan roughly triples memory footprint and some corpus seeds (test scripts) are legitimately memory-hungry computations
- **Makefile**: Updated the `fuzz-interpret` target to include the same RSS limit increase for consistency with the nightly workflow

## Implementation Details

- The host target triple is determined using `rustc -vV | sed -n 's/host: //p'` and stored in the `HOST_TARGET` environment variable
- Both fuzzing targets now use `--target "$HOST_TARGET"` to ensure they compile against the correct libc
- Added explanatory comments in the workflow to document why the explicit target triple is necessary and why the RSS limit needs to be increased

https://claude.ai/code/session_014zEBy1DysfUhCcUXEnQnHr