### PR TITLE
Handle TagBox and FormBox wrappers in layout and SVG export

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -5119,8 +5119,12 @@ pub fn layout_box(expr: &Expr, font_size: f64) -> BoxLayout {
         }
       }
 
-      // TagBox, InterpretationBox — delegate to content
-      "TagBox" if args.len() == 2 => layout_box(&args[0], font_size),
+      // TagBox, FormBox, InterpretationBox — delegate to content.
+      // TagBox[boxes, tag, opts...] may carry trailing options such as
+      // `Editable -> True` (e.g. from TraditionalForm), so accept 2+ args.
+      "TagBox" if args.len() >= 2 => layout_box(&args[0], font_size),
+      // FormBox[boxes, TraditionalForm] — the form marker is display-only.
+      "FormBox" if !args.is_empty() => layout_box(&args[0], font_size),
       // InterpretationBox[boxes, expr, opts...] — render the boxes; the
       // interpretation expression and any trailing options (e.g.
       // `AutoDelete -> True`) are display pass-throughs.
@@ -6325,8 +6329,11 @@ pub fn boxes_to_svg(expr: &Expr) -> String {
         format!("[{}]", content)
       }
 
-      // TagBox[boxes, tag] → render boxes, ignore tag
-      "TagBox" if args.len() == 2 => boxes_to_svg(&args[0]),
+      // TagBox[boxes, tag, opts...] → render boxes, ignore tag and options
+      "TagBox" if args.len() >= 2 => boxes_to_svg(&args[0]),
+
+      // FormBox[boxes, form] → render boxes, ignore the form marker
+      "FormBox" if !args.is_empty() => boxes_to_svg(&args[0]),
 
       // InterpretationBox[display, interpretation] → render display part only
       "InterpretationBox" if args.len() >= 2 => boxes_to_svg(&args[0]),
@@ -6752,7 +6759,8 @@ pub fn estimate_box_display_width(expr: &Expr) -> f64 {
       "FrameBox" if !args.is_empty() => {
         estimate_box_display_width(&args[0]) + 2.0
       }
-      "TagBox" if args.len() == 2 => estimate_box_display_width(&args[0]),
+      "TagBox" if args.len() >= 2 => estimate_box_display_width(&args[0]),
+      "FormBox" if !args.is_empty() => estimate_box_display_width(&args[0]),
       "InterpretationBox" if args.len() >= 2 => {
         estimate_box_display_width(&args[0])
       }

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -3087,7 +3087,8 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         matches!(e, Expr::Integer(_) | Expr::Real(_))
           || matches!(e, Expr::FunctionCall { name, .. } if name == "Rational")
       }
-      if (matches!(&args[0], Expr::Real(_)) || matches!(&args[1], Expr::Real(_)))
+      if (matches!(&args[0], Expr::Real(_))
+        || matches!(&args[1], Expr::Real(_)))
         && is_plain_number(&args[0])
         && is_plain_number(&args[1])
         && let (Some(base), Some(x)) =

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -1916,10 +1916,7 @@ mod cancel {
     assert_eq!(interpret("Together[-1/(1 + x)]").unwrap(), "(-1 - x)^(-1)");
     // Boundaries: a product denominator keeps its rational coefficient, a
     // non-unit numerator is untouched, and Simplify does NOT fold.
-    assert_eq!(
-      interpret("Cancel[-1/(2 + 2 x)]").unwrap(),
-      "-1/2*1/(1 + x)"
-    );
+    assert_eq!(interpret("Cancel[-1/(2 + 2 x)]").unwrap(), "-1/2*1/(1 + x)");
     assert_eq!(interpret("Cancel[-2/(1 + x)]").unwrap(), "-2/(1 + x)");
     assert_eq!(interpret("Simplify[-1/(1 + x)]").unwrap(), "-(1 + x)^(-1)");
   }

--- a/tests/miscellaneous_tests/high_level_functions.rs
+++ b/tests/miscellaneous_tests/high_level_functions.rs
@@ -4276,6 +4276,63 @@ mod high_level_functions {
     }
   }
 
+  mod math_svg_export_tests {
+    use super::*;
+
+    /// The typeset SVG must carry the math glyphs and fraction rules of the
+    /// expression — not a textual dump of its TagBox/FormBox wrapper.
+    fn assert_basel_svg(svg: &str) {
+      assert!(svg.starts_with("<svg"), "should be SVG markup: {svg}");
+      assert!(svg.contains('\u{2211}'), "∑ rendered: {svg}");
+      assert!(svg.contains('\u{221E}'), "∞ rendered: {svg}");
+      assert!(svg.contains('\u{03C0}'), "π rendered: {svg}");
+      // The two fractions (1/n² and π²/6) draw horizontal rule lines.
+      assert!(svg.contains("<line"), "fraction bars drawn: {svg}");
+      for wrapper in ["TagBox", "FormBox", "RowBox", "HoldForm", "Sum["] {
+        assert!(!svg.contains(wrapper), "no literal {wrapper} text: {svg}");
+      }
+    }
+
+    #[test]
+    fn test_export_string_traditional_form_math_svg() {
+      let svg = interpret(
+        "ExportString[TraditionalForm[HoldForm[Sum[1/n^2, {n, 1, Infinity}] \
+         == Pi^2/6]], \"SVG\"]",
+      )
+      .unwrap();
+      assert_basel_svg(&svg);
+    }
+
+    #[test]
+    fn test_export_traditional_form_math_svg_file() {
+      let tmp = std::env::temp_dir().join("woxi_test_math_basel_sum.svg");
+      let path = tmp.display().to_string();
+      let result = interpret(&format!(
+        "Export[\"{path}\", TraditionalForm[HoldForm[Sum[1/n^2, \
+         {{n, 1, Infinity}}] == Pi^2/6]]]"
+      ))
+      .unwrap();
+      assert_eq!(result, path);
+      let svg = std::fs::read_to_string(&tmp).unwrap();
+      assert_basel_svg(&svg);
+      std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn test_export_string_traditional_form_integral_svg() {
+      let svg = interpret(
+        "ExportString[TraditionalForm[HoldForm[Integrate[Exp[-x^2], \
+         {x, 0, Infinity}] == Sqrt[Pi]/2]], \"SVG\"]",
+      )
+      .unwrap();
+      assert!(svg.starts_with("<svg"), "should be SVG markup: {svg}");
+      assert!(svg.contains('\u{222B}'), "∫ rendered: {svg}");
+      assert!(svg.contains('\u{2146}'), "ⅆ differential rendered: {svg}");
+      assert!(!svg.contains("Integrate["), "no literal head: {svg}");
+      assert!(!svg.contains("TagBox"), "no box-wrapper dump: {svg}");
+    }
+  }
+
   mod wav_export_tests {
     use super::*;
 

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -2718,4 +2718,61 @@ mod tests {
       );
     }
   }
+
+  // ── TagBox / FormBox pass-through ────────────────────────────────────
+  //
+  // An evaluated TraditionalForm[…] expression is a 3-argument
+  // TagBox[FormBox[boxes, TraditionalForm], TraditionalForm,
+  // Editable -> True]. The layout / SVG / width functions must all
+  // delegate to the wrapped boxes instead of dumping the wrapper as text.
+  mod tag_and_form_box_passthrough {
+    use super::*;
+
+    /// TagBox[FormBox["x", TraditionalForm], TraditionalForm,
+    /// Editable -> True] — the wrapper an evaluated TraditionalForm carries.
+    fn wrapped_atom() -> Expr {
+      Expr::FunctionCall {
+        name: "TagBox".to_string(),
+        args: vec![
+          Expr::FunctionCall {
+            name: "FormBox".to_string(),
+            args: vec![
+              Expr::String("x".to_string()),
+              Expr::Identifier("TraditionalForm".to_string()),
+            ]
+            .into(),
+          },
+          Expr::Identifier("TraditionalForm".to_string()),
+          Expr::Rule {
+            pattern: Box::new(Expr::Identifier("Editable".to_string())),
+            replacement: Box::new(Expr::Identifier("True".to_string())),
+          },
+        ]
+        .into(),
+      }
+    }
+
+    #[test]
+    fn layout_box_unwraps_three_arg_tagbox_and_formbox() {
+      let wrapped = layout_box(&wrapped_atom(), 14.0);
+      let bare = layout_box(&Expr::String("x".to_string()), 14.0);
+      assert_eq!(
+        wrapped.elements, bare.elements,
+        "wrapper must be invisible in the layout"
+      );
+      assert_eq!(wrapped.width, bare.width);
+    }
+
+    #[test]
+    fn boxes_to_svg_unwraps_three_arg_tagbox_and_formbox() {
+      let svg = boxes_to_svg(&wrapped_atom());
+      assert_eq!(svg, "x", "wrapper must be invisible in the SVG: {svg}");
+    }
+
+    #[test]
+    fn estimate_width_unwraps_three_arg_tagbox_and_formbox() {
+      let w = estimate_box_display_width(&wrapped_atom());
+      assert_eq!(w, 1.0, "width is that of the wrapped content");
+    }
+  }
 }


### PR DESCRIPTION
## Summary

This PR fixes SVG export and layout rendering to properly unwrap `TagBox` and `FormBox` containers that are produced by `TraditionalForm` evaluation, ensuring mathematical expressions render correctly instead of dumping wrapper text.

## Key Changes

- **Updated `layout_box()` function** to handle `TagBox` with variable argument counts (2+ args) and added support for `FormBox` unwrapping. `TagBox` can carry trailing options like `Editable -> True` from `TraditionalForm`.

- **Updated `boxes_to_svg()` function** to unwrap both `TagBox` (with 2+ args) and `FormBox` containers, delegating to their wrapped content for rendering.

- **Updated `estimate_box_display_width()` function** to unwrap `TagBox` (with 2+ args) and `FormBox` containers when calculating display widths.

- **Added comprehensive test coverage** in `svg_rendering.rs` with a new `tag_and_form_box_passthrough` module that verifies all three functions correctly delegate through the wrappers.

- **Added high-level integration tests** in `high_level_functions.rs` with a new `math_svg_export_tests` module that validates end-to-end SVG export of mathematical expressions (Basel sum and integral examples) containing proper glyphs and fraction rules without literal wrapper text.

## Implementation Details

When `TraditionalForm` is evaluated, it produces a 3-argument `TagBox[FormBox[boxes, TraditionalForm], TraditionalForm, Editable -> True]` structure. The layout, SVG rendering, and width estimation functions now properly recognize and unwrap these containers to render the actual mathematical content rather than treating them as opaque wrappers.

The changes ensure that mathematical symbols (∑, ∞, π, ∫, ⅆ) and structural elements (fraction bars) are properly rendered in SVG output while eliminating literal text dumps of box wrapper names.

https://claude.ai/code/session_011KicYkHyysyHqt3LhkjvUN