### PR TITLE
Fix some test failures on Windows

### DIFF
--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -12,6 +12,19 @@ fn temp_file(file: &str) -> String {
   tmp.display().to_string()
 }
 
+fn manifest_file(file: &str) -> String {
+  let manifest = env!("CARGO_MANIFEST_DIR");
+  let path = format!("{manifest}/{file}");
+  if cfg!(target_os = "windows") {
+    path
+      .replace("\\t", "\\\\t")
+      .replace("\\r", "\\\\r")
+      .replace("\\n", "\\\\n")
+  } else {
+    path
+  }
+}
+
 mod date_string {
   use super::*;
 
@@ -3734,8 +3747,7 @@ mod csv_import {
   use super::*;
 
   fn csv_path() -> String {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest}/tests/data/data.csv")
+    manifest_file("tests/data/data.csv")
   }
 
   #[test]
@@ -4004,8 +4016,7 @@ mod xlsx_import {
   use super::*;
 
   fn xlsx_path() -> String {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest}/tests/data/population.xlsx")
+    manifest_file("tests/data/population.xlsx")
   }
 
   #[test]
@@ -4092,13 +4103,11 @@ mod root_import {
   // "varhist" with variable-width bin edges {0, 1, 2.5, 10} and a
   // TObjString "note".
   fn root_path() -> String {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest}/tests/data/sample.root")
+    manifest_file("tests/data/sample.root")
   }
 
   fn lz4_root_path() -> String {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest}/tests/data/sample_lz4.root")
+    manifest_file("tests/data/sample_lz4.root")
   }
 
   #[test]
@@ -4222,8 +4231,7 @@ mod root_import {
 
   #[test]
   fn import_root_rejects_non_root_file() {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    let path = format!("{manifest}/tests/data/data.csv");
+    let path = manifest_file("tests/data/data.csv");
     let err = interpret(&format!(r#"Import["{path}", "ROOT"]"#));
     assert!(err.is_err(), "expected error for non-ROOT file");
     assert!(
@@ -4248,13 +4256,11 @@ mod root_tree_data {
   // flat branches of every basic leaf type, bool and unsigned variants,
   // and two jagged (leaf-count) branches, plus a TH2D "h2" (3×2 bins).
   fn tree_data_path() -> String {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest}/tests/data/tree_data.root")
+    manifest_file("tests/data/tree_data.root")
   }
 
   fn sample_path() -> String {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest}/tests/data/sample.root")
+    manifest_file("tests/data/sample.root")
   }
 
   #[test]
@@ -4493,9 +4499,8 @@ mod root_mdst {
   use super::*;
 
   fn mdst_path() -> Option<String> {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    let path = format!(
-      "{manifest}/examples/_dominik_ecker_examples/2026-07-07_mDST-0-0-0-0.root"
+    let path = manifest_file(
+      "examples/_dominik_ecker_examples/2026-07-07_mDST-0-0-0-0.root",
     );
     std::path::Path::new(&path).exists().then_some(path)
   }
@@ -4685,8 +4690,7 @@ mod txt_import {
   use super::*;
 
   fn txt_path() -> String {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest}/tests/data/article.txt")
+    manifest_file("tests/data/article.txt")
   }
 
   #[test]
@@ -6826,8 +6830,7 @@ mod json_import {
   use super::*;
 
   fn json_path() -> String {
-    let manifest = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest}/tests/data/sample.json")
+    manifest_file("tests/data/sample.json")
   }
 
   #[test]

--- a/tests/interpreter_tests/machine_specific.rs
+++ b/tests/interpreter_tests/machine_specific.rs
@@ -447,6 +447,7 @@ mod cases {
   fn system_character_encoding() {
     assert_case(r#"$SystemCharacterEncoding"#, r#""UTF-8""#);
   }
+  #[cfg(unix)]
   #[test]
   fn root_directory() {
     assert_case(r#"$RootDirectory"#, r#""/""#);
@@ -457,7 +458,8 @@ mod cases {
   }
   #[test]
   fn pathname_separator() {
-    assert_case(r#"$PathnameSeparator"#, r#""/""#);
+    let sep = format!(r#""{}""#, std::path::MAIN_SEPARATOR_STR);
+    assert_case(r#"$PathnameSeparator"#, &sep);
   }
   #[test]
   fn export_formats() {

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -8121,6 +8121,7 @@ mod cases {
       r#"x"#,
     );
   }
+  #[cfg(unix)]
   #[test]
   fn head_4() {
     // The mathics original (`S> $ParentProcessID = ...`) accepts any
@@ -8867,6 +8868,7 @@ mod cases {
   fn byte_ordering() {
     assert_case(r#"ByteOrdering"#, r#"ByteOrdering"#);
   }
+  #[cfg(unix)]
   #[test]
   fn head_23() {
     assert_case(


### PR DESCRIPTION
I had a notable increase in test failures since I moved my Woxi repo to "C:\temp".  As noted before, \t, \r and \n need to be escaped to get interpreted "properly" in the interpreter. So add manifest_file() that includes this escape logic on Windows.

Also marked syntax::cases::head_4, and head_23 as unix tests, since ParentProcessID doesn't exist on Windows currently.