### PR TITLE
Consolidate utility functions into centralized modules

### DIFF
--- a/src/evaluator/binary_ops.rs
+++ b/src/evaluator/binary_ops.rs
@@ -291,23 +291,7 @@ fn precision_for_add(lv: f64, lp: f64, rv: f64, rp: f64, result: f64) -> f64 {
   }
 }
 
-/// Format an f64 value as a BigFloat string with the given number of significant digits.
-fn format_bigfloat_value(value: f64, sig_digits: usize) -> String {
-  if value == 0.0 {
-    return "0.".to_string();
-  }
-  let sign = if value < 0.0 { "-" } else { "" };
-  let abs_val = value.abs();
-  let magnitude = abs_val.log10().floor() as i32;
-  let decimal_places = ((sig_digits as i32) - magnitude - 1).max(0) as usize;
-  let formatted = format!("{}{:.prec$}", sign, abs_val, prec = decimal_places);
-  // Ensure trailing dot if no decimal point
-  if !formatted.contains('.') {
-    format!("{}.", formatted)
-  } else {
-    formatted
-  }
-}
+use crate::functions::math_ast::format_bigfloat_value;
 
 /// Perform a binary operation on BigFloat operands with precision tracking.
 /// Returns None if operands are not numeric, so the caller can fall through.

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -11913,9 +11913,7 @@ fn rational_to_expr(n: i128, d: i128) -> Expr {
   }
 }
 
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  if b == 0 { a } else { gcd_i128(b, a % b) }
-}
+use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Rational arithmetic helpers
 fn rat_sub(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -11876,22 +11876,7 @@ fn find_sequence_function(
   })
 }
 
-/// Convert an Expr to a rational number (numerator, denominator).
-fn expr_to_rational(expr: &Expr) -> Option<(i128, i128)> {
-  match expr {
-    Expr::Integer(n) => Some((*n, 1)),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
-        Some((*n, *d))
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
+use crate::functions::math_ast::expr_to_rational;
 
 /// Convert a rational (n, d) back to an Expr.
 fn rational_to_expr(n: i128, d: i128) -> Expr {
@@ -14359,15 +14344,4 @@ fn contains_unevaluated_integrate(expr: &Expr) -> bool {
 /// structure. Used by `DirectedInfinity` to distinguish exact closed-form
 /// directions like `(1 + 2 I)/Sqrt[5]` from inexact ones like
 /// `1. + 2. I` — only the latter should be normalised numerically.
-fn expr_contains_real(expr: &Expr) -> bool {
-  match expr {
-    Expr::Real(_) => true,
-    Expr::UnaryOp { operand, .. } => expr_contains_real(operand),
-    Expr::BinaryOp { left, right, .. } => {
-      expr_contains_real(left) || expr_contains_real(right)
-    }
-    Expr::FunctionCall { args, .. } => args.iter().any(expr_contains_real),
-    Expr::List(items) => items.iter().any(expr_contains_real),
-    _ => false,
-  }
-}
+use crate::functions::math_ast::expr_contains_real;

--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -2069,14 +2069,7 @@ pub fn dispatch_linear_algebra_functions(
         let mut matrix = Expr::List(rows.into());
         // If any input is inexact (contains a Real), the whole matrix is
         // numeric in Wolfram — promote every entry to machine precision.
-        fn is_inexact(e: &Expr) -> bool {
-          match e {
-            Expr::Real(_) | Expr::BigFloat(_, _) => true,
-            Expr::List(items) => items.iter().any(is_inexact),
-            Expr::FunctionCall { args, .. } => args.iter().any(is_inexact),
-            _ => false,
-          }
-        }
+        use crate::functions::math_ast::contains_inexact_real as is_inexact;
         if args.iter().any(is_inexact) {
           matrix = Expr::FunctionCall {
             name: "N".to_string(),

--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -3879,16 +3879,7 @@ fn kronecker_product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(acc_owned)
 }
 
-fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
-  a = a.abs();
-  b = b.abs();
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
+use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Binary dissimilarity functions for binary (0/1) vectors.
 fn binary_dissimilarity_ast(

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -7064,23 +7064,7 @@ fn expand_part_spec(
   Some(out)
 }
 
-/// Extract a value from an association by key string
-fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
-
-fn lcm_i128(a: i128, b: i128) -> i128 {
-  if a == 0 || b == 0 {
-    return 0;
-  }
-  let g = gcd_i128(a.abs(), b.abs());
-  (a / g * b).abs()
-}
+use crate::functions::math_ast::lcm_i128;
 
 /// If `expr` is `Cycles[{{...}, {...}, ...}]` with all-integer cycles,
 /// return each cycle as `Vec<i128>`. Returns `None` for any other shape

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -8002,22 +8002,7 @@ fn nearest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 /// Try to convert an Expr to f64 for distance computation
-fn expr_to_f64(expr: &Expr) -> Option<f64> {
-  match expr {
-    Expr::Integer(n) => Some(*n as f64),
-    Expr::Real(f) => Some(*f),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(a), Expr::Integer(b)) = (&args[0], &args[1]) {
-        Some(*a as f64 / *b as f64)
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
+use crate::functions::math_ast::expr_to_f64;
 
 fn array_reshape_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Flatten the input list

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -5638,22 +5638,7 @@ fn cantor_staircase_ast(arg: &Expr) -> Result<Expr, InterpreterError> {
   })
 }
 
-/// Extract numerator and denominator from a rational expression
-fn extract_rational(expr: &Expr) -> Option<(i128, i128)> {
-  match expr {
-    Expr::Integer(n) => Some((*n, 1)),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(a), Expr::Integer(b)) = (&args[0], &args[1]) {
-        Some((*a, *b))
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
+use crate::functions::math_ast::expr_to_rational as extract_rational;
 
 /// Compute cantor staircase for exact rational p/q where 0 < p/q < 1
 fn cantor_staircase_rational(p: i128, q: i128) -> Expr {
@@ -8247,22 +8232,7 @@ fn image_min_max_filter(
   })
 }
 
-fn expr_to_f64(expr: &Expr) -> Option<f64> {
-  match expr {
-    Expr::Integer(n) => Some(*n as f64),
-    Expr::Real(f) => Some(*f),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(a), Expr::Integer(b)) = (&args[0], &args[1]) {
-        Some(*a as f64 / *b as f64)
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
+use crate::functions::math_ast::expr_to_f64;
 
 /// Standardize[data] — subtract mean and divide by standard deviation
 /// Standardize[data, f1, f2] — use f1 for location and f2 for scale

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::make_sqrt;
+use crate::functions::math_ast::{gcd as gcd_i128, gcd_u64, make_sqrt};
 use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator, unevaluated};
 
 /// Columnwise quartile-family statistic for a matrix argument.
@@ -2797,7 +2797,7 @@ pub fn dispatch_math_functions(
           return Some(Ok(Expr::Integer(1)));
         }
         let a_mod = ((*a % *n) + *n) % *n;
-        if a_mod != 0 && crate::functions::math_ast::gcd_i128(a_mod, *n) == 1 {
+        if a_mod != 0 && crate::functions::math_ast::gcd(a_mod, *n) == 1 {
           let mut power = a_mod;
           for k in 1..=*n {
             if power == 1 {
@@ -2844,7 +2844,7 @@ pub fn dispatch_math_functions(
           let phi = crate::functions::math_ast::euler_phi_i128(m);
           let start = if m == 2 { 1 } else { 2 };
           for g in start..m {
-            if crate::functions::math_ast::gcd_i128(g, m) != 1 {
+            if crate::functions::math_ast::gcd(g, m) != 1 {
               continue;
             }
             let mut power = g % m;
@@ -5962,15 +5962,6 @@ fn rat_mul(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
   (n / g, d / g)
 }
 
-fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  if a == 0 { 1 } else { a }
-}
-
 fn solve_rational_system(
   matrix: &mut [Vec<(i128, i128)>],
   rhs: &mut [(i128, i128)],
@@ -7972,15 +7963,6 @@ fn is_primitive_root(g: u64, n: u64, phi: u64) -> bool {
     return false;
   }
   true
-}
-
-fn gcd_u64(mut a: u64, mut b: u64) -> u64 {
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
 }
 
 fn pow_mod(mut base: u64, mut exp: u64, modulus: u64) -> u64 {

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use super::*;
 
+use crate::functions::math_ast::gcd as gcd_i128;
+
 // Re-export crate types/functions for submodules (used by submodules via `use super::*`)
 #[allow(unused_imports)]
 pub(crate) use crate::syntax::{
@@ -10953,10 +10955,6 @@ fn expr_to_rational(expr: &Expr) -> Option<(i128, i128)> {
     }
     _ => None,
   }
-}
-
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  if b == 0 { a } else { gcd_i128(b, a % b) }
 }
 
 /// Build a petgraph UnGraph from Wolfram Graph vertices and edges.

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -8570,14 +8570,7 @@ pub fn evaluate_function_call_ast_inner(
       // Circular embedding: angle_k = π/2 + k * 2π/n for k = 1..n
       // Snap coordinates near simple rational values (0, ±0.5, ±1) to
       // eliminate platform-dependent ULP differences in f64 trig.
-      fn snap_coord(v: f64) -> f64 {
-        for &target in &[0.0, 0.5, -0.5, 1.0, -1.0] {
-          if (v - target).abs() < 1e-14 {
-            return target;
-          }
-        }
-        v
-      }
+      use crate::functions::graph::snap_coord;
       let coords: Vec<Expr> = (1..=n)
         .map(|k| {
           let angle = std::f64::consts::FRAC_PI_2

--- a/src/evaluator/dispatch/polynomial_functions.rs
+++ b/src/evaluator/dispatch/polynomial_functions.rs
@@ -1189,16 +1189,7 @@ fn sinusoid_extremum(expr: &Expr, var: &str, maximize: bool) -> Option<Expr> {
     norm((a.0 * b.1 + b.0 * a.1, a.1 * b.1))
   }
   fn norm(f: Frac) -> Frac {
-    fn gcd(a: i128, b: i128) -> i128 {
-      let (mut a, mut b) = (a.abs(), b.abs());
-      while b != 0 {
-        let t = b;
-        b = a % b;
-        a = t;
-      }
-      a.max(1)
-    }
-    let g = gcd(f.0, f.1);
+    let g = crate::functions::math_ast::gcd(f.0, f.1).max(1);
     let (mut n, mut d) = (f.0 / g, f.1 / g);
     if d < 0 {
       n = -n;

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -4,19 +4,7 @@ use crate::syntax::{ComparisonOp, unevaluated};
 
 /// True if `expr` contains any Real or BigFloat node — used to decide
 /// between exact and inexact number predicates.
-fn contains_real(expr: &Expr) -> bool {
-  match expr {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::FunctionCall { args, .. } | Expr::List(args) => {
-      args.iter().any(contains_real)
-    }
-    Expr::BinaryOp { left, right, .. } => {
-      contains_real(left) || contains_real(right)
-    }
-    Expr::UnaryOp { operand, .. } => contains_real(operand),
-    _ => false,
-  }
-}
+use crate::functions::math_ast::contains_inexact_real as contains_real;
 
 /// ExactNumberQ[x]: True for Integer/Rational/exact Complex (and their
 /// expanded forms). `I`, `1 + I`, `4 I + 5/6` are all exact.

--- a/src/evaluator/type_helpers.rs
+++ b/src/evaluator/type_helpers.rs
@@ -16,49 +16,12 @@ pub fn expr_to_number(expr: &Expr) -> Option<f64> {
   }
 }
 
-/// Extract an i128 from Integer or BigInteger (if it fits)
-pub fn expr_to_i128(expr: &Expr) -> Option<i128> {
-  use num_traits::ToPrimitive;
-  match expr {
-    Expr::Integer(n) => Some(*n),
-    Expr::BigInteger(n) => n.to_i128(),
-    _ => None,
-  }
-}
+pub use crate::functions::math_ast::expr_to_i128;
 
-/// Resolve a named constant to its numeric f64 value.
-/// Constants (Pi, E, Degree) are kept symbolic — use try_eval_to_f64 for numeric evaluation.
-pub fn constant_to_f64(_name: &str) -> Option<f64> {
-  None
-}
-
-/// Convert a number to an appropriate Expr (Integer if whole, Real otherwise)
-pub fn num_to_expr(n: f64) -> Expr {
-  if n.fract() == 0.0 && n.abs() < i128::MAX as f64 {
-    Expr::Integer(n as i128)
-  } else {
-    Expr::Real(n)
-  }
-}
-
-/// Convert an Expr to BigInt if it's an integer type
-pub fn expr_to_bigint(expr: &Expr) -> Option<num_bigint::BigInt> {
-  match expr {
-    Expr::Integer(n) => Some(num_bigint::BigInt::from(*n)),
-    Expr::BigInteger(n) => Some(n.clone()),
-    _ => None,
-  }
-}
-
-/// Check if an expression requires BigInt arithmetic (exceeds f64 precision).
-/// f64 can only represent integers exactly up to 2^53.
-pub fn needs_bigint(expr: &Expr) -> bool {
-  match expr {
-    Expr::BigInteger(_) => true,
-    Expr::Integer(n) => n.unsigned_abs() > (1u128 << 53),
-    _ => false,
-  }
-}
+pub use crate::functions::math_ast::needs_bigint_arithmetic as needs_bigint;
+pub use crate::functions::math_ast::{
+  constant_to_f64, expr_to_bigint, num_to_expr,
+};
 
 /// Check if an expression contains the imaginary unit I
 pub fn contains_i(expr: &Expr) -> bool {

--- a/src/functions/assessment_ast.rs
+++ b/src/functions/assessment_ast.rs
@@ -88,9 +88,7 @@ fn score_expr(score: f64) -> Expr {
   }
 }
 
-fn bool_expr(b: bool) -> Expr {
-  Expr::Identifier(if b { "True" } else { "False" }.to_string())
-}
+use crate::syntax::bool_expr;
 
 /// Build an `AssessmentResultObject[<|"AnswerCorrect" -> …, "Score" -> …|>]`.
 fn result_object(score: f64, correct: bool) -> Expr {

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -1239,9 +1239,6 @@ fn is_pi_x_squared_over_two(expr: &Expr, var: &str) -> bool {
            && matches!(&args[1], Expr::Integer(2))
     )
   }
-  fn is_pi(e: &Expr) -> bool {
-    matches!(e, Expr::Constant(c) if c == "Pi")
-  }
   fn is_var_squared(e: &Expr, var: &str) -> bool {
     match e {
       Expr::BinaryOp {
@@ -6879,7 +6876,7 @@ fn is_exponential(expr: &Expr) -> bool {
 }
 
 /// Compare two expressions by their string representation.
-fn expr_str_eq(a: &Expr, b: &Expr) -> bool {
+pub(crate) fn expr_str_eq(a: &Expr, b: &Expr) -> bool {
   crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
 }
 

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -4,7 +4,7 @@
 //! and integration.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::{is_sqrt, make_sqrt};
+use crate::functions::math_ast::{gcd, gcd as gcd_i128, is_sqrt, make_sqrt};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -14308,10 +14308,6 @@ fn reduce_frac(num: i128, den: i128) -> (i128, i128) {
   (n, d)
 }
 
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  if b == 0 { a } else { gcd_i128(b, a % b) }
-}
-
 /// If `f` has a leading non-integer rational power of the shift `(var - x0)`
 /// (so that its expansion about `x0` is a genuine Puiseux series), return the
 /// reduced exponent `(p, q)` with `q > 1` together with the analytic cofactor
@@ -15363,16 +15359,6 @@ fn expand_series_data_coefficients(
   }
   // If not a SeriesData, just expand the expression
   series_ast(&[series.clone(), spec.clone()])
-}
-
-fn gcd(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
 }
 
 /// NIntegrate[expr, {var, lo, hi}] - Numerical integration

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -5,7 +5,7 @@ use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{
   BinSpec, DEFAULT_HEIGHT, DEFAULT_WIDTH, HistogramHeight, MarginOverrides,
   PLOT_COLORS, RESOLUTION_SCALE, generate_bar_svg, generate_histogram_svg,
-  parse_image_size,
+  html_escape, parse_image_size, svg_header,
 };
 use crate::syntax::{Expr, unevaluated};
 
@@ -662,22 +662,6 @@ fn parse_chart_options(args: &[Expr]) -> ChartOptions {
     }
   }
   opts
-}
-
-fn svg_header(w: u32, h: u32, full_width: bool) -> String {
-  let (bg, _, _, _, _) = crate::functions::plot::plot_theme();
-  let bg_fill = format!("rgb({},{},{})", bg.0, bg.1, bg.2);
-  if full_width {
-    format!(
-      "<svg width=\"100%\" viewBox=\"0 0 {w} {h}\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\">\n\
-       <rect width=\"{w}\" height=\"{h}\" fill=\"{bg_fill}\"/>\n"
-    )
-  } else {
-    format!(
-      "<svg width=\"{w}\" height=\"{h}\" viewBox=\"0 0 {w} {h}\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\">\n\
-       <rect width=\"{w}\" height=\"{h}\" fill=\"{bg_fill}\"/>\n"
-    )
-  }
 }
 
 /// Format a numeric value for display in chart tooltips.
@@ -2664,14 +2648,6 @@ fn inject_date_labels(
   } else {
     svg.to_string()
   }
-}
-
-/// Escape special HTML characters in text content.
-fn html_escape(s: &str) -> String {
-  s.replace('&', "&amp;")
-    .replace('<', "&lt;")
-    .replace('>', "&gt;")
-    .replace('"', "&quot;")
 }
 
 /// WordCloud[{"word1", "word2", ...}] or WordCloud[{1, 2, 3, ...}]

--- a/src/functions/convolve_ast.rs
+++ b/src/functions/convolve_ast.rs
@@ -11,20 +11,12 @@
 //! (e.g. Sqrt[Pi/2]/E^(y^2/2), (y*UnitStep[y])/E^(2*y)).
 
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 type Frac = (i128, i128);
 
 fn frac(n: i128, d: i128) -> Frac {
-  fn gcd(a: i128, b: i128) -> i128 {
-    let (mut a, mut b) = (a.abs(), b.abs());
-    while b != 0 {
-      let t = b;
-      b = a % b;
-      a = t;
-    }
-    a
-  }
   let g = gcd(n, d).max(1);
   let (mut n, mut d) = (n / g, d / g);
   if d < 0 {

--- a/src/functions/count_roots_ast.rs
+++ b/src/functions/count_roots_ast.rs
@@ -27,16 +27,7 @@ struct Rat {
   d: BigInt, // invariant: d > 0, gcd(|n|, d) == 1
 }
 
-fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-  let mut a = a.abs();
-  let mut b = b.abs();
-  while !b.is_zero() {
-    let r = &a % &b;
-    a = b;
-    b = r;
-  }
-  a
-}
+use crate::functions::math_ast::gcd_bigint;
 
 impl Rat {
   fn new(mut n: BigInt, mut d: BigInt) -> Rat {

--- a/src/functions/country_data.rs
+++ b/src/functions/country_data.rs
@@ -269,12 +269,7 @@ fn lookup(name: &str) -> Option<&'static Country> {
   })
 }
 
-fn make_quantity(magnitude: Expr, unit: &str) -> Expr {
-  Expr::FunctionCall {
-    name: "Quantity".to_string(),
-    args: vec![magnitude, Expr::String(unit.to_string())].into(),
-  }
-}
+use crate::functions::element_data::make_quantity;
 
 fn missing(reason: &str, name: &str) -> Expr {
   Expr::FunctionCall {

--- a/src/functions/csv_ast.rs
+++ b/src/functions/csv_ast.rs
@@ -391,19 +391,27 @@ pub fn csv_import_data_spec(
   }
 }
 
-/// Import a CSV file and optionally extract a specific element.
+/// Read and parse a CSV file from disk.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn csv_import_file(
+fn read_csv_file(
   path: &str,
-  element: Option<&str>,
-) -> Result<Expr, crate::InterpreterError> {
+) -> Result<Vec<Vec<String>>, crate::InterpreterError> {
   let content = std::fs::read_to_string(path).map_err(|e| {
     crate::InterpreterError::EvaluationError(format!(
       "Import: cannot open \"{}\": {}",
       path, e
     ))
   })?;
-  let rows = parse_csv(&content);
+  Ok(parse_csv(&content))
+}
+
+/// Import a CSV file and optionally extract a specific element.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn csv_import_file(
+  path: &str,
+  element: Option<&str>,
+) -> Result<Expr, crate::InterpreterError> {
+  let rows = read_csv_file(path)?;
   Ok(csv_import_element(&rows, element))
 }
 
@@ -415,13 +423,7 @@ pub fn csv_import_file_data_spec(
   row_spec: &Expr,
   col_spec: Option<&Expr>,
 ) -> Result<Expr, crate::InterpreterError> {
-  let content = std::fs::read_to_string(path).map_err(|e| {
-    crate::InterpreterError::EvaluationError(format!(
-      "Import: cannot open \"{}\": {}",
-      path, e
-    ))
-  })?;
-  let rows = parse_csv(&content);
+  let rows = read_csv_file(path)?;
   csv_import_data_spec(&rows, row_spec, col_spec)
 }
 

--- a/src/functions/datetime_ast.rs
+++ b/src/functions/datetime_ast.rs
@@ -2937,7 +2937,7 @@ pub fn day_plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// "BusinessDay"), which cannot be reproduced without that data. Producing a
 /// non-holiday-aware result would diverge from wolframscript.
 /// Map a weekday symbol name to `day_of_week`'s index (0=Monday … 6=Sunday).
-fn weekday_index(name: &str) -> Option<i64> {
+pub(crate) fn weekday_index(name: &str) -> Option<i64> {
   match name {
     "Monday" => Some(0),
     "Tuesday" => Some(1),

--- a/src/functions/dendrogram.rs
+++ b/src/functions/dendrogram.rs
@@ -3,7 +3,8 @@ use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::list_helpers_ast::apply_func_to_two_args;
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{
-  DEFAULT_HEIGHT, DEFAULT_WIDTH, RESOLUTION_SCALE, parse_image_size,
+  DEFAULT_HEIGHT, DEFAULT_WIDTH, RESOLUTION_SCALE, html_escape,
+  parse_image_size,
 };
 use crate::syntax::{Expr, unevaluated};
 
@@ -452,14 +453,6 @@ fn leaf_order(nodes: &[Node], node: usize, out: &mut Vec<usize>) {
 /// Estimate the pixel width of a text label at the given font size.
 fn est_text_width(label: &str, font_size: f64) -> f64 {
   label.chars().count() as f64 * font_size * 0.6
-}
-
-/// Escape special HTML characters in text content.
-fn html_escape(s: &str) -> String {
-  s.replace('&', "&amp;")
-    .replace('<', "&lt;")
-    .replace('>', "&gt;")
-    .replace('"', "&quot;")
 }
 
 /// Theme colors: `(background, line, label)`.

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -257,11 +257,7 @@ fn pow_mod(mut b: i128, mut e: i128, m: i128) -> i128 {
 }
 
 fn gcd(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    (a, b) = (b, a % b);
-  }
-  a.max(1)
+  crate::functions::math_ast::gcd(a, b).max(1)
 }
 
 fn euler_phi(k: i128) -> i128 {

--- a/src/functions/element_data.rs
+++ b/src/functions/element_data.rs
@@ -33,7 +33,7 @@ static ATOMIC_WEIGHT_PRECISIONS: &[f64] = &[
   3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, // 111-118
 ];
 
-fn make_quantity(magnitude: Expr, unit: &str) -> Expr {
+pub(crate) fn make_quantity(magnitude: Expr, unit: &str) -> Expr {
   Expr::FunctionCall {
     name: "Quantity".to_string(),
     args: vec![magnitude, Expr::String(unit.to_string())].into(),

--- a/src/functions/expr_form.rs
+++ b/src/functions/expr_form.rs
@@ -501,18 +501,7 @@ fn expr_contains_imag_unit(expr: &Expr) -> bool {
 /// together with `expr_contains_imag_unit` to decide whether a sum
 /// like `Real + Real*I` should collapse to `Complex[re\`, im\`]` in
 /// FullForm.
-fn expr_contains_real(expr: &Expr) -> bool {
-  match expr {
-    Expr::Real(_) => true,
-    Expr::List(items) => items.iter().any(expr_contains_real),
-    Expr::FunctionCall { args, .. } => args.iter().any(expr_contains_real),
-    Expr::BinaryOp { left, right, .. } => {
-      expr_contains_real(left) || expr_contains_real(right)
-    }
-    Expr::UnaryOp { operand, .. } => expr_contains_real(operand),
-    _ => false,
-  }
-}
+use crate::functions::math_ast::expr_contains_real;
 
 /// Render a machine-precision Real for FullForm/InputForm output:
 /// integer values lose their trailing zero (`1.0` → `1.`) and every

--- a/src/functions/expr_form.rs
+++ b/src/functions/expr_form.rs
@@ -418,16 +418,7 @@ pub fn decompose_expr(expr: &Expr) -> ExprForm {
 /// Helper: render a rational (num, denom) pair in FullForm notation.
 fn render_rational_full_form(num: i128, denom: i128) -> String {
   // Reduce to lowest terms
-  fn gcd(a: i128, b: i128) -> i128 {
-    let (mut a, mut b) = (a.abs(), b.abs());
-    while b != 0 {
-      let t = b;
-      b = a % b;
-      a = t;
-    }
-    a
-  }
-  let g = gcd(num, denom);
+  let g = crate::functions::math_ast::gcd(num, denom);
   let (n, d) = if g > 0 {
     (num / g, denom / g)
   } else {

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -8,62 +8,14 @@ use crate::functions::math_ast::{
   build_complex_float_expr, try_extract_complex_f64,
 };
 use crate::functions::plot::{
-  DEFAULT_HEIGHT, DEFAULT_WIDTH, RESOLUTION_SCALE, generate_axes_only,
-  parse_image_size, plot_theme, rewrite_svg_header, substitute_var,
+  DEFAULT_HEIGHT, DEFAULT_WIDTH, RESOLUTION_SCALE, evaluate_at_xy,
+  generate_axes_only, parse_image_size, parse_iterator, plot_theme,
+  rewrite_svg_header, substitute_var, svg_header,
 };
 use crate::syntax::Expr;
 
 const FIELD_GRID: usize = 100;
 const VECTOR_GRID: usize = 15;
-
-/// Parse iterator: {var, min, max}
-fn parse_iterator(
-  spec: &Expr,
-  label: &str,
-) -> Result<(String, f64, f64), InterpreterError> {
-  match spec {
-    Expr::List(items) if items.len() == 3 => {
-      let var = match &items[0] {
-        Expr::Identifier(name) => name.clone(),
-        _ => {
-          return Err(InterpreterError::EvaluationError(format!(
-            "{label}: iterator variable must be a symbol"
-          )));
-        }
-      };
-      let min_expr = evaluate_expr_to_expr(&items[1])?;
-      let max_expr = evaluate_expr_to_expr(&items[2])?;
-      let min_val = try_eval_to_f64(&min_expr).ok_or_else(|| {
-        InterpreterError::EvaluationError(format!(
-          "{label}: cannot evaluate iterator min to a number"
-        ))
-      })?;
-      let max_val = try_eval_to_f64(&max_expr).ok_or_else(|| {
-        InterpreterError::EvaluationError(format!(
-          "{label}: cannot evaluate iterator max to a number"
-        ))
-      })?;
-      Ok((var, min_val, max_val))
-    }
-    _ => Err(InterpreterError::EvaluationError(format!(
-      "{label}: iterator must be {{var, min, max}}"
-    ))),
-  }
-}
-
-/// Evaluate f(x, y)
-fn evaluate_at_xy(
-  body: &Expr,
-  xvar: &str,
-  yvar: &str,
-  xval: f64,
-  yval: f64,
-) -> Option<f64> {
-  let sub1 = substitute_var(body, xvar, &Expr::Real(xval));
-  let sub2 = substitute_var(&sub1, yvar, &Expr::Real(yval));
-  let result = evaluate_expr_to_expr(&sub2).ok()?;
-  try_eval_to_f64(&result)
-}
 
 /// Evaluate a boolean condition at (x, y) - returns true/false
 fn evaluate_condition(
@@ -123,23 +75,6 @@ fn parse_field_options(args: &[Expr], start: usize) -> (u32, u32, bool) {
     }
   }
   (svg_width, svg_height, full_width)
-}
-
-/// Simple SVG header for plots without plotters axes (ArrayPlot, MatrixPlot).
-fn svg_header(w: u32, h: u32, full_width: bool) -> String {
-  let (bg, _, _, _, _) = crate::functions::plot::plot_theme();
-  let bg_fill = format!("rgb({},{},{})", bg.0, bg.1, bg.2);
-  if full_width {
-    format!(
-      "<svg width=\"100%\" viewBox=\"0 0 {w} {h}\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\">\n\
-       <rect width=\"{w}\" height=\"{h}\" fill=\"{bg_fill}\"/>\n"
-    )
-  } else {
-    format!(
-      "<svg width=\"{w}\" height=\"{h}\" viewBox=\"0 0 {w} {h}\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\">\n\
-       <rect width=\"{w}\" height=\"{h}\" fill=\"{bg_fill}\"/>\n"
-    )
-  }
 }
 
 /// Map value to a blue-white-red color

--- a/src/functions/function_range_ast.rs
+++ b/src/functions/function_range_ast.rs
@@ -168,16 +168,7 @@ fn as_power(expr: &Expr) -> Option<(Expr, Expr)> {
 }
 
 fn simplify_frac(n: i128, d: i128) -> (i128, i128) {
-  fn gcd(a: i128, b: i128) -> i128 {
-    let (mut a, mut b) = (a.abs(), b.abs());
-    while b != 0 {
-      let t = b;
-      b = a % b;
-      a = t;
-    }
-    a.max(1)
-  }
-  let g = gcd(n, d);
+  let g = crate::functions::math_ast::gcd(n, d).max(1);
   let (mut n, mut d) = (n / g, d / g);
   if d < 0 {
     n = -n;

--- a/src/functions/geo_math.rs
+++ b/src/functions/geo_math.rs
@@ -315,12 +315,7 @@ fn rat_add(a: (i128, i128), b: (i128, i128)) -> Option<(i128, i128)> {
   Some((num / g, den / g))
 }
 
-fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
-  while b != 0 {
-    (a, b) = (b, a % b);
-  }
-  a.max(1)
-}
+use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Convert a numeric scalar expression to an `AngleVal`. Exactness is
 /// preserved for Integer/Rational; Reals and exact-but-irrational numerics

--- a/src/functions/geometric_test_ast.rs
+++ b/src/functions/geometric_test_ast.rs
@@ -53,9 +53,7 @@ fn approx_eq(a: f64, b: f64) -> bool {
   (a - b).abs() <= REL * (1.0 + a.abs().max(b.abs()))
 }
 
-fn bool_expr(b: bool) -> Expr {
-  Expr::Identifier(if b { "True" } else { "False" }.to_string())
-}
+use crate::syntax::bool_expr;
 
 /// Parse a single 2D point `{x, y}` with numeric coordinates.
 fn extract_point(expr: &Expr) -> Option<Pt> {

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -1005,7 +1005,7 @@ fn pack_components(
   result
 }
 
-fn snap_coord(v: f64) -> f64 {
+pub(crate) fn snap_coord(v: f64) -> f64 {
   for &target in &[0.0, 0.5, -0.5, 1.0, -1.0] {
     if (v - target).abs() < 1e-14 {
       return target;
@@ -4633,9 +4633,7 @@ fn parse_graph_pairs(expr: &Expr) -> Option<(usize, Vec<(usize, usize)>)> {
   Some((vkeys.len(), pairs))
 }
 
-fn bool_expr(b: bool) -> Expr {
-  Expr::Identifier(if b { "True" } else { "False" }.to_string())
-}
+use crate::syntax::bool_expr;
 
 pub fn graph_predicate_ast(
   name: &str,

--- a/src/functions/groebner_ast.rs
+++ b/src/functions/groebner_ast.rs
@@ -53,15 +53,7 @@ fn mod_inverse(a: i128, p: i128) -> Option<i128> {
   Some(old_s.rem_euclid(p))
 }
 
-fn gcd(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
+use crate::functions::math_ast::gcd;
 
 fn norm(f: Frac) -> Option<Frac> {
   if f.1 == 0 {

--- a/src/functions/groebner_ast.rs
+++ b/src/functions/groebner_ast.rs
@@ -325,19 +325,7 @@ fn groebner_modulus_option(opt: &Expr) -> Option<i128> {
   None
 }
 
-fn is_prime_i128(n: i128) -> bool {
-  if n < 2 {
-    return false;
-  }
-  let mut d = 2i128;
-  while d * d <= n {
-    if n % d == 0 {
-      return false;
-    }
-    d += 1;
-  }
-  true
-}
+use crate::functions::math_ast::is_prime_i128;
 
 pub fn groebner_basis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let full_args = args;

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -569,10 +569,7 @@ pub fn image_aspect_ratio_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
   fn ratio(h: i128, w: i128) -> Expr {
-    fn gcd(a: i128, b: i128) -> i128 {
-      if b == 0 { a.abs() } else { gcd(b, a % b) }
-    }
-    let g = gcd(h, w);
+    let g = crate::functions::math_ast::gcd(h, w);
     let (num, den) = (h / g, w / g);
     if den == 1 {
       Expr::Integer(num)

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -1220,15 +1220,7 @@ fn eval_divide(a: &Expr, b: &Expr) -> Expr {
   }
 }
 
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a, b);
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
+use crate::functions::math_ast::gcd as gcd_i128;
 
 /// The rectangular shape of a nested-List array, found by descending through
 /// the first element of each level. A non-list has an empty shape; `{a, b}`

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -857,16 +857,6 @@ fn hypoexponential_median(arg: &Expr) -> Option<Expr> {
   None
 }
 
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = a % b;
-    a = b;
-    b = t;
-  }
-  a
-}
-
 /// Numeric ordering key for a Median element. Handles plain numbers and
 /// rationals directly, and falls back to numericizing symbolic-but-real values
 /// (Pi, E, Sin[1], ...) via `N[expr]` so an exact list like {Pi, E, 1} can be
@@ -1038,10 +1028,7 @@ pub fn median_ast(list: &Expr) -> Result<Expr, InterpreterError> {
         Ok(Expr::Integer(sum / 2))
       } else {
         // Return as Rational
-        fn gcd(a: i128, b: i128) -> i128 {
-          if b == 0 { a } else { gcd(b, a % b) }
-        }
-        let g = gcd(sum.abs(), 2);
+        let g = gcd_i128(sum.abs(), 2);
         Ok(Expr::FunctionCall {
           name: "Rational".to_string(),
           args: vec![Expr::Integer(sum / g), Expr::Integer(2 / g)].into(),

--- a/src/functions/list_helpers_ast/construction.rs
+++ b/src/functions/list_helpers_ast/construction.rs
@@ -501,23 +501,7 @@ pub fn table_ast(
   }
 }
 
-/// Extract a rational (numerator, denominator) from an Expr.
-/// Returns Some((n, d)) for Integer, Rational, None for anything else.
-fn expr_to_rational(expr: &Expr) -> Option<(i128, i128)> {
-  match expr {
-    Expr::Integer(n) => Some((*n, 1)),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
-        Some((*n, *d))
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
+use crate::functions::math_ast::expr_to_rational;
 
 /// AST-based Range: generate a range of numbers.
 /// Range[n] -> {1, 2, ..., n}

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -594,16 +594,6 @@ fn explicit_real(e: &Expr) -> Option<f64> {
   }
 }
 
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = a % b;
-    a = b;
-    b = t;
-  }
-  a
-}
-
 /// A CoefficientList entry as an exact `(num, den)` rational, or None.
 fn coeff_to_ratio(e: &Expr) -> Option<(i128, i128)> {
   match e {

--- a/src/functions/list_helpers_ast/utilities.rs
+++ b/src/functions/list_helpers_ast/utilities.rs
@@ -264,15 +264,7 @@ pub fn f64_to_expr(n: f64) -> Expr {
   }
 }
 
-pub(crate) fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
+pub(crate) use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Identity[x] - returns x unchanged
 pub fn identity_ast(arg: &Expr) -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/airy.rs
+++ b/src/functions/math_ast/airy.rs
@@ -44,17 +44,6 @@ pub fn airy_ai_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 /// True if the expression tree contains a Real or BigFloat node.
-fn contains_inexact_real(expr: &Expr) -> bool {
-  match expr {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::UnaryOp { operand, .. } => contains_inexact_real(operand),
-    Expr::BinaryOp { left, right, .. } => {
-      contains_inexact_real(left) || contains_inexact_real(right)
-    }
-    Expr::FunctionCall { args, .. } => args.iter().any(contains_inexact_real),
-    _ => false,
-  }
-}
 
 /// Complex Airy Ai via the power series
 ///   Ai(z) = c1·f(z) − c2·g(z)
@@ -88,9 +77,7 @@ fn airy_ai_complex(re: f64, im: f64) -> (f64, f64) {
   (c1 * f.0 - c2 * g.0, c1 * f.1 - c2 * g.1)
 }
 
-fn cmul(a: (f64, f64), b: (f64, f64)) -> (f64, f64) {
-  (a.0 * b.0 - a.1 * b.1, a.0 * b.1 + a.1 * b.0)
-}
+use super::zeta_functions::cmul;
 
 /// Compute Ai(x) using the two power series
 /// Ai(x) = c1 * f(x) - c2 * g(x)

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::gcd as gcd_i128;
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
 };

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -8657,7 +8657,8 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
           // wolframscript). Differential fuzzer, seed
           // 15033838239546199922; wolframscript-verified.
           if matches!(b, Expr::Real(_)) {
-            let (p, q) = crate::functions::polynomial_ast::together::extract_num_den(a);
+            let (p, q) =
+              crate::functions::polynomial_ast::together::extract_num_den(a);
             let q_is_number = matches!(
               &q,
               Expr::Integer(_) | Expr::Real(_) | Expr::BigInteger(_)

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::InterpreterError;
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
@@ -1543,23 +1544,6 @@ fn promote_integer_times_i_to_real(e: Expr) -> Expr {
     };
   }
   e
-}
-
-fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-  let mut a = match a.sign() {
-    Sign::Minus => -a,
-    _ => a.clone(),
-  };
-  let mut b = match b.sign() {
-    Sign::Minus => -b,
-    _ => b.clone(),
-  };
-  while b != BigInt::from(0) {
-    let t = &a % &b;
-    a = b;
-    b = t;
-  }
-  a
 }
 
 /// Coefficient: either exact rational (i128 or BigInt) or approximate real
@@ -8357,7 +8341,6 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
 
   // For BigInteger / BigInteger (or mixed Integer/BigInteger), reduce by GCD
   {
-    use crate::functions::math_ast::number_theory::gcd_bigint;
     let a_big = expr_to_bigint(a);
     let b_big = expr_to_bigint(b);
     if let (Some(numer), Some(denom)) = (a_big, b_big) {
@@ -8365,7 +8348,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
       if denom.is_zero() {
         return Ok(divide_by_zero_result(a));
       }
-      let g = gcd_bigint(numer.clone(), denom.clone());
+      let g = gcd_bigint(&numer, &denom);
       let mut rn = &numer / &g;
       let mut rd = &denom / &g;
       // Normalize sign: put sign in numerator
@@ -8618,14 +8601,13 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
       // preserved instead of collapsing to a lossy Real (e.g. iterating
       // `#/2 &` past a 2^127 denominator must stay an exact fraction).
       _ => {
-        use crate::functions::math_ast::number_theory::gcd_bigint;
         use num_traits::Zero;
         let numer = BigInt::from(a_n) * BigInt::from(b_d);
         let denom = BigInt::from(a_d) * BigInt::from(b_n);
         if denom.is_zero() {
           return Ok(divide_by_zero_result(a));
         }
-        let g = gcd_bigint(numer.clone(), denom.clone());
+        let g = gcd_bigint(&numer, &denom);
         let mut rn = &numer / &g;
         let mut rd = &denom / &g;
         if rd < BigInt::from(0) {
@@ -9941,26 +9923,6 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     && im_n != 0
   {
     use num_traits::{ToPrimitive, Zero};
-
-    // BigInt GCD helper
-    fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-      let mut a = if *a < BigInt::from(0) {
-        -a.clone()
-      } else {
-        a.clone()
-      };
-      let mut b = if *b < BigInt::from(0) {
-        -b.clone()
-      } else {
-        b.clone()
-      };
-      while !b.is_zero() {
-        let t = &a % &b;
-        a = b;
-        b = t;
-      }
-      a
-    }
 
     // Normalize denominators to be positive
     let (re_n, re_d) = if re_d < 0 {

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -2361,23 +2361,6 @@ fn extract_var_exp_pairs(e: &Expr) -> Option<Vec<(String, f64)>> {
 }
 
 /// Convert an expression to an f64 if it represents a number.
-fn expr_to_f64(e: &Expr) -> Option<f64> {
-  match e {
-    Expr::Integer(n) => Some(*n as f64),
-    Expr::Real(f) => Some(*f),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
-        Some(*n as f64 / *d as f64)
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
-
 /// Returns true if `e` contains free variables (identifiers that are not
 /// well-known constants like I, Infinity).  Used to distinguish transcendental
 /// expressions-of-variables (e.g. Sin[2*x]) from pure numeric constants
@@ -10910,18 +10893,7 @@ pub fn try_around_unary(
   Some(Ok(make_around_general(fa, m, p, ar.asym)))
 }
 
-fn contains_real(expr: &Expr) -> bool {
-  match expr {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::BinaryOp { left, right, .. } => {
-      contains_real(left) || contains_real(right)
-    }
-    Expr::UnaryOp { operand, .. } => contains_real(operand),
-    Expr::FunctionCall { args, .. } => args.iter().any(contains_real),
-    Expr::List(items) => items.iter().any(contains_real),
-    _ => false,
-  }
-}
+use crate::functions::math_ast::contains_inexact_real as contains_real;
 
 /// Try to extract rational coefficient k = numer/denom from an expression
 /// of the form `k * I * Pi`.
@@ -11755,21 +11727,6 @@ fn bigfloat_times(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 /// Format an f64 value as a BigFloat digit string with the given significant digits.
-fn format_bigfloat_value(value: f64, sig_digits: usize) -> String {
-  if value == 0.0 {
-    return "0.".to_string();
-  }
-  let sign = if value < 0.0 { "-" } else { "" };
-  let abs_val = value.abs();
-  let magnitude = abs_val.log10().floor() as i32;
-  let decimal_places = ((sig_digits as i32) - magnitude - 1).max(0) as usize;
-  let formatted = format!("{}{:.prec$}", sign, abs_val, prec = decimal_places);
-  if !formatted.contains('.') {
-    format!("{}.", formatted)
-  } else {
-    formatted
-  }
-}
 
 /// Check if Plus args represent DateObject subtraction (d1 - d2) and handle it.
 /// Returns Some(Ok(Quantity[n, "Days"])) if applicable.

--- a/src/functions/math_ast/carlson.rs
+++ b/src/functions/math_ast/carlson.rs
@@ -11,17 +11,7 @@ use crate::InterpreterError;
 use crate::syntax::{Expr, unevaluated};
 
 /// True if `e` contains an inexact (machine) number anywhere.
-fn is_inexact(e: &Expr) -> bool {
-  match e {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::BinaryOp { left, right, .. } => is_inexact(left) || is_inexact(right),
-    Expr::UnaryOp { operand, .. } => is_inexact(operand),
-    Expr::FunctionCall { args, .. } | Expr::List(args) => {
-      args.iter().any(is_inexact)
-    }
-    _ => false,
-  }
-}
+use crate::functions::math_ast::contains_inexact_real as is_inexact;
 
 /// R_C(x, y) — degenerate Carlson integral.
 fn carlson_rc(x: f64, y: f64) -> f64 {

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -1691,40 +1691,6 @@ fn rationalize_machine_default(
   }
 }
 
-/// Convert a floating-point number to an exact decimal fraction p/10^n, simplified by GCD.
-/// Uses the shortest decimal representation of the double (Rust's Display format).
-fn decimal_to_fraction(x: f64) -> (i64, i64) {
-  if x == 0.0 {
-    return (0, 1);
-  }
-  let sign: i64 = if x < 0.0 { -1 } else { 1 };
-  let s = format!("{}", x.abs());
-
-  if let Some(dot_pos) = s.find('.') {
-    let int_part = &s[..dot_pos];
-    let frac_part = &s[dot_pos + 1..];
-    let n_decimals = frac_part.len() as u32;
-    let denom = 10i64.pow(n_decimals);
-    let numer: i64 = format!("{}{}", int_part, frac_part).parse().unwrap_or(0);
-    let g = gcd_i64(numer, denom);
-    (sign * numer / g, denom / g)
-  } else {
-    let numer: i64 = s.parse().unwrap_or(0);
-    (sign * numer, 1)
-  }
-}
-
-fn gcd_i64(mut a: i64, mut b: i64) -> i64 {
-  a = a.abs();
-  b = b.abs();
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
-
 /// Find best rational approximation using continued fractions
 fn find_rational(x: f64, tolerance: f64, max_denom: i64) -> (i64, i64) {
   if x == 0.0 {

--- a/src/functions/math_ast/coordinate_arrays.rs
+++ b/src/functions/math_ast/coordinate_arrays.rs
@@ -4,6 +4,7 @@
 //! pairs versus the two corner points `{mins, maxs}`.
 
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd;
 use crate::syntax::{Expr, UnaryOperator, expr_to_output, unevaluated};
 
 /// One coordinate value: an exact rational (p/q, q > 0) or a machine real.
@@ -35,7 +36,7 @@ impl Num {
     match self {
       Num::Exact(0, _) => Expr::Integer(0),
       Num::Exact(p, q) => {
-        let g = gcd(p.abs(), q);
+        let g = gcd(p.abs(), q).max(1);
         let (p, q) = (p / g, q / g);
         if q == 1 {
           Expr::Integer(p)
@@ -49,13 +50,6 @@ impl Num {
       Num::Real(v) => Expr::Real(v),
     }
   }
-}
-
-fn gcd(mut a: i128, mut b: i128) -> i128 {
-  while b != 0 {
-    (a, b) = (b, a % b);
-  }
-  a.max(1)
 }
 
 /// Combine two numbers with an exact rational operation, falling back to f64

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -1187,17 +1187,7 @@ pub fn continued_fraction_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(unevaluated("ContinuedFraction", args))
 }
 
-/// Greatest common divisor of two non-negative integers.
-fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
-  a = a.abs();
-  b = b.abs();
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
+use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Exact rational with i128 numerator/denominator, kept reduced with a
 /// positive denominator. Used to evaluate a periodic continued fraction in
@@ -1468,16 +1458,6 @@ pub fn from_continued_fraction_ast(
   }
 
   // Simplify by GCD
-  fn gcd(mut a: i128, mut b: i128) -> i128 {
-    a = a.abs();
-    b = b.abs();
-    while b != 0 {
-      let t = b;
-      b = a % b;
-      a = t;
-    }
-    a
-  }
 
   let g = gcd(num, den);
   num /= g;
@@ -2648,17 +2628,6 @@ pub fn from_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       // Need a rational: int_val / base^(-shift)
       let denom = big_base.pow((-shift) as u32);
-      // Simplify the fraction using Euclidean gcd
-      fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-        let mut a = if a < &BigInt::from(0) { -a } else { a.clone() };
-        let mut b = if b < &BigInt::from(0) { -b } else { b.clone() };
-        while b > BigInt::from(0) {
-          let t = &a % &b;
-          a = b;
-          b = t;
-        }
-        a
-      }
       let g = gcd_bigint(&int_val, &denom);
       let num = &int_val / &g;
       let den = &denom / &g;

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -3497,12 +3497,7 @@ fn nice_step_rational(raw: f64) -> Option<(i128, i128)> {
   Some((sn / g, sd / g))
 }
 
-fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
-  while b != 0 {
-    (a, b) = (b, a % b);
-  }
-  a.abs()
-}
+use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Reduce a (numerator, denominator) pair to lowest terms with a positive
 /// denominator.

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -2797,20 +2797,7 @@ pub fn integer_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 // ─── IntegerPart / FractionalPart ──────────────────────────────────
 
-/// True when `expr` carries a machine-precision (inexact) literal anywhere.
-fn contains_inexact_literal(e: &Expr) -> bool {
-  match e {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::BinaryOp { left, right, .. } => {
-      contains_inexact_literal(left) || contains_inexact_literal(right)
-    }
-    Expr::UnaryOp { operand, .. } => contains_inexact_literal(operand),
-    Expr::FunctionCall { args, .. } | Expr::List(args) => {
-      args.iter().any(contains_inexact_literal)
-    }
-    _ => false,
-  }
-}
+use crate::functions::math_ast::contains_inexact_real as contains_inexact_literal;
 
 /// Build `re + im*I`, dropping a zero imaginary part. Used by the complex
 /// branches of IntegerPart/FractionalPart.
@@ -3288,20 +3275,6 @@ pub fn cube_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// True when `e` is a fully concrete number (integer, real, big number, or a
 /// Rational), possibly negated. Used to distinguish a bad numeric argument
 /// (which triggers a message) from a symbolic one (left unevaluated silently).
-fn is_concrete_number(e: &Expr) -> bool {
-  match e {
-    Expr::Integer(_)
-    | Expr::Real(_)
-    | Expr::BigInteger(_)
-    | Expr::BigFloat(_, _) => true,
-    Expr::FunctionCall { name, .. } => name == "Rational",
-    Expr::UnaryOp {
-      op: UnaryOperator::Minus,
-      operand,
-    } => is_concrete_number(operand),
-    _ => false,
-  }
-}
 
 pub fn subdivide_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.is_empty() || args.len() > 3 {

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -765,18 +765,6 @@ fn upper_incomplete_gamma_cf(a: f64, z: f64) -> f64 {
   f * (-z).exp() * z.powf(a)
 }
 
-fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-  use num_traits::Zero;
-  let mut a = a.magnitude().clone();
-  let mut b = b.magnitude().clone();
-  while !b.is_zero() {
-    let t = b.clone();
-    b = &a % &b;
-    a = t;
-  }
-  a.into()
-}
-
 /// Lanczos approximation for the Gamma function
 pub fn gamma_fn(x: f64) -> f64 {
   if x < 0.5 {

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -484,17 +484,6 @@ fn gamma_half_expr(numer: BigInt, denom: BigInt, is_neg: bool) -> Expr {
 /// number anywhere in the tree. Used to distinguish exact symbolic
 /// arguments (which Gamma should not evaluate numerically) from inexact
 /// ones (which should be evaluated to floats).
-fn contains_inexact_real(expr: &Expr) -> bool {
-  match expr {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::UnaryOp { operand, .. } => contains_inexact_real(operand),
-    Expr::BinaryOp { left, right, .. } => {
-      contains_inexact_real(left) || contains_inexact_real(right)
-    }
-    Expr::FunctionCall { args, .. } => args.iter().any(contains_inexact_real),
-    _ => false,
-  }
-}
 
 /// Upper incomplete gamma function Gamma[a, z]
 fn gamma_incomplete_upper(

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1316,8 +1316,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Result = (e_num · E^z + const_num) / z_max  — reduce by gcd.
     // Reduce by the gcd shared between numerator e^z coefficient, the
     // numerator constant, and the denominator.
-    let g_all =
-      gcd_bigint(&gcd_bigint(&e_num, &const_num), &z_max);
+    let g_all = gcd_bigint(&gcd_bigint(&e_num, &const_num), &z_max);
     let denom = if g_all != BigInt::from(0) {
       &z_max / &g_all
     } else {

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -962,15 +962,7 @@ fn hypergeometric_2f1_regularized_non_positive_c(
   Ok(Some(crate::evaluator::evaluate_expr_to_expr(&product)?))
 }
 
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a, b);
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a.max(1)
-}
+use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Hypergeometric1F1[a, b, z] - Kummer's confluent hypergeometric function
 fn is_half(expr: &Expr) -> bool {
@@ -1192,22 +1184,6 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       let denom = fact(n - k) * &b_pochhammer * &k_fact;
       // coeff = n! / denom (reduce GCD).
-      fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-        use num_traits::Zero;
-        let (mut a, mut b) = (a.clone(), b.clone());
-        if a < BigInt::from(0) {
-          a = -a;
-        }
-        if b < BigInt::from(0) {
-          b = -b;
-        }
-        while !b.is_zero() {
-          let r = &a % &b;
-          a = b;
-          b = r;
-        }
-        a
-      }
       let g = gcd_bigint(&n_fact, &denom);
       let cn = &n_fact / &g;
       let cd = &denom / &g;
@@ -1338,11 +1314,10 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     e_num *= &prefactor;
     const_num *= &prefactor;
     // Result = (e_num · E^z + const_num) / z_max  — reduce by gcd.
-    use num_traits::Signed;
     // Reduce by the gcd shared between numerator e^z coefficient, the
     // numerator constant, and the denominator.
     let g_all =
-      gcd_bigint(gcd_bigint(e_num.abs(), const_num.abs()), z_max.abs());
+      gcd_bigint(&gcd_bigint(&e_num, &const_num), &z_max);
     let denom = if g_all != BigInt::from(0) {
       &z_max / &g_all
     } else {
@@ -1362,7 +1337,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // when the numerator has a common factor — pull that factor out so
     // the inner Plus shows the smallest integer coefficients.
     let mut outer_factor = BigInt::from(1);
-    let g_num = gcd_bigint(e_n.abs(), c_n.abs());
+    let g_num = gcd_bigint(&e_n, &c_n);
     if g_num > BigInt::from(1) {
       outer_factor = g_num.clone();
       e_n /= &g_num;
@@ -1405,21 +1380,6 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       crate::evaluator::evaluate_function_call_ast("Times", &factors)
     };
-  }
-
-  fn gcd_bigint(a: BigInt, b: BigInt) -> BigInt {
-    use num_traits::Zero;
-    let (mut a, mut b) = (a, b);
-    while !b.is_zero() {
-      let r = &a % &b;
-      a = b;
-      b = r;
-    }
-    if a == BigInt::from(0) {
-      BigInt::from(1)
-    } else {
-      a
-    }
   }
 
   // Closed form for 1F1[positive integer a, 1, z]:

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -47,7 +47,6 @@ pub fn is_prime(n: usize) -> bool {
 /// decide whether a "not a valid index" message should fire: a concrete
 /// non-integer argument is an error, but a symbolic one stays unevaluated.
 
-
 /// Primality test for i128 values (Miller-Rabin via BigInt beyond usize).
 pub fn is_prime_i128(n: i128) -> bool {
   if n < 2 {
@@ -1061,7 +1060,6 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Compute the nth Bernoulli polynomial B_n(z) = sum_{k=0}^{n} C(n,k) * B_k * z^(n-k)
 fn bernoulli_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
-
   fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
     let num = a.0 * b.1 + b.0 * a.1;
     let den = a.1 * b.1;
@@ -1260,7 +1258,6 @@ pub fn euler_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Compute the nth Euler polynomial and either evaluate at a point or return symbolic expression
 fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
-
   fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
     let num = a.0 * b.1 + b.0 * a.1;
     let den = a.1 * b.1;
@@ -4324,7 +4321,6 @@ fn lcm_u128(a: u128, b: u128) -> u128 {
     a / gcd_u128(a, b) * b
   }
 }
-
 
 /// JacobiSymbol[n, m] - Compute the Jacobi symbol (n/m)
 pub fn jacobi_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -61,16 +61,6 @@ fn is_concrete_number(e: &Expr) -> bool {
   }
 }
 
-pub fn gcd_bigint(a: BigInt, b: BigInt) -> BigInt {
-  use num_traits::Zero;
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while !b.is_zero() {
-    let t = b.clone();
-    b = &a % &b;
-    a = t;
-  }
-  a
-}
 
 /// GCD[a, b, ...] - Greatest common divisor.
 ///
@@ -237,7 +227,7 @@ pub fn gcd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut num_gcd = fractions[0].0.clone().abs();
   let mut den_lcm = fractions[0].1.clone().abs();
   for (n, d) in &fractions[1..] {
-    num_gcd = gcd_bigint(num_gcd, n.clone());
+    num_gcd = gcd_bigint(&num_gcd, n);
     den_lcm = lcm_bigint(den_lcm, d.clone());
   }
 
@@ -400,7 +390,7 @@ pub fn lcm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut den_gcd = fractions[0].1.clone().abs();
   for (n, d) in &fractions[1..] {
     num_lcm = lcm_bigint(num_lcm, n.clone());
-    den_gcd = gcd_bigint(den_gcd, d.clone());
+    den_gcd = gcd_bigint(&den_gcd, d);
   }
 
   Ok(make_rational_expr(num_lcm, den_gcd))
@@ -437,7 +427,7 @@ fn lcm_bigint(a: BigInt, b: BigInt) -> BigInt {
   if a.is_zero() || b.is_zero() {
     return BigInt::from(0);
   }
-  let g = gcd_bigint(a.clone(), b.clone());
+  let g = gcd_bigint(&a, &b);
   (a.abs() / g) * b.abs()
 }
 
@@ -450,7 +440,7 @@ pub fn make_rational_expr(num: BigInt, den: BigInt) -> Expr {
     // callers see the same surface behaviour.
     return Expr::Identifier("ComplexInfinity".to_string());
   }
-  let g = gcd_bigint(num.clone(), den.clone());
+  let g = gcd_bigint(&num, &den);
   let mut n = num / &g;
   let mut d = den / g;
   if d < BigInt::from(0) {
@@ -1038,15 +1028,6 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Represent each Bernoulli number as a reduced (numerator, denominator)
   // pair in BigInt, so large numerators (e.g. BernoulliB[60]) don't overflow
   // i128.
-  fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-    let (mut a, mut b) = (a.clone().abs(), b.clone().abs());
-    while b != BigInt::from(0) {
-      let t = b.clone();
-      b = &a % &b;
-      a = t;
-    }
-    a
-  }
   fn reduce(num: BigInt, den: BigInt) -> (BigInt, BigInt) {
     let mut g = gcd_bigint(&num, &den);
     if g == BigInt::from(0) {
@@ -1093,20 +1074,11 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Compute the nth Bernoulli polynomial B_n(z) = sum_{k=0}^{n} C(n,k) * B_k * z^(n-k)
 fn bernoulli_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
-  fn rat_gcd(a: i128, b: i128) -> i128 {
-    let (mut a, mut b) = (a.abs(), b.abs());
-    while b != 0 {
-      let t = b;
-      b = a % b;
-      a = t;
-    }
-    a
-  }
 
   fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
     let num = a.0 * b.1 + b.0 * a.1;
     let den = a.1 * b.1;
-    let g = rat_gcd(num, den);
+    let g = gcd(num, den);
     if den < 0 {
       (-num / g, -den / g)
     } else {
@@ -1117,7 +1089,7 @@ fn bernoulli_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
   fn rat_mul(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
     let num = a.0 * b.0;
     let den = a.1 * b.1;
-    let g = rat_gcd(num, den);
+    let g = gcd(num, den);
     if den < 0 {
       (-num / g, -den / g)
     } else {
@@ -1164,7 +1136,7 @@ fn bernoulli_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
     for k in (0..=n).rev() {
       let rn = result.0 * z_num;
       let rd = result.1 * z_den;
-      let g = rat_gcd(rn, rd);
+      let g = gcd(rn, rd);
       let (rn, rd) = if rd < 0 {
         (-rn / g, -rd / g)
       } else {
@@ -1301,20 +1273,11 @@ pub fn euler_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Compute the nth Euler polynomial and either evaluate at a point or return symbolic expression
 fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
-  fn rat_gcd(a: i128, b: i128) -> i128 {
-    let (mut a, mut b) = (a.abs(), b.abs());
-    while b != 0 {
-      let t = b;
-      b = a % b;
-      a = t;
-    }
-    a
-  }
 
   fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
     let num = a.0 * b.1 + b.0 * a.1;
     let den = a.1 * b.1;
-    let g = rat_gcd(num, den);
+    let g = gcd(num, den);
     if den < 0 {
       (-num / g, -den / g)
     } else {
@@ -1338,7 +1301,7 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
       let (cn, cd) = coeffs[k];
       let num = degree as i128 * cn;
       let den = cd * (k as i128 + 1);
-      let g = rat_gcd(num, den);
+      let g = gcd(num, den);
       let (num, den) = if den < 0 {
         (-num / g, -den / g)
       } else {
@@ -1359,7 +1322,7 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
     // C = -sum_at_1 / 2
     let c_num = -sum_at_1.0;
     let c_den = sum_at_1.1 * 2;
-    let g = rat_gcd(c_num, c_den);
+    let g = gcd(c_num, c_den);
     let (c_num, c_den) = if c_den < 0 {
       (-c_num / g, -c_den / g)
     } else {
@@ -1380,7 +1343,7 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
       // result = result * z + coeffs[k]
       let rn = result.0 * z_num;
       let rd = result.1 * z_den;
-      let g = rat_gcd(rn, rd);
+      let g = gcd(rn, rd);
       let (rn, rd) = if rd < 0 {
         (-rn / g, -rd / g)
       } else {
@@ -1954,26 +1917,6 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Compute as exact rational: sum of 1/k^r for k = 1 to n
   // Use BigInt numerator and denominator
-  fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-    use num_traits::Zero;
-    let mut a = if *a < BigInt::zero() {
-      -a.clone()
-    } else {
-      a.clone()
-    };
-    let mut b = if *b < BigInt::zero() {
-      -b.clone()
-    } else {
-      b.clone()
-    };
-    while !b.is_zero() {
-      let t = b.clone();
-      b = &a % &b;
-      a = t;
-    }
-    a
-  }
-
   let mut num = BigInt::from(0);
   let mut den = BigInt::from(1);
   if r >= 0 {
@@ -2271,7 +2214,7 @@ pub fn alternating_harmonic_number_ast(
           };
           num = &num * &k_pow + signed;
           den = &den * &k_pow;
-          let g = gcd_bigint(num.clone(), den.clone());
+          let g = gcd_bigint(&num, &den);
           use num_traits::One;
           if g > BigInt::one() {
             num /= &g;
@@ -4395,14 +4338,6 @@ fn lcm_u128(a: u128, b: u128) -> u128 {
   }
 }
 
-fn gcd_u128(mut a: u128, mut b: u128) -> u128 {
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
 
 /// JacobiSymbol[n, m] - Compute the Jacobi symbol (n/m)
 pub fn jacobi_symbol_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -5809,13 +5744,10 @@ pub fn frobenius_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Compute GCD of all elements
-  fn gcd_i128(a: i128, b: i128) -> i128 {
-    if b == 0 { a.abs() } else { gcd_i128(b, a % b) }
-  }
 
   let mut g = nums[0];
   for &n in &nums[1..] {
-    g = gcd_i128(g, n);
+    g = gcd(g, n);
   }
 
   // If GCD > 1, infinitely many integers can't be represented
@@ -9195,7 +9127,7 @@ fn bigint_rational_to_expr(num: BigInt, den: BigInt) -> Expr {
   if den.is_zero() {
     return Expr::Identifier("ComplexInfinity".to_string());
   }
-  let g = gcd_bigint(num.clone().abs(), den.clone().abs());
+  let g = gcd_bigint(&num, &den);
   let (mut n, mut d) = (num / &g, den / &g);
   if d < BigInt::from(0) {
     n = -n;

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -46,21 +46,19 @@ pub fn is_prime(n: usize) -> bool {
 /// rational, possibly negated) rather than a symbolic expression. Used to
 /// decide whether a "not a valid index" message should fire: a concrete
 /// non-integer argument is an error, but a symbolic one stays unevaluated.
-fn is_concrete_number(e: &Expr) -> bool {
-  match e {
-    Expr::Integer(_)
-    | Expr::Real(_)
-    | Expr::BigInteger(_)
-    | Expr::BigFloat(_, _) => true,
-    Expr::FunctionCall { name, .. } => name == "Rational",
-    Expr::UnaryOp {
-      op: UnaryOperator::Minus,
-      operand,
-    } => is_concrete_number(operand),
-    _ => false,
-  }
-}
 
+
+/// Primality test for i128 values (Miller-Rabin via BigInt beyond usize).
+pub fn is_prime_i128(n: i128) -> bool {
+  if n < 2 {
+    return false;
+  }
+  if n <= usize::MAX as i128 {
+    return is_prime(n as usize);
+  }
+  let big = num_bigint::BigInt::from(n);
+  is_prime_bigint(&big)
+}
 
 /// GCD[a, b, ...] - Greatest common divisor.
 ///
@@ -493,17 +491,6 @@ fn factorial2_extract_real(expr: &Expr) -> Option<(f64, Option<f64>)> {
 
 /// Returns true if the expression contains a Real or BigFloat anywhere
 /// in the tree — i.e., the value is inexact.
-fn contains_inexact_real(expr: &Expr) -> bool {
-  match expr {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::UnaryOp { operand, .. } => contains_inexact_real(operand),
-    Expr::BinaryOp { left, right, .. } => {
-      contains_inexact_real(left) || contains_inexact_real(right)
-    }
-    Expr::FunctionCall { args, .. } => args.iter().any(contains_inexact_real),
-    _ => false,
-  }
-}
 
 /// Factorial[n] or n!
 /// Factorial[n] = Gamma[n+1]

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -643,6 +643,47 @@ pub fn gcd(a: i128, b: i128) -> i128 {
   a as i128
 }
 
+/// Compute GCD of two u64 values using Euclidean algorithm
+pub fn gcd_u64(mut a: u64, mut b: u64) -> u64 {
+  while b != 0 {
+    let t = b;
+    b = a % b;
+    a = t;
+  }
+  a
+}
+
+/// Compute GCD of two unsigned integers using Euclidean algorithm
+pub fn gcd_u128(mut a: u128, mut b: u128) -> u128 {
+  while b != 0 {
+    let t = b;
+    b = a % b;
+    a = t;
+  }
+  a
+}
+
+/// Compute the (non-negative) LCM of two integers; 0 if either is 0.
+pub fn lcm_i128(a: i128, b: i128) -> i128 {
+  if a == 0 || b == 0 {
+    return 0;
+  }
+  (a / gcd(a, b) * b).abs()
+}
+
+/// Compute the (non-negative) GCD of two BigInts.
+pub fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
+  use num_traits::{Signed, Zero};
+  let mut a = a.abs();
+  let mut b = b.abs();
+  while !b.is_zero() {
+    let t = b.clone();
+    b = &a % &b;
+    a = t;
+  }
+  a
+}
+
 /// Extract the largest easily-found perfect-square factor from a positive
 /// i128: returns `(outside, inside)` with `n == outside^2 * inside`, so
 /// `Sqrt[n] = outside * Sqrt[inside]`. Square factors of primes below a

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -630,6 +630,73 @@ pub fn expr_to_rational(expr: &Expr) -> Option<(i128, i128)> {
   }
 }
 
+/// True if the expression tree contains an inexact (Real or BigFloat)
+/// literal anywhere. Used to decide between exact/symbolic and
+/// machine-precision numerical evaluation.
+pub fn contains_inexact_real(expr: &Expr) -> bool {
+  match expr {
+    Expr::Real(_) | Expr::BigFloat(_, _) => true,
+    Expr::List(items) => items.iter().any(contains_inexact_real),
+    Expr::FunctionCall { args, .. } => args.iter().any(contains_inexact_real),
+    Expr::BinaryOp { left, right, .. } => {
+      contains_inexact_real(left) || contains_inexact_real(right)
+    }
+    Expr::UnaryOp { operand, .. } => contains_inexact_real(operand),
+    _ => false,
+  }
+}
+
+/// True if the expression tree contains a machine-precision Real literal
+/// (BigFloats do not count). Distinguishes exact directions like
+/// `(1 + 2 I)/Sqrt[5]` from inexact ones like `1. + 2. I`.
+pub fn expr_contains_real(expr: &Expr) -> bool {
+  match expr {
+    Expr::Real(_) => true,
+    Expr::List(items) => items.iter().any(expr_contains_real),
+    Expr::FunctionCall { args, .. } => args.iter().any(expr_contains_real),
+    Expr::BinaryOp { left, right, .. } => {
+      expr_contains_real(left) || expr_contains_real(right)
+    }
+    Expr::UnaryOp { operand, .. } => expr_contains_real(operand),
+    _ => false,
+  }
+}
+
+/// True for a literal concrete number: Integer, Real, BigInteger, BigFloat,
+/// Rational, or a negated concrete number.
+pub fn is_concrete_number(e: &Expr) -> bool {
+  match e {
+    Expr::Integer(_)
+    | Expr::Real(_)
+    | Expr::BigInteger(_)
+    | Expr::BigFloat(_, _) => true,
+    Expr::FunctionCall { name, .. } => name == "Rational",
+    Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      operand,
+    } => is_concrete_number(operand),
+    _ => false,
+  }
+}
+
+/// Format an f64 value as a BigFloat string with the given number of
+/// significant digits.
+pub fn format_bigfloat_value(value: f64, sig_digits: usize) -> String {
+  if value == 0.0 {
+    return "0.".to_string();
+  }
+  let sign = if value < 0.0 { "-" } else { "" };
+  let abs_val = value.abs();
+  let magnitude = abs_val.log10().floor() as i32;
+  let decimal_places = ((sig_digits as i32) - magnitude - 1).max(0) as usize;
+  let formatted = format!("{}{:.prec$}", sign, abs_val, prec = decimal_places);
+  if !formatted.contains('.') {
+    format!("{}.", formatted)
+  } else {
+    formatted
+  }
+}
+
 /// Compute GCD of two integers using Euclidean algorithm
 pub fn gcd(a: i128, b: i128) -> i128 {
   // Use `unsigned_abs` (u128) so `i128::MIN` (whose `abs()` overflows) is

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -2244,18 +2244,6 @@ pub fn rescale_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// inexact-Real or BigFloat leaf. Used by Norm (and similar) to
 /// decide between exact/symbolic and machine-precision numerical
 /// evaluation.
-fn contains_inexact_real(expr: &Expr) -> bool {
-  match expr {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::List(items) => items.iter().any(contains_inexact_real),
-    Expr::FunctionCall { args, .. } => args.iter().any(contains_inexact_real),
-    Expr::BinaryOp { left, right, .. } => {
-      contains_inexact_real(left) || contains_inexact_real(right)
-    }
-    Expr::UnaryOp { operand, .. } => contains_inexact_real(operand),
-    _ => false,
-  }
-}
 
 pub fn norm_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.is_empty() || args.len() > 2 {

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -75,7 +75,6 @@ fn integer_coeff_of_term(t: &Expr) -> Option<BigInt> {
 /// form (3 - 18 x + 18 x^2 - 4 x^3)/3. A no-op for non-fraction results or when
 /// any term carries a non-integer coefficient.
 fn reduce_poly_over_integer(expr: Expr) -> Result<Expr, InterpreterError> {
-  use num_traits::Signed;
   // Extract (polynomial, integer denominator d) from either the `poly / d`
   // (BinaryOp Divide) form or the post-evaluation `(1/d) * poly` form
   // (Times of a Rational[1, d] coefficient and a Plus). Returns None otherwise.
@@ -129,13 +128,13 @@ fn reduce_poly_over_integer(expr: Expr) -> Result<Expr, InterpreterError> {
   let mut content = BigInt::from(0);
   let mut bail = false;
   for_each_plus_term(&poly, &mut |t| match integer_coeff_of_term(t) {
-    Some(c) => content = gcd_bigint(content.clone(), c.abs()),
+    Some(c) => content = gcd_bigint(&content, &c),
     None => bail = true,
   });
   if bail {
     return Ok(expr);
   }
-  let g = gcd_bigint(content, d.abs());
+  let g = gcd_bigint(&content, &d);
   if g <= BigInt::from(1) {
     return Ok(expr);
   }
@@ -786,7 +785,7 @@ fn legendre_eval_rational(n: usize, x: (BigInt, BigInt)) -> (BigInt, BigInt) {
     let diff_n = &term1_n * &term2_d - &term2_n * &term1_d;
     let diff_d = &term1_d * &term2_d * (&m_i + BigInt::from(1));
 
-    let g = gcd_bigint(diff_n.clone(), diff_d.clone());
+    let g = gcd_bigint(&diff_n, &diff_d);
     let next_n = &diff_n / &g;
     let next_d = &diff_d / &g;
 
@@ -1592,14 +1591,6 @@ fn legendre_coefficients(n: usize) -> Option<Vec<(i128, i128)>> {
   Some(curr)
 }
 
-fn lcm_i128(a: i128, b: i128) -> i128 {
-  let g = gcd(a.abs(), b.abs());
-  if g == 0 {
-    return 0;
-  }
-  (a.abs() / g) * b.abs()
-}
-
 /// LegendreQ[n, x] / LegendreQ[n, m, x] - Legendre function of the second kind.
 /// The 3-arg associated form uses the Ferrers identity
 ///   Q_ν^μ(z) = (π / (2 sin(μπ))) ·
@@ -2289,7 +2280,7 @@ fn chebyshev_t_eval_rational(
     let a_d = &xd * &t.1;
     let new_n = &a_n * &tm1.1 - &tm1.0 * &a_d;
     let new_d = &a_d * &tm1.1;
-    let g = gcd_bigint(new_n.clone(), new_d.clone());
+    let g = gcd_bigint(&new_n, &new_d);
     tm1 = t;
     t = if g != BigInt::from(0) {
       (&new_n / &g, &new_d / &g)
@@ -2507,7 +2498,7 @@ fn chebyshev_u_eval_rational(
     let a_d = &xd * &u.1;
     let new_n = &a_n * &um1.1 - &um1.0 * &a_d;
     let new_d = &a_d * &um1.1;
-    let g = gcd_bigint(new_n.clone(), new_d.clone());
+    let g = gcd_bigint(&new_n, &new_d);
     um1 = u;
     u = if g != BigInt::from(0) {
       (&new_n / &g, &new_d / &g)
@@ -2869,7 +2860,7 @@ fn gegenbauer_eval_rational(
   // C_1 = 2λx = (2*lam_n*x_n, lam_d*x_d)
   let c1_n = BigInt::from(2) * &lam.0 * &x.0;
   let c1_d = &lam.1 * &x.1;
-  let g = gcd_bigint(c1_n.clone(), c1_d.clone());
+  let g = gcd_bigint(&c1_n, &c1_d);
   let c1 = if g != BigInt::from(0) {
     (&c1_n / &g, &c1_d / &g)
   } else {
@@ -2908,7 +2899,7 @@ fn gegenbauer_eval_rational(
     let new_n = diff_n;
     let new_d = diff_d * (&kk + BigInt::from(1));
 
-    let g = gcd_bigint(new_n.clone(), new_d.clone());
+    let g = gcd_bigint(&new_n, &new_d);
     cm1 = c;
     c = if g != BigInt::from(0) {
       (&new_n / &g, &new_d / &g)
@@ -3575,7 +3566,7 @@ fn laguerre_eval_rational(n: usize, x: (BigInt, BigInt)) -> (BigInt, BigInt) {
     let sub_n = &a_n * b_d - &b_n * &a_d;
     let sub_d = &a_d * b_d * (&kf + BigInt::from(1));
 
-    let g = gcd_bigint(sub_n.clone(), sub_d.clone());
+    let g = gcd_bigint(&sub_n, &sub_d);
     lm1 = l;
     l = if g != BigInt::from(0) {
       (&sub_n / &g, &sub_d / &g)

--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -1657,17 +1657,6 @@ fn collect_primes_in_range(min: i128, max: i128) -> Vec<i128> {
 }
 
 /// Primality test for i128 values, using Miller-Rabin for large numbers
-fn is_prime_i128(n: i128) -> bool {
-  if n < 2 {
-    return false;
-  }
-  if n <= usize::MAX as i128 {
-    return is_prime(n as usize);
-  }
-  // For values beyond usize, use BigInt Miller-Rabin
-  let big = num_bigint::BigInt::from(n);
-  super::number_theory::is_prime_bigint(&big)
-}
 
 /// SeedRandom[n] - Seed the random number generator
 /// SeedRandom[] - Reset to non-deterministic RNG

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -4029,17 +4029,6 @@ pub fn root_mean_square_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 }
 
-/// GCD for i128 values
-pub fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
-
 /// Floor of a rational number num/den
 pub fn rational_floor(num: i128, den: i128) -> i128 {
   if den == 0 {

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -6088,17 +6088,6 @@ fn reduce_trig_power(base: &Expr, n: i128) -> Option<Expr> {
   }
 
   // Compute GCD of all numerator coefficients and denom to simplify the fraction
-  fn gcd(mut a: i128, mut b: i128) -> i128 {
-    a = a.abs();
-    b = b.abs();
-    while b != 0 {
-      let t = b;
-      b = a % b;
-      a = t;
-    }
-    a
-  }
-
   let mut g = denom;
   for (c, _) in &num_terms {
     g = gcd(g, *c);

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -4542,18 +4542,6 @@ pub fn arccosh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// True if `expr` contains a Real or BigFloat anywhere — used to gate
 /// numeric evaluation of otherwise-exact symbolic inputs.
-fn contains_inexact_real(expr: &Expr) -> bool {
-  match expr {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::List(items) => items.iter().any(contains_inexact_real),
-    Expr::FunctionCall { args, .. } => args.iter().any(contains_inexact_real),
-    Expr::BinaryOp { left, right, .. } => {
-      contains_inexact_real(left) || contains_inexact_real(right)
-    }
-    Expr::UnaryOp { operand, .. } => contains_inexact_real(operand),
-    _ => false,
-  }
-}
 
 /// ArcTanh[x] - Inverse hyperbolic tangent
 pub fn arctanh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/weierstrass.rs
+++ b/src/functions/math_ast/weierstrass.rs
@@ -25,20 +25,7 @@ pub(crate) fn format_power_infy_2d(base: &str, exp: &str) -> String {
 /// in which case the Weierstrass functions numericize; otherwise they stay
 /// symbolic (matching wolframscript; `N[...]` makes the arguments inexact).
 fn any_inexact(exprs: &[&Expr]) -> bool {
-  fn is_inexact(e: &Expr) -> bool {
-    match e {
-      Expr::Real(_) | Expr::BigFloat(_, _) => true,
-      Expr::BinaryOp { left, right, .. } => {
-        is_inexact(left) || is_inexact(right)
-      }
-      Expr::UnaryOp { operand, .. } => is_inexact(operand),
-      Expr::FunctionCall { args, .. } | Expr::List(args) => {
-        args.iter().any(is_inexact)
-      }
-      _ => false,
-    }
-  }
-  exprs.iter().any(|e| is_inexact(e))
+  exprs.iter().any(|e| contains_inexact_real(e))
 }
 
 /// WeierstrassP[u, {g2, g3}] - Weierstrass elliptic function ℘(u; g₂, g₃)

--- a/src/functions/math_ast/zeta_functions.rs
+++ b/src/functions/math_ast/zeta_functions.rs
@@ -738,7 +738,7 @@ pub fn zeta_numeric(s: f64) -> f64 {
 
 // ─── Complex arithmetic helpers ──────────────────────────────────────
 
-fn cmul(a: (f64, f64), b: (f64, f64)) -> (f64, f64) {
+pub(crate) fn cmul(a: (f64, f64), b: (f64, f64)) -> (f64, f64) {
   (a.0 * b.0 - a.1 * b.1, a.0 * b.1 + a.1 * b.0)
 }
 

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -1836,10 +1836,7 @@ pub fn music_rest(args: &[Expr]) -> Option<Expr> {
   }
 }
 
-/// Greatest common divisor of two non-negative integers.
-fn gcd(a: i128, b: i128) -> i128 {
-  if b == 0 { a } else { gcd(b, a % b) }
-}
+use crate::functions::math_ast::gcd;
 
 /// Reduce `n/d` to lowest terms with a positive denominator, returning an
 /// `Integer` when the denominator is 1 and a `Rational[n, d]` otherwise.

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -1053,7 +1053,10 @@ fn music_assoc(head: &str, pairs: Vec<(&str, Expr)>) -> Expr {
 }
 
 /// Look up a string key in an association's `(key, value)` pairs.
-fn assoc_get<'a>(pairs: &'a [(Expr, Expr)], key: &str) -> Option<&'a Expr> {
+pub(crate) fn assoc_get<'a>(
+  pairs: &'a [(Expr, Expr)],
+  key: &str,
+) -> Option<&'a Expr> {
   pairs.iter().find_map(|(k, v)| match k {
     Expr::String(s) if s == key => Some(v),
     _ => None,

--- a/src/functions/music_midi.rs
+++ b/src/functions/music_midi.rs
@@ -69,13 +69,7 @@ fn element_midi(expr: &Expr) -> Option<i128> {
   }
 }
 
-/// Look up a string key in an association's `(key, value)` pairs.
-fn assoc_get<'a>(pairs: &'a [(Expr, Expr)], key: &str) -> Option<&'a Expr> {
-  pairs.iter().find_map(|(k, v)| match k {
-    Expr::String(s) if s == key => Some(v),
-    _ => None,
-  })
-}
+use crate::functions::music_ast::assoc_get;
 
 /// The integer beat count carried by a resolved note/rest's annotated duration
 /// (`MusicDuration[<|… "Beats" -> n|>]`), or `None` if absent.

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -4,7 +4,7 @@
 //! NDSolve solves initial-value problems numerically using RK4.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::make_sqrt;
+use crate::functions::math_ast::{gcd as gcd_i128, gcd_u128, make_sqrt};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -1392,7 +1392,7 @@ fn f64_to_nice_expr(f: f64) -> Expr {
     if (numer - numer.round()).abs() < 1e-10 {
       let n = numer.round() as i128;
       let d = denom as i128;
-      let g = gcd(n.unsigned_abs(), d as u128) as i128;
+      let g = gcd_u128(n.unsigned_abs(), d as u128) as i128;
       let nn = n / g;
       let dd = d / g;
       if dd == 1 {
@@ -1426,15 +1426,6 @@ fn f64_to_nice_expr(f: f64) -> Expr {
     }
   }
   Expr::Real(f)
-}
-
-fn gcd(mut a: u128, mut b: u128) -> u128 {
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
 }
 
 // ─── First-order Linear ODE Solver ─────────────────────────────────────
@@ -2973,16 +2964,6 @@ fn make_c_over_a(c: i128, a: i128) -> Expr {
   } else {
     make_rational(num, den)
   }
-}
-
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a, b);
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
 }
 
 /// Walk a Plus chain and accumulate signed integer coefficients of

--- a/src/functions/parametric_plot.rs
+++ b/src/functions/parametric_plot.rs
@@ -4,7 +4,7 @@ use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{
   NUM_SAMPLES, PlotOptions, PlotRangeOverrides, adjust_y_range_for_filling,
   apply_common_plot_option, build_plot_source, evaluate_at_point,
-  generate_svg_with_filling, substitute_var,
+  generate_svg_with_filling, parse_iterator, substitute_var,
 };
 use crate::syntax::Expr;
 
@@ -341,40 +341,6 @@ pub fn polar_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     plot_opts.filling,
   );
   Ok(crate::graphics_result_with_source(svg, source))
-}
-
-fn parse_iterator(
-  spec: &Expr,
-  label: &str,
-) -> Result<(String, f64, f64), InterpreterError> {
-  match spec {
-    Expr::List(items) if items.len() == 3 => {
-      let var = match &items[0] {
-        Expr::Identifier(name) => name.clone(),
-        _ => {
-          return Err(InterpreterError::EvaluationError(format!(
-            "{label}: iterator variable must be a symbol"
-          )));
-        }
-      };
-      let min_expr = evaluate_expr_to_expr(&items[1])?;
-      let max_expr = evaluate_expr_to_expr(&items[2])?;
-      let min_val = try_eval_to_f64(&min_expr).ok_or_else(|| {
-        InterpreterError::EvaluationError(format!(
-          "{label}: cannot evaluate iterator min to a number"
-        ))
-      })?;
-      let max_val = try_eval_to_f64(&max_expr).ok_or_else(|| {
-        InterpreterError::EvaluationError(format!(
-          "{label}: cannot evaluate iterator max to a number"
-        ))
-      })?;
-      Ok((var, min_val, max_val))
-    }
-    _ => Err(InterpreterError::EvaluationError(format!(
-      "{label}: iterator must be {{var, min, max}}"
-    ))),
-  }
 }
 
 /// Compute x/y ranges from point data with 4% padding.

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -139,6 +139,72 @@ pub(crate) fn substitute_var(expr: &Expr, var: &str, value: &Expr) -> Expr {
 }
 
 /// Evaluate the function body at a given x value
+/// Parse a plot iterator specification `{var, min, max}`.
+pub(crate) fn parse_iterator(
+  spec: &Expr,
+  label: &str,
+) -> Result<(String, f64, f64), InterpreterError> {
+  match spec {
+    Expr::List(items) if items.len() == 3 => {
+      let var = match &items[0] {
+        Expr::Identifier(name) => name.clone(),
+        _ => {
+          return Err(InterpreterError::EvaluationError(format!(
+            "{label}: iterator variable must be a symbol"
+          )));
+        }
+      };
+      let min_expr = evaluate_expr_to_expr(&items[1])?;
+      let max_expr = evaluate_expr_to_expr(&items[2])?;
+      let min_val = try_eval_to_f64(&min_expr).ok_or_else(|| {
+        InterpreterError::EvaluationError(format!(
+          "{label}: cannot evaluate iterator min to a number"
+        ))
+      })?;
+      let max_val = try_eval_to_f64(&max_expr).ok_or_else(|| {
+        InterpreterError::EvaluationError(format!(
+          "{label}: cannot evaluate iterator max to a number"
+        ))
+      })?;
+      Ok((var, min_val, max_val))
+    }
+    _ => Err(InterpreterError::EvaluationError(format!(
+      "{label}: iterator must be {{var, min, max}}"
+    ))),
+  }
+}
+
+/// Evaluate the function body at given (x, y) values.
+pub(crate) fn evaluate_at_xy(
+  body: &Expr,
+  xvar: &str,
+  yvar: &str,
+  xval: f64,
+  yval: f64,
+) -> Option<f64> {
+  let sub1 = substitute_var(body, xvar, &Expr::Real(xval));
+  let sub2 = substitute_var(&sub1, yvar, &Expr::Real(yval));
+  let result = evaluate_expr_to_expr(&sub2).ok()?;
+  try_eval_to_f64(&result)
+}
+
+/// Simple SVG header for plots without plotters axes (ArrayPlot, charts).
+pub(crate) fn svg_header(w: u32, h: u32, full_width: bool) -> String {
+  let (bg, _, _, _, _) = plot_theme();
+  let bg_fill = format!("rgb({},{},{})", bg.0, bg.1, bg.2);
+  if full_width {
+    format!(
+      "<svg width=\"100%\" viewBox=\"0 0 {w} {h}\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\">\n\
+       <rect width=\"{w}\" height=\"{h}\" fill=\"{bg_fill}\"/>\n"
+    )
+  } else {
+    format!(
+      "<svg width=\"{w}\" height=\"{h}\" viewBox=\"0 0 {w} {h}\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\">\n\
+       <rect width=\"{w}\" height=\"{h}\" fill=\"{bg_fill}\"/>\n"
+    )
+  }
+}
+
 pub(crate) fn evaluate_at_point(body: &Expr, var: &str, x: f64) -> Option<f64> {
   let substituted = substitute_var(body, var, &Expr::Real(x));
   let result = evaluate_expr_to_expr(&substituted).ok()?;
@@ -4084,8 +4150,8 @@ pub(crate) fn generate_bubble_chart_svg(
   Ok(buf)
 }
 
-/// Escape special characters for SVG text content.
-fn html_escape(s: &str) -> String {
+/// Escape special characters for SVG/HTML text content.
+pub(crate) fn html_escape(s: &str) -> String {
   s.replace('&', "&amp;")
     .replace('<', "&lt;")
     .replace('>', "&gt;")

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -2,7 +2,8 @@ use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{
-  PLOT_COLORS, format_tick, nice_step, parse_image_size, substitute_var,
+  PLOT_COLORS, evaluate_at_xy, format_tick, nice_step, parse_image_size,
+  substitute_var,
 };
 use crate::syntax::Expr;
 
@@ -165,20 +166,6 @@ pub(crate) fn apply_lighting(
   let g = (color.1 as f64 * intensity).round() as u8;
   let b = (color.2 as f64 * intensity).round() as u8;
   (r, g, b)
-}
-
-/// Evaluate the function body at given (x, y) values
-fn evaluate_at_xy(
-  body: &Expr,
-  xvar: &str,
-  yvar: &str,
-  xval: f64,
-  yval: f64,
-) -> Option<f64> {
-  let sub1 = substitute_var(body, xvar, &Expr::Real(xval));
-  let sub2 = substitute_var(&sub1, yvar, &Expr::Real(yval));
-  let result = evaluate_expr_to_expr(&sub2).ok()?;
-  try_eval_to_f64(&result)
 }
 
 fn parse_iterator(

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -442,13 +442,6 @@ fn poly_mul_i128(a: &[i128], b: &[i128]) -> Vec<i128> {
   out
 }
 
-fn lcm_i128(a: i128, b: i128) -> i128 {
-  if a == 0 || b == 0 {
-    return 0;
-  }
-  (a / gcd_i128(a.abs(), b.abs())) * b
-}
-
 /// Solve the square rational system `mat * x = rhs` by Gauss–Jordan
 /// elimination. `mat` is row-major `n x n`. Returns None if singular.
 fn solve_rat_system(
@@ -989,20 +982,9 @@ fn apart_repeated_roots(
   Some(build_sum(terms))
 }
 
-/// Polynomial long division returning (quotient, remainder) as coefficient vectors
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = a % b;
-    a = b;
-    b = t;
-  }
-  if a == 0 { 1 } else { a }
-}
-
 /// Reduce n/d to lowest terms with a positive denominator.
 fn rat_reduce(n: i128, d: i128) -> (i128, i128) {
-  let g = gcd_i128(n, d);
+  let g = gcd_i128(n, d).max(1);
   let (mut n, mut d) = (n / g, d / g);
   if d < 0 {
     n = -n;

--- a/src/functions/polynomial_ast/decompose.rs
+++ b/src/functions/polynomial_ast/decompose.rs
@@ -56,15 +56,7 @@ pub fn decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 type Rat = (i128, i128); // (numerator, denominator), always reduced
 
-fn rat_gcd(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
+use crate::functions::math_ast::gcd as rat_gcd;
 
 fn rat_reduce(n: i128, d: i128) -> Rat {
   if d == 0 {

--- a/src/functions/polynomial_ast/eliminate.rs
+++ b/src/functions/polynomial_ast/eliminate.rs
@@ -164,14 +164,6 @@ pub fn contains_var(expr: &Expr, var: &str) -> bool {
   !is_constant_wrt(expr, var)
 }
 
-/// Greatest common divisor of two non-negative integers.
-fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
-  while b != 0 {
-    (a, b) = (b, a % b);
-  }
-  a.abs()
-}
-
 /// Eliminate one variable from a system of equations
 fn eliminate_one_variable(
   equations: &[Expr],

--- a/src/functions/polynomial_ast/exponent.rs
+++ b/src/functions/polynomial_ast/exponent.rs
@@ -73,9 +73,7 @@ impl Rat {
   }
 }
 
-fn gcd(a: u128, b: u128) -> u128 {
-  if b == 0 { a } else { gcd(b, a % b) }
-}
+use crate::functions::math_ast::gcd_u128 as gcd;
 
 /// Try to interpret an Expr as a rational number.
 fn expr_to_rat(e: &Expr) -> Option<Rat> {

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -461,17 +461,6 @@ fn expr_has_negative_var_power(expr: &Expr) -> bool {
   }
 }
 
-/// GCD of two i128 values.
-pub fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
-
 /// Factor an integer polynomial given as coefficients.
 /// Returns a list of factor expressions, or empty if can't factor.
 pub fn factor_integer_poly(coeffs: &[i128], var: &str) -> Vec<Expr> {
@@ -2094,14 +2083,6 @@ fn extract_non_numeric_factors(term: &Expr) -> Vec<Expr> {
         .collect()
     }
     _ => vec![term.clone()],
-  }
-}
-
-fn lcm_i128(a: i128, b: i128) -> i128 {
-  if a == 0 || b == 0 {
-    0
-  } else {
-    (a / gcd_i128(a, b)) * b
   }
 }
 

--- a/src/functions/polynomial_ast/function_expand.rs
+++ b/src/functions/polynomial_ast/function_expand.rs
@@ -1,3 +1,4 @@
+use super::{mk_call, mk_int, mk_power, mk_ratio, mk_times};
 use crate::InterpreterError;
 use crate::syntax::{BinaryOperator, Expr};
 
@@ -60,43 +61,16 @@ fn function_expand_inner(expr: &Expr) -> Result<Expr, InterpreterError> {
   }
 }
 
-/// Helper to build common expressions
-fn mk_call(name: &str, args: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  }
-}
-
 fn mk_id(name: &str) -> Expr {
   Expr::Identifier(name.to_string())
-}
-
-fn mk_int(n: i128) -> Expr {
-  Expr::Integer(n)
-}
-
-fn mk_times(a: Expr, b: Expr) -> Expr {
-  mk_call("Times", vec![a, b])
 }
 
 fn mk_plus(a: Expr, b: Expr) -> Expr {
   mk_call("Plus", vec![a, b])
 }
 
-fn mk_power(base: Expr, exp: Expr) -> Expr {
-  mk_call("Power", vec![base, exp])
-}
-
 fn mk_div(a: Expr, b: Expr) -> Expr {
   mk_times(a, mk_power(b, mk_int(-1)))
-}
-
-fn mk_ratio(n: i128, d: i128) -> Expr {
-  Expr::FunctionCall {
-    name: "Rational".to_string(),
-    args: vec![Expr::Integer(n), Expr::Integer(d)].into(),
-  }
 }
 
 /// Try to expand a specific function call. Returns None if no expansion applies.

--- a/src/functions/polynomial_ast/gf_factor.rs
+++ b/src/functions/polynomial_ast/gf_factor.rs
@@ -17,20 +17,6 @@ const MAX_MODULUS: i128 = 65_536;
 
 // ─── GF(p) polynomial arithmetic (ascending trimmed coefficient vectors) ──
 
-fn trim(v: &mut Vec<i128>) {
-  while v.len() > 1 && *v.last().unwrap() == 0 {
-    v.pop();
-  }
-}
-
-fn is_zero(v: &[i128]) -> bool {
-  v == [0]
-}
-
-fn deg(v: &[i128]) -> usize {
-  v.len() - 1
-}
-
 fn mod_inv(a: i128, p: i128) -> i128 {
   let (mut old_r, mut r) = (a.rem_euclid(p), p);
   let (mut old_s, mut s) = (1i128, 0i128);

--- a/src/functions/polynomial_ast/helpers.rs
+++ b/src/functions/polynomial_ast/helpers.rs
@@ -36,10 +36,7 @@ pub fn extract_exponent_map(var_factors: &[Expr]) -> HashMap<String, i128> {
   map
 }
 
-/// Helper to create boolean result
-pub fn bool_expr(b: bool) -> Expr {
-  Expr::Identifier(if b { "True" } else { "False" }.to_string())
-}
+pub use crate::syntax::bool_expr;
 
 // ─── Helper functions for building expressions ─────────────────────
 

--- a/src/functions/polynomial_ast/helpers.rs
+++ b/src/functions/polynomial_ast/helpers.rs
@@ -38,6 +38,56 @@ pub fn extract_exponent_map(var_factors: &[Expr]) -> HashMap<String, i128> {
 
 pub use crate::syntax::bool_expr;
 
+/// Build a FunctionCall expression.
+pub fn mk_call(name: &str, args: Vec<Expr>) -> Expr {
+  Expr::FunctionCall {
+    name: name.to_string(),
+    args: args.into(),
+  }
+}
+
+/// Build an Integer expression.
+pub fn mk_int(n: i128) -> Expr {
+  Expr::Integer(n)
+}
+
+/// Build a `Rational[n, d]` expression.
+pub fn mk_ratio(n: i128, d: i128) -> Expr {
+  Expr::FunctionCall {
+    name: "Rational".to_string(),
+    args: vec![Expr::Integer(n), Expr::Integer(d)].into(),
+  }
+}
+
+/// Build `Times[a, b]`.
+pub fn mk_times(a: Expr, b: Expr) -> Expr {
+  mk_call("Times", vec![a, b])
+}
+
+/// Build `Power[base, exp]`.
+pub fn mk_power(base: Expr, exp: Expr) -> Expr {
+  mk_call("Power", vec![base, exp])
+}
+
+// ─── Ascending trimmed polynomial coefficient vectors ────────────────
+
+/// Drop trailing zero coefficients (keeping at least one entry).
+pub fn trim(v: &mut Vec<i128>) {
+  while v.len() > 1 && *v.last().unwrap() == 0 {
+    v.pop();
+  }
+}
+
+/// True for the zero polynomial `[0]`.
+pub fn is_zero(v: &[i128]) -> bool {
+  v == [0]
+}
+
+/// Degree of a trimmed coefficient vector.
+pub fn deg(v: &[i128]) -> usize {
+  v.len() - 1
+}
+
 // ─── Helper functions for building expressions ─────────────────────
 
 /// Build an equality comparison: lhs == rhs

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -1378,22 +1378,7 @@ fn negate_var_in_poly(coeffs: &[i128]) -> Vec<i128> {
     .collect()
 }
 
-/// Extract a rational number as (numerator, denominator) from an Expr
-fn extract_rational(expr: &Expr) -> Option<(i128, i128)> {
-  match expr {
-    Expr::Integer(n) => Some((*n, 1)),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(p), Expr::Integer(q)) = (&args[0], &args[1]) {
-        Some((*p, *q))
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
+use crate::functions::math_ast::expr_to_rational as extract_rational;
 
 /// Extract a rational pair (p, q) from a Rational expression or integer
 fn extract_rational_pair(expr: &Expr) -> Option<(i128, i128)> {

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -1612,16 +1612,7 @@ fn sturm_real_root_count(coeffs: &[i128]) -> usize {
     v
   }
 
-  fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-    let mut a = a.abs();
-    let mut b = b.abs();
-    while !b.is_zero() {
-      let t = &a % &b;
-      a = b;
-      b = t;
-    }
-    a
-  }
+  use crate::functions::math_ast::gcd_bigint;
 
   fn content_reduce(v: &[BigInt]) -> Vec<BigInt> {
     let mut g = BigInt::ZERO;

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -33,9 +33,7 @@ mod to_radicals;
 pub mod together;
 mod zassenhaus;
 
-pub(crate) use crate::functions::math_ast::{
-  gcd as gcd_i128, lcm_i128,
-};
+pub(crate) use crate::functions::math_ast::{gcd as gcd_i128, lcm_i128};
 
 pub use apart::*;
 pub use cancel::*;

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -33,6 +33,10 @@ mod to_radicals;
 pub mod together;
 mod zassenhaus;
 
+pub(crate) use crate::functions::math_ast::{
+  gcd as gcd_i128, lcm_i128,
+};
+
 pub use apart::*;
 pub use cancel::*;
 pub use coefficient::*;

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -101,19 +101,7 @@ pub fn reduce_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Does `e` contain any inexact (Real / BigFloat) literal? Such bounds make
 /// wolframscript emit a `Reduce::ratnz` warning, so they are left alone here.
-fn contains_inexact_literal(e: &Expr) -> bool {
-  match e {
-    Expr::Real(_) | Expr::BigFloat(_, _) => true,
-    Expr::FunctionCall { args, .. } => {
-      args.iter().any(contains_inexact_literal)
-    }
-    Expr::BinaryOp { left, right, .. } => {
-      contains_inexact_literal(left) || contains_inexact_literal(right)
-    }
-    Expr::UnaryOp { operand, .. } => contains_inexact_literal(operand),
-    _ => false,
-  }
-}
+use crate::functions::math_ast::contains_inexact_real as contains_inexact_literal;
 
 /// If `result` is a single one-sided comparison `var op c` with an exact numeric
 /// bound `c`, tighten it to the nearest admissible integer and pair it with

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -2885,13 +2885,7 @@ impl Rat {
 }
 
 fn rat_gcd(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = a % b;
-    a = b;
-    b = t;
-  }
-  a.max(1)
+  crate::functions::math_ast::gcd(a, b).max(1)
 }
 
 fn rat_simplify(num: i128, den: i128) -> Rat {

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -139,7 +139,7 @@ fn reduce_rat((n, d): (i128, i128)) -> (i128, i128) {
   if d == 0 {
     return (n, d);
   }
-  let g = super::factor::gcd_i128(n.abs(), d.abs()).max(1);
+  let g = gcd_i128(n.abs(), d.abs()).max(1);
   let (mut n, mut d) = (n / g, d / g);
   if d < 0 {
     n = -n;
@@ -7485,11 +7485,8 @@ fn simplify_quotient_select(
   if matches!(num, Expr::Integer(-1)) {
     return None;
   }
-  fn gcd(a: i128, b: i128) -> i128 {
-    if b == 0 { a.abs() } else { gcd(b, a % b) }
-  }
   let content = |terms: &[(i128, i128, i128)]| -> i128 {
-    let g = terms.iter().fold(0i128, |g, &(n, _, _)| gcd(g, n));
+    let g = terms.iter().fold(0i128, |g, &(n, _, _)| gcd_i128(g, n));
     // FactorTerms sign rule: the highest-degree coefficient's sign
     let sign = if terms.last().map(|&(n, _, _)| n < 0).unwrap_or(false) {
       -1
@@ -7600,7 +7597,7 @@ fn simplify_quotient_select(
       if *pull {
         coeff_n = -coeff_n;
       }
-      let g = gcd(coeff_n, coeff_d);
+      let g = gcd_i128(coeff_n, coeff_d);
       if g > 1 {
         // shared content would have been cancelled upstream; skip
         // rather than construct a misleading display
@@ -7690,7 +7687,7 @@ fn simplify_quotient_select(
       + n_terms
         .iter()
         .map(|&(n, _, e)| {
-          let g = gcd(n, den_mono_coeff);
+          let g = gcd_i128(n, den_mono_coeff);
           quotient_cost::sc_term(n / g, den_mono_coeff / g, e - den_mono_exp)
         })
         .sum::<i64>();
@@ -7740,7 +7737,7 @@ fn simplify_quotient_select(
       for (nc, nt) in flip_opts {
         let mut coeff_n = nc;
         let mut coeff_d = fdc;
-        let g = gcd(coeff_n, coeff_d);
+        let g = gcd_i128(coeff_n, coeff_d);
         if g > 1 {
           coeff_n /= g;
           coeff_d /= g;
@@ -8615,23 +8612,8 @@ fn parse_log_term(term: &Expr) -> Option<(i64, num_bigint::BigInt)> {
 /// a sanity bound on the coefficient magnitude).
 fn try_merge_logs(expr: &Expr) -> Option<Expr> {
   use num_bigint::BigInt;
-  use num_traits::{One, Zero};
+  use num_traits::One;
 
-  // gcd of two non-negative BigInts (Euclid).
-  fn gcd_bigint(mut a: BigInt, mut b: BigInt) -> BigInt {
-    while !b.is_zero() {
-      let r = &a % &b;
-      a = std::mem::replace(&mut b, r);
-    }
-    a
-  }
-  fn gcd_u64(mut a: u64, mut b: u64) -> u64 {
-    while b != 0 {
-      let r = a % b;
-      a = std::mem::replace(&mut b, r);
-    }
-    a
-  }
 
   // Flatten the additive structure (both FunctionCall and BinaryOp forms),
   // and distribute an integer coefficient over a parenthesised sum of logs so
@@ -8747,7 +8729,7 @@ fn try_merge_logs(expr: &Expr) -> Option<Expr> {
         den *= n.pow((-c) as u32);
       }
     }
-    let g = gcd_bigint(num.clone(), den.clone());
+    let g = crate::functions::math_ast::gcd_bigint(&num, &den);
     let num = &num / &g;
     let den = &den / &g;
     let q = if den.is_one() {
@@ -8775,7 +8757,7 @@ fn try_merge_logs(expr: &Expr) -> Option<Expr> {
     let g = logs
       .iter()
       .map(|(c, _)| c.unsigned_abs())
-      .fold(0u64, gcd_u64);
+      .fold(0u64, crate::functions::math_ast::gcd_u64);
     if g > 1 {
       let reduced: Vec<(i64, BigInt)> = logs
         .iter()

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -4420,8 +4420,7 @@ fn contains_zero_negative_power(expr: &Expr) -> bool {
 /// base (Times[Rational[-2,5], 1-x+x^2, (-1+x)^(-1)], a Factor rewrite of
 /// a flipped quotient) is NOT this display and must keep re-simplifying.
 fn is_rational_prefactor_quotient(e: &Expr) -> bool {
-  let factors =
-    super::together::flatten_times_args(std::slice::from_ref(e));
+  let factors = super::together::flatten_times_args(std::slice::from_ref(e));
   if factors.len() != 3 {
     return false;
   }
@@ -4499,7 +4498,9 @@ fn reciprocal_inside_sum_factor(e: &Expr) -> bool {
         matches!(right.as_ref(), Expr::Integer(n) if *n < 0)
           || has_neg_int_power(left)
       }
-      Expr::FunctionCall { name, args } if name == "Power" && args.len() == 2 => {
+      Expr::FunctionCall { name, args }
+        if name == "Power" && args.len() == 2 =>
+      {
         matches!(&args[1], Expr::Integer(n) if *n < 0)
           || has_neg_int_power(&args[0])
       }
@@ -4852,9 +4853,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
         .map(term_sqrt_radicand)
         .collect::<Option<Vec<i128>>>()
     {
-      let g = radicands
-        .iter()
-        .fold(0i128, |a, &b| super::factor::gcd_i128(a, b).abs());
+      let g = radicands.iter().fold(0i128, |a, &b| gcd_i128(a, b).abs());
       if g > 1 {
         let divided: Result<Vec<Expr>, _> = terms
           .iter()

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -8614,7 +8614,6 @@ fn try_merge_logs(expr: &Expr) -> Option<Expr> {
   use num_bigint::BigInt;
   use num_traits::One;
 
-
   // Flatten the additive structure (both FunctionCall and BinaryOp forms),
   // and distribute an integer coefficient over a parenthesised sum of logs so
   // that e.g. a `2*(Log[2]+Log[3])` produced by common-factor pulling is still

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2227,7 +2227,7 @@ pub fn solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               let root = if j == 0 {
                 val_root.clone()
               } else {
-                let g = super::factor::gcd_i128(j, n);
+                let g = gcd_i128(j, n);
                 let p = j / g;
                 let q = n / g;
                 let multiplier = Expr::FunctionCall {
@@ -2262,7 +2262,7 @@ pub fn solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             for j in 0..half_n {
               let frac_num = 2 * j;
               let frac_den = n;
-              let g = super::factor::gcd_i128(frac_num, frac_den);
+              let g = gcd_i128(frac_num, frac_den);
 
               if frac_num == 0 {
                 // frac = 0: roots are -val^(1/n) and val^(1/n)

--- a/src/functions/polynomial_ast/to_radicals.rs
+++ b/src/functions/polynomial_ast/to_radicals.rs
@@ -1,3 +1,4 @@
+use super::{mk_call, mk_int, mk_power, mk_ratio, mk_times};
 use crate::InterpreterError;
 use crate::syntax::{BinaryOperator, Expr};
 
@@ -71,39 +72,12 @@ fn to_radicals_inner(expr: &Expr) -> Result<Expr, InterpreterError> {
   }
 }
 
-/// Helper: build Expr from common constructors.
-fn mk_call(name: &str, args: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  }
-}
-
-fn mk_int(n: i128) -> Expr {
-  Expr::Integer(n)
-}
-
-fn mk_ratio(n: i128, d: i128) -> Expr {
-  Expr::FunctionCall {
-    name: "Rational".to_string(),
-    args: vec![Expr::Integer(n), Expr::Integer(d)].into(),
-  }
-}
-
-fn mk_times(a: Expr, b: Expr) -> Expr {
-  mk_call("Times", vec![a, b])
-}
-
 fn mk_plus(args: Vec<Expr>) -> Expr {
   if args.len() == 1 {
     args.into_iter().next().unwrap()
   } else {
     mk_call("Plus", args)
   }
-}
-
-fn mk_power(base: Expr, exp: Expr) -> Expr {
-  mk_call("Power", vec![base, exp])
 }
 
 /// Extract integer polynomial coefficients from a pure function body.

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -139,8 +139,7 @@ pub(super) fn distribute_unit_negative_numerator(expr: &Expr) -> Expr {
       }
     ) || matches!(e, Expr::FunctionCall { name, .. } if name == "Plus")
   };
-  let sum = if matches!(&factors[0], Expr::Integer(-1)) && is_sum(&factors[1])
-  {
+  let sum = if matches!(&factors[0], Expr::Integer(-1)) && is_sum(&factors[1]) {
     &factors[1]
   } else if matches!(&factors[1], Expr::Integer(-1)) && is_sum(&factors[0]) {
     &factors[0]

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -1809,8 +1809,7 @@ pub fn together_expr(expr: &Expr) -> Expr {
         && exp.0 > 0
         && let Ok(e) = u32::try_from(exp.0)
         && let Some(p) = n.checked_pow(e)
-        && let Some(l) =
-          int_lcm.checked_mul(p / gcd_i128(int_lcm, p).abs())
+        && let Some(l) = int_lcm.checked_mul(p / gcd_i128(int_lcm, p).abs())
       {
         int_lcm = l;
         merged += 1;

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -373,9 +373,6 @@ fn reduce_shared_integer_content(
   num: &Expr,
   den: &Expr,
 ) -> Option<(Expr, Expr)> {
-  fn gcd(a: i128, b: i128) -> i128 {
-    if b == 0 { a.abs() } else { gcd(b, a % b) }
-  }
   let mut den_factors = flatten_times_args(std::slice::from_ref(den));
   let (den_idx, den_int) =
     den_factors.iter().enumerate().find_map(|(i, f)| match f {
@@ -391,7 +388,7 @@ fn reduce_shared_integer_content(
       _ => None,
     })
   {
-    let g = gcd(c.abs(), den_int);
+    let g = gcd_i128(c.abs(), den_int);
     if g <= 1 {
       return None;
     }
@@ -436,7 +433,7 @@ fn reduce_shared_integer_content(
   if d != 1 || n.abs() <= 1 {
     return None;
   }
-  let g = gcd(n.abs(), den_int);
+  let g = gcd_i128(n.abs(), den_int);
   if g <= 1 {
     return None;
   }
@@ -1620,7 +1617,7 @@ fn shares_cancelable_factor(num: &Expr, den: &Expr) -> bool {
   };
   let (num_content, num_bases) = side(num);
   let (den_content, den_bases) = side(den);
-  if super::factor::gcd_i128(num_content, den_content).abs() > 1 {
+  if gcd_i128(num_content, den_content).abs() > 1 {
     return true;
   }
   num_bases.iter().any(|b| den_bases.contains(b))
@@ -1813,7 +1810,7 @@ pub fn together_expr(expr: &Expr) -> Expr {
         && let Ok(e) = u32::try_from(exp.0)
         && let Some(p) = n.checked_pow(e)
         && let Some(l) =
-          int_lcm.checked_mul(p / super::factor::gcd_i128(int_lcm, p).abs())
+          int_lcm.checked_mul(p / gcd_i128(int_lcm, p).abs())
       {
         int_lcm = l;
         merged += 1;

--- a/src/functions/polynomial_ast/zassenhaus.rs
+++ b/src/functions/polynomial_ast/zassenhaus.rs
@@ -8,6 +8,7 @@
 
 use super::gf_factor::gf_factor_coeffs;
 use super::poly_div;
+use super::{deg, is_zero, trim};
 use crate::functions::math_ast::gcd as gcd_i128;
 
 const PRIMES: [i128; 15] =
@@ -19,20 +20,6 @@ const MAX_DEGREE: usize = 24;
 const MAX_LIFT_TARGET: i128 = 1 << 30;
 
 // ─── modular polynomial arithmetic (ascending trimmed vectors) ───────
-
-fn trim(v: &mut Vec<i128>) {
-  while v.len() > 1 && *v.last().unwrap() == 0 {
-    v.pop();
-  }
-}
-
-fn is_zero(v: &[i128]) -> bool {
-  v == [0]
-}
-
-fn deg(v: &[i128]) -> usize {
-  v.len() - 1
-}
 
 fn mod_inv(a: i128, m: i128) -> Option<i128> {
   let (mut old_r, mut r) = (a.rem_euclid(m), m);

--- a/src/functions/polynomial_ast/zassenhaus.rs
+++ b/src/functions/polynomial_ast/zassenhaus.rs
@@ -8,6 +8,7 @@
 
 use super::gf_factor::gf_factor_coeffs;
 use super::poly_div;
+use crate::functions::math_ast::gcd as gcd_i128;
 
 const PRIMES: [i128; 15] =
   [3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53];
@@ -180,14 +181,6 @@ fn symmetric(v: &[i128], m: i128) -> Vec<i128> {
     .collect();
   trim(&mut out);
   out
-}
-
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    (a, b) = (b, a % b);
-  }
-  a
 }
 
 /// Primitive part with positive leading coefficient; also returns the

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -7,10 +7,7 @@ use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
 
-/// Helper to create boolean result
-fn bool_expr(b: bool) -> Expr {
-  Expr::Identifier(if b { "True" } else { "False" }.to_string())
-}
+use crate::syntax::bool_expr;
 
 /// NumberQ[expr] - Tests if the expression is a number
 pub fn number_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -1432,9 +1429,7 @@ pub fn free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let form = &args[1];
   let form_str = crate::syntax::expr_to_string(form);
 
-  fn expr_str_eq(a: &Expr, b: &Expr) -> bool {
-    crate::syntax::expr_to_string(a) == crate::syntax::expr_to_string(b)
-  }
+  use crate::functions::calculus_ast::expr_str_eq;
 
   /// Check if `needles` args are a subset of `haystack` args (for Flat+Orderless ops)
   fn is_args_subset(haystack: &[Expr], needles: &[Expr]) -> bool {

--- a/src/functions/quantity_ast.rs
+++ b/src/functions/quantity_ast.rs
@@ -2715,23 +2715,7 @@ pub fn try_quantity_divide(
   }
 }
 
-/// Extract a rational number (p, q) from an expression.
-/// Integer(n) → (n, 1), Rational[p, q] → (p, q).
-fn expr_to_rational(expr: &Expr) -> Option<(i128, i128)> {
-  match expr {
-    Expr::Integer(n) => Some((*n, 1)),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(p), Expr::Integer(q)) = (&args[0], &args[1]) {
-        Some((*p, *q))
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
+use crate::functions::math_ast::expr_to_rational;
 
 /// Raise a unit expression to a rational power (p/q) by decomposing the unit
 /// into its base components, multiplying each exponent by p/q, and rebuilding.

--- a/src/functions/quantity_ast.rs
+++ b/src/functions/quantity_ast.rs
@@ -712,16 +712,7 @@ fn resolve_lowercase_unit(name: &str) -> Option<String> {
   None
 }
 
-fn gcd(mut a: i128, mut b: i128) -> i128 {
-  a = a.abs();
-  b = b.abs();
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
+use crate::functions::math_ast::gcd;
 
 // ─── Compound unit decomposition ────────────────────────────────────────────
 

--- a/src/functions/resolve_ast.rs
+++ b/src/functions/resolve_ast.rs
@@ -295,15 +295,7 @@ fn contains_imaginary(expr: &Expr) -> bool {
 //    complexes a non-constant polynomial always has zeros (and a non-empty
 //    complement), so those collapse without needing separability.
 
-fn gcd(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
+use crate::functions::math_ast::gcd;
 
 /// Extract a rational literal (`Integer` or `Rational[n, d]`) from a leaf.
 fn expr_to_rational(e: &Expr) -> Option<(i128, i128)> {

--- a/src/functions/timeline_plot.rs
+++ b/src/functions/timeline_plot.rs
@@ -4,7 +4,7 @@ use crate::functions::interval_ast::is_interval;
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{
   DEFAULT_HEIGHT, DEFAULT_WIDTH, PLOT_COLORS, RESOLUTION_SCALE,
-  format_date_tick, generate_date_ticks, parse_image_size,
+  format_date_tick, generate_date_ticks, html_escape, parse_image_size,
 };
 use crate::syntax::{Expr, unevaluated};
 
@@ -464,14 +464,6 @@ fn render_timeline_svg(
   }
 
   buf
-}
-
-/// Escape special HTML characters in text content.
-fn html_escape(s: &str) -> String {
-  s.replace('&', "&amp;")
-    .replace('<', "&lt;")
-    .replace('>', "&gt;")
-    .replace('"', "&quot;")
 }
 
 /// Theme colors: `(background, axis, label, event)`.

--- a/src/functions/timeseries_ast.rs
+++ b/src/functions/timeseries_ast.rs
@@ -9,23 +9,10 @@
 
 use crate::InterpreterError;
 use crate::functions::datetime_ast::{
-  date_to_absolute_seconds, day_of_week, days_in_month, extract_date_components,
+  date_to_absolute_seconds, day_of_week, days_in_month,
+  extract_date_components, weekday_index,
 };
 use crate::syntax::{Expr, unevaluated};
-
-/// Monday = 0 … Sunday = 6, matching `day_of_week`.
-fn weekday_index(name: &str) -> Option<i64> {
-  match name {
-    "Monday" => Some(0),
-    "Tuesday" => Some(1),
-    "Wednesday" => Some(2),
-    "Thursday" => Some(3),
-    "Friday" => Some(4),
-    "Saturday" => Some(5),
-    "Sunday" => Some(6),
-    _ => None,
-  }
-}
 
 fn as_f64(e: &Expr) -> Option<f64> {
   match e {

--- a/src/functions/wavelet_ast/filters.rs
+++ b/src/functions/wavelet_ast/filters.rs
@@ -129,14 +129,7 @@ impl Rat {
   }
 }
 
-fn gcd(mut a: u128, mut b: u128) -> u128 {
-  while b != 0 {
-    let t = a % b;
-    a = b;
-    b = t;
-  }
-  a
-}
+use crate::functions::math_ast::gcd_u128 as gcd;
 
 fn binomial(n: u64, k: u64) -> i128 {
   if k > n {

--- a/src/functions/ztransform_ast.rs
+++ b/src/functions/ztransform_ast.rs
@@ -390,15 +390,7 @@ fn as_power(expr: &Expr) -> Option<(Expr, Expr)> {
   }
 }
 
-fn gcd(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
+use crate::functions::math_ast::gcd;
 
 fn plus(terms: Vec<Expr>) -> Expr {
   Expr::FunctionCall {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1729,17 +1729,7 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
         match denom {
           Some(d) => {
             // Simplify the fraction
-            fn gcd(mut a: i128, mut b: i128) -> i128 {
-              a = a.abs();
-              b = b.abs();
-              while b != 0 {
-                let t = b;
-                b = a % b;
-                a = t;
-              }
-              a
-            }
-            let g = gcd(mantissa, d);
+            let g = crate::functions::math_ast::gcd(mantissa, d);
             let num = mantissa / g;
             let den = d / g;
             if den == 1 {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -14034,6 +14034,11 @@ pub fn replace_identifier_in_expr(
   }
 }
 
+/// Build the boolean symbol `True` or `False`.
+pub fn bool_expr(b: bool) -> Expr {
+  Expr::Identifier(if b { "True" } else { "False" }.to_string())
+}
+
 pub fn unevaluated(name: &str, args: &[Expr]) -> Expr {
   Expr::FunctionCall {
     name: name.to_string(),

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -130,11 +130,8 @@ extern "C" {
   fn report_panic(msg: &str) -> Result<(), JsValue>;
 }
 
-/// Download a URL and decode the image bytes (WASM).
-/// Returns the image as an Expr::Image.
-pub fn import_image_from_url_wasm(
-  url: &str,
-) -> Result<Expr, crate::InterpreterError> {
+/// Fetch a URL via the host-provided hook and base64-decode the response.
+fn fetch_url_bytes(url: &str) -> Result<Vec<u8>, crate::InterpreterError> {
   let b64 = woxi_fetch_url(url).map_err(|e| {
     crate::InterpreterError::EvaluationError(format!(
       "Import: failed to fetch \"{}\": {:?}",
@@ -147,14 +144,21 @@ pub fn import_image_from_url_wasm(
       url
     )));
   }
-  let bytes =
-    base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &b64)
-      .map_err(|e| {
-        crate::InterpreterError::EvaluationError(format!(
-          "Import: failed to decode fetched data: {}",
-          e
-        ))
-      })?;
+  base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &b64)
+    .map_err(|e| {
+      crate::InterpreterError::EvaluationError(format!(
+        "Import: failed to decode fetched data: {}",
+        e
+      ))
+    })
+}
+
+/// Download a URL and decode the image bytes (WASM).
+/// Returns the image as an Expr::Image.
+pub fn import_image_from_url_wasm(
+  url: &str,
+) -> Result<Expr, crate::InterpreterError> {
+  let bytes = fetch_url_bytes(url)?;
   crate::functions::image_ast::import_image_from_bytes(&bytes)
 }
 
@@ -163,26 +167,7 @@ pub fn csv_import_from_url_wasm(
   url: &str,
   element: Option<&str>,
 ) -> Result<Expr, crate::InterpreterError> {
-  let b64 = woxi_fetch_url(url).map_err(|e| {
-    crate::InterpreterError::EvaluationError(format!(
-      "Import: failed to fetch \"{}\": {:?}",
-      url, e
-    ))
-  })?;
-  if b64.is_empty() {
-    return Err(crate::InterpreterError::EvaluationError(format!(
-      "Import: empty response from \"{}\"",
-      url
-    )));
-  }
-  let bytes =
-    base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &b64)
-      .map_err(|e| {
-        crate::InterpreterError::EvaluationError(format!(
-          "Import: failed to decode fetched data: {}",
-          e
-        ))
-      })?;
+  let bytes = fetch_url_bytes(url)?;
   let content = String::from_utf8(bytes).map_err(|e| {
     crate::InterpreterError::EvaluationError(format!(
       "Import: downloaded CSV is not valid UTF-8: {}",

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -5342,10 +5342,7 @@ mod float_division_fold {
       .unwrap(),
       "0.17575669287388962"
     );
-    assert_eq!(
-      interpret("19.6/(63 + Pi)").unwrap(),
-      "0.296333958915279"
-    );
+    assert_eq!(interpret("19.6/(63 + Pi)").unwrap(), "0.296333958915279");
   }
 
   #[test]


### PR DESCRIPTION
## Summary
This PR refactors the codebase to eliminate duplicate utility function definitions by consolidating them into centralized modules. Functions like `gcd`, `lcm`, `expr_to_rational`, `contains_inexact_real`, and others are now defined once in `math_ast` or `numeric_utils` and re-exported where needed.

## Key Changes

- **Centralized GCD/LCM functions**: Moved `gcd_i128`, `gcd_u64`, `gcd_u128`, `lcm_i128`, and `gcd_bigint` to `math_ast` module with consistent signatures (using references where appropriate)
- **Utility function consolidation**: Moved `expr_to_rational`, `expr_to_i128`, `is_concrete_number`, `contains_inexact_real`, and `expr_contains_real` to `numeric_utils` module
- **Helper expression builders**: Consolidated `mk_call`, `mk_int`, `mk_ratio`, `mk_times`, `mk_power` in `polynomial_ast/helpers.rs` and re-exported from `polynomial_ast/function_expand.rs` and `polynomial_ast/to_radicals.rs`
- **Plot utilities**: Moved `parse_iterator` and `evaluate_at_xy` to `plot.rs` module for shared use across field_plot, parametric_plot, and plot3d
- **Predicate helpers**: Moved `bool_expr` to `syntax.rs` for use across multiple modules
- **Format utilities**: Moved `format_bigfloat_value` to `numeric_utils` and `svg_header`, `html_escape` to `plot.rs`
- **Primality testing**: Added `is_prime_i128` function to `number_theory.rs` for i128 values using Miller-Rabin via BigInt
- **WASM utilities**: Refactored `import_image_from_url_wasm` to extract `fetch_url_bytes` helper
- **CSV utilities**: Refactored `csv_import_file` to extract `read_csv_file` helper

## Implementation Details

- Updated all call sites to use the centralized functions with proper imports
- Adjusted function signatures for consistency (e.g., `gcd_bigint` now takes references)
- Maintained backward compatibility by re-exporting functions where they were previously defined
- Removed ~40+ duplicate function definitions across the codebase

https://claude.ai/code/session_01QTVNrpCcTvok5bXhbNJg6g