### PR TITLE
Fix Power[BigInteger, -1] to fold to Rational (issue #215)

### DIFF
--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -9407,6 +9407,21 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     }
   }
 
+  // BigInteger base with negative integer exponent -> Rational. Mirrors the
+  // Integer case above so a reciprocal like `Power[BigInteger(6), -1]` folds to
+  // `1/6` rather than lingering as an unevaluated Power. Without this, a
+  // polynomial-over-factorial such as LaguerreL[3, x] (denominator built as a
+  // BigInteger) left a `Power[6, -1]` factor that failed to cancel after a
+  // numeric substitution, e.g. `LaguerreL[3, x] /. x -> 3` printing `6/6`.
+  if let (Expr::BigInteger(b), Expr::Integer(e)) = (base, exp)
+    && *e < 0
+    && *b != num_bigint::BigInt::from(0)
+  {
+    let pos_exp = (-*e) as u32;
+    let denom = num_traits::pow::pow(b.clone(), pos_exp as usize);
+    return Ok(make_rational_expr(num_bigint::BigInt::from(1), denom));
+  }
+
   // Special case: Rational^Integer -> exact rational result
   if let Expr::FunctionCall {
     name: rname,

--- a/tests/cli/math/special/LaguerreL.md
+++ b/tests/cli/math/special/LaguerreL.md
@@ -6,3 +6,11 @@ Laguerre polynomial.
 $ wo 'LaguerreL[2, x]'
 (2 - 4*x + x^2)/2
 ```
+
+Substituting a value into the symbolic polynomial reduces to the same number
+as evaluating it directly (issue #215):
+
+```scrut
+$ wo 'LaguerreL[3, x] /. x -> 3'
+1
+```

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -722,6 +722,19 @@ mod big_integer {
   }
 
   #[test]
+  fn big_reciprocal_folds_to_rational() {
+    // A negative exponent on a BigInteger base (2^130 exceeds i128) must fold
+    // to an exact Rational, mirroring the Integer-base case, instead of
+    // lingering as an unevaluated `...^(-1)` Power. Regression for issue #215
+    // (which surfaced this as LaguerreL[3, x] /. x -> 3 printing `6/6`).
+    assert_eq!(
+      interpret("Power[2^130, -1]").unwrap(),
+      "1/1361129467683753853853498429727072845824"
+    );
+    assert_eq!(interpret("Power[2^130, -1] * 2^130").unwrap(), "1");
+  }
+
+  #[test]
   fn large_i128_subtraction() {
     // 2^67 fits in i128 but exceeds f64 precision (> 2^53)
     assert_eq!(interpret("2^67 - 1").unwrap(), "147573952589676412927");

--- a/tests/interpreter_tests/math/special_functions.rs
+++ b/tests/interpreter_tests/math/special_functions.rs
@@ -3372,6 +3372,31 @@ mod laguerre_l {
     assert_eq!(interpret("LaguerreL[3, 1/2]").unwrap(), "-7/48");
   }
 
+  // Substituting a value into the symbolic polynomial must reduce to the same
+  // number the direct numeric path gives. The polynomial is built over its
+  // factorial denominator (a BigInteger), and `Power[BigInteger, -1]` used to
+  // linger unevaluated, so `LaguerreL[3, x] /. x -> 3` printed `6/6` instead of
+  // `1`. Regression for issue #215.
+  #[test]
+  fn substitute_reduces_like_direct_eval() {
+    assert_eq!(interpret("LaguerreL[3, x] /. x -> 3").unwrap(), "1");
+    assert_eq!(
+      interpret("LaguerreL[3, x] /. x -> 3").unwrap(),
+      interpret("LaguerreL[3, 3]").unwrap()
+    );
+  }
+
+  // Same reduction for a degree whose factorial denominator (35! here) exceeds
+  // i128, so the BigInteger reciprocal path is genuinely exercised. The
+  // symbolic-then-substitute path must agree with the direct rational path.
+  #[test]
+  fn substitute_reduces_large_n() {
+    assert_eq!(
+      interpret("LaguerreL[35, x] /. x -> 2").unwrap(),
+      interpret("LaguerreL[35, 2]").unwrap()
+    );
+  }
+
   // Non-integer (rational) n routes through the
   // `LaguerreL[n, x] = Hypergeometric1F1[-n, 1, x]` identity.
   // Regression for mathics specialfns/orthogonal.py:144.


### PR DESCRIPTION
## Summary

Fix a bug where `Power[BigInteger, -1]` would linger as an unevaluated expression instead of folding to a `Rational`, causing symbolic polynomial substitutions to fail to simplify correctly. This affected functions like `LaguerreL` that build polynomials with factorial denominators as `BigInteger` values.

## Key Changes

- **arithmetic.rs**: Added handling for `BigInteger` base with negative integer exponent to fold to `Rational`, mirroring the existing `Integer` case. This ensures expressions like `Power[BigInteger(6), -1]` reduce to `1/6` immediately.

- **special_functions.rs**: Added regression tests verifying that substituting a value into a symbolic Laguerre polynomial reduces to the same result as direct evaluation:
  - `LaguerreL[3, x] /. x -> 3` now correctly evaluates to `1` instead of `6/6`
  - Added test for large `n` (35) where the factorial denominator exceeds i128, ensuring the BigInteger reciprocal path is properly exercised

- **arithmetic.rs (tests)**: Added unit test confirming `Power[2^130, -1]` folds to the correct rational and cancels properly when multiplied back

- **LaguerreL.md**: Added documentation example showing the fix in action

## Implementation Details

The fix mirrors the existing `Integer` case in `power_two()`: when a `BigInteger` is raised to a negative integer exponent, compute the positive power and return `1/result` as a `Rational`. This ensures that polynomials built over factorial denominators (stored as `BigInteger`) properly simplify after numeric substitution, allowing rational cancellation to occur as expected.

https://claude.ai/code/session_019fCd2vUZGsKfs6wVgNuatu