### PR TITLE
Remove more dead code

### DIFF
--- a/src/evaluator/string_replace.rs
+++ b/src/evaluator/string_replace.rs
@@ -501,27 +501,3 @@ pub fn split_list_elements(inner: &str) -> Vec<String> {
 
   elements
 }
-
-/// Apply ReplaceRepeated with direct pattern and replacement strings
-pub fn apply_replace_repeated_direct(
-  expr: &str,
-  pattern: &str,
-  replacement: &str,
-) -> Result<String, InterpreterError> {
-  let mut current = expr.to_string();
-  let max_iterations = 1000; // Prevent infinite loops
-
-  for _ in 0..max_iterations {
-    let next = replace_in_expr(&current, pattern, replacement);
-
-    if next == current {
-      // No more changes, we're done
-      break;
-    }
-
-    // Re-evaluate to simplify (preserve FullForm for round-tripping)
-    current = evaluate_fullform(&next).unwrap_or(next);
-  }
-
-  Ok(current)
-}

--- a/src/functions/wavelet_ast/mod.rs
+++ b/src/functions/wavelet_ast/mod.rs
@@ -183,29 +183,6 @@ pub fn parse_continuous_wavelet(e: &Expr) -> Option<ContinuousWaveletSpec> {
   }
 }
 
-/// True if `name` is one of the wavelet family heads (they stay unevaluated
-/// as their canonical form, like other symbolic constructor objects).
-pub fn is_wavelet_family_head(name: &str) -> bool {
-  matches!(
-    name,
-    "HaarWavelet"
-      | "DaubechiesWavelet"
-      | "SymletWavelet"
-      | "CoifletWavelet"
-      | "BattleLemarieWavelet"
-      | "BiorthogonalSplineWavelet"
-      | "ReverseBiorthogonalSplineWavelet"
-      | "CDFWavelet"
-      | "MeyerWavelet"
-      | "ShannonWavelet"
-      | "MexicanHatWavelet"
-      | "GaborWavelet"
-      | "DGaussianWavelet"
-      | "MorletWavelet"
-      | "PaulWavelet"
-  )
-}
-
 /// Canonical expression for a discrete wavelet spec.
 pub fn spec_to_expr(spec: &WaveletSpec) -> Expr {
   let call = |name: &str, args: Vec<Expr>| Expr::FunctionCall {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4298,66 +4298,6 @@ pub fn format_real_result(result: f64) -> String {
   syntax::format_real(result)
 }
 
-/// GCD helper function for fraction simplification
-fn gcd_i64(a: i64, b: i64) -> i64 {
-  let mut a = a.abs();
-  let mut b = b.abs();
-  while b != 0 {
-    let temp = b;
-    b = a % b;
-    a = temp;
-  }
-  a
-}
-
-/// Format a rational number as a fraction (numerator/denominator)
-pub fn format_fraction(numerator: i64, denominator: i64) -> String {
-  if denominator == 0 {
-    return "ComplexInfinity".to_string();
-  }
-  let g = gcd_i64(numerator, denominator);
-  let num = numerator / g;
-  let den = denominator / g;
-
-  // Handle sign
-  let (num, den) = if den < 0 { (-num, -den) } else { (num, den) };
-
-  if den == 1 {
-    num.to_string()
-  } else {
-    format!("{}/{}", num, den)
-  }
-}
-
-// Parse display-form strings like "{1, 2, 3}" into top-level comma-separated
-// element strings.  Returns None if `s` is not a braced list.
-pub fn parse_list_string(s: &str) -> Option<Vec<String>> {
-  if !(s.starts_with('{') && s.ends_with('}')) {
-    return None;
-  }
-  let inner = &s[1..s.len() - 1];
-  let mut parts = Vec::new();
-  let mut depth = 0usize;
-  let mut start = 0usize;
-  for (i, c) in inner.char_indices() {
-    match c {
-      '{' | '[' | '(' | '<' => depth += 1,
-      '}' | ']' | ')' | '>' => {
-        depth = depth.saturating_sub(1);
-      }
-      ',' if depth == 0 => {
-        parts.push(inner[start..i].trim().to_string());
-        start = i + 1;
-      }
-      _ => {}
-    }
-  }
-  if start < inner.len() {
-    parts.push(inner[start..].trim().to_string());
-  }
-  Some(parts)
-}
-
 fn store_function_definition(
   pair: Pair<Rule>,
 ) -> Result<Option<String>, InterpreterError> {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -104,21 +104,6 @@ impl std::iter::FromIterator<Self> for WoNum {
   }
 }
 
-pub fn wonum_to_number_str(wo_num: WoNum) -> String {
-  match wo_num {
-    WoNum::Int(x) => x.to_string(),
-    WoNum::Float(x) => x.to_string(),
-  }
-}
-
-pub fn str_to_wonum(num_str: &str) -> WoNum {
-  num_str
-    .parse::<i128>()
-    .map(WoNum::Int)
-    .or(num_str.parse::<f64>().map(WoNum::Float))
-    .unwrap()
-}
-
 impl WoNum {
   pub fn abs(self) -> Self {
     match self {


### PR DESCRIPTION
A small assortment of functions I discovered were dead code.
```
src/evaluator/string_replace.rs
  pub fn apply_replace_repeated_direct(...) -> Result<String, InterpreterError>
src/functions/wavelet_ast/mod.rs
  pub fn is_wavelet_family_head(name: &str) -> bool
src/lib.rs
  fn gcd_i64(a: i64, b: i64) -> i64
  pub fn format_fraction(numerator: i64, denominator: i64) -> String
  pub fn parse_list_string(s: &str) -> Option<Vec<String>>
src/syntax.rs
  pub fn str_to_wonum(num_str: &str) -> WoNum
  pub fn wonum_to_number_str(wo_num: WoNum) -> String
```