### PR TITLE
Remove most crate::syntax::(BinaryOperator|UnaryOperator) prefixes

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 use std::cell::Cell;
 
 thread_local! {
@@ -473,7 +474,7 @@ fn count_pattern_specificity(pat: &Expr) -> u32 {
 /// flattening nested applications of the same operator.
 fn collect_binary_children(
   expr: &Expr,
-  target_op: &crate::syntax::BinaryOperator,
+  target_op: &BinaryOperator,
 ) -> Vec<Expr> {
   match expr {
     Expr::BinaryOp { op, left, right } if op == target_op => {
@@ -686,7 +687,7 @@ fn normalize_structural_pattern(pattern: &Expr) -> Expr {
 pub fn canonicalize_divide_in_expr(expr: &Expr) -> Expr {
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -699,14 +700,14 @@ pub fn canonicalize_divide_in_expr(expr: &Expr) -> Expr {
           } else {
             crate::functions::math_ast::times_ast(&[left.clone(), den_inv])
               .unwrap_or_else(|_| Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Divide,
+                op: BinaryOperator::Divide,
                 left: Box::new(left),
                 right: Box::new(right),
               })
           }
         }
         Err(_) => Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(left),
           right: Box::new(right),
         },
@@ -1163,7 +1164,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
     // place so a tight `Do[s = s <> c, …]` accumulator stays linear in
     // total work instead of paying an O(N) copy on every iteration.
     if let Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::StringJoin,
+      op: BinaryOperator::StringJoin,
       left,
       right,
     } = rhs
@@ -1773,7 +1774,7 @@ pub fn set_delayed_ast(
   // Protected.` and returns `$Failed`. Detect the BinaryOp head
   // here so the message and return value match.
   if let Expr::BinaryOp { op, .. } = lhs {
-    use crate::syntax::BinaryOperator as B;
+    use BinaryOperator as B;
     let tag = match op {
       B::Plus | B::Minus => Some("Plus"),
       B::Times | B::Divide => Some("Times"),
@@ -3058,50 +3059,50 @@ pub fn tag_set_delayed_ast(
     Expr::FunctionCall { name, args } => (name.clone(), args.to_vec()),
     Expr::BinaryOp { op, left, right } => {
       let (name, args) = match op {
-        crate::syntax::BinaryOperator::Plus => {
+        BinaryOperator::Plus => {
           ("Plus".to_string(), collect_binary_children(lhs, op))
         }
-        crate::syntax::BinaryOperator::Times => {
+        BinaryOperator::Times => {
           ("Times".to_string(), collect_binary_children(lhs, op))
         }
-        crate::syntax::BinaryOperator::Alternatives => {
+        BinaryOperator::Alternatives => {
           ("Alternatives".to_string(), collect_binary_children(lhs, op))
         }
-        crate::syntax::BinaryOperator::Minus => (
+        BinaryOperator::Minus => (
           "Plus".to_string(),
           vec![
             left.as_ref().clone(),
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(Expr::Integer(-1)),
               right: right.clone(),
             },
           ],
         ),
-        crate::syntax::BinaryOperator::Divide => (
+        BinaryOperator::Divide => (
           "Times".to_string(),
           vec![
             left.as_ref().clone(),
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: right.clone(),
               right: Box::new(Expr::Integer(-1)),
             },
           ],
         ),
-        crate::syntax::BinaryOperator::Power => (
+        BinaryOperator::Power => (
           "Power".to_string(),
           vec![left.as_ref().clone(), right.as_ref().clone()],
         ),
-        crate::syntax::BinaryOperator::And => (
+        BinaryOperator::And => (
           "And".to_string(),
           vec![left.as_ref().clone(), right.as_ref().clone()],
         ),
-        crate::syntax::BinaryOperator::Or => (
+        BinaryOperator::Or => (
           "Or".to_string(),
           vec![left.as_ref().clone(), right.as_ref().clone()],
         ),
-        crate::syntax::BinaryOperator::StringJoin => (
+        BinaryOperator::StringJoin => (
           "StringJoin".to_string(),
           vec![left.as_ref().clone(), right.as_ref().clone()],
         ),
@@ -3110,11 +3111,11 @@ pub fn tag_set_delayed_ast(
     }
     Expr::UnaryOp { op, operand } => {
       let (name, args) = match op {
-        crate::syntax::UnaryOperator::Minus => (
+        UnaryOperator::Minus => (
           "Times".to_string(),
           vec![Expr::Integer(-1), operand.as_ref().clone()],
         ),
-        crate::syntax::UnaryOperator::Not => {
+        UnaryOperator::Not => {
           ("Not".to_string(), vec![operand.as_ref().clone()])
         }
       };
@@ -3457,19 +3458,17 @@ fn normalize_lhs_for_upset(lhs: &Expr) -> Expr {
   match lhs {
     Expr::BinaryOp { op, left, right } => {
       let head = match op {
-        crate::syntax::BinaryOperator::Plus
-        | crate::syntax::BinaryOperator::Minus => "Plus",
-        crate::syntax::BinaryOperator::Times
-        | crate::syntax::BinaryOperator::Divide => "Times",
-        crate::syntax::BinaryOperator::Power => "Power",
+        BinaryOperator::Plus | BinaryOperator::Minus => "Plus",
+        BinaryOperator::Times | BinaryOperator::Divide => "Times",
+        BinaryOperator::Power => "Power",
         _ => return lhs.clone(),
       };
       let right_expr = match op {
-        crate::syntax::BinaryOperator::Minus => Expr::FunctionCall {
+        BinaryOperator::Minus => Expr::FunctionCall {
           name: "Times".to_string(),
           args: vec![Expr::Integer(-1), (**right).clone()].into(),
         },
-        crate::syntax::BinaryOperator::Divide => Expr::FunctionCall {
+        BinaryOperator::Divide => Expr::FunctionCall {
           name: "Power".to_string(),
           args: vec![(**right).clone(), Expr::Integer(-1)].into(),
         },

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::BinaryOperator;
 
 thread_local! {
   /// Symbols currently being looked up — prevents infinite recursion when
@@ -993,7 +994,7 @@ pub fn evaluate_expr_to_expr_inner(
               Expr::Integer(-1)
             };
             let new_val = evaluate_expr_to_expr(&Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(current_val.clone()),
               right: Box::new(delta),
             })?;
@@ -1019,7 +1020,7 @@ pub fn evaluate_expr_to_expr_inner(
               Expr::Integer(-1)
             };
             let new_val = evaluate_expr_to_expr(&Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(current_val.clone()),
               right: Box::new(delta),
             })?;
@@ -1258,10 +1259,10 @@ pub fn evaluate_expr_to_expr_inner(
           && args.len() == 2
         {
           let op = match name.as_str() {
-            "AddTo" => crate::syntax::BinaryOperator::Plus,
-            "SubtractFrom" => crate::syntax::BinaryOperator::Minus,
-            "TimesBy" => crate::syntax::BinaryOperator::Times,
-            "DivideBy" => crate::syntax::BinaryOperator::Divide,
+            "AddTo" => BinaryOperator::Plus,
+            "SubtractFrom" => BinaryOperator::Minus,
+            "TimesBy" => BinaryOperator::Times,
+            "DivideBy" => BinaryOperator::Divide,
             _ => unreachable!(),
           };
           if let Expr::Identifier(var_name) = &args[0] {

--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::is_sqrt;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 /// Check if the result of differentiation contains a
 /// `Derivative[...][func_name][...]` pattern (as CurriedCall),
@@ -43,7 +44,7 @@ fn contains_unresolved_derivative(expr: &Expr, func_name: &str) -> bool {
 fn match_slot_power(body: &Expr) -> Option<i128> {
   let (base, exp) = match body {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => (left.as_ref(), right.as_ref()),
@@ -78,7 +79,7 @@ pub fn build_var_power_derivative_chain(
   }
   let dn = k - n;
   let times = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(a),
     right: Box::new(b),
   };
@@ -94,7 +95,7 @@ pub fn build_var_power_derivative_chain(
       var_expr.clone()
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(var_expr.clone()),
         right: Box::new(Expr::Integer(dn)),
       }
@@ -122,7 +123,6 @@ pub fn extract_var_power_factor(
   var: &str,
 ) -> Option<(Expr, i128)> {
   use crate::functions::calculus_ast::is_constant_wrt;
-  use crate::syntax::BinaryOperator;
 
   // `var` (i.e. `var^1`).
   if matches!(expr, Expr::Identifier(s) if s == var) {
@@ -939,7 +939,6 @@ fn as_func_args(expr: &Expr) -> Option<(&str, Vec<&Expr>)> {
       Some((name.as_str(), args.iter().collect()))
     }
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator;
       let name = match op {
         BinaryOperator::Plus => "Plus",
         BinaryOperator::Minus => "Plus", // a - b is Plus[a, Times[-1, b]]
@@ -1518,8 +1517,6 @@ fn inverse_laplace_2d(
   x: &str,
   y: &str,
 ) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
-
   // F = 1/(p*q): extract num/den and check denominator = p*q.
   let (num, den) =
     crate::functions::polynomial_ast::together::extract_num_den(expr);
@@ -1795,7 +1792,7 @@ fn inverse_laplace_inner(expr: &Expr, s: &str, t: &str) -> Option<Expr> {
         || matches!(
           fargs[1],
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             ..
           }
         );
@@ -2100,7 +2097,6 @@ fn extract_s_squared_plus_const(expr: &Expr, s: &str) -> Option<Expr> {
 fn normalize_to_func_calls(expr: &Expr) -> Expr {
   match expr {
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator;
       let left = normalize_to_func_calls(left);
       let right = normalize_to_func_calls(right);
       match op {
@@ -2142,7 +2138,7 @@ fn normalize_to_func_calls(expr: &Expr) -> Expr {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let inner = normalize_to_func_calls(operand);
@@ -2450,7 +2446,7 @@ fn inverse_mellin_inner(
 ) -> Option<(Expr, bool)> {
   let neg = |e: Expr| make_times(vec![Expr::Integer(-1), e]);
   let e_pow = |e: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(Expr::Identifier("E".to_string())),
     right: Box::new(e),
   };
@@ -2671,7 +2667,7 @@ fn inverse_mellin_inner(
       && is_pi(&consts[0])
     {
       let result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(make_plus(vec![
           Expr::Constant("Pi".to_string()),
@@ -2757,10 +2753,10 @@ fn inverse_mellin_inner(
           let mut rest = consts.clone();
           rest.remove(pos);
           let result = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(make_plus(vec![Expr::Integer(1), x.clone()])),
             right: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(a_part.clone()),
             }),
           };
@@ -4037,7 +4033,7 @@ fn collect_domain_constraints(
   match expr {
     // Division: denominator != 0
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -4054,7 +4050,7 @@ fn collect_domain_constraints(
     // Power with negative exponent: base != 0
     // Power with fractional exponent (sqrt): base >= 0
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -4066,7 +4062,7 @@ fn collect_domain_constraints(
         let is_negative_power = match right.as_ref() {
           Expr::Integer(n) => *n < 0,
           Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             ..
           } => true,
           _ => false,
@@ -4161,7 +4157,7 @@ fn simplify_domain_constraint(constraint: &Expr, var: &str) -> Expr {
       ComparisonOp::NotEqual => {
         // Try to solve lhs == rhs for roots
         let diff = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(lhs.clone()),
           right: Box::new(rhs.clone()),
         };
@@ -4335,7 +4331,7 @@ fn expr_to_f64(e: &Expr) -> Option<f64> {
     Expr::Integer(n) => Some(*n as f64),
     Expr::Real(f) => Some(*f),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => expr_to_f64(operand).map(|v| -v),
     Expr::FunctionCall { name, args }
@@ -4380,7 +4376,6 @@ fn contains_variable(expr: &Expr, var: &str) -> bool {
 /// Returns `None` for anything else (left unevaluated), matching wolframscript's
 /// support for these forms.
 fn symbolic_series_coefficient(f: &Expr, spec: &Expr) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   let Expr::List(parts) = spec else {
     return None;
   };
@@ -4660,8 +4655,6 @@ fn gf_inner(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // Case 0: expr doesn't depend on n => constant * 1/(1-x)
   if !depends_on(expr, n) {
     // c/(1-x)
@@ -4842,7 +4835,6 @@ fn gf_inner(
 /// Extract shift from expression like n+1, n+2, etc.
 /// Returns (shift, variable_name) if the expression is var + constant.
 fn extract_shift<'a>(expr: &'a Expr, var: &str) -> Option<(i64, &'a str)> {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Plus,
@@ -4890,8 +4882,6 @@ fn gf_power(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // Case: a^n where a doesn't depend on n => 1/(1 - a*x)
   if matches!(exp, Expr::Identifier(name) if name == n) && !depends_on(base, n)
   {
@@ -4963,8 +4953,6 @@ fn gf_power(
 /// Uses the formula involving Eulerian numbers: result = Sum[A(k,j) * x^(j+1), j=0..k-1] / (1-x)^(k+1)
 /// where A(k,j) are the Eulerian numbers.
 fn gf_n_power_k(k: i128, x: &Expr) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // Compute Eulerian numbers A(k, j) for j = 0..k-1
   let k_usize = k as usize;
   let eulerian = compute_eulerian_numbers(k_usize);
@@ -5073,8 +5061,6 @@ fn gf_plus(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // Collect all terms
   let terms = collect_plus_terms(expr);
 
@@ -5101,7 +5087,6 @@ fn gf_plus(
 
 /// Collect all additive terms from a Plus expression tree
 fn collect_plus_terms(expr: &Expr) -> Vec<&Expr> {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Plus,
@@ -5125,8 +5110,6 @@ fn gf_times(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // Collect all multiplicative factors
   let factors = collect_times_factors(expr);
 
@@ -5226,7 +5209,6 @@ fn gf_times(
 
 /// Collect all multiplicative factors from a Times expression tree
 fn collect_times_factors(expr: &Expr) -> Vec<&Expr> {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Times,
@@ -5251,8 +5233,6 @@ fn gf_binomial(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // Binomial[n, k] where k is constant: x^k/(-1+x)^(k+1) (with sign adjustment)
   // Canonical Wolfram form uses (-1+x) as base.
   // (1-x)^(k+1) = (-1)^(k+1) * (-1+x)^(k+1), so negate numerator when (k+1) is odd.
@@ -5336,8 +5316,6 @@ fn gf_divide(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // 1/(n+k) for a positive integer k:
   //   Sum[x^m/(m+k), {m,0,Inf}]
   //     = (-Log[1-x]/x - Sum[x^(m-1)/m, {m,1,k-1}]) / x^(k-1)
@@ -5465,8 +5443,6 @@ fn egf_poly_part(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // Constant (doesn't depend on n) => P(x) = constant
   if !depends_on(expr, n) {
     return Ok(Some(expr.clone()));
@@ -5602,8 +5578,6 @@ fn egf_inner(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // First try the polynomial approach: EGF = E^x * P(x)
   // This produces properly factored results like E^x*(1+x) instead of E^x + E^x*x
   if let Some(poly) = egf_poly_part(expr, n, x)? {
@@ -5792,7 +5766,6 @@ fn egf_plus(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let terms = egf_collect_plus_terms(expr);
   let mut results = Vec::new();
   for term in &terms {
@@ -5819,7 +5792,6 @@ fn egf_times(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let factors = egf_collect_times_factors(expr);
 
   let mut constants = Vec::new();
@@ -5879,8 +5851,6 @@ fn egf_power(
   n: &str,
   x: &Expr,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // Case: c^n where c doesn't depend on n => e^(c*x)
   if !depends_on(base, n) && matches!(exp, Expr::Identifier(name) if name == n)
   {
@@ -5917,7 +5887,6 @@ fn egf_power(
 
 /// Collect all terms from a Plus expression.
 fn egf_collect_plus_terms(expr: &Expr) -> Vec<&Expr> {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Plus,
@@ -5937,7 +5906,6 @@ fn egf_collect_plus_terms(expr: &Expr) -> Vec<&Expr> {
 
 /// Collect all factors from a Times expression.
 fn egf_collect_times_factors(expr: &Expr) -> Vec<&Expr> {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Times,
@@ -5967,8 +5935,6 @@ fn egf_expr_to_nonneg_int(expr: &Expr) -> Option<usize> {
 /// For k >= 1, factors out x: x * (S(k,1) + S(k,2)*x + ... + S(k,k)*x^(k-1))
 /// to match Wolfram's canonical form (e.g. E^x*x*(1+x) instead of E^x*(x+x^2)).
 fn egf_stirling_polynomial(k: usize, x: &Expr) -> Expr {
-  use crate::syntax::BinaryOperator;
-
   let stirling = egf_stirling_numbers(k);
 
   // k=0: S(0,0)=1, polynomial is just 1
@@ -6918,7 +6884,7 @@ fn extract_neg_linear_coeff(expr: &Expr, t: &str) -> Option<Expr> {
   }
   // Check if it's -t directly: BinaryOp Times(-1, t)
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left,
     right,
   } = expr

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::{is_sqrt, make_sqrt};
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 pub fn dispatch_complex_and_special(
   name: &str,
@@ -118,7 +119,7 @@ pub fn dispatch_complex_and_special(
         // If real part is 0, return b*I
         if matches!(real, Expr::Integer(0)) {
           return Some(Ok(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(imag.clone()),
             right: Box::new(Expr::Identifier("I".to_string())),
           }));
@@ -126,7 +127,7 @@ pub fn dispatch_complex_and_special(
         // If imaginary is 1, return a + I
         if matches!(imag, Expr::Integer(1)) {
           return Some(Ok(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(real.clone()),
             right: Box::new(Expr::Identifier("I".to_string())),
           }));
@@ -159,10 +160,10 @@ pub fn dispatch_complex_and_special(
         // raw a + b*I BinaryOp shape so structural pattern matching against
         // Plus/Times complex trees still works.
         return Some(Ok(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(real.clone()),
           right: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(imag.clone()),
             right: Box::new(Expr::Identifier("I".to_string())),
           }),
@@ -231,7 +232,7 @@ pub fn dispatch_complex_and_special(
         }
         Expr::Integer(-1) => {
           return Some(Ok(Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand: Box::new(Expr::Identifier("Infinity".to_string())),
           }));
         }
@@ -250,7 +251,7 @@ pub fn dispatch_complex_and_special(
             }
             if v < 0.0 {
               return Some(Ok(Expr::UnaryOp {
-                op: crate::syntax::UnaryOperator::Minus,
+                op: UnaryOperator::Minus,
                 operand: Box::new(Expr::Identifier("Infinity".to_string())),
               }));
             }
@@ -266,7 +267,7 @@ pub fn dispatch_complex_and_special(
                 return Some(Ok(Expr::Identifier("Infinity".to_string())));
               } else if re_n < 0 {
                 return Some(Ok(Expr::UnaryOp {
-                  op: crate::syntax::UnaryOperator::Minus,
+                  op: UnaryOperator::Minus,
                   operand: Box::new(Expr::Identifier("Infinity".to_string())),
                 }));
               } else {
@@ -304,7 +305,7 @@ pub fn dispatch_complex_and_special(
                 }
               };
               let normalized = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Divide,
+                op: BinaryOperator::Divide,
                 left: Box::new(args[0].clone()),
                 right: Box::new(make_sqrt(sqrt_arg)),
               };
@@ -318,7 +319,7 @@ pub fn dispatch_complex_and_special(
               }
               if matches!(&normalized, Expr::Integer(-1)) {
                 return Some(Ok(Expr::UnaryOp {
-                  op: crate::syntax::UnaryOperator::Minus,
+                  op: UnaryOperator::Minus,
                   operand: Box::new(Expr::Identifier("Infinity".to_string())),
                 }));
               }
@@ -338,17 +339,17 @@ pub fn dispatch_complex_and_special(
             && !is_zero_expr(&im)
           {
             let re_sq = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(re.clone()),
               right: Box::new(Expr::Integer(2)),
             };
             let im_sq = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(im.clone()),
               right: Box::new(Expr::Integer(2)),
             };
             let mag_sq = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(re_sq),
               right: Box::new(im_sq),
             };
@@ -357,7 +358,7 @@ pub fn dispatch_complex_and_special(
               Err(e) => return Some(Err(e)),
             };
             let direction = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(args[0].clone()),
               right: Box::new(make_sqrt(mag_sq)),
             };
@@ -393,7 +394,7 @@ pub fn dispatch_complex_and_special(
                 }
                 if nre < 0.0 {
                   return Some(Ok(Expr::UnaryOp {
-                    op: crate::syntax::UnaryOperator::Minus,
+                    op: UnaryOperator::Minus,
                     operand: Box::new(Expr::Identifier("Infinity".to_string())),
                   }));
                 }
@@ -401,12 +402,12 @@ pub fn dispatch_complex_and_special(
               // Build `re + im*I` so the regular Times printer handles
               // sign placement and `0. + r*I` Re/Im split.
               let im_term = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::Real(nim)),
                 right: Box::new(Expr::Identifier("I".to_string())),
               };
               let direction = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Plus,
+                op: BinaryOperator::Plus,
                 left: Box::new(Expr::Real(nre)),
                 right: Box::new(im_term),
               };
@@ -2375,7 +2376,7 @@ pub fn dispatch_complex_and_special(
         args: vec![Expr::Integer(n as i128)].into(),
       };
       let std_err = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(std_dev),
         right: Box::new(sqrt_n),
       };
@@ -3306,13 +3307,11 @@ fn needs_paren_in_product(expr: &Expr) -> bool {
           && args.len() >= 2
           && matches!(&args[0], Expr::Integer(n) if *n < 0))
     }
-    Expr::BinaryOp { op, .. } => matches!(
-      op,
-      crate::syntax::BinaryOperator::Plus
-        | crate::syntax::BinaryOperator::Minus
-    ),
+    Expr::BinaryOp { op, .. } => {
+      matches!(op, BinaryOperator::Plus | BinaryOperator::Minus)
+    }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       ..
     } => true,
     _ => false,
@@ -3977,8 +3976,8 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
     // UnaryOp: -x → RowBox[{"-", box(x)}], !x → RowBox[{"!", box(x)}]
     Expr::UnaryOp { op, operand } => {
       let op_str = match op {
-        crate::syntax::UnaryOperator::Minus => "-",
-        crate::syntax::UnaryOperator::Not => "!",
+        UnaryOperator::Minus => "-",
+        UnaryOperator::Not => "!",
       };
       Expr::FunctionCall {
         name: "RowBox".to_string(),
@@ -3991,22 +3990,17 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
     }
     // BinaryOp::Plus/Minus/Times/And/Or/StringJoin/Alternatives
     Expr::BinaryOp { op, left, right }
-      if !matches!(
-        op,
-        crate::syntax::BinaryOperator::Power
-          | crate::syntax::BinaryOperator::Divide
-      ) =>
+      if !matches!(op, BinaryOperator::Power | BinaryOperator::Divide) =>
     {
       let (op_str, spaced) = match op {
-        crate::syntax::BinaryOperator::Plus => ("+", true),
-        crate::syntax::BinaryOperator::Minus => ("-", true),
-        crate::syntax::BinaryOperator::Times => (" ", false),
-        crate::syntax::BinaryOperator::And => ("&&", true),
-        crate::syntax::BinaryOperator::Or => ("||", true),
-        crate::syntax::BinaryOperator::StringJoin => ("<>", false),
-        crate::syntax::BinaryOperator::Alternatives => ("|", true),
-        crate::syntax::BinaryOperator::Power
-        | crate::syntax::BinaryOperator::Divide => unreachable!(),
+        BinaryOperator::Plus => ("+", true),
+        BinaryOperator::Minus => ("-", true),
+        BinaryOperator::Times => (" ", false),
+        BinaryOperator::And => ("&&", true),
+        BinaryOperator::Or => ("||", true),
+        BinaryOperator::StringJoin => ("<>", false),
+        BinaryOperator::Alternatives => ("|", true),
+        BinaryOperator::Power | BinaryOperator::Divide => unreachable!(),
       };
       let sep = if spaced {
         op_str.to_string()
@@ -4016,7 +4010,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
       // Additive operands of a product need parens so `(-5+n) (-4+n)`
       // doesn't render as `-5+n -4+n` (issue #135).
       let box_operand = |e: &Expr| {
-        if matches!(op, crate::syntax::BinaryOperator::Times) {
+        if matches!(op, BinaryOperator::Times) {
           box_with_paren_if_needed(e)
         } else {
           expr_to_box_form(e)
@@ -4380,7 +4374,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
     }
     // BinaryOp::Divide → FractionBox
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => Expr::FunctionCall {
@@ -4389,7 +4383,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
     },
     // BinaryOp::Power with rational exponents
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -5156,7 +5150,6 @@ fn tf_flatten_additive(expr: &Expr, neg: bool, out: &mut Vec<(bool, Expr)>) {
 
 /// Flatten a multiplicative expression into its factors.
 fn tf_flatten_times(expr: &Expr, out: &mut Vec<Expr>) {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Times,
@@ -5178,14 +5171,13 @@ fn tf_flatten_times(expr: &Expr, out: &mut Vec<Expr>) {
 /// Does this term need parentheses when placed as a factor in a product or
 /// as the base of a power?
 fn tf_needs_paren_factor(expr: &Expr) -> bool {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Plus | BinaryOperator::Minus,
       ..
     } => true,
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       ..
     } => true,
     Expr::Comparison { .. } => true,
@@ -5240,8 +5232,7 @@ fn tf_power(base: &Expr, exp: &Expr) -> Expr {
     || matches!(
       base,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power
-          | crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Power | BinaryOperator::Divide,
         ..
       }
     )
@@ -5379,8 +5370,7 @@ fn tf_integrate(args: &[Expr]) -> Expr {
   let body_needs_paren = matches!(
     &args[0],
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus
-        | crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Plus | BinaryOperator::Minus,
       ..
     }
   ) || matches!(&args[0], Expr::FunctionCall { name, .. } if name == "Plus");
@@ -5442,7 +5432,7 @@ fn tf_derivative(args: &[Expr]) -> Expr {
     || matches!(
       body,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         ..
       }
     )
@@ -5744,7 +5734,6 @@ pub fn expr_to_box_form_traditional(expr: &Expr) -> Expr {
 /// (division, multiplication, powers).
 fn unit_to_box_form(unit: &Expr, magnitude: &Expr) -> Expr {
   use crate::functions::quantity_ast::unit_to_abbreviation;
-  use crate::syntax::BinaryOperator;
 
   // Helper: abbreviate a single unit identifier
   fn abbrev(s: &str, mag: &Expr) -> Expr {
@@ -5842,7 +5831,6 @@ fn unit_to_box_form(unit: &Expr, magnitude: &Expr) -> Expr {
 /// Like `unit_to_box_form` but without singularization (for compound sub-units).
 fn unit_to_box_form_inner(unit: &Expr) -> Expr {
   use crate::functions::quantity_ast::unit_to_abbreviation;
-  use crate::syntax::BinaryOperator;
 
   if let Some((base, exp)) = crate::functions::graphics::as_power(unit) {
     let base_box = unit_to_box_form_inner(base);
@@ -6065,7 +6053,7 @@ fn make_inactive_head(head: &str, args: Vec<Expr>, wrap: bool) -> Expr {
 
 /// Flatten an associative binary chain (Plus/Times/And/Or/...) of `op` rooted
 /// at `expr` into its operand list, in left-to-right order.
-fn flatten_binop(expr: &Expr, op: crate::syntax::BinaryOperator) -> Vec<Expr> {
+fn flatten_binop(expr: &Expr, op: BinaryOperator) -> Vec<Expr> {
   if let Expr::BinaryOp { op: o, left, right } = expr
     && *o == op
   {
@@ -6097,7 +6085,7 @@ fn negate_plus_term(e: &Expr, filter: Option<&str>) -> Expr {
 /// operands, in left-to-right order. A `0` left operand of a subtraction
 /// (Woxi's encoding of unary minus) contributes no term.
 fn collect_plus_terms(expr: &Expr, out: &mut Vec<Expr>, filter: Option<&str>) {
-  use crate::syntax::BinaryOperator as B;
+  use BinaryOperator as B;
   match expr {
     Expr::BinaryOp {
       op: B::Plus,
@@ -6130,7 +6118,7 @@ fn inactivate_expr(expr: &Expr, filter: Option<&str>) -> Expr {
   let inact = |e: &Expr| inactivate_expr(e, filter);
   match expr {
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator as B;
+      use BinaryOperator as B;
       match op {
         B::Times | B::And | B::Or | B::StringJoin | B::Alternatives => {
           let head = match op {
@@ -6176,12 +6164,12 @@ fn inactivate_expr(expr: &Expr, filter: Option<&str>) -> Expr {
     }
     Expr::UnaryOp { op, operand } => match op {
       // -a  →  Times[-1, a]
-      crate::syntax::UnaryOperator::Minus => make_inactive_head(
+      UnaryOperator::Minus => make_inactive_head(
         "Times",
         vec![Expr::Integer(-1), inact(operand)],
         wants("Times"),
       ),
-      crate::syntax::UnaryOperator::Not => {
+      UnaryOperator::Not => {
         make_inactive_head("Not", vec![inact(operand)], wants("Not"))
       }
     },
@@ -6352,7 +6340,7 @@ fn line_nearest_point(
   pt: &[Expr],
   n: usize,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator::{Divide, Minus, Plus, Times};
+  use BinaryOperator::{Divide, Minus, Plus, Times};
   if verts.len() < 2 {
     return Ok(None);
   }
@@ -6502,7 +6490,6 @@ fn compute_region_distance(
   region: &Expr,
   point: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let unevaluated = || {
     Ok(Expr::FunctionCall {
       name: "RegionDistance".to_string(),
@@ -6658,7 +6645,6 @@ fn compute_region_nearest(
   region: &Expr,
   point: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let unevaluated = || {
     Ok(Expr::FunctionCall {
       name: "RegionNearest".to_string(),
@@ -6818,7 +6804,6 @@ fn compute_signed_region_distance(
   region: &Expr,
   point: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let unevaluated = || {
     Ok(Expr::FunctionCall {
       name: "SignedRegionDistance".to_string(),
@@ -7360,7 +7345,7 @@ fn compute_shortest_curve_distance(
         dot
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(dot),
           right: Box::new(call(
             "Power",
@@ -7480,7 +7465,7 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
           .into(),
         };
         let volume = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(product),
           right: Box::new(Expr::Integer(3)),
         };
@@ -7574,7 +7559,7 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
           return unevaluated();
         };
         let half = |e: Expr| Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(e),
           right: Box::new(Expr::Integer(2)),
         };
@@ -7655,7 +7640,7 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
           _ => return unevaluated(),
         };
         let half_n = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::Integer(n as i128)),
           right: Box::new(Expr::Integer(2)),
         };
@@ -7676,7 +7661,7 @@ fn compute_region_measure(expr: &Expr) -> Result<Expr, InterpreterError> {
           .into(),
         };
         let measure = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::FunctionCall {
             name: "Times".to_string(),
             args: vec![pi_pow, r_pow].into(),
@@ -7871,7 +7856,7 @@ fn compute_region_bounds(expr: &Expr) -> Result<Expr, InterpreterError> {
   {
     let inf = || Expr::Identifier("Infinity".to_string());
     let neg_inf = || Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Identifier("Infinity".to_string())),
     };
     let mut bounds = Vec::with_capacity(p1.len());
@@ -7968,7 +7953,7 @@ fn compute_region_bounds(expr: &Expr) -> Result<Expr, InterpreterError> {
       && let Some((center, r1, r2)) = torus_parts(args)
     {
       let tube = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::FunctionCall {
           name: "Subtract".to_string(),
           args: vec![r2.clone(), r1].into(),
@@ -8131,7 +8116,7 @@ fn det_measure(
     abs
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(abs),
       right: Box::new(Expr::Integer(divisor)),
     }
@@ -8345,7 +8330,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
     };
     if name == "Cone" {
       volume = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(volume),
         right: Box::new(Expr::Integer(3)),
       };
@@ -8470,7 +8455,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
         }
         // (4 Pi r^3) / 3
         let vol = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::FunctionCall {
             name: "Times".to_string(),
             args: vec![
@@ -8507,7 +8492,7 @@ fn compute_volume(expr: &Expr) -> Result<Expr, InterpreterError> {
           return undefined();
         }
         let vol = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::FunctionCall {
             name: "Times".to_string(),
             args: vec![
@@ -9197,7 +9182,7 @@ fn compute_region_centroid(expr: &Expr) -> Result<Expr, InterpreterError> {
             args: vec![
               p[d].clone(),
               Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Divide,
+                op: BinaryOperator::Divide,
                 left: Box::new(Expr::FunctionCall {
                   name: "Plus".to_string(),
                   args: vec![v1[d].clone(), v2[d].clone()].into(),
@@ -11360,7 +11345,7 @@ fn insphere_times(a: Expr, b: Expr) -> Expr {
 /// Helper: build a - b
 fn insphere_minus(a: Expr, b: Expr) -> Expr {
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left: Box::new(a),
     right: Box::new(b),
   }
@@ -11933,7 +11918,7 @@ pub fn split_real_imag_symbolic(expr: &Expr) -> Option<(Expr, Expr)> {
         })
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -11948,10 +11933,10 @@ pub fn split_real_imag_symbolic(expr: &Expr) -> Option<(Expr, Expr)> {
         pull_i_factor(&times_expr)
       }
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => pull_i_factor(operand).map(|r| Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(r),
       }),
       _ => None,
@@ -11965,7 +11950,7 @@ pub fn split_real_imag_symbolic(expr: &Expr) -> Option<(Expr, Expr)> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -11983,7 +11968,7 @@ pub fn split_real_imag_symbolic(expr: &Expr) -> Option<(Expr, Expr)> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left,
         right,
       } => {
@@ -11991,13 +11976,13 @@ pub fn split_real_imag_symbolic(expr: &Expr) -> Option<(Expr, Expr)> {
         collect_plus(right, out);
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left,
         right,
       } => {
         collect_plus(left, out);
         out.push(Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new((**right).clone()),
         });
       }

--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::make_sqrt;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 pub fn dispatch_linear_algebra_functions(
   name: &str,
@@ -467,22 +468,22 @@ pub fn dispatch_linear_algebra_functions(
                 Expr::Integer(0)
               };
               let vi_vj = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(v[i].clone()),
                 right: Box::new(v[j].clone()),
               };
               let two_vi_vj = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::Integer(2)),
                 right: Box::new(vi_vj),
               };
               let frac = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Divide,
+                op: BinaryOperator::Divide,
                 left: Box::new(two_vi_vj),
                 right: Box::new(dot_vv.clone()),
               };
               let entry = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Minus,
+                op: BinaryOperator::Minus,
                 left: Box::new(delta),
                 right: Box::new(frac),
               };
@@ -519,7 +520,7 @@ pub fn dispatch_linear_algebra_functions(
             args: vec![args[1].clone(), args[1].clone()].into(),
           };
           let s_minus_1 = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Minus,
+            op: BinaryOperator::Minus,
             left: Box::new(s.clone()),
             right: Box::new(Expr::Integer(1)),
           };
@@ -533,22 +534,22 @@ pub fn dispatch_linear_algebra_functions(
                 Expr::Integer(0)
               };
               let vi_vj = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(v[i].clone()),
                 right: Box::new(v[j].clone()),
               };
               let numer = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(s_minus_1.clone()),
                 right: Box::new(vi_vj),
               };
               let frac = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Divide,
+                op: BinaryOperator::Divide,
                 left: Box::new(numer),
                 right: Box::new(dot_vv.clone()),
               };
               let sum = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Plus,
+                op: BinaryOperator::Plus,
                 left: Box::new(delta),
                 right: Box::new(frac),
               };
@@ -1586,12 +1587,12 @@ pub fn dispatch_linear_algebra_functions(
         let nv = sqrt(plus(sq(&v[0]), sq(&v[1])));
         let denom = times(nu, nv);
         let cos_t = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(dot),
           right: Box::new(denom.clone()),
         };
         let sin_t = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(cross),
           right: Box::new(denom),
         };
@@ -1882,10 +1883,10 @@ pub fn dispatch_linear_algebra_functions(
           // Translation column: ci - si*ci = ci*(1 - si)
           if let Some(c) = center {
             let translation = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(c[i].clone()),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(scales[i].clone()),
                 right: Box::new(c[i].clone()),
               }),
@@ -2167,7 +2168,7 @@ pub fn dispatch_linear_algebra_functions(
                 Ok(d) => {
                   let sign = if (i + j) % 2 == 0 { 1 } else { -1 };
                   let cofactor = evaluate_expr_to_expr(&Expr::BinaryOp {
-                    op: crate::syntax::BinaryOperator::Times,
+                    op: BinaryOperator::Times,
                     left: Box::new(Expr::Integer(sign)),
                     right: Box::new(d),
                   })
@@ -2488,10 +2489,10 @@ pub fn dispatch_linear_algebra_functions(
               })
               .unwrap_or(matrix[j][i].clone());
               let diff = evaluate_expr_to_expr(&Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Plus,
+                op: BinaryOperator::Plus,
                 left: Box::new(matrix[i][j].clone()),
                 right: Box::new(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(Expr::Integer(-1)),
                   right: Box::new(conj),
                 }),
@@ -2529,7 +2530,7 @@ pub fn dispatch_linear_algebra_functions(
               })
               .unwrap_or(matrix[j][i].clone());
               let sum = evaluate_expr_to_expr(&Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Plus,
+                op: BinaryOperator::Plus,
                 left: Box::new(matrix[i][j].clone()),
                 right: Box::new(conj),
               })
@@ -2822,7 +2823,7 @@ pub fn dispatch_linear_algebra_functions(
             evaluate_expr_to_expr(&sqrt_n_expr).unwrap_or(sqrt_n_expr);
           // Compute 1/Sqrt[n] once (evaluated)
           let inv_sqrt_n_expr = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(sqrt_n.clone()),
           };
@@ -2849,7 +2850,7 @@ pub fn dispatch_linear_algebra_functions(
                     } else {
                       // v / Sqrt[n]
                       let entry = Expr::BinaryOp {
-                        op: crate::syntax::BinaryOperator::Divide,
+                        op: BinaryOperator::Divide,
                         left: Box::new(Expr::Integer(v)),
                         right: Box::new(sqrt_n.clone()),
                       };
@@ -4206,7 +4207,7 @@ fn matrix_power_block_symbolic(rows: &[Expr], n_expr: &Expr) -> Option<Expr> {
         let entry = matrix[i][i].clone();
         result[i][i] =
           match crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(entry),
             right: Box::new(n_expr.clone()),
           }) {
@@ -4252,7 +4253,6 @@ fn matrix_power_2x2_symbolic_block(
   m: &[[Expr; 2]; 2],
   n_expr: &Expr,
 ) -> Option<[[Expr; 2]; 2]> {
-  use crate::syntax::BinaryOperator;
   // Extract integer entries.
   let a = crate::functions::math_ast::expr_to_i128(&m[0][0])?;
   let b = crate::functions::math_ast::expr_to_i128(&m[0][1])?;
@@ -4599,7 +4599,7 @@ fn rotation_transform_3d_axis(
   let u: Vec<Expr> = axis
     .iter()
     .map(|a| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(a.clone()),
       right: Box::new(norm.clone()),
     })
@@ -4811,7 +4811,7 @@ fn lyapunov_solve_common(
         }
       }
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => {
         let q = parse_matrix_entry_recur(operand)?;

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::list_helpers_ast;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 /// Parse the `m` argument of NestWhile[f, x, test, m, ...]. Returns `All` for
 /// the symbol `All`, `Last(n)` for a positive integer, and `None` otherwise.
@@ -2828,9 +2829,9 @@ pub fn dispatch_list_operations(
           var.clone()
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(x0.clone()),
             }),
             right: Box::new(var.clone()),
@@ -2870,7 +2871,7 @@ pub fn dispatch_list_operations(
             Some(base.clone())
           } else {
             Some(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(base.clone()),
               right: Box::new(Expr::Integer(power)),
             })
@@ -2883,7 +2884,7 @@ pub fn dispatch_list_operations(
             Some(bp) => {
               // Evaluate the Times to get canonical form
               let t = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(coeff_normalised),
                 right: Box::new(bp),
               };
@@ -2916,7 +2917,7 @@ pub fn dispatch_list_operations(
         let result = terms
           .into_iter()
           .reduce(|acc, t| Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(acc),
             right: Box::new(t),
           })
@@ -3296,7 +3297,7 @@ pub fn dispatch_list_operations(
           let mut next = Vec::with_capacity(current.len() - 1);
           for i in 1..current.len() {
             let ratio = match evaluate_expr_to_expr(&Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(current[i].clone()),
               right: Box::new(current[i - 1].clone()),
             }) {

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::make_sqrt;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 /// Columnwise quartile-family statistic for a matrix argument.
 ///
@@ -314,7 +315,7 @@ pub fn dispatch_math_functions(
             args: vec![Expr::Integer(3)].into(),
           };
           let iqr = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(log3),
             right: Box::new(lambda),
           };
@@ -332,7 +333,7 @@ pub fn dispatch_math_functions(
         && qs.len() == 3
       {
         let diff = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(qs[2].clone()),
           right: Box::new(qs[0].clone()),
         };
@@ -349,9 +350,9 @@ pub fn dispatch_math_functions(
         && qs.len() == 3
       {
         let half_iqr = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Minus,
+            op: BinaryOperator::Minus,
             left: Box::new(qs[2].clone()),
             right: Box::new(qs[0].clone()),
           }),
@@ -370,7 +371,7 @@ pub fn dispatch_math_functions(
         dispatch_math_functions("Quartiles", args)
         && qs.len() == 3
       {
-        use crate::syntax::BinaryOperator::{Divide, Minus, Plus, Times};
+        use BinaryOperator::{Divide, Minus, Plus, Times};
         // numerator = Q1 - 2*Q2 + Q3
         let numerator = Expr::BinaryOp {
           op: Plus,
@@ -959,7 +960,7 @@ pub fn dispatch_math_functions(
             args: trimmed.to_vec().into(),
           };
           let result = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(sum_expr),
             right: Box::new(Expr::Integer(trimmed.len() as i128)),
           };
@@ -1015,7 +1016,7 @@ pub fn dispatch_math_functions(
             args: winsorized.into(),
           };
           let result = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(sum_expr),
             right: Box::new(Expr::Integer(n as i128)),
           };
@@ -1529,7 +1530,7 @@ pub fn dispatch_math_functions(
           args: vec![z.clone(), args[2].clone(), args[3].clone()].into(),
         };
         let diff = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(f(&args[1])),
           right: Box::new(f(&args[0])),
         };
@@ -1573,7 +1574,7 @@ pub fn dispatch_math_functions(
           args: vec![args[0].clone(), z.clone()].into(),
         };
         let diff = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(g(&args[1])),
           right: Box::new(g(&args[2])),
         };
@@ -1592,7 +1593,7 @@ pub fn dispatch_math_functions(
           .into(),
         };
         let diff = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(exp_neg(&args[1])),
           right: Box::new(exp_neg(&args[2])),
         };
@@ -1750,7 +1751,7 @@ pub fn dispatch_math_functions(
           args: vec![z.clone(), args[2].clone(), args[3].clone()].into(),
         };
         let diff = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(f(&args[1])),
           right: Box::new(f(&args[0])),
         };
@@ -2118,7 +2119,7 @@ pub fn dispatch_math_functions(
           return Some(Ok(Expr::Identifier("Indeterminate".to_string())));
         }
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand,
         } if matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity") =>
         {
@@ -2142,7 +2143,7 @@ pub fn dispatch_math_functions(
             Expr::FunctionCall { name, .. } if name == "Sin");
           if !is_symbolic {
             let div_expr = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(sin_val.clone()),
               right: Box::new(args[0].clone()),
             };
@@ -2169,7 +2170,7 @@ pub fn dispatch_math_functions(
       }
       if contains_real(&args[0]) {
         let half = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(args[0].clone()),
           right: Box::new(Expr::Integer(2)),
         };
@@ -2178,7 +2179,7 @@ pub fn dispatch_math_functions(
           args: vec![half].into(),
         };
         let expr = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(sin_expr),
           right: Box::new(Expr::Integer(2)),
         };
@@ -2194,9 +2195,9 @@ pub fn dispatch_math_functions(
         args: vec![args[0].clone()].into(),
       };
       let half = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(Expr::Integer(1)),
           right: Box::new(cos_x),
         }),
@@ -2320,7 +2321,7 @@ pub fn dispatch_math_functions(
         args: vec![sqrt_expr].into(),
       };
       let expr = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(asin_expr),
       };
@@ -4008,7 +4009,7 @@ pub fn dispatch_math_functions(
         let widths: Vec<Expr> = (0..dim)
           .map(|d| {
             evaluate_expr_to_expr(&Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(maxs[d].clone()),
               right: Box::new(mins[d].clone()),
             })
@@ -4049,13 +4050,13 @@ pub fn dispatch_math_functions(
           let bounds: Vec<Expr> = (0..dim)
             .map(|d| {
               let new_min = evaluate_expr_to_expr(&Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Minus,
+                op: BinaryOperator::Minus,
                 left: Box::new(mins[d].clone()),
                 right: Box::new(pads[d].0.clone()),
               })
               .unwrap_or_else(|_| mins[d].clone());
               let new_max = evaluate_expr_to_expr(&Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Plus,
+                op: BinaryOperator::Plus,
                 left: Box::new(maxs[d].clone()),
                 right: Box::new(pads[d].1.clone()),
               })
@@ -4117,10 +4118,10 @@ pub fn dispatch_math_functions(
           .map(|(ai, bi)| Expr::FunctionCall {
             name: "Abs".to_string(),
             args: vec![Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(ai.clone()),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::Integer(-1)),
                 right: Box::new(bi.clone()),
               }),
@@ -4141,10 +4142,10 @@ pub fn dispatch_math_functions(
         let abs_expr = Expr::FunctionCall {
           name: "Abs".to_string(),
           args: vec![Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(args[0].clone()),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(Expr::Integer(-1)),
               right: Box::new(args[1].clone()),
             }),
@@ -4163,10 +4164,10 @@ pub fn dispatch_math_functions(
         let num = Expr::FunctionCall {
           name: "Abs".to_string(),
           args: vec![Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(args[0].clone()),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(Expr::Integer(-1)),
               right: Box::new(args[1].clone()),
             }),
@@ -4176,14 +4177,14 @@ pub fn dispatch_math_functions(
         let den = Expr::FunctionCall {
           name: "Abs".to_string(),
           args: vec![Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(args[0].clone()),
             right: Box::new(args[1].clone()),
           }]
           .into(),
         };
         let result = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(num),
           right: Box::new(den),
         };
@@ -4199,10 +4200,10 @@ pub fn dispatch_math_functions(
           num_terms.push(Expr::FunctionCall {
             name: "Abs".to_string(),
             args: vec![Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(ai.clone()),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::Integer(-1)),
                 right: Box::new(bi.clone()),
               }),
@@ -4212,7 +4213,7 @@ pub fn dispatch_math_functions(
           den_terms.push(Expr::FunctionCall {
             name: "Abs".to_string(),
             args: vec![Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(ai.clone()),
               right: Box::new(bi.clone()),
             }]
@@ -4228,7 +4229,7 @@ pub fn dispatch_math_functions(
           args: den_terms.into(),
         };
         let result = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(num),
           right: Box::new(den),
         };
@@ -4244,10 +4245,10 @@ pub fn dispatch_math_functions(
         let num = Expr::FunctionCall {
           name: "Abs".to_string(),
           args: vec![Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(args[0].clone()),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(Expr::Integer(-1)),
               right: Box::new(args[1].clone()),
             }),
@@ -4255,7 +4256,7 @@ pub fn dispatch_math_functions(
           .into(),
         };
         let den = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(Expr::FunctionCall {
             name: "Abs".to_string(),
             args: vec![args[0].clone()].into(),
@@ -4266,7 +4267,7 @@ pub fn dispatch_math_functions(
           }),
         };
         let result = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(num),
           right: Box::new(den),
         };
@@ -4281,10 +4282,10 @@ pub fn dispatch_math_functions(
           let num = Expr::FunctionCall {
             name: "Abs".to_string(),
             args: vec![Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(ai.clone()),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::Integer(-1)),
                 right: Box::new(bi.clone()),
               }),
@@ -4292,7 +4293,7 @@ pub fn dispatch_math_functions(
             .into(),
           };
           let den = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::FunctionCall {
               name: "Abs".to_string(),
               args: vec![ai.clone()].into(),
@@ -4303,7 +4304,7 @@ pub fn dispatch_math_functions(
             }),
           };
           terms.push(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(num),
             right: Box::new(den),
           });
@@ -4373,25 +4374,25 @@ pub fn dispatch_math_functions(
           args: vec![args[1].clone()].into(),
         };
         let u_over_abs_u = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(args[0].clone()),
           right: Box::new(abs_u),
         };
         let conj_v_over_abs_v = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(conj_v),
           right: Box::new(abs_v),
         };
         let ratio = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(u_over_abs_u),
           right: Box::new(conj_v_over_abs_v),
         };
         let result = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(Expr::Integer(1)),
           right: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(-1)),
             right: Box::new(ratio),
           }),
@@ -4437,16 +4438,16 @@ pub fn dispatch_math_functions(
           args: vec![args[1].clone()].into(),
         };
         let result = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(Expr::Integer(1)),
           right: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(-1)),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(dot),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(norm_a),
                 right: Box::new(norm_b),
               }),
@@ -5436,7 +5437,7 @@ pub fn dispatch_math_functions(
             true
           }
           Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand,
           } => definite_non_integer(operand),
           _ => false,
@@ -5779,7 +5780,7 @@ fn midpoint_ast(arg: &Expr) -> Result<Expr, InterpreterError> {
     args: vec![p1.clone(), p2.clone()].into(),
   };
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(sum),
     right: Box::new(Expr::Integer(2)),
   };
@@ -5823,22 +5824,22 @@ fn qfactorial_ast(
   for k in 1..=n {
     // [k]_q = (1 - q^k) / (1 - q)
     let q_k = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(q_expr.clone()),
       right: Box::new(Expr::Integer(k as i128)),
     };
     let numerator = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::Integer(1)),
       right: Box::new(q_k),
     };
     let denominator = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::Integer(1)),
       right: Box::new(q_expr.clone()),
     };
     let factor = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(numerator),
       right: Box::new(denominator),
     };
@@ -6680,7 +6681,7 @@ fn split_real_imag(expr: &Expr) -> Option<(Expr, Expr)> {
     }
     // -(a + b*I) = -a - b*I
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let (r, i) = split_real_imag(operand)?;
@@ -7454,7 +7455,7 @@ fn exp_to_trig_recursive(expr: &Expr) -> Expr {
   match expr {
     // E^z where E is the constant
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } if matches!(left.as_ref(), Expr::Constant(c) if c == "E")
@@ -7588,7 +7589,7 @@ fn extract_imaginary_part(z: &Expr) -> Option<Expr> {
     }
     // z = BinaryOp Times with I
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -3407,12 +3407,12 @@ pub fn evaluate_function_call_ast_inner(
       for (j, bj) in b_coeffs.iter().enumerate() {
         if i >= j {
           let term = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(bj.clone()),
             right: Box::new(data[i - j].clone()),
           };
           sum = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(sum),
             right: Box::new(term),
           };
@@ -3421,19 +3421,19 @@ pub fn evaluate_function_call_ast_inner(
       for (k, ak) in a_coeffs.iter().enumerate().skip(1) {
         if i >= k {
           let term = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(ak.clone()),
             right: Box::new(output[i - k].clone()),
           };
           sum = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Minus,
+            op: BinaryOperator::Minus,
             left: Box::new(sum),
             right: Box::new(term),
           };
         }
       }
       let result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(sum),
         right: Box::new(a_coeffs[0].clone()),
       };
@@ -3790,7 +3790,7 @@ pub fn evaluate_function_call_ast_inner(
           let mut out = Vec::with_capacity(items.len());
           for x in items.iter() {
             let diff = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(x.clone()),
               right: Box::new(median.clone()),
             };
@@ -3818,12 +3818,12 @@ pub fn evaluate_function_call_ast_inner(
           let mut out = Vec::with_capacity(items.len());
           for x in items.iter() {
             let diff = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(x.clone()),
               right: Box::new(mean.clone()),
             };
             let sq = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(diff),
               right: Box::new(Expr::Integer(2)),
             };
@@ -3838,7 +3838,7 @@ pub fn evaluate_function_call_ast_inner(
           args: vec![squared_diffs].into(),
         };
         let variance = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(sum_sq),
           right: Box::new(Expr::Integer(n)),
         };
@@ -9199,7 +9199,7 @@ pub fn evaluate_function_call_ast_inner(
                 conds.push(Expr::Comparison {
                   operands: vec![
                     Expr::BinaryOp {
-                      op: crate::syntax::BinaryOperator::Minus,
+                      op: BinaryOperator::Minus,
                       left: Box::new(fargs[i].clone()),
                       right: Box::new(fargs[j].clone()),
                     },
@@ -9242,7 +9242,7 @@ pub fn evaluate_function_call_ast_inner(
                 conds.push(Expr::Comparison {
                   operands: vec![
                     Expr::BinaryOp {
-                      op: crate::syntax::BinaryOperator::Minus,
+                      op: BinaryOperator::Minus,
                       left: Box::new(fargs[i].clone()),
                       right: Box::new(fargs[j].clone()),
                     },
@@ -9460,7 +9460,7 @@ pub fn evaluate_function_call_ast_inner(
       let mut terms: Vec<Expr> = Vec::with_capacity(r);
       for j in 0..r {
         terms.push(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(window[j].clone()),
           right: Box::new(items[i + j].clone()),
         });
@@ -9470,7 +9470,7 @@ pub fn evaluate_function_call_ast_inner(
         args: terms.into(),
       };
       let avg = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(sum),
         right: Box::new(divisor.clone()),
       };
@@ -10225,12 +10225,12 @@ pub fn evaluate_function_call_ast_inner(
     // Apply radius if present
     let (x_comp, y_comp) = if let Some(r) = r {
       let rx = evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(r.clone()),
         right: Box::new(cos_expr),
       })?;
       let ry = evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(r),
         right: Box::new(sin_expr),
       })?;
@@ -10242,12 +10242,12 @@ pub fn evaluate_function_call_ast_inner(
     // Apply center offset if present
     let (final_x, final_y) = if let Some((cx, cy)) = center {
       let fx = evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(cx),
         right: Box::new(x_comp),
       })?;
       let fy = evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(cy),
         right: Box::new(y_comp),
       })?;
@@ -10307,16 +10307,16 @@ pub fn evaluate_function_call_ast_inner(
     // Base angle theta0: explicit, or the default Pi/2 - (n-1)*Pi/n.
     let pi = || Expr::Identifier("Pi".to_string());
     let base = theta.unwrap_or_else(|| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(pi()),
         right: Box::new(Expr::Integer(2)),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer((n - 1) as i128)),
           right: Box::new(pi()),
         }),
@@ -10327,12 +10327,12 @@ pub fn evaluate_function_call_ast_inner(
     for k in 0..n {
       // angle_k = base + 2*k*Pi/n
       let angle = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(base.clone()),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(k as i128 * 2)),
             right: Box::new(pi()),
           }),
@@ -10341,10 +10341,10 @@ pub fn evaluate_function_call_ast_inner(
       };
       // coordinate = center + radius * trig(angle)
       let coord = |trig: &str, c: &Expr| Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(c.clone()),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(radius.clone()),
           right: Box::new(Expr::FunctionCall {
             name: trig.to_string(),

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::BinaryOperator;
 
 /// Wrap a plot function call in Quiet mode so that messages emitted during
 /// function sampling (e.g. Power::indet for 0^0) are suppressed and discarded.
@@ -290,10 +291,10 @@ pub fn dispatch_plotting(
       let yv = "y".to_string();
       // Substitute z -> x + I*y in f.
       let xy_expr = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Identifier(xv.clone())),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Identifier("I".to_string())),
           right: Box::new(Expr::Identifier(yv.clone())),
         }),
@@ -379,19 +380,19 @@ pub fn dispatch_plotting(
                 args: vec![r.clone()].into(),
               };
               let corner_lo = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Plus,
+                op: BinaryOperator::Plus,
                 left: Box::new(neg_r.clone()),
                 right: Box::new(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(neg_r.clone()),
                   right: Box::new(Expr::Identifier("I".to_string())),
                 }),
               };
               let corner_hi = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Plus,
+                op: BinaryOperator::Plus,
                 left: Box::new(r.clone()),
                 right: Box::new(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(r),
                   right: Box::new(Expr::Identifier("I".to_string())),
                 }),
@@ -406,10 +407,10 @@ pub fn dispatch_plotting(
       let xv = "x".to_string();
       let yv = "y".to_string();
       let xy_expr = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Identifier(xv.clone())),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Identifier("I".to_string())),
           right: Box::new(Expr::Identifier(yv.clone())),
         }),

--- a/src/evaluator/dispatch/polynomial_functions.rs
+++ b/src/evaluator/dispatch/polynomial_functions.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::BinaryOperator;
 
 pub fn dispatch_polynomial_functions(
   name: &str,
@@ -602,7 +603,7 @@ pub fn dispatch_polynomial_functions(
           let mut product = vars[indices[0]].clone();
           for &idx in &indices[1..] {
             product = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(product),
               right: Box::new(vars[idx].clone()),
             };
@@ -617,7 +618,7 @@ pub fn dispatch_polynomial_functions(
               let mut result = terms[0].clone();
               for term in &terms[1..] {
                 result = Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Plus,
+                  op: BinaryOperator::Plus,
                   left: Box::new(result),
                   right: Box::new(term.clone()),
                 };
@@ -681,13 +682,13 @@ pub fn dispatch_polynomial_functions(
                 Expr::Integer(0) => continue,
                 Expr::Integer(1) => Expr::Identifier(var.clone()),
                 _ => Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Power,
+                  op: BinaryOperator::Power,
                   left: Box::new(Expr::Identifier(var.clone())),
                   right: Box::new(exp.clone()),
                 },
               };
               term = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(term),
                 right: Box::new(factor),
               };
@@ -702,7 +703,7 @@ pub fn dispatch_polynomial_functions(
                 term
               } else {
                 Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Plus,
+                  op: BinaryOperator::Plus,
                   left: Box::new(result),
                   right: Box::new(term),
                 }
@@ -1105,35 +1106,35 @@ fn try_constrained_linear_disk_symbolic(
   };
   let plus = |x: Expr, y: Expr| -> Expr {
     eval(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(x),
       right: Box::new(y),
     })
   };
   let minus = |x: Expr, y: Expr| -> Expr {
     eval(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(x),
       right: Box::new(y),
     })
   };
   let times = |x: Expr, y: Expr| -> Expr {
     eval(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(x),
       right: Box::new(y),
     })
   };
   let div = |x: Expr, y: Expr| -> Expr {
     eval(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(x),
       right: Box::new(y),
     })
   };
   let neg = |x: Expr| -> Expr {
     eval(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::Integer(0)),
       right: Box::new(x),
     })
@@ -1254,7 +1255,7 @@ fn sinusoid_extremum(expr: &Expr, var: &str, maximize: bool) -> Option<Expr> {
         args.iter().collect()
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => vec![left, right],

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::BinaryOperator;
 use std::cell::RefCell;
 
 // Thread-local stack of accumulated bindings from outer FunctionCall arg loops.
@@ -285,7 +286,7 @@ pub fn contains_pattern(expr: &Expr) -> bool {
     | Expr::PatternOptional { .. }
     | Expr::PatternTest { .. } => true,
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Alternatives,
+      op: BinaryOperator::Alternatives,
       ..
     } => true,
     Expr::FunctionCall { name, .. } if name == "Alternatives" => true,
@@ -350,7 +351,7 @@ pub fn try_ast_pattern_replace(
 /// Plus or Times) into its operand list, e.g. `(a + b) + c` → `[a, b, c]`.
 fn collect_flat_binary_operands(
   expr: &Expr,
-  op: &crate::syntax::BinaryOperator,
+  op: &BinaryOperator,
   out: &mut Vec<Expr>,
 ) {
   if let Expr::BinaryOp {
@@ -615,10 +616,8 @@ fn lookup_user_default(
 }
 
 /// Map a BinaryOperator to the corresponding Wolfram Language function name.
-pub fn binary_op_to_func_name(
-  op: &crate::syntax::BinaryOperator,
-) -> &'static str {
-  use crate::syntax::BinaryOperator;
+pub fn binary_op_to_func_name(op: &BinaryOperator) -> &'static str {
+  use BinaryOperator;
   match op {
     BinaryOperator::Plus => "Plus",
     BinaryOperator::Times => "Times",
@@ -3539,7 +3538,7 @@ fn match_pattern_impl(
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Alternatives,
+      op: BinaryOperator::Alternatives,
       left: alt_left,
       right: alt_right,
     } => {

--- a/src/evaluator/scoping.rs
+++ b/src/evaluator/scoping.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::BinaryOperator;
 
 /// AST-based Module implementation to avoid interpret() recursion
 pub fn module_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -371,7 +372,7 @@ pub fn is_member_of_domain(expr: &Expr, domain: &str) -> Option<bool> {
       // irrational (perfect powers are already simplified to integers).
       // Radicals are stored as a Power BinaryOp.
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } if is_rational_literal(left) && is_non_integer_rational(right) => {
@@ -473,7 +474,7 @@ pub fn is_member_of_domain(expr: &Expr, domain: &str) -> Option<bool> {
       // A radical Power[rational, rational] (e.g. Sqrt[2], 2^(1/3)) is
       // algebraic. Radicals are stored as a Power BinaryOp.
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } if is_rational_literal(left) && is_rational_literal(right) => {
@@ -597,7 +598,7 @@ pub fn element_ast(x: &Expr, domain: &Expr) -> Result<Expr, InterpreterError> {
 
   // Handle Alternatives: Element[a | b | c, dom]
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Alternatives,
+    op: BinaryOperator::Alternatives,
     ..
   } = x
   {
@@ -619,7 +620,7 @@ pub fn element_ast(x: &Expr, domain: &Expr) -> Result<Expr, InterpreterError> {
     let alt_expr = remaining
       .into_iter()
       .reduce(|acc, e| Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Alternatives,
+        op: BinaryOperator::Alternatives,
         left: Box::new(acc),
         right: Box::new(e),
       })
@@ -640,7 +641,7 @@ pub fn element_ast(x: &Expr, domain: &Expr) -> Result<Expr, InterpreterError> {
       .iter()
       .cloned()
       .reduce(|acc, e| Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Alternatives,
+        op: BinaryOperator::Alternatives,
         left: Box::new(acc),
         right: Box::new(e),
       })
@@ -727,7 +728,7 @@ pub fn not_element_ast(
 pub fn collect_alternatives(expr: &Expr) -> Vec<Expr> {
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Alternatives,
+      op: BinaryOperator::Alternatives,
       left,
       right,
     } => {

--- a/src/functions/boolean_ast.rs
+++ b/src/functions/boolean_ast.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// Helper to check if an Expr is True or False
 fn as_bool(expr: &Expr) -> Option<bool> {
@@ -77,7 +77,7 @@ pub fn not_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Double negation: Not[Not[x]] → x. The inner operand is already in
       // normal form (it was produced by evaluating the inner Not).
       if let Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Not,
+        op: UnaryOperator::Not,
         operand,
       } = &evaluated
       {
@@ -103,7 +103,7 @@ pub fn not_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         });
       }
       Ok(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Not,
+        op: UnaryOperator::Not,
         operand: Box::new(evaluated),
       })
     }
@@ -1165,7 +1165,7 @@ fn normalize_not(expr: &Expr) -> Expr {
   match expr {
     Expr::FunctionCall { name, args } if name == "Not" && args.len() == 1 => {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Not,
+        op: UnaryOperator::Not,
         operand: Box::new(normalize_not(&args[0])),
       }
     }
@@ -1194,7 +1194,7 @@ fn to_dnf(expr: &Expr) -> Expr {
 fn dnf_literal(e: &Expr) -> (String, bool, Expr) {
   match e {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Not,
+      op: UnaryOperator::Not,
       operand,
     } => (
       crate::syntax::expr_to_string(operand),
@@ -1326,7 +1326,7 @@ fn canonicalize_dnf(expr: &Expr) -> Expr {
           atom.clone()
         } else {
           Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Not,
+            op: UnaryOperator::Not,
             operand: Box::new(atom.clone()),
           }
         }
@@ -1533,7 +1533,7 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
     }
     // Convert UnaryOp(Not, x) to FunctionCall("Not", [x]) for uniform processing
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Not,
+      op: UnaryOperator::Not,
       operand,
     } => {
       let inner = eliminate_connectives(operand);
@@ -1558,7 +1558,7 @@ fn apply_not_inward(inner: &Expr) -> Expr {
     }
     // Not[Not[a]] → a (handles UnaryOp form)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Not,
+      op: UnaryOperator::Not,
       operand,
     } => push_not_inward(operand),
     // Not[And[a, b, ...]] → Or[Not[a], Not[b], ...]
@@ -1608,7 +1608,7 @@ fn push_not_inward(expr: &Expr) -> Expr {
     }
     // Handle Not as UnaryOp
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Not,
+      op: UnaryOperator::Not,
       operand,
     } => apply_not_inward(operand),
     Expr::FunctionCall { name, args } => {
@@ -1955,7 +1955,7 @@ pub fn boolean_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 (0, crate::syntax::expr_to_string(&args[0]))
               }
               Expr::UnaryOp {
-                op: crate::syntax::UnaryOperator::Not,
+                op: UnaryOperator::Not,
                 operand,
               } => (0, crate::syntax::expr_to_string(operand)),
               _ => (1, crate::syntax::expr_to_string(e)),
@@ -2334,7 +2334,7 @@ fn implicants_to_expr(
           literals.push(var);
         } else {
           literals.push(Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Not,
+            op: UnaryOperator::Not,
             operand: Box::new(var),
           });
         }
@@ -2557,7 +2557,7 @@ fn exactly_k_dnf(vars: &[String], k: usize) -> Expr {
         literals.push(var);
       } else {
         literals.push(Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Not,
+          op: UnaryOperator::Not,
           operand: Box::new(var),
         });
       }
@@ -2588,7 +2588,7 @@ fn at_most_k_dnf(vars: &[String], kmax: usize) -> Expr {
     let mut literals: Vec<Expr> = Vec::with_capacity(s.len());
     for &i in s {
       literals.push(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Not,
+        op: UnaryOperator::Not,
         operand: Box::new(Expr::Identifier(vars[i].clone())),
       });
     }
@@ -2621,7 +2621,7 @@ fn minterms_to_dnf(vars: &[String], count_set: &[usize]) -> Expr {
           literals.push(var);
         } else {
           literals.push(Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Not,
+            op: UnaryOperator::Not,
             operand: Box::new(var),
           });
         }
@@ -2853,7 +2853,7 @@ fn collect_boolean_variable_exprs(expr: &Expr, out: &mut Vec<Expr>) {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::And | crate::syntax::BinaryOperator::Or,
+      op: BinaryOperator::And | BinaryOperator::Or,
       left,
       right,
     } => {
@@ -2861,7 +2861,7 @@ fn collect_boolean_variable_exprs(expr: &Expr, out: &mut Vec<Expr>) {
       collect_boolean_variable_exprs(right, out);
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Not,
+      op: UnaryOperator::Not,
       operand,
     } => {
       collect_boolean_variable_exprs(operand, out);
@@ -3208,7 +3208,7 @@ pub fn boolean_minterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             vars[i].clone()
           } else {
             Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Not,
+              op: UnaryOperator::Not,
               operand: Box::new(vars[i].clone()),
             }
           }
@@ -3440,7 +3440,7 @@ pub fn boolean_maxterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             vars[i].clone()
           } else {
             Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Not,
+              op: UnaryOperator::Not,
               operand: Box::new(vars[i].clone()),
             }
           }

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -15924,8 +15924,13 @@ fn adaptive_simpson(
   // — for an integrand that never meets the tolerance (e.g. the oscillatory
   // Sin[x]/x transformed onto a finite interval) this never terminates in
   // practice. Cap the total number of subdivision nodes so NIntegrate always
-  // returns in bounded time, falling back to the current estimate.
-  let budget = std::cell::Cell::new(50_000u64);
+  // returns in bounded time, falling back to the current estimate. Convergent
+  // integrands stop at `error.abs() < tol` long before this ceiling, so it only
+  // bounds the divergent fallback; keep it small enough that even in a debug
+  // build the fallback returns in ~1s (each node re-interprets the integrand
+  // expression, which is slow unoptimized) rather than brushing the test
+  // harness's per-test timeout under parallel CI load.
+  let budget = std::cell::Cell::new(10_000u64);
   adaptive_simpson_rec(f, a, b, tol, whole, fa, fm, fb, max_depth, &budget)
 }
 

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -5,7 +5,7 @@
 
 use crate::InterpreterError;
 use crate::functions::math_ast::{is_sqrt, make_sqrt};
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 thread_local! {
   /// Active `NonConstants` context for `D`. Holds the symbol names that must be
@@ -347,11 +347,11 @@ fn differentiate_wrt_expr(
       | Expr::BigFloat(_, _) => true,
       Expr::BinaryOp { op, .. } => matches!(
         op,
-        crate::syntax::BinaryOperator::Plus
-          | crate::syntax::BinaryOperator::Minus
-          | crate::syntax::BinaryOperator::Times
-          | crate::syntax::BinaryOperator::Divide
-          | crate::syntax::BinaryOperator::Power
+        BinaryOperator::Plus
+          | BinaryOperator::Minus
+          | BinaryOperator::Times
+          | BinaryOperator::Divide
+          | BinaryOperator::Power
       ),
       Expr::FunctionCall { name, .. } => matches!(
         name.as_str(),
@@ -378,7 +378,7 @@ fn differentiate_wrt_expr(
   }
   // For products: use product rule
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left,
     right,
   } = expr
@@ -386,24 +386,24 @@ fn differentiate_wrt_expr(
     let dl = differentiate_wrt_expr(left, var_expr)?;
     let dr = differentiate_wrt_expr(right, var_expr)?;
     let term1 = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(dl),
       right: right.clone(),
     });
     let term2 = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: left.clone(),
       right: Box::new(dr),
     });
     return Ok(simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(term1),
       right: Box::new(term2),
     }));
   }
   // For sums
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left,
     right,
   } = expr
@@ -411,7 +411,7 @@ fn differentiate_wrt_expr(
     let dl = differentiate_wrt_expr(left, var_expr)?;
     let dr = differentiate_wrt_expr(right, var_expr)?;
     return Ok(simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(dl),
       right: Box::new(dr),
     }));
@@ -552,7 +552,7 @@ pub fn integrate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // case directly. A non-empty range is any range where lo and hi aren't
     // structurally identical (compared via their printed form).
     if is_constant_wrt(&args[0], &var_name) {
-      use crate::syntax::{UnaryOperator, expr_to_string};
+      use crate::syntax::expr_to_string;
       let lo_ne_hi = expr_to_string(lo) != expr_to_string(hi);
       // -Infinity must be returned through the evaluator so it gets
       // canonicalised to the same form `DirectedInfinity[-1]` / unary-minus
@@ -597,12 +597,12 @@ pub fn integrate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         && !is_negative_infinity(hi);
       if bounds_finite {
         let width = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Minus,
           left: Box::new(hi.clone()),
           right: Box::new(lo.clone()),
         };
         let product = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(width),
           right: Box::new(args[0].clone()),
         };
@@ -671,7 +671,7 @@ pub fn integrate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let at_hi = hornerize_product_polys(at_hi);
       let at_lo = hornerize_product_polys(at_lo);
       let result = simplify(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(at_hi),
         right: Box::new(at_lo),
       });
@@ -816,11 +816,11 @@ fn hornerize_product_polys(expr: Expr) -> Expr {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(try_horner_if_poly(left)),
       right: Box::new(try_horner_if_poly(right)),
     },
@@ -838,7 +838,7 @@ fn try_horner_if_poly(expr: &Expr) -> Expr {
     || matches!(
       expr,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         ..
       }
     );
@@ -881,11 +881,11 @@ fn is_nonfinite_result(expr: &Expr) -> bool {
 fn is_negative_infinity(expr: &Expr) -> bool {
   match expr {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_infinity(operand),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -1095,7 +1095,7 @@ fn try_definite_integral(
     let result = match coeff {
       Expr::Integer(1) => make_sqrt(Expr::Constant("Pi".to_string())),
       _ => make_sqrt(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(coeff),
       }),
@@ -1128,13 +1128,13 @@ fn try_definite_integral(
     let sqrt_part = match coeff {
       Expr::Integer(1) => make_sqrt(Expr::Constant("Pi".to_string())),
       _ => make_sqrt(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(coeff),
       }),
     };
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(sqrt_part),
       right: Box::new(Expr::Integer(2)),
     };
@@ -1181,7 +1181,7 @@ fn try_definite_integral(
       args: vec![Expr::Integer(0), n].into(),
     };
     return Some(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Constant("Pi".to_string())),
       right: Box::new(bessel),
     });
@@ -1269,7 +1269,7 @@ fn is_pi_x_squared_over_two(expr: &Expr, var: &str) -> bool {
   fn is_var_squared(e: &Expr, var: &str) -> bool {
     match e {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } => {
@@ -1308,7 +1308,7 @@ fn is_pi_x_squared_over_two(expr: &Expr, var: &str) -> bool {
       have_pi && have_sq && have_half
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -1334,7 +1334,7 @@ fn match_gaussian(expr: &Expr, var: &str) -> Option<Expr> {
   // canonical-form simplification of e.g. `Exp[-(x/2)^2]`) are accepted.
   let exponent = match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -1364,7 +1364,7 @@ fn flatten_times_factors(expr: &Expr) -> Vec<Expr> {
   fn rec(e: &Expr, out: &mut Vec<Expr>) {
     match e {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -1391,7 +1391,7 @@ fn match_var_power(expr: &Expr, var: &str) -> Option<i128> {
   }
   let (base, exp) = match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => (left.as_ref(), right.as_ref()),
@@ -1455,7 +1455,6 @@ fn gaussian_moment_result(
   consts: &[Expr],
   full_range: bool,
 ) -> Expr {
-  use crate::syntax::BinaryOperator;
   let pow = |base: Expr, exp: i128| Expr::FunctionCall {
     name: "Power".to_string(),
     args: vec![base, Expr::Integer(exp)].into(),
@@ -1516,7 +1515,7 @@ fn match_neg_a_x_squared(expr: &Expr, var: &str) -> Option<Expr> {
   match expr {
     // UnaryOp::Minus wrapping something
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       // -x^2 => a=1
@@ -1531,7 +1530,7 @@ fn match_neg_a_x_squared(expr: &Expr, var: &str) -> Option<Expr> {
     }
     // Times[-1, x^2] or Times[x^2, -1]
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -1635,7 +1634,7 @@ fn match_neg_a_x_squared(expr: &Expr, var: &str) -> Option<Expr> {
     }
     // BinaryOp::Minus: 0 - x^2 or similar (unlikely but handle)
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left,
       right,
     } => {
@@ -1659,7 +1658,7 @@ fn match_neg_a_x_squared(expr: &Expr, var: &str) -> Option<Expr> {
 /// `x*Exp[-1/x^2] + Sqrt[Pi]*Erf[1/x]`.
 fn is_var_to_minus_two(expr: &Expr, var: &str) -> bool {
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left,
     right,
   } = expr
@@ -1683,11 +1682,11 @@ fn is_var_to_minus_two(expr: &Expr, var: &str) -> bool {
 fn match_neg_inverse_x_squared(expr: &Expr, var: &str) -> bool {
   match expr {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_var_to_minus_two(operand, var),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -1711,7 +1710,7 @@ fn match_neg_inverse_x_squared(expr: &Expr, var: &str) -> bool {
 /// form (which is what falls out of simplifying `(x/2)^2` etc.).
 fn is_var_squared(expr: &Expr, var: &str) -> bool {
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left,
     right,
   } = expr
@@ -1732,7 +1731,7 @@ fn is_var_squared(expr: &Expr, var: &str) -> bool {
 /// Match a*x^2 and return 'a'
 fn match_a_x_squared(expr: &Expr, var: &str) -> Option<Expr> {
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left,
     right,
   } = expr
@@ -1881,7 +1880,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
 
     // Binary operations
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator::*;
+      use BinaryOperator::*;
       match op {
         Plus => {
           // d/dx[a + b] = d/dx[a] + d/dx[b]
@@ -2059,7 +2058,6 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
 
     // Unary minus
     Expr::UnaryOp { op, operand } => {
-      use crate::syntax::UnaryOperator;
       if matches!(op, UnaryOperator::Minus) {
         let d = differentiate(operand, var)?;
         Ok(Expr::UnaryOp {
@@ -2308,7 +2306,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[sin(f(x))] = cos(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::FunctionCall {
               name: "Cos".to_string(),
               args: args.clone(),
@@ -2320,9 +2318,9 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[cos(f(x))] = -sin(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::FunctionCall {
                 name: "Sin".to_string(),
                 args: args.clone(),
@@ -2335,7 +2333,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[gd(f(x))] = Sech[f(x)] * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::FunctionCall {
               name: "Sech".to_string(),
               args: args.clone(),
@@ -2347,7 +2345,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[gd^-1(f(x))] = Sec[f(x)] * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::FunctionCall {
               name: "Sec".to_string(),
               args: args.clone(),
@@ -2379,9 +2377,9 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[tan(f(x))] = sec^2(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(Expr::FunctionCall {
                 name: "Sec".to_string(),
                 args: args.clone(),
@@ -2395,9 +2393,9 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[sec(f(x))] = sec(f(x)) * tan(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(Expr::FunctionCall {
                 name: "Sec".to_string(),
                 args: args.clone(),
@@ -2414,11 +2412,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[csc(f(x))] = -csc(f(x)) * cot(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::FunctionCall {
                   name: "Csc".to_string(),
                   args: args.clone(),
@@ -2436,11 +2434,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[cot(f(x))] = -csc^2(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(Expr::FunctionCall {
                   name: "Csc".to_string(),
                   args: args.clone(),
@@ -2455,7 +2453,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[sinh(f(x))] = cosh(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::FunctionCall {
               name: "Cosh".to_string(),
               args: args.clone(),
@@ -2467,7 +2465,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[cosh(f(x))] = sinh(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::FunctionCall {
               name: "Sinh".to_string(),
               args: args.clone(),
@@ -2479,9 +2477,9 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[tanh(f(x))] = sech^2(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(Expr::FunctionCall {
                 name: "Sech".to_string(),
                 args: args.clone(),
@@ -2495,11 +2493,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[sech(f(x))] = -sech(f(x)) * tanh(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::FunctionCall {
                   name: "Sech".to_string(),
                   args: args.clone(),
@@ -2517,11 +2515,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[csch(f(x))] = -coth(f(x)) * csch(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::FunctionCall {
                   name: "Coth".to_string(),
                   args: args.clone(),
@@ -2539,11 +2537,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[coth(f(x))] = -csch^2(f(x)) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(Expr::FunctionCall {
                   name: "Csch".to_string(),
                   args: args.clone(),
@@ -2558,12 +2556,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[arcsin(f(x))] = f'(x) / sqrt(1 - f(x)^2)
           let df = differentiate(&args[0], var)?;
           let one_minus_f_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(args[0].clone()),
                 right: Box::new(Expr::Integer(2)),
               }),
@@ -2571,7 +2569,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           };
           let sqrt_expr = make_sqrt(one_minus_f_sq);
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(df),
             right: Box::new(Expr::FunctionCall {
               name: "Power".to_string(),
@@ -2583,12 +2581,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[arccos(f(x))] = -f'(x) / sqrt(1 - f(x)^2)
           let df = differentiate(&args[0], var)?;
           let one_minus_f_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(args[0].clone()),
                 right: Box::new(Expr::Integer(2)),
               }),
@@ -2596,9 +2594,9 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           };
           let sqrt_expr = make_sqrt(one_minus_f_sq);
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(df),
             }),
             right: Box::new(Expr::FunctionCall {
@@ -2617,14 +2615,14 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           let du = differentiate(&u, var)?;
           let dv = differentiate(&v, var)?;
           let denom = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(u.clone()),
               right: Box::new(Expr::Integer(2)),
             }),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(v.clone()),
               right: Box::new(Expr::Integer(2)),
             }),
@@ -2635,33 +2633,33 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           };
           // partial wrt first arg: -v / (u^2 + v^2)
           let d_first = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(v),
             }),
             right: Box::new(inv_denom.clone()),
           };
           // partial wrt second arg: u / (u^2 + v^2)
           let d_second = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(u),
             right: Box::new(inv_denom),
           };
           let term1 = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(d_first),
             right: Box::new(du),
           };
           let term2 = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(d_second),
             right: Box::new(dv),
           };
           // Order the second-argument term first to match Wolfram's output,
           // e.g. ArcTan[u, v]' = u v'/(u^2+v^2) - v u'/(u^2+v^2).
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(term2),
             right: Box::new(term1),
           }))
@@ -2670,16 +2668,16 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[arctan(f(x))] = f'(x) / (1 + f(x)^2)
           let df = differentiate(&args[0], var)?;
           let one_plus_f_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(args[0].clone()),
               right: Box::new(Expr::Integer(2)),
             }),
           };
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(df),
             right: Box::new(Expr::FunctionCall {
               name: "Power".to_string(),
@@ -2691,18 +2689,18 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[arccot(f(x))] = -f'(x) / (1 + f(x)^2)
           let df = differentiate(&args[0], var)?;
           let one_plus_f_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(args[0].clone()),
               right: Box::new(Expr::Integer(2)),
             }),
           };
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(df),
             }),
             right: Box::new(Expr::FunctionCall {
@@ -2715,17 +2713,17 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[arcsinh(f(x))] = f'(x) / sqrt(1 + f(x)^2)
           let df = differentiate(&args[0], var)?;
           let one_plus_f_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(args[0].clone()),
               right: Box::new(Expr::Integer(2)),
             }),
           };
           let sqrt_expr = make_sqrt(one_plus_f_sq);
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(df),
             right: Box::new(Expr::FunctionCall {
               name: "Power".to_string(),
@@ -2738,12 +2736,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // Using factored form to match Wolfram's branch-cut-aware convention
           let df = differentiate(&args[0], var)?;
           let f_minus_one = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(-1)),
             right: Box::new(args[0].clone()),
           };
           let f_plus_one = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(args[0].clone()),
           };
@@ -2751,12 +2749,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           let sqrt_plus = make_sqrt(f_plus_one);
           // f'(x) / (Sqrt[f-1] * Sqrt[f+1])
           let denom = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(sqrt_minus),
             right: Box::new(sqrt_plus),
           };
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(df),
             right: Box::new(Expr::FunctionCall {
               name: "Power".to_string(),
@@ -2768,19 +2766,19 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[arctanh(f(x))] = f'(x) / (1 - f(x)^2)
           let df = differentiate(&args[0], var)?;
           let one_minus_f_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(args[0].clone()),
                 right: Box::new(Expr::Integer(2)),
               }),
             }),
           };
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(df),
             right: Box::new(Expr::FunctionCall {
               name: "Power".to_string(),
@@ -2792,19 +2790,19 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[arccoth(f(x))] = f'(x) / (1 - f(x)^2) (same as ArcTanh)
           let df = differentiate(&args[0], var)?;
           let one_minus_f_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(args[0].clone()),
                 right: Box::new(Expr::Integer(2)),
               }),
             }),
           };
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(df),
             right: Box::new(Expr::FunctionCall {
               name: "Power".to_string(),
@@ -2816,7 +2814,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // d/dx[e^f(x)] = e^f(x) * f'(x)
           let df = differentiate(&args[0], var)?;
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::FunctionCall {
               name: "Exp".to_string(),
               args: args.clone(),
@@ -2843,7 +2841,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           for arg in &args[1..] {
             let d = differentiate(arg, var)?;
             result = simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(result),
               right: Box::new(d),
             });
@@ -2905,7 +2903,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
         // Handle evaluated Power[base, exp] (FunctionCall form of ^)
         "Power" if args.len() == 2 => differentiate(
           &Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(args[0].clone()),
             right: Box::new(args[1].clone()),
           },
@@ -2918,10 +2916,10 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(df),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(Expr::Integer(2)),
               right: Box::new(make_sqrt(args[0].clone())),
             }),
@@ -2950,7 +2948,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(deriv_expr)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(df),
               right: Box::new(deriv_expr),
             }))
@@ -2970,12 +2968,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             args: vec![f.clone()].into(),
           };
           let f_over_abs = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(f),
             right: Box::new(real_abs),
           };
           Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(df),
             right: Box::new(f_over_abs),
           }))
@@ -3003,7 +3001,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(deriv_expr)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(df),
               right: Box::new(deriv_expr),
             }))
@@ -3032,7 +3030,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           ])
           .unwrap_or_else(|_| {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(args[0].clone()),
               right: Box::new(Expr::Integer(1)),
             })
@@ -3043,7 +3041,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           ])
           .unwrap_or_else(|_| {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(args[0].clone()),
               right: Box::new(Expr::Integer(1)),
             })
@@ -3057,12 +3055,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             args: vec![n_plus_1, args[1].clone()].into(),
           };
           let diff = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Minus,
+            op: BinaryOperator::Minus,
             left: Box::new(bessel_nm1),
             right: Box::new(bessel_np1),
           });
           let half_diff = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(diff),
             right: Box::new(Expr::Integer(2)),
           };
@@ -3071,7 +3069,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(half_diff)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(half_diff),
             }))
@@ -3084,12 +3082,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           let exp_z = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::Constant("E".to_string())),
             right: Box::new(args[0].clone()),
           };
           let result = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(exp_z),
             right: Box::new(args[0].clone()),
           });
@@ -3097,7 +3095,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(result)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(result),
             }))
@@ -3113,12 +3111,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // (Pi * z^2) / 2, evaluated so a compound argument's square expands.
           let inner =
             crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::Constant("Pi".to_string())),
                 right: Box::new(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Power,
+                  op: BinaryOperator::Power,
                   left: Box::new(args[0].clone()),
                   right: Box::new(Expr::Integer(2)),
                 }),
@@ -3135,7 +3133,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             simplify(g)
           } else {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(g),
               right: Box::new(dz),
             })
@@ -3178,7 +3176,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             simplify(g)
           } else {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(g),
             })
@@ -3198,7 +3196,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             simplify(g)
           } else {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(g),
             })
@@ -3219,7 +3217,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           ])
           .unwrap_or_else(|_| {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(args[0].clone()),
               right: Box::new(Expr::Integer(1)),
             })
@@ -3232,7 +3230,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             simplify(g)
           } else {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(g),
             })
@@ -3257,7 +3255,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           ])
           .unwrap_or_else(|_| args[1].clone());
           let z_pow = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(z.clone()),
             right: Box::new(a_minus_1),
           };
@@ -3268,12 +3266,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           ])
           .unwrap_or_else(|_| args[2].clone());
           let one_minus_z = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Minus,
+            op: BinaryOperator::Minus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(z.clone()),
           });
           let omz_pow = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(one_minus_z),
             right: Box::new(b_minus_1),
           };
@@ -3281,7 +3279,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // product directly in that order rather than through the canonical
           // Times sorter (which would put the bare-symbol power first).
           let g = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(omz_pow),
             right: Box::new(z_pow),
           };
@@ -3289,7 +3287,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             g
           } else {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(g),
             })
@@ -3322,7 +3320,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           };
           // (a * F) / b
           let g = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(Expr::FunctionCall {
               name: "Times".to_string(),
               args: vec![args[0].clone(), f].into(),
@@ -3333,7 +3331,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             g
           } else {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(g),
             })
@@ -3372,7 +3370,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           };
           // (a * b * F) / c
           let g = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(Expr::FunctionCall {
               name: "Times".to_string(),
               args: vec![args[0].clone(), args[1].clone(), f].into(),
@@ -3383,7 +3381,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             g
           } else {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(g),
             })
@@ -3398,7 +3396,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           }
           // E^(F[z]^2) * Sqrt[Pi] / 2.
           let f_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::FunctionCall {
               name: name.clone(),
               args: args.clone(),
@@ -3406,12 +3404,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             right: Box::new(Expr::Integer(2)),
           };
           let core = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(Expr::FunctionCall {
               name: "Times".to_string(),
               args: vec![
                 Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Power,
+                  op: BinaryOperator::Power,
                   left: Box::new(Expr::Constant("E".to_string())),
                   right: Box::new(f_sq),
                 },
@@ -3429,7 +3427,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             core
           } else {
             Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(core),
             }
           };
@@ -3437,7 +3435,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             simplify(g)
           } else {
             simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(g),
             })
@@ -3450,7 +3448,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           let result = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::FunctionCall {
               name: "Gamma".to_string(),
               args: args.clone(),
@@ -3464,7 +3462,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(result)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(result),
             }))
@@ -3479,12 +3477,12 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           let one_plus_z = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(Expr::Integer(1)),
             right: Box::new(args[0].clone()),
           });
           let result = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::FunctionCall {
               name: "Gamma".to_string(),
               args: vec![one_plus_z.clone()].into(),
@@ -3498,7 +3496,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(result)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(result),
             }))
@@ -3518,28 +3516,28 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           let z = &args[1];
           // z^(a-1)
           let z_pow = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(z.clone()),
             right: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(a.clone()),
               right: Box::new(Expr::Integer(1)),
             }),
           };
           // E^(-z)
           let exp_neg_z = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::Constant("E".to_string())),
             right: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(z.clone()),
             }),
           };
           // -z^(a-1) E^(-z), times z' (chain rule).
           let core = Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(z_pow),
               right: Box::new(exp_neg_z),
             }),
@@ -3548,7 +3546,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             core
           } else {
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(core),
             }
@@ -3559,7 +3557,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
         // differentiate the difference so the two-argument rule applies.
         "Gamma" if args.len() == 3 && is_constant_wrt(&args[0], var) => {
           let diff = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Minus,
+            op: BinaryOperator::Minus,
             left: Box::new(Expr::FunctionCall {
               name: "Gamma".to_string(),
               args: vec![args[0].clone(), args[1].clone()].into(),
@@ -3602,7 +3600,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(result)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(result),
             }))
@@ -3638,7 +3636,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(result)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(result),
             }))
@@ -3684,7 +3682,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(result)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(result),
             }))
@@ -3694,7 +3692,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
         // the one-argument rule supplies each term's derivative.
         "Erf" if args.len() == 2 => {
           let diff = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Minus,
+            op: BinaryOperator::Minus,
             left: Box::new(Expr::FunctionCall {
               name: "Erf".to_string(),
               args: vec![args[1].clone()].into(),
@@ -3713,25 +3711,25 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           let z_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(args[0].clone()),
             right: Box::new(Expr::Integer(2)),
           };
           let exp_neg_z2 = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::Constant("E".to_string())),
             right: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(z_sq),
             }),
           };
           let two_over_sqrt_pi = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(Expr::Integer(2)),
             right: Box::new(make_sqrt(Expr::Constant("Pi".to_string()))),
           };
           let result = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(two_over_sqrt_pi),
             right: Box::new(exp_neg_z2),
           });
@@ -3739,7 +3737,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(result)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(result),
             }))
@@ -3752,28 +3750,28 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           let z_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(args[0].clone()),
             right: Box::new(Expr::Integer(2)),
           };
           let neg_exp_neg_z2 = Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand: Box::new(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(Expr::Constant("E".to_string())),
               right: Box::new(Expr::UnaryOp {
-                op: crate::syntax::UnaryOperator::Minus,
+                op: UnaryOperator::Minus,
                 operand: Box::new(z_sq),
               }),
             }),
           };
           let two_over_sqrt_pi = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(Expr::Integer(2)),
             right: Box::new(make_sqrt(Expr::Constant("Pi".to_string()))),
           };
           let result = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(two_over_sqrt_pi),
             right: Box::new(neg_exp_neg_z2),
           });
@@ -3781,7 +3779,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(result)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(result),
             }))
@@ -3794,22 +3792,22 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           let z_sq = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(args[0].clone()),
             right: Box::new(Expr::Integer(2)),
           };
           let exp_z2 = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::Constant("E".to_string())),
             right: Box::new(z_sq),
           };
           let two_over_sqrt_pi = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(Expr::Integer(2)),
             right: Box::new(make_sqrt(Expr::Constant("Pi".to_string()))),
           };
           let result = simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(two_over_sqrt_pi),
             right: Box::new(exp_z2),
           });
@@ -3817,7 +3815,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(result)
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dz),
               right: Box::new(result),
             }))
@@ -3886,7 +3884,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
                 simplify(f_at_hi)
               } else {
                 simplify(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(simplify(f_at_hi)),
                   right: Box::new(db),
                 })
@@ -3899,13 +3897,13 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
                 simplify(f_at_lo)
               } else {
                 simplify(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(simplify(f_at_lo)),
                   right: Box::new(da),
                 })
               };
               terms.push(Expr::UnaryOp {
-                op: crate::syntax::UnaryOperator::Minus,
+                op: UnaryOperator::Minus,
                 operand: Box::new(term),
               });
             }
@@ -3918,7 +3916,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
               let mut result = terms[0].clone();
               for t in terms.iter().skip(1) {
                 result = Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Plus,
+                  op: BinaryOperator::Plus,
                   left: Box::new(result),
                   right: Box::new(t.clone()),
                 };
@@ -3977,7 +3975,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Expr::Integer(k + 1)
           } else {
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(Expr::Integer(1)),
               right: Box::new(order.clone()),
             }
@@ -3996,7 +3994,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Ok(simplify(deriv_expr))
           } else {
             Ok(simplify(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(d_inner),
               right: Box::new(deriv_expr),
             }))
@@ -4076,7 +4074,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
                   // A structured-zero (list) index adds nothing: keep `a`.
                   _ if is_all_zero(b) => a.clone(),
                   _ => Expr::BinaryOp {
-                    op: crate::syntax::BinaryOperator::Plus,
+                    op: BinaryOperator::Plus,
                     left: Box::new(a.clone()),
                     right: Box::new(b.clone()),
                   },
@@ -4109,7 +4107,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
               terms.push(deriv_expr);
             } else {
               terms.push(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(dargs[i].clone()),
                 right: Box::new(deriv_expr),
               });
@@ -4124,7 +4122,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             let mut result = terms[0].clone();
             for term in &terms[1..] {
               result = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Plus,
+                op: BinaryOperator::Plus,
                 left: Box::new(result),
                 right: Box::new(term.clone()),
               };
@@ -4164,7 +4162,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           args: vec![expr.clone()],
         };
         let result = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(deriv_f_at_inv),
           right: Box::new(Expr::Integer(-1)),
         };
@@ -4172,7 +4170,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           return Ok(result);
         } else {
           return Ok(simplify(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(dx),
             right: Box::new(result),
           }));
@@ -4216,7 +4214,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
                   Expr::Integer(k + 1)
                 } else {
                   Expr::BinaryOp {
-                    op: crate::syntax::BinaryOperator::Plus,
+                    op: BinaryOperator::Plus,
                     left: Box::new(Expr::Integer(1)),
                     right: Box::new(idx.clone()),
                   }
@@ -4242,7 +4240,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             terms.push(deriv_expr);
           } else {
             terms.push(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(dargs[i].clone()),
               right: Box::new(deriv_expr),
             });
@@ -4257,7 +4255,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           let mut result = terms[0].clone();
           for term in &terms[1..] {
             result = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(result),
               right: Box::new(term.clone()),
             };
@@ -4309,14 +4307,14 @@ fn make_divided(expr: Expr, divisor: Expr) -> Expr {
     Expr::Integer(1) => expr,
     // expr / (a/b) → expr * b/a = (b * expr) / a
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: num,
       right: den,
     } => {
       let result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: den.clone(),
           right: Box::new(expr),
         }),
@@ -4331,9 +4329,9 @@ fn make_divided(expr: Expr, divisor: Expr) -> Expr {
       let num = &args[0]; // a
       let den = &args[1]; // b
       let result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(den.clone()),
           right: Box::new(expr),
         }),
@@ -4342,7 +4340,7 @@ fn make_divided(expr: Expr, divisor: Expr) -> Expr {
       simplify(result)
     }
     _ => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(expr),
       right: Box::new(divisor),
     },
@@ -4354,18 +4352,18 @@ fn make_divided(expr: Expr, divisor: Expr) -> Expr {
 fn make_neg_divided(expr: Expr, divisor: Expr) -> Expr {
   match &divisor {
     Expr::Integer(1) => Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(expr),
     },
     Expr::Integer(n) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(crate::functions::math_ast::make_rational(-1, *n)),
       right: Box::new(expr),
     },
     _ => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(expr),
       }),
       right: Box::new(divisor),
@@ -4386,7 +4384,7 @@ fn extract_trig_factor(expr: &Expr) -> Option<(&str, &Expr, i64)> {
   }
   // Sin[f]^n or Cos[f]^n as BinaryOp
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left,
     right,
   } = expr
@@ -4454,7 +4452,7 @@ fn try_integrate_exp_trig_product(
   let exp_exponent = |f: &Expr| -> Option<Expr> {
     match f {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } if matches!(left.as_ref(), Expr::Constant(c) | Expr::Identifier(c) if c == "E") => {
@@ -4534,12 +4532,12 @@ fn try_integrate_exp_trig_product(
       name: "Plus".to_string(),
       args: vec![
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(a.clone()),
           right: Box::new(Expr::Integer(2)),
         },
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(b.clone()),
           right: Box::new(Expr::Integer(2)),
         },
@@ -4547,7 +4545,7 @@ fn try_integrate_exp_trig_product(
       .into(),
     };
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(times(ef.clone(), combo)),
       right: Box::new(denom),
     };
@@ -4623,7 +4621,7 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
     };
     if coeff_is_nontrivial {
       let double_arg = simplify(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(arg.clone()),
       });
@@ -4632,7 +4630,7 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
         args: vec![double_arg].into(),
       };
       let divisor = simplify(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(4)),
         right: Box::new(coeff.clone()),
       });
@@ -4654,13 +4652,13 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
       args: vec![arg.clone()].into(),
     };
     let power_expr = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(cos_expr),
       right: Box::new(Expr::Integer(new_power as i128)),
     };
     // divisor = (n+1) * a
     let total_divisor = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(new_power as i128)),
       right: Box::new(coeff),
     });
@@ -4675,13 +4673,13 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
       args: vec![arg.clone()].into(),
     };
     let power_expr = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(sin_expr),
       right: Box::new(Expr::Integer(new_power as i128)),
     };
     // divisor = (m+1) * a
     let total_divisor = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(new_power as i128)),
       right: Box::new(coeff),
     });
@@ -4709,7 +4707,7 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
       let new_cos_power = cos_power + 2 * j;
       let new_power = new_cos_power + 1;
       let cos_power_expr = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(cos_f.clone()),
         right: Box::new(Expr::Integer(new_power as i128)),
       };
@@ -4717,7 +4715,7 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
       // = -binom * sign / (new_power * a)
       let numer = -sign * binom;
       let total_divisor = simplify(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(new_power as i128)),
         right: Box::new(coeff.clone()),
       });
@@ -4727,7 +4725,7 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
         make_neg_divided(cos_power_expr, total_divisor)
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(make_divided(Expr::Integer(numer), total_divisor)),
           right: Box::new(cos_power_expr),
         }
@@ -4758,13 +4756,13 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
       let new_sin_power = sin_power + 2 * j;
       let new_power = new_sin_power + 1;
       let sin_power_expr = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(sin_f.clone()),
         right: Box::new(Expr::Integer(new_power as i128)),
       };
       let numer = sign * binom;
       let total_divisor = simplify(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(new_power as i128)),
         right: Box::new(coeff.clone()),
       });
@@ -4774,7 +4772,7 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
         make_neg_divided(sin_power_expr, total_divisor)
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(make_divided(Expr::Integer(numer), total_divisor)),
           right: Box::new(sin_power_expr),
         }
@@ -4809,12 +4807,12 @@ fn make_gaussian_antiderivative(var: &str, coeff: &Expr) -> Expr {
       // concrete integer a: (Sqrt[Pi/a]*Erf[Sqrt[a]*x])/2 — matches Wolfram output
       let sqrt_a = make_sqrt(coeff.clone());
       let erf_arg = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(sqrt_a),
         right: Box::new(var_expr),
       };
       let prefix = make_sqrt(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Constant("Pi".to_string())),
         right: Box::new(coeff.clone()),
       });
@@ -4824,7 +4822,7 @@ fn make_gaussian_antiderivative(var: &str, coeff: &Expr) -> Expr {
       // symbolic a: (Sqrt[Pi]*Erf[Sqrt[a]*x])/(2*Sqrt[a]) — matches Wolfram output
       let sqrt_a = make_sqrt(coeff.clone());
       let erf_arg = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(sqrt_a.clone()),
         right: Box::new(var_expr),
       };
@@ -4835,14 +4833,14 @@ fn make_gaussian_antiderivative(var: &str, coeff: &Expr) -> Expr {
       };
       // (Sqrt[Pi] * Erf[Sqrt[a]*x]) / (2 * Sqrt[a])
       return Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(prefix),
           right: Box::new(erf_expr),
         }),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(2)),
           right: Box::new(sqrt_a),
         }),
@@ -4855,9 +4853,9 @@ fn make_gaussian_antiderivative(var: &str, coeff: &Expr) -> Expr {
   };
   // a=1 case: (Sqrt[Pi] * Erf[x]) / 2
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(prefix),
       right: Box::new(erf_expr),
     }),
@@ -4872,7 +4870,7 @@ fn try_match_linear_arg(expr: &Expr, var: &str) -> Option<Expr> {
   match expr {
     Expr::Identifier(name) if name == var => Some(Expr::Integer(1)),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -4890,7 +4888,7 @@ fn try_match_linear_arg(expr: &Expr, var: &str) -> Option<Expr> {
     }
     // x/c form: var/const → coefficient is 1/const (i.e., Rational[1,c] for integer c)
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -4905,7 +4903,7 @@ fn try_match_linear_arg(expr: &Expr, var: &str) -> Option<Expr> {
           Some(result)
         } else {
           Some(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(Expr::Integer(1)),
             right: right.clone(),
           })
@@ -4920,7 +4918,7 @@ fn try_match_linear_arg(expr: &Expr, var: &str) -> Option<Expr> {
             Some(result)
           } else {
             Some(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(inner_coeff),
               right: right.clone(),
             })
@@ -5013,7 +5011,7 @@ fn arcsin_arccos_linear_antideriv(
   }
   let x = Expr::Identifier(var.to_string());
   let x_sq = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(x.clone()),
     right: Box::new(Expr::Integer(2)),
   };
@@ -5024,13 +5022,13 @@ fn arcsin_arccos_linear_antideriv(
     x_sq
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(p_sq)),
       right: Box::new(x_sq),
     }
   };
   let sqrt_arg = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left: Box::new(Expr::Integer(q_sq)),
     right: Box::new(scaled_x_sq),
   };
@@ -5039,12 +5037,12 @@ fn arcsin_arccos_linear_antideriv(
     sqrt_expr
   } else if p == -1 {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(sqrt_expr),
     }
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(sqrt_expr),
       right: Box::new(Expr::Integer(p)),
     }
@@ -5054,14 +5052,14 @@ fn arcsin_arccos_linear_antideriv(
     args: args.to_vec().into(),
   };
   let x_times_atrig = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(Expr::Identifier(var.to_string())),
     right: Box::new(inverse_trig),
   };
   let join_op = if fname == "ArcCos" {
-    crate::syntax::BinaryOperator::Minus
+    BinaryOperator::Minus
   } else {
-    crate::syntax::BinaryOperator::Plus
+    BinaryOperator::Plus
   };
   Some(Expr::BinaryOp {
     op: join_op,
@@ -5220,7 +5218,7 @@ fn try_integrate_trig_squared(base: &Expr, var: &str) -> Option<Expr> {
         make_neg_divided(direct, coeff)
       };
       return Some(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(x_term),
         right: Box::new(direct_term),
       });
@@ -5231,7 +5229,7 @@ fn try_integrate_trig_squared(base: &Expr, var: &str) -> Option<Expr> {
     if name == "Sinh" || name == "Cosh" {
       let coeff = try_match_linear_arg(&args[0], var)?;
       let double_arg = simplify(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(args[0].clone()),
       });
@@ -5240,25 +5238,25 @@ fn try_integrate_trig_squared(base: &Expr, var: &str) -> Option<Expr> {
         args: vec![double_arg].into(),
       };
       let four_a = simplify(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(4)),
         right: Box::new(coeff),
       });
       let sinh_term = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(sinh_double),
         right: Box::new(four_a),
       };
       let x_half = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Identifier(var.to_string())),
         right: Box::new(Expr::Integer(2)),
       };
       return Some(Expr::BinaryOp {
         op: if name == "Cosh" {
-          crate::syntax::BinaryOperator::Plus
+          BinaryOperator::Plus
         } else {
-          crate::syntax::BinaryOperator::Minus
+          BinaryOperator::Minus
         },
         left: Box::new(sinh_term),
         right: Box::new(x_half),
@@ -5271,7 +5269,7 @@ fn try_integrate_trig_squared(base: &Expr, var: &str) -> Option<Expr> {
     let coeff = try_match_linear_arg(&args[0], var)?;
     // Build: 2*a*x
     let double_arg = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(2)),
       right: Box::new(args[0].clone()),
     });
@@ -5282,33 +5280,33 @@ fn try_integrate_trig_squared(base: &Expr, var: &str) -> Option<Expr> {
     };
     // 4*a
     let four_a = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(4)),
       right: Box::new(coeff),
     });
     // x/2
     let x_half = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Identifier(var.to_string())),
       right: Box::new(Expr::Integer(2)),
     };
     // sin(2*a*x)/(4*a)
     let sin_term = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(sin_double),
       right: Box::new(four_a),
     };
     if is_sin {
       // x/2 - sin(2*a*x)/(4*a)
       Some(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(x_half),
         right: Box::new(sin_term),
       })
     } else {
       // x/2 + sin(2*a*x)/(4*a)
       Some(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(x_half),
         right: Box::new(sin_term),
       })
@@ -5376,14 +5374,14 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
           Expr::Identifier(var.to_string())
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(freq)),
             right: Box::new(Expr::Identifier(var.to_string())),
           }
         }
       } else {
         simplify(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(freq)),
           right: Box::new(arg.clone()),
         })
@@ -5423,7 +5421,7 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
         let num = coeff_num / g;
         let den = denom / g;
         let den_expr = simplify(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(den)),
           right: Box::new(coeff.clone()),
         });
@@ -5444,19 +5442,19 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
         Expr::Identifier(var.to_string())
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(const_num)),
           right: Box::new(Expr::Identifier(var.to_string())),
         }
       }
     } else if matches!(&coeff, Expr::Integer(1)) {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(if const_num == 1 {
           Expr::Identifier(var.to_string())
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(const_num)),
             right: Box::new(Expr::Identifier(var.to_string())),
           }
@@ -5465,12 +5463,12 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
       }
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(if const_num == 1 {
           Expr::Identifier(var.to_string())
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(const_num)),
             right: Box::new(Expr::Identifier(var.to_string())),
           }
@@ -5496,14 +5494,14 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
           Expr::Identifier(var.to_string())
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(freq)),
             right: Box::new(Expr::Identifier(var.to_string())),
           }
         }
       } else {
         simplify(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(freq)),
           right: Box::new(arg.clone()),
         })
@@ -5532,7 +5530,7 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
         let num = coeff_num / g;
         let den = denom / g;
         let den_expr = simplify(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(den)),
           right: Box::new(coeff.clone()),
         });
@@ -5558,28 +5556,28 @@ fn make_fraction_term(num: i128, den: i128, expr: Expr) -> Expr {
       expr
     } else if num == -1 {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(expr),
       }
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(num)),
         right: Box::new(expr),
       }
     }
   } else if num == 1 {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(expr),
       right: Box::new(Expr::Integer(den)),
     }
   } else if num == -1 {
     // -(expr/den) so plus_ast displays as "- expr/den"
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(expr),
         right: Box::new(Expr::Integer(den)),
       }),
@@ -5587,11 +5585,11 @@ fn make_fraction_term(num: i128, den: i128, expr: Expr) -> Expr {
   } else if num < 0 {
     // -(|num|*expr/den) so plus_ast displays as "- num*expr/den"
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Integer(-num)),
           right: Box::new(expr),
         }),
@@ -5600,9 +5598,9 @@ fn make_fraction_term(num: i128, den: i128, expr: Expr) -> Expr {
     }
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(num)),
         right: Box::new(expr),
       }),
@@ -5617,18 +5615,18 @@ fn make_fraction_term_expr(num: i128, den_expr: Expr, expr: Expr) -> Expr {
     expr
   } else if num == -1 {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(expr),
     }
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(num)),
       right: Box::new(expr),
     }
   };
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(num_expr),
     right: Box::new(den_expr),
   }
@@ -5655,7 +5653,7 @@ fn try_match_exp_over_linear(
   let exp_linear_arg = match numerator {
     // E^(a*x) as BinaryOp::Power
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: base,
       right: exp,
     } if matches!(base.as_ref(), Expr::Constant(c) if c == "E") => {
@@ -5676,7 +5674,7 @@ fn try_match_exp_over_linear(
     Expr::Identifier(name) if name == var => Some(Expr::Integer(1)),
     // c*x (BinaryOp form)
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -5716,7 +5714,7 @@ fn try_match_exp_over_linear(
     Expr::Identifier(var.to_string())
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(linear_coeff),
       right: Box::new(Expr::Identifier(var.to_string())),
     }
@@ -5731,7 +5729,7 @@ fn try_match_exp_over_linear(
     Some(ei_expr)
   } else {
     Some(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(ei_expr),
       right: Box::new(denom_const),
     })
@@ -5792,11 +5790,11 @@ fn try_integrate_inverse_sqrt(base: &Expr, var: &str) -> Option<Expr> {
   if b_val < 0.0 {
     // ∫ (a - |b|*x^2)^(-1/2) dx = (1/sqrt(|b|)) * ArcSin[x * sqrt(|b|/a)]
     let abs_b = simplify(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(b.clone()),
     });
     let ratio = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(abs_b.clone()),
       right: Box::new(a.clone()),
     });
@@ -5809,7 +5807,7 @@ fn try_integrate_inverse_sqrt(base: &Expr, var: &str) -> Option<Expr> {
       args: vec![abs_b].into(),
     });
     let arg = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Identifier(var.to_string())),
       right: Box::new(sqrt_ratio),
     });
@@ -5821,7 +5819,7 @@ fn try_integrate_inverse_sqrt(base: &Expr, var: &str) -> Option<Expr> {
   } else {
     // ∫ (a + b*x^2)^(-1/2) dx = (1/sqrt(b)) * ArcSinh[x * sqrt(b/a)]
     let ratio = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(b.clone()),
       right: Box::new(a.clone()),
     });
@@ -5834,7 +5832,7 @@ fn try_integrate_inverse_sqrt(base: &Expr, var: &str) -> Option<Expr> {
       args: vec![b.clone()].into(),
     });
     let arg = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Identifier(var.to_string())),
       right: Box::new(sqrt_ratio),
     });
@@ -5856,7 +5854,7 @@ fn try_integrate_inverse_sqrt(base: &Expr, var: &str) -> Option<Expr> {
 /// forms are continuous, so substituting the integration bounds yields exact
 /// closed forms. Returns the antiderivative expression `F(var)`.
 fn sqrt_quadratic_antiderivative(base: &Expr, var: &str) -> Option<Expr> {
-  use crate::syntax::BinaryOperator::*;
+  use BinaryOperator::*;
   let base_eval = crate::evaluator::evaluate_expr_to_expr(base)
     .unwrap_or_else(|_| base.clone());
   let var_expr = Expr::Identifier(var.to_string());
@@ -5907,7 +5905,7 @@ fn sqrt_quadratic_antiderivative(base: &Expr, var: &str) -> Option<Expr> {
   // |b| for the b < 0 branch (ArcSin needs the positive coefficient).
   let abs_b = if b_neg {
     simplify(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(b.clone()),
     })
   } else {
@@ -5972,7 +5970,7 @@ fn try_definite_sqrt_quadratic(
     return None;
   }
   let diff = simplify(Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left: Box::new(at_hi),
     right: Box::new(at_lo),
   });
@@ -6016,7 +6014,6 @@ fn try_integrate_rational(
     expand_and_combine, extract_poly_coeffs, find_integer_root, gcd_i128,
     poly_long_divide,
   };
-  use crate::syntax::BinaryOperator;
 
   // Step 1: Extract polynomial coefficients
   let num_expanded = expand_and_combine(num_expr);
@@ -6180,7 +6177,7 @@ fn try_integrate_rational(
         log_expr
       } else if an == -1 {
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(log_expr),
         }
       } else {
@@ -6210,7 +6207,7 @@ fn try_integrate_rational(
       };
       if an < 0 {
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(frac_expr),
         }
       } else {
@@ -6745,8 +6742,6 @@ fn build_arctan_term(
   sqrt_expr: &Expr,
   arctan_expr: Expr,
 ) -> Expr {
-  use crate::syntax::BinaryOperator;
-
   let abs_coeff = coeff_num.abs();
 
   let term = if let Expr::Integer(s) = sqrt_expr {
@@ -6805,7 +6800,7 @@ fn build_arctan_term(
 
   if coeff_num < 0 {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(term),
     }
   } else {
@@ -6815,8 +6810,6 @@ fn build_arctan_term(
 
 /// Build (num/den) * expr, handling sign and simplifications.
 fn build_coeff_times_expr(num: i128, den: i128, expr: Expr) -> Expr {
-  use crate::syntax::BinaryOperator;
-
   let abs_num = num.abs();
 
   let unsigned_term = if den == 1 {
@@ -6845,7 +6838,7 @@ fn build_coeff_times_expr(num: i128, den: i128, expr: Expr) -> Expr {
 
   if num < 0 {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(unsigned_term),
     }
   } else {
@@ -6878,7 +6871,7 @@ fn liate_priority(expr: &Expr, var: &str) -> i32 {
     // x, x^n => algebraic
     Expr::Identifier(_) => 3,
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     }
@@ -6898,7 +6891,7 @@ fn normalize_power(expr: Expr) -> Expr {
     && args.len() == 2
   {
     return Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(args[0].clone()),
       right: Box::new(args[1].clone()),
     };
@@ -6909,7 +6902,7 @@ fn normalize_power(expr: Expr) -> Expr {
 /// Check if an expression is a pure exponential E^f(x).
 fn is_exponential(expr: &Expr) -> bool {
   matches!(expr, Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left,
     ..
   } if matches!(left.as_ref(), Expr::Constant(c) if c == "E"))
@@ -6950,7 +6943,7 @@ fn try_remove_factor(expr: &Expr, factor: &Expr) -> Option<Expr> {
       None
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -6995,7 +6988,7 @@ fn try_integrate_one_over_poly_rootsum(expr: &Expr, var: &str) -> Option<Expr> {
   use crate::functions::polynomial_ast::{
     expand_and_combine, extract_poly_coeffs, find_integer_root,
   };
-  use crate::syntax::BinaryOperator::*;
+  use BinaryOperator::*;
   // Match `Power[poly, -1]` in either BinaryOp or FunctionCall form.
   let poly_raw: Expr = match expr {
     Expr::BinaryOp {
@@ -7072,7 +7065,7 @@ fn try_integrate_poly_times_const_exp(
   coeff: &Expr,
   var: &str,
 ) -> Option<Expr> {
-  use crate::syntax::BinaryOperator::*;
+  use BinaryOperator::*;
 
   // For base E, Log[E] = 1, so rate = coeff directly.
   // For other bases, rate = coeff * Log[base].
@@ -7250,7 +7243,6 @@ fn try_u_substitution_binary(
   right: &Expr,
   var: &str,
 ) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   // Try both orderings: left * g(right_inner) and right * g(left_inner)
   for (factor, composite) in [(left, right), (right, left)] {
     // Look for composite functions: Exp[h(x)], Sin[h(x)], Cos[h(x)], etc.
@@ -7313,7 +7305,7 @@ fn try_u_substitution_binary(
     // For Sin, the antiderivative is -Cos, so flip the ratio sign
     let ratio = if outer_fn == "Sin" {
       crate::evaluator::evaluate_expr_to_expr(&Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(ratio),
       })
       .ok()?
@@ -7482,7 +7474,7 @@ fn try_integration_by_parts(factors: &[&Expr], var: &str) -> Option<Expr> {
   // For a=E, rate = c*Log[E] = c, giving direct polynomial-times-E^(cx) integration.
   if dv_factors.len() == 1
     && let Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: base,
       right: exp,
     } = dv_factors[0]
@@ -7519,7 +7511,7 @@ fn try_integration_by_parts(factors: &[&Expr], var: &str) -> Option<Expr> {
   // Decompose v into (v_core, v_denom) where v = v_core / v_denom
   // This allows proper fraction handling: u*v = (u*v_core)/v_denom
   let (v_core, v_denom) = if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: v_num,
     right: v_den,
   } = &v
@@ -7538,13 +7530,13 @@ fn try_integration_by_parts(factors: &[&Expr], var: &str) -> Option<Expr> {
   // e.g. Log[x] * (x^2/2) → (x^2*Log[x])/2 instead of x^2/2*Log[x]
   let uv = {
     let u_times_core = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(u.clone()),
       right: Box::new(v_core.clone()),
     });
     if let Some(ref denom) = v_denom {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(u_times_core),
         right: Box::new(denom.clone()),
       }
@@ -7568,7 +7560,7 @@ fn try_integration_by_parts(factors: &[&Expr], var: &str) -> Option<Expr> {
     let num_du =
       crate::functions::math_ast::times_ast(&[v_core.clone(), du]).ok()?;
     simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(num_du),
       right: Box::new(denom.clone()),
     })
@@ -7596,7 +7588,7 @@ fn try_integration_by_parts(factors: &[&Expr], var: &str) -> Option<Expr> {
       crate::functions::math_ast::subtract_ast(&[u.clone(), quotient]).ok()?;
     let inner = crate::functions::polynomial_ast::expand_and_combine(&inner);
     let result = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(v_core),
       right: Box::new(inner),
     });
@@ -7604,7 +7596,7 @@ fn try_integration_by_parts(factors: &[&Expr], var: &str) -> Option<Expr> {
   }
 
   Some(simplify(Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left: Box::new(uv),
     right: Box::new(int_v_du),
   }))
@@ -7623,7 +7615,6 @@ fn try_integration_by_parts(factors: &[&Expr], var: &str) -> Option<Expr> {
 /// substitution). Returns None unless the denominator is a power g^n (n >= 2)
 /// and the numerator is a nonzero constant multiple of g'(x).
 fn try_integrate_power_derivative(expr: &Expr, var: &str) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   // Extract the denominator: literal `a / b` or the Times[..., Power[d, -k]] form.
   let den = match expr {
     Expr::BinaryOp {
@@ -7699,7 +7690,7 @@ fn try_integrate_log_derivative(expr: &Expr, var: &str) -> Option<Expr> {
   // Times[..., Power[d, -k]] form.
   let den = match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       right,
       ..
     } => (**right).clone(),
@@ -7809,7 +7800,7 @@ fn match_const_times_log_power(
       return Some(*k);
     }
     if let Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } = e
@@ -7892,7 +7883,7 @@ fn symbolic_sqrt(e: &Expr) -> Expr {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -7904,7 +7895,7 @@ fn symbolic_sqrt(e: &Expr) -> Expr {
           (**left).clone()
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: left.clone(),
             right: Box::new(Expr::Integer(k / 2)),
           }
@@ -7926,7 +7917,7 @@ fn is_manifestly_positive_symbolic(e: &Expr) -> bool {
     || matches!(e, Expr::FunctionCall { name, args }
         if name == "Power" && args.len() == 2
           && matches!(&args[1], Expr::Integer(k) if *k > 0 && k % 2 == 0))
-    || matches!(e, Expr::BinaryOp { op: crate::syntax::BinaryOperator::Power, right, .. }
+    || matches!(e, Expr::BinaryOp { op: BinaryOperator::Power, right, .. }
         if matches!(right.as_ref(), Expr::Integer(k) if *k > 0 && k % 2 == 0))
 }
 
@@ -7956,7 +7947,7 @@ fn classify_quadratic_const(q: &Expr) -> Option<(bool, Expr)> {
       Some((true, symbolic_sqrt(&args[1])))
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if is_manifestly_positive_symbolic(operand) => {
       Some((true, symbolic_sqrt(operand)))
@@ -7969,7 +7960,7 @@ fn classify_quadratic_const(q: &Expr) -> Option<(bool, Expr)> {
 /// constant w.r.t. `var`; None otherwise.
 fn coeff_of_var_squared(term: &Expr, var: &str) -> Option<Expr> {
   let is_var_sq = |e: &Expr| {
-    matches!(e, Expr::BinaryOp { op: crate::syntax::BinaryOperator::Power, left, right }
+    matches!(e, Expr::BinaryOp { op: BinaryOperator::Power, left, right }
         if matches!(left.as_ref(), Expr::Identifier(n) if n == var)
           && matches!(right.as_ref(), Expr::Integer(2)))
       || matches!(e, Expr::FunctionCall { name, args }
@@ -7983,7 +7974,7 @@ fn coeff_of_var_squared(term: &Expr, var: &str) -> Option<Expr> {
   let factors: Vec<Expr> = match term {
     Expr::FunctionCall { name, args } if name == "Times" => args.to_vec(),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => vec![(**left).clone(), (**right).clone()],
@@ -8031,12 +8022,12 @@ fn try_integrate_reciprocal_quadratic(expr: &Expr, var: &str) -> Option<Expr> {
       args[0].clone()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } if matches!(right.as_ref(), Expr::Integer(-1)) => (**left).clone(),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } if matches!(left.as_ref(), Expr::Integer(1)) => (**right).clone(),
@@ -8129,7 +8120,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
   // (handles compound expressions like x^2, Sin[x], etc. when integrating w.r.t. a different variable)
   if is_constant_wrt(expr, var) {
     return Some(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(expr.clone()),
       right: Box::new(Expr::Identifier(var.to_string())),
     });
@@ -8155,12 +8146,12 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
   match expr {
     // Constant: ∫ c dx = c*x
     Expr::Integer(n) => Some(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(*n)),
       right: Box::new(Expr::Identifier(var.to_string())),
     }),
     Expr::Real(f) => Some(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Real(*f)),
       right: Box::new(Expr::Identifier(var.to_string())),
     }),
@@ -8169,9 +8160,9 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
     Expr::Identifier(name) => {
       if name == var {
         Some(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::Identifier(var.to_string())),
             right: Box::new(Expr::Integer(2)),
           }),
@@ -8180,7 +8171,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
       } else {
         // Constant * x
         Some(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(Expr::Identifier(name.clone())),
           right: Box::new(Expr::Identifier(var.to_string())),
         })
@@ -8189,7 +8180,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
 
     // Binary operations
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator::*;
+      use BinaryOperator::*;
       match op {
         Plus => {
           // ∫ (a + b) dx = ∫ a dx + ∫ b dx
@@ -8263,7 +8254,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               && is_constant_wrt(exp, var)
             {
               let neg_exp = Expr::UnaryOp {
-                op: crate::syntax::UnaryOperator::Minus,
+                op: UnaryOperator::Minus,
                 operand: exp.clone(),
               };
               let x_neg_n = Expr::BinaryOp {
@@ -8470,17 +8461,17 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
             if match_neg_inverse_x_squared(exp_arg, var) {
               let var_expr = Expr::Identifier(var.to_string());
               let inv_x = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(var_expr.clone()),
                 right: Box::new(Expr::Integer(-1)),
               };
               let term1 = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(var_expr),
                 right: Box::new(expr.clone()),
               };
               let term2 = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(make_sqrt(Expr::Constant("Pi".to_string()))),
                 right: Box::new(Expr::FunctionCall {
                   name: "Erf".to_string(),
@@ -8488,7 +8479,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                 }),
               };
               return Some(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Plus,
+                op: BinaryOperator::Plus,
                 left: Box::new(term1),
                 right: Box::new(term2),
               });
@@ -8580,7 +8571,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
           {
             let n1 = Expr::Integer(*n + 1);
             let base_pow = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(left.as_ref().clone()),
               right: Box::new(n1.clone()),
             };
@@ -8589,7 +8580,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               args: vec![n1, a].into(),
             };
             return Some(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(base_pow),
               right: Box::new(denom),
             });
@@ -8748,9 +8739,9 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               args: vec![x.clone()].into(),
             };
             Some(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(x),
                 right: Box::new(real_abs_x),
               }),
@@ -8785,12 +8776,12 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
           {
             let x = Expr::Identifier(var.to_string());
             let x_sq = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(x.clone()),
               right: Box::new(Expr::Integer(2)),
             };
             let one_plus = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(Expr::Integer(1)),
               right: Box::new(x_sq),
             };
@@ -8800,9 +8791,9 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
             };
             // x ArcTan[x] - Log[1 + x^2] / 2
             return Some(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(x),
                 right: Box::new(Expr::FunctionCall {
                   name: "ArcTan".to_string(),
@@ -8810,7 +8801,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                 }),
               }),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Divide,
+                op: BinaryOperator::Divide,
                 left: Box::new(log_term),
                 right: Box::new(Expr::Integer(2)),
               }),
@@ -9003,13 +8994,13 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
           {
             let x = Expr::Identifier(var.to_string());
             return Some(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Plus,
+              op: BinaryOperator::Plus,
               left: Box::new(Expr::UnaryOp {
-                op: crate::syntax::UnaryOperator::Minus,
+                op: UnaryOperator::Minus,
                 operand: Box::new(x.clone()),
               }),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(x),
                 right: Box::new(Expr::FunctionCall {
                   name: "Log".to_string(),
@@ -9037,7 +9028,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               }
             };
             Some(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(const_expr),
               right: Box::new(int_var),
             })
@@ -9048,7 +9039,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               args: args.clone(),
             };
             Some(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(const_expr),
               right: Box::new(Expr::Identifier(var.to_string())),
             })
@@ -9070,7 +9061,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                 }
               };
               return Some(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(const_expr),
                 right: Box::new(result),
               });
@@ -9097,7 +9088,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                   }
                 }
                 Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Power,
+                  op: BinaryOperator::Power,
                   left,
                   right,
                 } => {
@@ -9118,7 +9109,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                   den_factors.push(base);
                 } else {
                   den_factors.push(Expr::BinaryOp {
-                    op: crate::syntax::BinaryOperator::Power,
+                    op: BinaryOperator::Power,
                     left: Box::new(base),
                     right: Box::new(Expr::Integer(-neg_exp)),
                   });
@@ -9163,7 +9154,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                     }
                   };
                   Expr::BinaryOp {
-                    op: crate::syntax::BinaryOperator::Times,
+                    op: BinaryOperator::Times,
                     left: Box::new(const_expr),
                     right: Box::new(result),
                   }
@@ -9208,7 +9199,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                   }
                 };
                 return Some(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(const_expr),
                   right: Box::new(et_result),
                 });
@@ -9229,7 +9220,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                   }
                 };
                 return Some(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(const_expr),
                   right: Box::new(trig_result),
                 });
@@ -9252,7 +9243,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                   }
                 };
                 Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(const_expr),
                   right: Box::new(usub_result),
                 }
@@ -9274,7 +9265,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                   }
                 };
                 Some(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(const_expr),
                   right: Box::new(ibp_result),
                 })
@@ -9287,7 +9278,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
         // Power[base, exp] as FunctionCall → normalize to BinaryOp and recurse
         "Power" if args.len() == 2 => {
           let as_binop = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(args[0].clone()),
             right: Box::new(args[1].clone()),
           };
@@ -9299,7 +9290,6 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
 
     // Unary minus
     Expr::UnaryOp { op, operand } => {
-      use crate::syntax::UnaryOperator;
       if matches!(op, UnaryOperator::Minus) {
         let int = integrate(operand, var)?;
         Some(Expr::UnaryOp {
@@ -9324,7 +9314,7 @@ pub fn simplify(mut expr: Expr) -> Expr {
       let right =
         simplify(*std::mem::replace(right, Box::new(Expr::Integer(0))));
 
-      use crate::syntax::BinaryOperator::*;
+      use BinaryOperator::*;
       match (&op, &left, &right) {
         // 0 + x = x
         (Plus, Expr::Integer(0), _) => return right,
@@ -9349,7 +9339,7 @@ pub fn simplify(mut expr: Expr) -> Expr {
           Minus,
           Expr::Integer(0),
           Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand,
           },
         ) => {
@@ -9358,7 +9348,7 @@ pub fn simplify(mut expr: Expr) -> Expr {
         // 0 - x = -x  (general)
         (Minus, Expr::Integer(0), _) => {
           return Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand: Box::new(right),
           };
         }
@@ -9420,7 +9410,6 @@ pub fn simplify(mut expr: Expr) -> Expr {
       let op = *op;
       let operand =
         simplify(*std::mem::replace(operand, Box::new(Expr::Integer(0))));
-      use crate::syntax::UnaryOperator;
       if matches!(&op, UnaryOperator::Minus) {
         if let Expr::Integer(0) = operand {
           return Expr::Integer(0);
@@ -9495,7 +9484,7 @@ pub fn simplify(mut expr: Expr) -> Expr {
 fn extract_power(expr: &Expr) -> Option<(Expr, Expr)> {
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some((*left.clone(), *right.clone())),
@@ -9720,7 +9709,6 @@ fn eval_at_infinity_diverges(expr: &Expr, var: &str) -> Option<bool> {
 /// degree everywhere). Returns `None` if any summand isn't of that
 /// shape — the caller should fall back to its other heuristics.
 fn limit_bounded_oscillating_sum(expr: &Expr, var_name: &str) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   // Collect additive terms.
   let terms: Vec<Expr> = match expr {
     Expr::BinaryOp {
@@ -9795,11 +9783,10 @@ fn limit_bounded_oscillating_sum(expr: &Expr, var_name: &str) -> Option<Expr> {
 /// is the unique remaining factor. Returns None if there isn't exactly
 /// one var-dependent factor.
 fn split_constant_factor(t: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
-  use crate::syntax::BinaryOperator;
   // Pull out a leading unary minus.
   let (sign, inner) = match t {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => (-1i128, &**operand),
     _ => (1i128, t),
@@ -9846,7 +9833,7 @@ fn expr_to_abs_int(expr: &Expr) -> Option<i128> {
     return Some(n.unsigned_abs() as i128);
   }
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = &evaluated
     && let Expr::Integer(n) = **operand
@@ -9886,7 +9873,7 @@ fn diverges_pos_infinity(expr: &Expr, var: &str) -> Option<i32> {
 
   // -f
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = expr
   {
@@ -9895,7 +9882,7 @@ fn diverges_pos_infinity(expr: &Expr, var: &str) -> Option<i32> {
 
   // a - b  ==  a + (-b)
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Minus,
+    op: BinaryOperator::Minus,
     left,
     right,
   } = expr
@@ -9905,7 +9892,7 @@ fn diverges_pos_infinity(expr: &Expr, var: &str) -> Option<i32> {
       args: vec![
         (**left).clone(),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: right.clone(),
         },
       ]
@@ -9970,7 +9957,7 @@ fn times_divergence(expr: &Expr, var: &str) -> Option<i32> {
   let factors: Vec<Expr> = match expr {
     Expr::FunctionCall { name, args } if name == "Times" => args.to_vec(),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => vec![(**left).clone(), (**right).clone()],
@@ -10002,7 +9989,7 @@ fn plus_divergence(expr: &Expr, var: &str) -> Option<i32> {
   let terms: Vec<Expr> = match expr {
     Expr::FunctionCall { name, args } if name == "Plus" => args.to_vec(),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => vec![(**left).clone(), (**right).clone()],
@@ -10064,7 +10051,7 @@ fn net_poly_order(expr: &Expr, var: &str) -> Option<f64> {
       Some(total)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => Some(net_poly_order(left, var)? + net_poly_order(right, var)?),
@@ -10106,7 +10093,7 @@ fn tends_to_zero(expr: &Expr, var: &str) -> bool {
   let factors: Option<Vec<Expr>> = match expr {
     Expr::FunctionCall { name, args } if name == "Times" => Some(args.to_vec()),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => Some(vec![(**left).clone(), (**right).clone()]),
@@ -10147,7 +10134,7 @@ fn limit_decay_at_infinity(
   let terms: Vec<Expr> = match expr {
     Expr::FunctionCall { name, args } if name == "Plus" => args.to_vec(),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => vec![(**left).clone(), (**right).clone()],
@@ -10199,7 +10186,7 @@ fn sqrt_radicand(mag: &Expr, _var: &str) -> Option<Expr> {
   }
   // Treat the term as Sqrt[mag^2]; coefflist later rejects non-polynomials.
   let sq = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(mag.clone()),
     right: Box::new(Expr::Integer(2)),
   };
@@ -10227,7 +10214,6 @@ fn poly_coefflist(p: &Expr, var: &str) -> Option<Vec<Expr>> {
 /// where `a1`, `b1` are the next coefficients: 0 for `d < 2`, the finite
 /// constant for `d == 2`. Other shapes return None.
 fn limit_sqrt_difference(expr: &Expr, var: &str, point: &Expr) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   if !is_infinity(point) {
     return None;
   }
@@ -10428,7 +10414,7 @@ fn limit_at_infinity(
       if !matches!(&exp_limit, Expr::FunctionCall { name, .. } if name == "Limit")
       {
         let result = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(base.clone()),
           right: Box::new(exp_limit),
         };
@@ -10441,12 +10427,12 @@ fn limit_at_infinity(
     {
       // Use identity: Limit[f^g] = E^(Limit[g * (f - 1)]) when f -> 1, g -> inf
       let f_minus_1 = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(base),
         right: Box::new(Expr::Integer(1)),
       };
       let product = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(exp),
         right: Box::new(f_minus_1),
       };
@@ -10470,7 +10456,7 @@ fn limit_at_infinity(
         && is_constant_wrt(&exponent_limit, var_name);
       if is_clean_value(&exponent_limit) || resolved {
         let result = simplify(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(Expr::Constant("E".to_string())),
           right: Box::new(exponent_limit),
         });
@@ -10487,7 +10473,7 @@ fn limit_at_infinity(
       Expr::Identifier("Infinity".to_string())
     } else {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("Infinity".to_string())),
       }
     });
@@ -10542,7 +10528,7 @@ fn limit_at_infinity(
     // Both diverging to -infinity
     if f1 < -1e5 && f2 < f1 {
       return Ok(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("Infinity".to_string())),
       });
     }
@@ -10607,12 +10593,12 @@ fn limit_at_infinity(
           if denom == 1 {
             if numer == -1 {
               return Ok(Expr::UnaryOp {
-                op: crate::syntax::UnaryOperator::Minus,
+                op: UnaryOperator::Minus,
                 operand: Box::new(Expr::Constant("Pi".to_string())),
               });
             }
             return Ok(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Times,
+              op: BinaryOperator::Times,
               left: Box::new(Expr::Integer(numer)),
               right: Box::new(Expr::Constant("Pi".to_string())),
             });
@@ -10658,7 +10644,6 @@ fn limit_at_infinity(
 /// / Cosh / Tanh / Coth / Sech / Csch with a var-dependent argument, or E raised
 /// to a var-dependent power.
 fn contains_exponential_of_var(expr: &Expr, var: &str) -> bool {
-  use crate::syntax::BinaryOperator;
   // A growing exponential: E (or any numeric base > 1) raised to a
   // var-dependent power. Bases <= 1 decay and are handled by the ordinary
   // numeric probe.
@@ -10698,7 +10683,6 @@ fn contains_exponential_of_var(expr: &Expr, var: &str) -> bool {
 /// True when `expr` contains a Power whose exponent depends on `var` (c^x,
 /// x^x, …) — the case whose exact integer value explodes at large probes.
 fn contains_var_power(expr: &Expr, var: &str) -> bool {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::FunctionCall { name, args } => {
       (name == "Power" && args.len() == 2 && !is_constant_wrt(&args[1], var))
@@ -10742,7 +10726,7 @@ fn exp_growth_limit_at_infinity(
       Expr::Identifier("Infinity".to_string())
     } else {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("Infinity".to_string())),
       }
     });
@@ -11153,7 +11137,7 @@ fn piecewise_condition_bounds(
       Some((lo, hi))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::And,
+      op: BinaryOperator::And,
       left,
       right,
     } => {
@@ -11173,7 +11157,7 @@ fn negate_bound(c: &Expr) -> Expr {
   match c {
     Expr::Integer(n) => Expr::Integer(-n),
     _ => Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(c.clone()),
     },
   }
@@ -11288,7 +11272,7 @@ fn extract_quotient_from_times(expr: &Expr) -> Option<(Expr, Expr)> {
       args.iter().collect()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => vec![left.as_ref(), right.as_ref()],
@@ -11322,7 +11306,7 @@ fn extract_quotient_from_times(expr: &Expr) -> Option<(Expr, Expr)> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } if matches!(right.as_ref(), Expr::Integer(n) if *n < 0) => {
@@ -11331,7 +11315,7 @@ fn extract_quotient_from_times(expr: &Expr) -> Option<(Expr, Expr)> {
             Some(left.as_ref().clone())
           } else {
             Some(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: left.clone(),
               right: Box::new(Expr::Integer(-*n)),
             })
@@ -11528,7 +11512,7 @@ fn numerical_one_sided_limit(
       return Some(Expr::Identifier("Infinity".to_string()));
     } else {
       return Some(Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("Infinity".to_string())),
       });
     }
@@ -11546,7 +11530,7 @@ fn numerical_one_sided_limit(
         return Some(Expr::Identifier("Infinity".to_string()));
       } else {
         return Some(Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(Expr::Identifier("Infinity".to_string())),
         });
       }
@@ -11697,7 +11681,7 @@ fn limit_zero_times_infinity(
       args.iter().cloned().collect()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => vec![left.as_ref().clone(), right.as_ref().clone()],
@@ -11750,7 +11734,7 @@ fn limit_zero_times_infinity(
   // then recurse. Returns None if the step doesn't resolve or blows up.
   let try_orientation = |num: &Expr, den: &Expr| -> Option<Expr> {
     let recip = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Integer(1)),
       right: Box::new(den.clone()),
     };
@@ -11760,7 +11744,7 @@ fn limit_zero_times_infinity(
     // recombine — e.g. (1/x)/(-1/2 x^(-3/2)) collapses to -2 Sqrt[x], which the
     // recursive Limit can then resolve by direct substitution.
     let quotient = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(dn),
       right: Box::new(d_recip),
     };
@@ -11894,7 +11878,7 @@ fn limit_power_form(
 ) -> Option<Expr> {
   let (base, exp) = match &args[0] {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => ((**left).clone(), (**right).clone()),
@@ -12174,7 +12158,7 @@ pub fn limit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // like -((Pi - z)/Sin[z])) so the exact L'Hôpital paths apply instead
   // of the low-accuracy numeric fallback.
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = &args[0]
   {
@@ -12185,7 +12169,7 @@ pub fn limit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let inner = limit_ast(&inner_args)?;
     if !matches!(&inner, Expr::FunctionCall { name, .. } if name == "Limit") {
       return crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(-1)),
         right: Box::new(inner),
       });
@@ -12363,7 +12347,7 @@ pub fn limit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Extract numerator and denominator from either BinaryOp::Divide or
   // the canonical Times[Power[den, -1], num] form.
   let num_den: Option<(Expr, Expr)> = if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: num,
     right: den,
   } = &args[0]
@@ -12400,7 +12384,7 @@ pub fn limit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // unevaluated Derivative[1][Abs][g] (matching wolframscript), so rewrite
         // it here before recursing, otherwise Abs[x]/x-style quotients stall.
         let new_expr = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(abs_deriv_to_sign(&simplify(df))),
           right: Box::new(abs_deriv_to_sign(&simplify(dg))),
         };
@@ -12533,16 +12517,16 @@ fn is_numeric_complex_constant(expr: &Expr) -> bool {
     Expr::BinaryOp { op, left, right } => {
       matches!(
         op,
-        crate::syntax::BinaryOperator::Plus
-          | crate::syntax::BinaryOperator::Minus
-          | crate::syntax::BinaryOperator::Times
-          | crate::syntax::BinaryOperator::Divide
-          | crate::syntax::BinaryOperator::Power
+        BinaryOperator::Plus
+          | BinaryOperator::Minus
+          | BinaryOperator::Times
+          | BinaryOperator::Divide
+          | BinaryOperator::Power
       ) && is_numeric_complex_constant(left)
         && is_numeric_complex_constant(right)
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_numeric_complex_constant(operand),
     _ => false,
@@ -12565,7 +12549,7 @@ fn rewrite_reciprocal_trig(e: &Expr) -> Option<Expr> {
       Expr::FunctionCall { name, args } if args.len() == 1 => {
         let arg = walk(&args[0], changed);
         let recip = |head: &str| Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(Expr::FunctionCall {
             name: head.to_string(),
             args: vec![arg.clone()].into(),
@@ -12573,7 +12557,7 @@ fn rewrite_reciprocal_trig(e: &Expr) -> Option<Expr> {
           right: Box::new(Expr::Integer(-1)),
         };
         let quot = |num_head: &str, den_head: &str| Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(Expr::FunctionCall {
             name: num_head.to_string(),
             args: vec![arg.clone()].into(),
@@ -12645,14 +12629,14 @@ fn rewrite_reciprocal_trig(e: &Expr) -> Option<Expr> {
 /// Power of `var` in a monomial `c*var^k` (c free of `var`); None when the
 /// expression is not a monomial in `var`.
 fn monomial_power_in(e: &Expr, var: &str) -> Option<i128> {
-  use crate::syntax::BinaryOperator as Op;
+  use BinaryOperator as Op;
   if !crate::functions::polynomial_ast::contains_var(e, var) {
     return Some(0);
   }
   match e {
     Expr::Identifier(v) if v == var => Some(1),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => monomial_power_in(operand, var),
     Expr::BinaryOp {
@@ -12702,7 +12686,7 @@ const ENTIRE_HEADS: [&str; 5] = ["Exp", "Sin", "Cos", "Sinh", "Cosh"];
 /// local Laurent series, so the gate must reject it even though the series
 /// machinery would happily expand it. Returns (safe, has_essential).
 fn essential_series_safe(e: &Expr, var: &str) -> (bool, bool) {
-  use crate::syntax::BinaryOperator as Op;
+  use BinaryOperator as Op;
   if !crate::functions::polynomial_ast::contains_var(e, var) {
     return (true, false);
   }
@@ -12714,7 +12698,7 @@ fn essential_series_safe(e: &Expr, var: &str) -> (bool, bool) {
   match e {
     Expr::Identifier(v) if v == var => (true, false),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => essential_series_safe(operand, var),
     Expr::BinaryOp {
@@ -12847,7 +12831,7 @@ fn rewrite_pole_models(
   applied: &mut bool,
   gamma_applied: &mut bool,
 ) -> Expr {
-  use crate::syntax::BinaryOperator as Op;
+  use BinaryOperator as Op;
   let value_at = |u: &Expr| -> Option<Expr> {
     crate::evaluator::evaluate_expr_to_expr(
       &crate::syntax::substitute_variable(u, var, z0),
@@ -13025,7 +13009,7 @@ pub fn residue_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         expr,
         &var_name,
         &Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(Expr::Identifier(var_name.clone())),
           right: Box::new(z0.clone()),
         },
@@ -13039,7 +13023,7 @@ pub fn residue_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           &shifted,
           &var_name,
           &Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(Expr::Identifier(var_name.clone())),
             right: Box::new(Expr::Integer(-1)),
           },
@@ -13103,17 +13087,17 @@ pub fn residue_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Build g = (z - z0)^m * expr.
   let build_g = |m: i128| -> Expr {
     let shift = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::Identifier(var_name.clone())),
       right: Box::new(z0.clone()),
     };
     let powered = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(shift),
       right: Box::new(Expr::Integer(m)),
     };
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(powered),
       right: Box::new(expr.clone()),
     }
@@ -13199,7 +13183,7 @@ pub fn residue_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       simplify_full(limit_val)
     } else {
       simplify_full(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(limit_val),
         right: Box::new(Expr::FunctionCall {
           name: "Rational".to_string(),
@@ -13241,7 +13225,7 @@ fn series_coeff_to_rat(e: &Expr) -> Option<(i128, i128)> {
   match e {
     Expr::Integer(n) => Some((*n, 1)),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => series_coeff_to_rat(operand).map(|(n, d)| (-n, d)),
     Expr::FunctionCall { name, args }
@@ -13441,7 +13425,7 @@ pub fn pade_approximant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Identifier(var.clone())
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::Identifier(var.clone())),
       right: Box::new(x0.clone()),
     }
@@ -13456,7 +13440,7 @@ pub fn pade_approximant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         0 => Expr::Integer(1),
         1 => base.clone(),
         _ => Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(base.clone()),
           right: Box::new(Expr::Integer(k as i128)),
         },
@@ -13480,7 +13464,7 @@ pub fn pade_approximant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Result P/Q. Building Times[P, Power[Q, -1]] keeps the displayed form as a
   // ratio of the two polynomials (Woxi does not auto-combine it).
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(p_expr),
     right: Box::new(q_expr),
   };
@@ -13706,7 +13690,7 @@ fn split_for_series(expr: &Expr) -> Option<(Expr, Expr)> {
   };
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => Some(((**left).clone(), (**right).clone())),
@@ -13829,7 +13813,7 @@ fn try_series_quotient(
     }
     let numer = crate::functions::math_ast::plus_ast(&terms).ok()?;
     let quot = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(numer),
       right: Box::new(bm.clone()),
     };
@@ -14338,7 +14322,7 @@ pub fn normalize_series_data(args: &[Expr]) -> Option<Expr> {
 /// nested `Plus` (FunctionCall or BinaryOp) and treating `a - b` as
 /// `a + (-1)*b`. A non-additive expression yields a single-element vector.
 fn additive_terms(expr: &Expr) -> Vec<Expr> {
-  use crate::syntax::BinaryOperator as B;
+  use BinaryOperator as B;
   match expr {
     Expr::FunctionCall { name, args } if name == "Plus" => {
       args.iter().flat_map(additive_terms).collect()
@@ -14373,7 +14357,7 @@ fn additive_terms(expr: &Expr) -> Vec<Expr> {
 /// nested `Times` (FunctionCall or BinaryOp). A non-product yields a
 /// single-element vector.
 fn multiplicative_factors(expr: &Expr) -> Vec<Expr> {
-  use crate::syntax::BinaryOperator as B;
+  use BinaryOperator as B;
   match expr {
     Expr::FunctionCall { name, args } if name == "Times" => {
       args.iter().flat_map(multiplicative_factors).collect()
@@ -14471,7 +14455,7 @@ fn leading_fractional_power(
         pow_exp(&args[1]).map(Some)
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } if is_base(left) => pow_exp(right).map(Some),
@@ -15264,13 +15248,13 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         .into(),
       };
       let reg_term = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(log_sum),
         right: Box::new(Expr::Integer(2)),
       };
 
       let result = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(exp_part),
         right: Box::new(reg_term),
       };
@@ -15350,7 +15334,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             crate::functions::math_ast::make_rational(*n, d * factorial)
           } else {
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(value),
               right: Box::new(Expr::Integer(factorial)),
             }
@@ -15369,7 +15353,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           let val_clone = value.clone();
           crate::functions::math_ast::times_ast(&[value, inv]).unwrap_or(
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(val_clone),
               right: Box::new(Expr::Integer(factorial)),
             },
@@ -15494,7 +15478,6 @@ fn detect_gaussian_coefficient(
   integrand: &Expr,
   var_name: &str,
 ) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   // Peel `Exp[arg]` or `E^arg`.
   let arg: &Expr = match integrand {
     Expr::FunctionCall { name, args } if name == "Exp" && args.len() == 1 => {
@@ -15580,7 +15563,6 @@ fn gaussian_closed_form_integral(
   hi: f64,
   precision: Option<i128>,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   // Build `-α` and `Sqrt[-α]` as exact expressions so high-precision
   // evaluation later doesn't suffer f64-to-Real downcasting.
   let neg_alpha = Expr::FunctionCall {
@@ -16561,7 +16543,7 @@ pub fn curl_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let dsdy = differentiate_expr(&args[0], var2)?;
     let dsdx = differentiate_expr(&args[0], var1)?;
     let neg_dsdy = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(-1)),
       right: Box::new(dsdy),
     })?;
@@ -16649,7 +16631,7 @@ pub fn curl_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let df2_dx1 = differentiate_expr(&field[1], var1)?;
     let df1_dx2 = differentiate_expr(&field[0], var2)?;
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(df2_dx1),
       right: Box::new(df1_dx2),
     };
@@ -16674,7 +16656,7 @@ pub fn curl_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let d1 = differentiate_expr(&field[k], var_names[j])?;
       let d2 = differentiate_expr(&field[j], var_names[k])?;
       let comp = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(d1),
         right: Box::new(d2),
       };
@@ -16797,14 +16779,14 @@ pub fn dt_total_differential_ast(
       continue;
     }
     let term = simplify(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(partial),
       right: Box::new(dt_of(v)),
     });
     sum = Some(match sum {
       None => term,
       Some(acc) => Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(acc),
         right: Box::new(term),
       },
@@ -16822,7 +16804,7 @@ fn total_differentiate(
   expr: &Expr,
   var: &str,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator::*;
+  use BinaryOperator::*;
 
   match expr {
     // Constants
@@ -16950,7 +16932,6 @@ fn total_differentiate(
 
     // Unary minus
     Expr::UnaryOp { op, operand } => {
-      use crate::syntax::UnaryOperator;
       if matches!(op, UnaryOperator::Minus) {
         let d = total_differentiate(operand, var)?;
         Ok(Expr::UnaryOp {
@@ -16984,7 +16965,7 @@ fn total_differentiate(
           Ok(simplify(Expr::BinaryOp {
             op: Times,
             left: Box::new(Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               operand: Box::new(Expr::FunctionCall {
                 name: "Sin".to_string(),
                 args: args.clone(),
@@ -17143,7 +17124,7 @@ pub fn asymptotic_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let x0 = replacement.as_ref().clone();
       // Only finite expansion points are handled here.
       let is_infinite = matches!(&x0, Expr::Identifier(n) if n == "Infinity" || n == "ComplexInfinity")
-        || matches!(&x0, Expr::UnaryOp { op: crate::syntax::UnaryOperator::Minus, operand }
+        || matches!(&x0, Expr::UnaryOp { op: UnaryOperator::Minus, operand }
             if matches!(operand.as_ref(), Expr::Identifier(n) if n == "Infinity"));
       if is_infinite {
         return unevaluated();
@@ -17266,10 +17247,10 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         operands[0].clone()
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(operands[0].clone()),
           right: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(-1)),
             right: Box::new(operands[1].clone()),
           }),
@@ -17285,10 +17266,10 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         eq_args[0].clone()
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(eq_args[0].clone()),
           right: Box::new(Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(-1)),
             right: Box::new(eq_args[1].clone()),
           }),
@@ -17404,16 +17385,16 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       coeff.clone()
     } else if power == 1 {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(coeff.clone()),
         right: Box::new(t_var.clone()),
       }
     } else {
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(coeff.clone()),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(t_var.clone()),
           right: Box::new(Expr::Integer(power)),
         }),
@@ -17476,7 +17457,7 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 *replacement.clone()
               } else {
                 Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Plus,
+                  op: BinaryOperator::Plus,
                   left: Box::new(x0.clone()),
                   right: replacement.clone(),
                 }
@@ -17584,10 +17565,10 @@ pub fn discrete_convolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // n; the discrete convolution is Sum_k f[k] g[m-k], so g's n becomes m - k
   // (NOT m — g is not a function of the output variable).
   let m_minus_k = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(Expr::Identifier(m_var.clone())),
     right: Box::new(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::Integer(-1)),
       right: Box::new(k_expr.clone()),
     }),
@@ -17596,7 +17577,7 @@ pub fn discrete_convolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Build the product
   let product = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(f_sub),
     right: Box::new(g_sub),
   };
@@ -17706,7 +17687,7 @@ pub fn frenet_serret_system_ast(
     .iter()
     .map(|c| {
       eval(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(c.clone()),
         right: Box::new(speed.clone()),
       })
@@ -17717,29 +17698,29 @@ pub fn frenet_serret_system_ast(
     // 2D case
     // κ = (x'*y'' - y'*x'') / (speed_sq)^(3/2)
     let numerator = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(r1[0].clone()),
         right: Box::new(r2[1].clone()),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(r1[1].clone()),
         right: Box::new(r2[0].clone()),
       }),
     };
     let denom = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(speed_sq),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(3)),
         right: Box::new(Expr::Integer(2)),
       }),
     };
     let kappa = eval(&Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(numerator),
       right: Box::new(denom),
     })?;
@@ -17747,7 +17728,7 @@ pub fn frenet_serret_system_ast(
     // N = {-T2, T1} (rotate tangent 90° counterclockwise)
     let normal = vec![
       eval(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(-1)),
         right: Box::new(tangent[1].clone()),
       })?,
@@ -17805,16 +17786,16 @@ pub fn frenet_serret_system_ast(
 
     // κ = ||cross|| / ||r'||^3 = norm_cross / speed_sq^(3/2)
     let speed_cubed = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(speed_sq),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(3)),
         right: Box::new(Expr::Integer(2)),
       }),
     };
     let kappa = eval(&Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(norm_cross.clone()),
       right: Box::new(speed_cubed),
     })?;
@@ -17823,7 +17804,7 @@ pub fn frenet_serret_system_ast(
     let dot_cross_r3 = dot_product(&cross, &r3);
     let dot_cross_r3 = eval(&dot_cross_r3)?;
     let tau = eval(&Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(dot_cross_r3),
       right: Box::new(norm_cross_sq),
     })?;
@@ -17833,7 +17814,7 @@ pub fn frenet_serret_system_ast(
       .iter()
       .map(|c| {
         eval(&Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(c.clone()),
           right: Box::new(norm_cross.clone()),
         })
@@ -17869,7 +17850,7 @@ fn sum_of_squares(items: &[Expr]) -> Expr {
   let squared: Vec<Expr> = items
     .iter()
     .map(|e| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(e.clone()),
       right: Box::new(Expr::Integer(2)),
     })
@@ -17889,42 +17870,42 @@ fn cross_product_3d(a: &[Expr], b: &[Expr]) -> Vec<Expr> {
   vec![
     // a[1]*b[2] - a[2]*b[1]
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(a[1].clone()),
         right: Box::new(b[2].clone()),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(a[2].clone()),
         right: Box::new(b[1].clone()),
       }),
     },
     // a[2]*b[0] - a[0]*b[2]
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(a[2].clone()),
         right: Box::new(b[0].clone()),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(a[0].clone()),
         right: Box::new(b[2].clone()),
       }),
     },
     // a[0]*b[1] - a[1]*b[0]
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(a[0].clone()),
         right: Box::new(b[1].clone()),
       }),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(a[1].clone()),
         right: Box::new(b[0].clone()),
       }),
@@ -18044,7 +18025,7 @@ pub fn asymptotic_integrate_ast(
           x_var_expr.clone()
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Minus,
+            op: BinaryOperator::Minus,
             left: Box::new(x_var_expr.clone()),
             right: Box::new(x0_expr.clone()),
           }
@@ -18055,7 +18036,7 @@ pub fn asymptotic_integrate_ast(
           base
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: Box::new(base),
             right: Box::new(crate::functions::math_ast::make_rational(
               power_num, den,
@@ -18066,7 +18047,7 @@ pub fn asymptotic_integrate_ast(
           integrated_val
         } else {
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(integrated_val),
             right: Box::new(power_expr),
           }
@@ -18173,7 +18154,7 @@ pub fn asymptotic_integrate_ast(
             Expr::Identifier(var_name.clone())
           } else {
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Minus,
+              op: BinaryOperator::Minus,
               left: Box::new(Expr::Identifier(var_name.clone())),
               right: Box::new(x0.clone()),
             }
@@ -18182,7 +18163,7 @@ pub fn asymptotic_integrate_ast(
           // coeff / (new_power_num / den) * (x - x0)^(new_power_num/den)
           // = coeff * den / new_power_num * (x - x0)^(new_power_num/den)
           let factor = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(coeff.clone()),
             right: Box::new(crate::functions::math_ast::make_rational(
               den,
@@ -18193,7 +18174,7 @@ pub fn asymptotic_integrate_ast(
             base.clone()
           } else {
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(base),
               right: Box::new(crate::functions::math_ast::make_rational(
                 new_power_num,
@@ -18202,7 +18183,7 @@ pub fn asymptotic_integrate_ast(
             }
           };
           let term = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(factor),
             right: Box::new(power_expr),
           };
@@ -18288,7 +18269,7 @@ fn expr_has_var(expr: &Expr, var: &str) -> bool {
 fn try_exponential_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
   let (base, exponent) = match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => (left.as_ref(), right.as_ref()),
@@ -18310,7 +18291,7 @@ fn try_exponential_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
 
   // Compute f(x+h) - f(x) for the exponent
   let x_plus_h = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(Expr::Identifier(var.to_string())),
     right: Box::new(step.clone()),
   };
@@ -18321,7 +18302,7 @@ fn try_exponential_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
   let delta_exp = Expr::FunctionCall {
     name: "Expand".to_string(),
     args: vec![Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(shifted_exp),
       right: Box::new(exponent.clone()),
     }]
@@ -18330,12 +18311,12 @@ fn try_exponential_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
 
   // Result: base^exponent * (base^delta_exp - 1)
   let result = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(expr.clone()),
     right: Box::new(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(base.clone()),
         right: Box::new(delta_exp),
       }),
@@ -18366,7 +18347,7 @@ fn try_trig_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
   }
 
   let x_plus_h = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(Expr::Identifier(var.to_string())),
     right: Box::new(step.clone()),
   };
@@ -18374,11 +18355,11 @@ fn try_trig_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
 
   // Compute half_delta = (shifted_arg - arg) / 2 via evaluation
   let half_delta_raw = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(Expr::FunctionCall {
       name: "Expand".to_string(),
       args: vec![Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(shifted_arg.clone()),
         right: Box::new(arg.clone()),
       }]
@@ -18397,7 +18378,7 @@ fn try_trig_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
     Expr::Constant("Pi".to_string())
   } else {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Constant("Pi".to_string())),
     }
   };
@@ -18405,11 +18386,11 @@ fn try_trig_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
   // (step + Pi) / 2 to get a cleaner fraction when possible.
   // General form: half_delta + Pi/2 + arg, combined as arg + (2*half_delta ± Pi)/2
   let const_part = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(half_delta.clone()),
       }),
@@ -18418,7 +18399,7 @@ fn try_trig_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
     right: Box::new(Expr::Integer(2)),
   };
   let second_arg_expr = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Plus,
+    op: BinaryOperator::Plus,
     left: Box::new(const_part),
     right: Box::new(arg.clone()),
   };
@@ -18724,7 +18705,7 @@ pub fn difference_delta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
     // f(x + h)
     let x_plus_h = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(Expr::Identifier(var_name.clone())),
       right: Box::new(step.clone()),
     };
@@ -18732,7 +18713,7 @@ pub fn difference_delta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::syntax::substitute_variable(&current, &var_name, &x_plus_h);
     // f(x + h) - f(x)
     let diff = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(shifted),
       right: Box::new(current.clone()),
     };
@@ -18837,14 +18818,14 @@ pub fn difference_quotient_ast(
     step.clone()
   } else {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(step.clone()),
       right: Box::new(Expr::Integer(order as i128)),
     }
   };
 
   let quotient = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(delta_result),
     right: Box::new(divisor),
   };
@@ -18862,7 +18843,7 @@ fn dot_product(a: &[Expr], b: &[Expr]) -> Expr {
     .iter()
     .zip(b.iter())
     .map(|(ai, bi)| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(ai.clone()),
       right: Box::new(bi.clone()),
     })
@@ -19070,7 +19051,7 @@ fn weber_anger_series_at_zero(
     args: args.into(),
   };
   let divide = |left: Expr, right: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(left),
     right: Box::new(right),
   };

--- a/src/functions/count_roots_ast.rs
+++ b/src/functions/count_roots_ast.rs
@@ -13,7 +13,7 @@
 //! Real-valued bounds) returns the call unevaluated.
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 use num_bigint::BigInt;
 use num_traits::{One, Signed, Zero};
 
@@ -398,7 +398,6 @@ fn is_pos_infinity(e: &Expr) -> bool {
 /// Detect `-Infinity` across the forms the parser/evaluator may produce:
 /// `Times[-1, Infinity]` (FunctionCall or BinaryOp) and `-Infinity` (UnaryOp).
 fn is_neg_infinity(e: &Expr) -> bool {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   let is_neg = |x: &Expr| {
     matches!(x, Expr::Integer(n) if *n < 0)
       || matches!(x, Expr::Real(r) if *r < 0.0)

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -5,7 +5,7 @@
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::{make_sqrt, try_eval_to_f64};
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// Transpose a matrix (Vec<Vec<Expr>>)
 fn transpose_matrix(m: &[Vec<Expr>]) -> Vec<Vec<Expr>> {
@@ -407,7 +407,7 @@ fn fallback_plus(a: &Expr, b: &Expr) -> Expr {
   match crate::functions::math_ast::plus_ast(&[a.clone(), b.clone()]) {
     Ok(r) => r,
     Err(_) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left: Box::new(a.clone()),
       right: Box::new(b.clone()),
     },
@@ -422,7 +422,7 @@ fn eval_mul(a: &Expr, b: &Expr) -> Expr {
         match crate::functions::math_ast::times_ast(&[a.clone(), b.clone()]) {
           Ok(r) => r,
           Err(_) => Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(a.clone()),
             right: Box::new(b.clone()),
           },
@@ -436,7 +436,7 @@ fn eval_mul(a: &Expr, b: &Expr) -> Expr {
     _ => match crate::functions::math_ast::times_ast(&[a.clone(), b.clone()]) {
       Ok(r) => r,
       Err(_) => Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(a.clone()),
         right: Box::new(b.clone()),
       },
@@ -461,7 +461,7 @@ fn fallback_sub(a: &Expr, b: &Expr) -> Expr {
   match crate::functions::math_ast::subtract_ast(&[a.clone(), b.clone()]) {
     Ok(r) => r,
     Err(_) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(a.clone()),
       right: Box::new(b.clone()),
     },
@@ -1143,7 +1143,7 @@ fn eval_divide(a: &Expr, b: &Expr) -> Expr {
       match crate::functions::math_ast::divide_ast(&[a.clone(), b.clone()]) {
         Ok(r) => r,
         Err(_) => Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(a.clone()),
           right: Box::new(b.clone()),
         },
@@ -1806,12 +1806,12 @@ pub fn projection_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: vec![conj_v, v.clone()].into(),
     };
     let scalar = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(dot_cv_u),
       right: Box::new(dot_cv_v),
     };
     let result = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(scalar),
       right: Box::new(v),
     };
@@ -2507,7 +2507,7 @@ fn divide_exact_root(root: &Expr, d: i128) -> Option<Expr> {
   match root {
     Expr::Integer(n) => Some(simplify_fraction(*n, d)),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let pos = divide_exact_root(operand, d)?;
@@ -2530,7 +2530,7 @@ fn divide_exact_root(root: &Expr, d: i128) -> Option<Expr> {
       .ok()
     }
     _ => crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(root.clone()),
       right: Box::new(Expr::Integer(d)),
     })
@@ -2609,7 +2609,7 @@ fn quadratic_eigenvalues(b_coeff: i128, c_coeff: i128) -> Vec<Expr> {
     }
     // Otherwise keep the quotient form (3 + I*Sqrt[11])/2
     let halved = |num: Expr| Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(num),
       right: Box::new(Expr::Integer(2)),
     };
@@ -2882,7 +2882,7 @@ pub fn eigenvalues_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: vec![a, d].into(),
     };
     let lambda_minus = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::FunctionCall {
         name: "Plus".to_string(),
         args: vec![
@@ -2897,7 +2897,7 @@ pub fn eigenvalues_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       right: Box::new(Expr::Integer(2)),
     };
     let lambda_plus = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::FunctionCall {
         name: "Plus".to_string(),
         args: vec![trace, sqrt_disc].into(),
@@ -3539,7 +3539,7 @@ fn complex_2x2_eigenvectors(
   let quotient_vector =
     |num_minuend: &Expr, num_subtrahend: &Expr, den: &Expr| {
       let x = evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::FunctionCall {
           name: "Plus".to_string(),
           args: vec![
@@ -6842,8 +6842,6 @@ pub fn fitted_model_normal(
 pub fn cholesky_decomposition_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   let unevaluated = || Expr::FunctionCall {
     name: "CholeskyDecomposition".to_string(),
     args: args.to_vec().into(),
@@ -7048,8 +7046,6 @@ pub(crate) fn contains_imaginary_unit(e: &Expr) -> bool {
 }
 
 pub fn qr_decomposition_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   let matrix = match expr_to_matrix(&args[0]) {
     Some(m) => m,
     None => {
@@ -7320,7 +7316,6 @@ pub fn singular_value_decomposition_ast(
 /// pass through unchanged.
 fn simplify_radical_factor(expr: &Expr) -> Expr {
   use crate::functions::math_ast::{gcd, make_rational, sqrt_ast, times_ast};
-  use crate::syntax::BinaryOperator;
   let extract_int = |e: &Expr| -> Option<i128> {
     if let Expr::Integer(n) = e {
       Some(*n)
@@ -7388,7 +7383,7 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
   let mut other: Vec<Expr> = Vec::new();
   for f in &factors {
     if let Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } = f
     {
@@ -7594,7 +7589,6 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
 
 /// Helper: evaluate a dot product of two vectors
 fn eval_dot_product(a: &[Expr], b: &[Expr]) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let mut sum = Expr::Integer(0);
   for (ai, bi) in a.iter().zip(b.iter()) {
     let prod = Expr::BinaryOp {
@@ -8580,7 +8574,7 @@ pub fn jordan_decomposition_ast(
     let result = simplify(simplify(evaluate_expr_to_expr(&e)?)?)?;
     let inner = match &result {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => Some(operand.as_ref()),
       Expr::FunctionCall { name, args }
@@ -8598,7 +8592,7 @@ pub fn jordan_decomposition_ast(
           Some(args.iter().cloned().collect())
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left,
           right,
         } => {
@@ -8634,7 +8628,7 @@ pub fn jordan_decomposition_ast(
   let repeated = same(&l1, &l2);
 
   let div = |n: Expr, dn: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(n),
     right: Box::new(dn),
   };
@@ -9298,7 +9292,7 @@ fn expr_to_gq(e: &Expr) -> Option<GQNum> {
       Some(acc)
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => GQNum::zero().sub(&expr_to_gq(operand)?),
     // Complex-rational scalars can survive as unevaluated binary
@@ -9307,10 +9301,10 @@ fn expr_to_gq(e: &Expr) -> Option<GQNum> {
       let l = expr_to_gq(left)?;
       let r = expr_to_gq(right)?;
       match op {
-        crate::syntax::BinaryOperator::Plus => l.add(&r),
-        crate::syntax::BinaryOperator::Minus => l.sub(&r),
-        crate::syntax::BinaryOperator::Times => l.mul(&r),
-        crate::syntax::BinaryOperator::Divide => l.div(&r),
+        BinaryOperator::Plus => l.add(&r),
+        BinaryOperator::Minus => l.sub(&r),
+        BinaryOperator::Times => l.mul(&r),
+        BinaryOperator::Divide => l.div(&r),
         _ => None,
       }
     }
@@ -9504,7 +9498,7 @@ fn expr_mod_m(e: &Expr, m: i128) -> Result<i128, bool> {
       expr_mod_m(&rat, m)
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => expr_mod_m(operand, m).map(|v| (-v).rem_euclid(m)),
     _ => Err(false),
@@ -10030,7 +10024,7 @@ pub fn coordinate_transform_ast(
     args: fargs.into(),
   };
   let sq = |e: &Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(e.clone()),
     right: Box::new(Expr::Integer(2)),
   };

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 /// Shared AllTrue/AnyTrue/NoneTrue implementation: apply the predicate
 /// to every element at exactly the requested level (default 1) and
@@ -322,16 +323,16 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
       // Median[PowerDistribution[k, a]] = 1/(2^(1/a) k).
       let (k, a) = (dargs[0].clone(), dargs[1].clone());
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(Expr::FunctionCall {
           name: "Times".to_string(),
           args: vec![
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(Expr::Integer(2)),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(a),
                 right: Box::new(Expr::Integer(-1)),
               }),
@@ -368,7 +369,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![sqrt_pi, inverse_erf_half].into(),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(numer),
         right: Box::new(theta),
       };
@@ -388,7 +389,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![Expr::Integer(2)].into(),
       };
       let inv_a = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(a),
       };
@@ -397,13 +398,13 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![log2, inv_a].into(),
       };
       let b_over = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(b),
         right: Box::new(denom),
       };
       let med = match mu {
         Some(m) => Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(m),
           right: Box::new(b_over),
         },
@@ -427,10 +428,10 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![log2].into(),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(a),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(b),
           right: Box::new(log_log2),
         }),
@@ -461,7 +462,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
       };
       let v_half = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(v),
         right: Box::new(Expr::Integer(2)),
       };
@@ -478,7 +479,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![Expr::Integer(2)].into(),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(sqrt2),
         right: Box::new(sqrt_inner),
       };
@@ -510,32 +511,32 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
       let a = dargs[1].clone();
       let b = dargs[2].clone();
       let inv_p = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(p),
       };
       let two_pow = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(inv_p),
       };
       let base = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Integer(-1)),
         right: Box::new(two_pow),
       };
       let inv_a = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(a),
       };
       let denom = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(base),
         right: Box::new(inv_a),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(b),
         right: Box::new(denom),
       };
@@ -557,17 +558,17 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
       let k = dargs[0].clone();
       let a = dargs[1].clone();
       let inv_a = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(a),
       };
       let pow_term = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(Expr::Integer(2)),
         right: Box::new(inv_a),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(k),
         right: Box::new(pow_term),
       };
@@ -582,17 +583,17 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![Expr::Integer(2)].into(),
       };
       let inv_a = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(a),
       };
       let pow_term = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(log2),
         right: Box::new(inv_a),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(b),
         right: Box::new(pow_term),
       };
@@ -601,7 +602,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
     "LogNormalDistribution" if dargs.len() == 2 => {
       // Median[LogNormalDistribution[mu, sigma]] = E^mu
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(Expr::Constant("E".to_string())),
         right: Box::new(dargs[0].clone()),
       };
@@ -637,12 +638,12 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
       // Median = (a + b)/2. ArcSinDistribution is also symmetric about
       // the midpoint of its support, so the same formula applies.
       let sum = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(bounds[0].clone()),
         right: Box::new(bounds[1].clone()),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(sum),
         right: Box::new(Expr::Integer(2)),
       };
@@ -664,7 +665,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![log4].into(),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left: Box::new(sigma),
         right: Box::new(sqrt_log4),
       };
@@ -681,17 +682,17 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
       let imax = bounds[1].clone();
       // Median = -1 + min + Max[1, Ceiling[(1 + max - min)/2]]
       let diff = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(imax),
         right: Box::new(imin.clone()),
       };
       let one_plus_diff = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(diff),
       };
       let half = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(one_plus_diff),
         right: Box::new(Expr::Integer(2)),
       };
@@ -704,10 +705,10 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![Expr::Integer(1), ceiling].into(),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Integer(-1)),
         right: Box::new(Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus,
+          op: BinaryOperator::Plus,
           left: Box::new(imin),
           right: Box::new(max_call),
         }),
@@ -727,7 +728,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![a, half].into(),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(b),
         right: Box::new(denom),
       };
@@ -742,12 +743,12 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![Expr::Integer(2)].into(),
       };
       let log2_over_xi = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(log2),
         right: Box::new(xi),
       };
       let one_plus = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left: Box::new(Expr::Integer(1)),
         right: Box::new(log2_over_xi),
       };
@@ -756,7 +757,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
         args: vec![one_plus].into(),
       };
       let med = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(log_arg),
         right: Box::new(lambda),
       };
@@ -800,7 +801,7 @@ fn hypoexponential_median(arg: &Expr) -> Option<Expr> {
       args: vec![Expr::Integer(2)].into(),
     };
     let med = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(log2),
       right: Box::new(lambda),
     };
@@ -1008,7 +1009,7 @@ pub fn median_ast(list: &Expr) -> Result<Expr, InterpreterError> {
         return Ok(sorted[len / 2].clone());
       }
       let avg = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::FunctionCall {
           name: "Plus".to_string(),
           args: vec![sorted[len / 2 - 1].clone(), sorted[len / 2].clone()]
@@ -1091,7 +1092,7 @@ pub fn median_ast(list: &Expr) -> Result<Expr, InterpreterError> {
       Ok(keyed[len / 2].1.clone())
     } else {
       let avg = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(Expr::FunctionCall {
           name: "Plus".to_string(),
           args: vec![keyed[len / 2 - 1].1.clone(), keyed[len / 2].1.clone()]
@@ -1383,7 +1384,7 @@ pub fn min_max_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       vec![
         Expr::Identifier("Infinity".to_string()),
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(Expr::Identifier("Infinity".to_string())),
         },
       ]
@@ -1817,7 +1818,7 @@ fn edge_to_f64(e: &Expr) -> Option<f64> {
   // -Infinity is stored as UnaryOp[Minus, Infinity] inside an unevaluated
   // List (the evaluator leaves it as-is to preserve the surface syntax).
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = e
   {

--- a/src/functions/list_helpers_ast/sorting.rs
+++ b/src/functions/list_helpers_ast/sorting.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 /// Wolfram canonical ordering for expressions.
 /// For strings: case-insensitive first, then lowercase before uppercase for ties.
@@ -24,7 +25,7 @@ pub fn expr_to_complex_parts(e: &Expr) -> Option<(f64, f64)> {
   match e {
     // Pure imaginary: n*I (BinaryOp form)
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -42,7 +43,7 @@ pub fn expr_to_complex_parts(e: &Expr) -> Option<(f64, f64)> {
     }
     // a + b*I (BinaryOp form)
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => {
@@ -55,7 +56,7 @@ pub fn expr_to_complex_parts(e: &Expr) -> Option<(f64, f64)> {
     }
     // a - b*I (BinaryOp form)
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left,
       right,
     } => {
@@ -108,7 +109,7 @@ pub fn expr_to_complex_parts(e: &Expr) -> Option<(f64, f64)> {
     Expr::Identifier(name) if name == "I" => Some((0.0, 1.0)),
     // Negated: -I, -(a+bI)
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       if let Some((re, im)) = expr_to_complex_parts(operand) {
@@ -1291,7 +1292,7 @@ fn numeric_coeff_and_rest(e: &Expr) -> (f64, String) {
   };
   match e {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let (c, r) = numeric_coeff_and_rest(operand);
@@ -1313,7 +1314,7 @@ fn numeric_coeff_and_rest(e: &Expr) -> (f64, String) {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -1339,15 +1340,15 @@ fn sum_highest_term_negates(sum: &Expr, atom: &Expr) -> bool {
       args.last().cloned()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       right,
       ..
     } => Some(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: right.clone(),
     }),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       right,
       ..
     } => Some((**right).clone()),
@@ -1356,7 +1357,7 @@ fn sum_highest_term_negates(sum: &Expr, atom: &Expr) -> bool {
   let Some(last) = last else { return false };
   let negated_inner = match &last {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some((**operand).clone()),
     Expr::FunctionCall { name, args }
@@ -1367,7 +1368,7 @@ fn sum_highest_term_negates(sum: &Expr, atom: &Expr) -> bool {
       Some(args[1].clone())
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } if matches!(left.as_ref(), Expr::Integer(n) if *n < 0) => {
@@ -1405,7 +1406,7 @@ fn is_power_expr(e: &Expr) -> bool {
   matches!(
     e,
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       ..
     }
   ) || matches!(e, Expr::FunctionCall { name, args } if name == "Power" && args.len() == 2)

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 /// AnglePath[{θ1, θ2, ...}] - path with unit steps and cumulative turning angles.
 /// AnglePath[{{r1, θ1}, {r2, θ2}, ...}] - path with specified step lengths.
@@ -287,7 +288,6 @@ fn parse_initial_spec(expr: &Expr) -> Option<(Expr, Expr)> {
 /// parses: `Plus[1, Times[-1, Power[var, -4]]]`, `1 + Power[var, -4]*-1`,
 /// `1 - 1/var^4` (BinaryOp), etc.
 fn body_is_one_minus_one_over_var_quartic(body: &Expr, var_name: &str) -> bool {
-  use crate::syntax::BinaryOperator;
   let is_var_to_neg_four = |e: &Expr| -> bool {
     if let Expr::BinaryOp {
       op: BinaryOperator::Power,
@@ -445,7 +445,6 @@ fn telescope_linear_pair(
   max_expr: &Expr,
   k0: i128,
 ) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   if a == b {
     return Some(Expr::Integer(1));
   }
@@ -739,7 +738,6 @@ fn infinite_integer_root_product(
   var_name: &str,
   n0: i128,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   if n0 < 1 {
     return Ok(None);
   }
@@ -835,7 +833,7 @@ fn linear_shift_of_var(body: &Expr, var_name: &str) -> Option<Expr> {
       args.iter().collect()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => vec![left.as_ref(), right.as_ref()],
@@ -869,7 +867,6 @@ fn linear_shift_of_var(body: &Expr, var_name: &str) -> Option<Expr> {
 }
 
 fn body_is_one_plus_one_over_var_squared(body: &Expr, var_name: &str) -> bool {
-  use crate::syntax::BinaryOperator;
   let is_var_squared = |e: &Expr| -> bool {
     matches!(
       e,
@@ -1082,7 +1079,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 .into(),
               })?;
             let power = Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(body.clone()),
               right: Box::new(count),
             };
@@ -1116,7 +1113,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                   return Ok(n_factorial);
                 }
                 return Ok(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Divide,
+                  op: BinaryOperator::Divide,
                   left: Box::new(n_factorial),
                   right: Box::new(Expr::Integer(denom)),
                 });
@@ -1130,9 +1127,9 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                   min_expr.clone(),
                   // 1 - min + max
                   Expr::BinaryOp {
-                    op: crate::syntax::BinaryOperator::Plus,
+                    op: BinaryOperator::Plus,
                     left: Box::new(Expr::BinaryOp {
-                      op: crate::syntax::BinaryOperator::Minus,
+                      op: BinaryOperator::Minus,
                       left: Box::new(Expr::Integer(1)),
                       right: Box::new(min_expr.clone()),
                     }),
@@ -1155,7 +1152,6 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && !max_is_infinity
             && let Some(a) = linear_shift_of_var(body, &var_name)
           {
-            use crate::syntax::BinaryOperator;
             let one_plus_a =
               crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
                 op: BinaryOperator::Plus,
@@ -1228,7 +1224,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && max_concrete.is_none()
             && !max_is_infinity
             && let Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: base,
               right: exp,
             } = body
@@ -1238,12 +1234,12 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               // Product[c^i, {i, 1, n}] = c^((n*(1+n))/2)
               let n = max_expr.clone();
               let exponent = Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Divide,
+                op: BinaryOperator::Divide,
                 left: Box::new(Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Times,
+                  op: BinaryOperator::Times,
                   left: Box::new(n.clone()),
                   right: Box::new(Expr::BinaryOp {
-                    op: crate::syntax::BinaryOperator::Plus,
+                    op: BinaryOperator::Plus,
                     left: Box::new(Expr::Integer(1)),
                     right: Box::new(n),
                   }),
@@ -1251,7 +1247,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 right: Box::new(Expr::Integer(2)),
               };
               return Ok(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: base.clone(),
                 right: Box::new(exponent),
               });
@@ -1261,7 +1257,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             if matches!(base.as_ref(), Expr::Identifier(name) if name == &var_name)
             {
               return Ok(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Power,
+                op: BinaryOperator::Power,
                 left: Box::new(Expr::FunctionCall {
                   name: "Factorial".to_string(),
                   args: vec![max_expr.clone()].into(),
@@ -1285,7 +1281,6 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 body, &var_name,
               )
           {
-            use crate::syntax::BinaryOperator;
             // p = (d body / d var) * var / body — the exponent of a monomial.
             let p_expr = Expr::FunctionCall {
               name: "Simplify".to_string(),
@@ -1392,7 +1387,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && body_is_one_plus_one_over_var_squared(body, &var_name)
           {
             return Ok(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(Expr::FunctionCall {
                 name: "Sinh".to_string(),
                 args: vec![Expr::Constant("Pi".to_string())].into(),
@@ -1411,13 +1406,13 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && body_is_one_minus_one_over_var_quartic(body, &var_name)
           {
             return Ok(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(Expr::FunctionCall {
                 name: "Sinh".to_string(),
                 args: vec![Expr::Constant("Pi".to_string())].into(),
               }),
               right: Box::new(Expr::BinaryOp {
-                op: crate::syntax::BinaryOperator::Times,
+                op: BinaryOperator::Times,
                 left: Box::new(Expr::Integer(4)),
                 right: Box::new(Expr::Constant("Pi".to_string())),
               }),
@@ -1537,7 +1532,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let mut result = values.remove(0);
         for val in values {
           result = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(result),
             right: Box::new(val),
           };
@@ -1614,7 +1609,6 @@ fn summand_contains_var(expr: &Expr, var: &str) -> bool {
 /// polynomial/rational/fractional-power class (exponentials with var in
 /// the exponent, Log factors, unknown functions of var).
 fn summand_growth_degree(expr: &Expr, var: &str) -> Option<f64> {
-  use crate::syntax::BinaryOperator;
   if !summand_contains_var(expr, var) {
     // A var-free factor is degree 0 — but reject non-numeric leaves like
     // symbolic parameters only when they are the whole summand (handled
@@ -1701,7 +1695,7 @@ fn summand_numeric_value(expr: &Expr) -> Option<f64> {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some(-summand_numeric_value(operand)?),
     _ => None,
@@ -1735,7 +1729,6 @@ fn product_early_terms_clean(body: &Expr, var: &str, n0: i128) -> bool {
 /// to the degree. None for anything else (Log factors, a^n with
 /// non-numeric base, unknown functions of var).
 fn product_growth(expr: &Expr, var: &str) -> Option<(f64, f64)> {
-  use crate::syntax::BinaryOperator;
   if !summand_contains_var(expr, var) {
     return Some((0.0, 0.0));
   }
@@ -1848,7 +1841,6 @@ fn product_growth_power(
 
 /// The slope k of an expression linear in var (k*var + c with numeric k).
 fn linear_slope_in(expr: &Expr, var: &str) -> Option<f64> {
-  use crate::syntax::BinaryOperator;
   if !summand_contains_var(expr, var) {
     return Some(0.0);
   }
@@ -1899,7 +1891,7 @@ fn linear_slope_in(expr: &Expr, var: &str) -> Option<f64> {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some(-linear_slope_in(operand, var)?),
     _ => None,
@@ -2109,7 +2101,7 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let diff = crate::functions::math_ast::plus_ast(&[
           items[2].clone(),
           Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand: Box::new(items[1].clone()),
           },
         ]);
@@ -2127,7 +2119,7 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 min_eval.clone()
               } else {
                 crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-                  op: crate::syntax::BinaryOperator::Plus,
+                  op: BinaryOperator::Plus,
                   left: Box::new(min_eval.clone()),
                   right: Box::new(Expr::Integer(j)),
                 })?
@@ -2289,7 +2281,7 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 fn collect_times_factors(e: &Expr, out: &mut Vec<Expr>) {
   match e {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -2309,7 +2301,7 @@ fn collect_times_factors(e: &Expr, out: &mut Vec<Expr>) {
 fn power_with_exponent_var(f: &Expr, var_name: &str) -> Option<Expr> {
   match f {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } if matches!(right.as_ref(), Expr::Identifier(s) if s == var_name) => {
@@ -2337,7 +2329,6 @@ fn try_binomial_theorem_sum(
   max_expr: &Expr,
 ) -> Option<Expr> {
   use crate::functions::polynomial_ast::contains_var;
-  use crate::syntax::BinaryOperator;
 
   let mut factors = Vec::new();
   collect_times_factors(body, &mut factors);
@@ -2428,8 +2419,6 @@ fn try_symbolic_sum(
   min_concrete: Option<i128>,
   _max_concrete: Option<i128>,
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // If body doesn't contain the iteration variable, it's a constant sum:
   // Sum[c, {var, min, max}] = c * (max - min + 1)
   if !crate::functions::polynomial_ast::contains_var(body, var_name) {
@@ -3008,8 +2997,6 @@ fn is_leibniz_body(body: &Expr, var_name: &str) -> bool {
 /// and symbolic (not a plain number), and `var` appears only as the exponent.
 /// Returns `(coefficient, base)`.
 fn match_geometric_base(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
-  use crate::syntax::BinaryOperator;
-
   // Flatten the multiplicative factors of `body`. A `Divide` contributes its
   // denominator as a reciprocal factor `denominator^(-1)`.
   fn collect(e: &Expr, out: &mut Vec<Expr>) {
@@ -3181,7 +3168,6 @@ fn match_geometric_symbolic_exp(
   var_name: &str,
 ) -> Option<(Expr, Expr)> {
   use crate::functions::calculus_ast::is_constant_wrt;
-  use crate::syntax::BinaryOperator;
 
   let mut factors = Vec::new();
   collect_times_factors(body, &mut factors);
@@ -3385,7 +3371,7 @@ fn is_times_expr(e: &Expr) -> bool {
   matches!(
     e,
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       ..
     }
   ) || matches!(e, Expr::FunctionCall { name, .. } if name == "Times")
@@ -3394,7 +3380,6 @@ fn is_times_expr(e: &Expr) -> bool {
 /// If `exp` is `c * var` for a constant `c` (and `var` appears exactly once),
 /// return `c`; otherwise None. `var` alone gives `1`.
 fn linear_coeff_of_var(exp: &Expr, var_name: &str) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
   fn collect_times(e: &Expr, out: &mut Vec<Expr>) {
     match e {
       Expr::BinaryOp {
@@ -3445,7 +3430,6 @@ fn linear_coeff_of_var(exp: &Expr, var_name: &str) -> Option<Expr> {
 /// series Sum[base^k/k, {k,1,Infinity}] = -Log[1 - base]. Reciprocal forms such
 /// as `1/(2^n n)` and `2^(-n)/n` are normalised to base `1/2`.
 fn match_log_geometric(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
-  use crate::syntax::BinaryOperator;
   // Push 1/e as multiplicative factors, distributing over products and folding
   // one level of power so 1/(2^n n) yields [2^(-n), n^(-1)].
   fn recip(e: &Expr, out: &mut Vec<Expr>) {
@@ -3640,8 +3624,6 @@ fn match_log_geometric(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
 /// `base` and inside the factorial. Returns `(coefficient, base)`; the base
 /// defaults to `1` when there is no explicit `base^var` factor (e.g. `1/k!`).
 fn match_exponential_base(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
-  use crate::syntax::BinaryOperator;
-
   fn collect(e: &Expr, out: &mut Vec<Expr>) {
     match e {
       Expr::BinaryOp {
@@ -4166,7 +4148,6 @@ fn try_infinite_sum(
     && crate::functions::math_ast::try_eval_to_f64(&base)
       .is_none_or(|bf| bf.abs() < 1.0)
   {
-    use crate::syntax::BinaryOperator;
     let one_minus_base = Expr::BinaryOp {
       op: BinaryOperator::Plus,
       left: Box::new(Expr::Integer(1)),
@@ -4193,7 +4174,6 @@ fn try_infinite_sum(
     && let Some((coeff, eff_base)) =
       match_geometric_symbolic_exp(body, var_name)
   {
-    use crate::syntax::BinaryOperator;
     let neg_one_plus_base = Expr::BinaryOp {
       op: BinaryOperator::Plus,
       left: Box::new(Expr::Integer(-1)),
@@ -4219,7 +4199,6 @@ fn try_infinite_sum(
     && let Some(bf) = crate::functions::math_ast::try_eval_to_f64(&base)
     && bf.abs() < 1.0
   {
-    use crate::syntax::BinaryOperator;
     let one_minus_base = Expr::BinaryOp {
       op: BinaryOperator::Plus,
       left: Box::new(Expr::Integer(1)),
@@ -4255,7 +4234,6 @@ fn try_infinite_sum(
     && let Some((coeff, base)) = match_geometric_base(body, var_name)
     && crate::functions::math_ast::try_eval_to_f64(&base).is_none()
   {
-    use crate::syntax::BinaryOperator;
     let base_pow_min = if min == 1 {
       base.clone()
     } else {
@@ -4317,7 +4295,6 @@ fn try_infinite_sum(
   if min == 1
     && let Some((coeff, base)) = match_log_geometric(body, var_name)
   {
-    use crate::syntax::BinaryOperator;
     // The Mercator series Sum[base^k/k] converges on the real interval
     // [-1, 1): base == 1 is the divergent harmonic series, |base| > 1
     // diverges, but base == -1 converges conditionally to -Log[2]. (A
@@ -4399,7 +4376,6 @@ fn try_infinite_sum(
       && !is_exact
       && crate::functions::math_ast::try_eval_to_f64(&r).is_none()
     {
-      use crate::syntax::BinaryOperator;
       let denom = Expr::BinaryOp {
         op: BinaryOperator::Power,
         left: Box::new(Expr::BinaryOp {
@@ -4421,7 +4397,7 @@ fn try_infinite_sum(
   // Try Leibniz formula: Sum[(-1)^k / (2k+1), {k, 0, Infinity}] = Pi/4
   if min == 0 && is_leibniz_body(body, var_name) {
     return Ok(Some(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::Constant("Pi".to_string())),
       right: Box::new(Expr::Integer(4)),
     }));
@@ -4467,7 +4443,7 @@ fn try_infinite_sum(
       args: vec![Expr::Integer(s as i128)].into(),
     };
     let a_pow = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(a),
       right: Box::new(Expr::Integer(-(s as i128))),
     };
@@ -4549,7 +4525,6 @@ fn try_infinite_sum(
 
   // Sum[1/c^i, {i, 1, Infinity}] = 1/(c-1) for integer c > 1
   // Detect body = 1/c^var (Divide form)
-  use crate::syntax::BinaryOperator;
   if let Expr::BinaryOp {
     op: BinaryOperator::Divide,
     left,
@@ -4582,7 +4557,6 @@ fn collect_factors(
   den: &mut Vec<Expr>,
   invert: bool,
 ) {
-  use crate::syntax::BinaryOperator;
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Times,
@@ -4641,7 +4615,6 @@ fn match_alternating_reciprocal_power(
   body: &Expr,
   var_name: &str,
 ) -> Option<(i32, i64)> {
-  use crate::syntax::BinaryOperator;
   let mut num: Vec<Expr> = Vec::new();
   let mut den: Vec<Expr> = Vec::new();
   collect_factors(body, &mut num, &mut den, false);
@@ -4705,7 +4678,6 @@ fn match_reciprocal_power_general(
   expr: &Expr,
   var_name: &str,
 ) -> Option<(Expr, i64)> {
-  use crate::syntax::BinaryOperator;
   let has_var =
     |e: &Expr| crate::functions::polynomial_ast::contains_var(e, var_name);
   match expr {
@@ -4761,7 +4733,6 @@ fn match_scaled_reciprocal_power(
   body: &Expr,
   var_name: &str,
 ) -> Option<(Expr, i64)> {
-  use crate::syntax::BinaryOperator;
   let mut num: Vec<Expr> = Vec::new();
   let mut den: Vec<Expr> = Vec::new();
   collect_factors(body, &mut num, &mut den, false);
@@ -4818,7 +4789,6 @@ fn match_odd_reciprocal(
   var_name: &str,
   min: i128,
 ) -> Option<(bool, i32, i64)> {
-  use crate::syntax::BinaryOperator;
   let mut num: Vec<Expr> = Vec::new();
   let mut den: Vec<Expr> = Vec::new();
   collect_factors(body, &mut num, &mut den, false);
@@ -4879,8 +4849,6 @@ fn match_odd_reciprocal(
 }
 
 fn match_reciprocal_power(body: &Expr, var_name: &str) -> Option<i64> {
-  use crate::syntax::BinaryOperator;
-
   match body {
     // Direct Power[var, -s]
     Expr::BinaryOp {
@@ -4947,8 +4915,6 @@ fn match_reciprocal_power(body: &Expr, var_name: &str) -> Option<i64> {
 
 /// Match Power[Power[var, s], -1] or Power[var, -s]
 fn match_power_inverse(expr: &Expr, var_name: &str) -> Option<i64> {
-  use crate::syntax::BinaryOperator;
-
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Power,
@@ -4999,7 +4965,7 @@ fn get_integer(expr: &Expr) -> Option<i128> {
       n.to_i128()
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => match operand.as_ref() {
       Expr::Integer(n) => Some(-n),
@@ -5021,8 +4987,6 @@ fn is_one(expr: &Expr) -> bool {
 /// Compute ζ(2k) = |B_{2k}| * (2π)^{2k} / (2 * (2k)!) as a symbolic expression.
 /// Returns Pi^(2k) * rational_coefficient.
 fn zeta_even(s: i64) -> Result<Expr, InterpreterError> {
-  use crate::syntax::BinaryOperator;
-
   // Get B_s using bernoulli_b_ast
   let b_s =
     crate::functions::math_ast::bernoulli_b_ast(&[Expr::Integer(s as i128)])?;

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -77,12 +77,12 @@ fn reorder_factored_product(result: Expr) -> Expr {
   }
   // A negated product (-((1+x)*…)) reorders its inner factors the same way.
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = &result
   {
     return Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(reorder_factored_product(operand.as_ref().clone())),
     };
   }
@@ -1477,7 +1477,7 @@ pub fn decompose_product(
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -1485,7 +1485,7 @@ pub fn decompose_product(
       decompose_product(right, pairs, numeric_coeff);
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -1495,7 +1495,7 @@ pub fn decompose_product(
         *numeric_coeff = crate::functions::math_ast::times_ast(&[
           numeric_coeff.clone(),
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left: left.clone(),
             right: right.clone(),
           },
@@ -1533,7 +1533,7 @@ pub fn decompose_product(
       .unwrap_or(expr.clone());
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       // -expr: multiply coeff by -1 and decompose inner
@@ -1651,7 +1651,7 @@ fn extract_rational_coeff(term: &Expr) -> Option<(i128, i128)> {
     }
     // Negation
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let (n, d) = extract_rational_coeff(operand)?;
@@ -1687,7 +1687,7 @@ fn extract_rational_coeff(term: &Expr) -> Option<(i128, i128)> {
             }
           }
           Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand,
           } => match operand.as_ref() {
             Expr::Integer(n) => num *= -n,
@@ -1738,7 +1738,7 @@ fn extract_rational_coeff(term: &Expr) -> Option<(i128, i128)> {
 fn term_total_degree(term: &Expr) -> i128 {
   let inner = match term {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => operand.as_ref(),
     other => other,
@@ -1854,7 +1854,7 @@ fn divide_terms_by(
       Some(v) => match new_n {
         1 => v,
         -1 => Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           operand: Box::new(v),
         },
         _ => Expr::BinaryOp {
@@ -2079,7 +2079,7 @@ fn extract_non_numeric_factors(term: &Expr) -> Vec<Expr> {
       vec![] // Rational is purely numeric
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => extract_non_numeric_factors(operand),
     Expr::BinaryOp {
@@ -2092,7 +2092,7 @@ fn extract_non_numeric_factors(term: &Expr) -> Vec<Expr> {
         .filter(|f| {
           !matches!(f, Expr::Integer(_) | Expr::Real(_))
             && !matches!(f, Expr::FunctionCall { name, args } if name == "Rational" && args.len() == 2)
-            && !matches!(f, Expr::UnaryOp { op: crate::syntax::UnaryOperator::Minus, operand } if matches!(operand.as_ref(), Expr::Integer(_) | Expr::Real(_)))
+            && !matches!(f, Expr::UnaryOp { op: UnaryOperator::Minus, operand } if matches!(operand.as_ref(), Expr::Integer(_) | Expr::Real(_)))
         })
         .collect()
     }
@@ -2131,7 +2131,7 @@ fn multivariate_square_free(
   let factored = factor_ast(&[expanded.clone()])?;
   let (mut negated, product) = match &factored {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => (true, operand.as_ref().clone()),
     other => (false, other.clone()),
@@ -2277,7 +2277,7 @@ fn multivariate_square_free(
   };
   Ok(if negated {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(result),
     }
   } else {
@@ -2297,7 +2297,7 @@ fn decompose_content_factors(
   let (mut num, mut den) = (1i128, 1i128);
   let work = match e {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       num = -1;
@@ -2366,7 +2366,7 @@ fn product_square_free(expr: &Expr) -> Result<Option<Expr>, InterpreterError> {
   // negation of either. Everything else uses the expand-based paths.
   let inner = match expr {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => operand.as_ref(),
     other => other,
@@ -2583,7 +2583,7 @@ fn product_square_free(expr: &Expr) -> Result<Option<Expr>, InterpreterError> {
   let product = reorder_factored_product(product);
   Ok(Some(if negate {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(product),
     }
   } else {
@@ -2721,7 +2721,7 @@ fn factor_square_free_ast_impl(
   };
   Ok(if negate {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(product),
     }
   } else {
@@ -2949,7 +2949,7 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
   let summands: Vec<Expr> = match expanded {
     Expr::FunctionCall { name, args } if name == "Plus" => args.to_vec(),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => {
@@ -2966,7 +2966,7 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
     match term {
       Expr::Integer(n) => Some(*n),
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => term_coeff(operand).map(|c| -c),
       Expr::FunctionCall { name, args } if name == "Times" => {
@@ -2976,7 +2976,7 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
           if let Expr::Integer(n) = a {
             coeff *= n;
           } else if let Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand,
           } = a
             && let Expr::Integer(n) = operand.as_ref()
@@ -2987,7 +2987,7 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
         Some(coeff)
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => match (left.as_ref(), right.as_ref()) {
@@ -3032,7 +3032,7 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
         &summands[i],
         Expr::Integer(_)
           | Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             ..
           }
       ) && match &summands[i] {
@@ -3075,13 +3075,13 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
         }
       }
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => {
         let inner = divide_term(operand, div);
         crate::functions::math_ast::times_ast(&[Expr::Integer(-1), inner])
           .unwrap_or_else(|_| Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand: Box::new(divide_term(operand, div)),
           })
       }
@@ -3130,7 +3130,7 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
 fn collect_times_factors(expr: &Expr) -> Vec<Expr> {
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -3151,7 +3151,7 @@ fn collect_plus(expr: &Expr, out: &mut Vec<Expr>) {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Plus,
+      op: BinaryOperator::Plus,
       left,
       right,
     } => {

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -553,7 +553,7 @@ fn extract_element_vars(expr: &Expr) -> Vec<String> {
     Expr::Identifier(name) => vec![name.clone()],
     // Alternatives as BinaryOp: a | b
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Alternatives,
+      op: BinaryOperator::Alternatives,
       left,
       right,
     } => {
@@ -4344,7 +4344,7 @@ fn log_collapse_candidate(expr: &Expr) -> Option<Expr> {
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -4397,14 +4397,14 @@ fn contains_zero_negative_power(expr: &Expr) -> bool {
       || matches!(
         e,
         Expr::UnaryOp {
-          op: crate::syntax::UnaryOperator::Minus,
+          op: UnaryOperator::Minus,
           ..
         }
       )
   }
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -4496,8 +4496,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
       || matches!(
         &best,
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Plus
-            | crate::syntax::BinaryOperator::Minus,
+          op: BinaryOperator::Plus | BinaryOperator::Minus,
           ..
         }
       );
@@ -4605,7 +4604,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
           .iter()
           .map(|t| {
             crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(t.clone()),
               right: Box::new(divisor.clone()),
             })
@@ -4624,7 +4623,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
             product
           } else {
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Divide,
+              op: BinaryOperator::Divide,
               left: Box::new(product),
               right: Box::new(Expr::Integer(g_den)),
             }
@@ -4690,7 +4689,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
 /// arithmetic heads — the shapes Factor/FactorSquareFree treat as
 /// polynomials. Sums with other functions (Sin[x], Log[x], …) are not.
 pub(super) fn polynomial_like(e: &Expr) -> bool {
-  use crate::syntax::BinaryOperator as B;
+  use BinaryOperator as B;
   match e {
     Expr::Integer(_)
     | Expr::BigInteger(_)
@@ -5271,8 +5270,7 @@ pub fn full_simplify_expr(expr: &Expr) -> Expr {
     || matches!(
       &trig_simplified,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus
-          | crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Plus | BinaryOperator::Minus,
         ..
       }
     );
@@ -6288,7 +6286,7 @@ fn flatten_assumption_atoms(expr: &Expr) -> Vec<Expr> {
       args.iter().flat_map(flatten_assumption_atoms).collect()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::And,
+      op: BinaryOperator::And,
       left,
       right,
     } => {
@@ -6508,7 +6506,7 @@ pub fn extract_trig_squared(term: &Expr) -> Option<(Expr, Expr, String)> {
   // Negated term `-f[arg]^2` (a UnaryOp Minus, as produced when collecting the
   // terms of `a - b`): negate the coefficient of the inner term.
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = term
   {

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2850,7 +2850,7 @@ fn try_solve_abs_eq(
       // ({x -> -a} before {x -> a}); numeric cases are reordered by
       // sort_solutions anyway.
       let neg = crate::evaluator::evaluate_expr_to_expr(&Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(eff.clone()),
       })
       .ok()?;
@@ -2985,7 +2985,7 @@ fn try_solve_trig_eq(eq: &Expr, var: &str) -> Option<Expr> {
   };
   let negate = |e: Expr| {
     eval(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(e),
     })
   };
@@ -3005,7 +3005,7 @@ fn try_solve_trig_eq(eq: &Expr, var: &str) -> Option<Expr> {
       // Wolframscript returns the two-solution list `{x -> -Pi + 2*Pi*C[1],
       // x -> Pi + 2*Pi*C[1]}` even though they coincide modulo 2*Pi.
       let neg_pi = Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(pi.clone()),
       };
       vec![
@@ -5089,7 +5089,7 @@ fn minimize_eval_exact(
     return Ok(simplified);
   }
   if let Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand,
   } = &simplified
   {
@@ -5572,18 +5572,18 @@ fn minimize_neg_infinity_result(vars: &[String], maximize: bool) -> Expr {
     Expr::Identifier("Infinity".to_string())
   } else {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Identifier("Infinity".to_string())),
     }
   };
   let x_val = if maximize {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Identifier("Infinity".to_string())),
     }
   } else {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Identifier("Infinity".to_string())),
     }
   };
@@ -8930,7 +8930,7 @@ fn compile_numeric(expr: &Expr, vars: &[String]) -> Option<NumNode> {
       .or_else(|| named_constant_value(name).map(NumNode::Const)),
     Expr::Constant(name) => named_constant_value(name).map(NumNode::Const),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some(NumNode::Neg(Box::new(c(operand)?))),
     Expr::BinaryOp { op, left, right } => {
@@ -9124,7 +9124,7 @@ fn nminimize_infeasible_result(
 
   let inf = if maximize {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Identifier("Infinity".to_string())),
     }
   } else {
@@ -9150,7 +9150,7 @@ fn nminimize_unbounded_result(vars: &[String], maximize: bool) -> Expr {
     Expr::Identifier("Infinity".to_string())
   } else {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(Expr::Identifier("Infinity".to_string())),
     }
   };

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -3,7 +3,7 @@
 //! These functions work directly with `Expr` AST nodes.
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// Helper to create boolean result
 fn bool_expr(b: bool) -> Expr {
@@ -44,7 +44,7 @@ fn is_numeric_expr(expr: &Expr) -> bool {
     Expr::Identifier(name) if name == "I" => true,
     // n * I or I * n
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -64,8 +64,7 @@ fn is_numeric_expr(expr: &Expr) -> bool {
     }
     // a + b*I or a - b*I
     Expr::BinaryOp {
-      op:
-        crate::syntax::BinaryOperator::Plus | crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Plus | BinaryOperator::Minus,
       left,
       right,
     } => is_numeric_expr(left) && is_numeric_expr(right),
@@ -77,12 +76,12 @@ fn is_numeric_expr(expr: &Expr) -> bool {
     }
     // Unary minus
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_numeric_expr(operand),
     // a / b where both are numeric
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => is_numeric_expr(left) && is_numeric_expr(right),
@@ -367,7 +366,6 @@ fn sqrt_of_rational(rad: &Expr) -> Option<QuadNum> {
 /// quadratic field. Returns `None` for anything outside (machine reals,
 /// symbols, non-real radicals, higher-degree algebraics, …).
 fn as_quad_num(expr: &Expr) -> Option<QuadNum> {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   // Sqrt[r] (matches both the Power[r, 1/2] and Sqrt[r] representations).
   if let Some(rad) = crate::functions::is_sqrt(expr) {
     return sqrt_of_rational(rad);
@@ -774,7 +772,7 @@ fn is_known_positive(expr: &Expr) -> Option<bool> {
       _ => None,
     },
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_known_positive(operand).map(|p| !p),
     // Times[-1, x] is negative of x (e.g. -Pi parses as Times[-1, Pi])
@@ -786,7 +784,7 @@ fn is_known_positive(expr: &Expr) -> Option<bool> {
       is_known_positive(&args[1]).map(|p| !p)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } if matches!(left.as_ref(), Expr::Integer(-1)) => {
@@ -836,7 +834,7 @@ fn is_known_negative(expr: &Expr) -> Option<bool> {
       _ => None,
     },
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_known_positive(operand),
     // Times[-1, x] is negative of x (e.g. -Pi parses as Times[-1, Pi])
@@ -848,7 +846,7 @@ fn is_known_negative(expr: &Expr) -> Option<bool> {
       is_known_positive(&args[1])
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } if matches!(left.as_ref(), Expr::Integer(-1)) => is_known_positive(right),
@@ -910,7 +908,7 @@ fn is_nonnegative_abs_form(expr: &Expr) -> bool {
       args.iter().collect()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => vec![left.as_ref(), right.as_ref()],
@@ -1579,11 +1577,11 @@ pub fn free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Check if operator's head matches the form symbol
         if let Expr::Identifier(s) = form {
           let matches = match op {
-            crate::syntax::BinaryOperator::Plus => s == "Plus",
-            crate::syntax::BinaryOperator::Minus => s == "Plus",
-            crate::syntax::BinaryOperator::Times => s == "Times",
-            crate::syntax::BinaryOperator::Power => s == "Power",
-            crate::syntax::BinaryOperator::Divide => s == "Times",
+            BinaryOperator::Plus => s == "Plus",
+            BinaryOperator::Minus => s == "Plus",
+            BinaryOperator::Times => s == "Times",
+            BinaryOperator::Power => s == "Power",
+            BinaryOperator::Divide => s == "Times",
             _ => false,
           };
           if matches {
@@ -1621,7 +1619,7 @@ pub fn free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if matches!(
       form,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Alternatives,
+        op: BinaryOperator::Alternatives,
         ..
       }
     ) {
@@ -1952,12 +1950,12 @@ pub fn is_directed_infinity(expr: &Expr) -> bool {
       args.iter().any(is_inf_sym)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => is_inf_sym(left) || is_inf_sym(right),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => is_inf_sym(operand),
     _ => false,
@@ -2021,7 +2019,6 @@ pub fn head_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Rule { .. } => "Rule",
     Expr::RuleDelayed { .. } => "RuleDelayed",
     Expr::BinaryOp { op, left, .. } => {
-      use crate::syntax::BinaryOperator;
       match op {
         BinaryOperator::Plus => "Plus",
         BinaryOperator::Minus => "Plus", // Minus is represented as Plus internally
@@ -2041,13 +2038,10 @@ pub fn head_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         BinaryOperator::Alternatives => "Alternatives",
       }
     }
-    Expr::UnaryOp { op, .. } => {
-      use crate::syntax::UnaryOperator;
-      match op {
-        UnaryOperator::Minus => "Times",
-        UnaryOperator::Not => "Not",
-      }
-    }
+    Expr::UnaryOp { op, .. } => match op {
+      UnaryOperator::Minus => "Times",
+      UnaryOperator::Not => "Not",
+    },
     Expr::Comparison { operators, .. } => {
       use crate::syntax::ComparisonOp;
       // A uniform chain (all operators the same) has head equal to that operator.

--- a/src/functions/quantity_ast.rs
+++ b/src/functions/quantity_ast.rs
@@ -1,6 +1,6 @@
 use crate::InterpreterError;
 use crate::functions::math_ast::{is_sqrt, make_sqrt};
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr};
 use std::collections::BTreeMap;
 
 // ─── Unit dimension system ──────────────────────────────────────────────────
@@ -754,8 +754,6 @@ fn rational_pow(numer: i128, denom: i128, exp: i64) -> (i128, i128) {
 /// E.g. "KilometersPerHour" → Kilometers / Hours,
 ///      "MetersPerSecondSquared" → Meters / Seconds^2
 fn resolve_per_unit(s: &str) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
-
   // Split on "Per" (only the first occurrence)
   let idx = s.find("Per")?;
   if idx == 0 {
@@ -819,8 +817,6 @@ fn resolve_per_unit(s: &str) -> Option<Expr> {
 
 /// Resolve common unit abbreviation strings to full unit names.
 fn resolve_unit_abbreviation(s: &str) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
-
   // Simple abbreviations → single unit
   let simple = match s {
     "m" => "Meters",
@@ -1080,7 +1076,6 @@ fn decompose_unit_expr(expr: &Expr) -> Option<CompoundUnitInfo> {
       None
     }
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator;
       match op {
         BinaryOperator::Divide => {
           let mut left_info = decompose_unit_expr(left)?;
@@ -1271,8 +1266,6 @@ fn simplify_compound_unit(
 /// Build a unit Expr from simplified components.
 /// Positive exponents go in numerator, negative in denominator.
 fn components_to_unit_expr(components: &[(String, i64)]) -> Expr {
-  use crate::syntax::BinaryOperator;
-
   // wolframscript orders the factors of a compound unit alphabetically by
   // name (e.g. `Hours*Watts`, `Amperes*Seconds`), so sort the numerator and
   // denominator parts by unit name rather than by dimension signature.
@@ -1488,12 +1481,12 @@ fn canonical_unit_name(name: &str) -> &str {
 pub fn format_expand_compound_unit(name: &str) -> Option<Expr> {
   match name {
     "KilowattHours" => Some(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::String("Hours".to_string())),
       right: Box::new(Expr::String("Kilowatts".to_string())),
     }),
     "WattHours" => Some(Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(Expr::String("Hours".to_string())),
       right: Box::new(Expr::String("Watts".to_string())),
     }),
@@ -1979,11 +1972,10 @@ fn known_unit_q_recursive(unit: &Expr) -> bool {
     Expr::Integer(n) => *n == 1,
     Expr::String(s) => get_unit_info(s).is_some(),
     Expr::BinaryOp { op, left, right } => match op {
-      crate::syntax::BinaryOperator::Times
-      | crate::syntax::BinaryOperator::Divide => {
+      BinaryOperator::Times | BinaryOperator::Divide => {
         known_unit_q_recursive(left) && known_unit_q_recursive(right)
       }
-      crate::syntax::BinaryOperator::Power => {
+      BinaryOperator::Power => {
         known_unit_q_recursive(left)
           && matches!(right.as_ref(), Expr::Integer(_))
       }
@@ -2187,7 +2179,6 @@ fn temp_output_unit(scale: &str) -> &'static str {
 fn try_temperature_convert(
   args: &[Expr],
 ) -> Result<Option<Expr>, InterpreterError> {
-  use crate::syntax::BinaryOperator;
   let Some((mag, unit)) = is_quantity(&args[0]) else {
     return Ok(None);
   };
@@ -2704,7 +2695,7 @@ pub fn try_quantity_divide(
         Some(Ok(new_mag))
       } else {
         let raw_compound = Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(unit_a.clone()),
           right: Box::new(unit_b.clone()),
         };
@@ -2744,7 +2735,7 @@ pub fn try_quantity_divide(
           Err(e) => return Some(Err(e)),
         };
       let inv_unit = Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(unit.clone()),
         right: Box::new(Expr::Integer(-1)),
       };
@@ -2787,8 +2778,6 @@ fn expr_to_rational(expr: &Expr) -> Option<(i128, i128)> {
 /// into its base components, multiplying each exponent by p/q, and rebuilding.
 /// Returns None if the unit cannot be decomposed.
 fn power_unit_expr(unit: &Expr, p: i128, q: i128) -> Option<Expr> {
-  use crate::syntax::BinaryOperator;
-
   let info = decompose_unit_expr(unit)?;
   let mut numer_parts: Vec<Expr> = Vec::new();
   let mut denom_parts: Vec<Expr> = Vec::new();
@@ -2893,7 +2882,7 @@ pub fn try_quantity_power(
 
   // Fallback: wrap unit in Power without simplification
   let new_unit = Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(unit.clone()),
     right: Box::new(exp.clone()),
   };

--- a/src/functions/resolve_ast.rs
+++ b/src/functions/resolve_ast.rs
@@ -6,7 +6,7 @@
 //! c > 0 return their conditions.
 
 use crate::InterpreterError;
-use crate::syntax::{ComparisonOp, Expr};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr};
 
 pub fn resolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = |args: &[Expr]| Expr::FunctionCall {
@@ -149,7 +149,7 @@ fn parametric_template(head: &str, var: &str, cond: &Expr) -> Option<Expr> {
         (&args[0], &args[1])
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         right,
       } => (&**left as &Expr, &**right as &Expr),
@@ -593,7 +593,6 @@ fn add_var_power(
 }
 
 fn collect_plus<'a>(e: &'a Expr, out: &mut Vec<&'a Expr>) {
-  use crate::syntax::BinaryOperator;
   match e {
     Expr::FunctionCall { name, args } if name == "Plus" => {
       for a in args.iter() {

--- a/src/functions/rsolve_ast.rs
+++ b/src/functions/rsolve_ast.rs
@@ -1,5 +1,5 @@
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// RSolve[{recurrence, initial_conditions...}, a, n]
 /// RSolve[recurrence, a[n], n] — single equation, return rule for `a[n]`
@@ -155,7 +155,7 @@ fn collect_terms_with_forcing(
       e.clone()
     } else {
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(e.clone()),
       }
     });
@@ -220,7 +220,7 @@ fn collect_terms_with_forcing(
       )
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => collect_terms_with_forcing(
       operand, func_name, var_name, -sign, terms, forcing,
@@ -296,7 +296,7 @@ fn solve_first_order_arithmetic(
   let d = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
     op: BinaryOperator::Divide,
     left: Box::new(Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(forcing_total),
     }),
     right: Box::new(Expr::Integer(c_hi)),
@@ -660,7 +660,7 @@ fn build_first_order_with_ic(
     power
   } else if v == -1 {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(power),
     }
   } else {
@@ -764,7 +764,7 @@ fn build_partial_solution(
     r2_pow_n.clone()
   } else if v == -1 {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(r2_pow_n.clone()),
     }
   } else {
@@ -777,7 +777,7 @@ fn build_partial_solution(
 
   // Term 3: -C[1] * r_2^n
   let neg_c1_r2n = Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(if matches!(&r2_pow_n, Expr::Integer(1)) {
       c1.clone()
     } else {
@@ -934,7 +934,7 @@ fn collect_recurrence_terms(
         && collect_recurrence_terms(right, func_name, var_name, -sign, terms)
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => collect_recurrence_terms(operand, func_name, var_name, -sign, terms),
     // A zero constant contributes nothing (e.g. `a[n+2] - a[n] == 0`)
@@ -1340,7 +1340,7 @@ fn build_solution(
     };
     if num < 0 {
       term = Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(term),
       };
     }

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -2764,7 +2764,7 @@ fn string_pattern_to_regex_inner(
 
     // Alternatives as BinaryOp (e.g. pat1 | pat2)
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Alternatives,
+      op: BinaryOperator::Alternatives,
       left,
       right,
     } => {
@@ -5032,7 +5032,6 @@ fn pad_bigfloat_to_precision(digits: &str, prec: f64) -> String {
 }
 
 pub fn expr_to_tex(expr: &Expr) -> String {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   // HoldForm[x] is a display wrapper; render its content transparently.
   if let Expr::FunctionCall { name, args } = expr
     && name == "HoldForm"
@@ -5272,7 +5271,7 @@ fn as_neg_int_power(expr: &Expr) -> Option<(&Expr, i128)> {
       None
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -5334,7 +5333,7 @@ fn tex_parens_plain(expr: &Expr) -> String {
 /// Handle n-ary Times in TeX, splitting into \frac when negative-integer
 /// Power factors are present (matching Wolfram TeXForm).
 fn tex_times_nary(args: &[Expr]) -> String {
-  use crate::syntax::BinaryOperator::{Minus, Plus};
+  use BinaryOperator::{Minus, Plus};
   let tex_needs_product_parens = |arg: &Expr| -> bool {
     matches!(
       arg,
@@ -5448,7 +5447,7 @@ fn tex_times_nary(args: &[Expr]) -> String {
 fn tex_power(base: &Expr, exp: &Expr) -> String {
   // Special case: Power[x, 1/2] → \sqrt{x}
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left,
     right,
   } = exp
@@ -5600,7 +5599,6 @@ fn tex_derivative(
 /// Classify a logical operator for TeX parenthesization, returning
 /// `(kind, precedence)` for And/Or/Xor/Implies/Not (higher binds tighter).
 fn tex_logic_op(expr: &Expr) -> Option<(&'static str, u8)> {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   match expr {
     Expr::FunctionCall { name, args } => match name.as_str() {
       "And" if args.len() >= 2 => Some(("And", 20)),
@@ -5746,7 +5744,7 @@ fn tex_function_call(name: &str, args: &[Expr]) -> String {
       let lhs = if matches!(
         &args[0],
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Alternatives,
+          op: BinaryOperator::Alternatives,
           ..
         }
       ) {
@@ -6426,7 +6424,6 @@ pub fn expr_to_mathml(expr: &Expr) -> String {
 
 /// Render a single expression as a MathML fragment at the given indentation depth.
 fn mathml_inner(expr: &Expr, depth: usize) -> String {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   let indent = " ".repeat(depth);
 
   match expr {
@@ -6789,8 +6786,6 @@ pub fn expr_to_box_form(expr: &Expr) -> String {
 /// Convert an expression to its box form representation.
 /// All atoms are string-quoted to match Wolfram's box format.
 pub fn expr_to_boxes(expr: &Expr) -> String {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
-
   match expr {
     // Simple atoms — all quoted in box form
     Expr::Integer(n) => format!("\"{}\"", n),

--- a/src/functions/ztransform_ast.rs
+++ b/src/functions/ztransform_ast.rs
@@ -14,7 +14,7 @@
 
 use crate::InterpreterError;
 use crate::functions::calculus_ast::is_constant_wrt;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 pub fn z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = |args: &[Expr]| Expr::FunctionCall {
@@ -242,7 +242,7 @@ fn collect_factors(
       .iter()
       .all(|a| collect_factors(a, n_var, inverted, parts)),
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -250,7 +250,7 @@ fn collect_factors(
         && collect_factors(right, n_var, inverted, parts)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -307,7 +307,7 @@ fn collect_factors(
             true
           }
           Expr::UnaryOp {
-            op: crate::syntax::UnaryOperator::Minus,
+            op: UnaryOperator::Minus,
             operand,
           } if matches!(operand.as_ref(), Expr::Identifier(e) if e == n_var) => {
             true
@@ -383,7 +383,7 @@ fn as_power(expr: &Expr) -> Option<(Expr, Expr)> {
       Some((args[0].clone(), args[1].clone()))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some(((**left).clone(), (**right).clone())),
@@ -417,7 +417,7 @@ fn times(factors: Vec<Expr>) -> Expr {
 
 fn divide(num: Expr, den: Expr) -> Expr {
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(num),
     right: Box::new(den),
   }
@@ -425,7 +425,7 @@ fn divide(num: Expr, den: Expr) -> Expr {
 
 fn power(base: Expr, exp: i128) -> Expr {
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(base),
     right: Box::new(Expr::Integer(exp)),
   }
@@ -433,7 +433,7 @@ fn power(base: Expr, exp: i128) -> Expr {
 
 fn negate(e: Expr) -> Expr {
   Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(e),
   }
 }
@@ -518,7 +518,7 @@ fn poly_coeffs(expr: &Expr, var: &str) -> Option<Vec<Frac>> {
     }
     Expr::Identifier(v) if v == var => Some(vec![(0, 1), (1, 1)]),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some(poly_neg(&poly_coeffs(operand, var)?)),
     Expr::FunctionCall { name, args } if name == "Plus" => {
@@ -536,19 +536,19 @@ fn poly_coeffs(expr: &Expr, var: &str) -> Option<Vec<Frac>> {
       Some(acc)
     }
     Expr::BinaryOp { op, left, right } => match op {
-      crate::syntax::BinaryOperator::Plus => Some(poly_add(
+      BinaryOperator::Plus => Some(poly_add(
         &poly_coeffs(left, var)?,
         &poly_coeffs(right, var)?,
       )),
-      crate::syntax::BinaryOperator::Minus => Some(poly_add(
+      BinaryOperator::Minus => Some(poly_add(
         &poly_coeffs(left, var)?,
         &poly_neg(&poly_coeffs(right, var)?),
       )),
-      crate::syntax::BinaryOperator::Times => Some(poly_mul(
+      BinaryOperator::Times => Some(poly_mul(
         &poly_coeffs(left, var)?,
         &poly_coeffs(right, var)?,
       )),
-      crate::syntax::BinaryOperator::Power => {
+      BinaryOperator::Power => {
         if let Expr::Integer(k) = right.as_ref()
           && *k >= 1
         {
@@ -604,14 +604,14 @@ fn poly_trim(mut p: Vec<Frac>) -> Vec<Frac> {
 fn split_fraction(expr: &Expr) -> (i128, Expr, Expr) {
   match expr {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let (s, n, d) = split_fraction(operand);
       (-s, n, d)
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -635,7 +635,7 @@ fn split_fraction(expr: &Expr) -> (i128, Expr, Expr) {
             base
           } else {
             Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(base),
               right: Box::new(Expr::Integer(-e)),
             }
@@ -699,7 +699,7 @@ pub fn inverse_z_transform_ast(
         Some(1)
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left,
         right,
       } if matches!(right.as_ref(), Expr::Identifier(v) if *v == z_var) => {
@@ -724,13 +724,13 @@ pub fn inverse_z_transform_ast(
     };
     return Ok(match c {
       Some(1) => Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left: Box::new(factorial_n),
         right: Box::new(Expr::Integer(-1)),
       },
       Some(c) => divide(
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(Expr::Integer(c)),
           right: Box::new(n.clone()),
         },
@@ -778,7 +778,7 @@ pub fn inverse_z_transform_ast(
     };
     sign = norm_sign;
     let a_pow_n = Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left: Box::new(a.clone()),
       right: Box::new(n.clone()),
     };
@@ -817,7 +817,7 @@ pub fn inverse_z_transform_ast(
       return Ok(times(vec![
         a_pow_n,
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left: Box::new(n.clone()),
           right: Box::new(Expr::Integer(2)),
         },
@@ -991,7 +991,7 @@ fn format_inverse_result(
   }
 
   let power = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(b),
     right: Box::new(e),
   };
@@ -1103,7 +1103,7 @@ fn times_factors(expr: &Expr) -> Vec<Expr> {
       args.iter().flat_map(times_factors).collect()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -1164,12 +1164,12 @@ pub fn fourier_coefficient_ast(
     args: fs.into(),
   };
   let div = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(a),
     right: Box::new(b),
   };
   let pow = |b: Expr, e: i128| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(b),
     right: Box::new(Expr::Integer(e)),
   };
@@ -1238,7 +1238,7 @@ pub fn fourier_coefficient_ast(
     }
   };
   let m1n = || Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(Expr::Integer(-1)),
     right: Box::new(n_arg.clone()),
   };
@@ -1357,19 +1357,19 @@ pub fn fourier_sin_cos_coefficient_ast(
     args: ts.into(),
   };
   let div = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(a),
     right: Box::new(b),
   };
   let pow = |b: Expr, e: i128| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(b),
     right: Box::new(Expr::Integer(e)),
   };
   let pi = || Expr::Constant("Pi".to_string());
   let n_e = || n_arg.clone();
   let m1 = || Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(Expr::Integer(-1)),
     right: Box::new(n_arg.clone()),
   };


### PR DESCRIPTION
More prefix reduction for files in the src/ directory, targeting BinaryOperator and UnaryOperator.