### PR TITLE
Apply unevaluated(...) function to math_ast/*.rs

### DIFF
--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
+use crate::syntax::{
+  BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
+};
 use num_bigint::BigInt;
 use num_traits::Signed;
 
@@ -17,20 +19,14 @@ pub fn digit_count_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_bigint(&args[0]) {
     Some(n) => n.abs(),
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "DigitCount".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("DigitCount", args));
     }
   };
   let base = if args.len() >= 2 {
     match expr_to_i128(&args[1]) {
       Some(b) if b >= 2 => b,
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "DigitCount".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("DigitCount", args));
       }
     }
   } else {
@@ -58,10 +54,7 @@ pub fn digit_count_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let d = match expr_to_i128(&args[2]) {
       Some(d) => d as usize,
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "DigitCount".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("DigitCount", args));
       }
     };
     let count = digits.iter().filter(|&&x| x == d).count();
@@ -94,10 +87,7 @@ pub fn digit_sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_bigint(&args[0]) {
     Some(n) => n.abs(),
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "DigitSum".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("DigitSum", args));
     }
   };
   // DigitSum[n, MixedRadix[{b1, b2, ..., bk}]]
@@ -113,18 +103,12 @@ pub fn digit_sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut base_vals: Vec<BigInt> = Vec::with_capacity(bases.len());
     for b in bases.iter() {
       let Some(bi) = expr_to_i128(b) else {
-        return Ok(Expr::FunctionCall {
-          name: "DigitSum".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("DigitSum", args));
       };
       // A MixedRadix specification may legitimately contain a radix of 1
       // (e.g. MixedRadix[{60, 60, 1}]); only reject non-positive radices.
       if bi < 1 {
-        return Ok(Expr::FunctionCall {
-          name: "DigitSum".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("DigitSum", args));
       }
       base_vals.push(BigInt::from(bi));
     }
@@ -148,10 +132,7 @@ pub fn digit_sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match expr_to_i128(&args[1]) {
       Some(b) if b >= 2 => b,
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "DigitSum".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("DigitSum", args));
       }
     }
   } else {
@@ -1083,12 +1064,7 @@ pub fn continued_fraction_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // A whole-number Real (Rationalize gives an integer) is left unevaluated, as
   // is a non-positive/non-integer second argument.
   if matches!(&args[0], Expr::Real(_)) {
-    let unevaluated = || {
-      Ok(Expr::FunctionCall {
-        name: "ContinuedFraction".to_string(),
-        args: args.to_vec().into(),
-      })
-    };
+    let unevaluated = || Ok(unevaluated("ContinuedFraction", args));
     let n_cap: Option<usize> = if args.len() == 2 {
       match &args[1] {
         Expr::Integer(n) if *n > 0 => Some(*n as usize),
@@ -1181,10 +1157,7 @@ pub fn continued_fraction_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let n = match &args[1] {
       Expr::Integer(n) if *n > 0 => *n as usize,
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "ContinuedFraction".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("ContinuedFraction", args));
       }
     };
 
@@ -1211,10 +1184,7 @@ pub fn continued_fraction_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::FunctionCall {
-    name: "ContinuedFraction".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ContinuedFraction", args))
 }
 
 /// Greatest common divisor of two non-negative integers.
@@ -1435,10 +1405,7 @@ pub fn from_continued_fraction_ast(
   let elements = match &args[0] {
     Expr::List(elems) => elems,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "FromContinuedFraction".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("FromContinuedFraction", args));
     }
   };
 
@@ -1473,10 +1440,7 @@ pub fn from_continued_fraction_ast(
       }
       _ => {}
     }
-    return Ok(Expr::FunctionCall {
-      name: "FromContinuedFraction".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("FromContinuedFraction", args));
   }
 
   // Collect all integers
@@ -1485,10 +1449,7 @@ pub fn from_continued_fraction_ast(
     match elem {
       Expr::Integer(n) => ints.push(*n),
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "FromContinuedFraction".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("FromContinuedFraction", args));
       }
     }
   }
@@ -1546,10 +1507,7 @@ pub fn integer_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  let unevaluated = || Expr::FunctionCall {
-    name: "IntegerDigits".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("IntegerDigits", args);
   let show =
     |e: &Expr| crate::syntax::format_expr(e, crate::syntax::ExprForm::Output);
 
@@ -2374,10 +2332,7 @@ pub fn real_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Ok(v) => v,
     Err(_) => {
       // Non-numeric expression (e.g. bare symbol): return unevaluated.
-      return Ok(Expr::FunctionCall {
-        name: "RealDigits".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("RealDigits", args));
     }
   };
 
@@ -2537,10 +2492,7 @@ pub fn from_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let digits = match &args[0] {
       Expr::List(items) => items,
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "FromDigits".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("FromDigits", args));
       }
     };
     if digits.is_empty() {
@@ -2588,10 +2540,7 @@ pub fn from_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let items = match &args[0] {
       Expr::List(items) => items.clone(),
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "FromDigits".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("FromDigits", args));
       }
     };
     if items.is_empty() {
@@ -2641,10 +2590,7 @@ pub fn from_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       } else if ch.is_ascii_uppercase() {
         (ch as i128) - ('A' as i128) + 10
       } else {
-        return Ok(Expr::FunctionCall {
-          name: "FromDigits".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("FromDigits", args));
       };
       // Wolfram allows digit values >= base (overflow digits)
       // e.g. FromDigits["a0"] in base 10 gives 10*10+0 = 100
@@ -2656,10 +2602,7 @@ pub fn from_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match &args[0] {
     Expr::List(items) => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "FromDigits".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("FromDigits", args));
     }
   };
 
@@ -2787,10 +2730,7 @@ pub fn integer_length_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::Integer(items.len() as i128));
     }
     // IntegerDigits left it unevaluated (e.g. bad radix) — mirror that.
-    return Ok(Expr::FunctionCall {
-      name: "IntegerLength".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("IntegerLength", args));
   }
 
   let base_i128 = if args.len() == 2 {
@@ -2801,16 +2741,10 @@ pub fn integer_length_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           "IntegerLength::ibase: Base {} is not an integer greater than 1.",
           b
         ));
-        return Ok(Expr::FunctionCall {
-          name: "IntegerLength".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("IntegerLength", args));
       }
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "IntegerLength".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("IntegerLength", args));
       }
     }
   } else {
@@ -2833,10 +2767,7 @@ pub fn integer_length_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Integer(count));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "IntegerLength".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("IntegerLength", args))
 }
 
 /// IntegerReverse[n] - reverse the digits of an integer in base 10.
@@ -2851,12 +2782,7 @@ pub fn integer_reverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  let uneval = || {
-    Ok(Expr::FunctionCall {
-      name: "IntegerReverse".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let uneval = || Ok(unevaluated("IntegerReverse", args));
 
   let base = if args.len() >= 2 {
     match expr_to_i128(&args[1]) {
@@ -2879,10 +2805,7 @@ pub fn integer_reverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Some(_) => {
         crate::emit_message(&format!(
           "IntegerReverse::intpm: Positive machine-sized integer expected at position 3 in {}.",
-          crate::syntax::expr_to_string(&Expr::FunctionCall {
-            name: "IntegerReverse".to_string(),
-            args: args.to_vec().into(),
-          })
+          crate::syntax::expr_to_string(&unevaluated("IntegerReverse", args))
         ));
         return uneval();
       }
@@ -3382,12 +3305,7 @@ fn integer_name_german(n: i128, ordinal: bool) -> Option<String> {
 }
 
 pub fn integer_name_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "IntegerName".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("IntegerName", args));
 
   // IntegerName works on lists; thread over the first argument, carrying any
   // second argument (the name type) along.
@@ -3488,10 +3406,7 @@ pub fn roman_numeral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(&args[0]) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "RomanNumeral".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("RomanNumeral", args));
     }
   };
 
@@ -3504,10 +3419,7 @@ pub fn roman_numeral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // For values >= 5000, Wolfram uses display forms with overscript bars.
   // We support up to 4999 with plain Roman numerals.
   if abs_n >= 5000 {
-    return Ok(Expr::FunctionCall {
-      name: "RomanNumeral".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("RomanNumeral", args));
   }
 
   const VALUES: [(u64, &str); 13] = [
@@ -3550,10 +3462,7 @@ pub fn convergents_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let elements = match &cf_list {
     Expr::List(elems) => elems,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Convergents".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Convergents", args));
     }
   };
 
@@ -3567,10 +3476,7 @@ pub fn convergents_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match elem {
       Expr::Integer(n) => ints.push(*n),
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "Convergents".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Convergents", args));
       }
     }
   }
@@ -3642,10 +3548,7 @@ fn gcd_convergents(a: i128, b: i128) -> i128 {
 pub fn number_digit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   use num_bigint::BigUint;
   use num_traits::{One, ToPrimitive};
-  let unevaluated = || Expr::FunctionCall {
-    name: "NumberDigit".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("NumberDigit", args);
   if args.len() != 2 && args.len() != 3 {
     return Ok(unevaluated());
   }
@@ -3911,10 +3814,7 @@ pub fn number_digit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// and machine reals stay unevaluated (the real-number expansion with
 /// its trailing machine-precision residual term is not implemented).
 pub fn number_expand_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "NumberExpand".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("NumberExpand", args);
   if args.is_empty() || args.len() > 3 {
     return Ok(unevaluated(args));
   }
@@ -3992,10 +3892,7 @@ pub fn number_expand_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// positive numbers (NumberDecompose::psv otherwise, but only once the
 /// value itself is numeric); symbolic input stays unevaluated.
 pub fn number_decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "NumberDecompose".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("NumberDecompose", args);
   if args.len() != 2 {
     return Ok(unevaluated(args));
   }
@@ -4117,10 +4014,7 @@ pub fn number_decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// units, so `NumberCompose[{1, 2, 3}, {100, 10, 1}]` is `123` and the shorter
 /// `NumberCompose[{1, 2}, {100, 10, 1}]` is `12`.
 pub fn number_compose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "NumberCompose".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("NumberCompose", args);
   if args.len() != 2 {
     return Ok(unevaluated(args));
   }
@@ -4203,10 +4097,7 @@ pub fn number_compose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn minkowski_question_mark_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "MinkowskiQuestionMark".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("MinkowskiQuestionMark", args);
   if args.len() != 1 {
     return Ok(unevaluated(args));
   }
@@ -4366,10 +4257,7 @@ pub fn minkowski_question_mark_ast(
 /// Other characters emit FromRomanNumeral::nrom; non-strings emit
 /// FromRomanNumeral::string.
 pub fn from_roman_numeral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "FromRomanNumeral".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("FromRomanNumeral", args);
   if args.len() != 1 {
     return Ok(unevaluated(args));
   }
@@ -4432,10 +4320,7 @@ pub fn from_roman_numeral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// arguments produce a message and stay unevaluated (matching wolframscript);
 /// symbolic arguments echo silently.
 pub fn thue_morse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "ThueMorse".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("ThueMorse", args);
   if args.len() != 1 {
     return Ok(unevaluated(args));
   }
@@ -4472,10 +4357,7 @@ pub fn thue_morse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// expansion of n. Defined only for non-negative integers; negative or
 /// non-integer arguments stay unevaluated (matching wolframscript).
 pub fn rudin_shapiro_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "RudinShapiro".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("RudinShapiro", args);
   if args.len() != 1 {
     return Ok(unevaluated(args));
   }

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -4,6 +4,7 @@ use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  unevaluated,
 };
 
 /// Helper to build a binary operation expression
@@ -121,12 +122,8 @@ pub fn pdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && targs.len() == 1
   {
     if name == "DiscreteMarkovProcess" {
-      return dmp_step_pdf(dargs, &targs[0], &args[1]).map(|r| {
-        r.unwrap_or_else(|| Expr::FunctionCall {
-          name: "PDF".to_string(),
-          args: args.to_vec().into(),
-        })
-      });
+      return dmp_step_pdf(dargs, &targs[0], &args[1])
+        .map(|r| r.unwrap_or_else(|| unevaluated("PDF", args)));
     }
     if let Some(slice) = process_slice_distribution(name, dargs, &targs[0]) {
       return pdf_ast(&[slice, args[1].clone()]);
@@ -139,10 +136,7 @@ pub fn pdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       (name.as_str(), dargs.as_slice())
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "PDF".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("PDF", args));
     }
   };
 
@@ -153,20 +147,13 @@ pub fn pdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && let Expr::FunctionCall { name, args: mp } = &dargs[0]
     && name == "DiscreteMarkovProcess"
   {
-    return dmp_stationary_pdf(mp, &args[1]).map(|r| {
-      r.unwrap_or_else(|| Expr::FunctionCall {
-        name: "PDF".to_string(),
-        args: args.to_vec().into(),
-      })
-    });
+    return dmp_stationary_pdf(mp, &args[1])
+      .map(|r| r.unwrap_or_else(|| unevaluated("PDF", args)));
   }
 
   if args.len() == 1 {
     // PDF[dist] - return unevaluated for now
-    return Ok(Expr::FunctionCall {
-      name: "PDF".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("PDF", args));
   }
 
   // PDF[MixtureDistribution[{w1, …}, {d1, …}], x] is the weight-normalized sum
@@ -177,10 +164,7 @@ pub fn pdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       super::statistics::mixture_weighted_component_quantity(dargs, |d| {
         pdf_ast(&[d.clone(), x.clone()])
       })?
-      .unwrap_or_else(|| Expr::FunctionCall {
-        name: "PDF".to_string(),
-        args: args.to_vec().into(),
-      }),
+      .unwrap_or_else(|| unevaluated("PDF", args)),
     );
   }
 
@@ -219,14 +203,7 @@ pub fn pdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Some(v) => v,
       None => Ok(Expr::FunctionCall {
         name: "PDF".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "DataDistribution".to_string(),
-            args: dargs.to_vec().into(),
-          },
-          x,
-        ]
-        .into(),
+        args: vec![unevaluated("DataDistribution", dargs), x].into(),
       }),
     },
     "UniformDistribution" => pdf_uniform(dargs, x),
@@ -316,10 +293,7 @@ pub fn pdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     "FRatioDistribution" => pdf_f_ratio(dargs, x),
     "WaringYuleDistribution" => pdf_waring_yule(dargs, x),
     "JohnsonDistribution" => pdf_johnson(dargs, x),
-    _ => Ok(Expr::FunctionCall {
-      name: "PDF".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("PDF", args)),
   }
 }
 
@@ -332,10 +306,7 @@ pub fn survival_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   if args.len() == 1 {
     // SurvivalFunction[dist] — symbolic pure form, leave unevaluated.
-    return Ok(Expr::FunctionCall {
-      name: "SurvivalFunction".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("SurvivalFunction", args));
   }
   // FailureDistribution has its own survival shape:
   // Piecewise[{{1, t < 0}}, 1 - cdfvalue] (wolframscript-verified).
@@ -357,10 +328,7 @@ pub fn survival_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let below = comparison(args[1].clone(), ComparisonOp::Less, int(0));
       return eval(piecewise(vec![(int(1), below)], complement));
     }
-    return Ok(Expr::FunctionCall {
-      name: "SurvivalFunction".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("SurvivalFunction", args));
   }
   let cdf = cdf_ast(args)?;
 
@@ -423,10 +391,7 @@ pub fn survival_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// normal. Other distributions stay unevaluated rather than risking a
 /// differently-shaped (though equivalent) answer.
 pub fn hazard_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "HazardFunction".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("HazardFunction", args);
   if args.len() != 2 {
     return Ok(unevaluated(args));
   }
@@ -1119,10 +1084,7 @@ fn quantile_discrete(
   if q_num >= 1.0 {
     return Some(kmax.map(int).unwrap_or_else(infinity));
   }
-  let dist = Expr::FunctionCall {
-    name: dist_name.to_string(),
-    args: dargs.to_vec().into(),
-  };
+  let dist = unevaluated(dist_name, dargs);
   let mut k = kmin;
   loop {
     let cdf_k = eval(Expr::FunctionCall {
@@ -1194,10 +1156,7 @@ pub fn quantile_distribution_numeric(
   if hi_is_infinite {
     hi_known = None;
   }
-  let dist_expr = Expr::FunctionCall {
-    name: "ProbabilityDistribution".to_string(),
-    args: dargs.to_vec().into(),
-  };
+  let dist_expr = unevaluated("ProbabilityDistribution", dargs);
   // Helper: numeric CDF evaluation at `x`.
   let cdf_at = |x: f64| -> Option<f64> {
     let val = cdf_ast(&[dist_expr.clone(), Expr::Real(x)]).ok()?;
@@ -1255,53 +1214,25 @@ fn pdf_probability_distribution(
   if dargs.len() != 2 {
     return Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "ProbabilityDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("ProbabilityDistribution", dargs), x].into(),
     });
   }
   let Expr::List(items) = &dargs[1] else {
     return Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "ProbabilityDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("ProbabilityDistribution", dargs), x].into(),
     });
   };
   if items.len() != 3 {
     return Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "ProbabilityDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("ProbabilityDistribution", dargs), x].into(),
     });
   }
   let Expr::Identifier(var) = &items[0] else {
     return Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "ProbabilityDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("ProbabilityDistribution", dargs), x].into(),
     });
   };
   let lo = items[1].clone();
@@ -1321,54 +1252,26 @@ fn cdf_probability_distribution(
   if dargs.len() != 2 {
     return Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "ProbabilityDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("ProbabilityDistribution", dargs), x].into(),
     });
   }
   let pdf = &dargs[0];
   let Expr::List(items) = &dargs[1] else {
     return Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "ProbabilityDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("ProbabilityDistribution", dargs), x].into(),
     });
   };
   if items.len() != 3 {
     return Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "ProbabilityDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("ProbabilityDistribution", dargs), x].into(),
     });
   }
   let Expr::Identifier(var) = &items[0] else {
     return Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "ProbabilityDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("ProbabilityDistribution", dargs), x].into(),
     });
   };
   let lo = items[1].clone();
@@ -1701,27 +1604,13 @@ fn pdf_binormal(dargs: &[Expr], xy: Expr) -> Result<Expr, InterpreterError> {
   let Expr::List(coords) = &xy else {
     return Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "BinormalDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        xy,
-      ]
-      .into(),
+      args: vec![unevaluated("BinormalDistribution", dargs), xy].into(),
     });
   };
   if coords.len() != 2 {
     return Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "BinormalDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        xy,
-      ]
-      .into(),
+      args: vec![unevaluated("BinormalDistribution", dargs), xy].into(),
     });
   }
   let x = coords[0].clone();
@@ -2000,18 +1889,12 @@ pub fn cdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       (name.as_str(), dargs.as_slice())
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "CDF".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("CDF", args));
     }
   };
 
   if args.len() == 1 {
-    return Ok(Expr::FunctionCall {
-      name: "CDF".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("CDF", args));
   }
 
   // CDF[MixtureDistribution[{w1, …}, {d1, …}], x] is the weight-normalized sum
@@ -2022,10 +1905,7 @@ pub fn cdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       super::statistics::mixture_weighted_component_quantity(dargs, |d| {
         cdf_ast(&[d.clone(), x.clone()])
       })?
-      .unwrap_or_else(|| Expr::FunctionCall {
-        name: "CDF".to_string(),
-        args: args.to_vec().into(),
-      }),
+      .unwrap_or_else(|| unevaluated("CDF", args)),
     );
   }
 
@@ -2084,14 +1964,7 @@ pub fn cdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Some(v) => v,
       None => Ok(Expr::FunctionCall {
         name: "CDF".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "DataDistribution".to_string(),
-            args: dargs.to_vec().into(),
-          },
-          x,
-        ]
-        .into(),
+        args: vec![unevaluated("DataDistribution", dargs), x].into(),
       }),
     },
     "UniformDistribution" => cdf_uniform(dargs, x),
@@ -2143,10 +2016,7 @@ pub fn cdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     "FRatioDistribution" => cdf_f_ratio(dargs, x),
     "WaringYuleDistribution" => cdf_waring_yule(dargs, x),
     "JohnsonDistribution" => cdf_johnson(dargs, x),
-    _ => Ok(Expr::FunctionCall {
-      name: "CDF".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("CDF", args)),
   }
 }
 
@@ -2944,10 +2814,7 @@ pub fn probability_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         args: vec![result].into(),
       });
     }
-    return Ok(Expr::FunctionCall {
-      name: "Probability".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Probability", args));
   }
 
   // Parse Distributed[var, dist] from the second argument
@@ -2958,17 +2825,11 @@ pub fn probability_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Expr::Identifier(v) = &dargs[0] {
         (v.as_str(), &dargs[1])
       } else {
-        return Ok(Expr::FunctionCall {
-          name: "Probability".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Probability", args));
       }
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Probability".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Probability", args));
     }
   };
 
@@ -3396,28 +3257,19 @@ pub fn expectation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             if let Expr::Identifier(n) = item {
               names.push(n.clone());
             } else {
-              return Ok(Expr::FunctionCall {
-                name: "Expectation".to_string(),
-                args: args.to_vec().into(),
-              });
+              return Ok(unevaluated("Expectation", args));
             }
           }
           names
         }
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "Expectation".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("Expectation", args));
         }
       };
       (vars, &dargs[1])
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Expectation".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Expectation", args));
     }
   };
 
@@ -3453,10 +3305,7 @@ pub fn expectation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let (dist_name, dargs) = match dist {
     Expr::FunctionCall { name, args: da } => (name.as_str(), da.as_slice()),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Expectation".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Expectation", args));
     }
   };
 
@@ -3498,10 +3347,7 @@ pub fn expectation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // For unsupported parameterizations (e.g. list-of-vars over a standard
   // distribution) just return unevaluated.
   if vars.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "Expectation".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Expectation", args));
   }
   let var_name = vars.into_iter().next().unwrap();
 
@@ -3869,10 +3715,7 @@ pub fn n_probability_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // If it stayed unevaluated, re-wrap as NProbability so the user sees the
   // numerical-evaluation request rather than the symbolic fallback.
   if matches!(&prob, Expr::FunctionCall { name, .. } if name == "Probability") {
-    return Ok(Expr::FunctionCall {
-      name: "NProbability".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("NProbability", args));
   }
   eval(Expr::FunctionCall {
     name: "N".to_string(),
@@ -3884,10 +3727,7 @@ pub fn n_probability_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn n_expectation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let exp = expectation_ast(args)?;
   if matches!(&exp, Expr::FunctionCall { name, .. } if name == "Expectation") {
-    return Ok(Expr::FunctionCall {
-      name: "NExpectation".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("NExpectation", args));
   }
   eval(Expr::FunctionCall {
     name: "N".to_string(),
@@ -5093,11 +4933,7 @@ pub fn distribution_mean_variance(
       // to the user. Provide an unevaluated stub so the tuple typechecks.
       let var = Expr::FunctionCall {
         name: "Variance".to_string(),
-        args: vec![Expr::FunctionCall {
-          name: "GompertzMakehamDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        }]
-        .into(),
+        args: vec![unevaluated("GompertzMakehamDistribution", dargs)].into(),
       };
       Ok((mean, var))
     }
@@ -5913,10 +5749,7 @@ fn expectation_numerical(
             name: "Distributed".to_string(),
             args: vec![
               Expr::Identifier(var.to_string()),
-              Expr::FunctionCall {
-                name: dist_name.to_string(),
-                args: dargs.to_vec().into(),
-              },
+              unevaluated(dist_name, dargs),
             ]
             .into(),
           },
@@ -5929,10 +5762,7 @@ fn expectation_numerical(
   // Numerical integration: E[f(x)] = integral f(x) * pdf(x) dx
   let dx = (hi - lo) / n_points as f64;
   let mut sum = 0.0;
-  let dist_expr = Expr::FunctionCall {
-    name: dist_name.to_string(),
-    args: dargs.to_vec().into(),
-  };
+  let dist_expr = unevaluated(dist_name, dargs);
 
   for i in 0..=n_points {
     let x = lo + i as f64 * dx;
@@ -7336,14 +7166,7 @@ fn cdf_failure_distribution(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "FailureDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("FailureDistribution", dargs), x].into(),
     })
   };
   // Compose against a symbolic variable (component CDFs keep their
@@ -7389,14 +7212,7 @@ fn pdf_failure_distribution(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "FailureDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("FailureDistribution", dargs), x].into(),
     })
   };
   // The derivative needs a symbolic variable to differentiate against.
@@ -7831,14 +7647,7 @@ fn pdf_first_passage(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "FirstPassageTimeDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("FirstPassageTimeDistribution", dargs), x].into(),
     })
   };
   let Some(f) = fptd_parts(dargs) else {
@@ -7866,14 +7675,7 @@ fn cdf_first_passage(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "FirstPassageTimeDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("FirstPassageTimeDistribution", dargs), x].into(),
     })
   };
   let Some(f) = fptd_parts(dargs) else {
@@ -8108,12 +7910,8 @@ fn wakeby_checked(dargs: &[Expr]) -> Option<()> {
     return None;
   }
   let num = crate::functions::math_ast::try_eval_to_f64;
-  let dist = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
-      name: "WakebyDistribution".to_string(),
-      args: dargs.to_vec().into(),
-    })
-  };
+  let dist =
+    || crate::syntax::expr_to_string(&unevaluated("WakebyDistribution", dargs));
   for pos in [0usize, 2] {
     if num(&dargs[pos]).is_some_and(|v| v <= 0.0) {
       crate::emit_message(&format!(
@@ -8160,14 +7958,7 @@ pub fn wakeby_quantile(
   let unevaluated = || {
     Ok(Expr::FunctionCall {
       name: "Quantile".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "WakebyDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        q.clone(),
-      ]
-      .into(),
+      args: vec![unevaluated("WakebyDistribution", dargs), q.clone()].into(),
     })
   };
   let Some(()) = wakeby_checked(dargs) else {
@@ -8335,10 +8126,10 @@ fn compound_poisson_mean_variance(
   }
   let num = crate::functions::math_ast::try_eval_to_f64;
   let dist_str = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
-      name: "CompoundPoissonDistribution".to_string(),
-      args: dargs.to_vec().into(),
-    })
+    crate::syntax::expr_to_string(&unevaluated(
+      "CompoundPoissonDistribution",
+      dargs,
+    ))
   };
   if num(&dargs[0]).is_some_and(|v| v <= 0.0) {
     crate::emit_message(&format!(
@@ -8397,12 +8188,8 @@ fn hoyt_checked(dargs: &[Expr]) -> Option<()> {
     return None;
   }
   let num = crate::functions::math_ast::try_eval_to_f64;
-  let dist = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
-      name: "HoytDistribution".to_string(),
-      args: dargs.to_vec().into(),
-    })
-  };
+  let dist =
+    || crate::syntax::expr_to_string(&unevaluated("HoytDistribution", dargs));
   if num(&dargs[0]).is_some_and(|v| !(v > 0.0 && v <= 1.0)) {
     crate::emit_message(&format!(
       "HoytDistribution::pprobprm: Parameter {} at position 1 in {} is expected to be positive and less than or equal to 1.",
@@ -8429,14 +8216,7 @@ fn hoyt_pdf(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "HoytDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("HoytDistribution", dargs), x].into(),
     })
   };
   let Some(()) = hoyt_checked(dargs) else {
@@ -8545,10 +8325,10 @@ fn variance_gamma_checked(dargs: &[Expr]) -> Option<()> {
   }
   let num = crate::functions::math_ast::try_eval_to_f64;
   let dist = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
-      name: "VarianceGammaDistribution".to_string(),
-      args: dargs.to_vec().into(),
-    })
+    crate::syntax::expr_to_string(&unevaluated(
+      "VarianceGammaDistribution",
+      dargs,
+    ))
   };
   for pos in 0..2 {
     if num(&dargs[pos]).is_some_and(|v| v <= 0.0) {
@@ -8583,14 +8363,7 @@ fn variance_gamma_pdf(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "VarianceGammaDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("VarianceGammaDistribution", dargs), x].into(),
     })
   };
   let Some(()) = variance_gamma_checked(dargs) else {
@@ -8750,10 +8523,10 @@ fn tsallis_checked(dargs: &[Expr]) -> Option<()> {
   }
   let num = crate::functions::math_ast::try_eval_to_f64;
   let dist = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
-      name: "TsallisQGaussianDistribution".to_string(),
-      args: dargs.to_vec().into(),
-    })
+    crate::syntax::expr_to_string(&unevaluated(
+      "TsallisQGaussianDistribution",
+      dargs,
+    ))
   };
   if num(&dargs[1]).is_some_and(|v| v <= 0.0) {
     crate::emit_message(&format!(
@@ -8898,14 +8671,7 @@ fn tsallis_qgaussian_pdf(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "TsallisQGaussianDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("TsallisQGaussianDistribution", dargs), x].into(),
     })
   };
   let Some(()) = tsallis_checked(dargs) else {
@@ -8974,14 +8740,7 @@ fn tsallis_qgaussian_cdf(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "TsallisQGaussianDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("TsallisQGaussianDistribution", dargs), x].into(),
     })
   };
   let Some(()) = tsallis_checked(dargs) else {
@@ -9106,14 +8865,7 @@ fn tukey_lambda_pdf_cdf(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: head.to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "TukeyLambdaDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("TukeyLambdaDistribution", dargs), x].into(),
     })
   };
   let Some(()) = tukey_lambda_checked(dargs) else {
@@ -9380,10 +9132,10 @@ fn hotelling_checked(dargs: &[Expr]) -> Option<()> {
         "HotellingTSquareDistribution::posprm: Parameter {} at position {} in {} is expected to be positive.",
         crate::syntax::expr_to_string(&dargs[pos]),
         pos + 1,
-        crate::syntax::expr_to_string(&Expr::FunctionCall {
-          name: "HotellingTSquareDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        })
+        crate::syntax::expr_to_string(&unevaluated(
+          "HotellingTSquareDistribution",
+          dargs
+        ))
       ));
       return None;
     }
@@ -9398,14 +9150,7 @@ fn pdf_hotelling(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "HotellingTSquareDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("HotellingTSquareDistribution", dargs), x].into(),
     })
   };
   let Some(()) = hotelling_checked(dargs) else {
@@ -9500,14 +9245,7 @@ fn cdf_hotelling(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "HotellingTSquareDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("HotellingTSquareDistribution", dargs), x].into(),
     })
   };
   let Some(()) = hotelling_checked(dargs) else {
@@ -9631,12 +9369,8 @@ fn benini_checked(dargs: &[Expr]) -> Option<()> {
     return None;
   }
   let num = crate::functions::math_ast::try_eval_to_f64;
-  let dist = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
-      name: "BeniniDistribution".to_string(),
-      args: dargs.to_vec().into(),
-    })
-  };
+  let dist =
+    || crate::syntax::expr_to_string(&unevaluated("BeniniDistribution", dargs));
   for pos in 0..2 {
     if num(&dargs[pos]).is_some_and(|v| v < 0.0) {
       crate::emit_message(&format!(
@@ -9674,14 +9408,7 @@ fn pdf_benini(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "BeniniDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("BeniniDistribution", dargs), x].into(),
     })
   };
   let Some(()) = benini_checked(dargs) else {
@@ -9733,14 +9460,7 @@ fn cdf_benini(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "BeniniDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("BeniniDistribution", dargs), x].into(),
     })
   };
   let Some(()) = benini_checked(dargs) else {
@@ -9876,10 +9596,10 @@ fn vonmises_checked(dargs: &[Expr]) -> Option<()> {
     crate::emit_message(&format!(
       "VonMisesDistribution::nnegprm: Parameter {} at position 2 in {} is expected to be non-negative.",
       crate::syntax::expr_to_string(&dargs[1]),
-      crate::syntax::expr_to_string(&Expr::FunctionCall {
-        name: "VonMisesDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      })
+      crate::syntax::expr_to_string(&unevaluated(
+        "VonMisesDistribution",
+        dargs
+      ))
     ));
     return None;
   }
@@ -9893,14 +9613,7 @@ fn pdf_vonmises(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "VonMisesDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("VonMisesDistribution", dargs), x].into(),
     })
   };
   let Some(()) = vonmises_checked(dargs) else {
@@ -9946,10 +9659,10 @@ fn hyperexponential_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
     return None;
   };
   let dist = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
-      name: "HyperexponentialDistribution".to_string(),
-      args: dargs.to_vec().into(),
-    })
+    crate::syntax::expr_to_string(&unevaluated(
+      "HyperexponentialDistribution",
+      dargs,
+    ))
   };
   if probs.len() != rates.len() {
     crate::emit_message(&format!(
@@ -10031,14 +9744,7 @@ fn pdf_hyperexponential(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "HyperexponentialDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("HyperexponentialDistribution", dargs), x].into(),
     })
   };
   let Some((probs, rates)) = hyperexponential_checked(dargs) else {
@@ -10073,14 +9779,7 @@ fn cdf_hyperexponential(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "HyperexponentialDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("HyperexponentialDistribution", dargs), x].into(),
     })
   };
   let Some((probs, rates)) = hyperexponential_checked(dargs) else {
@@ -10153,12 +9852,8 @@ fn coxian_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
   let [Expr::List(alphas), Expr::List(rates)] = dargs else {
     return None;
   };
-  let dist = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
-      name: "CoxianDistribution".to_string(),
-      args: dargs.to_vec().into(),
-    })
-  };
+  let dist =
+    || crate::syntax::expr_to_string(&unevaluated("CoxianDistribution", dargs));
   if rates.len() != alphas.len() + 1 {
     crate::emit_message(&format!(
       "CoxianDistribution::eqln2: The length of {} at position 2 should be 1 more than the length of {} at position 1 in {}.",
@@ -10382,14 +10077,7 @@ fn pdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "CoxianDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("CoxianDistribution", dargs), x].into(),
     })
   };
   let Some((alphas, rates)) = coxian_checked(dargs) else {
@@ -10449,24 +10137,17 @@ fn pdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 /// rates. The all-equal form reproduces wolframscript's Piecewise
 /// default of 1 (a WS quirk: CDF[..., -1] is 1 there).
 fn cdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
-  let unevaluated = |x: Expr| {
+  let uneval = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "CoxianDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("CoxianDistribution", dargs), x].into(),
     })
   };
   let Some((alphas, rates)) = coxian_checked(dargs) else {
-    return unevaluated(x);
+    return uneval(x);
   };
   let Some(distinct) = coxian_rate_layout(&alphas, &rates) else {
-    return unevaluated(x);
+    return uneval(x);
   };
   let mut terms: Vec<Expr> = vec![int(1)];
   let default;
@@ -10493,10 +10174,7 @@ fn cdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       for f in 2..=j {
         fact = times(fact, int(f as i128));
       }
-      let wsum = Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: weights[j..].to_vec().into(),
-      };
+      let wsum = unevaluated("Plus", &weights[j..]);
       let c = eval(times(
         int(-1),
         divide(times(wsum, power(lam.clone(), int(j as i128))), fact),
@@ -10588,14 +10266,7 @@ fn pdf_hypoexponential(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "HypoexponentialDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("HypoexponentialDistribution", dargs), x].into(),
     })
   };
   let Some(rates) = hypoexponential_distinct_rates(dargs) else {
@@ -10629,14 +10300,7 @@ fn cdf_hypoexponential(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "HypoexponentialDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("HypoexponentialDistribution", dargs), x].into(),
     })
   };
   let Some(rates) = hypoexponential_distinct_rates(dargs) else {
@@ -10700,14 +10364,8 @@ fn pdf_negative_multinomial(
       // A point of the wrong shape stays unevaluated, as in wolframscript.
       return Ok(Expr::FunctionCall {
         name: "PDF".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "NegativeMultinomialDistribution".to_string(),
-            args: dargs.to_vec().into(),
-          },
-          x,
-        ]
-        .into(),
+        args: vec![unevaluated("NegativeMultinomialDistribution", dargs), x]
+          .into(),
       });
     }
   };
@@ -10768,14 +10426,8 @@ fn cdf_negative_multinomial(
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "CDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "NegativeMultinomialDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("NegativeMultinomialDistribution", dargs), x]
+        .into(),
     })
   };
   let Ok((n, probs)) = negative_multinomial_params(dargs) else {
@@ -10864,14 +10516,8 @@ fn pdf_multivariate_poisson(
     _ => {
       return Ok(Expr::FunctionCall {
         name: "PDF".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "MultivariatePoissonDistribution".to_string(),
-            args: dargs.to_vec().into(),
-          },
-          x,
-        ]
-        .into(),
+        args: vec![unevaluated("MultivariatePoissonDistribution", dargs), x]
+          .into(),
       });
     }
   };
@@ -11053,10 +10699,10 @@ pub fn wishart_mean_variance(
   dargs: &[Expr],
 ) -> Result<(Expr, Expr), InterpreterError> {
   let dist_str = || {
-    crate::syntax::expr_to_string(&Expr::FunctionCall {
-      name: "WishartMatrixDistribution".to_string(),
-      args: dargs.to_vec().into(),
-    })
+    crate::syntax::expr_to_string(&unevaluated(
+      "WishartMatrixDistribution",
+      dargs,
+    ))
   };
   let fail = |msg: String| -> Result<(Expr, Expr), InterpreterError> {
     crate::emit_message(&msg);
@@ -11237,10 +10883,7 @@ fn dirichlet_alphas(
 
 /// The Dirichlet normalizing total α0 = α1 + … + α(k+1), unevaluated.
 fn dirichlet_total(alphas: &[Expr]) -> Expr {
-  Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: alphas.to_vec().into(),
-  }
+  unevaluated("Plus", alphas)
 }
 
 /// The common denominator of the Dirichlet second moments,
@@ -11321,14 +10964,7 @@ fn pdf_dirichlet(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |x: Expr| {
     Ok(Expr::FunctionCall {
       name: "PDF".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "DirichletDistribution".to_string(),
-          args: dargs.to_vec().into(),
-        },
-        x,
-      ]
-      .into(),
+      args: vec![unevaluated("DirichletDistribution", dargs), x].into(),
     })
   };
   let alphas = dirichlet_alphas(dargs)?;
@@ -11514,14 +11150,7 @@ fn pdf_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     _ => {
       return Ok(Expr::FunctionCall {
         name: "PDF".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "StableDistribution".to_string(),
-            args: dargs.to_vec().into(),
-          },
-          x,
-        ]
-        .into(),
+        args: vec![unevaluated("StableDistribution", dargs), x].into(),
       });
     }
   };
@@ -11552,14 +11181,7 @@ fn pdf_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // General case: return unevaluated
   Ok(Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "StableDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("StableDistribution", dargs), x].into(),
   })
 }
 
@@ -11583,14 +11205,7 @@ fn cdf_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     _ => {
       return Ok(Expr::FunctionCall {
         name: "CDF".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "StableDistribution".to_string(),
-            args: dargs.to_vec().into(),
-          },
-          x,
-        ]
-        .into(),
+        args: vec![unevaluated("StableDistribution", dargs), x].into(),
       });
     }
   };
@@ -11616,14 +11231,7 @@ fn cdf_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // General case: return unevaluated
   Ok(Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "StableDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("StableDistribution", dargs), x].into(),
   })
 }
 
@@ -11839,14 +11447,7 @@ fn pdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     _ => {
       return Ok(Expr::FunctionCall {
         name: "PDF".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "JohnsonDistribution".to_string(),
-            args: dargs.to_vec().into(),
-          },
-          x,
-        ]
-        .into(),
+        args: vec![unevaluated("JohnsonDistribution", dargs), x].into(),
       });
     }
   };
@@ -11987,14 +11588,7 @@ fn cdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     _ => {
       return Ok(Expr::FunctionCall {
         name: "CDF".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "JohnsonDistribution".to_string(),
-            args: dargs.to_vec().into(),
-          },
-          x,
-        ]
-        .into(),
+        args: vec![unevaluated("JohnsonDistribution", dargs), x].into(),
       });
     }
   };
@@ -12273,27 +11867,24 @@ fn contains_variable(expr: &Expr, var: &str) -> bool {
 /// distributions; symbolic observations (which wolframscript wraps in
 /// domain Piecewise conditions) stay unevaluated.
 pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "LogLikelihood".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("LogLikelihood", args);
   if args.len() != 2 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let (dist_name, dargs) = match &args[0] {
     Expr::FunctionCall { name, args } => (name.as_str(), args.as_slice()),
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   };
   let data = match &args[1] {
     Expr::List(items) if !items.is_empty() => items,
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   };
   let is_numeric = |e: &Expr| {
     matches!(e, Expr::Integer(_) | Expr::Real(_))
       || matches!(e, Expr::FunctionCall { name, .. } if name == "Rational")
   };
   if !data.iter().all(is_numeric) {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let n = data.len() as i128;
 
@@ -12301,12 +11892,8 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     name: "Log".to_string(),
     args: vec![e].into(),
   };
-  let sum_expr = || -> Result<Expr, InterpreterError> {
-    eval(Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: data.to_vec().into(),
-    })
-  };
+  let sum_expr =
+    || -> Result<Expr, InterpreterError> { eval(unevaluated("Plus", data)) };
 
   match (dist_name, dargs) {
     // n*Log[a] - a*Sum[x]
@@ -12323,7 +11910,7 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         .iter()
         .all(|e| matches!(e, Expr::Integer(v) if *v >= 0))
       {
-        return Ok(unevaluated(args));
+        return Ok(uneval());
       }
       let total = sum_expr()?;
       let mut terms =
@@ -12354,7 +11941,7 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         .filter(|e| matches!(e, Expr::Integer(0)))
         .count() as i128;
       if ones + zeros != n {
-        return Ok(unevaluated(args));
+        return Ok(uneval());
       }
       // Evaluate each term individually but keep the raw Plus order
       // (Log[1 - p] first): full evaluation reorders the sum away from
@@ -12407,7 +11994,7 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       );
       eval(result)
     }
-    _ => Ok(unevaluated(args)),
+    _ => Ok(uneval()),
   }
 }
 
@@ -12710,10 +12297,8 @@ fn polynomial_expectation(
 pub fn transformed_distribution_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "TransformedDistribution".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated =
+    |args: &[Expr]| unevaluated("TransformedDistribution", args);
   if args.len() != 2 {
     return Ok(unevaluated(args));
   }
@@ -12822,14 +12407,7 @@ fn frac_to_rational_expr(f: (i128, i128)) -> Expr {
 fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = || Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "MultinormalDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x.clone(),
-    ]
-    .into(),
+    args: vec![unevaluated("MultinormalDistribution", dargs), x.clone()].into(),
   };
   let (mu, sigma) = match dargs {
     [Expr::List(mu), Expr::List(rows)] => (mu, rows),
@@ -12999,10 +12577,7 @@ fn frac_cmp(a: (i128, i128), b: (i128, i128)) -> std::cmp::Ordering {
 pub fn empirical_distribution_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "EmpiricalDistribution".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("EmpiricalDistribution", args);
   if args.len() != 1 {
     return Ok(unevaluated(args));
   }
@@ -13092,12 +12667,7 @@ fn frac_expr((n, d): (i128, i128)) -> Expr {
 pub fn histogram_distribution_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "HistogramDistribution".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("HistogramDistribution", args));
   let (data, width_spec) = match args {
     [Expr::List(d)] if !d.is_empty() => (d, None),
     [Expr::List(d), Expr::List(spec)] if !d.is_empty() && spec.len() == 1 => {
@@ -13535,14 +13105,7 @@ fn pdf_product_distribution(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = || Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "ProductDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x.clone(),
-    ]
-    .into(),
+    args: vec![unevaluated("ProductDistribution", dargs), x.clone()].into(),
   };
   let vars = match &x {
     Expr::List(vars) if vars.len() == dargs.len() => vars,
@@ -13887,14 +13450,7 @@ fn coeff_power_term(num: i128, den: i128, base: &Expr, i: i128) -> Expr {
 fn pdf_uniform_sum(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "UniformSumDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("UniformSumDistribution", dargs), x].into(),
   };
   let Some(n) = uniform_sum_n(dargs) else {
     return Ok(unevaluated(dargs, x));
@@ -13960,14 +13516,7 @@ fn pdf_uniform_sum(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_uniform_sum(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "UniformSumDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("UniformSumDistribution", dargs), x].into(),
   };
   let Some(n) = uniform_sum_n(dargs) else {
     return Ok(unevaluated(dargs, x));
@@ -14111,14 +13660,7 @@ fn pdf_beta_binomial(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BetaBinomialDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BetaBinomialDistribution", dargs), x].into(),
   };
   if dargs.len() != 3 {
     return Ok(unevaluated(dargs, x));
@@ -14212,14 +13754,7 @@ fn cdf_beta_binomial(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BetaBinomialDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BetaBinomialDistribution", dargs), x].into(),
   };
   if dargs.len() != 3 {
     return Ok(unevaluated(dargs, x));
@@ -14275,14 +13810,7 @@ fn beta_prime_general_body(
 fn pdf_beta_prime(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BetaPrimeDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BetaPrimeDistribution", dargs), x].into(),
   };
   // Generalized forms: BetaPrimeDistribution[p, q, s] (power 1, scale s) and
   // BetaPrimeDistribution[p, q, b, a] (power b, scale a).
@@ -14408,14 +13936,7 @@ fn pdf_beta_prime(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_beta_prime(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BetaPrimeDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BetaPrimeDistribution", dargs), x].into(),
   };
   // Generalized forms: CDF = BetaRegularized[x^w/(s^w + x^w), p, q] with power
   // w and scale s (w = 1 for the 3-argument form).
@@ -14496,14 +14017,7 @@ fn pdf_noncentral_chi_square(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "NoncentralChiSquareDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("NoncentralChiSquareDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
     return Ok(unevaluated(dargs, x));
@@ -14721,14 +14235,7 @@ fn cdf_noncentral_chi_square(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "NoncentralChiSquareDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("NoncentralChiSquareDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
     return Ok(unevaluated(dargs, x));
@@ -14786,14 +14293,7 @@ fn pdf_exponential_power(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "ExponentialPowerDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("ExponentialPowerDistribution", dargs), x].into(),
   };
   if dargs.len() != 3 || !matches!(&x, Expr::Identifier(_)) {
     return Ok(unevaluated(dargs, x));
@@ -14893,14 +14393,7 @@ fn cdf_exponential_power(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "ExponentialPowerDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("ExponentialPowerDistribution", dargs), x].into(),
   };
   if dargs.len() != 3 || !matches!(&x, Expr::Identifier(_)) {
     return Ok(unevaluated(dargs, x));
@@ -14978,14 +14471,7 @@ fn rice_numeric(e: &Expr) -> Option<f64> {
 fn pdf_rice(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "RiceDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("RiceDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
     return Ok(unevaluated(dargs, x));
@@ -15043,14 +14529,7 @@ fn pdf_rice(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_rice(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "RiceDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("RiceDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
     return Ok(unevaluated(dargs, x));
@@ -15374,14 +14853,7 @@ fn ms_z(a: &Expr, b: &Expr, x: &Expr) -> Expr {
 fn pdf_min_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "MinStableDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("MinStableDistribution", dargs), x].into(),
   };
   if dargs.len() != 3 {
     return Ok(unevaluated(dargs, x));
@@ -15530,14 +15002,7 @@ fn pdf_min_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_min_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "MinStableDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("MinStableDistribution", dargs), x].into(),
   };
   if dargs.len() != 3 {
     return Ok(unevaluated(dargs, x));
@@ -15842,14 +15307,7 @@ fn msx_z(a: &Expr, b: &Expr, x: &Expr) -> Expr {
 fn pdf_max_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "MaxStableDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("MaxStableDistribution", dargs), x].into(),
   };
   if dargs.len() != 3 {
     return Ok(unevaluated(dargs, x));
@@ -15990,14 +15448,7 @@ fn pdf_max_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_max_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "MaxStableDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("MaxStableDistribution", dargs), x].into(),
   };
   if dargs.len() != 3 {
     return Ok(unevaluated(dargs, x));
@@ -16204,14 +15655,7 @@ fn triangular_params(
 fn pdf_triangular(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "TriangularDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("TriangularDistribution", dargs), x].into(),
   };
   let Some((a, b, c)) = triangular_params(dargs)? else {
     return Ok(unevaluated(dargs, x));
@@ -16330,14 +15774,7 @@ fn pdf_triangular(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_triangular(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "TriangularDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("TriangularDistribution", dargs), x].into(),
   };
   let Some((a, b, c)) = triangular_params(dargs)? else {
     return Ok(unevaluated(dargs, x));
@@ -16607,14 +16044,7 @@ fn maxwell_rational(e: &Expr) -> Option<(i128, i128)> {
 fn pdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "MaxwellDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("MaxwellDistribution", dargs), x].into(),
   };
   if dargs.len() != 1 {
     return Ok(unevaluated(dargs, x));
@@ -16687,14 +16117,7 @@ fn pdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "MaxwellDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("MaxwellDistribution", dargs), x].into(),
   };
   if dargs.len() != 1 {
     return Ok(unevaluated(dargs, x));
@@ -16800,14 +16223,7 @@ fn pdf_birnbaum_saunders(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BirnbaumSaundersDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BirnbaumSaundersDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
     return Ok(unevaluated(dargs, x));
@@ -16861,14 +16277,7 @@ fn cdf_birnbaum_saunders(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BirnbaumSaundersDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BirnbaumSaundersDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
     return Ok(unevaluated(dargs, x));
@@ -16910,14 +16319,7 @@ fn cdf_birnbaum_saunders(
 fn pdf_levy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "LevyDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("LevyDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
     return Ok(unevaluated(dargs, x));
@@ -16961,14 +16363,7 @@ fn pdf_levy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_levy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "LevyDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("LevyDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
     return Ok(unevaluated(dargs, x));
@@ -17006,14 +16401,7 @@ fn cdf_levy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn pdf_lindley(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "LindleyDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("LindleyDistribution", dargs), x].into(),
   };
   if dargs.len() != 1 {
     return Ok(unevaluated(dargs, x));
@@ -17046,14 +16434,7 @@ fn pdf_lindley(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_lindley(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "LindleyDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("LindleyDistribution", dargs), x].into(),
   };
   if dargs.len() != 1 {
     return Ok(unevaluated(dargs, x));
@@ -17132,14 +16513,7 @@ fn pdf_wigner_semicircle(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "WignerSemicircleDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("WignerSemicircleDistribution", dargs), x].into(),
   };
   let Some((a, r)) = wigner_params(dargs) else {
     return Ok(unevaluated(dargs, x));
@@ -17216,14 +16590,7 @@ fn cdf_wigner_semicircle(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "WignerSemicircleDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("WignerSemicircleDistribution", dargs), x].into(),
   };
   let Some((a, r)) = wigner_params(dargs) else {
     return Ok(unevaluated(dargs, x));
@@ -17384,14 +16751,7 @@ fn sech_arg(m: &Expr, s: &Expr, x: &Expr) -> Result<Expr, InterpreterError> {
 fn pdf_sech(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "SechDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("SechDistribution", dargs), x].into(),
   };
   let Some((m, s)) = sech_params(dargs) else {
     return Ok(unevaluated(dargs, x));
@@ -17415,14 +16775,7 @@ fn pdf_sech(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_sech(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "SechDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("SechDistribution", dargs), x].into(),
   };
   let Some((m, s)) = sech_params(dargs) else {
     return Ok(unevaluated(dargs, x));
@@ -17468,14 +16821,7 @@ fn sech_mean_variance(
 fn pdf_moyal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "MoyalDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("MoyalDistribution", dargs), x].into(),
   };
   let (m, s) = match dargs {
     [] => (int(0), int(1)),
@@ -17586,14 +16932,7 @@ fn pdf_moyal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_moyal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "MoyalDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("MoyalDistribution", dargs), x].into(),
   };
   let (m, s) = match dargs {
     [] => (int(0), int(1)),
@@ -17687,14 +17026,7 @@ pub fn moyal_mean_variance(
 fn pdf_borel_tanner(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BorelTannerDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BorelTannerDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
     return Ok(unevaluated(dargs, x));
@@ -17874,27 +17206,17 @@ fn pdf_benktander_gibrat(
   dargs: &[Expr],
   x: Expr,
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
+  let uneval = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BenktanderGibratDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BenktanderGibratDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
-    return Ok(unevaluated(dargs, x));
+    return Ok(uneval(dargs, x));
   }
   let (a, b) = (dargs[0].clone(), dargs[1].clone());
-  let dist = Expr::FunctionCall {
-    name: "BenktanderGibratDistribution".to_string(),
-    args: dargs.to_vec().into(),
-  };
+  let dist = unevaluated("BenktanderGibratDistribution", dargs);
   if !benktander_valid(&a, &b, &dist)? {
-    return Ok(unevaluated(dargs, x));
+    return Ok(uneval(dargs, x));
   }
   let call = |name: &str, args: Vec<Expr>| Expr::FunctionCall {
     name: name.to_string(),
@@ -17905,7 +17227,7 @@ fn pdf_benktander_gibrat(
 
   if ms_numeric(&x).is_some() {
     if !numeric {
-      return Ok(unevaluated(dargs, x));
+      return Ok(uneval(dargs, x));
     }
     if ms_numeric(&x).is_some_and(|v| v < 1.0) {
       return Ok(int(0));
@@ -17945,7 +17267,7 @@ fn pdf_benktander_gibrat(
     });
   }
   if !matches!(&x, Expr::Identifier(_)) {
-    return Ok(unevaluated(dargs, x));
+    return Ok(uneval(dargs, x));
   }
 
   // t1 = -2 b/a; f1 = 1 + a + 2 b Log[x]; f2 = 1 + 2 b Log[x]/a
@@ -18021,27 +17343,17 @@ fn cdf_benktander_gibrat(
   dargs: &[Expr],
   x: Expr,
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
+  let uneval = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BenktanderGibratDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BenktanderGibratDistribution", dargs), x].into(),
   };
   if dargs.len() != 2 {
-    return Ok(unevaluated(dargs, x));
+    return Ok(uneval(dargs, x));
   }
   let (a, b) = (dargs[0].clone(), dargs[1].clone());
-  let dist = Expr::FunctionCall {
-    name: "BenktanderGibratDistribution".to_string(),
-    args: dargs.to_vec().into(),
-  };
+  let dist = unevaluated("BenktanderGibratDistribution", dargs);
   if !benktander_valid(&a, &b, &dist)? {
-    return Ok(unevaluated(dargs, x));
+    return Ok(uneval(dargs, x));
   }
   let call = |name: &str, args: Vec<Expr>| Expr::FunctionCall {
     name: name.to_string(),
@@ -18097,7 +17409,7 @@ fn cdf_benktander_gibrat(
   };
   if ms_numeric(&x).is_some() {
     if !numeric {
-      return Ok(unevaluated(dargs, x));
+      return Ok(uneval(dargs, x));
     }
     if ms_numeric(&x).is_some_and(|v| v < 1.0) {
       return Ok(int(0));
@@ -18105,7 +17417,7 @@ fn cdf_benktander_gibrat(
     return eval(body(&x)?);
   }
   if !matches!(&x, Expr::Identifier(_)) {
-    return Ok(unevaluated(dargs, x));
+    return Ok(uneval(dargs, x));
   }
   let cond = comparison(x.clone(), ComparisonOp::GreaterEqual, int(1));
   Ok(piecewise(vec![(body(&x)?, cond)], int(0)))
@@ -18200,21 +17512,14 @@ fn benktander_gibrat_mean_variance(
 /// PDF[GumbelDistribution[a, b], x] = E^(-E^z + z)/b with
 /// z = (x - a)/b (the minimum-extreme-value Gumbel; [] is (0, 1)).
 fn pdf_gumbel(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
-  let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
+  let uneval = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "GumbelDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("GumbelDistribution", dargs), x].into(),
   };
   let (a, b) = match dargs {
     [] => (int(0), int(1)),
     [a, b] => (a.clone(), b.clone()),
-    _ => return Ok(unevaluated(dargs, x)),
+    _ => return Ok(uneval(dargs, x)),
   };
   let call = |name: &str, args: Vec<Expr>| Expr::FunctionCall {
     name: name.to_string(),
@@ -18262,7 +17567,7 @@ fn pdf_gumbel(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     return eval(body(&x)?);
   }
   if !matches!(&x, Expr::Identifier(_)) {
-    return Ok(unevaluated(dargs, x));
+    return Ok(uneval(dargs, x));
   }
   body(&x)
 }
@@ -18271,14 +17576,7 @@ fn pdf_gumbel(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_gumbel(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "GumbelDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("GumbelDistribution", dargs), x].into(),
   };
   let (a, b) = match dargs {
     [] => (int(0), int(1)),
@@ -18370,14 +17668,7 @@ fn gumbel_mean_variance(
 fn pdf_zipf(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "ZipfDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("ZipfDistribution", dargs), x].into(),
   };
   let (n, r) = match dargs {
     [r] => (None, r.clone()),
@@ -18561,14 +17852,7 @@ fn zipf_mean_variance(
 fn pdf_benford(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BenfordDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BenfordDistribution", dargs), x].into(),
   };
   let [b] = dargs else {
     return Ok(unevaluated(dargs, x));
@@ -18616,14 +17900,7 @@ fn pdf_benford(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_benford(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BenfordDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BenfordDistribution", dargs), x].into(),
   };
   let [b] = dargs else {
     return Ok(unevaluated(dargs, x));
@@ -18745,14 +18022,7 @@ fn pdf_benktander_weibull(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "PDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BenktanderWeibullDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BenktanderWeibullDistribution", dargs), x].into(),
   };
   let [a, b] = dargs else {
     return Ok(unevaluated(dargs, x));
@@ -18804,14 +18074,7 @@ fn cdf_benktander_weibull(
 ) -> Result<Expr, InterpreterError> {
   let unevaluated = |dargs: &[Expr], x: Expr| Expr::FunctionCall {
     name: "CDF".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "BenktanderWeibullDistribution".to_string(),
-        args: dargs.to_vec().into(),
-      },
-      x,
-    ]
-    .into(),
+    args: vec![unevaluated("BenktanderWeibullDistribution", dargs), x].into(),
   };
   let [a, b] = dargs else {
     return Ok(unevaluated(dargs, x));

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, Expr, ExprForm, UnaryOperator, expr_to_string,
+  BinaryOperator, Expr, ExprForm, UnaryOperator, expr_to_string, unevaluated,
 };
 use num_bigint::BigInt;
 use num_bigint::Sign;
@@ -240,10 +240,7 @@ pub fn abs_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     return Ok(args[0].clone());
   }
-  Ok(Expr::FunctionCall {
-    name: "Abs".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Abs", args))
 }
 
 /// True iff `expr` mentions the imaginary unit `I` (either as the symbol
@@ -787,10 +784,7 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: vec![sign_base, exp.clone()].into(),
     });
   }
-  Ok(Expr::FunctionCall {
-    name: "Sign".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Sign", args))
 }
 
 /// Extract the largest easily-found perfect-square factor from a non-negative
@@ -1273,10 +1267,7 @@ fn extract_int_coeff(term: &Expr) -> Option<(i128, Expr)> {
         let base = if args.len() == 2 {
           args[1].clone()
         } else {
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: args[1..].to_vec().into(),
-          }
+          unevaluated("Times", &args[1..])
         };
         Some((*n, base))
       } else {
@@ -1519,19 +1510,13 @@ pub fn surd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         -((-x).powf(1.0 / n))
       } else if x < 0.0 {
         // Even root of negative number - return symbolic
-        return Ok(Expr::FunctionCall {
-          name: "Surd".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Surd", args));
       } else {
         x.powf(1.0 / n)
       };
       Ok(num_to_expr(result))
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "Surd".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("Surd", args)),
   }
 }
 
@@ -1738,10 +1723,7 @@ pub fn floor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else if let Some(r) = try_symbolic_complex_rounding(&args[0], floor_ast) {
     Ok(r)
   } else {
-    Ok(Expr::FunctionCall {
-      name: "Floor".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("Floor", args))
   }
 }
 
@@ -1806,10 +1788,7 @@ pub fn ceiling_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else if let Some(r) = try_symbolic_complex_rounding(&args[0], ceiling_ast) {
     Ok(r)
   } else {
-    Ok(Expr::FunctionCall {
-      name: "Ceiling".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("Ceiling", args))
   }
 }
 
@@ -2082,10 +2061,7 @@ pub fn round_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       return Ok(Expr::Real(rounded));
     }
-    return Ok(Expr::FunctionCall {
-      name: "Round".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Round", args));
   }
   // Complex[re, im]: round real and imaginary parts separately
   if let Expr::FunctionCall { name, args: cargs } = &args[0]
@@ -2130,10 +2106,7 @@ pub fn round_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else if let Some(r) = try_symbolic_complex_rounding(&args[0], round_ast) {
     Ok(r)
   } else {
-    Ok(Expr::FunctionCall {
-      name: "Round".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("Round", args))
   }
 }
 
@@ -2526,10 +2499,7 @@ pub fn quotient_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       is_literal_zero(&args[0])
     };
-    let call = expr_to_string(&Expr::FunctionCall {
-      name: "Quotient".to_string(),
-      args: args.to_vec().into(),
-    });
+    let call = expr_to_string(&unevaluated("Quotient", args));
     if numerator_is_zero {
       crate::emit_message(&format!(
         "Quotient::indet: Indeterminate expression {call} encountered."
@@ -2574,10 +2544,7 @@ pub fn quotient_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       return Ok(Expr::Integer(((a - c) / b).floor() as i128));
     }
-    return Ok(Expr::FunctionCall {
-      name: "Quotient".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Quotient", args));
   }
 
   // 2-argument form: Quotient[n, m] = Floor[n / m]
@@ -2656,10 +2623,7 @@ pub fn quotient_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         crate::evaluator::evaluate_expr_to_expr(&round_quot)
       } else {
-        Ok(Expr::FunctionCall {
-          name: "Quotient".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("Quotient", args))
       }
     }
   }
@@ -2686,12 +2650,7 @@ pub fn clip_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::List(results?.into()));
   }
 
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "Clip".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("Clip", args));
 
   // Special values that don't compare like an ordinary real.
   match &args[0] {
@@ -2794,10 +2753,7 @@ pub fn integer_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(k) => BigInt::from(*k),
     Expr::BigInteger(k) => k.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "IntegerExponent".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("IntegerExponent", args));
     }
   };
   let base: BigInt = if args.len() == 2 {
@@ -2807,10 +2763,7 @@ pub fn integer_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // A non-integer base is invalid: emit IntegerExponent::ibase.
       _ => {
         emit_integer_exponent_ibase(&args[1]);
-        return Ok(Expr::FunctionCall {
-          name: "IntegerExponent".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("IntegerExponent", args));
       }
     }
   } else {
@@ -2823,10 +2776,7 @@ pub fn integer_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // invalid; the default base 10 is always valid.
   if args.len() == 2 && base <= BigInt::from(1) {
     emit_integer_exponent_ibase(&args[1]);
-    return Ok(Expr::FunctionCall {
-      name: "IntegerExponent".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("IntegerExponent", args));
   }
 
   if n.is_zero() {
@@ -2964,10 +2914,7 @@ pub fn integer_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Truncate towards zero
         return Ok(Expr::Integer(n / d));
       }
-      Ok(Expr::FunctionCall {
-        name: "IntegerPart".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("IntegerPart", args))
     }
     _ => {
       if let Some(f) = try_eval_to_f64(&args[0]) {
@@ -2977,10 +2924,7 @@ pub fn integer_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         Ok(r)
       } else {
-        Ok(Expr::FunctionCall {
-          name: "IntegerPart".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("IntegerPart", args))
       }
     }
   }
@@ -3088,10 +3032,7 @@ pub fn fractional_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         return Ok(make_rational(frac_n, *d));
       }
-      Ok(Expr::FunctionCall {
-        name: "FractionalPart".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("FractionalPart", args))
     }
     _ => {
       // For symbolic expressions that contain no Real/BigFloat literal but
@@ -3145,10 +3086,7 @@ pub fn fractional_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Ok(Expr::Real(frac))
         }
       } else {
-        Ok(Expr::FunctionCall {
-          name: "FractionalPart".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("FractionalPart", args))
       }
     }
   }
@@ -3182,10 +3120,7 @@ pub fn chop_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match try_eval_to_f64(&args[1]) {
       Some(t) => t,
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "Chop".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Chop", args));
       }
     }
   } else {
@@ -3388,10 +3323,7 @@ pub fn subdivide_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // 3.0). A concrete number that is not a positive integer triggers the
   // Subdivide::sdmint message and leaves the call unevaluated; a symbolic n is
   // left unevaluated silently.
-  let unevaluated = || Expr::FunctionCall {
-    name: "Subdivide".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("Subdivide", args);
   let n_val = match &n_expr {
     Expr::Integer(n) if *n > 0 => *n,
     Expr::BigInteger(b) => {
@@ -3402,9 +3334,9 @@ pub fn subdivide_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           crate::emit_message(&format!(
             "Subdivide::sdmint: The number of subdivisions given in position {} of {} should be a positive machine-sized integer.",
             args.len(),
-            crate::syntax::format_expr(&unevaluated(), ExprForm::Output)
+            crate::syntax::format_expr(&uneval(), ExprForm::Output)
           ));
-          return Ok(unevaluated());
+          return Ok(uneval());
         }
       }
     }
@@ -3417,12 +3349,12 @@ pub fn subdivide_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::emit_message(&format!(
         "Subdivide::sdmint: The number of subdivisions given in position {} of {} should be a positive machine-sized integer.",
         args.len(),
-        crate::syntax::format_expr(&unevaluated(), ExprForm::Output)
+        crate::syntax::format_expr(&uneval(), ExprForm::Output)
       ));
-      return Ok(unevaluated());
+      return Ok(uneval());
     }
     // Symbolic n: leave unevaluated without a message.
-    _ => return Ok(unevaluated()),
+    _ => return Ok(uneval()),
   };
 
   // Fast path: both endpoints are integers
@@ -3444,10 +3376,7 @@ pub fn subdivide_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Both must be lists of the same length
     if let (Expr::List(xmin_items), Expr::List(xmax_items)) = (&xmin, &xmax) {
       if xmin_items.len() != xmax_items.len() {
-        return Ok(Expr::FunctionCall {
-          name: "Subdivide".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Subdivide", args));
       }
       let dim = xmin_items.len();
       let mut result_items = Vec::with_capacity(n_val as usize + 1);
@@ -3462,10 +3391,7 @@ pub fn subdivide_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       return Ok(Expr::List(result_items.into()));
     }
-    return Ok(Expr::FunctionCall {
-      name: "Subdivide".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Subdivide", args));
   }
 
   // Scalar, general (symbolic or float) endpoints
@@ -3691,12 +3617,7 @@ fn nested_divisions(
 /// nested subdivision). Division endpoints may fall just outside [xmin, xmax].
 /// Non-numeric endpoints stay unevaluated.
 pub fn find_divisions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "FindDivisions".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("FindDivisions", args));
   if args.len() != 2 {
     return unevaluated();
   }
@@ -3779,10 +3700,7 @@ pub fn ramp_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     other => match crate::functions::math_ast::try_eval_to_f64(other) {
       Some(v) if v >= 0.0 => Ok(other.clone()),
       Some(_) => Ok(Expr::Integer(0)),
-      None => Ok(Expr::FunctionCall {
-        name: "Ramp".to_string(),
-        args: args.to_vec().into(),
-      }),
+      None => Ok(unevaluated("Ramp", args)),
     },
   }
 }
@@ -3799,10 +3717,7 @@ pub fn kronecker_delta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return match &args[0] {
       Expr::Integer(n) => Ok(Expr::Integer(if *n == 0 { 1 } else { 0 })),
       Expr::Real(f) => Ok(Expr::Integer(if *f == 0.0 { 1 } else { 0 })),
-      _ => Ok(Expr::FunctionCall {
-        name: "KroneckerDelta".to_string(),
-        args: args.to_vec().into(),
-      }),
+      _ => Ok(unevaluated("KroneckerDelta", args)),
     };
   }
 
@@ -3830,10 +3745,7 @@ pub fn kronecker_delta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
   if has_symbolic {
-    Ok(Expr::FunctionCall {
-      name: "KroneckerDelta".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("KroneckerDelta", args))
   } else if all_equal {
     Ok(Expr::Integer(1))
   } else {
@@ -3866,10 +3778,7 @@ pub fn discrete_delta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
   if has_symbolic {
-    Ok(Expr::FunctionCall {
-      name: "DiscreteDelta".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("DiscreteDelta", args))
   } else {
     Ok(Expr::Integer(1))
   }
@@ -3920,10 +3829,7 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Real(f) => Ok(Expr::Integer(if *f >= 0.0 { 1 } else { 0 })),
     Expr::Constant(c) => match c.as_str() {
       "Pi" | "E" | "Degree" => Ok(Expr::Integer(1)),
-      _ => Ok(Expr::FunctionCall {
-        name: "UnitStep".to_string(),
-        args: args.to_vec().into(),
-      }),
+      _ => Ok(unevaluated("UnitStep", args)),
     },
     Expr::Identifier(name) if name == "Infinity" => Ok(Expr::Integer(1)),
     Expr::UnaryOp {
@@ -3934,10 +3840,7 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(Expr::Integer(0))
       }
       Expr::Identifier(name) if name == "Infinity" => Ok(Expr::Integer(0)),
-      _ => Ok(Expr::FunctionCall {
-        name: "UnitStep".to_string(),
-        args: args.to_vec().into(),
-      }),
+      _ => Ok(unevaluated("UnitStep", args)),
     },
     // Times[-1, x] pattern (e.g. -Pi parses as Times[-1, Pi])
     Expr::FunctionCall { name, args: fargs }
@@ -3950,10 +3853,7 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Ok(Expr::Integer(0))
         }
         Expr::Identifier(n) if n == "Infinity" => Ok(Expr::Integer(0)),
-        _ => Ok(Expr::FunctionCall {
-          name: "UnitStep".to_string(),
-          args: args.to_vec().into(),
-        }),
+        _ => Ok(unevaluated("UnitStep", args)),
       }
     }
     Expr::BinaryOp {
@@ -3965,10 +3865,7 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(Expr::Integer(0))
       }
       Expr::Identifier(n) if n == "Infinity" => Ok(Expr::Integer(0)),
-      _ => Ok(Expr::FunctionCall {
-        name: "UnitStep".to_string(),
-        args: args.to_vec().into(),
-      }),
+      _ => Ok(unevaluated("UnitStep", args)),
     },
     Expr::List(items) => {
       let results: Result<Vec<Expr>, InterpreterError> =
@@ -3980,10 +3877,7 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     other => match crate::functions::math_ast::try_eval_to_f64(other) {
       Some(v) if v >= 0.0 => Ok(Expr::Integer(1)),
       Some(_) => Ok(Expr::Integer(0)),
-      None => Ok(Expr::FunctionCall {
-        name: "UnitStep".to_string(),
-        args: args.to_vec().into(),
-      }),
+      None => Ok(unevaluated("UnitStep", args)),
     },
   }
 }
@@ -4075,10 +3969,7 @@ pub fn heaviside_theta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     Expr::Constant(c) => match c.as_str() {
       "Pi" | "E" | "Degree" => Ok(Expr::Integer(1)),
-      _ => Ok(Expr::FunctionCall {
-        name: "HeavisideTheta".to_string(),
-        args: args.to_vec().into(),
-      }),
+      _ => Ok(unevaluated("HeavisideTheta", args)),
     },
     Expr::Identifier(name) if name == "Infinity" => Ok(Expr::Integer(1)),
     // Exact rationals and real-valued symbolic numerics (Sqrt[2] - 2, …):
@@ -4086,10 +3977,7 @@ pub fn heaviside_theta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     other => match crate::functions::math_ast::try_eval_to_f64(other) {
       Some(v) if v > 0.0 => Ok(Expr::Integer(1)),
       Some(v) if v < 0.0 => Ok(Expr::Integer(0)),
-      _ => Ok(Expr::FunctionCall {
-        name: "HeavisideTheta".to_string(),
-        args: args.to_vec().into(),
-      }),
+      _ => Ok(unevaluated("HeavisideTheta", args)),
     },
   }
 }
@@ -4115,10 +4003,7 @@ pub fn dirac_delta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // If all args are zero, or mixed with symbolic, stay symbolic
-  Ok(Expr::FunctionCall {
-    name: "DiracDelta".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("DiracDelta", args))
 }
 
 /// UnitBox[x] = 1 for |x| <= 1/2, 0 otherwise
@@ -4143,15 +4028,9 @@ pub fn unit_box_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let abs_val = (*n as f64 / *d as f64).abs();
         return Ok(Expr::Integer(if abs_val <= 0.5 { 1 } else { 0 }));
       }
-      Ok(Expr::FunctionCall {
-        name: "UnitBox".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("UnitBox", args))
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "UnitBox".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("UnitBox", args)),
   }
 }
 
@@ -4167,10 +4046,7 @@ pub fn heaviside_pi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let v = f.abs();
       if (v - 0.5).abs() < f64::EPSILON {
         // At boundary, return unevaluated
-        Ok(Expr::FunctionCall {
-          name: "HeavisidePi".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("HeavisidePi", args))
       } else if v < 0.5 {
         Ok(Expr::Integer(1))
       } else {
@@ -4188,25 +4064,16 @@ pub fn heaviside_pi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let d_abs = d.unsigned_abs();
         return if two_n_abs == d_abs {
           // At boundary, return unevaluated
-          Ok(Expr::FunctionCall {
-            name: "HeavisidePi".to_string(),
-            args: args.to_vec().into(),
-          })
+          Ok(unevaluated("HeavisidePi", args))
         } else if two_n_abs < d_abs {
           Ok(Expr::Integer(1))
         } else {
           Ok(Expr::Integer(0))
         };
       }
-      Ok(Expr::FunctionCall {
-        name: "HeavisidePi".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("HeavisidePi", args))
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "HeavisidePi".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("HeavisidePi", args)),
   }
 }
 
@@ -4253,15 +4120,9 @@ pub fn unit_triangle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(Expr::Integer(0));
         }
       }
-      Ok(Expr::FunctionCall {
-        name: "UnitTriangle".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("UnitTriangle", args))
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "UnitTriangle".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("UnitTriangle", args)),
   }
 }
 
@@ -4301,14 +4162,8 @@ pub fn heaviside_lambda_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let num = abs_d - abs_n;
         return Ok(crate::functions::math_ast::make_rational(num, abs_d));
       }
-      Ok(Expr::FunctionCall {
-        name: "HeavisideLambda".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("HeavisideLambda", args))
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "HeavisideLambda".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("HeavisideLambda", args)),
   }
 }

--- a/src/functions/math_ast/elliptic.rs
+++ b/src/functions/math_ast/elliptic.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// True if `e` contains an inexact (machine) number. Elliptic functions
 /// numericize only when an argument is inexact; exact (integer/rational)
@@ -50,16 +50,10 @@ pub fn elliptic_k_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(Expr::Real(elliptic_k(*f)))
       } else {
         // m > 1 requires complex numbers, return unevaluated
-        Ok(Expr::FunctionCall {
-          name: "EllipticK".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("EllipticK", args))
       }
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "EllipticK".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("EllipticK", args)),
   }
 }
 
@@ -110,10 +104,7 @@ pub fn elliptic_nome_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(Expr::Real(q))
       } else {
         // m > 1: complex result, return unevaluated for now
-        Ok(Expr::FunctionCall {
-          name: "EllipticNomeQ".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("EllipticNomeQ", args))
       }
     }
     // Symbolic special case: EllipticNomeQ[1/2] = E^(-Pi) (since K(1/2)=K(1-1/2)=K(1/2))
@@ -145,15 +136,9 @@ pub fn elliptic_nome_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(Expr::Real(q));
         }
       }
-      Ok(Expr::FunctionCall {
-        name: "EllipticNomeQ".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("EllipticNomeQ", args))
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "EllipticNomeQ".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("EllipticNomeQ", args)),
   }
 }
 
@@ -211,10 +196,7 @@ pub fn inverse_elliptic_nome_q_ast(
       {
         return Ok(Expr::Real(inverse_elliptic_nome_q_numeric(q)));
       }
-      Ok(Expr::FunctionCall {
-        name: "InverseEllipticNomeQ".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("InverseEllipticNomeQ", args))
     }
   }
 }
@@ -259,10 +241,7 @@ pub fn elliptic_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::Real(elliptic_e_incomplete(phi, m)));
     }
 
-    return Ok(Expr::FunctionCall {
-      name: "EllipticE".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("EllipticE", args));
   }
 
   // One-argument form: EllipticE[m] - complete elliptic integral
@@ -287,16 +266,10 @@ pub fn elliptic_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       } else if *f < 1.0 {
         Ok(Expr::Real(elliptic_e(*f)))
       } else {
-        Ok(Expr::FunctionCall {
-          name: "EllipticE".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("EllipticE", args))
       }
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "EllipticE".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("EllipticE", args)),
   }
 }
 
@@ -374,10 +347,7 @@ pub fn jacobi_zeta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(e_phi_m - (e_m / k_m) * f_phi_m));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiZeta".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiZeta", args))
 }
 
 /// Compute incomplete elliptic integral E(phi, m) via Simpson's rule
@@ -439,10 +409,7 @@ pub fn elliptic_f_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(elliptic_f(phi, m)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "EllipticF".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("EllipticF", args))
 }
 
 /// At parameter m == 0, EllipticF[phi, 0] = EllipticE[phi, 0] = phi and
@@ -562,10 +529,7 @@ pub fn elliptic_pi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::FunctionCall {
-    name: "EllipticPi".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("EllipticPi", args))
 }
 
 /// Compute incomplete elliptic integral of the third kind via Simpson's rule
@@ -606,10 +570,7 @@ pub fn elliptic_theta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // an integer-valued Real so the numeric path still fires.
     Expr::Real(f) if f.fract() == 0.0 && *f >= 1.0 && *f <= 4.0 => *f as u32,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "EllipticTheta".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("EllipticTheta", args));
     }
   };
 
@@ -642,10 +603,7 @@ pub fn elliptic_theta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated (symbolic)
-  Ok(Expr::FunctionCall {
-    name: "EllipticTheta".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("EllipticTheta", args))
 }
 
 /// Compute Jacobi theta function numerically via series expansion
@@ -724,10 +682,7 @@ pub fn elliptic_theta_prime_ast(
   let a_val = match &args[0] {
     Expr::Integer(n) if *n >= 1 && *n <= 4 => *n as u32,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "EllipticThetaPrime".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("EllipticThetaPrime", args));
     }
   };
 
@@ -738,10 +693,7 @@ pub fn elliptic_theta_prime_ast(
     return Ok(Expr::Real(elliptic_theta_prime_numeric(a_val, z_f, q_f)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "EllipticThetaPrime".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("EllipticThetaPrime", args))
 }
 
 /// Compute derivative of Jacobi theta function numerically via series expansion
@@ -872,10 +824,7 @@ pub fn dedekind_eta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "DedekindEta".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("DedekindEta", args))
 }
 
 fn expr_contains_real(expr: &Expr) -> bool {
@@ -1155,12 +1104,7 @@ pub fn weierstrass_invariants_ast(
       "WeierstrassInvariants expects exactly 1 argument".into(),
     ));
   }
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "WeierstrassInvariants".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("WeierstrassInvariants", args));
   let periods = match &args[0] {
     Expr::List(items) if items.len() == 2 => items,
     _ => return unevaluated(),
@@ -1211,12 +1155,7 @@ pub fn weierstrass_half_periods_ast(
       "WeierstrassHalfPeriods expects exactly 1 argument".into(),
     ));
   }
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "WeierstrassHalfPeriods".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("WeierstrassHalfPeriods", args));
   let items = match &args[0] {
     Expr::List(items) if items.len() == 2 => items,
     _ => return unevaluated(),
@@ -1274,12 +1213,7 @@ pub fn modular_lambda_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "ModularLambda expects exactly 1 argument".into(),
     ));
   }
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "ModularLambda".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("ModularLambda", args));
   // Exact value at the lemniscatic point: λ(i) = 1/2.
   if matches!(&args[0], Expr::Identifier(s) if s == "I") {
     return crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
@@ -1308,12 +1242,7 @@ pub fn klein_invariant_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "KleinInvariantJ expects exactly 1 argument".into(),
     ));
   }
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "KleinInvariantJ".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("KleinInvariantJ", args));
   // Exact value at the lemniscatic point: J(i) = 1.
   if matches!(&args[0], Expr::Identifier(s) if s == "I") {
     return Ok(Expr::Integer(1));
@@ -1356,18 +1285,12 @@ pub fn klein_invariant_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 pub fn elliptic_exp_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "EllipticExp".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("EllipticExp", args));
   }
   let u = match expr_to_real_f64(&args[0]) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "EllipticExp".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("EllipticExp", args));
     }
   };
   let (a, b) = match &args[1] {
@@ -1375,18 +1298,12 @@ pub fn elliptic_exp_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       match (expr_to_real_f64(&items[0]), expr_to_real_f64(&items[1])) {
         (Some(a), Some(b)) => (a, b),
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "EllipticExp".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("EllipticExp", args));
         }
       }
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "EllipticExp".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("EllipticExp", args));
     }
   };
   if u == 0.0 {
@@ -1400,17 +1317,11 @@ pub fn elliptic_exp_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Only numericize when an argument is inexact; exact arguments stay symbolic.
   if !(expr_is_inexact(&args[0]) || expr_is_inexact(&args[1])) {
-    return Ok(Expr::FunctionCall {
-      name: "EllipticExp".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("EllipticExp", args));
   }
   match elliptic_exp_real(u, a, b) {
     Some((x, y)) => Ok(Expr::List(vec![Expr::Real(x), Expr::Real(y)].into())),
-    None => Ok(Expr::FunctionCall {
-      name: "EllipticExp".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("EllipticExp", args)),
   }
 }
 
@@ -1634,12 +1545,7 @@ pub fn neville_theta_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   let kind = name.as_bytes()[12].to_ascii_lowercase() as char;
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated(name, args));
   if args.len() != 2 {
     let word = if args.len() == 1 {
       "argument"

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 use num_bigint::BigInt;
 
 /// Pochhammer[a, n] - Rising factorial (Pochhammer symbol): a * (a+1) * ... * (a+n-1)
@@ -122,10 +122,7 @@ pub fn pochhammer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       };
       crate::evaluator::evaluate_expr_to_expr(&result)
     } else {
-      Ok(Expr::FunctionCall {
-        name: "Pochhammer".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Pochhammer", args))
     }
   } else {
     // Exact numeric a with a non-integer rational b (integer b is handled
@@ -172,10 +169,7 @@ pub fn pochhammer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
     }
-    Ok(Expr::FunctionCall {
-      name: "Pochhammer".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("Pochhammer", args))
   }
 }
 
@@ -188,10 +182,7 @@ pub fn factorial_power_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "FactorialPower expects 2 or 3 arguments".into(),
     ));
   }
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "FactorialPower".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("FactorialPower", args);
 
   let Some(k) = expr_to_i128(&args[1]) else {
     return Ok(unevaluated(args));
@@ -302,10 +293,7 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         right: Box::new(g1),
       });
     }
-    return Ok(Expr::FunctionCall {
-      name: "Gamma".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Gamma", args));
   }
 
   // Two-argument form: Gamma[a, z] = upper incomplete gamma function
@@ -427,10 +415,7 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(gamma_half_expr(numer, denom, is_neg));
         }
       }
-      Ok(Expr::FunctionCall {
-        name: "Gamma".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Gamma", args))
     }
     _ => {
       // Complex floating-point argument: use the Lanczos approximation.
@@ -448,10 +433,7 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           gr, gi,
         ));
       }
-      Ok(Expr::FunctionCall {
-        name: "Gamma".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Gamma", args))
     }
   }
 }
@@ -1048,10 +1030,7 @@ pub fn beta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "Beta".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Beta", args))
 }
 
 /// Beta[z, a, b] — incomplete Beta function.
@@ -1176,10 +1155,7 @@ fn log_gamma_stirling(z: f64) -> f64 {
 /// LogGamma[z] — logarithm of the gamma function.
 pub fn log_gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "LogGamma".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("LogGamma", args));
   }
 
   let z = &args[0];
@@ -1257,10 +1233,7 @@ pub fn log_gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated for symbolic case
-  Ok(Expr::FunctionCall {
-    name: "LogGamma".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("LogGamma", args))
 }
 
 /// Compute parts of Gamma at half-integer: Gamma(k/2) for integer k > 0
@@ -1425,10 +1398,7 @@ pub fn beta_regularized_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "BetaRegularized".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("BetaRegularized", args))
 }
 
 /// Check if an expression is a positive number
@@ -1553,12 +1523,7 @@ fn inverse_beta_regularized_numeric(s: f64, a: f64, b: f64) -> f64 {
 pub fn inverse_beta_regularized_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let symbolic = || {
-    Ok(Expr::FunctionCall {
-      name: "InverseBetaRegularized".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let symbolic = || Ok(unevaluated("InverseBetaRegularized", args));
 
   // Generalized 4-arg form InverseBetaRegularized[z0, s, a, b] solves
   // BetaRegularized[z0, z, a, b] = I_z(a, b) - I_z0(a, b) == s for z, i.e.
@@ -1772,10 +1737,7 @@ pub fn gamma_regularized_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "GammaRegularized".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("GammaRegularized", args))
 }
 
 /// MarcumQ[m, a, b] / MarcumQ[m, a, b0, b1] — generalized Marcum Q.
@@ -1786,10 +1748,7 @@ pub fn gamma_regularized_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Poisson-weighted incomplete-gamma series; the four-argument form is
 /// the difference Q(m,a,b0) - Q(m,a,b1).
 pub fn marcum_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "MarcumQ".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("MarcumQ", args);
   if args.len() != 3 && args.len() != 4 {
     return Ok(unevaluated(args));
   }
@@ -1959,12 +1918,7 @@ fn owen_t_numeric(h: f64, a: f64) -> f64 {
 /// argument is inexact, and stays symbolic for exact non-special arguments
 /// (matching wolframscript).
 pub fn owen_t_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "OwenT".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("OwenT", args));
   if args.len() != 2 {
     return unevaluated();
   }
@@ -2098,12 +2052,7 @@ fn inverse_gamma_regularized_numeric(a: f64, q: f64) -> f64 {
 pub fn inverse_gamma_regularized_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let symbolic = || {
-    Ok(Expr::FunctionCall {
-      name: "InverseGammaRegularized".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let symbolic = || Ok(unevaluated("InverseGammaRegularized", args));
 
   // 3-arg form InverseGammaRegularized[a, z0, q] solves
   // GammaRegularized[a, z0, z] = Q(a, z0) - Q(a, z) == q for z, i.e.
@@ -2221,15 +2170,9 @@ pub fn barnes_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if name == "Rational" && fargs.len() == 2 =>
     {
       // For N[BarnesG[rational]], return unevaluated; N[] will handle conversion
-      Ok(Expr::FunctionCall {
-        name: "BarnesG".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("BarnesG", args))
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "BarnesG".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("BarnesG", args)),
   }
 }
 
@@ -2284,10 +2227,7 @@ fn log_barnes_g_float(z: f64) -> f64 {
 /// LogBarnesG[5.] as 2.4849066497880052 while Log[12.] is
 /// 2.4849066497880004).
 pub fn log_barnes_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "LogBarnesG".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("LogBarnesG", args);
   if args.len() != 1 {
     return Ok(unevaluated(args));
   }

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, expr_to_string};
+use crate::syntax::{BinaryOperator, Expr, expr_to_string, unevaluated};
 
 /// Hypergeometric0F1[a, z] - confluent hypergeometric limit function
 /// 0F1(a; z) = Σ z^k / (k! * Pochhammer(a,k)) for k = 0, 1, 2, ...
@@ -30,10 +30,7 @@ pub fn hypergeometric_0f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(hypergeometric_0f1_f64(a, z)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "Hypergeometric0F1".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Hypergeometric0F1", args))
 }
 
 /// Compute 0F1(a; z) numerically via series expansion
@@ -92,10 +89,7 @@ pub fn hypergeometric_0f1_regularized_ast(
     return Ok(Expr::Real(hypergeometric_0f1_regularized_f64(a, z)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "Hypergeometric0F1Regularized".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Hypergeometric0F1Regularized", args))
 }
 
 /// Compute regularized 0F1~(a; z) = sum_{k=0}^{inf} z^k / (Gamma(a + k) * k!)
@@ -135,19 +129,13 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let a_list = match &args[0] {
     Expr::List(v) => v.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "HypergeometricPFQ".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HypergeometricPFQ", args));
     }
   };
   let b_list = match &args[1] {
     Expr::List(v) => v.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "HypergeometricPFQ".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HypergeometricPFQ", args));
     }
   };
   let z = &args[2];
@@ -513,10 +501,7 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => None,
   };
   if z_val.is_none() {
-    return Ok(Expr::FunctionCall {
-      name: "HypergeometricPFQ".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("HypergeometricPFQ", args));
   }
   let z_val = z_val.unwrap();
 
@@ -569,10 +554,7 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // For p > q+1 and |z| >= 1, the series diverges
     if z_val.abs() >= 1.0 && a_vals.len() > b_vals.len() + 1 {
-      return Ok(Expr::FunctionCall {
-        name: "HypergeometricPFQ".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HypergeometricPFQ", args));
     }
     let result = hypergeometric_pfq_numeric(&a_vals, &b_vals, z_val);
     if result.is_infinite() {
@@ -581,10 +563,7 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(result));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "HypergeometricPFQ".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("HypergeometricPFQ", args))
 }
 
 /// Compute generalized hypergeometric function pFq numerically via series
@@ -739,10 +718,7 @@ pub fn hypergeometric_pfq_regularized_ast(
   let b_list = match &args[1] {
     Expr::List(v) => v.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "HypergeometricPFQRegularized".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HypergeometricPFQRegularized", args));
     }
   };
 
@@ -757,10 +733,7 @@ pub fn hypergeometric_pfq_regularized_ast(
   // If it stays symbolic, return regularized form
   match &pfq_result {
     Expr::FunctionCall { name, .. } if name == "HypergeometricPFQ" => {
-      return Ok(Expr::FunctionCall {
-        name: "HypergeometricPFQRegularized".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HypergeometricPFQRegularized", args));
     }
     _ => {}
   }
@@ -790,10 +763,7 @@ pub fn hypergeometric_pfq_regularized_ast(
       {
         return Ok(result);
       }
-      return Ok(Expr::FunctionCall {
-        name: "HypergeometricPFQRegularized".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HypergeometricPFQRegularized", args));
     }
     return Ok(Expr::Identifier("Infinity".to_string()));
   }
@@ -869,10 +839,7 @@ pub fn hypergeometric_2f1_regularized_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   if args.len() != 4 {
-    return Ok(Expr::FunctionCall {
-      name: "Hypergeometric2F1Regularized".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Hypergeometric2F1Regularized", args));
   }
   let a = args[0].clone();
   let b = args[1].clone();
@@ -902,10 +869,7 @@ pub fn hypergeometric_2f1_regularized_ast(
   if let Expr::FunctionCall { name, .. } = &result
     && name == "HypergeometricPFQRegularized"
   {
-    return Ok(Expr::FunctionCall {
-      name: "Hypergeometric2F1Regularized".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Hypergeometric2F1Regularized", args));
   }
 
   Ok(result)
@@ -1565,10 +1529,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::FunctionCall {
-    name: "Hypergeometric1F1".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Hypergeometric1F1", args))
 }
 
 /// Accurate real U(a, b, z) for `b` a positive integer (b = n + 1, n ≥ 0)
@@ -1984,10 +1945,7 @@ pub fn hypergeometric_u_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "HypergeometricU".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("HypergeometricU", args))
 }
 
 /// Compute U(a, b, z) numerically using the relation:
@@ -2293,10 +2251,7 @@ pub fn hypergeometric2f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "Hypergeometric2F1".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Hypergeometric2F1", args))
 }
 
 /// True if the expression has the surface form `Times[neg_int, …]` —
@@ -2844,10 +2799,7 @@ pub fn hypergeometric_1f1_regularized_ast(
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "Hypergeometric1F1Regularized".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Hypergeometric1F1Regularized", args))
 }
 
 /// WhittakerM[k, m, z] - Whittaker M function.
@@ -2882,10 +2834,7 @@ pub fn whittaker_m_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       // re == 0 (m = -1/2): no closed-form simplification, fall through.
     }
-    return Ok(Expr::FunctionCall {
-      name: "WhittakerM".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("WhittakerM", args));
   }
 
   // Numeric evaluation: complex double precision covers real & complex args.
@@ -2938,10 +2887,7 @@ pub fn whittaker_m_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated symbolic form.
-  Ok(Expr::FunctionCall {
-    name: "WhittakerM".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("WhittakerM", args))
 }
 
 /// WhittakerW[k, m, z] - Whittaker W function.
@@ -3026,10 +2972,7 @@ pub fn whittaker_w_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
     }
-    return Ok(Expr::FunctionCall {
-      name: "WhittakerW".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("WhittakerW", args));
   }
 
   // Numeric evaluation: an argument is "inexact" when it carries a
@@ -3077,10 +3020,7 @@ pub fn whittaker_w_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated symbolic form.
-  Ok(Expr::FunctionCall {
-    name: "WhittakerW".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("WhittakerW", args))
 }
 
 /// Evaluate WhittakerW[k, m, z] in double-precision complex arithmetic.

--- a/src/functions/math_ast/integrals.rs
+++ b/src/functions/math_ast/integrals.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// ExpIntegralEi[x] - Exponential integral Ei(x)
 pub fn exp_integral_ei_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -30,10 +30,7 @@ pub fn exp_integral_ei_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         return Ok(Expr::Integer(0));
       }
       // Unevaluated
-      Ok(Expr::FunctionCall {
-        name: "ExpIntegralEi".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("ExpIntegralEi", args))
     }
   }
 }
@@ -116,10 +113,7 @@ pub fn cos_integral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         });
       }
       // Unevaluated
-      Ok(Expr::FunctionCall {
-        name: "CosIntegral".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("CosIntegral", args))
     }
   }
 }
@@ -266,10 +260,7 @@ pub fn fresnel_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           ],
         );
       }
-      Ok(Expr::FunctionCall {
-        name: "FresnelS".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("FresnelS", args))
     }
     // FresnelS[-n] for negative integer
     Expr::Integer(n) if *n < 0 => Ok(negate_fresnel_s(Expr::Integer(-*n))),
@@ -281,10 +272,7 @@ pub fn fresnel_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         return Ok(crate::functions::math_ast::make_rational(-1, 2));
       }
       // Unevaluated
-      Ok(Expr::FunctionCall {
-        name: "FresnelS".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("FresnelS", args))
     }
   }
 }
@@ -386,10 +374,7 @@ pub fn fresnel_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           ],
         );
       }
-      Ok(Expr::FunctionCall {
-        name: "FresnelC".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("FresnelC", args))
     }
     // FresnelC[-n] for negative integer
     Expr::Integer(n) if *n < 0 => Ok(negate_fresnel_c(Expr::Integer(-*n))),
@@ -401,10 +386,7 @@ pub fn fresnel_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         return Ok(crate::functions::math_ast::make_rational(-1, 2));
       }
       // Unevaluated
-      Ok(Expr::FunctionCall {
-        name: "FresnelC".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("FresnelC", args))
     }
   }
 }
@@ -636,10 +618,7 @@ pub fn sin_integral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         });
       }
       // Unevaluated
-      Ok(Expr::FunctionCall {
-        name: "SinIntegral".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("SinIntegral", args))
     }
   }
 }
@@ -751,10 +730,7 @@ pub fn exp_integral_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(result));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "ExpIntegralE".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ExpIntegralE", args))
 }
 
 /// Compute E_n(z) = ∫_1^∞ e^{-zt}/t^n dt
@@ -859,10 +835,7 @@ pub fn log_integral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Ok(Expr::Real(result))
     }
     // Unevaluated
-    _ => Ok(Expr::FunctionCall {
-      name: "LogIntegral".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("LogIntegral", args)),
   }
 }
 
@@ -881,10 +854,7 @@ pub fn riemann_r_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Numeric evaluation for real values
     Expr::Real(x) if *x > 0.0 => Ok(Expr::Real(riemann_r_numeric(*x))),
     // Unevaluated for symbolic and other args
-    _ => Ok(Expr::FunctionCall {
-      name: "RiemannR".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("RiemannR", args)),
   }
 }
 
@@ -944,10 +914,7 @@ pub fn sinh_integral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         });
       }
       // Unevaluated
-      Ok(Expr::FunctionCall {
-        name: "SinhIntegral".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("SinhIntegral", args))
     }
   }
 }
@@ -1045,10 +1012,7 @@ pub fn cosh_integral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         return Ok(Expr::Identifier("Infinity".to_string()));
       }
       // Unevaluated
-      Ok(Expr::FunctionCall {
-        name: "CoshIntegral".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("CoshIntegral", args))
     }
   }
 }
@@ -1113,12 +1077,7 @@ pub fn fresnel_fg_ast(
   name: &str,
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated(name, args));
   if args.len() != 1 {
     return unevaluated();
   }

--- a/src/functions/math_ast/jacobi.rs
+++ b/src/functions/math_ast/jacobi.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// Compute Jacobi elliptic functions sn(u, m), cn(u, m), dn(u, m) numerically
 /// using the descending Landen (AGM) transformation.
@@ -99,10 +99,7 @@ pub fn jacobi_amplitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(sn.atan2(cn)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiAmplitude".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiAmplitude", args))
 }
 
 /// JacobiEpsilon[u, m] - the Jacobi epsilon function, the integral of dn^2,
@@ -155,10 +152,7 @@ pub fn jacobi_epsilon_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiEpsilon".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiEpsilon", args))
 }
 
 /// JacobiDN[u, m] - Jacobi elliptic function dn
@@ -209,10 +203,7 @@ pub fn jacobi_dn_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "JacobiDN".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiDN", args))
 }
 
 /// JacobiSN[u, m] - Jacobi elliptic function sn
@@ -270,10 +261,7 @@ pub fn jacobi_sn_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "JacobiSN".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiSN", args))
 }
 
 /// JacobiCN[u, m] - Jacobi elliptic function cn
@@ -327,10 +315,7 @@ pub fn jacobi_cn_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "JacobiCN".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiCN", args))
 }
 
 // ─── InverseJacobi functions ────────────────────────────────────────
@@ -394,10 +379,7 @@ pub fn inverse_jacobi_sn_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiSN".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiSN", args))
 }
 
 /// InverseJacobiCN[v, m]
@@ -446,10 +428,7 @@ pub fn inverse_jacobi_cn_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiCN".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiCN", args))
 }
 
 /// InverseJacobiDN[v, m]
@@ -484,10 +463,7 @@ pub fn inverse_jacobi_dn_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiDN".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiDN", args))
 }
 
 /// InverseJacobiCD[v, m]
@@ -529,10 +505,7 @@ pub fn inverse_jacobi_cd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiCD".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiCD", args))
 }
 
 /// InverseJacobiSC[v, m]
@@ -577,10 +550,7 @@ pub fn inverse_jacobi_sc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiSC".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiSC", args))
 }
 
 /// InverseJacobiCS[v, m]
@@ -609,10 +579,7 @@ pub fn inverse_jacobi_cs_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiCS".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiCS", args))
 }
 
 /// InverseJacobiSD[v, m]
@@ -657,10 +624,7 @@ pub fn inverse_jacobi_sd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiSD".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiSD", args))
 }
 
 /// InverseJacobiDS[v, m]
@@ -697,10 +661,7 @@ pub fn inverse_jacobi_ds_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiDS".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiDS", args))
 }
 
 /// InverseJacobiNS[v, m]
@@ -737,10 +698,7 @@ pub fn inverse_jacobi_ns_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiNS".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiNS", args))
 }
 
 /// InverseJacobiNC[v, m]
@@ -782,10 +740,7 @@ pub fn inverse_jacobi_nc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiNC".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiNC", args))
 }
 
 /// InverseJacobiND[v, m]
@@ -820,10 +775,7 @@ pub fn inverse_jacobi_nd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiND".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiND", args))
 }
 
 /// InverseJacobiDC[v, m]
@@ -849,10 +801,7 @@ pub fn inverse_jacobi_dc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(elliptic_f(arg.asin(), m_f)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "InverseJacobiDC".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseJacobiDC", args))
 }
 
 /// Extract the inner expression from a negated expression like Times[-1, x] or -x
@@ -931,10 +880,7 @@ pub fn jacobi_sc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(sn / cn));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiSC".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiSC", args))
 }
 
 /// JacobiDC[u, m] - Jacobi DC elliptic function (DN/CN)
@@ -976,10 +922,7 @@ pub fn jacobi_dc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(dn / cn));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiDC".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiDC", args))
 }
 
 /// JacobiCD[u, m] - Jacobi CD elliptic function (CN/DN)
@@ -1021,10 +964,7 @@ pub fn jacobi_cd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(cn / dn));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiCD".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiCD", args))
 }
 
 /// JacobiSD[u, m] - Jacobi SD elliptic function (SN/DN)
@@ -1064,10 +1004,7 @@ pub fn jacobi_sd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(sn / dn));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiSD".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiSD", args))
 }
 
 /// JacobiCS[u, m] - Jacobi CS elliptic function (CN/SN)
@@ -1103,10 +1040,7 @@ pub fn jacobi_cs_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(cn / sn));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiCS".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiCS", args))
 }
 
 /// JacobiDS[u, m] - Jacobi DS elliptic function (DN/SN)
@@ -1142,10 +1076,7 @@ pub fn jacobi_ds_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(dn / sn));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiDS".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiDS", args))
 }
 
 /// JacobiNS[u, m] - Jacobi NS elliptic function (1/SN)
@@ -1181,10 +1112,7 @@ pub fn jacobi_ns_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(1.0 / sn));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiNS".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiNS", args))
 }
 
 /// JacobiND[u, m] - Jacobi ND elliptic function (1/DN)
@@ -1221,10 +1149,7 @@ pub fn jacobi_nd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(1.0 / dn));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiND".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiND", args))
 }
 
 /// JacobiNC[u, m] - Jacobi NC elliptic function (1/CN)
@@ -1264,10 +1189,7 @@ pub fn jacobi_nc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(1.0 / cn));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "JacobiNC".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiNC", args))
 }
 
 /// Check if an expression is numerically zero

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
+use crate::syntax::{
+  BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
+};
 use num_bigint::BigInt;
 
 /// QPochhammer[a, q, n] — q-Pochhammer symbol.
@@ -18,10 +20,7 @@ pub fn q_pochhammer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return q_pochhammer_infinite(&args[0], &args[1]);
   }
   if args.len() != 3 {
-    return Ok(Expr::FunctionCall {
-      name: "QPochhammer".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("QPochhammer", args));
   }
 
   let a = &args[0];
@@ -32,10 +31,7 @@ pub fn q_pochhammer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(n_expr) {
     Some(n) if n >= 0 => n as usize,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "QPochhammer".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("QPochhammer", args));
     }
   };
 
@@ -466,10 +462,7 @@ pub fn product_log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
     }
     // Otherwise return unevaluated
-    return Ok(Expr::FunctionCall {
-      name: "ProductLog".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("ProductLog", args));
   }
 
   // ProductLog[-1/E] = -1 (principal branch at the branch point).
@@ -554,10 +547,7 @@ pub fn product_log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     _ => {}
   }
-  Ok(Expr::FunctionCall {
-    name: "ProductLog".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ProductLog", args))
 }
 
 /// Helper: convert a list of Expr to Vec<f64>, returning None if any element is not numeric
@@ -585,10 +575,7 @@ fn expr_list_to_f64_vec(list: &[Expr]) -> Option<Vec<f64>> {
 /// Meijer G-function
 pub fn meijer_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 3 {
-    return Ok(Expr::FunctionCall {
-      name: "MeijerG".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("MeijerG", args));
   }
   // wolframscript emits `MeijerG::hdiv` when the upper/lower parameter
   // arguments aren't both nested length-2 lists. Trigger the same warning
@@ -603,10 +590,7 @@ pub fn meijer_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       expr_to_string(&args[1]),
       expr_to_string(&args[2])
     ));
-    return Ok(Expr::FunctionCall {
-      name: "MeijerG".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("MeijerG", args));
   }
 
   // Parse upper parameters: {{a1,...,an}, {an+1,...,ap}}
@@ -615,28 +599,19 @@ pub fn meijer_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let list_n = match &v[0] {
         Expr::List(l) => l.clone(),
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "MeijerG".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("MeijerG", args));
         }
       };
       let list_rest = match &v[1] {
         Expr::List(l) => l.clone(),
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "MeijerG".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("MeijerG", args));
         }
       };
       (list_n, list_rest)
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "MeijerG".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("MeijerG", args));
     }
   };
 
@@ -646,28 +621,19 @@ pub fn meijer_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let list_m = match &v[0] {
         Expr::List(l) => l.clone(),
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "MeijerG".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("MeijerG", args));
         }
       };
       let list_rest = match &v[1] {
         Expr::List(l) => l.clone(),
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "MeijerG".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("MeijerG", args));
         }
       };
       (list_m, list_rest)
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "MeijerG".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("MeijerG", args));
     }
   };
 
@@ -681,10 +647,7 @@ pub fn meijer_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Consistency check: need m > 0 or n > 0, and p+q < 2(m+n) or other conditions
   if m == 0 && n == 0 {
     // No poles to sum over - function doesn't exist
-    return Ok(Expr::FunctionCall {
-      name: "MeijerG".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("MeijerG", args));
   }
 
   // MeijerG[{{}, {}}, {{0}, {}}, 0] = 1
@@ -784,10 +747,7 @@ pub fn meijer_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && diff.round() >= 1.0
           {
             // hdiv: function does not exist
-            return Ok(Expr::FunctionCall {
-              name: "MeijerG".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("MeijerG", args));
           }
         }
       }
@@ -806,18 +766,12 @@ pub fn meijer_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       } else {
         // Integer/rational args - only evaluate via N[]
         // Return unevaluated for pure integer/rational input
-        return Ok(Expr::FunctionCall {
-          name: "MeijerG".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("MeijerG", args));
       }
     }
   }
 
-  Ok(Expr::FunctionCall {
-    name: "MeijerG".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("MeijerG", args))
 }
 
 /// Numeric evaluation of MeijerG using residue series.
@@ -1247,10 +1201,7 @@ pub fn struve_h_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "StruveH".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("StruveH", args))
 }
 
 /// Compute Struve H_n(z) using series expansion.
@@ -1349,10 +1300,7 @@ pub fn struve_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "StruveL".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("StruveL", args))
 }
 
 /// Compute modified Struve L_n(z) using series expansion.
@@ -1424,10 +1372,7 @@ pub fn square_wave_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(Expr::Integer(-1));
         }
       }
-      Ok(Expr::FunctionCall {
-        name: "SquareWave".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("SquareWave", args))
     }
     2 => {
       // SquareWave[{d1, d2, ...}, t]
@@ -1443,10 +1388,7 @@ pub fn square_wave_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let idx = (n - 1).saturating_sub(idx_raw.min(n - 1));
         return Ok(levels[idx].clone());
       }
-      Ok(Expr::FunctionCall {
-        name: "SquareWave".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("SquareWave", args))
     }
     _ => Err(InterpreterError::EvaluationError(
       "SquareWave expects 1 or 2 arguments".into(),
@@ -1507,10 +1449,7 @@ pub fn triangle_wave_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let val = 4.0 * (frac - 0.5).abs() - 1.0;
         return Ok(Expr::Real(val));
       }
-      Ok(Expr::FunctionCall {
-        name: "TriangleWave".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("TriangleWave", args))
     }
     2 => {
       // TriangleWave[{min, max}, t]
@@ -1529,10 +1468,7 @@ pub fn triangle_wave_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(Expr::Real(result));
         }
       }
-      Ok(Expr::FunctionCall {
-        name: "TriangleWave".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("TriangleWave", args))
     }
     _ => Err(InterpreterError::EvaluationError(
       "TriangleWave expects 1 or 2 arguments".into(),
@@ -1579,10 +1515,7 @@ pub fn sawtooth_wave_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let frac = t - t.floor();
         return Ok(Expr::Real(frac));
       }
-      Ok(Expr::FunctionCall {
-        name: "SawtoothWave".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("SawtoothWave", args))
     }
     2 => {
       // SawtoothWave[{min, max}, t]
@@ -1600,10 +1533,7 @@ pub fn sawtooth_wave_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(Expr::Real(result));
         }
       }
-      Ok(Expr::FunctionCall {
-        name: "SawtoothWave".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("SawtoothWave", args))
     }
     _ => Err(InterpreterError::EvaluationError(
       "SawtoothWave expects 1 or 2 arguments".into(),
@@ -1628,10 +1558,7 @@ pub fn parabolic_cylinder_d_ast(
     return Ok(Expr::Real(parabolic_cylinder_d(nu, z)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "ParabolicCylinderD".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ParabolicCylinderD", args))
 }
 
 /// Compute D_ν(z) using the relation to confluent hypergeometric functions:
@@ -1717,10 +1644,7 @@ pub fn anger_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "AngerJ".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AngerJ", args))
 }
 
 /// Compute AngerJ[nu, z] numerically using Gauss-Legendre quadrature.
@@ -1816,10 +1740,7 @@ pub fn weber_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "WeberE".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("WeberE", args))
 }
 
 /// WeberE[n, z] for an integer order n and exact argument z, as the finite
@@ -1968,10 +1889,7 @@ pub fn wigner_d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // WignerD[{j, m1, m2}, theta]
   // WignerD[{j, m1, m2}, phi, theta, psi]
   if args.len() != 2 && args.len() != 4 {
-    return Ok(Expr::FunctionCall {
-      name: "WignerD".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("WignerD", args));
   }
 
   let (j_val, m1_val, m2_val) = match &args[0] {
@@ -1979,37 +1897,25 @@ pub fn wigner_d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let j = match try_eval_to_f64(&items[0]) {
         Some(v) => v,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "WignerD".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("WignerD", args));
         }
       };
       let m1 = match try_eval_to_f64(&items[1]) {
         Some(v) => v,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "WignerD".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("WignerD", args));
         }
       };
       let m2 = match try_eval_to_f64(&items[2]) {
         Some(v) => v,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "WignerD".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("WignerD", args));
         }
       };
       (j, m1, m2)
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "WignerD".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("WignerD", args));
     }
   };
 
@@ -2020,15 +1926,9 @@ pub fn wigner_d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       None => {
         // Check if at least one is Real
         if !matches!(&args[1], Expr::Real(_)) {
-          return Ok(Expr::FunctionCall {
-            name: "WignerD".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("WignerD", args));
         }
-        return Ok(Expr::FunctionCall {
-          name: "WignerD".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("WignerD", args));
       }
     };
     let result = wigner_d_small(j_val, m1_val, m2_val, theta);
@@ -2049,10 +1949,7 @@ pub fn wigner_d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         return crate::evaluator::evaluate_expr_to_expr(&result);
       }
-      return Ok(Expr::FunctionCall {
-        name: "WignerD".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("WignerD", args));
     }
     let phi = phi_n.unwrap();
     let theta = theta_n.unwrap();
@@ -2417,19 +2314,13 @@ pub fn norlund_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return norlund_b_poly_ast(args);
   }
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "NorlundB".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("NorlundB", args));
   }
 
   let n = match &args[0] {
     Expr::Integer(n) if *n >= 0 => *n as usize,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "NorlundB".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NorlundB", args));
     }
   };
 
@@ -2494,10 +2385,7 @@ fn norlund_b_poly_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match &args[0] {
     Expr::Integer(n) if *n >= 0 => *n as usize,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "NorlundB".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NorlundB", args));
     }
   };
   let a = &args[1];
@@ -2762,10 +2650,7 @@ pub fn appell_f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "AppellF1".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AppellF1", args))
 }
 
 fn exprs_structurally_equal(a: &Expr, b: &Expr) -> bool {
@@ -2890,10 +2775,7 @@ pub fn appell_f2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "AppellF2".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AppellF2", args))
 }
 
 /// Compute F2(a, b1, b2; c1, c2; x, y) using double series
@@ -3009,10 +2891,7 @@ pub fn appell_f3_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "AppellF3".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AppellF3", args))
 }
 
 /// Compute F3(a1, a2, b1, b2; c; x, y) using double series
@@ -3127,10 +3006,7 @@ pub fn appell_f4_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Unevaluated
-  Ok(Expr::FunctionCall {
-    name: "AppellF4".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("AppellF4", args))
 }
 
 /// Compute F4(a, b; c1, c2; x, y) using double series
@@ -3227,10 +3103,7 @@ pub fn perfect_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         expr_to_string(&args[0]),
         expr_to_string(&args[0])
       ));
-      return Ok(Expr::FunctionCall {
-        name: "PerfectNumber".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("PerfectNumber", args));
     }
   };
 
@@ -3244,10 +3117,7 @@ pub fn perfect_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   ];
 
   if n > mersenne_exponents.len() {
-    return Ok(Expr::FunctionCall {
-      name: "PerfectNumber".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("PerfectNumber", args));
   }
 
   let p = mersenne_exponents[n - 1];
@@ -3287,10 +3157,7 @@ pub fn ramanujan_tau_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let tau = ramanujan_tau_compute(n);
       Ok(Expr::Integer(tau))
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "RamanujanTau".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("RamanujanTau", args)),
   }
 }
 
@@ -3354,10 +3221,7 @@ pub fn powers_representations_ast(
   let n = match &args[0] {
     Expr::Integer(v) => *v,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "PowersRepresentations".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("PowersRepresentations", args));
     }
   };
 
@@ -3365,26 +3229,17 @@ pub fn powers_representations_ast(
     Expr::Integer(v) if *v >= 0 => *v as usize,
     Expr::Integer(_) => return Ok(Expr::List(vec![].into())),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "PowersRepresentations".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("PowersRepresentations", args));
     }
   };
 
   let p = match &args[2] {
     Expr::Integer(v) if *v >= 1 => *v as u32,
     Expr::Integer(_) => {
-      return Ok(Expr::FunctionCall {
-        name: "PowersRepresentations".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("PowersRepresentations", args));
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "PowersRepresentations".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("PowersRepresentations", args));
     }
   };
 
@@ -3488,10 +3343,7 @@ fn powers_rep_search(
 /// compounding). Listable in `r`.
 pub fn effective_interest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "EffectiveInterest".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("EffectiveInterest", args));
   }
   // Listable on the first argument.
   if let Expr::List(items) = &args[0] {
@@ -3562,20 +3414,14 @@ pub fn entropy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     1 => (None, &args[0]),
     2 => (Some(&args[0]), &args[1]),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Entropy".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Entropy", args));
     }
   };
 
   let items = match list {
     Expr::List(items) => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Entropy".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Entropy", args));
     }
   };
 
@@ -3639,16 +3485,10 @@ pub fn entropy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// An exact zero magnitude yields -Infinity.
 pub fn real_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.is_empty() || args.len() > 2 {
-    return Ok(Expr::FunctionCall {
-      name: "RealExponent".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("RealExponent", args));
   }
 
-  let unevaluated = || Expr::FunctionCall {
-    name: "RealExponent".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("RealExponent", args);
 
   // Determine the base. Default is 10. The base must be a real number > 1.
   let base: f64 = if args.len() == 2 {

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -3,6 +3,7 @@ use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  unevaluated,
 };
 use num_bigint::BigInt;
 use num_traits::Signed;
@@ -85,10 +86,7 @@ fn emit_gcd_lcm_exact_message(name: &str, args: &[Expr]) {
     .iter()
     .find(|a| matches!(a, Expr::Real(_) | Expr::BigFloat(_, _)))
   {
-    let call = Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    };
+    let call = unevaluated(name, args);
     crate::emit_message(&format!(
       "{}::exact: Argument {} in {} is not an exact number.",
       name,
@@ -230,10 +228,7 @@ pub fn gcd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Some(f) => fractions.push(f),
       None => {
         emit_gcd_lcm_exact_message("GCD", args);
-        return Ok(Expr::FunctionCall {
-          name: "GCD".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("GCD", args));
       }
     }
   }
@@ -304,10 +299,7 @@ pub fn extended_gcd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::Integer(n) => BigInt::from(*n),
       Expr::BigInteger(n) => n.clone(),
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "ExtendedGCD".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("ExtendedGCD", args));
       }
     };
     vals.push(val);
@@ -399,10 +391,7 @@ pub fn lcm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Some(f) => fractions.push(f),
       None => {
         emit_gcd_lcm_exact_message("LCM", args);
-        return Ok(Expr::FunctionCall {
-          name: "LCM".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("LCM", args));
       }
     }
   }
@@ -603,18 +592,12 @@ pub fn factorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }
         } else {
           // Can't simplify, return unevaluated
-          return Ok(Expr::FunctionCall {
-            name: "Factorial".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("Factorial", args));
         }
       }
       _ => {
         // Return unevaluated for other symbolic arguments
-        return Ok(Expr::FunctionCall {
-          name: "Factorial".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Factorial", args));
       }
     };
     super::gamma_ast(&[n_plus_1])
@@ -644,10 +627,7 @@ pub fn factorial2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let numer = BigInt::from(if (-n + 1) % 4 == 0 { -1 } else { 1 });
         return Ok(make_rational_expr(numer, denom));
       }
-      return Ok(Expr::FunctionCall {
-        name: "Factorial2".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Factorial2", args));
     }
     if n == -1 || n == 0 {
       return Ok(Expr::Integer(1));
@@ -672,10 +652,7 @@ pub fn factorial2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let pi_pow = std::f64::consts::PI.powf(shift);
     let result = pow2 * gamma / pi_pow;
     if result.is_nan() || result.is_infinite() {
-      return Ok(Expr::FunctionCall {
-        name: "Factorial2".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Factorial2", args));
     }
     // BigFloat input → BigFloat result at the same precision marker, so
     // `N[Pi!!, 6]` lands on a precision-tagged real instead of falling back
@@ -686,10 +663,7 @@ pub fn factorial2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     Ok(Expr::Real(result))
   } else {
-    Ok(Expr::FunctionCall {
-      name: "Factorial2".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("Factorial2", args))
   }
 }
 
@@ -715,10 +689,7 @@ pub fn subfactorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   });
   if let Some(n) = n_opt {
     if n < 0 {
-      return Ok(Expr::FunctionCall {
-        name: "Subfactorial".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Subfactorial", args));
     }
     let result = if n == 0 {
       Expr::Integer(1)
@@ -746,10 +717,7 @@ pub fn subfactorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Ok(result)
     }
   } else {
-    Ok(Expr::FunctionCall {
-      name: "Subfactorial".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("Subfactorial", args))
   }
 }
 
@@ -772,10 +740,7 @@ pub fn lucas_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let n_raw = match expr_to_i128(&args[0]) {
       Some(n) => n,
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "LucasL".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("LucasL", args));
       }
     };
     let negate = n_raw < 0 && n_raw % 2 != 0;
@@ -840,10 +805,7 @@ pub fn lucas_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n_raw = match expr_to_i128(&args[0]) {
     Some(n) => n,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "LucasL".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("LucasL", args));
     }
   };
   let negate = n_raw < 0 && n_raw % 2 != 0;
@@ -874,17 +836,12 @@ pub fn chinese_remainder_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "ChineseRemainder expects 2 or 3 arguments".into(),
     ));
   }
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "ChineseRemainder".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let uneval = || Ok(unevaluated("ChineseRemainder", args));
   // The optional third argument shifts the result into [d, d + lcm).
   let offset = if args.len() == 3 {
     match expr_to_i128(&args[2]) {
       Some(d) => Some(d),
-      None => return unevaluated(),
+      None => return uneval(),
     }
   } else {
     None
@@ -892,19 +849,13 @@ pub fn chinese_remainder_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let remainders = match &args[0] {
     Expr::List(items) => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "ChineseRemainder".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("ChineseRemainder", args));
     }
   };
   let moduli = match &args[1] {
     Expr::List(items) => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "ChineseRemainder".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("ChineseRemainder", args));
     }
   };
   if remainders.len() != moduli.len() {
@@ -923,17 +874,11 @@ pub fn chinese_remainder_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           r_vals.push(expr_to_i128(r).unwrap());
           m_vals.push(mv);
         } else {
-          return Ok(Expr::FunctionCall {
-            name: "ChineseRemainder".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("ChineseRemainder", args));
         }
       }
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "ChineseRemainder".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("ChineseRemainder", args));
       }
     }
   }
@@ -959,7 +904,7 @@ pub fn chinese_remainder_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if (ri - result) % g != 0 {
       // Incompatible congruences: no solution. wolframscript leaves the call
       // unevaluated rather than erroring.
-      return unevaluated();
+      return uneval();
     }
     let lcm = modulus / g * mi;
     result =
@@ -987,10 +932,7 @@ pub fn divisor_sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(&args[0]) {
     Some(n) if n > 0 => n,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "DivisorSum".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("DivisorSum", args));
     }
   };
   let func = &args[1];
@@ -1057,10 +999,7 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(&args[0]) {
     Some(n) if n >= 0 => n as usize,
     _ => {
-      let call = Expr::FunctionCall {
-        name: "BernoulliB".to_string(),
-        args: args.to_vec().into(),
-      };
+      let call = unevaluated("BernoulliB", args);
       // A concrete first argument that isn't a non-negative integer (a
       // negative integer, a real, or a rational) emits intnm; a symbolic
       // argument stays unevaluated silently. The two-argument polynomial
@@ -1302,10 +1241,7 @@ pub fn euler_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(&args[0]) {
     Some(n) if n >= 0 => n as usize,
     _ => {
-      let call = Expr::FunctionCall {
-        name: "EulerE".to_string(),
-        args: args.to_vec().into(),
-      };
+      let call = unevaluated("EulerE", args);
       // As with BernoulliB: a concrete non-(non-negative-integer) first
       // argument emits intnm; symbolic stays silent; the polynomial form
       // never emits it.
@@ -1523,10 +1459,7 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(&args[0]) {
     Some(n) if n >= 0 => n as usize,
     _ => {
-      let call = Expr::FunctionCall {
-        name: "BellB".to_string(),
-        args: args.to_vec().into(),
-      };
+      let call = unevaluated("BellB", args);
       // As with BernoulliB/EulerE: a concrete first argument that isn't a
       // non-negative integer emits intnm; symbolic stays silent; the Bell
       // polynomial form never emits it.
@@ -1647,10 +1580,7 @@ pub fn pauli_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let k = match expr_to_i128(&args[0]) {
     Some(k) => k,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "PauliMatrix".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("PauliMatrix", args));
     }
   };
   let i_expr = Expr::Identifier("I".to_string());
@@ -1691,10 +1621,7 @@ pub fn pauli_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       ]
       .into(),
     )),
-    _ => Ok(Expr::FunctionCall {
-      name: "PauliMatrix".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("PauliMatrix", args)),
   }
 }
 
@@ -1743,10 +1670,7 @@ pub fn catalan_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(-1) => return Ok(Expr::Integer(-1)),
     Some(_) => return Ok(Expr::Integer(0)),
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "CatalanNumber".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("CatalanNumber", args));
     }
   };
 
@@ -1761,10 +1685,7 @@ pub fn catalan_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// non-negative machine integer emits `::intnm` with the offending
 /// position, matching wolframscript (symbolic arguments stay silent).
 fn stirling_intnm_unevaluated(fname: &str, args: &[Expr], pos: usize) -> Expr {
-  let call = Expr::FunctionCall {
-    name: fname.to_string(),
-    args: args.to_vec().into(),
-  };
+  let call = unevaluated(fname, args);
   if is_concrete_number(&args[pos - 1]) {
     crate::emit_message(&format!(
       "{fname}::intnm: Non-negative machine-sized integer expected at position {pos} in {}.",
@@ -1940,10 +1861,7 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
     }
     // Symbolic order: stay unevaluated.
-    return Ok(Expr::FunctionCall {
-      name: "HarmonicNumber".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("HarmonicNumber", args));
   }
 
   // Handle inexact real argument: H(x) = digamma(x+1) + EulerGamma. Only a
@@ -2012,16 +1930,10 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if order_is_positive {
         return Ok(Expr::Identifier("ComplexInfinity".to_string()));
       }
-      return Ok(Expr::FunctionCall {
-        name: "HarmonicNumber".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HarmonicNumber", args));
     }
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "HarmonicNumber".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HarmonicNumber", args));
     }
   };
 
@@ -2029,10 +1941,7 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match expr_to_i128(&args[1]) {
       Some(r) => r,
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "HarmonicNumber".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("HarmonicNumber", args));
       }
     }
   } else {
@@ -2113,10 +2022,7 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn multiple_harmonic_number_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "MultipleHarmonicNumber".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("MultipleHarmonicNumber", args);
   if args.is_empty() || args.len() > 2 {
     return Ok(unevaluated());
   }
@@ -2196,10 +2102,7 @@ pub fn multiple_harmonic_number_ast(
 pub fn alternating_harmonic_number_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = Expr::FunctionCall {
-    name: "AlternatingHarmonicNumber".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = unevaluated("AlternatingHarmonicNumber", args);
 
   // Exact negation of the order r, used to build k^(-r) terms.
   fn negate_exact(r: &Expr) -> Option<Expr> {
@@ -2445,10 +2348,7 @@ pub fn alternating_harmonic_number_ast(
 pub fn hyper_harmonic_number_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = Expr::FunctionCall {
-    name: "HyperHarmonicNumber".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = unevaluated("HyperHarmonicNumber", args);
 
   let contains_real = |e: &Expr| -> bool {
     fn walk(e: &Expr) -> bool {
@@ -2585,10 +2485,7 @@ pub fn prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "Prime expects exactly 1 argument".into(),
     ));
   }
-  let unevaluated = Expr::FunctionCall {
-    name: "Prime".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = unevaluated("Prime", args);
   // Prime requires an exact positive integer index. wolframscript rejects
   // every Real argument with Prime::intpp, even an integer-valued one like
   // 3.0, so do NOT coerce Reals to integers here.
@@ -2657,10 +2554,7 @@ pub fn fibonacci_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(bigint_to_expr(fibonacci_number_bigint(n as u128)))
       }
     }
-    None => Ok(Expr::FunctionCall {
-      name: "Fibonacci".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("Fibonacci", args)),
   }
 }
 
@@ -2776,10 +2670,7 @@ pub fn factor_integer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     e if extract_gaussian_integer(e).is_some_and(|(_, im)| im != 0) => {
       factor_integer_gaussian(&args[0])
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "FactorInteger".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("FactorInteger", args)),
   }
 }
 
@@ -3597,10 +3488,7 @@ pub fn integer_partitions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(&args[0]) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "IntegerPartitions".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("IntegerPartitions", args));
     }
   };
 
@@ -3621,15 +3509,9 @@ pub fn integer_partitions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let nninfseq = || {
     crate::emit_message(&format!(
       "IntegerPartitions::nninfseq: Position 2 of {} must be All, Infinity, nmax, {{nmin}}, {{nmin, nmax}} or {{nmin, nmax, dn}}, where nmin is a non-negative integer, nmax is a non-negative integer or Infinity, and dn is a nonzero integer.",
-      crate::syntax::expr_to_string(&Expr::FunctionCall {
-        name: "IntegerPartitions".to_string(),
-        args: args.to_vec().into(),
-      })
+      crate::syntax::expr_to_string(&unevaluated("IntegerPartitions", args))
     ));
-    Ok(Expr::FunctionCall {
-      name: "IntegerPartitions".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("IntegerPartitions", args))
   };
 
   // Parse length constraints from the second arg into
@@ -3695,10 +3577,7 @@ pub fn integer_partitions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           match expr_to_i128(e) {
             Some(v) => vals.push(v),
             _ => {
-              return Ok(Expr::FunctionCall {
-                name: "IntegerPartitions".to_string(),
-                args: args.to_vec().into(),
-              });
+              return Ok(unevaluated("IntegerPartitions", args));
             }
           }
         }
@@ -3708,10 +3587,7 @@ pub fn integer_partitions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Some(vals)
       }
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "IntegerPartitions".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("IntegerPartitions", args));
       }
     }
   } else {
@@ -3737,10 +3613,7 @@ pub fn integer_partitions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match expr_to_i128(&args[3]) {
       Some(k) if k >= 0 => Some(k as usize),
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "IntegerPartitions".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("IntegerPartitions", args));
       }
     }
   } else {
@@ -4105,10 +3978,7 @@ fn divisors_gaussian_expr(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   let Some(divs) = gaussian_divisors(a, b) else {
-    return Ok(Expr::FunctionCall {
-      name: "Divisors".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Divisors", args));
   };
   let mut items = Vec::with_capacity(divs.len());
   for (re, im) in divs {
@@ -4124,16 +3994,10 @@ pub fn divisors_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return match gaussian_integers_option(&args[1]) {
       Some(true) => match extract_gaussian_integer(&args[0]) {
         Some((a, b)) if (a, b) != (0, 0) => divisors_gaussian_expr(a, b, args),
-        _ => Ok(Expr::FunctionCall {
-          name: "Divisors".to_string(),
-          args: args.to_vec().into(),
-        }),
+        _ => Ok(unevaluated("Divisors", args)),
       },
       Some(false) => divisors_ast(&args[..1]),
-      None => Ok(Expr::FunctionCall {
-        name: "Divisors".to_string(),
-        args: args.to_vec().into(),
-      }),
+      None => Ok(unevaluated("Divisors", args)),
     };
   }
   if args.len() != 1 {
@@ -4153,17 +4017,11 @@ pub fn divisors_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(&args[0]) {
     // Divisors[0] is undefined; Wolfram leaves the call unevaluated.
     Some(0) => {
-      return Ok(Expr::FunctionCall {
-        name: "Divisors".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Divisors", args));
     }
     Some(n) => n.unsigned_abs(),
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "Divisors".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Divisors", args));
     }
   };
 
@@ -4196,12 +4054,7 @@ fn divisor_sigma_gaussian_expr(
   b: i128,
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "DivisorSigma".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("DivisorSigma", args));
   let Some(k) = expr_to_i128(k_expr).filter(|&k| k >= 0) else {
     return unevaluated();
   };
@@ -4221,16 +4074,10 @@ pub fn divisor_sigma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Some((a, b)) if (a, b) != (0, 0) => {
           divisor_sigma_gaussian_expr(&args[0], a, b, args)
         }
-        _ => Ok(Expr::FunctionCall {
-          name: "DivisorSigma".to_string(),
-          args: args.to_vec().into(),
-        }),
+        _ => Ok(unevaluated("DivisorSigma", args)),
       },
       Some(false) => divisor_sigma_ast(&args[..2]),
-      None => Ok(Expr::FunctionCall {
-        name: "DivisorSigma".to_string(),
-        args: args.to_vec().into(),
-      }),
+      None => Ok(unevaluated("DivisorSigma", args)),
     };
   }
   if args.len() == 2
@@ -4261,17 +4108,11 @@ pub fn divisor_sigma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(0) => {
       // 0 has no (finite) divisor sum; wolframscript leaves it unevaluated
       // rather than raising an error.
-      return Ok(Expr::FunctionCall {
-        name: "DivisorSigma".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("DivisorSigma", args));
     }
     Some(n) => n.unsigned_abs(),
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "DivisorSigma".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("DivisorSigma", args));
     }
   };
 
@@ -4322,10 +4163,7 @@ pub fn moebius_mu_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(0) if is_integer => return Ok(Expr::Integer(0)),
     Some(v) if is_integer => v.unsigned_abs(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "MoebiusMu".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("MoebiusMu", args));
     }
   };
 
@@ -4399,10 +4237,7 @@ pub fn euler_phi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return euler_phi_bigint(n).map(bigint_to_expr);
   }
 
-  let call = Expr::FunctionCall {
-    name: "EulerPhi".to_string(),
-    args: args.to_vec().into(),
-  };
+  let call = unevaluated("EulerPhi", args);
   // A concrete non-integer number emits ::int like wolframscript
   // (EulerPhi[1/2], EulerPhi[2.5]); symbolic arguments stay silent.
   if is_concrete_number(&args[0]) {
@@ -4499,10 +4334,7 @@ pub fn carmichael_lambda_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(0) => return Ok(Expr::Integer(0)),
     Some(n) => n.unsigned_abs(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "CarmichaelLambda".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("CarmichaelLambda", args));
     }
   };
 
@@ -4583,20 +4415,14 @@ pub fn jacobi_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(&args[0]) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "JacobiSymbol".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("JacobiSymbol", args));
     }
   };
 
   let m = match expr_to_i128(&args[1]) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "JacobiSymbol".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("JacobiSymbol", args));
     }
   };
 
@@ -4741,10 +4567,7 @@ pub fn coprime_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     .collect();
 
   if nums.len() != args.len() {
-    return Ok(Expr::FunctionCall {
-      name: "CoprimeQ".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("CoprimeQ", args));
   }
 
   // Check all pairs are coprime, i.e. GCD == 1. A zero argument must NOT be
@@ -4900,10 +4723,7 @@ pub fn binomial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let result = log_result.exp();
         Ok(Expr::Real(result))
       } else {
-        Ok(Expr::FunctionCall {
-          name: "Binomial".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("Binomial", args))
       }
     }
   }
@@ -4995,10 +4815,7 @@ pub fn multinomial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     .sort_by(crate::functions::list_helpers_ast::sorting::canonical_cmp);
   let args = sorted_args.as_slice();
 
-  let unevaluated = || Expr::FunctionCall {
-    name: "Multinomial".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("Multinomial", args);
 
   // Fast path: all integers → integer arithmetic via the cumulative
   // binomial product Multinomial[n1,..,nk] = prod_j Binomial[n1+..+nj, nj].
@@ -5141,10 +4958,7 @@ pub fn power_mod_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           expr_to_string(&args[0]),
           expr_to_string(&args[1])
         ));
-        return Ok(Expr::FunctionCall {
-          name: "PowerMod".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("PowerMod", args));
       }
       if exp < BigInt::from(0) {
         // Negative exponent: need modular inverse
@@ -5163,16 +4977,10 @@ pub fn power_mod_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 expr_to_string(&args[0]),
                 expr_to_string(&args[2])
               ));
-              Ok(Expr::FunctionCall {
-                name: "PowerMod".to_string(),
-                args: args.to_vec().into(),
-              })
+              Ok(unevaluated("PowerMod", args))
             }
           }
-          _ => Ok(Expr::FunctionCall {
-            name: "PowerMod".to_string(),
-            args: args.to_vec().into(),
-          }),
+          _ => Ok(unevaluated("PowerMod", args)),
         }
       } else {
         let result = base.modpow(&exp, &modulus);
@@ -5181,10 +4989,7 @@ pub fn power_mod_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(bigint_to_expr(result))
       }
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "PowerMod".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("PowerMod", args)),
   }
 }
 
@@ -5223,12 +5028,7 @@ fn power_mod_root_ast(
   n: u128,
 ) -> Result<Expr, InterpreterError> {
   use num_traits::{ToPrimitive, Zero};
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "PowerMod".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("PowerMod", args));
   let exp_str = || expr_to_string(&args[1]);
   let (Some(a), Some(m)) = (expr_to_bigint(&args[0]), expr_to_bigint(&args[2]))
   else {
@@ -5368,10 +5168,7 @@ pub fn mersenne_prime_exponent_ast(
       )));
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "MersennePrimeExponent".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("MersennePrimeExponent", args));
     }
   };
 
@@ -5455,10 +5252,7 @@ pub fn prime_pi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         Ok(Expr::Integer(count))
       } else {
-        Ok(Expr::FunctionCall {
-          name: "PrimePi".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("PrimePi", args))
       }
     }
   }
@@ -5552,10 +5346,7 @@ pub fn next_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match &args[1] {
       Expr::Integer(k) => *k,
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "NextPrime".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("NextPrime", args));
       }
     }
   } else {
@@ -5573,20 +5364,14 @@ pub fn next_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       return Ok(bigint_to_expr(current));
     }
-    return Ok(Expr::FunctionCall {
-      name: "NextPrime".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("NextPrime", args));
   }
 
   let n = match &args[0] {
     Expr::Integer(n) => *n,
     Expr::Real(f) => f.floor() as i128,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "NextPrime".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NextPrime", args));
     }
   };
 
@@ -5604,10 +5389,7 @@ pub fn next_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Ok(Expr::Integer(current))
   } else {
     // k == 0: return unevaluated
-    Ok(Expr::FunctionCall {
-      name: "NextPrime".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("NextPrime", args))
   }
 }
 
@@ -5711,12 +5493,7 @@ pub fn modular_inverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "ModularInverse expects exactly 2 arguments".into(),
     ));
   }
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "ModularInverse".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("ModularInverse", args));
 
   use num_traits::{One, Signed, Zero};
 
@@ -5805,10 +5582,7 @@ pub fn bit_length_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(Expr::Integer(val.bits() as i128))
       }
     }
-    None => Ok(Expr::FunctionCall {
-      name: "BitLength".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("BitLength", args)),
   }
 }
 
@@ -5830,10 +5604,7 @@ pub fn bit_and_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         });
       }
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "BitAnd".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("BitAnd", args));
       }
     }
   }
@@ -5860,10 +5631,7 @@ pub fn bit_or_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         });
       }
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "BitOr".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("BitOr", args));
       }
     }
   }
@@ -5890,10 +5658,7 @@ pub fn bit_xor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         });
       }
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "BitXor".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("BitXor", args));
       }
     }
   }
@@ -5913,10 +5678,7 @@ pub fn bit_not_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   match expr_to_bigint(&args[0]) {
     Some(n) => Ok(bigint_to_expr(!n)),
-    None => Ok(Expr::FunctionCall {
-      name: "BitNot".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("BitNot", args)),
   }
 }
 
@@ -5929,26 +5691,17 @@ pub fn bit_shift_right_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Some(b) => match b.try_into() {
           Ok(v) => v,
           Err(_) => {
-            return Ok(Expr::FunctionCall {
-              name: "BitShiftRight".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("BitShiftRight", args));
           }
         },
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "BitShiftRight".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("BitShiftRight", args));
         }
       };
       (&args[0], k_val)
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BitShiftRight".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitShiftRight", args));
     }
   };
   match expr_to_bigint(n_expr) {
@@ -5959,10 +5712,7 @@ pub fn bit_shift_right_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(bigint_to_expr(n << (-k) as usize))
       }
     }
-    None => Ok(Expr::FunctionCall {
-      name: "BitShiftRight".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("BitShiftRight", args)),
   }
 }
 
@@ -5984,26 +5734,17 @@ pub fn bit_shift_left_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Some(b) => match b.try_into() {
           Ok(v) => v,
           Err(_) => {
-            return Ok(Expr::FunctionCall {
-              name: "BitShiftLeft".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("BitShiftLeft", args));
           }
         },
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "BitShiftLeft".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("BitShiftLeft", args));
         }
       };
       (&args[0], k_val)
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BitShiftLeft".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitShiftLeft", args));
     }
   };
   match expr_to_bigint(n_expr) {
@@ -6016,10 +5757,7 @@ pub fn bit_shift_left_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Ok(bigint_to_expr(truncating_shift_right(n, (-k) as usize)))
       }
     }
-    None => Ok(Expr::FunctionCall {
-      name: "BitShiftLeft".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("BitShiftLeft", args)),
   }
 }
 
@@ -6030,19 +5768,13 @@ pub fn bit_shift_left_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Returns Infinity if the GCD is not 1, -1 if 1 is in the set.
 pub fn frobenius_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "FrobeniusNumber".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("FrobeniusNumber", args));
   }
 
   let items = match &args[0] {
     Expr::List(items) => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "FrobeniusNumber".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("FrobeniusNumber", args));
     }
   };
 
@@ -6051,10 +5783,7 @@ pub fn frobenius_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "FrobeniusNumber::coef: The first argument {} of FrobeniusNumber should be a nonempty list of positive integers.",
       expr_to_string(&args[0])
     ));
-    return Ok(Expr::FunctionCall {
-      name: "FrobeniusNumber".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("FrobeniusNumber", args));
   }
 
   // Extract positive integers
@@ -6069,10 +5798,7 @@ pub fn frobenius_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           "FrobeniusNumber::coef: The first argument {} of FrobeniusNumber should be a nonempty list of positive integers.",
           expr_to_string(&args[0])
         ));
-        return Ok(Expr::FunctionCall {
-          name: "FrobeniusNumber".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("FrobeniusNumber", args));
       }
     }
   }
@@ -6144,20 +5870,14 @@ pub fn frobenius_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// positive integer or `All`).
 pub fn frobenius_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.is_empty() || args.len() > 3 {
-    return Ok(Expr::FunctionCall {
-      name: "FrobeniusSolve".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("FrobeniusSolve", args));
   }
 
   // First argument: a non-empty list of positive integers.
   let items = match &args[0] {
     Expr::List(items) => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "FrobeniusSolve".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("FrobeniusSolve", args));
     }
   };
   let coef_err = || {
@@ -6165,10 +5885,7 @@ pub fn frobenius_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "FrobeniusSolve::coef: The first argument {} of FrobeniusSolve should be a nonempty list of positive integers.",
       expr_to_string(&args[0])
     ));
-    Ok::<Expr, InterpreterError>(Expr::FunctionCall {
-      name: "FrobeniusSolve".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok::<Expr, InterpreterError>(unevaluated("FrobeniusSolve", args))
   };
   if items.is_empty() {
     return coef_err();
@@ -6185,10 +5902,7 @@ pub fn frobenius_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let target = match expr_to_i128(&args[1]) {
     Some(n) if n >= 0 => n,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "FrobeniusSolve".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("FrobeniusSolve", args));
     }
   };
 
@@ -6203,10 +5917,7 @@ pub fn frobenius_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             "FrobeniusSolve::nsol: The number {} of requested solutions should be a positive integer.",
             expr_to_string(&args[2])
           ));
-          return Ok(Expr::FunctionCall {
-            name: "FrobeniusSolve".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("FrobeniusSolve", args));
         }
       },
     }
@@ -6273,10 +5984,7 @@ pub fn partitions_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let result = partitions_p(n);
       Ok(bigint_to_expr(result))
     }
-    None => Ok(Expr::FunctionCall {
-      name: "PartitionsP".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("PartitionsP", args)),
   }
 }
 
@@ -6309,10 +6017,7 @@ pub fn partitions_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let result = partitions_q(n);
       Ok(bigint_to_expr(result))
     }
-    None => Ok(Expr::FunctionCall {
-      name: "PartitionsQ".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("PartitionsQ", args)),
   }
 }
 
@@ -6381,10 +6086,7 @@ pub fn arithmetic_geometric_mean_ast(
   }
 
   // Stay unevaluated for symbolic/exact inputs
-  Ok(Expr::FunctionCall {
-    name: "ArithmeticGeometricMean".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArithmeticGeometricMean", args))
 }
 
 /// Compute AGM iteratively
@@ -6429,10 +6131,7 @@ pub fn prime_omega_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // factorization); without this guard FactorInteger[0] = {{0, 1}} would
   // be miscounted as one prime factor.
   if matches!(&args[0], Expr::Integer(0)) {
-    return Ok(Expr::FunctionCall {
-      name: "PrimeOmega".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("PrimeOmega", args));
   }
   let factors = factor_integer_ast(args)?;
   if let Expr::List(ref pairs) = factors {
@@ -6453,10 +6152,7 @@ pub fn prime_omega_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     Ok(Expr::Integer(total))
   } else {
-    Ok(Expr::FunctionCall {
-      name: "PrimeOmega".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("PrimeOmega", args))
   }
 }
 
@@ -6474,10 +6170,7 @@ pub fn prime_nu_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // factorization); without this guard FactorInteger[0] = {{0, 1}} would
   // be miscounted as one distinct prime.
   if matches!(&args[0], Expr::Integer(0)) {
-    return Ok(Expr::FunctionCall {
-      name: "PrimeNu".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("PrimeNu", args));
   }
   let factors = factor_integer_ast(args)?;
   if let Expr::List(ref pairs) = factors {
@@ -6497,10 +6190,7 @@ pub fn prime_nu_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     Ok(Expr::Integer(count))
   } else {
-    Ok(Expr::FunctionCall {
-      name: "PrimeNu".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("PrimeNu", args))
   }
 }
 
@@ -6508,10 +6198,7 @@ pub fn prime_nu_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// BitSet[n, {k1, k2, ...}] - map over list of bit positions
 pub fn bit_set_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "BitSet".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("BitSet", args));
   }
 
   // Handle list of bit positions
@@ -6533,20 +6220,14 @@ pub fn bit_set_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_bigint(&args[0]) {
     Some(n) => n,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "BitSet".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitSet", args));
     }
   };
 
   let k = match &args[1] {
     Expr::Integer(k) if *k >= 0 => *k as u64,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BitSet".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitSet", args));
     }
   };
 
@@ -6558,10 +6239,7 @@ pub fn bit_set_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// BitClear[n, {k1, k2, ...}] - map over list of bit positions
 pub fn bit_clear_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "BitClear".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("BitClear", args));
   }
 
   if let Expr::List(positions) = &args[1] {
@@ -6582,20 +6260,14 @@ pub fn bit_clear_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_bigint(&args[0]) {
     Some(n) => n,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "BitClear".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitClear", args));
     }
   };
 
   let k = match &args[1] {
     Expr::Integer(k) if *k >= 0 => *k as u64,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BitClear".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitClear", args));
     }
   };
 
@@ -6608,29 +6280,20 @@ pub fn bit_clear_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// For k < 0: flip bit (BitLength(n) + k) from LSB
 pub fn bit_flip_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "BitFlip".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("BitFlip", args));
   }
 
   let n = match expr_to_bigint(&args[0]) {
     Some(n) => n,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "BitFlip".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitFlip", args));
     }
   };
 
   let k = match &args[1] {
     Expr::Integer(k) => *k,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BitFlip".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitFlip", args));
     }
   };
 
@@ -6640,17 +6303,11 @@ pub fn bit_flip_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Negative index: count from MSB
     let bit_length = n.bits();
     if bit_length == 0 {
-      return Ok(Expr::FunctionCall {
-        name: "BitFlip".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitFlip", args));
     }
     let pos = bit_length as i128 + k;
     if pos < 0 {
-      return Ok(Expr::FunctionCall {
-        name: "BitFlip".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BitFlip", args));
     }
     pos as u64
   };
@@ -6687,10 +6344,7 @@ pub fn hyperfactorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     return Ok(bigint_to_expr(product));
   }
-  Ok(Expr::FunctionCall {
-    name: "Hyperfactorial".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Hyperfactorial", args))
 }
 
 /// DeBruijnSequence[alphabet, n] - De Bruijn sequence
@@ -6700,19 +6354,13 @@ pub fn debruijn_sequence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let alphabet = match &args[0] {
     Expr::List(items) => items.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "DeBruijnSequence".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("DeBruijnSequence", args));
     }
   };
   let n = match expr_to_i128(&args[1]) {
     Some(n) if n >= 1 => n as usize,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "DeBruijnSequence".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("DeBruijnSequence", args));
     }
   };
 
@@ -6766,28 +6414,19 @@ pub fn bell_y_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match expr_to_i128(&args[0]) {
     Some(n) if n >= 0 => n as usize,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BellY".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BellY", args));
     }
   };
   let k = match expr_to_i128(&args[1]) {
     Some(k) if k >= 0 => k as usize,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BellY".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BellY", args));
     }
   };
   let xs = match &args[2] {
     Expr::List(items) => items.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BellY".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BellY", args));
     }
   };
 
@@ -6936,16 +6575,10 @@ pub fn finite_group_count_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(0) => return Ok(bigint_to_expr(BigInt::from(0))),
     Some(_) => {
       // Negative: return unevaluated (Wolfram returns error message)
-      return Ok(Expr::FunctionCall {
-        name: "FiniteGroupCount".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("FiniteGroupCount", args));
     }
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "FiniteGroupCount".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("FiniteGroupCount", args));
     }
   };
 
@@ -6956,10 +6589,7 @@ pub fn finite_group_count_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Beyond lookup table range, return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "FiniteGroupCount".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("FiniteGroupCount", args))
 }
 
 /// FiniteAbelianGroupCount[n] - Number of abelian groups of order n
@@ -6972,16 +6602,10 @@ pub fn finite_abelian_group_count_ast(
     // There are no abelian groups of order 0, so Wolfram returns 0.
     Some(0) => return Ok(bigint_to_expr(BigInt::from(0))),
     Some(_) => {
-      return Ok(Expr::FunctionCall {
-        name: "FiniteAbelianGroupCount".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("FiniteAbelianGroupCount", args));
     }
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "FiniteAbelianGroupCount".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("FiniteAbelianGroupCount", args));
     }
   };
 
@@ -9100,10 +8724,7 @@ pub fn three_j_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "ThreeJSymbol expects exactly 3 arguments".into(),
     ));
   }
-  let unchanged = || Expr::FunctionCall {
-    name: "ThreeJSymbol".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unchanged = || unevaluated("ThreeJSymbol", args);
   let mut two_j = [0i128; 3];
   let mut two_m = [0i128; 3];
   for (i, arg) in args.iter().enumerate() {
@@ -9265,10 +8886,7 @@ pub fn six_j_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "SixJSymbol expects exactly 2 arguments".into(),
     ));
   }
-  let unchanged = || Expr::FunctionCall {
-    name: "SixJSymbol".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unchanged = || unevaluated("SixJSymbol", args);
   let mut two_j = [0i128; 6];
   // Track exactly-one symbolic j-index for the Piecewise fallback.
   let mut symbolic: Option<(usize, String)> = None;
@@ -9626,10 +9244,7 @@ pub fn clebsch_gordan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "ClebschGordan expects exactly 3 arguments".into(),
     ));
   }
-  let unchanged = || Expr::FunctionCall {
-    name: "ClebschGordan".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unchanged = || unevaluated("ClebschGordan", args);
   let mut two_j = [0i128; 3];
   let mut two_m = [0i128; 3];
   // Track which `m_i` (if any) is symbolic so we can fall through to the
@@ -9823,10 +9438,7 @@ impl PipeThroughRational for Expr {
 /// FareySequence::rank and stays unevaluated; everything else
 /// (symbolic, rational, rank 0) stays silently unevaluated.
 pub fn farey_sequence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "FareySequence".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("FareySequence", args);
   if args.is_empty() || args.len() > 2 {
     return Ok(unevaluated(args));
   }
@@ -9881,10 +9493,7 @@ pub fn farey_sequence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Negative integers give ComplexInfinity; non-integer numbers emit
 /// Fibonorial::intnm and stay unevaluated; symbols stay quiet.
 pub fn fibonorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "Fibonorial".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = |args: &[Expr]| unevaluated("Fibonorial", args);
   if args.len() != 1 {
     return Ok(unevaluated(args));
   }

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -3,6 +3,7 @@ use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, expr_to_string, substitute_variable,
+  unevaluated,
 };
 
 pub fn n_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -34,10 +35,7 @@ pub fn n_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             "N::precbd: Requested precision {} is not a machine-sized real number between $MinPrecision and $MaxPrecision.",
             expr_to_string(other)
           ));
-          return Ok(Expr::FunctionCall {
-            name: "N".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("N", args));
         }
       }
     };
@@ -648,10 +646,7 @@ pub fn bigfloat_to_string(
 /// preserved verbatim.
 pub fn set_precision_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "SetPrecision".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("SetPrecision", args));
   }
   let expr = &args[0];
   let target = &args[1];
@@ -668,10 +663,7 @@ pub fn set_precision_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         v
       } else {
-        return Ok(Expr::FunctionCall {
-          name: "SetPrecision".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("SetPrecision", args));
       }
     }
   };
@@ -818,10 +810,7 @@ fn leaf_to_bigfloat(
 /// accuracy-form `0``accuracy`. Mirrors SetPrecision but the precision is
 /// computed per leaf from its magnitude.
 pub fn set_accuracy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "SetAccuracy".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("SetAccuracy", args);
   if args.len() != 2 {
     return Ok(unevaluated());
   }
@@ -2123,10 +2112,7 @@ pub fn rescale_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         &mut ok,
       );
       if !ok || vals.is_empty() {
-        return Ok(Expr::FunctionCall {
-          name: "Rescale".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Rescale", args));
       }
       let min_f = vals.iter().cloned().fold(f64::INFINITY, f64::min);
       let max_f = vals.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
@@ -2149,10 +2135,7 @@ pub fn rescale_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       ));
     }
     // Single non-list value needs {xmin, xmax}
-    return Ok(Expr::FunctionCall {
-      name: "Rescale".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Rescale", args));
   }
 
   // Handle list first argument: Rescale[{x1, x2, ...}, range] maps over elements
@@ -2172,10 +2155,7 @@ pub fn rescale_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let range = match &args[1] {
     Expr::List(r) if r.len() == 2 => r,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Rescale".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Rescale", args));
     }
   };
 
@@ -2183,22 +2163,14 @@ pub fn rescale_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match &args[2] {
       Expr::List(r) if r.len() == 2 => (&r[0], &r[1]),
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "Rescale".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Rescale", args));
       }
     }
   } else {
     (&Expr::Integer(0) as &Expr, &Expr::Integer(1) as &Expr)
   };
 
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "Rescale".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("Rescale", args));
 
   // A literal exact number: Integer, BigInteger, Real or Rational[p, q].
   let is_numeric_literal = |e: &Expr| -> bool {
@@ -2305,10 +2277,7 @@ pub fn norm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     crate::emit_message(
       "Norm::nvm: The first Norm argument should be a scalar, vector or matrix.",
     );
-    return Ok(Expr::FunctionCall {
-      name: "Norm".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Norm", args));
   }
   // Determine the norm parameter p
   let p_expr = if args.len() == 2 {
@@ -2341,10 +2310,7 @@ pub fn norm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         crate::syntax::expr_to_string(p)
       ));
     }
-    Ok(Expr::FunctionCall {
-      name: "Norm".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("Norm", args))
   };
 
   // Norm[matrix, "Frobenius"] — sqrt of sum of squared absolute values
@@ -2407,10 +2373,7 @@ pub fn norm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::emit_message(
         "Norm::nvm: The first Norm argument should be a scalar, vector or matrix.",
       );
-      return Ok(Expr::FunctionCall {
-        name: "Norm".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Norm", args));
     }
     let ncols = mat[0].len();
     if ncols > 0 && mat.iter().all(|r| r.len() == ncols) {
@@ -2495,10 +2458,7 @@ pub fn norm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           match try_eval_to_f64(item) {
             Some(v) => vals.push(v),
             None => {
-              return Ok(Expr::FunctionCall {
-                name: "Norm".to_string(),
-                args: args.to_vec().into(),
-              });
+              return Ok(unevaluated("Norm", args));
             }
           }
         }
@@ -2673,10 +2633,7 @@ pub fn norm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if crate::functions::predicate_ast::is_numeric_q(&args[0]) {
         crate::evaluator::evaluate_function_call_ast("Abs", &[args[0].clone()])
       } else {
-        Ok(Expr::FunctionCall {
-          name: "Norm".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("Norm", args))
       }
     }
   }
@@ -2856,10 +2813,7 @@ pub fn unitize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
 
     // Non-numeric arguments remain unevaluated.
-    return Ok(Expr::FunctionCall {
-      name: "Unitize".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Unitize", args));
   }
 
   match &args[0] {
@@ -2885,10 +2839,7 @@ pub fn unitize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         return Ok(Expr::Integer(1));
       }
-      Ok(Expr::FunctionCall {
-        name: "Unitize".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Unitize", args))
     }
   }
 }
@@ -3115,10 +3066,7 @@ pub fn accuracy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             min_finite = Some(min_finite.map_or(v, |m| m.min(v)));
           }
           _ => {
-            return Ok(Expr::FunctionCall {
-              name: "Accuracy".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("Accuracy", args));
           }
         }
       }
@@ -3145,10 +3093,7 @@ pub fn accuracy_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           _ => {
             // Some child still couldn't be reduced to a number — keep the
             // call symbolic rather than guess.
-            return Ok(Expr::FunctionCall {
-              name: "Accuracy".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("Accuracy", args));
           }
         }
       }
@@ -3680,29 +3625,20 @@ fn collect_variables(expr: &Expr, vars: &mut Vec<Expr>) {
 /// LinearRecurrence[ker, init, {n}] - returns the list containing only the nth element.
 pub fn linear_recurrence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 3 {
-    return Ok(Expr::FunctionCall {
-      name: "LinearRecurrence".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("LinearRecurrence", args));
   }
 
   let kernel = match &args[0] {
     Expr::List(items) => items.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "LinearRecurrence".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("LinearRecurrence", args));
     }
   };
 
   let init = match &args[1] {
     Expr::List(items) => items.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "LinearRecurrence".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("LinearRecurrence", args));
     }
   };
 
@@ -3713,10 +3649,7 @@ pub fn linear_recurrence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Some(n) = expr_to_i128(&items[0]) {
         (n as usize, Some((n as usize, n as usize)))
       } else {
-        return Ok(Expr::FunctionCall {
-          name: "LinearRecurrence".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("LinearRecurrence", args));
       }
     }
     Expr::List(items) if items.len() == 2 => {
@@ -3725,17 +3658,11 @@ pub fn linear_recurrence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         (nmax as usize, Some((nmin as usize, nmax as usize)))
       } else {
-        return Ok(Expr::FunctionCall {
-          name: "LinearRecurrence".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("LinearRecurrence", args));
       }
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "LinearRecurrence".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("LinearRecurrence", args));
     }
   };
 
@@ -3869,12 +3796,7 @@ fn warping_correspondence_path(
 pub fn warping_correspondence_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "WarpingCorrespondence".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("WarpingCorrespondence", args));
   if args.len() != 2 {
     return unevaluated();
   }
@@ -3926,10 +3848,7 @@ pub fn warping_distance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       ));
     }
   }
-  Ok(Expr::FunctionCall {
-    name: "WarpingDistance".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("WarpingDistance", args))
 }
 
 pub fn euclidean_distance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -4219,10 +4138,7 @@ fn fourier_impl(
         func_name,
         expr_to_string(&args[0])
       ));
-      return Ok(Expr::FunctionCall {
-        name: func_name.to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated(func_name, args));
     }
   };
 
@@ -4237,10 +4153,7 @@ fn fourier_impl(
         func_name,
         expr_to_string(&args[0])
       ));
-      return Ok(Expr::FunctionCall {
-        name: func_name.to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated(func_name, args));
     }
   }
 
@@ -4337,10 +4250,7 @@ pub fn fourier_dct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "FourierDCT::fftl: Argument {} is not a nonempty list or rectangular array of numeric quantities.",
       expr_to_string(&args[0])
     ));
-    Ok(Expr::FunctionCall {
-      name: "FourierDCT".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("FourierDCT", args))
   };
 
   let items = match &args[0] {
@@ -4383,12 +4293,7 @@ pub fn fourier_dct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn discrete_hilbert_transform_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "DiscreteHilbertTransform".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("DiscreteHilbertTransform", args));
   // Emit the ::data message and leave the expression unevaluated, matching
   // wolframscript's handling of empty or non-real arguments.
   let data_err = || {
@@ -4517,10 +4422,7 @@ pub fn fourier_dst_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "FourierDST::fftl: Argument {} is not a nonempty list or rectangular array of numeric quantities.",
       expr_to_string(&args[0])
     ));
-    Ok(Expr::FunctionCall {
-      name: "FourierDST".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("FourierDST", args))
   };
 
   let items = match &args[0] {
@@ -4584,10 +4486,7 @@ fn neville_extrapolation(xs: &[f64], ys: &[f64]) -> f64 {
 /// NSum[expr, {i, min, max}] - Numerical summation
 pub fn nsum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() < 2 {
-    return Ok(Expr::FunctionCall {
-      name: "NSum".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("NSum", args));
   }
 
   let body = &args[0];
@@ -4596,37 +4495,25 @@ pub fn nsum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match iter_spec {
     Expr::List(items) if items.len() >= 2 => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "NSum".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NSum", args));
     }
   };
 
   let var_name = match &items[0] {
     Expr::Identifier(name) => name.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "NSum".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NSum", args));
     }
   };
 
   if items.len() < 3 {
-    return Ok(Expr::FunctionCall {
-      name: "NSum".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("NSum", args));
   }
 
   let min_val = match try_eval_to_f64(&items[1]) {
     Some(v) => v as i64,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "NSum".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NSum", args));
     }
   };
 
@@ -4651,10 +4538,7 @@ pub fn nsum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let term = match try_eval_to_f64(&val) {
         Some(f) => f,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "NSum".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("NSum", args));
         }
       };
 
@@ -4685,10 +4569,7 @@ pub fn nsum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let max_val = match try_eval_to_f64(&items[2]) {
     Some(v) => v as i64,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "NSum".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NSum", args));
     }
   };
 
@@ -4700,10 +4581,7 @@ pub fn nsum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let term = match try_eval_to_f64(&val) {
       Some(f) => f,
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "NSum".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("NSum", args));
       }
     };
     sum += term;
@@ -4715,10 +4593,7 @@ pub fn nsum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// NProduct[f, {i, imin, imax}] - Numerical product
 pub fn nproduct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() < 2 {
-    return Ok(Expr::FunctionCall {
-      name: "NProduct".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("NProduct", args));
   }
 
   let body = &args[0];
@@ -4727,37 +4602,25 @@ pub fn nproduct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match iter_spec {
     Expr::List(items) if items.len() >= 2 => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "NProduct".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NProduct", args));
     }
   };
 
   let var_name = match &items[0] {
     Expr::Identifier(name) => name.clone(),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "NProduct".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NProduct", args));
     }
   };
 
   if items.len() < 3 {
-    return Ok(Expr::FunctionCall {
-      name: "NProduct".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("NProduct", args));
   }
 
   let min_val = match try_eval_to_f64(&items[1]) {
     Some(v) => v as i64,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "NProduct".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NProduct", args));
     }
   };
 
@@ -4791,17 +4654,11 @@ pub fn nproduct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let term = match eval_term(i)? {
         Some(f) => f,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "NProduct".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("NProduct", args));
         }
       };
       if term <= 0.0 || !term.is_finite() {
-        return Ok(Expr::FunctionCall {
-          name: "NProduct".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("NProduct", args));
       }
       log_product += term.ln();
       if k + 1 >= next_sample {
@@ -4855,10 +4712,7 @@ pub fn nproduct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let max_val = match try_eval_to_f64(&items[2]) {
     Some(v) => v as i64,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "NProduct".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("NProduct", args));
     }
   };
 
@@ -4867,10 +4721,7 @@ pub fn nproduct_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let term = match eval_term(i)? {
       Some(f) => f,
       None => {
-        return Ok(Expr::FunctionCall {
-          name: "NProduct".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("NProduct", args));
       }
     };
     product *= term;
@@ -5450,19 +5301,13 @@ pub fn list_fourier_sequence_transform_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "ListFourierSequenceTransform".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("ListFourierSequenceTransform", args));
   }
 
   let list = match &args[0] {
     Expr::List(items) => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "ListFourierSequenceTransform".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("ListFourierSequenceTransform", args));
     }
   };
 
@@ -5535,10 +5380,7 @@ pub fn window_function_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated(name, args));
   }
 
   // For exact rational arguments, try exact evaluation
@@ -5560,10 +5402,7 @@ pub fn window_function_ast(
   let x = match try_eval_to_f64(&args[0]) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: name.to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated(name, args));
     }
   };
 
@@ -5604,10 +5443,7 @@ pub fn window_function_ast(
         + 5388.0 / 18608.0 * (4.0 * pi * x).cos()
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: name.to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated(name, args));
     }
   };
 
@@ -5636,10 +5472,7 @@ pub fn window_function_ast(
 /// evaluated symbolically (so Cos simplifies to wolframscript's radical forms,
 /// e.g. TukeyWindow[1/4] -> (1 + 1/Sqrt[2])/2); Real arguments numericize.
 pub fn tukey_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "TukeyWindow".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("TukeyWindow", args);
   if args.is_empty() || args.len() > 2 {
     return Ok(unevaluated());
   }
@@ -5753,10 +5586,7 @@ fn window_arg_inexact(e: &Expr) -> bool {
 /// Exact arguments give the exact polynomial value (e.g. ParzenWindow[1/3] ->
 /// 2/27); Real arguments numericize.
 pub fn parzen_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "ParzenWindow".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("ParzenWindow", args);
   if args.len() != 1 {
     return Ok(unevaluated());
   }
@@ -5829,10 +5659,7 @@ pub fn parzen_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Exact arguments give E^(rational) (e.g. GaussianWindow[1/4] -> E^(-25/72));
 /// Real arguments numericize.
 pub fn gaussian_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "GaussianWindow".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("GaussianWindow", args);
   if args.is_empty() || args.len() > 2 {
     return Ok(unevaluated());
   }
@@ -5883,10 +5710,7 @@ pub fn gaussian_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// (1 - 2|x|) Cos[2 Pi |x|] + Sin[2 Pi |x|] / Pi. Exact arguments evaluate the
 /// symbolic form (e.g. BohmanWindow[1/4] -> 1/Pi); Real arguments numericize.
 pub fn bohman_window_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "BohmanWindow".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("BohmanWindow", args);
   if args.len() != 1 {
     return Ok(unevaluated());
   }
@@ -5979,10 +5803,7 @@ fn approximate_rational(val: f64) -> Option<(i128, i128)> {
 /// Default order n = length of data. Default SampleRate = 1.
 pub fn bandpass_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() < 2 || args.len() > 4 {
-    return Ok(Expr::FunctionCall {
-      name: "BandpassFilter".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("BandpassFilter", args));
   }
 
   // Extract {omega1, omega2}
@@ -5991,28 +5812,19 @@ pub fn bandpass_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let o1 = match try_eval_to_f64(&freqs[0]) {
         Some(v) => v,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "BandpassFilter".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("BandpassFilter", args));
         }
       };
       let o2 = match try_eval_to_f64(&freqs[1]) {
         Some(v) => v,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "BandpassFilter".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("BandpassFilter", args));
         }
       };
       (o1, o2)
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BandpassFilter".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BandpassFilter", args));
     }
   };
 
@@ -6098,10 +5910,7 @@ pub fn bandpass_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match &args[0] {
     Expr::List(items) if !items.is_empty() => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BandpassFilter".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BandpassFilter", args));
     }
   };
 
@@ -6230,19 +6039,13 @@ fn convolve_edge_padded_symbolic(data: &[Expr], kernel: &[f64]) -> Vec<Expr> {
 /// Applies a lowpass FIR filter using a windowed-sinc kernel with exact Hamming window.
 pub fn lowpass_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() < 2 || args.len() > 4 {
-    return Ok(Expr::FunctionCall {
-      name: "LowpassFilter".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("LowpassFilter", args));
   }
 
   let omega_c = match try_eval_to_f64(&args[1]) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "LowpassFilter".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("LowpassFilter", args));
     }
   };
 
@@ -6330,20 +6133,14 @@ pub fn lowpass_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match &args[0] {
     Expr::List(items) if !items.is_empty() => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "LowpassFilter".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("LowpassFilter", args));
     }
   };
   let order = explicit_order.unwrap_or(items.len());
 
   let data: Vec<f64> = items.iter().filter_map(try_eval_to_f64).collect();
   if data.len() != items.len() {
-    return Ok(Expr::FunctionCall {
-      name: "LowpassFilter".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("LowpassFilter", args));
   }
 
   let kernel = lowpass_kernel(order, wc);
@@ -6385,19 +6182,13 @@ fn lowpass_kernel(n: usize, omega_c: f64) -> Vec<f64> {
 /// Applies a highpass FIR filter using a windowed-sinc kernel with exact Hamming window.
 pub fn highpass_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() < 2 || args.len() > 4 {
-    return Ok(Expr::FunctionCall {
-      name: "HighpassFilter".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("HighpassFilter", args));
   }
 
   let omega_c = match try_eval_to_f64(&args[1]) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "HighpassFilter".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HighpassFilter", args));
     }
   };
 
@@ -6481,20 +6272,14 @@ pub fn highpass_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match &args[0] {
     Expr::List(items) if !items.is_empty() => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "HighpassFilter".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HighpassFilter", args));
     }
   };
   let order = explicit_order.unwrap_or(items.len());
 
   let data: Vec<f64> = items.iter().filter_map(try_eval_to_f64).collect();
   if data.len() != items.len() {
-    return Ok(Expr::FunctionCall {
-      name: "HighpassFilter".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("HighpassFilter", args));
   }
 
   let kernel = highpass_kernel(order, wc);
@@ -6531,10 +6316,7 @@ fn highpass_kernel(n: usize, omega_c: f64) -> Vec<f64> {
 /// Applies a bandstop (notch) FIR filter.
 pub fn bandstop_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() < 2 || args.len() > 4 {
-    return Ok(Expr::FunctionCall {
-      name: "BandstopFilter".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("BandstopFilter", args));
   }
 
   let (omega1, omega2) = match &args[1] {
@@ -6542,28 +6324,19 @@ pub fn bandstop_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let o1 = match try_eval_to_f64(&freqs[0]) {
         Some(v) => v,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "BandstopFilter".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("BandstopFilter", args));
         }
       };
       let o2 = match try_eval_to_f64(&freqs[1]) {
         Some(v) => v,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "BandstopFilter".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("BandstopFilter", args));
         }
       };
       (o1, o2)
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BandstopFilter".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BandstopFilter", args));
     }
   };
 
@@ -6648,20 +6421,14 @@ pub fn bandstop_filter_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match &args[0] {
     Expr::List(items) if !items.is_empty() => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "BandstopFilter".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("BandstopFilter", args));
     }
   };
   let order = explicit_order.unwrap_or(items.len());
 
   let data: Vec<f64> = items.iter().filter_map(try_eval_to_f64).collect();
   if data.len() != items.len() {
-    return Ok(Expr::FunctionCall {
-      name: "BandstopFilter".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("BandstopFilter", args));
   }
 
   let kernel = bandstop_kernel(order, w1, w2);
@@ -7142,10 +6909,7 @@ pub fn cosine_sum_window_ast(
   name: &str,
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated(name, args);
   if args.len() != 1 {
     return Ok(unevaluated());
   }
@@ -7240,18 +7004,13 @@ pub fn cosine_sum_window_ast(
 /// starting index (default 0). An empty list gives {}; non-list first
 /// arguments emit ::arg1 and echo, like wolframscript.
 pub fn list_z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "ListZTransform".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let uneval = || Ok(unevaluated("ListZTransform", args));
   let Expr::List(items) = &args[0] else {
     crate::emit_message(&format!(
       "ListZTransform::arg1: Expected a numeric array instead of {}.",
       crate::syntax::expr_to_output(&args[0])
     ));
-    return unevaluated();
+    return uneval();
   };
   if items.is_empty() {
     return Ok(Expr::List(vec![].into()));
@@ -7259,7 +7018,7 @@ pub fn list_z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let shift: i128 = match args.get(2) {
     None => 0,
     Some(Expr::Integer(n)) => *n,
-    Some(_) => return unevaluated(),
+    Some(_) => return uneval(),
   };
   let terms: Vec<Expr> = items
     .iter()
@@ -7294,24 +7053,16 @@ pub fn list_z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn discrete_hadamard_transform_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "DiscreteHadamardTransform".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let uneval = || Ok(unevaluated("DiscreteHadamardTransform", args));
   if args.len() != 1 {
-    return unevaluated();
+    return uneval();
   }
   let data_err = || {
     crate::emit_message(&format!(
       "DiscreteHadamardTransform::data: {} is not a numerical array.",
       crate::syntax::expr_to_output(&args[0])
     ));
-    Ok(Expr::FunctionCall {
-      name: "DiscreteHadamardTransform".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("DiscreteHadamardTransform", args))
   };
   let Expr::List(items) = &args[0] else {
     return data_err();
@@ -7332,7 +7083,7 @@ pub fn discrete_hadamard_transform_ast(
   }
   let n = 1usize << bits;
   if n > 1 << 16 {
-    return unevaluated();
+    return uneval();
   }
   // Natural-order row for sequency slot s: bitreverse(gray(s)).
   let natural_row = |s: usize| -> usize {
@@ -7412,23 +7163,18 @@ pub fn parametric_window_ast(
   name: &str,
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let uneval = || Ok(unevaluated(name, args));
   let max_args = if name == "BartlettHannWindow" { 1 } else { 2 };
   if args.is_empty() || args.len() > max_args {
-    return unevaluated();
+    return uneval();
   }
   let Some(x) = try_eval_to_f64(&args[0]) else {
-    return unevaluated();
+    return uneval();
   };
   let is_real = matches!(&args[0], Expr::Real(_) | Expr::BigFloat(..))
     || matches!(args.get(1), Some(Expr::Real(_) | Expr::BigFloat(..)));
   if !x.is_finite() {
-    return unevaluated();
+    return uneval();
   }
   if x.abs() > 0.5 {
     return Ok(if is_real {
@@ -7440,7 +7186,7 @@ pub fn parametric_window_ast(
   // The α parameter (Cauchy/Poisson only; default 3).
   let alpha_expr = args.get(1).cloned().unwrap_or(Expr::Integer(3));
   let Some(alpha) = try_eval_to_f64(&alpha_expr) else {
-    return unevaluated();
+    return uneval();
   };
   let eval = crate::evaluator::evaluate_expr_to_expr;
   let fc = |n: &str, a: Vec<Expr>| Expr::FunctionCall {

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 use num_bigint::BigInt;
 
 /// Visit every additive term of a polynomial expression, flattening nested and
@@ -327,10 +327,7 @@ pub fn jacobi_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match &args[0] {
     Expr::Integer(n) if *n >= 0 => *n as usize,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "JacobiP".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("JacobiP", args));
     }
   };
 
@@ -403,10 +400,7 @@ pub fn jacobi_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if is_exact_rational(&args[1]) && is_exact_rational(&args[2]) {
     return jacobi_p_rational_ab(n, &args[1], &args[2], &args[3]);
   }
-  Ok(Expr::FunctionCall {
-    name: "JacobiP".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("JacobiP", args))
 }
 
 /// P_n^{(a,b)}(x) for n >= 2 and exact rational order parameters, in
@@ -537,10 +531,7 @@ pub fn legendre_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(Expr::Real(value));
         }
       }
-      return Ok(Expr::FunctionCall {
-        name: "LegendreP".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("LegendreP", args));
     }
   };
 
@@ -561,10 +552,7 @@ pub fn legendre_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           legendre_eval_rational(n, (BigInt::from(*p), BigInt::from(*q)));
         Ok(make_rational_expr(num, den))
       } else {
-        Ok(Expr::FunctionCall {
-          name: "LegendreP".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("LegendreP", args))
       }
     }
     Expr::Real(f) => {
@@ -580,10 +568,7 @@ pub fn legendre_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let evaluated = crate::evaluator::evaluate_expr_to_expr(&expr)?;
         reduce_poly_over_integer(evaluated)
       } else {
-        Ok(Expr::FunctionCall {
-          name: "LegendreP".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("LegendreP", args))
       }
     }
   }
@@ -959,10 +944,7 @@ pub fn spherical_harmonic_y_ast(
         let leg_val = match crate::evaluator::evaluate_expr_to_expr(&leg_call) {
           Ok(Expr::Real(v)) => v,
           _ => {
-            return Ok(Expr::FunctionCall {
-              name: "SphericalHarmonicY".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("SphericalHarmonicY", args));
           }
         };
         // Normalization: Sqrt[(2ℓ+1)/(4π) · Γ(ℓ−m+1)/Γ(ℓ+m+1)]
@@ -977,19 +959,13 @@ pub fn spherical_harmonic_y_ast(
         let g_num = match crate::evaluator::evaluate_expr_to_expr(&g_num_call) {
           Ok(Expr::Real(v)) => v,
           _ => {
-            return Ok(Expr::FunctionCall {
-              name: "SphericalHarmonicY".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("SphericalHarmonicY", args));
           }
         };
         let g_den = match crate::evaluator::evaluate_expr_to_expr(&g_den_call) {
           Ok(Expr::Real(v)) => v,
           _ => {
-            return Ok(Expr::FunctionCall {
-              name: "SphericalHarmonicY".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("SphericalHarmonicY", args));
           }
         };
         let norm = ((2.0 * lf + 1.0) / (4.0 * std::f64::consts::PI) * g_num
@@ -1005,10 +981,7 @@ pub fn spherical_harmonic_y_ast(
         }
         return Ok(build_complex_float_expr(re, im));
       }
-      return Ok(Expr::FunctionCall {
-        name: "SphericalHarmonicY".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("SphericalHarmonicY", args));
     }
   };
 
@@ -1019,10 +992,7 @@ pub fn spherical_harmonic_y_ast(
 
   // l < 0 → undefined, return unevaluated
   if l < 0 {
-    return Ok(Expr::FunctionCall {
-      name: "SphericalHarmonicY".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("SphericalHarmonicY", args));
   }
 
   // Try numerical evaluation
@@ -1711,10 +1681,7 @@ pub fn legendre_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(Expr::Real(q));
         }
       }
-      return Ok(Expr::FunctionCall {
-        name: "LegendreQ".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("LegendreQ", args));
     }
   };
 
@@ -2262,10 +2229,7 @@ pub fn chebyshev_t_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Some(result) = chebyshev_general_exact("T", &args[0], &args[1]) {
         return Ok(result);
       }
-      return Ok(Expr::FunctionCall {
-        name: "ChebyshevT".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("ChebyshevT", args));
     }
   };
 
@@ -2285,10 +2249,7 @@ pub fn chebyshev_t_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           chebyshev_t_eval_rational(n, (BigInt::from(*p), BigInt::from(*q)));
         Ok(make_rational_expr(num, den))
       } else {
-        Ok(Expr::FunctionCall {
-          name: "ChebyshevT".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("ChebyshevT", args))
       }
     }
     Expr::Real(f) => Ok(Expr::Real(chebyshev_t_eval_f64(n, *f))),
@@ -2297,10 +2258,7 @@ pub fn chebyshev_t_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Some(expr) = chebyshev_t_polynomial_symbolic(n, &args[1]) {
         crate::evaluator::evaluate_expr_to_expr(&expr)
       } else {
-        Ok(Expr::FunctionCall {
-          name: "ChebyshevT".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("ChebyshevT", args))
       }
     }
   }
@@ -2492,10 +2450,7 @@ pub fn chebyshev_u_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Some(result) = chebyshev_general_exact("U", &args[0], &args[1]) {
         return Ok(result);
       }
-      return Ok(Expr::FunctionCall {
-        name: "ChebyshevU".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("ChebyshevU", args));
     }
   };
 
@@ -2515,10 +2470,7 @@ pub fn chebyshev_u_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           chebyshev_u_eval_rational(n, (BigInt::from(*p), BigInt::from(*q)));
         Ok(make_rational_expr(num, den))
       } else {
-        Ok(Expr::FunctionCall {
-          name: "ChebyshevU".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("ChebyshevU", args))
       }
     }
     Expr::Real(f) => Ok(Expr::Real(chebyshev_u_eval_f64(n, *f))),
@@ -2526,10 +2478,7 @@ pub fn chebyshev_u_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Some(expr) = chebyshev_u_polynomial_symbolic(n, &args[1]) {
         crate::evaluator::evaluate_expr_to_expr(&expr)
       } else {
-        Ok(Expr::FunctionCall {
-          name: "ChebyshevU".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("ChebyshevU", args))
       }
     }
   }
@@ -2748,10 +2697,7 @@ pub fn gegenbauer_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match &args[0] {
     Expr::Integer(n) if *n >= 0 => *n as usize,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "GegenbauerC".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("GegenbauerC", args));
     }
   };
 
@@ -2812,10 +2758,7 @@ pub fn gegenbauer_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         );
         Ok(make_rational_expr(num, den))
       } else {
-        Ok(Expr::FunctionCall {
-          name: "GegenbauerC".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("GegenbauerC", args))
       }
     }
     Expr::Real(f) => {
@@ -2831,10 +2774,7 @@ pub fn gegenbauer_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let evaluated = crate::evaluator::evaluate_expr_to_expr(&expr)?;
         reduce_poly_over_integer(evaluated)
       } else {
-        Ok(Expr::FunctionCall {
-          name: "GegenbauerC".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("GegenbauerC", args))
       }
     }
   }
@@ -3319,10 +3259,7 @@ pub fn laguerre_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if matches!(evaluated, Expr::Real(_) | Expr::BigFloat(_, _)) {
         return Ok(evaluated);
       }
-      return Ok(Expr::FunctionCall {
-        name: "LaguerreL".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("LaguerreL", args));
     }
   };
 
@@ -3342,10 +3279,7 @@ pub fn laguerre_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           laguerre_eval_rational(n, (BigInt::from(*p), BigInt::from(*q)));
         Ok(make_rational_expr(num, den))
       } else {
-        Ok(Expr::FunctionCall {
-          name: "LaguerreL".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("LaguerreL", args))
       }
     }
     Expr::Real(f) => Ok(Expr::Real(laguerre_eval_f64(n, *f))),
@@ -3357,10 +3291,7 @@ pub fn laguerre_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let evaluated = crate::evaluator::evaluate_expr_to_expr(&expr)?;
         reduce_poly_over_integer(evaluated)
       } else {
-        Ok(Expr::FunctionCall {
-          name: "LaguerreL".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("LaguerreL", args))
       }
     }
   }
@@ -3813,16 +3744,10 @@ pub fn hermite_h_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           return Ok(Expr::Real(result));
         }
       }
-      return Ok(Expr::FunctionCall {
-        name: "HermiteH".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HermiteH", args));
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "HermiteH".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("HermiteH", args));
     }
   };
 
@@ -3852,10 +3777,7 @@ pub fn hermite_h_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // while a sum argument like `1 + x` keeps `(1 + x)^k` factored.
         crate::evaluator::evaluate_expr_to_expr(&expr)
       } else {
-        Ok(Expr::FunctionCall {
-          name: "HermiteH".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("HermiteH", args))
       }
     }
   }
@@ -4200,10 +4122,7 @@ pub fn zernike_r_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     (Expr::Integer(n), Expr::Integer(m)) if *n >= 0 && *m >= 0 => ((*n), (*m)),
     // Negative / non-integer orders are left unevaluated by wolframscript.
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "ZernikeR".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("ZernikeR", args));
     }
   };
 
@@ -4217,10 +4136,7 @@ pub fn zernike_r_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let coeffs = match zernike_r_coefficients(n, m) {
     Some(c) => c,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "ZernikeR".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("ZernikeR", args));
     }
   };
 
@@ -4232,10 +4148,7 @@ pub fn zernike_r_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let (Expr::Integer(p), Expr::Integer(q)) = (&ra[0], &ra[1]) {
         Ok(zernike_eval_rational(&coeffs, (*p, *q)))
       } else {
-        Ok(Expr::FunctionCall {
-          name: "ZernikeR".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("ZernikeR", args))
       }
     }
     Expr::Real(f) => Ok(Expr::Real(zernike_eval_f64(&coeffs, *f))),

--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// Emit the `<Name>::array` message and return the call unevaluated for an
 /// invalid dimension specification (a negative integer, a non-integer, or a
@@ -11,10 +11,7 @@ fn random_array_dims_error(
   name: &str,
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let call = Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
-  };
+  let call = unevaluated(name, args);
   crate::emit_message(&format!(
     "{}::array: The array dimensions {} given in position 2 of {} should be a list of non-negative machine-sized integers giving the dimensions for the result.",
     name,
@@ -460,15 +457,9 @@ pub fn random_color_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         Ok(Expr::List(out.into()))
       }
-      _ => Ok(Expr::FunctionCall {
-        name: "RandomColor".to_string(),
-        args: args.to_vec().into(),
-      }),
+      _ => Ok(unevaluated("RandomColor", args)),
     },
-    _ => Ok(Expr::FunctionCall {
-      name: "RandomColor".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("RandomColor", args)),
   }
 }
 
@@ -530,15 +521,9 @@ pub fn random_date_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         Ok(Expr::List(out.into()))
       }
-      _ => Ok(Expr::FunctionCall {
-        name: "RandomDate".to_string(),
-        args: args.to_vec().into(),
-      }),
+      _ => Ok(unevaluated("RandomDate", args)),
     },
-    _ => Ok(Expr::FunctionCall {
-      name: "RandomDate".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("RandomDate", args)),
   }
 }
 
@@ -595,15 +580,9 @@ pub fn random_date_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         Ok(Expr::List(out.into()))
       }
-      _ => Ok(Expr::FunctionCall {
-        name: "RandomDate".to_string(),
-        args: args.to_vec().into(),
-      }),
+      _ => Ok(unevaluated("RandomDate", args)),
     },
-    _ => Ok(Expr::FunctionCall {
-      name: "RandomDate".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("RandomDate", args)),
   }
 }
 
@@ -763,12 +742,7 @@ pub fn random_time_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     None
   }
 
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "RandomTime".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("RandomTime", args));
 
   // Split the arguments into an optional spec and an optional count.
   let (interval, count): (Option<(f64, f64)>, Option<i128>) = match args {
@@ -824,10 +798,7 @@ pub fn random_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     "Real" => random_real_ast(&rest),
     "Integer" => random_integer_ast(&rest),
     "Complex" => random_complex_ast(&rest),
-    _ => Ok(Expr::FunctionCall {
-      name: "Random".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("Random", args)),
   }
 }
 
@@ -854,10 +825,7 @@ pub fn random_choice_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let (Expr::List(weights), Expr::List(values)) =
           (pattern.as_ref(), replacement.as_ref())
         else {
-          return Ok(Expr::FunctionCall {
-            name: "RandomChoice".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("RandomChoice", args));
         };
         if weights.is_empty() || weights.len() != values.len() {
           return Err(InterpreterError::EvaluationError(
@@ -902,16 +870,10 @@ pub fn random_choice_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           "RandomChoice::lrwl: The items for choice {} should be a nonempty list or a rule weights -> choices.",
           crate::syntax::expr_to_string(&args[0])
         ));
-        return Ok(Expr::FunctionCall {
-          name: "RandomChoice".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("RandomChoice", args));
       }
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "RandomChoice".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("RandomChoice", args));
       }
     }
   };
@@ -1000,10 +962,7 @@ pub fn random_sample_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let (Expr::List(weights), Expr::List(values)) =
         (pattern.as_ref(), replacement.as_ref())
       else {
-        return Ok(Expr::FunctionCall {
-          name: "RandomSample".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("RandomSample", args));
       };
       if weights.is_empty() || weights.len() != values.len() {
         return Err(InterpreterError::EvaluationError(
@@ -1036,10 +995,7 @@ pub fn random_sample_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match &args[0] {
       Expr::List(items) => items.as_ref(),
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "RandomSample".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("RandomSample", args));
       }
     }
   };
@@ -1087,10 +1043,7 @@ pub fn random_sample_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           "RandomSample::intnm: Non-negative machine-sized integer expected at position 2 in RandomSample[{}].",
           arg_strs.join(", "),
         ));
-        return Ok(Expr::FunctionCall {
-          name: "RandomSample".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("RandomSample", args));
       }
     };
     if n > items.len() {
@@ -1199,10 +1152,7 @@ pub fn random_permutation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = match &args[0] {
     Expr::Integer(n) if *n >= 0 => *n as usize,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "RandomPermutation".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("RandomPermutation", args));
     }
   };
 
@@ -1212,10 +1162,7 @@ pub fn random_permutation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let k = match &args[1] {
         Expr::Integer(k) if *k >= 0 => *k as usize,
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "RandomPermutation".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("RandomPermutation", args));
         }
       };
       let perms: Vec<Expr> =
@@ -1446,10 +1393,7 @@ pub fn random_variate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           (mu1, mu2, sigma1, sigma2, r)
         }
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "RandomVariate".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("RandomVariate", args));
         }
       };
       if !(-1.0..=1.0).contains(&rho) {
@@ -1531,10 +1475,7 @@ pub fn random_variate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "RandomVariate".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("RandomVariate", args)),
   }
 }
 
@@ -1552,12 +1493,7 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // positive integer emits `RandomPrime::intp` and an otherwise-valid interval
   // that contains no primes emits `RandomPrime::noprime`. In both cases it
   // returns the expression unevaluated.
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "RandomPrime".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let uneval = || Ok(unevaluated("RandomPrime", args));
 
   // Parse the range from first argument
   let (min, max) = match &args[0] {
@@ -1566,7 +1502,7 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         crate::emit_message(&format!(
           "RandomPrime::intp: {imax} is not a positive integer."
         ));
-        return unevaluated();
+        return uneval();
       }
       (2i128, *imax)
     }
@@ -1575,7 +1511,7 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "RandomPrime::intp: {} is not a positive integer.",
         crate::syntax::expr_to_string(&args[0])
       ));
-      return unevaluated();
+      return uneval();
     }
     Expr::List(items) if items.len() == 2 => {
       // Both bounds must be positive integers; report the first offender.
@@ -1587,20 +1523,20 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               "RandomPrime::intp: {} is not a positive integer.",
               crate::syntax::expr_to_string(it)
             ));
-            return unevaluated();
+            return uneval();
           }
           // A symbolic bound stays unevaluated (no message), matching WL.
-          _ => return unevaluated(),
+          _ => return uneval(),
         }
       }
       if let (Expr::Integer(a), Expr::Integer(b)) = (&items[0], &items[1]) {
         // wolframscript orders the bounds, so {5, 2} samples from [2, 5].
         ((*a).min(*b), (*a).max(*b))
       } else {
-        return unevaluated();
+        return uneval();
       }
     }
-    _ => return unevaluated(),
+    _ => return uneval(),
   };
 
   // The second arg may be a positive integer (length of a flat list)
@@ -1615,10 +1551,7 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "RandomPrime::posdim: The dimensions parameter {} is expected to be a positive integer or a list of positive integers.",
       crate::syntax::expr_to_string(&args[1])
     ));
-    Ok(Expr::FunctionCall {
-      name: "RandomPrime".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("RandomPrime", args))
   };
   let dims: Vec<usize> = if args.len() == 2 {
     match &args[1] {
@@ -1669,7 +1602,7 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::emit_message(
         "RandomPrime::noprime: There are no primes in the specified interval.",
       );
-      return unevaluated();
+      return uneval();
     }
     if dims.is_empty() {
       let idx = crate::with_rng(|rng| rng.gen_range(0..primes.len()));
@@ -1689,7 +1622,7 @@ pub fn random_prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::emit_message(
         "RandomPrime::noprime: There are no primes in the specified interval.",
       );
-      return unevaluated();
+      return uneval();
     }
     let mut results = Vec::with_capacity(count);
     for _ in 0..count {
@@ -1771,10 +1704,7 @@ pub fn random_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   use rand::Rng;
   use rand::seq::SliceRandom;
 
-  let unevaluated = || Expr::FunctionCall {
-    name: "RandomGraph".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("RandomGraph", args);
 
   // Split positional args from trailing Rule options.
   let mut positional: Vec<&Expr> = Vec::new();

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, ExprForm, UnaryOperator, expr_to_output,
-  expr_to_string, format_expr,
+  expr_to_string, format_expr, unevaluated,
 };
 
 /// If the first argument is a numeric scalar, emit
@@ -18,13 +18,7 @@ pub fn emit_rectt_if_numeric(name: &str, args: &[Expr]) {
     crate::emit_message(&format!(
       "{}::rectt: Rectangular array expected at position 1 in {}.",
       name,
-      format_expr(
-        &Expr::FunctionCall {
-          name: name.to_string(),
-          args: args.to_vec().into(),
-        },
-        ExprForm::Output
-      )
+      format_expr(&unevaluated(name, args), ExprForm::Output)
     ));
   }
 }
@@ -69,18 +63,9 @@ fn rectt_if_ragged(name: &str, args: &[Expr]) -> Option<Expr> {
     crate::emit_message(&format!(
       "{}::rectt: Rectangular array expected at position 1 in {}.",
       name,
-      format_expr(
-        &Expr::FunctionCall {
-          name: name.to_string(),
-          args: args.to_vec().into(),
-        },
-        ExprForm::Output
-      )
+      format_expr(&unevaluated(name, args), ExprForm::Output)
     ));
-    Some(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    })
+    Some(unevaluated(name, args))
   } else {
     None
   }
@@ -121,18 +106,9 @@ pub fn rectn_if_not_real_rectangular(
     crate::emit_message(&format!(
       "{}::rectn: A rectangular array of real numbers is expected at position 1 in {}.",
       name,
-      format_expr(
-        &Expr::FunctionCall {
-          name: name.to_string(),
-          args: args.to_vec().into(),
-        },
-        ExprForm::Output
-      )
+      format_expr(&unevaluated(name, args), ExprForm::Output)
     ));
-    Some(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    })
+    Some(unevaluated(name, args))
   } else {
     None
   }
@@ -142,25 +118,22 @@ pub fn rectn_if_not_real_rectangular(
 /// Total[list, n] - Sum across levels 1 through n
 /// Total[list, {n}] - Sum at exactly level n
 pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "Total".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("Total", args);
   // A wrong argument count leaves the call unevaluated (with a message),
   // matching wolframscript, rather than raising an evaluation error.
   if args.is_empty() {
     crate::emit_message(
       "Total::argt: Total called with 0 arguments; 1 or 2 arguments are expected.",
     );
-    return Ok(unevaluated());
+    return Ok(uneval());
   }
   if args.len() > 2 {
     crate::emit_message(&format!(
       "Total::nonopt: Options expected (instead of {}) beyond position 2 in {}. An option must be a rule or a list of rules.",
       format_expr(&args[2], ExprForm::Output),
-      format_expr(&unevaluated(), ExprForm::Output)
+      format_expr(&uneval(), ExprForm::Output)
     ));
-    return Ok(unevaluated());
+    return Ok(uneval());
   }
 
   // A SparseArray argument is summed over its dense form.
@@ -216,10 +189,7 @@ pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(n) = resolve_level(&items[0]) {
           TotalLevelSpec::Exact(n)
         } else {
-          return Ok(Expr::FunctionCall {
-            name: "Total".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("Total", args));
         }
       }
       // Total[list, {n1, n2}] - sum across levels n1 through n2
@@ -229,10 +199,7 @@ pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         {
           TotalLevelSpec::Range(n1, n2)
         } else {
-          return Ok(Expr::FunctionCall {
-            name: "Total".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("Total", args));
         }
       }
       // Total[list, Infinity]
@@ -244,10 +211,7 @@ pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(n) = resolve_level(&args[1]) {
           TotalLevelSpec::Through(n)
         } else {
-          return Ok(Expr::FunctionCall {
-            name: "Total".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("Total", args));
         }
       }
     }
@@ -266,10 +230,7 @@ pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "Total::tllen: Lists of unequal length in {} cannot be added.",
         format_expr(&args[0], ExprForm::Output)
       ));
-      Ok(Expr::FunctionCall {
-        name: "Total".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Total", args))
     }
     other => other,
   };
@@ -311,19 +272,10 @@ pub fn total_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if matches!(other, Expr::String(_)) {
           crate::emit_message(&format!(
             "Total::normal: Nonatomic expression expected at position 1 in {}.",
-            format_expr(
-              &Expr::FunctionCall {
-                name: "Total".to_string(),
-                args: args.to_vec().into(),
-              },
-              ExprForm::Output
-            )
+            format_expr(&unevaluated("Total", args), ExprForm::Output)
           ));
         }
-        Ok(Expr::FunctionCall {
-          name: "Total".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("Total", args))
       }
     }
   }
@@ -745,10 +697,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // they must not surface as an evaluation error.
       match super::distributions::distribution_mean_variance(dist_name, dargs) {
         Ok((mean, _)) => crate::evaluator::evaluate_expr_to_expr(&mean),
-        Err(_) => Ok(Expr::FunctionCall {
-          name: "Mean".to_string(),
-          args: args.to_vec().into(),
-        }),
+        Err(_) => Ok(unevaluated("Mean", args)),
       }
     }
     Expr::FunctionCall {
@@ -777,10 +726,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         mean_ast(std::slice::from_ref(d))
       })? {
         Some(mean) => Ok(mean),
-        None => Ok(Expr::FunctionCall {
-          name: "Mean".to_string(),
-          args: args.to_vec().into(),
-        }),
+        None => Ok(unevaluated("Mean", args)),
       }
     }
     Expr::FunctionCall {
@@ -806,10 +752,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // stays unevaluated.
       match super::distributions::wishart_mean_variance(dargs) {
         Ok((mean, _)) => Ok(mean),
-        Err(_) => Ok(Expr::FunctionCall {
-          name: "Mean".to_string(),
-          args: args.to_vec().into(),
-        }),
+        Err(_) => Ok(unevaluated("Mean", args)),
       }
     }
     Expr::FunctionCall {
@@ -818,10 +761,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } if dist_name == "FirstPassageTimeDistribution" && dargs.len() == 2 => {
       match super::distributions::fptd_mean(dargs)? {
         Some(mean) => Ok(mean),
-        None => Ok(Expr::FunctionCall {
-          name: "Mean".to_string(),
-          args: args.to_vec().into(),
-        }),
+        None => Ok(unevaluated("Mean", args)),
       }
     }
     Expr::FunctionCall {
@@ -835,10 +775,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         return Ok(mean);
       }
-      Ok(Expr::FunctionCall {
-        name: "Mean".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Mean", args))
     }
     Expr::FunctionCall {
       name: dist_name,
@@ -849,10 +786,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // rewrites it to HypoexponentialDistribution.)
       match standby_component_moments(dargs, mean_ast)? {
         Some(total) => Ok(total),
-        None => Ok(Expr::FunctionCall {
-          name: "Mean".to_string(),
-          args: args.to_vec().into(),
-        }),
+        None => Ok(unevaluated("Mean", args)),
       }
     }
     Expr::FunctionCall {
@@ -877,10 +811,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Mean[BinormalDistribution[{m1, m2}, …]] = {m1, m2}.
       match super::distributions::binormal_params(dargs) {
         Some((m1, m2, ..)) => Ok(Expr::List(vec![m1, m2].into())),
-        None => Ok(Expr::FunctionCall {
-          name: "Mean".to_string(),
-          args: args.to_vec().into(),
-        }),
+        None => Ok(unevaluated("Mean", args)),
       }
     }
     Expr::FunctionCall {
@@ -907,17 +838,11 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         return mean_ast(&[slice]);
       }
-      Ok(Expr::FunctionCall {
-        name: "Mean".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Mean", args))
     }
     _ => {
       emit_rectt_if_numeric("Mean", args);
-      Ok(Expr::FunctionCall {
-        name: "Mean".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Mean", args))
     }
   }
 }
@@ -1088,10 +1013,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Symbolic/complex path: compute Variance = Sum[Abs[xi - mean]^2] / (n-1)
         return variance_symbolic(items);
       }
-      Ok(Expr::FunctionCall {
-        name: "Variance".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Variance", args))
     }
     Expr::FunctionCall {
       name: dist_name,
@@ -1186,10 +1108,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // (matching wolframscript), never an evaluation error.
       match super::distributions::distribution_mean_variance(dist_name, dargs) {
         Ok((_, variance)) => crate::evaluator::evaluate_expr_to_expr(&variance),
-        Err(_) => Ok(Expr::FunctionCall {
-          name: "Variance".to_string(),
-          args: args.to_vec().into(),
-        }),
+        Err(_) => Ok(unevaluated("Variance", args)),
       }
     }
     Expr::FunctionCall {
@@ -1216,10 +1135,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       //   Var = Σ (w_i/W)(σ_i² + μ_i²) − (Σ (w_i/W) μ_i)²
       match mixture_variance(dargs)? {
         Some(v) => Ok(v),
-        None => Ok(Expr::FunctionCall {
-          name: "Variance".to_string(),
-          args: args.to_vec().into(),
-        }),
+        None => Ok(unevaluated("Variance", args)),
       }
     }
     Expr::FunctionCall {
@@ -1246,10 +1162,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // stays unevaluated.
       match super::distributions::wishart_mean_variance(dargs) {
         Ok((_, variance)) => Ok(variance),
-        Err(_) => Ok(Expr::FunctionCall {
-          name: "Variance".to_string(),
-          args: args.to_vec().into(),
-        }),
+        Err(_) => Ok(unevaluated("Variance", args)),
       }
     }
     Expr::FunctionCall {
@@ -1258,10 +1171,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } if dist_name == "FirstPassageTimeDistribution" && dargs.len() == 2 => {
       match super::distributions::fptd_variance(dargs)? {
         Some(variance) => Ok(variance),
-        None => Ok(Expr::FunctionCall {
-          name: "Variance".to_string(),
-          args: args.to_vec().into(),
-        }),
+        None => Ok(unevaluated("Variance", args)),
       }
     }
     Expr::FunctionCall {
@@ -1271,10 +1181,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Independent lifetimes add, so variances sum too.
       match standby_component_moments(dargs, variance_ast)? {
         Some(total) => Ok(total),
-        None => Ok(Expr::FunctionCall {
-          name: "Variance".to_string(),
-          args: args.to_vec().into(),
-        }),
+        None => Ok(unevaluated("Variance", args)),
       }
     }
     Expr::FunctionCall {
@@ -1308,10 +1215,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             vec![sq(s1), sq(s2)].into(),
           ))
         }
-        None => Ok(Expr::FunctionCall {
-          name: "Variance".to_string(),
-          args: args.to_vec().into(),
-        }),
+        None => Ok(unevaluated("Variance", args)),
       }
     }
     Expr::FunctionCall {
@@ -1339,17 +1243,11 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         return variance_ast(&[slice]);
       }
-      Ok(Expr::FunctionCall {
-        name: "Variance".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Variance", args))
     }
     _ => {
       emit_rectt_if_numeric("Variance", args);
-      Ok(Expr::FunctionCall {
-        name: "Variance".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Variance", args))
     }
   }
 }
@@ -1440,20 +1338,14 @@ pub fn standard_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         expr_to_string(&args[0])
       ));
     }
-    return Ok(Expr::FunctionCall {
-      name: "StandardDeviation".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("StandardDeviation", args));
   }
   // A numeric scalar isn't a rectangular array: emit StandardDeviation::rectt
   // directly and stay unevaluated, rather than delegating to Variance below
   // (which would emit Variance::rectt instead).
   if crate::functions::predicate_ast::is_numeric_q(&args[0]) {
     emit_rectt_if_numeric("StandardDeviation", args);
-    return Ok(Expr::FunctionCall {
-      name: "StandardDeviation".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("StandardDeviation", args));
   }
   // StandardDeviation[BinormalDistribution[…, {s1, s2}, …]] = {s1, s2}. Return
   // the sigmas directly rather than Sqrt[s1^2], which Woxi cannot reduce for a
@@ -1471,10 +1363,7 @@ pub fn standard_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Expr::FunctionCall { name, .. } = &var
     && name == "Variance"
   {
-    return Ok(Expr::FunctionCall {
-      name: "StandardDeviation".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("StandardDeviation", args));
   }
   match &var {
     Expr::List(items) => {
@@ -1511,10 +1400,7 @@ pub fn standard_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     _ => {
       emit_rectt_if_numeric("StandardDeviation", args);
-      Ok(Expr::FunctionCall {
-        name: "StandardDeviation".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("StandardDeviation", args))
     }
   }
 }
@@ -1768,10 +1654,7 @@ pub fn geometric_mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // An empty list stays unevaluated (matching wolframscript) rather than
       // raising an error.
       if items.is_empty() {
-        return Ok(Expr::FunctionCall {
-          name: "GeometricMean".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("GeometricMean", args));
       }
       // List-of-lists (matrix) → column-wise geometric mean.
       if items.iter().all(|item| matches!(item, Expr::List(_))) {
@@ -1796,10 +1679,7 @@ pub fn geometric_mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(v) = try_eval_to_f64(item) {
           vals.push(v);
         } else {
-          return Ok(Expr::FunctionCall {
-            name: "GeometricMean".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("GeometricMean", args));
         }
       }
       let n_f = vals.len() as f64;
@@ -1813,10 +1693,7 @@ pub fn geometric_mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         num_to_expr(result)
       })
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "GeometricMean".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("GeometricMean", args)),
   }
 }
 
@@ -1875,10 +1752,7 @@ pub fn harmonic_mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::List(items) => {
       // An empty list stays unevaluated (matching wolframscript).
       if items.is_empty() {
-        return Ok(Expr::FunctionCall {
-          name: "HarmonicMean".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("HarmonicMean", args));
       }
       // Try all-integer exact path using rational arithmetic
       let mut all_int = true;
@@ -1938,10 +1812,7 @@ pub fn harmonic_mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             }
             vals.push(v);
           } else {
-            return Ok(Expr::FunctionCall {
-              name: "HarmonicMean".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("HarmonicMean", args));
           }
         }
         let n = vals.len() as f64;
@@ -1957,10 +1828,7 @@ pub fn harmonic_mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // x^(-1), which matches wolframscript's display form.
       harmonic_mean_symbolic(items)
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "HarmonicMean".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("HarmonicMean", args)),
   }
 }
 
@@ -2035,12 +1903,7 @@ fn harmonic_mean_columnwise(rows: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn contraharmonic_mean_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "ContraharmonicMean".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("ContraharmonicMean", args));
   if args.is_empty() || args.len() > 2 {
     return unevaluated();
   }
@@ -2089,12 +1952,7 @@ pub fn absolute_correlation_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   use crate::evaluator::evaluate_function_call_ast;
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "AbsoluteCorrelation".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("AbsoluteCorrelation", args));
   if args.is_empty() || args.len() > 2 {
     return unevaluated();
   }
@@ -2273,10 +2131,7 @@ fn symbolic_covariance(
       right: Box::new(Expr::Integer(2)),
     }
   } else {
-    let sum_x = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: xs.to_vec().into(),
-    };
+    let sum_x = unevaluated("Plus", xs);
     let mut terms = Vec::with_capacity(n);
     for (x, y) in xs.iter().zip(ys.iter()) {
       let coeff = Expr::BinaryOp {
@@ -2319,12 +2174,7 @@ fn covariance_two(xs: &[Expr], ys: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Covariance[list1, list2] - sample covariance of two equal-length lists.
 /// Covariance[matrix] - covariance matrix of the columns of an n×p matrix.
 pub fn covariance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "Covariance".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("Covariance", args));
 
   // Covariance[DirichletDistribution[{α1, …}]] is the k×k moment matrix.
   if args.len() == 1
@@ -2530,12 +2380,7 @@ fn average_ranks(items: &[Expr]) -> Option<Vec<Expr>> {
 /// lists. Mismatched lengths or non-numeric vectors emit the `::rctneqln`
 /// message and stay unevaluated.
 pub fn spearman_rho_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "SpearmanRho".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("SpearmanRho", args));
   let rctneqln = || {
     crate::emit_message(
       "SpearmanRho::rctneqln: The arguments to SpearmanRho are not a pair of vectors or matrices of equal length.",
@@ -2570,12 +2415,7 @@ pub fn spearman_rho_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// yield a machine-real result. Constant data (zero variance in either vector)
 /// emits `KendallTau::zrvr` and returns Indeterminate.
 pub fn kendall_tau_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "KendallTau".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("KendallTau", args));
   let rctneqln = || {
     crate::emit_message(
       "KendallTau::rctneqln: The arguments to KendallTau are not a pair of vectors or matrices of equal length.",
@@ -2684,12 +2524,7 @@ pub fn kendall_tau_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// matrices give the cross matrix. Lists shorter than 5 emit `::dtlnth`;
 /// length mismatches and non-numeric data emit `::rctneqln`.
 pub fn hoeffding_d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "HoeffdingD".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("HoeffdingD", args));
   let rctneqln = || {
     crate::emit_message(
       "HoeffdingD::rctneqln: The arguments to HoeffdingD are not a pair of vectors or matrices of equal length.",
@@ -2875,12 +2710,7 @@ fn rank_statistic_forms(
   args: &[Expr],
   pair: &dyn Fn(&[f64], &[f64], bool) -> Result<Expr, InterpreterError>,
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated(name, args));
   let rctneqln = || {
     crate::emit_message(&format!(
       "{name}::rctneqln: The arguments to {name} are not a pair of vectors or matrices of equal length.",
@@ -3110,12 +2940,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       .collect();
     return correlation_ast(&new_args);
   }
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "Correlation".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let uneval = || Ok(unevaluated("Correlation", args));
   // Single-argument form.
   if args.len() == 1 {
     if let Expr::List(items) = &args[0]
@@ -3146,10 +2971,10 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         return Ok(corr);
       }
     }
-    return unevaluated();
+    return uneval();
   }
   if args.len() != 2 {
-    return unevaluated();
+    return uneval();
   }
   // Matrix form: Correlation[A, B] for m×n A and m×p B → cross-correlation
   // matrix R[i, j] = Correlation(column_i(A), column_j(B)).
@@ -3185,10 +3010,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       (xs, ys)
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Correlation".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Correlation", args));
     }
   };
   // Require all elements to be numeric; otherwise leave unevaluated. A
@@ -3248,10 +3070,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         right: Box::new(denom),
       });
     }
-    return Ok(Expr::FunctionCall {
-      name: "Correlation".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Correlation", args));
   }
   // If any input is a machine-precision Real, fall through to a direct
   // f64 computation: the result is a machine number either way, and the
@@ -3276,10 +3095,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let denom = (var_x * var_y).sqrt();
     if denom == 0.0 {
       // Wolfram emits Correlation::zerosd and leaves the expression unevaluated.
-      return Ok(Expr::FunctionCall {
-        name: "Correlation".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Correlation", args));
     }
     return Ok(num_to_expr(cov / denom));
   }
@@ -3296,10 +3112,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let (Some(vx), Some(vy)) = (expr_to_num(&var_x), expr_to_num(&var_y))
     && (vx == 0.0 || vy == 0.0)
   {
-    return Ok(Expr::FunctionCall {
-      name: "Correlation".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Correlation", args));
   }
   let var_product = Expr::BinaryOp {
     op: BinaryOperator::Times,
@@ -3737,10 +3550,7 @@ pub fn central_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "CentralMoment".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("CentralMoment", args));
   }
   // A matrix reduces column-wise: the r-th central moment of each column.
   // (This also fixes Kurtosis/Skewness of a matrix, which build on it.)
@@ -3773,30 +3583,21 @@ pub fn central_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match &args[0] {
     Expr::List(items) if !items.is_empty() => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "CentralMoment".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("CentralMoment", args));
     }
   };
   let r_expr = &args[1];
   let r = match expr_to_num(r_expr) {
     Some(r) => r as i32,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "CentralMoment".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("CentralMoment", args));
     }
   };
 
   // Check if all items are numeric (integer or rational or real)
   let all_numeric = items.iter().all(|item| expr_to_num(item).is_some());
   if !all_numeric {
-    return Ok(Expr::FunctionCall {
-      name: "CentralMoment".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("CentralMoment", args));
   }
 
   // Compute mean symbolically to preserve exact arithmetic
@@ -3843,12 +3644,7 @@ pub fn central_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// All arithmetic is carried out symbolically so exact rational results are
 /// preserved.
 pub fn cumulant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let symbolic = || {
-    Ok(Expr::FunctionCall {
-      name: "Cumulant".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let symbolic = || Ok(unevaluated("Cumulant", args));
   if args.len() != 2 {
     return symbolic();
   }
@@ -3953,10 +3749,7 @@ fn cumulant_from_raw_moments(
 /// Kurtosis[list] - CentralMoment[list, 4] / CentralMoment[list, 2]^2
 pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "Kurtosis".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Kurtosis", args));
   }
   // Skellam: Kurtosis = 3 + 1/(a+b). Built directly because the generic
   // moment-ratio Expand mangles the multi-parameter denominator.
@@ -4032,10 +3825,7 @@ fn maybe_expand_for_distribution(arg: &Expr, result: Expr) -> Expr {
 /// Skewness[list] - CentralMoment[list, 3] / CentralMoment[list, 2]^(3/2)
 pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "Skewness".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Skewness", args));
   }
   // Skellam: Skewness = (a-b)/(a+b)^(3/2). Built directly so the compact form
   // is preserved (the generic moment-ratio Expand would distribute it).
@@ -4176,10 +3966,7 @@ pub fn root_mean_square_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::List(items) => {
       // An empty list stays unevaluated (matching wolframscript).
       if items.is_empty() {
-        return Ok(Expr::FunctionCall {
-          name: "RootMeanSquare".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("RootMeanSquare", args));
       }
       // Try all-integer exact path
       let mut all_int = true;
@@ -4229,25 +4016,16 @@ pub fn root_mean_square_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           if let Some(v) = expr_to_num(item) {
             vals.push(v);
           } else {
-            return Ok(Expr::FunctionCall {
-              name: "RootMeanSquare".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("RootMeanSquare", args));
           }
         }
         let n = vals.len() as f64;
         let mean_sq = vals.iter().map(|x| x * x).sum::<f64>() / n;
         return Ok(num_to_expr(mean_sq.sqrt()));
       }
-      Ok(Expr::FunctionCall {
-        name: "RootMeanSquare".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("RootMeanSquare", args))
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "RootMeanSquare".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("RootMeanSquare", args)),
   }
 }
 
@@ -4326,10 +4104,7 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "Quantile::nquan: The Quantile specification {} should be a number or a list of numbers between 0 and 1.",
       crate::syntax::expr_to_string(&args[1])
     ));
-    return Ok(Expr::FunctionCall {
-      name: "Quantile".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Quantile", args));
   }
   // ErlangDistribution[k, λ] == GammaDistribution[k, 1/λ]
   if let Expr::FunctionCall { name, args: dargs } = &args[0]
@@ -4381,19 +4156,13 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         (r0[0].clone(), r0[1].clone(), r1[0].clone(), r1[1].clone())
       }
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "Quantile".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Quantile", args));
       }
     };
     let items = match &args[0] {
       Expr::List(items) if !items.is_empty() => items,
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "Quantile".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Quantile", args));
       }
     };
     let mut sorted: Vec<&Expr> = items.iter().collect();
@@ -4433,10 +4202,7 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match &args[0] {
     Expr::List(items) if !items.is_empty() => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Quantile".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Quantile", args));
     }
   };
 
@@ -4588,10 +4354,7 @@ fn quantile_parametric(
 /// Moment[data, r] — the r-th raw moment: Sum[x_i^r] / n.
 pub fn moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "Moment".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Moment", args));
   }
 
   // Distribution form: Moment[dist, n] = E[x^n].
@@ -4604,10 +4367,7 @@ pub fn moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let items = match &args[0] {
     Expr::List(items) if !items.is_empty() => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Moment".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Moment", args));
     }
   };
 
@@ -4789,12 +4549,9 @@ fn factorial_moment_via_expectation(
 }
 
 pub fn factorial_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "FactorialMoment".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("FactorialMoment", args);
   if args.len() != 2 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
 
   // Distribution factorial moment E[X(X-1)...(X-r+1)] for a non-negative
@@ -4825,7 +4582,7 @@ pub fn factorial_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let items = match &args[0] {
     Expr::List(items) if !items.is_empty() => items,
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   };
 
   let factorial_power = |x: &Expr, r: &Expr| {
@@ -4843,7 +4600,7 @@ pub fn factorial_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       for item in items {
         let coords = match item {
           Expr::List(coords) if coords.len() == orders.len() => coords,
-          _ => return Ok(unevaluated(args)),
+          _ => return Ok(uneval()),
         };
         let mut factors = Vec::with_capacity(coords.len());
         for (x, r) in coords.iter().zip(orders.iter()) {
@@ -4903,10 +4660,7 @@ pub fn mean_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     };
     crate::evaluator::evaluate_expr_to_expr(&result)
   } else {
-    Ok(Expr::FunctionCall {
-      name: "MeanDeviation".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("MeanDeviation", args))
   }
 }
 
@@ -4938,10 +4692,7 @@ pub fn median_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let devs_list = Expr::List(abs_devs.into());
     crate::functions::list_helpers_ast::median_ast(&devs_list)
   } else {
-    Ok(Expr::FunctionCall {
-      name: "MedianDeviation".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("MedianDeviation", args))
   }
 }
 
@@ -4968,10 +4719,7 @@ pub fn location_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(v) = try_eval_to_f64(other) {
           v
         } else {
-          return Ok(Expr::FunctionCall {
-            name: "LocationTest".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("LocationTest", args));
         }
       }
     }
@@ -4984,10 +4732,7 @@ pub fn location_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match &args[2] {
       Expr::String(s) => s.clone(),
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "LocationTest".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("LocationTest", args));
       }
     }
   } else {
@@ -5024,10 +4769,7 @@ pub fn location_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let (t_stat, df) = one_sample_t_test(&vals, mu0);
       format_location_test_result(t_stat, df, &property, "T")
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "LocationTest".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("LocationTest", args)),
   }
 }
 
@@ -5219,20 +4961,14 @@ fn t_test_p_value(t_stat: f64, df: f64) -> f64 {
 /// Likelihood[dist, {x1, x2, ...}] - product of PDF[dist, xi] for each xi
 pub fn likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 2 {
-    return Ok(Expr::FunctionCall {
-      name: "Likelihood".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Likelihood", args));
   }
 
   let dist = &args[0];
   let data = match &args[1] {
     Expr::List(items) => items,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Likelihood".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Likelihood", args));
     }
   };
 
@@ -5294,10 +5030,7 @@ pub fn pearson_chi_square_test_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   if args.is_empty() || args.len() > 3 {
-    return Ok(Expr::FunctionCall {
-      name: "PearsonChiSquareTest".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("PearsonChiSquareTest", args));
   }
 
   let data = match &args[0] {
@@ -5307,19 +5040,13 @@ pub fn pearson_chi_square_test_ast(
         if let Some(v) = try_eval_to_f64(item) {
           vals.push(v);
         } else {
-          return Ok(Expr::FunctionCall {
-            name: "PearsonChiSquareTest".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("PearsonChiSquareTest", args));
         }
       }
       vals
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "PearsonChiSquareTest".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("PearsonChiSquareTest", args));
     }
   };
 
@@ -5363,17 +5090,11 @@ pub fn pearson_chi_square_test_ast(
           )
         }
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "PearsonChiSquareTest".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("PearsonChiSquareTest", args));
         }
       },
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "PearsonChiSquareTest".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("PearsonChiSquareTest", args));
       }
     }
   } else {
@@ -5499,10 +5220,7 @@ fn gamma_cf(a: f64, x: f64) -> f64 {
 /// Longitude[GeoPosition[{lat, lon}]] or Longitude[{lat, lon}] → Quantity[lon, "AngularDegrees"]
 pub fn longitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "Longitude".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Longitude", args));
   }
   let coords = extract_geo_coords(&args[0]);
   match coords {
@@ -5510,20 +5228,14 @@ pub fn longitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: "Quantity".to_string(),
       args: vec![lon, Expr::String("AngularDegrees".to_string())].into(),
     }),
-    None => Ok(Expr::FunctionCall {
-      name: "Longitude".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("Longitude", args)),
   }
 }
 
 /// Latitude[GeoPosition[{lat, lon}]] or Latitude[{lat, lon}] → Quantity[lat, "AngularDegrees"]
 pub fn latitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "Latitude".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Latitude", args));
   }
   let coords = extract_geo_coords(&args[0]);
   match coords {
@@ -5531,10 +5243,7 @@ pub fn latitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: "Quantity".to_string(),
       args: vec![lat, Expr::String("AngularDegrees".to_string())].into(),
     }),
-    None => Ok(Expr::FunctionCall {
-      name: "Latitude".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("Latitude", args)),
   }
 }
 
@@ -5561,10 +5270,7 @@ fn extract_geo_coords(expr: &Expr) -> Option<(Expr, Expr)> {
 /// LatitudeLongitude[GeoPosition[{lat, lon}]] → {Quantity[lat, "AngularDegrees"], Quantity[lon, "AngularDegrees"]}
 pub fn latitude_longitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "LatitudeLongitude".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("LatitudeLongitude", args));
   }
   match extract_geo_coords(&args[0]) {
     Some((lat, lon)) => Ok(Expr::List(
@@ -5580,10 +5286,7 @@ pub fn latitude_longitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       ]
       .into(),
     )),
-    None => Ok(Expr::FunctionCall {
-      name: "LatitudeLongitude".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("LatitudeLongitude", args)),
   }
 }
 
@@ -5714,10 +5417,7 @@ fn mathieu_generators_expr(name: &str) -> Option<Expr> {
 /// GroupGenerators[group] - return a list of generators for the given group
 pub fn group_generators_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "GroupGenerators".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("GroupGenerators", args));
   }
 
   if let Expr::FunctionCall { name, args: gargs } = &args[0]
@@ -5752,10 +5452,7 @@ pub fn group_generators_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let n = match &gargs[0] {
         Expr::Integer(n) if *n >= min_n => *n as usize,
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "GroupGenerators".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("GroupGenerators", args));
         }
       };
       match name.as_str() {
@@ -5763,16 +5460,10 @@ pub fn group_generators_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "CyclicGroup" => Ok(cyclic_group_generators(n)),
         "DihedralGroup" => Ok(dihedral_group_generators(n)),
         "AlternatingGroup" => Ok(alternating_group_generators(n)),
-        _ => Ok(Expr::FunctionCall {
-          name: "GroupGenerators".to_string(),
-          args: args.to_vec().into(),
-        }),
+        _ => Ok(unevaluated("GroupGenerators", args)),
       }
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "GroupGenerators".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("GroupGenerators", args)),
   }
 }
 
@@ -5810,10 +5501,7 @@ fn abelian_group_generators(factors: &[usize]) -> Expr {
 
 /// GroupOrder[group] - the number of elements in a group.
 pub fn group_order_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "GroupOrder".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("GroupOrder", args);
   if args.len() != 1 {
     return Ok(unevaluated());
   }
@@ -5876,10 +5564,7 @@ pub fn group_order_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// GroupElements[group] - list of all elements in a group as cycle notation.
 pub fn group_elements_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "GroupElements".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("GroupElements", args);
   // GroupElements[group, {positions…}] - the elements at the given 1-based
   // positions of the full element list, in the given order (negative positions
   // count from the end; out-of-range positions emit GroupElements::lrank).
@@ -6093,10 +5778,7 @@ fn perms_equal(p: &Expr, q: &Expr) -> bool {
 /// `GroupElementQ::perm` message and stays unevaluated; a group that
 /// GroupElements cannot expand also stays unevaluated.
 pub fn group_element_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "GroupElementQ".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("GroupElementQ", args);
   if args.len() != 2 {
     return Ok(unevaluated());
   }
@@ -6127,10 +5809,7 @@ pub fn group_element_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn group_element_position_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "GroupElementPosition".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("GroupElementPosition", args);
   if args.len() != 2 {
     return Ok(unevaluated());
   }
@@ -6158,10 +5837,7 @@ pub fn group_element_position_ast(
 /// every group element; duplicate orbits are removed and the result is sorted
 /// lexicographically (independent of the seed order), matching wolframscript.
 pub fn group_orbits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "GroupOrbits".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("GroupOrbits", args);
   if args.len() != 2 {
     return Ok(unevaluated());
   }
@@ -6541,10 +6217,7 @@ pub fn discrete_asymptotic_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   if args.len() < 2 || args.len() > 3 {
-    return Ok(Expr::FunctionCall {
-      name: "DiscreteAsymptotic".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("DiscreteAsymptotic", args));
   }
 
   // Parse second argument: must be Rule[var, Infinity] or Expr::Rule { var, Infinity }
@@ -6557,10 +6230,7 @@ pub fn discrete_asymptotic_ast(
           s.clone()
         }
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "DiscreteAsymptotic".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("DiscreteAsymptotic", args));
         }
       }
     }
@@ -6572,27 +6242,18 @@ pub fn discrete_asymptotic_ast(
         s.clone()
       }
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "DiscreteAsymptotic".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("DiscreteAsymptotic", args));
       }
     },
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "DiscreteAsymptotic".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("DiscreteAsymptotic", args));
     }
   };
 
   let expr = &args[0];
   match discrete_asymptotic_leading(expr, &var_name) {
     Some(result) => crate::evaluator::evaluate_expr_to_expr(&result),
-    None => Ok(Expr::FunctionCall {
-      name: "DiscreteAsymptotic".to_string(),
-      args: args.to_vec().into(),
-    }),
+    None => Ok(unevaluated("DiscreteAsymptotic", args)),
   }
 }
 
@@ -7127,12 +6788,7 @@ pub fn covariance_function_data(
 pub fn absolute_correlation_function_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "AbsoluteCorrelationFunction".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("AbsoluteCorrelationFunction", args));
   if args.len() != 2 {
     return unevaluated();
   }
@@ -7208,10 +6864,7 @@ pub fn covariance_function_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   if args.len() != 3 {
-    return Ok(Expr::FunctionCall {
-      name: "CovarianceFunction".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("CovarianceFunction", args));
   }
   if let Some(result) = process_covariance(&args[0], &args[1], &args[2]) {
     return crate::evaluator::evaluate_expr_to_expr(&result);
@@ -7222,10 +6875,7 @@ pub fn covariance_function_ast(
     // as the parser's literal `Times[-1, x/y]` instead of `-((x*y)/z)`.
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
-  Ok(Expr::FunctionCall {
-    name: "CovarianceFunction".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("CovarianceFunction", args))
 }
 
 /// CovarianceFunction[proc, t1, t2] closed forms for the directly
@@ -7349,12 +6999,7 @@ fn process_covariance(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
 pub fn biweight_midvariance_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "BiweightMidvariance".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("BiweightMidvariance", args));
   if args.is_empty() || args.len() > 2 {
     return unevaluated();
   }
@@ -7894,12 +7539,9 @@ fn cov_arma11(a: &Expr, b: &Expr, sigma2: &Expr, s: &Expr, t: &Expr) -> Expr {
 pub fn characteristic_function_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "CharacteristicFunction".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("CharacteristicFunction", args);
   if args.len() != 2 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let t = args[1].clone();
 
@@ -7935,7 +7577,7 @@ pub fn characteristic_function_ast(
 
   let (dist_name, dargs) = match &args[0] {
     Expr::FunctionCall { name, args } => (name.as_str(), args.as_slice()),
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   };
 
   // Raw templates only make sense while everything stays symbolic
@@ -8254,7 +7896,7 @@ pub fn characteristic_function_ast(
     // folds to 1.
     Some((expr, raw)) if raw && symbolic => Ok(expr),
     Some((expr, _)) => crate::evaluator::evaluate_expr_to_expr(&expr),
-    None => Ok(unevaluated(args)),
+    None => Ok(uneval()),
   }
 }
 
@@ -8267,12 +7909,9 @@ pub fn characteristic_function_ast(
 pub fn moment_generating_function_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "MomentGeneratingFunction".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("MomentGeneratingFunction", args);
   if args.len() != 2 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let t = args[1].clone();
 
@@ -8318,7 +7957,7 @@ pub fn moment_generating_function_ast(
 
   let (dist_name, dargs) = match &args[0] {
     Expr::FunctionCall { name, args } => (name.as_str(), args.as_slice()),
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   };
 
   fn is_symbolic_param(e: &Expr) -> bool {
@@ -8586,7 +8225,7 @@ pub fn moment_generating_function_ast(
   match template {
     Some((expr, raw)) if raw && symbolic => Ok(expr),
     Some((expr, _)) => crate::evaluator::evaluate_expr_to_expr(&expr),
-    None => Ok(unevaluated(args)),
+    None => Ok(uneval()),
   }
 }
 
@@ -8658,12 +8297,9 @@ fn cgf_term(f: &Expr) -> Expr {
 pub fn cumulant_generating_function_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "CumulantGeneratingFunction".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("CumulantGeneratingFunction", args);
   if args.len() != 2 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let t = args[1].clone();
 
@@ -8693,7 +8329,7 @@ pub fn cumulant_generating_function_ast(
 
   let (dist_name, dargs) = match &args[0] {
     Expr::FunctionCall { name, args } => (name.as_str(), args.as_slice()),
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   };
 
   fn is_symbolic_param(e: &Expr) -> bool {
@@ -8761,7 +8397,7 @@ pub fn cumulant_generating_function_ast(
   if matches!(&mgf, Expr::FunctionCall { name, .. }
     if name == "MomentGeneratingFunction")
   {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   // A distribution with no MGF (e.g. Cauchy, Student-t) also has no CGF:
   // Log[Indeterminate] is Indeterminate.
@@ -8801,12 +8437,9 @@ pub fn cumulant_generating_function_ast(
 pub fn factorial_moment_generating_function_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "FactorialMomentGeneratingFunction".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("FactorialMomentGeneratingFunction", args);
   if args.len() != 2 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let log_t = Expr::FunctionCall {
     name: "Log".to_string(),
@@ -8852,7 +8485,7 @@ pub fn factorial_moment_generating_function_ast(
   if matches!(&mgf, Expr::FunctionCall { name, .. }
     if name == "MomentGeneratingFunction")
   {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   crate::evaluator::evaluate_expr_to_expr(&mgf)
 }
@@ -8862,25 +8495,22 @@ pub fn factorial_moment_generating_function_ast(
 pub fn central_moment_generating_function_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "CentralMomentGeneratingFunction".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("CentralMomentGeneratingFunction", args);
   if args.len() != 2 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let mgf = moment_generating_function_ast(args)?;
   if matches!(&mgf, Expr::FunctionCall { name, .. }
     if name == "MomentGeneratingFunction")
   {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let mean = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
     name: "Mean".to_string(),
     args: vec![args[0].clone()].into(),
   })?;
   if matches!(&mean, Expr::FunctionCall { name, .. } if name == "Mean") {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let damp_exponent =
     crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
@@ -9025,27 +8655,24 @@ pub fn central_moment_generating_function_ast(
 pub fn correlation_function_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "CorrelationFunction".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("CorrelationFunction", args);
   if args.len() != 2 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let data = match &args[0] {
     Expr::List(items) if !items.is_empty() => items,
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   };
   let is_numeric = |e: &Expr| {
     matches!(e, Expr::Integer(_) | Expr::Real(_))
       || matches!(e, Expr::FunctionCall { name, .. } if name == "Rational")
   };
   if !data.iter().all(is_numeric) {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let k = match &args[1] {
     Expr::Integer(k) => *k,
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   };
   let n = data.len() as i128;
   if k.abs() >= n {
@@ -9054,7 +8681,7 @@ pub fn correlation_function_ast(
        symbol, an integer with magnitude less than the length of the data \
        or a range specification indicating such integers.",
     ));
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let lag = k.unsigned_abs() as usize;
 
@@ -9116,22 +8743,16 @@ pub fn correlation_function_ast(
 /// Erfc[|z|/Sqrt[2]] with z = (mean - mu0)/Sqrt[var/n]. Properties:
 /// "PValue" (default) and "TestStatistic".
 pub fn ztest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "ZTest".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("ZTest", args);
   if args.is_empty() || args.len() > 4 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let bad_data = |args: &[Expr]| {
     crate::emit_message(&format!(
       "ZTest::rctndm1: The argument {} at position 1 should be a rectangular array of real numbers with length greater than the dimension of the array or two such arrays of equal dimensionality.",
       expr_to_string(&args[0])
     ));
-    Ok(Expr::FunctionCall {
-      name: "ZTest".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("ZTest", args))
   };
   let data: Vec<f64> = match &args[0] {
     Expr::List(items) if items.len() >= 2 => {
@@ -9154,7 +8775,7 @@ pub fn ztest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(e) => {
       match crate::functions::math_ast::numeric_utils::try_eval_to_f64(e) {
         Some(v) if v > 0.0 => Some(v),
-        _ => return Ok(unevaluated(args)),
+        _ => return Ok(uneval()),
       }
     }
   }
@@ -9166,7 +8787,7 @@ pub fn ztest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(e) => {
       match crate::functions::math_ast::numeric_utils::try_eval_to_f64(e) {
         Some(v) => v,
-        None => return Ok(unevaluated(args)),
+        None => return Ok(uneval()),
       }
     }
   };
@@ -9183,7 +8804,7 @@ pub fn ztest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       ),
     )),
     Some(Expr::String(p)) if p == "TestStatistic" => Ok(Expr::Real(z)),
-    _ => Ok(unevaluated(args)),
+    _ => Ok(uneval()),
   }
 }
 
@@ -9194,22 +8815,16 @@ pub fn ztest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// two-sided 2 Min[F[T], 1 - F[T]]. A non-positive or non-numeric
 /// second argument emits FisherRatioTest::sigmnt.
 pub fn fisher_ratio_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = |args: &[Expr]| Expr::FunctionCall {
-    name: "FisherRatioTest".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("FisherRatioTest", args);
   if args.is_empty() || args.len() > 3 {
-    return Ok(unevaluated(args));
+    return Ok(uneval());
   }
   let bad_data = |args: &[Expr]| {
     crate::emit_message(&format!(
       "FisherRatioTest::vctnln1: The argument {} at position 1 should be a vector of real numbers with length greater than 1 or a list containing two such vectors.",
       expr_to_string(&args[0])
     ));
-    Ok(Expr::FunctionCall {
-      name: "FisherRatioTest".to_string(),
-      args: args.to_vec().into(),
-    })
+    Ok(unevaluated("FisherRatioTest", args))
   };
   let data: Vec<f64> = match &args[0] {
     Expr::List(items) if items.len() >= 2 => {
@@ -9234,7 +8849,7 @@ pub fn fisher_ratio_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             "FisherRatioTest::sigmnt: The argument {} should be a positive number.",
             expr_to_string(&args[1])
           ));
-          return Ok(unevaluated(args));
+          return Ok(uneval());
         }
       }
     }
@@ -9248,7 +8863,7 @@ pub fn fisher_ratio_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(Expr::String(p)) if p == "TestStatistic" => {
       return Ok(Expr::Real(t));
     }
-    _ => return Ok(unevaluated(args)),
+    _ => return Ok(uneval()),
   }
   // Two-sided p-value from the chi-square(n-1) CDF
   let upper = crate::functions::math_ast::gamma::gamma_regularized_numeric(
@@ -9319,21 +8934,12 @@ fn cycles_expr_lengths(e: &Expr) -> Option<Vec<usize>> {
 pub fn cycle_index_polynomial_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "CycleIndexPolynomial".to_string(),
-    args: args.to_vec().into(),
-  };
+  let uneval = || unevaluated("CycleIndexPolynomial", args);
   if args.len() != 2 {
-    return Ok(unevaluated());
+    return Ok(uneval());
   }
   let call_str = || {
-    format_expr(
-      &Expr::FunctionCall {
-        name: "CycleIndexPolynomial".to_string(),
-        args: args.to_vec().into(),
-      },
-      ExprForm::Output,
-    )
+    format_expr(&unevaluated("CycleIndexPolynomial", args), ExprForm::Output)
   };
 
   // Resolve the group to (element list, degree of the action)
@@ -9375,7 +8981,7 @@ pub fn cycle_index_polynomial_ast(
         "CycleIndexPolynomial::grp: {} is not a valid group.",
         format_expr(&args[0], ExprForm::Output)
       ));
-      return Ok(unevaluated());
+      return Ok(uneval());
     }
   };
   let vars = match &args[1] {
@@ -9385,16 +8991,16 @@ pub fn cycle_index_polynomial_ast(
         "CycleIndexPolynomial::list: List expected at position 2 in {}.",
         call_str()
       ));
-      return Ok(unevaluated());
+      return Ok(uneval());
     }
   };
   let element_list = match &elements {
     Expr::List(items) => items,
-    _ => return Ok(unevaluated()),
+    _ => return Ok(uneval()),
   };
   let order = element_list.len() as i128;
   if order == 0 {
-    return Ok(unevaluated());
+    return Ok(uneval());
   }
 
   // Aggregate cycle types: counts of (multiplicity per cycle length)
@@ -9403,7 +9009,7 @@ pub fn cycle_index_polynomial_ast(
   for e in element_list.iter() {
     let lengths = match cycles_expr_lengths(e) {
       Some(l) => l,
-      None => return Ok(unevaluated()),
+      None => return Ok(uneval()),
     };
     let moved: usize = lengths.iter().sum();
     let mut mult = vec![0usize; degree + 1];
@@ -9628,10 +9234,7 @@ fn looks_like_group(e: &Expr) -> bool {
 pub fn group_multiplication_table_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "GroupMultiplicationTable".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("GroupMultiplicationTable", args);
   let Some((images, _)) = group_element_images(&args[0]) else {
     if !looks_like_group(&args[0]) {
       crate::emit_message(&format!(
@@ -9670,10 +9273,7 @@ pub fn group_multiplication_table_ast(
 /// PermutationGroup form follows wolframscript's internal Schreier-Sims
 /// generator selection and is not replicated.
 pub fn group_stabilizer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || Expr::FunctionCall {
-    name: "GroupStabilizer".to_string(),
-    args: args.to_vec().into(),
-  };
+  let unevaluated = || unevaluated("GroupStabilizer", args);
   if !looks_like_group(&args[0]) {
     crate::emit_message(&format!(
       "GroupStabilizer::grp: {} is not a valid group.",
@@ -9824,10 +9424,7 @@ fn erlang_b_symbolic(
       expr_to_output(&args[0]),
       expr_to_output(&args[1]),
     ));
-    return Some(Ok(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    }));
+    return Some(Ok(unevaluated(name, args)));
   }
   let (c, a) = (args[0].clone(), args[1].clone());
   // a^c * E^(-a) / Gamma[1 + c, a]
@@ -9943,12 +9540,7 @@ fn erlang_common(
     }
   }
 
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated(name, args));
   if args.len() != 2 {
     return unevaluated();
   }
@@ -10098,24 +9690,14 @@ pub fn erlang_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// the earliest element. Rule forms ({k...} -> {v...} or {k -> v, ...})
 /// return the value belonging to the central key.
 pub fn central_feature_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "CentralFeature".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
-  let call_display = || {
-    expr_to_string(&Expr::FunctionCall {
-      name: "CentralFeature".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let uneval = || Ok(unevaluated("CentralFeature", args));
+  let call_display = || expr_to_string(&unevaluated("CentralFeature", args));
 
   if args.is_empty() {
     crate::emit_message(
       "CentralFeature::argx: CentralFeature called with 0 arguments; 1 argument is expected.",
     );
-    return unevaluated();
+    return uneval();
   }
   for extra in &args[1..] {
     let is_opt = matches!(
@@ -10128,7 +9710,7 @@ pub fn central_feature_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         expr_to_string(extra),
         call_display()
       ));
-      return unevaluated();
+      return uneval();
     }
   }
 
@@ -10136,7 +9718,7 @@ pub fn central_feature_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Wrapped data forms Woxi does not model (e.g. WeightedData) stay
   // silently unevaluated instead of wrongly emitting `near1`.
   if matches!(data, Expr::FunctionCall { name, .. } if name == "WeightedData") {
-    return unevaluated();
+    return uneval();
   }
   let near1 = || {
     crate::emit_message(&format!(
@@ -10155,7 +9737,7 @@ pub fn central_feature_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       _ => {
         near1();
-        return unevaluated();
+        return uneval();
       }
     },
     Expr::List(items) if !items.is_empty() => {
@@ -10179,7 +9761,7 @@ pub fn central_feature_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     _ => {
       near1();
-      return unevaluated();
+      return uneval();
     }
   };
 

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// Try to express a symbolic expression as a rational multiple of Pi: k*Pi/n.
 /// Returns Some((k, n)) in lowest terms, None if not recognized.
@@ -1455,10 +1455,7 @@ pub fn sin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Expr::BigFloat(digits, prec) = &args[0] {
     let p_in = (*prec).max(1.0);
     let result = crate::functions::math_ast::n_eval_arbitrary(
-      &Expr::FunctionCall {
-        name: "Sin".to_string(),
-        args: args.to_vec().into(),
-      },
+      &unevaluated("Sin", args),
       p_in,
     )?;
     if let Expr::BigFloat(ref out_digits, _) = result {
@@ -1530,10 +1527,7 @@ pub fn sin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       );
     }
     // Non-Pi-fraction real part: leave unevaluated (matches Wolfram)
-    return Ok(Expr::FunctionCall {
-      name: "Sin".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Sin", args));
   }
   // General complex with non-float components: try splitting into
   // real_part + im*I where real_part can be any expression (e.g., Pi, Pi/6)
@@ -1580,10 +1574,7 @@ pub fn sin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       );
     }
     // Non-Pi-fraction real part: leave unevaluated
-    return Ok(Expr::FunctionCall {
-      name: "Sin".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Sin", args));
   }
   // Complex float: sin(a+bi) = sin(a)cosh(b) + i*cos(a)sinh(b)
   // Only use float path when the argument actually contains a float value
@@ -1606,10 +1597,7 @@ pub fn sin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return r;
   }
   // Return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "Sin".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Sin", args))
 }
 
 pub fn cos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -1670,10 +1658,7 @@ pub fn cos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Expr::BigFloat(digits, prec) = &args[0] {
     let p_in = (*prec).max(1.0);
     let result = crate::functions::math_ast::n_eval_arbitrary(
-      &Expr::FunctionCall {
-        name: "Cos".to_string(),
-        args: args.to_vec().into(),
-      },
+      &unevaluated("Cos", args),
       p_in,
     )?;
     if let Expr::BigFloat(ref out_digits, _) = result {
@@ -1734,10 +1719,7 @@ pub fn cos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       );
     }
     // Non-Pi-fraction real part: leave unevaluated
-    return Ok(Expr::FunctionCall {
-      name: "Cos".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Cos", args));
   }
   // General complex with non-float components: try splitting into
   // real_part + im*I
@@ -1776,10 +1758,7 @@ pub fn cos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         &[real_term, im_term],
       );
     }
-    return Ok(Expr::FunctionCall {
-      name: "Cos".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Cos", args));
   }
   // Complex float: cos(a+bi) = cos(a)cosh(b) - i*sin(a)sinh(b)
   if contains_float(&args[0])
@@ -1798,10 +1777,7 @@ pub fn cos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some(r) = try_trig_pi_phase("Cos", &args[0]) {
     return r;
   }
-  Ok(Expr::FunctionCall {
-    name: "Cos".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Cos", args))
 }
 
 /// Evaluate a circular function ratio at an arbitrary-precision argument, e.g.
@@ -1903,10 +1879,7 @@ pub fn tan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       );
     }
     // Non-zero real part: leave unevaluated (matches Wolfram)
-    return Ok(Expr::FunctionCall {
-      name: "Tan".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Tan", args));
   }
   // Complex float: tan(z) = sin(z)/cos(z)
   if contains_float(&args[0])
@@ -1933,10 +1906,7 @@ pub fn tan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some(r) = try_trig_pi_phase("Tan", &args[0]) {
     return r;
   }
-  Ok(Expr::FunctionCall {
-    name: "Tan".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Tan", args))
 }
 
 pub fn sec_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -1988,10 +1958,7 @@ pub fn sec_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some(r) = try_trig_pi_phase("Sec", &args[0]) {
     return r;
   }
-  Ok(Expr::FunctionCall {
-    name: "Sec".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Sec", args))
 }
 
 pub fn csc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -2044,10 +2011,7 @@ pub fn csc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some(r) = try_trig_pi_phase("Csc", &args[0]) {
     return r;
   }
-  Ok(Expr::FunctionCall {
-    name: "Csc".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Csc", args))
 }
 
 pub fn cot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -2100,10 +2064,7 @@ pub fn cot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some(r) = try_trig_pi_phase("Cot", &args[0]) {
     return r;
   }
-  Ok(Expr::FunctionCall {
-    name: "Cot".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Cot", args))
 }
 
 pub fn exp_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -2200,10 +2161,7 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::Real(result));
     }
     // Otherwise keep the symbolic two-argument form.
-    return Ok(Expr::FunctionCall {
-      name: "Erf".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("Erf", args));
   }
   // Helper: negate the Erf of the positive part
   let negate_erf = |inner: Expr| -> Expr {
@@ -2226,10 +2184,7 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       match &dargs[0] {
         Expr::Integer(1) => Ok(Expr::Integer(1)),
         Expr::Integer(-1) => Ok(Expr::Integer(-1)),
-        _ => Ok(Expr::FunctionCall {
-          name: "Erf".to_string(),
-          args: args.to_vec().into(),
-        }),
+        _ => Ok(unevaluated("Erf", args)),
       }
     }
     // Erf[-Infinity] = -1 (UnaryOp form)
@@ -2264,10 +2219,7 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         return Ok(negate_erf(pos_arg));
       }
-      Ok(Expr::FunctionCall {
-        name: "Erf".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Erf", args))
     }
     // BinaryOp::Times form: -1 * x
     Expr::BinaryOp {
@@ -2291,20 +2243,14 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         return Ok(negate_erf(pos_arg));
       }
-      Ok(Expr::FunctionCall {
-        name: "Erf".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Erf", args))
     }
     // Erf[-n] for negative integer
     Expr::Integer(n) if *n < 0 => Ok(negate_erf(Expr::Integer(-*n))),
     // Numeric evaluation for Real arguments
     Expr::Real(f) => Ok(Expr::Real(erf_f64(*f))),
     // Otherwise symbolic
-    _ => Ok(Expr::FunctionCall {
-      name: "Erf".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("Erf", args)),
   }
 }
 
@@ -2331,10 +2277,7 @@ pub fn erfc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       match &dargs[0] {
         Expr::Integer(1) => Ok(Expr::Integer(0)),
         Expr::Integer(-1) => Ok(Expr::Integer(2)),
-        _ => Ok(Expr::FunctionCall {
-          name: "Erfc".to_string(),
-          args: args.to_vec().into(),
-        }),
+        _ => Ok(unevaluated("Erfc", args)),
       }
     }
     // Numeric evaluation for Real arguments
@@ -2342,10 +2285,7 @@ pub fn erfc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // 2 - Erfc[x] rewrite.)
     Expr::Real(f) => Ok(Expr::Real(1.0 - erf_f64(*f))),
     // Otherwise symbolic
-    _ => Ok(Expr::FunctionCall {
-      name: "Erfc".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("Erfc", args)),
   }
 }
 
@@ -2395,10 +2335,7 @@ pub fn erfi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         return negate_erfi(pos_arg);
       }
-      Ok(Expr::FunctionCall {
-        name: "Erfi".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Erfi", args))
     }
     // BinaryOp::Times form: -1 * x
     Expr::BinaryOp {
@@ -2422,20 +2359,14 @@ pub fn erfi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         return negate_erfi(pos_arg);
       }
-      Ok(Expr::FunctionCall {
-        name: "Erfi".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Erfi", args))
     }
     // Erfi[-n] for negative integer
     Expr::Integer(n) if *n < 0 => negate_erfi(Expr::Integer(-*n)),
     // Numeric evaluation for Real arguments
     Expr::Real(f) => Ok(Expr::Real(erfi_f64(*f))),
     // Otherwise symbolic
-    _ => Ok(Expr::FunctionCall {
-      name: "Erfi".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("Erfi", args)),
   }
 }
 
@@ -2485,10 +2416,7 @@ pub fn dawson_f_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         return negate(pos_arg);
       }
-      Ok(Expr::FunctionCall {
-        name: "DawsonF".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("DawsonF", args))
     }
     // BinaryOp::Times form: -1 * x
     Expr::BinaryOp {
@@ -2512,20 +2440,14 @@ pub fn dawson_f_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         };
         return negate(pos_arg);
       }
-      Ok(Expr::FunctionCall {
-        name: "DawsonF".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("DawsonF", args))
     }
     // DawsonF[-n] for negative integer
     Expr::Integer(n) if *n < 0 => negate(Expr::Integer(-*n)),
     // Numeric evaluation for Real arguments
     Expr::Real(f) => Ok(Expr::Real(dawson_f64(*f))),
     // Otherwise symbolic
-    _ => Ok(Expr::FunctionCall {
-      name: "DawsonF".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("DawsonF", args)),
   }
 }
 
@@ -2559,17 +2481,11 @@ pub fn inverse_erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           operand: Box::new(Expr::Identifier("Infinity".to_string())),
         })
       } else {
-        Ok(Expr::FunctionCall {
-          name: "InverseErf".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("InverseErf", args))
       }
     }
     // Otherwise symbolic — return unevaluated
-    _ => Ok(Expr::FunctionCall {
-      name: "InverseErf".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("InverseErf", args)),
   }
 }
 
@@ -2624,16 +2540,10 @@ pub fn inverse_erfc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           operand: Box::new(Expr::Identifier("Infinity".to_string())),
         })
       } else {
-        Ok(Expr::FunctionCall {
-          name: "InverseErfc".to_string(),
-          args: args.to_vec().into(),
-        })
+        Ok(unevaluated("InverseErfc", args))
       }
     }
-    _ => Ok(Expr::FunctionCall {
-      name: "InverseErfc".to_string(),
-      args: args.to_vec().into(),
-    }),
+    _ => Ok(unevaluated("InverseErfc", args)),
   }
 }
 
@@ -3105,10 +3015,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           re, im,
         ));
       }
-      Ok(Expr::FunctionCall {
-        name: "Log".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Log", args))
     }
     2 => {
       // Log[base, x] — integer base and a positive rational argument x = p/q.
@@ -3221,10 +3128,7 @@ pub fn log10_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Symbolic fallback: Log10[x] = Log[x] / Log[10]
   let expr = Expr::BinaryOp {
     op: BinaryOperator::Divide,
-    left: Box::new(Expr::FunctionCall {
-      name: "Log".to_string(),
-      args: args.to_vec().into(),
-    }),
+    left: Box::new(unevaluated("Log", args)),
     right: Box::new(Expr::FunctionCall {
       name: "Log".to_string(),
       args: vec![Expr::Integer(10)].into(),
@@ -3264,10 +3168,7 @@ pub fn log2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Symbolic fallback: Log2[x] = Log[x] / Log[2]
   let expr = Expr::BinaryOp {
     op: BinaryOperator::Divide,
-    left: Box::new(Expr::FunctionCall {
-      name: "Log".to_string(),
-      args: args.to_vec().into(),
-    }),
+    left: Box::new(unevaluated("Log", args)),
     right: Box::new(Expr::FunctionCall {
       name: "Log".to_string(),
       args: vec![Expr::Integer(2)].into(),
@@ -3352,10 +3253,7 @@ pub fn arcsin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     return Ok(result);
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcSin".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcSin", args))
 }
 
 /// ArcCos[x] - Inverse cosine (symbolic)
@@ -3504,10 +3402,7 @@ pub fn arccos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     return Ok(result);
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcCos".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcCos", args))
 }
 
 /// Check if a float value matches a known ArcCos special angle
@@ -3768,10 +3663,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::FunctionCall {
-    name: "ArcTan".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcTan", args))
 }
 
 /// ArcTan[x, y] - Two-argument arctangent (atan2)
@@ -3896,10 +3788,7 @@ pub fn arctan2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Return unevaluated for symbolic args
-  Ok(Expr::FunctionCall {
-    name: "ArcTan".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcTan", args))
 }
 
 /// Try to split an expression into real part and exact imaginary coefficient.
@@ -4081,10 +3970,7 @@ fn try_extract_negated(expr: &Expr) -> Option<Expr> {
           if args.len() == 2 {
             return Some(args[1].clone());
           }
-          return Some(Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: args[1..].to_vec().into(),
-          });
+          return Some(unevaluated("Times", &args[1..]));
         }
         let mut new_args = vec![negated_first];
         new_args.extend_from_slice(&args[1..]);
@@ -4274,10 +4160,7 @@ pub fn sinh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let inner = crate::evaluator::evaluate_function_call_ast("Sinh", &[pos])?;
     return Ok(negate_expr(inner));
   }
-  Ok(Expr::FunctionCall {
-    name: "Sinh".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Sinh", args))
 }
 
 /// Cosh[x] - Hyperbolic cosine
@@ -4325,10 +4208,7 @@ pub fn cosh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some(pos) = try_extract_negated(&args[0]) {
     return crate::evaluator::evaluate_function_call_ast("Cosh", &[pos]);
   }
-  Ok(Expr::FunctionCall {
-    name: "Cosh".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Cosh", args))
 }
 
 /// Tanh[x] - Hyperbolic tangent
@@ -4378,10 +4258,7 @@ pub fn tanh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let inner = crate::evaluator::evaluate_function_call_ast("Tanh", &[pos])?;
     return Ok(negate_expr(inner));
   }
-  Ok(Expr::FunctionCall {
-    name: "Tanh".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Tanh", args))
 }
 
 /// Coth[x] - Hyperbolic cotangent
@@ -4435,10 +4312,7 @@ pub fn coth_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let inner = crate::evaluator::evaluate_function_call_ast("Coth", &[pos])?;
     return Ok(negate_expr(inner));
   }
-  Ok(Expr::FunctionCall {
-    name: "Coth".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Coth", args))
 }
 
 /// Sech[x] - Hyperbolic secant
@@ -4481,10 +4355,7 @@ pub fn sech_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some(pos) = try_extract_negated(&args[0]) {
     return crate::evaluator::evaluate_function_call_ast("Sech", &[pos]);
   }
-  Ok(Expr::FunctionCall {
-    name: "Sech".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Sech", args))
 }
 
 /// Csch[x] - Hyperbolic cosecant
@@ -4538,10 +4409,7 @@ pub fn csch_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let inner = crate::evaluator::evaluate_function_call_ast("Csch", &[pos])?;
     return Ok(negate_expr(inner));
   }
-  Ok(Expr::FunctionCall {
-    name: "Csch".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Csch", args))
 }
 
 /// ArcSinh[x] - Inverse hyperbolic sine
@@ -4586,10 +4454,7 @@ pub fn arcsinh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::evaluator::evaluate_function_call_ast("ArcSinh", &[neg])?;
     return Ok(negate_expr(inner));
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcSinh".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcSinh", args))
 }
 
 /// ArcCosh[x] - Inverse hyperbolic cosine
@@ -4672,10 +4537,7 @@ pub fn arccosh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     _ => {}
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcCosh".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcCosh", args))
 }
 
 /// True if `expr` contains a Real or BigFloat anywhere — used to gate
@@ -4763,10 +4625,7 @@ pub fn arctanh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       crate::evaluator::evaluate_function_call_ast("ArcTanh", &[neg])?;
     return Ok(negate_expr(inner));
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcTanh".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcTanh", args))
 }
 
 /// ArcCoth[x] - Inverse hyperbolic cotangent
@@ -4873,10 +4732,7 @@ pub fn arccoth_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       &[Expr::Integer(-1), inner],
     );
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcCoth".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcCoth", args))
 }
 
 /// ArcSech[x] - Inverse hyperbolic secant
@@ -4908,10 +4764,7 @@ pub fn arcsech_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     _ => {}
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcSech".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcSech", args))
 }
 
 pub fn arccot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -4921,12 +4774,7 @@ pub fn arccot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
   let x = &args[0];
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "ArcCot".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("ArcCot", args));
 
   // ArcCot[±Infinity] = 0; ArcCot[0] = Pi/2.
   if matches!(x, Expr::Identifier(s) if s == "Infinity")
@@ -5007,10 +4855,7 @@ pub fn arccsc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       &[Expr::Real(1.0 / *f)],
     );
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcCsc".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcCsc", args))
 }
 
 pub fn arcsec_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -5054,10 +4899,7 @@ pub fn arcsec_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       &[Expr::Real(1.0 / *f)],
     );
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcSec".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcSec", args))
 }
 
 pub fn arccsch_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -5094,10 +4936,7 @@ pub fn arccsch_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       &[Expr::Integer(-1), inner],
     );
   }
-  Ok(Expr::FunctionCall {
-    name: "ArcCsch".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("ArcCsch", args))
 }
 
 /// Helper to construct -Pi/2 matching wolframscript output format
@@ -5236,10 +5075,7 @@ pub fn gudermannian_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     Expr::Identifier(name) if name == "ComplexInfinity" => {
       // Gudermannian[ComplexInfinity] is unevaluated in Wolfram
-      return Ok(Expr::FunctionCall {
-        name: "Gudermannian".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("Gudermannian", args));
     }
     Expr::Identifier(name) if name == "Undefined" => {
       return Ok(Expr::Identifier("Undefined".to_string()));
@@ -5276,10 +5112,7 @@ pub fn gudermannian_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => {}
   }
   // Symbolic: return unevaluated (matching wolframscript behavior)
-  Ok(Expr::FunctionCall {
-    name: "Gudermannian".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("Gudermannian", args))
 }
 
 /// InverseGudermannian[x] - the inverse Gudermannian function
@@ -5307,10 +5140,7 @@ pub fn inverse_gudermannian_ast(
     }
     _ => {}
   }
-  Ok(Expr::FunctionCall {
-    name: "InverseGudermannian".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("InverseGudermannian", args))
 }
 
 /// LogisticSigmoid[x] = 1 / (1 + Exp[-x])
@@ -5386,10 +5216,7 @@ pub fn logistic_sigmoid_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       .into(),
     });
   }
-  Ok(Expr::FunctionCall {
-    name: "LogisticSigmoid".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("LogisticSigmoid", args))
 }
 
 // ─── Degree Trig Functions ──────────────────────────────────────────────
@@ -5417,10 +5244,7 @@ fn trig_degrees_ast(
   if let Expr::FunctionCall { name, .. } = &result
     && name == func_name
   {
-    return Ok(Expr::FunctionCall {
-      name: degrees_name.to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated(degrees_name, args));
   }
   Ok(result)
 }
@@ -5445,10 +5269,7 @@ fn arc_trig_degrees_ast(
   if let Expr::FunctionCall { name, .. } = &radians
     && name == func_name
   {
-    return Ok(Expr::FunctionCall {
-      name: degrees_name.to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated(degrees_name, args));
   }
   // For numeric results, convert radians to degrees (keep as Real)
   if let Expr::Real(f) = &radians {
@@ -5524,10 +5345,7 @@ pub fn arccsc_degrees_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// TrigExpand[expr] — expand trig functions of sums and integer multiples.
 pub fn trig_expand_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "TrigExpand".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("TrigExpand", args));
   }
   let result = trig_expand_recursive(&args[0]);
   // TrigExpand distributes products over sums (and expands powers).
@@ -5918,10 +5736,7 @@ fn expand_cosh_multiple(n: usize, x: &Expr) -> Expr {
 // ─── AST building helpers ───────────────────────────────────────────
 
 fn make_fn(name: &str, args: &[Expr]) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.to_vec().into(),
-  }
+  unevaluated(name, args)
 }
 
 fn make_times(a: &Expr, b: &Expr) -> Expr {
@@ -5984,10 +5799,7 @@ fn build_sum(terms: &[Expr]) -> Expr {
   if terms.len() == 1 {
     return terms[0].clone();
   }
-  Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.to_vec().into(),
-  }
+  unevaluated("Plus", terms)
 }
 
 // ─── TrigReduce ─────────────────────────────────────────────────────────
@@ -5996,10 +5808,7 @@ fn build_sum(terms: &[Expr]) -> Expr {
 /// sums of trig functions with linear arguments.
 pub fn trig_reduce_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "TrigReduce".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("TrigReduce", args));
   }
   let result = trig_reduce_recursive(&args[0]);
   let evaluated = crate::evaluator::evaluate_expr_to_expr(&result)?;

--- a/src/functions/math_ast/weierstrass.rs
+++ b/src/functions/math_ast/weierstrass.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{Expr, unevaluated};
 
 // Format a `Power::infy` warning in wolframscript's 2D layout, e.g.
 // `0^-3` renders as:
@@ -53,10 +53,7 @@ pub fn weierstrass_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let (g2, g3) = match &args[1] {
     Expr::List(items) if items.len() == 2 => (&items[0], &items[1]),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "WeierstrassP".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("WeierstrassP", args));
     }
   };
 
@@ -79,10 +76,7 @@ pub fn weierstrass_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Symbolic: return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "WeierstrassP".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("WeierstrassP", args))
 }
 
 /// WeierstrassPPrime[u, {g2, g3}] - Derivative of Weierstrass elliptic function ℘'(u; g₂, g₃)
@@ -99,10 +93,7 @@ pub fn weierstrass_p_prime_ast(
   let (g2, g3) = match &args[1] {
     Expr::List(items) if items.len() == 2 => (&items[0], &items[1]),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "WeierstrassPPrime".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("WeierstrassPPrime", args));
     }
   };
 
@@ -125,10 +116,7 @@ pub fn weierstrass_p_prime_ast(
   }
 
   // Symbolic: return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "WeierstrassPPrime".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("WeierstrassPPrime", args))
 }
 
 /// Compute WeierstrassPPrime numerically via central difference of WeierstrassP
@@ -270,10 +258,7 @@ pub fn inverse_weierstrass_p_ast(
   let (g2, g3) = match &args[1] {
     Expr::List(items) if items.len() == 2 => (&items[0], &items[1]),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "InverseWeierstrassP".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("InverseWeierstrassP", args));
     }
   };
 
@@ -281,19 +266,13 @@ pub fn inverse_weierstrass_p_ast(
   let g2_f = match try_eval_to_f64(g2) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "InverseWeierstrassP".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("InverseWeierstrassP", args));
     }
   };
   let g3_f = match try_eval_to_f64(g3) {
     Some(v) => v,
     None => {
-      return Ok(Expr::FunctionCall {
-        name: "InverseWeierstrassP".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("InverseWeierstrassP", args));
     }
   };
 
@@ -306,19 +285,13 @@ pub fn inverse_weierstrass_p_ast(
       let p_f = match try_eval_to_f64(&items[0]) {
         Some(v) => v,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "InverseWeierstrassP".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("InverseWeierstrassP", args));
         }
       };
       let pp_f = match try_eval_to_f64(&items[1]) {
         Some(v) => v,
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "InverseWeierstrassP".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("InverseWeierstrassP", args));
         }
       };
       let u = inverse_weierstrass_p_with_prime(p_f, pp_f, g2_f, g3_f);
@@ -333,15 +306,9 @@ pub fn inverse_weierstrass_p_ast(
           if !matches!(&args[0], Expr::Real(_))
             && !matches!(&args[0], Expr::Integer(_))
           {
-            return Ok(Expr::FunctionCall {
-              name: "InverseWeierstrassP".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("InverseWeierstrassP", args));
           }
-          return Ok(Expr::FunctionCall {
-            name: "InverseWeierstrassP".to_string(),
-            args: args.to_vec().into(),
-          });
+          return Ok(unevaluated("InverseWeierstrassP", args));
         }
       };
       // Need at least one Real for numeric eval
@@ -349,10 +316,7 @@ pub fn inverse_weierstrass_p_ast(
         || matches!(g2, Expr::Real(_))
         || matches!(g3, Expr::Real(_));
       if !has_real {
-        return Ok(Expr::FunctionCall {
-          name: "InverseWeierstrassP".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("InverseWeierstrassP", args));
       }
       let (u, pp) = inverse_weierstrass_p_numeric(p_f, g2_f, g3_f);
       Ok(Expr::List(vec![Expr::Real(u), Expr::Real(pp)].into()))

--- a/src/functions/math_ast/zeta_functions.rs
+++ b/src/functions/math_ast/zeta_functions.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// Check if an expression contains any float-valued components (Real or BigFloat).
 fn contains_float(expr: &Expr) -> bool {
@@ -81,10 +81,7 @@ pub fn zeta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       // Positive odd integer >= 3 or overflow: return unevaluated
-      Ok(Expr::FunctionCall {
-        name: "Zeta".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Zeta", args))
     }
     Expr::Real(f) => {
       // Zeta has a simple pole at s = 1: Zeta[1.] = ComplexInfinity (like the
@@ -113,10 +110,7 @@ pub fn zeta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       // Symbolic argument: return unevaluated
-      Ok(Expr::FunctionCall {
-        name: "Zeta".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Zeta", args))
     }
   }
 }
@@ -133,12 +127,7 @@ pub fn zeta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn hurwitz_zeta_public_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "HurwitzZeta".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let unevaluated = || Ok(unevaluated("HurwitzZeta", args));
   if args.len() != 2 {
     return unevaluated();
   }
@@ -291,10 +280,7 @@ fn hurwitz_zeta_ast(
           }
         }
         // Symbolic a: return unevaluated
-        return Ok(Expr::FunctionCall {
-          name: "Zeta".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Zeta", args));
       }
 
       // Zeta[-n, a] for non-negative integer n: uses Bernoulli polynomials
@@ -313,10 +299,7 @@ fn hurwitz_zeta_ast(
             }
           }
         }
-        return Ok(Expr::FunctionCall {
-          name: "Zeta".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("Zeta", args));
       }
 
       // Positive integer s >= 2 with positive integer a:
@@ -343,16 +326,10 @@ fn hurwitz_zeta_ast(
               sum_num = new_num / g;
               sum_den = new_den / g;
             } else {
-              return Ok(Expr::FunctionCall {
-                name: "Zeta".to_string(),
-                args: args.to_vec().into(),
-              });
+              return Ok(unevaluated("Zeta", args));
             }
           } else {
-            return Ok(Expr::FunctionCall {
-              name: "Zeta".to_string(),
-              args: args.to_vec().into(),
-            });
+            return Ok(unevaluated("Zeta", args));
           }
         }
         let sum_rational = make_rational(sum_num, sum_den);
@@ -375,10 +352,7 @@ fn hurwitz_zeta_ast(
       }
 
       // Return unevaluated
-      Ok(Expr::FunctionCall {
-        name: "Zeta".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Zeta", args))
     }
     Expr::Real(s_f) => {
       // Numeric evaluation
@@ -400,10 +374,7 @@ fn hurwitz_zeta_ast(
             let result = hurwitz_zeta_numeric(s, a);
             return Ok(Expr::Real(result));
           }
-          Ok(Expr::FunctionCall {
-            name: "Zeta".to_string(),
-            args: args.to_vec().into(),
-          })
+          Ok(unevaluated("Zeta", args))
         }
         _ => {
           if contains_float(a_expr)
@@ -413,10 +384,7 @@ fn hurwitz_zeta_ast(
             let result = hurwitz_zeta_numeric(s, re);
             return Ok(Expr::Real(result));
           }
-          Ok(Expr::FunctionCall {
-            name: "Zeta".to_string(),
-            args: args.to_vec().into(),
-          })
+          Ok(unevaluated("Zeta", args))
         }
       }
     }
@@ -429,10 +397,7 @@ fn hurwitz_zeta_ast(
         let result = hurwitz_zeta_numeric(s_f, a_f);
         return Ok(Expr::Real(result));
       }
-      Ok(Expr::FunctionCall {
-        name: "Zeta".to_string(),
-        args: args.to_vec().into(),
-      })
+      Ok(unevaluated("Zeta", args))
     }
   }
 }
@@ -987,16 +952,10 @@ pub fn polygamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(z) = extract_f64(z_expr_from_args(&args[1])) {
           return Ok(Expr::Real(polygamma_numeric(*f as usize, z)));
         }
-        return Ok(Expr::FunctionCall {
-          name: "PolyGamma".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("PolyGamma", args));
       }
       _ => {
-        return Ok(Expr::FunctionCall {
-          name: "PolyGamma".to_string(),
-          args: args.to_vec().into(),
-        });
+        return Ok(unevaluated("PolyGamma", args));
       }
     },
     _ => {
@@ -1007,10 +966,7 @@ pub fn polygamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   if n_val < 0 {
-    return Ok(Expr::FunctionCall {
-      name: "PolyGamma".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("PolyGamma", args));
   }
   let n = n_val as usize;
 
@@ -1437,10 +1393,7 @@ pub fn lerch_phi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Symbolic: return unevaluated
-  Ok(Expr::FunctionCall {
-    name: "LerchPhi".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("LerchPhi", args))
 }
 
 /// HurwitzLerchPhi[z, s, a] - the Hurwitz-Lerch transcendent
@@ -1448,12 +1401,7 @@ pub fn lerch_phi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// at a non-positive integer `a`, where the singular k = -a term is included
 /// and the value is ComplexInfinity (LerchPhi instead omits that term).
 pub fn hurwitz_lerch_phi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let symbolic = || {
-    Ok(Expr::FunctionCall {
-      name: "HurwitzLerchPhi".to_string(),
-      args: args.to_vec().into(),
-    })
-  };
+  let symbolic = || Ok(unevaluated("HurwitzLerchPhi", args));
   if args.len() != 3 {
     return symbolic();
   }
@@ -1664,20 +1612,14 @@ fn lerch_phi_numeric(z: f64, s: f64, a: f64) -> f64 {
 /// Computed via Möbius inversion: P(s) = sum_{k=1}^∞ μ(k)/k * log(ζ(ks)).
 pub fn prime_zeta_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
-    return Ok(Expr::FunctionCall {
-      name: "PrimeZetaP".to_string(),
-      args: args.to_vec().into(),
-    });
+    return Ok(unevaluated("PrimeZetaP", args));
   }
 
   // Only evaluate numerically for Real (approximate) arguments
   let s = match &args[0] {
     Expr::Real(v) if *v > 1.0 => *v,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "PrimeZetaP".to_string(),
-        args: args.to_vec().into(),
-      });
+      return Ok(unevaluated("PrimeZetaP", args));
     }
   };
 
@@ -1841,10 +1783,7 @@ pub fn riemann_siegel_z_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(riemann_siegel_z_numeric(t)));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "RiemannSiegelZ".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("RiemannSiegelZ", args))
 }
 
 /// RiemannSiegelTheta[t] — the Riemann-Siegel theta function for real t.
@@ -1866,10 +1805,7 @@ pub fn riemann_siegel_theta_ast(
     return Ok(Expr::Real(v));
   }
 
-  Ok(Expr::FunctionCall {
-    name: "RiemannSiegelTheta".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("RiemannSiegelTheta", args))
 }
 
 /// RamanujanTauTheta[t] — the Riemann-Siegel-style theta function for the
@@ -1995,10 +1931,7 @@ pub fn ramanujan_tau_z_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Expr::Real(t) = &args[0] {
     return Ok(Expr::Real(ramanujan_tau_z_numeric(*t)));
   }
-  Ok(Expr::FunctionCall {
-    name: "RamanujanTauZ".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("RamanujanTauZ", args))
 }
 
 /// RamanujanTauL[s] — numeric for real/complex machine input, symbolic for
@@ -2024,10 +1957,7 @@ pub fn ramanujan_tau_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       v.0, v.1,
     ));
   }
-  Ok(Expr::FunctionCall {
-    name: "RamanujanTauL".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("RamanujanTauL", args))
 }
 
 /// RamanujanTauTheta[t] — numeric for real (machine) input, symbolic otherwise.
@@ -2044,10 +1974,7 @@ pub fn ramanujan_tau_theta_ast(
     let v = if v == 0.0 { 0.0 } else { v };
     return Ok(Expr::Real(v));
   }
-  Ok(Expr::FunctionCall {
-    name: "RamanujanTauTheta".to_string(),
-    args: args.to_vec().into(),
-  })
+  Ok(unevaluated("RamanujanTauTheta", args))
 }
 
 /// DirichletEta[s] — the Dirichlet eta function: (1 - 2^(1-s)) * Zeta[s]


### PR DESCRIPTION
Use unevaluated() throughout math_ast/*.rs.
Changes were done by script, renaming some closures with the same name as needed.