### PR TITLE
Fix Accumulate real promotion and Discriminant degree-0 case

### DIFF
--- a/src/functions/list_helpers_ast/functional.rs
+++ b/src/functions/list_helpers_ast/functional.rs
@@ -286,36 +286,21 @@ pub fn accumulate_ast(list: &Expr) -> Result<Expr, InterpreterError> {
     return Ok(wrap(Vec::new()));
   }
 
-  // Try numeric accumulation first
-  let all_numeric = items.iter().all(|item| expr_to_f64(item).is_some());
-
-  if all_numeric {
-    let has_real = items.iter().any(|item| matches!(item, Expr::Real(_)));
-    let mut sum = 0.0;
-    let mut results = Vec::new();
-    for item in items {
-      sum += expr_to_f64(item).unwrap();
-      if has_real {
-        results.push(Expr::Real(sum));
-      } else {
-        results.push(f64_to_expr(sum));
-      }
-    }
-    Ok(wrap(results))
-  } else {
-    // Symbolic accumulation using Plus
-    let mut results = Vec::new();
-    let mut running_sum = items[0].clone();
+  // Accumulate via Plus so each partial sum keeps exact arithmetic and is
+  // promoted element-by-element: a prefix summing only integers stays an
+  // integer, and a Real (or Rational) only affects the sums it enters —
+  // matching Wolfram's Accumulate[{4, -50, 20.0, 12.6}] = {4, -46, -26., -13.4}.
+  let mut results = Vec::new();
+  let mut running_sum = items[0].clone();
+  results.push(running_sum.clone());
+  for item in &items[1..] {
+    running_sum = crate::evaluator::evaluate_function_call_ast(
+      "Plus",
+      &[running_sum, item.clone()],
+    )?;
     results.push(running_sum.clone());
-    for item in &items[1..] {
-      running_sum = crate::evaluator::evaluate_function_call_ast(
-        "Plus",
-        &[running_sum, item.clone()],
-      )?;
-      results.push(running_sum.clone());
-    }
-    Ok(wrap(results))
   }
+  Ok(wrap(results))
 }
 
 /// AST-based Differences: successive differences.

--- a/src/functions/polynomial_ast/discriminant.rs
+++ b/src/functions/polynomial_ast/discriminant.rs
@@ -3,6 +3,15 @@ use super::*;
 use crate::InterpreterError;
 use crate::syntax::Expr;
 
+/// True when `e` is a numeric literal equal to zero (integer or real).
+fn is_zero_const(e: &Expr) -> bool {
+  match e {
+    Expr::Integer(0) => true,
+    Expr::Real(r) => *r == 0.0,
+    _ => false,
+  }
+}
+
 /// Discriminant[poly, var] - polynomial discriminant
 /// Disc(p, x) = (-1)^(n(n-1)/2) / a_n * Resultant(p, p', x)
 pub fn discriminant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -43,13 +52,6 @@ pub fn discriminant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   };
 
-  // Compute derivative p'(x)
-  let dpoly =
-    crate::functions::calculus_ast::differentiate_expr(poly, var_name)?;
-
-  // Compute Resultant(p, p', x)
-  let res = super::resultant_ast(&[poly.clone(), dpoly, var.clone()])?;
-
   // Get degree and leading coefficient
   let expanded = expand_and_combine(poly);
   let degree = match max_power_int(&expanded, var_name) {
@@ -67,6 +69,32 @@ pub fn discriminant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     var.clone(),
     Expr::Integer(degree),
   ])?;
+
+  // Degree 0: the resultant formula does not apply (p' = 0). Following the
+  // root-product form disc = (-1)^(n(n-1)/2) a_n^(2n-2) prod_{i<j}(r_i-r_j)^2,
+  // the empty product leaves a_0^(2*0-2) = a_0^(-2); the zero polynomial is
+  // special-cased to 0 (matching Wolfram).
+  if degree == 0 {
+    if is_zero_const(&leading_coeff) {
+      return Ok(Expr::Integer(0));
+    }
+    let inv_sq = Expr::FunctionCall {
+      name: "Power".to_string(),
+      args: vec![leading_coeff, Expr::Integer(-2)].into(),
+    };
+    let simplified = crate::evaluator::evaluate_expr_to_expr(&inv_sq)?;
+    return match super::cancel_ast(&[simplified.clone()]) {
+      Ok(c) => Ok(c),
+      Err(_) => Ok(simplified),
+    };
+  }
+
+  // Compute derivative p'(x)
+  let dpoly =
+    crate::functions::calculus_ast::differentiate_expr(poly, var_name)?;
+
+  // Compute Resultant(p, p', x)
+  let res = super::resultant_ast(&[poly.clone(), dpoly, var.clone()])?;
 
   // sign = (-1)^(n*(n-1)/2)
   let sign_exp = degree * (degree - 1) / 2;

--- a/tests/cli/list/statistics/Accumulate.md
+++ b/tests/cli/list/statistics/Accumulate.md
@@ -37,6 +37,14 @@ $ wo 'Accumulate[{1.5, 2.5}]'
 {1.5, 4.}
 ```
 
+A real value only promotes the partial sums it enters, so earlier
+integer prefixes stay exact:
+
+```scrut
+$ wo 'Accumulate[{4, -50, 20.0, 12.6}]'
+{4, -46, -26., -13.4}
+```
+
 ```scrut
 $ wo 'Accumulate[{0, 0, 1}]'
 {0, 0, 1}

--- a/tests/cli/math/polynomials/Discriminant.md
+++ b/tests/cli/math/polynomials/Discriminant.md
@@ -6,3 +6,16 @@ Discriminant of a polynomial.
 $ wo 'Discriminant[x^2 + b x + c, x]'
 b^2 - 4*c
 ```
+
+A degree-0 (constant) polynomial has discriminant `a^(-2)`, with the
+zero polynomial special-cased to `0`:
+
+```scrut
+$ wo 'Discriminant[3, x]'
+1/9
+```
+
+```scrut
+$ wo 'Discriminant[0, x]'
+0
+```

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -8540,6 +8540,27 @@ mod join_non_list {
   }
 
   #[test]
+  fn accumulate_promotes_reals_per_partial_sum() {
+    // Regression (diff-fuzz): a Real must only promote the partial sums it
+    // actually enters. Prefixes summing only integers stay exact integers,
+    // so 4 and -46 remain integers while later sums become reals.
+    assert_eq!(
+      interpret("Accumulate[{4, -50, 20.0, 12.6}]").unwrap(),
+      "{4, -46, -26., -13.4}"
+    );
+    assert_eq!(interpret("Accumulate[{0, 12.6}]").unwrap(), "{0, 12.6}");
+    assert_eq!(
+      interpret("Accumulate[{2, 3, 4.0, 5, 6.0}]").unwrap(),
+      "{2, 5, 9., 14., 20.}"
+    );
+    // Exact rationals stay exact rather than collapsing to floats.
+    assert_eq!(
+      interpret("Accumulate[{1/2, 1/3, 1/6}]").unwrap(),
+      "{1/2, 5/6, 1}"
+    );
+  }
+
+  #[test]
   fn accumulate_preserves_arbitrary_head() {
     // Accumulate threads through any head (not just List), preserving it.
     assert_eq!(

--- a/tests/interpreter_tests/special_functions.rs
+++ b/tests/interpreter_tests/special_functions.rs
@@ -1762,6 +1762,21 @@ mod discriminant {
   }
 
   #[test]
+  fn degree_zero_constant() {
+    // Regression (diff-fuzz): the resultant formula does not apply when the
+    // polynomial has degree 0 (p' = 0). The root-product form leaves
+    // a_0^(2n-2) = a_0^(-2); the zero polynomial is special-cased to 0.
+    assert_eq!(interpret("Discriminant[3, x]").unwrap(), "1/9");
+    assert_eq!(interpret("Discriminant[1/2, x]").unwrap(), "4");
+    assert_eq!(interpret("Discriminant[-4, x]").unwrap(), "1/16");
+    assert_eq!(interpret("Discriminant[2.0, x]").unwrap(), "0.25");
+    assert_eq!(interpret("Discriminant[a, x]").unwrap(), "a^(-2)");
+    assert_eq!(interpret("Discriminant[0, x]").unwrap(), "0");
+    // Reduces to degree 0 after the zero-coefficient term cancels.
+    assert_eq!(interpret("Discriminant[3 + 0 x, x]").unwrap(), "1/9");
+  }
+
+  #[test]
   fn attributes() {
     assert_eq!(
       interpret("Attributes[Discriminant]").unwrap(),


### PR DESCRIPTION
## Summary

Two more divergences from the differential fuzzer (`make fuzz-diff`), fixed and verified byte-for-byte against `wolframscript`. Follow-up to #212, built fresh on top of the squash-merged `main`.

### `Accumulate` — per-partial-sum real promotion (`src/functions/...`)
`Accumulate` now folds through `Plus`, so each partial sum keeps exact arithmetic and promotes element-by-element rather than converting the whole list to `f64` when any element is a `Real`.

- `Accumulate[{4, -50, 20.0, 12.6}]` → `{4, -46, -26., -13.4}` — the integer-only prefixes stay exact integers; a `Real` only affects the sums it enters.
- `Accumulate[{1/2, 1/3, 1/6}]` → `{1/2, 5/6, 1}` — rational prefixes stay exact.

### `Discriminant` — degree-0 convention
The resultant formula needs `p'`, which is `0` for a constant, so degree 0 is special-cased following the root-product form `disc = (-1)^(n(n-1)/2) · a_n^(2n-2) · ∏(r_i − r_j)^2`: the empty product leaves `a_0^(-2)`, and the zero polynomial is special-cased to `0`.

- `Discriminant[3, x]` → `1/9`
- `Discriminant[a, x]` → `a^(-2)`
- `Discriminant[0, x]` → `0`

## Testing

- New unit tests plus `scrut` CLI doc-test cases for both functions, each verified against `wolframscript`.
- Full suite green: **23,556 tests pass** on the current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt

---
_Generated by [Claude Code](https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt)_