### PR TITLE
Remove unneeded pub(crate), pub(super) declarations

### DIFF
--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -3369,7 +3369,7 @@ fn boxes_to_text_svg(boxes: &Expr) -> String {
 /// to a non-trivial SVG. Used to decide whether a `List` passed to
 /// `Export[..., "gif"]` should be treated as an animated frame sequence.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn is_rasterizable_frame(expr: &Expr) -> bool {
+fn is_rasterizable_frame(expr: &Expr) -> bool {
   matches!(expr, Expr::Graphics { .. } | Expr::Image { .. })
     || matches!(
       expr,

--- a/src/functions/datetime_ast.rs
+++ b/src/functions/datetime_ast.rs
@@ -204,7 +204,7 @@ pub fn day_count_weekday_ast(
 }
 
 /// Convert a date {y,m,d} to absolute days since 1900-01-01 (day 0)
-pub(crate) fn date_to_absolute_days(year: i64, month: i64, day: i64) -> i64 {
+fn date_to_absolute_days(year: i64, month: i64, day: i64) -> i64 {
   let mut total_days: i64 = 0;
 
   if year >= 1900 {
@@ -387,7 +387,7 @@ pub fn calendar_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 /// Convert absolute days since 1900-01-01 to {year, month, day}
-pub(crate) fn absolute_days_to_date(mut days: i64) -> (i64, i64, i64) {
+fn absolute_days_to_date(mut days: i64) -> (i64, i64, i64) {
   let mut year: i64 = 1900;
 
   if days >= 0 {

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -7942,11 +7942,7 @@ fn is_infinity_like(expr: &Expr) -> bool {
 /// before the box, e.g. `"Power::infy: Infinite expression "`. The numerator
 /// and denominator are centered within a box whose width is the longer of the
 /// two, and the dash run spans that width.
-pub(crate) fn format_infy_fraction_2d(
-  prefix: &str,
-  num: &str,
-  denom: &str,
-) -> String {
+fn format_infy_fraction_2d(prefix: &str, num: &str, denom: &str) -> String {
   let base_lead = prefix.len();
   let width = num.chars().count().max(denom.chars().count());
   let dashes = "-".repeat(width);

--- a/src/functions/math_ast/carlson.rs
+++ b/src/functions/math_ast/carlson.rs
@@ -24,7 +24,7 @@ fn is_inexact(e: &Expr) -> bool {
 }
 
 /// R_C(x, y) — degenerate Carlson integral.
-pub(crate) fn carlson_rc(x: f64, y: f64) -> f64 {
+fn carlson_rc(x: f64, y: f64) -> f64 {
   const ERRTOL: f64 = 0.0012;
   const C1: f64 = 0.3;
   const C2: f64 = 1.0 / 7.0;
@@ -51,7 +51,7 @@ pub(crate) fn carlson_rc(x: f64, y: f64) -> f64 {
 }
 
 /// R_F(x, y, z) — symmetric elliptic integral of the first kind.
-pub(crate) fn carlson_rf(x: f64, y: f64, z: f64) -> f64 {
+fn carlson_rf(x: f64, y: f64, z: f64) -> f64 {
   const ERRTOL: f64 = 0.0025;
   const C1: f64 = 1.0 / 24.0;
   const C2: f64 = 0.1;
@@ -82,7 +82,7 @@ pub(crate) fn carlson_rf(x: f64, y: f64, z: f64) -> f64 {
 
 /// R_D(x, y, z) — symmetric elliptic integral of the second kind (R_J with the
 /// last two arguments equal: R_D(x, y, z) = R_J(x, y, z, z)).
-pub(crate) fn carlson_rd(x: f64, y: f64, z: f64) -> f64 {
+fn carlson_rd(x: f64, y: f64, z: f64) -> f64 {
   const ERRTOL: f64 = 0.0015;
   const C1: f64 = 3.0 / 14.0;
   const C2: f64 = 1.0 / 6.0;
@@ -128,7 +128,7 @@ pub(crate) fn carlson_rd(x: f64, y: f64, z: f64) -> f64 {
 /// R_J(x, y, z, p) — symmetric elliptic integral of the third kind. Only the
 /// principal branch p > 0 is implemented here; for p <= 0 the caller leaves the
 /// expression unevaluated.
-pub(crate) fn carlson_rj(x: f64, y: f64, z: f64, p: f64) -> f64 {
+fn carlson_rj(x: f64, y: f64, z: f64, p: f64) -> f64 {
   const ERRTOL: f64 = 0.0015;
   const C1: f64 = 3.0 / 14.0;
   const C2: f64 = 1.0 / 3.0;
@@ -182,7 +182,7 @@ pub(crate) fn carlson_rj(x: f64, y: f64, z: f64, p: f64) -> f64 {
 /// R_G(x, y, z) — symmetric elliptic integral of the second kind, evaluated via
 /// 2 R_G = z R_F(x, y, z) - (1/3)(x - z)(y - z) R_D(x, y, z) + sqrt(x y / z),
 /// choosing the largest argument as z to avoid division by a vanishing value.
-pub(crate) fn carlson_rg(x: f64, y: f64, z: f64) -> f64 {
+fn carlson_rg(x: f64, y: f64, z: f64) -> f64 {
   // Order so that c is the largest (used as the formula's z); R_D is symmetric
   // in its first two arguments.
   let mut v = [x, y, z];

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -1950,7 +1950,7 @@ fn bankers_round(n: f64) -> f64 {
 /// `BigInteger` when the magnitude exceeds the `i128` range (a plain `as i128`
 /// cast would saturate to `i128::MAX`). `{:.0}` renders the float's exact
 /// integer value without scientific notation.
-pub(crate) fn f64_to_int_expr(v: f64) -> Expr {
+fn f64_to_int_expr(v: f64) -> Expr {
   if v.abs() < i128::MAX as f64 {
     Expr::Integer(v as i128)
   } else if v.is_finite() {

--- a/src/functions/math_ast/elliptic.rs
+++ b/src/functions/math_ast/elliptic.rs
@@ -1591,7 +1591,7 @@ fn jacobi_theta1_prime0(q: f64) -> f64 {
 }
 
 /// Numeric Neville theta θs/θc/θd/θn at real z, m ∈ [0, 1].
-pub fn neville_theta_numeric(kind: char, z: f64, m: f64) -> Option<f64> {
+fn neville_theta_numeric(kind: char, z: f64, m: f64) -> Option<f64> {
   if !(0.0..=1.0).contains(&m) || !z.is_finite() {
     return None;
   }

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -1526,7 +1526,7 @@ fn beta_regularized_numeric(x: f64, a: f64, b: f64) -> f64 {
 /// [0, 1] such that `beta_regularized_numeric(z, a, b) == s`. Because I_z(a, b)
 /// increases monotonically from 0 (at z = 0) to 1 (at z = 1), the root is found
 /// by bisection.
-pub(crate) fn inverse_beta_regularized_numeric(s: f64, a: f64, b: f64) -> f64 {
+fn inverse_beta_regularized_numeric(s: f64, a: f64, b: f64) -> f64 {
   if s <= 0.0 {
     return 0.0;
   }
@@ -2064,7 +2064,7 @@ pub(crate) fn gamma_regularized_numeric(a: f64, z: f64) -> f64 {
 /// returns z such that `gamma_regularized_numeric(a, z) == q`. Because Q(a, z)
 /// decreases monotonically from 1 (at z = 0) to 0 (as z -> Infinity), the root
 /// is found by bracketing then bisection.
-pub(crate) fn inverse_gamma_regularized_numeric(a: f64, q: f64) -> f64 {
+fn inverse_gamma_regularized_numeric(a: f64, q: f64) -> f64 {
   if q <= 0.0 {
     return f64::INFINITY;
   }

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -5282,10 +5282,7 @@ fn compute_khinchin(
 /// to `decimal_digits` decimal places, as a "0.ddd…" string. Computed
 /// exactly: enough base-b digits accumulate into a big integer M so that
 /// M/b^K determines the requested decimal digits, then long-divided.
-pub(crate) fn champernowne_decimal_digits(
-  base: i128,
-  decimal_digits: usize,
-) -> String {
+fn champernowne_decimal_digits(base: i128, decimal_digits: usize) -> String {
   use num_bigint::BigInt;
   let k_needed = ((decimal_digits as f64 + 2.0) * std::f64::consts::LN_10
     / (base as f64).ln())

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -307,7 +307,7 @@ pub(crate) fn split_into_segments(
 /// Clip line segments to a y-range, interpolating at boundaries.
 /// Points outside the range are removed and the line is split,
 /// with interpolated points added at the boundary crossings.
-pub(crate) fn clip_segments_to_y_range(
+fn clip_segments_to_y_range(
   segments: Vec<Vec<(f64, f64)>>,
   y_min: f64,
   y_max: f64,
@@ -401,7 +401,7 @@ pub(crate) fn nice_step(range: f64, target_labels: usize) -> f64 {
 /// y-axis/frame label just left of the tick column instead of at the far edge
 /// of the (fixed-width) gutter — so narrow ticks (e.g. single digits) don't
 /// leave a large gap.
-pub(crate) fn max_y_tick_label_chars(y_min: f64, y_max: f64) -> usize {
+fn max_y_tick_label_chars(y_min: f64, y_max: f64) -> usize {
   let step = nice_step(y_max - y_min, 5);
   if step <= 0.0 || !step.is_finite() {
     return 3;
@@ -465,7 +465,7 @@ pub(crate) enum DateStep {
 }
 
 /// Compute a nice step for date axis ticks based on the range in seconds.
-pub(crate) fn nice_date_step_spec(range_seconds: f64) -> DateStep {
+fn nice_date_step_spec(range_seconds: f64) -> DateStep {
   let range_days = range_seconds / 86400.0;
   let range_years = range_days / 365.25;
 
@@ -566,7 +566,7 @@ pub(crate) fn generate_date_ticks(x_min: f64, x_max: f64) -> Vec<f64> {
 }
 
 /// Approximate step in seconds for date ticks (used for tick count estimation).
-pub(crate) fn nice_date_step(range_seconds: f64) -> f64 {
+fn nice_date_step(range_seconds: f64) -> f64 {
   match nice_date_step_spec(range_seconds) {
     DateStep::Years(n) => (n as f64) * 365.25 * 86400.0,
     DateStep::Months(n) => (n as f64) * 30.44 * 86400.0,
@@ -690,7 +690,7 @@ pub(crate) fn format_tick(v: f64) -> String {
 /// The extension is drawn from `minor_len` to `major_len` along the tick
 /// direction, so it connects seamlessly with the plotters-drawn tick.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn inject_major_tick_extensions(
+fn inject_major_tick_extensions(
   buf: &mut String,
   plot_x0: f64,
   plot_y0: f64,
@@ -771,7 +771,7 @@ pub(crate) fn inject_major_tick_extensions(
 /// `x_axis` / `y_axis` each supply `(min, max, major_step)`. Minor ticks are
 /// drawn at `major_step / 5` intervals. When an axis is `None` the
 /// corresponding frame line is still drawn, but without tick marks.
-pub(crate) fn inject_top_right_frame(
+fn inject_top_right_frame(
   buf: &mut String,
   plot_x0: f64,
   plot_y0: f64,
@@ -4120,7 +4120,7 @@ fn legend_plot_area_width(vb_w: f64, opts: &PlotOptions) -> f64 {
 
 /// Inject a legend into an SVG plot. Depending on `legend_position`, the legend
 /// is placed on the right (default), top, or bottom of the plot.
-pub(crate) fn inject_legend(buf: &mut String, opts: &PlotOptions) {
+fn inject_legend(buf: &mut String, opts: &PlotOptions) {
   if opts.plot_legends.is_empty() {
     return;
   }
@@ -5145,7 +5145,7 @@ pub(crate) fn generate_axes_only_opts(
 /// Add a border to filled chart bars in the SVG.
 /// Plotters' SVG backend doesn't support stroke-width on rects,
 /// so we post-process the SVG to add it.
-pub(crate) fn add_bar_borders(buf: &mut String, stroke_width: u32) {
+fn add_bar_borders(buf: &mut String, stroke_width: u32) {
   // The first <rect> is the background, skip it.
   // All subsequent filled rects (with stroke="none") are bars.
   let marker = "stroke=\"none\"/>";
@@ -5257,7 +5257,7 @@ pub(crate) fn rewrite_svg_header(
 /// polyline — identified by the exact stroke color of its series — is
 /// tagged with the filter attribute. Shadow parameters are scaled by
 /// RESOLUTION_SCALE to match the oversampled render coordinates.
-pub(crate) fn inject_drop_shadows(
+fn inject_drop_shadows(
   buf: &mut String,
   plot_style: &[SeriesStyle],
   n_series: usize,

--- a/src/functions/polynomial_ast/gf_factor.rs
+++ b/src/functions/polynomial_ast/gf_factor.rs
@@ -333,7 +333,7 @@ pub(super) fn gf_factor_coeffs(
 
 /// Recognize `expr` as a univariate integer-coefficient polynomial;
 /// returns its variable name and ascending coefficients.
-pub(super) fn univariate_int_coeffs(
+fn univariate_int_coeffs(
   expr: &Expr,
 ) -> Result<Option<(String, Vec<i128>)>, InterpreterError> {
   use crate::functions::math_ast::expr_to_i128;
@@ -376,7 +376,7 @@ pub(super) fn univariate_int_coeffs(
   Ok(Some((var, coeffs)))
 }
 
-pub(super) fn gf_poly_to_expr(
+fn gf_poly_to_expr(
   coeffs: &[i128],
   var: &str,
 ) -> Result<Expr, InterpreterError> {
@@ -410,7 +410,7 @@ pub(super) fn gf_poly_to_expr(
 }
 
 /// The factored `Times` presentation used by Factor and PolynomialLCM.
-pub(super) fn gf_factored_expr(
+fn gf_factored_expr(
   constant: i128,
   factors: &[(Vec<i128>, usize)],
   var: &str,

--- a/src/functions/polynomial_ast/polynomial_gcd.rs
+++ b/src/functions/polynomial_ast/polynomial_gcd.rs
@@ -133,7 +133,7 @@ pub(super) fn poly_to_coeffs_mod(
   Ok(coeffs)
 }
 
-pub(super) fn mod_norm(a: i128, p: i128) -> i128 {
+fn mod_norm(a: i128, p: i128) -> i128 {
   ((a % p) + p) % p
 }
 
@@ -155,13 +155,13 @@ pub(super) fn mod_inv(a: i128, p: i128) -> i128 {
 }
 
 /// Drop high-degree zero coefficients, keeping at least `[0]`.
-pub(super) fn trim_high(c: &mut Vec<i128>) {
+fn trim_high(c: &mut Vec<i128>) {
   while c.len() > 1 && *c.last().unwrap() == 0 {
     c.pop();
   }
 }
 
-pub(super) fn is_zero_poly(c: &[i128]) -> bool {
+fn is_zero_poly(c: &[i128]) -> bool {
   c.iter().all(|&x| x == 0)
 }
 
@@ -206,7 +206,7 @@ fn poly_rem_mod(a: &[i128], b: &[i128], p: i128) -> Vec<i128> {
 }
 
 /// Product of two coefficient vectors over GF(p) (polynomial multiplication).
-pub(super) fn poly_mul_mod(a: &[i128], b: &[i128], p: i128) -> Vec<i128> {
+fn poly_mul_mod(a: &[i128], b: &[i128], p: i128) -> Vec<i128> {
   if is_zero_poly(a) || is_zero_poly(b) {
     return vec![0];
   }
@@ -221,7 +221,7 @@ pub(super) fn poly_mul_mod(a: &[i128], b: &[i128], p: i128) -> Vec<i128> {
 }
 
 /// Difference `a - b` of two coefficient vectors over GF(p).
-pub(super) fn poly_sub_mod(a: &[i128], b: &[i128], p: i128) -> Vec<i128> {
+fn poly_sub_mod(a: &[i128], b: &[i128], p: i128) -> Vec<i128> {
   let n = a.len().max(b.len());
   let mut res = vec![0i128; n];
   for (i, ri) in res.iter_mut().enumerate() {

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -24,7 +24,7 @@ thread_local! {
 /// exists. Identical pattern strings always produce identical compiled
 /// regexes, so caching is observationally indistinguishable from
 /// recompiling — only faster.
-pub(crate) fn compile_regex(pat: &str) -> Result<regex::Regex, regex::Error> {
+fn compile_regex(pat: &str) -> Result<regex::Regex, regex::Error> {
   use regex::Regex;
   REGEX_CACHE.with(|c| {
     if let Some(re) = c.borrow().get(pat) {
@@ -2550,7 +2550,7 @@ fn maybe_named_group(
 /// records these `(orig, dup)` capture-name pairs and matching sites verify
 /// them here. A missing capture (optional group didn't participate) is treated
 /// as satisfied.
-pub(crate) fn caps_satisfy_constraints(
+fn caps_satisfy_constraints(
   caps: &regex::Captures,
   constraints: &[(String, String)],
 ) -> bool {


### PR DESCRIPTION
I extended my private detection tool to examine functions marked pub(crate) and pub(super), which found another 33 functions unnecessarily exported.