### PR TITLE
Remove crate::syntax::(BinaryOperator|UnaryOperator|Expr) prefixes

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::{is_sqrt, make_sqrt};
-use crate::syntax::{BinaryOperator, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 pub fn dispatch_complex_and_special(
   name: &str,
@@ -763,18 +763,17 @@ pub fn dispatch_complex_and_special(
             crate::StoredValue::ExprVal(e) => expr_to_string(&e),
             crate::StoredValue::Raw(val) => val,
             crate::StoredValue::Association(items) => {
-              let items_expr: Vec<(crate::syntax::Expr, crate::syntax::Expr)> =
-                items
-                  .iter()
-                  .map(|(k, v)| {
-                    let key_expr = crate::syntax::string_to_expr(k)
-                      .unwrap_or(crate::syntax::Expr::Identifier(k.clone()));
-                    let val_expr = crate::syntax::string_to_expr(v)
-                      .unwrap_or(crate::syntax::Expr::Raw(v.clone()));
-                    (key_expr, val_expr)
-                  })
-                  .collect();
-              expr_to_string(&crate::syntax::Expr::Association(items_expr))
+              let items_expr: Vec<(Expr, Expr)> = items
+                .iter()
+                .map(|(k, v)| {
+                  let key_expr = crate::syntax::string_to_expr(k)
+                    .unwrap_or(Expr::Identifier(k.clone()));
+                  let val_expr = crate::syntax::string_to_expr(v)
+                    .unwrap_or(Expr::Raw(v.clone()));
+                  (key_expr, val_expr)
+                })
+                .collect();
+              expr_to_string(&Expr::Association(items_expr))
             }
           };
           lines.push(format!("{} = {}", sym, val_str));
@@ -873,9 +872,7 @@ pub fn dispatch_complex_and_special(
             // Check if this is a specific-value definition (SameQ conditions)
             let has_sameq_conds = conds.iter().any(|c| {
               if let Some(Expr::Comparison { operators, .. }) = c {
-                operators
-                  .iter()
-                  .any(|op| matches!(op, crate::syntax::ComparisonOp::SameQ))
+                operators.iter().any(|op| matches!(op, ComparisonOp::SameQ))
               } else {
                 false
               }
@@ -892,9 +889,9 @@ pub fn dispatch_complex_and_special(
                     operators,
                     ..
                   }) = c
-                    && operators.iter().any(|op| {
-                      matches!(op, crate::syntax::ComparisonOp::SameQ)
-                    })
+                    && operators
+                      .iter()
+                      .any(|op| matches!(op, ComparisonOp::SameQ))
                     && operands.len() == 2
                     && matches!(&operands[0], Expr::Identifier(n) if n == p)
                   {
@@ -987,14 +984,14 @@ pub fn dispatch_complex_and_special(
             // SameQ condition on this slot. Reconstruct via the same
             // helper used by DefaultValues.
             let lit = _conds.iter().find_map(|c| {
-              if let Some(crate::syntax::Expr::Comparison {
+              if let Some(Expr::Comparison {
                 operands,
                 operators,
               }) = c
                 && operators.len() == 1
-                && matches!(operators[0], crate::syntax::ComparisonOp::SameQ)
+                && matches!(operators[0], ComparisonOp::SameQ)
                 && operands.len() == 2
-                && let crate::syntax::Expr::Identifier(name) = &operands[0]
+                && let Expr::Identifier(name) = &operands[0]
                 && name == p
               {
                 Some(expr_to_string(&operands[1]))
@@ -1178,20 +1175,17 @@ pub fn dispatch_complex_and_special(
               crate::StoredValue::ExprVal(e) => expr_to_string(&e),
               crate::StoredValue::Raw(val) => val,
               crate::StoredValue::Association(items) => {
-                let items_expr: Vec<(
-                  crate::syntax::Expr,
-                  crate::syntax::Expr,
-                )> = items
+                let items_expr: Vec<(Expr, Expr)> = items
                   .iter()
                   .map(|(k, v)| {
                     let key_expr = crate::syntax::string_to_expr(k)
-                      .unwrap_or(crate::syntax::Expr::Identifier(k.clone()));
+                      .unwrap_or(Expr::Identifier(k.clone()));
                     let val_expr = crate::syntax::string_to_expr(v)
-                      .unwrap_or(crate::syntax::Expr::Raw(v.clone()));
+                      .unwrap_or(Expr::Raw(v.clone()));
                     (key_expr, val_expr)
                   })
                   .collect();
-                expr_to_string(&crate::syntax::Expr::Association(items_expr))
+                expr_to_string(&Expr::Association(items_expr))
               }
             };
             lines.push(format!("{} = {}", sym, val_str));
@@ -1204,9 +1198,7 @@ pub fn dispatch_complex_and_special(
             {
               let has_sameq_conds = conds.iter().any(|c| {
                 if let Some(Expr::Comparison { operators, .. }) = c {
-                  operators
-                    .iter()
-                    .any(|op| matches!(op, crate::syntax::ComparisonOp::SameQ))
+                  operators.iter().any(|op| matches!(op, ComparisonOp::SameQ))
                 } else {
                   false
                 }
@@ -1222,9 +1214,9 @@ pub fn dispatch_complex_and_special(
                       operators,
                       ..
                     }) = c
-                      && operators.iter().any(|op| {
-                        matches!(op, crate::syntax::ComparisonOp::SameQ)
-                      })
+                      && operators
+                        .iter()
+                        .any(|op| matches!(op, ComparisonOp::SameQ))
                       && operands.len() == 2
                       && matches!(&operands[0], Expr::Identifier(n) if n == p)
                     {
@@ -3031,7 +3023,7 @@ fn lookup_usage_message(sym: &str) -> Option<String> {
         operators,
       }) = c
         && operators.len() == 1
-        && matches!(operators[0], crate::syntax::ComparisonOp::SameQ)
+        && matches!(operators[0], ComparisonOp::SameQ)
         && operands.len() == 2
         && let Expr::Identifier(pname) = &operands[0]
       {
@@ -3102,17 +3094,17 @@ fn format_user_information(
       crate::StoredValue::ExprVal(e) => expr_to_string(&e),
       crate::StoredValue::Raw(val) => val,
       crate::StoredValue::Association(items) => {
-        let items_expr: Vec<(crate::syntax::Expr, crate::syntax::Expr)> = items
+        let items_expr: Vec<(Expr, Expr)> = items
           .iter()
           .map(|(k, v)| {
             let key_expr = crate::syntax::string_to_expr(k)
-              .unwrap_or(crate::syntax::Expr::Identifier(k.clone()));
-            let val_expr = crate::syntax::string_to_expr(v)
-              .unwrap_or(crate::syntax::Expr::Raw(v.clone()));
+              .unwrap_or(Expr::Identifier(k.clone()));
+            let val_expr =
+              crate::syntax::string_to_expr(v).unwrap_or(Expr::Raw(v.clone()));
             (key_expr, val_expr)
           })
           .collect();
-        expr_to_string(&crate::syntax::Expr::Association(items_expr))
+        expr_to_string(&Expr::Association(items_expr))
       }
     };
     format!(
@@ -3136,9 +3128,7 @@ fn format_user_information(
               operands,
               operators,
             })) = conds.get(i)
-              && operators
-                .iter()
-                .any(|op| matches!(op, crate::syntax::ComparisonOp::SameQ))
+              && operators.iter().any(|op| matches!(op, ComparisonOp::SameQ))
               && let Some(literal_val) = operands.get(1)
             {
               return expr_to_string(literal_val);
@@ -3406,7 +3396,6 @@ fn to_graphics_boxes(expr: &Expr) -> Expr {
 /// FunctionCall head (Plus / Times / Power; Subtract → Plus[a, Times[-1,
 /// b]]; Divide → Times[a, Power[b, -1]]; UnaryMinus → Times[-1, x]).
 fn expr_to_full_box_form(expr: &Expr) -> Expr {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   // Atoms.
   match expr {
     Expr::Integer(n) => {
@@ -4055,14 +4044,14 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
       parts.push(expr_to_box_form(&operands[0]));
       for (i, op) in operators.iter().enumerate() {
         let op_str = match op {
-          crate::syntax::ComparisonOp::Equal => "==",
-          crate::syntax::ComparisonOp::NotEqual => "!=",
-          crate::syntax::ComparisonOp::Less => "<",
-          crate::syntax::ComparisonOp::LessEqual => "<=",
-          crate::syntax::ComparisonOp::Greater => ">",
-          crate::syntax::ComparisonOp::GreaterEqual => ">=",
-          crate::syntax::ComparisonOp::SameQ => "===",
-          crate::syntax::ComparisonOp::UnsameQ => "=!=",
+          ComparisonOp::Equal => "==",
+          ComparisonOp::NotEqual => "!=",
+          ComparisonOp::Less => "<",
+          ComparisonOp::LessEqual => "<=",
+          ComparisonOp::Greater => ">",
+          ComparisonOp::GreaterEqual => ">=",
+          ComparisonOp::SameQ => "===",
+          ComparisonOp::UnsameQ => "=!=",
         };
         parts.push(Expr::String(op_str.to_string()));
         parts.push(expr_to_box_form(&operands[i + 1]));
@@ -5138,7 +5127,6 @@ fn tf_is_zero(expr: &Expr) -> bool {
 /// Plus/Minus and unary minus and dropping literal `0` terms. Each entry is
 /// `(is_negative, term)`.
 fn tf_flatten_additive(expr: &Expr, neg: bool, out: &mut Vec<(bool, Expr)>) {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Plus,
@@ -5649,7 +5637,6 @@ fn tf_call(name: &str, args: &[Expr]) -> Expr {
 
 /// Core TraditionalForm typesetter: expression → 2D box tree.
 fn tf(expr: &Expr) -> Expr {
-  use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
   match expr {
     Expr::Identifier(s) | Expr::Constant(s) => tf_string(&tf_symbol(s)),
     Expr::FunctionCall { name, args } => tf_call(name, args),
@@ -6200,7 +6187,7 @@ fn inactivate_expr(expr: &Expr, filter: Option<&str>) -> Expr {
       operands,
       operators,
     } if operators.len() == 1 && operands.len() == 2 => {
-      use crate::syntax::ComparisonOp as C;
+      use ComparisonOp as C;
       let head = match operators[0] {
         C::Equal => "Equal",
         C::NotEqual => "Unequal",

--- a/src/evaluator/dispatch/datetime_functions.rs
+++ b/src/evaluator/dispatch/datetime_functions.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 pub fn dispatch_datetime_functions(
   name: &str,
@@ -82,7 +83,7 @@ pub fn dispatch_datetime_functions(
           || matches!(
             e,
             Expr::UnaryOp {
-              op: crate::syntax::UnaryOperator::Minus,
+              op: UnaryOperator::Minus,
               ..
             }
           )
@@ -133,7 +134,7 @@ pub fn dispatch_datetime_functions(
         return Some(Ok(zones[0].clone()));
       }
       return Some(crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left: Box::new(zones[0].clone()),
         right: Box::new(zones[1].clone()),
       }));

--- a/src/evaluator/dispatch/evaluation_control.rs
+++ b/src/evaluator/dispatch/evaluation_control.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::BinaryOperator;
 
 pub fn dispatch_evaluation_control(
   name: &str,
@@ -694,7 +695,7 @@ pub fn dispatch_evaluation_control(
         }
         [r] if !matches!(r, Expr::List(_)) => {
           let half = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Divide,
+            op: BinaryOperator::Divide,
             left: Box::new(r.clone()),
             right: Box::new(Expr::Integer(2)),
           });

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -961,8 +961,7 @@ pub fn evaluate_function_call_ast_inner(
                   );
                 // Push positional parameter bindings as context so inner
                 // Orderless matching can check compatibility (e.g. x_Symbol=r).
-                let mut positional_ctx: Vec<(String, crate::syntax::Expr)> =
-                  Vec::new();
+                let mut positional_ctx: Vec<(String, Expr)> = Vec::new();
                 for (pi, param) in params.iter().enumerate() {
                   if pi == idx
                     || pi >= effective_args.len()
@@ -1239,8 +1238,7 @@ pub fn evaluate_function_call_ast_inner(
                     );
                   // Push positional parameter bindings as context so inner
                   // Orderless matching can check compatibility.
-                  let mut positional_ctx: Vec<(String, crate::syntax::Expr)> =
-                    Vec::new();
+                  let mut positional_ctx: Vec<(String, Expr)> = Vec::new();
                   for (pi, param) in params.iter().enumerate() {
                     if pi == idx
                       || pi >= effective_args.len()
@@ -12042,8 +12040,6 @@ fn chromatic_poly_coeffs(n: usize, edges: &[(usize, usize)]) -> Vec<i128> {
 
 /// Convert polynomial coefficients to an expression in variable k.
 fn poly_to_expr(coeffs: &[i128], k: &Expr) -> Expr {
-  use crate::syntax::BinaryOperator;
-
   let mut terms: Vec<Expr> = Vec::new();
   for (i, &c) in coeffs.iter().enumerate() {
     if c == 0 {

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::BinaryOperator;
 
 /// MapAll[f, expr] - apply f to every subexpression in expr (bottom-up)
 pub fn map_all_ast(f: &Expr, expr: &Expr) -> Result<Expr, InterpreterError> {
@@ -251,7 +252,7 @@ fn differentiate_function_body(body: &Expr, orders: &[i128]) -> Option<Expr> {
         Expr::Integer(0)
       } else {
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Times,
+          op: BinaryOperator::Times,
           left: Box::new(factor),
           right: Box::new(chain),
         }
@@ -2237,7 +2238,7 @@ fn apply_transformation_function(
     if !matches!(&h, Expr::Integer(1)) {
       for comp in &mut result {
         *comp = evaluate_expr_to_expr(&Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           left: Box::new(comp.clone()),
           right: Box::new(h.clone()),
         })?;

--- a/src/evaluator/part_extraction.rs
+++ b/src/evaluator/part_extraction.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 fn expr_to_i64(expr: &Expr) -> Option<i64> {
   match expr {
@@ -676,7 +677,6 @@ pub fn extract_part_ast(
     // Strings are atoms in Wolfram Language — Part[string, n] for n ≠ 0
     // returns unevaluated (handled by the fallback arm below).
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator;
       // Decompose BinaryOp into head + args consistent with Head[]
       let (head_name, parts): (&str, Vec<Expr>) = match op {
         BinaryOperator::Plus => ("Plus", vec![*left.clone(), *right.clone()]),
@@ -729,7 +729,6 @@ pub fn extract_part_ast(
       }
     }
     Expr::UnaryOp { op, operand } => {
-      use crate::syntax::UnaryOperator;
       let (head_name, parts): (&str, Vec<Expr>) = match op {
         UnaryOperator::Minus => {
           ("Times", vec![Expr::Integer(-1), *operand.clone()])

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::BinaryOperator;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 use std::cell::RefCell;
 
 // Thread-local stack of accumulated bindings from outer FunctionCall arg loops.
@@ -3649,7 +3649,6 @@ fn match_pattern_impl(
 /// ComplexInfinity → DirectedInfinity[]. Returns None for anything else (and
 /// for an already-explicit DirectedInfinity[…], which needs no rewriting).
 fn directed_infinity_canonical(expr: &Expr) -> Option<Expr> {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   let is_inf = |e: &Expr| matches!(e, Expr::Identifier(s) | Expr::Constant(s) if s == "Infinity");
   let di = |dir: Vec<Expr>| Expr::FunctionCall {
     name: "DirectedInfinity".to_string(),
@@ -3689,7 +3688,6 @@ fn directed_infinity_canonical(expr: &Expr) -> Option<Expr> {
 }
 
 pub fn get_expr_head(expr: &Expr) -> String {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   // Check for complex numbers before general matching,
   // so that e.g. 2I (stored as Times[2, I]) is recognized as Complex
   if crate::functions::predicate_ast::is_complex_number(expr) {

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -14692,7 +14692,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // that special functions (ExpIntegralEi, Log, …) keep their dedicated
   // asymptotic handlers further below.
   fn is_rational_function(expr: &Expr) -> bool {
-    use crate::syntax::{BinaryOperator as B, UnaryOperator as U};
+    use {BinaryOperator as B, UnaryOperator as U};
     match expr {
       Expr::Integer(_)
       | Expr::Real(_)

--- a/src/functions/convolve_ast.rs
+++ b/src/functions/convolve_ast.rs
@@ -11,7 +11,7 @@
 //! (e.g. Sqrt[Pi/2]/E^(y^2/2), (y*UnitStep[y])/E^(2*y)).
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 type Frac = (i128, i128);
 
@@ -94,12 +94,12 @@ pub fn convolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     args: factors.into(),
   };
   let div = |n: Expr, d: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(n),
     right: Box::new(d),
   };
   let pow = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(b),
     right: Box::new(e),
   };
@@ -164,7 +164,7 @@ fn exp_step_rate(expr: &Expr, x_var: &str) -> Option<Frac> {
       args.iter().collect()
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => vec![left, right],
@@ -198,7 +198,7 @@ fn exp_exponent(expr: &Expr) -> Option<Expr> {
       Some(args[0].clone())
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => is_e(left).then(|| (**right).clone()),
@@ -224,7 +224,7 @@ fn neg_coeff_of(exponent: &Expr, x_var: &str, deg: i128) -> Option<Frac> {
             && matches!(&args[1], Expr::Integer(d) if *d == deg)
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Power,
+          op: BinaryOperator::Power,
           left,
           right,
         } => {
@@ -237,7 +237,7 @@ fn neg_coeff_of(exponent: &Expr, x_var: &str, deg: i128) -> Option<Frac> {
   };
   match exponent {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       if x_pow_matches(operand) {
@@ -260,7 +260,7 @@ fn neg_coeff_of(exponent: &Expr, x_var: &str, deg: i128) -> Option<Frac> {
       negative_frac(&args[0])
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -13,6 +13,7 @@
 
 use crate::InterpreterError;
 use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 pub fn dirichlet_character_ast(
   args: &[Expr],
@@ -296,7 +297,7 @@ fn assemble_value(quarter: i128, num: i128, den: i128) -> Expr {
       1 => Expr::Identifier("I".to_string()),
       2 => Expr::Integer(-1),
       _ => Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("I".to_string())),
       },
     };
@@ -648,8 +649,6 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 //    `unknown * 1 -> DivisorSum`, irreducible pairs stay as inert
 //    DirichletConvolve terms.
 
-use crate::syntax::BinaryOperator;
-
 #[derive(Clone)]
 enum ConvAtom {
   /// var^k for integer k >= 0 (k = 0 is the constant 1, k = 1 is var)
@@ -703,7 +702,7 @@ fn flatten_times(expr: &Expr, out: &mut Vec<Expr>) {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       out.push(Expr::Integer(-1));

--- a/src/functions/function_range_ast.rs
+++ b/src/functions/function_range_ast.rs
@@ -7,7 +7,7 @@
 //! LessEqual, 1].
 
 use crate::InterpreterError;
-use crate::syntax::{ComparisonOp, Expr};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr};
 
 pub fn function_range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = |args: &[Expr]| Expr::FunctionCall {
@@ -162,7 +162,7 @@ fn as_power(expr: &Expr) -> Option<(Expr, Expr)> {
       Some((args[0].clone(), args[1].clone()))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some(((**left).clone(), (**right).clone())),

--- a/src/functions/geo_math.rs
+++ b/src/functions/geo_math.rs
@@ -7,7 +7,7 @@
 
 use crate::InterpreterError;
 use crate::functions::geographics::{position_to_latlon, positions_from_arg};
-use crate::syntax::Expr;
+use crate::syntax::{Expr, UnaryOperator};
 use geographiclib_rs::{DirectGeodesic, Geodesic, InverseGeodesic};
 use std::sync::OnceLock;
 
@@ -348,7 +348,7 @@ fn to_angle(expr: &Expr) -> Option<AngleVal> {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => to_angle(operand).map(|v| match v {
       AngleVal::Exact(p, q) => AngleVal::Exact(-p, q),

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -1,6 +1,6 @@
 use crate::InterpreterError;
 use crate::functions::graphics::{Color, graphics_ast, parse_color};
-use crate::syntax::{Expr, expr_to_output, expr_to_string};
+use crate::syntax::{BinaryOperator, Expr, expr_to_output, expr_to_string};
 use petgraph::graph::{DiGraph, NodeIndex, UnGraph};
 use petgraph::visit::EdgeRef;
 use std::collections::HashMap;
@@ -5576,10 +5576,10 @@ pub fn graph_metric_ast(
       return Ok(unevaluated());
     }
     return crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Minus,
+      op: BinaryOperator::Minus,
       left: Box::new(Expr::Integer(1)),
       right: Box::new(Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Divide,
+        op: BinaryOperator::Divide,
         left: Box::new(mgd),
         right: Box::new(ec),
       }),

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -2,7 +2,7 @@ use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{DEFAULT_HEIGHT, DEFAULT_WIDTH, parse_image_size};
-use crate::syntax::{Expr, expr_to_string};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
 
 /// Dash length for the "Small" named size in Dashing directives.
 /// This is the default dash segment length used by Dashed, Dotted, etc.
@@ -4385,7 +4385,7 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn as_power(expr: &Expr) -> Option<(&Expr, &Expr)> {
   match expr {
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some((left.as_ref(), right.as_ref())),
@@ -4398,7 +4398,6 @@ pub fn as_power(expr: &Expr) -> Option<(&Expr, &Expr)> {
 
 /// Check if expression is an additive form (Plus/Minus) for parenthesization.
 fn is_additive_expr(e: &Expr) -> bool {
-  use crate::syntax::BinaryOperator;
   matches!(
     e,
     Expr::BinaryOp {
@@ -5453,7 +5452,6 @@ pub fn has_fraction(expr: &Expr) -> bool {
 /// E.g. `"Meters"/"Seconds"` → `m/s`, `"Meters"^2` → `m²` (with superscript).
 fn quantity_unit_to_svg_abbrev(unit: &Expr) -> String {
   use crate::functions::quantity_ast::unit_to_abbreviation;
-  use crate::syntax::BinaryOperator;
 
   // Handle Power in both BinaryOp and FunctionCall form
   if let Some((base, exp)) = as_power(unit) {
@@ -5583,9 +5581,7 @@ fn digit_group_extra_width(digit_count: usize) -> f64 {
 /// Recursively handles all expression types so that Power expressions
 /// anywhere in the tree are rendered with `<tspan>` superscripts.
 pub fn expr_to_svg_markup(expr: &Expr) -> String {
-  use crate::syntax::{
-    BinaryOperator, ComparisonOp, UnaryOperator, expr_to_output,
-  };
+  use crate::syntax::{ComparisonOp, expr_to_output};
 
   // Power → superscript (handles both BinaryOp and FunctionCall forms)
   if let Some((base, exp)) = as_power(expr) {
@@ -5928,7 +5924,7 @@ pub fn expr_to_svg_markup(expr: &Expr) -> String {
 /// accounting for superscript sizing (exponents rendered at ~70% width).
 /// Recursively mirrors `expr_to_svg_markup` structure.
 pub fn estimate_display_width(expr: &Expr) -> f64 {
-  use crate::syntax::{BinaryOperator, expr_to_output};
+  use crate::syntax::expr_to_output;
 
   if let Some((base, exp)) = as_power(expr) {
     let parens = if is_additive_expr(base) { 2.0 } else { 0.0 };
@@ -6152,7 +6148,6 @@ pub fn estimate_display_width(expr: &Expr) -> f64 {
 /// Estimate the display width of an abbreviated unit expression.
 fn estimate_unit_abbrev_width(unit: &Expr) -> f64 {
   use crate::functions::quantity_ast::unit_to_abbreviation;
-  use crate::syntax::BinaryOperator;
 
   if let Some((base, exp)) = as_power(unit) {
     return estimate_unit_abbrev_width(base)
@@ -11161,7 +11156,7 @@ pub fn drop_shadowing_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         is_number(&args[0]) && is_number(&args[1])
       }
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => is_number(operand),
       _ => false,
@@ -13421,7 +13416,6 @@ fn display_node_to_json(node: &DisplayNode) -> String {
 #[cfg(test)]
 mod manipulate_label_tests {
   use super::*;
-  use crate::syntax::Expr;
 
   fn call(name: &str, args: Vec<Expr>) -> Expr {
     Expr::FunctionCall {

--- a/src/functions/groebner_ast.rs
+++ b/src/functions/groebner_ast.rs
@@ -8,7 +8,7 @@
 //! unevaluated.
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 use std::collections::BTreeMap;
 
 type Frac = (i128, i128);
@@ -168,7 +168,6 @@ fn reduce(p: &Poly, basis: &[Poly]) -> Option<Poly> {
 /// Render a `Poly` (lex order, leading term first) back to an `Expr`, then
 /// evaluate it so the result is canonicalized like wolframscript.
 fn poly_to_expr(p: &Poly, vars: &[String]) -> Expr {
-  use crate::syntax::BinaryOperator;
   if p.is_empty() {
     return Expr::Integer(0);
   }
@@ -548,7 +547,7 @@ pub fn groebner_basis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             factors.push(Expr::Identifier(vars[vi].clone()));
           } else if e > 1 {
             factors.push(Expr::BinaryOp {
-              op: crate::syntax::BinaryOperator::Power,
+              op: BinaryOperator::Power,
               left: Box::new(Expr::Identifier(vars[vi].clone())),
               right: Box::new(Expr::Integer(e as i128)),
             });
@@ -591,7 +590,7 @@ fn expr_to_poly(expr: &Expr, vars: &[String]) -> Option<Poly> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Plus,
+        op: BinaryOperator::Plus,
         left,
         right,
       } => {
@@ -599,7 +598,7 @@ fn expr_to_poly(expr: &Expr, vars: &[String]) -> Option<Poly> {
         split(right, sign, out);
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Minus,
+        op: BinaryOperator::Minus,
         left,
         right,
       } => {
@@ -607,7 +606,7 @@ fn expr_to_poly(expr: &Expr, vars: &[String]) -> Option<Poly> {
         split(right, -sign, out);
       }
       Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } => split(operand, -sign, out),
       other => out.push((other, sign)),
@@ -634,7 +633,7 @@ fn term_to_mono(term: &Expr, vars: &[String]) -> Option<(Mono, Frac)> {
         }
       }
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Times,
+        op: BinaryOperator::Times,
         left,
         right,
       } => {
@@ -671,7 +670,7 @@ fn term_to_mono(term: &Expr, vars: &[String]) -> Option<(Mono, Frac)> {
             (&args[0], &args[1])
           }
           Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Power,
+            op: BinaryOperator::Power,
             left,
             right,
           } => (&**left as &Expr, &**right as &Expr),

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -1,4 +1,5 @@
 use crate::InterpreterError;
+use crate::syntax::BinaryOperator;
 use crate::syntax::{Expr, ImageType};
 use std::sync::Arc;
 
@@ -5980,7 +5981,7 @@ fn extract_image_weight(
 
   // w * Image or Image * w
   if let Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left,
     right,
   } = expr

--- a/src/functions/interval_ast.rs
+++ b/src/functions/interval_ast.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr};
 use std::cmp::Ordering;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -222,7 +222,7 @@ pub fn coth_csch_interval(head: &str, expr: &Expr) -> Option<Expr> {
   }
   let inf = || Expr::Identifier("Infinity".to_string());
   let neg_inf = || Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(Expr::Integer(-1)),
     right: Box::new(Expr::Identifier("Infinity".to_string())),
   };
@@ -296,7 +296,7 @@ pub fn tan_cot_interval(head: &str, expr: &Expr) -> Option<Expr> {
   let period = std::f64::consts::PI;
   let inf = || Expr::Identifier("Infinity".to_string());
   let neg_inf = || Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(Expr::Integer(-1)),
     right: Box::new(Expr::Identifier("Infinity".to_string())),
   };
@@ -353,7 +353,7 @@ pub fn sec_csc_interval(head: &str, expr: &Expr) -> Option<Expr> {
   };
   let inf = || Expr::Identifier("Infinity".to_string());
   let neg_inf = || Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Times,
+    op: BinaryOperator::Times,
     left: Box::new(Expr::Integer(-1)),
     right: Box::new(Expr::Identifier("Infinity".to_string())),
   };

--- a/src/functions/list_helpers_ast/construction.rs
+++ b/src/functions/list_helpers_ast/construction.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::BinaryOperator;
 
 /// AST-based Table: generate a table of values.
 /// Table[expr, {i, min, max}] -> {expr with i=min, ..., expr with i=max}
@@ -774,12 +775,12 @@ pub fn range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           min_expr.clone()
         } else {
           let k_times_step = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Times,
+            op: BinaryOperator::Times,
             left: Box::new(Expr::Integer(k)),
             right: Box::new(step_expr.clone()),
           };
           let sum = Expr::BinaryOp {
-            op: crate::syntax::BinaryOperator::Plus,
+            op: BinaryOperator::Plus,
             left: Box::new(min_expr.clone()),
             right: Box::new(k_times_step),
           };
@@ -1027,7 +1028,7 @@ pub fn constant_array_ast(
     },
     Expr::Integer(1) => ones(),
     _ => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left: Box::new(elem.clone()),
       right: Box::new(ones()),
     },

--- a/src/functions/list_helpers_ast/element_access.rs
+++ b/src/functions/list_helpers_ast/element_access.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// Decompose a BinaryOp or UnaryOp expression into canonical Wolfram
 /// (head_name, args) form so that First/Rest/Part/etc. can operate on them.
@@ -10,20 +11,17 @@ use super::*;
 /// Flatten a chained binary operator (Plus/Times/And/Or/StringJoin/Alternatives)
 /// into its full n-ary argument list. e.g. `(((1+2)+3)+4)` → `[1, 2, 3, 4]`.
 fn flatten_assoc_binop(
-  op: crate::syntax::BinaryOperator,
-  left: &crate::syntax::Expr,
-  right: &crate::syntax::Expr,
-) -> Vec<crate::syntax::Expr> {
+  op: BinaryOperator,
+  left: &Expr,
+  right: &Expr,
+) -> Vec<Expr> {
   let mut out = flatten_assoc_one(op, left);
   out.extend(flatten_assoc_one(op, right));
   out
 }
 
-fn flatten_assoc_one(
-  op: crate::syntax::BinaryOperator,
-  expr: &crate::syntax::Expr,
-) -> Vec<crate::syntax::Expr> {
-  if let crate::syntax::Expr::BinaryOp {
+fn flatten_assoc_one(op: BinaryOperator, expr: &Expr) -> Vec<Expr> {
+  if let Expr::BinaryOp {
     op: inner_op,
     left,
     right,
@@ -37,7 +35,6 @@ fn flatten_assoc_one(
 }
 
 pub fn expr_to_head_args(expr: &Expr) -> Option<(String, Vec<Expr>)> {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   match expr {
     Expr::BinaryOp { op, left, right } => {
       let (head, args) = match op {

--- a/src/functions/list_helpers_ast/filtering.rs
+++ b/src/functions/list_helpers_ast/filtering.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::BinaryOperator;
 
 /// AST-based Select: filter elements where predicate returns True.
 /// Select[{a, b, c}, pred] -> elements where pred[elem] is True
@@ -679,7 +680,7 @@ pub fn matches_pattern_ast(expr: &Expr, pattern: &Expr) -> bool {
     }
     // Alternatives: a | b - matches if either side matches
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Alternatives,
+      op: BinaryOperator::Alternatives,
       left,
       right,
     } => matches_pattern_ast(expr, left) || matches_pattern_ast(expr, right),

--- a/src/functions/list_helpers_ast/functional.rs
+++ b/src/functions/list_helpers_ast/functional.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::{BinaryOperator, UnaryOperator};
 
 /// AST-based Fold/FoldList: fold a function over a list.
 /// Fold[f, x, {a, b, c}] -> f[f[f[x, a], b], c]
@@ -728,7 +729,6 @@ fn expr_children(expr: &Expr) -> Option<Vec<Expr>> {
     Expr::List(items) => Some(items.to_vec()),
     Expr::FunctionCall { args, .. } => Some(args.to_vec()),
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator;
       match op {
         // a - b → Plus[a, Times[-1, b]]
         BinaryOperator::Minus => Some(vec![
@@ -961,8 +961,8 @@ fn apply_at_level_recursive(
   }
 }
 
-fn binary_op_to_name(op: crate::syntax::BinaryOperator) -> &'static str {
-  use crate::syntax::BinaryOperator::*;
+fn binary_op_to_name(op: BinaryOperator) -> &'static str {
+  use BinaryOperator::*;
   match op {
     Plus => "Plus",
     Minus => "Subtract",
@@ -976,8 +976,8 @@ fn binary_op_to_name(op: crate::syntax::BinaryOperator) -> &'static str {
   }
 }
 
-fn unary_op_to_name(op: crate::syntax::UnaryOperator) -> &'static str {
-  use crate::syntax::UnaryOperator::*;
+fn unary_op_to_name(op: UnaryOperator) -> &'static str {
+  use UnaryOperator::*;
   match op {
     Minus => "Times",
     Not => "Not",

--- a/src/functions/list_helpers_ast/sorting.rs
+++ b/src/functions/list_helpers_ast/sorting.rs
@@ -1463,7 +1463,6 @@ pub fn expr_sort_key(e: &Expr) -> String {
       crate::syntax::expr_to_string(e)
     }
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator;
       match op {
         BinaryOperator::Power => {
           // Power: sort key is the base (recurse for compound bases)

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -3246,8 +3246,6 @@ fn match_geometric_symbolic_exp(
 /// (the last from a `k/r^k` division). Other factors reject the match.
 /// Used for Sum[k^p r^k, {k, 1, Infinity}] = PolyLog[-p, r].
 fn match_arith_geometric(body: &Expr, var_name: &str) -> Option<(i128, Expr)> {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
-
   fn collect(e: &Expr, out: &mut Vec<Expr>) {
     match e {
       Expr::BinaryOp {

--- a/src/functions/list_helpers_ast/utilities.rs
+++ b/src/functions/list_helpers_ast/utilities.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
 
 /// Convert an Expr to a boolean value.
 /// Returns Some(true) for Identifier("True"), Some(false) for Identifier("False").
@@ -113,7 +114,6 @@ pub fn apply_func_to_args(
 /// `a-b` is `Plus`, `a==b` is `Equal` — so head-constrained patterns
 /// (`_Power`, `_Plus`, …) match them correctly. Mirrors `Head[]`.
 pub fn get_expr_head_str(expr: &Expr) -> &str {
-  use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
   match expr {
     Expr::Integer(_) | Expr::BigInteger(_) => "Integer",
     Expr::Real(_) | Expr::BigFloat(_, _) => "Real",

--- a/src/functions/math_ast/bessel.rs
+++ b/src/functions/math_ast/bessel.rs
@@ -182,7 +182,7 @@ fn wrap_with_sqrt_factor_rationalised(
   p: &Expr,
   z_expr: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::Expr::*;
+  use Expr::*;
   // Build Distribute[2*p, Plus] / (Sqrt[2*Pi] * Sqrt[z]).
   let two_p = FunctionCall {
     name: "Times".to_string(),
@@ -305,7 +305,7 @@ fn bessel_poly_recurrence(
   sign: BesselSign,
   forward: bool,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::Expr::*;
+  use Expr::*;
   // Coefficient on the (m/z) * P_m term and on P_{other}.
   let (a_coef, b_coef): (i128, i128) = match (sign, forward) {
     (BesselSign::J, _) => (coef, -1), // (m/z) P_m - P_other
@@ -342,7 +342,7 @@ fn wrap_with_sqrt_factor(
   p: &Expr,
   z_expr: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::Expr::*;
+  use Expr::*;
   let expr = FunctionCall {
     name: "Times".to_string(),
     args: vec![
@@ -805,7 +805,7 @@ fn bessel_k_polynomial(
   let mut curr = Expr::Integer(1); // P_{1}
   let mut m_cur: i128 = 1;
   while m_cur < m {
-    use crate::syntax::Expr::*;
+    use Expr::*;
     // P_{m_cur+2} = (m_cur/z) * curr + prev
     let next_expr = FunctionCall {
       name: "Plus".to_string(),
@@ -841,7 +841,7 @@ fn wrap_bessel_k_factor(
   p: &Expr,
   z_expr: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::Expr::*;
+  use Expr::*;
   let expr = FunctionCall {
     name: "Times".to_string(),
     args: vec![
@@ -1223,7 +1223,7 @@ fn coulomb_wave_reduce(
   args: &[Expr],
   kind: CoulombKind,
 ) -> Result<Expr, InterpreterError> {
-  use crate::syntax::Expr::*;
+  use Expr::*;
   let name = match kind {
     CoulombKind::F => "CoulombF",
     CoulombKind::G => "CoulombG",

--- a/src/functions/math_ast/elliptic.rs
+++ b/src/functions/math_ast/elliptic.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// True if `e` contains an inexact (machine) number. Elliptic functions
 /// numericize only when an argument is inexact; exact (integer/rational)
@@ -1691,7 +1691,7 @@ pub fn neville_theta_ast(
       Some(ta[1].clone())
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some((**operand).clone()),
     _ => None,

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -1109,7 +1109,7 @@ fn struve_half_integer_closed_form(
   two_nu: i64,
   z: &Expr,
 ) -> Option<Result<Expr, InterpreterError>> {
-  use crate::syntax::BinaryOperator as B;
+  use BinaryOperator as B;
   let bin = |op, a: Expr, b: Expr| Expr::BinaryOp {
     op,
     left: Box::new(a),

--- a/src/functions/math_ast/mod.rs
+++ b/src/functions/math_ast/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! These functions work directly with `Expr` AST nodes.
 
+use crate::syntax::Expr;
+
 mod airy;
 mod arithmetic;
 mod bessel;
@@ -63,32 +65,32 @@ pub use zeta_functions::*;
 /// SliceDistribution).
 pub fn distributions_slice(
   proc_name: &str,
-  dargs: &[crate::syntax::Expr],
-  t: &crate::syntax::Expr,
-) -> Option<crate::syntax::Expr> {
+  dargs: &[Expr],
+  t: &Expr,
+) -> Option<Expr> {
   distributions::process_slice_distribution(proc_name, dargs, t)
 }
 
 /// Public accessors for the process correlation closed forms.
 pub fn statistics_process_correlation(
-  proc: &crate::syntax::Expr,
-  t1: &crate::syntax::Expr,
-  t2: &crate::syntax::Expr,
-) -> Option<crate::syntax::Expr> {
+  proc: &Expr,
+  t1: &Expr,
+  t2: &Expr,
+) -> Option<Expr> {
   statistics::process_correlation(proc, t1, t2)
 }
 
 pub fn statistics_process_absolute_correlation(
-  proc: &crate::syntax::Expr,
-  t1: &crate::syntax::Expr,
-  t2: &crate::syntax::Expr,
-) -> Option<crate::syntax::Expr> {
+  proc: &Expr,
+  t1: &Expr,
+  t2: &Expr,
+) -> Option<Expr> {
   statistics::process_absolute_correlation(proc, t1, t2)
 }
 
 /// Public accessor for BiweightMidvariance.
 pub fn statistics_biweight_midvariance(
-  args: &[crate::syntax::Expr],
-) -> Result<crate::syntax::Expr, crate::InterpreterError> {
+  args: &[Expr],
+) -> Result<Expr, crate::InterpreterError> {
   statistics::biweight_midvariance_ast(args)
 }

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -3898,7 +3898,7 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // PolyaAeppli: Kurtosis = 3 + (1 + 10 p + p^2)/((1 + p) t).
   if let Some((t, p)) = two_params_of(&args[0], "PolyaAeppliDistribution") {
-    use crate::syntax::BinaryOperator as B;
+    use BinaryOperator as B;
     let bin = |op, l, r| Expr::BinaryOp {
       op,
       left: Box::new(l),
@@ -3984,7 +3984,7 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // PolyaAeppli: Skewness = (1 + 4 p + p^2)/((1 + p) Sqrt[(1 + p) t]).
   if let Some((t, p)) = two_params_of(&args[0], "PolyaAeppliDistribution") {
-    use crate::syntax::BinaryOperator as B;
+    use BinaryOperator as B;
     let bin = |op, l, r| Expr::BinaryOp {
       op,
       left: Box::new(l),

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -931,7 +931,7 @@ fn exact_cot(k: i64, n: i64) -> Option<Expr> {
 /// keeps wolframscript's "-2 - Sqrt[3]" form rather than "-(2 + Sqrt[3])".
 fn canonicalize_exact_trig_value(
   exact: Expr,
-) -> Result<Expr, crate::InterpreterError> {
+) -> Result<Expr, InterpreterError> {
   if let Expr::UnaryOp {
     op: UnaryOperator::Minus,
     operand,
@@ -4055,7 +4055,7 @@ fn hyperbolic_of_log(
   name: &str,
   arg: &Expr,
 ) -> Option<Result<Expr, InterpreterError>> {
-  use crate::syntax::BinaryOperator as B;
+  use BinaryOperator as B;
   let u = match arg {
     Expr::FunctionCall { name: n, args } if n == "Log" && args.len() == 1 => {
       &args[0]

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -5,7 +5,7 @@
 
 use crate::InterpreterError;
 use crate::functions::math_ast::make_sqrt;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 // ─── DSolve ────────────────────────────────────────────────────────────
 
@@ -725,7 +725,7 @@ fn collect_additive_terms(
       collect_additive_terms(right, y_name, x_name, !negated, terms)?;
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       collect_additive_terms(operand, y_name, x_name, !negated, terms)?;
@@ -1014,7 +1014,7 @@ fn negate_expr(expr: &Expr) -> Expr {
     Expr::Integer(n) => Expr::Integer(-n),
     Expr::Real(f) => Expr::Real(-f),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => *operand.clone(),
     _ => Expr::BinaryOp {
@@ -1654,7 +1654,7 @@ fn make_exp_term_expr(coeff: &Expr, x_name: &str) -> Expr {
   let exponent = match coeff {
     Expr::Integer(1) => x,
     Expr::Integer(-1) => Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand: Box::new(x),
     },
     _ => Expr::BinaryOp {
@@ -2076,7 +2076,7 @@ fn expr_to_f64(expr: &Expr) -> Result<f64, InterpreterError> {
     Expr::Constant(name) if name == "E" => Ok(std::f64::consts::E),
     Expr::Constant(name) if name == "Pi" => Ok(std::f64::consts::PI),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Ok(-expr_to_f64(operand)?),
     Expr::BinaryOp { op, left, right } => {
@@ -2938,7 +2938,7 @@ fn try_direct_linear_pde_body(
   let mut c = match &rhs {
     Expr::Integer(n) => *n,
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => match operand.as_ref() {
       Expr::Integer(n) => -*n,

--- a/src/functions/polynomial_ast/cancel.rs
+++ b/src/functions/polynomial_ast/cancel.rs
@@ -158,7 +158,7 @@ fn cancel_expr_impl(expr: &Expr, canonicalize_sign: bool) -> Expr {
         let terms = collect_additive_terms(&num);
         if terms.len() >= 2 {
           // For each term, extract base→exp map of its multiplicative factors
-          type BaseExpMap = Vec<(String, crate::syntax::Expr, i128)>;
+          type BaseExpMap = Vec<(String, Expr, i128)>;
           fn term_base_exp(term: &Expr) -> BaseExpMap {
             let factors = collect_multiplicative_factors(term);
             let mut map: BaseExpMap = Vec::new();

--- a/src/functions/polynomial_ast/decompose.rs
+++ b/src/functions/polynomial_ast/decompose.rs
@@ -1,5 +1,5 @@
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 use super::coefficient::collect_additive_terms;
 use super::coefficient::term_var_power_and_coeff;
@@ -237,7 +237,7 @@ fn expr_to_rat(expr: &Expr) -> Option<Rat> {
       }
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       let (n, d) = expr_to_rat(operand)?;

--- a/src/functions/polynomial_ast/expand.rs
+++ b/src/functions/polynomial_ast/expand.rs
@@ -985,7 +985,6 @@ fn is_numeric_scalar(e: &Expr) -> bool {
 /// own output, leaving the shared `combine_product_factors` (used by Simplify)
 /// untouched.
 fn fold_term_numerics(expr: &Expr) -> Expr {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   match expr {
     Expr::BinaryOp {
       op: BinaryOperator::Plus,
@@ -1249,7 +1248,7 @@ fn sort_var_factors_canonical(factors: &mut [Expr]) {
     match e {
       Expr::Identifier(_) | Expr::Constant(_) => 0,
       Expr::BinaryOp {
-        op: crate::syntax::BinaryOperator::Power,
+        op: BinaryOperator::Power,
         left,
         ..
       } => factor_subpriority(left),

--- a/src/functions/polynomial_ast/function_expand.rs
+++ b/src/functions/polynomial_ast/function_expand.rs
@@ -1,5 +1,5 @@
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr};
 
 /// FunctionExpand[expr] — expand special mathematical functions into simpler forms.
 pub fn function_expand_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -363,7 +363,7 @@ fn reciprocal_gamma_arg(f: &Expr) -> Option<Expr> {
       (&args[0], &args[1])
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => (left.as_ref(), right.as_ref()),

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::InterpreterError;
 use crate::functions::math_ast::{expr_to_f64, expr_to_i128, is_sqrt};
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 /// MinimalPolynomial[α, x] - Computes the minimal polynomial of an algebraic number α
 /// in the variable x.
@@ -170,7 +170,7 @@ fn compute_minpoly_coeffs(
 
     // Unary minus
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       // minpoly(-α) = minpoly(α) with x replaced by -x
@@ -229,7 +229,7 @@ fn compute_minpoly_coeffs(
     } => {
       // a - b = a + (-b)
       let neg_right = Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new((**right).clone()),
       };
       let sum_expr = Expr::BinaryOp {
@@ -1026,7 +1026,7 @@ fn collect_rad_poly(expr: &Expr, depth: usize) -> Option<RadPoly> {
       power(&args[0], &args[1])
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some(rad_scale(&collect_rad_poly(operand, depth + 1)?, (-1, 1))),
     Expr::BinaryOp { op, left, right } => match op {

--- a/src/functions/polynomial_ast/polynomial_gcd.rs
+++ b/src/functions/polynomial_ast/polynomial_gcd.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{Expr, expr_to_string};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
 
 /// PolynomialGCD[p1, p2, ...] - greatest common divisor of polynomials
 pub fn polynomial_gcd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -460,7 +460,7 @@ fn poly_integer_content(
           int_coeffs.push(crate::evaluator::evaluate_expr_to_expr(&abs)?);
         }
         Expr::BinaryOp {
-          op: crate::syntax::BinaryOperator::Divide,
+          op: BinaryOperator::Divide,
           ..
         } => {
           // Rational number - include it
@@ -543,12 +543,12 @@ fn normalize_poly_sign(
     Expr::Integer(n) => *n < 0,
     Expr::Real(f) => *f < 0.0,
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       ..
     } => matches!(left.as_ref(), Expr::Integer(n) if *n < 0),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       ..
     } => true,
     _ => {

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2,7 +2,9 @@ use super::together::negate_expr;
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+};
 
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 use crate::functions::math_ast::{is_sqrt, make_sqrt};
@@ -266,7 +268,6 @@ fn complex_pow(a: f64, b: f64, c: f64, d: f64) -> (f64, f64) {
 /// `Times[-1, Power[-1, 1/3]]` — fully numericize instead of leaking a
 /// symbolic `Power` into NSolve's output.
 fn eval_complex_full(expr: &Expr) -> Option<(f64, f64)> {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
   // Reuse the existing extractor for everything but Power.
   if let Some(v) = crate::functions::math_ast::try_extract_complex_float(expr) {
     return Some(v);
@@ -2863,7 +2864,6 @@ fn try_solve_abs_eq(
 }
 
 fn try_solve_trig_eq(eq: &Expr, var: &str) -> Option<Expr> {
-  use crate::syntax::ComparisonOp;
   // Extract lhs == rhs.
   let (lhs, rhs) = match eq {
     Expr::Comparison {
@@ -6757,7 +6757,6 @@ fn minimize_constrained_1d(
         operands,
         operators,
       } if operands.len() == 2 && operators.len() == 1 => {
-        use crate::syntax::ComparisonOp;
         let lhs = &operands[0];
         let rhs = &operands[1];
         match &operators[0] {
@@ -6977,7 +6976,6 @@ fn minimize_satisfies_constraints(
   vars: &[String],
   vals: &[f64],
 ) -> bool {
-  use crate::syntax::ComparisonOp;
   for con in constraints {
     if let Expr::Comparison {
       operands,
@@ -7023,7 +7021,6 @@ fn minimize_satisfies_constraints(
 /// True if `con` is a strict comparison (`<` or `>`), as opposed to `<=`/`>=`
 /// or `==`. Used by integer enumeration to exclude boundary integers.
 fn constraint_is_strict(con: &Expr) -> bool {
-  use crate::syntax::ComparisonOp;
   matches!(con, Expr::Comparison { operators, .. }
     if operators.len() == 1
       && matches!(operators[0], ComparisonOp::Greater | ComparisonOp::Less))
@@ -7033,7 +7030,6 @@ fn minimize_extract_linear_constraint(
   con: &Expr,
   vars: &[String],
 ) -> Option<(Vec<f64>, f64, i32)> {
-  use crate::syntax::ComparisonOp;
   let (operands, operators) = match con {
     Expr::Comparison {
       operands,
@@ -7314,7 +7310,6 @@ fn minimize_lp_2d(
     let lhs = &operands[0];
     let rhs = &operands[1];
 
-    use crate::syntax::ComparisonOp;
     let sense = match &operators[0] {
       ComparisonOp::GreaterEqual => 1,
       ComparisonOp::LessEqual => -1,
@@ -8934,7 +8929,7 @@ fn compile_numeric(expr: &Expr, vars: &[String]) -> Option<NumNode> {
       operand,
     } => Some(NumNode::Neg(Box::new(c(operand)?))),
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator::*;
+      use BinaryOperator::*;
       let l = Box::new(c(left)?);
       let r = Box::new(c(right)?);
       match op {
@@ -9184,7 +9179,7 @@ fn constraint_violation(
   vars: &[String],
   point: &[f64],
 ) -> f64 {
-  use crate::syntax::ComparisonOp::*;
+  use ComparisonOp::*;
   let mut total = 0.0;
   for c in comparisons {
     let l = eval_expr_at_point(&c.left, vars, point);
@@ -9438,7 +9433,7 @@ fn nminimize_penalty(
 
   // Total constraint violation at a point (0 when feasible).
   let violation = |point: &[f64]| -> f64 {
-    use crate::syntax::ComparisonOp::*;
+    use ComparisonOp::*;
     let mut total = 0.0;
     for (c, compiled) in comparisons.iter().zip(cmp_compiled.iter()) {
       let (l, r) = match compiled {
@@ -9646,7 +9641,6 @@ fn extract_bound_from_comparison(
   vars: &[String],
   bounds: &mut [(f64, f64)],
 ) -> Result<(), InterpreterError> {
-  use crate::syntax::ComparisonOp;
   if let Expr::Comparison {
     operands,
     operators,

--- a/src/functions/polynomial_ast/symmetric_reduction.rs
+++ b/src/functions/polynomial_ast/symmetric_reduction.rs
@@ -10,7 +10,7 @@
 //! lexicographic monomial order.
 
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 fn eval(e: Expr) -> Result<Expr, InterpreterError> {
   crate::evaluator::evaluate_expr_to_expr(&e)
@@ -110,7 +110,7 @@ fn negative_numeric(e: &Expr) -> bool {
       )
     }
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => {
       matches!(

--- a/src/functions/polynomial_ast/to_radicals.rs
+++ b/src/functions/polynomial_ast/to_radicals.rs
@@ -1,5 +1,5 @@
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr};
 
 /// ToRadicals[expr] — convert Root objects to explicit radical expressions.
 pub fn to_radicals_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -149,7 +149,7 @@ fn get_slot_power_degree(expr: &Expr) -> Option<usize> {
       None
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => {
@@ -187,7 +187,7 @@ fn classify_term(term: &Expr) -> Option<(usize, Expr)> {
       Some((&args[0], &args[1]))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => Some((left.as_ref(), right.as_ref())),

--- a/src/functions/resolve_ast.rs
+++ b/src/functions/resolve_ast.rs
@@ -6,7 +6,7 @@
 //! c > 0 return their conditions.
 
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, ComparisonOp, Expr};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 pub fn resolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = |args: &[Expr]| Expr::FunctionCall {
@@ -506,8 +506,6 @@ fn walk_monomial(
   coeff: &mut Q,
   vp: &mut Option<(String, i128)>,
 ) -> Option<()> {
-  use crate::syntax::{BinaryOperator, UnaryOperator};
-
   if let Some((n, d)) = expr_to_rational(e) {
     *coeff = coeff.mul(Q::new(n, d));
     return Some(());

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -5359,7 +5359,7 @@ fn as_neg_int_power(expr: &Expr) -> Option<(&Expr, i128)> {
       }
       // Also handle UnaryOp Minus wrapping an integer
       if let Expr::UnaryOp {
-        op: crate::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand,
       } = right.as_ref()
         && let Expr::Integer(n) = operand.as_ref()
@@ -7242,7 +7242,7 @@ pub fn to_expression_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // ToExpression[InterpretationBox[boxes, expr]] returns the interpreted
   // expression directly (the second argument), evaluated. This matches
   // wolframscript: `ToExpression[InterpretationBox["Four", 4]]` → 4.
-  if let crate::syntax::Expr::FunctionCall {
+  if let Expr::FunctionCall {
     name,
     args: ib_args,
   } = &args[0]
@@ -7251,7 +7251,7 @@ pub fn to_expression_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     let interpreted = crate::evaluator::evaluate_expr_to_expr(&ib_args[1])?;
     if args.len() == 3 {
-      let wrapped = crate::syntax::Expr::FunctionCall {
+      let wrapped = Expr::FunctionCall {
         name: crate::syntax::expr_to_string(&args[2]),
         args: vec![interpreted].into(),
       };
@@ -7276,7 +7276,7 @@ pub fn to_expression_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // ToExpression["1+1", InputForm, Hold] is Hold[1 + 1], not Hold[2].
   if args.len() == 3 {
     let parsed = parse_program_to_expr(&s)?;
-    let wrapped = crate::syntax::Expr::FunctionCall {
+    let wrapped = Expr::FunctionCall {
       name: crate::syntax::expr_to_string(&args[2]),
       args: vec![parsed].into(),
     };

--- a/src/functions/sum_convergence_ast.rs
+++ b/src/functions/sum_convergence_ast.rs
@@ -8,7 +8,7 @@
 //! - 1/n! decay: True
 
 use crate::InterpreterError;
-use crate::syntax::{ComparisonOp, Expr};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 pub fn sum_convergence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = |args: &[Expr]| Expr::FunctionCall {
@@ -130,7 +130,7 @@ fn classify_factors(
       }
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } => {
@@ -154,7 +154,7 @@ fn classify_factors(
       );
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left,
       right,
     } => {
@@ -281,7 +281,7 @@ fn n_linear_sign(exp: &Expr, n_var: &str) -> Option<i128> {
   match exp {
     Expr::Identifier(v) if v == n_var => Some(1),
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } if matches!(operand.as_ref(), Expr::Identifier(v) if v == n_var) => {
       Some(-1)
@@ -302,7 +302,7 @@ fn n_linear_sign(exp: &Expr, n_var: &str) -> Option<i128> {
 fn negated_symbol(exp: &Expr, n_var: &str) -> Option<Expr> {
   match exp {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => match operand.as_ref() {
       p @ Expr::Identifier(v) if v != n_var => Some(p.clone()),
@@ -328,7 +328,7 @@ fn as_power(expr: &Expr) -> Option<(Expr, Expr)> {
       Some((args[0].clone(), args[1].clone()))
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } => Some(((**left).clone(), (**right).clone())),

--- a/src/functions/trig_factor_ast.rs
+++ b/src/functions/trig_factor_ast.rs
@@ -9,7 +9,7 @@
 //! wolframscript does for already-factored or non-trig input.
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 
 pub fn trig_factor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
@@ -44,14 +44,14 @@ fn plus(ts: Vec<Expr>) -> Expr {
 
 fn neg(e: Expr) -> Expr {
   Expr::UnaryOp {
-    op: crate::syntax::UnaryOperator::Minus,
+    op: UnaryOperator::Minus,
     operand: Box::new(e),
   }
 }
 
 fn div(a: Expr, b: i128) -> Expr {
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Divide,
+    op: BinaryOperator::Divide,
     left: Box::new(a),
     right: Box::new(Expr::Integer(b)),
   }
@@ -75,7 +75,7 @@ fn half_diff(p: &Expr, q: &Expr) -> Expr {
 
 fn pow2(e: Expr) -> Expr {
   Expr::BinaryOp {
-    op: crate::syntax::BinaryOperator::Power,
+    op: BinaryOperator::Power,
     left: Box::new(e),
     right: Box::new(Expr::Integer(2)),
   }
@@ -184,7 +184,7 @@ fn trig_of(e: &Expr) -> Option<(bool, Expr)> {
 fn negated(e: &Expr) -> Option<&Expr> {
   match e {
     Expr::UnaryOp {
-      op: crate::syntax::UnaryOperator::Minus,
+      op: UnaryOperator::Minus,
       operand,
     } => Some(operand),
     Expr::FunctionCall { name, args }
@@ -333,7 +333,7 @@ fn factor(expr: &Expr) -> Option<Expr> {
       return Some((is_sin, negd, u));
     }
     if let Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Power,
+      op: BinaryOperator::Power,
       left,
       right,
     } = inner
@@ -375,7 +375,7 @@ fn halved(arg: &Expr) -> Option<Expr> {
       })
     }
     Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Times,
+      op: BinaryOperator::Times,
       left,
       right,
     } if matches!(left.as_ref(), Expr::Integer(2)) => Some((**right).clone()),

--- a/src/functions/wikidata_ast.rs
+++ b/src/functions/wikidata_ast.rs
@@ -16,7 +16,7 @@
 //! - strings, external ids and monolingual texts → plain strings
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{BinaryOperator, Expr};
 
 /// `ExternalIdentifier[type, id]` / `ExternalIdentifier[type, id, assoc]` —
 /// inert symbolic construct; the arguments are kept exactly as given.
@@ -563,7 +563,7 @@ fn time_to_date_object(
 fn unit_to_expr(label: &str) -> Expr {
   match label.split_once(" per ") {
     Some((num, den)) => Expr::BinaryOp {
-      op: crate::syntax::BinaryOperator::Divide,
+      op: BinaryOperator::Divide,
       left: Box::new(Expr::String(unit_name(num))),
       right: Box::new(Expr::String(unit_name(den))),
     },

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use wasm_bindgen::prelude::*;
 
+use crate::syntax::Expr;
 use crate::{clear_state, interpret, interpret_with_stdout};
 
 thread_local! {
@@ -61,7 +62,7 @@ extern "C" {
 /// Returns the image as an Expr::Image.
 pub fn import_image_from_url_wasm(
   url: &str,
-) -> Result<crate::syntax::Expr, crate::InterpreterError> {
+) -> Result<Expr, crate::InterpreterError> {
   let b64 = woxi_fetch_url(url).map_err(|e| {
     crate::InterpreterError::EvaluationError(format!(
       "Import: failed to fetch \"{}\": {:?}",
@@ -89,7 +90,7 @@ pub fn import_image_from_url_wasm(
 pub fn csv_import_from_url_wasm(
   url: &str,
   element: Option<&str>,
-) -> Result<crate::syntax::Expr, crate::InterpreterError> {
+) -> Result<Expr, crate::InterpreterError> {
   let b64 = woxi_fetch_url(url).map_err(|e| {
     crate::InterpreterError::EvaluationError(format!(
       "Import: failed to fetch \"{}\": {:?}",


### PR DESCRIPTION
Remove the remaining prefixes for the BinaryOperator, UnaryOperator and Expr syntax enums.  Some ComparisonOp's were simplified as well.