### PR TITLE
Remove more wrapper functions

### DIFF
--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -280,7 +280,7 @@ pub fn dispatch_linear_algebra_functions(
           let mut row = Vec::with_capacity(n);
           for j in 0..n {
             let denom = (i + j + 1) as i128;
-            row.push(crate::functions::math_ast::make_rational_pub(1, denom));
+            row.push(crate::functions::math_ast::make_rational(1, denom));
           }
           rows.push(Expr::List(row.into()));
         }
@@ -2913,12 +2913,12 @@ pub fn dispatch_linear_algebra_functions(
           )));
         }
         {
-          use crate::functions::math_ast::make_rational_pub;
+          use crate::functions::math_ast::make_rational;
           let cos_pi = |num: i128, den: i128| -> Expr {
             let angle = Expr::FunctionCall {
               name: "Times".to_string(),
               args: vec![
-                make_rational_pub(num, den),
+                make_rational(num, den),
                 Expr::Identifier("Pi".to_string()),
               ]
               .into(),
@@ -2938,20 +2938,20 @@ pub fn dispatch_linear_algebra_functions(
             for j in 1..=n {
               let entry = match m {
                 1 => {
-                  let base = make_sqrt(make_rational_pub(2, n - 1));
+                  let base = make_sqrt(make_rational(2, n - 1));
                   let scale = if i == 1 || i == n {
-                    times(make_rational_pub(1, 2), base)
+                    times(make_rational(1, 2), base)
                   } else {
                     base
                   };
                   times(scale, cos_pi((i - 1) * (j - 1), n - 1))
                 }
                 2 => times(
-                  make_sqrt(make_rational_pub(1, n)),
+                  make_sqrt(make_rational(1, n)),
                   cos_pi((2 * i - 1) * (j - 1), 2 * n),
                 ),
                 3 => {
-                  let base = make_sqrt(make_rational_pub(1, n));
+                  let base = make_sqrt(make_rational(1, n));
                   let scale = if i == 1 {
                     base
                   } else {
@@ -2960,7 +2960,7 @@ pub fn dispatch_linear_algebra_functions(
                   times(scale, cos_pi((2 * j - 1) * (i - 1), 2 * n))
                 }
                 _ => times(
-                  make_sqrt(make_rational_pub(2, n)),
+                  make_sqrt(make_rational(2, n)),
                   cos_pi((2 * i - 1) * (2 * j - 1), 4 * n),
                 ),
               };

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -49,7 +49,7 @@ fn listrp_invalid_atom(e: &Expr) -> bool {
     Expr::List(_) => false,
     Expr::String(_) | Expr::Association(_) => true,
     Expr::Identifier(s) if s == "True" || s == "False" => true,
-    _ => crate::functions::predicate_ast::is_numeric_q_pub(e),
+    _ => crate::functions::predicate_ast::is_numeric_q(e),
   }
 }
 
@@ -3567,7 +3567,7 @@ pub fn dispatch_list_operations(
           crate::functions::quantile_distribution_closed_form(
             dn,
             da,
-            &crate::functions::math_ast::make_rational_pub(1, 2),
+            &crate::functions::math_ast::make_rational(1, 2),
           )
       {
         return Some(Ok(result));

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -774,7 +774,7 @@ pub fn dispatch_math_functions(
             return None;
           };
           let Ok((mean, var)) =
-            crate::functions::math_ast::distribution_mean_variance_pub(cn, ca)
+            crate::functions::math_ast::distribution_mean_variance(cn, ca)
           else {
             return None;
           };
@@ -2578,8 +2578,7 @@ pub fn dispatch_math_functions(
         if base_int >= 2 {
           let denom = (base_int as f64).powi(e as i32) as i128;
           if denom > 0 {
-            let mantissa =
-              crate::functions::math_ast::make_rational_pub(*n, denom);
+            let mantissa = crate::functions::math_ast::make_rational(*n, denom);
             return Some(Ok(Expr::List(
               vec![mantissa, Expr::Integer(e)].into(),
             )));

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use crate::syntax::{
 };
 #[allow(unused_imports)]
 pub(crate) use crate::{
-  ENV, InterpreterError, PART_DEPTH, StoredValue, format_real_result, interpret,
+  ENV, InterpreterError, PART_DEPTH, StoredValue, interpret,
 };
 
 pub mod arg_count;

--- a/src/evaluator/dispatch/polynomial_functions.rs
+++ b/src/evaluator/dispatch/polynomial_functions.rs
@@ -1287,6 +1287,6 @@ fn sinusoid_extremum(expr: &Expr, var: &str, maximize: bool) -> Option<Expr> {
   Some(if value.1 == 1 {
     Expr::Integer(value.0)
   } else {
-    crate::functions::math_ast::make_rational_pub(value.0, value.1)
+    crate::functions::math_ast::make_rational(value.0, value.1)
   })
 }

--- a/src/evaluator/dispatch/structural.rs
+++ b/src/evaluator/dispatch/structural.rs
@@ -87,7 +87,7 @@ pub fn dispatch_structural(
         if d == 0 {
           return Some(Ok(Expr::Identifier("ComplexInfinity".to_string())));
         }
-        return Some(Ok(crate::functions::math_ast::make_rational_pub(n, d)));
+        return Some(Ok(crate::functions::math_ast::make_rational(n, d)));
       }
       return Some(Ok(Expr::FunctionCall {
         name: "Rational".to_string(),

--- a/src/functions/boolean_ast.rs
+++ b/src/functions/boolean_ast.rs
@@ -582,7 +582,7 @@ pub fn infinity_equal_verdict(a: &Expr, b: &Expr) -> Option<Option<bool>> {
     (None, None) => None,
     (Some(_), None) | (None, Some(_)) => {
       let finite = if ka.is_some() { b } else { a };
-      if crate::functions::predicate_ast::is_numeric_q_pub(finite) {
+      if crate::functions::predicate_ast::is_numeric_q(finite) {
         Some(Some(false))
       } else {
         None // symbolic operand — leave to the normal machinery

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -4352,7 +4352,7 @@ fn make_neg_divided(expr: Expr, divisor: Expr) -> Expr {
     },
     Expr::Integer(n) => Expr::BinaryOp {
       op: crate::syntax::BinaryOperator::Times,
-      left: Box::new(crate::functions::math_ast::make_rational_pub(-1, *n)),
+      left: Box::new(crate::functions::math_ast::make_rational(-1, *n)),
       right: Box::new(expr),
     },
     _ => Expr::BinaryOp {
@@ -6197,9 +6197,7 @@ fn try_integrate_rational(
       } else {
         Expr::BinaryOp {
           op: BinaryOperator::Times,
-          left: Box::new(crate::functions::math_ast::make_rational_pub(
-            abs_an, ad,
-          )),
+          left: Box::new(crate::functions::math_ast::make_rational(abs_an, ad)),
           right: Box::new(log_expr.clone()),
         }
       };
@@ -6833,9 +6831,7 @@ fn build_coeff_times_expr(num: i128, den: i128, expr: Expr) -> Expr {
   } else {
     Expr::BinaryOp {
       op: BinaryOperator::Times,
-      left: Box::new(crate::functions::math_ast::make_rational_pub(
-        abs_num, den,
-      )),
+      left: Box::new(crate::functions::math_ast::make_rational(abs_num, den)),
       right: Box::new(expr),
     }
   };
@@ -10568,9 +10564,7 @@ fn limit_at_infinity(
         let pf = l_ext * q as f64;
         let p = pf.round();
         if (pf - p).abs() < 1e-6 {
-          return Ok(crate::functions::math_ast::make_rational_pub(
-            p as i128, q,
-          ));
+          return Ok(crate::functions::math_ast::make_rational(p as i128, q));
         }
       }
       // Check for known constants
@@ -10767,7 +10761,7 @@ fn exp_growth_limit_at_infinity(
     let pf = f2 * q as f64;
     let p = pf.round();
     if (pf - p).abs() < 1e-7 {
-      return Some(crate::functions::math_ast::make_rational_pub(p as i128, q));
+      return Some(crate::functions::math_ast::make_rational(p as i128, q));
     }
   }
   None
@@ -14062,7 +14056,7 @@ fn rat_to_expr(r: (i128, i128)) -> Expr {
   if r.1 == 1 {
     Expr::Integer(r.0)
   } else {
-    crate::functions::math_ast::make_rational_pub(r.0, r.1)
+    crate::functions::math_ast::make_rational(r.0, r.1)
   }
 }
 
@@ -15335,7 +15329,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           if den == 1 {
             Expr::Integer(num)
           } else {
-            crate::functions::math_ast::make_rational_pub(num, den)
+            crate::functions::math_ast::make_rational(num, den)
           }
         }
         // Handle Rational[n, d] / factorial → Rational[n, d*factorial] simplified
@@ -15346,7 +15340,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && matches!(&rargs[1], Expr::Integer(_)) =>
         {
           if let (Expr::Integer(n), Expr::Integer(d)) = (&rargs[0], &rargs[1]) {
-            crate::functions::math_ast::make_rational_pub(*n, d * factorial)
+            crate::functions::math_ast::make_rational(*n, d * factorial)
           } else {
             Expr::BinaryOp {
               op: crate::syntax::BinaryOperator::Divide,

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -1451,7 +1451,7 @@ pub fn graph_reciprocity(edges: &[Expr]) -> Option<Expr> {
       ku == kv || dir_set.contains(&(kv, ku))
     })
     .count();
-  Some(crate::functions::math_ast::make_rational_pub(
+  Some(crate::functions::math_ast::make_rational(
     reciprocated as i128,
     parsed.len() as i128,
   ))

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -11135,7 +11135,7 @@ fn evenly_spaced_stops(n: usize) -> Vec<Expr> {
   }
   let denom = (n - 1) as i128;
   (0..n)
-    .map(|i| crate::functions::make_rational_pub(i as i128, denom))
+    .map(|i| crate::functions::make_rational(i as i128, denom))
     .collect()
 }
 
@@ -11223,7 +11223,7 @@ pub fn drop_shadowing_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       color.unwrap_or_else(|| Expr::FunctionCall {
         name: "Opacity".to_string(),
         args: vec![
-          crate::functions::make_rational_pub(1, 3),
+          crate::functions::make_rational(1, 3),
           Expr::FunctionCall {
             name: "ThemeColor".to_string(),
             args: vec![Expr::Identifier("Foreground".to_string())].into(),

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -323,11 +323,8 @@ pub fn orthogonalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // e = w / Sqrt[normsq] = w * normsq^(-1/2).
       let inv_norm = Expr::FunctionCall {
         name: "Power".to_string(),
-        args: vec![
-          normsq,
-          crate::functions::math_ast::make_rational_pub(-1, 2),
-        ]
-        .into(),
+        args: vec![normsq, crate::functions::math_ast::make_rational(-1, 2)]
+          .into(),
       };
       let e: Vec<Expr> = w
         .iter()
@@ -727,7 +724,7 @@ pub fn is_nonempty_square(m: &[Vec<Expr>]) -> bool {
 /// symbolic expressions (`x`, `a + b`, `f[x]`) stay held with no message.
 pub fn is_matsq_subject(arg: &Expr) -> bool {
   matches!(arg, Expr::List(_))
-    || crate::functions::predicate_ast::is_numeric_q_pub(arg)
+    || crate::functions::predicate_ast::is_numeric_q(arg)
 }
 
 /// Emit `<F>::matsq: Argument <m> at position 1 is not a nonempty square
@@ -1119,9 +1116,9 @@ fn eval_divide(a: &Expr, b: &Expr) -> Expr {
         let (n, d) = (x / g, y / g);
         if d < 0 {
           // Keep denominator positive
-          crate::functions::math_ast::make_rational_pub(-n, -d)
+          crate::functions::math_ast::make_rational(-n, -d)
         } else {
-          crate::functions::math_ast::make_rational_pub(n, d)
+          crate::functions::math_ast::make_rational(n, d)
         }
       }
     }
@@ -2658,7 +2655,7 @@ fn simplify_fraction(n: i128, d: i128) -> Expr {
   if d == 1 {
     Expr::Integer(n)
   } else {
-    crate::functions::math_ast::make_rational_pub(n, d)
+    crate::functions::math_ast::make_rational(n, d)
   }
 }
 
@@ -9307,7 +9304,7 @@ fn gq_to_expr(q: &GQNum) -> Option<Expr> {
     if x.d == 1 {
       Expr::Integer(x.n)
     } else {
-      crate::functions::math_ast::make_rational_pub(x.n, x.d)
+      crate::functions::math_ast::make_rational(x.n, x.d)
     }
   };
   if q.im.is_zero() {

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -765,7 +765,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
     // Median[dist] = Quantile[dist, 1/2]; delegate to the closed-form quantile
     // for the gamma family. (BetaDistribution is handled by an earlier arm.)
     "GammaDistribution" | "ChiSquareDistribution" => {
-      let half = crate::functions::math_ast::make_rational_pub(1, 2);
+      let half = crate::functions::math_ast::make_rational(1, 2);
       crate::functions::math_ast::quantile_distribution_closed_form(
         name, dargs, &half,
       )

--- a/src/functions/list_helpers_ast/construction.rs
+++ b/src/functions/list_helpers_ast/construction.rs
@@ -598,7 +598,7 @@ pub fn range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
 
-      results.push(crate::functions::math_ast::make_rational_pub(cur_n, cur_d));
+      results.push(crate::functions::math_ast::make_rational(cur_n, cur_d));
 
       // cur += step: cur_n/cur_d + step_n/step_d = (cur_n*step_d + step_n*cur_d) / (cur_d*step_d)
       cur_n = cur_n * step_d + step_n * cur_d;
@@ -919,7 +919,7 @@ pub fn power_range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         break;
       }
 
-      results.push(crate::functions::math_ast::make_rational_pub(cur_n, cur_d));
+      results.push(crate::functions::math_ast::make_rational(cur_n, cur_d));
 
       // cur *= factor: (cur_n/cur_d) * (fac_n/fac_d) = (cur_n*fac_n) / (cur_d*fac_d)
       cur_n *= fac_n;
@@ -993,7 +993,7 @@ pub fn constant_array_ast(
       None => {
         // A concrete but invalid dimension is an error, so leave unevaluated;
         // a symbolic dimension yields a SymbolicZeros/OnesArray placeholder.
-        if crate::functions::predicate_ast::is_numeric_q_pub(d) {
+        if crate::functions::predicate_ast::is_numeric_q(d) {
           return unevaluated();
         }
         has_symbolic = true;

--- a/src/functions/list_helpers_ast/functional.rs
+++ b/src/functions/list_helpers_ast/functional.rs
@@ -1048,7 +1048,7 @@ pub fn tensor_product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let times = Expr::Identifier("Times".to_string());
   let is_scalar = |e: &Expr| -> bool {
     !matches!(e, Expr::List(_))
-      && crate::functions::predicate_ast::is_numeric_q_pub(e)
+      && crate::functions::predicate_ast::is_numeric_q(e)
   };
 
   // Pull scalars out; they distribute over the tensor part via Times.

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -8511,7 +8511,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     let y_expr = if yd == 1 {
       Expr::Integer(yn)
     } else {
-      crate::functions::math_ast::make_rational_pub(yn, yd)
+      crate::functions::math_ast::make_rational(yn, yd)
     };
     let neg_one_pow = Expr::FunctionCall {
       name: "Power".to_string(),
@@ -8559,7 +8559,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     let y_expr = if yd == 1 {
       Expr::Integer(yn)
     } else {
-      crate::functions::math_ast::make_rational_pub(yn, yd)
+      crate::functions::math_ast::make_rational(yn, yd)
     };
     let neg_one_pow = Expr::FunctionCall {
       name: "Power".to_string(),
@@ -10454,7 +10454,7 @@ fn simplify_neg1_rational_power(
     let rq = q / g2;
     let inner = Expr::FunctionCall {
       name: "Power".to_string(),
-      args: vec![Expr::Integer(-1), make_rational_pub(rp, rq)].into(),
+      args: vec![Expr::Integer(-1), make_rational(rp, rq)].into(),
     };
     return Ok(negate_expr(inner));
   }
@@ -10465,7 +10465,7 @@ fn simplify_neg1_rational_power(
   // 0 < p < q: return (-1)^(p/q)
   Ok(Expr::FunctionCall {
     name: "Power".to_string(),
-    args: vec![Expr::Integer(-1), make_rational_pub(p, q)].into(),
+    args: vec![Expr::Integer(-1), make_rational(p, q)].into(),
   })
 }
 

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -107,7 +107,7 @@ fn re_im_via_complex_expand(
   which: &str,
   arg: &Expr,
 ) -> Option<Result<Expr, InterpreterError>> {
-  if !crate::functions::predicate_ast::is_numeric_q_pub(arg) {
+  if !crate::functions::predicate_ast::is_numeric_q(arg) {
     return None;
   }
   let expanded = match crate::evaluator::evaluate_function_call_ast(
@@ -511,7 +511,7 @@ pub fn is_real_valued(expr: &Expr) -> bool {
     return true;
   }
   // NumericQ expressions: check if they evaluate to a real number
-  if crate::functions::predicate_ast::is_numeric_q_pub(expr) {
+  if crate::functions::predicate_ast::is_numeric_q(expr) {
     // Try to evaluate numerically - if it gives a real, it's real-valued
     if let Some(val) = crate::functions::math_ast::try_eval_to_f64(expr) {
       return val.is_finite() || val.is_nan();
@@ -800,7 +800,7 @@ pub fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
     left,
     right,
   } = expr
-    && crate::functions::predicate_ast::is_numeric_q_pub(expr)
+    && crate::functions::predicate_ast::is_numeric_q(expr)
   {
     let num = conjugate_one(left)?;
     let den = conjugate_one(right)?;

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -527,7 +527,7 @@ pub fn quantile_distribution_closed_form(
           return Some(if v.1 == 1 {
             Expr::Integer(v.0)
           } else {
-            crate::functions::math_ast::make_rational_pub(v.0, v.1)
+            crate::functions::math_ast::make_rational(v.0, v.1)
           });
         }
       }
@@ -535,7 +535,7 @@ pub fn quantile_distribution_closed_form(
         if v.1 == 1 {
           Expr::Integer(v.0)
         } else {
-          crate::functions::math_ast::make_rational_pub(v.0, v.1)
+          crate::functions::math_ast::make_rational(v.0, v.1)
         }
       })
     }
@@ -570,10 +570,8 @@ pub fn quantile_distribution_closed_form(
       }
       let (a, b) = (dargs[0].clone(), dargs[1].clone());
       let pi = Expr::Constant("Pi".to_string());
-      let q_minus_half = minus(
-        q.clone(),
-        crate::functions::math_ast::make_rational_pub(1, 2),
-      );
+      let q_minus_half =
+        minus(q.clone(), crate::functions::math_ast::make_rational(1, 2));
       let tan = Expr::FunctionCall {
         name: "Tan".to_string(),
         args: vec![times(pi, q_minus_half)].into(),
@@ -818,7 +816,7 @@ pub fn quantile_distribution_closed_form(
         args: vec![
           s,
           divide(nu.clone(), int(2)),
-          crate::functions::math_ast::make_rational_pub(1, 2),
+          crate::functions::math_ast::make_rational(1, 2),
         ]
         .into(),
       };
@@ -3939,14 +3937,6 @@ fn try_expectation_probability_distribution(
   Ok(Some(eval(integral)?))
 }
 
-/// Public wrapper for distribution_mean_variance for use by Mean/Variance
-pub fn distribution_mean_variance_pub(
-  dist_name: &str,
-  dargs: &[Expr],
-) -> Result<(Expr, Expr), InterpreterError> {
-  distribution_mean_variance(dist_name, dargs)
-}
-
 /// Parameters of a BinormalDistribution as `(m1, m2, s1, s2, rho)`.
 ///   BinormalDistribution[{m1, m2}, {s1, s2}, rho]  — full form
 ///   BinormalDistribution[rho]                       — standard (means 0,
@@ -3977,7 +3967,7 @@ pub fn binormal_params(
 }
 
 /// Returns (Mean, Variance) as symbolic expressions for known distributions.
-fn distribution_mean_variance(
+pub fn distribution_mean_variance(
   dist_name: &str,
   dargs: &[Expr],
 ) -> Result<(Expr, Expr), InterpreterError> {
@@ -8232,7 +8222,7 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let half_log_2pi = divide(plus(log_of(int(2)), log_of(pi())), int(2));
       let result = plus(
         times(
-          crate::functions::math_ast::make_rational_pub(-1, 2),
+          crate::functions::math_ast::make_rational(-1, 2),
           divide(poly, times(s.clone(), s.clone())),
         ),
         times(int(-n), plus(half_log_2pi, log_of(s.clone()))),
@@ -8640,7 +8630,7 @@ fn frac_to_rational_expr(f: (i128, i128)) -> Expr {
   if f.1 == 1 {
     Expr::Integer(f.0)
   } else {
-    crate::functions::math_ast::make_rational_pub(f.0, f.1)
+    crate::functions::math_ast::make_rational(f.0, f.1)
   }
 }
 
@@ -8725,7 +8715,7 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     } else if !first_scaled_seen {
       first_scaled_seen = true;
       times(
-        crate::functions::math_ast::make_rational_pub(-1, variances[i]),
+        crate::functions::math_ast::make_rational(-1, variances[i]),
         sq,
       )
     } else {
@@ -8770,7 +8760,7 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     let pi_pow = Expr::BinaryOp {
       op: crate::syntax::BinaryOperator::Power,
       left: Box::new(pi()),
-      right: Box::new(crate::functions::math_ast::make_rational_pub(3, 2)),
+      right: Box::new(crate::functions::math_ast::make_rational(3, 2)),
     };
     match &sqrt_part {
       Expr::Integer(s) => Expr::FunctionCall {
@@ -8865,7 +8855,7 @@ pub fn empirical_distribution_ast(
     uniques.push(if v.1 == 1 {
       Expr::Integer(v.0)
     } else {
-      crate::functions::math_ast::make_rational_pub(v.0, v.1)
+      crate::functions::math_ast::make_rational(v.0, v.1)
     });
   }
   Ok(Expr::FunctionCall {
@@ -8909,7 +8899,7 @@ fn frac_expr((n, d): (i128, i128)) -> Expr {
   if d == 1 {
     Expr::Integer(n)
   } else {
-    crate::functions::math_ast::make_rational_pub(n, d)
+    crate::functions::math_ast::make_rational(n, d)
   }
 }
 
@@ -9311,7 +9301,7 @@ pub fn data_distribution_moment(dargs: &[Expr], k: u32) -> Option<Expr> {
   Some(if den == 1 {
     Expr::Integer(num)
   } else {
-    crate::functions::math_ast::make_rational_pub(num, den)
+    crate::functions::math_ast::make_rational(num, den)
   })
 }
 
@@ -9349,7 +9339,7 @@ fn data_distribution_pdf_cdf(
   Some(if den == 1 {
     Expr::Integer(num)
   } else {
-    crate::functions::math_ast::make_rational_pub(num, den)
+    crate::functions::math_ast::make_rational(num, den)
   })
 }
 
@@ -9443,7 +9433,7 @@ fn pdf_product_distribution(
         let sq = pow2(v);
         terms.push(if !first_scaled_seen {
           first_scaled_seen = true;
-          times(crate::functions::math_ast::make_rational_pub(-1, 2), sq)
+          times(crate::functions::math_ast::make_rational(-1, 2), sq)
         } else {
           neg(div2(sq, int(2)))
         });

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -1995,7 +1995,7 @@ pub fn round_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let (Some(num), Some(den)) =
         (expr_to_i128(&rargs[0]), expr_to_i128(&rargs[1]))
       {
-        return Ok(make_rational_pub(n * num, den));
+        return Ok(make_rational(n * num, den));
       }
     }
 
@@ -2074,8 +2074,8 @@ pub fn round_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     crate::functions::math_ast::try_extract_complex_exact(&args[0])
     && in_ != 0
   {
-    let re_rat = make_rational_pub(rn, rd);
-    let im_rat = make_rational_pub(in_, id);
+    let re_rat = make_rational(rn, rd);
+    let im_rat = make_rational(in_, id);
     let re_rounded = round_ast(&[re_rat])?;
     let im_rounded = round_ast(&[im_rat])?;
     return crate::evaluator::evaluate_function_call_ast(
@@ -4041,7 +4041,7 @@ pub fn heaviside_lambda_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         // 1 - |n/d| = (|d| - |n|) / |d|
         let num = abs_d - abs_n;
-        return Ok(crate::functions::math_ast::make_rational_pub(num, abs_d));
+        return Ok(crate::functions::math_ast::make_rational(num, abs_d));
       }
       Ok(Expr::FunctionCall {
         name: "HeavisideLambda".to_string(),

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1485,7 +1485,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           &[Expr::Integer(num), z_pow],
         )?,
         (num, den) => {
-          let rat = crate::functions::math_ast::make_rational_pub(num, den);
+          let rat = crate::functions::math_ast::make_rational(num, den);
           crate::evaluator::evaluate_function_call_ast("Times", &[rat, z_pow])?
         }
       };
@@ -2997,9 +2997,7 @@ pub fn whittaker_w_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               for n in 1..=(-ki) {
                 fact *= n;
               }
-              return Ok(crate::functions::math_ast::make_rational_pub(
-                1, fact,
-              ));
+              return Ok(crate::functions::math_ast::make_rational(1, fact));
             }
             let rounded = value.round();
             if (value - rounded).abs() < 1e-12 {

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -2396,7 +2396,7 @@ pub fn alternating_harmonic_number_ast(
   let r_expr = &args[1];
   let x = &args[2];
   if !is_exact_order(r_expr)
-    || !crate::functions::predicate_ast::is_numeric_q_pub(x)
+    || !crate::functions::predicate_ast::is_numeric_q(x)
   {
     return Ok(unevaluated);
   }
@@ -2520,7 +2520,7 @@ pub fn hyper_harmonic_number_ast(
     return Ok(unevaluated);
   }
   if let Some(x) = x
-    && !crate::functions::predicate_ast::is_numeric_q_pub(x)
+    && !crate::functions::predicate_ast::is_numeric_q(x)
   {
     return Ok(unevaluated);
   }
@@ -9446,7 +9446,7 @@ fn six_j_symbol_symbolic(
       let forced = if v_2j.rem_euclid(2) == 0 {
         Expr::Integer(v_j)
       } else {
-        crate::functions::math_ast::make_rational_pub(v_2j, 2)
+        crate::functions::math_ast::make_rational(v_2j, 2)
       };
       new_items[k] = forced.clone();
       new_args[group] = Expr::List(new_items.into());
@@ -9606,7 +9606,7 @@ pub fn clebsch_gordan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let forced_m_expr = if two_m[idx].rem_euclid(2) == 0 {
       Expr::Integer(two_m[idx] / 2)
     } else {
-      crate::functions::math_ast::make_rational_pub(two_m[idx], 2)
+      crate::functions::math_ast::make_rational(two_m[idx], 2)
     };
     // Build the concrete-m args and recurse so all the existing
     // selection-rule machinery runs.
@@ -9734,7 +9734,7 @@ impl PipeThroughRational for Expr {
       if n.rem_euclid(denom) == 0 {
         return Expr::Integer(n / denom);
       }
-      return crate::functions::math_ast::make_rational_pub(n, denom);
+      return crate::functions::math_ast::make_rational(n, denom);
     }
     self
   }

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -617,13 +617,6 @@ pub fn gcd(a: i128, b: i128) -> i128 {
   a as i128
 }
 
-/// Create a rational or integer result from numerator/denominator
-/// Simplifies the fraction and returns Integer if denominator is 1
-/// Public wrapper for creating rational expressions
-pub fn make_rational_pub(numer: i128, denom: i128) -> Expr {
-  make_rational(numer, denom)
-}
-
 /// Extract the largest easily-found perfect-square factor from a positive
 /// i128: returns `(outside, inside)` with `n == outside^2 * inside`, so
 /// `Sqrt[n] = outside * Sqrt[inside]`. Square factors of primes below a
@@ -660,6 +653,8 @@ pub fn extract_square_factor_i128(n: i128) -> (i128, i128) {
   (outside, inside)
 }
 
+/// Create a rational or integer result from numerator/denominator
+/// Simplifies the fraction and returns Integer if denominator is 1
 pub fn make_rational(numer: i128, denom: i128) -> Expr {
   if denom == 0 {
     // Division by zero - shouldn't reach here but be safe

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -2568,7 +2568,7 @@ pub fn norm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Norm[2/3] -> 2/3, Norm[3 + 4 I] -> 5). For a non-numeric scalar (x,
     // a + b I, …) wolframscript leaves Norm unevaluated.
     _ => {
-      if crate::functions::predicate_ast::is_numeric_q_pub(&args[0]) {
+      if crate::functions::predicate_ast::is_numeric_q(&args[0]) {
         crate::evaluator::evaluate_function_call_ast("Abs", &[args[0].clone()])
       } else {
         Ok(Expr::FunctionCall {

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -2179,7 +2179,7 @@ fn chebyshev_general_exact(
     _ => return None,
   };
   // A half-integer order rewrites for any x; other orders only for numeric x.
-  if q != 2 && !crate::functions::predicate_ast::is_numeric_q_pub(x_expr) {
+  if q != 2 && !crate::functions::predicate_ast::is_numeric_q(x_expr) {
     return None;
   }
   // ChebyshevU[n, 1] = n + 1 (the Sin/Sqrt form is 0/0 there).

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -10,7 +10,7 @@ use crate::syntax::Expr;
 /// strings, Infinity, True) and expressions stay unevaluated with no message.
 pub fn emit_rectt_if_numeric(name: &str, args: &[Expr]) {
   if let Some(first) = args.first()
-    && crate::functions::predicate_ast::is_numeric_q_pub(first)
+    && crate::functions::predicate_ast::is_numeric_q(first)
   {
     crate::emit_message(&format!(
       "{}::rectt: Rectangular array expected at position 1 in {}.",
@@ -97,7 +97,7 @@ fn all_leaves_real_numeric(e: &Expr) -> bool {
       all_leaves_real_numeric(&args[0])
     }
     _ => {
-      crate::functions::predicate_ast::is_numeric_q_pub(e)
+      crate::functions::predicate_ast::is_numeric_q(e)
         && !crate::functions::predicate_ast::is_complex_number(e)
     }
   }
@@ -305,7 +305,7 @@ pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // True, x + y, f[…], rules) stays unevaluated with no message, matching
     // wolframscript.
     other => {
-      if crate::functions::predicate_ast::is_numeric_q_pub(other) {
+      if crate::functions::predicate_ast::is_numeric_q(other) {
         Ok(other.clone())
       } else {
         if matches!(other, Expr::String(_)) {
@@ -727,9 +727,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Invalid parameters (e.g. BenktanderGibratDistribution[1, 2]) emit a
       // message and leave the call unevaluated, matching wolframscript;
       // they must not surface as an evaluation error.
-      match super::distributions::distribution_mean_variance_pub(
-        dist_name, dargs,
-      ) {
+      match super::distributions::distribution_mean_variance(dist_name, dargs) {
         Ok((mean, _)) => crate::evaluator::evaluate_expr_to_expr(&mean),
         Err(_) => Ok(Expr::FunctionCall {
           name: "Mean".to_string(),
@@ -741,9 +739,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "JohnsonDistribution" => {
-      match super::distributions::distribution_mean_variance_pub(
-        dist_name, dargs,
-      ) {
+      match super::distributions::distribution_mean_variance(dist_name, dargs) {
         Ok((mean, _)) => crate::evaluator::evaluate_expr_to_expr(&mean),
         Err(_) => Ok(Expr::FunctionCall {
           name: "Mean".to_string(),
@@ -1043,9 +1039,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       // Invalid parameters emit a message and leave the call unevaluated
       // (matching wolframscript), never an evaluation error.
-      match super::distributions::distribution_mean_variance_pub(
-        dist_name, dargs,
-      ) {
+      match super::distributions::distribution_mean_variance(dist_name, dargs) {
         Ok((_, variance)) => crate::evaluator::evaluate_expr_to_expr(&variance),
         Err(_) => Ok(Expr::FunctionCall {
           name: "Variance".to_string(),
@@ -1057,9 +1051,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "JohnsonDistribution" => {
-      match super::distributions::distribution_mean_variance_pub(
-        dist_name, dargs,
-      ) {
+      match super::distributions::distribution_mean_variance(dist_name, dargs) {
         Ok((_, variance)) => crate::evaluator::evaluate_expr_to_expr(&variance),
         Err(_) => Ok(Expr::FunctionCall {
           name: "Variance".to_string(),
@@ -1244,7 +1236,7 @@ pub fn standard_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // A numeric scalar isn't a rectangular array: emit StandardDeviation::rectt
   // directly and stay unevaluated, rather than delegating to Variance below
   // (which would emit Variance::rectt instead).
-  if crate::functions::predicate_ast::is_numeric_q_pub(&args[0]) {
+  if crate::functions::predicate_ast::is_numeric_q(&args[0]) {
     emit_rectt_if_numeric("StandardDeviation", args);
     return Ok(Expr::FunctionCall {
       name: "StandardDeviation".to_string(),
@@ -7034,7 +7026,7 @@ pub fn characteristic_function_ast(
         call(
           "Times",
           vec![
-            crate::functions::math_ast::make_rational_pub(-1, 2),
+            crate::functions::math_ast::make_rational(-1, 2),
             pow(t.clone(), Expr::Integer(2)),
           ],
         ),

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1099,7 +1099,7 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
       // -((-1 + Sqrt[3])/(2 Sqrt[2])) => -1/2*(-1 + Sqrt[3])/Sqrt[2].
       if let Some((k, rest)) = denom_integer_factor(right) {
         let mut factors = vec![
-          crate::functions::math_ast::make_rational_pub(-1, k),
+          crate::functions::math_ast::make_rational(-1, k),
           (**left).clone(),
         ];
         if let Some(rest) = rest {
@@ -2825,7 +2825,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           "Times",
           &[
             Expr::Identifier("I".to_string()),
-            crate::functions::math_ast::make_rational_pub(1, 2),
+            crate::functions::math_ast::make_rational(1, 2),
             Expr::Constant("Pi".to_string()),
           ],
         );
@@ -2864,7 +2864,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             &[
               Expr::Integer(-1),
               Expr::Identifier("I".to_string()),
-              crate::functions::math_ast::make_rational_pub(1, 2),
+              crate::functions::math_ast::make_rational(1, 2),
               Expr::Constant("Pi".to_string()),
             ],
           );
@@ -2901,7 +2901,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                     name: "Sign".to_string(),
                     args: vec![coeff.clone()].into(),
                   },
-                  crate::functions::math_ast::make_rational_pub(1, 2),
+                  crate::functions::math_ast::make_rational(1, 2),
                   Expr::Identifier("I".to_string()),
                   Expr::Constant("Pi".to_string()),
                 ]

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -2972,7 +2972,7 @@ fn try_direct_linear_pde_body(
 /// `-b/a` reduced to either an `Integer` (if `a` divides `b`) or a
 /// `Rational` literal. Sign is folded into the numerator.
 fn make_neg_b_over_a(b: i128, a: i128) -> Expr {
-  use crate::functions::math_ast::make_rational_pub;
+  use crate::functions::math_ast::make_rational;
   let g = gcd_i128(b.abs(), a.abs());
   let g = if g == 0 { 1 } else { g };
   let (num, den) = (-b / g, a / g);
@@ -2980,12 +2980,12 @@ fn make_neg_b_over_a(b: i128, a: i128) -> Expr {
   if den == 1 {
     Expr::Integer(num)
   } else {
-    make_rational_pub(num, den)
+    make_rational(num, den)
   }
 }
 
 fn make_c_over_a(c: i128, a: i128) -> Expr {
-  use crate::functions::math_ast::make_rational_pub;
+  use crate::functions::math_ast::make_rational;
   let g = gcd_i128(c.abs(), a.abs());
   let g = if g == 0 { 1 } else { g };
   let (num, den) = (c / g, a / g);
@@ -2993,7 +2993,7 @@ fn make_c_over_a(c: i128, a: i128) -> Expr {
   if den == 1 {
     Expr::Integer(num)
   } else {
-    make_rational_pub(num, den)
+    make_rational(num, den)
   }
 }
 

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -67,7 +67,7 @@ pub fn apart_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       None => {
         // A variable-free (numeric) argument is already apart:
         // Apart[Divide[1, 2]] → 1/2, not the unevaluated call.
-        if crate::functions::predicate_ast::is_numeric_q_pub(&args[0]) {
+        if crate::functions::predicate_ast::is_numeric_q(&args[0]) {
           return Ok(args[0].clone());
         }
         return Ok(Expr::FunctionCall {

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -3104,8 +3104,7 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
         }
         if !consumed {
           // No integer factor matched — prepend 1/div as a Rational.
-          new_args
-            .insert(0, crate::functions::math_ast::make_rational_pub(1, div));
+          new_args.insert(0, crate::functions::math_ast::make_rational(1, div));
         }
         crate::functions::math_ast::times_ast(&new_args)
           .unwrap_or_else(|_| term.clone())

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -1950,7 +1950,7 @@ pub fn solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 name: "Power".to_string(),
                 args: vec![
                   Expr::Integer(-1),
-                  crate::functions::math_ast::make_rational_pub(p, q),
+                  crate::functions::math_ast::make_rational(p, q),
                 ]
                 .into(),
               }
@@ -2870,7 +2870,7 @@ fn try_solve_trig_eq(eq: &Expr, var: &str) -> Option<Expr> {
   };
   let neg_half_pi = Expr::BinaryOp {
     op: BinaryOperator::Times,
-    left: Box::new(crate::functions::math_ast::make_rational_pub(-1, 2)),
+    left: Box::new(crate::functions::math_ast::make_rational(-1, 2)),
     right: Box::new(pi.clone()),
   };
   let half_pi = Expr::BinaryOp {

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -856,7 +856,7 @@ pub(super) fn canonicalize_quotient_sign(
         build_product(rest)
       };
       let mut parts: Vec<Expr> =
-        vec![crate::functions::math_ast::make_rational_pub(-1, content)];
+        vec![crate::functions::math_ast::make_rational(-1, content)];
       if let Some(nf) = num_factor {
         parts.push(nf);
       }

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -563,11 +563,7 @@ pub fn numeric_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 /// Check if an expression is numeric (can be numerically evaluated)
-pub fn is_numeric_q_pub(expr: &Expr) -> bool {
-  is_numeric_q(expr)
-}
-
-fn is_numeric_q(expr: &Expr) -> bool {
+pub fn is_numeric_q(expr: &Expr) -> bool {
   match expr {
     Expr::Integer(_)
     | Expr::BigInteger(_)
@@ -702,7 +698,7 @@ fn sign_via_numeric(expr: &Expr, cmp: impl Fn(f64) -> bool) -> Option<bool> {
   // Only fire when NumericQ would succeed — that's how Wolfram decides
   // it can numerically evaluate. Avoids forcing Negative[a] to True or
   // anything weird for unevaluated user symbols.
-  if !is_numeric_q_pub(expr) {
+  if !is_numeric_q(expr) {
     return None;
   }
   let val = super::math_ast::try_eval_to_f64(expr)?;

--- a/src/functions/quantity_ast.rs
+++ b/src/functions/quantity_ast.rs
@@ -1763,7 +1763,7 @@ fn multiply_magnitude_by_rational(
       if rd == 1 {
         Ok(Expr::Integer(rn))
       } else {
-        Ok(crate::functions::math_ast::make_rational_pub(rn, rd))
+        Ok(crate::functions::math_ast::make_rational(rn, rd))
       }
     }
     // Collapse the rational scale to a f64 first so the multiplication
@@ -1776,12 +1776,12 @@ fn multiply_magnitude_by_rational(
       if let (Expr::Integer(mn), Expr::Integer(md)) = (&args[0], &args[1]) {
         let rn = mn * numer;
         let rd = md * denom;
-        Ok(crate::functions::math_ast::make_rational_pub(rn, rd))
+        Ok(crate::functions::math_ast::make_rational(rn, rd))
       } else {
         // Symbolic magnitude — wrap in Times
         Ok(crate::functions::math_ast::times_ast(&[
           magnitude.clone(),
-          crate::functions::math_ast::make_rational_pub(numer, denom),
+          crate::functions::math_ast::make_rational(numer, denom),
         ])?)
       }
     }
@@ -1790,7 +1790,7 @@ fn multiply_magnitude_by_rational(
       let factor = if denom == 1 {
         Expr::Integer(numer)
       } else {
-        crate::functions::math_ast::make_rational_pub(numer, denom)
+        crate::functions::math_ast::make_rational(numer, denom)
       };
       crate::functions::math_ast::times_ast(&[magnitude.clone(), factor])
     }
@@ -2262,7 +2262,7 @@ pub fn unit_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // stay unevaluated. This is what makes e.g.
     // `Quantity[1, "Hours"] / Quantity[1, "Minutes"] // UnitConvert` → 60
     // rather than the spurious `UnitConvert[60]`.
-    if crate::functions::predicate_ast::is_numeric_q_pub(&args[0]) {
+    if crate::functions::predicate_ast::is_numeric_q(&args[0]) {
       return Ok(args[0].clone());
     }
     return Ok(Expr::FunctionCall {
@@ -2823,9 +2823,7 @@ fn power_unit_expr(unit: &Expr, p: i128, q: i128) -> Option<Expr> {
       Expr::BinaryOp {
         op: BinaryOperator::Power,
         left: Box::new(base),
-        right: Box::new(crate::functions::math_ast::make_rational_pub(
-          abs_rn, rd,
-        )),
+        right: Box::new(crate::functions::math_ast::make_rational(abs_rn, rd)),
       }
     };
 

--- a/src/functions/rsolve_ast.rs
+++ b/src/functions/rsolve_ast.rs
@@ -821,7 +821,7 @@ fn build_general_solution(
       let root_expr = if rd == 1 {
         Expr::Integer(rn)
       } else {
-        crate::functions::math_ast::make_rational_pub(rn, rd)
+        crate::functions::math_ast::make_rational(rn, rd)
       };
       let exponent = if single_root {
         // `-1 + n` (constant first) to match wolframscript's display order.
@@ -1302,7 +1302,7 @@ fn build_solution(
       let root_expr = if rd == 1 {
         Expr::Integer(rn)
       } else {
-        crate::functions::math_ast::make_rational_pub(rn, rd)
+        crate::functions::math_ast::make_rational(rn, rd)
       };
       factors.push(Expr::BinaryOp {
         op: BinaryOperator::Power,

--- a/src/functions/wavelet_ast/filters.rs
+++ b/src/functions/wavelet_ast/filters.rs
@@ -82,7 +82,7 @@ fn wl(code: &str) -> Expr {
 }
 
 fn rational(num: i128, den: i128) -> Expr {
-  crate::functions::math_ast::make_rational_pub(num, den)
+  crate::functions::math_ast::make_rational(num, den)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1341,13 +1341,13 @@ pub fn interpret(input: &str) -> Result<String, InterpreterError> {
         if is_visual_mode() {
           generate_output_svg(&syntax::Expr::Real(n));
         }
-        return Ok(format_real_result(n));
+        return Ok(syntax::format_real(n));
       }
     } else {
       if is_visual_mode() {
         generate_output_svg(&syntax::Expr::Real(n));
       }
-      return Ok(format_real_result(n));
+      return Ok(syntax::format_real(n));
     }
   }
   // Check for quoted string - return content without quotes (like wolframscript)
@@ -4291,11 +4291,6 @@ pub fn interpret_with_stdout(
     sound,
     warnings,
   })
-}
-
-/// Format a result as a real number (with trailing dot for whole numbers)
-pub fn format_real_result(result: f64) -> String {
-  syntax::format_real(result)
 }
 
 fn store_function_definition(


### PR DESCRIPTION
Additional wrapper functions deletions, the widely used is_numeric_q_pub and make_rational_pub, plus
distribution_mean_variance_pub and format_real_result.