### PR TITLE
Fix Factorial2[n] for n < -57, n odd

### DIFF
--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -597,27 +597,16 @@ pub fn factorial2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Negative odd integers: n!! = (n+2)!! / (n+2)
       // (-1)!! = 1, (-3)!! = -1, (-5)!! = 1/3, (-7)!! = -1/15, ...
       if n % 2 != 0 {
-        // Compute by working from -1 down
-        let mut numer: i128 = 1;
-        let mut denom: i128 = 1;
-        let mut k = -1i128;
-        while k > n {
-          k -= 2;
-          // (k)!! = (k+2)!! / (k+2)
-          denom *= k + 2;
-          // Simplify
-          let g = gcd_i128(numer.abs(), denom.abs());
-          numer /= g;
-          denom /= g;
+        // (-n)!! = (-1)^((n-1)/2) / (n-2)!! for n>1 odd
+        let mut denom = BigInt::from(1);
+        let mut i = -n - 2;
+        while i >= 2 {
+          denom *= i;
+          i -= 2;
         }
-        if denom < 0 {
-          numer = -numer;
-          denom = -denom;
-        }
-        if denom == 1 {
-          return Ok(Expr::Integer(numer));
-        }
-        return Ok(make_rational(numer, denom));
+
+        let numer = BigInt::from(if (-n + 1) % 4 == 0 { -1 } else { 1 });
+        return Ok(make_rational_expr(numer, denom));
       }
       return Ok(Expr::FunctionCall {
         name: "Factorial2".to_string(),

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -3155,6 +3155,24 @@ mod expand_threading {
     assert_eq!(interpret("Factorial2[-7]").unwrap(), "-1/15");
   }
 
+  // The denominator (|n| - 2)!! exceeds i128 for n < -57, so these need
+  // BigInt arithmetic. Also covers both signs of (-1)^((|n| - 1)/2).
+  #[test]
+  fn factorial2_negative_odd_large() {
+    assert_eq!(
+      interpret("Factorial2[-59]").unwrap(),
+      "-1/495179769008019818390136611716089140625"
+    );
+    assert_eq!(
+      interpret("Factorial2[-61]").unwrap(),
+      "1/29215606371473169285018060091249259296875"
+    );
+    assert_eq!(
+      interpret("Factorial2[-101]").unwrap(),
+      "1/2725392139750729502980713245400918633290796330545803413734328823443106201171875"
+    );
+  }
+
   // Factorial2 should render with the `!!` suffix (not as `Factorial2[x]`),
   // matching wolframscript. Parentheses wrap Plus/Times operands so the
   // suffix binds to the whole expression.


### PR DESCRIPTION
Factorial2[n] uses BigInt for n>1, but i128 for n<-1 and odd, making it overflow for n<-57.  Use BigInt in both cases, and the formula (-n)!! = (-1)^((n-1)/2) / (n-2)!! for n>1 odd.