### PR TITLE
Expand use of the unevaluated(...) function

### DIFF
--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -1,14 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::list_helpers_ast;
-use crate::syntax::{BinaryOperator, UnaryOperator};
-
-fn unevaluated(name: &str, args: &[Expr]) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
-  }
-}
+use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
 
 /// Parse the `m` argument of NestWhile[f, x, test, m, ...]. Returns `All` for
 /// the symbol `All`, `Last(n)` for a positive integer, and `None` otherwise.

--- a/src/functions/audio_ast/mod.rs
+++ b/src/functions/audio_ast/mod.rs
@@ -19,7 +19,7 @@ pub mod spectral;
 
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::sound;
-use crate::syntax::Expr;
+use crate::syntax::{Expr, unevaluated};
 
 /// In-memory view of an audio object: per-channel samples plus the sample
 /// rate in Hz. Channels are non-empty and equally long.
@@ -167,15 +167,6 @@ pub fn make_audio(audio: &AudioData) -> Expr {
       },
     ]
     .into(),
-  }
-}
-
-/// The unevaluated form `name[args…]`, returned when arguments don't match
-/// (wolframscript likewise leaves the expression symbolic).
-pub fn unevaluated(name: &str, args: &[Expr]) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
   }
 }
 

--- a/src/functions/geo_math.rs
+++ b/src/functions/geo_math.rs
@@ -7,7 +7,7 @@
 
 use crate::InterpreterError;
 use crate::functions::geographics::{position_to_latlon, positions_from_arg};
-use crate::syntax::{Expr, UnaryOperator};
+use crate::syntax::{Expr, UnaryOperator, unevaluated};
 use geographiclib_rs::{DirectGeodesic, Geodesic, InverseGeodesic};
 use std::sync::OnceLock;
 
@@ -66,14 +66,6 @@ fn geo_position(lat: f64, lon: f64) -> Expr {
     name: "GeoPosition".to_string(),
     args: vec![Expr::List(vec![Expr::Real(lat), Expr::Real(lon)].into())]
       .into(),
-  }
-}
-
-/// Leave the call symbolic (unevaluated) when arguments don't match.
-fn unevaluated(name: &str, args: &[Expr]) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
   }
 }
 
@@ -503,12 +495,7 @@ fn parse_dms_string(s: &str) -> Option<AngleVal> {
 /// DMS strings parse and re-format. The optional second argument is the
 /// number of decimals on the seconds (default 3).
 pub fn dms_string_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "DMSString".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("DMSString", args));
   if args.is_empty() || args.len() > 2 {
     return unevaluated();
   }

--- a/src/functions/groebner_ast.rs
+++ b/src/functions/groebner_ast.rs
@@ -8,7 +8,7 @@
 //! unevaluated.
 
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 use std::collections::BTreeMap;
 
 type Frac = (i128, i128);
@@ -347,15 +347,9 @@ fn is_prime_i128(n: i128) -> bool {
   true
 }
 
-fn unevaluated_call(name: &str, args: &[Expr]) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
-  }
-}
-
 pub fn groebner_basis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| unevaluated_call("GroebnerBasis", args);
+  let full_args = args;
+  let uneval = || unevaluated("GroebnerBasis", full_args);
   // GroebnerBasis[polys, vars, Modulus -> p] computes over GF(p);
   // Modulus -> 0 is ordinary arithmetic, and composite moduli (which
   // would need strong Z/m bases) stay unevaluated.
@@ -364,15 +358,13 @@ pub fn groebner_basis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match groebner_modulus_option(&args[2]) {
       Some(0) => return groebner_basis_ast(&args[..2]),
       Some(p) if is_prime_i128(p) => modulus = Some(p),
-      _ => return Ok(unevaluated(args)),
+      _ => return Ok(uneval()),
     }
   } else if args.len() != 2 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let _guard = modulus.map(set_modulus);
-  let full_args = args;
   let args = &args[..2];
-  let unevaluated = |_: &[Expr]| unevaluated_call("GroebnerBasis", full_args);
   let polys_in: Vec<Expr> = match &args[0] {
     Expr::List(items) if !items.is_empty() => items.iter().cloned().collect(),
     single => vec![single.clone()],
@@ -383,16 +375,16 @@ pub fn groebner_basis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       for v in items {
         match v {
           Expr::Identifier(name) => out.push(name.clone()),
-          _ => return Ok(unevaluated(args)),
+          _ => return Ok(uneval()),
         }
       }
       out
     }
     Expr::Identifier(name) => vec![name.clone()],
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   };
   if vars.is_empty() || vars.len() > 6 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
 
   // Parse the input polynomials
@@ -406,7 +398,7 @@ pub fn groebner_basis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match expr_to_poly(&expanded, &vars) {
       Some(poly) if !poly.is_empty() => basis.push(poly),
       Some(_) => {} // zero polynomial contributes nothing
-      None => return Ok(unevaluated(args)),
+      None => return Ok(uneval()),
     }
   }
   if basis.is_empty() {
@@ -480,7 +472,7 @@ pub fn groebner_basis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(reduced)
   })();
   let Some(mut reduced) = result else {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   };
 
   // Trivial ideal: any nonzero constant
@@ -506,10 +498,10 @@ pub fn groebner_basis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let monic;
     let p = if let Some(pm) = modulus {
       let Some((_, lc)) = leading(p) else {
-        return Ok(unevaluated(args));
+        return Ok(uneval());
       };
       let Some(inv) = mod_inverse(lc.0, pm) else {
-        return Ok(unevaluated(args));
+        return Ok(uneval());
       };
       let mut q = Poly::new();
       for (k, &c) in p {
@@ -573,7 +565,7 @@ pub fn groebner_basis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     })();
     match rendered {
       Some(e) => out.push(e),
-      None => return Ok(unevaluated(args)),
+      None => return Ok(uneval()),
     }
   }
   Ok(Expr::List(out.into()))

--- a/src/functions/math_ast/airy.rs
+++ b/src/functions/math_ast/airy.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// AiryAi[x] - Airy function of the first kind
 pub fn airy_ai_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -40,10 +40,7 @@ pub fn airy_ai_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(crate::functions::math_ast::build_complex_float_expr(ar, ai));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "AiryAi".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AiryAi", args))
 }
 
 /// True if the expression tree contains a Real or BigFloat node.
@@ -188,10 +185,7 @@ pub fn airy_bi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(crate::functions::math_ast::build_complex_float_expr(br, bi));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "AiryBi".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AiryBi", args))
 }
 
 /// Complex Airy Bi via the same power series as `airy_ai_complex`,
@@ -303,10 +297,7 @@ pub fn airy_ai_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(airy_ai_prime(x_f)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "AiryAiPrime".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AiryAiPrime", args))
 }
 
 /// Compute Ai'(x) using power series and asymptotic expansion
@@ -414,10 +405,7 @@ pub fn airy_bi_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(airy_bi_prime(x_f)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "AiryBiPrime".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AiryBiPrime", args))
 }
 
 /// Compute Bi'(x) using the same series as Ai' but with different sign
@@ -577,10 +565,7 @@ pub fn airy_ai_zero_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "AiryAiZero expects exactly 1 argument".into(),
     ));
   }
-  Ok(Expr::FunctionCall {
-    name: "AiryAiZero".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AiryAiZero", args))
 }
 
 /// AiryBiZero[n] - n-th real zero of AiryBi. Stays symbolic until N[].
@@ -590,10 +575,7 @@ pub fn airy_bi_zero_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "AiryBiZero expects exactly 1 argument".into(),
     ));
   }
-  Ok(Expr::FunctionCall {
-    name: "AiryBiZero".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AiryBiZero", args))
 }
 
 /// Numeric evaluation of AiryAiZero[n] for use by N[]. Accepts a
@@ -684,10 +666,7 @@ pub fn scorer_hi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     return Ok(Expr::Real(scorer_hi(x)));
   }
-  Ok(Expr::FunctionCall {
-    name: "ScorerHi".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ScorerHi", args))
 }
 
 /// ScorerGi[x] — inhomogeneous Airy function solving y'' - x y = -1/Pi.
@@ -706,8 +685,5 @@ pub fn scorer_gi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     return Ok(Expr::Real(airy_bi(x) - scorer_hi(x)));
   }
-  Ok(Expr::FunctionCall {
-    name: "ScorerGi".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ScorerGi", args))
 }

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
+use crate::syntax::{
+  BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
+};
 use num_bigint::BigInt;
 use num_bigint::Sign;
 
@@ -7716,10 +7718,7 @@ pub fn minus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     times_ast(&[Expr::Integer(-1), args[0].clone()])
   } else {
     // Return unevaluated (like Wolfram) — error message emitted by centralized arg_count check
-    Ok(Expr::FunctionCall {
-      name: "Minus".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("Minus", args))
   }
 }
 
@@ -10941,10 +10940,7 @@ where
 /// Subtract[a, b] - Returns a - b
 pub fn subtract_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "Subtract".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Subtract", args));
   }
   // Subtract[a, b] = a + (-1 * b)
   let negated_b = times_ast(&[Expr::Integer(-1), args[1].clone()])?;

--- a/src/functions/math_ast/bessel.rs
+++ b/src/functions/math_ast/bessel.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// True if `z_expr` is `<zero_name>[order, k, ...]` whose first argument equals
 /// `n_expr` AND both `order` and `k` are concrete positive integers — the only
@@ -122,10 +122,7 @@ pub fn bessel_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "BesselJ".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("BesselJ", args))
 }
 
 /// Compute BesselJ[m/2, z] for odd integer m using the recurrence
@@ -423,10 +420,7 @@ pub fn bessel_j_zero_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated (symbolic)
-  Ok(Expr::FunctionCall {
-    name: "BesselJZero".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("BesselJZero", args))
 }
 
 /// BesselYZero[n, k] — k-th positive zero of the Bessel function Y_n
@@ -465,10 +459,7 @@ pub fn bessel_y_zero_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let result = bessel_y_zero(n, k as usize);
     return Ok(Expr::Real(result));
   }
-  Ok(Expr::FunctionCall {
-    name: "BesselYZero".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("BesselYZero", args))
 }
 
 /// Find the k-th positive zero of Y_n(x) using bisection + Newton's method.
@@ -681,10 +672,7 @@ pub fn bessel_i_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(result);
   }
 
-  Ok(Expr::FunctionCall {
-    name: "BesselI".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("BesselI", args))
 }
 
 /// Compute I_n(z) using series: I_n(z) = Σ (z/2)^{2m+n} / (m! * Γ(n+m+1))
@@ -768,10 +756,7 @@ pub fn bessel_k_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(result);
   }
 
-  Ok(Expr::FunctionCall {
-    name: "BesselK".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("BesselK", args))
 }
 
 /// Compute BesselK[m/2, z] for odd integer m. Anchors P_1 = P_{-1} = 1
@@ -1078,10 +1063,7 @@ pub fn bessel_y_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return wrap_with_sqrt_factor(&p_signed, z_expr);
   }
 
-  Ok(Expr::FunctionCall {
-    name: "BesselY".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("BesselY", args))
 }
 
 /// Compute Bessel Y_n(z) (second kind)
@@ -1226,12 +1208,7 @@ fn coulomb_wave_reduce(
     CoulombKind::H1 => "CoulombH1",
     CoulombKind::H2 => "CoulombH2",
   };
-  let uneval = || {
-    Ok(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let uneval = || Ok(unevaluated(name, args));
   if args.len() != 3 {
     return uneval();
   }
@@ -1303,10 +1280,7 @@ fn coulomb_wave_reduce(
 
 pub fn spherical_bessel_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "SphericalBesselJ".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("SphericalBesselJ", args));
   }
 
   let n_expr = &args[0];
@@ -1373,10 +1347,7 @@ pub fn spherical_bessel_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated for symbolic case
-  Ok(Expr::FunctionCall {
-    name: "SphericalBesselJ".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("SphericalBesselJ", args))
 }
 
 /// Helper to build a Hankel-type function from two Bessel-type results
@@ -1431,10 +1402,7 @@ fn build_hankel(
     };
     return crate::evaluator::evaluate_expr_to_expr(&expr);
   }
-  Ok(Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated(name, args))
 }
 
 /// SphericalBesselY[n, z] — spherical Bessel function of the second kind.
@@ -1445,10 +1413,7 @@ fn build_hankel(
 /// Falls back to Sqrt[Pi/(2z)] * BesselY[n + 1/2, z] for non-integer `n`.
 pub fn spherical_bessel_y_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "SphericalBesselY".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("SphericalBesselY", args));
   }
 
   let n_expr = &args[0];
@@ -1501,10 +1466,7 @@ pub fn spherical_bessel_y_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated for symbolic case
-  Ok(Expr::FunctionCall {
-    name: "SphericalBesselY".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("SphericalBesselY", args))
 }
 
 /// HankelH1[n, z] = BesselJ[n, z] + I * BesselY[n, z]
@@ -1723,10 +1685,7 @@ pub fn kelvin_ber_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let (ber, _) = ber_bei_nu_series(nu, x);
       return Ok(Expr::Real(ber));
     }
-    return Ok(Expr::FunctionCall {
-      name: "KelvinBer".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("KelvinBer", args));
   }
   if let Some(x) = match &args[0] {
     Expr::Real(f) => Some(*f),
@@ -1773,10 +1732,7 @@ pub fn kelvin_bei_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let (_, bei) = ber_bei_nu_series(nu, x);
       return Ok(Expr::Real(bei));
     }
-    return Ok(Expr::FunctionCall {
-      name: "KelvinBei".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("KelvinBei", args));
   }
   if let Some(x) = match &args[0] {
     Expr::Real(f) => Some(*f),
@@ -2017,10 +1973,7 @@ pub fn kelvin_ker_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       return Ok(Expr::Real(ker));
     }
-    return Ok(Expr::FunctionCall {
-      name: "KelvinKer".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("KelvinKer", args));
   }
   if let Some(x) = match &args[0] {
     Expr::Real(f) if *f > 0.0 => Some(*f),
@@ -2069,10 +2022,7 @@ pub fn kelvin_kei_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       return Ok(Expr::Real(kei));
     }
-    return Ok(Expr::FunctionCall {
-      name: "KelvinKei".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("KelvinKei", args));
   }
   if let Some(x) = match &args[0] {
     Expr::Real(f) if *f > 0.0 => Some(*f),

--- a/src/functions/math_ast/carlson.rs
+++ b/src/functions/math_ast/carlson.rs
@@ -8,7 +8,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{Expr, unevaluated};
 
 /// True if `e` contains an inexact (machine) number anywhere.
 fn is_inexact(e: &Expr) -> bool {
@@ -205,12 +205,7 @@ fn carlson_ast(
   arity: usize,
   f: impl Fn(&[f64]) -> Option<f64>,
 ) -> Result<Expr, InterpreterError> {
-  let symbolic = || {
-    Ok(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let symbolic = || Ok(unevaluated(name, args));
   if args.len() != arity {
     return symbolic();
   }

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// True if `t` carries the imaginary unit `I` as a direct factor (possibly
 /// nested inside Times/negation): `I`, `b I`, `-2 b I`, etc.
@@ -216,10 +216,7 @@ pub fn re_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Symbolic: return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "Re".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Re", args))
 }
 
 /// Im[z] - Imaginary part of a complex number (for real numbers, returns 0)
@@ -306,10 +303,7 @@ pub fn im_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Symbolic: return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "Im".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Im", args))
 }
 
 /// Flatten a product into its leaf factors, descending through nested Times
@@ -1335,10 +1329,7 @@ pub fn arg_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(im.atan2(re)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "Arg".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Arg", args))
 }
 
 /// Helper: create a rational multiple of Pi as an expression.
@@ -1533,10 +1524,7 @@ pub fn rationalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         Some(x) => x,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "Rationalize".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("Rationalize", args));
         }
       }
     }

--- a/src/functions/math_ast/coordinate_arrays.rs
+++ b/src/functions/math_ast/coordinate_arrays.rs
@@ -4,7 +4,7 @@
 //! pairs versus the two corner points `{mins, maxs}`.
 
 use crate::InterpreterError;
-use crate::syntax::{Expr, UnaryOperator, expr_to_output};
+use crate::syntax::{Expr, UnaryOperator, expr_to_output, unevaluated};
 
 /// One coordinate value: an exact rational (p/q, q > 0) or a machine real.
 /// Grids over exact bounds with exact steps stay exact (`Into[2]` of a unit
@@ -289,12 +289,7 @@ fn build_array(
 pub fn coordinate_bounds_array_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "CoordinateBoundsArray".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("CoordinateBoundsArray", args));
   if args.is_empty() || args.len() > 3 {
     return unevaluated();
   }
@@ -332,12 +327,7 @@ pub fn coordinate_bounds_array_ast(
 pub fn coordinate_bounding_box_array_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "CoordinateBoundingBoxArray".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("CoordinateBoundingBoxArray", args));
   if args.is_empty() || args.len() > 3 {
     return unevaluated();
   }

--- a/src/functions/math_ast/mathieu.rs
+++ b/src/functions/math_ast/mathieu.rs
@@ -15,7 +15,7 @@
 //! agreement should compare ratios `MathieuSPrime(a, q, z) /
 //! MathieuSPrime(a, q, 0)` (these match to numerical precision).
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{Expr, unevaluated};
 
 fn try_real_f64(e: &Expr) -> Option<f64> {
   match e {
@@ -77,10 +77,7 @@ fn integrate_mathieu(
 /// `sin(√a · z)` at q = 0 (BC `y(0) = 0`, `y'(0) = √a`).
 pub fn mathieu_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 3 {
-    return Ok(Expr::FunctionCall {
-      name: "MathieuS".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("MathieuS", args));
   }
   let (a, q, z) = match (
     try_real_f64(&args[0]),
@@ -89,17 +86,11 @@ pub fn mathieu_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   ) {
     (Some(a), Some(q), Some(z)) => (a, q, z),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "MathieuS".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("MathieuS", args));
     }
   };
   if a < 0.0 {
-    return Ok(Expr::FunctionCall {
-      name: "MathieuS".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("MathieuS", args));
   }
   let yp0 = a.sqrt();
   let (y, _) = integrate_mathieu(a, q, z, 0.0, yp0);
@@ -109,10 +100,7 @@ pub fn mathieu_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// MathieuSPrime[a, q, z] — derivative of MathieuS w.r.t. z.
 pub fn mathieu_s_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 3 {
-    return Ok(Expr::FunctionCall {
-      name: "MathieuSPrime".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("MathieuSPrime", args));
   }
   let (a, q, z) = match (
     try_real_f64(&args[0]),
@@ -121,17 +109,11 @@ pub fn mathieu_s_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   ) {
     (Some(a), Some(q), Some(z)) => (a, q, z),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "MathieuSPrime".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("MathieuSPrime", args));
     }
   };
   if a < 0.0 {
-    return Ok(Expr::FunctionCall {
-      name: "MathieuSPrime".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("MathieuSPrime", args));
   }
   let yp0 = a.sqrt();
   let (_, yp) = integrate_mathieu(a, q, z, 0.0, yp0);

--- a/src/functions/math_ast/polylog.rs
+++ b/src/functions/math_ast/polylog.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// PolyLog[s, z] - Polylogarithm function Li_s(z)
 pub fn polylog_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -40,10 +40,7 @@ pub fn polylog_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => {}
   }
 
-  Ok(Expr::FunctionCall {
-    name: "PolyLog".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("PolyLog", args))
 }
 
 fn polylog_integer_s(
@@ -98,10 +95,7 @@ fn polylog_integer_s(
     _ => {}
   }
 
-  Ok(Expr::FunctionCall {
-    name: "PolyLog".to_string(),
-    args: orig_args.to_vec().into(),
-  })
+  Ok(unevaluated("PolyLog", orig_args))
 }
 
 /// PolyLog[1, z] = -Log[1-z]

--- a/src/functions/math_ast/triangles.rs
+++ b/src/functions/math_ast/triangles.rs
@@ -9,7 +9,7 @@
 //! lengths pass through fine.
 
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, expr_to_output};
+use crate::syntax::{BinaryOperator, Expr, expr_to_output, unevaluated};
 
 fn fc(name: &str, args: Vec<Expr>) -> Expr {
   Expr::FunctionCall {
@@ -181,12 +181,7 @@ fn two_angle_triangle(
   side_is_included: bool,
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: head.to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated(head, args));
   // Numeric angles must be positive with a sum below Pi; symbolic angles
   // evaluate symbolically (wolframscript computes `AASTriangle[a, Pi/3, 1]`
   // via its trig canonicalization).
@@ -275,10 +270,7 @@ fn two_angle_triangle(
 /// AASTriangle[α, β, a] — angles α, β and the side a opposite α.
 pub fn aas_triangle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 3 {
-    return Ok(Expr::FunctionCall {
-      name: "AASTriangle".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("AASTriangle", args));
   }
   two_angle_triangle("AASTriangle", &args[0], &args[1], &args[2], false, args)
 }
@@ -286,10 +278,7 @@ pub fn aas_triangle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// ASATriangle[α, c, β] — angles α, β with the included side c.
 pub fn asa_triangle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 3 {
-    return Ok(Expr::FunctionCall {
-      name: "ASATriangle".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("ASATriangle", args));
   }
   two_angle_triangle("ASATriangle", &args[0], &args[2], &args[1], true, args)
 }
@@ -298,12 +287,7 @@ pub fn asa_triangle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// side comes from the law of cosines; the apex is written with the
 /// (b² - a b Cos[γ])/c and a b Sin[γ]/c forms wolframscript displays.
 pub fn sas_triangle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "SASTriangle".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("SASTriangle", args));
   if args.len() != 3 {
     return unevaluated();
   }
@@ -380,12 +364,7 @@ pub fn sas_triangle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn triangle_measurement_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "TriangleMeasurement".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("TriangleMeasurement", args));
   if args.is_empty() || args.len() > 2 {
     return unevaluated();
   }

--- a/src/functions/molecule_ast.rs
+++ b/src/functions/molecule_ast.rs
@@ -14,7 +14,7 @@ use crate::InterpreterError;
 use crate::functions::element_data::{
   abbreviation_for_atomic_number, is_element_abbreviation,
 };
-use crate::syntax::Expr;
+use crate::syntax::{Expr, unevaluated};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum BondKind {
@@ -887,13 +887,6 @@ fn molecular_formula(graph: &MolGraph) -> String {
 // ---------------------------------------------------------------------------
 // Public entry points
 // ---------------------------------------------------------------------------
-
-fn unevaluated(name: &str, args: &[Expr]) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
-  }
-}
 
 /// Molecule[spec] / Molecule[{atoms…}, {bonds…}] — build the canonical
 /// molecule expression.

--- a/src/functions/wavelet_ast/mod.rs
+++ b/src/functions/wavelet_ast/mod.rs
@@ -11,7 +11,7 @@ pub mod tables;
 pub mod transforms;
 
 use crate::InterpreterError;
-use crate::syntax::{Expr, expr_to_string};
+use crate::syntax::{Expr, expr_to_string, unevaluated};
 
 /// A validated discrete wavelet family (one that has filter coefficients
 /// and works with the discrete transforms).
@@ -376,11 +376,4 @@ fn single_filter_result(
       .collect()
   };
   Ok(Expr::List(pairs.into()))
-}
-
-pub(crate) fn unevaluated(name: &str, args: &[Expr]) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
-  }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -13987,3 +13987,10 @@ pub fn replace_identifier_in_expr(
     _ => expr.clone(),
   }
 }
+
+pub fn unevaluated(name: &str, args: &[Expr]) -> Expr {
+  Expr::FunctionCall {
+    name: name.to_string(),
+    args: args.to_vec().into(),
+  }
+}


### PR DESCRIPTION
Implement the unevaluated() function in syntax.rs, eliminate duplicates in list_operations.rs, audio_ast/mod.rs, geo_math.rs groebner_ast.rs, molecule_ast.rs, and wavelet_ast/mod.rs. Start using the function in math_ast/*.rs.