### PR TITLE
Add histogram height specs and multi-dataset support

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -217,7 +217,7 @@ While,Evaluates an expression repeatedly while a condition is true,✅,pure,1.0,
 FrameLabel,Axis labels for framed charts (alias for AxesLabel),✅,pure,2.0,221
 FindRoot,Numerically finds a root of an equation using Newton's method,✅,pure,1.0,222
 Image,Constructs an image from pixel data,✅,pure,7.0,223
-ColorData,List of color data categories (no-arg form only),🚧,pure,6.0,224
+ColorData,Color scheme data (categories; gradient names; indexed color lists),🚧,pure,6.0,224
 Binomial,Returns the binomial coefficient,✅,pure,1.0,225
 Which,Evaluates conditions and returns the value for the first true one,✅,pure,1.0,226
 Replace,Applies transformation rules to an expression,✅,pure,1.0,227

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -1,6 +1,31 @@
 #[allow(unused_imports)]
 use super::*;
 
+/// Colors of a Wolfram `ColorData` indexed scheme (`ColorData[n, "ColorList"]`).
+///
+/// Scheme 97 is the default plot-color palette; its exact RGB values are
+/// reproduced here (verified against wolframscript's output). Other indexed
+/// schemes are not yet tabulated.
+fn indexed_color_list(n: i128) -> Option<&'static [(f64, f64, f64)]> {
+  // ColorData[97, "ColorList"] — the modern default plot palette (10 colors).
+  const SCHEME_97: [(f64, f64, f64); 10] = [
+    (0.368417, 0.506779, 0.709798),
+    (0.880722, 0.611041, 0.142051),
+    (0.560181, 0.691569, 0.194885),
+    (0.922526, 0.385626, 0.209179),
+    (0.528488, 0.470624, 0.701351),
+    (0.772079, 0.431554, 0.102387),
+    (0.363898, 0.618501, 0.782349),
+    (1.0, 0.75, 0.0),
+    (0.647624, 0.37816, 0.614037),
+    (0.571589, 0.586483, 0.0),
+  ];
+  match n {
+    97 => Some(&SCHEME_97),
+    _ => None,
+  }
+}
+
 /// Extract a lowercase file extension from a path or URL.
 /// Strips any `?query` or `#fragment` first, so
 /// `"http://host/file.csv?x=1"` yields `"csv"`.
@@ -433,6 +458,24 @@ pub fn dispatch_image_functions(
         ]
         .into(),
       )));
+    }
+    // ColorData[n, "ColorList"]: the ordered list of colors in indexed
+    // scheme n (e.g. `ColorData[97, "ColorList"]` — the default plot palette).
+    "ColorData" if args.len() == 2 => {
+      if let (Expr::Integer(n), Expr::String(prop)) = (&args[0], &args[1])
+        && prop == "ColorList"
+        && let Some(colors) = indexed_color_list(*n)
+      {
+        return Some(Ok(Expr::List(
+          colors
+            .iter()
+            .map(|&(r, g, b)| Expr::FunctionCall {
+              name: "RGBColor".to_string(),
+              args: vec![Expr::Real(r), Expr::Real(g), Expr::Real(b)].into(),
+            })
+            .collect(),
+        )));
+      }
     }
     // ColorData["Gradients"]: list of named built-in color gradients.
     "ColorData" if args.len() == 1 => {

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -3,30 +3,11 @@ use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::graphics::{Color, parse_color};
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{
-  BinSpec, DEFAULT_HEIGHT, DEFAULT_WIDTH, MarginOverrides, PLOT_COLORS,
-  RESOLUTION_SCALE, generate_bar_svg, generate_histogram_svg, parse_image_size,
+  BinSpec, DEFAULT_HEIGHT, DEFAULT_WIDTH, HistogramHeight, MarginOverrides,
+  PLOT_COLORS, RESOLUTION_SCALE, generate_bar_svg, generate_histogram_svg,
+  parse_image_size,
 };
 use crate::syntax::Expr;
-
-/// Extract a flat list of f64 values from the first argument.
-fn extract_values(arg: &Expr) -> Result<Vec<f64>, InterpreterError> {
-  let data = evaluate_expr_to_expr(arg)?;
-  match &data {
-    Expr::List(items) => {
-      let mut vals = Vec::with_capacity(items.len());
-      for item in items {
-        let v = evaluate_expr_to_expr(item).unwrap_or(item.clone());
-        if let Some(f) = try_eval_to_f64(&v) {
-          vals.push(f);
-        }
-      }
-      Ok(vals)
-    }
-    _ => Err(InterpreterError::EvaluationError(
-      "Chart: first argument must be a list".into(),
-    )),
-  }
-}
 
 /// Extract grouped values from the first argument.
 /// Returns a list of groups, where each group is a list of f64 values.
@@ -1437,46 +1418,116 @@ fn render_3d_triangles(
 /// Histogram[{d1, d2, ...}] or Histogram[{d1, d2, ...}, nbins]
 /// or Histogram[{d1, d2, ...}, {{e1, e2, ...}}]
 pub fn histogram_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let values = extract_values(&args[0])?;
-  if values.is_empty() {
+  // A flat list `{v1, v2, ...}` is one dataset; a list of lists
+  // `{{...}, {...}}` is several datasets drawn overlaid.
+  let datasets = parse_datasets(&args[0])?;
+  if datasets.is_empty() || datasets.iter().all(|d| d.is_empty()) {
     return Ok(crate::graphics_result(
       "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>".to_string(),
     ));
   }
 
-  // Check if args[1] is a bin count, custom bin edges, or an option
-  let bin_spec = if args.len() > 1 {
-    let evaluated = evaluate_expr_to_expr(&args[1])?;
-    // Check for {{e1, e2, ...}} — a list containing a single list of bin edges
-    if let Expr::List(outer) = &evaluated {
-      if outer.len() == 1 {
-        if let Expr::List(inner) = &outer[0] {
-          let edges: Vec<f64> =
-            inner.iter().filter_map(try_eval_to_f64).collect();
-          if edges.len() >= 2 {
-            Some(BinSpec::Edges(edges))
-          } else {
-            None
-          }
-        } else {
-          None
-        }
-      } else {
-        None
-      }
-    } else if let Some(f) = try_eval_to_f64(&evaluated) {
-      let n = f as usize;
-      if n > 0 { Some(BinSpec::Count(n)) } else { None }
-    } else {
-      None
-    }
-  } else {
-    None
-  };
+  // Positional (non-option) args after the data: `bspec` then `hspec`.
+  let positional: Vec<&Expr> = args[1..]
+    .iter()
+    .filter(|a| !matches!(a, Expr::Rule { .. }))
+    .collect();
+
+  let bin_spec = positional.first().and_then(|e| parse_bin_spec(e));
+  let height = positional
+    .get(1)
+    .and_then(|e| parse_histogram_height(e))
+    .unwrap_or(HistogramHeight::Count);
 
   let mut opts = parse_chart_options(args);
-  let svg = generate_histogram_svg(&values, bin_spec, &mut opts)?;
-  Ok(crate::graphics_result(svg))
+  let svg =
+    generate_histogram_svg(&datasets, bin_spec.clone(), height, &mut opts)?;
+
+  // Per-dataset colors matching the rendered bars, used to build a PlotSource
+  // so `Show[Histogram[...], Plot[...]]` overlays the bars with the curves.
+  let colors: Vec<(u8, u8, u8)> = (0..datasets.len())
+    .map(|di| {
+      if !opts.chart_style.is_empty() {
+        let c = &opts.chart_style[di % opts.chart_style.len()];
+        (
+          (c.r.clamp(0.0, 1.0) * 255.0).round() as u8,
+          (c.g.clamp(0.0, 1.0) * 255.0).round() as u8,
+          (c.b.clamp(0.0, 1.0) * 255.0).round() as u8,
+        )
+      } else {
+        PLOT_COLORS[di % PLOT_COLORS.len()]
+      }
+    })
+    .collect();
+
+  match crate::functions::plot::histogram_plot_source(
+    &datasets,
+    &bin_spec,
+    height,
+    &colors,
+    (opts.svg_width, opts.svg_height),
+  ) {
+    Some(src) => Ok(crate::graphics_result_with_source(svg, src)),
+    None => Ok(crate::graphics_result(svg)),
+  }
+}
+
+/// Parse a Histogram bin specification (`bspec`): an integer bin count,
+/// `{w}` (bin width), or `{{e1, e2, ...}}` (explicit bin edges). Anything
+/// else (e.g. `Automatic`) yields `None` (automatic binning).
+fn parse_bin_spec(arg: &Expr) -> Option<BinSpec> {
+  let evaluated = evaluate_expr_to_expr(arg).unwrap_or_else(|_| arg.clone());
+  match &evaluated {
+    Expr::List(outer) => {
+      // {{e1, e2, ...}} — a list wrapping the explicit bin edges.
+      if outer.len() == 1
+        && let Expr::List(inner) = &outer[0]
+      {
+        let edges: Vec<f64> =
+          inner.iter().filter_map(try_eval_to_f64).collect();
+        return (edges.len() >= 2).then_some(BinSpec::Edges(edges));
+      }
+      // {w} — a bin width.
+      if outer.len() == 1
+        && let Some(w) = try_eval_to_f64(&outer[0])
+      {
+        return (w > 0.0).then_some(BinSpec::Width(w));
+      }
+      // {min, max, w} — width w over an explicit range: use the width and
+      // let the shared edge builder align to it.
+      if outer.len() == 3
+        && let Some(w) = try_eval_to_f64(&outer[2])
+      {
+        return (w > 0.0).then_some(BinSpec::Width(w));
+      }
+      None
+    }
+    _ => {
+      let f = try_eval_to_f64(&evaluated)?;
+      let n = f as usize;
+      (n > 0).then_some(BinSpec::Count(n))
+    }
+  }
+}
+
+/// Parse a Histogram height specification (`hspec`) string into a
+/// `HistogramHeight`. Unknown specs fall back to plain counts.
+fn parse_histogram_height(arg: &Expr) -> Option<HistogramHeight> {
+  let s = match arg {
+    Expr::String(s) => s.as_str(),
+    Expr::Identifier(s) => s.as_str(),
+    _ => return None,
+  };
+  Some(match s {
+    "Count" => HistogramHeight::Count,
+    "CumulativeCount" => HistogramHeight::CumulativeCount,
+    "Probability" | "Relative" | "Fraction" | "PMF" => {
+      HistogramHeight::Probability
+    }
+    "PDF" => HistogramHeight::Pdf,
+    "CDF" => HistogramHeight::Cdf,
+    _ => return None,
+  })
 }
 
 /// Compute box-whisker statistics for a sorted dataset.
@@ -1507,7 +1558,7 @@ fn parse_datasets(arg: &Expr) -> Result<Vec<Vec<f64>>, InterpreterError> {
     Expr::List(items) => items,
     _ => {
       return Err(InterpreterError::EvaluationError(
-        "BoxWhiskerChart: first argument must be a list".into(),
+        "Chart: first argument must be a list".into(),
       ));
     }
   };

--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -7,6 +7,16 @@ use crate::syntax::Expr;
 pub fn random_integer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   use rand::Rng;
 
+  // RandomInteger[dist] / RandomInteger[dist, n] samples from a discrete
+  // distribution, exactly like RandomVariate (e.g. `RandomInteger[
+  // PoissonDistribution[10], 1000]`). Delegate to RandomVariate so every
+  // distribution it supports works here too.
+  if let Some(Expr::FunctionCall { name, .. }) = args.first()
+    && name.ends_with("Distribution")
+  {
+    return random_variate_ast(args);
+  }
+
   match args.len() {
     0 => Ok(Expr::Integer(crate::with_rng(|rng| rng.gen_range(0..=1)))),
     1 => match &args[0] {

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -4375,16 +4375,216 @@ pub(crate) fn inject_legend(buf: &mut String, opts: &PlotOptions) {
 
 /// Generate SVG for a histogram using plotters.
 /// Specifies how histogram bins are determined.
+#[derive(Clone)]
 pub enum BinSpec {
   /// A fixed number of equal-width bins.
   Count(usize),
+  /// A fixed bin width; bin boundaries are aligned to multiples of the width.
+  Width(f64),
   /// Explicit bin edges (must be sorted, at least 2 elements).
   Edges(Vec<f64>),
 }
 
+/// Histogram bar-height specification (Wolfram's `hspec`).
+#[derive(Clone, Copy, PartialEq)]
+pub enum HistogramHeight {
+  /// Raw counts per bin (the default).
+  Count,
+  /// Running total of counts up to and including each bin.
+  CumulativeCount,
+  /// Fraction of samples in each bin (`c / n`); heights sum to 1.
+  Probability,
+  /// Probability density (`c / (n * width)`); total area is 1.
+  Pdf,
+  /// Cumulative fraction of samples (`cumsum / n`); reaches 1 at the last bin.
+  Cdf,
+}
+
+/// Compute the common bin edges for one or more datasets given a bin spec.
+fn histogram_bin_edges(
+  all_values: &[f64],
+  bin_spec: &Option<BinSpec>,
+) -> Vec<f64> {
+  if let Some(BinSpec::Edges(edges)) = bin_spec {
+    let mut edges = edges.clone();
+    edges.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    return edges;
+  }
+
+  let d_min = all_values.iter().cloned().fold(f64::INFINITY, f64::min);
+  let d_max = all_values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+  let (d_min, d_max) = if d_min.is_finite() && d_max.is_finite() {
+    (d_min, d_max)
+  } else {
+    (0.0, 1.0)
+  };
+
+  match bin_spec {
+    Some(BinSpec::Width(w)) if *w > 0.0 => {
+      let w = *w;
+      // Align boundaries to multiples of the width (Wolfram convention),
+      // so `{1}` yields integer-aligned unit bins `[k w, (k+1) w)`.
+      let start = (d_min / w).floor() * w;
+      // Top edge: the first multiple of w strictly greater than d_max, so the
+      // largest sample gets its own bin (matching Wolfram — data 0..9 with
+      // width 1 yields the 10 bins [0,1),…,[9,10)).
+      let mut top = (d_max / w).floor() * w + w;
+      if top <= d_max + w * 1e-9 {
+        top += w;
+      }
+      let n_bins = (((top - start) / w).round() as usize).max(1);
+      (0..=n_bins).map(|i| start + i as f64 * w).collect()
+    }
+    _ => {
+      let num_bins = match bin_spec {
+        Some(BinSpec::Count(c)) if *c > 0 => *c,
+        _ => ((1.0 + (all_values.len().max(1) as f64).log2()).ceil() as usize)
+          .max(1),
+      };
+      let range = d_max - d_min;
+      let bin_width = if range.abs() < f64::EPSILON {
+        1.0
+      } else {
+        range / num_bins as f64
+      };
+      (0..=num_bins)
+        .map(|i| d_min + i as f64 * bin_width)
+        .collect()
+    }
+  }
+}
+
+/// Count how many values of `values` fall into each bin defined by `edges`.
+/// The last bin is closed on the right; all others are half-open `[lo, hi)`.
+fn histogram_bin_counts(values: &[f64], edges: &[f64]) -> Vec<usize> {
+  let num_bins = edges.len().saturating_sub(1);
+  let mut counts = vec![0usize; num_bins];
+  if num_bins == 0 {
+    return counts;
+  }
+  for &v in values {
+    for i in 0..num_bins {
+      let in_bin = if i == num_bins - 1 {
+        v >= edges[i] && v <= edges[i + 1]
+      } else {
+        v >= edges[i] && v < edges[i + 1]
+      };
+      if in_bin {
+        counts[i] += 1;
+        break;
+      }
+    }
+  }
+  counts
+}
+
+/// Convert per-bin counts into bar heights according to a height spec.
+fn histogram_bin_heights(
+  counts: &[usize],
+  edges: &[f64],
+  height: HistogramHeight,
+) -> Vec<f64> {
+  let n: usize = counts.iter().sum();
+  let n_f = n.max(1) as f64;
+  match height {
+    HistogramHeight::Count => counts.iter().map(|&c| c as f64).collect(),
+    HistogramHeight::Probability => {
+      counts.iter().map(|&c| c as f64 / n_f).collect()
+    }
+    HistogramHeight::Pdf => counts
+      .iter()
+      .enumerate()
+      .map(|(i, &c)| {
+        let w = (edges[i + 1] - edges[i]).abs();
+        if w > 0.0 { c as f64 / (n_f * w) } else { 0.0 }
+      })
+      .collect(),
+    HistogramHeight::CumulativeCount => {
+      let mut acc = 0.0;
+      counts
+        .iter()
+        .map(|&c| {
+          acc += c as f64;
+          acc
+        })
+        .collect()
+    }
+    HistogramHeight::Cdf => {
+      let mut acc = 0.0;
+      counts
+        .iter()
+        .map(|&c| {
+          acc += c as f64;
+          acc / n_f
+        })
+        .collect()
+    }
+  }
+}
+
+/// Build a `PlotSource` describing histogram bars as one filled step-outline
+/// series per dataset. This lets `Show` overlay a Histogram with plots
+/// (`Show[Histogram[...], Plot[...]]`) in a shared coordinate system, exactly
+/// as Wolfram does — the bars and any overlaid curves share the same axes.
+pub(crate) fn histogram_plot_source(
+  datasets: &[Vec<f64>],
+  bin_spec: &Option<BinSpec>,
+  height: HistogramHeight,
+  colors: &[(u8, u8, u8)],
+  image_size: (u32, u32),
+) -> Option<crate::syntax::PlotSource> {
+  let all_values: Vec<f64> =
+    datasets.iter().flat_map(|d| d.iter().copied()).collect();
+  if all_values.is_empty() {
+    return None;
+  }
+  let bin_edges = histogram_bin_edges(&all_values, bin_spec);
+  let num_bins = bin_edges.len().saturating_sub(1);
+  if num_bins == 0 {
+    return None;
+  }
+
+  let mut series = Vec::with_capacity(datasets.len());
+  let mut max_h = 0.0_f64;
+  for (di, d) in datasets.iter().enumerate() {
+    let counts = histogram_bin_counts(d, &bin_edges);
+    let heights = histogram_bin_heights(&counts, &bin_edges, height);
+    // Trace the bar silhouette: up each bar's left edge, across its top,
+    // then back down to the axis at the end. Filling to the axis paints
+    // the bars.
+    let mut points = Vec::with_capacity(num_bins * 2 + 2);
+    points.push((bin_edges[0], 0.0));
+    for i in 0..num_bins {
+      points.push((bin_edges[i], heights[i]));
+      points.push((bin_edges[i + 1], heights[i]));
+      max_h = max_h.max(heights[i]);
+    }
+    points.push((bin_edges[num_bins], 0.0));
+    let color = colors
+      .get(di)
+      .copied()
+      .unwrap_or(PLOT_COLORS[di % PLOT_COLORS.len()]);
+    series.push(crate::syntax::PlotSeriesData {
+      points,
+      color,
+      is_scatter: false,
+      filling: crate::syntax::SeriesFilling::Axis,
+    });
+  }
+
+  let y_hi = if max_h > 0.0 { max_h * 1.05 } else { 1.0 };
+  Some(crate::syntax::PlotSource {
+    series,
+    x_range: (bin_edges[0], bin_edges[num_bins]),
+    y_range: (0.0, y_hi),
+    image_size,
+  })
+}
+
 pub(crate) fn generate_histogram_svg(
-  values: &[f64],
+  datasets: &[Vec<f64>],
   bin_spec: Option<BinSpec>,
+  height: HistogramHeight,
   opts: &mut ChartOptions,
 ) -> Result<String, InterpreterError> {
   let (svg_width, svg_height, full_width) =
@@ -4392,66 +4592,35 @@ pub(crate) fn generate_histogram_svg(
   let render_width = svg_width * RESOLUTION_SCALE;
   let render_height = svg_height * RESOLUTION_SCALE;
 
-  // Build bin edges and counts based on the bin specification
-  let (bin_edges, counts) = match bin_spec {
-    Some(BinSpec::Edges(mut edges)) => {
-      edges.sort_by(|a, b| a.partial_cmp(b).unwrap());
-      let num_bins = edges.len() - 1;
-      let mut cnts = vec![0usize; num_bins];
-      for &v in values {
-        // Find the bin for this value
-        for i in 0..num_bins {
-          let in_bin = if i == num_bins - 1 {
-            v >= edges[i] && v <= edges[i + 1]
-          } else {
-            v >= edges[i] && v < edges[i + 1]
-          };
-          if in_bin {
-            cnts[i] += 1;
-            break;
-          }
-        }
-      }
-      (edges, cnts)
-    }
-    _ => {
-      // Use provided bin count or fall back to Sturges' rule
-      let n = values.len();
-      let num_bins = match &bin_spec {
-        Some(BinSpec::Count(c)) => *c,
-        _ => ((1.0 + (n as f64).log2()).ceil() as usize).max(1),
-      };
-      let d_min = values.iter().cloned().fold(f64::INFINITY, f64::min);
-      let d_max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-      let range = d_max - d_min;
-      let bin_width = if range.abs() < f64::EPSILON {
-        1.0
-      } else {
-        range / num_bins as f64
-      };
+  // Shared bin edges spanning every dataset, then per-dataset counts and
+  // bar heights (heights depend on the height spec: Count, PDF, …).
+  let all_values: Vec<f64> =
+    datasets.iter().flat_map(|d| d.iter().copied()).collect();
+  let bin_edges = histogram_bin_edges(&all_values, &bin_spec);
+  let num_bins = bin_edges.len().saturating_sub(1);
+  if num_bins == 0 {
+    return Ok("<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>".to_string());
+  }
+  let dataset_counts: Vec<Vec<usize>> = datasets
+    .iter()
+    .map(|d| histogram_bin_counts(d, &bin_edges))
+    .collect();
+  let dataset_heights: Vec<Vec<f64>> = dataset_counts
+    .iter()
+    .map(|c| histogram_bin_heights(c, &bin_edges, height))
+    .collect();
 
-      let mut cnts = vec![0usize; num_bins];
-      for &v in values {
-        let idx = ((v - d_min) / bin_width).floor() as usize;
-        cnts[idx.min(num_bins - 1)] += 1;
-      }
-
-      let edges: Vec<f64> = (0..=num_bins)
-        .map(|i| d_min + i as f64 * bin_width)
-        .collect();
-      (edges, cnts)
-    }
-  };
-
-  let num_bins = counts.len();
   // A named ChartStyle scheme colors each bin with a distinct sampled color.
   crate::functions::chart::apply_color_scheme(opts, num_bins);
-  let max_count = *counts.iter().max().unwrap_or(&1);
+  let max_height = dataset_heights
+    .iter()
+    .flat_map(|h| h.iter().copied())
+    .fold(0.0_f64, f64::max);
+  let max_height = if max_height > 0.0 { max_height } else { 1.0 };
 
   // Explicit PlotRange overrides the auto-computed extents (10% headroom
   // above the tallest bar, bins spanning exactly the edge range).
-  let (y_min, y_max) =
-    opts.plot_range_y.unwrap_or((0.0, max_count as f64 * 1.1));
+  let (y_min, y_max) = opts.plot_range_y.unwrap_or((0.0, max_height * 1.1));
   let y_max = if y_max <= y_min { y_min + 1.0 } else { y_max };
   let (x_lo, x_hi) = opts
     .plot_range_x
@@ -4540,28 +4709,45 @@ pub(crate) fn generate_histogram_svg(
     // Draw contiguous histogram bars using plotters Rectangles.
     // ChartStyle colors cycle per bin (matching BarChart's per-element
     // convention); the default is a single uniform color.
-    for (i, &count) in counts.iter().enumerate() {
-      let (r, g, b) = if !opts.chart_style.is_empty() {
-        let c = &opts.chart_style[i % opts.chart_style.len()];
+    // With one dataset, ChartStyle colors cycle per bin (matching BarChart);
+    // the default is a single uniform color. With several datasets, each is
+    // drawn in its own color and overlaid semi-transparently so overlapping
+    // bars stay visible.
+    let multi = dataset_heights.len() > 1;
+    let style_color = |idx: usize| -> (u8, u8, u8) {
+      if !opts.chart_style.is_empty() {
+        let c = &opts.chart_style[idx % opts.chart_style.len()];
         (
           (c.r.clamp(0.0, 1.0) * 255.0).round() as u8,
           (c.g.clamp(0.0, 1.0) * 255.0).round() as u8,
           (c.b.clamp(0.0, 1.0) * 255.0).round() as u8,
         )
+      } else if multi {
+        PLOT_COLORS[idx % PLOT_COLORS.len()]
       } else {
         PLOT_COLORS[0]
-      };
-      let color = RGBColor(r, g, b);
-      let bx0 = bin_edges[i];
-      let bx1 = bin_edges[i + 1];
-      chart
-        .draw_series(std::iter::once(Rectangle::new(
-          [(bx0, 0.0), (bx1, count as f64)],
-          color.filled(),
-        )))
-        .map_err(|e| {
-          InterpreterError::EvaluationError(format!("Histogram: {e}"))
-        })?;
+      }
+    };
+    for (di, heights) in dataset_heights.iter().enumerate() {
+      for (i, &h) in heights.iter().enumerate() {
+        let (r, g, b) = if multi { style_color(di) } else { style_color(i) };
+        let color = RGBColor(r, g, b);
+        let bx0 = bin_edges[i];
+        let bx1 = bin_edges[i + 1];
+        let fill: ShapeStyle = if multi {
+          color.mix(0.55).filled()
+        } else {
+          color.filled()
+        };
+        chart
+          .draw_series(std::iter::once(Rectangle::new(
+            [(bx0, 0.0), (bx1, h)],
+            fill,
+          )))
+          .map_err(|e| {
+            InterpreterError::EvaluationError(format!("Histogram: {e}"))
+          })?;
+      }
     }
 
     root.present().map_err(|e| {
@@ -4571,14 +4757,16 @@ pub(crate) fn generate_histogram_svg(
 
   add_bar_borders(&mut buf, RESOLUTION_SCALE);
 
-  // Inject hover tooltips with bin range and count into histogram rects
-  let hist_tooltips: Vec<String> = counts
+  // Inject hover tooltips with bin range and count into histogram rects.
+  // Order matches the draw order above (dataset-major, then bin).
+  let hist_tooltips: Vec<String> = dataset_counts
     .iter()
-    .enumerate()
-    .map(|(i, &c)| {
-      let lo = format_tooltip_value(bin_edges[i]);
-      let hi = format_tooltip_value(bin_edges[i + 1]);
-      format!("[{lo}, {hi}): {c}")
+    .flat_map(|counts| {
+      counts.iter().enumerate().map(|(i, &c)| {
+        let lo = format_tooltip_value(bin_edges[i]);
+        let hi = format_tooltip_value(bin_edges[i + 1]);
+        format!("[{lo}, {hi}): {c}")
+      })
     })
     .collect();
   inject_bar_tooltips_str(&mut buf, &hist_tooltips);

--- a/tests/cli/plotting/Histogram.md
+++ b/tests/cli/plotting/Histogram.md
@@ -7,7 +7,25 @@ $ wo 'Head[Histogram[{1, 2, 2, 3, 3, 3}]]'
 Graphics
 ```
 
+A bin specification and a height specification may follow the data.
+`{w}` sets the bin width and `"PDF"` normalizes the bars to a probability
+density:
+
+```scrut
+$ wo 'Head[Histogram[{1, 2, 2, 3, 3, 3}, {1}, "PDF"]]'
+Graphics
+```
+
+Several datasets (a list of lists) are drawn as overlaid histograms:
+
+```scrut
+$ wo 'Head[Histogram[{{1, 2, 2, 3}, {5, 6, 6, 7}}]]'
+Graphics
+```
+
 Same options as `BarChart`, plus:
 
-- **`Bins`** — `Automatic`, an integer (number of bins),
-  or a list of bin edges.
+- **`Bins`** — `Automatic`, an integer (number of bins), a bin width `{w}`,
+  or a list of bin edges `{{e1, e2, ...}}`.
+- **Height spec** — `"Count"` (default), `"PDF"`, `"Probability"`,
+  `"CumulativeCount"`, or `"CDF"`.

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -5256,6 +5256,35 @@ mod random_integer {
       "{{}, {}, {}}"
     );
   }
+
+  #[test]
+  fn distribution_single() {
+    // RandomInteger[dist] samples one integer from the distribution
+    // (identical to RandomVariate for discrete distributions).
+    let v: i128 = interpret("RandomInteger[PoissonDistribution[10]]")
+      .unwrap()
+      .parse()
+      .unwrap();
+    assert!(v >= 0, "Poisson sample must be non-negative");
+  }
+
+  #[test]
+  fn distribution_count() {
+    // Regression: `RandomInteger[PoissonDistribution[10], 1000]` used to
+    // error with "invalid range"; it must sample 1000 integers instead.
+    assert_eq!(
+      interpret("Length[RandomInteger[PoissonDistribution[10], 1000]]")
+        .unwrap(),
+      "1000"
+    );
+    assert_eq!(
+      interpret(
+        "AllTrue[RandomInteger[PoissonDistribution[5], 200], IntegerQ[#] && # >= 0 &]"
+      )
+      .unwrap(),
+      "True"
+    );
+  }
 }
 
 mod distributions {


### PR DESCRIPTION
## Summary

This PR extends `Histogram` to support multiple height specifications (Count, PDF, Probability, CumulativeCount, CDF) and enables rendering multiple datasets as overlaid histograms. It also adds bin width specification via `{w}` syntax and improves integration with `Show[]` for overlaying histograms with plots.

## Key Changes

- **Height specifications**: Added `HistogramHeight` enum with five variants (Count, CumulativeCount, Probability, PDF, CDF) to control how bar heights are computed. Bars can now be normalized to probability densities, cumulative fractions, or raw counts.

- **Bin width support**: Extended `BinSpec` with a `Width(f64)` variant. Bin boundaries are aligned to multiples of the width (Wolfram convention), so `{1}` yields unit-aligned bins.

- **Multi-dataset histograms**: `Histogram` now accepts a list of lists to render multiple datasets as overlaid, semi-transparent bars. Each dataset uses a distinct color from the default plot palette.

- **Refactored histogram computation**: Extracted bin edge calculation, counting, and height computation into separate functions (`histogram_bin_edges`, `histogram_bin_counts`, `histogram_bin_heights`) for clarity and reusability.

- **PlotSource integration**: Added `histogram_plot_source()` to generate a `PlotSource` describing histogram bars as filled step-outline series, enabling `Show[Histogram[...], Plot[...]]` to overlay bars and curves in a shared coordinate system.

- **ColorData support**: Implemented `ColorData[97, "ColorList"]` to return the default plot palette (10 colors), matching Wolfram's indexed color scheme.

- **RandomInteger distribution sampling**: Fixed `RandomInteger[dist, n]` to delegate to `RandomVariate` for discrete distributions, allowing sampling from distributions like `PoissonDistribution`.

## Notable Implementation Details

- Bin edges are computed once across all datasets to ensure consistent binning.
- Multi-dataset rendering uses semi-transparent fills (55% opacity) to keep overlapping bars visible.
- Height specs are parsed from string arguments ("PDF", "Count", etc.) with fallback to Count.
- Tooltip generation now iterates dataset-major then bin-major to match the draw order.
- The `parse_bin_spec()` function handles `{w}`, `{{e1, e2, ...}}`, and `{min, max, w}` syntaxes.

## Tests Added

- `histogram_bin_width`: Verifies `{w}` syntax produces correct number of bins.
- `histogram_grouped_datasets`: Regression test for multi-dataset rendering.
- `histogram_pdf_height_spec`: Verifies PDF normalization produces fractional heights.
- `show_histogram_with_plot_overlays_both`: Regression test for `Show[Histogram[...], Plot[...]]` overlay.
- `distribution_single` and `distribution_count`: Regression tests for `RandomInteger[dist, n]`.
- `color_data_indexed_color_list`: Verifies `ColorData[97, "ColorList"]` output.

https://claude.ai/code/session_01TyNzRQ5DfDzhyy1UfDFJ1u