### PR TITLE
Prefer BigInt to num_bigint::BigInt in math_ast/*.rs

### DIFF
--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -4126,7 +4126,6 @@ pub fn number_compose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn minkowski_question_mark_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  use num_bigint::BigInt;
   let unevaluated = |args: &[Expr]| Expr::FunctionCall {
     name: "MinkowskiQuestionMark".to_string(),
     args: args.to_vec().into(),

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -2,6 +2,8 @@
 use super::*;
 use crate::InterpreterError;
 use crate::syntax::Expr;
+use num_bigint::BigInt;
+use num_bigint::Sign;
 
 /// Check if an expression is known to be non-negative without assumptions.
 /// Used for simplifications like Sqrt[x^2] → x (only valid when x >= 0).
@@ -58,7 +60,7 @@ pub fn abs_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // to a BigInteger in that case.
       return Ok(match n.checked_abs() {
         Some(a) => Expr::Integer(a),
-        None => Expr::BigInteger(-num_bigint::BigInt::from(*n)),
+        None => Expr::BigInteger(-BigInt::from(*n)),
       });
     }
     Expr::Real(f) => return Ok(Expr::Real(f.abs())),
@@ -342,7 +344,7 @@ fn is_imaginary_unit(expr: &Expr) -> bool {
 fn is_positive_real_literal(expr: &Expr) -> bool {
   match expr {
     Expr::Integer(n) => *n > 0,
-    Expr::BigInteger(n) => n > &num_bigint::BigInt::from(0),
+    Expr::BigInteger(n) => n > &BigInt::from(0),
     Expr::Real(f) => *f > 0.0,
     Expr::FunctionCall { name, args }
       if name == "Rational" && args.len() == 2 =>
@@ -785,10 +787,7 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// that is square-free over the bound but not itself a perfect square stays
 /// in `inside` (matching wolframscript, which also can't factor large semiprimes
 /// cheaply).
-fn extract_square_factor_big(
-  n: &num_bigint::BigInt,
-) -> (num_bigint::BigInt, num_bigint::BigInt) {
-  use num_bigint::BigInt;
+fn extract_square_factor_big(n: &BigInt) -> (BigInt, BigInt) {
   let zero = BigInt::from(0);
   let one = BigInt::from(1);
   let mut outside = BigInt::from(1);
@@ -879,7 +878,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Perfect squares: Sqrt[0]=0, Sqrt[1]=1, Sqrt[4]=2, etc.
     Expr::Integer(n) if *n >= 0 => {
       // Exact perfect square via BigInt (f64 sqrt is imprecise near i128 max).
-      let bn = num_bigint::BigInt::from(*n);
+      let bn = BigInt::from(*n);
       let r = bn.sqrt();
       if &r * &r == bn {
         return Ok(crate::functions::math_ast::bigint_to_expr(r));
@@ -910,7 +909,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       } else {
         // Larger than u64: extract square factors in BigInt.
         let (outside, inside) = extract_square_factor_big(&bn);
-        if outside > num_bigint::BigInt::from(1) {
+        if outside > BigInt::from(1) {
           let sqrt_part =
             make_sqrt(crate::functions::math_ast::bigint_to_expr(inside));
           return times_ast(&[
@@ -924,13 +923,13 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // Sqrt of a BigInteger: extract the largest perfect-square factor, e.g.
     // Sqrt[10^41] -> 10^20 Sqrt[10].
-    Expr::BigInteger(n) if *n >= num_bigint::BigInt::from(0) => {
+    Expr::BigInteger(n) if *n >= BigInt::from(0) => {
       let r = n.sqrt();
       if &r * &r == *n {
         return Ok(crate::functions::math_ast::bigint_to_expr(r));
       }
       let (outside, inside) = extract_square_factor_big(n);
-      if outside > num_bigint::BigInt::from(1) {
+      if outside > BigInt::from(1) {
         let sqrt_part =
           make_sqrt(crate::functions::math_ast::bigint_to_expr(inside));
         return times_ast(&[
@@ -1007,20 +1006,18 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // BigInt fallback for rational arguments whose numerator/denominator is a
       // BigInteger or exceeds u64 (e.g. Sqrt[2744*10^90/729] = 14*10^45/27 *
       // Sqrt[14], reached via Skewness/Correlation of large-integer lists).
-      let to_big = |e: &Expr| -> Option<num_bigint::BigInt> {
+      let to_big = |e: &Expr| -> Option<BigInt> {
         match e {
-          Expr::Integer(v) if *v >= 0 => Some(num_bigint::BigInt::from(*v)),
-          Expr::BigInteger(v) if *v >= num_bigint::BigInt::from(0) => {
-            Some(v.clone())
-          }
+          Expr::Integer(v) if *v >= 0 => Some(BigInt::from(*v)),
+          Expr::BigInteger(v) if *v >= BigInt::from(0) => Some(v.clone()),
           _ => None,
         }
       };
       if let (Some(nb), Some(db)) = (to_big(&rargs[0]), to_big(&rargs[1]))
-        && db > num_bigint::BigInt::from(0)
+        && db > BigInt::from(0)
       {
         use crate::functions::math_ast::{bigint_to_expr, make_rational_expr};
-        let one = num_bigint::BigInt::from(1);
+        let one = BigInt::from(1);
         let (n_out, n_in) = extract_square_factor_big(&nb);
         let (d_out, d_in) = extract_square_factor_big(&db);
         let coeff = make_rational_expr(n_out.clone(), d_out.clone());
@@ -1554,11 +1551,10 @@ fn floor_via_bigfloat(
   let frac_part = &rest[dot_pos + 1..];
   // Parse the integer part as a BigInt.
   let int_str = format!("{}{}", sign, int_part);
-  let int_bi = int_str.parse::<num_bigint::BigInt>().ok()?;
+  let int_bi = int_str.parse::<BigInt>().ok()?;
   // For Floor on a negative number with a non-zero fractional part, subtract 1.
   // For Ceiling on a positive number with a non-zero fractional part, add 1.
   let has_frac = !frac_part.chars().all(|c| c == '0');
-  use num_bigint::BigInt;
   let adjusted = if is_floor {
     if sign == "-" && has_frac {
       int_bi - BigInt::from(1)
@@ -1587,7 +1583,6 @@ fn floor_via_bigfloat(
 /// for non-exact arguments (Real, symbolic, complex), which fall through.
 fn exact_floor_ceil(arg: &Expr, is_floor: bool) -> Option<Expr> {
   use crate::functions::math_ast::{bigint_to_expr, expr_to_bigint};
-  use num_bigint::Sign;
   use num_traits::Zero;
   // Plain integers are already integral.
   if let Some(n) = expr_to_bigint(arg) {
@@ -1932,7 +1927,7 @@ pub(crate) fn f64_to_int_expr(v: f64) -> Expr {
   if v.abs() < i128::MAX as f64 {
     Expr::Integer(v as i128)
   } else if v.is_finite() {
-    match format!("{v:.0}").parse::<num_bigint::BigInt>() {
+    match format!("{v:.0}").parse::<BigInt>() {
       Ok(b) => Expr::BigInteger(b),
       Err(_) => Expr::Real(v),
     }
@@ -2019,7 +2014,7 @@ pub fn round_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let rounded = quotient_f * a_val;
         if a_is_int
           && rounded.fract() == 0.0
-          && let Ok(b) = format!("{rounded:.0}").parse::<num_bigint::BigInt>()
+          && let Ok(b) = format!("{rounded:.0}").parse::<BigInt>()
         {
           return Ok(Expr::BigInteger(b));
         }
@@ -2203,17 +2198,16 @@ pub fn mod2_ast(m: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
   // to the float branch and lose precision. Mirrors the
   // `((m % n) + n) % n` rule the small-integer path uses.
   let m_big = match m {
-    Expr::Integer(v) => Some(num_bigint::BigInt::from(*v)),
+    Expr::Integer(v) => Some(BigInt::from(*v)),
     Expr::BigInteger(v) => Some(v.clone()),
     _ => None,
   };
   let n_big = match n {
-    Expr::Integer(v) => Some(num_bigint::BigInt::from(*v)),
+    Expr::Integer(v) => Some(BigInt::from(*v)),
     Expr::BigInteger(v) => Some(v.clone()),
     _ => None,
   };
   if let (Some(mb), Some(nb)) = (m_big, n_big) {
-    use num_bigint::BigInt;
     use num_traits::Zero;
     if nb.is_zero() {
       crate::emit_message(&format!(
@@ -2569,7 +2563,6 @@ pub fn quotient_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Exact arbitrary-precision path: if both args are Integer or
       // BigInteger, compute floor division without falling back to f64
       // (which loses precision for numbers that don't fit in 53 bits).
-      use num_bigint::BigInt;
       use num_traits::Zero;
       let as_bigint = |e: &Expr| -> Option<BigInt> {
         match e {
@@ -2589,8 +2582,7 @@ pub fn quotient_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // quotient toward -infinity.
         let (mut q, r) = (&a / &b, &a % &b);
         if !r.is_zero()
-          && ((a.sign() != num_bigint::Sign::NoSign
-            && b.sign() != num_bigint::Sign::NoSign)
+          && ((a.sign() != Sign::NoSign && b.sign() != Sign::NoSign)
             && (a.sign() != b.sign()))
         {
           q -= 1;
@@ -2757,7 +2749,6 @@ fn emit_integer_exponent_ibase(b: &Expr) {
 /// IntegerExponent[n, b] - largest power of b that divides n
 /// IntegerExponent[n] - largest power of 2 that divides n
 pub fn integer_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  use num_bigint::BigInt;
   use num_traits::Zero;
 
   if args.is_empty() || args.len() > 2 {
@@ -2812,7 +2803,7 @@ pub fn integer_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let mut count: i128 = 0;
   let mut val = n.clone();
-  if val.sign() == num_bigint::Sign::Minus {
+  if val.sign() == Sign::Minus {
     val = -val;
   }
   while !val.is_zero() && (&val % &base).is_zero() {

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -2099,11 +2099,11 @@ pub fn barnes_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // G(n) = product_{k=0}^{n-2} k!
       // Use recurrence: G(n+1) = Gamma(n) * G(n) = (n-1)! * G(n)
       // G(1) = 1, G(2) = 1, G(3) = 1, G(4) = 2, G(5) = 12, ...
-      let mut result = num_bigint::BigInt::from(1);
-      let mut factorial = num_bigint::BigInt::from(1);
+      let mut result = BigInt::from(1);
+      let mut factorial = BigInt::from(1);
       // factorial tracks (k-1)! as we compute G(k+1) = (k-1)! * G(k)
       for k in 1..n - 1 {
-        factorial *= num_bigint::BigInt::from(k);
+        factorial *= BigInt::from(k);
         result *= &factorial;
       }
       // Try to convert to i128

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -530,7 +530,7 @@ pub fn factorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       use num_traits::ToPrimitive;
       let n = *f as i128;
       let exact = if n <= 1 {
-        num_bigint::BigInt::from(1)
+        BigInt::from(1)
       } else {
         let mut shift: u64 = 0;
         kg_inner(n, 1, &mut shift) << shift
@@ -1058,7 +1058,6 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Represent each Bernoulli number as a reduced (numerator, denominator)
   // pair in BigInt, so large numerators (e.g. BernoulliB[60]) don't overflow
   // i128.
-  use num_bigint::BigInt;
   fn bgcd(a: &BigInt, b: &BigInt) -> BigInt {
     let (mut a, mut b) = (a.clone().abs(), b.clone().abs());
     while b != BigInt::from(0) {
@@ -1524,14 +1523,13 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // Compute Stirling numbers of the second kind for all k, in BigInt so
     // large coefficients (e.g. BellB[50, x]) don't overflow i128.
-    let zero = num_bigint::BigInt::from(0);
-    let one = num_bigint::BigInt::from(1);
+    let zero = BigInt::from(0);
+    let one = BigInt::from(1);
     let mut stirling = vec![vec![zero.clone(); n + 1]; n + 1];
     stirling[0][0] = one.clone();
     for i in 1..=n {
       for k in 1..=i {
-        stirling[i][k] = num_bigint::BigInt::from(k as i128)
-          * &stirling[i - 1][k]
+        stirling[i][k] = BigInt::from(k as i128) * &stirling[i - 1][k]
           + &stirling[i - 1][k - 1];
       }
     }
@@ -1669,17 +1667,16 @@ pub fn catalan_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if f.fract() == 0.0 {
       let m = *f as i128;
       let exact = if m >= 0 {
-        let two_m = num_bigint::BigInt::from(2 * m);
-        let mut c = num_bigint::BigInt::from(1);
+        let two_m = BigInt::from(2 * m);
+        let mut c = BigInt::from(1);
         for i in 0..m {
-          c = c * (&two_m - num_bigint::BigInt::from(i))
-            / num_bigint::BigInt::from(i + 1);
+          c = c * (&two_m - BigInt::from(i)) / BigInt::from(i + 1);
         }
-        c / num_bigint::BigInt::from(m + 1)
+        c / BigInt::from(m + 1)
       } else if m == -1 {
-        num_bigint::BigInt::from(-1)
+        BigInt::from(-1)
       } else {
-        num_bigint::BigInt::from(0)
+        BigInt::from(0)
       };
       return Ok(Expr::Real(exact.to_f64().unwrap_or(f64::INFINITY)));
     }
@@ -1707,7 +1704,7 @@ pub fn catalan_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // CatalanNumber[n] = Binomial[2n, n] / (n + 1), in BigInt so large results
   // (e.g. CatalanNumber[100], 57 digits) don't overflow i128.
-  let result = binomial_coeff_big(2 * n, n) / num_bigint::BigInt::from(n + 1);
+  let result = binomial_coeff_big(2 * n, n) / BigInt::from(n + 1);
   Ok(crate::functions::math_ast::bigint_to_expr(result))
 }
 
@@ -2048,7 +2045,6 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn multiple_harmonic_number_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  use num_bigint::BigInt;
   let unevaluated = || Expr::FunctionCall {
     name: "MultipleHarmonicNumber".to_string(),
     args: args.to_vec().into(),
@@ -5287,8 +5283,7 @@ pub fn prime_pi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Uses deterministic witnesses for small numbers and a set of strong
 /// witnesses that provides correct results for all numbers < 3.317e24,
 /// plus additional witnesses for larger numbers.
-pub fn is_prime_bigint(n: &num_bigint::BigInt) -> bool {
-  use num_bigint::BigInt;
+pub fn is_prime_bigint(n: &BigInt) -> bool {
   use num_traits::{One, Zero};
 
   let one = BigInt::one();
@@ -5484,8 +5479,7 @@ pub fn prev_prime_before(n: i128) -> i128 {
 }
 
 /// Find the smallest prime > n for BigInt values.
-pub fn next_prime_after_bigint(n: &num_bigint::BigInt) -> num_bigint::BigInt {
-  use num_bigint::BigInt;
+pub fn next_prime_after_bigint(n: &BigInt) -> BigInt {
   use num_traits::{One, Zero};
 
   let one = BigInt::one();
@@ -8965,7 +8959,6 @@ pub fn three_j_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   //                      · (j3-j2+m1+t)!·(j3-j1-m2+t)!]
   // Everything below is computed in integer 2j/2m units; halve the
   // sums/differences before plugging into factorial.
-  use num_bigint::BigInt;
   fn fact(n: i128) -> BigInt {
     let mut acc = BigInt::from(1);
     for i in 2..=n {
@@ -9130,18 +9123,14 @@ pub fn six_j_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Compute Δ²(a, b, c) = (a+b-c)!(a-b+c)!(-a+b+c)!/(a+b+c+1)! using
   // half-integer arithmetic — every triangle has an even sum so each of
   // (a±b±c)/2 is an integer.
-  fn fact(n: i128) -> num_bigint::BigInt {
-    let mut acc = num_bigint::BigInt::from(1);
+  fn fact(n: i128) -> BigInt {
+    let mut acc = BigInt::from(1);
     for i in 2..=n {
       acc *= i;
     }
     acc
   }
-  fn delta_sq_num_den(
-    a: i128,
-    b: i128,
-    c: i128,
-  ) -> (num_bigint::BigInt, num_bigint::BigInt) {
+  fn delta_sq_num_den(a: i128, b: i128, c: i128) -> (BigInt, BigInt) {
     // Each triangle satisfies a+b+c even, so the half-integer factorials
     // collapse to integer factorials.
     let n1 = (a + b - c) / 2;
@@ -9150,7 +9139,6 @@ pub fn six_j_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let nd = (a + b + c) / 2 + 1;
     (fact(n1) * fact(n2) * fact(n3), fact(nd))
   }
-  use num_bigint::BigInt;
   // Δ_total² = Π Δ²(triangle_i). Accumulate as (num, den).
   let mut delta_sq_num = BigInt::from(1);
   let mut delta_sq_den = BigInt::from(1);
@@ -9226,7 +9214,7 @@ pub fn six_j_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let coeff_num = sum_num * &delta_sq_outside_num;
   let coeff_den = &sum_den * &delta_sq_outside_den;
   let coeff_expr = bigint_rational_to_expr(coeff_num, coeff_den);
-  let radicand_expr = if delta_sq_inside_den == num_bigint::BigInt::from(1) {
+  let radicand_expr = if delta_sq_inside_den == BigInt::from(1) {
     bigint_to_expr(delta_sq_inside_num)
   } else {
     crate::evaluator::evaluate_function_call_ast(
@@ -9365,10 +9353,7 @@ fn six_j_symbol_symbolic(
 /// `n == outside^2 · inside` and `inside` is square-free. Operates on
 /// BigInt directly so it works for arguments far beyond u64 range — the
 /// general `Sqrt` path trial-divides over u64.
-fn extract_perfect_square_bigint(
-  n: &num_bigint::BigInt,
-) -> (num_bigint::BigInt, num_bigint::BigInt) {
-  use num_bigint::BigInt;
+fn extract_perfect_square_bigint(n: &BigInt) -> (BigInt, BigInt) {
   use num_traits::Zero;
   if n.is_zero() {
     return (BigInt::from(1), BigInt::from(0));
@@ -9390,21 +9375,18 @@ fn extract_perfect_square_bigint(
   (outside, inside)
 }
 
-fn bigint_rational_to_expr(
-  num: num_bigint::BigInt,
-  den: num_bigint::BigInt,
-) -> Expr {
+fn bigint_rational_to_expr(num: BigInt, den: BigInt) -> Expr {
   use num_traits::Zero;
   if den.is_zero() {
     return Expr::Identifier("ComplexInfinity".to_string());
   }
   let g = bigint_gcd(num.clone().abs(), den.clone().abs());
   let (mut n, mut d) = (num / &g, den / &g);
-  if d < num_bigint::BigInt::from(0) {
+  if d < BigInt::from(0) {
     n = -n;
     d = -d;
   }
-  if d == num_bigint::BigInt::from(1) {
+  if d == BigInt::from(1) {
     return bigint_to_expr(n);
   }
   Expr::FunctionCall {
@@ -9569,26 +9551,25 @@ pub fn clebsch_gordan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // General case via the standard CG↔3j relation:
   //   CG[{j1,m1},{j2,m2},{j,m}] = (-1)^(j1-j2+m) · Sqrt[2j+1]
   //                                · ThreeJSymbol[{j1,m1},{j2,m2},{j,-m}]
-  let neg_m3 =
-    bigint_to_expr(num_bigint::BigInt::from(-m3)).pipe_through_rational(2);
+  let neg_m3 = bigint_to_expr(BigInt::from(-m3)).pipe_through_rational(2);
   let three_j_args = vec![
     Expr::List(
       vec![
-        bigint_to_expr(num_bigint::BigInt::from(j1)).pipe_through_rational(2),
-        bigint_to_expr(num_bigint::BigInt::from(m1)).pipe_through_rational(2),
+        bigint_to_expr(BigInt::from(j1)).pipe_through_rational(2),
+        bigint_to_expr(BigInt::from(m1)).pipe_through_rational(2),
       ]
       .into(),
     ),
     Expr::List(
       vec![
-        bigint_to_expr(num_bigint::BigInt::from(j2)).pipe_through_rational(2),
-        bigint_to_expr(num_bigint::BigInt::from(m2)).pipe_through_rational(2),
+        bigint_to_expr(BigInt::from(j2)).pipe_through_rational(2),
+        bigint_to_expr(BigInt::from(m2)).pipe_through_rational(2),
       ]
       .into(),
     ),
     Expr::List(
       vec![
-        bigint_to_expr(num_bigint::BigInt::from(j3)).pipe_through_rational(2),
+        bigint_to_expr(BigInt::from(j3)).pipe_through_rational(2),
         neg_m3,
       ]
       .into(),

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -503,7 +503,7 @@ pub fn num_to_expr(n: f64) -> Expr {
 }
 
 /// Convert a BigInt to Expr::Integer if it fits in i128, otherwise Expr::BigInteger
-pub fn bigint_to_expr(n: num_bigint::BigInt) -> Expr {
+pub fn bigint_to_expr(n: BigInt) -> Expr {
   use num_traits::ToPrimitive;
   match n.to_i128() {
     Some(i) => Expr::Integer(i),


### PR DESCRIPTION
These are some more updates to math_ast/*.rs files to try to more consistently use the shorter BigInt symbol instead of num_bigint::BigInt.  No actual code changes.