### PR TITLE
Reduce Stirling number memory usage.

### DIFF
--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -19337,15 +19337,15 @@ fn signed_stirling_first_row(n: usize) -> Vec<i128> {
   // Start at row 0: s(0, 0) = 1, all other s(0, k) = 0.
   let mut row = vec![0i128; n + 1];
   row[0] = 1;
+  let mut next = vec![0i128; n + 1];
   // Build up row by row using s(m+1, k) = s(m, k-1) - m * s(m, k).
   for m in 0..n {
-    let mut next = vec![0i128; n + 1];
     for k in 0..=(m + 1) {
       let from_left = if k > 0 { row[k - 1] } else { 0 };
-      let from_above = row.get(k).copied().unwrap_or(0);
+      let from_above = row[k];
       next[k] = from_left - (m as i128) * from_above;
     }
-    row = next;
+    (row, next) = (next, row);
   }
   row
 }

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -1539,21 +1539,26 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   if args.len() == 1 {
-    // Bell number B_n
+    // Bell number B_n via the Bell triangle
     if n == 0 {
       return Ok(Expr::Integer(1));
     }
-    // Compute using B[n] = Sum[Binomial[n-1, k] B[k], {k, 0, n-1}]
-    let mut bell = vec![BigInt::from(0); n + 1];
-    bell[0] = BigInt::from(1);
+    // Compute using the Bell triangle (first column of each row), in BigInt
+    // so large Bell numbers (e.g. BellB[50], 48 digits) don't overflow i128.
+    let zero = BigInt::from(0);
+    let one = BigInt::from(1);
+    let mut row = vec![zero.clone(); n + 1];
+    row[0] = one.clone();
+    let mut next = vec![zero.clone(); n + 1];
     for i in 1..=n {
-      for k in 0..=i - 1 {
-        bell[i] =
-          &bell[i] + binomial_coeff_big((i - 1) as i128, k as i128) * &bell[k];
+      next[0] = &row[i - 1] - &row[0];
+      for j in 1..=i {
+        next[j] = &next[j - 1] + &row[j - 1];
       }
+      (row, next) = (next, row);
     }
 
-    Ok(crate::functions::math_ast::bigint_to_expr(bell[n].clone()))
+    Ok(crate::functions::math_ast::bigint_to_expr(row[n].clone()))
   } else {
     // Bell polynomial B_n(x) = sum_{k=0}^{n} S(n,k) * x^k
     // where S(n,k) is the Stirling number of the second kind
@@ -1564,19 +1569,21 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // large coefficients (e.g. BellB[50, x]) don't overflow i128.
     let zero = BigInt::from(0);
     let one = BigInt::from(1);
-    let mut stirling = vec![vec![zero.clone(); n + 1]; n + 1];
-    stirling[0][0] = one.clone();
+    let mut row = vec![zero.clone(); n + 1];
+    row[0] = one.clone();
+    let mut next = vec![zero.clone(); n + 1];
     for i in 1..=n {
-      for k in 1..=i {
-        stirling[i][k] = BigInt::from(k as i128) * &stirling[i - 1][k]
-          + &stirling[i - 1][k - 1];
+      next[0] = zero.clone();
+      for j in 1..=i {
+        next[j] = &row[j - 1] + BigInt::from(j as i128) * &row[j];
       }
+      (row, next) = (next, row);
     }
     // Build polynomial: sum_{k=0}^{n} S(n,k) * x^k
     let x = &args[1];
     let mut terms = Vec::new();
     for k in 0..=n {
-      let s = stirling[n][k].clone();
+      let s = row[k].clone();
       if s == zero {
         continue;
       }
@@ -1794,15 +1801,17 @@ pub fn stirling_s1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Use DP table with BigInt to avoid overflow
   let zero = BigInt::from(0);
   let one = BigInt::from(1);
-  let mut table = vec![vec![zero.clone(); k + 1]; n + 1];
-  table[0][0] = one;
+  let mut row = vec![zero.clone(); k + 1];
+  row[0] = one.clone();
+  let mut next = vec![zero.clone(); k + 1];
   for i in 1..=n {
+    next[0] = zero.clone();
     for j in 1..=k.min(i) {
-      table[i][j] =
-        &table[i - 1][j - 1] - BigInt::from(i - 1) * &table[i - 1][j];
+      next[j] = &row[j - 1] - BigInt::from(i - 1) * &row[j];
     }
+    (row, next) = (next, row);
   }
-  Ok(bigint_to_expr(table[n][k].clone()))
+  Ok(bigint_to_expr(row[k].clone()))
 }
 
 /// StirlingS2[n, k] - Stirling number of the second kind
@@ -1834,14 +1843,17 @@ pub fn stirling_s2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // S(n,k) = k*S(n-1,k) + S(n-1,k-1)
   let zero = BigInt::from(0);
   let one = BigInt::from(1);
-  let mut table = vec![vec![zero.clone(); k + 1]; n + 1];
-  table[0][0] = one;
+  let mut row = vec![zero.clone(); k + 1];
+  row[0] = one.clone();
+  let mut next = vec![zero.clone(); k + 1];
   for i in 1..=n {
+    next[0] = zero.clone();
     for j in 1..=k.min(i) {
-      table[i][j] = BigInt::from(j) * &table[i - 1][j] + &table[i - 1][j - 1];
+      next[j] = BigInt::from(j) * &row[j] + &row[j - 1];
     }
+    (row, next) = (next, row);
   }
-  Ok(bigint_to_expr(table[n][k].clone()))
+  Ok(bigint_to_expr(row[k].clone()))
 }
 
 /// Digamma function approximation using the asymptotic series.


### PR DESCRIPTION
S(n,k) computations only depends on S(n-1,j) values, so there's no need to remember further back than the last row of values.  So change all the code to use only two rows, and swap them on each iteration.  Do the same for Bell numbers, making the code closer to the original code I changed in fc9874f64b28a8ae0e092e3a083f598d2056ed0d.