### PR TITLE
Remove more duplicate expr_to_rational logic

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::{is_sqrt, make_sqrt};
+use crate::functions::math_ast::{expr_to_rational, is_sqrt, make_sqrt};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -11875,8 +11875,6 @@ fn find_sequence_function(
     args: vec![data_expr.clone(), var_expr.clone()].into(),
   })
 }
-
-use crate::functions::math_ast::expr_to_rational;
 
 /// Convert a rational (n, d) back to an Expr.
 fn rational_to_expr(n: i128, d: i128) -> Expr {

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::{gcd as gcd_i128, gcd_u64, make_sqrt};
+use crate::functions::math_ast::{
+  expr_to_rational, gcd as gcd_i128, gcd_u64, make_sqrt,
+};
 use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator, unevaluated};
 
 /// Columnwise quartile-family statistic for a matrix argument.
@@ -4946,10 +4948,8 @@ pub fn dispatch_math_functions(
         }
         // All-rational input: combine into a rational degree value and
         // fall through to the existing rational-path conversion below.
-        let parts: Option<Vec<(i128, i128)>> = items
-          .iter()
-          .map(crate::functions::math_ast::expr_to_rational)
-          .collect();
+        let parts: Option<Vec<(i128, i128)>> =
+          items.iter().map(expr_to_rational).collect();
         if let Some(p) = parts
           && p.len() == 3
         {
@@ -5004,9 +5004,7 @@ pub fn dispatch_math_functions(
         }
       }
 
-      if let Some((num, den)) =
-        crate::functions::math_ast::expr_to_rational(&val)
-      {
+      if let Some((num, den)) = expr_to_rational(&val) {
         let d = num / den;
         let remainder = num - d * den;
         let min_num = remainder * 60;
@@ -5532,9 +5530,7 @@ pub fn dispatch_math_functions(
 /// `n <= 3` (e.g. `QGamma[3, q]` → `1 + q`) and otherwise stays unevaluated.
 /// Non-integer first arguments are left unevaluated.
 fn qgamma_ast(z_expr: &Expr, q_expr: &Expr) -> Result<Expr, InterpreterError> {
-  use crate::functions::math_ast::{
-    expr_to_f64, expr_to_i128, expr_to_rational,
-  };
+  use crate::functions::math_ast::{expr_to_f64, expr_to_i128};
 
   let unevaluated = || {
     Ok(Expr::FunctionCall {
@@ -5609,7 +5605,7 @@ fn cantor_staircase_ast(arg: &Expr) -> Result<Expr, InterpreterError> {
   }
 
   // Handle rationals
-  if let Some((num, den)) = extract_rational(arg) {
+  if let Some((num, den)) = expr_to_rational(arg) {
     if num <= 0 {
       return Ok(Expr::Integer(0));
     }
@@ -5637,8 +5633,6 @@ fn cantor_staircase_ast(arg: &Expr) -> Result<Expr, InterpreterError> {
     args: vec![arg.clone()].into(),
   })
 }
-
-use crate::functions::math_ast::expr_to_rational as extract_rational;
 
 /// Compute cantor staircase for exact rational p/q where 0 < p/q < 1
 fn cantor_staircase_rational(p: i128, q: i128) -> Expr {
@@ -5813,7 +5807,7 @@ fn qfactorial_ast(
   // `QFactorial[n, q]` unevaluated rather than expanding to a rational
   // form. The rational form blows up combinatorially for Series and Plot.
   if crate::functions::math_ast::expr_to_f64(q_expr).is_none()
-    && crate::functions::math_ast::expr_to_rational(q_expr).is_none()
+    && expr_to_rational(q_expr).is_none()
   {
     return Ok(Expr::FunctionCall {
       name: "QFactorial".to_string(),
@@ -5859,8 +5853,6 @@ fn qfactorial_ast(
 /// Find minimum linear recurrence coefficients {c1, c2, ..., cd} such that
 /// a[n] = c1*a[n-1] + c2*a[n-2] + ... + cd*a[n-d] for all valid n.
 fn find_linear_recurrence_impl(seq: &[Expr]) -> Result<Expr, InterpreterError> {
-  use crate::functions::math_ast::expr_to_rational;
-
   // Convert sequence to rationals
   let mut rats: Vec<(i128, i128)> = Vec::new();
   for e in seq {

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -10922,8 +10922,10 @@ fn extract_rgb_rational(color: &Expr) -> Option<[(i128, i128); 3]> {
 
 /// Convert an expression to a rational (numerator, denominator) pair.
 fn expr_to_rational(expr: &Expr) -> Option<(i128, i128)> {
+  if let Some(pair) = crate::functions::math_ast::expr_to_rational(expr) {
+    return Some(pair);
+  }
   match expr {
-    Expr::Integer(n) => Some((*n, 1)),
     Expr::Real(f) => {
       // Try to convert common float values to exact rationals
       if *f == 0.0 {
@@ -10935,15 +10937,6 @@ fn expr_to_rational(expr: &Expr) -> Option<(i128, i128)> {
         let n = (*f * 1000.0).round() as i128;
         let g = gcd_i128(n.abs(), 1000);
         Some((n / g, 1000 / g))
-      }
-    }
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
-        Some((*n, *d))
-      } else {
-        None
       }
     }
     _ => None,

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -4,7 +4,9 @@
 
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
-use crate::functions::math_ast::{make_sqrt, try_eval_to_f64};
+use crate::functions::math_ast::{
+  expr_to_rational, make_sqrt, try_eval_to_f64,
+};
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// Transpose a matrix (Vec<Vec<Expr>>)
@@ -3613,27 +3615,10 @@ fn complex_2x2_eigenvectors(
   )))
 }
 
-/// Extract rational parts (numerator, denominator) from an Expr.
-fn expr_to_rational_parts(e: &Expr) -> Option<(i128, i128)> {
-  match e {
-    Expr::Integer(n) => Some((*n, 1)),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
-        Some((*n, *d))
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
-
 /// Scale a vector of rational Exprs to integer entries (clear denominators, reduce GCD).
 fn scale_to_integers(vec: &[Expr]) -> Vec<Expr> {
   let rationals: Vec<Option<(i128, i128)>> =
-    vec.iter().map(expr_to_rational_parts).collect();
+    vec.iter().map(expr_to_rational).collect();
   if rationals.iter().any(|r| r.is_none()) {
     return vec.to_vec();
   }
@@ -7191,19 +7176,6 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
       None
     }
   };
-  let extract_rational = |e: &Expr| -> Option<(i128, i128)> {
-    if let Expr::Integer(n) = e {
-      return Some((*n, 1));
-    }
-    if let Expr::FunctionCall { name, args } = e
-      && name == "Rational"
-      && args.len() == 2
-      && let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1])
-    {
-      return Some((*n, *d));
-    }
-    None
-  };
   // Pull factors out of Times (FunctionCall or BinaryOp) into a flat Vec.
   let mut factors: Vec<Expr> = Vec::new();
   let mut sign: i128 = 1;
@@ -7256,7 +7228,7 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
     } = f
     {
       sign = -sign;
-      if let Some((n, d)) = extract_rational(operand) {
+      if let Some((n, d)) = expr_to_rational(operand) {
         coeff_num *= n;
         coeff_den *= d;
         continue;
@@ -7264,7 +7236,7 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
       other.push(*operand.clone());
       continue;
     }
-    if let Some((n, d)) = extract_rational(f) {
+    if let Some((n, d)) = expr_to_rational(f) {
       coeff_num *= n;
       coeff_den *= d;
       continue;
@@ -7273,7 +7245,7 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
       && name == "Sqrt"
       && args.len() == 1
     {
-      if let Some((n, d)) = extract_rational(&args[0])
+      if let Some((n, d)) = expr_to_rational(&args[0])
         && n > 0
         && d > 0
       {
@@ -7320,7 +7292,7 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
       };
       // Power[base, ±1/2] with integer/Rational base.
       if (exp_kind == 1 || exp_kind == -1)
-        && let Some((bn, bd)) = extract_rational(base)
+        && let Some((bn, bd)) = expr_to_rational(base)
         && bn > 0
         && bd > 0
       {
@@ -7350,7 +7322,7 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
         if let Expr::FunctionCall { name: sn, args: sa } = base
           && sn == "Sqrt"
           && sa.len() == 1
-          && let Some((sn_n, sn_d)) = extract_rational(&sa[0])
+          && let Some((sn_n, sn_d)) = expr_to_rational(&sa[0])
           && sn_n > 0
           && sn_d > 0
         {
@@ -7384,7 +7356,7 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
                 && args.len() == 2
                 && matches!((&args[0], &args[1]), (Expr::Integer(1), Expr::Integer(2)))
           )
-          && let Some((bn, bd)) = extract_rational(ibase)
+          && let Some((bn, bd)) = expr_to_rational(ibase)
           && bn > 0
           && bd > 0
         {

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd as gcd_i128;
+use crate::functions::math_ast::{expr_to_rational, gcd as gcd_i128};
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
 };
@@ -9833,7 +9833,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     };
     if let (Some(ib), Some(ie)) = (inner_base, inner_exp)
       && matches!(ib, Expr::Integer(-1))
-      && let Some((p, q)) = extract_rational_pair(ie)
+      && let Some((p, q)) = expr_to_rational(ie)
     {
       let new_p = p * n;
       let new_q = q;
@@ -9876,7 +9876,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
       };
       if let (Some(ib), Some(ie)) = (inner_base, inner_exp)
         && matches!(ib, Expr::Integer(-1))
-        && let Some((p, q)) = extract_rational_pair(ie)
+        && let Some((p, q)) = expr_to_rational(ie)
       {
         let new_p = n * (q + p);
         let new_q = q;
@@ -11025,20 +11025,6 @@ fn try_extract_i_pi_rational_multiple(expr: &Expr) -> Option<(i128, i128)> {
 
   if has_i && has_pi {
     Some((coeff_numer, coeff_denom))
-  } else {
-    None
-  }
-}
-
-/// Extract (p, q) from a Rational[p, q] FunctionCall expression.
-fn extract_rational_pair(expr: &Expr) -> Option<(i128, i128)> {
-  if let Expr::FunctionCall { name, args } = expr
-    && name == "Rational"
-    && args.len() == 2
-    && let Expr::Integer(p) = &args[0]
-    && let Expr::Integer(q) = &args[1]
-  {
-    Some((*p, *q))
   } else {
     None
   }

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd as gcd_i128;
+use crate::functions::math_ast::{expr_to_rational, gcd as gcd_i128};
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
 };
@@ -1859,24 +1859,6 @@ fn bigfloat_to_digits(
   Ok((ascii_digits, exponent as i64))
 }
 
-/// Extract numerator and denominator from a Rational expression.
-/// Returns Some((numer, denom)) for Rational[n,d] or Integer n, None otherwise.
-fn extract_rational_for_digits(expr: &Expr) -> Option<(i128, i128)> {
-  match expr {
-    Expr::Integer(n) => Some((*n, 1)),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(a), Expr::Integer(b)) = (&args[0], &args[1]) {
-        Some((*a, *b))
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
-
 /// Convert a decimal-literal Real to an exact rational `(numerator, denominator)`
 /// by parsing its {:?} representation. This preserves the decimal value the
 /// user typed (e.g. 123.45 → (12345, 100)) rather than the binary-floating
@@ -2137,7 +2119,7 @@ pub fn real_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // For rationals, use long division with cycle detection
   if let Some((numer, denom)) =
-    rational_from_real.or_else(|| extract_rational_for_digits(&abs_expr))
+    rational_from_real.or_else(|| expr_to_rational(&abs_expr))
     && denom != 0
   {
     if !treat_as_explicit {

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
+use crate::functions::math_ast::expr_to_rational;
 use crate::syntax::{
   BinaryOperator, Expr, ExprForm, UnaryOperator, expr_to_string, unevaluated,
 };
@@ -3413,23 +3414,6 @@ fn subdivide_scalar_at(
   evaluate_expr_to_expr(&result)
 }
 
-/// Extract an exact (numerator, denominator) pair from an Integer or Rational.
-fn expr_to_rational_pair(e: &Expr) -> Option<(i128, i128)> {
-  match e {
-    Expr::Integer(n) => Some((*n, 1)),
-    Expr::FunctionCall { name, args }
-      if name == "Rational" && args.len() == 2 =>
-    {
-      if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
-        Some((*n, *d))
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
-
 /// Round a raw step up to the nearest "nice" number m * 10^k with
 /// m in {1, 2, 2.5, 5}, returned as an exact (numerator, denominator).
 fn nice_step_rational(raw: f64) -> Option<(i128, i128)> {
@@ -3593,17 +3577,16 @@ pub fn find_divisions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::List(items) if items.len() == 2 || items.len() == 3 => items,
     _ => return unevaluated(),
   };
-  let (Some(min), Some(max)) = (
-    expr_to_rational_pair(&range[0]),
-    expr_to_rational_pair(&range[1]),
-  ) else {
+  let (Some(min), Some(max)) =
+    (expr_to_rational(&range[0]), expr_to_rational(&range[1]))
+  else {
     return unevaluated();
   };
   let (min, max) = (reduce_rat(min.0, min.1), reduce_rat(max.0, max.1));
 
   // Optional spacing unit dx (the 3-element range form). Must be positive.
   let dx = if range.len() == 3 {
-    match expr_to_rational_pair(&range[2]) {
+    match expr_to_rational(&range[2]) {
       Some(d) if d.0 > 0 => Some(reduce_rat(d.0, d.1)),
       _ => return unevaluated(),
     }

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::InterpreterError;
 use crate::functions::math_ast::{
-  expr_to_f64, expr_to_i128, gcd as gcd_i128, is_sqrt,
+  expr_to_f64, expr_to_i128, expr_to_rational, gcd as gcd_i128, is_sqrt,
 };
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
@@ -249,12 +249,11 @@ fn handle_power(
   exp: &Expr,
 ) -> Result<Option<Vec<i128>>, InterpreterError> {
   // Case: a^(p/q) where a is rational
-  if let Some(a_val) = extract_rational(base)
-    && let Some((p, q)) = extract_rational_pair(exp)
+  if let Some((a_num, a_den)) = expr_to_rational(base)
+    && let Some((p, q)) = expr_to_rational(exp)
   {
     // α = (a_num/a_den)^(p/q)
     // α^q = (a_num/a_den)^p
-    let (a_num, a_den) = a_val;
     if q > 0 && q <= 20 && p.abs() <= 20 {
       let q_us = q as u32;
       let p_abs = p.unsigned_abs() as u32;
@@ -328,7 +327,7 @@ fn handle_power(
   // Case: algebraic ^ (1/q) — a q-th root of an algebraic number.
   // If p(t) is the minpoly of base, then α = base^(1/q) satisfies p(α^q) = 0,
   // so x^q substituted into p(t) gives a polynomial vanishing at α.
-  if let Some((p, q)) = extract_rational_pair(exp)
+  if let Some((p, q)) = expr_to_rational(exp)
     && p == 1
     && (2..=10).contains(&q)
   {
@@ -438,7 +437,7 @@ fn handle_complex_algebraic(
   // b*I has minpoly: if b is rational p/q, then (x/b)^2 + 1 = 0 → q^2*x^2 + p^2 = 0... no
   // Actually b*I: (α/(b))^2 = -1 → α^2 = -b^2 → α^2 + b^2 = 0
   // If b = p/q: q^2*x^2 + p^2 = 0
-  if let (Some(re_c), Some((p, q))) = (re_poly, extract_rational(im)) {
+  if let (Some(re_c), Some((p, q))) = (re_poly, expr_to_rational(im)) {
     // minpoly of b*I is q^2*x^2 + p^2
     let im_poly = vec![p * p, 0, q * q];
     let numeric_val =
@@ -1378,13 +1377,6 @@ fn negate_var_in_poly(coeffs: &[i128]) -> Vec<i128> {
     .enumerate()
     .map(|(i, &c)| if i % 2 == 1 { -c } else { c })
     .collect()
-}
-
-use crate::functions::math_ast::expr_to_rational as extract_rational;
-
-/// Extract a rational pair (p, q) from a Rational expression or integer
-fn extract_rational_pair(expr: &Expr) -> Option<(i128, i128)> {
-  extract_rational(expr)
 }
 
 /// Collect factors from a Times expression

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -9004,17 +9004,10 @@ fn factor_common_power_base(terms: &[Expr]) -> Option<Expr> {
   }
 
   fn extract_rational_exp(exp: &Expr) -> Option<(i128, i128)> {
+    if let Some(pair) = crate::functions::math_ast::expr_to_rational(exp) {
+      return Some(pair);
+    }
     match exp {
-      Expr::Integer(n) => Some((*n, 1)),
-      Expr::FunctionCall { name, args }
-        if name == "Rational" && args.len() == 2 =>
-      {
-        if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
-          Some((*n, *d))
-        } else {
-          None
-        }
-      }
       // Handle Times[-1, Rational[p, q]] → (-p, q)
       Expr::FunctionCall { name, args }
         if name == "Times"


### PR DESCRIPTION
This PR uses the expr_to_rational pub fn in more places. In arithmetic.rs, extract_rational_pair doesn't handle integers, which seems an oversight so I replaced it which might cause power_two to simplify more cases.  The tests should catch any divergences that matter.