### PR TITLE
Prefer gcd_(bigint|i128) over (i128|bigint)_gcd

### DIFF
--- a/src/functions/count_roots_ast.rs
+++ b/src/functions/count_roots_ast.rs
@@ -27,7 +27,7 @@ struct Rat {
   d: BigInt, // invariant: d > 0, gcd(|n|, d) == 1
 }
 
-fn bigint_gcd(a: &BigInt, b: &BigInt) -> BigInt {
+fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
   let mut a = a.abs();
   let mut b = b.abs();
   while !b.is_zero() {
@@ -45,7 +45,7 @@ impl Rat {
       n = -n;
       d = -d;
     }
-    let g = bigint_gcd(&n, &d);
+    let g = gcd_bigint(&n, &d);
     if !g.is_zero() && !g.is_one() {
       n /= &g;
       d /= &g;

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -510,7 +510,7 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Fraction helpers over BigInt
   type Frac = (BigInt, BigInt);
-  let gcd_big = |a: &BigInt, b: &BigInt| -> BigInt {
+  let gcd_bigint = |a: &BigInt, b: &BigInt| -> BigInt {
     let (mut a, mut b) = (a.clone(), b.clone());
     if a < BigInt::from(0) {
       a = -a;
@@ -530,7 +530,7 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   };
   let reduce = |num: BigInt, den: BigInt| -> Frac {
-    let g = gcd_big(&num, &den);
+    let g = gcd_bigint(&num, &den);
     let (mut n, mut d) = (num / &g, den / g);
     if d < BigInt::from(0) {
       n = -n;

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -524,7 +524,7 @@ fn explicit_real(e: &Expr) -> Option<f64> {
   }
 }
 
-fn i128_gcd(a: i128, b: i128) -> i128 {
+fn gcd_i128(a: i128, b: i128) -> i128 {
   let (mut a, mut b) = (a.abs(), b.abs());
   while b != 0 {
     let t = a % b;
@@ -566,7 +566,7 @@ fn integer_coefficient_list(poly: &Expr, var_name: &str) -> Option<Vec<i128>> {
     items.iter().map(coeff_to_ratio).collect::<Option<_>>()?;
   let mut lcm: i128 = 1;
   for &(_, d) in &ratios {
-    let g = i128_gcd(lcm, d);
+    let g = gcd_i128(lcm, d);
     lcm = (lcm / g).checked_mul(d.abs())?;
   }
   let mut out = Vec::with_capacity(ratios.len());

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1517,7 +1517,7 @@ fn promote_integer_times_i_to_real(e: Expr) -> Expr {
   e
 }
 
-fn bigint_gcd(a: &BigInt, b: &BigInt) -> BigInt {
+fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
   let mut a = match a.sign() {
     Sign::Minus => -a,
     _ => a.clone(),
@@ -1608,7 +1608,7 @@ impl Coeff {
         let (n2, d2) = Self::to_big(*n2, *d2);
         let mut sn = &n1 * &d2 + &n2 * &d1;
         let mut sd = d1 * d2;
-        let g = bigint_gcd(&sn, &sd);
+        let g = gcd_bigint(&sn, &sd);
         sn /= &g;
         sd /= g;
         if sd < BigInt::from(0) {
@@ -1620,7 +1620,7 @@ impl Coeff {
       (Self::BigExact(n1, d1), Self::BigExact(n2, d2)) => {
         let mut sn = n1 * d2 + n2 * d1;
         let mut sd = d1 * d2;
-        let g = bigint_gcd(&sn, &sd);
+        let g = gcd_bigint(&sn, &sd);
         sn /= &g;
         sd /= g;
         if sd < BigInt::from(0) {
@@ -1669,7 +1669,7 @@ impl Coeff {
         let (n2, d2) = Self::to_big(*n2, *d2);
         let mut sn = &n1 * &n2;
         let mut sd = d1 * d2;
-        let g = bigint_gcd(&sn, &sd);
+        let g = gcd_bigint(&sn, &sd);
         sn /= &g;
         sd /= g;
         if sd < BigInt::from(0) {
@@ -1681,7 +1681,7 @@ impl Coeff {
       (Self::BigExact(n1, d1), Self::BigExact(n2, d2)) => {
         let mut sn = n1 * n2;
         let mut sd = d1 * d2;
-        let g = bigint_gcd(&sn, &sd);
+        let g = gcd_bigint(&sn, &sd);
         sn /= &g;
         sd /= g;
         if sd < BigInt::from(0) {
@@ -6657,7 +6657,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
     // Reduce the fraction by gcd and fix the sign onto the numerator.
     {
-      let g = bigint_gcd(&big_numer, &big_denom);
+      let g = gcd_bigint(&big_numer, &big_denom);
       if g != BigInt::from(0) {
         big_numer /= &g;
         big_denom /= &g;
@@ -6979,7 +6979,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     None => {
       let big_numer = BigInt::from(int_product) * BigInt::from(rat_numer);
       let big_denom = BigInt::from(rat_denom);
-      let g = bigint_gcd(&big_numer, &big_denom);
+      let g = gcd_bigint(&big_numer, &big_denom);
       let mut sn = big_numer / &g;
       let mut sd = big_denom / g;
       if sd < BigInt::from(0) {
@@ -7811,7 +7811,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
 
   // For BigInteger / BigInteger (or mixed Integer/BigInteger), reduce by GCD
   {
-    use crate::functions::math_ast::number_theory::bigint_gcd;
+    use crate::functions::math_ast::number_theory::gcd_bigint;
     let a_big = expr_to_bigint(a);
     let b_big = expr_to_bigint(b);
     if let (Some(numer), Some(denom)) = (a_big, b_big) {
@@ -7819,7 +7819,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
       if denom.is_zero() {
         return Ok(divide_by_zero_result(a));
       }
-      let g = bigint_gcd(numer.clone(), denom.clone());
+      let g = gcd_bigint(numer.clone(), denom.clone());
       let mut rn = &numer / &g;
       let mut rd = &denom / &g;
       // Normalize sign: put sign in numerator
@@ -8072,14 +8072,14 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
       // preserved instead of collapsing to a lossy Real (e.g. iterating
       // `#/2 &` past a 2^127 denominator must stay an exact fraction).
       _ => {
-        use crate::functions::math_ast::number_theory::bigint_gcd;
+        use crate::functions::math_ast::number_theory::gcd_bigint;
         use num_traits::Zero;
         let numer = BigInt::from(a_n) * BigInt::from(b_d);
         let denom = BigInt::from(a_d) * BigInt::from(b_n);
         if denom.is_zero() {
           return Ok(divide_by_zero_result(a));
         }
-        let g = bigint_gcd(numer.clone(), denom.clone());
+        let g = gcd_bigint(numer.clone(), denom.clone());
         let mut rn = &numer / &g;
         let mut rd = &denom / &g;
         if rd < BigInt::from(0) {
@@ -9259,7 +9259,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     use num_traits::{ToPrimitive, Zero};
 
     // BigInt GCD helper
-    fn bigint_gcd(a: &BigInt, b: &BigInt) -> BigInt {
+    fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
       let mut a = if *a < BigInt::from(0) {
         -a.clone()
       } else {
@@ -9325,10 +9325,10 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     let k_n = num_traits::pow::pow(k_big, *n as usize);
 
     // Reduce fractions
-    let g_re = bigint_gcd(&result_re, &k_n);
+    let g_re = gcd_bigint(&result_re, &k_n);
     let final_re_n = &result_re / &g_re;
     let final_re_d = &k_n / &g_re;
-    let g_im = bigint_gcd(&result_im, &k_n);
+    let g_im = gcd_bigint(&result_im, &k_n);
     let final_im_n = &result_im / &g_im;
     let final_im_d = &k_n / &g_im;
 

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -2686,7 +2686,7 @@ pub fn from_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Need a rational: int_val / base^(-shift)
       let denom = big_base.pow((-shift) as u32);
       // Simplify the fraction using Euclidean gcd
-      fn bigint_gcd(a: &BigInt, b: &BigInt) -> BigInt {
+      fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
         let mut a = if a < &BigInt::from(0) { -a } else { a.clone() };
         let mut b = if b < &BigInt::from(0) { -b } else { b.clone() };
         while b > BigInt::from(0) {
@@ -2696,7 +2696,7 @@ pub fn from_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         a
       }
-      let g = bigint_gcd(&int_val, &denom);
+      let g = gcd_bigint(&int_val, &denom);
       let num = &int_val / &g;
       let den = &denom / &g;
       if den == BigInt::from(1) {
@@ -3996,7 +3996,7 @@ pub fn number_decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
     }
   } else {
-    let gcd = |mut a: i128, mut b: i128| -> i128 {
+    let gcd_i128 = |mut a: i128, mut b: i128| -> i128 {
       a = a.abs();
       b = b.abs();
       while b != 0 {
@@ -4024,7 +4024,7 @@ pub fn number_decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // rem -= q_int * u
         rn = rn * ud - q_int * un * rd;
         rd *= ud;
-        let g = gcd(rn, rd);
+        let g = gcd_i128(rn, rd);
         rn /= g;
         rd /= g;
       }
@@ -4209,7 +4209,7 @@ pub fn minkowski_question_mark_ast(
   };
 
   // Exact fraction arithmetic over BigInt
-  let gcd = |a: &BigInt, b: &BigInt| -> BigInt {
+  let gcd_bigint = |a: &BigInt, b: &BigInt| -> BigInt {
     let (mut a, mut b) = (a.clone(), b.clone());
     if a < BigInt::from(0) {
       a = -a;
@@ -4229,7 +4229,7 @@ pub fn minkowski_question_mark_ast(
     }
   };
   let reduce = |num: BigInt, den: BigInt| -> (BigInt, BigInt) {
-    let g = gcd(&num, &den);
+    let g = gcd_bigint(&num, &den);
     let (mut n, mut d) = (num / &g, den / g);
     if d < BigInt::from(0) {
       n = -n;

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1206,7 +1206,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       let denom = fact(n - k) * &b_pochhammer * &k_fact;
       // coeff = n! / denom (reduce GCD).
-      fn bigint_gcd(a: &BigInt, b: &BigInt) -> BigInt {
+      fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
         use num_traits::Zero;
         let (mut a, mut b) = (a.clone(), b.clone());
         if a < BigInt::from(0) {
@@ -1222,7 +1222,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         a
       }
-      let g = bigint_gcd(&n_fact, &denom);
+      let g = gcd_bigint(&n_fact, &denom);
       let cn = &n_fact / &g;
       let cd = &denom / &g;
       let z_pow = if k == 0 {
@@ -1356,7 +1356,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Reduce by the gcd shared between numerator e^z coefficient, the
     // numerator constant, and the denominator.
     let g_all =
-      bigint_gcd(bigint_gcd(e_num.abs(), const_num.abs()), z_max.abs());
+      gcd_bigint(gcd_bigint(e_num.abs(), const_num.abs()), z_max.abs());
     let denom = if g_all != BigInt::from(0) {
       &z_max / &g_all
     } else {
@@ -1376,7 +1376,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // when the numerator has a common factor — pull that factor out so
     // the inner Plus shows the smallest integer coefficients.
     let mut outer_factor = BigInt::from(1);
-    let g_num = bigint_gcd(e_n.abs(), c_n.abs());
+    let g_num = gcd_bigint(e_n.abs(), c_n.abs());
     if g_num > BigInt::from(1) {
       outer_factor = g_num.clone();
       e_n /= &g_num;
@@ -1421,7 +1421,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     };
   }
 
-  fn bigint_gcd(a: BigInt, b: BigInt) -> BigInt {
+  fn gcd_bigint(a: BigInt, b: BigInt) -> BigInt {
     use num_traits::Zero;
     let (mut a, mut b) = (a, b);
     while !b.is_zero() {

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -58,7 +58,7 @@ fn is_concrete_number(e: &Expr) -> bool {
   }
 }
 
-pub fn bigint_gcd(a: BigInt, b: BigInt) -> BigInt {
+pub fn gcd_bigint(a: BigInt, b: BigInt) -> BigInt {
   use num_traits::Zero;
   let (mut a, mut b) = (a.abs(), b.abs());
   while !b.is_zero() {
@@ -240,8 +240,8 @@ pub fn gcd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut num_gcd = fractions[0].0.clone().abs();
   let mut den_lcm = fractions[0].1.clone().abs();
   for (n, d) in &fractions[1..] {
-    num_gcd = bigint_gcd(num_gcd, n.clone());
-    den_lcm = bigint_lcm(den_lcm, d.clone());
+    num_gcd = gcd_bigint(num_gcd, n.clone());
+    den_lcm = lcm_bigint(den_lcm, d.clone());
   }
 
   Ok(make_rational_expr(num_gcd, den_lcm))
@@ -408,8 +408,8 @@ pub fn lcm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut num_lcm = fractions[0].0.clone().abs();
   let mut den_gcd = fractions[0].1.clone().abs();
   for (n, d) in &fractions[1..] {
-    num_lcm = bigint_lcm(num_lcm, n.clone());
-    den_gcd = bigint_gcd(den_gcd, d.clone());
+    num_lcm = lcm_bigint(num_lcm, n.clone());
+    den_gcd = gcd_bigint(den_gcd, d.clone());
   }
 
   Ok(make_rational_expr(num_lcm, den_gcd))
@@ -441,12 +441,12 @@ fn expr_to_fraction(expr: &Expr) -> Option<(BigInt, BigInt)> {
 }
 
 /// LCM helper for BigInts. LCM(0, _) = LCM(_, 0) = 0.
-fn bigint_lcm(a: BigInt, b: BigInt) -> BigInt {
+fn lcm_bigint(a: BigInt, b: BigInt) -> BigInt {
   use num_traits::Zero;
   if a.is_zero() || b.is_zero() {
     return BigInt::from(0);
   }
-  let g = bigint_gcd(a.clone(), b.clone());
+  let g = gcd_bigint(a.clone(), b.clone());
   (a.abs() / g) * b.abs()
 }
 
@@ -459,7 +459,7 @@ pub fn make_rational_expr(num: BigInt, den: BigInt) -> Expr {
     // callers see the same surface behaviour.
     return Expr::Identifier("ComplexInfinity".to_string());
   }
-  let g = bigint_gcd(num.clone(), den.clone());
+  let g = gcd_bigint(num.clone(), den.clone());
   let mut n = num / &g;
   let mut d = den / g;
   if d < BigInt::from(0) {
@@ -1092,7 +1092,7 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Represent each Bernoulli number as a reduced (numerator, denominator)
   // pair in BigInt, so large numerators (e.g. BernoulliB[60]) don't overflow
   // i128.
-  fn bgcd(a: &BigInt, b: &BigInt) -> BigInt {
+  fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
     let (mut a, mut b) = (a.clone().abs(), b.clone().abs());
     while b != BigInt::from(0) {
       let t = b.clone();
@@ -1102,7 +1102,7 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     a
   }
   fn reduce(num: BigInt, den: BigInt) -> (BigInt, BigInt) {
-    let mut g = bgcd(&num, &den);
+    let mut g = gcd_bigint(&num, &den);
     if g == BigInt::from(0) {
       g = BigInt::from(1);
     }
@@ -2008,7 +2008,7 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Compute as exact rational: sum of 1/k^r for k = 1 to n
   // Use BigInt numerator and denominator
-  fn bigint_gcd(a: &BigInt, b: &BigInt) -> BigInt {
+  fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
     use num_traits::Zero;
     let mut a = if *a < BigInt::zero() {
       -a.clone()
@@ -2039,7 +2039,7 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       num = &num * &k_pow + &den;
       den = &den * &k_pow;
       // Reduce
-      let g = bigint_gcd(&num, &den);
+      let g = gcd_bigint(&num, &den);
       use num_traits::One;
       if g > BigInt::one() {
         num /= &g;
@@ -2331,7 +2331,7 @@ pub fn alternating_harmonic_number_ast(
           };
           num = &num * &k_pow + signed;
           den = &den * &k_pow;
-          let g = bigint_gcd(num.clone(), den.clone());
+          let g = gcd_bigint(num.clone(), den.clone());
           use num_traits::One;
           if g > BigInt::one() {
             num /= &g;
@@ -5934,13 +5934,13 @@ pub fn frobenius_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Compute GCD of all elements
-  fn gcd(a: i128, b: i128) -> i128 {
-    if b == 0 { a.abs() } else { gcd(b, a % b) }
+  fn gcd_i128(a: i128, b: i128) -> i128 {
+    if b == 0 { a.abs() } else { gcd_i128(b, a % b) }
   }
 
   let mut g = nums[0];
   for &n in &nums[1..] {
-    g = gcd(g, n);
+    g = gcd_i128(g, n);
   }
 
   // If GCD > 1, infinitely many integers can't be represented
@@ -9429,7 +9429,7 @@ fn bigint_rational_to_expr(num: BigInt, den: BigInt) -> Expr {
   if den.is_zero() {
     return Expr::Identifier("ComplexInfinity".to_string());
   }
-  let g = bigint_gcd(num.clone().abs(), den.clone().abs());
+  let g = gcd_bigint(num.clone().abs(), den.clone().abs());
   let (mut n, mut d) = (num / &g, den / &g);
   if d < BigInt::from(0) {
     n = -n;

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -129,13 +129,13 @@ fn reduce_poly_over_integer(expr: Expr) -> Result<Expr, InterpreterError> {
   let mut content = BigInt::from(0);
   let mut bail = false;
   for_each_plus_term(&poly, &mut |t| match integer_coeff_of_term(t) {
-    Some(c) => content = bigint_gcd(content.clone(), c.abs()),
+    Some(c) => content = gcd_bigint(content.clone(), c.abs()),
     None => bail = true,
   });
   if bail {
     return Ok(expr);
   }
-  let g = bigint_gcd(content, d.abs());
+  let g = gcd_bigint(content, d.abs());
   if g <= BigInt::from(1) {
     return Ok(expr);
   }
@@ -718,7 +718,7 @@ fn legendre_eval_rational(n: usize, x: (BigInt, BigInt)) -> (BigInt, BigInt) {
     let diff_n = &term1_n * &term2_d - &term2_n * &term1_d;
     let diff_d = &term1_d * &term2_d * (&m_i + BigInt::from(1));
 
-    let g = bigint_gcd(diff_n.clone(), diff_d.clone());
+    let g = gcd_bigint(diff_n.clone(), diff_d.clone());
     let next_n = &diff_n / &g;
     let next_d = &diff_d / &g;
 
@@ -2236,7 +2236,7 @@ fn chebyshev_t_eval_rational(
     let a_d = &xd * &t.1;
     let new_n = &a_n * &tm1.1 - &tm1.0 * &a_d;
     let new_d = &a_d * &tm1.1;
-    let g = bigint_gcd(new_n.clone(), new_d.clone());
+    let g = gcd_bigint(new_n.clone(), new_d.clone());
     tm1 = t;
     t = if g != BigInt::from(0) {
       (&new_n / &g, &new_d / &g)
@@ -2463,7 +2463,7 @@ fn chebyshev_u_eval_rational(
     let a_d = &xd * &u.1;
     let new_n = &a_n * &um1.1 - &um1.0 * &a_d;
     let new_d = &a_d * &um1.1;
-    let g = bigint_gcd(new_n.clone(), new_d.clone());
+    let g = gcd_bigint(new_n.clone(), new_d.clone());
     um1 = u;
     u = if g != BigInt::from(0) {
       (&new_n / &g, &new_d / &g)
@@ -2760,7 +2760,7 @@ fn gegenbauer_eval_rational(
   // C_1 = 2λx = (2*lam_n*x_n, lam_d*x_d)
   let c1_n = BigInt::from(2) * &lam.0 * &x.0;
   let c1_d = &lam.1 * &x.1;
-  let g = bigint_gcd(c1_n.clone(), c1_d.clone());
+  let g = gcd_bigint(c1_n.clone(), c1_d.clone());
   let c1 = if g != BigInt::from(0) {
     (&c1_n / &g, &c1_d / &g)
   } else {
@@ -2799,7 +2799,7 @@ fn gegenbauer_eval_rational(
     let new_n = diff_n;
     let new_d = diff_d * (&kk + BigInt::from(1));
 
-    let g = bigint_gcd(new_n.clone(), new_d.clone());
+    let g = gcd_bigint(new_n.clone(), new_d.clone());
     cm1 = c;
     c = if g != BigInt::from(0) {
       (&new_n / &g, &new_d / &g)
@@ -3425,7 +3425,7 @@ fn laguerre_eval_rational(n: usize, x: (BigInt, BigInt)) -> (BigInt, BigInt) {
     let sub_n = &a_n * b_d - &b_n * &a_d;
     let sub_d = &a_d * b_d * (&kf + BigInt::from(1));
 
-    let g = bigint_gcd(sub_n.clone(), sub_d.clone());
+    let g = gcd_bigint(sub_n.clone(), sub_d.clone());
     lm1 = l;
     l = if g != BigInt::from(0) {
       (&sub_n / &g, &sub_d / &g)

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -154,7 +154,7 @@ fn apart_expr_raw(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
         // the proper-fraction path hoist the content and normalize signs.
         let mut lcm: i128 = 1;
         for &(_, d) in &remainder {
-          let g = i128_gcd(lcm, d);
+          let g = gcd_i128(lcm, d);
           lcm = match (lcm / g).checked_mul(d) {
             Some(v) => v,
             None => {
@@ -989,7 +989,7 @@ fn apart_repeated_roots(
 }
 
 /// Polynomial long division returning (quotient, remainder) as coefficient vectors
-fn i128_gcd(a: i128, b: i128) -> i128 {
+fn gcd_i128(a: i128, b: i128) -> i128 {
   let (mut a, mut b) = (a.abs(), b.abs());
   while b != 0 {
     let t = a % b;
@@ -1001,7 +1001,7 @@ fn i128_gcd(a: i128, b: i128) -> i128 {
 
 /// Reduce n/d to lowest terms with a positive denominator.
 fn rat_reduce(n: i128, d: i128) -> (i128, i128) {
-  let g = i128_gcd(n, d);
+  let g = gcd_i128(n, d);
   let (mut n, mut d) = (n / g, d / g);
   if d < 0 {
     n = -n;

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -1624,7 +1624,7 @@ fn sturm_real_root_count(coeffs: &[i128]) -> usize {
     v
   }
 
-  fn big_gcd(a: &BigInt, b: &BigInt) -> BigInt {
+  fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
     let mut a = a.abs();
     let mut b = b.abs();
     while !b.is_zero() {
@@ -1638,7 +1638,7 @@ fn sturm_real_root_count(coeffs: &[i128]) -> usize {
   fn content_reduce(v: &[BigInt]) -> Vec<BigInt> {
     let mut g = BigInt::ZERO;
     for c in v {
-      g = big_gcd(&g, c);
+      g = gcd_bigint(&g, c);
     }
     if g > BigInt::from(1) {
       v.iter().map(|c| c / &g).collect()

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -7848,14 +7848,14 @@ fn try_merge_logs(expr: &Expr) -> Option<Expr> {
   use num_traits::{One, Zero};
 
   // gcd of two non-negative BigInts (Euclid).
-  fn big_gcd(mut a: BigInt, mut b: BigInt) -> BigInt {
+  fn gcd_bigint(mut a: BigInt, mut b: BigInt) -> BigInt {
     while !b.is_zero() {
       let r = &a % &b;
       a = std::mem::replace(&mut b, r);
     }
     a
   }
-  fn u64_gcd(mut a: u64, mut b: u64) -> u64 {
+  fn gcd_u64(mut a: u64, mut b: u64) -> u64 {
     while b != 0 {
       let r = a % b;
       a = std::mem::replace(&mut b, r);
@@ -7977,7 +7977,7 @@ fn try_merge_logs(expr: &Expr) -> Option<Expr> {
         den *= n.pow((-c) as u32);
       }
     }
-    let g = big_gcd(num.clone(), den.clone());
+    let g = gcd_bigint(num.clone(), den.clone());
     let num = &num / &g;
     let den = &den / &g;
     let q = if den.is_one() {
@@ -8005,7 +8005,7 @@ fn try_merge_logs(expr: &Expr) -> Option<Expr> {
     let g = logs
       .iter()
       .map(|(c, _)| c.unsigned_abs())
-      .fold(0u64, u64_gcd);
+      .fold(0u64, gcd_u64);
     if g > 1 {
       let reduced: Vec<(i64, BigInt)> = logs
         .iter()


### PR DESCRIPTION
Woxi source code seems to prefer type suffixes in function names rather than type prefixes.  So for gcd, we should standardize on gcd_i128 and gcd_bigint. The generic "gcd" with no type I left mostly as is for now.