### PR TITLE
Remove most pub wrapper functions

### DIFF
--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -205,11 +205,7 @@ fn gray_level_expr(g: f64) -> Expr {
 /// Map named color identifiers to their Wolfram Language evaluation result.
 /// Basic colors → RGBColor[r, g, b] or GrayLevel[g]
 /// Light* colors → RGBColor[r, g, b] or GrayLevel[g]
-pub fn named_color_expr_pub(name: &str) -> Option<Expr> {
-  named_color_expr(name)
-}
-
-fn named_color_expr(name: &str) -> Option<Expr> {
+pub fn named_color_expr(name: &str) -> Option<Expr> {
   Some(match name {
     // Basic colors
     "Red" => rgb_color_expr(1.0, 0.0, 0.0),

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -5744,7 +5744,7 @@ fn unit_to_box_form(unit: &Expr, magnitude: &Expr) -> Expr {
   }
 
   // Handle Power in both BinaryOp and FunctionCall form
-  if let Some((base, exp)) = crate::functions::graphics::as_power_pub(unit) {
+  if let Some((base, exp)) = crate::functions::graphics::as_power(unit) {
     let base_box = unit_to_box_form_inner(base);
     let exp_box = expr_to_box_form(exp);
     return Expr::FunctionCall {
@@ -5834,7 +5834,7 @@ fn unit_to_box_form_inner(unit: &Expr) -> Expr {
   use crate::functions::quantity_ast::unit_to_abbreviation;
   use crate::syntax::BinaryOperator;
 
-  if let Some((base, exp)) = crate::functions::graphics::as_power_pub(unit) {
+  if let Some((base, exp)) = crate::functions::graphics::as_power(unit) {
     let base_box = unit_to_box_form_inner(base);
     let exp_box = expr_to_box_form(exp);
     return Expr::FunctionCall {

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -974,7 +974,7 @@ pub fn evaluate_function_call_ast_inner(
                   positional_ctx
                     .push((param.clone(), effective_args[pi].clone()));
                 }
-                crate::evaluator::pattern_matching::push_match_context_pub(
+                crate::evaluator::pattern_matching::push_match_context(
                   &positional_ctx,
                 );
                 let match_result =
@@ -982,7 +982,7 @@ pub fn evaluate_function_call_ast_inner(
                     &canonical_arg,
                     pattern,
                   );
-                crate::evaluator::pattern_matching::pop_match_context_pub();
+                crate::evaluator::pattern_matching::pop_match_context();
                 if let Some(bindings) = match_result {
                   // Check consistency: structural bindings must not conflict
                   // with positional parameter bindings (skip the structural
@@ -1252,7 +1252,7 @@ pub fn evaluate_function_call_ast_inner(
                     positional_ctx
                       .push((param.clone(), effective_args[pi].clone()));
                   }
-                  crate::evaluator::pattern_matching::push_match_context_pub(
+                  crate::evaluator::pattern_matching::push_match_context(
                     &positional_ctx,
                   );
                   let match_result =
@@ -1260,7 +1260,7 @@ pub fn evaluate_function_call_ast_inner(
                       &canonical_arg,
                       pattern,
                     );
-                  crate::evaluator::pattern_matching::pop_match_context_pub();
+                  crate::evaluator::pattern_matching::pop_match_context();
                   if let Some(bindings) = match_result {
                     // Check consistency: structural bindings must not conflict
                     // with positional parameter bindings (skip the structural

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -34,21 +34,12 @@ fn lhs_condition_definitely_fails(bindings: &[(String, Expr)]) -> bool {
   })
 }
 
-fn push_match_context(bindings: &[(String, Expr)]) {
+pub fn push_match_context(bindings: &[(String, Expr)]) {
   MATCH_CONTEXT.with(|ctx| ctx.borrow_mut().push(bindings.to_vec()));
 }
 
-fn pop_match_context() {
+pub fn pop_match_context() {
   MATCH_CONTEXT.with(|ctx| ctx.borrow_mut().pop());
-}
-
-/// Public wrappers for use from dispatch code.
-pub fn push_match_context_pub(bindings: &[(String, Expr)]) {
-  push_match_context(bindings);
-}
-
-pub fn pop_match_context_pub() {
-  pop_match_context();
 }
 
 /// Check if bindings are compatible with all outer context bindings.

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -4382,11 +4382,7 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Extract the base and exponent from a Power expression (either BinaryOp or FunctionCall form).
 /// Public accessor for `as_power` — used by `expr_to_box_form` for unit handling.
-pub fn as_power_pub(expr: &Expr) -> Option<(&Expr, &Expr)> {
-  as_power(expr)
-}
-
-fn as_power(expr: &Expr) -> Option<(&Expr, &Expr)> {
+pub fn as_power(expr: &Expr) -> Option<(&Expr, &Expr)> {
   match expr {
     Expr::BinaryOp {
       op: crate::syntax::BinaryOperator::Power,

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -6109,7 +6109,7 @@ fn resolve_color_value(
     }
     // Named color (Red, Blue, etc.)
     Expr::Identifier(name) => {
-      if let Some(color_expr) = crate::evaluator::named_color_expr_pub(name) {
+      if let Some(color_expr) = crate::evaluator::named_color_expr(name) {
         resolve_color_value(&color_expr)
       } else {
         Err(InterpreterError::EvaluationError(format!(

--- a/src/functions/list_helpers_ast/sorting.rs
+++ b/src/functions/list_helpers_ast/sorting.rs
@@ -9,7 +9,7 @@ use super::*;
 /// Mixed: numbers before strings.
 /// Extract (real, imaginary) parts from a numeric expression for sorting.
 /// Returns None for non-numeric expressions.
-fn expr_to_complex_parts(e: &Expr) -> Option<(f64, f64)> {
+pub fn expr_to_complex_parts(e: &Expr) -> Option<(f64, f64)> {
   use crate::functions::math_ast::try_eval_to_f64;
   use crate::functions::math_ast::try_eval_to_f64_with_infinity;
   // Pure real number (including Infinity/-Infinity)
@@ -118,11 +118,6 @@ fn expr_to_complex_parts(e: &Expr) -> Option<(f64, f64)> {
     }
     _ => None,
   }
-}
-
-/// Public wrapper for expr_to_complex_parts.
-pub fn expr_to_complex_parts_pub(e: &Expr) -> Option<(f64, f64)> {
-  expr_to_complex_parts(e)
 }
 
 /// Check if an expression is Infinity or -Infinity (DirectedInfinity).

--- a/src/functions/math_ast/integrals.rs
+++ b/src/functions/math_ast/integrals.rs
@@ -291,7 +291,7 @@ pub fn fresnel_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Compute S(x) = ∫₀ˣ sin(π t²/2) dt numerically
 /// Uses the identity: S(x) = Im[(1+i)/2 · erf(√π/2 · (1+i) · x)]
-fn fresnel_s_numeric(x: f64) -> f64 {
+pub fn fresnel_s_numeric(x: f64) -> f64 {
   if x == 0.0 {
     return 0.0;
   }
@@ -411,7 +411,7 @@ pub fn fresnel_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Compute C(x) = ∫₀ˣ cos(π t²/2) dt numerically
 /// Uses the identity: C(x) = Re[(1+i)/2 · erf(√π/2 · (1+i) · x)]
-fn fresnel_c_numeric(x: f64) -> f64 {
+pub fn fresnel_c_numeric(x: f64) -> f64 {
   if x == 0.0 {
     return 0.0;
   }
@@ -598,16 +598,6 @@ fn erf_complex_taylor(a: f64, b: f64) -> (f64, f64) {
     sum_im += terms_im[i];
   }
   (two_over_sqrt_pi * sum_re, two_over_sqrt_pi * sum_im)
-}
-
-/// Public wrapper for FresnelS numeric computation (used by try_eval_to_f64)
-pub fn fresnel_s_numeric_pub(x: f64) -> f64 {
-  fresnel_s_numeric(x)
-}
-
-/// Public wrapper for FresnelC numeric computation (used by try_eval_to_f64)
-pub fn fresnel_c_numeric_pub(x: f64) -> f64 {
-  fresnel_c_numeric(x)
 }
 
 /// SinIntegral[z] - Sine integral Si(z)

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -398,10 +398,10 @@ pub fn try_eval_to_f64(expr: &Expr) -> Option<f64> {
       "Erfi" if args.len() == 1 => try_eval_to_f64(&args[0]).map(erfi_f64),
       "DawsonF" if args.len() == 1 => try_eval_to_f64(&args[0]).map(dawson_f64),
       "FresnelS" if args.len() == 1 => {
-        try_eval_to_f64(&args[0]).map(super::fresnel_s_numeric_pub)
+        try_eval_to_f64(&args[0]).map(super::fresnel_s_numeric)
       }
       "FresnelC" if args.len() == 1 => {
-        try_eval_to_f64(&args[0]).map(super::fresnel_c_numeric_pub)
+        try_eval_to_f64(&args[0]).map(super::fresnel_c_numeric)
       }
       "InverseErf" if args.len() == 1 => {
         try_eval_to_f64(&args[0]).and_then(|v| {

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -8572,7 +8572,7 @@ pub fn central_feature_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Index of the element with the smallest total distance to the others
 /// (earliest wins ties), using the automatic metric described above.
 fn central_feature_index(keys: &[Expr]) -> Result<usize, InterpreterError> {
-  use crate::functions::list_helpers_ast::expr_to_complex_parts_pub;
+  use crate::functions::list_helpers_ast::expr_to_complex_parts;
 
   let n = keys.len();
   if n == 1 {
@@ -8580,7 +8580,7 @@ fn central_feature_index(keys: &[Expr]) -> Result<usize, InterpreterError> {
   }
 
   let numeric_parts = |e: &Expr| -> Option<(f64, f64)> {
-    if let Some(p) = expr_to_complex_parts_pub(e) {
+    if let Some(p) = expr_to_complex_parts(e) {
       return Some(p);
     }
     let evaluated =
@@ -8589,7 +8589,7 @@ fn central_feature_index(keys: &[Expr]) -> Result<usize, InterpreterError> {
         args: vec![e.clone()].into(),
       })
       .ok()?;
-    expr_to_complex_parts_pub(&evaluated)
+    expr_to_complex_parts(&evaluated)
   };
 
   // Distance matrix column sums for whichever metric applies.

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -3862,9 +3862,9 @@ pub fn root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Order roots the way Wolfram's `Root` does: real roots first, sorted
 /// ascending, then complex roots sorted by (real, imag).
 pub fn root_order(a: &Expr, b: &Expr) -> std::cmp::Ordering {
-  use crate::functions::list_helpers_ast::expr_to_complex_parts_pub;
-  let pa = expr_to_complex_parts_pub(a);
-  let pb = expr_to_complex_parts_pub(b);
+  use crate::functions::list_helpers_ast::expr_to_complex_parts;
+  let pa = expr_to_complex_parts(a);
+  let pb = expr_to_complex_parts(b);
 
   match (pa, pb) {
     (Some((a_re, a_im)), Some((b_re, b_im))) => {
@@ -3901,9 +3901,9 @@ pub fn root_order(a: &Expr, b: &Expr) -> std::cmp::Ordering {
 /// they share real part 0. (`Root` uses a different rule that floats
 /// every real to the head; both functions are intentionally distinct.)
 pub fn solve_order(a: &Expr, b: &Expr) -> std::cmp::Ordering {
-  use crate::functions::list_helpers_ast::expr_to_complex_parts_pub;
-  let pa = expr_to_complex_parts_pub(a);
-  let pb = expr_to_complex_parts_pub(b);
+  use crate::functions::list_helpers_ast::expr_to_complex_parts;
+  let pa = expr_to_complex_parts(a);
+  let pb = expr_to_complex_parts(b);
 
   match (pa, pb) {
     (Some((a_re, a_im)), Some((b_re, b_im))) => {

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -2759,7 +2759,7 @@ fn is_structural_zero(expr: &Expr) -> bool {
 pub fn mandelbrot_set_iteration_count_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  use crate::functions::list_helpers_ast::expr_to_complex_parts_pub;
+  use crate::functions::list_helpers_ast::expr_to_complex_parts;
 
   let unevaluated = || {
     Ok(Expr::FunctionCall {
@@ -2860,7 +2860,7 @@ pub fn mandelbrot_set_iteration_count_ast(
   fn all_leaves_numeric(e: &Expr) -> bool {
     match e {
       Expr::List(items) => items.iter().all(all_leaves_numeric),
-      _ => expr_to_complex_parts_pub(e)
+      _ => expr_to_complex_parts(e)
         .is_some_and(|(x, y)| x.is_finite() && y.is_finite()),
     }
   }
@@ -2877,7 +2877,7 @@ pub fn mandelbrot_set_iteration_count_ast(
           .into(),
       ),
       _ => {
-        let (x, y) = expr_to_complex_parts_pub(e).unwrap();
+        let (x, y) = expr_to_complex_parts(e).unwrap();
         Expr::Integer(count(x, y, max_iter))
       }
     }
@@ -2896,7 +2896,7 @@ pub fn mandelbrot_set_iteration_count_ast(
 pub fn mandelbrot_set_member_q_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  use crate::functions::list_helpers_ast::expr_to_complex_parts_pub;
+  use crate::functions::list_helpers_ast::expr_to_complex_parts;
 
   let unevaluated = || {
     Ok(Expr::FunctionCall {
@@ -3030,7 +3030,7 @@ pub fn mandelbrot_set_member_q_ast(
   fn all_leaves_numeric(e: &Expr) -> bool {
     match e {
       Expr::List(items) => items.iter().all(all_leaves_numeric),
-      _ => expr_to_complex_parts_pub(e)
+      _ => expr_to_complex_parts(e)
         .is_some_and(|(x, y)| x.is_finite() && y.is_finite()),
     }
   }
@@ -3048,7 +3048,7 @@ pub fn mandelbrot_set_member_q_ast(
           .into(),
       ),
       _ => {
-        let (x, y) = expr_to_complex_parts_pub(e).unwrap();
+        let (x, y) = expr_to_complex_parts(e).unwrap();
         let (is_member, hit_max) = member(x, y, max_iter);
         if hit_max {
           *msg_count += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1409,7 +1409,7 @@ pub fn interpret(input: &str) -> Result<String, InterpreterError> {
       // Check if any element needs evaluation (named colors, date symbols, etc.)
       let needs_eval = trimmed[1..trimmed.len() - 1].split(',').any(|item| {
         let item = item.trim();
-        evaluator::named_color_expr_pub(item).is_some()
+        evaluator::named_color_expr(item).is_some()
           || matches!(
             item,
             "Now"
@@ -1592,7 +1592,7 @@ pub fn interpret(input: &str) -> Result<String, InterpreterError> {
       return Ok(syntax::expr_to_output(&expr));
     }
     // Handle named colors (Red → RGBColor[1, 0, 0], etc.)
-    if let Some(color_expr) = evaluator::named_color_expr_pub(trimmed) {
+    if let Some(color_expr) = evaluator::named_color_expr(trimmed) {
       return Ok(syntax::expr_to_output(&color_expr));
     }
     // Thick → Thickness[Large]


### PR DESCRIPTION
pub wrapper functions don't serve any purpose near as I can tell. This patch removes seven of them (listed below).  The remaining ones are either widely used (is_numeric_q_pub, make_rational_pub) or in a file with an outstanding pull request (distribution_mean_variance_pub), and will be addressed later.
```
  pub fn named_color_expr_pub(name: &str) -> Option<Expr>
  pub fn push_match_context_pub(bindings: &[(String, Expr)])
  pub fn pop_match_context_pub()
  pub fn as_power_pub(expr: &Expr) -> Option<(&Expr, &Expr)>
  pub fn expr_to_complex_parts_pub(e: &Expr) -> Option<(f64, f64)>
  pub fn fresnel_s_numeric_pub(x: f64) -> f64
  pub fn fresnel_c_numeric_pub(x: f64) -> f64
```