### PR TITLE
Fix Cancel/Together reciprocal canonicalization for unit numerators

### DIFF
--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -8151,14 +8151,62 @@ pub fn make_divide(a: Expr, b: Expr) -> Expr {
   if matches!(&a, Expr::Integer(0)) {
     return Expr::Integer(0);
   }
+  // 1 / b → Power[b, -1]
+  if matches!(&a, Expr::Integer(1)) {
+    // 1 / (c * rest) → (1/c) * rest^(-1): the integer content shows as a
+    // rational coefficient rather than staying inside the reciprocal base.
+    // Wolfram never displays (2*(-1+2*x))^(-1); it is 1/(2*(-1+2*x)) — the
+    // same form the evaluator yields for Power[c*rest, -1]. Cancel/Together
+    // build this quotient directly (via make_divide) without re-evaluating,
+    // so the split has to happen here.
+    if let Expr::FunctionCall { name, args } = &b
+      && name == "Times"
+    {
+      let mut int_prod: i128 = 1;
+      let mut rest: Vec<Expr> = Vec::new();
+      for f in args.iter() {
+        match f {
+          Expr::Integer(n) => int_prod = int_prod.saturating_mul(*n),
+          other => rest.push(other.clone()),
+        }
+      }
+      if int_prod != 0 && int_prod.unsigned_abs() != 1 && !rest.is_empty() {
+        let rest_expr = if rest.len() == 1 {
+          rest.remove(0)
+        } else {
+          Expr::FunctionCall {
+            name: "Times".to_string(),
+            args: rest.into(),
+          }
+        };
+        let rest_inv = Expr::FunctionCall {
+          name: "Power".to_string(),
+          args: vec![rest_expr, Expr::Integer(-1)].into(),
+        };
+        // Sign is carried on the rational's numerator (Rational[-1, |c|]).
+        let coeff = Expr::FunctionCall {
+          name: "Rational".to_string(),
+          args: vec![
+            Expr::Integer(int_prod.signum()),
+            Expr::Integer(int_prod.abs()),
+          ]
+          .into(),
+        };
+        return Expr::FunctionCall {
+          name: "Times".to_string(),
+          args: vec![coeff, rest_inv].into(),
+        };
+      }
+    }
+    return Expr::FunctionCall {
+      name: "Power".to_string(),
+      args: vec![b, Expr::Integer(-1)].into(),
+    };
+  }
   let b_inv = Expr::FunctionCall {
     name: "Power".to_string(),
     args: vec![b, Expr::Integer(-1)].into(),
   };
-  // 1 / b → Power[b, -1]
-  if matches!(&a, Expr::Integer(1)) {
-    return b_inv;
-  }
   // Flatten: if a is already Times, merge b_inv into its args
   if let Expr::FunctionCall { name, args } = &a
     && name == "Times"

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -512,6 +512,30 @@ pub(super) fn canonicalize_quotient_sign(
     }
   }
   if !flipped_any {
+    // Cancel and Together fold a bare unit-negative reciprocal into its
+    // base: -1/(1+x) → (-1-x)^(-1) and -1/(-1+x) → (1-x)^(-1). (Simplify
+    // keeps -(1+x)^(-1), so this is gated to the non-Simplify callers.)
+    // Only fires when the numerator is exactly -1 and the denominator is a
+    // single sum: a product denominator keeps a rational coefficient
+    // (-1/(2+2x) → -1/2*1/(1+x)), and a negative-content sum was already
+    // handled by the flip above.
+    let den_is_bare_sum = matches!(
+      den,
+      Expr::BinaryOp {
+        op: BinaryOperator::Plus,
+        ..
+      }
+    ) || matches!(den, Expr::FunctionCall { name, .. } if name == "Plus");
+    if !require_negative_numerator
+      && matches!(num, Expr::Integer(-1))
+      && den_is_bare_sum
+    {
+      return Some(Expr::BinaryOp {
+        op: BinaryOperator::Power,
+        left: Box::new(negate(den)),
+        right: Box::new(Expr::Integer(-1)),
+      });
+    }
     return None;
   }
   if sign < 0 && matches!(num, Expr::Integer(1)) {
@@ -583,16 +607,18 @@ pub(super) fn canonicalize_quotient_sign(
     });
   };
   // A numerator flipped to exactly 1 displays as a reciprocal power:
-  // Simplify[-1/(1-x)] → (-1+x)^(-1).
-  if matches!(&new_num, Expr::Integer(1))
-    && !matches!(
-      &new_den,
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        ..
-      }
-    )
-  {
+  // Simplify[-1/(1-x)] → (-1+x)^(-1). A product denominator stays a
+  // quotient (1/(2*(-1+2*x)), never (2*(-1+2*x))^(-1)) — the numeric
+  // content must show as a rational coefficient, so exclude a Times
+  // denominator in either representation (BinaryOp or FunctionCall).
+  let den_is_product = matches!(
+    &new_den,
+    Expr::BinaryOp {
+      op: BinaryOperator::Times,
+      ..
+    }
+  ) || matches!(&new_den, Expr::FunctionCall { name, .. } if name == "Times");
+  if matches!(&new_num, Expr::Integer(1)) && !den_is_product {
     return Some(Expr::BinaryOp {
       op: BinaryOperator::Power,
       left: Box::new(new_den),

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -1833,6 +1833,38 @@ mod cancel {
     assert_eq!(interpret("Cancel[2/(2 - 2 x)]").unwrap(), "(1 - x)^(-1)");
     assert_eq!(interpret("Cancel[1/(1 - x)]").unwrap(), "(1 - x)^(-1)");
   }
+
+  // Regression (diff-fuzz seed 1783624199336595105): a reciprocal whose
+  // numerator cancels to 1 over a denominator carrying integer content
+  // keeps the content as a rational coefficient — 1/(2*(-1+2*x)), never
+  // (2*(-1+2*x))^(-1) — and a bare -1 numerator folds into a sum
+  // denominator: -1/(1+x) → (-1-x)^(-1). All wolframscript-verified.
+  #[test]
+  fn unit_numerator_reciprocal_forms() {
+    // Integer content stays a rational coefficient, not inside the power.
+    assert_eq!(
+      interpret("Cancel[-1/(2 - 4 x)]").unwrap(),
+      "1/(2*(-1 + 2*x))"
+    );
+    assert_eq!(
+      interpret("Cancel[-1/(3 - 6 x)]").unwrap(),
+      "1/(3*(-1 + 2*x))"
+    );
+    // A bare -1 numerator folds into a sum denominator.
+    assert_eq!(interpret("Cancel[-1/(1 + x)]").unwrap(), "(-1 - x)^(-1)");
+    assert_eq!(interpret("Cancel[-1/(2 + x)]").unwrap(), "(-2 - x)^(-1)");
+    assert_eq!(interpret("Cancel[-1/(x + y)]").unwrap(), "(-x - y)^(-1)");
+    assert_eq!(interpret("Cancel[-1/(-1 + x)]").unwrap(), "(1 - x)^(-1)");
+    assert_eq!(interpret("Together[-1/(1 + x)]").unwrap(), "(-1 - x)^(-1)");
+    // Boundaries: a product denominator keeps its rational coefficient, a
+    // non-unit numerator is untouched, and Simplify does NOT fold.
+    assert_eq!(
+      interpret("Cancel[-1/(2 + 2 x)]").unwrap(),
+      "-1/2*1/(1 + x)"
+    );
+    assert_eq!(interpret("Cancel[-2/(1 + x)]").unwrap(), "-2/(1 + x)");
+    assert_eq!(interpret("Simplify[-1/(1 + x)]").unwrap(), "-(1 + x)^(-1)");
+  }
 }
 
 mod expand_modulus {


### PR DESCRIPTION
## Summary

`make fuzz-diff` on the latest `main` surfaced a `Cancel` divergence (seed `1783624199336595105`): reciprocal forms that are mathematically equal to `wolframscript` but structurally different.

| Input | woxi (before) | wolframscript |
|---|---|---|
| `Cancel[-1/(2 - 4 x)]` | `(2*(-1 + 2*x))^(-1)` | `1/(2*(-1 + 2*x))` |
| `Cancel[-1/(1 + x)]` (shrunk) | `-(1 + x)^(-1)` | `(-1 - x)^(-1)` |

## Fixes

- **`canonicalize_quotient_sign` collapse guard** — the "numerator flipped to 1 → `poly^(-1)`" step only excluded a `BinaryOp` `Times` denominator, so the integer-content-split denominator (a `FunctionCall` `Times`) wrongly collapsed `1/(2·poly)` into `(2·poly)^(-1)`. Now excludes both `Times` representations, keeping the content as a rational coefficient.
- **Unit-negative fold** — Cancel and Together fold a bare `-1` numerator into a sum denominator (`-1/(1+x)` → `(-1-x)^(-1)`, `-1/(-1+x)` → `(1-x)^(-1)`), while **Simplify does not**. Added that fold gated on `require_negative_numerator` (the non-Simplify callers), only for an exact `-1` over a single sum — a product denominator keeps `-1/2*1/(1+x)`, and a negative-content sum was already handled by the existing flip.
- **`make_divide`** — now splits integer content out of `1/(c·rest)` → `(1/c)·rest^(-1)`, matching what the evaluator yields for `Power[c·rest, -1]`, so callers building a quotient directly never emit `(c·rest)^(-1)`.

## Testing

- New regression test `unit_numerator_reciprocal_forms` (covers both fixed forms plus the boundary cases: product denominator, non-unit numerator, and that Simplify still keeps `-(1+x)^(-1)`), all `wolframscript`-verified.
- Full suite green: **23,557 tests pass**.
- Fuzzer replay on the original seed now reports **0 divergences**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt

---
_Generated by [Claude Code](https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt)_