### PR TITLE
Fix 2D output formatting and arithmetic precision issues

### DIFF
--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -629,11 +629,14 @@ pub fn evaluate_function_call_ast_inner(
   };
 
   // Apply Orderless attribute: sort arguments into canonical order.
-  // Plus is exempt: Wolfram's machine-precision fold is input-order-
-  // sensitive (Plus[0.1, 0.7, 0.3] → 1.0999999999999999 but
-  // Plus[0.1, 0.3, 0.7] → 1.1), so plus_ast must see the original
-  // argument order; it canonically sorts its own symbolic output.
+  // Plus and Times are exempt: Wolfram's machine-precision fold is
+  // input-order-sensitive (Plus[0.1, 0.7, 0.3] → 1.0999999999999999 but
+  // Plus[0.1, 0.3, 0.7] → 1.1; Times[3, 1/7, 0.1, 0.2, 0.3] →
+  // 0.002571428571428571 but Times[0.1, 0.2, 3, 1/7, 0.3] →
+  // 0.0025714285714285717), so plus_ast/times_ast must see the original
+  // argument order; both canonically sort their own symbolic output.
   let has_orderless = name != "Plus"
+    && name != "Times"
     && (is_builtin_orderless(name)
       || crate::FUNC_ATTRS.with(|m| {
         m.borrow()

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -808,6 +808,39 @@ fn split_numeric_complex_minus(e: &Expr) -> Option<(Expr, Expr)> {
   Some(((**left).clone(), neg_imag))
 }
 
+/// Wolfram's machine-precision fold: the operands combine as a balanced
+/// divide-and-conquer tree with ceil split (left half gets the extra
+/// element), not left-to-right. Total[Table[0.1, 10]] is exactly 1.
+/// (a left-to-right fold gives 0.9999999999999999) and
+/// Plus[22, -59, 34, 14.6] is 11.600000000000001 because 22-59 and
+/// 34+14.6 combine first. The same tree shape applies to Times
+/// (Times[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7] → 0.000504).
+fn machine_tree_fold(xs: &[f64], op: fn(f64, f64) -> f64) -> f64 {
+  match xs.len() {
+    1 => xs[0],
+    2 => op(xs[0], xs[1]),
+    n => {
+      let m = n.div_ceil(2);
+      op(
+        machine_tree_fold(&xs[..m], op),
+        machine_tree_fold(&xs[m..], op),
+      )
+    }
+  }
+}
+
+/// Machine-precision Plus over the numeric terms, in input order. Every
+/// exact term converts to f64 individually — Wolfram does NOT coalesce
+/// exact terms into a rational sum first: Plus[2^60, 1, -2^60, 0.5] is
+/// 0. (the 1 is absorbed into 2^60 in f64) and Plus[22, -59, 34, 14.6]
+/// is 11.600000000000001, not (-3 + 14.6) = 11.6.
+fn machine_sum(terms: &[f64]) -> f64 {
+  if terms.is_empty() {
+    return 0.0;
+  }
+  machine_tree_fold(terms, |a, b| a + b)
+}
+
 pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.is_empty() {
     return Ok(Expr::Integer(0));
@@ -1044,8 +1077,13 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     matches!(a, Expr::FunctionCall { name, args }
       if name == "Rational" && args.len() == 2)
   });
+  // Likewise a machine Real forces the general machine fold (which is
+  // BigInt-aware via expr_to_coeff): Plus[2^60, 1, -2^60, 0.5] is 0.
+  // because every term converts to f64 individually — the fast path
+  // would sum the integers exactly and leave `1 + 0.5` uncombined.
+  let has_real_arg = flat_args.iter().any(|a| matches!(a, Expr::Real(_)));
 
-  if has_bigint && !has_rational {
+  if has_bigint && !has_rational && !has_real_arg {
     use num_bigint::BigInt;
     let mut big_sum = BigInt::from(0);
     let mut all_int = true;
@@ -1120,40 +1158,19 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return bigfloat_plus(&flat_args);
   }
 
-  // If all numeric but has Reals, use f64. Wolfram's machine fold is
-  // input-order-sensitive: exact terms coalesce into ONE exact rational
-  // sum, which seeds the f64 fold when the first numeric term is exact
-  // and is appended after the reals otherwise (Plus[1/3, 0.1, 0.7, 0.3]
-  // → 1.4333333333333333 but Plus[0.1, 0.7, 1/3, 0.3] →
-  // 1.4333333333333331; Total[{1/3,1/3,1/3,0.5}] → 1.5 exactly).
+  // If all numeric but has Reals, use f64: every term (exact or real)
+  // converts to f64 individually, in input order, and folds as the
+  // balanced machine tree (see machine_sum).
   if all_numeric && !has_bigfloat {
-    let mut exact_sum = Coeff::Exact(0, 1);
-    let mut has_exact = false;
-    let mut exact_first = false;
-    let mut reals: Vec<f64> = Vec::new();
+    let mut terms: Vec<f64> = Vec::new();
     for arg in &flat_args {
       if let Expr::Real(f) = arg {
-        reals.push(*f);
+        terms.push(*f);
       } else if let Some(c) = expr_to_coeff(arg) {
-        if !has_exact && reals.is_empty() {
-          exact_first = true;
-        }
-        exact_sum = exact_sum.add(&c);
-        has_exact = true;
+        terms.push(c.to_f64());
       }
     }
-    let mut total = if has_exact && exact_first {
-      exact_sum.to_f64()
-    } else {
-      0.0
-    };
-    for r in &reals {
-      total += r;
-    }
-    if has_exact && !exact_first {
-      total += exact_sum.to_f64();
-    }
-    return Ok(Expr::Real(total));
+    return Ok(Expr::Real(machine_sum(&terms)));
   }
   if all_numeric {
     let mut sum = 0.0;
@@ -1166,24 +1183,24 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   {
-    // Separate numeric and symbolic terms
+    // Separate numeric and symbolic terms. numeric_terms keeps every
+    // numeric operand as f64 in input order (for the machine tree fold
+    // when a Real is present); exact_sum keeps the exact rational sum
+    // (used when NO Real is present, so 1 + 1/2 + x stays 3/2 + x).
     let mut symbolic_args: Vec<Expr> = Vec::new();
     let mut has_exact = false;
-    let mut exact_first = false;
     let mut exact_sum = Coeff::Exact(0, 1);
-    let mut real_terms: Vec<f64> = Vec::new();
+    let mut numeric_terms: Vec<f64> = Vec::new();
     let mut has_real_term = false;
 
     for arg in &flat_args {
       if let Some(c) = expr_to_coeff(arg) {
-        if !has_exact && real_terms.is_empty() {
-          exact_first = true;
-        }
+        numeric_terms.push(c.to_f64());
         // Coeff::add promotes to BigInt on i128 overflow.
         exact_sum = exact_sum.add(&c);
         has_exact = true;
       } else if let Expr::Real(f) = arg {
-        real_terms.push(*f);
+        numeric_terms.push(*f);
         has_real_term = true;
       } else {
         symbolic_args.push(arg.clone());
@@ -1247,21 +1264,11 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
 
     // With any machine Real present, fold to f64 in Wolfram's order: the
-    // coalesced exact sum first when the first numeric term was exact
-    // (otherwise after the reals), then the reals in input order, then
-    // the numerified constants one at a time.
+    // literal numeric terms (exact and real alike, each converted to f64
+    // individually) combine as the balanced machine tree, then the
+    // numerified constants fold one at a time.
     if has_real_term {
-      let mut total = if has_exact && exact_first {
-        exact_sum.to_f64()
-      } else {
-        0.0
-      };
-      for r in &real_terms {
-        total += r;
-      }
-      if has_exact && !exact_first {
-        total += exact_sum.to_f64();
-      }
+      let mut total = machine_sum(&numeric_terms);
       for f in &numerified_tail {
         total += f;
       }
@@ -5764,6 +5771,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Integer(1));
   }
 
+
   // Threaded[...] broadcasting takes precedence over ordinary list threading.
   if let Some(result) = try_threaded_op(args, ThreadedOp::Times) {
     return result;
@@ -6429,6 +6437,33 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
+  // Times is exempt from the dispatch Orderless pre-sort so the machine
+  // fold below sees the original argument order (it is order-sensitive:
+  // Times[3, 1/7, 0.1, 0.2, 0.3] ≠ Times[0.1, 0.2, 3, 1/7, 0.3]).
+  // Without a machine Real the product is order-insensitive (exact
+  // arithmetic commutes), so restore the canonical order here — the
+  // exact/symbolic paths below rely on canonically sorted input. This
+  // runs AFTER the container handlers above (Quantity, SeriesData, …),
+  // which pick their result forms from the original order.
+  let sorted_storage;
+  let args: &[Expr] = if args.iter().any(|a| matches!(a, Expr::Real(_))) {
+    args
+  } else {
+    let mut sorted = args.to_vec();
+    sorted.sort_by(|a, b| {
+      let ord = crate::functions::list_helpers_ast::compare_exprs(a, b);
+      if ord > 0 {
+        std::cmp::Ordering::Less
+      } else if ord < 0 {
+        std::cmp::Ordering::Greater
+      } else {
+        std::cmp::Ordering::Equal
+      }
+    });
+    sorted_storage = sorted;
+    &sorted_storage
+  };
+
   // BigFloat-aware product. When any factor is a precision-tagged
   // BigFloat and every factor evaluates to a BigFloat (via expr_to_bigfloat
   // — Integer, Rational, BigFloat, or one of the math constants E / Pi /
@@ -6605,15 +6640,23 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  // Separate into: integers, rationals, reals, and symbolic arguments
+  // Separate into: integers, rationals, reals, and symbolic arguments.
+  // real_factors keeps the machine Reals in input order, and
+  // first_numeric_exact records whether the first numeric factor was
+  // exact — Wolfram coalesces the exact factors into ONE exact product
+  // which seeds the machine fold when it comes first and multiplies
+  // after the reals otherwise (Times[3, 1/7, 0.1, 0.2, 0.3] →
+  // 0.002571428571428571 but Times[0.1, 0.2, 3, 1/7, 0.3] →
+  // 0.0025714285714285717).
   let mut int_product: i128 = 1;
   let mut int_overflow = false;
   let mut has_int = false;
   let mut rat_numer: i128 = 1;
   let mut rat_denom: i128 = 1;
   let mut has_rational = false;
-  let mut real_product: f64 = 1.0;
+  let mut real_factors: Vec<f64> = Vec::new();
   let mut any_real = false;
+  let mut first_numeric_exact: Option<bool> = None;
   let mut symbolic_args: Vec<Expr> = Vec::new();
 
   // Pre-check: is there an explicit Rational or non-unity Integer coefficient among the args?
@@ -6634,10 +6677,12 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           int_overflow = true;
         }
         has_int = true;
+        first_numeric_exact.get_or_insert(true);
       }
       Expr::Real(f) => {
-        real_product *= f;
+        real_factors.push(*f);
         any_real = true;
+        first_numeric_exact.get_or_insert(false);
       }
       Expr::FunctionCall { name, args: rargs }
         if name == "Rational" && rargs.len() == 2 =>
@@ -6652,6 +6697,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             int_overflow = true;
           }
           has_rational = true;
+          first_numeric_exact.get_or_insert(true);
         } else {
           symbolic_args.push(arg.clone());
         }
@@ -6673,6 +6719,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             if let Some(rd) = rat_denom.checked_mul(pow) {
               rat_denom = rd;
               has_rational = true;
+              first_numeric_exact.get_or_insert(true);
             } else {
               int_overflow = true;
             }
@@ -6704,8 +6751,9 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             symbolic_args.push(arg.clone());
           }
         } else if let Some(n) = expr_to_num(arg) {
-          real_product *= n;
+          real_factors.push(n);
           any_real = true;
+          first_numeric_exact.get_or_insert(false);
         } else {
           symbolic_args.push(arg.clone());
         }
@@ -6747,21 +6795,45 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  // If any Real, try to convert symbolic constants (Pi, E, etc.) to floats
+  // If any Real, try to convert symbolic constants (Pi, E, etc.) to floats.
+  // They fold LAST, one at a time (Times[0.1, Pi, 0.3, -Pi] multiplies
+  // 0.1*0.3 first) — mirroring the numerified-constant tail in Plus.
   if any_real {
+    let mut numerified_tail: Vec<f64> = Vec::new();
     let mut remaining_symbolic: Vec<Expr> = Vec::new();
     for arg in symbolic_args.drain(..) {
       if let Some(f) = try_eval_to_f64(&arg) {
-        real_product *= f;
+        numerified_tail.push(f);
       } else {
         remaining_symbolic.push(arg);
       }
     }
     symbolic_args = remaining_symbolic;
 
-    let total = (int_product as f64)
-      * (rat_numer as f64 / rat_denom as f64)
-      * real_product;
+    // Machine fold in Wolfram's order: the coalesced exact coefficient
+    // joins the tree fold as the leading factor when the first numeric
+    // factor was exact, and multiplies after the reals otherwise; the
+    // numerified constants come last.
+    let has_exact_coeff = has_int || has_rational;
+    let exact_f = Coeff::Exact(int_product, 1)
+      .mul(&Coeff::Exact(rat_numer, rat_denom))
+      .to_f64();
+    let mut fold_factors: Vec<f64> = Vec::new();
+    if has_exact_coeff && first_numeric_exact == Some(true) {
+      fold_factors.push(exact_f);
+    }
+    fold_factors.extend_from_slice(&real_factors);
+    let mut total = if fold_factors.is_empty() {
+      1.0
+    } else {
+      machine_tree_fold(&fold_factors, |a, b| a * b)
+    };
+    if has_exact_coeff && first_numeric_exact != Some(true) {
+      total *= exact_f;
+    }
+    for f in &numerified_tail {
+      total *= f;
+    }
     if symbolic_args.is_empty() {
       return Ok(Expr::Real(total));
     }

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -2618,6 +2618,12 @@ fn compare_plus_terms(a: &Expr, b: &Expr) -> std::cmp::Ordering {
     return pa.cmp(&pb);
   }
 
+  // A reciprocal-of-a-sum term orders against other univariate terms in
+  // the same variable by base polynomial (see the helper).
+  if let Some(ord) = sum_recip_vs_univar_order(a, b) {
+    return ord;
+  }
+
   let (_, base_a) = decompose_term(a);
   let (_, base_b) = decompose_term(b);
 
@@ -3423,6 +3429,66 @@ fn cmp_is_call_like(e: &Expr) -> bool {
 
 /// `Power[base, n]` with a negative integer exponent, in either the
 /// FunctionCall or BinaryOp representation.
+/// A reciprocal-of-a-sum term (2/(-1+x), (1+x)^(-1)) orders against
+/// another univariate term in the same variable by comparing the BASE
+/// polynomials coefficient-wise from the constant term up, a bare-`x`
+/// base counting as constant 0: `(-1+x)^(-1) + x` keeps the reciprocal
+/// first, `x + (1+x)^(-1)` keeps x first, and `2/(-1+x) + x^2` leads
+/// with the reciprocal while `x^2/2 + 15/(8(1+2x))` trails it — all
+/// wolframscript-verified. Equal bases return None so the existing
+/// shared-denominator exponent rules decide.
+fn sum_recip_vs_univar_order(a: &Expr, b: &Expr) -> Option<std::cmp::Ordering> {
+  use std::cmp::Ordering;
+  // (var, ascending base-polynomial coeffs, is_sum_reciprocal).
+  fn base_info(e: &Expr) -> Option<(String, Vec<i128>, bool)> {
+    let (_, base) = decompose_term(e);
+    if let Some((inner, _)) = cmp_neg_pow(&base) {
+      if cmp_is_sum_base(inner) {
+        let (v, c) = univar_int_coeffs(inner)?;
+        return Some((v, c, true));
+      }
+      if let Expr::Identifier(v) = inner {
+        return Some((v.clone(), vec![0, 1], false));
+      }
+      return None;
+    }
+    let var_power = |b: &Expr, e: &Expr| -> Option<String> {
+      match (b, e) {
+        (Expr::Identifier(v), Expr::Integer(n)) if *n > 0 => Some(v.clone()),
+        _ => None,
+      }
+    };
+    match &base {
+      Expr::Identifier(v) => Some((v.clone(), vec![0, 1], false)),
+      Expr::FunctionCall { name, args }
+        if name == "Power" && args.len() == 2 =>
+      {
+        var_power(&args[0], &args[1]).map(|v| (v, vec![0, 1], false))
+      }
+      Expr::BinaryOp {
+        op: crate::syntax::BinaryOperator::Power,
+        left,
+        right,
+      } => var_power(left, right).map(|v| (v, vec![0, 1], false)),
+      _ => None,
+    }
+  }
+  let (va, ca, ra) = base_info(a)?;
+  let (vb, cb, rb) = base_info(b)?;
+  if (!ra && !rb) || va != vb {
+    return None;
+  }
+  for i in 0..ca.len().max(cb.len()) {
+    let x = ca.get(i).copied().unwrap_or(0);
+    let y = cb.get(i).copied().unwrap_or(0);
+    match x.cmp(&y) {
+      Ordering::Equal => {}
+      ord => return Some(ord),
+    }
+  }
+  None
+}
+
 fn cmp_neg_pow(f: &Expr) -> Option<(&Expr, i128)> {
   match f {
     Expr::FunctionCall { name, args } if name == "Power" && args.len() == 2 => {

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -2482,12 +2482,32 @@ pub fn norm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
 
       if p_expr.is_none() || p_val == Some(2.0) {
-        // Sqrt[Plus[item^2, ...]] (or Abs[item]^2 for unknown items)
+        // A one-element vector IS its Abs: Norm[{1 + Pi}] → 1 + Pi and
+        // Norm[{x}] → Abs[x], never Sqrt[(1 + Pi)^2]. (wolframscript
+        // parity; differential fuzzer, seed 1783520505113402110)
+        if items.len() == 1 {
+          return crate::evaluator::evaluate_function_call_ast(
+            "Abs",
+            &[items[0].clone()],
+          );
+        }
+        // Sqrt[Plus[item^2, ...]] (or Abs[item]^2 for unknown items).
+        // Wolfram squares Abs[item], so a numerically negative exact item
+        // flips sign first: Norm[{-46, -63, 1 - 81 + Pi}] carries
+        // (80 - Pi)^2, not (-80 + Pi)^2.
         let sq_items: Vec<Expr> = items
           .iter()
           .map(|item| {
             let base = if is_real_valued(item) {
-              item.clone()
+              if try_eval_to_f64(item).is_some_and(|v| v < 0.0) {
+                evaluate_expr_to_expr(&Expr::FunctionCall {
+                  name: "Times".to_string(),
+                  args: vec![Expr::Integer(-1), item.clone()].into(),
+                })
+                .unwrap_or_else(|_| item.clone())
+              } else {
+                item.clone()
+              }
             } else {
               Expr::FunctionCall {
                 name: "Abs".to_string(),

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -65,6 +65,11 @@ pub fn apart_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match find_single_variable(&args[0]) {
       Some(v) => v,
       None => {
+        // A variable-free (numeric) argument is already apart:
+        // Apart[Divide[1, 2]] → 1/2, not the unevaluated call.
+        if crate::functions::predicate_ast::is_numeric_q_pub(&args[0]) {
+          return Ok(args[0].clone());
+        }
         return Ok(Expr::FunctionCall {
           name: "Apart".to_string(),
           args: args.to_vec().into(),
@@ -77,6 +82,15 @@ pub fn apart_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 pub fn apart_expr(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
+  // Apart's value is an ordinary expression: run the assembled sum
+  // through the evaluator so each term takes its canonical form
+  // (Apart[1/(-3 x)] prints -1/3*1/x, exactly like evaluating the
+  // input directly — the hand-built Divide tree printed -1/(3*x)).
+  let raw = apart_expr_raw(expr, var)?;
+  crate::evaluator::evaluate_expr_to_expr(&raw)
+}
+
+fn apart_expr_raw(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
   // Extract numerator and denominator using the general-purpose extractor
   // which handles BinaryOp::Divide, Times[..., Power[..., -1]], etc.
   let (num, den) = super::together::extract_num_den(expr);
@@ -128,6 +142,53 @@ pub fn apart_expr(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
       if let Some(quot_coeffs) = poly_exact_divide(nc, dc) {
         return Ok(coeffs_to_expr(&quot_coeffs, var));
       }
+      // Rational-coefficient division, so a non-integer leading quotient
+      // decomposes too: Apart[(2 - 4 x)/(2 - 5 x)] → 4/5 - 2/(5*(-2 + 5*x)).
+      if let Some((quotient, remainder)) = poly_long_divide_rat(nc, dc) {
+        if remainder.iter().all(|&(n, _)| n == 0) {
+          return rat_coeffs_to_expr(&quotient, var);
+        }
+        let quot_expr = rat_coeffs_to_expr(&quotient, var)?;
+        // Clear the remainder's coefficient denominators into the
+        // fraction's denominator: r(x)/den = r_int(x)/(L*den), then let
+        // the proper-fraction path hoist the content and normalize signs.
+        let mut lcm: i128 = 1;
+        for &(_, d) in &remainder {
+          let g = i128_gcd(lcm, d);
+          lcm = match (lcm / g).checked_mul(d) {
+            Some(v) => v,
+            None => return apart_symbolic(&divide_expr, &num_expanded, &den, var),
+          };
+        }
+        let rem_int: Option<Vec<i128>> = remainder
+          .iter()
+          .map(|&(n, d)| n.checked_mul(lcm / d))
+          .collect();
+        let den_scaled: Option<Vec<i128>> =
+          dc.iter().map(|&c| c.checked_mul(lcm)).collect();
+        let (Some(rem_int), Some(den_scaled)) = (rem_int, den_scaled) else {
+          return apart_symbolic(&divide_expr, &num_expanded, &den, var);
+        };
+        let frac = Expr::BinaryOp {
+          op: BinaryOperator::Divide,
+          left: Box::new(coeffs_to_expr(&rem_int, var)),
+          right: Box::new(coeffs_to_expr(&den_scaled, var)),
+        };
+        let apart_remainder = apart_proper_fraction(&frac, var)?;
+        // Splice the polynomial quotient in front of the partial-fraction
+        // terms as one flat sum so the result reads `q + f1 + f2`, not the
+        // parenthesized `q + (f1 + f2)`. A zero quotient is dropped rather
+        // than emitting a spurious `0 + …` term.
+        let mut parts = if matches!(quot_expr, Expr::Integer(0)) {
+          Vec::new()
+        } else {
+          vec![quot_expr]
+        };
+        flatten_plus(&apart_remainder, &mut parts);
+        return Ok(build_sum(parts));
+      }
+      // i128 overflow in the rational division: fall back to the
+      // integer-only division (best effort, matching the old behavior).
       let (quotient, remainder) = poly_long_divide(nc, dc);
       if remainder.iter().all(|&c| c == 0) {
         return Ok(coeffs_to_expr(&quotient, var));
@@ -140,11 +201,6 @@ pub fn apart_expr(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
         right: Box::new(den_expanded.clone()),
       };
       let apart_remainder = apart_proper_fraction(&frac, var)?;
-      // Splice the polynomial quotient in front of the partial-fraction
-      // terms as one flat sum so the result reads `q + f1 + f2`, not the
-      // parenthesized `q + (f1 + f2)`. A zero quotient (non-exact
-      // leading-coefficient division) is dropped rather than emitting a
-      // spurious `0 + …` term.
       let mut parts = if matches!(quot_expr, Expr::Integer(0)) {
         Vec::new()
       } else {
@@ -931,6 +987,123 @@ fn apart_repeated_roots(
 }
 
 /// Polynomial long division returning (quotient, remainder) as coefficient vectors
+fn i128_gcd(a: i128, b: i128) -> i128 {
+  let (mut a, mut b) = (a.abs(), b.abs());
+  while b != 0 {
+    let t = a % b;
+    a = b;
+    b = t;
+  }
+  if a == 0 { 1 } else { a }
+}
+
+/// Reduce n/d to lowest terms with a positive denominator.
+fn rat_reduce(n: i128, d: i128) -> (i128, i128) {
+  let g = i128_gcd(n, d);
+  let (mut n, mut d) = (n / g, d / g);
+  if d < 0 {
+    n = -n;
+    d = -d;
+  }
+  (n, d)
+}
+
+/// a - b*c over i128 fractions, reduced; None on overflow.
+fn rat_sub_mul(
+  a: (i128, i128),
+  b: (i128, i128),
+  c: (i128, i128),
+) -> Option<(i128, i128)> {
+  let bn = b.0.checked_mul(c.0)?;
+  let bd = b.1.checked_mul(c.1)?;
+  let (bn, bd) = rat_reduce(bn, bd);
+  let n = a.0.checked_mul(bd)?.checked_sub(bn.checked_mul(a.1)?)?;
+  let d = a.1.checked_mul(bd)?;
+  Some(rat_reduce(n, d))
+}
+
+/// Rational-coefficient polynomial long division: num/den → (quotient,
+/// remainder) as reduced (numerator, denominator) fraction pairs. Unlike
+/// `poly_long_divide` this never bails on a non-integer leading quotient
+/// (Apart[(2 - 4 x)/(2 - 5 x)] needs the quotient 4/5). Returns None on
+/// i128 overflow.
+fn poly_long_divide_rat(
+  num: &[i128],
+  den: &[i128],
+) -> Option<(Vec<(i128, i128)>, Vec<(i128, i128)>)> {
+  let n_deg = num.len();
+  let d_deg = den.len();
+  let lead_den = den[d_deg - 1];
+  if n_deg < d_deg || lead_den == 0 {
+    return None;
+  }
+  let mut remainder: Vec<(i128, i128)> =
+    num.iter().map(|&c| (c, 1)).collect();
+  let mut quotient: Vec<(i128, i128)> = vec![(0, 1); n_deg - d_deg + 1];
+
+  for i in (0..quotient.len()).rev() {
+    let rem_idx = i + d_deg - 1;
+    if rem_idx >= remainder.len() {
+      continue;
+    }
+    let q = rat_reduce(remainder[rem_idx].0, remainder[rem_idx].1 * lead_den);
+    quotient[i] = q;
+    for j in 0..d_deg {
+      remainder[i + j] = rat_sub_mul(remainder[i + j], q, (den[j], 1))?;
+    }
+  }
+  Some((quotient, remainder))
+}
+
+/// Build the polynomial expression for rational coefficients (ascending
+/// powers of `var`), evaluated so terms canonicalize.
+fn rat_coeffs_to_expr(
+  coeffs: &[(i128, i128)],
+  var: &str,
+) -> Result<Expr, InterpreterError> {
+  let mut terms: Vec<Expr> = Vec::new();
+  for (i, &(n, d)) in coeffs.iter().enumerate() {
+    if n == 0 {
+      continue;
+    }
+    let coeff = if d == 1 {
+      Expr::Integer(n)
+    } else {
+      Expr::FunctionCall {
+        name: "Rational".to_string(),
+        args: vec![Expr::Integer(n), Expr::Integer(d)].into(),
+      }
+    };
+    let term = match i {
+      0 => coeff,
+      _ => {
+        let var_pow = if i == 1 {
+          Expr::Identifier(var.to_string())
+        } else {
+          Expr::BinaryOp {
+            op: BinaryOperator::Power,
+            left: Box::new(Expr::Identifier(var.to_string())),
+            right: Box::new(Expr::Integer(i as i128)),
+          }
+        };
+        Expr::BinaryOp {
+          op: BinaryOperator::Times,
+          left: Box::new(coeff),
+          right: Box::new(var_pow),
+        }
+      }
+    };
+    terms.push(term);
+  }
+  if terms.is_empty() {
+    return Ok(Expr::Integer(0));
+  }
+  crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
+    name: "Plus".to_string(),
+    args: terms.into(),
+  })
+}
+
 pub fn poly_long_divide(num: &[i128], den: &[i128]) -> (Vec<i128>, Vec<i128>) {
   let n_deg = num.len();
   let d_deg = den.len();

--- a/src/functions/polynomial_ast/cancel.rs
+++ b/src/functions/polynomial_ast/cancel.rs
@@ -130,6 +130,21 @@ fn cancel_expr_impl(expr: &Expr, canonicalize_sign: bool) -> Expr {
             coeffs_to_expr(&new_den, &var),
           );
         }
+
+        // A bare negative-constant denominator absorbs its sign into the
+        // expanded numerator: Cancel[(x + x^2)/(-3)] → (-x - x^2)/3, not
+        // -1/3*x*(1+x) (differential fuzzer, seed 1783537668073123846).
+        if canonicalize_sign
+          && den_coeffs.len() == 1
+          && den_coeffs[0] < 0
+          && num_coeffs.len() > 1
+        {
+          let neg_num: Vec<i128> = num_coeffs.iter().map(|c| -c).collect();
+          return crate::functions::math_ast::make_divide(
+            coeffs_to_expr(&neg_num, &var),
+            Expr::Integer(-den_coeffs[0]),
+          );
+        }
       }
 
       // Try multivariate cancellation: extract common monomial factors from
@@ -410,7 +425,12 @@ fn cancel_expr_impl(expr: &Expr, canonicalize_sign: bool) -> Expr {
       // canonicalizes an untouched quotient's denominator sign:
       // Cancel[(-4-3x^2)/(4+x-4x^2)] → (4+3x^2)/(-4-x+4x^2).
       let fallback =
-        super::simplify::simplify_division_impl(&num, &den, canonicalize_sign);
+        super::simplify::simplify_division_impl(
+          &num,
+          &den,
+          canonicalize_sign,
+          false,
+        );
       if canonicalize_sign {
         let (fnum, fden) = super::together::extract_num_den(&fallback);
         if !matches!(&fden, Expr::Integer(1))

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -4168,12 +4168,38 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
       let accept = if is_sum {
         simplify_cost_key(&factored) <= simplify_cost_key(&best)
       } else {
+        // Wolfram never factors a quotient's DENOMINATOR into a product
+        // of distinct factors: Simplify[1/(4x+3x^2)] stays
+        // (4x+3x^2)^(-1), not 1/(x(4+3x)). Powers still collapse
+        // (x^2/(1-3x+3x^2-x^3) → -(x^2/(-1+x)^3)).
         leaf_count(&factored) <= best_c
+          && factored_den_acceptable(&best, &factored)
       };
       if accept && !exprs_equal(&factored, &best) {
-        best = factored;
+        // Canonicalize a factored POLYNOMIAL product's factor order
+        // through the evaluator: 4x^2-2x factors as 2*(-1+2x)*x but
+        // Wolfram prints 2*x*(-1+2x). Non-polynomial results (with I,
+        // E^…, Sqrt[…] factors) keep the pipeline's own ordering.
+        best = if polynomial_like(&factored) {
+          crate::evaluator::evaluate_expr_to_expr(&factored)
+            .unwrap_or(factored)
+        } else {
+          factored
+        };
         let _ = best_c;
       }
+    }
+  }
+
+  // Simplify's quotient sign extraction (see together::extract_quotient_minus):
+  // a numerator with negative content or an all-nonpositive denominator
+  // pulls a -1 out front.
+  {
+    let (n, d) = super::together::extract_num_den(&best);
+    if !matches!(&d, Expr::Integer(1))
+      && let Some(signed) = super::together::extract_quotient_minus(&n, &d)
+    {
+      best = signed;
     }
   }
 
@@ -4188,7 +4214,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
 /// True when the expression is built purely from numbers, symbols and the
 /// arithmetic heads — the shapes Factor/FactorSquareFree treat as
 /// polynomials. Sums with other functions (Sin[x], Log[x], …) are not.
-fn polynomial_like(e: &Expr) -> bool {
+pub(super) fn polynomial_like(e: &Expr) -> bool {
   use crate::syntax::BinaryOperator as B;
   match e {
     Expr::Integer(_)
@@ -6224,17 +6250,74 @@ pub(crate) fn simplify_division_impl(
     basic
   };
 
-  // Try factoring the result: Factor[p/q] = Factor[p]/Factor[q] often produces
-  // a simpler form (e.g. x^2/(1-3x+3x^2-x^3) → x^2/(-1+x)^3).
+  // Try factoring the result: Factor[p/q] = Factor[p]/Factor[q] often
+  // produces a simpler form (e.g. x^2/(1-3x+3x^2-x^3) → x^2/(-1+x)^3).
+  // Wolfram only keeps a factored DENOMINATOR when it collapses to a
+  // (power of a) single factor — Simplify[1/(4x+3x^2)] stays
+  // (4x+3x^2)^(-1), never 1/(x(4+3x)) — while quotient numerators factor
+  // freely (Simplify[(4x^2-2x)/(2+3x)] → (2x(-1+2x))/(2+3x)).
   if let Ok(factored) = super::factor::factor_ast(&[basic.clone()]) {
     let fc = leaf_count(&factored);
     let bc = leaf_count(&basic);
-    if fc <= bc {
-      return factored;
+    if fc <= bc && factored_den_acceptable(&basic, &factored) {
+      return finish_quotient_sign(factored, canonicalize_sign);
+    }
+  }
+  // Denominator factoring rejected: still try the numerator alone.
+  {
+    let (bn, bd) = super::together::extract_num_den(&basic);
+    if !matches!(&bd, Expr::Integer(1))
+      && polynomial_like(&bn)
+      && let Ok(factored_num) = super::factor::factor_ast(&[bn.clone()])
+      && leaf_count(&factored_num) <= leaf_count(&bn)
+      && !exprs_equal(&factored_num, &bn)
+    {
+      return finish_quotient_sign(
+        Expr::BinaryOp {
+          op: BinaryOperator::Divide,
+          left: Box::new(factored_num),
+          right: Box::new(bd),
+        },
+        canonicalize_sign,
+      );
     }
   }
 
-  basic
+  finish_quotient_sign(basic, canonicalize_sign)
+}
+
+/// Final Simplify sign normalization for a quotient (see
+/// together::extract_quotient_minus).
+fn finish_quotient_sign(e: Expr, canonicalize_sign: bool) -> Expr {
+  if !canonicalize_sign {
+    return e;
+  }
+  let (n, d) = super::together::extract_num_den(&e);
+  if matches!(&d, Expr::Integer(1)) {
+    return e;
+  }
+  super::together::extract_quotient_minus(&n, &d).unwrap_or(e)
+}
+
+/// Accept a factored quotient only when its denominator stayed unchanged
+/// or collapsed to a (constant multiple of a) single base or power —
+/// never a product of two or more non-constant factors.
+fn factored_den_acceptable(basic: &Expr, factored: &Expr) -> bool {
+  let (_, bd) = super::together::extract_num_den(basic);
+  let (_, fd) = super::together::extract_num_den(factored);
+  if exprs_equal(&bd, &fd) {
+    return true;
+  }
+  let factors = super::together::flatten_times_args(std::slice::from_ref(&fd));
+  let non_constant = factors
+    .iter()
+    .filter(|f| {
+      let mut vars = std::collections::HashSet::new();
+      collect_variables(f, &mut vars);
+      !vars.is_empty()
+    })
+    .count();
+  non_constant <= 1
 }
 
 /// Find a single variable in an expression (for univariate polynomial division).

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -6349,18 +6349,25 @@ pub(crate) fn simplify_division_impl(
     let fc = leaf_count(&factored);
     let bc = leaf_count(&basic);
     let num_ok = factor_num || {
-      // Numerator must be unchanged (modulo the sign an outer Minus
-      // pulls out: Factor gives -(x^2/(-1+x)^3) for
-      // x^2/(1-3x+3x^2-x^3), whose extracted numerator is -x^2).
+      // Cancel keeps sums expanded: reject a factored numerator that
+      // SPLITS the numerator into more non-constant factors than it had
+      // (4x+2x^2 → 2x(2+x) is out) but keep content extraction over an
+      // existing product (Sqrt[1-x^2]*(-3+15x^2) → 3*Sqrt[…]*(-1+5x^2)),
+      // perfect-power collapses ((1+2n+n^2) → (1+n)^2), and full
+      // cancellations.
       let (bn, _) = super::together::extract_num_den(&basic);
       let (fn_, _) = super::together::extract_num_den(&factored);
-      let neg_fn = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(fn_.clone()),
-      })
-      .unwrap_or_else(|_| fn_.clone());
-      exprs_equal(&bn, &fn_) || exprs_equal(&bn, &neg_fn)
+      let non_constant_count = |e: &Expr| {
+        super::together::flatten_times_args(std::slice::from_ref(e))
+          .iter()
+          .filter(|f| {
+            let mut vars = std::collections::HashSet::new();
+            collect_variables(f, &mut vars);
+            !vars.is_empty()
+          })
+          .count()
+      };
+      non_constant_count(&fn_) <= non_constant_count(&bn)
     };
     if fc <= bc && num_ok && factored_den_acceptable(&basic, &factored) {
       return finish_quotient_sign(factored, canonicalize_sign);

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -4203,6 +4203,90 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
     }
   }
 
+  // Candidate 5: numeric-content extraction for NON-polynomial sums —
+  // Simplify[9 + 9*Sqrt[19]] → 9*(1 + Sqrt[19]), Simplify[-12*Sqrt[5] +
+  // 3*Sqrt[19]] → 3*(-4*Sqrt[5] + Sqrt[19]), Simplify[-2 - 2*Sqrt[2]] →
+  // -2*(1 + Sqrt[2]) (the content goes negative only when EVERY term
+  // is), and Simplify[3/2 + (3/2)*Sqrt[2]] → (3*(1 + Sqrt[2]))/2.
+  // Polynomial sums already go through the Factor candidate above.
+  if !polynomial_like(&best) {
+    let terms = super::coefficient::collect_additive_terms(&best);
+    if terms.len() >= 2
+      && let Some((_, _, coeffs)) = super::factor::rational_content(&terms)
+    {
+      let g_num = coeffs
+        .iter()
+        .map(|(n, _)| *n)
+        .filter(|&n| n != 0)
+        .fold(0i128, |a, b| {
+          let (mut a, mut b) = (a.abs(), b.abs());
+          while b != 0 {
+            let t = a % b;
+            a = b;
+            b = t;
+          }
+          a
+        });
+      let g_den = coeffs.iter().map(|(_, d)| *d).fold(1i128, |a, b| {
+        let g = {
+          let (mut x, mut y) = (a.abs(), b.abs());
+          while y != 0 {
+            let t = x % y;
+            x = y;
+            y = t;
+          }
+          x.max(1)
+        };
+        (a / g) * b
+      });
+      let all_negative = coeffs.iter().all(|(n, _)| *n < 0);
+      let content = if all_negative { -g_num } else { g_num };
+      if g_num > 1 || g_den > 1 {
+        let content_expr = Expr::Integer(content);
+        let divisor = if g_den == 1 {
+          Expr::Integer(content)
+        } else {
+          Expr::FunctionCall {
+            name: "Rational".to_string(),
+            args: vec![Expr::Integer(content), Expr::Integer(g_den)].into(),
+          }
+        };
+        let divided: Result<Vec<Expr>, _> = terms
+          .iter()
+          .map(|t| {
+            crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
+              op: crate::syntax::BinaryOperator::Divide,
+              left: Box::new(t.clone()),
+              right: Box::new(divisor.clone()),
+            })
+          })
+          .collect();
+        if let Ok(divided) = divided {
+          let inner = Expr::FunctionCall {
+            name: "Plus".to_string(),
+            args: divided.into(),
+          };
+          let product = Expr::FunctionCall {
+            name: "Times".to_string(),
+            args: vec![content_expr, inner].into(),
+          };
+          let candidate = if g_den == 1 {
+            product
+          } else {
+            Expr::BinaryOp {
+              op: crate::syntax::BinaryOperator::Divide,
+              left: Box::new(product),
+              right: Box::new(Expr::Integer(g_den)),
+            }
+          };
+          if simplify_cost_key(&candidate) <= simplify_cost_key(&best) {
+            best = candidate;
+          }
+        }
+      }
+    }
+  }
+
   best
 }
 
@@ -6189,16 +6273,21 @@ fn try_simplify_trig_ratio(num: &Expr, den: &Expr) -> Option<Expr> {
 }
 
 pub fn simplify_division(num: &Expr, den: &Expr) -> Expr {
-  simplify_division_impl(num, den, true)
+  simplify_division_impl(num, den, true, true)
 }
 
 /// `canonicalize_sign: false` skips the wolframscript Simplify/Cancel
 /// quotient-sign canonicalization for callers whose WL counterpart keeps
 /// the raw quotient (D[ArcCoth[x^2], x] stays (2*x)/(1 - x^4)).
+/// `factor_num: false` (Cancel) keeps quotient numerators EXPANDED with
+/// only their numeric content pulled out — Cancel[(4x+2x^2)/(-3-4x+2x^2)]
+/// → (2*(2x+x^2))/(-3-4x+2x^2) — while Simplify factors them
+/// ((2x(-1+2x))/(2+3x)).
 pub(crate) fn simplify_division_impl(
   num: &Expr,
   den: &Expr,
   canonicalize_sign: bool,
+  factor_num: bool,
 ) -> Expr {
   // If same expression, return 1
   if expr_to_string(num) == expr_to_string(den) {
@@ -6259,31 +6348,114 @@ pub(crate) fn simplify_division_impl(
   if let Ok(factored) = super::factor::factor_ast(&[basic.clone()]) {
     let fc = leaf_count(&factored);
     let bc = leaf_count(&basic);
-    if fc <= bc && factored_den_acceptable(&basic, &factored) {
+    let num_ok = factor_num || {
+      // Numerator must be unchanged (modulo the sign an outer Minus
+      // pulls out: Factor gives -(x^2/(-1+x)^3) for
+      // x^2/(1-3x+3x^2-x^3), whose extracted numerator is -x^2).
+      let (bn, _) = super::together::extract_num_den(&basic);
+      let (fn_, _) = super::together::extract_num_den(&factored);
+      let neg_fn = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
+        op: BinaryOperator::Times,
+        left: Box::new(Expr::Integer(-1)),
+        right: Box::new(fn_.clone()),
+      })
+      .unwrap_or_else(|_| fn_.clone());
+      exprs_equal(&bn, &fn_) || exprs_equal(&bn, &neg_fn)
+    };
+    if fc <= bc && num_ok && factored_den_acceptable(&basic, &factored) {
       return finish_quotient_sign(factored, canonicalize_sign);
     }
   }
-  // Denominator factoring rejected: still try the numerator alone.
+  // Denominator factoring rejected: handle the numerator alone — factor
+  // it (Simplify) or pull out its numeric content (Cancel).
   {
     let (bn, bd) = super::together::extract_num_den(&basic);
-    if !matches!(&bd, Expr::Integer(1))
-      && polynomial_like(&bn)
-      && let Ok(factored_num) = super::factor::factor_ast(&[bn.clone()])
-      && leaf_count(&factored_num) <= leaf_count(&bn)
-      && !exprs_equal(&factored_num, &bn)
-    {
-      return finish_quotient_sign(
-        Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(factored_num),
-          right: Box::new(bd),
-        },
-        canonicalize_sign,
-      );
+    if !matches!(&bd, Expr::Integer(1)) && polynomial_like(&bn) {
+      if factor_num {
+        if let Ok(factored_num) = super::factor::factor_ast(&[bn.clone()])
+          && leaf_count(&factored_num) <= leaf_count(&bn)
+          && !exprs_equal(&factored_num, &bn)
+        {
+          return finish_quotient_sign(
+            Expr::BinaryOp {
+              op: BinaryOperator::Divide,
+              left: Box::new(factored_num),
+              right: Box::new(bd),
+            },
+            canonicalize_sign,
+          );
+        }
+      } else if let Some(content_num) = extract_numeric_content(&bn) {
+        return finish_quotient_sign(
+          Expr::BinaryOp {
+            op: BinaryOperator::Divide,
+            left: Box::new(content_num),
+            right: Box::new(bd),
+          },
+          canonicalize_sign,
+        );
+      }
     }
   }
 
   finish_quotient_sign(basic, canonicalize_sign)
+}
+
+/// Pull the integer content out of a sum, keeping the polynomial
+/// expanded: 4x + 2x^2 → Times[2, Plus[2x, x^2]] (unevaluated so the
+/// product does not redistribute). None when the content is 1 or the
+/// terms don't have rational coefficients.
+fn extract_numeric_content(e: &Expr) -> Option<Expr> {
+  let terms = super::coefficient::collect_additive_terms(e);
+  if terms.len() < 2 {
+    return None;
+  }
+  let (_, _, coeffs) = super::factor::rational_content(&terms)?;
+  if coeffs.iter().any(|(_, d)| *d != 1) {
+    return None;
+  }
+  let mut g: i128 = 0;
+  for (n, _) in &coeffs {
+    if *n != 0 {
+      let (mut a, mut b) = (g.abs(), n.abs());
+      while b != 0 {
+        let t = a % b;
+        a = b;
+        b = t;
+      }
+      g = a;
+    }
+  }
+  if g <= 1 {
+    return None;
+  }
+  let content = if coeffs.iter().all(|(n, _)| *n < 0) {
+    -g
+  } else {
+    g
+  };
+  let divided: Result<Vec<Expr>, _> = terms
+    .iter()
+    .map(|t| {
+      crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(t.clone()),
+        right: Box::new(Expr::Integer(content)),
+      })
+    })
+    .collect();
+  let divided = divided.ok()?;
+  Some(Expr::FunctionCall {
+    name: "Times".to_string(),
+    args: vec![
+      Expr::Integer(content),
+      Expr::FunctionCall {
+        name: "Plus".to_string(),
+        args: divided.into(),
+      },
+    ]
+    .into(),
+  })
 }
 
 /// Final Simplify sign normalization for a quotient (see

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -536,6 +536,65 @@ pub(super) fn canonicalize_quotient_sign(
   })
 }
 
+/// Wolfram's Simplify pulls a `-1` out in front of a quotient when the
+/// numerator's content sign is negative (its highest-degree coefficient
+/// for a univariate sum): Simplify[(-2-3x)/(4x+3x²)] →
+/// -((2+3x)/(4x+3x²)) and Simplify[(1-5x-3x²-x³)/(-1-2x+4x²)] →
+/// -((-1+5x+3x²+x³)/(-1-2x+4x²)). An entirely-nonpositive denominator
+/// flips too — Simplify[(2+3x)/(-4x-3x²)] → -((2+3x)/(4x+3x²)) — while
+/// a mixed-sign denominator like 1-x stays put (Simplify[x/(1-x)] keeps
+/// its form; that case is canonicalize_quotient_sign's). Two flips
+/// cancel. Returns None when nothing changes.
+pub(super) fn extract_quotient_minus(num: &Expr, den: &Expr) -> Option<Expr> {
+  let negate = |e: &Expr| {
+    expand_and_combine(&Expr::BinaryOp {
+      op: BinaryOperator::Times,
+      left: Box::new(Expr::Integer(-1)),
+      right: Box::new(e.clone()),
+    })
+  };
+  // Only UNIVARIATE polynomial sums participate: wolframscript keeps
+  // (-b + d*y)/(a - c*y) and (1 - Cos[2x])/2 exactly as they are.
+  let is_variable_sum = |e: &Expr| {
+    collect_additive_terms(e).len() >= 2
+      && !super::reduce::contains_imaginary(e)
+      && super::simplify::polynomial_like(e)
+      && {
+        let mut vars = std::collections::HashSet::new();
+        super::simplify::collect_variables(e, &mut vars);
+        vars.len() == 1
+      }
+  };
+  let all_terms_nonpositive = |e: &Expr| {
+    collect_additive_terms(e).iter().all(|t| {
+      super::factor::rational_content(std::slice::from_ref(t))
+        .is_some_and(|(n, _, _)| n <= 0)
+    })
+  };
+
+  let num_flip =
+    is_variable_sum(num) && additive_content_sign(num) == Some(-1);
+  let den_flip = is_variable_sum(den) && all_terms_nonpositive(den);
+  if !num_flip && !den_flip {
+    return None;
+  }
+  let new_num = if num_flip { negate(num) } else { num.clone() };
+  let new_den = if den_flip { negate(den) } else { den.clone() };
+  let quotient = Expr::BinaryOp {
+    op: BinaryOperator::Divide,
+    left: Box::new(new_num),
+    right: Box::new(new_den),
+  };
+  if num_flip != den_flip {
+    Some(Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      operand: Box::new(quotient),
+    })
+  } else {
+    Some(quotient)
+  }
+}
+
 /// Recursively run `together_expr` on sub-expressions so that nested fractions
 /// inside Power bases, Divide operands, and Times factors are combined first.
 /// Also rewrites `1 / (a/b)` → `b/a` (Power[Divide[a,b], -1]) so the outer

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -412,6 +412,7 @@ pub(super) fn canonicalize_quotient_sign(
   let factors = flatten_times_args(std::slice::from_ref(den));
   let mut sign: i128 = 1;
   let mut flipped_any = false;
+  let mut any_flipped_content_one = false;
   let mut new_factors: Vec<Expr> = Vec::new();
   for f in &factors {
     let (base, exp) = match f {
@@ -454,7 +455,51 @@ pub(super) fn canonicalize_quotient_sign(
       if exp % 2 != 0 {
         sign = -sign;
       }
+      let base_content = super::factor::rational_content(
+        &collect_additive_terms(&base),
+      )
+      .map(|(n, d, _)| (n.abs(), d))
+      .unwrap_or((1, 1));
+      if base_content == (1, 1) {
+        any_flipped_content_one = true;
+      }
       let neg_base = negate(&base);
+      // Simplify displays a flipped denominator with its integer content
+      // factored out (term-wise division; the whole-sum quotient would
+      // stay an unreduced Divide): Simplify[(2-x)/(5-5x)] →
+      // (-2+x)/(5*(-1+x)).
+      let neg_base = if require_negative_numerator
+        && base_content.1 == 1
+        && base_content.0 > 1
+      {
+        let divided: Result<Vec<Expr>, _> =
+          collect_additive_terms(&neg_base)
+            .iter()
+            .map(|t| {
+              crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
+                op: BinaryOperator::Divide,
+                left: Box::new(t.clone()),
+                right: Box::new(Expr::Integer(base_content.0)),
+              })
+            })
+            .collect();
+        match divided {
+          Ok(terms) => Expr::FunctionCall {
+            name: "Times".to_string(),
+            args: vec![
+              Expr::Integer(base_content.0),
+              Expr::FunctionCall {
+                name: "Plus".to_string(),
+                args: terms.into(),
+              },
+            ]
+            .into(),
+          },
+          Err(_) => neg_base,
+        }
+      } else {
+        neg_base
+      };
       new_factors.push(if exp == 1 {
         neg_base
       } else {
@@ -480,16 +525,34 @@ pub(super) fn canonicalize_quotient_sign(
       super::simplify::collect_variables(num, &mut vars);
       vars.is_empty()
     };
-    // The numerator must be able to absorb the flip outright: a constant,
-    // or a sum whose every term is nonpositive. A mixed-sign numerator
-    // with a merely negative LEADING coefficient stays put —
-    // Simplify[(5-4x-3x^2)/(5-5x)] keeps its form (differential fuzzer,
-    // seed 1783537668073123846).
-    let all_nonpositive_num = collect_additive_terms(num).iter().all(|t| {
+    // The numerator must be able to absorb the flip: a constant, a sum
+    // whose every term is nonpositive, or — for a mixed-sign numerator
+    // with a negative leading coefficient — only when the flip is
+    // "free": the flipped denominator factor has integer content 1, or
+    // the numerator carries a bare unit-negative monomial (-x) whose
+    // sign disappears. Simplify[(2-x)/(1-x)] → (-2+x)/(-1+x) and
+    // Simplify[(2-x)/(5-5x)] → (-2+x)/(5*(-1+x)) flip, but
+    // Simplify[(5-4x-3x^2)/(5-5x)] and Simplify[(5-4x)/(5-5x)] keep
+    // their form (differential fuzzer, seed 1783537668073123846; all
+    // wolframscript-verified).
+    let num_terms = collect_additive_terms(num);
+    let all_nonpositive_num = num_terms.iter().all(|t| {
       super::factor::rational_content(std::slice::from_ref(t))
         .is_some_and(|(n, _, _)| n <= 0)
     });
-    if sign >= 0 || (!constant_num && !all_nonpositive_num) {
+    let mixed_leading_neg = additive_content_sign(num) == Some(-1);
+    let has_unit_neg_term = num_terms.iter().any(|t| {
+      let mut vars = std::collections::HashSet::new();
+      super::simplify::collect_variables(t, &mut vars);
+      !vars.is_empty()
+        && super::factor::rational_content(std::slice::from_ref(t))
+          .is_some_and(|(_, _, coeffs)| coeffs.first() == Some(&(-1, 1)))
+    });
+    let mixed_flip_is_free = mixed_leading_neg
+      && (any_flipped_content_one || has_unit_neg_term);
+    if sign >= 0
+      || (!constant_num && !all_nonpositive_num && !mixed_flip_is_free)
+    {
       return None;
     }
   }

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -480,7 +480,16 @@ pub(super) fn canonicalize_quotient_sign(
       super::simplify::collect_variables(num, &mut vars);
       vars.is_empty()
     };
-    if sign >= 0 || (!constant_num && additive_content_sign(num) != Some(-1)) {
+    // The numerator must be able to absorb the flip outright: a constant,
+    // or a sum whose every term is nonpositive. A mixed-sign numerator
+    // with a merely negative LEADING coefficient stays put —
+    // Simplify[(5-4x-3x^2)/(5-5x)] keeps its form (differential fuzzer,
+    // seed 1783537668073123846).
+    let all_nonpositive_num = collect_additive_terms(num).iter().all(|t| {
+      super::factor::rational_content(std::slice::from_ref(t))
+        .is_some_and(|(n, _, _)| n <= 0)
+    });
+    if sign >= 0 || (!constant_num && !all_nonpositive_num) {
       return None;
     }
   }
@@ -572,8 +581,12 @@ pub(super) fn extract_quotient_minus(num: &Expr, den: &Expr) -> Option<Expr> {
     })
   };
 
-  let num_flip =
-    is_variable_sum(num) && additive_content_sign(num) == Some(-1);
+  // A numerator flip needs the denominator already in canonical
+  // (positive-leading) form: Simplify[(1-5x-3x²-x³)/(-1-2x+4x²)] pulls
+  // the minus out, but Simplify[(5-4x-3x²)/(5-5x)] keeps its form.
+  let num_flip = is_variable_sum(num)
+    && additive_content_sign(num) == Some(-1)
+    && additive_content_sign(den) == Some(1);
   let den_flip = is_variable_sum(den) && all_terms_nonpositive(den);
   if !num_flip && !den_flip {
     return None;

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -4654,15 +4654,19 @@ pub fn to_string_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::String(s));
   }
 
-  // Default (no form or unrecognized form): OutputForm-like
+  // Default (no form or unrecognized form): OutputForm.
   // Resolve any nested form wrappers (TeXForm, CForm, FortranForm) first,
   // matching wolframscript behavior where ToString extracts form conversions.
   // Then truncate machine-precision Reals to 6 significant digits — Wolfram's
   // ToString default for `Real` values, which is *not* the same as the REPL
-  // /Print display (those keep full f64 precision).
+  // /Print display (those keep full f64 precision). The default form IS
+  // OutputForm, so the 2D renderer applies: `ToString[3/4]` is the
+  // three-line `3` / `-` / `4`, and `ToString[x^2]` puts the exponent on
+  // its own line (wolframscript-verified; differential fuzzer, seed
+  // 1783530056735545937).
   let resolved = strip_hold_form(&resolve_form_wrappers(&args[0]));
   let truncated = truncate_machine_reals_for_to_string(&resolved);
-  let s = crate::syntax::expr_to_output(&truncated);
+  let s = crate::syntax::expr_to_output_form_2d(&truncated);
   Ok(Expr::String(s))
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -12853,14 +12853,41 @@ fn expr_to_textbox(expr: &Expr) -> TextBox {
       TextBox::atom(&format!("Sqrt[{}]", expr_to_string(sqrt_arg)))
     }
 
-    // Power[base, exp]
+    // A standalone Power with exponent -1 or -1/2 renders as a fraction
+    // (`x^-1` → 1/x, `x^(-1/2)` → 1/Sqrt[x]); other negative exponents
+    // keep the superscript with the sign (`x^-2` shows ` -2` over `x`,
+    // wolframscript-verified). Inside Times every negative power moves
+    // into the display denominator instead (see render_times_textbox).
+    expr
+      if negative_power_parts(expr).is_some_and(|(_, pos)| {
+        matches!(pos, Expr::Integer(1))
+          || matches!(&pos, Expr::FunctionCall { name, args }
+            if name == "Rational"
+              && matches!(args.as_slice(), [Expr::Integer(1), Expr::Integer(2)]))
+      }) =>
+    {
+      let (base, pos_exp) = negative_power_parts(expr).unwrap();
+      let denom = if matches!(pos_exp, Expr::Integer(1)) {
+        expr_to_textbox(&base)
+      } else {
+        expr_to_textbox(&Expr::FunctionCall {
+          name: "Power".to_string(),
+          args: vec![base, pos_exp].into(),
+        })
+      };
+      TextBox::fraction(&TextBox::atom("1"), &denom)
+    }
+
+    // Power[base, exp]. The exponent renders in LINEAR form — Wolfram
+    // keeps superscripts one line high (`x^(2/3)` shows ` 2/3` over `x`,
+    // not a three-line fraction above the base).
     Expr::BinaryOp {
       op: BinaryOperator::Power,
       left,
       right,
     } => {
       let base = expr_to_textbox_base(left);
-      let exp = expr_to_textbox(right);
+      let exp = TextBox::atom(&exponent_linear_form(right));
       TextBox::superscript(&base, &exp)
     }
 
@@ -12869,19 +12896,28 @@ fn expr_to_textbox(expr: &Expr) -> TextBox {
       // Check for fraction: Power[denom, -1] inside Times will be handled by Times
       // Here handle standalone Power
       let base = expr_to_textbox_base(&args[0]);
-      let exp = expr_to_textbox(&args[1]);
+      let exp = TextBox::atom(&exponent_linear_form(&args[1]));
       TextBox::superscript(&base, &exp)
     }
 
-    // Plus[args...]
+    // Plus[args...]. A term that is itself a Plus (possible with held
+    // forms: HoldForm[1 + 1] + HoldForm[2 + 2]) parenthesizes.
     Expr::FunctionCall { name, args } if name == "Plus" && args.len() >= 2 => {
+      let render_term = |e: &Expr| -> TextBox {
+        let tb = expr_to_textbox(e);
+        if is_plus_expr(e) {
+          parenthesize(&tb)
+        } else {
+          tb
+        }
+      };
       let mut parts: Vec<TextBox> = Vec::new();
-      parts.push(expr_to_textbox(&args[0]));
+      parts.push(render_term(&args[0]));
       for arg in args.iter().skip(1) {
         // Check for negative terms
         let (sign, term) = extract_sign_for_plus(arg);
         parts.push(TextBox::atom(sign));
-        parts.push(expr_to_textbox(&term));
+        parts.push(render_term(&term));
       }
       TextBox::hconcat(&parts)
     }
@@ -12923,22 +12959,37 @@ fn expr_to_textbox(expr: &Expr) -> TextBox {
       TextBox::fraction(&num, &denom)
     }
 
-    // Rational[num, denom]
+    // Rational[num, denom]. A negative rational atom parenthesizes:
+    // `-3/4` shows as `-(` 3/4 `)` with the sign on the bar row.
     Expr::FunctionCall { name, args }
       if name == "Rational" && args.len() == 2 =>
     {
+      if let Expr::Integer(n) = &args[0]
+        && *n < 0
+      {
+        let frac = TextBox::fraction(
+          &expr_to_textbox(&Expr::Integer(-n)),
+          &expr_to_textbox(&args[1]),
+        );
+        return TextBox::hconcat(&[TextBox::atom("-"), parenthesize(&frac)]);
+      }
       let num = expr_to_textbox(&args[0]);
       let denom = expr_to_textbox(&args[1]);
       TextBox::fraction(&num, &denom)
     }
 
-    // UnaryOp Minus
+    // UnaryOp Minus. A multi-line operand (a fraction) parenthesizes so
+    // the sign reads on the bar row: `-(x/y)`.
     Expr::UnaryOp {
       op: UnaryOperator::Minus,
       operand,
     } => {
       let inner = expr_to_textbox(operand);
-      TextBox::hconcat(&[TextBox::atom("-"), inner])
+      if inner.height() > 1 {
+        TextBox::hconcat(&[TextBox::atom("-"), parenthesize(&inner)])
+      } else {
+        TextBox::hconcat(&[TextBox::atom("-"), inner])
+      }
     }
 
     // List
@@ -13020,6 +13071,22 @@ fn expr_to_textbox_base(expr: &Expr) -> TextBox {
 }
 
 /// Extract sign and unsigned term for Plus rendering.
+/// If `e` is a `Rational[n, d]` with n < 0, return `Rational[-n, d]`.
+fn negate_negative_rational(e: &Expr) -> Option<Expr> {
+  if let Expr::FunctionCall { name, args } = e
+    && name == "Rational"
+    && args.len() == 2
+    && let Expr::Integer(n) = &args[0]
+    && *n < 0
+  {
+    return Some(Expr::FunctionCall {
+      name: "Rational".to_string(),
+      args: vec![Expr::Integer(-n), args[1].clone()].into(),
+    });
+  }
+  None
+}
+
 fn extract_sign_for_plus(expr: &Expr) -> (&'static str, Expr) {
   match expr {
     Expr::UnaryOp {
@@ -13027,6 +13094,40 @@ fn extract_sign_for_plus(expr: &Expr) -> (&'static str, Expr) {
       operand,
     } => (" - ", *operand.clone()),
     Expr::Integer(n) if *n < 0 => (" - ", Expr::Integer(-n)),
+    Expr::Real(f) if *f < 0.0 => (" - ", Expr::Real(-f)),
+    // Negative rational atom: 1/2 - 1/3 x renders `- 1/3 x`, not `+ -(1/3) x`.
+    _ if negate_negative_rational(expr).is_some() => {
+      (" - ", negate_negative_rational(expr).unwrap())
+    }
+    // Times with a leading negative Rational coefficient: negate it, so
+    // `1 - x/2` renders as a subtraction of `x/2`.
+    Expr::FunctionCall { name, args }
+      if name == "Times"
+        && !args.is_empty()
+        && negate_negative_rational(&args[0]).is_some() =>
+    {
+      let mut new_args = args.to_vec();
+      new_args[0] = negate_negative_rational(&args[0]).unwrap();
+      (
+        " - ",
+        Expr::FunctionCall {
+          name: "Times".to_string(),
+          args: new_args.into(),
+        },
+      )
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Times,
+      left,
+      right,
+    } if negate_negative_rational(left).is_some() => (
+      " - ",
+      Expr::BinaryOp {
+        op: BinaryOperator::Times,
+        left: Box::new(negate_negative_rational(left).unwrap()),
+        right: right.clone(),
+      },
+    ),
     Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
       (" - ", Expr::BigInteger(-n))
     }
@@ -13132,74 +13233,205 @@ fn extract_sign_for_plus(expr: &Expr) -> (&'static str, Expr) {
   }
 }
 
-/// Render Times arguments as 2D, handling fractions (Power[x, -1]).
+/// Is this expression a Plus node (either representation)?
+fn is_plus_expr(e: &Expr) -> bool {
+  matches!(e, Expr::FunctionCall { name, .. } if name == "Plus")
+    || matches!(
+      e,
+      Expr::BinaryOp {
+        op: BinaryOperator::Plus,
+        ..
+      }
+    )
+}
+
+/// Linear (one-line) rendering of a superscript exponent. A negative
+/// rational parenthesizes with the sign outside — `x^(-3/2)` shows
+/// ` -(3/2)` over `x` in wolframscript.
+fn exponent_linear_form(exp: &Expr) -> String {
+  if let Expr::FunctionCall { name, args } = exp
+    && name == "Rational"
+    && args.len() == 2
+    && let Expr::Integer(n) = &args[0]
+    && *n < 0
+  {
+    return format!("-({}/{})", -n, expr_to_output(&args[1]));
+  }
+  expr_to_output(exp)
+}
+
+/// If `e` is `Power[base, exp]` (either node shape) with a NEGATIVE
+/// numeric exponent, return `(base, -exp)` so the factor can move into a
+/// display denominator: `x^-1` → denominator `x`, `x^-2` → `x^2`,
+/// `x^(-1/2)` → `Sqrt[x]`.
+fn negative_power_parts(e: &Expr) -> Option<(Expr, Expr)> {
+  let (base, exp) = match e {
+    Expr::FunctionCall { name, args } if name == "Power" && args.len() == 2 => {
+      (&args[0], &args[1])
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Power,
+      left,
+      right,
+    } => (left.as_ref(), right.as_ref()),
+    _ => return None,
+  };
+  match exp {
+    Expr::Integer(n) if *n < 0 => Some((base.clone(), Expr::Integer(-n))),
+    Expr::FunctionCall { name, args }
+      if name == "Rational"
+        && args.len() == 2
+        && matches!(&args[0], Expr::Integer(n) if *n < 0) =>
+    {
+      if let Expr::Integer(n) = &args[0] {
+        Some((
+          base.clone(),
+          Expr::FunctionCall {
+            name: "Rational".to_string(),
+            args: vec![Expr::Integer(-n), args[1].clone()].into(),
+          },
+        ))
+      } else {
+        None
+      }
+    }
+    _ => None,
+  }
+}
+
+/// Join boxes with single-space separators, Wolfram's product row.
+fn product_row(parts: &[TextBox]) -> TextBox {
+  let mut row: Vec<TextBox> = Vec::new();
+  for (i, p) in parts.iter().enumerate() {
+    if i > 0 {
+      row.push(TextBox::atom(" "));
+    }
+    row.push(p.clone());
+  }
+  TextBox::hconcat(&row)
+}
+
+/// Wrap a box in parentheses on the baseline row.
+fn parenthesize(inner: &TextBox) -> TextBox {
+  TextBox::hconcat(&[
+    TextBox::atom("("),
+    inner.clone(),
+    TextBox::atom(")"),
+  ])
+}
+
+/// Render Times arguments the way Wolfram's OutputForm does (all shapes
+/// wolframscript-verified):
+///   3 x/4     →  numerator `3 x` over `4`
+///   -3 x/4    →  numerator `-3 x` over `4` (|p| ≠ 1 keeps the sign inline)
+///   -x/3      →  `-(1/3) x` (p = -1 with a rational coefficient)
+///   -x/y      →  `-(x/y)`   (p = -1, integer coefficient)
+///   -2/x      →  numerator `-2` over `x`
+///   1/(2 x)   →  `1` over `2 x`
+///   x^-2      →  `1` over `x^2` (negative powers move to the denominator)
 fn render_times_textbox(args: &[Expr]) -> TextBox {
-  // Separate numerator and denominator factors
-  let mut num_factors: Vec<&Expr> = Vec::new();
-  let mut denom_factors: Vec<&Expr> = Vec::new();
+  // Split into: exact numeric coefficient p/q, numerator factors, and
+  // denominator factors (bases of negative powers, with |exp|).
+  let mut coeff_num: Option<Expr> = None; // p (Integer or BigInteger)
+  let mut coeff_den: Option<Expr> = None; // q
+  let mut num_factors: Vec<Expr> = Vec::new();
+  let mut denom_factors: Vec<Expr> = Vec::new();
 
   for arg in args {
     match arg {
-      Expr::FunctionCall { name, args: pargs }
-        if name == "Power"
-          && pargs.len() == 2
-          && matches!(&pargs[1], Expr::Integer(-1)) =>
-      {
-        denom_factors.push(&pargs[0]);
+      Expr::Integer(_) | Expr::BigInteger(_) if coeff_num.is_none() => {
+        coeff_num = Some(arg.clone());
       }
-      Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        right,
-        left,
-      } if matches!(right.as_ref(), Expr::Integer(-1)) => {
-        denom_factors.push(left);
+      Expr::FunctionCall { name, args: rargs }
+        if name == "Rational" && rargs.len() == 2 && coeff_num.is_none() =>
+      {
+        coeff_num = Some(rargs[0].clone());
+        coeff_den = Some(rargs[1].clone());
       }
       _ => {
-        num_factors.push(arg);
+        if let Some((base, pos_exp)) = negative_power_parts(arg) {
+          if matches!(pos_exp, Expr::Integer(1)) {
+            denom_factors.push(base);
+          } else {
+            denom_factors.push(Expr::FunctionCall {
+              name: "Power".to_string(),
+              args: vec![base, pos_exp].into(),
+            });
+          }
+        } else {
+          num_factors.push(arg.clone());
+        }
       }
     }
   }
 
-  if denom_factors.is_empty() {
-    // No fractions - just render as product
-    let mut parts: Vec<TextBox> = Vec::new();
-    for (i, f) in num_factors.iter().enumerate() {
-      if i > 0 {
-        parts.push(TextBox::atom(" "));
-      }
-      parts.push(expr_to_textbox(f));
-    }
-    TextBox::hconcat(&parts)
-  } else {
-    // Has fractions - render as num/denom
-    let num_box = if num_factors.is_empty() {
-      TextBox::atom("1")
-    } else if num_factors.len() == 1 {
-      expr_to_textbox(num_factors[0])
-    } else {
-      let mut parts: Vec<TextBox> = Vec::new();
-      for (i, f) in num_factors.iter().enumerate() {
-        if i > 0 {
-          parts.push(TextBox::atom(" "));
-        }
-        parts.push(expr_to_textbox(f));
-      }
-      TextBox::hconcat(&parts)
-    };
-    let denom_box = if denom_factors.len() == 1 {
-      expr_to_textbox(denom_factors[0])
-    } else {
-      let mut parts: Vec<TextBox> = Vec::new();
-      for (i, f) in denom_factors.iter().enumerate() {
-        if i > 0 {
-          parts.push(TextBox::atom(" "));
-        }
-        parts.push(expr_to_textbox(f));
-      }
-      TextBox::hconcat(&parts)
-    };
-    TextBox::fraction(&num_box, &denom_box)
+  let p_is_minus_one = matches!(coeff_num, Some(Expr::Integer(-1)));
+  let p_is_one = matches!(coeff_num, Some(Expr::Integer(1)));
+  let has_den = coeff_den.is_some() || !denom_factors.is_empty();
+
+  let num_boxes: Vec<TextBox> =
+    num_factors.iter().map(expr_to_textbox).collect();
+  let mut den_boxes: Vec<TextBox> = Vec::new();
+  if let Some(q) = &coeff_den {
+    den_boxes.push(expr_to_textbox(q));
   }
+  den_boxes.extend(denom_factors.iter().map(expr_to_textbox));
+
+  if !has_den {
+    // Plain product row: `3 x`, `-2 x`, `-x`.
+    let mut parts: Vec<TextBox> = Vec::new();
+    if p_is_minus_one {
+      return TextBox::hconcat(&[
+        TextBox::atom("-"),
+        product_row(&num_boxes),
+      ]);
+    }
+    if let Some(p) = &coeff_num
+      && !p_is_one
+    {
+      parts.push(expr_to_textbox(p));
+    }
+    parts.extend(num_boxes);
+    return product_row(&parts);
+  }
+
+  if p_is_minus_one {
+    // The sign pulls out in front of a parenthesized fraction. With
+    // numerator factors and a rational coefficient the factors stay
+    // OUTSIDE the parens (`-x/3` → `-(1/3) x`); with an integer
+    // coefficient they form the fraction numerator (`-x/y` → `-(x/y)`).
+    if coeff_den.is_some() && !num_boxes.is_empty() {
+      let frac =
+        TextBox::fraction(&TextBox::atom("1"), &product_row(&den_boxes));
+      let mut parts =
+        vec![TextBox::hconcat(&[TextBox::atom("-"), parenthesize(&frac)])];
+      parts.extend(num_boxes);
+      return product_row(&parts);
+    }
+    let num_box = if num_boxes.is_empty() {
+      TextBox::atom("1")
+    } else {
+      product_row(&num_boxes)
+    };
+    let frac = TextBox::fraction(&num_box, &product_row(&den_boxes));
+    return TextBox::hconcat(&[TextBox::atom("-"), parenthesize(&frac)]);
+  }
+
+  // General fraction: numerator `p f1 f2` (p omitted when 1), denominator
+  // `q d1 d2` (q omitted when absent).
+  let mut num_parts: Vec<TextBox> = Vec::new();
+  if let Some(p) = &coeff_num
+    && !p_is_one
+  {
+    num_parts.push(expr_to_textbox(p));
+  }
+  num_parts.extend(num_boxes);
+  let num_box = if num_parts.is_empty() {
+    TextBox::atom("1")
+  } else {
+    product_row(&num_parts)
+  };
+  TextBox::fraction(&num_box, &product_row(&den_boxes))
 }
 
 /// Render an expression in 2D OutputForm.

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -13311,6 +13311,30 @@ fn product_row(parts: &[TextBox]) -> TextBox {
   TextBox::hconcat(&row)
 }
 
+/// Is this optional coefficient literally 1 (hidden in display)?
+fn p_is_one_local(c: &Option<Expr>) -> bool {
+  matches!(c, Some(Expr::Integer(1)))
+}
+
+/// Render the factors of a product row, parenthesizing sums — but only
+/// when the row has company: ToString[2*(2 + y)] shows `2 (2 + y)`,
+/// while a LONE sum filling a fraction's numerator stays bare
+/// ((1 + x)/(1 - x) has no parens).
+fn factor_boxes(factors: &[&Expr], extra_boxes: usize) -> Vec<TextBox> {
+  let row_len = factors.len() + extra_boxes;
+  factors
+    .iter()
+    .map(|e| {
+      let tb = expr_to_textbox(e);
+      if row_len > 1 && is_plus_expr(e) {
+        parenthesize(&tb)
+      } else {
+        tb
+      }
+    })
+    .collect()
+}
+
 /// Wrap a box in parentheses on the baseline row.
 fn parenthesize(inner: &TextBox) -> TextBox {
   TextBox::hconcat(&[
@@ -13369,13 +13393,21 @@ fn render_times_textbox(args: &[Expr]) -> TextBox {
   let p_is_one = matches!(coeff_num, Some(Expr::Integer(1)));
   let has_den = coeff_den.is_some() || !denom_factors.is_empty();
 
+  // Row lengths decide sum parenthesization: the numerator row also
+  // carries the coefficient p when it is shown (p ≠ ±1).
+  let p_shown = coeff_num.is_some() && !p_is_one_local(&coeff_num);
+  let num_refs: Vec<&Expr> = num_factors.iter().collect();
   let num_boxes: Vec<TextBox> =
-    num_factors.iter().map(expr_to_textbox).collect();
+    factor_boxes(&num_refs, if p_shown { 1 } else { 0 });
+  let den_refs: Vec<&Expr> = denom_factors.iter().collect();
   let mut den_boxes: Vec<TextBox> = Vec::new();
   if let Some(q) = &coeff_den {
     den_boxes.push(expr_to_textbox(q));
   }
-  den_boxes.extend(denom_factors.iter().map(expr_to_textbox));
+  den_boxes.extend(factor_boxes(
+    &den_refs,
+    if coeff_den.is_some() { 1 } else { 0 },
+  ));
 
   if !has_den {
     // Plain product row: `3 x`, `-2 x`, `-x`.

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -2111,6 +2111,62 @@ mod apart {
     );
   }
 
+  // Polynomial division with a NON-integer leading quotient still
+  // decomposes (the shrunk differential-fuzzer reproducers, seed
+  // 1783520505113402110; all wolframscript-verified).
+  #[test]
+  fn apart_rational_quotient() {
+    assert_eq!(
+      interpret("Apart[Divide[Plus[2, Times[-4, x]], Plus[2, Times[-5, x]]]]")
+        .unwrap(),
+      "4/5 - 2/(5*(-2 + 5*x))"
+    );
+    assert_eq!(
+      interpret("Apart[Divide[Plus[2, Times[-1, x]], Plus[0, Times[-3, x]]]]")
+        .unwrap(),
+      "1/3 - 2/(3*x)"
+    );
+    assert_eq!(
+      interpret("Apart[(x^3 + 2)/(2 x + 1)]").unwrap(),
+      "1/8 - x/4 + x^2/2 + 15/(8*(1 + 2*x))"
+    );
+    assert_eq!(
+      interpret("Apart[(3 x^2 + 2 x + 1)/(x^2 + x)]").unwrap(),
+      "3 + x^(-1) - 2/(1 + x)"
+    );
+  }
+
+  // Apart returns ordinary evaluated expressions: a variable-free
+  // argument passes through, and single-fraction results take their
+  // canonical evaluated form (not a hand-built Divide tree).
+  #[test]
+  fn apart_result_is_canonical() {
+    assert_eq!(interpret("Apart[Divide[1, 2]]").unwrap(), "1/2");
+    assert_eq!(interpret("Apart[1/(-3 x)]").unwrap(), "-1/3*1/x");
+    assert_eq!(
+      interpret("Apart[(x^2 + 1)/(x - 1)]").unwrap(),
+      "1 + 2/(-1 + x) + x"
+    );
+  }
+
+  // Reciprocal-of-sum terms order by base polynomial, constant term
+  // first — a bare-x base counts as constant 0 (wolframscript-verified).
+  #[test]
+  fn sum_reciprocal_term_order() {
+    assert_eq!(interpret("x + 1/(-1 + x)").unwrap(), "(-1 + x)^(-1) + x");
+    assert_eq!(interpret("x + 2/(-1 + x)").unwrap(), "2/(-1 + x) + x");
+    assert_eq!(interpret("x + 1/(1 + x)").unwrap(), "x + (1 + x)^(-1)");
+    assert_eq!(interpret("x^2 + 2/(-1 + x)").unwrap(), "2/(-1 + x) + x^2");
+    assert_eq!(
+      interpret("1/x + 1/(-1 + x)").unwrap(),
+      "(-1 + x)^(-1) + x^(-1)"
+    );
+    assert_eq!(
+      interpret("1/x + 1/(1 + x)").unwrap(),
+      "x^(-1) + (1 + x)^(-1)"
+    );
+  }
+
   #[test]
   fn apart_two_linear_factors() {
     assert_eq!(

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -631,6 +631,54 @@ mod simplify {
     );
   }
 
+  // Sums of radicals pull out their integer content (the content goes
+  // negative only when EVERY term is negative). Differential fuzzer,
+  // seed 1783537668073123846; wolframscript-verified.
+  #[test]
+  fn radical_sum_content_extraction() {
+    assert_eq!(
+      interpret(
+        "Simplify[Plus[Times[Times[-1, Sqrt[9]], Times[4, Sqrt[5]]], \
+         Times[Sqrt[19], Sqrt[9]]]]"
+      )
+      .unwrap(),
+      "3*(-4*Sqrt[5] + Sqrt[19])"
+    );
+    assert_eq!(
+      interpret("Simplify[Plus[9, Times[Sqrt[19], 9]]]").unwrap(),
+      "9*(1 + Sqrt[19])"
+    );
+    assert_eq!(
+      interpret("Simplify[-2 - 2*Sqrt[2]]").unwrap(),
+      "-2*(1 + Sqrt[2])"
+    );
+    assert_eq!(
+      interpret("Simplify[-9 + 9*Sqrt[19]]").unwrap(),
+      "9*(-1 + Sqrt[19])"
+    );
+    assert_eq!(
+      interpret("Simplify[(3/2) + (3/2)*Sqrt[2]]").unwrap(),
+      "(3*(1 + Sqrt[2]))/2"
+    );
+    // Content 1 stays untouched.
+    assert_eq!(
+      interpret("Simplify[Sqrt[2] + Sqrt[3]]").unwrap(),
+      "Sqrt[2] + Sqrt[3]"
+    );
+  }
+
+  // A mixed-sign numerator with a negative leading coefficient only
+  // pulls the minus out when the denominator is already in canonical
+  // positive-leading form (differential fuzzer, seed
+  // 1783537668073123846).
+  #[test]
+  fn no_flip_when_denominator_leading_negative() {
+    assert_eq!(
+      interpret("Simplify[(5 - 4 x - 3 x^2)/(5 - 5 x)]").unwrap(),
+      "(5 - 4*x - 3*x^2)/(5 - 5*x)"
+    );
+  }
+
   // Standalone polynomials factor (2*x*(-1+2*x), canonical factor order),
   // and quotient NUMERATORS factor too — but a quotient's DENOMINATOR
   // stays expanded unless it collapses to a power of a single factor.
@@ -1665,6 +1713,39 @@ mod cancel {
   #[test]
   fn cancel_simple() {
     assert_eq!(interpret("Cancel[(x^2 - 1)/(x - 1)]").unwrap(), "1 + x");
+  }
+
+  // Cancel keeps quotient numerators EXPANDED, pulling out only their
+  // numeric content — unlike Simplify, which factors them. A bare
+  // negative-constant denominator absorbs its sign into the numerator.
+  // (differential fuzzer, seed 1783537668073123846; wolframscript-verified)
+  #[test]
+  fn cancel_keeps_numerator_expanded() {
+    assert_eq!(
+      interpret(
+        "Cancel[Divide[Plus[0, Times[4, x], Times[2, Power[x, 2]]], \
+         Plus[-3, Times[-4, x], Times[2, Power[x, 2]]]]]"
+      )
+      .unwrap(),
+      "(2*(2*x + x^2))/(-3 - 4*x + 2*x^2)"
+    );
+    assert_eq!(
+      interpret("Cancel[(4 x^2 - 2 x)/(2 + 3 x)]").unwrap(),
+      "(2*(-x + 2*x^2))/(2 + 3*x)"
+    );
+    assert_eq!(
+      interpret("Cancel[Divide[Plus[0, x, Power[x, 2]], -3]]").unwrap(),
+      "(-x - x^2)/3"
+    );
+    assert_eq!(
+      interpret("Cancel[(x^2 + x)/(3 + x)]").unwrap(),
+      "(x + x^2)/(3 + x)"
+    );
+    // The perfect-power denominator collapse is kept.
+    assert_eq!(
+      interpret("Cancel[x^2/(1 - 3 x + 3 x^2 - x^3)]").unwrap(),
+      "-(x^2/(-1 + x)^3)"
+    );
   }
 
   #[test]

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -592,6 +592,78 @@ mod simplify {
     assert_eq!(interpret("Simplify[x + x]").unwrap(), "2*x");
   }
 
+  // Simplify pulls a -1 out in front of a quotient when the univariate
+  // numerator's highest-degree coefficient is negative, or when the
+  // denominator is entirely nonpositive; two flips cancel. All
+  // wolframscript-verified (differential fuzzer, seeds
+  // 1783520505113402110 and 1783530056735545937).
+  #[test]
+  fn quotient_minus_extraction() {
+    assert_eq!(
+      interpret(
+        "Simplify[Divide[Plus[-2, Times[-3, x]], Plus[0, Times[4, x], \
+         Times[3, Power[x, 2]]]]]"
+      )
+      .unwrap(),
+      "-((2 + 3*x)/(4*x + 3*x^2))"
+    );
+    assert_eq!(
+      interpret("Simplify[(1 - 5 x - 3 x^2 - x^3)/(-1 - 2 x + 4 x^2)]")
+        .unwrap(),
+      "-((-1 + 5*x + 3*x^2 + x^3)/(-1 - 2*x + 4*x^2))"
+    );
+    assert_eq!(
+      interpret("Simplify[(2 + 3 x)/(-4 x - 3 x^2)]").unwrap(),
+      "-((2 + 3*x)/(4*x + 3*x^2))"
+    );
+    assert_eq!(
+      interpret("Simplify[(-2 - 3 x)/(-4 x - 3 x^2)]").unwrap(),
+      "(2 + 3*x)/(4*x + 3*x^2)"
+    );
+    // Multivariate and non-polynomial numerators keep their form.
+    assert_eq!(
+      interpret("Simplify[(-b + d*y)/(a - c*y)]").unwrap(),
+      "(-b + d*y)/(a - c*y)"
+    );
+    assert_eq!(
+      interpret("Simplify[(1 - Cos[2*x])/2]").unwrap(),
+      "(1 - Cos[2*x])/2"
+    );
+  }
+
+  // Standalone polynomials factor (2*x*(-1+2*x), canonical factor order),
+  // and quotient NUMERATORS factor too — but a quotient's DENOMINATOR
+  // stays expanded unless it collapses to a power of a single factor.
+  #[test]
+  fn factoring_respects_quotient_denominators() {
+    assert_eq!(interpret("Simplify[4 x^2 - 2 x]").unwrap(), "2*x*(-1 + 2*x)");
+    assert_eq!(interpret("Simplify[x^2 + x]").unwrap(), "x*(1 + x)");
+    assert_eq!(
+      interpret("Simplify[1/(4 x + 3 x^2)]").unwrap(),
+      "(4*x + 3*x^2)^(-1)"
+    );
+    assert_eq!(
+      interpret(
+        "Simplify[Divide[1, Plus[0, Times[2, x], Times[3, Power[x, 2]]]]]"
+      )
+      .unwrap(),
+      "(2*x + 3*x^2)^(-1)"
+    );
+    assert_eq!(
+      interpret("Simplify[(4 x^2 - 2 x)/(2 + 3 x)]").unwrap(),
+      "(2*x*(-1 + 2*x))/(2 + 3*x)"
+    );
+    assert_eq!(
+      interpret("Simplify[(x^2 + x)/3]").unwrap(),
+      "(x*(1 + x))/3"
+    );
+    // A denominator that IS a perfect power still factors.
+    assert_eq!(
+      interpret("Simplify[x^2/(1 - 3 x + 3 x^2 - x^3)]").unwrap(),
+      "-(x^2/(-1 + x)^3)"
+    );
+  }
+
   // wolframscript's Simplify flips p/q → (-p)/(-q) only when the
   // denominator's leading sign is negative AND the numerator is constant
   // or itself negative-signed (found by the differential fuzzer).

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -3408,14 +3408,28 @@ mod expand_threading {
     assert_eq!(interpret("Norm[{3, 4}, 3]").unwrap(), "91^(1/3)");
   }
 
-  // Wolfram's machine-precision Plus fold is input-order-sensitive: exact
-  // terms coalesce into ONE exact sum (seeded first iff the first numeric
-  // term is exact), reals fold in input order, and numerified constants
+  // Wolfram's machine-precision Plus fold is input-order-sensitive: every
+  // numeric term (exact or real) converts to f64 individually — exact
+  // terms are NOT coalesced first — and the terms combine as a balanced
+  // divide-and-conquer tree (ceil split), while numerified constants
   // (Pi, E, …) fold one at a time at the very end — they never cancel
   // symbolically once a Real is present. All wolframscript-verified
-  // (differential fuzzer, seed 1783515124284605000).
+  // (differential fuzzer, seeds 1783515124284605000 and
+  // 1783520505113402110).
   #[test]
   fn plus_machine_fold_order() {
+    // Balanced tree: 22-59 and 34+14.6 combine first, so the integers do
+    // not coalesce to an exact -3 (which would give exactly 11.6).
+    assert_eq!(
+      interpret("Plus[22, -59, 34, 14.6]").unwrap(),
+      "11.600000000000001"
+    );
+    // Exact terms convert to f64 individually: the 1 is absorbed into
+    // 2^60 in machine precision (exact coalescing would give 1.5).
+    assert_eq!(
+      interpret("Plus[2^60, 1, -2^60, 0.5]").unwrap(),
+      "0."
+    );
     assert_eq!(
       interpret("Plus[-7.4, Subtract[38, Pi]]").unwrap(),
       "27.45840734641021"
@@ -3465,9 +3479,90 @@ mod expand_threading {
       interpret("Total[{0.1, 0.7, 0.3}]").unwrap(),
       "1.0999999999999999"
     );
-    // Exact rationals sum exactly regardless of position.
     assert_eq!(interpret("Total[{1/3, 1/3, 1/3, 0.5}]").unwrap(), "1.5");
     assert_eq!(interpret("Total[{0.5, 1/3, 1/3, 1/3}]").unwrap(), "1.5");
+    // The balanced tree sums Table[0.1, 10] to exactly 1. (left-to-right
+    // gives 0.9999999999999999) but leaves the half-ulp drift at 7 terms.
+    assert_eq!(interpret("Total[Table[0.1, 10]]").unwrap(), "1.");
+    assert_eq!(
+      interpret("Total[Table[0.1, 7]]").unwrap(),
+      "0.7000000000000001"
+    );
+    assert_eq!(
+      interpret("Total[{1, 2.2, 3, 4.4, 5, 6.6}]").unwrap(),
+      "22.2"
+    );
+    assert_eq!(
+      interpret("Total[{1, 2.2, 3, 4.4, 5, 6.6, 7}]").unwrap(),
+      "29.200000000000003"
+    );
+  }
+
+  // Mean is Total[list]/Length[list] on top of the machine tree fold
+  // (differential fuzzer, seed 1783520505113402110).
+  #[test]
+  fn mean_machine_fold_order() {
+    assert_eq!(
+      interpret("Mean[{22, -59, 34, 14.6}]").unwrap(),
+      "2.9000000000000004"
+    );
+    assert_eq!(
+      interpret("Mean[{0, -59, 34, 14.6}]").unwrap(),
+      "-2.5999999999999996"
+    );
+  }
+
+  // Wolfram's machine-precision Times mirrors Plus's balanced tree for
+  // the Real factors, but — unlike Plus — coalesces the exact factors
+  // into ONE exact product, which seeds the tree fold iff the first
+  // numeric factor is exact and multiplies after the reals otherwise.
+  // Numerified constants (Pi, E, …) multiply last, one at a time. All
+  // wolframscript-verified (differential fuzzer, seed
+  // 1783530056735545937).
+  #[test]
+  fn times_machine_fold_order() {
+    assert_eq!(
+      interpret("Times[0.1, 0.2, 0.3]").unwrap(),
+      "0.006000000000000001"
+    );
+    assert_eq!(interpret("Times[0.3, 0.2, 0.1]").unwrap(), "0.006");
+    // Balanced tree over the reals: left-to-right would give
+    // 0.0005040000000000001.
+    assert_eq!(
+      interpret("Times[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]").unwrap(),
+      "0.000504"
+    );
+    // Exact product seeds the fold when the first numeric factor is exact…
+    assert_eq!(
+      interpret("Times[3, 1/7, 0.1, 0.2, 0.3]").unwrap(),
+      "0.0025714285714285713"
+    );
+    // …and multiplies after the reals otherwise.
+    assert_eq!(
+      interpret("Times[0.1, 0.2, 3, 1/7, 0.3]").unwrap(),
+      "0.0025714285714285717"
+    );
+    assert_eq!(
+      interpret("Times[1.5, 2, 3, 0.1]").unwrap(),
+      "0.9000000000000001"
+    );
+    // Constants numerify at the end, one at a time (no Pi*Pi collapse
+    // before the reals combine).
+    assert_eq!(
+      interpret("Times[0.1, Pi, 0.3, -Pi]").unwrap(),
+      "-0.2960881320326807"
+    );
+    // The shrunk differential-fuzzer reproducer: exact -36 * (-6179/56)
+    // coalesces exactly before the real factor multiplies in.
+    assert_eq!(
+      interpret(
+        "Times[-36, Subtract[Subtract[Subtract[Divide[-13, 8], -56], \
+         Plus[83, Divide[-16, 7]]], 84], Subtract[Divide[Divide[17, 1], \
+         67], -17.5]]"
+      )
+      .unwrap(),
+      "70521.62526652453"
+    );
   }
 
   #[test]

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -3565,6 +3565,26 @@ mod expand_threading {
     );
   }
 
+  // The exact 2-norm squares Abs[item]: numerically negative exact
+  // entries flip sign inside the square, and a one-element vector IS its
+  // Abs (wolframscript-verified; differential fuzzer, seed
+  // 1783520505113402110).
+  #[test]
+  fn norm_exact_entries_square_via_abs() {
+    assert_eq!(
+      interpret("Norm[{-46, -63, Plus[Plus[1, -81], Pi]}]").unwrap(),
+      "Sqrt[6085 + (80 - Pi)^2]"
+    );
+    assert_eq!(
+      interpret("Norm[{2, Pi - 4}]").unwrap(),
+      "Sqrt[4 + (4 - Pi)^2]"
+    );
+    assert_eq!(interpret("Norm[{1 + Pi}]").unwrap(), "1 + Pi");
+    assert_eq!(interpret("Norm[{Pi - 4}]").unwrap(), "4 - Pi");
+    assert_eq!(interpret("Norm[{-3}]").unwrap(), "3");
+    assert_eq!(interpret("Norm[{x}]").unwrap(), "Abs[x]");
+  }
+
   #[test]
   fn norm_vector_general_p_symbolic_entries() {
     assert_eq!(

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__complex_plot__complex_plot_rational_function.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__complex_plot__complex_plot_rational_function.snap
@@ -3443,7 +3443,7 @@ expression: "export_svg(\"ComplexPlot[(z^2 + 1)/(z^2 - 1), {z, -2 - 2 I, 2 + 2 I
 <rect x="1630.0" y="1150.0" width="28.0" height="30.5" fill="rgb(90,1,131)" stroke="none"/>
 <rect x="1630.0" y="1120.0" width="28.0" height="30.5" fill="rgb(82,0,130)" stroke="none"/>
 <rect x="1630.0" y="1090.0" width="28.0" height="30.5" fill="rgb(74,0,129)" stroke="none"/>
-<rect x="1630.0" y="1060.0" width="28.0" height="30.5" fill="rgb(66,0,128)" stroke="none"/>
+<rect x="1630.0" y="1060.0" width="28.0" height="30.5" fill="rgb(66,0,127)" stroke="none"/>
 <rect x="1630.0" y="1030.0" width="28.0" height="30.5" fill="rgb(59,0,126)" stroke="none"/>
 <rect x="1630.0" y="1000.0" width="28.0" height="30.5" fill="rgb(52,0,125)" stroke="none"/>
 <rect x="1630.0" y="970.0" width="28.0" height="30.5" fill="rgb(45,1,125)" stroke="none"/>
@@ -3542,7 +3542,7 @@ expression: "export_svg(\"ComplexPlot[(z^2 + 1)/(z^2 - 1), {z, -2 - 2 I, 2 + 2 I
 <rect x="1657.5" y="1180.0" width="28.0" height="30.5" fill="rgb(106,1,131)" stroke="none"/>
 <rect x="1657.5" y="1150.0" width="28.0" height="30.5" fill="rgb(97,0,130)" stroke="none"/>
 <rect x="1657.5" y="1120.0" width="28.0" height="30.5" fill="rgb(89,0,129)" stroke="none"/>
-<rect x="1657.5" y="1090.0" width="28.0" height="30.5" fill="rgb(80,0,128)" stroke="none"/>
+<rect x="1657.5" y="1090.0" width="28.0" height="30.5" fill="rgb(80,0,127)" stroke="none"/>
 <rect x="1657.5" y="1060.0" width="28.0" height="30.5" fill="rgb(73,0,126)" stroke="none"/>
 <rect x="1657.5" y="1030.0" width="28.0" height="30.5" fill="rgb(65,0,125)" stroke="none"/>
 <rect x="1657.5" y="1000.0" width="28.0" height="30.5" fill="rgb(57,1,124)" stroke="none"/>

--- a/tests/interpreter_tests/string.rs
+++ b/tests/interpreter_tests/string.rs
@@ -5405,6 +5405,81 @@ mod fortran_form_division {
   }
 }
 
+// ToString's default form is OutputForm, which typesets in 2D: rationals
+// stack as numerator/bar/denominator, exponents ride one line above the
+// base. All strings wolframscript-verified (differential fuzzer, seed
+// 1783530056735545937).
+mod to_string_output_form_2d {
+  use super::*;
+
+  #[test]
+  fn rational_atoms() {
+    assert_eq!(interpret("ToString[3/4]").unwrap(), "3\n-\n4");
+    // The shrunk fuzzer reproducer: a negative rational parenthesizes
+    // with the sign on the bar row.
+    assert_eq!(interpret("ToString[-3/4]").unwrap(), "  3\n-(-)\n  4");
+    assert_eq!(
+      interpret("ToString[{Divide[1, -29]}]").unwrap(),
+      "   1\n{-(--)}\n   29"
+    );
+    assert_eq!(interpret("ToString[75/59]").unwrap(), "75\n--\n59");
+    assert_eq!(interpret("ToString[{1/2, 5}]").unwrap(), " 1\n{-, 5}\n 2");
+  }
+
+  #[test]
+  fn fractions_in_sums() {
+    assert_eq!(interpret("ToString[1/2 + x]").unwrap(), "1\n- + x\n2");
+    assert_eq!(interpret("ToString[1 - x/2]").unwrap(), "    x\n1 - -\n    2");
+    assert_eq!(
+      interpret("ToString[2/3 + x/5]").unwrap(),
+      "2   x\n- + -\n3   5"
+    );
+    assert_eq!(
+      interpret("ToString[1/2 - 1/(3 x)]").unwrap(),
+      "1    1\n- - ---\n2   3 x"
+    );
+  }
+
+  #[test]
+  fn products_and_quotients() {
+    // Positive rational coefficients merge into one fraction…
+    assert_eq!(interpret("ToString[3 x/4]").unwrap(), "3 x\n---\n 4");
+    assert_eq!(interpret("ToString[Pi/2]").unwrap(), "Pi\n--\n2");
+    assert_eq!(interpret("ToString[x/(2 y)]").unwrap(), " x\n---\n2 y");
+    assert_eq!(interpret("ToString[1/(2 x)]").unwrap(), " 1\n---\n2 x");
+    // …and a numerator of -1 pulls the sign out in front of the parens:
+    // rational coefficients keep the factors outside, integer ones inside.
+    assert_eq!(interpret("ToString[-x/3]").unwrap(), "  1\n-(-) x\n  3");
+    assert_eq!(interpret("ToString[-x/y]").unwrap(), "  x\n-(-)\n  y");
+    assert_eq!(interpret("ToString[-2/x]").unwrap(), "-2\n--\nx");
+    assert_eq!(interpret("ToString[-3 x/4]").unwrap(), "-3 x\n----\n 4");
+    assert_eq!(
+      interpret("ToString[(1 + x)/(1 - x)]").unwrap(),
+      "1 + x\n-----\n1 - x"
+    );
+  }
+
+  #[test]
+  fn powers() {
+    assert_eq!(interpret("ToString[x^2]").unwrap(), " 2\nx");
+    // Superscripts render one line high, even for rational exponents.
+    assert_eq!(interpret("ToString[x^(2/3)]").unwrap(), " 2/3\nx");
+    assert_eq!(interpret("ToString[x^(a/b)]").unwrap(), " a/b\nx");
+    // Exponent -1 and -1/2 display as fractions; other negative
+    // exponents keep the superscript with the sign.
+    assert_eq!(interpret("ToString[x^-1]").unwrap(), "1\n-\nx");
+    assert_eq!(
+      interpret("ToString[x^(-1/2)]").unwrap(),
+      "   1\n-------\nSqrt[x]"
+    );
+    assert_eq!(interpret("ToString[x^-2]").unwrap(), " -2\nx");
+    assert_eq!(interpret("ToString[x^(-3/2)]").unwrap(), " -(3/2)\nx");
+    // Inside a product every negative power moves into the denominator.
+    assert_eq!(interpret("ToString[3 x^-2]").unwrap(), "3\n--\n 2\nx");
+    assert_eq!(interpret("ToString[Sqrt[x]]").unwrap(), "Sqrt[x]");
+  }
+}
+
 mod to_string_hold_form {
   use super::*;
 

--- a/tests/interpreter_tests/string.rs
+++ b/tests/interpreter_tests/string.rs
@@ -5459,6 +5459,30 @@ mod to_string_output_form_2d {
     );
   }
 
+  // Sum factors in a product row parenthesize — but a lone sum filling
+  // a fraction's numerator or denominator stays bare (differential
+  // fuzzer, seed 1783542791764080894; wolframscript-verified).
+  #[test]
+  fn sum_factors_parenthesize_in_products() {
+    assert_eq!(interpret("ToString[2*(2 + y)]").unwrap(), "2 (2 + y)");
+    assert_eq!(
+      interpret("ToString[3 x (1 + x)]").unwrap(),
+      "3 x (1 + x)"
+    );
+    assert_eq!(
+      interpret("ToString[Factor[4 x^2 + 2 y^2 + 4]]").unwrap(),
+      "          2    2\n2 (2 + 2 x  + y )"
+    );
+    assert_eq!(
+      interpret("ToString[1/(x*(4 + 3*x))]").unwrap(),
+      "     1\n-----------\nx (4 + 3 x)"
+    );
+    assert_eq!(
+      interpret("ToString[(1 + x)/(1 - x)]").unwrap(),
+      "1 + x\n-----\n1 - x"
+    );
+  }
+
   #[test]
   fn powers() {
     assert_eq!(interpret("ToString[x^2]").unwrap(), " 2\nx");


### PR DESCRIPTION
## Summary
This PR fixes multiple issues in expression rendering and arithmetic evaluation to match Wolfram's behavior more closely. The changes focus on 2D OutputForm formatting (fractions, exponents, products), machine-precision arithmetic folding, and simplification/cancellation of quotients.

## Key Changes

### 2D Output Formatting (src/syntax.rs)
- **Negative power handling**: Standalone powers with exponent -1 or -1/2 now render as fractions (e.g., `x^-1` → `1/x`, `x^(-1/2)` → `1/Sqrt[x]`)
- **Linear exponent form**: Exponents in superscripts now render as one-line text (e.g., `x^(-3/2)` shows `-(3/2)` over `x`)
- **Parenthesization of sums**: Plus expressions nested in other contexts now parenthesize correctly, including in products and fractions
- **Negative rational atoms**: Negative rationals like `-3/4` now display as `-(3/4)` with the sign on the fraction bar
- **Minus operator**: Multi-line operands (fractions) now parenthesize when negated (e.g., `-(x/y)`)
- **Product row rendering**: Factors in Times expressions now properly parenthesize sums when the row has multiple elements, while lone sums in fraction numerators/denominators stay bare

### Machine-Precision Arithmetic (src/functions/math_ast/arithmetic.rs)
- **Balanced tree folding**: Plus and Times now use divide-and-conquer tree folding (ceil split) instead of left-to-right, matching Wolfram's machine-precision behavior
- **Per-term f64 conversion**: When a Real is present, every numeric term (exact or real) converts to f64 individually in input order, rather than coalescing exact terms first
- **Norm edge case**: Single-element vectors now return `Abs[element]` instead of `Sqrt[element^2]`

### Simplification and Cancellation (src/functions/polynomial_ast/simplify.rs, together.rs, cancel.rs, apart.rs)
- **Quotient sign extraction**: Simplify now pulls `-1` out front when numerator has negative leading coefficient or denominator is all-nonpositive, with proper handling of mixed-sign numerators
- **Denominator factoring restrictions**: Quotient denominators no longer factor into multiple distinct factors (e.g., `1/(4x+3x^2)` stays expanded), only collapse to powers of single factors
- **Numerator factoring**: Quotient numerators still factor freely in Simplify
- **Radical sum content**: Non-polynomial sums now extract integer content (e.g., `9 + 9*Sqrt[19]` → `9*(1 + Sqrt[19])`)
- **Cancel behavior**: Cancel keeps numerators expanded with only numeric content extracted, unlike Simplify which factors them
- **Rational-coefficient polynomial division**: Apart now handles non-integer leading quotients via rational coefficient division
- **Negative constant denominators**: Cancel absorbs negative constant denominators into the numerator

### Plus Term Ordering (src/functions/math_ast/arithmetic.rs)
- **Reciprocal-of-sum ordering**: Terms like `1/(1+x)` now order correctly against univariate terms by comparing base polynomials coefficient-wise

## Testing
All changes are covered by new test cases in `tests/interpreter_tests/algebra.rs`, `tests/interpreter_tests/arithmetic.rs`, and `tests/interpreter_tests/string.rs`, with test cases verified against wolframscript output.

https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt