### PR TITLE
Fix six differential-fuzzer divergences against wolframscript

### DIFF
--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -7096,20 +7096,36 @@ pub fn qr_decomposition_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         right: Box::new(norm.clone()),
       })?);
     }
-    q.push(qi.clone());
+    q.push(qi);
 
-    // Orthogonalize remaining columns
+    // Orthogonalize the remaining columns against the UNNORMALIZED u[i]:
+    // the projection coefficient (u_i·u_j)/(u_i·u_i) stays rational for
+    // rational input, so every intermediate column stays rational and
+    // radicals appear only in the final normalization. Projecting against
+    // the normalized q_i instead mixes radical shapes (1/Sqrt[35] vs
+    // Sqrt[5/7]) that neither woxi nor wolframscript re-combines, leaving
+    // the later norms as unsimplified nested radicals.
     for j in (i + 1)..m {
-      let proj = dot(&qi, &u[j])?;
-      r_entries[i][j] = proj.clone();
+      let unum = dot(&u[i], &u[j])?;
+      // R[i][j] = q_i·u_j = (u_i·u_j)/‖u_i‖ — one exact division.
+      r_entries[i][j] = eval_expr(&Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(unum.clone()),
+        right: Box::new(norm.clone()),
+      })?;
+      let coeff = eval_expr(&Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(unum),
+        right: Box::new(norm_sq.clone()),
+      })?;
       for k in 0..n {
         u[j][k] = eval_expr(&Expr::BinaryOp {
           op: BinaryOperator::Minus,
           left: Box::new(u[j][k].clone()),
           right: Box::new(Expr::BinaryOp {
             op: BinaryOperator::Times,
-            left: Box::new(proj.clone()),
-            right: Box::new(qi[k].clone()),
+            left: Box::new(coeff.clone()),
+            right: Box::new(u[i][k].clone()),
           }),
         })?;
       }

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -3421,12 +3421,16 @@ fn cmp_is_call_like(e: &Expr) -> bool {
 /// FunctionCall or BinaryOp representation.
 /// A reciprocal-of-a-sum term (2/(-1+x), (1+x)^(-1)) orders against
 /// another univariate term in the same variable by comparing the BASE
-/// polynomials coefficient-wise from the constant term up, a bare-`x`
-/// base counting as constant 0: `(-1+x)^(-1) + x` keeps the reciprocal
-/// first, `x + (1+x)^(-1)` keeps x first, and `2/(-1+x) + x^2` leads
-/// with the reciprocal while `x^2/2 + 15/(8(1+2x))` trails it — all
-/// wolframscript-verified. Equal bases return None so the existing
-/// shared-denominator exponent rules decide.
+/// polynomials: lower degree first, then coefficients from the LEADING
+/// term down by signed value (missing coefficients count as 0), a bare
+/// `x^m` base flattening to the coefficients of plain `x`. All
+/// wolframscript-verified: `(-1+x)^(-1) + x` and `(1-2*x)^(-1) + x` keep
+/// the reciprocal first (negative constant / leading term sorts early),
+/// `x + (1+x)^(-1)` and `x + (-5+2*x)^(-1)` keep x first (positive
+/// constant, larger leading coefficient), `2/(-1+x) + x^2` leads with the
+/// reciprocal while `x^2/2 + 15/(8(1+2x))` trails it, and any degree-≥2
+/// base ((1+x^2)^(-1)) trails every monomial. Equal bases return None so
+/// the existing shared-denominator exponent rules decide.
 fn sum_recip_vs_univar_order(a: &Expr, b: &Expr) -> Option<std::cmp::Ordering> {
   use std::cmp::Ordering;
   // (var, ascending base-polynomial coeffs, is_sum_reciprocal).
@@ -3468,7 +3472,13 @@ fn sum_recip_vs_univar_order(a: &Expr, b: &Expr) -> Option<std::cmp::Ordering> {
   if (!ra && !rb) || va != vb {
     return None;
   }
-  for i in 0..ca.len().max(cb.len()) {
+  let degree =
+    |c: &[i128]| c.iter().rposition(|&k| k != 0).unwrap_or(0);
+  let (da, db) = (degree(&ca), degree(&cb));
+  if da != db {
+    return Some(da.cmp(&db));
+  }
+  for i in (0..=da).rev() {
     let x = ca.get(i).copied().unwrap_or(0);
     let y = cb.get(i).copied().unwrap_or(0);
     match x.cmp(&y) {
@@ -7097,6 +7107,37 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         _ => None,
       }
     };
+    // A merged factor can itself be a product carrying a numeric
+    // coefficient (Sqrt[46]*Sqrt[10/3] → Times[2, Sqrt[115/3]] via the
+    // square extraction in sqrt_ast). Splice those inline so the numeric
+    // fold below absorbs the coefficient and the product stays flat
+    // (otherwise `3*Sqrt[46]*Sqrt[10/3]` printed as `3*2*Sqrt[115/3]`).
+    let mut i = 0;
+    while i < symbolic_args.len() {
+      let inner: Option<Vec<Expr>> = match &symbolic_args[i] {
+        Expr::FunctionCall { name, args: ta }
+          if name == "Times"
+            && ta.iter().any(|a| as_int_rational(a).is_some()) =>
+        {
+          Some(ta.iter().cloned().collect())
+        }
+        Expr::BinaryOp {
+          op: crate::syntax::BinaryOperator::Times,
+          left,
+          right,
+        } if as_int_rational(left).is_some()
+          || as_int_rational(right).is_some() =>
+        {
+          Some(vec![left.as_ref().clone(), right.as_ref().clone()])
+        }
+        _ => None,
+      };
+      if let Some(inner) = inner {
+        symbolic_args.splice(i..=i, inner);
+      } else {
+        i += 1;
+      }
+    }
     let mut fold_num = combined_numer;
     let mut fold_den = combined_denom;
     let mut any = false;
@@ -7226,45 +7267,95 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Build final args: coefficient (if not 1) + sorted symbolic terms
   sort_symbolic_factors(&mut symbolic_args);
 
-  // Final-pass canonicalization: Rational[±1, cd] * Sqrt[Rational[p, q]] →
-  // ±Sqrt[Rational[p, q*cd^2]] reduced. Only triggers when:
-  // (1) the sqrt argument is itself a rational (avoids recursion with the
-  //     (1/d)*Sqrt[n] form which is already canonical), and
-  // (2) gcd(p, cd^2) > 1, so absorption actually reduces the inner rational
-  //     (otherwise sqrt_ast would re-extract the cd^2 factor from the
-  //     denominator and recurse). Wolfram-canonical: (1/3)*Sqrt[15/11] →
-  //     Sqrt[5/33] (absorb), (1/3)*Sqrt[5/11] stays as Sqrt[5/11]/3.
+  // Final-pass canonicalization: a rational coefficient times a square root
+  // of a positive rational merges into one canonical radical, wolframscript
+  // style — square the coefficient into the radicand, reduce the fraction,
+  // then pull the largest square factor back out of the numerator and the
+  // denominator separately:
+  //   30*Sqrt[23/15] → 2*Sqrt[345]      2/Sqrt[30]        → Sqrt[2/15]
+  //   6*Sqrt[5/3]    → 2*Sqrt[15]       (1/3)*Sqrt[15/11] → Sqrt[5/33]
+  //   (2/5)/Sqrt[14] → Sqrt[2/7]/5     (13/35)*Sqrt[35/6] → 13/Sqrt[210]
+  // Already-canonical shapes are fixed points (2*Sqrt[3], 2/Sqrt[3],
+  // Sqrt[5/3]/2, (1/3)*Sqrt[5/11] all reproduce themselves) and are left
+  // untouched to avoid rewrite recursion.
   if symbolic_args.len() == 1
-    && let Expr::FunctionCall {
-      name: rname,
-      args: rargs,
-    } = &coeff
-    && rname == "Rational"
-    && rargs.len() == 2
-    && let (Expr::Integer(cn), Expr::Integer(cd)) = (&rargs[0], &rargs[1])
-    && cn.unsigned_abs() == 1
-    && *cd > 1
-    && let Some(sqrt_arg) = is_sqrt(&symbolic_args[0])
-    && let Expr::FunctionCall {
-      name: sname,
-      args: sargs,
-    } = sqrt_arg
-    && sname == "Rational"
-    && sargs.len() == 2
-    && let (Expr::Integer(sp), Expr::Integer(sq)) = (&sargs[0], &sargs[1])
-    && *sp > 0
-    && *sq > 0
-    // Guard cd*cd against i128 overflow for a large denominator (e.g. d=10^20);
-    // on overflow this absorption optimization is simply skipped.
-    && let Some(cd_sq) = cd.checked_mul(*cd)
-    && gcd(*sp, cd_sq) > 1
-    && let Some(new_sq) = sq.checked_mul(cd_sq)
+    && let Some((cn, cd)) = (match &coeff {
+      Expr::Integer(n) => Some((*n, 1i128)),
+      Expr::FunctionCall { name, args } if name == "Rational" && args.len() == 2 => {
+        match (&args[0], &args[1]) {
+          (Expr::Integer(n), Expr::Integer(d)) if *d > 0 => Some((*n, *d)),
+          _ => None,
+        }
+      }
+      _ => None,
+    })
+    && cn != 0
   {
-    let absorbed = sqrt_ast(&[make_rational(*sp, new_sq)])?;
-    if *cn < 0 {
-      return times_ast(&[Expr::Integer(-1), absorbed]);
-    } else {
-      return Ok(absorbed);
+    let (base, exp) = extract_base_exponent(&symbolic_args[0]);
+    let half = match &exp {
+      Expr::FunctionCall { name, args } if name == "Rational" && args.len() == 2 => {
+        match (&args[0], &args[1]) {
+          (Expr::Integer(1), Expr::Integer(2)) => Some(1),
+          (Expr::Integer(-1), Expr::Integer(2)) => Some(-1),
+          _ => None,
+        }
+      }
+      _ => None,
+    };
+    let base_frac = match &base {
+      Expr::Integer(n) if *n > 0 => Some((*n, 1i128)),
+      Expr::FunctionCall { name, args } if name == "Rational" && args.len() == 2 => {
+        match (&args[0], &args[1]) {
+          (Expr::Integer(n), Expr::Integer(d)) if *n > 0 && *d > 0 => {
+            Some((*n, *d))
+          }
+          _ => None,
+        }
+      }
+      _ => None,
+    };
+    if let (Some(half), Some((bn, bd))) = (half, base_frac) {
+      // Radicand of the whole product squared: cn^2*bn / (cd^2*bd), with
+      // the base fraction inverted for a -1/2 exponent.
+      let (rn, rd) = if half > 0 { (bn, bd) } else { (bd, bn) };
+      let merged = cn
+        .checked_mul(cn)
+        .and_then(|c2| c2.checked_mul(rn))
+        .and_then(|num| {
+          cd.checked_mul(cd)
+            .and_then(|d2| d2.checked_mul(rd))
+            .map(|den| (num, den))
+        });
+      if let Some((mut num, mut den)) = merged {
+        let g = gcd(num.abs(), den).max(1);
+        num /= g;
+        den /= g;
+        let (s, p1) = extract_square_factor_i128(num.abs());
+        let (t, q1) = extract_square_factor_i128(den);
+        let sign = if cn < 0 { -1 } else { 1 };
+        let new_coeff = make_rational(sign * s, t);
+        if p1 == 1 && q1 == 1 {
+          // The radical vanished entirely — c*Sqrt[r] is exactly rational.
+          return Ok(new_coeff);
+        }
+        let rebuilt: Expr = if q1 == 1 {
+          sqrt_ast(&[Expr::Integer(p1)])?
+        } else {
+          sqrt_ast(&[make_rational(p1, q1)])?
+        };
+        // Only rewrite when something actually changed; canonical inputs
+        // are fixed points and must return through the generic path.
+        let coeff_str = crate::syntax::expr_to_string(&coeff);
+        let new_coeff_str = crate::syntax::expr_to_string(&new_coeff);
+        let factor_str = crate::syntax::expr_to_string(&symbolic_args[0]);
+        let rebuilt_str = crate::syntax::expr_to_string(&rebuilt);
+        if coeff_str != new_coeff_str || factor_str != rebuilt_str {
+          if matches!(&new_coeff, Expr::Integer(1)) {
+            return Ok(rebuilt);
+          }
+          return times_ast(&[new_coeff, rebuilt]);
+        }
+      }
     }
   }
 
@@ -7381,7 +7472,55 @@ pub fn divide_head_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::Identifier("ComplexInfinity".to_string()));
     }
   }
+  // wolframscript compiles the explicit `Divide[a, b]` head over machine
+  // numbers into a single IEEE division. The `/` operator is different: its
+  // Times[a, Power[b, -1]] form multiplies by the rounded reciprocal (see
+  // divide_two), which lands one ULP away for roughly half of all operand
+  // pairs — Divide[37, 1.8] is 20.555555555555554 while 37/1.8 is
+  // 20.555555555555557. Only an explicit Real denominator with a plain
+  // numeric numerator takes the direct path; symbolic numerators and inexact
+  // constants like Pi still evaluate through the reciprocal, and lists
+  // thread element-wise with the same head semantics.
+  if args.len() == 2 {
+    if args.iter().any(|a| matches!(a, Expr::List(_))) {
+      return thread_binary_over_lists(args, divide_two_head);
+    }
+    return divide_two_head(&args[0], &args[1]);
+  }
   divide_ast(args)
+}
+
+/// Division with explicit-`Divide`-head semantics: a plain-number numerator
+/// over an explicit machine-Real denominator divides directly (single
+/// rounding); everything else shares the operator path in `divide_two`.
+fn divide_two_head(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
+  if let Some(r) = direct_real_divide(a, b) {
+    return Ok(r);
+  }
+  divide_two(a, b)
+}
+
+/// `Divide[number, Real]` as a single IEEE division, or None when the
+/// operands don't qualify for the direct machine path.
+fn direct_real_divide(a: &Expr, b: &Expr) -> Option<Expr> {
+  let Expr::Real(y) = b else { return None };
+  if *y == 0.0 {
+    return None;
+  }
+  let x = match a {
+    Expr::Integer(_) | Expr::Real(_) => expr_to_num(a)?,
+    Expr::FunctionCall { name, args }
+      if name == "Rational" && args.len() == 2 =>
+    {
+      expr_to_num(a)?
+    }
+    Expr::BigInteger(n) => {
+      use num_traits::ToPrimitive;
+      n.to_f64()?
+    }
+    _ => return None,
+  };
+  Some(Expr::Real(x / y))
 }
 
 /// The 2D box lines for a message numerator: one line for integers and

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -1852,6 +1852,57 @@ fn exact_complex_rational_numden(expr: &Expr) -> Option<(Expr, Expr)> {
 }
 
 /// Numerator[x] - Returns the numerator of a rational expression
+/// Split a power of a rational with a positive fractional exponent into
+/// its numerator and denominator parts: wolframscript treats (2/15)^(1/2)
+/// as 2^(1/2) * 15^(-1/2), so Numerator[Sqrt[2/15]] is Sqrt[2] and
+/// Denominator[Sqrt[2/15]] is Sqrt[15]. Returns (p^e, q^e), both evaluated.
+fn split_rational_base_power(expr: &Expr) -> Option<(Expr, Expr)> {
+  let (base, exp) = match expr {
+    Expr::BinaryOp {
+      op: crate::syntax::BinaryOperator::Power,
+      left,
+      right,
+    } => (left.as_ref().clone(), right.as_ref().clone()),
+    Expr::FunctionCall { name, args } if name == "Power" && args.len() == 2 => {
+      (args[0].clone(), args[1].clone())
+    }
+    Expr::FunctionCall { name, args } if name == "Sqrt" && args.len() == 1 => (
+      args[0].clone(),
+      Expr::FunctionCall {
+        name: "Rational".to_string(),
+        args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
+      },
+    ),
+    _ => return None,
+  };
+  let positive_fraction = matches!(&exp, Expr::FunctionCall { name, args }
+    if name == "Rational"
+      && args.len() == 2
+      && matches!(&args[0], Expr::Integer(n) if *n > 0));
+  if !positive_fraction {
+    return None;
+  }
+  let Expr::FunctionCall {
+    name: bname,
+    args: bargs,
+  } = &base
+  else {
+    return None;
+  };
+  if bname != "Rational" || bargs.len() != 2 {
+    return None;
+  }
+  let part = |b: &Expr| -> Option<Expr> {
+    crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
+      op: crate::syntax::BinaryOperator::Power,
+      left: Box::new(b.clone()),
+      right: Box::new(exp.clone()),
+    })
+    .ok()
+  };
+  Some((part(&bargs[0])?, part(&bargs[1])?))
+}
+
 pub fn numerator_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.is_empty() || args.len() > 2 {
     return Err(InterpreterError::EvaluationError(
@@ -1898,6 +1949,11 @@ pub fn numerator_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(neg_exp) = get_negative_power_exponent(factor) {
           // Power[base, negative] → skip (denominator factor)
           let _ = neg_exp;
+        } else if let Some((num_part, _)) = split_rational_base_power(factor) {
+          // (p/q)^(n/d) → numerator contributes p^(n/d)
+          if !matches!(num_part, Expr::Integer(1)) {
+            num_factors.push(num_part);
+          }
         } else if let Expr::FunctionCall {
           name: rname,
           args: rargs,
@@ -1930,6 +1986,9 @@ pub fn numerator_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // pure denominator, so its numerator is 1.
       if get_negative_power_exponent(other).is_some() {
         Ok(Expr::Integer(1))
+      } else if let Some((num_part, _)) = split_rational_base_power(other) {
+        // Numerator[Sqrt[2/15]] → Sqrt[2]
+        Ok(num_part)
       } else {
         Ok(other.clone())
       }
@@ -1989,6 +2048,11 @@ pub fn denominator_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               right: Box::new(neg_exp),
             });
           }
+        } else if let Some((_, den_part)) = split_rational_base_power(factor) {
+          // (p/q)^(n/d) → denominator contributes q^(n/d)
+          if !matches!(den_part, Expr::Integer(1)) {
+            denom_factors.push(den_part);
+          }
         } else if let Expr::FunctionCall {
           name: rname,
           args: rargs,
@@ -2025,6 +2089,9 @@ pub fn denominator_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             right: Box::new(pos_exp),
           })
         }
+      } else if let Some((_, den_part)) = split_rational_base_power(other) {
+        // Denominator[Sqrt[2/15]] → Sqrt[15]
+        Ok(den_part)
       } else {
         Ok(Expr::Integer(1))
       }

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -624,6 +624,42 @@ pub fn make_rational_pub(numer: i128, denom: i128) -> Expr {
   make_rational(numer, denom)
 }
 
+/// Extract the largest easily-found perfect-square factor from a positive
+/// i128: returns `(outside, inside)` with `n == outside^2 * inside`, so
+/// `Sqrt[n] = outside * Sqrt[inside]`. Square factors of primes below a
+/// bound come out by trial division; a leftover whole-square cofactor
+/// (e.g. a large prime squared) is caught by a final integer-sqrt check.
+/// A cofactor that is square-free over the bound but not a perfect square
+/// stays in `inside` (matching wolframscript, which also can't factor
+/// large semiprimes cheaply).
+pub fn extract_square_factor_i128(n: i128) -> (i128, i128) {
+  let mut outside: i128 = 1;
+  let mut inside = n.max(1);
+  let mut f: i128 = 2;
+  while f <= 100_000 && f.saturating_mul(f) <= inside {
+    let mut count = 0u32;
+    while inside % f == 0 {
+      inside /= f;
+      count += 1;
+    }
+    if count >= 2 {
+      outside *= f.pow(count / 2);
+    }
+    if count % 2 == 1 {
+      inside *= f;
+    }
+    f += 1;
+  }
+  if inside > 1 {
+    let r = (inside as u128).isqrt() as i128;
+    if r.saturating_mul(r) == inside {
+      outside *= r;
+      inside = 1;
+    }
+  }
+  (outside, inside)
+}
+
 pub fn make_rational(numer: i128, denom: i128) -> Expr {
   if denom == 0 {
     // Division by zero - shouldn't reach here but be safe

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -2496,19 +2496,30 @@ fn product_square_free(expr: &Expr) -> Result<Option<Expr>, InterpreterError> {
     return Ok(None);
   }
 
-  // Sort sum factors by ascending degree, ties by the descending
-  // coefficient vector (wolframscript lists (2-5x+2x²+x³) before
-  // (-5-x+5x²+5x³): leading 1 < 5). Non-sum factors keep their positions
-  // relative to each other; the final reorder pass places them against
-  // the sums (x² after (-1+x), before (1+x)).
-  let sum_key = |e: &Expr| -> Option<(usize, Vec<i128>)> {
+  // Sort sum factors by ascending degree, then ascending leading
+  // coefficient (wolframscript lists (2-5x+2x²+x³) before (-5-x+5x²+5x³):
+  // leading 1 < 5), then termwise on the nonzero (degree, coefficient)
+  // terms ascending — zero coefficients are skipped, so (-2+x³) precedes
+  // (2-4x²+x³) (constants -2 < 2) and (1+x+x³) precedes (1-x²+x³) (the x
+  // term outranks the x² term) — all wolframscript-verified. Non-sum
+  // factors keep their positions relative to each other; the final
+  // reorder pass places them against the sums (x² after (-1+x), before
+  // (1+x)).
+  let sum_key = |e: &Expr| -> Option<(usize, i128, Vec<(usize, i128)>)> {
     if !is_sum(e) {
       return None;
     }
     let var = super::simplify::find_single_variable(e)?;
     let coeffs = extract_poly_coeffs(e, &var)?;
     let deg = coeffs.len().saturating_sub(1);
-    Some((deg, coeffs.into_iter().rev().collect()))
+    let lead = coeffs.last().copied().unwrap_or(0);
+    let terms: Vec<(usize, i128)> = coeffs
+      .iter()
+      .enumerate()
+      .filter(|&(_, &c)| c != 0)
+      .map(|(i, &c)| (i, c))
+      .collect();
+    Some((deg, lead, terms))
   };
   // Symbol monomials (x, x²) start before the sums (the reorder pass
   // then applies the decoded monomial-vs-sum rule); other factors like
@@ -2529,7 +2540,7 @@ fn product_square_free(expr: &Expr) -> Result<Option<Expr>, InterpreterError> {
       _ => false,
     }
   };
-  let rank = |e: &Expr| -> (u8, Option<(usize, Vec<i128>)>) {
+  let rank = |e: &Expr| -> (u8, Option<(usize, i128, Vec<(usize, i128)>)>) {
     match sum_key(e) {
       Some(k) => (1, Some(k)),
       None if is_symbol_factor(e) => (0, None),
@@ -2581,6 +2592,14 @@ fn product_square_free(expr: &Expr) -> Result<Option<Expr>, InterpreterError> {
 }
 
 pub fn factor_square_free_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  // Monomial factors take their canonical position against sum factors
+  // (x*(-5 + 3*x), not (-5 + 3*x)*x), exactly like factor_ast.
+  Ok(reorder_factored_product(factor_square_free_ast_impl(args)?))
+}
+
+fn factor_square_free_ast_impl(
+  args: &[Expr],
+) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
     return Err(InterpreterError::EvaluationError(
       "FactorSquareFree expects exactly 1 argument".into(),
@@ -3620,6 +3639,18 @@ fn try_factor_homogeneous_binomial(expr: &Expr) -> Option<Expr> {
     .map(|d| homogeneous_cyclotomic(d, &a, &b))
     .collect();
 
+  // Pull a leading minus out of any factor whose canonical first term is
+  // negative: wolframscript writes Factor[-x^2 + y^2] as
+  // -((x - y)*(x + y)), never (-x + y)*(x + y).
+  let mut negated = false;
+  for f in &mut factors {
+    if expr_to_string(f).starts_with('-') {
+      let terms = collect_additive_terms(f);
+      *f = combine_and_build(terms.iter().map(negate_term).collect());
+      negated = !negated;
+    }
+  }
+
   // Sort factors to match wolframscript's display order:
   //   degree ASC, then term count ASC, then min coefficient ASC.
   // This puts smaller-degree factors first, then within a degree the
@@ -3640,10 +3671,19 @@ fn try_factor_homogeneous_binomial(expr: &Expr) -> Option<Expr> {
     mx.cmp(&my)
   });
 
-  if factors.len() == 1 {
-    return Some(factors.remove(0));
-  }
-  Some(build_product(factors))
+  let product = if factors.len() == 1 {
+    factors.remove(0)
+  } else {
+    build_product(factors)
+  };
+  Some(if negated {
+    Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      operand: Box::new(product),
+    }
+  } else {
+    product
+  })
 }
 
 /// Minimum integer coefficient across all additive terms of `expr`.
@@ -4493,39 +4533,14 @@ fn build_multivariate_result(
 
   let mut result_factors: Vec<Expr> = Vec::new();
 
-  // If overall is exactly -1, absorb the sign into one of the factors with
-  // odd multiplicity. For |overall| > 1 the negative integer content stays
-  // a standalone factor (Factor[-4*y^2 + 4*x*y - 4*x^2] →
-  // -4*(x^2 - x*y + y^2), matching wolframscript), so no factor is negated.
-  let mut remaining_overall = overall;
-  if remaining_overall == -1 {
-    // Find the best factor to negate: prefer one whose first variable term
-    // has a negative coefficient (so negation makes the expression look more canonical)
-    let mut best_idx: Option<usize> = None;
-    for (i, (factor, mult)) in grouped.iter().enumerate() {
-      if *mult % 2 == 1 {
-        // Check if first variable term is negative
-        let s = expr_to_string(factor);
-        let starts_negative = s.starts_with('-');
-        if starts_negative {
-          best_idx = Some(i);
-          break;
-        }
-        if best_idx.is_none() {
-          best_idx = Some(i);
-        }
-      }
-    }
-    if let Some(idx) = best_idx {
-      let terms = collect_additive_terms(&grouped[idx].0);
-      let negated: Vec<Expr> = terms.iter().map(negate_term).collect();
-      grouped[idx].0 = combine_and_build(negated);
-      remaining_overall = -remaining_overall;
-    }
-  }
-
-  if remaining_overall != 1 {
-    result_factors.push(Expr::Integer(remaining_overall));
+  // A negative overall sign stays OUTSIDE the product: wolframscript
+  // writes Factor[5*y - 3*x*y] as -((-5 + 3*x)*y), never un-normalizing a
+  // canonically-signed sum factor back to (5 - 3*x). The -1 pushed here is
+  // pulled into a UnaryOp Minus by the Times canonicalization downstream.
+  // For |overall| > 1 the negative integer content stays a standalone
+  // factor (Factor[-4*y^2 + 4*x*y - 4*x^2] → -4*(x^2 - x*y + y^2)).
+  if overall != 1 {
+    result_factors.push(Expr::Integer(overall));
   }
 
   for (factor, mult) in &grouped {

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -2548,6 +2548,41 @@ mod apart {
     );
   }
 
+  // A reciprocal-of-a-sum term orders against a monomial by the base
+  // polynomial: lower degree first, then coefficients from the LEADING
+  // term down (differential-fuzzer regression, seed 1783672988021454491:
+  // the 87/(4*(-5 + 2*x)) term must trail (5*x)/2, not lead it).
+  #[test]
+  fn apart_reciprocal_term_order() {
+    assert_eq!(
+      interpret(
+        "Apart[Divide[Plus[-3, Times[5, x], Times[-5, Power[x, 2]]], \
+         Plus[5, Times[-2, x]]]]"
+      )
+      .unwrap(),
+      "15/4 + (5*x)/2 + 87/(4*(-5 + 2*x))"
+    );
+    // wolframscript-verified sum orderings around reciprocal bases.
+    assert_eq!(interpret("x + 1/(-5+2 x)").unwrap(), "x + (-5 + 2*x)^(-1)");
+    assert_eq!(interpret("x + 1/(-1+x)").unwrap(), "(-1 + x)^(-1) + x");
+    assert_eq!(interpret("x + 1/(1-2 x)").unwrap(), "(1 - 2*x)^(-1) + x");
+    assert_eq!(interpret("x + 1/(1-x)").unwrap(), "(1 - x)^(-1) + x");
+    assert_eq!(interpret("x + 1/(1+x)").unwrap(), "x + (1 + x)^(-1)");
+    assert_eq!(interpret("x + 1/(1+x^2)").unwrap(), "x + (1 + x^2)^(-1)");
+    assert_eq!(
+      interpret("1/(-1+x) + 1/(-5+2 x)").unwrap(),
+      "(-1 + x)^(-1) + (-5 + 2*x)^(-1)"
+    );
+    assert_eq!(
+      interpret("1/(1+2 x) + 1/(2+x)").unwrap(),
+      "(2 + x)^(-1) + (1 + 2*x)^(-1)"
+    );
+    assert_eq!(
+      interpret("1/(3-x) + 1/(-3+x)").unwrap(),
+      "(3 - x)^(-1) + (-3 + x)^(-1)"
+    );
+  }
+
   // Apart returns ordinary evaluated expressions: a variable-free
   // argument passes through, and single-fraction results take their
   // canonical evaluated form (not a hand-built Divide tree).
@@ -7266,6 +7301,65 @@ mod factor_square_free {
   #[test]
   fn square_free_unchanged() {
     assert_eq!(interpret("FactorSquareFree[x^6 - 1]").unwrap(), "-1 + x^6");
+  }
+
+  // Sum factors sort by degree, then leading coefficient, then termwise on
+  // the nonzero (degree, coefficient) terms ascending — zero coefficients
+  // are skipped (differential-fuzzer regression, seed 1783672988021454491;
+  // all wolframscript-verified).
+  #[test]
+  fn factor_order_matches_wolframscript() {
+    assert_eq!(
+      interpret("FactorSquareFree[(2 - 4 x^2 + x^3)(-2 + x^3)]").unwrap(),
+      "(-2 + x^3)*(2 - 4*x^2 + x^3)"
+    );
+    assert_eq!(
+      interpret("FactorSquareFree[(1 - x^2 + x^3)(1 + x + x^3)]").unwrap(),
+      "(1 + x + x^3)*(1 - x^2 + x^3)"
+    );
+    assert_eq!(
+      interpret(
+        "FactorSquareFree[(2 - 5 x + 2 x^2 + x^3)(-5 - x + 5 x^2 + 5 x^3)]"
+      )
+      .unwrap(),
+      "(2 - 5*x + 2*x^2 + x^3)*(-5 - x + 5*x^2 + 5*x^3)"
+    );
+    assert_eq!(
+      interpret("FactorSquareFree[(-2 + x^4)(2 + x^2)]").unwrap(),
+      "(2 + x^2)*(-2 + x^4)"
+    );
+  }
+
+  // A monomial factor takes its canonical position before the sum, and the
+  // extracted -1 stays outside the product (differential-fuzzer regression,
+  // seed 424242; wolframscript-verified).
+  #[test]
+  fn multivariate_monomial_before_sum() {
+    assert_eq!(
+      interpret("InputForm[FactorSquareFree[5 y - 3 x y^2]]").unwrap(),
+      "InputForm[-(y*(-5 + 3*x*y))]"
+    );
+    assert_eq!(
+      interpret("InputForm[FactorSquareFree[5 x - 3 x^2]]").unwrap(),
+      "InputForm[-(x*(-5 + 3*x))]"
+    );
+    assert_eq!(
+      interpret("InputForm[Factor[5 y - 3 x y]]").unwrap(),
+      "InputForm[-((-5 + 3*x)*y)]"
+    );
+    assert_eq!(
+      interpret("InputForm[Factor[5 x y - 3 x^2 y^2]]").unwrap(),
+      "InputForm[-(x*y*(-5 + 3*x*y))]"
+    );
+    // The homogeneous-binomial fast path extracts the sign the same way.
+    assert_eq!(
+      interpret("InputForm[Factor[-x^2 + y^2]]").unwrap(),
+      "InputForm[-((x - y)*(x + y))]"
+    );
+    assert_eq!(
+      interpret("InputForm[Factor[x^2 - y^2]]").unwrap(),
+      "InputForm[(x - y)*(x + y)]"
+    );
   }
 
   // Regression: negative integer content stays a standalone `-4` factor

--- a/tests/interpreter_tests/math/misc.rs
+++ b/tests/interpreter_tests/math/misc.rs
@@ -1779,4 +1779,143 @@ mod machine_real_division {
       "0.4070412816074878"
     );
   }
+
+  // The explicit `Divide[a, b]` head is different from the `/` operator:
+  // wolframscript compiles it to a single IEEE division when the
+  // denominator is an explicit machine Real and the numerator is a plain
+  // number, so it lands one ULP away from the operator's
+  // multiply-by-reciprocal for roughly half of all operand pairs
+  // (differential-fuzzer regression, seed 1783672988021454491).
+  #[test]
+  fn divide_head_over_real_is_direct_division() {
+    assert_eq!(
+      interpret("Divide[Divide[-37, -1.8], 95]").unwrap(),
+      "0.21637426900584794"
+    );
+    assert_eq!(interpret("Divide[-37, -1.8]").unwrap(), "20.555555555555554");
+    assert_eq!(interpret("-37/-1.8").unwrap(), "20.555555555555557");
+    assert_eq!(
+      interpret("Divide[52.75492379532281, -48.98619485211566]").unwrap(),
+      "-1.0769345109287334"
+    );
+    assert_eq!(
+      interpret("52.75492379532281/(-48.98619485211566)").unwrap(),
+      "-1.0769345109287332"
+    );
+    // A Rational numerator also divides directly under the Divide head.
+    assert_eq!(
+      interpret("Divide[42/25, 5.7744670227102635]").unwrap(),
+      "0.2909359415150815"
+    );
+    assert_eq!(
+      interpret("(42/25)/5.7744670227102635").unwrap(),
+      "0.29093594151508145"
+    );
+    // Lists thread with the same head semantics.
+    assert_eq!(
+      interpret(
+        "InputForm[Divide[{52.75492379532281, 1.}, -48.98619485211566]]"
+      )
+      .unwrap(),
+      "InputForm[{-1.0769345109287334, -0.0204139146349068}]"
+    );
+    // A symbolic numerator falls back to the reciprocal coefficient.
+    assert_eq!(
+      interpret("InputForm[Divide[x, -48.98619485211566]]").unwrap(),
+      "InputForm[-0.0204139146349068*x]"
+    );
+  }
+}
+
+mod radical_coefficient_merge {
+  use super::*;
+
+  // A rational coefficient times a square root of a positive rational
+  // merges into one canonical radical: square the coefficient into the
+  // radicand, reduce, then pull the largest square factors back out of
+  // numerator and denominator separately (differential-fuzzer regression,
+  // seed 1783672988021454491; all wolframscript-verified).
+  #[test]
+  fn coefficient_merges_into_radical() {
+    assert_eq!(interpret("InputForm[2/Sqrt[30]]").unwrap(), "InputForm[Sqrt[2/15]]");
+    assert_eq!(interpret("InputForm[6*Sqrt[5/3]]").unwrap(), "InputForm[2*Sqrt[15]]");
+    assert_eq!(interpret("InputForm[30*Sqrt[23/15]]").unwrap(), "InputForm[2*Sqrt[345]]");
+    assert_eq!(interpret("InputForm[-2/Sqrt[30]]").unwrap(), "InputForm[-Sqrt[2/15]]");
+    assert_eq!(interpret("InputForm[(3/2)*Sqrt[2/3]]").unwrap(), "InputForm[Sqrt[3/2]]");
+    assert_eq!(interpret("InputForm[2*Sqrt[1/2]]").unwrap(), "InputForm[Sqrt[2]]");
+    assert_eq!(interpret("InputForm[(1/3)*Sqrt[15/11]]").unwrap(), "InputForm[Sqrt[5/33]]");
+    assert_eq!(
+      interpret("InputForm[(2/5)/Sqrt[14]]").unwrap(),
+      "InputForm[Sqrt[2/7]/5]"
+    );
+    assert_eq!(
+      interpret("InputForm[(4/35)*Sqrt[3/2]]").unwrap(),
+      "InputForm[(2*Sqrt[6])/35]"
+    );
+    assert_eq!(
+      interpret("InputForm[(13/35)*Sqrt[35/6]]").unwrap(),
+      "InputForm[13/Sqrt[210]]"
+    );
+    assert_eq!(
+      interpret("InputForm[3*Sqrt[46]*Sqrt[10/3]]").unwrap(),
+      "InputForm[2*Sqrt[345]]"
+    );
+    assert_eq!(
+      interpret(
+        "InputForm[Times[Times[Times[3, Sqrt[2]], Sqrt[23]], \
+         Divide[Times[2, Sqrt[25]], Sqrt[30]]]]"
+      )
+      .unwrap(),
+      "InputForm[2*Sqrt[345]]"
+    );
+  }
+
+  // Already-canonical shapes are fixed points and must not be rewritten.
+  #[test]
+  fn canonical_shapes_are_fixed_points() {
+    assert_eq!(interpret("InputForm[2/Sqrt[3]]").unwrap(), "InputForm[2/Sqrt[3]]");
+    assert_eq!(interpret("InputForm[2*Sqrt[3]]").unwrap(), "InputForm[2*Sqrt[3]]");
+    assert_eq!(interpret("InputForm[Sqrt[5/3]/2]").unwrap(), "InputForm[Sqrt[5/3]/2]");
+    assert_eq!(
+      interpret("InputForm[(1/3)*Sqrt[5/11]]").unwrap(),
+      "InputForm[Sqrt[5/11]/3]"
+    );
+    assert_eq!(interpret("InputForm[1/Sqrt[3]]").unwrap(), "InputForm[1/Sqrt[3]]");
+  }
+
+  // Numerator/Denominator split a fractional power of a rational into its
+  // parts: (2/15)^(1/2) is 2^(1/2) * 15^(-1/2) (fuzzer regression:
+  // Numerator[Divide[Sqrt[2], Divide[Times[-4, Sqrt[3]], Times[-1,
+  // Sqrt[10]]]]] must give Sqrt[5], not Sqrt[5/3]).
+  #[test]
+  fn numerator_denominator_split_rational_radicand() {
+    assert_eq!(
+      interpret("InputForm[Numerator[2/Sqrt[30]]]").unwrap(),
+      "InputForm[Sqrt[2]]"
+    );
+    assert_eq!(
+      interpret("InputForm[Denominator[2/Sqrt[30]]]").unwrap(),
+      "InputForm[Sqrt[15]]"
+    );
+    assert_eq!(
+      interpret(
+        "InputForm[Numerator[Divide[Sqrt[2], Divide[Times[-4, Sqrt[3]], \
+         Times[-1, Sqrt[10]]]]]]"
+      )
+      .unwrap(),
+      "InputForm[Sqrt[5]]"
+    );
+    assert_eq!(
+      interpret("InputForm[Denominator[Sqrt[5/3]/2]]").unwrap(),
+      "InputForm[2*Sqrt[3]]"
+    );
+    assert_eq!(
+      interpret("InputForm[Numerator[(2/15)^(3/2)]]").unwrap(),
+      "InputForm[2*Sqrt[2]]"
+    );
+    assert_eq!(
+      interpret("InputForm[Denominator[(2/15)^(3/2)]]").unwrap(),
+      "InputForm[15*Sqrt[15]]"
+    );
+  }
 }

--- a/tests/interpreter_tests/special_functions.rs
+++ b/tests/interpreter_tests/special_functions.rs
@@ -2203,13 +2203,15 @@ mod cases {
   #[test]
   fn six_j_symbol_symbolic_5() {
     // Audit case: SixJSymbol[{1, 2, 3}, {2, m, 2}] is non-zero for
-    // m ∈ {1, 2, 3}. Concrete values:
+    // m ∈ {1, 2, 3}. Concrete values (wolframscript-canonical radical
+    // forms: -2/(5*Sqrt[14]) merges to -Sqrt[2/7]/5 and (4*Sqrt[3/2])/35
+    // to (2*Sqrt[6])/35):
     //   m=1 → 1/(5*Sqrt[21])
-    //   m=2 → -2/(5*Sqrt[14])
-    //   m=3 → (4*Sqrt[3/2])/35
+    //   m=2 → -1/5*Sqrt[2/7]
+    //   m=3 → (2*Sqrt[6])/35
     assert_case(
       r#"SixJSymbol[{1, 2, 3}, {2, m, 2}]"#,
-      r#"Piecewise[{{1/(5*Sqrt[21]), m == 1}, {-2/(5*Sqrt[14]), m == 2}, {(4*Sqrt[3/2])/35, m == 3}}, 0]"#,
+      r#"Piecewise[{{1/(5*Sqrt[21]), m == 1}, {-1/5*Sqrt[2/7], m == 2}, {(2*Sqrt[6])/35, m == 3}}, 0]"#,
     );
   }
 


### PR DESCRIPTION
## Summary

Fresh differential-fuzzer rounds (`woxi-diff-fuzz`, seeds `1783672988021454491` and `424242`, 900 cases total) flagged six output divergences against `wolframscript`. All six are fixed and byte-verified against the oracle.

## Fixes

- **`Divide` head vs `/` operator (arithmetic.rs):** wolframscript compiles an explicit `Divide[a, b]` over machine numbers into a *single IEEE division*, while the `/` operator's `Times[a, Power[b, -1]]` form multiplies by the rounded reciprocal — one ULP apart for roughly half of all operand pairs. `divide_head_ast` now divides directly when the denominator is an explicit machine Real and the numerator is a plain number (`Divide[Divide[-37, -1.8], 95]` → `0.21637426900584794`, `Divide[37, 1.8]` → `20.555555555555554` vs `37/1.8` → `20.555555555555557`). Lists thread with the same head semantics; symbolic numerators and inexact constants like `Pi` keep the reciprocal path.

- **Plus ordering of reciprocal-of-a-sum terms (arithmetic.rs):** decoded from ~45 oracle probes — the reciprocal's base polynomial compares against the other term by ascending degree, then coefficients from the *leading term down* by signed value (missing = 0). Fixes `Apart[(-3 + 5 x - 5 x^2)/(5 - 2 x)]` → `15/4 + (5*x)/2 + 87/(4*(-5 + 2*x))` and a family of `x + 1/(…)` orderings (`(1 - 2*x)^(-1) + x` but `x + (-5 + 2*x)^(-1)`).

- **FactorSquareFree factor ordering (factor.rs):** sum factors sort by degree, then leading coefficient, then termwise on the nonzero (degree, coefficient) terms ascending — zero coefficients are skipped, so `(-2 + x^3)` precedes `(2 - 4*x^2 + x^3)` while `(1 + x + x^3)` precedes `(1 - x^2 + x^3)`. `FactorSquareFree` also runs the same monomial-vs-sum reorder pass as `Factor` (`FactorSquareFree[5 y - 3 x y^2]` → `-(y*(-5 + 3*x*y))`).

- **Radical coefficient merge (arithmetic.rs, numeric_utils.rs):** a rational coefficient times a square root of a positive rational merges into one canonical radical — square the coefficient into the radicand, reduce, then pull the largest square factors back out of numerator and denominator separately: `30*Sqrt[23/15]` → `2*Sqrt[345]`, `2/Sqrt[30]` → `Sqrt[2/15]`, `(2/5)/Sqrt[14]` → `Sqrt[2/7]/5`. Canonical shapes (`2/Sqrt[3]`, `Sqrt[5/3]/2`, …) are fixed points. `Numerator`/`Denominator` split fractional powers of rationals into their parts (`Numerator[Sqrt[2/15]]` → `Sqrt[2]`, complex.rs).

- **Factor sign normalization (factor.rs):** an extracted `-1` stays *outside* the product instead of un-normalizing a canonically-signed sum factor: `Factor[5 y - 3 x y]` → `-((-5 + 3*x)*y)`, including the homogeneous-binomial fast path (`Factor[-x^2 + y^2]` → `-((x - y)*(x + y))`).

- **QRDecomposition (linear_algebra_ast.rs):** Gram-Schmidt now projects against the *unnormalized* vectors, so intermediates stay rational for rational input and radicals appear only at the final normalization. Restores the wolframscript-identical `{{1/Sqrt[35], 3/Sqrt[35], Sqrt[5/7]}, {13/Sqrt[210], 2*Sqrt[2/105], -Sqrt[5/42]}}, …` (the old normalized-projection path left unsimplifiable nested radicals once `5/Sqrt[35]` canonicalizes to `Sqrt[5/7]`).

Also updated one stale expectation: current wolframscript canonicalizes `SixJSymbol[{1,2,3},{2,2,2}]` to `-Sqrt[2/7]/5` (was `-2/(5*Sqrt[14])`).

The known cosmetic `D[u/v]` term-ordering/expansion difference remains deferred, as in #220.

## Verification

- Every fix byte-verified against `wolframscript` (division ULP cases, ~45 sum-ordering probes, ~30 Times factor-ordering probes, radical merges, Factor signs, QR).
- Full unit suite: **23659 passed, 0 failed** (includes new regression tests for all six fixes).
- Fuzzer replay: **300/300 clean on both flagging seeds**, no new divergences.

## Test plan

- [x] `make test-unit` — all green
- [x] `woxi-diff-fuzz --cases 300 --seed 1783672988021454491` — 0 divergences
- [x] `woxi-diff-fuzz --cases 300 --seed 424242` — 0 divergences

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt

---
_Generated by [Claude Code](https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt)_