### PR TITLE
Remove most crate::syntax:: prefixes in math_ast

### DIFF
--- a/src/functions/math_ast/airy.rs
+++ b/src/functions/math_ast/airy.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// AiryAi[x] - Airy function of the first kind
 pub fn airy_ai_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -292,7 +292,7 @@ pub fn airy_ai_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if matches!(&args[0], Expr::Integer(0)) {
     let result = airy_build_value((2, 3), (1, 3), true)?;
     return crate::evaluator::evaluate_expr_to_expr(&Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(result),
     });
   }
@@ -401,7 +401,7 @@ pub fn airy_bi_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       .into(),
     };
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(power_3),
       right: Box::new(gamma),
     };
@@ -514,7 +514,7 @@ fn airy_build_value(
     gamma
   };
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(power_3),
     right: Box::new(denom),
   };
@@ -662,7 +662,7 @@ fn scorer_value_at_zero(numer: i128) -> Result<Expr, InterpreterError> {
     args: vec![Expr::Integer(3), three_sixth, gamma].into(),
   };
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(Expr::Integer(numer)),
     right: Box::new(denom),
   };

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{Expr, expr_to_string};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
 use num_bigint::BigInt;
 use num_bigint::Sign;
 
@@ -72,7 +72,7 @@ fn polynomial_term_to_series_data(
     None
   };
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left,
     right,
   } = e
@@ -89,7 +89,7 @@ fn polynomial_term_to_series_data(
   }
   // `-var` and `-var^n`
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = e
   {
@@ -104,7 +104,7 @@ fn polynomial_term_to_series_data(
         .map(|c| match c {
           Expr::Integer(n) => Expr::Integer(-n),
           other => Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand: Box::new(other.clone()),
           },
         })
@@ -129,7 +129,7 @@ fn polynomial_term_to_series_data(
   let times_args: Option<Vec<Expr>> = match e {
     Expr::FunctionCall { name, args } if name == "Times" => Some(args.to_vec()),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => Some(vec![*left.clone(), *right.clone()]),
@@ -147,7 +147,7 @@ fn polynomial_term_to_series_data(
       let n = if matches!(f, Expr::Identifier(s) if s == var_name) {
         1
       } else if let Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } = f
@@ -259,10 +259,8 @@ fn try_series_data_plus(
   };
   for &idx in &series_indices[1..] {
     if let Expr::FunctionCall { args: sa, .. } = &args[idx] {
-      let var_eq = crate::syntax::expr_to_string(&sa[0])
-        == crate::syntax::expr_to_string(&var0);
-      let x0_eq = crate::syntax::expr_to_string(&sa[1])
-        == crate::syntax::expr_to_string(&x0_0);
+      let var_eq = expr_to_string(&sa[0]) == expr_to_string(&var0);
+      let x0_eq = expr_to_string(&sa[1]) == expr_to_string(&x0_0);
       if !var_eq || !x0_eq {
         return Ok(None);
       }
@@ -431,10 +429,8 @@ fn try_series_data_times(
   };
   for &idx in &series_indices[1..] {
     if let Expr::FunctionCall { args: sa, .. } = &args[idx] {
-      let var_eq = crate::syntax::expr_to_string(&sa[0])
-        == crate::syntax::expr_to_string(&var0);
-      let x0_eq = crate::syntax::expr_to_string(&sa[1])
-        == crate::syntax::expr_to_string(&x0_0);
+      let var_eq = expr_to_string(&sa[0]) == expr_to_string(&var0);
+      let x0_eq = expr_to_string(&sa[1]) == expr_to_string(&x0_0);
       if !var_eq || !x0_eq {
         return Ok(None);
       }
@@ -719,8 +715,8 @@ pub fn try_threaded_op(
         // "Too shallow" — emit the message and leave the operation
         // unevaluated as a left-folded BinaryOp (which is not re-evaluated).
         let bin_op = match op {
-          ThreadedOp::Plus => crate::syntax::BinaryOperator::Plus,
-          ThreadedOp::Times => crate::syntax::BinaryOperator::Times,
+          ThreadedOp::Plus => BinaryOperator::Plus,
+          ThreadedOp::Times => BinaryOperator::Times,
         };
         let mut folded = args[0].clone();
         for a in &args[1..] {
@@ -739,7 +735,7 @@ pub fn try_threaded_op(
           "Threaded::thrdts: The level specified for threading the argument \
            at position {} in {} is too shallow.",
           pos,
-          crate::syntax::expr_to_string(&folded)
+          expr_to_string(&folded)
         ));
         return Some(Ok(folded));
       }
@@ -772,7 +768,7 @@ fn is_numeric_literal_part(e: &Expr) -> bool {
 /// differences return None and keep their opaque shape.
 fn split_numeric_complex_minus(e: &Expr) -> Option<(Expr, Expr)> {
   let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left,
     right,
   } = e
@@ -785,7 +781,7 @@ fn split_numeric_complex_minus(e: &Expr) -> Option<(Expr, Expr)> {
   let is_i = |x: &Expr| matches!(x, Expr::Identifier(s) if s == "I");
   let neg_imag = match right.as_ref() {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: coeff,
       right: i,
     } if is_i(i) => {
@@ -795,13 +791,13 @@ fn split_numeric_complex_minus(e: &Expr) -> Option<(Expr, Expr)> {
         _ => return None,
       };
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(neg_coeff),
         right: i.clone(),
       }
     }
     i if is_i(i) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(-1)),
       right: Box::new(Expr::Identifier("I".to_string())),
     },
@@ -950,7 +946,7 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         ref left,
         ref right,
       } => {
@@ -970,7 +966,7 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         flat_args.push(cargs[0].clone());
         stack.push(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(cargs[1].clone()),
           right: Box::new(Expr::Identifier("I".to_string())),
         });
@@ -1004,13 +1000,13 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       match arg {
         Expr::Identifier(name) if name == "Infinity" => has_pos_inf = true,
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand,
         } if matches!(operand.as_ref(), Expr::Identifier(n) if n == "Infinity") => {
           has_neg_inf = true
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left,
           right,
         } if matches!(left.as_ref(), Expr::Integer(-1))
@@ -1034,7 +1030,7 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     if has_neg_inf {
       return Ok(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("Infinity".to_string())),
       });
     }
@@ -1056,13 +1052,13 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       && flat_args.len() == 2
     {
       let unevaluated = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(flat_args[0].clone()),
         right: Box::new(flat_args[1].clone()),
       };
       crate::emit_message(&format!(
         "Thread::tdlen: Objects of unequal length in {} cannot be combined.",
-        crate::syntax::expr_to_string(&unevaluated)
+        expr_to_string(&unevaluated)
       ));
       return Ok(unevaluated);
     }
@@ -1256,7 +1252,7 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       ) || matches!(
         e,
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left,
           right,
         } if matches!(left.as_ref(), Expr::Real(_))
@@ -1390,7 +1386,7 @@ fn is_integer_times_i(e: &Expr) -> bool {
       has_i
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -1453,7 +1449,7 @@ fn promote_integer_times_i_to_real(e: Expr) -> Expr {
     };
   }
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left,
     right,
   } = &e
@@ -1799,7 +1795,7 @@ fn decompose_term(e: &Expr) -> (Coeff, Expr) {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -1820,7 +1816,7 @@ fn decompose_term(e: &Expr) -> (Coeff, Expr) {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -1835,7 +1831,7 @@ fn decompose_term(e: &Expr) -> (Coeff, Expr) {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let (c, base) = decompose_term(operand);
@@ -1858,7 +1854,7 @@ fn collect_like_terms(terms: &[Expr]) -> Vec<Expr> {
 
   for term in terms {
     let (c, base) = decompose_term(term);
-    let key = crate::syntax::expr_to_string(&base);
+    let key = expr_to_string(&base);
     if let Some(&idx) = index.get(&key) {
       let entry = &mut groups[idx];
       entry.2 = entry.2.add(&c);
@@ -2111,7 +2107,7 @@ fn extract_latest_variable(e: &Expr) -> Option<String> {
 /// their base rather than by the coefficient digits.
 fn term_sort_key(e: &Expr) -> String {
   let (_, base) = decompose_term(e);
-  let s = crate::syntax::expr_to_string(&base);
+  let s = expr_to_string(&base);
   s.strip_prefix('-').unwrap_or(&s).to_string()
 }
 
@@ -2127,7 +2123,7 @@ fn is_numeric_factor(e: &Expr) -> bool {
       is_numeric_factor(&args[0]) && is_numeric_factor(&args[1])
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => is_numeric_factor(left) && is_numeric_factor(right),
@@ -2238,7 +2234,7 @@ fn extract_var_exp_pairs(e: &Expr) -> Option<Vec<(String, f64)>> {
       Some(vec![(expr_to_string(e), 1.0)])
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -2303,7 +2299,7 @@ fn extract_var_exp_pairs(e: &Expr) -> Option<Vec<(String, f64)>> {
       None
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -2322,7 +2318,7 @@ fn extract_var_exp_pairs(e: &Expr) -> Option<Vec<(String, f64)>> {
       Some(pairs)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -2501,7 +2497,7 @@ fn constant_symbol_name(base: &Expr) -> Option<&str> {
   match base {
     Expr::Constant(name) if name != "I" => Some(name),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       ..
     } => constant_symbol_name(left),
@@ -2560,7 +2556,7 @@ fn compare_plus_terms(a: &Expr, b: &Expr) -> std::cmp::Ordering {
         args.iter().any(is_i_factor)
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -2698,7 +2694,7 @@ fn compare_plus_terms(a: &Expr, b: &Expr) -> std::cmp::Ordering {
         let is_numeric_base_symbolic_power = |e: &Expr| -> bool {
           let (base, exp): (&Expr, &Expr) = match e {
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left,
               right,
             } => (left, right),
@@ -2770,8 +2766,7 @@ fn compare_plus_terms(a: &Expr, b: &Expr) -> std::cmp::Ordering {
           || matches!(
             &none_base,
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus
-                | crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Plus | BinaryOperator::Minus,
               ..
             }
           );
@@ -3041,7 +3036,7 @@ fn collect_fn_call_factors(e: &Expr) -> Vec<&Expr> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -3168,7 +3163,7 @@ fn extract_primary_fn_name(e: &Expr) -> Option<String> {
       Some(name.clone())
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -3181,7 +3176,7 @@ fn extract_primary_fn_name(e: &Expr) -> Option<String> {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       ..
     } => extract_primary_fn_name(left),
@@ -3209,7 +3204,7 @@ fn extract_primary_fn_exponent(e: &Expr, name: &str) -> f64 {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -3233,7 +3228,7 @@ fn extract_primary_fn_exponent(e: &Expr, name: &str) -> f64 {
       total
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -3280,7 +3275,7 @@ fn extract_trig_factors(e: &Expr) -> Vec<(String, Expr, i64)> {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -3307,7 +3302,7 @@ fn extract_trig_factors(e: &Expr) -> Vec<(String, Expr, i64)> {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -3366,7 +3361,7 @@ fn extract_poly_degree_in_product(e: &Expr) -> f64 {
       max_deg
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -3460,7 +3455,7 @@ fn sum_recip_vs_univar_order(a: &Expr, b: &Expr) -> Option<std::cmp::Ordering> {
         var_power(&args[0], &args[1]).map(|v| (v, vec![0, 1], false))
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } => var_power(left, right).map(|v| (v, vec![0, 1], false)),
@@ -3497,7 +3492,7 @@ fn cmp_neg_pow(f: &Expr) -> Option<(&Expr, i128)> {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => match right.as_ref() {
@@ -3513,8 +3508,7 @@ fn cmp_is_sum_base(e: &Expr) -> bool {
     || matches!(
       e,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus
-          | crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Plus | BinaryOperator::Minus,
         ..
       }
     )
@@ -3539,7 +3533,7 @@ fn univar_int_coeffs(e: &Expr) -> Option<(String, Vec<i128>)> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } => match (left.as_ref(), right.as_ref()) {
@@ -3559,7 +3553,7 @@ fn univar_int_coeffs(e: &Expr) -> Option<(String, Vec<i128>)> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => match (left.as_ref(), monomial(right)) {
@@ -3567,7 +3561,7 @@ fn univar_int_coeffs(e: &Expr) -> Option<(String, Vec<i128>)> {
         _ => None,
       },
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => {
         let (v, d, c) = monomial(operand)?;
@@ -3644,7 +3638,7 @@ fn cross_shape_shared_denom_order(
       || matches!(
         e,
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           ..
         }
       )
@@ -3655,7 +3649,7 @@ fn cross_shape_shared_denom_order(
         args.iter().for_each(|x| collect_factors(x, out));
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -3740,17 +3734,15 @@ fn compare_expr_canonical(a: &Expr, b: &Expr) -> std::cmp::Ordering {
   }
 
   // Normalize a top-level BinaryOp head to the canonical FunctionCall name.
-  fn binop_head(op: &crate::syntax::BinaryOperator) -> &'static str {
+  fn binop_head(op: &BinaryOperator) -> &'static str {
     match op {
-      crate::syntax::BinaryOperator::Plus
-      | crate::syntax::BinaryOperator::Minus => "Plus",
-      crate::syntax::BinaryOperator::Times
-      | crate::syntax::BinaryOperator::Divide => "Times",
-      crate::syntax::BinaryOperator::Power => "Power",
-      crate::syntax::BinaryOperator::And => "And",
-      crate::syntax::BinaryOperator::Or => "Or",
-      crate::syntax::BinaryOperator::StringJoin => "StringJoin",
-      crate::syntax::BinaryOperator::Alternatives => "Alternatives",
+      BinaryOperator::Plus | BinaryOperator::Minus => "Plus",
+      BinaryOperator::Times | BinaryOperator::Divide => "Times",
+      BinaryOperator::Power => "Power",
+      BinaryOperator::And => "And",
+      BinaryOperator::Or => "Or",
+      BinaryOperator::StringJoin => "StringJoin",
+      BinaryOperator::Alternatives => "Alternatives",
     }
   }
 
@@ -4097,61 +4089,59 @@ fn compare_expr_canonical(a: &Expr, b: &Expr) -> std::cmp::Ordering {
     ) => {
       // Normalize Minus→Plus and Divide→Times for comparison,
       // matching Wolfram's canonical form.
-      let (norm_op_a, norm_ra) =
-        if *op_a == crate::syntax::BinaryOperator::Minus {
-          (
-            crate::syntax::BinaryOperator::Plus,
-            Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
-              operand: ra.clone(),
-            },
-          )
-        } else if *op_a == crate::syntax::BinaryOperator::Divide {
-          (
-            crate::syntax::BinaryOperator::Times,
-            Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
-              left: ra.clone(),
-              right: Box::new(Expr::Integer(-1)),
-            },
-          )
-        } else {
-          (*op_a, *ra.clone())
-        };
-      let (norm_op_b, norm_rb) =
-        if *op_b == crate::syntax::BinaryOperator::Minus {
-          (
-            crate::syntax::BinaryOperator::Plus,
-            Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
-              operand: rb.clone(),
-            },
-          )
-        } else if *op_b == crate::syntax::BinaryOperator::Divide {
-          (
-            crate::syntax::BinaryOperator::Times,
-            Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
-              left: rb.clone(),
-              right: Box::new(Expr::Integer(-1)),
-            },
-          )
-        } else {
-          (*op_b, *rb.clone())
-        };
+      let (norm_op_a, norm_ra) = if *op_a == BinaryOperator::Minus {
+        (
+          BinaryOperator::Plus,
+          Expr::UnaryOp {
+            op: UnaryOperator::Minus,
+            operand: ra.clone(),
+          },
+        )
+      } else if *op_a == BinaryOperator::Divide {
+        (
+          BinaryOperator::Times,
+          Expr::BinaryOp {
+            op: BinaryOperator::Power,
+            left: ra.clone(),
+            right: Box::new(Expr::Integer(-1)),
+          },
+        )
+      } else {
+        (*op_a, *ra.clone())
+      };
+      let (norm_op_b, norm_rb) = if *op_b == BinaryOperator::Minus {
+        (
+          BinaryOperator::Plus,
+          Expr::UnaryOp {
+            op: UnaryOperator::Minus,
+            operand: rb.clone(),
+          },
+        )
+      } else if *op_b == BinaryOperator::Divide {
+        (
+          BinaryOperator::Times,
+          Expr::BinaryOp {
+            op: BinaryOperator::Power,
+            left: rb.clone(),
+            right: Box::new(Expr::Integer(-1)),
+          },
+        )
+      } else {
+        (*op_b, *rb.clone())
+      };
       // Compare by canonical operator name (alphabetical) rather than
       // enum discriminant, so Power sorts before Times, matching Wolfram.
-      let op_name = |op: &crate::syntax::BinaryOperator| -> &str {
+      let op_name = |op: &BinaryOperator| -> &str {
         match op {
-          crate::syntax::BinaryOperator::Plus => "Plus",
-          crate::syntax::BinaryOperator::Minus => "Plus",
-          crate::syntax::BinaryOperator::Times => "Times",
-          crate::syntax::BinaryOperator::Divide => "Times",
-          crate::syntax::BinaryOperator::Power => "Power",
-          crate::syntax::BinaryOperator::And => "And",
-          crate::syntax::BinaryOperator::Or => "Or",
-          crate::syntax::BinaryOperator::StringJoin => "StringJoin",
-          crate::syntax::BinaryOperator::Alternatives => "Alternatives",
+          BinaryOperator::Plus => "Plus",
+          BinaryOperator::Minus => "Plus",
+          BinaryOperator::Times => "Times",
+          BinaryOperator::Divide => "Times",
+          BinaryOperator::Power => "Power",
+          BinaryOperator::And => "And",
+          BinaryOperator::Or => "Or",
+          BinaryOperator::StringJoin => "StringJoin",
+          BinaryOperator::Alternatives => "Alternatives",
         }
       };
       let cmp = op_name(&norm_op_a).cmp(op_name(&norm_op_b));
@@ -4213,8 +4203,8 @@ fn compare_expr_canonical(a: &Expr, b: &Expr) -> std::cmp::Ordering {
         ta.cmp(&tb)
       } else {
         // Fall back to string comparison
-        let sa = crate::syntax::expr_to_string(a);
-        let sb = crate::syntax::expr_to_string(b);
+        let sa = expr_to_string(a);
+        let sb = expr_to_string(b);
         sa.cmp(&sb)
       }
     }
@@ -4235,7 +4225,7 @@ fn sum_term_list(e: &Expr) -> Option<Vec<Expr>> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left,
         right,
       } => {
@@ -4243,13 +4233,13 @@ fn sum_term_list(e: &Expr) -> Option<Vec<Expr>> {
         collect(right, out);
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left,
         right,
       } => {
         collect(left, out);
         out.push(Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: right.clone(),
         });
       }
@@ -4263,8 +4253,7 @@ fn sum_term_list(e: &Expr) -> Option<Vec<Expr>> {
       Some(out)
     }
     Expr::BinaryOp {
-      op:
-        crate::syntax::BinaryOperator::Plus | crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Plus | BinaryOperator::Minus,
       ..
     } => {
       let mut out = Vec::new();
@@ -4279,7 +4268,7 @@ fn sum_term_list(e: &Expr) -> Option<Vec<Expr>> {
 fn extract_power_base_exp(e: &Expr) -> Option<(Expr, Expr)> {
   match e {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some(((**left).clone(), (**right).clone())),
@@ -4300,14 +4289,14 @@ fn exprs_equal_canonically(a: &Expr, b: &Expr) -> bool {
 fn is_negated_form(e: &Expr) -> bool {
   match e {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       ..
     } => true,
     Expr::FunctionCall { name, args } if name == "Times" && args.len() >= 2 => {
       matches!(&args[0], Expr::Integer(n) if *n < 0)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       ..
     } => matches!(left.as_ref(), Expr::Integer(n) if *n < 0),
@@ -4319,7 +4308,7 @@ fn is_negated_form(e: &Expr) -> bool {
 fn strip_negation(e: &Expr) -> Expr {
   match e {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => *operand.clone(),
     Expr::FunctionCall { name, args } if name == "Times" && args.len() >= 2 => {
@@ -4340,7 +4329,7 @@ fn strip_negation(e: &Expr) -> Expr {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -4350,7 +4339,7 @@ fn strip_negation(e: &Expr) -> Expr {
           *right.clone()
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(pos_n)),
             right: right.clone(),
           }
@@ -4371,17 +4360,17 @@ pub fn term_priority(e: &Expr) -> i32 {
   match e {
     Expr::Identifier(_) => 0,
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       ..
     } => term_priority(left),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       ..
     } => term_priority(left),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => term_priority(left).max(term_priority(right)),
@@ -4416,7 +4405,7 @@ fn times_factor_subpriority(e: &Expr) -> i32 {
     Expr::Identifier(name) if name == "I" => -2,
     Expr::Identifier(_) | Expr::Constant(_) => 0,
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       ..
     } => {
@@ -4428,8 +4417,7 @@ fn times_factor_subpriority(e: &Expr) -> i32 {
       if base_sp == 1 { 0 } else { base_sp }
     }
     Expr::BinaryOp {
-      op:
-        crate::syntax::BinaryOperator::Plus | crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Plus | BinaryOperator::Minus,
       ..
     } => 1,
     Expr::FunctionCall { name, args } => match name.as_str() {
@@ -4497,7 +4485,7 @@ fn times_factor_subpriority(e: &Expr) -> i32 {
 fn times_term_base_exp(e: &Expr) -> (Expr, Option<f64>) {
   match e {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => times_term_base_exp(operand),
     Expr::FunctionCall { name, args }
@@ -4506,7 +4494,7 @@ fn times_term_base_exp(e: &Expr) -> (Expr, Option<f64>) {
       times_term_base_exp(args.last().unwrap())
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       right,
       ..
     } => times_term_base_exp(right),
@@ -4564,8 +4552,8 @@ fn order_factor_vs_additive(
     && matches!(hb, Expr::Identifier(_) | Expr::Constant(_))
   {
     crate::functions::list_helpers_ast::wolfram_string_order(
-      &crate::syntax::expr_to_string(&fb),
-      &crate::syntax::expr_to_string(&hb),
+      &expr_to_string(&fb),
+      &expr_to_string(&hb),
     )
   } else {
     crate::functions::list_helpers_ast::compare_exprs(&fb, &hb)
@@ -4601,7 +4589,7 @@ fn order_factor_vs_additive(
     top,
     Expr::UnaryOp { .. }
       | Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         ..
       }
   ) && !matches!(top, Expr::FunctionCall { name, .. } if name == "Times");
@@ -4636,7 +4624,7 @@ pub fn order_monomial_vs_sum(
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left,
         right,
       } => {
@@ -4650,7 +4638,7 @@ pub fn order_monomial_vs_sum(
     || matches!(
       sum,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         ..
       }
     );
@@ -4843,8 +4831,8 @@ pub fn sort_symbolic_factors(symbolic_args: &mut [Expr]) {
         // Equal sort keys: tie-break with full base string comparison
         // e.g. Plus[-1, x] vs Plus[1, x] both have sort key "x"
         // but "-1 + x" < "1 + x" lexicographically
-        let full_a = crate::syntax::expr_to_string(&aa[0]);
-        let full_b = crate::syntax::expr_to_string(&ab[0]);
+        let full_a = expr_to_string(&aa[0]);
+        let full_b = expr_to_string(&ab[0]);
         let full_ord = crate::functions::list_helpers_ast::wolfram_string_order(&full_a, &full_b);
         if full_ord > 0 {
           return std::cmp::Ordering::Less;
@@ -4903,7 +4891,7 @@ pub fn sort_symbolic_factors(symbolic_args: &mut [Expr]) {
     // to match Wolfram's Times ordering. This handles both same-variant
     // (e.g. both BinaryOp::Power) and cross-variant (BinaryOp vs FunctionCall) cases.
     let is_power_like = |e: &Expr| -> bool {
-      matches!(e, Expr::BinaryOp { op: crate::syntax::BinaryOperator::Power, .. })
+      matches!(e, Expr::BinaryOp { op: BinaryOperator::Power, .. })
         || matches!(e, Expr::FunctionCall { name, args } if (name == "Power" && args.len() == 2))
         || is_sqrt(e).is_some()
     };
@@ -4951,8 +4939,8 @@ pub fn sort_symbolic_factors(symbolic_args: &mut [Expr]) {
           if na == "Plus" && nb == "Plus" && aa.len() == ab.len()
       ) || matches!(
         (&base_a, &base_b),
-        (Expr::BinaryOp { op: crate::syntax::BinaryOperator::Plus, .. },
-         Expr::BinaryOp { op: crate::syntax::BinaryOperator::Plus, .. })
+        (Expr::BinaryOp { op: BinaryOperator::Plus, .. },
+         Expr::BinaryOp { op: BinaryOperator::Plus, .. })
       );
       if same_fn_base || same_arity_plus_base {
         let base_cmp = compare_expr_canonical(&base_a, &base_b);
@@ -4982,8 +4970,8 @@ pub fn sort_symbolic_factors(symbolic_args: &mut [Expr]) {
         matches!(
           e,
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus
-              | crate::syntax::BinaryOperator::Minus,
+            op: BinaryOperator::Plus
+              | BinaryOperator::Minus,
             ..
           }
         ) || matches!(e, Expr::FunctionCall { name, .. } if name == "Plus")
@@ -5005,8 +4993,8 @@ pub fn sort_symbolic_factors(symbolic_args: &mut [Expr]) {
         return std::cmp::Ordering::Less; // additive base first
       }
       // Fall back to string length then alphabetical
-      let as_str = crate::syntax::expr_to_string(a);
-      let bs_str = crate::syntax::expr_to_string(b);
+      let as_str = expr_to_string(a);
+      let bs_str = expr_to_string(b);
       let len_cmp = as_str.len().cmp(&bs_str.len());
       if len_cmp != std::cmp::Ordering::Equal {
         return len_cmp;
@@ -5034,7 +5022,7 @@ pub fn sort_symbolic_factors(symbolic_args: &mut [Expr]) {
         std::cmp::Ordering::Greater
       } else {
         // Equal sort keys: fall back to full string comparison
-        crate::syntax::expr_to_string(a).cmp(&crate::syntax::expr_to_string(b))
+        expr_to_string(a).cmp(&expr_to_string(b))
       }
     }
   });
@@ -5045,7 +5033,7 @@ pub fn sort_symbolic_factors(symbolic_args: &mut [Expr]) {
 fn power_const_base(e: &Expr) -> Option<String> {
   let base = match e {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       ..
     } => left.as_ref(),
@@ -5056,9 +5044,7 @@ fn power_const_base(e: &Expr) -> Option<String> {
   };
   match base {
     Expr::Constant(c) => Some(c.clone()),
-    Expr::Integer(_) | Expr::Real(_) => {
-      Some(crate::syntax::expr_to_string(base))
-    }
+    Expr::Integer(_) | Expr::Real(_) => Some(expr_to_string(base)),
     _ => None,
   }
 }
@@ -5073,7 +5059,7 @@ fn additive_contains_negated(additive: &Expr, ident: &Expr) -> bool {
   };
   match additive {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       right,
       ..
     } => {
@@ -5081,7 +5067,7 @@ fn additive_contains_negated(additive: &Expr, ident: &Expr) -> bool {
       matches!(right.as_ref(), Expr::Identifier(name) if name == ident_name)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => {
@@ -5100,13 +5086,13 @@ fn additive_contains_negated(additive: &Expr, ident: &Expr) -> bool {
 fn has_negated_ident(expr: &Expr, ident_name: &str) -> bool {
   match expr {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       matches!(operand.as_ref(), Expr::Identifier(name) if name == ident_name)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -5171,7 +5157,7 @@ pub fn additive_is_neg_const_plus_ident(additive: &Expr, ident: &Expr) -> bool {
 
   // Check for BinaryOp Plus with negative number and same variable
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left,
     right,
   } = additive
@@ -5198,14 +5184,14 @@ fn multiply_exponents(a: &Expr, b: &Expr) -> Expr {
         make_rational(n * m, *d)
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(a.clone()),
           right: Box::new(b.clone()),
         }
       }
     }
     _ => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(a.clone()),
       right: Box::new(b.clone()),
     },
@@ -5229,12 +5215,12 @@ fn is_numeric_like(expr: &Expr) -> bool {
       args.iter().all(is_numeric_like)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => is_numeric_like(left) && is_numeric_like(right),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => is_numeric_like(left) && is_numeric_like(right),
@@ -5247,7 +5233,7 @@ fn is_numeric_like(expr: &Expr) -> bool {
 fn extract_base_exponent(expr: &Expr) -> (Expr, Expr) {
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -5373,7 +5359,7 @@ fn combine_reciprocal_trig(
       continue;
     };
     let signed = if is_recip { negate_exp(&exp) } else { exp };
-    let key = format!("{}|{}", primary, crate::syntax::expr_to_string(farg));
+    let key = format!("{}|{}", primary, expr_to_string(farg));
     if let Some(gi) = groups.iter().position(|g| g.key == key) {
       groups[gi].count += 1;
       groups[gi].exps.push(signed);
@@ -5468,11 +5454,11 @@ fn combine_like_bases(args: Vec<Expr>) -> Result<Vec<Expr>, InterpreterError> {
       Expr::Identifier(_) | Expr::Constant(_) => true,
       Expr::FunctionCall { .. } => true,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         ..
       }
       | Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         ..
       } => true,
       _ => false,
@@ -5481,7 +5467,7 @@ fn combine_like_bases(args: Vec<Expr>) -> Result<Vec<Expr>, InterpreterError> {
       non_combinable.push(arg.clone());
       continue;
     }
-    let base_key = crate::syntax::expr_to_string(&base);
+    let base_key = expr_to_string(&base);
     if let Some(group) = groups.iter_mut().find(|(k, _, _)| *k == base_key) {
       group.2.push(exp);
     } else {
@@ -5536,16 +5522,14 @@ fn combine_like_bases(args: Vec<Expr>) -> Result<Vec<Expr>, InterpreterError> {
       combined.push(result[i].clone());
       continue;
     }
-    let exp_key = crate::syntax::expr_to_string(&exp_i);
+    let exp_key = expr_to_string(&exp_i);
     let mut bases_to_multiply = vec![base_i];
     for j in (i + 1)..result.len() {
       if used[j] {
         continue;
       }
       let (base_j, exp_j) = extract_base_exponent(&result[j]);
-      if is_numeric_like(&base_j)
-        && crate::syntax::expr_to_string(&exp_j) == exp_key
-      {
+      if is_numeric_like(&base_j) && expr_to_string(&exp_j) == exp_key {
         bases_to_multiply.push(base_j);
         used[j] = true;
       }
@@ -5595,12 +5579,12 @@ fn combine_like_bases(args: Vec<Expr>) -> Result<Vec<Expr>, InterpreterError> {
         args.iter().all(is_pos_numeric)
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => is_pos_numeric(left) && is_pos_numeric(right),
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         ..
       } => is_pos_numeric(left),
@@ -5624,15 +5608,13 @@ fn combine_like_bases(args: Vec<Expr>) -> Result<Vec<Expr>, InterpreterError> {
       continue;
     }
     let neg_exp_i = times_ast(&[Expr::Integer(-1), exp_i.clone()])?;
-    let neg_exp_key = crate::syntax::expr_to_string(&neg_exp_i);
+    let neg_exp_key = expr_to_string(&neg_exp_i);
     for j in 0..combined.len() {
       if j == i || consumed[j] {
         continue;
       }
       let (base_j, exp_j) = extract_base_exponent(&combined[j]);
-      if is_pos_numeric(&base_j)
-        && crate::syntax::expr_to_string(&exp_j) == neg_exp_key
-      {
+      if is_pos_numeric(&base_j) && expr_to_string(&exp_j) == neg_exp_key {
         pairs.push((i, j));
         consumed[i] = true;
         consumed[j] = true;
@@ -5731,7 +5713,7 @@ fn try_series_data_times_var_power(
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left,
         right,
       } => {
@@ -5750,7 +5732,7 @@ fn try_series_data_times_var_power(
   let (p, q) = match power {
     e if same_var(e) => (1i128, 1i128),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } if same_var(left) => match extract_pq(right) {
@@ -5981,7 +5963,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -5989,20 +5971,20 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         flatten_times(right, out);
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left,
         right,
       } => {
         // a/b → a * b^(-1)
         flatten_times(left, out);
         out.push(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: right.clone(),
           right: Box::new(Expr::Integer(-1)),
         });
       }
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => {
         // -x → (-1) * x
@@ -6111,7 +6093,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let inf_idx = flat_args.iter().position(|a| {
     matches!(a, Expr::Identifier(n) if n == "Infinity")
       || matches!(a, Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand,
         } if matches!(operand.as_ref(), Expr::Identifier(n) if n == "Infinity"))
       || matches!(a, Expr::FunctionCall { name, args } if name == "DirectedInfinity" && args.len() == 1)
@@ -6173,7 +6155,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }
         }
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand,
         } => real_factor_sign(operand).map(|s| -s),
         Expr::FunctionCall { name, args } if name == "Times" => {
@@ -6184,7 +6166,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Some(sign)
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left,
           right,
         } => Some(real_factor_sign(left)? * real_factor_sign(right)?),
@@ -6195,7 +6177,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       match a {
         Expr::Identifier(n) if n == "Infinity" => Some(1),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand,
         } if matches!(operand.as_ref(), Expr::Identifier(n) if n == "Infinity") => {
           Some(-1)
@@ -6229,7 +6211,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           inf
         } else {
           Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand: Box::new(inf),
           }
         });
@@ -6301,7 +6283,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           &args[1]
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left,
           right,
         } if matches!(left.as_ref(), Expr::Identifier(s) if s == "E")
@@ -6335,9 +6317,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           if pi == ei || consumed.contains(ei) {
             continue;
           }
-          if crate::syntax::expr_to_string(pz)
-            == crate::syntax::expr_to_string(ez)
-          {
+          if expr_to_string(pz) == expr_to_string(ez) {
             consumed.insert(*pi);
             consumed.insert(*ei);
             replacements.push(pz.clone());
@@ -6588,7 +6568,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // `(10^40)^(-1)`) is otherwise left symbolic and never cancels against a
         // large integer numerator (the BigInteger analogue of the Rational case).
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: base,
           right: exp,
         } if matches!(
@@ -6794,7 +6774,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Power[Integer(n), Integer(neg)] → absorb into rational coefficient
       // e.g. 2^(-1) → rat_denom *= 2, or 3^(-2) → rat_denom *= 9
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: base,
         right: exp,
       } if matches!(base.as_ref(), Expr::Integer(n) if *n != 0)
@@ -6824,7 +6804,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // But leave Times[I, Pi/2] unchanged (no explicit rational coefficient).
         if has_rational_coeff_in_args
           && let Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: num_expr,
             right: den_expr,
           } = arg
@@ -6933,10 +6913,10 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if has_imag {
         // 0.0 * I → 0. + 0.*I (Complex form)
         return Ok(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(Expr::Real(0.0)),
           right: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Real(0.0)),
             right: Box::new(Expr::Identifier("I".to_string())),
           }),
@@ -7042,7 +7022,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       matches!(&symbolic_args[0], Expr::Identifier(s) if s == "Infinity");
     let is_neg_inf = match &symbolic_args[0] {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity"),
       _ => false,
@@ -7056,7 +7036,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         return Ok(Expr::Identifier("Infinity".to_string()));
       } else {
         return Ok(Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(Expr::Identifier("Infinity".to_string())),
         });
       }
@@ -7119,7 +7099,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Some(ta.iter().cloned().collect())
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left,
           right,
         } if as_int_rational(left).is_some()
@@ -7197,7 +7177,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               symbolic_args[i] = base;
             } else {
               symbolic_args[i] = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(base),
                 right: Box::new(new_exp),
               };
@@ -7344,10 +7324,10 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         // Only rewrite when something actually changed; canonical inputs
         // are fixed points and must return through the generic path.
-        let coeff_str = crate::syntax::expr_to_string(&coeff);
-        let new_coeff_str = crate::syntax::expr_to_string(&new_coeff);
-        let factor_str = crate::syntax::expr_to_string(&symbolic_args[0]);
-        let rebuilt_str = crate::syntax::expr_to_string(&rebuilt);
+        let coeff_str = expr_to_string(&coeff);
+        let new_coeff_str = expr_to_string(&new_coeff);
+        let factor_str = expr_to_string(&symbolic_args[0]);
+        let rebuilt_str = expr_to_string(&rebuilt);
         if coeff_str != new_coeff_str || factor_str != rebuilt_str {
           if matches!(&new_coeff, Expr::Integer(1)) {
             return Ok(rebuilt);
@@ -7625,7 +7605,7 @@ fn is_infinity_like(expr: &Expr) -> bool {
     Expr::Identifier(name) => name == "Infinity" || name == "ComplexInfinity",
     Expr::FunctionCall { name, .. } => name == "DirectedInfinity",
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => matches!(operand.as_ref(), Expr::Identifier(n) if n == "Infinity"),
     _ => false,
@@ -7770,7 +7750,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
       // Negative divisor flips Infinity → -Infinity. Use UnaryOp Minus
       // so the formatter prints `-Infinity` consistently.
       return Ok(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(a.clone()),
       });
     }
@@ -7841,7 +7821,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
   {
     // BinaryOp form
     if let Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } = a
@@ -7893,7 +7873,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
     && matches!(is_sqrt(b).unwrap(), Expr::Integer(m) if *m > 0)
   {
     let b_inv = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(b.clone()),
       right: Box::new(Expr::Integer(-1)),
     };
@@ -8130,7 +8110,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
     }
     _ => {
       // x / x → 1 for identical symbolic expressions
-      if crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b) {
+      if expr_to_string(a) == expr_to_string(b) {
         return Ok(Expr::Integer(1));
       }
 
@@ -8202,8 +8182,7 @@ fn flip_unit_negative_rational_product(expr: Expr) -> Expr {
       || matches!(
         e,
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus
-            | crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Plus | BinaryOperator::Minus,
           ..
         }
       )
@@ -8476,7 +8455,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
       true
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "I") => true,
     _ => false,
@@ -8612,12 +8591,12 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
           args.iter().any(term_has_log)
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left,
           right,
         } => term_has_log(left) || term_has_log(right),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand,
         } => term_has_log(operand),
         _ => false,
@@ -8628,7 +8607,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         Some(args.iter().collect())
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left,
         right,
       } => Some(vec![left.as_ref(), right.as_ref()]),
@@ -8693,7 +8672,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         Some(targs.iter().collect())
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => Some(vec![left.as_ref(), right.as_ref()]),
@@ -8781,7 +8760,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     crate::emit_message(&format!(
       "\n{:>40}\nInfinity::indet: Indeterminate expression {}  encountered.",
       "0",
-      crate::syntax::expr_to_string(base)
+      expr_to_string(base)
     ));
     return Ok(Expr::Identifier("Indeterminate".to_string()));
   }
@@ -8894,7 +8873,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
   // `-Sin[t]^2` instead of `Sin[t]^2`.
   if let Expr::Integer(n) = exp
     && let Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } = base
   {
@@ -8917,7 +8896,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         Some(targs.iter().collect())
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => Some(vec![left.as_ref(), right.as_ref()]),
@@ -8959,7 +8938,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         Some(targs.iter().collect())
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => Some(vec![left.as_ref(), right.as_ref()]),
@@ -9028,14 +9007,14 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
                 && is_numeric_like_extended(&args[1])
             }
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left,
               right,
             } => {
               is_numeric_like_extended(left) && is_numeric_like_extended(right)
             }
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left,
               right,
             } => {
@@ -9095,7 +9074,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
   if let Expr::Integer(e2) = exp {
     let inner = match base {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } => Some((left.as_ref(), right.as_ref())),
@@ -9144,7 +9123,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
   if let Expr::Real(_) = exp {
     let inner = match base {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } => Some((left.as_ref(), right.as_ref())),
@@ -9173,7 +9152,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         (Some(&fargs[0]), Some(&fargs[1]))
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } => (Some(left.as_ref()), Some(right.as_ref())),
@@ -9202,7 +9181,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         Some(&targs[1])
       }
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => Some(operand.as_ref()),
       _ => None,
@@ -9216,7 +9195,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
           (Some(&pargs[0]), Some(&pargs[1]))
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left,
           right,
         } => (Some(left.as_ref()), Some(right.as_ref())),
@@ -9354,7 +9333,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         negate_expr(i_expr.clone())
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(im_expr),
           right: Box::new(i_expr),
         }
@@ -9363,7 +9342,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         return Ok(imag_term);
       }
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(re_expr),
         right: Box::new(imag_term),
       });
@@ -9424,7 +9403,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         Some(args.iter().collect())
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left,
         right,
       } => Some(vec![left.as_ref(), right.as_ref()]),
@@ -9487,16 +9466,16 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
       }
       if real_part == 0.0 {
         return Ok(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Real(imag_part)),
           right: Box::new(Expr::Identifier("I".to_string())),
         });
       }
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Real(real_part)),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Real(imag_part)),
           right: Box::new(Expr::Identifier("I".to_string())),
         }),
@@ -9510,8 +9489,8 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
   let exp_is_zero = matches!(exp, Expr::Integer(0))
     || matches!(exp, Expr::Real(f) if *f == 0.0);
   if base_is_zero && exp_is_zero {
-    let base_str = crate::syntax::expr_to_string(base);
-    let exp_str = crate::syntax::expr_to_string(exp);
+    let base_str = expr_to_string(base);
+    let exp_str = expr_to_string(exp);
     // Align exponent above the base in the warning message
     // "Power::indet: Indeterminate expression " is 39 chars
     // Exponent starts at column 39 + len(base), right-align needs + len(exp)
@@ -9534,7 +9513,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     && let Some(e) = expr_to_num(exp)
     && e < 0.0
   {
-    let base_str = crate::syntax::expr_to_string(base);
+    let base_str = expr_to_string(base);
     if e == -1.0 {
       crate::emit_message(&format_infy_fraction_2d(
         "Power::infy: Infinite expression ",
@@ -9542,7 +9521,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         &base_str,
       ));
     } else {
-      let exp_str = crate::syntax::expr_to_string(exp);
+      let exp_str = expr_to_string(exp);
       crate::emit_message(&super::format_power_infy_2d(&base_str, &exp_str));
     }
     return Ok(Expr::Identifier("ComplexInfinity".to_string()));
@@ -9668,7 +9647,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         return divide_ast(&[p_root, q_root]);
       }
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(base.clone()),
         right: Box::new(exp.clone()),
       });
@@ -9735,7 +9714,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
       if !matches!(
         &pos_result,
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           ..
         }
       ) && !matches!(&pos_result, Expr::FunctionCall { name, .. } if name == "Power")
@@ -9826,7 +9805,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
           radical_factors.iter().map(|(p, _)| *p).product();
         if combined_base == *b {
           return Ok(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(base.clone()),
             right: Box::new(exp.clone()),
           });
@@ -9836,7 +9815,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
           return Ok(make_sqrt(Expr::Integer(combined_base)));
         }
         return Ok(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(Expr::Integer(combined_base)),
           right: Box::new(make_rational(rn, rd)),
         });
@@ -9855,7 +9834,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
           rad_parts.push(make_sqrt(Expr::Integer(*prime)));
         } else {
           rad_parts.push(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::Integer(*prime)),
             right: Box::new(make_rational(reduced_num, reduced_den)),
           });
@@ -9877,7 +9856,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
 
     // Not exact — keep symbolic
     return Ok(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(base.clone()),
       right: Box::new(exp.clone()),
     });
@@ -10013,7 +9992,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         return Ok(build_complex_float_expr(re, im));
       }
       Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(base.clone()),
         right: Box::new(exp.clone()),
       })
@@ -10293,7 +10272,7 @@ fn try_extract_i_pi_rational_multiple(expr: &Expr) -> Option<(i128, i128)> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -10307,7 +10286,7 @@ fn try_extract_i_pi_rational_multiple(expr: &Expr) -> Option<(i128, i128)> {
     || matches!(
       expr,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         ..
       }
     );
@@ -10545,7 +10524,7 @@ fn flatten_lists(args: &[Expr]) -> Vec<&Expr> {
 /// Like try_eval_to_f64 but also handles Infinity/-Infinity (for Max/Min)
 pub fn try_eval_to_f64_with_infinity(expr: &Expr) -> Option<f64> {
   // Check by string representation for Infinity forms
-  let s = crate::syntax::expr_to_string(expr);
+  let s = expr_to_string(expr);
   if s == "Infinity" {
     return Some(f64::INFINITY);
   }
@@ -10606,7 +10585,7 @@ pub fn max_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // (numeric duplicates already collapse into the single best value).
   {
     let mut seen = std::collections::HashSet::new();
-    symbolic.retain(|e| seen.insert(crate::syntax::expr_to_string(e)));
+    symbolic.retain(|e| seen.insert(expr_to_string(e)));
   }
 
   if symbolic.is_empty() {
@@ -10683,7 +10662,7 @@ pub fn min_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Min is idempotent: Min[a, a] == a. Drop duplicate symbolic arguments.
   {
     let mut seen = std::collections::HashSet::new();
-    symbolic.retain(|e| seen.insert(crate::syntax::expr_to_string(e)));
+    symbolic.retain(|e| seen.insert(expr_to_string(e)));
   }
 
   if symbolic.is_empty() {
@@ -10794,7 +10773,7 @@ fn is_bigfloat_evaluable_factor(e: &Expr) -> bool {
         && bigfloat_int_exponent(&args[1]).is_some()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -10802,7 +10781,7 @@ fn is_bigfloat_evaluable_factor(e: &Expr) -> bool {
         && bigfloat_int_exponent(right).is_some()
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_bigfloat_evaluable_factor(operand),
     _ => false,
@@ -10815,7 +10794,7 @@ fn bigfloat_int_exponent(e: &Expr) -> Option<i128> {
   match e {
     Expr::Integer(n) => Some(*n),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       if let Expr::Integer(n) = operand.as_ref() {
@@ -10835,7 +10814,7 @@ fn factor_precision_contribution(e: &Expr) -> Option<f64> {
   match e {
     Expr::BigFloat(_, p) if *p > 0.0 => Some(*p),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => factor_precision_contribution(operand),
     Expr::FunctionCall { name, args } if name == "Power" && args.len() == 2 => {
@@ -10845,7 +10824,7 @@ fn factor_precision_contribution(e: &Expr) -> Option<f64> {
       Some(p - abs_n.log10())
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -10949,7 +10928,7 @@ fn try_date_object_subtraction(
     // Matches Times[-1, DateObject[...]] or UnaryOp(Minus, DateObject[...])
     match e {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -10977,7 +10956,7 @@ fn try_date_object_subtraction(
         }
       }
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } if is_date_object(operand) => Some(operand),
       _ => None,

--- a/src/functions/math_ast/bessel.rs
+++ b/src/functions/math_ast/bessel.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr};
 
 /// True if `z_expr` is `<zero_name>[order, k, ...]` whose first argument equals
 /// `n_expr` AND both `order` and `k` are concrete positive integers — the only
@@ -168,11 +168,9 @@ fn half_int_bessel_i(
 fn is_plus_expr(e: &Expr) -> bool {
   match e {
     Expr::FunctionCall { name, .. } if name == "Plus" => true,
-    Expr::BinaryOp { op, .. } => matches!(
-      op,
-      crate::syntax::BinaryOperator::Plus
-        | crate::syntax::BinaryOperator::Minus
-    ),
+    Expr::BinaryOp { op, .. } => {
+      matches!(op, BinaryOperator::Plus | BinaryOperator::Minus)
+    }
     _ => false,
   }
 }

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// True if `t` carries the imaginary unit `I` as a direct factor (possibly
 /// nested inside Times/negation): `I`, `b I`, `-2 b I`, etc.
@@ -13,7 +13,7 @@ fn has_i_factor(t: &Expr) -> bool {
       args.iter().any(has_i_factor)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => has_i_factor(left) || has_i_factor(right),
@@ -324,7 +324,7 @@ fn flatten_times_factors(expr: &Expr, out: &mut Vec<Expr>) {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -342,7 +342,7 @@ fn split_i_factors(expr: &Expr) -> Option<(usize, Vec<Expr>)> {
     || matches!(
       expr,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         ..
       }
     );
@@ -406,7 +406,6 @@ fn extract_i_times_any(expr: &Expr) -> Option<Expr> {
 /// Only matches when the input contains at least one BigFloat to avoid
 /// stealing simpler real cases handled elsewhere.
 fn try_extract_complex_bigfloat(expr: &Expr) -> Option<(Expr, Expr)> {
-  use crate::syntax::BinaryOperator;
   let plus_args: Vec<Expr> = match expr {
     Expr::FunctionCall { name, args } if name == "Plus" => args.to_vec(),
     Expr::BinaryOp {
@@ -570,7 +569,6 @@ fn contains_machine_real(expr: &Expr) -> bool {
 /// Flatten a Plus/Minus expression into its summands, rewriting `a - b` into
 /// `a + (-1)*b`. Returns None for non-additive expressions.
 fn collect_plus_terms(expr: &Expr) -> Option<Vec<Expr>> {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::FunctionCall { name, args } if name == "Plus" && !args.is_empty() => {
       Some(args.to_vec())
@@ -635,7 +633,7 @@ fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
       Expr::Integer(n) => Expr::Integer(-*n),
       Expr::Real(f) => Expr::Real(-*f),
       other => Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(other.clone()),
       },
     };
@@ -779,7 +777,7 @@ fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
     }
   }
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left,
     right,
   } = expr
@@ -796,7 +794,7 @@ fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
   // (1 - I)/Sqrt[2]. Only when both parts conjugate cleanly — symbolic
   // quotients like b/Sqrt[a] stay wrapped as a whole, matching Wolfram.
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left,
     right,
   } = expr
@@ -808,7 +806,7 @@ fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
       |e: &Expr| !crate::syntax::expr_to_string(e).contains("Conjugate[");
     if clean(&num) && clean(&den) {
       return crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(num),
         right: Box::new(den),
       });
@@ -834,7 +832,7 @@ fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
 
   // UnaryOp Minus: Conjugate[-x] = -Conjugate[x]
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = expr
   {
@@ -849,7 +847,7 @@ fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
   //     Conjugate[base]^n (e.g. Conjugate[x^2] = Conjugate[x]^2).
   let power_parts: Option<(&Expr, &Expr)> = match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some((left.as_ref(), right.as_ref())),
@@ -861,14 +859,14 @@ fn conjugate_one(expr: &Expr) -> Result<Expr, InterpreterError> {
   if let Some((base, exp)) = power_parts {
     if is_strictly_positive_real(base) {
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(base.clone()),
         right: Box::new(conjugate_one(exp)?),
       });
     }
     if matches!(exp, Expr::Integer(_)) {
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(conjugate_one(base)?),
         right: Box::new(exp.clone()),
       });
@@ -927,7 +925,7 @@ pub fn is_strictly_positive_real(e: &Expr) -> bool {
       is_strictly_positive_real(&args[0]) && is_real_valued(&args[1])
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => is_strictly_positive_real(left) && is_real_valued(right),
@@ -947,7 +945,7 @@ fn match_re_plus_i_im(expr: &Expr) -> Option<String> {
   let plus_args: Vec<Expr> = match expr {
     Expr::FunctionCall { name, args } if name == "Plus" => args.to_vec(),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => vec![*left.clone(), *right.clone()],
@@ -972,7 +970,7 @@ fn match_re_plus_i_im(expr: &Expr) -> Option<String> {
         args.iter().collect()
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => vec![left.as_ref(), right.as_ref()],
@@ -1058,7 +1056,7 @@ pub fn arg_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     let e_exp: Option<&Expr> = match &args[0] {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } if matches!(left.as_ref(), Expr::Constant(c) | Expr::Identifier(c) if c == "E") => {
@@ -1300,13 +1298,13 @@ pub fn arg_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           let pi = Expr::Identifier("Pi".to_string());
           if in_ > 0 {
             return Ok(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(pi),
               right: Box::new(arctan_expr),
             });
           } else {
             return Ok(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(negate_expr(pi)),
               right: Box::new(arctan_expr),
             });
@@ -1362,7 +1360,7 @@ pub fn make_rational_times_pi(n: i128, d: i128) -> Expr {
       negate_expr(Expr::Identifier("Pi".to_string()))
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(n)),
         right: Box::new(Expr::Identifier("Pi".to_string())),
       }
@@ -1370,7 +1368,7 @@ pub fn make_rational_times_pi(n: i128, d: i128) -> Expr {
   } else {
     let coeff = make_rational(n, d);
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(coeff),
       right: Box::new(Expr::Identifier("Pi".to_string())),
     }
@@ -1887,7 +1885,7 @@ pub fn numerator_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Real(_) => Ok(args[0].clone()),
     // Numerator[a / b] (BinaryOp Divide) → a
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       ..
     } => Ok(left.as_ref().clone()),
@@ -1978,7 +1976,7 @@ pub fn denominator_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Real(_) => Ok(Expr::Integer(1)),
     // Denominator[a / b] → b
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       right,
       ..
     } => Ok(right.as_ref().clone()),
@@ -1992,7 +1990,7 @@ pub fn denominator_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             denom_factors.push(base);
           } else {
             denom_factors.push(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(base),
               right: Box::new(neg_exp),
             });
@@ -2033,7 +2031,7 @@ pub fn denominator_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Ok(base)
         } else {
           Ok(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(base),
             right: Box::new(pos_exp),
           })
@@ -2162,7 +2160,7 @@ fn denominator_trig(expr: &Expr) -> Option<Expr> {
 fn split_rational_power(expr: &Expr) -> Option<(Expr, Expr)> {
   let (base, exp) = match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => (left.as_ref(), right.as_ref()),
@@ -2200,12 +2198,12 @@ fn split_rational_power(expr: &Expr) -> Option<(Expr, Expr)> {
   }
   let pow = |b: i128| {
     crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(Expr::Integer(b)),
       right: Box::new(exp.clone()),
     })
     .unwrap_or_else(|_| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(Expr::Integer(b)),
       right: Box::new(exp.clone()),
     })
@@ -2216,7 +2214,7 @@ fn split_rational_power(expr: &Expr) -> Option<(Expr, Expr)> {
 pub fn get_negative_power_exponent(expr: &Expr) -> Option<(Expr, Expr)> {
   let (base, exp) = match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => (left.as_ref().clone(), right.as_ref().clone()),
@@ -2250,7 +2248,7 @@ fn negate_if_negative(exp: &Expr) -> Option<Expr> {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some(operand.as_ref().clone()),
     Expr::FunctionCall { name, args }

--- a/src/functions/math_ast/coordinate_arrays.rs
+++ b/src/functions/math_ast/coordinate_arrays.rs
@@ -4,7 +4,7 @@
 //! pairs versus the two corner points `{mins, maxs}`.
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{Expr, UnaryOperator, expr_to_output};
 
 /// One coordinate value: an exact rational (p/q, q > 0) or a machine real.
 /// Grids over exact bounds with exact steps stay exact (`Into[2]` of a unit
@@ -158,7 +158,7 @@ fn to_num(expr: &Expr) -> Option<Num> {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => to_num(operand).map(|v| match v {
       Num::Exact(p, q) => Num::Exact(-p, q),
@@ -313,14 +313,14 @@ pub fn coordinate_bounds_array_ast(
   let Some(ranges) = ranges else {
     crate::emit_message(&format!(
       "CoordinateBoundsArray::bound: Invalid bounds specification {}.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     return unevaluated();
   };
   match build_array(&ranges, args.get(1), args.get(2), &|off| {
     crate::emit_message(&format!(
       "CoordinateBoundsArray::offs: Invalid offset specification {}.",
-      crate::syntax::expr_to_output(off)
+      expr_to_output(off)
     ));
   }) {
     Some(result) => Ok(result),
@@ -361,14 +361,14 @@ pub fn coordinate_bounding_box_array_ast(
   let Some(ranges) = ranges else {
     crate::emit_message(&format!(
       "CoordinateBoundingBoxArray::bbox: Invalid bounding box specification {}.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     return unevaluated();
   };
   match build_array(&ranges, args.get(1), args.get(2), &|off| {
     crate::emit_message(&format!(
       "CoordinateBoundingBoxArray::offs: Invalid offset specification {}.",
-      crate::syntax::expr_to_output(off)
+      expr_to_output(off)
     ));
   }) {
     Some(result) => Ok(result),

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
 use num_bigint::BigInt;
 use num_traits::Signed;
 
@@ -670,7 +670,7 @@ fn extract_sqrt_integer(expr: &Expr) -> Option<i128> {
       None
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -709,7 +709,7 @@ fn extract_reciprocal_sqrt_integer(expr: &Expr) -> Option<i128> {
       None
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -739,7 +739,7 @@ fn extract_quadratic_irrational(
   // overall Rational coefficient and whatever Plus-sum remains.
   let (inner_owned, scale_num, scale_den): (Expr, i128, i128) = match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -789,7 +789,7 @@ fn extract_quadratic_irrational(
   let mut d: i128 = 0;
   let terms: Vec<&Expr> = match inner {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => vec![left.as_ref(), right.as_ref()],
@@ -814,7 +814,7 @@ fn extract_quadratic_irrational(
     // k * Sqrt[d] — canonically as Times[k, Sqrt[d]].
     let (coeff, sqrt_expr) = match t {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => (left.as_ref(), right.as_ref()),
@@ -2161,7 +2161,7 @@ pub fn real_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(n) => *n < 0,
     Expr::Real(f) => *f < 0.0,
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       ..
     } => true,
     _ => false,
@@ -3560,7 +3560,7 @@ fn make_rational_expr(num: i128, den: i128) -> Expr {
         Expr::Integer(-n)
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::Integer(-n)),
           right: Box::new(Expr::Integer(-d)),
         }
@@ -3569,7 +3569,7 @@ fn make_rational_expr(num: i128, den: i128) -> Expr {
       Expr::Integer(n)
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(n)),
         right: Box::new(Expr::Integer(d)),
       }
@@ -3959,7 +3959,7 @@ pub fn number_decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let psv = |args: &[Expr]| {
     crate::emit_message(&format!(
       "NumberDecompose::psv: {} is not a list of nonincreasing positive numbers.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     Ok(unevaluated(args))
   };
@@ -4061,8 +4061,8 @@ pub fn number_compose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if coeff_exprs.len() > unit_exprs.len() {
     crate::emit_message(&format!(
       "NumberCompose::ulen: List {} of coefficients cannot be longer than list {} of units.",
-      crate::syntax::expr_to_string(&args[0]),
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[0]),
+      expr_to_string(&args[1])
     ));
     return Ok(unevaluated(args));
   }
@@ -4089,7 +4089,7 @@ pub fn number_compose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let psv = |args: &[Expr]| {
     crate::emit_message(&format!(
       "NumberCompose::psv: {} is not a list of nonincreasing positive numbers.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     Ok(unevaluated(args))
   };
@@ -4163,7 +4163,7 @@ pub fn minkowski_question_mark_ast(
       let golden = matches!(other, Expr::Identifier(s) | Expr::Constant(s) if s == "GoldenRatio");
       let neg_golden = match other {
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand,
         } => matches!(
           operand.as_ref(),
@@ -4342,7 +4342,7 @@ pub fn from_roman_numeral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => {
       crate::emit_message(&format!(
         "FromRomanNumeral::string: String expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated(args))
+        expr_to_string(&unevaluated(args))
       ));
       Ok(unevaluated(args))
     }
@@ -4381,8 +4381,8 @@ pub fn thue_morse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         crate::emit_message(&format!(
           "ThueMorse::nnintprm: Parameter {} at position 1 in {} is expected \
            to be a non-negative integer.",
-          crate::syntax::expr_to_string(&args[0]),
-          crate::syntax::expr_to_string(&unevaluated(args))
+          expr_to_string(&args[0]),
+          expr_to_string(&unevaluated(args))
         ));
       }
       Ok(unevaluated(args))
@@ -4416,8 +4416,8 @@ pub fn rudin_shapiro_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         crate::emit_message(&format!(
           "RudinShapiro::nnintprm: Parameter {} at position 1 in {} is \
            expected to be a non-negative integer.",
-          crate::syntax::expr_to_string(&args[0]),
-          crate::syntax::expr_to_string(&unevaluated(args))
+          expr_to_string(&args[0]),
+          expr_to_string(&unevaluated(args))
         ));
       }
       Ok(unevaluated(args))

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -2,7 +2,9 @@
 use super::*;
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
-use crate::syntax::{BinaryOperator, ComparisonOp, Expr};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+};
 
 /// Helper to build a binary operation expression
 fn binop(op: BinaryOperator, left: Expr, right: Expr) -> Expr {
@@ -363,11 +365,11 @@ pub fn hazard_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         name: "Times".to_string(),
         args: vec![
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::Identifier("E".to_string())),
             right: Box::new(divide(
               Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(x.clone()),
                 right: Box::new(int(2)),
               },
@@ -423,8 +425,7 @@ pub fn hazard_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       };
       if p_pair.len() != 2
         || s_pair.len() != 2
-        || crate::syntax::expr_to_string(&p_pair[1])
-          != crate::syntax::expr_to_string(&s_pair[1])
+        || expr_to_string(&p_pair[1]) != expr_to_string(&s_pair[1])
       {
         return Ok(unevaluated(args));
       }
@@ -455,7 +456,7 @@ fn match_erfc_half(expr: &Expr) -> Option<Expr> {
   };
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } if matches!(right.as_ref(), Expr::Integer(2)) => erfc_arg(left),
@@ -493,7 +494,7 @@ pub fn quantile_distribution_closed_form(
   }
   let infinity = || Expr::Identifier("Infinity".to_string());
   let neg_infinity = || Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(infinity()),
   };
   let is_exact_q = !matches!(q, Expr::Real(_));
@@ -709,7 +710,7 @@ pub fn quantile_distribution_closed_form(
           _ => vec![sqrt2, s.clone(), inverse_erfc],
         };
         let term = Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(Expr::FunctionCall {
             name: "Times".to_string(),
             args: factors.into(),
@@ -881,7 +882,7 @@ pub fn inverse_survival_closed_form(
   let is_exact_q = !matches!(q, Expr::Real(_));
   let infinity = || Expr::Identifier("Infinity".to_string());
   let neg_infinity = || Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(infinity()),
   };
 
@@ -2118,7 +2119,7 @@ fn cdf_exponential(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       e(),
       times(
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(lambda),
         },
         x.clone(),
@@ -2308,7 +2309,7 @@ fn pdf_gamma(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let exp_part = power(
     e(),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(divide(x.clone(), beta.clone())),
     },
   );
@@ -2409,7 +2410,7 @@ fn pdf_logistic(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // (1 + E^(...))^2
   let denom_sq = power(
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(int(1)),
       right: Box::new(exp_val.clone()),
     },
@@ -2431,7 +2432,7 @@ fn cdf_logistic(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   let exp_val = power(e(), divide(minus(m, x), s));
   let denom = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(int(1)),
     right: Box::new(exp_val),
   };
@@ -2456,7 +2457,7 @@ fn pdf_inverse_chi_square(
   let x_part = power(
     power(x.clone(), int(-1)),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(int(1)),
       right: Box::new(divide(n.clone(), int(2))),
     },
@@ -2519,9 +2520,9 @@ fn pdf_frechet(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let xb_part = power(
     xb.clone(),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(int(1)),
         right: Box::new(a.clone()),
       }),
@@ -2533,7 +2534,7 @@ fn pdf_frechet(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     power(
       xb,
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(a.clone()),
       },
     ),
@@ -2563,11 +2564,11 @@ fn cdf_frechet(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let value = power(
     e(),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(power(
         divide(shifted, b),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(a),
         },
       )),
@@ -2594,9 +2595,9 @@ fn pdf_extreme_value(
   let ab = divide(minus(a.clone(), x), b.clone());
   // E^(-E^((a-x)/b) + (a-x)/b)
   let exp_arg = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(power(e(), ab.clone())),
     }),
     right: Box::new(ab),
@@ -2622,7 +2623,7 @@ fn cdf_extreme_value(
   eval(power(
     e(),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(power(e(), ab)),
     },
   ))
@@ -2649,7 +2650,7 @@ fn pdf_gompertz_makeham(
   let inner = times(minus(int(1), e_lx), x0.clone());
   // l*x + (1 - E^(l*x))*x0
   let exp_arg = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(lx),
     right: Box::new(inner),
   };
@@ -2741,7 +2742,7 @@ fn cdf_inverse_gaussian(
     times(
       sqrt_lx,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(m.clone()),
         right: Box::new(x.clone()),
       },
@@ -2756,7 +2757,7 @@ fn cdf_inverse_gaussian(
     int(2),
   );
   let value = eval(Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(erfc1),
     right: Box::new(times(exp_part, erfc2)),
   })?;
@@ -3471,7 +3472,7 @@ fn extract_mgf_pattern(expr: &Expr, var: &str) -> Option<(Expr, Expr)> {
       args[1].clone()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -4973,7 +4974,7 @@ pub fn distribution_mean_variance(
       let b_gamma = times(b.clone(), gamma_1_minus_inv_a.clone());
       let mean_value = match &mu {
         Some(m) => Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(m.clone()),
           right: Box::new(b_gamma),
         },
@@ -5571,9 +5572,7 @@ pub fn distribution_mean_variance(
 /// Check if expression is var^n
 fn is_power_of_var(expr: &Expr, var: &str, n: i128) -> bool {
   match expr {
-    Expr::BinaryOp { op, left, right }
-      if *op == crate::syntax::BinaryOperator::Power =>
-    {
+    Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Power => {
       matches!(left.as_ref(), Expr::Identifier(v) if v == var)
         && matches!(right.as_ref(), Expr::Integer(k) if *k == n)
     }
@@ -5588,9 +5587,7 @@ fn extract_linear(expr: &Expr, var: &str) -> Option<(Expr, Expr)> {
     // Pure variable: x → (1, 0)
     Expr::Identifier(n) if n == var => Some((int(1), int(0))),
     // a * x
-    Expr::BinaryOp { op, left, right }
-      if *op == crate::syntax::BinaryOperator::Times =>
-    {
+    Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Times => {
       if matches!(right.as_ref(), Expr::Identifier(n) if n == var)
         && !contains_var(left, var)
       {
@@ -5604,9 +5601,7 @@ fn extract_linear(expr: &Expr, var: &str) -> Option<(Expr, Expr)> {
       }
     }
     // a + b (try linear decomposition)
-    Expr::BinaryOp { op, left, right }
-      if *op == crate::syntax::BinaryOperator::Plus =>
-    {
+    Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Plus => {
       // If left is linear in var and right is constant (or vice versa)
       if !contains_var(right, var)
         && let Some((a, b)) = extract_linear(left, var)
@@ -5622,9 +5617,7 @@ fn extract_linear(expr: &Expr, var: &str) -> Option<(Expr, Expr)> {
       }
       None
     }
-    Expr::BinaryOp { op, left, right }
-      if *op == crate::syntax::BinaryOperator::Minus =>
-    {
+    Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Minus => {
       if !contains_var(right, var)
         && let Some((a, b)) = extract_linear(left, var)
       {
@@ -6266,7 +6259,7 @@ fn cdf_lognormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     args: vec![x.clone()].into(),
   };
   let arg = Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(divide(minus(log_x, mu), times(sqrt(int(2)), sigma))),
   };
   let cdf_val = divide(
@@ -6486,7 +6479,7 @@ fn pdf_pareto(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     power(
       x.clone(),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(plus(int(1), a)),
       },
     ),
@@ -6590,7 +6583,7 @@ fn cdf_weibull(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     power(
       e(),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(power(xb, a)),
       },
     ),
@@ -6689,7 +6682,7 @@ fn pdf_laplace(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     power(
       e(),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(divide(abs_diff, b.clone())),
       },
     ),
@@ -6715,7 +6708,7 @@ fn cdf_laplace(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       power(
         e(),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(divide(diff, b)),
         },
       ),
@@ -6740,7 +6733,7 @@ fn pdf_rayleigh(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     power(
       e(),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(divide(power(x.clone(), int(2)), times(int(2), s2))),
       },
     ),
@@ -6763,7 +6756,7 @@ fn cdf_rayleigh(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     power(
       e(),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(divide(power(x.clone(), int(2)), times(int(2), s2))),
       },
     ),
@@ -6916,7 +6909,7 @@ fn pdf_multivariate_poisson(
   let neg_mu1_mu2_over_mu0 = eval(times(
     int(-1),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(times(mu1.clone(), mu2.clone())),
       right: Box::new(mu0.clone()),
     },
@@ -6951,7 +6944,7 @@ fn pdf_multivariate_poisson(
   let denominator = times(times(exp_sum, x_fact), y_fact);
 
   let pdf_val = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(numerator),
     right: Box::new(denominator),
   };
@@ -7480,10 +7473,7 @@ fn pdf_arcsin(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // condition: a < x < b
   let cond = Expr::Comparison {
     operands: vec![a, x, b],
-    operators: vec![
-      crate::syntax::ComparisonOp::Less,
-      crate::syntax::ComparisonOp::Less,
-    ],
+    operators: vec![ComparisonOp::Less, ComparisonOp::Less],
   };
 
   eval(piecewise(vec![(density, cond)], int(0)))
@@ -7680,7 +7670,7 @@ fn pdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // (-mu + x): Wolfram canonical ordering
   let neg_mu_plus_x = plus(
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(mu.clone()),
     },
     x.clone(),
@@ -7753,7 +7743,7 @@ fn pdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       let mu_plus_sigma_minus_x = plus(
         plus(mu.clone(), sigma.clone()),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(x.clone()),
         },
       );
@@ -7828,7 +7818,7 @@ fn cdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // t = (-mu + x) / sigma (canonical ordering)
   let neg_mu_plus_x = plus(
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(mu.clone()),
     },
     x.clone(),
@@ -7851,7 +7841,7 @@ fn cdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       let mu_plus_sigma_minus_x = plus(
         plus(mu.clone(), sigma.clone()),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(x.clone()),
         },
       );
@@ -7869,11 +7859,11 @@ fn cdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   // Distribute negative sign: (-gamma - delta*h) / Sqrt[2]
   let neg_gamma = Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(gamma.clone()),
   };
   let neg_delta_h = Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(times(delta.clone(), h_of_t.clone())),
   };
   let erfc_arg = divide(plus(neg_gamma, neg_delta_h), sqrt(int(2)));
@@ -8057,7 +8047,7 @@ fn additive_terms(expr: &Expr) -> Vec<Expr> {
       out
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => {
@@ -8246,7 +8236,7 @@ fn extract_polynomial_in_var(
       args.iter().cloned().collect()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => vec![(**left).clone(), (**right).clone()],
@@ -8269,7 +8259,7 @@ fn extract_polynomial_in_var(
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } if matches!(left.as_ref(), Expr::Identifier(v) if v == var) => {
@@ -8683,16 +8673,16 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
 
   let pow2 = |e: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(e),
     right: Box::new(int(2)),
   };
   let neg = |e: Expr| Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(e),
   };
   let div2 = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(a),
     right: Box::new(b),
   };
@@ -8731,7 +8721,7 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     int(2),
   );
   let e_pow = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(Expr::Identifier("E".to_string())),
     right: Box::new(exponent),
   };
@@ -8758,7 +8748,7 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       args: vec![int(2 * det)].into(),
     })?;
     let pi_pow = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(pi()),
       right: Box::new(crate::functions::math_ast::make_rational(3, 2)),
     };
@@ -9404,16 +9394,16 @@ fn pdf_product_distribution(
   }
 
   let neg = |e: Expr| Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(e),
   };
   let pow2 = |e: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(e),
     right: Box::new(int(2)),
   };
   let div2 = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(a),
     right: Box::new(b),
   };
@@ -9447,13 +9437,13 @@ fn pdf_product_distribution(
         });
         conds.push(Expr::Comparison {
           operands: vec![v, int(0)],
-          operators: vec![crate::syntax::ComparisonOp::GreaterEqual],
+          operators: vec![ComparisonOp::GreaterEqual],
         });
       }
     }
   }
   let e_pow = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(Expr::Identifier("E".to_string())),
     right: Box::new(Expr::FunctionCall {
       name: "Plus".to_string(),
@@ -9676,7 +9666,7 @@ fn coeff_power_term(num: i128, den: i128, base: &Expr, i: i128) -> Expr {
   // Pull the sign out so Plus prints "- (3*x)/2" instead of "+ (-3*x)/2"
   if num < 0 {
     return Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(coeff_power_term(-num, den, base, i)),
     };
   }
@@ -10699,9 +10689,7 @@ fn pdf_exponential_power(
   } else {
     return Ok(unevaluated(dargs, x));
   };
-  if crate::syntax::expr_to_string(&b_plus)
-    == crate::syntax::expr_to_string(&b_minus)
-  {
+  if expr_to_string(&b_plus) == expr_to_string(&b_minus) {
     return Ok(b_plus);
   }
   let cond = comparison(x, ComparisonOp::GreaterEqual, m);
@@ -11049,17 +11037,14 @@ pub fn rice_mean_variance(
       eval(times(int(rd), e_half))?
     };
     // Single-factor denominators print without parentheses
-    let den_str = crate::syntax::expr_to_string(&denominator);
+    let den_str = expr_to_string(&denominator);
     let den_str = if den_str.contains('*') {
       format!("({den_str})")
     } else {
       den_str
     };
-    let mean = Expr::Raw(format!(
-      "({})/{}",
-      crate::syntax::expr_to_string(&numerator),
-      den_str
-    ));
+    let mean =
+      Expr::Raw(format!("({})/{}", expr_to_string(&numerator), den_str));
     // Var = base - Pi sum^2 / (q^2 2 e^k / b^2)
     let base = eval(plus(pow2(a), times(int(2), pow2(b))))?;
     let denom = eval(divide(
@@ -11068,9 +11053,9 @@ pub fn rice_mean_variance(
     ))?;
     let var = Expr::Raw(format!(
       "{} - (Pi*({})^2)/({})",
-      crate::syntax::expr_to_string(&base),
-      crate::syntax::expr_to_string(&sum),
-      crate::syntax::expr_to_string(&denom)
+      expr_to_string(&base),
+      expr_to_string(&sum),
+      expr_to_string(&denom)
     ));
     return Ok((mean, var));
   }
@@ -11390,7 +11375,7 @@ fn cdf_min_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     one_minus(power(
       e(),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(power(
           u,
           call("Times", vec![int(-1), power(g.clone(), int(-1))]),
@@ -11705,7 +11690,7 @@ fn pdf_max_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
           "Plus",
           vec![
             Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(power(e(), z)),
             },
             call("Times", vec![int(-1), neg_za]),
@@ -11756,7 +11741,7 @@ fn pdf_max_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
           "Plus",
           vec![
             Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(power(e(), z.clone())),
             },
             z,
@@ -11838,7 +11823,7 @@ fn cdf_max_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     power(
       e(),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(power(e(), msx_z(&a, &b, at))),
       },
     )
@@ -11848,7 +11833,7 @@ fn cdf_max_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     power(
       e(),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(power(
           u,
           call("Times", vec![int(-1), power(g.clone(), int(-1))]),
@@ -11873,7 +11858,7 @@ fn cdf_max_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       Ok(power(
         e(),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(power(e(), z)),
         },
       ))
@@ -12545,7 +12530,7 @@ fn cdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
         ))?,
       );
       let term1 = Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(maxwell_term(sq, sp, at.clone(), e_part)),
       };
       let erf = call(
@@ -12937,10 +12922,7 @@ pub fn maxwell_mean_variance(
   } else {
     // wolframscript puts the Pi-sum factor first; assembled raw since
     // evaluation would reorder it
-    Expr::Raw(format!(
-      "((-8 + 3*Pi)*{}^2)/Pi",
-      crate::syntax::expr_to_string(s)
-    ))
+    Expr::Raw(format!("((-8 + 3*Pi)*{}^2)/Pi", expr_to_string(s)))
   };
   Ok((mean, var))
 }
@@ -13689,9 +13671,9 @@ fn benktander_valid(
         eval(divide(times(a.clone(), plus(a.clone(), int(1))), int(2)))?;
       crate::emit_message(&format!(
         "BenktanderGibratDistribution::lsseq: Parameter {} at position 2 in {} is expected to be less than or equal to {}.",
-        crate::syntax::expr_to_string(b),
-        crate::syntax::expr_to_string(context),
-        crate::syntax::expr_to_string(&bound_expr)
+        expr_to_string(b),
+        expr_to_string(context),
+        expr_to_string(&bound_expr)
       ));
       return Ok(false);
     }
@@ -14071,7 +14053,7 @@ fn pdf_gumbel(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       "Plus",
       vec![
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(power(e(), z.clone())),
         },
         z,
@@ -14144,7 +14126,7 @@ fn cdf_gumbel(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
             power(
               e(),
               Expr::UnaryOp {
-                op: crate::syntax::UnaryOperator::Minus,
+                op: UnaryOperator::Minus,
                 operand: Box::new(power(e(), z)),
               },
             ),

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{
+  BinaryOperator, Expr, ExprForm, UnaryOperator, expr_to_string,
+};
 use num_bigint::BigInt;
 use num_bigint::Sign;
 
@@ -298,7 +300,7 @@ fn negative_literal_abs(f: &Expr) -> Option<Expr> {
 fn as_power(expr: &Expr) -> Option<(&Expr, &Expr)> {
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some((left.as_ref(), right.as_ref())),
@@ -312,7 +314,7 @@ fn as_power(expr: &Expr) -> Option<(&Expr, &Expr)> {
 fn power_with_real_exponent(expr: &Expr) -> Option<(&Expr, &Expr)> {
   let (base, exp) = match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => (left.as_ref(), right.as_ref()),
@@ -380,7 +382,7 @@ fn collect_times_factors<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) -> bool {
       true
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -447,7 +449,7 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // product whose only I-mentioning factor is I itself).
   let power_parts: Option<(&Expr, &Expr)> = match &args[0] {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some((left.as_ref(), right.as_ref())),
@@ -497,7 +499,7 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Check for -Infinity (UnaryOp::Minus applied to Infinity)
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = &args[0]
     && matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity")
@@ -568,7 +570,7 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left,
           right,
         } => inner(left) && !mentions_imaginary_unit(right),
@@ -673,7 +675,7 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let z_expr = build_complex_expr(rn, rd, in_, id);
         let abs_expr = make_sqrt(make_rational(abs2_n, abs2_d));
         return Ok(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(z_expr),
           right: Box::new(abs_expr),
         });
@@ -869,7 +871,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // canonicalisation (Sqrt[I] = (-1)^(1/4), Sqrt[-I] = -(-1)^(3/4)) applies.
   if matches!(&args[0], Expr::Identifier(s) if s == "I")
     || matches!(&args[0],
-      Expr::UnaryOp { op: crate::syntax::UnaryOperator::Minus, operand }
+      Expr::UnaryOp { op: UnaryOperator::Minus, operand }
         if matches!(operand.as_ref(), Expr::Identifier(s) if s == "I"))
   {
     return crate::functions::math_ast::power_two(
@@ -1068,7 +1070,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // Sqrt[base^(2n)] → base^n only when base is known non-negative
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: base,
       right: exp,
     } if matches!(exp.as_ref(), Expr::Integer(n) if *n > 0 && n % 2 == 0)
@@ -1080,7 +1082,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(*base.clone());
         } else {
           return Ok(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: base.clone(),
             right: Box::new(Expr::Integer(half)),
           });
@@ -1090,7 +1092,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // Sqrt of a product: Sqrt[n * expr^2 * ...] → simplify factors
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       ..
     }
     | Expr::FunctionCall { name: _, args: _ }
@@ -1112,7 +1114,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }
           // expr^2 → move expr outside only if expr is known non-negative
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: base,
             right: exp,
           } if matches!(exp.as_ref(), Expr::Integer(2))
@@ -1123,7 +1125,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           // expr^(2n) → move expr^n outside (for any even n, including negative)
           // only if expr is known non-negative
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: base,
             right: exp,
           } if matches!(exp.as_ref(), Expr::Integer(n) if n % 2 == 0 && *n != 0)
@@ -1135,7 +1137,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 outside.push(*base.clone());
               } else {
                 outside.push(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Power,
+                  op: BinaryOperator::Power,
                   left: base.clone(),
                   right: Box::new(Expr::Integer(half)),
                 });
@@ -1158,7 +1160,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 outside.push(pargs[0].clone());
               } else {
                 outside.push(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Power,
+                  op: BinaryOperator::Power,
                   left: Box::new(pargs[0].clone()),
                   right: Box::new(Expr::Integer(half)),
                 });
@@ -1273,7 +1275,7 @@ fn extract_int_coeff(term: &Expr) -> Option<(i128, Expr)> {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let (c, base) = extract_int_coeff(operand)?;
@@ -1455,7 +1457,7 @@ pub fn surd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if is_literal_zero(degree) {
     crate::emit_message(&format!(
       "Surd::indet: Indeterminate expression Surd[{}, 0] encountered.",
-      crate::syntax::expr_to_string(base)
+      expr_to_string(base)
     ));
     return Ok(Expr::Identifier("Indeterminate".to_string()));
   }
@@ -2037,7 +2039,7 @@ pub fn round_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if !a_is_real && !a_is_int {
         // Symbolic: return n * a
         return crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(n)),
           right: Box::new(eval_a),
         });
@@ -2202,7 +2204,7 @@ pub fn mod2_ast(m: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
   if is_literal_zero(n) {
     crate::emit_message(&format!(
       "Mod::indet: Indeterminate expression Mod[{}, 0] encountered.",
-      crate::syntax::expr_to_string(m)
+      expr_to_string(m)
     ));
     return Ok(Expr::Identifier("Indeterminate".to_string()));
   }
@@ -2224,7 +2226,7 @@ pub fn mod2_ast(m: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
     if nb.is_zero() {
       crate::emit_message(&format!(
         "Mod::indet: Indeterminate expression Mod[{}, 0] encountered.",
-        crate::syntax::expr_to_string(m)
+        expr_to_string(m)
       ));
       return Ok(Expr::Identifier("Indeterminate".to_string()));
     }
@@ -2244,7 +2246,7 @@ pub fn mod2_ast(m: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
       // Mod[m, 0] => Indeterminate
       crate::emit_message(&format!(
         "Mod::indet: Indeterminate expression Mod[{}, 0] encountered.",
-        crate::syntax::expr_to_string(m)
+        expr_to_string(m)
       ));
       return Ok(Expr::Identifier("Indeterminate".to_string()));
     }
@@ -2270,14 +2272,14 @@ pub fn mod2_ast(m: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
     if b == 0.0 {
       crate::emit_message(&format!(
         "Mod::indet: Indeterminate expression Mod[{}, 0] encountered.",
-        crate::syntax::expr_to_string(m)
+        expr_to_string(m)
       ));
       return Ok(Expr::Identifier("Indeterminate".to_string()));
     }
     // floor_quot = Floor[m/n]; evaluating the quotient first lets exact
     // cancellations (e.g. 2*Pi/Pi -> 2) happen so the floor is exact.
     let quotient = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(m.clone()),
       right: Box::new(n.clone()),
     };
@@ -2287,10 +2289,10 @@ pub fn mod2_ast(m: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
     };
     // result = m - n*Floor[m/n]
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(m.clone()),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(n.clone()),
         right: Box::new(floor_quot),
       }),
@@ -2308,7 +2310,7 @@ pub fn mod2_ast(m: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
     && (m_im != 0 || n_im != 0)
   {
     let quotient = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(m.clone()),
       right: Box::new(n.clone()),
     };
@@ -2317,10 +2319,10 @@ pub fn mod2_ast(m: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
       args: vec![quotient].into(),
     };
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(m.clone()),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(n.clone()),
         right: Box::new(round_quot),
       }),
@@ -2333,7 +2335,7 @@ pub fn mod2_ast(m: &Expr, n: &Expr) -> Result<Expr, InterpreterError> {
     if b == 0.0 {
       crate::emit_message(&format!(
         "Mod::indet: Indeterminate expression Mod[{}, 0] encountered.",
-        crate::syntax::expr_to_string(m)
+        expr_to_string(m)
       ));
       return Ok(Expr::Identifier("Indeterminate".to_string()));
     }
@@ -2375,8 +2377,8 @@ pub fn mod3_ast(
   if is_literal_zero(n) {
     crate::emit_message(&format!(
       "Mod::indet: Indeterminate expression Mod[{}, 0, {}] encountered.",
-      crate::syntax::expr_to_string(m),
-      crate::syntax::expr_to_string(d)
+      expr_to_string(m),
+      expr_to_string(d)
     ));
     return Ok(Expr::Identifier("Indeterminate".to_string()));
   }
@@ -2387,8 +2389,8 @@ pub fn mod3_ast(
     if nn == 0 && nd != 0 {
       crate::emit_message(&format!(
         "Mod::indet: Indeterminate expression Mod[{}, 0, {}] encountered.",
-        crate::syntax::expr_to_string(m),
-        crate::syntax::expr_to_string(d)
+        expr_to_string(m),
+        expr_to_string(d)
       ));
       return Ok(Expr::Identifier("Indeterminate".to_string()));
     }
@@ -2418,19 +2420,19 @@ pub fn mod3_ast(
     if b == 0.0 {
       crate::emit_message(&format!(
         "Mod::indet: Indeterminate expression Mod[{}, 0, {}] encountered.",
-        crate::syntax::expr_to_string(m),
-        crate::syntax::expr_to_string(d)
+        expr_to_string(m),
+        expr_to_string(d)
       ));
       return Ok(Expr::Identifier("Indeterminate".to_string()));
     }
     // floor_quot = Floor[(m - d)/n]
     let diff = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(m.clone()),
       right: Box::new(d.clone()),
     };
     let quotient = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(diff),
       right: Box::new(n.clone()),
     };
@@ -2440,10 +2442,10 @@ pub fn mod3_ast(
     };
     // result = m - n*Floor[(m - d)/n]
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(m.clone()),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(n.clone()),
         right: Box::new(floor_quot),
       }),
@@ -2458,8 +2460,8 @@ pub fn mod3_ast(
     if b == 0.0 {
       crate::emit_message(&format!(
         "Mod::indet: Indeterminate expression Mod[{}, 0, {}] encountered.",
-        crate::syntax::expr_to_string(m),
-        crate::syntax::expr_to_string(d)
+        expr_to_string(m),
+        expr_to_string(d)
       ));
       return Ok(Expr::Identifier("Indeterminate".to_string()));
     }
@@ -2506,7 +2508,7 @@ pub fn quotient_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       is_literal_zero(&args[0])
     };
-    let call = crate::syntax::expr_to_string(&Expr::FunctionCall {
+    let call = expr_to_string(&Expr::FunctionCall {
       name: "Quotient".to_string(),
       args: args.to_vec().into(),
     });
@@ -2626,7 +2628,7 @@ pub fn quotient_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // the identity Mod[m, n] = m - n*Quotient[m, n]. Building the symbolic
         // Round and evaluating it also normalises the display to `a + b*I`.
         let quotient = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(args[0].clone()),
           right: Box::new(args[1].clone()),
         };
@@ -2754,7 +2756,7 @@ pub fn clip_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 fn emit_integer_exponent_ibase(b: &Expr) {
   crate::emit_message(&format!(
     "IntegerExponent::ibase: Base {} is not an integer greater than 1.",
-    crate::syntax::format_expr(b, crate::syntax::ExprForm::Output)
+    crate::syntax::format_expr(b, ExprForm::Output)
   ));
 }
 
@@ -3274,7 +3276,7 @@ pub fn cube_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if cube_part > 1 {
         // CubeRoot[n] = cube_part * CubeRoot[remainder]
         let cube_root_remainder = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(Expr::Integer(remainder as i128)),
           right: Box::new(Expr::FunctionCall {
             name: "Rational".to_string(),
@@ -3282,7 +3284,7 @@ pub fn cube_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }),
         };
         let result = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(sign * cube_part as i128)),
           right: Box::new(cube_root_remainder),
         };
@@ -3292,7 +3294,7 @@ pub fn cube_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Sign[n] * abs[n]^(1/3) (matching wolframscript: CubeRoot[-5]
         // -> -5^(1/3), i.e. -(5^(1/3)), not the complex (-5)^(1/3)).
         let pow = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(Expr::Integer(abs_n as i128)),
           right: Box::new(Expr::FunctionCall {
             name: "Rational".to_string(),
@@ -3301,7 +3303,7 @@ pub fn cube_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         if sign < 0 {
           Ok(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(-1)),
             right: Box::new(pow),
           })
@@ -3341,7 +3343,7 @@ fn is_concrete_number(e: &Expr) -> bool {
     | Expr::BigFloat(_, _) => true,
     Expr::FunctionCall { name, .. } => name == "Rational",
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_concrete_number(operand),
     _ => false,
@@ -3382,10 +3384,7 @@ pub fn subdivide_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           crate::emit_message(&format!(
             "Subdivide::sdmint: The number of subdivisions given in position {} of {} should be a positive machine-sized integer.",
             args.len(),
-            crate::syntax::format_expr(
-              &unevaluated(),
-              crate::syntax::ExprForm::Output
-            )
+            crate::syntax::format_expr(&unevaluated(), ExprForm::Output)
           ));
           return Ok(unevaluated());
         }
@@ -3400,10 +3399,7 @@ pub fn subdivide_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::emit_message(&format!(
         "Subdivide::sdmint: The number of subdivisions given in position {} of {} should be a positive machine-sized integer.",
         args.len(),
-        crate::syntax::format_expr(
-          &unevaluated(),
-          crate::syntax::ExprForm::Output
-        )
+        crate::syntax::format_expr(&unevaluated(), ExprForm::Output)
       ));
       return Ok(unevaluated());
     }
@@ -3470,7 +3466,6 @@ fn subdivide_scalar_at(
   n: i128,
 ) -> Result<Expr, InterpreterError> {
   use crate::evaluator::evaluate_expr_to_expr;
-  use crate::syntax::BinaryOperator;
 
   if i == 0 {
     return Ok(xmin.clone());
@@ -3558,9 +3553,9 @@ pub fn kronecker_delta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // First check if any are symbolic (non-numeric)
   let mut has_symbolic = false;
   let mut all_equal = true;
-  let first_str = crate::syntax::expr_to_string(&args[0]);
+  let first_str = expr_to_string(&args[0]);
   for arg in &args[1..] {
-    let s = crate::syntax::expr_to_string(arg);
+    let s = expr_to_string(arg);
     if s != first_str {
       all_equal = false;
       // Check if both are numeric and compare numerically
@@ -3645,11 +3640,8 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Some(v) if v < 0.0 => return Ok(Expr::Integer(0)),
         Some(_) => {} // >= 0: contributes 1, drop it
         None => {
-          let s = crate::syntax::expr_to_string(arg);
-          if !remaining
-            .iter()
-            .any(|e| crate::syntax::expr_to_string(e) == s)
-          {
+          let s = expr_to_string(arg);
+          if !remaining.iter().any(|e| expr_to_string(e) == s) {
             remaining.push(arg.clone());
           }
         }
@@ -3678,7 +3670,7 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     },
     Expr::Identifier(name) if name == "Infinity" => Ok(Expr::Integer(1)),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => match operand.as_ref() {
       Expr::Constant(c) if matches!(c.as_str(), "Pi" | "E" | "Degree") => {
@@ -3708,7 +3700,7 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } if matches!(left.as_ref(), Expr::Integer(-1)) => match right.as_ref() {

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 use num_bigint::BigInt;
 
 /// Pochhammer[a, n] - Rising factorial (Pochhammer symbol): a * (a+1) * ... * (a+n-1)
@@ -297,7 +297,7 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let g0 = gamma_incomplete_upper(a, z0)?;
       let g1 = gamma_incomplete_upper(a, z1)?;
       return crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(g0),
         right: Box::new(g1),
       });
@@ -324,7 +324,7 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::Identifier("ComplexInfinity".to_string()));
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity") => {
       return Ok(Expr::Identifier("Indeterminate".to_string()));
@@ -1963,7 +1963,7 @@ pub fn owen_t_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Exact h = 0: T(0, a) = ArcTan[a]/(2π).
   if matches!(h, Expr::Integer(0)) && !has_real {
     return Ok(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::FunctionCall {
         name: "ArcTan".to_string(),
         args: vec![a.clone()].into(),
@@ -2273,7 +2273,7 @@ pub fn log_barnes_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(unevaluated(args));
   }
   let neg_infinity = || Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(Expr::Identifier("Infinity".to_string())),
   };
   match &args[0] {

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, expr_to_string};
 
 /// Hypergeometric0F1[a, z] - confluent hypergeometric limit function
 /// 0F1(a; z) = Σ z^k / (k! * Pochhammer(a,k)) for k = 0, 1, 2, ...
@@ -201,7 +201,7 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // When each upper parameter cancels a lower parameter (identical
   // multisets), (a)_n / (a)_n = 1 and the series reduces to Σ z^n/n! = E^z.
   if a_list.len() == b_list.len() && !a_list.is_empty() {
-    let key = |e: &Expr| crate::syntax::expr_to_string(e);
+    let key = |e: &Expr| expr_to_string(e);
     let mut a_keys: Vec<String> = a_list.iter().map(key).collect();
     let mut b_keys: Vec<String> = b_list.iter().map(key).collect();
     a_keys.sort();
@@ -851,14 +851,14 @@ pub fn hypergeometric_pfq_regularized_ast(
   for b_expr in &b_list {
     let gamma_val = gamma_ast(&[b_expr.clone()])?;
     gamma_product = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(gamma_product),
       right: Box::new(gamma_val),
     })?;
   }
 
   crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(pfq_result),
     right: Box::new(gamma_product),
   })
@@ -938,7 +938,7 @@ fn hypergeometric_2f1_regularized_non_positive_c(
           x.clone()
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(x.clone()),
             right: Box::new(Expr::Integer(k)),
           }
@@ -969,19 +969,19 @@ fn hypergeometric_2f1_regularized_non_positive_c(
 
   // z^{m+1}
   let z_pow = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(z.clone()),
     right: Box::new(Expr::Integer(shift)),
   };
 
   // 2F1(a + m + 1, b + m + 1; m + 2; z)
   let inner_a = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(a.clone()),
     right: Box::new(Expr::Integer(shift)),
   };
   let inner_b = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(b.clone()),
     right: Box::new(Expr::Integer(shift)),
   };
@@ -1018,7 +1018,7 @@ fn is_half(expr: &Expr) -> bool {
         && matches!(&args[1], Expr::Integer(2))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -1057,8 +1057,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // A non-positive integer a is excluded: there the series terminates first,
   // giving a truncated-exponential polynomial (e.g. 1F1[-2, -2, z] =
   // 1 + z + z^2/2), handled by the terminating-series branch below.
-  if crate::syntax::expr_to_string(&args[0])
-    == crate::syntax::expr_to_string(&args[1])
+  if expr_to_string(&args[0]) == expr_to_string(&args[1])
     && !matches!(&args[0], Expr::Integer(n) if *n <= 0)
   {
     let exp_call = Expr::FunctionCall {
@@ -1072,12 +1071,12 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if is_half(&args[0]) && matches!(&args[1], Expr::Integer(1)) {
     let z = &args[2];
     let half_z = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(z.clone()),
       right: Box::new(Expr::Integer(2)),
     };
     let exp_part = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(Expr::Constant("E".to_string())),
       right: Box::new(half_z.clone()),
     };
@@ -1100,7 +1099,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     let z = &args[2];
     let exp_z = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(Expr::Constant("E".to_string())),
       right: Box::new(z.clone()),
     };
@@ -1303,7 +1302,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: vec![Expr::Integer(b_int), z.clone()].into(),
     };
     let ratio = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(plus),
       right: Box::new(Expr::Integer(b_int)),
     };
@@ -1312,7 +1311,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: vec![Expr::Identifier("E".to_string()), z.clone()].into(),
     };
     let prod = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(ratio),
       right: Box::new(exp_z),
     };
@@ -2079,9 +2078,7 @@ pub fn hypergeometric2f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // 2F1(a, b, b, z) = (1-z)^(-a)
-  if crate::syntax::expr_to_string(&args[1])
-    == crate::syntax::expr_to_string(&args[2])
-  {
+  if expr_to_string(&args[1]) == expr_to_string(&args[2]) {
     let neg_a = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
       name: "Times".to_string(),
       args: vec![Expr::Integer(-1), args[0].clone()].into(),
@@ -2107,9 +2104,7 @@ pub fn hypergeometric2f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // 2F1(a, b, a, z) = (1-z)^(-b)
-  if crate::syntax::expr_to_string(&args[0])
-    == crate::syntax::expr_to_string(&args[2])
-  {
+  if expr_to_string(&args[0]) == expr_to_string(&args[2]) {
     let neg_b = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
       name: "Times".to_string(),
       args: vec![Expr::Integer(-1), args[1].clone()].into(),
@@ -2315,7 +2310,7 @@ fn inner_has_negative_int_coefficient(expr: &Expr) -> bool {
       matches!(&args[0], Expr::Integer(n) if *n < 0)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       ..
     } => matches!(left.as_ref(), Expr::Integer(n) if *n < 0),
@@ -2341,7 +2336,7 @@ fn negate_leading_integer_coefficient(expr: &Expr) -> Expr {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -2351,7 +2346,7 @@ fn negate_leading_integer_coefficient(expr: &Expr) -> Expr {
         (**left).clone()
       };
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(new_left),
         right: right.clone(),
       }

--- a/src/functions/math_ast/integrals.rs
+++ b/src/functions/math_ast/integrals.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// ExpIntegralEi[x] - Exponential integral Ei(x)
 pub fn exp_integral_ei_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -188,7 +188,7 @@ pub fn fresnel_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Helper: negate FresnelS (odd function)
   let negate_fresnel_s = |inner: Expr| -> Expr {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::FunctionCall {
         name: "FresnelS".to_string(),
         args: vec![inner].into(),
@@ -223,7 +223,7 @@ pub fn fresnel_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // FresnelS[-x] = -FresnelS[x] (UnaryOp form)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       // Check for -Infinity first
@@ -310,7 +310,7 @@ pub fn fresnel_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Helper: negate FresnelC (odd function)
   let negate_fresnel_c = |inner: Expr| -> Expr {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::FunctionCall {
         name: "FresnelC".to_string(),
         args: vec![inner].into(),
@@ -344,7 +344,7 @@ pub fn fresnel_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // FresnelC[-x] = -FresnelC[x] (UnaryOp form)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       // Check for -Infinity first
@@ -720,7 +720,6 @@ pub fn exp_integral_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // arguments are handled here; a machine-Real argument folds to the same value
   // the numeric path below would give.
   if matches!(n_expr, Expr::Integer(0)) {
-    use crate::syntax::BinaryOperator;
     let exp_neg_z = Expr::FunctionCall {
       name: "Exp".to_string(),
       args: vec![Expr::BinaryOp {

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
 use num_bigint::BigInt;
 
 /// QPochhammer[a, q, n] — q-Pochhammer symbol.
@@ -357,7 +357,7 @@ fn is_e_pow_neg1(e: &Expr) -> bool {
     |x: &Expr| matches!(x, Expr::Identifier(s) | Expr::Constant(s) if s == "E");
   match e {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => is_e(left) && matches!(right.as_ref(), Expr::Integer(-1)),
@@ -377,7 +377,7 @@ fn is_neg_inv_e(e: &Expr) -> bool {
       matches!(&args[0], Expr::Integer(-1)) && is_e_pow_neg1(&args[1])
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -599,9 +599,9 @@ pub fn meijer_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !upper_ok || !lower_ok {
     crate::emit_message(&format!(
       "MeijerG::hdiv: MeijerG[{}, {}, {}] does not exist. Arguments are not consistent.",
-      crate::syntax::expr_to_string(&args[0]),
-      crate::syntax::expr_to_string(&args[1]),
-      crate::syntax::expr_to_string(&args[2])
+      expr_to_string(&args[0]),
+      expr_to_string(&args[1]),
+      expr_to_string(&args[2])
     ));
     return Ok(Expr::FunctionCall {
       name: "MeijerG".to_string(),
@@ -1828,7 +1828,6 @@ fn weber_e_integer_closed_form(
   n: i128,
   z: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let m = n.unsigned_abs() as i128; // |n|
   let fact = |k: i128| -> BigInt {
     let mut r = BigInt::from(1);
@@ -1894,7 +1893,7 @@ fn weber_e_integer_closed_form(
 fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
   let pi = Expr::Constant("Pi".to_string());
   let nu_pi = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(nu.clone()),
     right: Box::new(pi.clone()),
   };
@@ -1903,7 +1902,7 @@ fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
     args: vec![nu_pi.clone()].into(),
   };
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(sin_nu_pi),
     right: Box::new(nu_pi),
   }
@@ -1913,7 +1912,7 @@ fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
 fn weber_e_at_zero_symbolic(nu: &Expr) -> Expr {
   let pi = Expr::Constant("Pi".to_string());
   let nu_pi = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(nu.clone()),
     right: Box::new(pi.clone()),
   };
@@ -1922,12 +1921,12 @@ fn weber_e_at_zero_symbolic(nu: &Expr) -> Expr {
     args: vec![nu_pi.clone()].into(),
   };
   let one_minus_cos = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left: Box::new(Expr::Integer(1)),
     right: Box::new(cos_nu_pi),
   };
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(one_minus_cos),
     right: Box::new(nu_pi),
   }
@@ -2732,12 +2731,12 @@ pub fn appell_f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if exprs_structurally_equal(&args[0], &args[3]) {
     let one = Expr::Integer(1);
     let one_minus_x = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(one.clone()),
       right: Box::new(args[4].clone()),
     };
     let one_minus_y = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(one.clone()),
       right: Box::new(args[5].clone()),
     };
@@ -2750,12 +2749,12 @@ pub fn appell_f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: vec![one_minus_y, args[2].clone()].into(),
     };
     let denom = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(factor_x),
       right: Box::new(factor_y),
     };
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(one),
       right: Box::new(denom),
     };
@@ -2770,7 +2769,7 @@ pub fn appell_f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 fn exprs_structurally_equal(a: &Expr, b: &Expr) -> bool {
-  crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
+  expr_to_string(a) == expr_to_string(b)
 }
 
 /// Compute F1(a, b1, b2; c; x, y) using double series
@@ -3225,8 +3224,8 @@ pub fn perfect_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => {
       crate::emit_message(&format!(
         "PerfectNumber::pintprm: Parameter {} at position 1 in PerfectNumber[{}] is expected to be a positive integer.",
-        crate::syntax::expr_to_string(&args[0]),
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0]),
+        expr_to_string(&args[0])
       ));
       return Ok(Expr::FunctionCall {
         name: "PerfectNumber".to_string(),
@@ -3590,7 +3589,7 @@ pub fn entropy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut counts: HashMap<String, i128> = HashMap::new();
   let mut order: Vec<String> = Vec::new();
   for item in items.iter() {
-    let key = crate::syntax::expr_to_string(item);
+    let key = expr_to_string(item);
     if let Some(c) = counts.get_mut(&key) {
       *c += 1;
     } else {
@@ -3599,7 +3598,7 @@ pub fn entropy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
   let n = items.len() as i128;
-  let base_str = base.map(crate::syntax::expr_to_string);
+  let base_str = base.map(expr_to_string);
 
   // Build: Log[n] + (1/n) Sum[-c_i Log[c_i]], rebasing each Log to the given
   // base when one is supplied. Use the two-argument `Log[base, x]` form rather
@@ -3670,7 +3669,7 @@ pub fn real_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     || matches!(&abs_expr, Expr::Real(f) if *f == 0.0)
   {
     return Ok(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Identifier("Infinity".to_string())),
     });
   }

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+};
 use num_bigint::BigInt;
 use num_traits::Signed;
 
@@ -51,7 +53,7 @@ fn is_concrete_number(e: &Expr) -> bool {
     | Expr::BigFloat(_, _) => true,
     Expr::FunctionCall { name, .. } => name == "Rational",
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_concrete_number(operand),
     _ => false,
@@ -90,8 +92,8 @@ fn emit_gcd_lcm_exact_message(name: &str, args: &[Expr]) {
     crate::emit_message(&format!(
       "{}::exact: Argument {} in {} is not an exact number.",
       name,
-      crate::syntax::expr_to_string(inexact),
-      crate::syntax::expr_to_string(&call),
+      expr_to_string(inexact),
+      expr_to_string(&call),
     ));
   }
 }
@@ -1249,7 +1251,7 @@ fn bernoulli_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
         z.clone()
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(z.clone()),
           right: Box::new(Expr::Integer(k as i128)),
         }
@@ -1258,13 +1260,13 @@ fn bernoulli_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
         power
       } else if cn == -cd {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(-1)),
           right: Box::new(power),
         }
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(coeff_expr),
           right: Box::new(power),
         }
@@ -1280,7 +1282,7 @@ fn bernoulli_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
   let mut result = terms[0].clone();
   for term in &terms[1..] {
     result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(result),
       right: Box::new(term.clone()),
     };
@@ -1468,7 +1470,7 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
         z.clone()
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(z.clone()),
           right: Box::new(Expr::Integer(k as i128)),
         }
@@ -1479,13 +1481,13 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
       } else if cn == -cd {
         // coefficient is -1
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(-1)),
           right: Box::new(power),
         }
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(coeff_expr),
           right: Box::new(power),
         }
@@ -1501,7 +1503,7 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
   let mut result = terms[0].clone();
   for term in &terms[1..] {
     result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(result),
       right: Box::new(term.clone()),
     };
@@ -1589,14 +1591,14 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           x.clone()
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(coeff),
             right: Box::new(x.clone()),
           }
         }
       } else {
         let power = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(x.clone()),
           right: Box::new(Expr::Integer(k as i128)),
         };
@@ -1604,7 +1606,7 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           power
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(coeff),
             right: Box::new(power),
           }
@@ -1619,7 +1621,7 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut result = terms[0].clone();
     for term in &terms[1..] {
       result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(result),
         right: Box::new(term.clone()),
       };
@@ -1646,7 +1648,7 @@ pub fn pauli_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
   let i_expr = Expr::Identifier("I".to_string());
   let neg_i = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(Expr::Integer(-1)),
     right: Box::new(i_expr.clone()),
   };
@@ -1963,7 +1965,7 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Build the BinaryOp Power form (k^j), which Sum's closed-form path
       // recognises; FunctionCall Power[k, j] would be left unevaluated.
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(k.clone()),
         right: Box::new(Expr::Integer(j)),
       }
@@ -2131,7 +2133,7 @@ pub fn multiple_harmonic_number_ast(
     // A non-list second argument is a usage error in wolframscript.
     crate::emit_message(&format!(
       "MultipleHarmonicNumber::list: List expected at position 2 in {}.",
-      crate::syntax::expr_to_string(&unevaluated())
+      expr_to_string(&unevaluated())
     ));
     return Ok(unevaluated());
   };
@@ -2146,7 +2148,7 @@ pub fn multiple_harmonic_number_ast(
   ) {
     let Some((&s, rest)) = exps.split_first() else {
       terms.push(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(bigint_to_expr(denom.clone())),
       });
@@ -2211,7 +2213,7 @@ pub fn alternating_harmonic_number_ast(
     let mut terms = Vec::new();
     for k in 1..=n {
       let k_pow = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(Expr::Integer(k)),
         right: Box::new(neg_r.clone()),
       };
@@ -2221,7 +2223,7 @@ pub fn alternating_harmonic_number_ast(
       }
       if let Some(x) = x {
         factors.push(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(x.clone()),
           right: Box::new(Expr::Integer(k)),
         });
@@ -2268,7 +2270,7 @@ pub fn alternating_harmonic_number_ast(
         }
         // Eta[r] in wolframscript's form: ((-2 + 2^r) Zeta[r])/2^r
         let two_pow_r = |exp: Expr| Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(Expr::Integer(2)),
           right: Box::new(exp),
         };
@@ -2489,7 +2491,7 @@ pub fn hyper_harmonic_number_ast(
   // for symbolic s and x (e.g. HyperHarmonicNumber[0, 5, s] -> 5^(-s)).
   if r == 0 {
     let n_pow = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(Expr::Integer(n)),
       right: Box::new(neg_s(&s)),
     };
@@ -2498,7 +2500,7 @@ pub fn hyper_harmonic_number_ast(
         name: "Times".to_string(),
         args: vec![
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(x.clone()),
             right: Box::new(Expr::Integer(n)),
           },
@@ -2539,14 +2541,14 @@ pub fn hyper_harmonic_number_ast(
   for k in 1..=n {
     let coeff = bigint_to_expr(binom(n - k + r - 1, r - 1));
     let k_pow = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(Expr::Integer(k)),
       right: Box::new(neg_s.clone()),
     };
     let mut factors = vec![coeff];
     if let Some(x) = x {
       factors.push(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(x.clone()),
         right: Box::new(Expr::Integer(k)),
       });
@@ -2582,7 +2584,7 @@ pub fn prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(n) if n >= 1 => Ok(Expr::Integer(nth_prime(n as usize) as i128)),
     Some(_) => {
       // Concrete non-positive integer: emit message like wolframscript
-      let arg_str = crate::syntax::expr_to_string(&args[0]);
+      let arg_str = expr_to_string(&args[0]);
       crate::emit_message(&format!(
         "Prime::intpp: Positive integer argument expected in Prime[{}].",
         arg_str
@@ -2593,7 +2595,7 @@ pub fn prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Concrete non-integer numeric (e.g. 1.5): emit message like wolframscript
       // Symbolic arguments return unevaluated silently
       if matches!(&args[0], Expr::Real(_) | Expr::BigFloat(_, _)) {
-        let arg_str = crate::syntax::expr_to_string(&args[0]);
+        let arg_str = expr_to_string(&args[0]);
         crate::emit_message(&format!(
           "Prime::intpp: Positive integer argument expected in Prime[{}].",
           arg_str
@@ -4700,9 +4702,7 @@ pub fn binomial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Binomial[k, k] = 1 for any k (including symbolic), matching wolframscript.
   // Inexact arguments (machine reals) yield 1. rather than the exact integer.
-  if crate::syntax::expr_to_string(&args[0])
-    == crate::syntax::expr_to_string(&args[1])
-  {
+  if expr_to_string(&args[0]) == expr_to_string(&args[1]) {
     let inexact = matches!(&args[0], Expr::Real(_) | Expr::BigFloat(_, _))
       || matches!(&args[1], Expr::Real(_) | Expr::BigFloat(_, _));
     return Ok(if inexact {
@@ -5063,8 +5063,8 @@ pub fn power_mod_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if modulus.is_zero() {
         crate::emit_message(&format!(
           "PowerMod::divz: The argument 0 in PowerMod[{}, {}, 0] should be nonzero.",
-          crate::syntax::expr_to_string(&args[0]),
-          crate::syntax::expr_to_string(&args[1])
+          expr_to_string(&args[0]),
+          expr_to_string(&args[1])
         ));
         return Ok(Expr::FunctionCall {
           name: "PowerMod".to_string(),
@@ -5085,8 +5085,8 @@ pub fn power_mod_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             } else {
               crate::emit_message(&format!(
                 "PowerMod::ninv: {} is not invertible modulo {}.",
-                crate::syntax::expr_to_string(&args[0]),
-                crate::syntax::expr_to_string(&args[2])
+                expr_to_string(&args[0]),
+                expr_to_string(&args[2])
               ));
               Ok(Expr::FunctionCall {
                 name: "PowerMod".to_string(),
@@ -5154,7 +5154,7 @@ fn power_mod_root_ast(
       args: args.to_vec().into(),
     })
   };
-  let exp_str = || crate::syntax::expr_to_string(&args[1]);
+  let exp_str = || expr_to_string(&args[1]);
   let (Some(a), Some(m)) = (expr_to_bigint(&args[0]), expr_to_bigint(&args[2]))
   else {
     return unevaluated();
@@ -5162,7 +5162,7 @@ fn power_mod_root_ast(
   if m.is_zero() {
     crate::emit_message(&format!(
       "PowerMod::divz: The argument 0 in PowerMod[{}, {}, 0] should be nonzero.",
-      crate::syntax::expr_to_string(&args[0]),
+      expr_to_string(&args[0]),
       exp_str()
     ));
     return unevaluated();
@@ -5209,8 +5209,8 @@ fn power_mod_root_ast(
       crate::emit_message(&format!(
         "PowerMod::root: The equation x^{} = {} (mod {}) has no integer solutions.",
         n,
-        crate::syntax::expr_to_string(&args[0]),
-        crate::syntax::expr_to_string(&args[2])
+        expr_to_string(&args[0]),
+        expr_to_string(&args[2])
       ));
       unevaluated()
     }
@@ -5662,8 +5662,8 @@ pub fn modular_inverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     crate::emit_message(&format!(
       "ModularInverse::intnz: Nonzero integer expected at position 2 in \
        ModularInverse[{}, {}].",
-      crate::syntax::expr_to_string(&args[0]),
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[0]),
+      expr_to_string(&args[1])
     ));
     return unevaluated();
   }
@@ -5680,8 +5680,8 @@ pub fn modular_inverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !gcd.abs().is_one() {
     crate::emit_message(&format!(
       "ModularInverse::ninv: {} is not invertible modulo {}.",
-      crate::syntax::expr_to_string(&args[0]),
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[0]),
+      expr_to_string(&args[1])
     ));
     return unevaluated();
   }
@@ -5974,7 +5974,7 @@ pub fn frobenius_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if items.is_empty() {
     crate::emit_message(&format!(
       "FrobeniusNumber::coef: The first argument {} of FrobeniusNumber should be a nonempty list of positive integers.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     return Ok(Expr::FunctionCall {
       name: "FrobeniusNumber".to_string(),
@@ -5992,7 +5992,7 @@ pub fn frobenius_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       _ => {
         crate::emit_message(&format!(
           "FrobeniusNumber::coef: The first argument {} of FrobeniusNumber should be a nonempty list of positive integers.",
-          crate::syntax::expr_to_string(&args[0])
+          expr_to_string(&args[0])
         ));
         return Ok(Expr::FunctionCall {
           name: "FrobeniusNumber".to_string(),
@@ -6088,7 +6088,7 @@ pub fn frobenius_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let coef_err = || {
     crate::emit_message(&format!(
       "FrobeniusSolve::coef: The first argument {} of FrobeniusSolve should be a nonempty list of positive integers.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     Ok::<Expr, InterpreterError>(Expr::FunctionCall {
       name: "FrobeniusSolve".to_string(),
@@ -6126,7 +6126,7 @@ pub fn frobenius_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         _ => {
           crate::emit_message(&format!(
             "FrobeniusSolve::nsol: The number {} of requested solutions should be a positive integer.",
-            crate::syntax::expr_to_string(&args[2])
+            expr_to_string(&args[2])
           ));
           return Ok(Expr::FunctionCall {
             name: "FrobeniusSolve".to_string(),
@@ -6273,8 +6273,7 @@ pub fn arithmetic_geometric_mean_ast(
   // matching wolframscript; equal numbers are handled by the numeric path
   // below.
   if matches!(&args[0], Expr::Identifier(_) | Expr::Constant(_))
-    && crate::syntax::expr_to_string(&args[0])
-      == crate::syntax::expr_to_string(&args[1])
+    && expr_to_string(&args[0]) == expr_to_string(&args[1])
   {
     return Ok(args[0].clone());
   }
@@ -9236,8 +9235,8 @@ pub fn six_j_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if c < (a - b).abs() || c > a + b || (a + b + c).rem_euclid(2) != 0 {
       crate::emit_message(&format!(
         "SixJSymbol::tri: SixJSymbol[{}, {}] is not triangular.",
-        crate::syntax::expr_to_string(&args[0]),
-        crate::syntax::expr_to_string(&args[1])
+        expr_to_string(&args[0]),
+        expr_to_string(&args[1])
       ));
       return Ok(Expr::Integer(0));
     }
@@ -9458,7 +9457,7 @@ fn six_j_symbol_symbolic(
     let forced_value = Expr::Integer(v_2j / 2);
     let cond = Expr::Comparison {
       operands: vec![Expr::Identifier(sym_name.clone()), forced_value],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     };
     branches.push(Expr::List(vec![value, cond].into()));
   }
@@ -9523,7 +9522,7 @@ fn bigint_rational_to_expr(num: BigInt, den: BigInt) -> Expr {
 fn two_half_int_signed(expr: &Expr) -> Option<i128> {
   // UnaryOp::Minus wrapping an integer/rational.
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = expr
   {
@@ -9627,7 +9626,7 @@ pub fn clebsch_gordan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     let condition = Expr::Comparison {
       operands: vec![Expr::Identifier(sym_name.clone()), forced_m_expr],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     };
     let branch = Expr::List(vec![value, condition].into());
     let pw_args = Expr::List(vec![branch].into());
@@ -9761,7 +9760,7 @@ pub fn farey_sequence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(_) if args.len() == 1 => {
       crate::emit_message(&format!(
         "FareySequence::intpm: Positive machine-sized integer expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated(args))
+        expr_to_string(&unevaluated(args))
       ));
       return Ok(Expr::Identifier("Null".to_string()));
     }
@@ -9792,7 +9791,7 @@ pub fn farey_sequence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         crate::emit_message(&format!(
           "FareySequence::rank: Farey sequence rank {} at position 2 of {} is expected to be a positive integer less than or equal to {}.",
           rank,
-          crate::syntax::expr_to_string(&unevaluated(args)),
+          expr_to_string(&unevaluated(args)),
           terms.len()
         ));
         return Ok(unevaluated(args));
@@ -9837,7 +9836,7 @@ pub fn fibonorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ if is_non_integer_number => {
       crate::emit_message(&format!(
         "Fibonorial::intnm: Non-negative machine-sized integer expected at position 1 in {}.",
-        crate::syntax::expr_to_string(&unevaluated(args))
+        expr_to_string(&unevaluated(args))
       ));
       Ok(unevaluated(args))
     }

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 use num_bigint::BigInt;
 
 /// Helper - constants are kept symbolic, no direct f64 conversion in expr_to_num.
@@ -244,7 +244,6 @@ pub fn dawson_f64(x: f64) -> f64 {
 /// This handles constants (Pi, E, Degree), arithmetic operations, and known functions.
 /// Used by N[], comparisons, and anywhere a numeric value is needed from a symbolic expression.
 pub fn try_eval_to_f64(expr: &Expr) -> Option<f64> {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::Integer(n) => Some(*n as f64),
     Expr::BigInteger(n) => {
@@ -275,7 +274,7 @@ pub fn try_eval_to_f64(expr: &Expr) -> Option<f64> {
       _ => None,
     },
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => try_eval_to_f64(operand).map(|v| -v),
     Expr::BinaryOp { op, left, right } => {
@@ -689,7 +688,7 @@ pub fn make_rational(numer: i128, denom: i128) -> Expr {
 /// In Wolfram Language, Sqrt[x] is just syntactic sugar for Power[x, 1/2].
 pub fn make_sqrt(arg: Expr) -> Expr {
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(arg),
     right: Box::new(make_rational(1, 2)),
   }
@@ -700,7 +699,7 @@ pub fn make_sqrt(arg: Expr) -> Expr {
 pub fn is_sqrt(expr: &Expr) -> Option<&Expr> {
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -758,12 +757,12 @@ pub fn complex_rational_to_expr(
     }
     if matches!(&imag_part, Expr::Integer(-1)) {
       return Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(i_expr),
       };
     }
     return Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(imag_part),
       right: Box::new(i_expr),
     };
@@ -774,19 +773,19 @@ pub fn complex_rational_to_expr(
     i_expr
   } else if matches!(&imag_part, Expr::Integer(-1)) {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(i_expr),
     }
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(imag_part),
       right: Box::new(i_expr),
     }
   };
 
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(real_part),
     right: Box::new(imag_term),
   }
@@ -806,7 +805,7 @@ pub fn multiply_scalar_by_expr(
       args: vec![Expr::Integer(-1), expr.clone()].into(),
     }),
     _ => Ok(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(scalar.clone()),
       right: Box::new(expr.clone()),
     }),
@@ -819,7 +818,6 @@ pub fn multiply_scalar_by_expr(
 pub fn try_extract_complex_exact(
   expr: &Expr,
 ) -> Option<((i128, i128), (i128, i128))> {
-  use crate::syntax::BinaryOperator;
   match expr {
     // Pure imaginary: I
     Expr::Identifier(name) if name == "I" => Some(((0, 1), (1, 1))),
@@ -830,7 +828,7 @@ pub fn try_extract_complex_exact(
     }
     // -I or -expr
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let ((rn, rd), (in_, id)) = try_extract_complex_exact(operand)?;
@@ -945,7 +943,6 @@ pub fn try_extract_complex_exact(
 /// Try to extract float complex parts (re, im) from an expression.
 /// Returns Some((re, im)) if the expression contains float components with I.
 pub fn try_extract_complex_float(expr: &Expr) -> Option<(f64, f64)> {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   match expr {
     Expr::Identifier(name) if name == "I" => Some((0.0, 1.0)),
     Expr::Integer(n) => Some((*n as f64, 0.0)),
@@ -1042,7 +1039,7 @@ pub fn build_complex_float_expr(re: f64, im: f64) -> Expr {
     i_expr
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Real(im_abs)),
       right: Box::new(i_expr),
     }
@@ -1053,7 +1050,7 @@ pub fn build_complex_float_expr(re: f64, im: f64) -> Expr {
       im_term
     } else {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(im_term),
       }
     }
@@ -1063,13 +1060,13 @@ pub fn build_complex_float_expr(re: f64, im: f64) -> Expr {
     let re_expr = Expr::Real(re);
     if im > 0.0 {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(re_expr),
         right: Box::new(im_term),
       }
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(re_expr),
         right: Box::new(im_term),
       }
@@ -1086,20 +1083,20 @@ pub fn build_complex_float_expr_keep_real(re: f64, im: f64) -> Expr {
   // Always materialise the coefficient as `Real * I` so the |coeff|==1 case
   // prints as `1.*I` rather than bare `I` — wolframscript's numeric form.
   let im_term = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(Expr::Real(im_abs)),
     right: Box::new(i_expr),
   };
   let re_expr = Expr::Real(re);
   if im >= 0.0 {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(re_expr),
       right: Box::new(im_term),
     }
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(re_expr),
       right: Box::new(im_term),
     }
@@ -1136,7 +1133,7 @@ pub fn build_complex_expr(
   } else {
     let coeff = make_rational(im_abs_num, id_s);
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(coeff),
       right: Box::new(i_expr),
     }
@@ -1152,14 +1149,14 @@ pub fn build_complex_expr(
     } else if im_abs_num == 1 && id_s == 1 {
       // -I
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(im_term),
       }
     } else {
       // -n*I: build Times[-n, I] directly
       let coeff = make_rational(-im_abs_num, id_s);
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(coeff),
         right: Box::new(Expr::Identifier("I".to_string())),
       }
@@ -1169,13 +1166,13 @@ pub fn build_complex_expr(
   // Build re ± im*I
   if im_positive {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(re),
       right: Box::new(im_term),
     }
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(re),
       right: Box::new(im_term),
     }
@@ -1185,11 +1182,10 @@ pub fn build_complex_expr(
 /// Try to extract complex parts as (re: f64, im: f64) from an expression.
 /// Handles Real, Integer, I, Plus, Times, Minus, Complex, and FunctionCall variants.
 pub fn try_extract_complex_f64(expr: &Expr) -> Option<(f64, f64)> {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::Identifier(name) if name == "I" => Some((0.0, 1.0)),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let (r, i) = try_extract_complex_f64(operand)?;

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{
+  BinaryOperator, Expr, UnaryOperator, expr_to_string, substitute_variable,
+};
 
 pub fn n_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.is_empty() || args.len() > 2 {
@@ -30,7 +32,7 @@ pub fn n_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         } else {
           crate::emit_message(&format!(
             "N::precbd: Requested precision {} is not a machine-sized real number between $MinPrecision and $MaxPrecision.",
-            crate::syntax::expr_to_string(other)
+            expr_to_string(other)
           ));
           return Ok(Expr::FunctionCall {
             name: "N".to_string(),
@@ -180,7 +182,7 @@ pub fn n_eval(expr: &Expr) -> Result<Expr, InterpreterError> {
       // If the result is still a Power with complex operands, force
       // numeric evaluation via z^w = exp(w * log(z))
       if let Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: ref base,
         right: ref exp,
       } = result
@@ -205,10 +207,10 @@ pub fn n_eval(expr: &Expr) -> Result<Expr, InterpreterError> {
             // Preserve complex form: re + 0.*I (matching Wolfram's convention
             // for complex power results where imaginary part is numerically zero)
             return Ok(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(Expr::Real(re)),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::Real(0.0)),
                 right: Box::new(Expr::Identifier("I".to_string())),
               }),
@@ -288,11 +290,11 @@ pub fn n_eval(expr: &Expr) -> Result<Expr, InterpreterError> {
       if !has_user_n_rules {
         return Ok(expr.clone());
       }
-      let original_str = crate::syntax::expr_to_string(expr);
+      let original_str = expr_to_string(expr);
       let n_call_str = format!("N[{}]", original_str);
       match crate::evaluator::evaluate_function_call_ast("N", &[expr.clone()]) {
         Ok(result) => {
-          let result_str = crate::syntax::expr_to_string(&result);
+          let result_str = expr_to_string(&result);
           if result_str == n_call_str {
             Ok(expr.clone())
           } else {
@@ -337,7 +339,7 @@ fn try_as_integer(expr: &Expr) -> Option<i128> {
   match expr {
     Expr::Integer(n) => Some(*n),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       if let Expr::Integer(n) = operand.as_ref() {
@@ -1199,7 +1201,7 @@ fn is_blank_pattern_expr(e: &Expr) -> bool {
       is_blank_pattern_expr(&pa[1])
     }
     _ => {
-      let rendered = crate::syntax::expr_to_string(e);
+      let rendered = expr_to_string(e);
       rendered == "_"
         || rendered.starts_with("Blank[")
         || rendered.contains("Pattern[")
@@ -1240,7 +1242,6 @@ pub fn expr_to_bigfloat(
   rm: astro_float::RoundingMode,
   cc: &mut astro_float::Consts,
 ) -> Result<astro_float::BigFloat, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   use astro_float::BigFloat;
 
   match expr {
@@ -1321,7 +1322,7 @@ pub fn expr_to_bigfloat(
       Ok(fifty_three.mul(&log10_2, bits, rm))
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let val = expr_to_bigfloat(operand, bits, rm, cc)?;
@@ -1490,7 +1491,7 @@ pub fn expr_to_bigfloat(
     }
     _ => Err(InterpreterError::EvaluationError(format!(
       "N: cannot evaluate expression to arbitrary precision: {}",
-      crate::syntax::expr_to_string(expr)
+      expr_to_string(expr)
     ))),
   }
 }
@@ -1504,7 +1505,6 @@ fn expr_to_complex_bigfloat(
   rm: astro_float::RoundingMode,
   cc: &mut astro_float::Consts,
 ) -> Result<(astro_float::BigFloat, astro_float::BigFloat), InterpreterError> {
-  use crate::syntax::BinaryOperator;
   use astro_float::BigFloat;
 
   // Fast path: if purely real, delegate
@@ -1519,7 +1519,7 @@ fn expr_to_complex_bigfloat(
     }
     // Unary minus
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let (re, im) = expr_to_complex_bigfloat(operand, bits, rm, cc)?;
@@ -1758,7 +1758,7 @@ fn expr_to_complex_bigfloat(
     },
     _ => Err(InterpreterError::EvaluationError(format!(
       "N: cannot evaluate expression to complex arbitrary precision: {}",
-      crate::syntax::expr_to_string(expr)
+      expr_to_string(expr)
     ))),
   }
 }
@@ -1787,7 +1787,7 @@ fn build_complex_bigfloat_result(
 
   // Build |im| * I term (always positive coefficient)
   let abs_im_term = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(im_bf),
     right: Box::new(i_expr),
   };
@@ -1798,7 +1798,7 @@ fn build_complex_bigfloat_result(
       let neg_im_str = bigfloat_to_string(&im, max_digits, rm, cc)?;
       let neg_im_bf = Expr::BigFloat(neg_im_str, precision as f64);
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(neg_im_bf),
         right: Box::new(Expr::Identifier("I".to_string())),
       });
@@ -1812,14 +1812,14 @@ fn build_complex_bigfloat_result(
   if im_negative {
     // re - |im|*I
     Ok(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(re_bf),
       right: Box::new(abs_im_term),
     })
   } else {
     // re + |im|*I
     Ok(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(re_bf),
       right: Box::new(abs_im_term),
     })
@@ -1851,20 +1851,20 @@ fn build_complex_result_with_string_precision(
 
   let i_expr = Expr::Identifier("I".to_string());
   let abs_im_term = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(im_raw),
     right: Box::new(i_expr),
   };
 
   if im_negative {
     Ok(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(re_raw),
       right: Box::new(abs_im_term),
     })
   } else {
     Ok(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(re_raw),
       right: Box::new(abs_im_term),
     })
@@ -2587,7 +2587,7 @@ pub fn normalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::functions::list_helpers_ast::apply_func_ast(&args[1], &args[0])?;
     // v / norm_val
     let result = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(args[0].clone()),
       right: Box::new(norm_val),
     })?;
@@ -2623,7 +2623,7 @@ pub fn normalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             let squared_terms: Vec<Expr> = items
               .iter()
               .map(|e| Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(Expr::FunctionCall {
                   name: "Abs".to_string(),
                   args: vec![e.clone()].into(),
@@ -2650,7 +2650,7 @@ pub fn normalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               .iter()
               .map(|e| {
                 crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Divide,
+                  op: BinaryOperator::Divide,
                   left: Box::new(e.clone()),
                   right: Box::new(norm_expr.clone()),
                 })
@@ -2686,7 +2686,7 @@ pub fn normalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             } else {
               // x / Sqrt[sum_sq] = x * Power[sum_sq, -1/2]
               Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Divide,
+                op: BinaryOperator::Divide,
                 left: Box::new(Expr::Integer(*x)),
                 right: Box::new(make_sqrt(Expr::Integer(sum_sq))),
               }
@@ -2821,7 +2821,7 @@ pub fn precision_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Ok(Expr::Identifier("Infinity".to_string()))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       ..
     } => {
       // Exact rationals like 1/2 have infinite precision
@@ -2980,7 +2980,7 @@ pub fn accuracy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Ok(Expr::Identifier("Infinity".to_string()))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       ..
     } => Ok(Expr::Identifier("Infinity".to_string())),
     // Complex number with finite-accuracy parts: apply Wolfram's formula
@@ -2997,10 +2997,10 @@ pub fn accuracy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // to Infinity even though both operands have finite accuracy.
     Expr::BinaryOp {
       op:
-        crate::syntax::BinaryOperator::Plus
-        | crate::syntax::BinaryOperator::Minus
-        | crate::syntax::BinaryOperator::Times
-        | crate::syntax::BinaryOperator::Power,
+        BinaryOperator::Plus
+        | BinaryOperator::Minus
+        | BinaryOperator::Times
+        | BinaryOperator::Power,
       left,
       right,
     } => {
@@ -3067,7 +3067,6 @@ pub fn accuracy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// either part has infinite accuracy, or if there's no I factor — in
 /// those cases the caller falls back to the generic min-of-children path.
 fn try_complex_accuracy(expr: &Expr) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   let plus_args: Vec<Expr> = match expr {
     Expr::FunctionCall { name, args } if name == "Plus" && args.len() == 2 => {
       args.to_vec()
@@ -3161,7 +3160,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
   let extract_power = |e: &Expr| -> Option<(Expr, Expr)> {
     match e {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } => Some((*left.clone(), *right.clone())),
@@ -3195,7 +3194,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
         args.iter().flat_map(collect_times_factors).collect()
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -3204,13 +3203,13 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
         factors
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left,
         right,
       } => {
         let mut factors = collect_times_factors(left);
         factors.push(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: right.clone(),
           right: Box::new(Expr::Integer(-1)),
         });
@@ -3240,13 +3239,13 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
         let new_exp = match times_ast(&[inner_exp.clone(), exp.clone()]) {
           Ok(r) => r,
           Err(_) => Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(inner_exp),
             right: Box::new(exp),
           },
         };
         return match crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(inner_base),
           right: Box::new(new_exp),
         }) {
@@ -3266,7 +3265,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
               let new_exp = match times_ast(&[inner_exp.clone(), exp.clone()]) {
                 Ok(r) => r,
                 Err(_) => Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(inner_exp),
                   right: Box::new(exp.clone()),
                 },
@@ -3274,7 +3273,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
               match power_two(&inner_base, &new_exp) {
                 Ok(r) => r,
                 Err(_) => Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Power,
+                  op: BinaryOperator::Power,
                   left: Box::new(inner_base),
                   right: Box::new(new_exp),
                 },
@@ -3283,7 +3282,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
               match power_two(factor, &exp) {
                 Ok(r) => r,
                 Err(_) => Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Power,
+                  op: BinaryOperator::Power,
                   left: Box::new(factor.clone()),
                   right: Box::new(exp.clone()),
                 },
@@ -3330,7 +3329,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
                 Ok(r) => r,
                 Err(_) => {
                   return Expr::BinaryOp {
-                    op: crate::syntax::BinaryOperator::Power,
+                    op: BinaryOperator::Power,
                     left: Box::new(base),
                     right: Box::new(exp),
                   };
@@ -3340,7 +3339,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
             return match power_two(&log_arg, &new_exp) {
               Ok(r) => r,
               Err(_) => Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(log_arg),
                 right: Box::new(new_exp),
               },
@@ -3350,7 +3349,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
       }
 
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(base),
         right: Box::new(exp),
       }
@@ -3366,7 +3365,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
       // Convert a/b to Times[a, Power[b, -1]] and fall through to product rule
       let expanded_arg = match &expanded_arg {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left,
           right,
         } => Expr::FunctionCall {
@@ -3374,7 +3373,7 @@ fn power_expand_recursive(expr: &Expr) -> Expr {
           args: vec![
             *left.clone(),
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: right.clone(),
               right: Box::new(Expr::Integer(-1)),
             },
@@ -3498,13 +3497,11 @@ pub fn variables_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   collect_variables(&args[0], &mut vars);
   // Deduplicate while preserving order
   let mut seen = std::collections::HashSet::new();
-  vars.retain(|v| seen.insert(crate::syntax::expr_to_string(v)));
+  vars.retain(|v| seen.insert(expr_to_string(v)));
   // For List input, sort in canonical order (alphabetical);
   // for non-List input, preserve first-appearance order (matching Wolfram).
   if matches!(&args[0], Expr::List(_)) {
-    vars.sort_by(|a, b| {
-      crate::syntax::expr_to_string(a).cmp(&crate::syntax::expr_to_string(b))
-    });
+    vars.sort_by(|a, b| expr_to_string(a).cmp(&expr_to_string(b)));
   }
   Ok(Expr::List(vars.into()))
 }
@@ -3540,11 +3537,11 @@ fn collect_variables(expr: &Expr, vars: &mut Vec<Expr>) {
     }
     Expr::BinaryOp { op, left, right } => {
       match op {
-        crate::syntax::BinaryOperator::Plus
-        | crate::syntax::BinaryOperator::Minus
-        | crate::syntax::BinaryOperator::Times
-        | crate::syntax::BinaryOperator::Power
-        | crate::syntax::BinaryOperator::Divide => {
+        BinaryOperator::Plus
+        | BinaryOperator::Minus
+        | BinaryOperator::Times
+        | BinaryOperator::Power
+        | BinaryOperator::Divide => {
           collect_variables(left, vars);
           collect_variables(right, vars);
         }
@@ -3648,12 +3645,12 @@ pub fn linear_recurrence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for (i, coeff) in kernel.iter().enumerate() {
       let idx = seq.len() - 1 - i;
       let term = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(coeff.clone()),
         right: Box::new(seq[idx].clone()),
       };
       next = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(next),
         right: Box::new(term),
       };
@@ -4118,7 +4115,7 @@ fn fourier_impl(
       crate::emit_message(&format!(
         "{}::fftl: Argument {} is not a nonempty list or rectangular array of numeric quantities.",
         func_name,
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0])
       ));
       return Ok(Expr::FunctionCall {
         name: func_name.to_string(),
@@ -4136,7 +4133,7 @@ fn fourier_impl(
       crate::emit_message(&format!(
         "{}::fftl: Argument {} is not a nonempty list or rectangular array of numeric quantities.",
         func_name,
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0])
       ));
       return Ok(Expr::FunctionCall {
         name: func_name.to_string(),
@@ -4236,7 +4233,7 @@ pub fn fourier_dct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = || {
     crate::emit_message(&format!(
       "FourierDCT::fftl: Argument {} is not a nonempty list or rectangular array of numeric quantities.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     Ok(Expr::FunctionCall {
       name: "FourierDCT".to_string(),
@@ -4295,7 +4292,7 @@ pub fn discrete_hilbert_transform_ast(
   let data_err = || {
     crate::emit_message(&format!(
       "DiscreteHilbertTransform::data: {} is empty or not a real valued numerical array.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     unevaluated()
   };
@@ -4416,7 +4413,7 @@ pub fn fourier_dst_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = || {
     crate::emit_message(&format!(
       "FourierDST::fftl: Argument {} is not a nonempty list or rectangular array of numeric quantities.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     Ok(Expr::FunctionCall {
       name: "FourierDST".to_string(),
@@ -4547,8 +4544,7 @@ pub fn nsum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let max_n = *checkpoints.last().unwrap();
     for i in min_val..(min_val + max_n) {
       let sub_val = Expr::Integer(i as i128);
-      let substituted =
-        crate::syntax::substitute_variable(body, &var_name, &sub_val);
+      let substituted = substitute_variable(body, &var_name, &sub_val);
       let val = crate::evaluator::evaluate_expr_to_expr(&substituted)?;
       let term = match try_eval_to_f64(&val) {
         Some(f) => f,
@@ -4597,8 +4593,7 @@ pub fn nsum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut sum = 0.0_f64;
   for i in min_val..=max_val {
     let sub_val = Expr::Integer(i as i128);
-    let substituted =
-      crate::syntax::substitute_variable(body, &var_name, &sub_val);
+    let substituted = substitute_variable(body, &var_name, &sub_val);
     let val = crate::evaluator::evaluate_expr_to_expr(&substituted)?;
     let term = match try_eval_to_f64(&val) {
       Some(f) => f,
@@ -4672,8 +4667,7 @@ pub fn nproduct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let eval_term = |i: i64| -> Result<Option<f64>, InterpreterError> {
     let sub_val = Expr::Integer(i as i128);
-    let substituted =
-      crate::syntax::substitute_variable(body, &var_name, &sub_val);
+    let substituted = substitute_variable(body, &var_name, &sub_val);
     let val = crate::evaluator::evaluate_expr_to_expr(&substituted)?;
     Ok(try_eval_to_f64(&val))
   };
@@ -5381,7 +5375,6 @@ pub fn list_fourier_sequence_transform_ast(
 
   // Build the sum: Sum[a_k * E^(-I * omega * k), {k, 0, n-1}]
   use crate::evaluator::evaluate_expr_to_expr;
-  use crate::syntax::BinaryOperator;
 
   let mut terms: Vec<Expr> = Vec::new();
   for (k, coeff) in list.iter().enumerate() {
@@ -5600,7 +5593,6 @@ pub fn tukey_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Exact: build (1 + Cos[Pi (2 Abs[x] - 1 + alpha)/alpha]) / 2 and evaluate
   // symbolically so Cos simplifies (matching wolframscript's radical forms).
-  use crate::syntax::BinaryOperator;
   let abs_x = Expr::FunctionCall {
     name: "Abs".to_string(),
     args: vec![x.clone()].into(),
@@ -5662,7 +5654,6 @@ fn window_arg_inexact(e: &Expr) -> bool {
 /// Exact arguments give the exact polynomial value (e.g. ParzenWindow[1/3] ->
 /// 2/27); Real arguments numericize.
 pub fn parzen_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let unevaluated = || Expr::FunctionCall {
     name: "ParzenWindow".to_string(),
     args: args.to_vec().into(),
@@ -5739,7 +5730,6 @@ pub fn parzen_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Exact arguments give E^(rational) (e.g. GaussianWindow[1/4] -> E^(-25/72));
 /// Real arguments numericize.
 pub fn gaussian_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let unevaluated = || Expr::FunctionCall {
     name: "GaussianWindow".to_string(),
     args: args.to_vec().into(),
@@ -5794,7 +5784,6 @@ pub fn gaussian_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// (1 - 2|x|) Cos[2 Pi |x|] + Sin[2 Pi |x|] / Pi. Exact arguments evaluate the
 /// symbolic form (e.g. BohmanWindow[1/4] -> 1/Pi); Real arguments numericize.
 pub fn bohman_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let unevaluated = || Expr::FunctionCall {
     name: "BohmanWindow".to_string(),
     args: args.to_vec().into(),
@@ -6613,11 +6602,8 @@ fn root_sum_n_eval(poly_arg: &Expr, fn_arg: &Expr) -> Option<Expr> {
   // Substitute Slot(1) → __rs_x__ to get a polynomial in a named variable
   // (extract_poly_coeffs needs an identifier).
   let var = "__rs_x__";
-  let poly_in_var = crate::syntax::substitute_variable(
-    poly_body,
-    "#1",
-    &Expr::Identifier(var.to_string()),
-  );
+  let poly_in_var =
+    substitute_variable(poly_body, "#1", &Expr::Identifier(var.to_string()));
   // Slot(1) inside Function bodies is stored differently from Identifier
   // "#1"; substitute that variant too.
   let poly_in_var = substitute_slot_with_identifier(&poly_in_var, 1, var);
@@ -6677,11 +6663,8 @@ fn root_n_eval(poly_arg: &Expr, k_arg: &Expr) -> Option<Expr> {
     _ => return None,
   };
   let var = "__root_x__";
-  let poly_in_var = crate::syntax::substitute_variable(
-    poly_body,
-    "#1",
-    &Expr::Identifier(var.to_string()),
-  );
+  let poly_in_var =
+    substitute_variable(poly_body, "#1", &Expr::Identifier(var.to_string()));
   let poly_in_var = substitute_slot_with_identifier(&poly_in_var, 1, var);
   let expanded =
     crate::functions::polynomial_ast::expand_and_combine(&poly_in_var);

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 use num_bigint::BigInt;
 
 /// Visit every additive term of a polynomial expression, flattening nested and
@@ -33,7 +33,7 @@ fn integer_coeff_of_term(t: &Expr) -> Option<BigInt> {
     Expr::Integer(c) => Some(BigInt::from(*c)),
     Expr::BigInteger(c) => Some(c.clone()),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => integer_coeff_of_term(operand).map(|c| -c),
     Expr::FunctionCall { name, .. } if name == "Rational" => None,
@@ -697,10 +697,10 @@ fn associated_legendre_p_ast(
       name: "Power".to_string(),
       args: vec![
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(Expr::Integer(1)),
           right: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(x_expr.clone()),
             right: Box::new(Expr::Integer(2)),
           }),
@@ -716,10 +716,10 @@ fn associated_legendre_p_ast(
       name: "Power".to_string(),
       args: vec![
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(Expr::Integer(1)),
           right: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(x_expr.clone()),
             right: Box::new(Expr::Integer(2)),
           }),
@@ -735,15 +735,15 @@ fn associated_legendre_p_ast(
       sqrt_part
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::FunctionCall {
           name: "Power".to_string(),
           args: vec![
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(Expr::Integer(1)),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(x_expr.clone()),
                 right: Box::new(Expr::Integer(2)),
               }),
@@ -759,10 +759,10 @@ fn associated_legendre_p_ast(
 
   // Build: sign * factor * deriv
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(Expr::Integer(sign)),
     right: Box::new(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(factor),
       right: Box::new(deriv),
     }),
@@ -1902,11 +1902,10 @@ fn legendre_q_complex(n: (f64, f64), z: (f64, f64)) -> (f64, f64) {
 /// through to the unevaluated form when any argument fails to reduce
 /// to a complex `(re, im)` pair.
 fn legendre_q_associated_ast(
-  n_expr: &crate::syntax::Expr,
-  m_expr: &crate::syntax::Expr,
-  z_expr: &crate::syntax::Expr,
-) -> Result<crate::syntax::Expr, crate::InterpreterError> {
-  use crate::syntax::Expr;
+  n_expr: &Expr,
+  m_expr: &Expr,
+  z_expr: &Expr,
+) -> Result<Expr, InterpreterError> {
   let unevaluated = || Expr::FunctionCall {
     name: "LegendreQ".to_string(),
     args: vec![n_expr.clone(), m_expr.clone(), z_expr.clone()].into(),
@@ -2072,7 +2071,6 @@ fn chebyshev_general_numeric(
   n_expr: &Expr,
   x_expr: &Expr,
 ) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   fn has_real_literal(e: &Expr) -> bool {
     match e {
       Expr::Real(_) | Expr::BigFloat(_, _) => true,
@@ -2165,7 +2163,6 @@ fn chebyshev_general_exact(
   n_expr: &Expr,
   x_expr: &Expr,
 ) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   // n must be a non-integer rational p/q (q > 1).
   let q = match n_expr {
     Expr::FunctionCall { name, args }
@@ -3485,7 +3482,7 @@ fn generalized_laguerre_l_ast(
           x_expr.clone()
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(x_expr.clone()),
             right: Box::new(Expr::Integer(k as i128)),
           }
@@ -3494,13 +3491,13 @@ fn generalized_laguerre_l_ast(
           power
         } else if scaled == -1 {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(-1)),
             right: Box::new(power),
           }
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(coeff_expr),
             right: Box::new(power),
           }
@@ -3516,7 +3513,7 @@ fn generalized_laguerre_l_ast(
     let mut numer = terms[0].clone();
     for term in &terms[1..] {
       numer = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(numer),
         right: Box::new(term.clone()),
       };
@@ -3525,7 +3522,7 @@ fn generalized_laguerre_l_ast(
       numer
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(numer),
         right: Box::new(Expr::Integer(common_denom)),
       }
@@ -3591,7 +3588,7 @@ fn generalized_laguerre_l_ast(
     vec![Expr::Integer(n_fact), call("Plus", sum_terms)],
   );
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(call("Expand", vec![scaled])),
     right: Box::new(Expr::Integer(n_fact)),
   };
@@ -4025,7 +4022,7 @@ fn rewrite_sqrt_one_minus_cos_sq(expr: &Expr, theta: &Expr) -> Expr {
   let is_cos_theta_sq = |e: &Expr| -> bool {
     let (base, exp) = match e {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } => (left.as_ref(), right.as_ref()),
@@ -4045,7 +4042,7 @@ fn rewrite_sqrt_one_minus_cos_sq(expr: &Expr, theta: &Expr) -> Expr {
     // Match: 1 - Cos[θ]^2 in either `BinaryOp::Minus` or
     // `Plus[1, Times[-1, Cos[θ]^2]]` shape.
     if let Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left,
       right,
     } = e
@@ -4127,7 +4124,7 @@ fn rewrite_sqrt_one_minus_cos_sq(expr: &Expr, theta: &Expr) -> Expr {
   }
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -4137,7 +4134,7 @@ fn rewrite_sqrt_one_minus_cos_sq(expr: &Expr, theta: &Expr) -> Expr {
         return sin_pow(e2);
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(rewrite_sqrt_one_minus_cos_sq(left, theta)),
         right: Box::new(rewrite_sqrt_one_minus_cos_sq(right, theta)),
       }

--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr};
 
 /// RandomInteger[max] or RandomInteger[{min, max}] - Random integer
 pub fn random_integer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -242,7 +242,6 @@ pub fn random_real_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// or RandomComplex[range, dims]. Real and imaginary parts are drawn
 /// uniformly from the specified rectangle.
 pub fn random_complex_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   use rand::Rng;
 
   fn complex_parts(expr: &Expr) -> Option<(f64, f64)> {
@@ -363,10 +362,10 @@ pub fn random_complex_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       rng.gen_range(im_lo..im_hi)
     };
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(Expr::Real(re)),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Real(im)),
         right: Box::new(Expr::Identifier("I".to_string())),
       }),

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -1,7 +1,10 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, ExprForm, UnaryOperator, expr_to_output,
+  expr_to_string, format_expr,
+};
 
 /// If the first argument is a numeric scalar, emit
 /// `<F>::rectt: Rectangular array expected at position 1 in <call>.`,
@@ -15,12 +18,12 @@ pub fn emit_rectt_if_numeric(name: &str, args: &[Expr]) {
     crate::emit_message(&format!(
       "{}::rectt: Rectangular array expected at position 1 in {}.",
       name,
-      crate::syntax::format_expr(
+      format_expr(
         &Expr::FunctionCall {
           name: name.to_string(),
           args: args.to_vec().into(),
         },
-        crate::syntax::ExprForm::Output
+        ExprForm::Output
       )
     ));
   }
@@ -66,12 +69,12 @@ pub fn rectt_if_ragged(name: &str, args: &[Expr]) -> Option<Expr> {
     crate::emit_message(&format!(
       "{}::rectt: Rectangular array expected at position 1 in {}.",
       name,
-      crate::syntax::format_expr(
+      format_expr(
         &Expr::FunctionCall {
           name: name.to_string(),
           args: args.to_vec().into(),
         },
-        crate::syntax::ExprForm::Output
+        ExprForm::Output
       )
     ));
     Some(Expr::FunctionCall {
@@ -118,12 +121,12 @@ pub fn rectn_if_not_real_rectangular(
     crate::emit_message(&format!(
       "{}::rectn: A rectangular array of real numbers is expected at position 1 in {}.",
       name,
-      crate::syntax::format_expr(
+      format_expr(
         &Expr::FunctionCall {
           name: name.to_string(),
           args: args.to_vec().into(),
         },
-        crate::syntax::ExprForm::Output
+        ExprForm::Output
       )
     ));
     Some(Expr::FunctionCall {
@@ -154,11 +157,8 @@ pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() > 2 {
     crate::emit_message(&format!(
       "Total::nonopt: Options expected (instead of {}) beyond position 2 in {}. An option must be a rule or a list of rules.",
-      crate::syntax::format_expr(&args[2], crate::syntax::ExprForm::Output),
-      crate::syntax::format_expr(
-        &unevaluated(),
-        crate::syntax::ExprForm::Output
-      )
+      format_expr(&args[2], ExprForm::Output),
+      format_expr(&unevaluated(), ExprForm::Output)
     ));
     return Ok(unevaluated());
   }
@@ -264,7 +264,7 @@ pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       crate::emit_message(&format!(
         "Total::tllen: Lists of unequal length in {} cannot be added.",
-        crate::syntax::format_expr(&args[0], crate::syntax::ExprForm::Output)
+        format_expr(&args[0], ExprForm::Output)
       ));
       Ok(Expr::FunctionCall {
         name: "Total".to_string(),
@@ -311,12 +311,12 @@ pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if matches!(other, Expr::String(_)) {
           crate::emit_message(&format!(
             "Total::normal: Nonatomic expression expected at position 1 in {}.",
-            crate::syntax::format_expr(
+            format_expr(
               &Expr::FunctionCall {
                 name: "Total".to_string(),
                 args: args.to_vec().into(),
               },
-              crate::syntax::ExprForm::Output
+              ExprForm::Output
             )
           ));
         }
@@ -632,7 +632,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // while a Quantity sum collapses (Quantity[6, Meters]/2 →
         // Quantity[3, Meters]), matching wolframscript.
         crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(evaluated_sum),
           right: Box::new(Expr::Integer(n)),
         })
@@ -883,7 +883,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if items.len() == 1 {
           crate::emit_message(&format!(
             "Variance::shlen: The argument {} should have at least two elements.",
-            crate::syntax::expr_to_string(&args[0])
+            expr_to_string(&args[0])
           ));
         }
         return Ok(Expr::FunctionCall {
@@ -1105,7 +1105,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       match super::distributions::binormal_params(dargs) {
         Some((_, _, s1, s2, _)) => {
           let sq = |s: Expr| Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(s),
             right: Box::new(Expr::Integer(2)),
           };
@@ -1126,7 +1126,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Variance[QuantityDistribution[dist, unit]] = Quantity[Variance[dist], unit^2]
       let inner_var = variance_ast(&[dargs[0].clone()])?;
       let unit_sq = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(dargs[1].clone()),
         right: Box::new(Expr::Integer(2)),
       };
@@ -1222,7 +1222,7 @@ pub fn standard_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if items.len() == 1 {
       crate::emit_message(&format!(
         "StandardDeviation::shlen: The argument {} should have at least two elements.",
-        crate::syntax::expr_to_string(&args[0])
+        expr_to_string(&args[0])
       ));
     }
     return Ok(Expr::FunctionCall {
@@ -1431,8 +1431,6 @@ fn try_sqrt_extract_denom_factors(
   use crate::functions::polynomial_ast::{
     build_product, collect_multiplicative_factors,
   };
-  use crate::syntax::BinaryOperator;
-
   // Build `base^half`, collapsing the exponent to a bare base when half == 1.
   let power_or_base = |base: Expr, half: i128| -> Expr {
     if half == 1 {
@@ -1751,7 +1749,7 @@ fn harmonic_mean_symbolic(items: &[Expr]) -> Result<Expr, InterpreterError> {
   let recips: Vec<Expr> = items
     .iter()
     .map(|x| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Integer(1)),
       right: Box::new(x.clone()),
     })
@@ -1762,7 +1760,7 @@ fn harmonic_mean_symbolic(items: &[Expr]) -> Result<Expr, InterpreterError> {
   })?;
   let n = items.len() as i128;
   crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(Expr::Integer(n)),
     right: Box::new(sum),
   })
@@ -1832,7 +1830,7 @@ pub fn contraharmonic_mean_ast(
     if matches!(&args[1], Expr::List(_)) {
       crate::emit_message(&format!(
         "ContraharmonicMean::scalar: Argument {} at position 2 is not a scalar.",
-        crate::syntax::format_expr(&args[1], crate::syntax::ExprForm::Output)
+        format_expr(&args[1], ExprForm::Output)
       ));
       return unevaluated();
     }
@@ -1973,12 +1971,12 @@ fn covariance_pair(xs: &[Expr], ys: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut terms = Vec::with_capacity(n);
   for (x, y) in xs.iter().zip(ys.iter()) {
     let dx = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(x.clone()),
       right: Box::new(mean_x.clone()),
     };
     let dy = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(y.clone()),
       right: Box::new(mean_y.clone()),
     };
@@ -1987,7 +1985,7 @@ fn covariance_pair(xs: &[Expr], ys: &[Expr]) -> Result<Expr, InterpreterError> {
       args: vec![dy].into(),
     };
     let product = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(dx),
       right: Box::new(conj_dy),
     };
@@ -2001,7 +1999,7 @@ fn covariance_pair(xs: &[Expr], ys: &[Expr]) -> Result<Expr, InterpreterError> {
   };
   let sum_val = crate::evaluator::evaluate_expr_to_expr(&sum_expr)?;
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(sum_val),
     right: Box::new(Expr::Integer((n - 1) as i128)),
   };
@@ -2023,7 +2021,7 @@ fn symbolic_covariance(
   xs: &[Expr],
   ys: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator::{Divide, Minus, Times};
+  use BinaryOperator::{Divide, Minus, Times};
   let n = xs.len();
   let conj = |e: &Expr| Expr::FunctionCall {
     name: "Conjugate".to_string(),
@@ -2119,7 +2117,7 @@ pub fn covariance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && let Some((_, _, s1, s2, rho)) =
       super::distributions::binormal_params(dargs)
   {
-    use crate::syntax::BinaryOperator::{Power, Times};
+    use BinaryOperator::{Power, Times};
     let sq = |s: Expr| Expr::BinaryOp {
       op: Power,
       left: Box::new(s),
@@ -2467,7 +2465,7 @@ pub fn hoeffding_d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let dtlnth = |pos: usize, arg: &Expr| {
     crate::emit_message(&format!(
       "HoeffdingD::dtlnth: The argument {} at position {} is expected to have length greater than 5.",
-      crate::syntax::expr_to_output(arg),
+      expr_to_output(arg),
       pos
     ));
     unevaluated()
@@ -2813,7 +2811,7 @@ pub fn blomqvist_beta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // emit Divide::indet instead).
     if exact || a * b == 0 {
       crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(num)),
         right: Box::new(Expr::FunctionCall {
           name: "Sqrt".to_string(),
@@ -2963,7 +2961,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let w0 = ys[0].clone();
       let w1 = ys[1].clone();
       let diff = |a: &Expr, b: &Expr| Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(a.clone()),
         right: Box::new(b.clone()),
       };
@@ -2976,7 +2974,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         args: vec![a, b].into(),
       };
       let conj_diff = |a: &Expr, b: &Expr| Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(conj(a)),
         right: Box::new(conj(b)),
       };
@@ -2998,7 +2996,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // inside each Sqrt (which Woxi's canonical sort would otherwise
       // reorder differently than wolframscript for some variable names).
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(numer),
         right: Box::new(denom),
       });
@@ -3057,7 +3055,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
   let var_product = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(var_x),
     right: Box::new(var_y),
   };
@@ -3066,7 +3064,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     args: vec![var_product].into(),
   };
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(cov_xy),
     right: Box::new(denom),
   };
@@ -3117,7 +3115,7 @@ fn distribution_raw_moment(
   var: &str,
 ) -> Result<Option<Expr>, InterpreterError> {
   let powered = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(Expr::Identifier(var.to_string())),
     right: Box::new(Expr::Integer(n)),
   };
@@ -3204,13 +3202,13 @@ fn skellam_central_moment(a: &Expr, b: &Expr, n: i128) -> Expr {
   let kappa = |j: usize| -> Expr {
     if j.is_multiple_of(2) {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(a.clone()),
         right: Box::new(b.clone()),
       }
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(a.clone()),
         right: Box::new(b.clone()),
       }
@@ -3286,7 +3284,7 @@ fn distribution_moment(
         args: vec![
           Expr::Integer(fact_i128(n)),
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(b),
             right: Box::new(Expr::Integer(n)),
           },
@@ -3315,7 +3313,7 @@ fn distribution_moment(
   // 0 and Kurtosis to 21/5.
   if let Some((_, b)) = two_params_of(dist, "LogisticDistribution") {
     let power = |base: Expr, exp: Expr| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(base),
       right: Box::new(exp),
     };
@@ -3376,7 +3374,7 @@ fn distribution_moment(
         .into(),
       };
       let num = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(diff),
         right: Box::new(Expr::Integer(n)),
       };
@@ -3385,7 +3383,7 @@ fn distribution_moment(
         name: "Times".to_string(),
         args: vec![
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::Integer(2)),
             right: Box::new(Expr::Integer(n)),
           },
@@ -3394,7 +3392,7 @@ fn distribution_moment(
         .into(),
       };
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(num),
         right: Box::new(denom),
       }
@@ -3408,7 +3406,7 @@ fn distribution_moment(
   // Kurtosis 5.
   if let Some((_, s)) = two_params_of(dist, "SechDistribution") {
     let power = |base: Expr, exp: Expr| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(base),
       right: Box::new(exp),
     };
@@ -3445,7 +3443,7 @@ fn distribution_moment(
       Expr::Integer(1)
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(Expr::FunctionCall {
           name: "Times".to_string(),
           args: vec![Expr::Integer(-1), mean.clone()].into(),
@@ -3525,12 +3523,12 @@ pub fn central_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for item in items {
     // (item - mean)^r
     let diff = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(item.clone()),
       right: Box::new(mean_expr.clone()),
     };
     let powered = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(diff),
       right: Box::new(Expr::Integer(r as i128)),
     };
@@ -3545,7 +3543,7 @@ pub fn central_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
   let sum_val = crate::evaluator::evaluate_expr_to_expr(&sum_expr)?;
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(sum_val),
     right: Box::new(Expr::Integer(n as i128)),
   };
@@ -3608,7 +3606,7 @@ pub fn cumulant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut terms = Vec::with_capacity(items.len());
     for item in items {
       let powered = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(item.clone()),
         right: Box::new(Expr::Integer(j as i128)),
       };
@@ -3619,7 +3617,7 @@ pub fn cumulant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: terms.into(),
     };
     let div = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(sum_expr),
       right: Box::new(Expr::Integer(n)),
     };
@@ -3656,7 +3654,7 @@ fn cumulant_from_raw_moments(
           .into(),
       };
       acc = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(acc),
         right: Box::new(term),
       };
@@ -3679,15 +3677,15 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // moment-ratio Expand mangles the multi-parameter denominator.
   if let Some((a, b)) = skellam_params(&args[0]) {
     let a_plus_b = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(a),
       right: Box::new(b),
     };
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(Expr::Integer(3)),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(a_plus_b),
       }),
@@ -3719,12 +3717,12 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let m2 = central_moment_ast(&[args[0].clone(), Expr::Integer(2)])?;
   // Compute m4 / m2^2 symbolically
   let m2_squared = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(m2),
     right: Box::new(Expr::Integer(2)),
   };
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(m4),
     right: Box::new(m2_squared),
   };
@@ -3758,21 +3756,21 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // is preserved (the generic moment-ratio Expand would distribute it).
   if let Some((a, b)) = skellam_params(&args[0]) {
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(a.clone()),
         right: Box::new(b.clone()),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(a),
           right: Box::new(b),
         }),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::Integer(3)),
           right: Box::new(Expr::Integer(2)),
         }),
@@ -3818,7 +3816,7 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     matches!(&m2, Expr::Real(_)) || matches!(&m3, Expr::Real(_));
   let result = if moments_inexact {
     let m2_pow = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(m2),
       right: Box::new(Expr::FunctionCall {
         name: "Rational".to_string(),
@@ -3826,17 +3824,17 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }),
     };
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(m3),
       right: Box::new(m2_pow),
     }
   } else {
     // Compute m3 / m2^(3/2) symbolically
     let m2_pow = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(m2),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(3)),
         right: Box::new(Expr::Integer(2)),
       }),
@@ -3844,7 +3842,7 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     maybe_expand_for_distribution(
       &args[0],
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(m3),
         right: Box::new(m2_pow),
       },
@@ -4323,7 +4321,7 @@ fn factorial_moment_of_distribution(
   r: i128,
 ) -> Option<Expr> {
   let pow = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(b),
     right: Box::new(e),
   };
@@ -4378,7 +4376,7 @@ fn factorial_moment_of_distribution(
       // so (r-1) such factors contribute (-1)^(r-1).
       Some(if (r - 1).rem_euclid(2) == 1 {
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(product),
         }
       } else {
@@ -4565,7 +4563,7 @@ pub fn mean_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut abs_devs = Vec::new();
     for item in items {
       let diff = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(item.clone()),
         right: Box::new(mean_expr.clone()),
       };
@@ -4580,7 +4578,7 @@ pub fn mean_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: abs_devs.into(),
     };
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(sum),
       right: Box::new(Expr::Integer(n)),
     };
@@ -4607,7 +4605,7 @@ pub fn median_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut abs_devs = Vec::new();
     for item in items {
       let diff = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(item.clone()),
         right: Box::new(median_expr.clone()),
       };
@@ -5787,7 +5785,7 @@ pub fn group_element_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[1], Expr::FunctionCall { name, .. } if name == "Cycles") {
     crate::emit_message(&format!(
       "GroupElementQ::perm: {} is not a valid permutation.",
-      crate::syntax::expr_to_string(&args[1])
+      expr_to_string(&args[1])
     ));
     return Ok(unevaluated());
   }
@@ -5829,7 +5827,7 @@ pub fn group_element_position_ast(
     None => {
       crate::emit_message(&format!(
         "GroupElementPosition::noin: Permutation {} does not belong to group.",
-        crate::syntax::expr_to_string(&args[1])
+        expr_to_string(&args[1])
       ));
       Ok(unevaluated())
     }
@@ -6373,7 +6371,7 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
 
     // BinaryOp Power
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       ..
     } => Some(expr.clone()),
 
@@ -6384,14 +6382,14 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
 
     // BinaryOp Plus
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => asymptotic_sum(&[*left.clone(), *right.clone()], var),
 
     // BinaryOp Minus
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left,
       right,
     } => {
@@ -6425,7 +6423,7 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
 
     // BinaryOp Times
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -6439,14 +6437,14 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
 
     // BinaryOp Divide
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
       let l = discrete_asymptotic_leading(left, var)?;
       let r = discrete_asymptotic_leading(right, var)?;
       Some(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(l),
         right: Box::new(r),
       })
@@ -6605,7 +6603,7 @@ fn growth_order(expr: &Expr, var: &str) -> Option<f64> {
 
     // BinaryOp variants
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -6615,7 +6613,7 @@ fn growth_order(expr: &Expr, var: &str) -> Option<f64> {
     }
 
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -6672,7 +6670,7 @@ fn asymptotic_binomial(
   // Check if k = n/2
   let is_half = match k_expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => is_pure_var(left, var) && matches!(**right, Expr::Integer(2)),
@@ -6777,7 +6775,7 @@ pub fn covariance_function_data(
     Err(e) => return Some(Err(e)),
   };
   let dev = |x: &Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left: Box::new(x.clone()),
     right: Box::new(mean.clone()),
   };
@@ -6785,7 +6783,7 @@ pub fn covariance_function_data(
   let mut terms = Vec::new();
   for t in 0..(n - h_us) {
     terms.push(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(dev(&items[t])),
       right: Box::new(dev(&items[t + h_us])),
     });
@@ -6795,7 +6793,7 @@ pub fn covariance_function_data(
     args: terms.into(),
   };
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(sum),
     right: Box::new(Expr::Integer(n as i128)),
   };
@@ -6896,7 +6894,7 @@ fn cf_pow(b: Expr, e: Expr) -> Expr {
 }
 fn cf_div(n: Expr, d: Expr) -> Expr {
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(n),
     right: Box::new(d),
   }
@@ -6932,7 +6930,7 @@ fn cov_ma1(b: &Expr, sigma2: &Expr, s: &Expr, t: &Expr) -> Expr {
       cf_times(vec![b.clone(), sigma2.clone()]),
       Expr::Comparison {
         operands: vec![lag.clone(), Expr::Integer(1)],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       },
     ]
     .into(),
@@ -6945,7 +6943,7 @@ fn cov_ma1(b: &Expr, sigma2: &Expr, s: &Expr, t: &Expr) -> Expr {
       ]),
       Expr::Comparison {
         operands: vec![lag.clone(), Expr::Integer(0)],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       },
     ]
     .into(),
@@ -7009,7 +7007,7 @@ fn cov_arma11(a: &Expr, b: &Expr, sigma2: &Expr, s: &Expr, t: &Expr) -> Expr {
       nonzero_value,
       Expr::Comparison {
         operands: vec![lag, Expr::Integer(0)],
-        operators: vec![crate::syntax::ComparisonOp::Greater],
+        operators: vec![ComparisonOp::Greater],
       },
     ]
     .into(),
@@ -7053,16 +7051,16 @@ pub fn characteristic_function_ast(
     args: fargs.into(),
   };
   let neg = |e: Expr| Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(e),
   };
   let pow = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(b),
     right: Box::new(e),
   };
   let div = |n: Expr, d: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(n),
     right: Box::new(d),
   };
@@ -7423,16 +7421,16 @@ pub fn moment_generating_function_ast(
     args: fargs.into(),
   };
   let neg = |e: Expr| Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(e),
   };
   let pow = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(b),
     right: Box::new(e),
   };
   let div = |n: Expr, d: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(n),
     right: Box::new(d),
   };
@@ -7738,7 +7736,7 @@ pub fn moment_generating_function_ast(
 fn as_power_pair(e: &Expr) -> Option<(&Expr, &Expr)> {
   match e {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some((left, right)),
@@ -7765,12 +7763,12 @@ fn cgf_term(f: &Expr) -> Expr {
     if is_e_base(base) {
       exp.clone()
     } else if let Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } = exp
     {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::FunctionCall {
           name: "Times".to_string(),
           args: vec![(**operand).clone(), log(base.clone())].into(),
@@ -7814,16 +7812,16 @@ pub fn cumulant_generating_function_ast(
     args: fargs.into(),
   };
   let neg = |e: Expr| Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(e),
   };
   let pow = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(b),
     right: Box::new(e),
   };
   let div = |n: Expr, d: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(n),
     right: Box::new(d),
   };
@@ -7914,11 +7912,11 @@ pub fn cumulant_generating_function_ast(
   // m t - Log[1 - b^2 t^2]. A quotient without an exponential numerator (e.g.
   // Exponential's a/(a - t)) is left as a single Log.
   let num_is_e_power = matches!(&mgf, Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide, left, ..
+    op: BinaryOperator::Divide, left, ..
   } if as_power_pair(left).is_some_and(|(base, _)| is_e_base(base)));
   let cgf = if num_is_e_power
     && let Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } = &mgf
@@ -7968,19 +7966,19 @@ pub fn factorial_moment_generating_function_ast(
       args: f.into(),
     };
     let sq = |e: Expr| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(e),
       right: Box::new(Expr::Integer(2)),
     };
     return Ok(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(Expr::Identifier("E".to_string())),
       right: Box::new(Expr::FunctionCall {
         name: "Plus".to_string(),
         args: vec![
           times(vec![m, log_t.clone()]),
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(times(vec![sq(sd), sq(log_t)])),
             right: Box::new(Expr::Integer(2)),
           },
@@ -8044,7 +8042,7 @@ pub fn central_moment_generating_function_ast(
       args: f.into(),
     };
     let e_pow = |e: Expr| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(Expr::Identifier("E".to_string())),
       right: Box::new(e),
     };
@@ -8054,7 +8052,7 @@ pub fn central_moment_generating_function_ast(
     };
     let t = args[1].clone();
     let expr = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::FunctionCall {
         name: "Plus".to_string(),
         args: vec![
@@ -8094,7 +8092,7 @@ pub fn central_moment_generating_function_ast(
   // merge the terms in a different order.
   let e_exponent = match &mgf {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } if matches!(left.as_ref(), Expr::Identifier(b) if b == "E")
@@ -8128,7 +8126,7 @@ pub fn central_moment_generating_function_ast(
       match e {
         Expr::FunctionCall { name, args } if name == "Plus" => args.len(),
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           ..
         } => 2,
         _ => 1,
@@ -8141,13 +8139,13 @@ pub fn central_moment_generating_function_ast(
       raw
     };
     return Ok(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(Expr::Identifier("E".to_string())),
       right: Box::new(exponent),
     });
   }
   let damp = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(Expr::Identifier("E".to_string())),
     right: Box::new(damp_exponent),
   };
@@ -8244,7 +8242,7 @@ pub fn correlation_function_ast(
   }
 
   crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(numerator),
     right: Box::new(denominator),
   })
@@ -8267,7 +8265,7 @@ pub fn ztest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let bad_data = |args: &[Expr]| {
     crate::emit_message(&format!(
       "ZTest::rctndm1: The argument {} at position 1 should be a rectangular array of real numbers with length greater than the dimension of the array or two such arrays of equal dimensionality.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     Ok(Expr::FunctionCall {
       name: "ZTest".to_string(),
@@ -8345,7 +8343,7 @@ pub fn fisher_ratio_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let bad_data = |args: &[Expr]| {
     crate::emit_message(&format!(
       "FisherRatioTest::vctnln1: The argument {} at position 1 should be a vector of real numbers with length greater than 1 or a list containing two such vectors.",
-      crate::syntax::expr_to_string(&args[0])
+      expr_to_string(&args[0])
     ));
     Ok(Expr::FunctionCall {
       name: "FisherRatioTest".to_string(),
@@ -8373,7 +8371,7 @@ pub fn fisher_ratio_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         _ => {
           crate::emit_message(&format!(
             "FisherRatioTest::sigmnt: The argument {} should be a positive number.",
-            crate::syntax::expr_to_string(&args[1])
+            expr_to_string(&args[1])
           ));
           return Ok(unevaluated(args));
         }
@@ -8468,12 +8466,12 @@ pub fn cycle_index_polynomial_ast(
     return Ok(unevaluated());
   }
   let call_str = || {
-    crate::syntax::format_expr(
+    format_expr(
       &Expr::FunctionCall {
         name: "CycleIndexPolynomial".to_string(),
         args: args.to_vec().into(),
       },
-      crate::syntax::ExprForm::Output,
+      ExprForm::Output,
     )
   };
 
@@ -8514,7 +8512,7 @@ pub fn cycle_index_polynomial_ast(
     None => {
       crate::emit_message(&format!(
         "CycleIndexPolynomial::grp: {} is not a valid group.",
-        crate::syntax::format_expr(&args[0], crate::syntax::ExprForm::Output)
+        format_expr(&args[0], ExprForm::Output)
       ));
       return Ok(unevaluated());
     }
@@ -8577,7 +8575,7 @@ pub fn cycle_index_polynomial_ast(
           base
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(base),
             right: Box::new(Expr::Integer(m as i128)),
           }
@@ -8777,7 +8775,7 @@ pub fn group_multiplication_table_ast(
     if !looks_like_group(&args[0]) {
       crate::emit_message(&format!(
         "GroupMultiplicationTable::grp: {} is not a valid group.",
-        crate::syntax::format_expr(&args[0], crate::syntax::ExprForm::Output)
+        format_expr(&args[0], ExprForm::Output)
       ));
     }
     return Ok(unevaluated());
@@ -8818,7 +8816,7 @@ pub fn group_stabilizer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !looks_like_group(&args[0]) {
     crate::emit_message(&format!(
       "GroupStabilizer::grp: {} is not a valid group.",
-      crate::syntax::format_expr(&args[0], crate::syntax::ExprForm::Output)
+      format_expr(&args[0], ExprForm::Output)
     ));
     return Ok(unevaluated());
   }
@@ -8960,10 +8958,10 @@ fn erlang_b_symbolic(
     crate::emit_message(&format!(
       "{}::posprm: Parameter {} at position 2 in {}[{}, {}] is expected to be positive.",
       name,
-      crate::syntax::expr_to_output(&args[1]),
+      expr_to_output(&args[1]),
       name,
-      crate::syntax::expr_to_output(&args[0]),
-      crate::syntax::expr_to_output(&args[1]),
+      expr_to_output(&args[0]),
+      expr_to_output(&args[1]),
     ));
     return Some(Ok(Expr::FunctionCall {
       name: name.to_string(),
@@ -9005,7 +9003,7 @@ fn erlang_b_symbolic(
   let reals = || Expr::Identifier("Reals".to_string());
   let positive = |e: &Expr| Expr::Comparison {
     operands: vec![e.clone(), Expr::Integer(0)],
-    operators: vec![crate::syntax::ComparisonOp::Greater],
+    operators: vec![ComparisonOp::Greater],
   };
   let mut conds: Vec<Expr> = Vec::new();
   if c_num.is_none() {
@@ -9106,8 +9104,8 @@ fn erlang_common(
         "{}::intp: Positive integer expected at position 1 in {}[{}, {}].",
         name,
         name,
-        crate::syntax::expr_to_output(&args[0]),
-        crate::syntax::expr_to_output(&args[1])
+        expr_to_output(&args[0]),
+        expr_to_output(&args[1])
       ));
       return unevaluated();
     }
@@ -9165,10 +9163,10 @@ fn erlang_common(
     crate::emit_message(&format!(
       "{}::posprm: Parameter {} at position 2 in {}[{}, {}] is expected to be positive.",
       name,
-      crate::syntax::expr_to_output(&args[1]),
+      expr_to_output(&args[1]),
       name,
-      crate::syntax::expr_to_output(&args[0]),
-      crate::syntax::expr_to_output(&args[1])
+      expr_to_output(&args[0]),
+      expr_to_output(&args[1])
     ));
     return unevaluated();
   }
@@ -9246,7 +9244,7 @@ pub fn central_feature_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     })
   };
   let call_display = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
+    expr_to_string(&Expr::FunctionCall {
       name: "CentralFeature".to_string(),
       args: args.to_vec().into(),
     })
@@ -9266,7 +9264,7 @@ pub fn central_feature_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if !is_opt {
       crate::emit_message(&format!(
         "CentralFeature::nonopt: Options expected (instead of {}) beyond position 1 in {}. An option must be a rule or a list of rules.",
-        crate::syntax::expr_to_string(extra),
+        expr_to_string(extra),
         call_display()
       ));
       return unevaluated();
@@ -9282,7 +9280,7 @@ pub fn central_feature_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let near1 = || {
     crate::emit_message(&format!(
       "CentralFeature::near1: {} is neither a list of real points nor a valid list of rules.",
-      crate::syntax::expr_to_string(data)
+      expr_to_string(data)
     ));
   };
 
@@ -9416,8 +9414,7 @@ fn central_feature_index(keys: &[Expr]) -> Result<usize, InterpreterError> {
       .collect()
   } else {
     // Discrete equality metric.
-    let reprs: Vec<String> =
-      keys.iter().map(crate::syntax::expr_to_string).collect();
+    let reprs: Vec<String> = keys.iter().map(expr_to_string).collect();
     (0..n)
       .map(|i| (0..n).filter(|&j| reprs[i] != reprs[j]).count() as f64)
       .collect()

--- a/src/functions/math_ast/triangles.rs
+++ b/src/functions/math_ast/triangles.rs
@@ -9,7 +9,7 @@
 //! lengths pass through fine.
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, expr_to_output};
 
 fn fc(name: &str, args: Vec<Expr>) -> Expr {
   Expr::FunctionCall {
@@ -45,10 +45,7 @@ fn fraction_parts(e: &Expr) -> Option<(String, String)> {
     Expr::FunctionCall { name, args }
       if name == "Rational" && args.len() == 2 =>
     {
-      Some((
-        crate::syntax::expr_to_output(&args[0]),
-        crate::syntax::expr_to_output(&args[1]),
-      ))
+      Some((expr_to_output(&args[0]), expr_to_output(&args[1])))
     }
     // A product with a Rational coefficient — Times may appear either as a
     // FunctionCall or as an infix BinaryOp node.
@@ -56,18 +53,15 @@ fn fraction_parts(e: &Expr) -> Option<(String, String)> {
       rational_times(&args[0], &args[1])
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => rational_times(left, right),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
-    } => Some((
-      crate::syntax::expr_to_output(left),
-      crate::syntax::expr_to_output(right),
-    )),
+    } => Some((expr_to_output(left), expr_to_output(right))),
     _ => None,
   }
 }
@@ -79,12 +73,12 @@ fn rational_times(coeff: &Expr, rest: &Expr) -> Option<(String, String)> {
     && name == "Rational"
     && args.len() == 2
   {
-    let rest = crate::syntax::expr_to_output(rest);
+    let rest = expr_to_output(rest);
     let num = match &args[0] {
       Expr::Integer(1) => rest,
-      p => format!("{} {}", crate::syntax::expr_to_output(p), rest),
+      p => format!("{} {}", expr_to_output(p), rest),
     };
-    return Some((num, crate::syntax::expr_to_output(&args[1])));
+    return Some((num, expr_to_output(&args[1])));
   }
   None
 }
@@ -126,7 +120,7 @@ fn emit_asm(head: &str, a1: &Expr, a2: &Expr) {
           bot.push_str(&center(&den));
         }
         None => {
-          let s = crate::syntax::expr_to_output(e);
+          let s = expr_to_output(e);
           mid.push_str(&s);
           top.push_str(&" ".repeat(s.chars().count()));
           bot.push_str(&" ".repeat(s.chars().count()));
@@ -453,7 +447,7 @@ pub fn triangle_measurement_ast(
   if crate::functions::math_ast::try_eval_to_f64(&signed) == Some(0.0) {
     crate::emit_message(&format!(
       "TriangleMeasurement::invtri: {} expected to specify a nondegenerate triangle in the plane.",
-      crate::syntax::expr_to_output(&args[0])
+      expr_to_output(&args[0])
     ));
     return unevaluated();
   }

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1,14 +1,12 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// Try to express a symbolic expression as a rational multiple of Pi: k*Pi/n.
 /// Returns Some((k, n)) in lowest terms, None if not recognized.
 /// Handles patterns: Pi, n*Pi, Pi/d, n*Pi/d, n*Degree, Degree, and FunctionCall variants.
 fn try_symbolic_pi_fraction(expr: &Expr) -> Option<(i64, i64)> {
-  use crate::syntax::BinaryOperator;
-
   // Helper to extract an integer value
   fn as_int(e: &Expr) -> Option<i64> {
     match e {
@@ -195,7 +193,7 @@ fn try_symbolic_pi_fraction(expr: &Expr) -> Option<(i64, i64)> {
       // Times[n, BinaryOp::Divide(Pi, d)] or Times[n, BinaryOp::Divide(n2*Pi, d)]
       if let Some(n) = as_int(&args[0])
         && let Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: num,
           right: den,
         } = &args[1]
@@ -216,7 +214,6 @@ fn try_symbolic_pi_fraction(expr: &Expr) -> Option<(i64, i64)> {
 /// Collect the additive terms of a sum, handling both the `Plus[...]` and the
 /// `BinaryOp` Plus/Minus representations.
 fn collect_plus_terms(e: &Expr, out: &mut Vec<Expr>) {
-  use crate::syntax::BinaryOperator;
   match e {
     Expr::FunctionCall { name, args } if name == "Plus" => {
       for a in args {
@@ -246,12 +243,11 @@ fn collect_plus_terms(e: &Expr, out: &mut Vec<Expr>) {
 /// Whether a canonical Plus term carries a negative leading sign
 /// (a negative number, `-x`, or a product with a negative coefficient).
 fn term_is_negative(e: &Expr) -> bool {
-  use crate::syntax::BinaryOperator;
   match e {
     Expr::Integer(n) => *n < 0,
     Expr::Real(v) => *v < 0.0,
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       ..
     } => true,
     Expr::FunctionCall { name, args }
@@ -283,7 +279,6 @@ fn term_is_negative(e: &Expr) -> bool {
 /// Returns `(k mod 4, flip, (pn, pd), rest_terms)` with the residual phase
 /// `pn/pd * Pi`, or None when the argument is already canonical.
 fn extract_pi_phase(arg: &Expr) -> Option<(i64, bool, (i64, i64), Vec<Expr>)> {
-  use crate::syntax::BinaryOperator;
   let is_sum = matches!(arg, Expr::FunctionCall { name, .. } if name == "Plus")
     || matches!(
       arg,
@@ -520,14 +515,14 @@ fn exact_sin(k: i64, n: i64) -> Option<Expr> {
     (0, _) => Expr::Integer(0),
     // sin(Pi/12) = (-1 + Sqrt[3]) / (2*Sqrt[2])
     (1, 12) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Integer(-1)),
         right: Box::new(make_sqrt(Expr::Integer(3))),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(make_sqrt(Expr::Integer(2))),
       }),
@@ -536,26 +531,26 @@ fn exact_sin(k: i64, n: i64) -> Option<Expr> {
     (1, 6) => make_rational(1, 2),
     // sin(Pi/4) = 1/Sqrt[2]
     (1, 4) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Integer(1)),
       right: Box::new(make_sqrt(Expr::Integer(2))),
     },
     // sin(Pi/3) = Sqrt[3]/2
     (1, 3) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(make_sqrt(Expr::Integer(3))),
       right: Box::new(Expr::Integer(2)),
     },
     // sin(5*Pi/12) = (1 + Sqrt[3]) / (2*Sqrt[2])
     (5, 12) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(make_sqrt(Expr::Integer(3))),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(make_sqrt(Expr::Integer(2))),
       }),
@@ -611,27 +606,27 @@ fn exact_cos(k: i64, n: i64) -> Option<Expr> {
     (0, _) => Expr::Integer(1),
     // cos(Pi/12) = (1 + Sqrt[3]) / (2*Sqrt[2])
     (1, 12) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(make_sqrt(Expr::Integer(3))),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(make_sqrt(Expr::Integer(2))),
       }),
     },
     // cos(Pi/6) = Sqrt[3]/2
     (1, 6) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(make_sqrt(Expr::Integer(3))),
       right: Box::new(Expr::Integer(2)),
     },
     // cos(Pi/4) = 1/Sqrt[2]
     (1, 4) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Integer(1)),
       right: Box::new(make_sqrt(Expr::Integer(2))),
     },
@@ -639,14 +634,14 @@ fn exact_cos(k: i64, n: i64) -> Option<Expr> {
     (1, 3) => make_rational(1, 2),
     // cos(5*Pi/12) = (-1 + Sqrt[3]) / (2*Sqrt[2])
     (5, 12) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Integer(-1)),
         right: Box::new(make_sqrt(Expr::Integer(3))),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(make_sqrt(Expr::Integer(2))),
       }),
@@ -703,13 +698,13 @@ fn exact_tan(k: i64, n: i64) -> Option<Expr> {
     (0, _) => Expr::Integer(0),
     // tan(Pi/12) = 2 - Sqrt[3]
     (1, 12) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::Integer(2)),
       right: Box::new(make_sqrt(Expr::Integer(3))),
     },
     // tan(Pi/6) = 1/Sqrt[3]
     (1, 6) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Integer(1)),
       right: Box::new(make_sqrt(Expr::Integer(3))),
     },
@@ -719,7 +714,7 @@ fn exact_tan(k: i64, n: i64) -> Option<Expr> {
     (1, 3) => make_sqrt(Expr::Integer(3)),
     // tan(5*Pi/12) = 2 + Sqrt[3]
     (5, 12) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(Expr::Integer(2)),
       right: Box::new(make_sqrt(Expr::Integer(3))),
     },
@@ -770,7 +765,7 @@ fn exact_sec(k: i64, n: i64) -> Option<Expr> {
     (0, _) => Expr::Integer(1),
     // Sec(Pi/6) = 2/Sqrt[3]
     (1, 6) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Integer(2)),
       right: Box::new(make_sqrt(Expr::Integer(3))),
     },
@@ -831,7 +826,7 @@ fn exact_csc(k: i64, n: i64) -> Option<Expr> {
     (1, 4) => make_sqrt(Expr::Integer(2)),
     // Csc(Pi/3) = 2/Sqrt[3]
     (1, 3) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Integer(2)),
       right: Box::new(make_sqrt(Expr::Integer(3))),
     },
@@ -884,7 +879,7 @@ fn exact_cot(k: i64, n: i64) -> Option<Expr> {
   let val = match (kr, nr) {
     // Cot(Pi/12) = 2 + Sqrt[3]
     (1, 12) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(Expr::Integer(2)),
       right: Box::new(make_sqrt(Expr::Integer(3))),
     },
@@ -894,13 +889,13 @@ fn exact_cot(k: i64, n: i64) -> Option<Expr> {
     (1, 4) => Expr::Integer(1),
     // Cot(Pi/3) = 1/Sqrt[3]
     (1, 3) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Integer(1)),
       right: Box::new(make_sqrt(Expr::Integer(3))),
     },
     // Cot(5*Pi/12) = 2 - Sqrt[3]
     (5, 12) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::Integer(2)),
       right: Box::new(make_sqrt(Expr::Integer(3))),
     },
@@ -938,17 +933,17 @@ fn canonicalize_exact_trig_value(
   exact: Expr,
 ) -> Result<Expr, crate::InterpreterError> {
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = &exact
     && let Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } = operand.as_ref()
   {
     let distributed = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(negate_expr((**left).clone())),
       right: Box::new(negate_expr((**right).clone())),
     };
@@ -963,7 +958,7 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
     Expr::Real(f) => return Expr::Real(-*f),
     // --x => x (collapse instead of stacking another wrapper)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       return *std::mem::replace(operand, Box::new(Expr::Integer(0)));
@@ -1010,7 +1005,7 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
       };
     }
     Expr::BinaryOp { op, left, right }
-      if *op == crate::syntax::BinaryOperator::Times
+      if *op == BinaryOperator::Times
         && matches!(left.as_ref(), Expr::Integer(n) if *n != 0) =>
     {
       let Expr::Integer(n) = **left else {
@@ -1021,7 +1016,7 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
       }
       let right = std::mem::replace(right, Box::new(Expr::Integer(0)));
       return Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(-n)),
         right,
       };
@@ -1054,34 +1049,28 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
     }
     // -(a + b) => (-a) + (-b): distribute over a sum so the result keeps the
     // flattened additive form Wolfram displays (e.g. -(-1 + Sqrt[5]) => 1 - Sqrt[5]).
-    Expr::BinaryOp { op, left, right }
-      if *op == crate::syntax::BinaryOperator::Plus =>
-    {
+    Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Plus => {
       let left = std::mem::replace(left, Box::new(Expr::Integer(0)));
       let right = std::mem::replace(right, Box::new(Expr::Integer(0)));
       return Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(negate_expr(*left)),
         right: Box::new(negate_expr(*right)),
       };
     }
     // -(a - b) => (-a) + b: likewise distribute over a difference so the
     // result keeps the additive form (e.g. -(2 - Sqrt[3]) => -2 + Sqrt[3]).
-    Expr::BinaryOp { op, left, right }
-      if *op == crate::syntax::BinaryOperator::Minus =>
-    {
+    Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Minus => {
       let left = std::mem::replace(left, Box::new(Expr::Integer(0)));
       let right = std::mem::replace(right, Box::new(Expr::Integer(0)));
       return Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(negate_expr(*left)),
         right: Box::new(*right),
       };
     }
     // -(a/b) => Times[-1, a/b] to match Wolfram output style
-    Expr::BinaryOp { op, left, right }
-      if *op == crate::syntax::BinaryOperator::Divide =>
-    {
+    Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Divide => {
       // If numerator is an integer, negate it directly: -(n/b) => (-n)/b
       if let Expr::Integer(n) = &**left
         && *n > 1
@@ -1089,7 +1078,7 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
         let neg_left = Box::new(Expr::Integer(-*n));
         let right = std::mem::replace(right, Box::new(Expr::Integer(0)));
         return Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: neg_left,
           right,
         };
@@ -1104,7 +1093,7 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
         ];
         if let Some(rest) = rest {
           factors.push(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(rest),
             right: Box::new(Expr::Integer(-1)),
           });
@@ -1151,7 +1140,7 @@ fn denom_integer_factor(denom: &Expr) -> Option<(i128, Option<Expr>)> {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -1269,15 +1258,15 @@ fn imaginary_arg_reduction(
 /// argument's square expands (e.g. `(2 y)^2 -> 4 y^2`), matching wolframscript.
 fn sqrt_one_pm_sq(x: &Expr, plus: bool) -> Expr {
   let x_sq = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(x.clone()),
     right: Box::new(Expr::Integer(2)),
   };
   let inner = Expr::BinaryOp {
     op: if plus {
-      crate::syntax::BinaryOperator::Plus
+      BinaryOperator::Plus
     } else {
-      crate::syntax::BinaryOperator::Minus
+      BinaryOperator::Minus
     },
     left: Box::new(Expr::Integer(1)),
     right: Box::new(x_sq),
@@ -1305,7 +1294,7 @@ fn sqrt_one_plus_sq(x: &Expr) -> Expr {
 
 fn divide(num: Expr, den: Expr) -> Expr {
   let quotient = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(num),
     right: Box::new(den),
   };
@@ -1358,19 +1347,19 @@ fn reciprocal_trig_of_inverse(outer: &str, inner: &Expr) -> Option<Expr> {
 /// the hyperbolic-of-ArcCosh identities.
 fn arccosh_branch_form(x: &Expr) -> Expr {
   let one_plus = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(Expr::Integer(1)),
     right: Box::new(x.clone()),
   };
   let minus_one_plus = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(Expr::Integer(-1)),
     right: Box::new(x.clone()),
   };
   let sqrt = Expr::FunctionCall {
     name: "Sqrt".to_string(),
     args: vec![Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(minus_one_plus),
       right: Box::new(one_plus.clone()),
     }]
@@ -2132,7 +2121,7 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if matches!(&args[1], Expr::Integer(0)) {
       let erf_z0 = erf_ast(&args[..1])?;
       return crate::evaluator::evaluate_expr_to_expr(&Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(erf_z0),
       });
     }
@@ -2167,7 +2156,7 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Helper: negate the Erf of the positive part
   let negate_erf = |inner: Expr| -> Expr {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::FunctionCall {
         name: "Erf".to_string(),
         args: vec![inner].into(),
@@ -2193,14 +2182,14 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // Erf[-Infinity] = -1 (UnaryOp form)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity") => {
       Ok(Expr::Integer(-1))
     }
     // Erf[-x] = -Erf[x] (UnaryOp form)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Ok(negate_erf(*operand.clone())),
     // Erf[Times[-1, x]] = -Erf[x] (evaluated form of -x)
@@ -2230,7 +2219,7 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // BinaryOp::Times form: -1 * x
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -2244,7 +2233,7 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         && *n < 0
       {
         let pos_arg = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(-*n)),
           right: right.clone(),
         };
@@ -2279,7 +2268,7 @@ pub fn erfc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Erfc[Infinity] = 0, Erfc[-Infinity] = 2
     Expr::Identifier(s) if s == "Infinity" => Ok(Expr::Integer(0)),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity") => {
       Ok(Expr::Integer(2))
@@ -2318,7 +2307,7 @@ pub fn erfi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let negate_erfi = |inner: Expr| -> Result<Expr, InterpreterError> {
     let inner_result = erfi_ast(&[inner])?;
     Ok(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(inner_result),
     })
   };
@@ -2331,7 +2320,7 @@ pub fn erfi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // Erfi[-x] = -Erfi[x] (UnaryOp form)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => negate_erfi(*operand.clone()),
     // Erfi[Times[-1, x]] = -Erfi[x] (evaluated form of -x)
@@ -2361,7 +2350,7 @@ pub fn erfi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // BinaryOp::Times form: -1 * x
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -2375,7 +2364,7 @@ pub fn erfi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         && *n < 0
       {
         let pos_arg = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(-*n)),
           right: right.clone(),
         };
@@ -2411,7 +2400,7 @@ pub fn dawson_f_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let negate = |inner: Expr| -> Result<Expr, InterpreterError> {
     let inner_result = dawson_f_ast(&[inner])?;
     Ok(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(inner_result),
     })
   };
@@ -2422,7 +2411,7 @@ pub fn dawson_f_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Identifier(s) if s == "Infinity" => Ok(Expr::Integer(0)),
     // DawsonF[-x] = -DawsonF[x] (UnaryOp form)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => negate(*operand.clone()),
     // DawsonF[Times[-1, x]] = -DawsonF[x]
@@ -2451,7 +2440,7 @@ pub fn dawson_f_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // BinaryOp::Times form: -1 * x
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -2465,7 +2454,7 @@ pub fn dawson_f_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         && *n < 0
       {
         let pos_arg = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(-*n)),
           right: right.clone(),
         };
@@ -2501,7 +2490,7 @@ pub fn inverse_erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(1) => Ok(Expr::Identifier("Infinity".to_string())),
     // InverseErf[-1] = -Infinity
     Expr::Integer(-1) => Ok(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Identifier("Infinity".to_string())),
     }),
     // Numeric evaluation for Real arguments
@@ -2514,7 +2503,7 @@ pub fn inverse_erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(Expr::Identifier("Infinity".to_string()))
       } else if *f == -1.0 {
         Ok(Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(Expr::Identifier("Infinity".to_string())),
         })
       } else {
@@ -2547,7 +2536,7 @@ pub fn inverse_erfc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(1) => Ok(Expr::Integer(0)),
     // InverseErfc[2] = -Infinity
     Expr::Integer(2) => Ok(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Identifier("Infinity".to_string())),
     }),
     // Reflection for an exact rational z with 1 < z < 2:
@@ -2564,7 +2553,7 @@ pub fn inverse_erfc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       };
       let inner = inverse_erfc_ast(&[make_rational(2 * q - p, *q)])?;
       Ok(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(inner),
       })
     }
@@ -2579,7 +2568,7 @@ pub fn inverse_erfc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(Expr::Identifier("Infinity".to_string()))
       } else if *f == 2.0 {
         Ok(Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(Expr::Identifier("Infinity".to_string())),
         })
       } else {
@@ -2666,7 +2655,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Log[0] = -Infinity
       if matches!(&args[0], Expr::Integer(0)) {
         return Ok(Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(Expr::Identifier("Infinity".to_string())),
         });
       }
@@ -2695,7 +2684,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           )
         };
         if let Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left,
           right,
         } = &args[0]
@@ -2725,7 +2714,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         let e_exp: Option<&Expr> = match &args[0] {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left,
             right,
           } if matches!(left.as_ref(), Expr::Constant(c) if c == "E") => {
@@ -2782,7 +2771,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         let power_parts: Option<(&Expr, &Expr)> = match &args[0] {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left,
             right,
           } => Some((left.as_ref(), right.as_ref())),
@@ -2842,13 +2831,13 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             true
           }
           Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand,
           } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "I") => {
             true
           }
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left,
             right,
           } if matches!(left.as_ref(), Expr::Integer(-1))
@@ -2924,7 +2913,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           name: "Plus".to_string(),
           args: vec![
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(Expr::Identifier("I".to_string())),
               right: Box::new(Expr::Constant("Pi".to_string())),
             },
@@ -2944,7 +2933,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let abs_n = -*n;
         // I*Pi
         let i_pi = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Identifier("I".to_string())),
           right: Box::new(Expr::Constant("Pi".to_string())),
         };
@@ -2965,7 +2954,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         let inner = match &args[0] {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left,
             right,
           } if matches!(left.as_ref(), Expr::Integer(-1)) => {
@@ -2982,7 +2971,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         if let Some(inner_expr) = inner {
           let i_pi = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Identifier("I".to_string())),
             right: Box::new(Expr::Constant("Pi".to_string())),
           };
@@ -3023,7 +3012,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           args: vec![inverted].into(),
         };
         return Ok(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(-1)),
           right: Box::new(log_inv),
         });
@@ -3118,7 +3107,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Canonicalize Log[base, x] → Log[x]/Log[base] (evaluated so
       // sub-expressions like Log[0] collapse to -Infinity).
       let result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::FunctionCall {
           name: "Log".to_string(),
           args: vec![args[1].clone()].into(),
@@ -3171,7 +3160,7 @@ pub fn log10_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Symbolic fallback: Log10[x] = Log[x] / Log[10]
   let expr = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(Expr::FunctionCall {
       name: "Log".to_string(),
       args: args.to_vec().into(),
@@ -3214,7 +3203,7 @@ pub fn log2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Symbolic fallback: Log2[x] = Log[x] / Log[2]
   let expr = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(Expr::FunctionCall {
       name: "Log".to_string(),
       args: args.to_vec().into(),
@@ -3267,7 +3256,7 @@ pub fn arcsin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(0) => return Ok(Expr::Integer(0)),
     Expr::Integer(1) => {
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(Expr::Integer(2)),
       });
@@ -3275,7 +3264,7 @@ pub fn arcsin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(-1) => {
       // -1/2*Pi = Times[Rational[-1, 2], Pi]
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::FunctionCall {
           name: "Rational".to_string(),
           args: vec![Expr::Integer(-1), Expr::Integer(2)].into(),
@@ -3322,12 +3311,12 @@ fn imaginary_infinity_sign(expr: &Expr) -> Option<i8> {
   };
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } if match_pair(left, right) => Some(1),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => imaginary_infinity_sign(operand).map(|s| -s),
     Expr::FunctionCall { name, args } if name == "Times" => {
@@ -3356,7 +3345,7 @@ fn imaginary_infinity_sign(expr: &Expr) -> Option<i8> {
               has_inf = true;
             }
             Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand,
             } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "I") => {
               has_i = true;
@@ -3380,7 +3369,7 @@ fn imaginary_infinity_sign(expr: &Expr) -> Option<i8> {
       match &args[0] {
         Expr::Identifier(s) if s == "I" => Some(1),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand,
         } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "I") => {
           Some(-1)
@@ -3410,7 +3399,7 @@ pub fn arccos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(1) => return Ok(Expr::Integer(0)),
     Expr::Integer(0) => {
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(Expr::Integer(2)),
       });
@@ -3437,7 +3426,7 @@ pub fn arccos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let direction = if sign > 0 {
       // Negate I: Times[-1, I]
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(-1)),
         right: Box::new(Expr::Identifier("I".to_string())),
       }
@@ -3472,7 +3461,7 @@ fn arccos_special_value(v: f64) -> Option<Expr> {
         Expr::Constant("Pi".to_string())
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(num)),
           right: Box::new(Expr::Constant("Pi".to_string())),
         }
@@ -3482,13 +3471,13 @@ fn arccos_special_value(v: f64) -> Option<Expr> {
         Expr::Constant("Pi".to_string())
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(num)),
           right: Box::new(Expr::Constant("Pi".to_string())),
         }
       };
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(numerator),
         right: Box::new(Expr::Integer(den)),
       }
@@ -3531,7 +3520,7 @@ fn arcsin_special_value(v: f64) -> Option<Expr> {
       if v < 0.0 {
         // Negative: build Times[Rational[-1, den], Pi] to display as -1/den*Pi
         return Some(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::FunctionCall {
             name: "Rational".to_string(),
             args: vec![Expr::Integer(-1), Expr::Integer(den)].into(),
@@ -3542,7 +3531,7 @@ fn arcsin_special_value(v: f64) -> Option<Expr> {
         return Some(Expr::Constant("Pi".to_string()));
       } else {
         return Some(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::Constant("Pi".to_string())),
           right: Box::new(Expr::Integer(den)),
         });
@@ -3588,7 +3577,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(0) => return Ok(Expr::Integer(0)),
     Expr::Integer(1) => {
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(Expr::Integer(4)),
       });
@@ -3596,7 +3585,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(-1) => {
       // -1/4*Pi = Times[Rational[-1, 4], Pi]
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::FunctionCall {
           name: "Rational".to_string(),
           args: vec![Expr::Integer(-1), Expr::Integer(4)].into(),
@@ -3607,7 +3596,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Identifier(s) if s == "Infinity" => {
       // ArcTan[Infinity] = Pi/2
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(Expr::Integer(2)),
       });
@@ -3638,7 +3627,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if (val - sqrt3).abs() < eps {
       // ArcTan[Sqrt[3]] = Pi/3
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(Expr::Integer(3)),
       });
@@ -3661,7 +3650,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if (val - inv_sqrt3).abs() < eps {
       // ArcTan[1/Sqrt[3]] = Pi/6
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(Expr::Integer(6)),
       });
@@ -3685,7 +3674,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let k_over_12_pi = |k: i128| -> Expr {
       if k == 1 {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::Constant("Pi".to_string())),
           right: Box::new(Expr::Integer(12)),
         }
@@ -3771,14 +3760,14 @@ pub fn arctan2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Expr::Constant("Pi".to_string())
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(num)),
           right: Box::new(Expr::Constant("Pi".to_string())),
         }
       }
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::FunctionCall {
           name: "Rational".to_string(),
           args: vec![Expr::Integer(num), Expr::Integer(den)].into(),
@@ -3835,7 +3824,7 @@ pub fn arctan2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::Constant("Pi".to_string())
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(-1)),
         right: Box::new(Expr::Constant("Pi".to_string())),
       }
@@ -3860,14 +3849,12 @@ pub fn arctan2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// This is more general than try_extract_complex_exact since real_part
 /// can be any expression (e.g., Pi, Pi/6, symbolic).
 fn try_split_real_imag(expr: &Expr) -> Option<(Expr, (i128, i128))> {
-  use crate::syntax::BinaryOperator;
-
   // Helper: check if expr is purely I*rational (no real part)
   fn as_imag_only(e: &Expr) -> Option<(i128, i128)> {
     match e {
       Expr::Identifier(name) if name == "I" => Some((1, 1)),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => {
         let (n, d) = as_imag_only(operand)?;
@@ -3987,7 +3974,7 @@ fn try_extract_negated(expr: &Expr) -> Option<Expr> {
     Expr::Integer(n) if *n < 0 => Some(Expr::Integer(-n)),
     Expr::Real(f) if *f < 0.0 => Some(Expr::Real(-f)),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some((**operand).clone()),
     Expr::FunctionCall { name, args }
@@ -4004,7 +3991,7 @@ fn try_extract_negated(expr: &Expr) -> Option<Expr> {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -4013,7 +4000,7 @@ fn try_extract_negated(expr: &Expr) -> Option<Expr> {
           Some((**right).clone())
         } else {
           Some(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(negated),
             right: right.clone(),
           })
@@ -4160,7 +4147,7 @@ fn circular_at_infinity(
   }
   let inf = || Expr::Identifier("Infinity".to_string());
   let neg_inf = || Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(Expr::Integer(-1)),
     right: Box::new(Expr::Identifier("Infinity".to_string())),
   };
@@ -4522,11 +4509,11 @@ pub fn arcsinh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::Identifier("ComplexInfinity".to_string()));
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity") => {
       return Ok(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("Infinity".to_string())),
       });
     }
@@ -4618,7 +4605,7 @@ pub fn arccosh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::Identifier("Infinity".to_string()));
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity") => {
       return Ok(Expr::Identifier("Infinity".to_string()));
@@ -4664,7 +4651,7 @@ pub fn arctanh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(1) => return Ok(Expr::Identifier("Infinity".to_string())),
     Expr::Integer(-1) => {
       return Ok(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("Infinity".to_string())),
       });
     }
@@ -4753,7 +4740,7 @@ pub fn arccoth_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(1) => return Ok(Expr::Identifier("Infinity".to_string())),
     Expr::Integer(-1) => {
       return Ok(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("Infinity".to_string())),
       });
     }
@@ -5057,7 +5044,7 @@ pub fn arccsch_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Construct Pi/n as an AST expression
 fn pi_over_n(n: i128) -> Expr {
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(Expr::Constant("Pi".to_string())),
     right: Box::new(Expr::Integer(n)),
   }
@@ -5065,9 +5052,9 @@ fn pi_over_n(n: i128) -> Expr {
 
 fn negative_pi_over_2() -> Expr {
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Integer(-1)),
       right: Box::new(Expr::Integer(2)),
     }),
@@ -5091,7 +5078,7 @@ fn extract_half_odd_pi_i_coefficient(e: &Expr) -> Option<i128> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -5162,7 +5149,7 @@ pub fn gudermannian_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::Identifier("I".to_string())
     } else {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("I".to_string())),
       }
     };
@@ -5182,7 +5169,7 @@ pub fn gudermannian_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Identifier(name) if name == "Infinity" => {
       // Gudermannian[Infinity] = Pi/2
       return Ok(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(Expr::Integer(2)),
       });
@@ -5202,14 +5189,14 @@ pub fn gudermannian_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // -Infinity (as UnaryOp)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if matches!(operand.as_ref(), Expr::Identifier(n) if n == "Infinity") => {
       return Ok(negative_pi_over_2());
     }
     // -Infinity (as BinaryOp)
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } if matches!(left.as_ref(), Expr::Integer(-1))
@@ -5291,7 +5278,7 @@ pub fn logistic_sigmoid_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // they are NOT numericized.
     Expr::Identifier(s) if s == "Infinity" => return Ok(Expr::Integer(1)),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity") => {
       return Ok(Expr::Integer(0));
@@ -5631,7 +5618,6 @@ fn expand_trig_function(name: &str, arg: &Expr) -> Expr {
 
 /// Collect additive terms from a Plus/Minus expression.
 fn collect_additive_terms(expr: &Expr) -> Vec<Expr> {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Plus,
@@ -5662,7 +5648,6 @@ fn collect_additive_terms(expr: &Expr) -> Vec<Expr> {
 
 /// Extract integer factor from n*x. Returns (n, x).
 fn extract_integer_factor(expr: &Expr) -> (i128, Expr) {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Times,
@@ -5977,7 +5962,7 @@ fn trig_reduce_recursive(expr: &Expr) -> Expr {
     }
     // Handle BinaryOp Times — two-factor product
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -5987,7 +5972,7 @@ fn trig_reduce_recursive(expr: &Expr) -> Expr {
     }
     // Handle Power[Sin[x], n] or Power[Cos[x], n]
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -5999,7 +5984,7 @@ fn trig_reduce_recursive(expr: &Expr) -> Expr {
         return result;
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(base),
         right: Box::new(trig_reduce_recursive(right)),
       }
@@ -6080,7 +6065,7 @@ fn reduce_two_factor_product(a: &Expr, b: &Expr) -> Expr {
     return result;
   }
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(a.clone()),
     right: Box::new(b.clone()),
   }
@@ -6092,19 +6077,19 @@ fn try_reduce_trig_pair(a: &Expr, b: &Expr) -> Option<Expr> {
   let (b_name, b_arg) = extract_trig(b)?;
 
   let sum = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(a_arg.clone()),
     right: Box::new(b_arg.clone()),
   };
   let diff = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left: Box::new(a_arg.clone()),
     right: Box::new(b_arg.clone()),
   };
 
   let half = |e: Expr| -> Expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(e),
       right: Box::new(Expr::Integer(2)),
     }
@@ -6132,17 +6117,17 @@ fn try_reduce_trig_pair(a: &Expr, b: &Expr) -> Option<Expr> {
         (b_arg, a_arg)
       };
       let s = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(sin_arg.clone()),
         right: Box::new(cos_arg.clone()),
       };
       let d = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(sin_arg),
         right: Box::new(cos_arg),
       };
       let result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(sin(s)),
         right: Box::new(sin(d)),
       };
@@ -6151,7 +6136,7 @@ fn try_reduce_trig_pair(a: &Expr, b: &Expr) -> Option<Expr> {
     // Cos[a]*Cos[b] = (Cos[a-b] + Cos[a+b])/2
     ("Cos", "Cos") => {
       let result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(cos(diff)),
         right: Box::new(cos(sum)),
       };
@@ -6160,7 +6145,7 @@ fn try_reduce_trig_pair(a: &Expr, b: &Expr) -> Option<Expr> {
     // Sin[a]*Sin[b] = (Cos[a-b] - Cos[a+b])/2
     ("Sin", "Sin") => {
       let result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(cos(diff)),
         right: Box::new(cos(sum)),
       };
@@ -6194,7 +6179,7 @@ fn reduce_trig_power(base: &Expr, n: i128) -> Option<Expr> {
       arg.clone()
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(coeff)),
         right: Box::new(arg.clone()),
       }
@@ -6265,13 +6250,13 @@ fn reduce_trig_power(base: &Expr, n: i128) -> Option<Expr> {
           terms.push(trig_call);
         } else if reduced_c == -1 {
           terms.push(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(-1)),
             right: Box::new(trig_call),
           });
         } else {
           terms.push(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(reduced_c)),
             right: Box::new(trig_call),
           });
@@ -6293,7 +6278,7 @@ fn reduce_trig_power(base: &Expr, n: i128) -> Option<Expr> {
     Some(numerator)
   } else {
     Some(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(numerator),
       right: Box::new(Expr::Integer(reduced_denom)),
     })
@@ -6303,7 +6288,7 @@ fn reduce_trig_power(base: &Expr, n: i128) -> Option<Expr> {
 fn try_reduce_with_power(a: &Expr, b: &Expr) -> Option<Expr> {
   // Check if a is Sin[x]^n or Cos[x]^n
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left,
     right,
   } = a


### PR DESCRIPTION
Using full names for types and functions introduces a lot of visual noise to the woxi source code.  BinaryOperator reads better than crate::syntax::BinaryOperator. This change makes those changes throughout the math_ast source files.