### PR TITLE
Move debug build to opt_level = 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,7 @@ harness = false
 # ~400k-line crate. `split-debuginfo = "unpacked"` additionally skips the
 # slow dsymutil packaging step on macOS.
 [profile.dev]
+opt-level = 1
 debug = "line-tables-only"
 split-debuginfo = "unpacked"
 


### PR DESCRIPTION
The debug build generates awful code, which prompted me to change the pair_to_expr implementation so as to not consume so much stack. An alternative/supplementary fix would be to enable basic optimization in the debug build.  At least for Windows, this leads to much smaller binaries/symbols (~110M -> ~80M/~230M -> ~130M), and the incremental build is actually slightly faster.  The huge stack consumption for closures largely gets fixed by this.