### PR TITLE
Match wolframscript's multiply-by-reciprocal machine division

### DIFF
--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -7952,7 +7952,24 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
       if y == 0.0 {
         Ok(divide_by_zero_result(a))
       } else {
-        Ok(Expr::Real(x / y))
+        // Wolfram evaluates division a/b as Times[a, Power[b, -1]]. When the
+        // denominator is an exact number (Integer/Rational) its reciprocal is an
+        // exact rational, so the product is single-rounded — identical to a
+        // direct IEEE division (e.g. CentralMoment's sum/n). But when the
+        // denominator is inexact — a machine Real, or an irrational constant like
+        // Pi or Sqrt[2] whose reciprocal must itself be rounded to a machine real
+        // first — the reciprocal introduces a second rounding, landing one ULP
+        // away from `x / y` for roughly half of all operand pairs. Mirror that
+        // multiply-by-reciprocal so results match wolframscript byte-for-byte
+        // (e.g. 15.9/Pi, 13.52.../84.75...) without perturbing exact-denominator
+        // divisions.
+        let den_is_exact = matches!(b, Expr::Integer(_))
+          || matches!(b, Expr::FunctionCall { name, .. } if name == "Rational");
+        if den_is_exact {
+          Ok(Expr::Real(x / y))
+        } else {
+          Ok(Expr::Real(x * (1.0 / y)))
+        }
       }
     }
     _ => {

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -1115,10 +1115,19 @@ fn incomplete_beta_ast(
         "Times",
         &[signed_coeff, z_pow],
       )?;
-      let summand = crate::evaluator::evaluate_function_call_ast(
-        "Divide",
-        &[numer, denom],
-      )?;
+      // This closed form is an internal numerical routine, not a user-level
+      // Divide: when both operands are machine reals compute the quotient with a
+      // plain (single-rounded) division. The language-level Divide models
+      // wolframscript's Times[a, Power[b, -1]] multiply-by-reciprocal, which
+      // would add a second rounding here and drift the incomplete-Beta value one
+      // ULP away from wolframscript (e.g. N[Beta[2, 1/2, 3]]).
+      let summand = match (&numer, &denom) {
+        (Expr::Real(nf), Expr::Real(df)) => Expr::Real(nf / df),
+        _ => crate::evaluator::evaluate_function_call_ast(
+          "Divide",
+          &[numer, denom],
+        )?,
+      };
       term.push(summand);
     }
     let closed = crate::evaluator::evaluate_function_call_ast("Plus", &term)?;

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -3495,22 +3495,48 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let m3 = central_moment_ast(&[args[0].clone(), Expr::Integer(3)])?;
   let m2 = central_moment_ast(&[args[0].clone(), Expr::Integer(2)])?;
-  // Compute m3 / m2^(3/2) symbolically
-  let m2_pow = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
-    left: Box::new(m2),
-    right: Box::new(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(3)),
-      right: Box::new(Expr::Integer(2)),
-    }),
+  // Skewness = m3 * m2^(-3/2). For a numeric list wolframscript evaluates the
+  // reciprocal power *directly* (m2^(-3/2) via powf(-1.5)), not as the two-step
+  // 1/m2^(3/2); for machine-real moments those differ by one ULP. Build the
+  // m3 * m2^(-3/2) form for lists so the value matches wolframscript
+  // (Skewness[{1.1, 1.2, 1.4, 2.1, 2.4}] == 0.4070412816074878), while
+  // distributions keep the m3 / m2^(3/2) shape their symbolic output relies on.
+  let moments_inexact =
+    matches!(&m2, Expr::Real(_)) || matches!(&m3, Expr::Real(_));
+  let result = if moments_inexact {
+    let m2_pow = Expr::BinaryOp {
+      op: crate::syntax::BinaryOperator::Power,
+      left: Box::new(m2),
+      right: Box::new(Expr::FunctionCall {
+        name: "Rational".to_string(),
+        args: vec![Expr::Integer(-3), Expr::Integer(2)].into(),
+      }),
+    };
+    Expr::BinaryOp {
+      op: crate::syntax::BinaryOperator::Times,
+      left: Box::new(m3),
+      right: Box::new(m2_pow),
+    }
+  } else {
+    // Compute m3 / m2^(3/2) symbolically
+    let m2_pow = Expr::BinaryOp {
+      op: crate::syntax::BinaryOperator::Power,
+      left: Box::new(m2),
+      right: Box::new(Expr::BinaryOp {
+        op: crate::syntax::BinaryOperator::Divide,
+        left: Box::new(Expr::Integer(3)),
+        right: Box::new(Expr::Integer(2)),
+      }),
+    };
+    maybe_expand_for_distribution(
+      &args[0],
+      Expr::BinaryOp {
+        op: crate::syntax::BinaryOperator::Divide,
+        left: Box::new(m3),
+        right: Box::new(m2_pow),
+      },
+    )
   };
-  let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
-    left: Box::new(m3),
-    right: Box::new(m2_pow),
-  };
-  let result = maybe_expand_for_distribution(&args[0], result);
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
 

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -3075,11 +3075,26 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         return Ok(result);
       }
-      // Log[base, x] — evaluate for Real args
-      if let (Expr::Real(base), Expr::Real(x)) = (&args[0], &args[1])
-        && *base > 0.0
-        && *base != 1.0
-        && *x > 0.0
+      // Log[base, x] — numeric result whenever at least one operand is an
+      // inexact (machine Real) plain number. Wolfram's two-argument Log is a
+      // dedicated primitive that evaluates as the *direct* division
+      // Log[x]/Log[base]; unlike a user-level Divide it does NOT round through
+      // multiply-by-reciprocal, so Log[10, 100.0] == 2. exactly (whereas
+      // Log[100.0]/Log[10] == 1.9999999999999998). Handle any positive plain
+      // numeric base/argument here so the value never falls through to the
+      // generic reciprocal-multiply division below.
+      fn is_plain_number(e: &Expr) -> bool {
+        matches!(e, Expr::Integer(_) | Expr::Real(_))
+          || matches!(e, Expr::FunctionCall { name, .. } if name == "Rational")
+      }
+      if (matches!(&args[0], Expr::Real(_)) || matches!(&args[1], Expr::Real(_)))
+        && is_plain_number(&args[0])
+        && is_plain_number(&args[1])
+        && let (Some(base), Some(x)) =
+          (try_eval_to_f64(&args[0]), try_eval_to_f64(&args[1]))
+        && base > 0.0
+        && base != 1.0
+        && x > 0.0
       {
         return Ok(Expr::Real(x.ln() / base.ln()));
       }

--- a/tests/interpreter_tests/math/complex.rs
+++ b/tests/interpreter_tests/math/complex.rs
@@ -1377,6 +1377,21 @@ mod log_negative_real_base {
     assert_eq!(interpret("Log2[8.0]").unwrap(), "3.");
     assert_eq!(interpret("Log10[100.0]").unwrap(), "2.");
   }
+
+  // wolframscript's two-argument Log is a dedicated primitive that evaluates as
+  // the *direct* division Log[x]/Log[base] — it does NOT round via the
+  // multiply-by-reciprocal that a user-level Divide uses. So Log[10, 100.0] is
+  // exactly 2. even though Log[100.0]/Log[10] is 1.9999999999999998. This holds
+  // for any mix of exact/inexact plain-number base and argument.
+  #[test]
+  fn two_arg_log_uses_direct_division() {
+    assert_eq!(interpret("Log[10, 100.0]").unwrap(), "2.");
+    assert_eq!(interpret("Log[2, 8.0]").unwrap(), "3.");
+    assert_eq!(interpret("Log[2.0, 8]").unwrap(), "3.");
+    assert_eq!(interpret("Log[3, 9.0]").unwrap(), "2.");
+    assert_eq!(interpret("Log[10, 50.0]").unwrap(), "1.6989700043360185");
+    assert_eq!(interpret("Log[2.5, 30.0]").unwrap(), "3.71191944144785");
+  }
 }
 
 mod re_im_constants {

--- a/tests/interpreter_tests/math/misc.rs
+++ b/tests/interpreter_tests/math/misc.rs
@@ -1725,3 +1725,58 @@ mod cases {
     assert_case(r#"0!"#, r#"1"#);
   }
 }
+
+mod machine_real_division {
+  use super::*;
+
+  // wolframscript evaluates a/b as Times[a, Power[b, -1]]. When the denominator
+  // is inexact (a machine Real, or an irrational constant whose reciprocal must
+  // be rounded to a machine real), the multiply-by-reciprocal double-rounds and
+  // lands one ULP away from a single IEEE division. Woxi must match byte-for-byte.
+  #[test]
+  fn real_over_real_uses_multiply_by_reciprocal() {
+    // Direct IEEE 13.522987986828882 / 84.75863032002954 == 0.15954703297787043,
+    // but wolframscript reports the reciprocal-multiply value ...046.
+    assert_eq!(
+      interpret("13.522987986828882/84.75863032002954").unwrap(),
+      "0.15954703297787046"
+    );
+    assert_eq!(
+      interpret("65.19413797500401/78.89346277843777").unwrap(),
+      "0.8263566546456889"
+    );
+    assert_eq!(
+      interpret("44.594180686074665/72.18184923084418").unwrap(),
+      "0.6178032450160481"
+    );
+  }
+
+  #[test]
+  fn real_over_symbolic_constant_double_rounds() {
+    // 15.9/Pi: direct IEEE is 5.061127190322272, reciprocal-multiply is ...725.
+    assert_eq!(interpret("15.9/Pi").unwrap(), "5.0611271903222725");
+    assert_eq!(interpret("Divide[15.9, Pi]").unwrap(), "5.0611271903222725");
+  }
+
+  // Dividing by an exact Integer/Rational is Times[a, Rational[..]] — an exact
+  // reciprocal, so the product is single-rounded (identical to direct division).
+  // The reciprocal-multiply rule must NOT touch these (regression: CentralMoment,
+  // Kurtosis, Skewness and AbsoluteCorrelation all divide by an integer count).
+  #[test]
+  fn real_over_exact_denominator_stays_direct() {
+    assert_eq!(interpret("15.9/3").unwrap(), "5.3");
+    assert_eq!(interpret("3/15.9").unwrap(), "0.18867924528301888");
+    assert_eq!(
+      interpret("CentralMoment[{1.1, 1.2, 1.4, 2.1, 2.4}, 4]").unwrap(),
+      "0.10084511999999998"
+    );
+    assert_eq!(
+      interpret("Kurtosis[{1.1, 1.2, 1.4, 2.1, 2.4}]").unwrap(),
+      "1.4209750290831373"
+    );
+    assert_eq!(
+      interpret("Skewness[{1.1, 1.2, 1.4, 2.1, 2.4}]").unwrap(),
+      "0.4070412816074878"
+    );
+  }
+}


### PR DESCRIPTION
## Summary

The differential fuzzer (`make fuzz-diff`, seed 1783627783025706045) flagged `Divide[Plus[-2.1, 18], Pi]` and bare real/real quotients like `13.522987986828882/84.75863032002954`: woxi's result was one ULP away from wolframscript.

**Root cause:** wolframscript evaluates a machine-real division `a/b` as `Times[a, Power[b, -1]]` — it multiplies by the machine reciprocal `1.0/b` (two roundings) rather than doing a single IEEE division. For roughly half of all operand pairs those differ in the last bit.

## Changes

- **`divide_two` (arithmetic.rs):** multiply by the reciprocal when the denominator is *inexact* (a machine Real, or an irrational constant like `Pi`/`Sqrt[2]` whose reciprocal must itself be rounded to a machine real first). Keep a direct division when the denominator is an exact Integer/Rational — its reciprocal is an exact rational, so the product is single-rounded and identical to direct division (e.g. `CentralMoment`'s `sum/n`, which must stay correctly rounded).

Follow-on adjustments for internal numeric routines that wolframscript computes with dedicated algorithms rather than a user-level `Divide`:

- **Two-argument `Log` (trigonometric.rs):** evaluates as the *direct* division `Log[x]/Log[base]` for any plain-number base/argument, so `Log[10, 100.0]` stays exactly `2.` (a user-level `Log[100.0]/Log[10]` is `1.9999999999999998`).
- **List `Skewness` (statistics.rs):** builds `m3 * m2^(-3/2)` (direct reciprocal power) instead of `m3 / m2^(3/2)`, matching wolframscript's `0.4070412816074878` for `{1.1, 1.2, 1.4, 2.1, 2.4}`. Distributions keep their symbolic shape.
- **Incomplete Beta closed form (gamma.rs):** divides its machine-real summands directly, restoring `N[Beta[2, 1/2, 3]] == 1.3199326582148885`.

## Verification

- Every boundary case verified byte-for-byte against `wolframscript` (real/real, real/Pi, real/Sqrt[2], real/integer, statistics, Log, Beta).
- Full unit suite: **23561 passed, 0 failed** (includes 4 new regression tests).
- CLI doc-tests: `Beta.md` fixed; remaining failures are pre-existing and unrelated.
- Fuzzer replay on the flagging seed: **2 → 1 divergences, no new ones.** The remaining divergence is a cosmetic `D[u/v]` term-ordering/expansion difference (mathematically identical output), deliberately left out of scope.
- Confirmed the ULP differences in `Gamma`/`Zeta`/`BesselJ`/`Erf` were already present on `main` (pre-existing, untouched by this change).

## Test plan

- [x] `cargo nextest run` — all green
- [x] `scrut test tests/cli` — no new failures, Beta fixed
- [x] `woxi-diff-fuzz` replay on seed 1783627783025706045

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt

---
_Generated by [Claude Code](https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt)_