### PR TITLE
Remove crate::syntax::ComparisonOp prefixes

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
 use std::cell::Cell;
 
 thread_local! {
@@ -196,9 +196,7 @@ fn condition_is_literal_arg(c: &Expr) -> bool {
       Some(Expr::FunctionCall { name, .. }) if name == "Length"
     );
     !is_length_check
-      && operators
-        .iter()
-        .any(|op| matches!(op, crate::syntax::ComparisonOp::SameQ))
+      && operators.iter().any(|op| matches!(op, ComparisonOp::SameQ))
   } else {
     false
   }
@@ -416,9 +414,7 @@ fn count_specificity_clauses(c: &Expr) -> u32 {
     Expr::Comparison {
       operators,
       operands,
-    } if operators
-      .iter()
-      .any(|op| matches!(op, crate::syntax::ComparisonOp::SameQ))
+    } if operators.iter().any(|op| matches!(op, ComparisonOp::SameQ))
       && matches!(
         operands.first(),
         Some(Expr::FunctionCall { name, .. }) if name == "Length"
@@ -1397,7 +1393,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
               operators,
             }) = c
               && operators.len() == 1
-              && matches!(operators[0], crate::syntax::ComparisonOp::SameQ)
+              && matches!(operators[0], ComparisonOp::SameQ)
               && operands.len() == 2
               && let Expr::Identifier(name) = &operands[0]
               && !params.is_empty()
@@ -1559,7 +1555,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
         // Condition: _dvN === eval_arg (using SameQ for exact matching)
         conditions.push(Some(Expr::Comparison {
           operands: vec![Expr::Identifier(param_name.clone()), eval_arg],
-          operators: vec![crate::syntax::ComparisonOp::SameQ],
+          operators: vec![ComparisonOp::SameQ],
         }));
         params.push(param_name);
         heads.push(None);
@@ -1592,7 +1588,7 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
       && conditions.iter().all(|c| {
         matches!(c, Some(Expr::Comparison { operators, .. })
           if operators.len() == 1
-            && operators[0] == crate::syntax::ComparisonOp::SameQ)
+            && operators[0] == ComparisonOp::SameQ)
       });
     if all_literal_sameq {
       let mut arg_exprs = Vec::with_capacity(conditions.len());
@@ -2292,7 +2288,7 @@ pub fn set_delayed_ast(
               let eval_arg = evaluate_expr_to_expr(arg)?;
               conditions.push(Some(Expr::Comparison {
                 operands: vec![Expr::Identifier(param_name.clone()), eval_arg],
-                operators: vec![crate::syntax::ComparisonOp::SameQ],
+                operators: vec![ComparisonOp::SameQ],
               }));
               params.push(param_name);
               blank_types.push(1);
@@ -2602,17 +2598,11 @@ fn build_list_pattern_match(
   // - Trailing `__` (BlankSequence): Length >= N (consumes ≥1).
   // - Trailing `___` (BlankNullSequence): Length >= N-1 (consumes ≥0).
   let len_cmp = if !trailing_seq {
-    (crate::syntax::ComparisonOp::SameQ, patterns.len() as i128)
+    (ComparisonOp::SameQ, patterns.len() as i128)
   } else if trailing_seq_blank == 2 {
-    (
-      crate::syntax::ComparisonOp::GreaterEqual,
-      patterns.len() as i128,
-    )
+    (ComparisonOp::GreaterEqual, patterns.len() as i128)
   } else {
-    (
-      crate::syntax::ComparisonOp::GreaterEqual,
-      (patterns.len() - 1) as i128,
-    )
+    (ComparisonOp::GreaterEqual, (patterns.len() - 1) as i128)
   };
   let mut rule_conds: Vec<Expr> = vec![Expr::Comparison {
     operands: vec![
@@ -2796,9 +2786,7 @@ fn reconstruct_list_param(
       {
         if let Some(Expr::Integer(n)) = operands.get(1) {
           length = Some(*n);
-          fixed = operators
-            .iter()
-            .any(|o| matches!(o, crate::syntax::ComparisonOp::SameQ));
+          fixed = operators.iter().any(|o| matches!(o, ComparisonOp::SameQ));
         }
       }
       Expr::FunctionCall { name, args }
@@ -2899,9 +2887,7 @@ pub fn reconstruct_list_downvalue(
       operands,
       operators,
     }) = cond
-      && operators
-        .iter()
-        .any(|op| matches!(op, crate::syntax::ComparisonOp::SameQ))
+      && operators.iter().any(|op| matches!(op, ComparisonOp::SameQ))
       && let Some(lit) = operands.get(1)
     {
       pattern_args.push(lit.clone());
@@ -3159,7 +3145,7 @@ pub fn tag_set_delayed_ast(
               },
               Expr::Integer(inner_args.len() as i128),
             ],
-            operators: vec![crate::syntax::ComparisonOp::SameQ],
+            operators: vec![ComparisonOp::SameQ],
           }));
         } else {
           conditions.push(None);
@@ -3182,7 +3168,7 @@ pub fn tag_set_delayed_ast(
             if let Some(prev_expr) = seen_pattern_vars.get(&pat_name) {
               extra_conditions.push(Expr::Comparison {
                 operands: vec![prev_expr.clone(), part_expr.clone()],
-                operators: vec![crate::syntax::ComparisonOp::SameQ],
+                operators: vec![ComparisonOp::SameQ],
               });
             } else {
               seen_pattern_vars.insert(pat_name.clone(), part_expr.clone());
@@ -3223,7 +3209,7 @@ pub fn tag_set_delayed_ast(
           let eval_arg = evaluate_expr_to_expr(arg)?;
           conditions.push(Some(Expr::Comparison {
             operands: vec![Expr::Identifier(param_name.clone()), eval_arg],
-            operators: vec![crate::syntax::ComparisonOp::SameQ],
+            operators: vec![ComparisonOp::SameQ],
           }));
           params.push(param_name);
           defaults.push(None);
@@ -3267,13 +3253,16 @@ pub fn tag_set_delayed_ast(
     }
     if !attached && !conditions.is_empty() {
       // All slots have conditions - combine with first non-SameQ one using And
-      let combine_idx = conditions.iter().position(|c| {
-        !matches!(
-          c,
-          Some(Expr::Comparison { operators, .. })
-          if operators.iter().any(|op| matches!(op, crate::syntax::ComparisonOp::SameQ))
-        )
-      }).unwrap_or(0);
+      let combine_idx = conditions
+        .iter()
+        .position(|c| {
+          !matches!(
+            c,
+            Some(Expr::Comparison { operators, .. })
+            if operators.iter().any(|op| matches!(op, ComparisonOp::SameQ))
+          )
+        })
+        .unwrap_or(0);
       let existing = conditions[combine_idx].take().unwrap();
       conditions[combine_idx] = Some(Expr::FunctionCall {
         name: "And".to_string(),

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::BinaryOperator;
+use crate::syntax::{BinaryOperator, ComparisonOp};
 
 thread_local! {
   /// Symbols currently being looked up — prevents infinite recursion when
@@ -1200,9 +1200,9 @@ pub fn evaluate_expr_to_expr_inner(
                           operands,
                           operators,
                         })) = conds.get(i)
-                          && operators.iter().any(|op| {
-                            matches!(op, crate::syntax::ComparisonOp::SameQ)
-                          })
+                          && operators
+                            .iter()
+                            .any(|op| matches!(op, ComparisonOp::SameQ))
                           && let Some(literal_val) = operands.get(1)
                         {
                           return literal_val.clone();

--- a/src/evaluator/dispatch/boolean_functions.rs
+++ b/src/evaluator/dispatch/boolean_functions.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::ComparisonOp;
 
 pub fn dispatch_boolean_functions(
   name: &str,
@@ -86,7 +87,6 @@ pub fn dispatch_boolean_functions(
     // as the operator syntax, so e.g. the ComplexInfinity `nord` messages
     // fire identically for LessEqual[1/0, 0] and 1/0 <= 0.
     "Less" | "Greater" | "LessEqual" | "GreaterEqual" if args.len() >= 2 => {
-      use crate::syntax::ComparisonOp;
       let op = match name {
         "Less" => ComparisonOp::Less,
         "Greater" => ComparisonOp::Greater,

--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::is_sqrt;
-use crate::syntax::{BinaryOperator, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
 
 /// Check if the result of differentiation contains a
 /// `Derivative[...][func_name][...]` pattern (as CurriedCall),
@@ -4043,7 +4043,7 @@ fn collect_domain_constraints(
       if contains_variable(right, var) {
         constraints.push(Expr::Comparison {
           operands: vec![right.as_ref().clone(), Expr::Integer(0)],
-          operators: vec![crate::syntax::ComparisonOp::NotEqual],
+          operators: vec![ComparisonOp::NotEqual],
         });
       }
     }
@@ -4070,7 +4070,7 @@ fn collect_domain_constraints(
         if is_negative_power {
           constraints.push(Expr::Comparison {
             operands: vec![left.as_ref().clone(), Expr::Integer(0)],
-            operators: vec![crate::syntax::ComparisonOp::NotEqual],
+            operators: vec![ComparisonOp::NotEqual],
           });
         }
 
@@ -4086,7 +4086,7 @@ fn collect_domain_constraints(
         if is_half_power {
           constraints.push(Expr::Comparison {
             operands: vec![left.as_ref().clone(), Expr::Integer(0)],
-            operators: vec![crate::syntax::ComparisonOp::GreaterEqual],
+            operators: vec![ComparisonOp::GreaterEqual],
           });
         }
       }
@@ -4103,7 +4103,7 @@ fn collect_domain_constraints(
       if contains_variable(arg, var) {
         constraints.push(Expr::Comparison {
           operands: vec![arg.clone(), Expr::Integer(0)],
-          operators: vec![crate::syntax::ComparisonOp::Greater],
+          operators: vec![ComparisonOp::Greater],
         });
       }
     }
@@ -4114,7 +4114,7 @@ fn collect_domain_constraints(
       if contains_variable(sqrt_arg, var) {
         constraints.push(Expr::Comparison {
           operands: vec![sqrt_arg.clone(), Expr::Integer(0)],
-          operators: vec![crate::syntax::ComparisonOp::GreaterEqual],
+          operators: vec![ComparisonOp::GreaterEqual],
         });
       }
     }
@@ -4140,8 +4140,6 @@ fn collect_domain_constraints(
 /// - `-1 + x >= 0` → `x >= 1`
 /// - `x^2 - 1 != 0` → `x < -1 || Inequality[-1, Less, x, Less, 1] || x > 1`
 fn simplify_domain_constraint(constraint: &Expr, var: &str) -> Expr {
-  use crate::syntax::ComparisonOp;
-
   if let Expr::Comparison {
     operands,
     operators,

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -2491,7 +2491,7 @@ pub fn dispatch_io_functions(
                   } = cond
                   && operators
                     .iter()
-                    .any(|op| matches!(op, crate::syntax::ComparisonOp::SameQ))
+                    .any(|op| matches!(op, ComparisonOp::SameQ))
                   && operands.len() == 2
                 {
                   // Literal value dispatch: use the value directly

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::make_sqrt;
-use crate::syntax::{BinaryOperator, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
 
 /// Columnwise quartile-family statistic for a matrix argument.
 ///
@@ -5171,7 +5171,7 @@ pub fn dispatch_math_functions(
         operators,
       } = &args[0]
         && operands.len() == 2
-        && operators.first() == Some(&crate::syntax::ComparisonOp::Equal)
+        && operators.first() == Some(&ComparisonOp::Equal)
         && !is_zero_literal(&operands[1])
       {
         let rhs = operands[1].clone();
@@ -5187,7 +5187,7 @@ pub fn dispatch_math_functions(
           }
           let cond = Expr::Comparison {
             operands: vec![rhs, Expr::Integer(0)],
-            operators: vec![crate::syntax::ComparisonOp::NotEqual],
+            operators: vec![ComparisonOp::NotEqual],
           };
           let branch = Expr::List(vec![divided, cond].into());
           let pw = Expr::FunctionCall {
@@ -8123,14 +8123,14 @@ fn guard_equation_scale(
     relation,
     Expr::Comparison { operands, operators }
       if operands.len() == 2
-        && operators.first() == Some(&crate::syntax::ComparisonOp::Equal)
+        && operators.first() == Some(&ComparisonOp::Equal)
   );
   if !is_equation || is_nonzero_number(scalar) {
     return Ok(scaled);
   }
   let cond = Expr::Comparison {
     operands: vec![scalar.clone(), Expr::Integer(0)],
-    operators: vec![crate::syntax::ComparisonOp::NotEqual],
+    operators: vec![ComparisonOp::NotEqual],
   };
   let branch = Expr::List(vec![scaled, cond].into());
   let pw = Expr::FunctionCall {
@@ -8172,7 +8172,7 @@ fn pair_sides(relation: &Expr, second: &Expr, op: SideOp) -> Option<Expr> {
     return None;
   }
   // The second argument must be an equation for the pairing to be meaningful.
-  if v_operators.first() != Some(&crate::syntax::ComparisonOp::Equal) {
+  if v_operators.first() != Some(&ComparisonOp::Equal) {
     return None;
   }
   // Multiplying/dividing an inequality requires sign-dependent reasoning
@@ -8180,7 +8180,7 @@ fn pair_sides(relation: &Expr, second: &Expr, op: SideOp) -> Option<Expr> {
   // Piecewise. Only handle the clean case where the first relation is an
   // equation; Add/Subtract preserve any relation's direction.
   if matches!(op, SideOp::Multiply | SideOp::Divide)
-    && operators.first() != Some(&crate::syntax::ComparisonOp::Equal)
+    && operators.first() != Some(&ComparisonOp::Equal)
   {
     return None;
   }
@@ -8234,7 +8234,7 @@ fn pair_sides(relation: &Expr, second: &Expr, op: SideOp) -> Option<Expr> {
     SideOp::Divide => {
       let cond = Expr::Comparison {
         operands: vec![v_ops[0].clone(), Expr::Integer(0)],
-        operators: vec![crate::syntax::ComparisonOp::NotEqual],
+        operators: vec![ComparisonOp::NotEqual],
       };
       let branch = Expr::List(vec![paired, cond].into());
       Some(Expr::FunctionCall {

--- a/src/evaluator/dispatch/polynomial_functions.rs
+++ b/src/evaluator/dispatch/polynomial_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::BinaryOperator;
+use crate::syntax::{BinaryOperator, ComparisonOp};
 
 pub fn dispatch_polynomial_functions(
   name: &str,
@@ -776,7 +776,7 @@ fn try_reduce_modulus(expr: &Expr, vars: &Expr, opt: &Expr) -> Option<Expr> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && matches!(operators[0], crate::syntax::ComparisonOp::Equal) =>
+      && matches!(operators[0], ComparisonOp::Equal) =>
     {
       (operands[0].clone(), operands[1].clone())
     }
@@ -848,12 +848,12 @@ fn try_reduce_modulus(expr: &Expr, vars: &Expr, opt: &Expr) -> Option<Expr> {
         if k == 1 {
           Expr::Comparison {
             operands: vec![Expr::Identifier(name.clone()), Expr::Integer(*v)],
-            operators: vec![crate::syntax::ComparisonOp::Equal],
+            operators: vec![ComparisonOp::Equal],
           }
         } else {
           Expr::Comparison {
             operands: vec![Expr::Identifier(name.clone()), Expr::Integer(*v)],
-            operators: vec![crate::syntax::ComparisonOp::Equal],
+            operators: vec![ComparisonOp::Equal],
           }
         }
       })
@@ -935,11 +935,11 @@ fn try_constrained_linear_disk(name: &str, args: &[Expr]) -> Option<Expr> {
       && operators.len() == 1
       && matches!(
         operators[0],
-        crate::syntax::ComparisonOp::LessEqual
-          | crate::syntax::ComparisonOp::Less
-          | crate::syntax::ComparisonOp::GreaterEqual
-          | crate::syntax::ComparisonOp::Greater
-          | crate::syntax::ComparisonOp::Equal
+        ComparisonOp::LessEqual
+          | ComparisonOp::Less
+          | ComparisonOp::GreaterEqual
+          | ComparisonOp::Greater
+          | ComparisonOp::Equal
       ) =>
     {
       let c = crate::functions::math_ast::expr_to_f64(&operands[1])?;
@@ -1064,11 +1064,11 @@ fn try_constrained_linear_disk_symbolic(
       && operators.len() == 1
       && matches!(
         operators[0],
-        crate::syntax::ComparisonOp::LessEqual
-          | crate::syntax::ComparisonOp::Less
-          | crate::syntax::ComparisonOp::GreaterEqual
-          | crate::syntax::ComparisonOp::Greater
-          | crate::syntax::ComparisonOp::Equal
+        ComparisonOp::LessEqual
+          | ComparisonOp::Less
+          | ComparisonOp::GreaterEqual
+          | ComparisonOp::Greater
+          | ComparisonOp::Equal
       ) =>
     {
       (operands[0].clone(), operands[1].clone())

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::ComparisonOp;
 
 /// True if `expr` contains any Real or BigFloat node — used to decide
 /// between exact and inexact number predicates.
@@ -206,7 +207,6 @@ pub fn dispatch_predicate_functions(
       // `ToString[Inequality[0, LessEqual, x, LessEqual, 1], InputForm]`
       // still renders the head form.
       if args.len() >= 5 && args.len() % 2 == 1 {
-        use crate::syntax::ComparisonOp;
         let op_names: Vec<Option<&str>> = args
           .iter()
           .enumerate()
@@ -733,10 +733,7 @@ pub fn dispatch_predicate_functions(
           // Symbolic: a <= x <= b (chained inequality, like wolframscript).
           let chained = Expr::Comparison {
             operands: vec![range[0].clone(), x.clone(), range[1].clone()],
-            operators: vec![
-              crate::syntax::ComparisonOp::LessEqual,
-              crate::syntax::ComparisonOp::LessEqual,
-            ],
+            operators: vec![ComparisonOp::LessEqual, ComparisonOp::LessEqual],
           };
           return Some(crate::evaluator::evaluate_expr_to_expr(&chained));
         } else if is_list_of_ranges {
@@ -781,10 +778,7 @@ pub fn dispatch_predicate_functions(
             }
             clauses.push(Expr::Comparison {
               operands: vec![pair[0].clone(), x.clone(), pair[1].clone()],
-              operators: vec![
-                crate::syntax::ComparisonOp::LessEqual,
-                crate::syntax::ComparisonOp::LessEqual,
-              ],
+              operators: vec![ComparisonOp::LessEqual, ComparisonOp::LessEqual],
             });
           }
           if shape_ok {
@@ -920,7 +914,7 @@ pub fn dispatch_predicate_functions(
                 operators,
               }) = c
                 && operators.len() == 1
-                && matches!(operators[0], crate::syntax::ComparisonOp::SameQ)
+                && matches!(operators[0], ComparisonOp::SameQ)
                 && operands.len() == 2
                 && let Expr::Identifier(name) = &operands[0]
                 && name == &params[0]
@@ -941,7 +935,7 @@ pub fn dispatch_predicate_functions(
                 operators,
               }) = c
                 && operators.len() == 1
-                && matches!(operators[0], crate::syntax::ComparisonOp::SameQ)
+                && matches!(operators[0], ComparisonOp::SameQ)
                 && operands.len() == 2
                 && let Expr::Identifier(name) = &operands[0]
                 && name == &params[1]
@@ -1101,7 +1095,7 @@ pub fn dispatch_predicate_functions(
                 operators,
               }) = c
                 && operators.len() == 1
-                && matches!(operators[0], crate::syntax::ComparisonOp::SameQ)
+                && matches!(operators[0], ComparisonOp::SameQ)
                 && operands.len() == 2
                 && let Expr::Identifier(name) = &operands[0]
                 && name == param
@@ -1218,9 +1212,9 @@ pub fn dispatch_predicate_functions(
                       operands,
                       operators,
                     })) = conds.get(i)
-                      && operators.iter().any(|op| {
-                        matches!(op, crate::syntax::ComparisonOp::SameQ)
-                      })
+                      && operators
+                        .iter()
+                        .any(|op| matches!(op, ComparisonOp::SameQ))
                       && let Some(literal_val) = operands.get(1)
                     {
                       return literal_val.clone();
@@ -1698,7 +1692,7 @@ pub fn dispatch_predicate_functions(
       return Some(Ok(Expr::Function {
         body: Box::new(Expr::Comparison {
           operands: vec![Expr::Slot(1), args[0].clone()],
-          operators: vec![crate::syntax::ComparisonOp::Equal],
+          operators: vec![ComparisonOp::Equal],
         }),
       }));
     }
@@ -1706,7 +1700,7 @@ pub fn dispatch_predicate_functions(
       return Some(Ok(Expr::Function {
         body: Box::new(Expr::Comparison {
           operands: vec![Expr::Slot(1), args[0].clone()],
-          operators: vec![crate::syntax::ComparisonOp::NotEqual],
+          operators: vec![ComparisonOp::NotEqual],
         }),
       }));
     }
@@ -1714,7 +1708,7 @@ pub fn dispatch_predicate_functions(
       return Some(Ok(Expr::Function {
         body: Box::new(Expr::Comparison {
           operands: vec![Expr::Slot(1), args[0].clone()],
-          operators: vec![crate::syntax::ComparisonOp::Greater],
+          operators: vec![ComparisonOp::Greater],
         }),
       }));
     }
@@ -1722,7 +1716,7 @@ pub fn dispatch_predicate_functions(
       return Some(Ok(Expr::Function {
         body: Box::new(Expr::Comparison {
           operands: vec![Expr::Slot(1), args[0].clone()],
-          operators: vec![crate::syntax::ComparisonOp::Less],
+          operators: vec![ComparisonOp::Less],
         }),
       }));
     }
@@ -1730,7 +1724,7 @@ pub fn dispatch_predicate_functions(
       return Some(Ok(Expr::Function {
         body: Box::new(Expr::Comparison {
           operands: vec![Expr::Slot(1), args[0].clone()],
-          operators: vec![crate::syntax::ComparisonOp::GreaterEqual],
+          operators: vec![ComparisonOp::GreaterEqual],
         }),
       }));
     }
@@ -1738,7 +1732,7 @@ pub fn dispatch_predicate_functions(
       return Some(Ok(Expr::Function {
         body: Box::new(Expr::Comparison {
           operands: vec![Expr::Slot(1), args[0].clone()],
-          operators: vec![crate::syntax::ComparisonOp::LessEqual],
+          operators: vec![ComparisonOp::LessEqual],
         }),
       }));
     }

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -1,6 +1,4 @@
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
-};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
 use crate::{ENV, InterpreterError, PART_DEPTH, StoredValue, interpret};
 
 use std::collections::{HashMap, HashSet};

--- a/src/evaluator/scoping.rs
+++ b/src/evaluator/scoping.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::BinaryOperator;
+use crate::syntax::{BinaryOperator, ComparisonOp};
 
 /// AST-based Module implementation to avoid interpret() recursion
 pub fn module_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -851,7 +851,7 @@ fn apply_assumption_substitutions(body: &Expr, assumption: &Expr) -> Expr {
         operators,
       } if operands.len() == 2
         && operators.len() == 1
-        && operators[0] == crate::syntax::ComparisonOp::Equal =>
+        && operators[0] == ComparisonOp::Equal =>
       {
         if let Expr::Identifier(var) = &operands[0] {
           out.push((var.clone(), operands[1].clone()));

--- a/src/functions/boolean_ast.rs
+++ b/src/functions/boolean_ast.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 /// Helper to check if an Expr is True or False
 fn as_bool(expr: &Expr) -> Option<bool> {
@@ -110,10 +110,7 @@ pub fn not_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 }
 
-fn negate_comparison_op(
-  op: &crate::syntax::ComparisonOp,
-) -> Option<crate::syntax::ComparisonOp> {
-  use crate::syntax::ComparisonOp;
+fn negate_comparison_op(op: &ComparisonOp) -> Option<ComparisonOp> {
   match op {
     ComparisonOp::Equal => Some(ComparisonOp::NotEqual),
     ComparisonOp::NotEqual => Some(ComparisonOp::Equal),
@@ -532,10 +529,7 @@ pub fn all_components_equal(a: &Expr, b: &Expr) -> bool {
 /// (`a < b`, `a == b == c`) rather than keeping the `Less[a, b]` head. Build
 /// the `Expr::Comparison` node the formatter renders that way; the evaluator's
 /// Comparison arm treats it as a stable fixpoint for symbolic operands.
-fn symbolic_comparison_chain(
-  args: &[Expr],
-  op: crate::syntax::ComparisonOp,
-) -> Expr {
+fn symbolic_comparison_chain(args: &[Expr], op: ComparisonOp) -> Expr {
   Expr::Comparison {
     operands: args.to_vec(),
     operators: vec![op; args.len().saturating_sub(1)],
@@ -607,10 +601,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         return Ok(Expr::Identifier("False".to_string()));
       }
       Some(None) => {
-        return Ok(symbolic_comparison_chain(
-          args,
-          crate::syntax::ComparisonOp::Equal,
-        ));
+        return Ok(symbolic_comparison_chain(args, ComparisonOp::Equal));
       }
       _ => {}
     }
@@ -657,10 +648,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.iter().any(
     |a| matches!(a, Expr::FunctionCall { name, .. } if name == "MusicPitch"),
   ) {
-    return Ok(symbolic_comparison_chain(
-      args,
-      crate::syntax::ComparisonOp::Equal,
-    ));
+    return Ok(symbolic_comparison_chain(args, ComparisonOp::Equal));
   }
 
   // Check if all args are numeric
@@ -754,10 +742,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Only stay symbolic if at least one arg has free symbols
   if args.iter().any(crate::evaluator::has_free_symbols) {
-    Ok(symbolic_comparison_chain(
-      args,
-      crate::syntax::ComparisonOp::Equal,
-    ))
+    Ok(symbolic_comparison_chain(args, ComparisonOp::Equal))
   } else {
     // No free symbols, not identical → False
     Ok(Expr::Identifier("False".to_string()))
@@ -786,10 +771,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         Some(Some(false)) => infinity_decided += 1,
         Some(None) => {
-          return Ok(symbolic_comparison_chain(
-            args,
-            crate::syntax::ComparisonOp::NotEqual,
-          ));
+          return Ok(symbolic_comparison_chain(args, ComparisonOp::NotEqual));
         }
         None => {}
       }
@@ -837,10 +819,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.iter().any(
     |a| matches!(a, Expr::FunctionCall { name, .. } if name == "MusicPitch"),
   ) {
-    return Ok(symbolic_comparison_chain(
-      args,
-      crate::syntax::ComparisonOp::NotEqual,
-    ));
+    return Ok(symbolic_comparison_chain(args, ComparisonOp::NotEqual));
   }
 
   // Check if all args are numeric
@@ -852,10 +831,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Only stay symbolic if at least one arg has free symbols
   if has_free {
-    Ok(symbolic_comparison_chain(
-      args,
-      crate::syntax::ComparisonOp::NotEqual,
-    ))
+    Ok(symbolic_comparison_chain(args, ComparisonOp::NotEqual))
   } else {
     // No free symbols, pairwise different → True
     Ok(Expr::Identifier("True".to_string()))

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -5,7 +5,7 @@
 
 use crate::InterpreterError;
 use crate::functions::math_ast::{is_sqrt, make_sqrt};
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 thread_local! {
   /// Active `NonConstants` context for `D`. Holds the symbol names that must be
@@ -3585,7 +3585,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
                     Expr::Integer(0),
                     Expr::Comparison {
                       operands: vec![args[0].clone(), Expr::Integer(0)],
-                      operators: vec![crate::syntax::ComparisonOp::NotEqual],
+                      operators: vec![ComparisonOp::NotEqual],
                     },
                   ]
                   .into(),
@@ -3621,7 +3621,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
                     Expr::Identifier("Indeterminate".to_string()),
                     Expr::Comparison {
                       operands: vec![args[0].clone(), Expr::Integer(0)],
-                      operators: vec![crate::syntax::ComparisonOp::Equal],
+                      operators: vec![ComparisonOp::Equal],
                     },
                   ]
                   .into(),
@@ -3649,7 +3649,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(0)) {
             return Ok(Expr::Integer(0));
           }
-          let clause = |val: Expr, op: crate::syntax::ComparisonOp| {
+          let clause = |val: Expr, op: ComparisonOp| {
             Expr::List(
               vec![
                 val,
@@ -3666,11 +3666,8 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             args: vec![
               Expr::List(
                 vec![
-                  clause(Expr::Integer(0), crate::syntax::ComparisonOp::Less),
-                  clause(
-                    Expr::Integer(1),
-                    crate::syntax::ComparisonOp::Greater,
-                  ),
+                  clause(Expr::Integer(0), ComparisonOp::Less),
+                  clause(Expr::Integer(1), ComparisonOp::Greater),
                 ]
                 .into(),
               ),
@@ -10933,7 +10930,6 @@ fn parse_direction(option: &Expr) -> Option<LimitDirection> {
 /// `x < c` ↔ `x ≥ c`, in either order. Used by Integrate[Piecewise[…]] to
 /// collapse two complementary pieces into one piece + default.
 fn conditions_are_complementary(a: &Expr, b: &Expr) -> bool {
-  use crate::syntax::ComparisonOp;
   let extract = |c: &Expr| -> Option<(Expr, ComparisonOp, Expr)> {
     if let Expr::Comparison {
       operands,
@@ -11052,7 +11048,6 @@ fn piecewise_condition_bounds(
   cond: &Expr,
   var: &str,
 ) -> Option<(Option<Expr>, Option<Expr>)> {
-  use crate::syntax::ComparisonOp;
   let is_var = |e: &Expr| matches!(e, Expr::Identifier(n) if n == var);
   let is_abs_var = |e: &Expr| {
     matches!(e,
@@ -11163,10 +11158,8 @@ fn negate_bound(c: &Expr) -> Expr {
   }
 }
 
-fn flip_comparison_op(
-  op: crate::syntax::ComparisonOp,
-) -> crate::syntax::ComparisonOp {
-  use crate::syntax::ComparisonOp::*;
+fn flip_comparison_op(op: ComparisonOp) -> ComparisonOp {
+  use ComparisonOp::*;
   match op {
     Less => Greater,
     LessEqual => GreaterEqual,
@@ -11176,8 +11169,8 @@ fn flip_comparison_op(
   }
 }
 
-fn comparison_op_from_symbol(e: &Expr) -> Option<crate::syntax::ComparisonOp> {
-  use crate::syntax::ComparisonOp::*;
+fn comparison_op_from_symbol(e: &Expr) -> Option<ComparisonOp> {
+  use ComparisonOp::*;
   match e {
     Expr::Identifier(s) => match s.as_str() {
       "Less" => Some(Less),
@@ -15074,7 +15067,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && matches!(&operands[0], Expr::Identifier(v) if v == &var_name)
             && matches!(&operands[1], Expr::Integer(0))
             && operators.len() == 1
-            && matches!(&operators[0], crate::syntax::ComparisonOp::Less)
+            && matches!(&operators[0], ComparisonOp::Less)
           {
             assume_negative = true;
           }
@@ -17244,7 +17237,7 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       operands,
       operators,
     } if operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal
+      && operators[0] == ComparisonOp::Equal
       && operands.len() == 2 =>
     {
       // f == g becomes f - g
@@ -17439,7 +17432,7 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     args: vec![
       Expr::Comparison {
         operands: vec![poly_expr, Expr::Integer(0)],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       },
       Expr::Identifier("AsymptoticSolve$t".to_string()),
     ]

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -2,7 +2,9 @@ use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{DEFAULT_HEIGHT, DEFAULT_WIDTH, parse_image_size};
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+};
 
 /// Dash length for the "Small" named size in Dashing directives.
 /// This is the default dash segment length used by Dashed, Dotted, etc.
@@ -5581,7 +5583,7 @@ fn digit_group_extra_width(digit_count: usize) -> f64 {
 /// Recursively handles all expression types so that Power expressions
 /// anywhere in the tree are rendered with `<tspan>` superscripts.
 pub fn expr_to_svg_markup(expr: &Expr) -> String {
-  use crate::syntax::{ComparisonOp, expr_to_output};
+  use crate::syntax::expr_to_output;
 
   // Power → superscript (handles both BinaryOp and FunctionCall forms)
   if let Some((base, exp)) = as_power(expr) {

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -2,7 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
 
 /// Shared AllTrue/AnyTrue/NoneTrue implementation: apply the predicate
 /// to every element at exactly the requested level (default 1) and
@@ -494,7 +494,7 @@ fn distribution_median(name: &str, dargs: &[Expr]) -> Option<Expr> {
       };
       let cond = Expr::Comparison {
         operands: vec![p, half],
-        operators: vec![crate::syntax::ComparisonOp::Greater],
+        operators: vec![ComparisonOp::Greater],
       };
       let pair = Expr::List(vec![Expr::Integer(1), cond].into());
       let cases = Expr::List(vec![pair].into());

--- a/src/functions/list_helpers_ast/mapping.rs
+++ b/src/functions/list_helpers_ast/mapping.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::ComparisonOp;
 
 /// AST-based Map: apply function to each element of a list or association.
 /// Map[f, {a, b, c}] -> {f[a], f[b], f[c]}
@@ -226,7 +227,6 @@ fn map_decompose(expr: &Expr) -> Option<(String, Vec<Expr>)> {
 
 /// Rebuild a mapped composite from its canonical head and new children.
 fn rewrap(head: &str, children: Vec<Expr>) -> Expr {
-  use crate::syntax::ComparisonOp;
   // Relational heads must be rebuilt as `Expr::Comparison` so they render
   // infix (`f[a] == f[b]`), not as `Equal[f[a], f[b]]`.
   let cmp_op = match head {

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -5,7 +5,7 @@
 
 use crate::InterpreterError;
 use crate::functions::math_ast::make_sqrt;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 // ─── DSolve ────────────────────────────────────────────────────────────
 
@@ -534,7 +534,7 @@ fn normalize_equation(eq: &Expr) -> Result<Expr, InterpreterError> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       let lhs = &operands[0];
       let rhs = &operands[1];
@@ -563,7 +563,7 @@ fn is_initial_condition(expr: &Expr, y_name: &str, x_name: &str) -> bool {
   } = expr
     && operands.len() == 2
     && operators.len() == 1
-    && operators[0] == crate::syntax::ComparisonOp::Equal
+    && operators[0] == ComparisonOp::Equal
   {
     let lhs = &operands[0];
     // y[val]
@@ -650,7 +650,7 @@ fn parse_numeric_initial_condition(
   } = expr
     && operands.len() == 2
     && operators.len() == 1
-    && operators[0] == crate::syntax::ComparisonOp::Equal
+    && operators[0] == ComparisonOp::Equal
   {
     let lhs = &operands[0];
 
@@ -1737,7 +1737,7 @@ fn apply_initial_conditions(
     } = ic
       && operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal
+      && operators[0] == ComparisonOp::Equal
     {
       let lhs = &operands[0];
       let rhs = &operands[1];
@@ -1794,7 +1794,7 @@ fn apply_initial_conditions(
       // Create equation: evaluated == rhs
       let equation = Expr::Comparison {
         operands: vec![evaluated, rhs.clone()],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       };
       equations.push(equation);
     }
@@ -3290,7 +3290,7 @@ fn pde_split_equation(eqn: &Expr) -> Option<(Expr, Expr)> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       Some((operands[0].clone(), operands[1].clone()))
     }

--- a/src/functions/polynomial_ast/eliminate.rs
+++ b/src/functions/polynomial_ast/eliminate.rs
@@ -2,7 +2,7 @@ use super::together::negate_expr;
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, expr_to_string};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, expr_to_string};
 
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 
@@ -155,7 +155,7 @@ fn extract_eq_sides(eq: &Expr) -> Option<(Expr, Expr)> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       Some((operands[0].clone(), operands[1].clone()))
     }
@@ -251,13 +251,13 @@ fn simplify_equation(eq: &Expr) -> Result<Expr, InterpreterError> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       let lhs = simplify(expand_and_combine(&operands[0]));
       let rhs = simplify(expand_and_combine(&operands[1]));
       Ok(Expr::Comparison {
         operands: vec![lhs, rhs],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       })
     }
     Expr::FunctionCall { name, args } if name == "Equal" && args.len() == 2 => {
@@ -265,7 +265,7 @@ fn simplify_equation(eq: &Expr) -> Result<Expr, InterpreterError> {
       let rhs = simplify(expand_and_combine(&args[1]));
       Ok(Expr::Comparison {
         operands: vec![lhs, rhs],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       })
     }
     other => Ok(simplify(expand_and_combine(other))),
@@ -281,7 +281,7 @@ fn is_trivially_true(eq: &Expr) -> bool {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       expr_to_string(&operands[0]) == expr_to_string(&operands[1])
     }
@@ -346,7 +346,7 @@ pub fn solve_always_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       // lhs == rhs => lhs - rhs
       let lhs_str = expr_to_string(&operands[0]);
@@ -724,7 +724,7 @@ fn normalize_eliminate_result(eq: &Expr, _eliminated_vars: &[String]) -> Expr {
       };
       return Expr::Comparison {
         operands: vec![lhs, Expr::Integer(-r)],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       };
     }
 
@@ -740,7 +740,7 @@ fn normalize_eliminate_result(eq: &Expr, _eliminated_vars: &[String]) -> Expr {
 
     return Expr::Comparison {
       operands: vec![Expr::Identifier(var.clone()), val],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     };
   }
 
@@ -812,7 +812,7 @@ fn normalize_eliminate_result(eq: &Expr, _eliminated_vars: &[String]) -> Expr {
 
     return Expr::Comparison {
       operands: vec![lhs_expr, rhs_expr],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     };
   }
 
@@ -826,7 +826,7 @@ fn normalize_eliminate_result(eq: &Expr, _eliminated_vars: &[String]) -> Expr {
 
   Expr::Comparison {
     operands: vec![expanded_neg, Expr::Integer(0)],
-    operators: vec![crate::syntax::ComparisonOp::Equal],
+    operators: vec![ComparisonOp::Equal],
   }
 }
 

--- a/src/functions/polynomial_ast/helpers.rs
+++ b/src/functions/polynomial_ast/helpers.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, Expr, expr_to_string};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, expr_to_string};
 
 // ─── helpers ────────────────────────────────────────────────────────
 
@@ -47,19 +47,19 @@ pub fn bool_expr(b: bool) -> Expr {
 pub fn make_equality(lhs: &Expr, rhs: &Expr) -> Expr {
   Expr::Comparison {
     operands: vec![lhs.clone(), rhs.clone()],
-    operators: vec![crate::syntax::ComparisonOp::Equal],
+    operators: vec![ComparisonOp::Equal],
   }
 }
 
 /// Build a comparison expression.
 pub fn make_comparison(lhs: &Expr, rhs: &Expr, op: CompOp) -> Expr {
   let comp_op = match op {
-    CompOp::Equal => crate::syntax::ComparisonOp::Equal,
-    CompOp::NotEqual => crate::syntax::ComparisonOp::NotEqual,
-    CompOp::Less => crate::syntax::ComparisonOp::Less,
-    CompOp::LessEqual => crate::syntax::ComparisonOp::LessEqual,
-    CompOp::Greater => crate::syntax::ComparisonOp::Greater,
-    CompOp::GreaterEqual => crate::syntax::ComparisonOp::GreaterEqual,
+    CompOp::Equal => ComparisonOp::Equal,
+    CompOp::NotEqual => ComparisonOp::NotEqual,
+    CompOp::Less => ComparisonOp::Less,
+    CompOp::LessEqual => ComparisonOp::LessEqual,
+    CompOp::Greater => ComparisonOp::Greater,
+    CompOp::GreaterEqual => ComparisonOp::GreaterEqual,
   };
   Expr::Comparison {
     operands: vec![lhs.clone(), rhs.clone()],

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -2,7 +2,9 @@ use super::together::negate_expr;
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+};
 
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 use crate::functions::math_ast::make_sqrt;
@@ -124,7 +126,6 @@ fn contains_inexact_literal(e: &Expr) -> bool {
 ///   var <= c  -> Element[var, Integers] && var <= floor(c)
 /// Returns `None` for any other shape, inexact bounds, or `==`/`!=`.
 fn tighten_integer_one_sided(result: &Expr, var: &str) -> Option<Expr> {
-  use crate::syntax::ComparisonOp;
   let Expr::Comparison {
     operands,
     operators,
@@ -180,7 +181,6 @@ fn tighten_integer_one_sided(result: &Expr, var: &str) -> Option<Expr> {
 /// any other shape, non-numeric bounds, or an enumeration that would be too
 /// large.
 fn enumerate_integer_interval(result: &Expr, var: &str) -> Option<Expr> {
-  use crate::syntax::ComparisonOp;
   let Expr::FunctionCall { name, args } = result else {
     return None;
   };
@@ -240,7 +240,6 @@ fn numeric_var_bounds(
   c: &Expr,
   var: &str,
 ) -> Option<(Option<i64>, Option<i64>)> {
-  use crate::syntax::ComparisonOp;
   let is_var = |e: &Expr| matches!(e, Expr::Identifier(s) if s == var);
   // lo op x -> lower bound; x op hi -> upper bound.
   let lower_from = |op: ComparisonOp, v: f64| -> Option<i64> {
@@ -326,8 +325,7 @@ fn numeric_var_bounds(
   None
 }
 
-fn comparison_op_of(e: &Expr) -> Option<crate::syntax::ComparisonOp> {
-  use crate::syntax::ComparisonOp;
+fn comparison_op_of(e: &Expr) -> Option<ComparisonOp> {
   match e {
     Expr::Identifier(s) => match s.as_str() {
       "Less" => Some(ComparisonOp::Less),
@@ -347,7 +345,6 @@ fn comparison_op_of(e: &Expr) -> Option<crate::syntax::ComparisonOp> {
 /// `None` when no finite two-sided range is derivable or there is no extra
 /// constraint — the plain interval paths handle those with their own format.
 fn try_reduce_bounded_integer_filtered(expr: &Expr, var: &str) -> Option<Expr> {
-  use crate::syntax::ComparisonOp;
   // Inexact bounds make wolframscript warn (Reduce::ratnz); leave them alone.
   if contains_inexact_literal(expr) {
     return None;
@@ -429,7 +426,7 @@ fn is_trig_equation(eq: &Expr, var: &str) -> bool {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       &operands[0]
     }
@@ -652,8 +649,8 @@ fn expand_numeric_two_sided_bound(expr: &Expr, var: &str) -> Option<Expr> {
     left: Box::new(left),
     right: Box::new(right),
   };
-  let is_ineq_op = |op: crate::syntax::ComparisonOp| {
-    use crate::syntax::ComparisonOp::*;
+  let is_ineq_op = |op: ComparisonOp| {
+    use ComparisonOp::*;
     matches!(op, Less | LessEqual | Greater | GreaterEqual)
   };
 
@@ -760,12 +757,12 @@ pub fn extract_comparison(expr: &Expr) -> Option<(Expr, Expr, CompOp)> {
       operators,
     } if operands.len() == 2 && operators.len() == 1 => {
       let op = match operators[0] {
-        crate::syntax::ComparisonOp::Equal => CompOp::Equal,
-        crate::syntax::ComparisonOp::NotEqual => CompOp::NotEqual,
-        crate::syntax::ComparisonOp::Less => CompOp::Less,
-        crate::syntax::ComparisonOp::LessEqual => CompOp::LessEqual,
-        crate::syntax::ComparisonOp::Greater => CompOp::Greater,
-        crate::syntax::ComparisonOp::GreaterEqual => CompOp::GreaterEqual,
+        ComparisonOp::Equal => CompOp::Equal,
+        ComparisonOp::NotEqual => CompOp::NotEqual,
+        ComparisonOp::Less => CompOp::Less,
+        ComparisonOp::LessEqual => CompOp::LessEqual,
+        ComparisonOp::Greater => CompOp::Greater,
+        ComparisonOp::GreaterEqual => CompOp::GreaterEqual,
         _ => return None,
       };
       Some((operands[0].clone(), operands[1].clone(), op))
@@ -970,7 +967,7 @@ fn reduce_equation(
   // Use the Solve infrastructure to find roots
   let eq_expr = Expr::Comparison {
     operands: vec![lhs.clone(), rhs.clone()],
-    operators: vec![crate::syntax::ComparisonOp::Equal],
+    operators: vec![ComparisonOp::Equal],
   };
   let solve_result = solve_ast(&[eq_expr, Expr::Identifier(var.to_string())])?;
 
@@ -1095,7 +1092,7 @@ fn reduce_not_equal(
   let _ = domain;
   Ok(Expr::Comparison {
     operands: vec![lhs.clone(), rhs.clone()],
-    operators: vec![crate::syntax::ComparisonOp::NotEqual],
+    operators: vec![ComparisonOp::NotEqual],
   })
 }
 
@@ -1682,7 +1679,7 @@ fn reduce_quadratic_inequality(
         }
         CompOp::Greater if ai > 0 => Ok(Expr::Comparison {
           operands: vec![Expr::Identifier(var.to_string()), root],
-          operators: vec![crate::syntax::ComparisonOp::NotEqual],
+          operators: vec![ComparisonOp::NotEqual],
         }),
         CompOp::LessEqual if ai > 0 => {
           Ok(make_equality(&Expr::Identifier(var.to_string()), &root))
@@ -1704,7 +1701,7 @@ fn reduce_quadratic_inequality(
         }
         CompOp::Less if ai < 0 => Ok(Expr::Comparison {
           operands: vec![Expr::Identifier(var.to_string()), root],
-          operators: vec![crate::syntax::ComparisonOp::NotEqual],
+          operators: vec![ComparisonOp::NotEqual],
         }),
         CompOp::GreaterEqual if ai < 0 => {
           Ok(make_equality(&Expr::Identifier(var.to_string()), &root))
@@ -1878,7 +1875,7 @@ fn try_factor_and_reduce_inequality(
   // Try using Solve to find roots, then determine sign intervals
   let eq = Expr::Comparison {
     operands: vec![lhs.clone(), rhs.clone()],
-    operators: vec![crate::syntax::ComparisonOp::Equal],
+    operators: vec![ComparisonOp::Equal],
   };
   let solve_result =
     solve_ast(&[eq, Expr::Identifier(var.to_string())]).ok()?;
@@ -2324,7 +2321,6 @@ fn reduce_combined_inequalities(
       && operators.len() == 2
       && operands.len() == 3
     {
-      use crate::syntax::ComparisonOp;
       let mid = &operands[1];
       if expr_to_string(mid) == var {
         let low_inc = matches!(
@@ -2531,7 +2527,7 @@ pub fn reduce_multi_var_and(
   if let Some((i, var, lhs, rhs, _deg)) = best {
     let eq = Expr::Comparison {
       operands: vec![lhs, rhs],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     };
     let solve_result = solve_ast(&[eq, Expr::Identifier(var.to_string())])?;
 
@@ -2865,7 +2861,7 @@ fn try_reduce_exists_quadratic_linear(
   let bound = inv_q(&k)?;
   Some(Expr::Comparison {
     operands: vec![Expr::Identifier(param.clone()), rational_to_expr(&bound)],
-    operators: vec![crate::syntax::ComparisonOp::LessEqual],
+    operators: vec![ComparisonOp::LessEqual],
   })
 }
 
@@ -3076,10 +3072,10 @@ fn extract_le_form(e: &Expr) -> Option<(Expr, Expr)> {
     && operators.len() == 1
   {
     match &operators[0] {
-      crate::syntax::ComparisonOp::LessEqual => {
+      ComparisonOp::LessEqual => {
         Some((operands[0].clone(), operands[1].clone()))
       }
-      crate::syntax::ComparisonOp::GreaterEqual => {
+      ComparisonOp::GreaterEqual => {
         Some((operands[1].clone(), operands[0].clone()))
       }
       _ => None,
@@ -3098,10 +3094,10 @@ fn extract_ge_form(e: &Expr) -> Option<(Expr, Expr)> {
     && operators.len() == 1
   {
     match &operators[0] {
-      crate::syntax::ComparisonOp::GreaterEqual => {
+      ComparisonOp::GreaterEqual => {
         Some((operands[0].clone(), operands[1].clone()))
       }
-      crate::syntax::ComparisonOp::LessEqual => {
+      ComparisonOp::LessEqual => {
         Some((operands[1].clone(), operands[0].clone()))
       }
       _ => None,

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+};
 
 use crate::functions::calculus_ast::simplify;
 
@@ -424,14 +426,14 @@ fn extract_assumptions_inner(assumption: &Expr, info: &mut AssumptionInfo) {
       let right = &operands[1];
 
       // x > c where c >= 0 → positive (strictly)
-      if matches!(op, crate::syntax::ComparisonOp::Greater)
+      if matches!(op, ComparisonOp::Greater)
         && let Expr::Identifier(name) = left
         && is_nonnegative_constant(right)
       {
         info.positive_vars.push(name.clone());
       }
       // x >= c where c > 0 → positive; where c == 0 → nonnegative
-      if matches!(op, crate::syntax::ComparisonOp::GreaterEqual)
+      if matches!(op, ComparisonOp::GreaterEqual)
         && let Expr::Identifier(name) = left
         && is_nonnegative_constant(right)
       {
@@ -443,14 +445,14 @@ fn extract_assumptions_inner(assumption: &Expr, info: &mut AssumptionInfo) {
       }
 
       // c < x where c >= 0 → positive
-      if matches!(op, crate::syntax::ComparisonOp::Less)
+      if matches!(op, ComparisonOp::Less)
         && let Expr::Identifier(name) = right
         && is_nonnegative_constant(left)
       {
         info.positive_vars.push(name.clone());
       }
       // c <= x where c > 0 → positive; where c == 0 → nonnegative
-      if matches!(op, crate::syntax::ComparisonOp::LessEqual)
+      if matches!(op, ComparisonOp::LessEqual)
         && let Expr::Identifier(name) = right
         && is_nonnegative_constant(left)
       {
@@ -464,11 +466,9 @@ fn extract_assumptions_inner(assumption: &Expr, info: &mut AssumptionInfo) {
       // x < c where c <= 0 → negative (x < c <= 0).
       // x <= c where c < 0  → negative; where c == 0 → nonpositive.
       if let Expr::Identifier(name) = left {
-        if matches!(op, crate::syntax::ComparisonOp::Less)
-          && is_nonpositive_constant(right)
-        {
+        if matches!(op, ComparisonOp::Less) && is_nonpositive_constant(right) {
           info.negative_vars.push(name.clone());
-        } else if matches!(op, crate::syntax::ComparisonOp::LessEqual) {
+        } else if matches!(op, ComparisonOp::LessEqual) {
           if is_negative_constant(right) {
             info.negative_vars.push(name.clone());
           } else if is_zero_constant(right) {
@@ -480,11 +480,10 @@ fn extract_assumptions_inner(assumption: &Expr, info: &mut AssumptionInfo) {
       // c > x where c <= 0 → negative.
       // c >= x where c < 0  → negative; where c == 0 → nonpositive.
       if let Expr::Identifier(name) = right {
-        if matches!(op, crate::syntax::ComparisonOp::Greater)
-          && is_nonpositive_constant(left)
+        if matches!(op, ComparisonOp::Greater) && is_nonpositive_constant(left)
         {
           info.negative_vars.push(name.clone());
-        } else if matches!(op, crate::syntax::ComparisonOp::GreaterEqual) {
+        } else if matches!(op, ComparisonOp::GreaterEqual) {
           if is_negative_constant(left) {
             info.negative_vars.push(name.clone());
           } else if is_zero_constant(left) {
@@ -631,20 +630,20 @@ fn check_comparison_under_assumption(
       if info.positive_vars.contains(var_name) {
         // x is positive
         match op {
-          crate::syntax::ComparisonOp::Greater if rhs_is_zero => {
+          ComparisonOp::Greater if rhs_is_zero => {
             return Some(true);
           }
-          crate::syntax::ComparisonOp::GreaterEqual
+          ComparisonOp::GreaterEqual
             if is_nonnegative_constant(right) && rhs_is_zero =>
           {
             return Some(true);
           }
-          crate::syntax::ComparisonOp::Less
+          ComparisonOp::Less
             if is_nonnegative_constant(right) && rhs_is_zero =>
           {
             return Some(false);
           }
-          crate::syntax::ComparisonOp::LessEqual
+          ComparisonOp::LessEqual
             if is_nonpositive_constant(right) && rhs_is_zero =>
           {
             return Some(false);
@@ -655,20 +654,20 @@ fn check_comparison_under_assumption(
       if info.negative_vars.contains(var_name) {
         // x is negative
         match op {
-          crate::syntax::ComparisonOp::Less if rhs_is_zero => {
+          ComparisonOp::Less if rhs_is_zero => {
             return Some(true);
           }
-          crate::syntax::ComparisonOp::LessEqual
+          ComparisonOp::LessEqual
             if is_nonpositive_constant(right) && rhs_is_zero =>
           {
             return Some(true);
           }
-          crate::syntax::ComparisonOp::Greater
+          ComparisonOp::Greater
             if is_nonpositive_constant(right) && rhs_is_zero =>
           {
             return Some(false);
           }
-          crate::syntax::ComparisonOp::GreaterEqual
+          ComparisonOp::GreaterEqual
             if is_nonnegative_constant(right) && rhs_is_zero =>
           {
             return Some(false);
@@ -680,10 +679,10 @@ fn check_comparison_under_assumption(
         // x <= 0: x > 0 is impossible, x <= 0 holds. The strict/nonstrict
         // lower cases (x < 0, x >= 0) stay undetermined since x may be 0.
         match op {
-          crate::syntax::ComparisonOp::Greater if rhs_is_zero => {
+          ComparisonOp::Greater if rhs_is_zero => {
             return Some(false);
           }
-          crate::syntax::ComparisonOp::LessEqual if rhs_is_zero => {
+          ComparisonOp::LessEqual if rhs_is_zero => {
             return Some(true);
           }
           _ => {}
@@ -692,10 +691,10 @@ fn check_comparison_under_assumption(
       if info.nonnegative_vars.contains(var_name) {
         // x >= 0: x < 0 is impossible, x >= 0 holds.
         match op {
-          crate::syntax::ComparisonOp::Less if rhs_is_zero => {
+          ComparisonOp::Less if rhs_is_zero => {
             return Some(false);
           }
-          crate::syntax::ComparisonOp::GreaterEqual if rhs_is_zero => {
+          ComparisonOp::GreaterEqual if rhs_is_zero => {
             return Some(true);
           }
           _ => {}
@@ -713,18 +712,16 @@ fn check_comparison_under_assumption(
         && let Expr::Integer(bound_val) = &bound
       {
         match op {
-          crate::syntax::ComparisonOp::Greater if *bound_val > *rhs_val => {
+          ComparisonOp::Greater if *bound_val > *rhs_val => {
             return Some(true);
           }
-          crate::syntax::ComparisonOp::GreaterEqual
-            if *bound_val >= *rhs_val =>
-          {
+          ComparisonOp::GreaterEqual if *bound_val >= *rhs_val => {
             return Some(true);
           }
-          crate::syntax::ComparisonOp::Less if *bound_val >= *rhs_val => {
+          ComparisonOp::Less if *bound_val >= *rhs_val => {
             return Some(false);
           }
-          crate::syntax::ComparisonOp::LessEqual if *bound_val > *rhs_val => {
+          ComparisonOp::LessEqual if *bound_val > *rhs_val => {
             return Some(false);
           }
           _ => {}
@@ -736,12 +733,12 @@ fn check_comparison_under_assumption(
     // Check if we can determine the sign of the LHS expression
     if matches!(right, Expr::Integer(0)) {
       match op {
-        crate::syntax::ComparisonOp::Greater
+        ComparisonOp::Greater
           if is_provably_positive_under_assumptions(left, info) =>
         {
           return Some(true);
         }
-        crate::syntax::ComparisonOp::GreaterEqual
+        ComparisonOp::GreaterEqual
           if is_provably_nonneg_under_assumptions(left, info) =>
         {
           return Some(true);
@@ -850,19 +847,15 @@ fn get_lower_bound(var_name: &str, assumption: &Expr) -> Option<Expr> {
       // var > c or var >= c
       if matches!(
         operators[0],
-        crate::syntax::ComparisonOp::Greater
-          | crate::syntax::ComparisonOp::GreaterEqual
+        ComparisonOp::Greater | ComparisonOp::GreaterEqual
       ) && let Expr::Identifier(name) = &operands[0]
         && name == var_name
       {
         return Some(operands[1].clone());
       }
       // c < var or c <= var
-      if matches!(
-        operators[0],
-        crate::syntax::ComparisonOp::Less
-          | crate::syntax::ComparisonOp::LessEqual
-      ) && let Expr::Identifier(name) = &operands[1]
+      if matches!(operators[0], ComparisonOp::Less | ComparisonOp::LessEqual)
+        && let Expr::Identifier(name) = &operands[1]
         && name == var_name
       {
         return Some(operands[0].clone());
@@ -886,7 +879,7 @@ fn get_lower_bound(var_name: &str, assumption: &Expr) -> Option<Expr> {
 /// comparison in the assumptions: `Some(1)` when `a >= b` is known, `Some(-1)`
 /// when `a <= b` is known, `None` otherwise. Used to collapse Max/Min.
 fn compare_operands(a: &Expr, b: &Expr, info: &AssumptionInfo) -> Option<i32> {
-  use crate::syntax::ComparisonOp::{Greater, GreaterEqual, Less, LessEqual};
+  use ComparisonOp::{Greater, GreaterEqual, Less, LessEqual};
   let a_s = expr_to_string(a);
   let b_s = expr_to_string(b);
   for asm in &info.raw_assumptions {
@@ -2510,10 +2503,7 @@ fn check_arctan_range_in_assumption(assumption: &Expr) -> bool {
       // Check pattern: -Pi/2 < Re[x] < Pi/2
       matches!(
         (&operators[0], &operators[1]),
-        (
-          crate::syntax::ComparisonOp::Less,
-          crate::syntax::ComparisonOp::Less
-        )
+        (ComparisonOp::Less, ComparisonOp::Less)
       ) && is_negative_pi_over_2(&operands[0])
         && is_pi_over_2(&operands[2])
     }
@@ -2702,10 +2692,7 @@ fn is_var_in_open_range(
       && operators.len() == 2
       && matches!(
         (&operators[0], &operators[1]),
-        (
-          crate::syntax::ComparisonOp::Less,
-          crate::syntax::ComparisonOp::Less
-        )
+        (ComparisonOp::Less, ComparisonOp::Less)
       )
     {
       // Pattern: lo_expr < var < hi_expr
@@ -2807,10 +2794,8 @@ fn extract_bounds_for_var(
       if let Expr::Identifier(name) = &operands[1]
         && name == var_name
       {
-        let lo_strict =
-          matches!(operators[0], crate::syntax::ComparisonOp::Less);
-        let hi_strict =
-          matches!(operators[1], crate::syntax::ComparisonOp::Less);
+        let lo_strict = matches!(operators[0], ComparisonOp::Less);
+        let hi_strict = matches!(operators[1], ComparisonOp::Less);
         return Some((
           operands[0].clone(),
           lo_strict,
@@ -2878,7 +2863,7 @@ fn find_mod_value_in_assumptions(
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && matches!(operators[0], crate::syntax::ComparisonOp::Equal) =>
+      && matches!(operators[0], ComparisonOp::Equal) =>
     {
       // Check if one side is Mod[expr, m]
       if is_mod_of(expr, m, &operands[0]) {
@@ -3116,7 +3101,7 @@ fn check_algebraic_comparison(
 
     // For >= 0 comparisons: check if left - right is provably non-negative
     match op {
-      crate::syntax::ComparisonOp::GreaterEqual => {
+      ComparisonOp::GreaterEqual => {
         if matches!(right, Expr::Integer(0))
           && is_provably_nonnegative(left, info)
         {
@@ -3133,7 +3118,7 @@ fn check_algebraic_comparison(
           return Some(true);
         }
       }
-      crate::syntax::ComparisonOp::Equal => {
+      ComparisonOp::Equal => {
         // Try substitution from equation assumptions
         if let Some(result) =
           check_equation_by_substitution(left, right, op, info, assumption)
@@ -3141,7 +3126,7 @@ fn check_algebraic_comparison(
           return Some(result);
         }
       }
-      crate::syntax::ComparisonOp::Less => {
+      ComparisonOp::Less => {
         // Try substitution-based reasoning
         if let Some(result) =
           check_inequality_by_substitution(left, right, op, info, assumption)
@@ -3490,7 +3475,7 @@ fn term_bivariate_powers_and_coeff(
 fn check_equation_by_substitution(
   left: &Expr,
   right: &Expr,
-  _op: &crate::syntax::ComparisonOp,
+  _op: &ComparisonOp,
   _info: &AssumptionInfo,
   assumption: &Expr,
 ) -> Option<bool> {
@@ -3532,7 +3517,7 @@ fn check_equation_by_substitution(
 fn check_inequality_by_substitution(
   left: &Expr,
   right: &Expr,
-  _op: &crate::syntax::ComparisonOp,
+  _op: &ComparisonOp,
   info: &AssumptionInfo,
   assumption: &Expr,
 ) -> Option<bool> {
@@ -3967,16 +3952,16 @@ fn extract_inequality_constraints_inner(
       operands,
       operators,
     } if operands.len() == 2 && operators.len() == 1 => match &operators[0] {
-      crate::syntax::ComparisonOp::LessEqual => {
+      ComparisonOp::LessEqual => {
         result.push((operands[0].clone(), operands[1].clone(), true));
       }
-      crate::syntax::ComparisonOp::Less => {
+      ComparisonOp::Less => {
         result.push((operands[0].clone(), operands[1].clone(), false));
       }
-      crate::syntax::ComparisonOp::GreaterEqual => {
+      ComparisonOp::GreaterEqual => {
         result.push((operands[1].clone(), operands[0].clone(), true));
       }
-      crate::syntax::ComparisonOp::Greater => {
+      ComparisonOp::Greater => {
         result.push((operands[1].clone(), operands[0].clone(), false));
       }
       _ => {}
@@ -4008,7 +3993,7 @@ fn extract_equation_substitutions_inner(
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && matches!(operators[0], crate::syntax::ComparisonOp::Equal) =>
+      && matches!(operators[0], ComparisonOp::Equal) =>
     {
       // Try to solve for a variable
       // Simple case: a + b == 0 → b = -a
@@ -6139,7 +6124,7 @@ fn simplify_expr_inner(expr: &Expr) -> Expr {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && matches!(operators[0], crate::syntax::ComparisonOp::Equal) =>
+      && matches!(operators[0], ComparisonOp::Equal) =>
     {
       let lhs = simplify_expr(&operands[0]);
       let rhs = simplify_expr(&operands[1]);
@@ -6302,7 +6287,6 @@ fn flatten_assumption_atoms(expr: &Expr) -> Vec<Expr> {
 /// `/`Less`/etc. node. Returns `None` for anything we can't read as a
 /// single-variable bound on a numeric constant.
 fn extract_var_bound(expr: &Expr) -> Option<(String, &'static str, f64)> {
-  use crate::syntax::ComparisonOp;
   let to_op = |op: &ComparisonOp| -> &'static str {
     match op {
       ComparisonOp::Less => "<",

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -142,7 +142,7 @@ fn try_nsolve_quadratic(
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       Expr::BinaryOp {
         op: BinaryOperator::Minus,
@@ -427,7 +427,7 @@ pub fn roots_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                   Expr::Identifier(var.clone()),
                   *replacement.clone(),
                 ],
-                operators: vec![crate::syntax::ComparisonOp::Equal],
+                operators: vec![ComparisonOp::Equal],
               });
             }
           }
@@ -499,7 +499,7 @@ pub fn nroots_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       Expr::BinaryOp {
         op: BinaryOperator::Minus,
@@ -587,7 +587,7 @@ pub fn nroots_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     };
     conds.push(Expr::Comparison {
       operands: vec![Expr::Identifier(var.clone()), rhs],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     });
   }
   if conds.len() == 1 {
@@ -803,7 +803,7 @@ pub fn to_rules_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       operators,
     } = expr
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal
+      && operators[0] == ComparisonOp::Equal
       && operands.len() == 2
     {
       return Some(Expr::Rule {
@@ -1175,15 +1175,17 @@ pub fn solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // path (which understands constraints) handles cases like
   // `m^2 == 4 && m > 0`.
   fn all_equalities(items: &[Expr]) -> bool {
-    items.iter().all(|e| matches!(
-      e,
-      Expr::Comparison { operators, .. }
-        if operators.iter().all(|o| matches!(o, crate::syntax::ComparisonOp::Equal))
-    ) || matches!(
-      e,
-      Expr::FunctionCall { name, args }
-        if name == "Equal" && args.len() == 2
-    ))
+    items.iter().all(|e| {
+      matches!(
+        e,
+        Expr::Comparison { operators, .. }
+          if operators.iter().all(|o| matches!(o, ComparisonOp::Equal))
+      ) || matches!(
+        e,
+        Expr::FunctionCall { name, args }
+          if name == "Equal" && args.len() == 2
+      )
+    })
   }
   let args_owned: Vec<Expr>;
   let args = match &args[0] {
@@ -1609,7 +1611,7 @@ pub fn solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           operators,
         } if operands.len() == 2
           && operators.len() == 1
-          && operators[0] == crate::syntax::ComparisonOp::Equal =>
+          && operators[0] == ComparisonOp::Equal =>
         {
           (operands[0].clone(), operands[1].clone(), true)
         }
@@ -1682,7 +1684,7 @@ pub fn solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       // lhs - rhs
       Expr::BinaryOp {
@@ -2367,7 +2369,7 @@ pub fn solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             }
             let factor_eq = Expr::Comparison {
               operands: vec![factor.clone(), Expr::Integer(0)],
-              operators: vec![crate::syntax::ComparisonOp::Equal],
+              operators: vec![ComparisonOp::Equal],
             };
             if let Ok(Expr::List(ref sols)) =
               solve_ast(&[factor_eq, args[1].clone()])
@@ -2798,7 +2800,7 @@ fn try_solve_abs_eq(
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       (operands[0].clone(), operands[1].clone())
     }
@@ -2830,7 +2832,7 @@ fn try_solve_abs_eq(
   let solve_branch = |value: Expr| -> Option<Vec<Expr>> {
     let branch_eq = Expr::Comparison {
       operands: vec![inner.clone(), value],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     };
     let r = solve_ast(&[branch_eq, Expr::Identifier(var.to_string())]).ok()?;
     match r {
@@ -3058,7 +3060,7 @@ fn try_solve_inverse_function(
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       (operands[0].clone(), operands[1].clone())
     }
@@ -3134,7 +3136,7 @@ fn try_solve_inverse_function(
         crate::evaluator::evaluate_expr_to_expr(&inverse_rhs).ok()?;
       let new_eq = Expr::Comparison {
         operands: vec![base, simplified_rhs],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       };
       return Some(solve_ast(&[new_eq, Expr::Identifier(var.to_string())]));
     }
@@ -3243,7 +3245,7 @@ fn try_solve_inverse_function(
         crate::evaluator::evaluate_expr_to_expr(&inverse_rhs).ok()?;
       let new_eq = Expr::Comparison {
         operands: vec![exp, simplified_rhs],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       };
       return Some(solve_ast(&[new_eq, Expr::Identifier(var.to_string())]));
     }
@@ -3350,7 +3352,7 @@ fn try_solve_inverse_function(
     // Build the new equation: inner == simplified_rhs
     let new_eq = Expr::Comparison {
       operands: vec![inner.clone(), simplified_rhs],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     };
 
     // Recursively solve the resulting equation
@@ -3586,7 +3588,7 @@ fn try_solve_factoring_powers(
       // Recursively solve
       let new_eq = Expr::Comparison {
         operands: vec![remaining, Expr::Integer(0)],
-        operators: vec![crate::syntax::ComparisonOp::Equal],
+        operators: vec![ComparisonOp::Equal],
       };
       return Some(solve_ast(&[new_eq, args[1].clone()]));
     }
@@ -3677,7 +3679,7 @@ fn build_eq_from_coeffs(coeffs: &[Expr], var: &str) -> Expr {
   };
   Expr::Comparison {
     operands: vec![poly_expr, Expr::Integer(0)],
-    operators: vec![crate::syntax::ComparisonOp::Equal],
+    operators: vec![ComparisonOp::Equal],
   }
 }
 
@@ -3934,7 +3936,7 @@ pub fn root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Solve the polynomial equation poly == 0
   let eq = Expr::Comparison {
     operands: vec![poly, Expr::Integer(0)],
-    operators: vec![crate::syntax::ComparisonOp::Equal],
+    operators: vec![ComparisonOp::Equal],
   };
 
   let solutions = solve_ast(&[eq, Expr::Identifier(var_name.into())])?;
@@ -4299,7 +4301,7 @@ fn build_find_root_func(arg: &Expr) -> Expr {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       Expr::BinaryOp {
         op: BinaryOperator::Minus,
@@ -5657,7 +5659,7 @@ fn minimize_abs_breakpoints(f: &Expr, var: &str) -> Vec<Expr> {
   for g in abs_args {
     let eq = Expr::Comparison {
       operands: vec![g, Expr::Integer(0)],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     };
     let solved = solve_ast(&[eq, Expr::Identifier(var.to_string())]);
     if let Ok(Expr::List(sol_sets)) = &solved {
@@ -5823,7 +5825,7 @@ fn minimize_find_critical_points_1d(
   // Fallback: try Solve[df == 0, var]
   let df_eq = Expr::Comparison {
     operands: vec![df.clone(), Expr::Integer(0)],
-    operators: vec![crate::syntax::ComparisonOp::Equal],
+    operators: vec![ComparisonOp::Equal],
   };
   match solve_ast(&[df_eq, Expr::Identifier(var.to_string())]) {
     Ok(solutions) => {
@@ -5946,7 +5948,7 @@ fn minimize_multi_var(
   for (i, var) in vars.iter().enumerate() {
     let grad_eq = Expr::Comparison {
       operands: vec![grad[i].clone(), Expr::Integer(0)],
-      operators: vec![crate::syntax::ComparisonOp::Equal],
+      operators: vec![ComparisonOp::Equal],
     };
     match solve_ast(&[grad_eq, Expr::Identifier(var.clone())]) {
       Ok(sol) => {
@@ -7880,7 +7882,7 @@ pub fn extract_eq_and_ineq_parts(expr: &Expr) -> (Option<Expr>, Vec<Expr>) {
       &c,
       Expr::Comparison { operators, .. }
         if operators.len() == 1
-          && operators[0] == crate::syntax::ComparisonOp::Equal
+          && operators[0] == ComparisonOp::Equal
     );
     if is_eq && eq_part.is_none() {
       eq_part = Some(c);
@@ -8025,7 +8027,7 @@ fn solve_linear_symbolic(eqs: &[Expr], var_names: &[String]) -> Option<Expr> {
         operands,
         operators,
       } if operators.len() == 1
-        && operators[0] == crate::syntax::ComparisonOp::Equal
+        && operators[0] == ComparisonOp::Equal
         && operands.len() == 2 =>
       {
         (&operands[0], &operands[1])
@@ -9048,7 +9050,7 @@ fn named_constant_value(name: &str) -> Option<f64> {
 /// constraint expression, e.g. `x*y >= 1` or `-3 <= x`.
 struct AtomicComparison {
   left: Expr,
-  op: crate::syntax::ComparisonOp,
+  op: ComparisonOp,
   right: Expr,
 }
 

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -3,7 +3,7 @@
 //! These functions work directly with `Expr` AST nodes.
 
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 /// Helper to create boolean result
 fn bool_expr(b: bool) -> Expr {
@@ -599,7 +599,7 @@ pub fn is_numeric_q(expr: &Expr) -> bool {
                   operators,
                 } = cond
                 && operators.len() == 1
-                && operators[0] == crate::syntax::ComparisonOp::SameQ
+                && operators[0] == ComparisonOp::SameQ
                 && operands.len() == 2
                 && let Expr::Identifier(cond_val) = &operands[1]
                 && cond_val == name
@@ -2043,7 +2043,6 @@ pub fn head_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       UnaryOperator::Not => "Not",
     },
     Expr::Comparison { operators, .. } => {
-      use crate::syntax::ComparisonOp;
       // A uniform chain (all operators the same) has head equal to that operator.
       // A mixed chain has head "Inequality". A single-op comparison also uses
       // the operator name directly.

--- a/src/functions/rsolve_ast.rs
+++ b/src/functions/rsolve_ast.rs
@@ -1,5 +1,5 @@
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 /// RSolve[{recurrence, initial_conditions...}, a, n]
 /// RSolve[recurrence, a[n], n] — single equation, return rule for `a[n]`
@@ -485,7 +485,7 @@ fn extract_equation(expr: &Expr) -> Option<(Expr, Expr)> {
       operators,
     } if operands.len() == 2
       && operators.len() == 1
-      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+      && operators[0] == ComparisonOp::Equal =>
     {
       Some((operands[0].clone(), operands[1].clone()))
     }

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -3,7 +3,7 @@
 //! These functions work directly with `Expr` AST nodes, avoiding string round-trips.
 
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -5216,7 +5216,6 @@ pub fn expr_to_tex(expr: &Expr) -> String {
       operands,
       operators,
     } => {
-      use crate::syntax::ComparisonOp;
       let mut result = expr_to_tex(&operands[0]);
       for (i, op) in operators.iter().enumerate() {
         let op_tex = match op {

--- a/src/functions/ztransform_ast.rs
+++ b/src/functions/ztransform_ast.rs
@@ -14,7 +14,7 @@
 
 use crate::InterpreterError;
 use crate::functions::calculus_ast::is_constant_wrt;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 pub fn z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = |args: &[Expr]| Expr::FunctionCall {
@@ -1288,7 +1288,7 @@ pub fn fourier_coefficient_ast(
   // Symbolic n: Piecewise[{{zero_piece, n == 0}}, general]
   let cond = Expr::Comparison {
     operands: vec![n_arg.clone(), Expr::Integer(0)],
-    operators: vec![crate::syntax::ComparisonOp::Equal],
+    operators: vec![ComparisonOp::Equal],
   };
   Ok(Expr::FunctionCall {
     name: "Piecewise".to_string(),

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -4,7 +4,7 @@ use woxi::functions::graphics::{
   estimate_box_display_width, estimate_display_width, expr_to_svg_markup,
   layout_box, layout_to_svg,
 };
-use woxi::syntax::{BinaryOperator, Expr};
+use woxi::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 mod tests {
   use super::*;
@@ -969,7 +969,7 @@ mod tests {
     #[test]
     fn box_unary_minus() {
       let expr = Expr::UnaryOp {
-        op: woxi::syntax::UnaryOperator::Minus,
+        op: UnaryOperator::Minus,
         operand: Box::new(Expr::Identifier("x".to_string())),
       };
       let boxes = expr_to_box_form(&expr);
@@ -980,7 +980,7 @@ mod tests {
     #[test]
     fn box_unary_not() {
       let expr = Expr::UnaryOp {
-        op: woxi::syntax::UnaryOperator::Not,
+        op: UnaryOperator::Not,
         operand: Box::new(Expr::Identifier("p".to_string())),
       };
       let boxes = expr_to_box_form(&expr);
@@ -997,7 +997,7 @@ mod tests {
           Expr::Identifier("a".to_string()),
           Expr::Identifier("b".to_string()),
         ],
-        operators: vec![woxi::syntax::ComparisonOp::Less],
+        operators: vec![ComparisonOp::Less],
       };
       let boxes = expr_to_box_form(&expr);
       let svg = boxes_to_svg(&boxes);


### PR DESCRIPTION
Remove the remaining prefixes for the ComparisonOp enum.