### PR TITLE
Remove more duplicate gcd functions

### DIFF
--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -5373,18 +5373,12 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
       // Total coefficient: coeff_num / (freq * 4^m)
       let denom = freq * (1i128 << (2 * m)); // freq * 4^m
       let term = if matches!(&coeff, Expr::Integer(1)) {
-        let g = gcd_i64(
-          coeff_num.unsigned_abs() as i128,
-          denom.unsigned_abs() as i128,
-        );
+        let g = gcd_i128(coeff_num, denom);
         let num = coeff_num / g;
         let den = denom / g;
         make_fraction_term(num, den, integrated_trig)
       } else {
-        let g = gcd_i64(
-          coeff_num.unsigned_abs() as i128,
-          denom.unsigned_abs() as i128,
-        );
+        let g = gcd_i128(coeff_num, denom);
         let num = coeff_num / g;
         let den = denom / g;
         let den_expr = simplify(Expr::BinaryOp {
@@ -5401,7 +5395,7 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
     // Constant term: C(n,m) / 4^m * x
     let binom_mid = crate::functions::binomial_coeff(n, m);
     let power_4m = 1i128 << (2 * m); // 4^m
-    let g = gcd_i64(binom_mid, power_4m);
+    let g = gcd_i128(binom_mid, power_4m);
     let const_num = binom_mid / g;
     let const_den = power_4m / g;
     let const_term = if const_den == 1 {
@@ -5482,18 +5476,12 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
 
       let denom = freq * power_4m;
       let term = if matches!(&coeff, Expr::Integer(1)) {
-        let g = gcd_i64(
-          coeff_num.unsigned_abs() as i128,
-          denom.unsigned_abs() as i128,
-        );
+        let g = gcd_i128(coeff_num, denom);
         let num = coeff_num / g;
         let den = denom / g;
         make_fraction_term(num, den, integrated_trig)
       } else {
-        let g = gcd_i64(
-          coeff_num.unsigned_abs() as i128,
-          denom.unsigned_abs() as i128,
-        );
+        let g = gcd_i128(coeff_num, denom);
         let num = coeff_num / g;
         let den = denom / g;
         let den_expr = simplify(Expr::BinaryOp {
@@ -5597,15 +5585,6 @@ fn make_fraction_term_expr(num: i128, den_expr: Expr, expr: Expr) -> Expr {
     left: Box::new(num_expr),
     right: Box::new(den_expr),
   }
-}
-
-fn gcd_i64(mut a: i128, mut b: i128) -> i128 {
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a.abs()
 }
 
 /// Try to match ∫ E^(a*x) / (c*x) dx = ExpIntegralEi[a*x] / c
@@ -6713,7 +6692,7 @@ fn build_arctan_term(
 
   let term = if let Expr::Integer(s) = sqrt_expr {
     // sqrt is an integer - can simplify
-    let g = gcd_i128_local(abs_coeff, *s);
+    let g = gcd_i128(abs_coeff, *s);
     let reduced_num = abs_coeff / g;
     let reduced_den = *s / g;
 
@@ -6811,17 +6790,6 @@ fn build_coeff_times_expr(num: i128, den: i128, expr: Expr) -> Expr {
   } else {
     unsigned_term
   }
-}
-
-/// Local gcd helper (avoids import issues)
-fn gcd_i128_local(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
 }
 
 /// LIATE priority for integration by parts: higher = choose as u first

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -12,6 +12,7 @@
 //! (1, -1, I, -I, or E^((a*I)/b*Pi) forms on the principal branch).
 
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd_bigint;
 use crate::syntax::Expr;
 use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
 
@@ -362,6 +363,7 @@ fn total_rotation(factors: &[Factor], exps: &[i128], a: i128) -> (i128, i128) {
 /// with higher-order values stay unevaluated.
 pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   use num_bigint::BigInt;
+  use num_traits::Zero;
   let unevaluated = |args: &[Expr]| unevaluated("DirichletL", args);
   if args.len() != 3 {
     return Ok(unevaluated(args));
@@ -501,27 +503,11 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Fraction helpers over BigInt
   type Frac = (BigInt, BigInt);
-  let gcd_bigint = |a: &BigInt, b: &BigInt| -> BigInt {
-    let (mut a, mut b) = (a.clone(), b.clone());
-    if a < BigInt::from(0) {
-      a = -a;
-    }
-    if b < BigInt::from(0) {
-      b = -b;
-    }
-    while b != BigInt::from(0) {
-      let r = &a % &b;
-      a = b;
-      b = r;
-    }
-    if a == BigInt::from(0) {
-      BigInt::from(1)
-    } else {
-      a
-    }
-  };
   let reduce = |num: BigInt, den: BigInt| -> Frac {
-    let g = gcd_bigint(&num, &den);
+    let mut g = gcd_bigint(&num, &den);
+    if g.is_zero() {
+      g = BigInt::from(1);
+    }
     let (mut n, mut d) = (num / &g, den / g);
     if d < BigInt::from(0) {
       n = -n;

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -1,11 +1,12 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
 };
 use num_bigint::BigInt;
-use num_traits::Signed;
+use num_traits::{Signed, Zero};
 
 /// DigitCount[n] - counts of each digit 1-9,0 in base 10
 /// DigitCount[n, b] - counts of each digit in base b
@@ -34,7 +35,6 @@ pub fn digit_count_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   // Get digit list in the given base
-  use num_traits::Zero;
   let big_base = BigInt::from(base);
   let mut digits = Vec::new();
   let mut val = n;
@@ -112,7 +112,6 @@ pub fn digit_sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       base_vals.push(BigInt::from(bi));
     }
-    use num_traits::Zero;
     let mut sum = BigInt::from(0);
     let mut val = n;
     // Right-to-left: rightmost digit uses last base, etc.
@@ -138,8 +137,6 @@ pub fn digit_sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     10
   };
-
-  use num_traits::Zero;
   let big_base = BigInt::from(base);
   let mut sum = BigInt::from(0);
   let mut val = n;
@@ -1187,8 +1184,6 @@ pub fn continued_fraction_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(unevaluated("ContinuedFraction", args))
 }
 
-use crate::functions::math_ast::gcd as gcd_i128;
-
 /// Exact rational with i128 numerator/denominator, kept reduced with a
 /// positive denominator. Used to evaluate a periodic continued fraction in
 /// the field Q(sqrt(disc)).
@@ -1669,9 +1664,6 @@ pub fn integer_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     BigInt::from(10)
   };
-
-  use num_traits::Zero;
-
   let mut digits = Vec::new();
   if n.is_zero() {
     digits.push(Expr::Integer(0));
@@ -2722,7 +2714,6 @@ pub fn integer_length_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Try BigInt path first (handles both Integer and BigInteger)
   if let Some(n) = expr_to_bigint(&args[0]) {
-    use num_traits::Zero;
     if n.is_zero() {
       return Ok(Expr::Integer(0));
     }
@@ -2786,7 +2777,6 @@ pub fn integer_reverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Handle BigInteger
   if let Some(n) = expr_to_bigint(&args[0]) {
-    use num_traits::Zero;
     let mut abs_n = if n < BigInt::zero() { -n } else { n };
     let base_big = BigInt::from(base);
     let mut result = BigInt::zero();
@@ -3483,7 +3473,7 @@ fn make_rational_expr(num: i128, den: i128) -> Expr {
   } else if den == -1 {
     Expr::Integer(-num)
   } else {
-    let g = gcd_convergents(num.abs(), den.abs());
+    let g = gcd(num, den);
     let (n, d) = (num / g, den / g);
     if d < 0 {
       if -d == 1 {
@@ -3505,10 +3495,6 @@ fn make_rational_expr(num: i128, den: i128) -> Expr {
       }
     }
   }
-}
-
-fn gcd_convergents(a: i128, b: i128) -> i128 {
-  if b == 0 { a } else { gcd_convergents(b, a % b) }
 }
 
 /// NumberDigit[x, n] — returns the digit at position n of a real number x.
@@ -3939,13 +3925,8 @@ pub fn number_decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
     }
   } else {
-    let gcd_i128 = |mut a: i128, mut b: i128| -> i128 {
-      a = a.abs();
-      b = b.abs();
-      while b != 0 {
-        (a, b) = (b, a % b);
-      }
-      a.max(1)
+    let gcd_i128 = |a: i128, b: i128| -> i128 {
+      crate::functions::math_ast::gcd(a, b).max(1)
     };
     let (mut rn, mut rd) = match value {
       Num::Exact(p, q) => (p, q),
@@ -4147,23 +4128,8 @@ pub fn minkowski_question_mark_ast(
 
   // Exact fraction arithmetic over BigInt
   let gcd_bigint = |a: &BigInt, b: &BigInt| -> BigInt {
-    let (mut a, mut b) = (a.clone(), b.clone());
-    if a < BigInt::from(0) {
-      a = -a;
-    }
-    if b < BigInt::from(0) {
-      b = -b;
-    }
-    while b != BigInt::from(0) {
-      let r = &a % &b;
-      a = b;
-      b = r;
-    }
-    if a == BigInt::from(0) {
-      BigInt::from(1)
-    } else {
-      a
-    }
+    let g = crate::functions::math_ast::gcd_bigint(a, b);
+    if g.is_zero() { BigInt::from(1) } else { g }
   };
   let reduce = |num: BigInt, den: BigInt| -> (BigInt, BigInt) {
     let g = gcd_bigint(&num, &den);

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -453,11 +453,6 @@ pub fn make_rational_expr(num: BigInt, den: BigInt) -> Expr {
   }
 }
 
-/// Helper function to compute GCD
-pub fn gcd_helper(a: i128, b: i128) -> i128 {
-  if b == 0 { a } else { gcd_helper(b, a % b) }
-}
-
 /// Split-recursive factorial helper based on Fateman's `kg` algorithm.
 /// k(n, m) computes n * (n-m) * (n-2m) * … (down to a value ≤ m).
 /// When n is even and m > 1, factors of 2 are extracted and deferred

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -703,9 +703,7 @@ pub fn gcd(a: i128, b: i128) -> i128 {
   // handled correctly, e.g. gcd(-2^127, 1).
   let (mut a, mut b) = (a.unsigned_abs(), b.unsigned_abs());
   while b != 0 {
-    let temp = b;
-    b = a % b;
-    a = temp;
+    (a, b) = (b, a % b);
   }
   a as i128
 }
@@ -713,9 +711,7 @@ pub fn gcd(a: i128, b: i128) -> i128 {
 /// Compute GCD of two u64 values using Euclidean algorithm
 pub fn gcd_u64(mut a: u64, mut b: u64) -> u64 {
   while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
+    (a, b) = (b, a % b);
   }
   a
 }
@@ -723,9 +719,7 @@ pub fn gcd_u64(mut a: u64, mut b: u64) -> u64 {
 /// Compute GCD of two unsigned integers using Euclidean algorithm
 pub fn gcd_u128(mut a: u128, mut b: u128) -> u128 {
   while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
+    (a, b) = (b, a % b);
   }
   a
 }
@@ -741,12 +735,10 @@ pub fn lcm_i128(a: i128, b: i128) -> i128 {
 /// Compute the (non-negative) GCD of two BigInts.
 pub fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
   use num_traits::{Signed, Zero};
-  let mut a = a.abs();
-  let mut b = b.abs();
+  let (mut a, mut b) = (a.abs(), b.abs());
   while !b.is_zero() {
-    let t = b.clone();
-    b = &a % &b;
-    a = t;
+    let r = &a % &b;
+    (a, b) = (b, r);
   }
   a
 }

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 use num_bigint::BigInt;
 
@@ -1240,14 +1241,14 @@ fn simplify_spherical_harmonic_form(expr: &Expr) -> Expr {
     };
     let mut comb_n = comb_n_pre.abs();
     let mut comb_d = comb_d_pre.abs();
-    let g = gcd_i128_local(comb_n, comb_d);
+    let g = gcd_i128(comb_n, comb_d);
     if g > 1 {
       comb_n /= g;
       comb_d /= g;
     }
     let (extract_n, residual_n) = extract_largest_square(comb_n);
     let (extract_d, residual_d) = extract_largest_square(comb_d);
-    let g2 = gcd_i128_local(extract_n, extract_d);
+    let g2 = gcd_i128(extract_n, extract_d);
     let coeff_n_abs = extract_n / g2;
     let coeff_d = extract_d / g2;
     let sign: i128 = if (ra_n.signum() * ra_d.signum()) < 0 {
@@ -1420,17 +1421,6 @@ fn simplify_spherical_harmonic_form(expr: &Expr) -> Expr {
   }
 }
 
-fn gcd_i128_local(mut a: i128, mut b: i128) -> i128 {
-  a = a.abs();
-  b = b.abs();
-  while b != 0 {
-    let t = a % b;
-    a = b;
-    b = t;
-  }
-  a
-}
-
 fn extract_largest_square(n: i128) -> (i128, i128) {
   if n <= 0 {
     return (1, n);
@@ -1557,7 +1547,7 @@ fn legendre_coefficients(n: usize) -> Option<Vec<(i128, i128)>> {
       let (nn, nd) = next[k + 1];
       let new_n = nn.checked_mul(cd)?.checked_add(term_n.checked_mul(nd)?)?;
       let new_d = nd.checked_mul(cd)?;
-      let g = gcd(new_n.abs(), new_d.abs());
+      let g = gcd_i128(new_n, new_d).max(1);
       next[k + 1] = (new_n / g, new_d / g);
     }
 
@@ -1570,7 +1560,7 @@ fn legendre_coefficients(n: usize) -> Option<Vec<(i128, i128)>> {
       let (nn, nd) = next[k];
       let new_n = nn.checked_mul(cd)?.checked_add(term_n.checked_mul(nd)?)?;
       let new_d = nd.checked_mul(cd)?;
-      let g = gcd(new_n.abs(), new_d.abs());
+      let g = gcd_i128(new_n, new_d).max(1);
       next[k] = (new_n / g, new_d / g);
     }
 
@@ -1580,7 +1570,7 @@ fn legendre_coefficients(n: usize) -> Option<Vec<(i128, i128)>> {
         continue;
       }
       let new_d = coeff.1.checked_mul(m_i + 1)?;
-      let g = gcd(coeff.0.abs(), new_d.abs());
+      let g = gcd_i128(coeff.0, new_d).max(1);
       *coeff = (coeff.0 / g, new_d / g);
     }
 
@@ -2778,12 +2768,6 @@ pub fn gegenbauer_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// the result matches wolframscript's factored form.
 fn gegenbauer_symbolic_lambda(n: usize, lambda: &Expr, x: &Expr) -> Expr {
   let fact = |m: usize| (1..=m).map(|v| v as i128).product::<i128>().max(1);
-  let gcd = |mut a: i128, mut b: i128| {
-    while b != 0 {
-      (a, b) = (b, a % b);
-    }
-    a.abs().max(1)
-  };
   let mut terms: Vec<Expr> = Vec::new();
   for k in 0..=(n / 2) {
     let power = n - 2 * k; // exponent of x
@@ -2792,7 +2776,7 @@ fn gegenbauer_symbolic_lambda(n: usize, lambda: &Expr, x: &Expr) -> Expr {
     let mut num: i128 = if k % 2 == 0 { 1 } else { -1 };
     num *= 1i128 << power;
     let den = fact(k) * fact(power);
-    let g = gcd(num, den);
+    let g = gcd_i128(num, den).max(1);
     let (num, den) = (num / g, den / g);
 
     let mut factors: Vec<Expr> = Vec::new();
@@ -3145,14 +3129,14 @@ fn gegenbauer_coefficients(
   if n == 1 {
     // 2λx: coefficient of x^1 is 2λ = 2*lam_n/lam_d
     let cn = 2i128.checked_mul(lam.0)?;
-    let g = gcd(cn.abs(), lam.1.abs());
+    let g = gcd_i128(cn, lam.1).max(1);
     return Some(vec![(0, 1), (cn / g, lam.1 / g)]);
   }
 
   // Store coefficients as (numerator, denominator) vectors
   let mut prev: Vec<(i128, i128)> = vec![(1, 1)]; // C_0
   let cn = 2i128.checked_mul(lam.0)?;
-  let g = gcd(cn.abs(), lam.1.abs());
+  let g = gcd_i128(cn, lam.1).max(1);
   let mut curr: Vec<(i128, i128)> = vec![(0, 1), (cn / g, lam.1 / g)]; // C_1
 
   for k in 1..n {
@@ -3175,8 +3159,8 @@ fn gegenbauer_coefficients(
       // a_n/a_d * cn/cd = a_n*cn / (a_d*cd)
       let nn = a_n.checked_mul(*cn)?;
       let nd = a_d.checked_mul(*cd)?;
-      let g = gcd(nn.abs(), nd.abs());
-      next[j + 1] = if g > 0 { (nn / g, nd / g) } else { (nn, nd) };
+      let g = gcd_i128(nn, nd).max(1);
+      next[j + 1] = (nn / g, nd / g);
     }
 
     // Subtract b * prev
@@ -3191,20 +3175,16 @@ fn gegenbauer_coefficients(
         .checked_mul(sub_d)?
         .checked_sub(sub_n.checked_mul(*nd)?)?;
       let res_d = nd.checked_mul(sub_d)?;
-      let g = gcd(res_n.abs(), res_d.abs());
-      next[j] = if g > 0 {
-        (res_n / g, res_d / g)
-      } else {
-        (res_n, res_d)
-      };
+      let g = gcd_i128(res_n, res_d).max(1);
+      next[j] = (res_n / g, res_d / g);
     }
 
     // Divide by (k+1)
     let div = kk + 1;
     for (cn, cd) in next.iter_mut() {
       *cd = cd.checked_mul(div)?;
-      let g = gcd(cn.abs(), cd.abs());
-      if g > 0 {
+      let g = gcd_i128(*cn, *cd).max(1);
+      if g > 1 {
         *cn /= g;
         *cd /= g;
       }
@@ -3322,11 +3302,8 @@ fn generalized_laguerre_l_ast(
       binom_den *= i;
     }
     // Simplify
-    let g = gcd(
-      binom_num.unsigned_abs() as i128,
-      binom_den.unsigned_abs() as i128,
-    );
-    if g > 0 {
+    let g = gcd_i128(binom_num, binom_den).max(1);
+    if g > 1 {
       binom_num /= g;
       binom_den /= g;
     }
@@ -3350,11 +3327,8 @@ fn generalized_laguerre_l_ast(
       let nf = n as i128;
       cur_binom_n *= nf - kf + 1;
       cur_binom_d *= a + kf;
-      let g2 = gcd(
-        cur_binom_n.unsigned_abs() as i128,
-        cur_binom_d.unsigned_abs() as i128,
-      );
-      if g2 > 0 {
+      let g2 = gcd_i128(cur_binom_n, cur_binom_d).max(1);
+      if g2 > 1 {
         cur_binom_n /= g2;
         cur_binom_d /= g2;
       }
@@ -3367,8 +3341,8 @@ fn generalized_laguerre_l_ast(
       let sign = if k % 2 == 0 { 1i128 } else { -1i128 };
       let cn = sign * cur_binom_n;
       let cd = cur_binom_d * factorial_k;
-      let g3 = gcd(cn.unsigned_abs() as i128, cd.unsigned_abs() as i128);
-      let (cn, cd) = if g3 > 0 { (cn / g3, cd / g3) } else { (cn, cd) };
+      let g3 = gcd_i128(cn, cd).max(1);
+      let (cn, cd) = (cn / g3, cd / g3);
       let (cn, cd) = if cd < 0 { (-cn, -cd) } else { (cn, cd) };
       coeffs.push((cn, cd));
     }
@@ -3384,7 +3358,7 @@ fn generalized_laguerre_l_ast(
       .filter(|(n, _)| *n != 0)
       .map(|(_, d)| *d)
       .fold(1i128, |acc, d| {
-        let g = gcd(acc.unsigned_abs() as i128, d.unsigned_abs() as i128);
+        let g = gcd_i128(acc, d);
         if g == 0 { acc * d } else { acc / g * d }
       });
 
@@ -4007,8 +3981,8 @@ fn rewrite_sqrt_one_minus_cos_sq(expr: &Expr, theta: &Expr) -> Expr {
         if let (Expr::Integer(a), Expr::Integer(b)) = (&args[0], &args[1]) {
           let mut num = 2 * a;
           let mut den = *b;
-          let g = gcd_i128_local(num, den);
-          if g != 0 {
+          let g = gcd_i128(num, den);
+          if g > 1 {
             num /= g;
             den /= g;
           }
@@ -4238,14 +4212,8 @@ fn zernike_eval_rational(coeffs: &[(i128, i128)], x: (i128, i128)) -> Expr {
         break;
       }
     };
-    let g = gcd(new_n.abs(), new_d.abs());
-    if g > 0 {
-      acc_n = new_n / g;
-      acc_d = new_d / g;
-    } else {
-      acc_n = new_n;
-      acc_d = new_d;
-    }
+    let g = gcd_i128(new_n, new_d).max(1);
+    (acc_n, acc_d) = (new_n / g, new_d / g);
   }
   if overflow {
     // Fall back to floating point if exact arithmetic overflows.

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, ExprForm, UnaryOperator, expr_to_output,
   expr_to_string, format_expr, unevaluated,
@@ -557,7 +558,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Ok(Expr::Integer(sum / count))
         } else {
           // Return as Rational
-          let g = gcd_helper(sum.abs(), count);
+          let g = gcd(sum.abs(), count);
           let num = sum / g;
           let denom = count / g;
           Ok(Expr::FunctionCall {

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// Try to express a symbolic expression as a rational multiple of Pi: k*Pi/n.
@@ -43,7 +44,7 @@ fn try_symbolic_pi_fraction(expr: &Expr) -> Option<(i64, i64)> {
     if k == 0 {
       return (0, 1);
     }
-    let g = gcd(k.unsigned_abs() as i128, n.unsigned_abs() as i128) as i64;
+    let g = gcd_i128(k as i128, n as i128) as i64;
     let (k, n) = (k / g, n / g);
     if n < 0 { (-k, -n) } else { (k, n) }
   }
@@ -300,7 +301,7 @@ fn extract_pi_phase(arg: &Expr) -> Option<(i64, bool, (i64, i64), Vec<Expr>)> {
       Some((a, b)) if a != 0 => {
         pn = pn.checked_mul(b)?.checked_add(a.checked_mul(pd)?)?;
         pd = pd.checked_mul(b)?;
-        let g = gcd(pn.unsigned_abs().max(1) as i128, pd as i128) as i64;
+        let g = gcd_i128(pn as i128, pd as i128).max(1) as i64;
         pn /= g;
         pd /= g;
       }
@@ -358,7 +359,7 @@ fn extract_pi_phase(arg: &Expr) -> Option<(i64, bool, (i64, i64), Vec<Expr>)> {
   let mut rpn = 2 * pn - k * pd;
   let mut rpd = 2 * pd;
   if rpn != 0 {
-    let g = gcd(rpn.unsigned_abs() as i128, rpd as i128) as i64;
+    let g = gcd_i128(rpn as i128, rpd as i128) as i64;
     rpn /= g;
     rpd /= g;
   }
@@ -467,7 +468,7 @@ fn octant_fallback(
     // Reference angle exceeds Pi/4 → co-function of the complement.
     let cm = nr - 2 * kr;
     let cd = 2 * nr;
-    let g = gcd(cm as i128, cd as i128) as i64;
+    let g = gcd_i128(cm as i128, cd as i128) as i64;
     build_trig_angle_call(cofunc_head, cm / g, cd / g)
   } else {
     build_trig_angle_call(self_head, kr, nr)
@@ -508,7 +509,7 @@ fn exact_sin(k: i64, n: i64) -> Option<Expr> {
   };
 
   // Reduce k_ref/n to lowest terms for table lookup
-  let g = gcd(k_ref as i128, n as i128) as i64;
+  let g = gcd_i128(k_ref as i128, n as i128) as i64;
   let (kr, nr) = (k_ref / g, n / g);
   // Now compute sin(kr * Pi / nr) for first quadrant reference angle
   let val = match (kr, nr) {
@@ -600,7 +601,7 @@ fn exact_cos(k: i64, n: i64) -> Option<Expr> {
   };
 
   // Reduce k_ref/n to lowest terms for table lookup
-  let g = gcd(k_ref as i128, n as i128) as i64;
+  let g = gcd_i128(k_ref as i128, n as i128) as i64;
   let (kr, nr) = (k_ref / g, n / g);
   let val = match (kr, nr) {
     (0, _) => Expr::Integer(1),
@@ -691,7 +692,7 @@ fn exact_tan(k: i64, n: i64) -> Option<Expr> {
     (n - k_mod, n, -1)
   };
   // Reduce fraction k_ref/n_ref
-  let g = gcd(k_ref as i128, n_ref as i128) as i64;
+  let g = gcd_i128(k_ref as i128, n_ref as i128) as i64;
   let (kr, nr) = (k_ref / g, n_ref / g);
 
   let val = match (kr, nr) {
@@ -758,7 +759,7 @@ fn exact_sec(k: i64, n: i64) -> Option<Expr> {
   if k_ref * 2 == n {
     return Some(Expr::Identifier("ComplexInfinity".to_string()));
   }
-  let g = gcd(k_ref as i128, n as i128) as i64;
+  let g = gcd_i128(k_ref as i128, n as i128) as i64;
   let (kr, nr) = (k_ref / g, n / g);
 
   let val = match (kr, nr) {
@@ -814,7 +815,7 @@ fn exact_csc(k: i64, n: i64) -> Option<Expr> {
   // In (0, Pi): Csc(Pi - x) = Csc(x), so reduce to (0, Pi/2]
   let k_ref = if k2 * 2 > n { n - k2 } else { k2 };
 
-  let g = gcd(k_ref as i128, n as i128) as i64;
+  let g = gcd_i128(k_ref as i128, n as i128) as i64;
   let (kr, nr) = (k_ref / g, n / g);
 
   let val = match (kr, nr) {
@@ -873,7 +874,7 @@ fn exact_cot(k: i64, n: i64) -> Option<Expr> {
     (k_mod, 1)
   };
 
-  let g = gcd(k_ref as i128, n as i128) as i64;
+  let g = gcd_i128(k_ref as i128, n as i128) as i64;
   let (kr, nr) = (k_ref / g, n / g);
 
   let val = match (kr, nr) {
@@ -6078,7 +6079,7 @@ fn reduce_trig_power(base: &Expr, n: i128) -> Option<Expr> {
   // Compute GCD of all numerator coefficients and denom to simplify the fraction
   let mut g = denom;
   for (c, _) in &num_terms {
-    g = gcd(g, *c);
+    g = gcd_i128(g, *c);
   }
   let reduced_denom = denom / g;
 

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -4,7 +4,7 @@
 //! NDSolve solves initial-value problems numerically using RK4.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::{gcd as gcd_i128, gcd_u128, make_sqrt};
+use crate::functions::math_ast::{gcd as gcd_i128, make_sqrt};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -1392,7 +1392,7 @@ fn f64_to_nice_expr(f: f64) -> Expr {
     if (numer - numer.round()).abs() < 1e-10 {
       let n = numer.round() as i128;
       let d = denom as i128;
-      let g = gcd_u128(n.unsigned_abs(), d as u128) as i128;
+      let g = gcd_i128(n, d);
       let nn = n / g;
       let dd = d / g;
       if dd == 1 {

--- a/src/functions/polynomial_ast/exponent.rs
+++ b/src/functions/polynomial_ast/exponent.rs
@@ -4,6 +4,7 @@ use crate::InterpreterError;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 use crate::functions::calculus_ast::is_constant_wrt;
+use crate::functions::math_ast::gcd as gcd_i128;
 
 // ─── Rational exponent helpers ─────────────────────────────────────
 
@@ -17,7 +18,7 @@ pub struct Rat {
 impl Rat {
   fn new(n: i128, d: i128) -> Self {
     assert!(d != 0);
-    let g = gcd(n.unsigned_abs(), d.unsigned_abs()) as i128;
+    let g = gcd_i128(n, d);
     let (n2, d2) = (n / g, d / g);
     // Keep denominator positive
     if d2 < 0 {
@@ -72,8 +73,6 @@ impl Rat {
     }
   }
 }
-
-use crate::functions::math_ast::gcd_u128 as gcd;
 
 /// Try to interpret an Expr as a rational number.
 fn expr_to_rat(e: &Expr) -> Option<Rat> {

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::functions::math_ast::{expr_to_f64, expr_to_i128, is_sqrt};
+use crate::functions::math_ast::{
+  expr_to_f64, expr_to_i128, gcd as gcd_i128, is_sqrt,
+};
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// MinimalPolynomial[α, x] - Computes the minimal polynomial of an algebraic number α
@@ -777,7 +779,7 @@ fn poly_sub_i128(a: &[i128], b: &[i128]) -> Vec<i128> {
 type Rat = (i128, i128);
 
 fn rat_norm(n: i128, d: i128) -> Rat {
-  let g = gcd_abs(n, d).max(1);
+  let g = gcd_i128(n, d).max(1);
   let s = if d < 0 { -1 } else { 1 };
   (s * n / g, d.abs() / g)
 }
@@ -817,7 +819,7 @@ fn rad_unify(a: &RadPoly, b: &RadPoly) -> Option<(Option<i128>, usize)> {
     (Some(x), _) => Some(x),
     (_, y) => y,
   };
-  let g = gcd_abs(a.q as i128, b.q as i128) as usize;
+  let g = gcd_i128(a.q as i128, b.q as i128) as usize;
   let l = a.q / g * b.q;
   if l > RAD_MAX_DEGREE {
     return None;
@@ -908,7 +910,7 @@ fn perfect_power_root(b: i128) -> Option<(i128, i128)> {
   }
   let mut g = 0i128;
   for &(_, e) in &factors {
-    g = gcd_abs(g, e);
+    g = gcd_i128(g, e);
   }
   let mut m = 1i128;
   for &(p, e) in &factors {
@@ -927,7 +929,7 @@ fn rad_radical(b: i128, p: i128, q: i128) -> Option<RadPoly> {
   }
   let (m, k) = perfect_power_root(b)?;
   let num = k.checked_mul(p)?;
-  let g = gcd_abs(num, q).max(1);
+  let g = gcd_i128(num, q).max(1);
   let (num, den) = (num / g, q / g);
   if num > 64 {
     return None;
@@ -1150,7 +1152,7 @@ fn single_radical_minpoly(
   }
   let mut den_lcm = 1i128;
   for &(_, d) in &rats {
-    den_lcm = den_lcm / gcd_abs(den_lcm, d).max(1) * d;
+    den_lcm = den_lcm / gcd_i128(den_lcm, d).max(1) * d;
   }
   let ints: Vec<i128> = rats.iter().map(|&(n, d)| n * (den_lcm / d)).collect();
   Ok(Some(make_square_free(&make_primitive_monic(&ints))))
@@ -1188,7 +1190,7 @@ fn make_primitive_monic(coeffs: &[i128]) -> Vec<i128> {
     .iter()
     .copied()
     .filter(|&c| c != 0)
-    .fold(0i128, gcd_abs);
+    .fold(0i128, gcd_i128);
   if g > 1 {
     for c in &mut result {
       *c /= g;
@@ -1400,17 +1402,6 @@ fn collect_times_factors(expr: &Expr) -> Vec<Expr> {
     Expr::FunctionCall { name, args } if name == "Times" => args.to_vec(),
     _ => vec![expr.clone()],
   }
-}
-
-/// GCD of absolute values
-fn gcd_abs(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
 }
 
 /// Small divisors of a positive integer (for root-finding)

--- a/src/functions/polynomial_ast/to_radicals.rs
+++ b/src/functions/polynomial_ast/to_radicals.rs
@@ -1,5 +1,6 @@
 use super::{mk_call, mk_int, mk_power, mk_ratio, mk_times};
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{BinaryOperator, Expr};
 
 /// ToRadicals[expr] — convert Root objects to explicit radical expressions.
@@ -541,17 +542,8 @@ fn simplify_fraction(mut n: i128, mut d: i128) -> (i128, i128) {
     n = -n;
     d = -d;
   }
-  let g = gcd_abs(n.unsigned_abs(), d.unsigned_abs()) as i128;
+  let g = gcd_i128(n, d);
   (n / g, d / g)
-}
-
-fn gcd_abs(mut a: u128, mut b: u128) -> u128 {
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
 }
 
 /// Solve quartic using Ferrari's method.

--- a/src/functions/rsolve_ast.rs
+++ b/src/functions/rsolve_ast.rs
@@ -1,4 +1,5 @@
 use crate::InterpreterError;
+use crate::functions::math_ast::{gcd as gcd_i128, lcm_i128};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -1192,7 +1193,7 @@ fn solve_initial_conditions(
         let rhs_n = fn_ * pd * bn * ad;
         let new_n = lhs_n - rhs_n;
         let new_d = lhs_d;
-        let g = gcd_abs(new_n.abs(), new_d.abs());
+        let g = gcd_i128(new_n, new_d);
         aug[row][j] = if g == 0 {
           (0, 1)
         } else {
@@ -1221,7 +1222,7 @@ fn solve_initial_conditions(
       // sn/sd - sub_n/sub_d
       sn = sn * sub_d - sub_n * sd;
       sd *= sub_d;
-      let g = gcd_abs(sn.abs(), sd.abs());
+      let g = gcd_i128(sn, sd);
       if g != 0 {
         sn /= g;
         sd /= g;
@@ -1235,7 +1236,7 @@ fn solve_initial_conditions(
     let (pn, pd) = aug[i][i];
     sn *= pd;
     sd *= pn;
-    let g = gcd_abs(sn.abs(), sd.abs());
+    let g = gcd_i128(sn, sd);
     if g != 0 {
       sn /= g;
       sd /= g;
@@ -1250,16 +1251,6 @@ fn solve_initial_conditions(
   Some(solution)
 }
 
-fn gcd_abs(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a, b);
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
-
 /// Build the solution expression: (c1_num*r1^n + c2_num*r2^n + ...) / common_denom
 fn build_solution(
   constants: &[(i128, i128)],
@@ -1269,7 +1260,7 @@ fn build_solution(
   // Find common denominator for all constants
   let mut common_denom = 1i128;
   for &(_, cd) in constants {
-    common_denom = lcm(common_denom, cd);
+    common_denom = lcm_i128(common_denom, cd);
   }
 
   // Build terms with integer numerators: (cn * common_denom/cd) * r^n
@@ -1362,14 +1353,6 @@ fn build_solution(
       left: Box::new(numerator),
       right: Box::new(Expr::Integer(common_denom)),
     })
-  }
-}
-
-fn lcm(a: i128, b: i128) -> i128 {
-  if a == 0 || b == 0 {
-    0
-  } else {
-    (a / gcd_abs(a.abs(), b.abs())) * b.abs()
   }
 }
 

--- a/src/functions/wavelet_ast/filters.rs
+++ b/src/functions/wavelet_ast/filters.rs
@@ -6,6 +6,7 @@
 //! biorthogonal families the primal lowpass is the synthesis filter and the
 //! dual lowpass the analysis filter; for orthogonal families they coincide.
 
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::Expr;
 
 /// One filter as ascending (index, coefficient) pairs.
@@ -107,7 +108,7 @@ struct Rat {
 impl Rat {
   fn new(num: i128, den: i128) -> Self {
     debug_assert!(den != 0);
-    let g = gcd(num.unsigned_abs(), den.unsigned_abs()).max(1) as i128;
+    let g = gcd_i128(num, den).max(1);
     let sign = if den < 0 { -1 } else { 1 };
     Rat {
       num: sign * num / g,
@@ -128,8 +129,6 @@ impl Rat {
     self.num as f64 / self.den as f64
   }
 }
-
-use crate::functions::math_ast::gcd_u128 as gcd;
 
 fn binomial(n: u64, k: u64) -> i128 {
   if k > n {


### PR DESCRIPTION
There are still a few "extra" gcd functions in woxi.  This patch aims to remove more of them.

- gcd_helper and gcd_convergents were recursive gcd's, and there's no tail call optimization guarantee in Rust, so these needed to be removed.
- gcd_i64 was really a misnamed gcd_i128.
- gcd_i128_local can be replaced with gcd_i128.
- gcd_abs can also be replaced by gcd_i128.