### PR TITLE
Use bool_expr in more places

### DIFF
--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, ComparisonOp, unevaluated};
+use crate::syntax::{BinaryOperator, ComparisonOp, bool_expr, unevaluated};
 
 thread_local! {
   /// Symbols currently being looked up — prevents infinite recursion when
@@ -2156,7 +2156,7 @@ pub fn evaluate_expr_to_expr_inner(
         BinaryOperator::And => {
           let left_val = evaluate_expr_to_expr(left)?;
           if matches!(&left_val, Expr::Identifier(s) if s == "False") {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
           let right_val = evaluate_expr_to_expr(right)?;
           let has_user_rules =
@@ -2171,7 +2171,7 @@ pub fn evaluate_expr_to_expr_inner(
         BinaryOperator::Or => {
           let left_val = evaluate_expr_to_expr(left)?;
           if matches!(&left_val, Expr::Identifier(s) if s == "True") {
-            return Ok(Expr::Identifier("True".to_string()));
+            return Ok(bool_expr(true));
           }
           let right_val = evaluate_expr_to_expr(right)?;
           let has_user_rules =
@@ -2431,9 +2431,9 @@ pub fn evaluate_expr_to_expr_inner(
         }
         UnaryOperator::Not => {
           if matches!(&val, Expr::Identifier(s) if s == "True") {
-            Ok(Expr::Identifier("False".to_string()))
+            Ok(bool_expr(false))
           } else if matches!(&val, Expr::Identifier(s) if s == "False") {
-            Ok(Expr::Identifier("True".to_string()))
+            Ok(bool_expr(true))
           } else {
             Ok(Expr::UnaryOp {
               op: *op,
@@ -2448,7 +2448,7 @@ pub fn evaluate_expr_to_expr_inner(
       operators,
     } => {
       if operands.len() < 2 || operators.is_empty() {
-        return Ok(Expr::Identifier("True".to_string()));
+        return Ok(bool_expr(true));
       }
 
       let values: Vec<Expr> = operands
@@ -2558,9 +2558,7 @@ pub fn evaluate_expr_to_expr_inner(
               // adjacent pair settles an Unequal chain) of any length;
               // a true pair is only decisive for a 2-operand comparison.
               if !result || operands.len() == 2 {
-                return Ok(Expr::Identifier(
-                  if result { "True" } else { "False" }.to_string(),
-                ));
+                return Ok(bool_expr(result));
               }
             }
             Some(None) => {
@@ -2650,7 +2648,7 @@ pub fn evaluate_expr_to_expr_inner(
             _ => true,
           };
           if !ok {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
         }
       }
@@ -2670,7 +2668,7 @@ pub fn evaluate_expr_to_expr_inner(
           && let Some(b) = interval_compare(op, left, right)
         {
           if !b {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
           continue;
         }
@@ -2698,7 +2696,7 @@ pub fn evaluate_expr_to_expr_inner(
             _ => true,
           };
           if !ok {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
           continue;
         }
@@ -2716,7 +2714,7 @@ pub fn evaluate_expr_to_expr_inner(
           )
         {
           if lm != rm {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
           continue;
         }
@@ -2731,7 +2729,7 @@ pub fn evaluate_expr_to_expr_inner(
         {
           if expr_to_string(left) == expr_to_string(right) {
             if matches!(op, ComparisonOp::NotEqual) {
-              return Ok(Expr::Identifier("False".to_string()));
+              return Ok(bool_expr(false));
             }
             continue;
           }
@@ -2775,7 +2773,7 @@ pub fn evaluate_expr_to_expr_inner(
                     d_l, d_r, shared,
                   )
                 {
-                  return Ok(Expr::Identifier("False".to_string()));
+                  return Ok(bool_expr(false));
                 }
               }
               if let (Some(l), Some(r)) =
@@ -2955,10 +2953,10 @@ pub fn evaluate_expr_to_expr_inner(
         };
 
         if !result {
-          return Ok(Expr::Identifier("False".to_string()));
+          return Ok(bool_expr(false));
         }
       }
-      Ok(Expr::Identifier("True".to_string()))
+      Ok(bool_expr(true))
     }
     Expr::CompoundExpr(exprs) => {
       let mut result = Expr::Identifier("Null".to_string());

--- a/src/evaluator/dispatch/boolean_functions.rs
+++ b/src/evaluator/dispatch/boolean_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::ComparisonOp;
+use crate::syntax::{ComparisonOp, bool_expr};
 
 pub fn dispatch_boolean_functions(
   name: &str,
@@ -63,7 +63,7 @@ pub fn dispatch_boolean_functions(
     // being actively manipulated. Outside an interactive notebook nothing is,
     // so it evaluates to False, matching wolframscript in script mode.
     "ControlActive" if args.is_empty() => {
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     "SameQ" => {
       return Some(crate::functions::boolean_ast::same_q_ast(args));
@@ -87,7 +87,7 @@ pub fn dispatch_boolean_functions(
     }
     // 0- or 1-arg Unequal is trivially True (no pair of unequal items).
     "Unequal" if args.len() < 2 => {
-      return Some(Ok(Expr::Identifier("True".to_string())));
+      return Some(Ok(bool_expr(true)));
     }
     // Route the functional forms through the same Comparison evaluation
     // as the operator syntax, so e.g. the ComplexInfinity `nord` messages

--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::is_sqrt;
-use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator, unevaluated};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, UnaryOperator, bool_expr, unevaluated,
+};
 
 /// Check if the result of differentiation contains a
 /// `Derivative[...][func_name][...]` pattern (as CurriedCall),
@@ -3979,7 +3981,7 @@ fn function_domain_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   if constraints.is_empty() {
     // No restrictions → domain is all reals
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Simplify each constraint and convert to interval representation

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::functions::math_ast::{expr_to_rational, is_sqrt, make_sqrt};
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
 
 pub fn dispatch_complex_and_special(
@@ -701,9 +701,7 @@ pub fn dispatch_complex_and_special(
                 }]
                 .into(),
               ),
-              Expr::Identifier(
-                if is_full { "True" } else { "False" }.to_string(),
-              ),
+              bool_expr(is_full),
             ]
             .into(),
           }));
@@ -4378,17 +4376,17 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
                 pattern: Box::new(Expr::Identifier(
                   "ShowSpecialCharacters".to_string(),
                 )),
-                replacement: Box::new(Expr::Identifier("False".to_string())),
+                replacement: Box::new(bool_expr(false)),
               },
               Expr::Rule {
                 pattern: Box::new(Expr::Identifier(
                   "ShowStringCharacters".to_string(),
                 )),
-                replacement: Box::new(Expr::Identifier("True".to_string())),
+                replacement: Box::new(bool_expr(true)),
               },
               Expr::Rule {
                 pattern: Box::new(Expr::Identifier("NumberMarks".to_string())),
-                replacement: Box::new(Expr::Identifier("True".to_string())),
+                replacement: Box::new(bool_expr(true)),
               },
             ]
             .into(),
@@ -4433,7 +4431,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
           Expr::Identifier(name.clone()),
           Expr::Rule {
             pattern: Box::new(Expr::Identifier("Editable".to_string())),
-            replacement: Box::new(Expr::Identifier("True".to_string())),
+            replacement: Box::new(bool_expr(true)),
           },
         ]
         .into(),
@@ -4516,11 +4514,11 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
           },
           Expr::Rule {
             pattern: Box::new(Expr::Identifier("Editable".to_string())),
-            replacement: Box::new(Expr::Identifier("True".to_string())),
+            replacement: Box::new(bool_expr(true)),
           },
           Expr::Rule {
             pattern: Box::new(Expr::Identifier("AutoDelete".to_string())),
-            replacement: Box::new(Expr::Identifier("True".to_string())),
+            replacement: Box::new(bool_expr(true)),
           },
         ]
         .into(),
@@ -4641,7 +4639,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
           },
           Expr::Rule {
             pattern: Box::new(Expr::Identifier("Editable".to_string())),
-            replacement: Box::new(Expr::Identifier("False".to_string())),
+            replacement: Box::new(bool_expr(false)),
           },
         ]
         .into(),
@@ -4673,11 +4671,11 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
                 pattern: Box::new(Expr::Identifier(
                   "ShowStringCharacters".to_string(),
                 )),
-                replacement: Box::new(Expr::Identifier("True".to_string())),
+                replacement: Box::new(bool_expr(true)),
               },
               Expr::Rule {
                 pattern: Box::new(Expr::Identifier("NumberMarks".to_string())),
-                replacement: Box::new(Expr::Identifier("True".to_string())),
+                replacement: Box::new(bool_expr(true)),
               },
             ]
             .into(),
@@ -4688,11 +4686,11 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
           },
           Expr::Rule {
             pattern: Box::new(Expr::Identifier("Editable".to_string())),
-            replacement: Box::new(Expr::Identifier("True".to_string())),
+            replacement: Box::new(bool_expr(true)),
           },
           Expr::Rule {
             pattern: Box::new(Expr::Identifier("AutoDelete".to_string())),
-            replacement: Box::new(Expr::Identifier("True".to_string())),
+            replacement: Box::new(bool_expr(true)),
           },
         ]
         .into(),
@@ -6109,11 +6107,7 @@ fn compute_region_member(
       None
     }
   };
-  let boolean = |b: bool| {
-    Ok(Expr::Identifier(
-      if b { "True" } else { "False" }.to_string(),
-    ))
-  };
+  let boolean = |b: bool| Ok(bool_expr(b));
   const EPS: f64 = 1e-10;
 
   let Some(pt) = to_vec(point) else {
@@ -6152,9 +6146,7 @@ fn compute_region_member(
       };
       let (cx, cy) = (ax + t * dx, ay + t * dy);
       let d2 = (px - cx) * (px - cx) + (py - cy) * (py - cy);
-      Ok(Expr::Identifier(
-        if d2 <= rv * rv { "True" } else { "False" }.to_string(),
-      ))
+      Ok(bool_expr(d2 <= rv * rv))
     }
     "Disk" | "Ball" | "Circle" | "Sphere" => {
       let default_dim = if name == "Ball" || name == "Sphere" {
@@ -6564,18 +6556,18 @@ fn compute_region_disjoint(args: &[Expr]) -> Result<Expr, InterpreterError> {
     .collect();
   let Some(shapes) = shapes else {
     if args.is_empty() {
-      return Ok(Expr::Identifier("True".to_string()));
+      return Ok(bool_expr(true));
     }
     return Ok(unevaluated("RegionDisjoint", args));
   };
   for i in 0..shapes.len() {
     for j in i + 1..shapes.len() {
       if disjoint_shapes_intersect(&shapes[i], &shapes[j]) {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
   }
-  Ok(Expr::Identifier("True".to_string()))
+  Ok(bool_expr(true))
 }
 
 /// Nearest point of a `Line[{v1, v2, …}]` (a segment or polyline) to `point`,
@@ -13059,7 +13051,7 @@ fn normalize_polygon_vertices(mut vertices: Vec<Expr>) -> Option<Expr> {
 fn compute_region_equal(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // RegionEqual[] and RegionEqual[r] → True
   if args.len() <= 1 {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Try to normalize all regions
@@ -13081,9 +13073,9 @@ fn compute_region_equal(args: &[Expr]) -> Result<Expr, InterpreterError> {
     .all(|n| format!("{n:?}") == format!("{first:?}"));
 
   if all_equal {
-    Ok(Expr::Identifier("True".to_string()))
+    Ok(bool_expr(true))
   } else {
-    Ok(Expr::Identifier("False".to_string()))
+    Ok(bool_expr(false))
   }
 }
 
@@ -14340,8 +14332,8 @@ fn region_within(
 
   let unevaluated = || Ok(unevaluated("RegionWithin", args));
 
-  let true_expr = || Ok(Expr::Identifier("True".to_string()));
-  let false_expr = || Ok(Expr::Identifier("False".to_string()));
+  let true_expr = || Ok(bool_expr(true));
+  let false_expr = || Ok(bool_expr(false));
 
   // Extract region info: (name, center_coords, radius_or_half_sizes)
   let parse_disk_ball = |r: &Expr| -> Option<(String, Vec<f64>, f64)> {

--- a/src/evaluator/dispatch/datetime_functions.rs
+++ b/src/evaluator/dispatch/datetime_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
+use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 
 pub fn dispatch_datetime_functions(
   name: &str,
@@ -234,9 +234,7 @@ pub fn dispatch_datetime_functions(
       } else {
         false
       };
-      return Some(Ok(Expr::Identifier(
-        if valid { "True" } else { "False" }.to_string(),
-      )));
+      return Some(Ok(bool_expr(valid)));
     }
     // DateObject is a data container — normalize granularity
     // FromDateString["string"] gives the DateObject for a date string. For the

--- a/src/evaluator/dispatch/evaluation_control.rs
+++ b/src/evaluator/dispatch/evaluation_control.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, unevaluated};
+use crate::syntax::{BinaryOperator, bool_expr, unevaluated};
 
 pub fn dispatch_evaluation_control(
   name: &str,
@@ -618,9 +618,7 @@ pub fn dispatch_evaluation_control(
       } = &args[0]
       {
         let result = validate_distribution_params(dist_name, dist_args);
-        return Some(Ok(Expr::Identifier(
-          if result { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(result)));
       }
       // Not a recognized distribution — return unevaluated
       return Some(Ok(unevaluated("DistributionParameterQ", args)));
@@ -816,7 +814,7 @@ pub fn dispatch_evaluation_control(
           .to_string(),
         )));
       }
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     "Piecewise" if !args.is_empty() && args.len() <= 2 => {
       return Some(crate::functions::control_flow_ast::piecewise_ast(args));

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::unevaluated;
+use crate::syntax::{bool_expr, unevaluated};
 
 /// Colors of a Wolfram `ColorData` indexed scheme (`ColorData[n, "ColorList"]`).
 ///
@@ -254,8 +254,8 @@ fn json_value_to_expr(value: &serde_json::Value, raw: bool) -> Expr {
   use serde_json::Value;
   match value {
     Value::Null => Expr::Identifier("Null".to_string()),
-    Value::Bool(true) => Expr::Identifier("True".to_string()),
-    Value::Bool(false) => Expr::Identifier("False".to_string()),
+    Value::Bool(true) => bool_expr(true),
+    Value::Bool(false) => bool_expr(false),
     Value::Number(n) => {
       if let Some(i) = n.as_i64() {
         Expr::Integer(i as i128)

--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::make_sqrt;
-use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
+use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 
 pub fn dispatch_linear_algebra_functions(
   name: &str,
@@ -443,7 +443,7 @@ pub fn dispatch_linear_algebra_functions(
       if let Expr::List(rows) = &args[0] {
         let n = rows.len();
         if n == 0 {
-          return Some(Ok(Expr::Identifier("False".to_string())));
+          return Some(Ok(bool_expr(false)));
         }
         let is_square = rows.iter().all(|r| {
           if let Expr::List(cols) = r {
@@ -453,7 +453,7 @@ pub fn dispatch_linear_algebra_functions(
           }
         });
         if !is_square {
-          return Some(Ok(Expr::Identifier("False".to_string())));
+          return Some(Ok(bool_expr(false)));
         }
         // Unitary tests ConjugateTranspose[m].m == Id; orthogonal tests
         // the plain Transpose[m].m == Id (so {{0, I}, {I, 0}} is unitary
@@ -481,14 +481,12 @@ pub fn dispatch_linear_algebra_functions(
             if let Ok(id) = identity {
               let result = crate::syntax::expr_to_string(&evaluated)
                 == crate::syntax::expr_to_string(&id);
-              return Some(Ok(Expr::Identifier(
-                if result { "True" } else { "False" }.to_string(),
-              )));
+              return Some(Ok(bool_expr(result)));
             }
           }
         }
       }
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     "ReflectionMatrix" if args.len() == 1 => {
       if let Expr::List(v) = &args[0] {
@@ -657,7 +655,7 @@ pub fn dispatch_linear_algebra_functions(
       // Non-square arguments are not positive definite. Guard before calling
       // eigenvalues_ast, which would otherwise emit a spurious matsq message.
       if !is_square_matrix_expr(&args[0]) {
-        return Some(Ok(Expr::Identifier("False".to_string())));
+        return Some(Ok(bool_expr(false)));
       }
       // Compute eigenvalues and check all are strictly positive
       let eigenvals_result =
@@ -674,19 +672,19 @@ pub fn dispatch_linear_algebra_functions(
           match n_val {
             Ok(Expr::Real(f)) if f > 0.0 => continue,
             Ok(Expr::Integer(n)) if n > 0 => continue,
-            _ => return Some(Ok(Expr::Identifier("False".to_string()))),
+            _ => return Some(Ok(bool_expr(false))),
           }
         }
-        return Some(Ok(Expr::Identifier("True".to_string())));
+        return Some(Ok(bool_expr(true)));
       }
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     "IndefiniteMatrixQ" if args.len() == 1 => {
       // A matrix is "explicitly indefinite" iff its Hermitian part
       // H = (m + ConjugateTranspose[m])/2 has at least one strictly
       // positive eigenvalue AND at least one strictly negative eigenvalue.
       // Anything that can't be confirmed indefinite returns False.
-      let false_res = || Some(Ok(Expr::Identifier("False".to_string())));
+      let false_res = || Some(Ok(bool_expr(false)));
       if let Expr::List(rows) = &args[0] {
         let n = rows.len();
         if n == 0 {
@@ -740,7 +738,7 @@ pub fn dispatch_linear_algebra_functions(
             }
           }
           if has_pos && has_neg {
-            return Some(Ok(Expr::Identifier("True".to_string())));
+            return Some(Ok(bool_expr(true)));
           }
         }
         return false_res();
@@ -2192,7 +2190,7 @@ pub fn dispatch_linear_algebra_functions(
         for row in rows {
           if let Expr::List(cols) = row {
             if cols.len() != n {
-              return Some(Ok(Expr::Identifier("False".to_string())));
+              return Some(Ok(bool_expr(false)));
             }
           } else {
             return None;
@@ -2221,7 +2219,7 @@ pub fn dispatch_linear_algebra_functions(
             }
             if !has_repeated {
               // All eigenvalues distinct => diagonalizable
-              return Some(Ok(Expr::Identifier("True".to_string())));
+              return Some(Ok(bool_expr(true)));
             }
             // Repeated eigenvalues: check if matrix is already diagonal
             let mut is_diagonal = true;
@@ -2238,19 +2236,17 @@ pub fn dispatch_linear_algebra_functions(
                 break;
               }
             }
-            return Some(Ok(Expr::Identifier(
-              if is_diagonal { "True" } else { "False" }.to_string(),
-            )));
+            return Some(Ok(bool_expr(is_diagonal)));
           }
         }
-        return Some(Ok(Expr::Identifier("False".to_string())));
+        return Some(Ok(bool_expr(false)));
       }
     }
     "PositiveSemidefiniteMatrixQ" if args.len() == 1 => {
       // Non-square arguments (scalar, vector, ragged) are not positive
       // semidefinite — answer False rather than staying unevaluated.
       if !is_square_matrix_expr(&args[0]) {
-        return Some(Ok(Expr::Identifier("False".to_string())));
+        return Some(Ok(bool_expr(false)));
       }
       // Check if all eigenvalues are non-negative
       if let Expr::List(rows) = &args[0] {
@@ -2258,7 +2254,7 @@ pub fn dispatch_linear_algebra_functions(
         for row in rows {
           if let Expr::List(cols) = row {
             if cols.len() != n {
-              return Some(Ok(Expr::Identifier("False".to_string())));
+              return Some(Ok(bool_expr(false)));
             }
           } else {
             return None;
@@ -2273,12 +2269,12 @@ pub fn dispatch_linear_algebra_functions(
             match &evaluated {
               Expr::Integer(v) => {
                 if *v < 0 {
-                  return Some(Ok(Expr::Identifier("False".to_string())));
+                  return Some(Ok(bool_expr(false)));
                 }
               }
               Expr::Real(v) => {
                 if *v < 0.0 {
-                  return Some(Ok(Expr::Identifier("False".to_string())));
+                  return Some(Ok(bool_expr(false)));
                 }
               }
               Expr::FunctionCall {
@@ -2288,7 +2284,7 @@ pub fn dispatch_linear_algebra_functions(
                 if let Expr::Integer(n) = &fargs[0]
                   && *n < 0
                 {
-                  return Some(Ok(Expr::Identifier("False".to_string())));
+                  return Some(Ok(bool_expr(false)));
                 }
               }
               _ => {
@@ -2300,20 +2296,20 @@ pub fn dispatch_linear_algebra_functions(
                 if let Ok(Expr::Real(v)) = nval
                   && v < 0.0
                 {
-                  return Some(Ok(Expr::Identifier("False".to_string())));
+                  return Some(Ok(bool_expr(false)));
                 }
               }
             }
           }
-          return Some(Ok(Expr::Identifier("True".to_string())));
+          return Some(Ok(bool_expr(true)));
         }
-        return Some(Ok(Expr::Identifier("False".to_string())));
+        return Some(Ok(bool_expr(false)));
       }
     }
     "NegativeDefiniteMatrixQ" if args.len() == 1 => {
       // Non-square arguments are not negative definite — answer False.
       if !is_square_matrix_expr(&args[0]) {
-        return Some(Ok(Expr::Identifier("False".to_string())));
+        return Some(Ok(bool_expr(false)));
       }
       // All eigenvalues must be strictly negative
       if let Expr::List(rows) = &args[0] {
@@ -2321,7 +2317,7 @@ pub fn dispatch_linear_algebra_functions(
         for row in rows {
           if let Expr::List(cols) = row {
             if cols.len() != n {
-              return Some(Ok(Expr::Identifier("False".to_string())));
+              return Some(Ok(bool_expr(false)));
             }
           } else {
             return None;
@@ -2357,18 +2353,18 @@ pub fn dispatch_linear_algebra_functions(
               }
             };
             if !is_neg {
-              return Some(Ok(Expr::Identifier("False".to_string())));
+              return Some(Ok(bool_expr(false)));
             }
           }
-          return Some(Ok(Expr::Identifier("True".to_string())));
+          return Some(Ok(bool_expr(true)));
         }
-        return Some(Ok(Expr::Identifier("False".to_string())));
+        return Some(Ok(bool_expr(false)));
       }
     }
     "NegativeSemidefiniteMatrixQ" if args.len() == 1 => {
       // Non-square arguments are not negative semidefinite — answer False.
       if !is_square_matrix_expr(&args[0]) {
-        return Some(Ok(Expr::Identifier("False".to_string())));
+        return Some(Ok(bool_expr(false)));
       }
       // All eigenvalues must be <= 0
       if let Expr::List(rows) = &args[0] {
@@ -2376,7 +2372,7 @@ pub fn dispatch_linear_algebra_functions(
         for row in rows {
           if let Expr::List(cols) = row {
             if cols.len() != n {
-              return Some(Ok(Expr::Identifier("False".to_string())));
+              return Some(Ok(bool_expr(false)));
             }
           } else {
             return None;
@@ -2412,12 +2408,12 @@ pub fn dispatch_linear_algebra_functions(
               }
             };
             if is_pos {
-              return Some(Ok(Expr::Identifier("False".to_string())));
+              return Some(Ok(bool_expr(false)));
             }
           }
-          return Some(Ok(Expr::Identifier("True".to_string())));
+          return Some(Ok(bool_expr(true)));
         }
-        return Some(Ok(Expr::Identifier("False".to_string())));
+        return Some(Ok(bool_expr(false)));
       }
     }
     "HermitianMatrixQ" if args.len() == 1 => {
@@ -2452,15 +2448,15 @@ pub fn dispatch_linear_algebra_functions(
               })
               .unwrap_or(Expr::Integer(1));
               if !is_zero_expr(&diff) {
-                return Some(Ok(Expr::Identifier("False".to_string())));
+                return Some(Ok(bool_expr(false)));
               }
             }
           }
-          return Some(Ok(Expr::Identifier("True".to_string())));
+          return Some(Ok(bool_expr(true)));
         }
       }
       // Not a square matrix → False (a predicate, like SymmetricMatrixQ).
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     "AntihermitianMatrixQ" if args.len() == 1 => {
       // Antihermitian: M == -ConjugateTranspose[M]
@@ -2489,15 +2485,15 @@ pub fn dispatch_linear_algebra_functions(
               })
               .unwrap_or(Expr::Integer(1));
               if !is_zero_expr(&sum) {
-                return Some(Ok(Expr::Identifier("False".to_string())));
+                return Some(Ok(bool_expr(false)));
               }
             }
           }
-          return Some(Ok(Expr::Identifier("True".to_string())));
+          return Some(Ok(bool_expr(true)));
         }
       }
       // Not a square matrix → False (a predicate, like SymmetricMatrixQ).
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     "NormalMatrixQ" if args.len() == 1 => {
       // Normal: M.M^H == M^H.M where M^H is conjugate transpose
@@ -2536,14 +2532,12 @@ pub fn dispatch_linear_algebra_functions(
           if let (Ok(a), Ok(b)) = (mmh, mhm) {
             let a_str = expr_to_string(&a);
             let b_str = expr_to_string(&b);
-            return Some(Ok(Expr::Identifier(
-              if a_str == b_str { "True" } else { "False" }.to_string(),
-            )));
+            return Some(Ok(bool_expr(a_str == b_str)));
           }
         }
       }
       // Not a square matrix → False (a predicate, like SymmetricMatrixQ).
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     // DiagonalMatrixQ[m] — True if m is diagonal (nonzeros only on the main
     // diagonal). DiagonalMatrixQ[m, k] allows nonzeros only on the k-th
@@ -2590,12 +2584,10 @@ pub fn dispatch_linear_algebra_functions(
             }
           }
         }
-        return Some(Ok(Expr::Identifier(
-          if is_diag { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(is_diag)));
       }
       // A non-list argument (scalar, symbol, …) is not a matrix → False.
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     // UpperTriangularMatrixQ[m] — True if m is upper triangular
     "UpperTriangularMatrixQ" if args.len() == 1 => {
@@ -2619,12 +2611,10 @@ pub fn dispatch_linear_algebra_functions(
             break;
           }
         }
-        return Some(Ok(Expr::Identifier(
-          if is_upper { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(is_upper)));
       }
       // A non-list argument (scalar, symbol, …) is not a matrix → False.
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     // LowerTriangularMatrixQ[m] — True if m is lower triangular
     "LowerTriangularMatrixQ" if args.len() == 1 => {
@@ -2648,12 +2638,10 @@ pub fn dispatch_linear_algebra_functions(
             break;
           }
         }
-        return Some(Ok(Expr::Identifier(
-          if is_lower { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(is_lower)));
       }
       // A non-list argument (scalar, symbol, …) is not a matrix → False.
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     // AntisymmetricMatrixQ[m] — True if m is antisymmetric (m[i][j] == -m[j][i])
     "AntisymmetricMatrixQ" if args.len() == 1 => {
@@ -2688,9 +2676,7 @@ pub fn dispatch_linear_algebra_functions(
             break;
           }
         }
-        return Some(Ok(Expr::Identifier(
-          if is_antisymmetric { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(is_antisymmetric)));
       }
     }
     // HankelMatrix[{c1,...,cn}] — Hankel matrix where entry (i,j) = c[i+j-1]

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::list_helpers_ast;
-use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
+use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 
 /// Parse the `m` argument of NestWhile[f, x, test, m, ...]. Returns `All` for
 /// the symbol `All`, `Last(n)` for a positive integer, and `None` otherwise.
@@ -33,11 +33,6 @@ fn same_test_true(test: &Expr, a: &Expr, b: &Expr) -> bool {
     list_helpers_ast::apply_func_to_two_args(test, a, b),
     Ok(Expr::Identifier(ref s)) if s == "True"
   )
-}
-
-/// Build the `True`/`False` symbol from a boolean.
-fn bool_ident(b: bool) -> Expr {
-  Expr::Identifier(if b { "True" } else { "False" }.to_string())
 }
 
 /// True for an argument that is a concrete non-list value the list-difference
@@ -1535,10 +1530,10 @@ pub fn dispatch_list_operations(
         for item in items {
           let s = expr_to_string(item);
           if !seen.insert(s) {
-            return Some(Ok(Expr::Identifier("False".to_string())));
+            return Some(Ok(bool_expr(false)));
           }
         }
-        return Some(Ok(Expr::Identifier("True".to_string())));
+        return Some(Ok(bool_expr(true)));
       }
     }
     // DuplicateFreeQ[list, test] — True iff no two elements are equivalent
@@ -1553,11 +1548,11 @@ pub fn dispatch_list_operations(
                 test, &items[i], &items[j],
               );
             if matches!(res, Ok(Expr::Identifier(ref s)) if s == "True") {
-              return Some(Ok(Expr::Identifier("False".to_string())));
+              return Some(Ok(bool_expr(false)));
             }
           }
         }
-        return Some(Ok(Expr::Identifier("True".to_string())));
+        return Some(Ok(bool_expr(true)));
       }
     }
     "TakeList" if args.len() == 2 => {
@@ -2180,9 +2175,7 @@ pub fn dispatch_list_operations(
             break;
           }
         }
-        return Some(Ok(Expr::Identifier(
-          if ordered { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(ordered)));
       }
     }
     "DeleteAdjacentDuplicates" if args.len() == 1 => {
@@ -3964,7 +3957,7 @@ pub fn dispatch_list_operations(
         if tn == "Tree"
           && ta.len() == 2
           && matches!(&ta[1], Expr::Identifier(s) if s == "None"));
-      return Some(Ok(bool_ident(is_leaf)));
+      return Some(Ok(bool_expr(is_leaf)));
     }
     // Structural recursions over a canonical Tree. Each emits ::tree and stays
     // unevaluated when given a non-tree (matching TreeData/TreeChildren).
@@ -4490,7 +4483,7 @@ pub fn dispatch_list_operations(
         // ArrayQ[expr, n] - depth must equal n
         if let Some(n) = expr_to_i128(&args[1]) {
           if depth != n as usize {
-            return Some(Ok(Expr::Identifier("False".to_string())));
+            return Some(Ok(bool_expr(false)));
           }
         } else {
           return Some(Ok(is_array));
@@ -4501,11 +4494,9 @@ pub fn dispatch_list_operations(
         let test = &args[2];
         let leaves_pass =
           list_helpers_ast::all_leaves_pass_test(&args[0], depth, test);
-        return Some(Ok(Expr::Identifier(
-          (if leaves_pass { "True" } else { "False" }).to_string(),
-        )));
+        return Some(Ok(bool_expr(leaves_pass)));
       }
-      return Some(Ok(Expr::Identifier("True".to_string())));
+      return Some(Ok(bool_expr(true)));
     }
     "VectorQ" if args.len() == 1 => {
       return Some(list_helpers_ast::vector_q_ast(&args[0]));
@@ -4534,12 +4525,12 @@ pub fn dispatch_list_operations(
           let result = list2
             .iter()
             .any(|y| list1.iter().any(|x| same_test_true(test, x, y)));
-          return Some(Ok(bool_ident(result)));
+          return Some(Ok(bool_expr(result)));
         }
         let set1: std::collections::HashSet<String> =
           list1.iter().map(expr_to_string).collect();
         let result = list2.iter().any(|x| set1.contains(&expr_to_string(x)));
-        return Some(Ok(bool_ident(result)));
+        return Some(Ok(bool_expr(result)));
       }
     }
     // ContainsAll[a, b] — every element of b is in a.
@@ -4552,12 +4543,12 @@ pub fn dispatch_list_operations(
           let result = list2
             .iter()
             .all(|y| list1.iter().any(|x| same_test_true(test, x, y)));
-          return Some(Ok(bool_ident(result)));
+          return Some(Ok(bool_expr(result)));
         }
         let set1: std::collections::HashSet<String> =
           list1.iter().map(expr_to_string).collect();
         let result = list2.iter().all(|x| set1.contains(&expr_to_string(x)));
-        return Some(Ok(bool_ident(result)));
+        return Some(Ok(bool_expr(result)));
       }
     }
     // ContainsNone[a, b] — no element of b is in a.
@@ -4570,12 +4561,12 @@ pub fn dispatch_list_operations(
           let result = !list2
             .iter()
             .any(|y| list1.iter().any(|x| same_test_true(test, x, y)));
-          return Some(Ok(bool_ident(result)));
+          return Some(Ok(bool_expr(result)));
         }
         let set1: std::collections::HashSet<String> =
           list1.iter().map(expr_to_string).collect();
         let result = !list2.iter().any(|x| set1.contains(&expr_to_string(x)));
-        return Some(Ok(bool_ident(result)));
+        return Some(Ok(bool_expr(result)));
       }
     }
     // ContainsExactly[list1, list2] — True if the two Lists contain exactly
@@ -4593,13 +4584,13 @@ pub fn dispatch_list_operations(
           let only = list1
             .iter()
             .all(|x| list2.iter().any(|y| same_test_true(test, x, y)));
-          return Some(Ok(bool_ident(all && only)));
+          return Some(Ok(bool_expr(all && only)));
         }
         let set1: std::collections::HashSet<String> =
           list1.iter().map(expr_to_string).collect();
         let set2: std::collections::HashSet<String> =
           list2.iter().map(expr_to_string).collect();
-        return Some(Ok(bool_ident(set1 == set2)));
+        return Some(Ok(bool_expr(set1 == set2)));
       }
     }
     // ContainsExactly[list2] — operator form, returns a callable.
@@ -4617,9 +4608,9 @@ pub fn dispatch_list_operations(
         _ => false,
       };
       return Some(Ok(if result {
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       } else {
-        Expr::Identifier("False".to_string())
+        bool_expr(false)
       }));
     }
     "TakeWhile" if args.len() == 2 => {
@@ -6357,9 +6348,7 @@ pub fn dispatch_list_operations(
       if let Expr::Association(pairs) = &args[0] {
         let key_str = expr_to_string(&args[1]);
         let found = pairs.iter().any(|(k, _)| expr_to_string(k) == key_str);
-        return Some(Ok(Expr::Identifier(
-          if found { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(found)));
       }
     }
     // Cycles[{cyc1, ...}] — canonicalise: drop length-1 cycles, rotate
@@ -6676,12 +6665,10 @@ pub fn dispatch_list_operations(
             break;
           }
         }
-        return Some(Ok(Expr::Identifier(
-          if valid { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(valid)));
       }
       // Non-list input
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     // FoldWhileList — fold while test is True, returning the whole history.
     // The 3-argument form takes the first list element as the initial value.
@@ -6711,8 +6698,7 @@ pub fn dispatch_list_operations(
       // The fold stops after the first result that fails the test (which
       // is still included), matching wolframscript.
       let passes = |v: &Expr| {
-        let r = apply_function_to_arg(test, v)
-          .unwrap_or(Expr::Identifier("False".to_string()));
+        let r = apply_function_to_arg(test, v).unwrap_or(bool_expr(false));
         matches!(&r, Expr::Identifier(s) if s == "True")
       };
       if passes(&acc) {
@@ -6773,8 +6759,8 @@ pub fn dispatch_list_operations(
           // If the test fails, we still include this value (Wolfram behavior).
           acc = new_acc;
           results.push(acc.clone());
-          let test_result = apply_function_to_arg(test, &acc)
-            .unwrap_or(Expr::Identifier("False".to_string()));
+          let test_result =
+            apply_function_to_arg(test, &acc).unwrap_or(bool_expr(false));
           let test_str = expr_to_string(&test_result);
           if test_str != "True" {
             break;
@@ -6815,11 +6801,9 @@ pub fn dispatch_list_operations(
             break;
           }
         }
-        return Some(Ok(Expr::Identifier(
-          if valid { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(valid)));
       }
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     // PermutationSupport[perm] — set of elements moved by the permutation
     "PermutationSupport" if args.len() == 1 => {

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -2,6 +2,7 @@
 use super::*;
 
 use crate::functions::math_ast::gcd as gcd_i128;
+use crate::syntax::bool_expr;
 
 // Re-export crate types/functions for submodules (used by submodules via `use super::*`)
 #[allow(unused_imports)]
@@ -4983,9 +4984,7 @@ pub fn evaluate_function_call_ast_inner(
   {
     let edge_str = expr_to_string(&args[1]);
     let found = edges.iter().any(|e| expr_to_string(e) == edge_str);
-    return Ok(Expr::Identifier(
-      if found { "True" } else { "False" }.to_string(),
-    ));
+    return Ok(bool_expr(found));
   }
 
   // EdgeRules[graph] — the edges as a list of rules (undirected edges
@@ -5047,9 +5046,7 @@ pub fn evaluate_function_call_ast_inner(
     } else {
       false
     };
-    return Ok(Expr::Identifier(
-      if found { "True" } else { "False" }.to_string(),
-    ));
+    return Ok(bool_expr(found));
   }
 
   // GraphQ[expr] — True iff expr is a valid Graph object
@@ -5089,9 +5086,7 @@ pub fn evaluate_function_call_ast_inner(
     } else {
       false
     };
-    return Ok(Expr::Identifier(
-      if is_graph { "True" } else { "False" }.to_string(),
-    ));
+    return Ok(bool_expr(is_graph));
   }
 
   // Graph analysis helper: extract adjacency list from graph
@@ -5108,11 +5103,9 @@ pub fn evaluate_function_call_ast_inner(
       let all_undirected = edges.iter().all(|e| {
         matches!(e, Expr::FunctionCall { name, .. } if name == "UndirectedEdge")
       });
-      return Ok(Expr::Identifier(
-        if all_undirected { "True" } else { "False" }.to_string(),
-      ));
+      return Ok(bool_expr(all_undirected));
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // DirectedGraphQ[graph] — True if all edges are directed
@@ -5128,11 +5121,9 @@ pub fn evaluate_function_call_ast_inner(
       let all_directed = edges.iter().all(|e| {
         matches!(e, Expr::FunctionCall { name, .. } if name == "DirectedEdge")
       });
-      return Ok(Expr::Identifier(
-        if all_directed { "True" } else { "False" }.to_string(),
-      ));
+      return Ok(bool_expr(all_directed));
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // MixedGraphQ[graph] — True if the graph has both directed and undirected
@@ -5161,7 +5152,7 @@ pub fn evaluate_function_call_ast_inner(
         .to_string(),
       ));
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // MultigraphQ[graph] — True if the graph has parallel edges (two edges with
@@ -5199,11 +5190,9 @@ pub fn evaluate_function_call_ast_inner(
           }
         }
       }
-      return Ok(Expr::Identifier(
-        if multi { "True" } else { "False" }.to_string(),
-      ));
+      return Ok(bool_expr(multi));
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // WeightedGraphQ[graph] — True if the graph carries explicit edge or vertex
@@ -5228,11 +5217,9 @@ pub fn evaluate_function_call_ast_inner(
         }
         _ => false,
       });
-      return Ok(Expr::Identifier(
-        if has_weight { "True" } else { "False" }.to_string(),
-      ));
+      return Ok(bool_expr(has_weight));
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // TreeGraphQ[graph] — True if graph is a tree (connected, n-1 edges for n vertices)
@@ -5248,16 +5235,14 @@ pub fn evaluate_function_call_ast_inner(
       let n = vertices.len();
       // A tree has exactly n-1 edges and is connected
       if edges.len() != n - 1 {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
       // Check connectivity via BFS/DFS
       let (pg_graph, _pg_idx) = build_undirected_graph(vertices, edges);
       let connected = is_connected_pg(&pg_graph);
-      return Ok(Expr::Identifier(
-        if connected { "True" } else { "False" }.to_string(),
-      ));
+      return Ok(bool_expr(connected));
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // AcyclicGraphQ[graph] — True if graph has no cycles
@@ -5274,11 +5259,9 @@ pub fn evaluate_function_call_ast_inner(
       // For undirected: acyclic iff edges < n and connected components have tree structure
       // Simple check: edges < n (forest)
       let is_acyclic = edges.len() < n;
-      return Ok(Expr::Identifier(
-        if is_acyclic { "True" } else { "False" }.to_string(),
-      ));
+      return Ok(bool_expr(is_acyclic));
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // EulerianGraphQ[graph] — True if graph has an Eulerian circuit
@@ -5293,7 +5276,7 @@ pub fn evaluate_function_call_ast_inner(
     {
       let n = vertices.len();
       if n == 0 || edges.is_empty() {
-        return Ok(Expr::Identifier("True".to_string()));
+        return Ok(bool_expr(true));
       }
 
       let is_directed = edges.iter().any(|e| {
@@ -5353,7 +5336,7 @@ pub fn evaluate_function_call_ast_inner(
         ));
       }
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // GraphDistance[g, s, t] — length of the shortest path from s to t.
@@ -7031,12 +7014,10 @@ pub fn evaluate_function_call_ast_inner(
         evaluate_function_call_ast_inner("ConnectedComponents", args)?;
       if let Expr::List(comp_lists) = &comps {
         let connected = comp_lists.len() <= 1;
-        return Ok(Expr::Identifier(
-          if connected { "True" } else { "False" }.to_string(),
-        ));
+        return Ok(bool_expr(connected));
       }
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // WeaklyConnectedGraphQ[g] — True iff the underlying undirected graph is
@@ -7053,12 +7034,10 @@ pub fn evaluate_function_call_ast_inner(
         evaluate_function_call_ast_inner("WeaklyConnectedComponents", args)?;
       if let Expr::List(comp_lists) = &comps {
         let connected = comp_lists.len() <= 1;
-        return Ok(Expr::Identifier(
-          if connected { "True" } else { "False" }.to_string(),
-        ));
+        return Ok(bool_expr(connected));
       }
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // ConnectedComponents[Graph[{vertices}, {edges}]]
@@ -7706,13 +7685,11 @@ pub fn evaluate_function_call_ast_inner(
     let iso =
       find_graph_isomorphism_impl(verts1, edges1, verts2, edges2, args)?;
     let found = matches!(&iso, Expr::List(maps) if !maps.is_empty());
-    return Ok(Expr::Identifier(
-      if found { "True" } else { "False" }.into(),
-    ));
+    return Ok(bool_expr(found));
   }
   // Any non-graph argument makes IsomorphicGraphQ False (matching wolframscript).
   if name == "IsomorphicGraphQ" && args.len() == 2 {
-    return Ok(Expr::Identifier("False".into()));
+    return Ok(bool_expr(false));
   }
 
   // FindSpanningTree[Graph[verts, edges]] — minimum spanning tree (Kruskal's)
@@ -8197,9 +8174,7 @@ pub fn evaluate_function_call_ast_inner(
       _ => None,
     };
     if let Some(b) = result {
-      return Ok(Expr::Identifier(
-        if b { "True" } else { "False" }.to_string(),
-      ));
+      return Ok(bool_expr(b));
     }
   }
 
@@ -8547,9 +8522,7 @@ pub fn evaluate_function_call_ast_inner(
       };
 
       if let Some(b) = result {
-        return Ok(Expr::Identifier(
-          if b { "True" } else { "False" }.to_string(),
-        ));
+        return Ok(bool_expr(b));
       }
     }
   }
@@ -8713,9 +8686,7 @@ pub fn evaluate_function_call_ast_inner(
     && let Expr::String(path) = &args[0]
   {
     let exists = std::path::Path::new(path).exists();
-    return Ok(Expr::Identifier(
-      if exists { "True" } else { "False" }.to_string(),
-    ));
+    return Ok(bool_expr(exists));
   }
 
   // FileInformation[path] — wolframscript returns `{}` when the file does
@@ -10272,11 +10243,9 @@ pub fn evaluate_function_call_ast_inner(
   if name == "DirectoryQ" && args.len() == 1 {
     if let Expr::String(path) = &args[0] {
       let is_dir = std::path::Path::new(path).is_dir();
-      return Ok(Expr::Identifier(
-        if is_dir { "True" } else { "False" }.to_string(),
-      ));
+      return Ok(bool_expr(is_dir));
     }
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // FirstCase[x, y] returns Missing["NotFound"] when x is not a list
@@ -12845,11 +12814,7 @@ fn bspline_structured(
   );
   let degree_list: Expr =
     Expr::List(degrees.iter().map(|&d| Expr::Integer(d as i128)).collect());
-  let closed: Expr = Expr::List(
-    (0..dim)
-      .map(|_| Expr::Identifier("False".to_string()))
-      .collect(),
-  );
+  let closed: Expr = Expr::List((0..dim).map(|_| bool_expr(false)).collect());
   let mut net_slot: Vec<Expr> = net.to_vec();
   net_slot.push(Expr::Identifier("Automatic".to_string()));
   let knot_lists: Expr =

--- a/src/evaluator/dispatch/polynomial_functions.rs
+++ b/src/evaluator/dispatch/polynomial_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, ComparisonOp, unevaluated};
+use crate::syntax::{BinaryOperator, ComparisonOp, bool_expr, unevaluated};
 
 pub fn dispatch_polynomial_functions(
   name: &str,
@@ -859,7 +859,7 @@ fn try_reduce_modulus(expr: &Expr, vars: &Expr, opt: &Expr) -> Option<Expr> {
   }
 
   if solutions.is_empty() {
-    return Some(Expr::Identifier("False".to_string()));
+    return Some(bool_expr(false));
   }
 
   // Build (x == v1 && y == w1) || (x == v2 && y == w2) || ...

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{ComparisonOp, unevaluated};
+use crate::syntax::{ComparisonOp, bool_expr, unevaluated};
 
 /// True if `expr` contains any Real or BigFloat node — used to decide
 /// between exact and inexact number predicates.
@@ -137,7 +137,7 @@ pub fn dispatch_predicate_functions(
   if args.len() < 2
     && matches!(name, "Less" | "LessEqual" | "Greater" | "GreaterEqual")
   {
-    return Some(Ok(Expr::Identifier("True".to_string())));
+    return Some(Ok(bool_expr(true)));
   }
   match name {
     // Inequality[a, Less, b, Less, c, ...] - evaluate chained comparisons
@@ -185,9 +185,7 @@ pub fn dispatch_predicate_functions(
           .iter()
           .zip(values.windows(2))
           .all(|(op, pair)| op(pair[0], pair[1]));
-        return Some(Ok(Expr::Identifier(
-          if result { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(result)));
       }
       // For mixed-direction chains (e.g. `Greater` with `LessEqual`, or
       // any NotEqual mixed in), split into pairwise `&&` — wolframscript's
@@ -295,18 +293,14 @@ pub fn dispatch_predicate_functions(
             && contains_real(&args[0])
         }
       };
-      return Some(Ok(Expr::Identifier(
-        if is_machine { "True" } else { "False" }.to_string(),
-      )));
+      return Some(Ok(bool_expr(is_machine)));
     }
     "MissingQ" if args.len() == 1 => {
       let is_missing = matches!(
         &args[0],
         Expr::FunctionCall { name, .. } if name == "Missing"
       );
-      return Some(Ok(Expr::Identifier(
-        if is_missing { "True" } else { "False" }.to_string(),
-      )));
+      return Some(Ok(bool_expr(is_missing)));
     }
     // FailureQ[expr] is True for $Failed, $Aborted, and Failure[...] objects
     // (note: Missing[...] is NOT a failure).
@@ -316,9 +310,7 @@ pub fn dispatch_predicate_functions(
         Expr::FunctionCall { name, .. } => name == "Failure",
         _ => false,
       };
-      return Some(Ok(Expr::Identifier(
-        if is_failure { "True" } else { "False" }.to_string(),
-      )));
+      return Some(Ok(bool_expr(is_failure)));
     }
     // AlgebraicIntegerQ[a] is True when a is an algebraic integer: an
     // algebraic number whose minimal polynomial over the rationals is monic
@@ -326,12 +318,10 @@ pub fn dispatch_predicate_functions(
     // integer polynomial, so the test reduces to a unit leading coefficient.
     "RootOfUnityQ" if args.len() == 1 => {
       let b = root_of_unity_q(&args[0]);
-      return Some(Ok(Expr::Identifier(
-        if b { "True" } else { "False" }.to_string(),
-      )));
+      return Some(Ok(bool_expr(b)));
     }
     "AlgebraicIntegerQ" if args.len() == 1 => {
-      let false_result = || Some(Ok(Expr::Identifier("False".to_string())));
+      let false_result = || Some(Ok(bool_expr(false)));
       // Inexact (machine-number) inputs are never algebraic integers.
       if contains_real(&args[0]) {
         return false_result();
@@ -368,9 +358,7 @@ pub fn dispatch_predicate_functions(
         Err(e) => return Some(Err(e)),
       };
       let is_monic = matches!(&lead, Expr::Integer(1) | Expr::Integer(-1));
-      return Some(Ok(Expr::Identifier(
-        if is_monic { "True" } else { "False" }.to_string(),
-      )));
+      return Some(Ok(bool_expr(is_monic)));
     }
     "ColorQ" if args.len() == 1 => {
       let is_color = match &args[0] {
@@ -388,16 +376,14 @@ pub fn dispatch_predicate_functions(
         ),
         _ => false,
       };
-      return Some(Ok(Expr::Identifier(
-        if is_color { "True" } else { "False" }.to_string(),
-      )));
+      return Some(Ok(bool_expr(is_color)));
     }
     "BooleanQ" if args.len() == 1 => {
       return Some(Ok(match &args[0] {
         Expr::Identifier(name) if name == "True" || name == "False" => {
-          Expr::Identifier("True".to_string())
+          bool_expr(true)
         }
-        _ => Expr::Identifier("False".to_string()),
+        _ => bool_expr(false),
       }));
     }
     // SymbolQ is not a standard Wolfram built-in (it's from GeneralUtilities package),
@@ -414,24 +400,24 @@ pub fn dispatch_predicate_functions(
       return Some(Ok(match &args[0] {
         Expr::String(s) => {
           if !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()) {
-            Expr::Identifier("True".to_string())
+            bool_expr(true)
           } else {
-            Expr::Identifier("False".to_string())
+            bool_expr(false)
           }
         }
-        _ => Expr::Identifier("False".to_string()),
+        _ => bool_expr(false),
       }));
     }
     "LetterQ" if args.len() == 1 => {
       return Some(Ok(match &args[0] {
         Expr::String(s) => {
           if !s.is_empty() && s.chars().all(|c| c.is_alphabetic()) {
-            Expr::Identifier("True".to_string())
+            bool_expr(true)
           } else {
-            Expr::Identifier("False".to_string())
+            bool_expr(false)
           }
         }
-        _ => Expr::Identifier("False".to_string()),
+        _ => bool_expr(false),
       }));
     }
     "Precision" if args.len() == 1 => {
@@ -495,7 +481,7 @@ pub fn dispatch_predicate_functions(
     "PerfectNumberQ" if args.len() == 1 => {
       if let Expr::Integer(n) = &args[0] {
         if *n <= 0 {
-          return Some(Ok(Expr::Identifier("False".to_string())));
+          return Some(Ok(bool_expr(false)));
         }
         let n_val = *n;
         // Sum of proper divisors
@@ -513,9 +499,7 @@ pub fn dispatch_predicate_functions(
         if n_val == 1 {
           sum = 0;
         }
-        return Some(Ok(Expr::Identifier(
-          if sum == n_val { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(sum == n_val)));
       }
       // wolframscript reports any non-(positive-integer) argument as not a
       // perfect number: PerfectNumberQ of a Real, rational, constant, or
@@ -524,7 +508,7 @@ pub fn dispatch_predicate_functions(
       if matches!(&args[0], Expr::BigInteger(_)) {
         return Some(Ok(unevaluated("PerfectNumberQ", args)));
       }
-      return Some(Ok(Expr::Identifier("False".to_string())));
+      return Some(Ok(bool_expr(false)));
     }
     "ListQ" if args.len() == 1 => {
       return Some(crate::functions::predicate_ast::list_q_ast(args));
@@ -614,15 +598,11 @@ pub fn dispatch_predicate_functions(
     }
     "ExactNumberQ" if args.len() == 1 => {
       let is_exact = is_exact_number(&args[0]);
-      return Some(Ok(Expr::Identifier(
-        if is_exact { "True" } else { "False" }.to_string(),
-      )));
+      return Some(Ok(bool_expr(is_exact)));
     }
     "InexactNumberQ" if args.len() == 1 => {
       let is_inexact = is_inexact_number(&args[0]);
-      return Some(Ok(Expr::Identifier(
-        if is_inexact { "True" } else { "False" }.to_string(),
-      )));
+      return Some(Ok(bool_expr(is_inexact)));
     }
     "Positive" if args.len() == 1 => {
       return Some(crate::functions::predicate_ast::positive_ast(args));
@@ -723,7 +703,7 @@ pub fn dispatch_predicate_functions(
                 (try_eval_to_f64(&pair[0]), try_eval_to_f64(&pair[1]));
               if let (Some(lo), Some(hi)) = (lo, hi) {
                 if lo <= xv && xv <= hi {
-                  return Some(Ok(Expr::Identifier("True".to_string())));
+                  return Some(Ok(bool_expr(true)));
                 }
               } else {
                 all_numeric = false;
@@ -731,7 +711,7 @@ pub fn dispatch_predicate_functions(
               }
             }
             if all_numeric {
-              return Some(Ok(Expr::Identifier("False".to_string())));
+              return Some(Ok(bool_expr(false)));
             }
           }
           // Symbolic disjunction over each {min_i, max_i}.
@@ -1614,9 +1594,9 @@ pub fn dispatch_predicate_functions(
           !crate::evaluator::attributes::get_builtin_attributes(name)
             .is_empty();
         if has_own || has_down || has_builtin_attrs {
-          return Some(Ok(Expr::Identifier("True".to_string())));
+          return Some(Ok(bool_expr(true)));
         }
-        return Some(Ok(Expr::Identifier("False".to_string())));
+        return Some(Ok(bool_expr(false)));
       }
       return Some(Ok(unevaluated("NameQ", args)));
     }
@@ -1740,11 +1720,11 @@ fn vector_order_ast(name: &str, arg: &Expr) -> Result<Expr, InterpreterError> {
     }
   }
   if any_false {
-    Ok(Expr::Identifier("False".to_string()))
+    Ok(bool_expr(false))
   } else if any_symbolic {
     unevaluated()
   } else {
-    Ok(Expr::Identifier("True".to_string()))
+    Ok(bool_expr(true))
   }
 }
 

--- a/src/evaluator/dispatch/string_functions.rs
+++ b/src/evaluator/dispatch/string_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::unevaluated;
+use crate::syntax::{bool_expr, unevaluated};
 
 pub fn dispatch_string_functions(
   name: &str,
@@ -346,9 +346,7 @@ pub fn dispatch_string_functions(
     "SyntaxQ" if args.len() == 1 => {
       if let Expr::String(s) = &args[0] {
         let is_valid = crate::parse(s).is_ok();
-        return Some(Ok(Expr::Identifier(
-          if is_valid { "True" } else { "False" }.to_string(),
-        )));
+        return Some(Ok(bool_expr(is_valid)));
       }
     }
     "LetterCounts" if args.len() == 1 => {

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, unevaluated};
+use crate::syntax::{BinaryOperator, bool_expr, unevaluated};
 
 /// MapAll[f, expr] - apply f to every subexpression in expr (bottom-up)
 pub fn map_all_ast(f: &Expr, expr: &Expr) -> Result<Expr, InterpreterError> {
@@ -1207,9 +1207,7 @@ pub fn apply_curried_call(
         v = (v << 1) | bit;
       }
       if ok {
-        return Ok(Expr::Identifier(
-          if (n >> v) & 1 == 1 { "True" } else { "False" }.to_string(),
-        ));
+        return Ok(bool_expr((n >> v) & 1 == 1));
       }
       Ok(Expr::CurriedCall {
         func: Box::new(func.clone()),

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use crate::syntax::bool_expr;
 
 /// Dispatch function call to built-in implementations (AST version).
 /// This is the AST equivalent of the string-based function dispatch.
@@ -487,7 +488,7 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
     }
     // In script mode (no Mathematica front end / notebook UI),
     // wolframscript returns `False`. Woxi is always headless.
-    "$Notebooks" => Some(Expr::Identifier("False".to_string())),
+    "$Notebooks" => Some(bool_expr(false)),
     // `$RandomState` is wolframscript's RNG state — a multi-thousand-digit
     // integer whose value depends on seed and history. Reproducing the
     // exact value isn't feasible without sharing wolframscript's PRNG
@@ -870,7 +871,7 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
         None
       }
     }
-    "$Assumptions" => Some(Expr::Identifier("True".to_string())),
+    "$Assumptions" => Some(bool_expr(true)),
     "$Context" => Some(Expr::String(crate::current_context())),
     // $Input is the name of the currently evaluating input source. In
     // wolframscript's -code mode it's the empty string.

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
+use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 use std::cell::RefCell;
 
 // Thread-local stack of accumulated bindings from outer FunctionCall arg loops.
@@ -2521,9 +2521,9 @@ fn apply_pattern_test(test: &Expr, elem: &Expr) -> bool {
         format!("({})[{}]", expr_to_string(test), expr_to_string(elem));
       interpret(&call_str).ok().map(|r| {
         if r == "True" {
-          Expr::Identifier("True".to_string())
+          bool_expr(true)
         } else {
-          Expr::Identifier("False".to_string())
+          bool_expr(false)
         }
       })
     }
@@ -3025,9 +3025,9 @@ fn match_pattern_impl(
             format!("({})[{}]", expr_to_string(test), expr_to_string(expr));
           interpret(&call_str).ok().map(|r| {
             if r == "True" {
-              Expr::Identifier("True".to_string())
+              bool_expr(true)
             } else {
-              Expr::Identifier("False".to_string())
+              bool_expr(false)
             }
           })
         }

--- a/src/evaluator/scoping.rs
+++ b/src/evaluator/scoping.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, ComparisonOp};
+use crate::syntax::{BinaryOperator, ComparisonOp, bool_expr};
 
 /// AST-based Module implementation to avoid interpret() recursion
 pub fn module_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -613,13 +613,13 @@ pub fn element_ast(x: &Expr, domain: &Expr) -> Result<Expr, InterpreterError> {
       match is_member_of_domain(alt, domain_name) {
         Some(true) => {} // Known member, skip
         Some(false) => {
-          return Ok(Expr::Identifier("False".to_string()));
+          return Ok(bool_expr(false));
         }
         None => remaining.push(alt.clone()),
       }
     }
     if remaining.is_empty() {
-      return Ok(Expr::Identifier("True".to_string()));
+      return Ok(bool_expr(true));
     }
     // Rebuild Alternatives from remaining
     let alt_expr = remaining
@@ -639,7 +639,7 @@ pub fn element_ast(x: &Expr, domain: &Expr) -> Result<Expr, InterpreterError> {
   // Handle lists: Element[{a, b, c}, dom] → Element[a | b | c, dom]
   if let Expr::List(items) = x {
     if items.is_empty() {
-      return Ok(Expr::Identifier("True".to_string()));
+      return Ok(bool_expr(true));
     }
     // Convert list to Alternatives and recurse
     let alt_expr = items
@@ -681,7 +681,7 @@ pub fn element_ast(x: &Expr, domain: &Expr) -> Result<Expr, InterpreterError> {
     if !any_dropped && !conflict {
       // No simplification possible; fall through.
     } else if remaining.is_empty() {
-      return Ok(Expr::Identifier("True".to_string()));
+      return Ok(bool_expr(true));
     } else if any_dropped && !conflict {
       let reduced = if remaining.len() == 1 {
         remaining.into_iter().next().unwrap()
@@ -697,8 +697,8 @@ pub fn element_ast(x: &Expr, domain: &Expr) -> Result<Expr, InterpreterError> {
 
   // Simple case: check single element
   match is_member_of_domain(x, domain_name) {
-    Some(true) => Ok(Expr::Identifier("True".to_string())),
-    Some(false) => Ok(Expr::Identifier("False".to_string())),
+    Some(true) => Ok(bool_expr(true)),
+    Some(false) => Ok(bool_expr(false)),
     None => Ok(Expr::FunctionCall {
       name: "Element".to_string(),
       args: vec![x.clone(), domain.clone()].into(),
@@ -713,12 +713,8 @@ pub fn not_element_ast(
 ) -> Result<Expr, InterpreterError> {
   let result = element_ast(x, domain)?;
   match &result {
-    Expr::Identifier(name) if name == "True" => {
-      Ok(Expr::Identifier("False".to_string()))
-    }
-    Expr::Identifier(name) if name == "False" => {
-      Ok(Expr::Identifier("True".to_string()))
-    }
+    Expr::Identifier(name) if name == "True" => Ok(bool_expr(false)),
+    Expr::Identifier(name) if name == "False" => Ok(bool_expr(true)),
     _ => {
       // Element returned unevaluated, so NotElement stays unevaluated too
       Ok(Expr::FunctionCall {

--- a/src/functions/assessment_ast.rs
+++ b/src/functions/assessment_ast.rs
@@ -18,7 +18,7 @@
 
 use crate::InterpreterError;
 use crate::evaluator::pattern_matching::expr_equal;
-use crate::syntax::{Expr, unevaluated};
+use crate::syntax::{Expr, bool_expr, unevaluated};
 
 /// Turn a numeric-or-boolean grade expression into a `(score, correct)` pair.
 /// Returns `None` when the expression is not a recognized grade value.
@@ -87,8 +87,6 @@ fn score_expr(score: f64) -> Expr {
     Expr::Real(score)
   }
 }
-
-use crate::syntax::bool_expr;
 
 /// Build an `AssessmentResultObject[<|"AnswerCorrect" -> …, "Score" -> …|>]`.
 fn result_object(score: f64, correct: bool) -> Expr {

--- a/src/functions/association_ast.rs
+++ b/src/functions/association_ast.rs
@@ -3,7 +3,7 @@
 //! These functions work directly with `Expr` AST nodes.
 
 use crate::InterpreterError;
-use crate::syntax::{Expr, unevaluated};
+use crate::syntax::{Expr, bool_expr, unevaluated};
 
 /// Whether an expression is a valid association entry: a single rule, a
 /// list of rules, or an association. Used by AssociationMap to decide when
@@ -289,10 +289,10 @@ pub fn key_exists_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let k_str = crate::syntax::expr_to_string(k);
         let k_cmp = k_str.as_str();
         if k_cmp == key_cmp {
-          return Ok(Expr::Identifier("True".to_string()));
+          return Ok(bool_expr(true));
         }
       }
-      Ok(Expr::Identifier("False".to_string()))
+      Ok(bool_expr(false))
     }
     // A list of rules is also a valid subject.
     Expr::List(items)
@@ -302,11 +302,11 @@ pub fn key_exists_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(k) = extract_rule_key(item) {
           let k_str = crate::syntax::expr_to_string(&k);
           if k_str.as_str() == key_cmp {
-            return Ok(Expr::Identifier("True".to_string()));
+            return Ok(bool_expr(true));
           }
         }
       }
-      Ok(Expr::Identifier("False".to_string()))
+      Ok(bool_expr(false))
     }
     other => {
       // Unlike its siblings, KeyExistsQ answers False after the message.
@@ -317,7 +317,7 @@ pub fn key_exists_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         other,
         args,
       );
-      Ok(Expr::Identifier("False".to_string()))
+      Ok(bool_expr(false))
     }
   }
 }

--- a/src/functions/boolean_ast.rs
+++ b/src/functions/boolean_ast.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
 
 /// Helper to check if an Expr is True or False
@@ -31,14 +31,14 @@ pub fn and_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     splice_flat_head(&evaluated, BinaryOperator::And, "And", &mut pieces);
     for piece in pieces {
       match as_bool(&piece) {
-        Some(false) => return Ok(Expr::Identifier("False".to_string())),
+        Some(false) => return Ok(bool_expr(false)),
         Some(true) => {} // Skip True values
         None => remaining.push(piece),
       }
     }
   }
   match remaining.len() {
-    0 => Ok(Expr::Identifier("True".to_string())),
+    0 => Ok(bool_expr(true)),
     1 => Ok(remaining.into_iter().next().unwrap()),
     _ => Ok(Expr::FunctionCall {
       name: "And".to_string(),
@@ -81,14 +81,14 @@ pub fn or_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     splice_flat_head(&evaluated, BinaryOperator::Or, "Or", &mut pieces);
     for piece in pieces {
       match as_bool(&piece) {
-        Some(true) => return Ok(Expr::Identifier("True".to_string())),
+        Some(true) => return Ok(bool_expr(true)),
         Some(false) => {} // Skip False values
         None => remaining.push(piece),
       }
     }
   }
   match remaining.len() {
-    0 => Ok(Expr::Identifier("False".to_string())),
+    0 => Ok(bool_expr(false)),
     1 => Ok(remaining.into_iter().next().unwrap()),
     _ => Ok(Expr::FunctionCall {
       name: "Or".to_string(),
@@ -106,8 +106,8 @@ pub fn not_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let evaluated = evaluate_expr_to_expr(&args[0])?;
   match as_bool(&evaluated) {
-    Some(true) => Ok(Expr::Identifier("False".to_string())),
-    Some(false) => Ok(Expr::Identifier("True".to_string())),
+    Some(true) => Ok(bool_expr(false)),
+    Some(false) => Ok(bool_expr(true)),
     None => {
       // Double negation: Not[Not[x]] → x. The inner operand is already in
       // normal form (it was produced by evaluating the inner Not).
@@ -199,7 +199,7 @@ fn reduce_xor_operands(
 pub fn xor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Xor[] = False (empty XOR is the identity element)
   if args.is_empty() {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
   // Single argument: Xor[x] => x
   if args.len() == 1 {
@@ -209,9 +209,7 @@ pub fn xor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let (remaining, odd_true) = reduce_xor_operands(args)?;
 
   if remaining.is_empty() {
-    return Ok(Expr::Identifier(
-      if odd_true { "True" } else { "False" }.to_string(),
-    ));
+    return Ok(bool_expr(odd_true));
   }
 
   let core = if remaining.len() == 1 {
@@ -231,7 +229,7 @@ pub fn xor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn xnor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Xnor[] => True (0 true values, even)
   if args.is_empty() {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
   // Xnor is the negation of Xor: reduce the operands the same way, then wrap
   // them in the Xnor head and apply the extra outer negation.
@@ -239,9 +237,7 @@ pub fn xnor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // No surviving operands: Xnor[] of an even True count is True, odd is False.
   if remaining.is_empty() {
-    return Ok(Expr::Identifier(
-      if odd_true { "False" } else { "True" }.to_string(),
-    ));
+    return Ok(bool_expr(!odd_true));
   }
 
   // A single operand x: Xnor reduces to x (odd True) or Not[x] (even True),
@@ -264,7 +260,7 @@ pub fn xnor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn same_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // SameQ[] and SameQ[x] return True (vacuously true)
   if args.len() < 2 {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // SameQ is not HoldAll, so its arguments are already evaluated by the time
@@ -277,10 +273,10 @@ pub fn same_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for arg in args.iter().skip(1) {
     let val_str = crate::syntax::expr_to_string(arg);
     if val_str != first_str && !same_q_real_bigfloat(first, arg) {
-      return Ok(Expr::Identifier("False".to_string()));
+      return Ok(bool_expr(false));
     }
   }
-  Ok(Expr::Identifier("True".to_string()))
+  Ok(bool_expr(true))
 }
 
 /// SameQ between two floating-point operands. Matches wolframscript's
@@ -373,7 +369,7 @@ fn within_one_ulp(a: f64, b: f64) -> bool {
 pub fn unsame_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // UnsameQ[] and UnsameQ[x] return True (vacuously true)
   if args.len() < 2 {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // UnsameQ is not HoldAll: arguments arrive already evaluated, so just take
@@ -385,11 +381,11 @@ pub fn unsame_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for i in 0..strs.len() {
     for j in (i + 1)..strs.len() {
       if strs[i] == strs[j] {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
   }
-  Ok(Expr::Identifier("True".to_string()))
+  Ok(bool_expr(true))
 }
 
 /// Which[test1, value1, test2, value2, ...] - Multi-way conditional
@@ -622,7 +618,7 @@ pub fn infinity_equal_verdict(a: &Expr, b: &Expr) -> Option<Option<bool>> {
 pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Equal[] and Equal[x] return True (like wolframscript)
   if args.len() < 2 {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Infinity rules run before the string-identity fast path so
@@ -630,7 +626,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for pair in args.windows(2) {
     match infinity_equal_verdict(&pair[0], &pair[1]) {
       Some(Some(false)) => {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
       Some(None) => {
         return Ok(symbolic_comparison_chain(args, ComparisonOp::Equal));
@@ -651,9 +647,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       .collect();
     if let Some(midis) = midis {
       let all_equal = midis.iter().all(|m| *m == midis[0]);
-      return Ok(Expr::Identifier(
-        if all_equal { "True" } else { "False" }.to_string(),
-      ));
+      return Ok(bool_expr(all_equal));
     }
   }
 
@@ -671,7 +665,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   if all_identical {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Any other equality touching a MusicPitch stays unevaluated, matching
@@ -726,7 +720,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // is True for 18-digit literals.
         let shared = (p0.min(*p1).floor() as usize).saturating_sub(1);
         if shared > 0 && !bigfloat_digits_match_to(d0, d1, shared) {
-          return Ok(Expr::Identifier("False".to_string()));
+          return Ok(bool_expr(false));
         }
       }
       if any_real {
@@ -750,13 +744,13 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }
         }
         if (first - v).abs() > tol && first != v {
-          return Ok(Expr::Identifier("False".to_string()));
+          return Ok(bool_expr(false));
         }
       } else if v != first {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Structured operands sharing head and arity are equal when every component
@@ -769,7 +763,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       .skip(1)
       .all(|a| all_components_equal(&args[0], a))
   {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Only stay symbolic if at least one arg has free symbols
@@ -777,7 +771,7 @@ pub fn equal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Ok(symbolic_comparison_chain(args, ComparisonOp::Equal))
   } else {
     // No free symbols, not identical → False
-    Ok(Expr::Identifier("False".to_string()))
+    Ok(bool_expr(false))
   }
 }
 
@@ -799,7 +793,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for j in i + 1..args.len() {
       match infinity_equal_verdict(&args[i], &args[j]) {
         Some(Some(true)) => {
-          return Ok(Expr::Identifier("False".to_string()));
+          return Ok(bool_expr(false));
         }
         Some(Some(false)) => infinity_decided += 1,
         Some(None) => {
@@ -812,7 +806,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // All pairs decided unequal by the infinity rules (e.g. the 2-operand
   // ComplexInfinity != -1/2) — True without consulting the numeric path.
   if infinity_decided == args.len() * (args.len() - 1) / 2 {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   use crate::functions::math_ast::try_eval_to_f64;
@@ -832,7 +826,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for i in 0..strs.len() {
       for j in i + 1..strs.len() {
         if strs[i] == strs[j] || all_components_equal(&args[i], &args[j]) {
-          return Ok(Expr::Identifier("False".to_string()));
+          return Ok(bool_expr(false));
         }
       }
     }
@@ -840,7 +834,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for i in 0..strs.len() - 1 {
       if strs[i] == strs[i + 1] || all_components_equal(&args[i], &args[i + 1])
       {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
   }
@@ -858,7 +852,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let nums: Vec<Option<f64>> = args.iter().map(try_eval_to_f64).collect();
   if nums.iter().all(|n| n.is_some()) {
     // All numeric and pairwise different (checked above via strings)
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Only stay symbolic if at least one arg has free symbols
@@ -866,7 +860,7 @@ pub fn unequal_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Ok(symbolic_comparison_chain(args, ComparisonOp::NotEqual))
   } else {
     // No free symbols, pairwise different → True
-    Ok(Expr::Identifier("True".to_string()))
+    Ok(bool_expr(true))
   }
 }
 
@@ -923,13 +917,11 @@ pub fn implies_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let a = evaluate_expr_to_expr(&args[0])?;
   match as_bool(&a) {
-    Some(false) => Ok(Expr::Identifier("True".to_string())), // False implies anything
+    Some(false) => Ok(bool_expr(true)), // False implies anything
     Some(true) => {
       let b = evaluate_expr_to_expr(&args[1])?;
       match as_bool(&b) {
-        Some(val) => Ok(Expr::Identifier(
-          if val { "True" } else { "False" }.to_string(),
-        )),
+        Some(val) => Ok(bool_expr(val)),
         None => Ok(b), // True implies symbolic expr → return the expr
       }
     }
@@ -938,7 +930,7 @@ pub fn implies_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let b = evaluate_expr_to_expr(&args[1])?;
       match as_bool(&b) {
         // Implies[a, True] → True (anything implies a truth).
-        Some(true) => Ok(Expr::Identifier("True".to_string())),
+        Some(true) => Ok(bool_expr(true)),
         // Implies[a, False] → Not[a].
         Some(false) => not_ast(&[a]),
         None => {
@@ -946,7 +938,7 @@ pub fn implies_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           if crate::syntax::expr_to_string(&a)
             == crate::syntax::expr_to_string(&b)
           {
-            Ok(Expr::Identifier("True".to_string()))
+            Ok(bool_expr(true))
           } else {
             Ok(Expr::FunctionCall {
               name: "Implies".to_string(),
@@ -963,7 +955,7 @@ pub fn implies_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn nand_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Nand[] = Not[And[]] = Not[True] = False
   if args.is_empty() {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
   // Nand[a] = Not[a]
   if args.len() == 1 {
@@ -975,14 +967,14 @@ pub fn nand_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for arg in args {
     let evaluated = evaluate_expr_to_expr(arg)?;
     match as_bool(&evaluated) {
-      Some(false) => return Ok(Expr::Identifier("True".to_string())),
+      Some(false) => return Ok(bool_expr(true)),
       Some(true) => {} // Skip True values
       None => remaining.push(evaluated),
     }
   }
   match remaining.len() {
     // All were True → Nand is Not[And[]] = Not[True] = False.
-    0 => Ok(Expr::Identifier("False".to_string())),
+    0 => Ok(bool_expr(false)),
     // A lone surviving operand collapses to its negation: Nand[a, True] -> !a.
     1 => not_ast(&[remaining.into_iter().next().unwrap()]),
     // Some symbolic: Nand[remaining...]
@@ -997,7 +989,7 @@ pub fn nand_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn nor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Nor[] = Not[Or[]] = Not[False] = True
   if args.is_empty() {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
   // Nor[a] = Not[a]
   if args.len() == 1 {
@@ -1009,14 +1001,14 @@ pub fn nor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for arg in args {
     let evaluated = evaluate_expr_to_expr(arg)?;
     match as_bool(&evaluated) {
-      Some(true) => return Ok(Expr::Identifier("False".to_string())),
+      Some(true) => return Ok(bool_expr(false)),
       Some(false) => {} // Skip False values
       None => remaining.push(evaluated),
     }
   }
   match remaining.len() {
     // All were False → Nor is Not[Or[]] = Not[False] = True.
-    0 => Ok(Expr::Identifier("True".to_string())),
+    0 => Ok(bool_expr(true)),
     // A lone surviving operand collapses to its negation: Nor[a, False] -> !a.
     1 => not_ast(&[remaining.into_iter().next().unwrap()]),
     // Some symbolic: Nor[remaining...]
@@ -1031,7 +1023,7 @@ pub fn nor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn equivalent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Equivalent[] and Equivalent[a] are vacuously True.
   if args.len() < 2 {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   let mut has_true = false;
@@ -1054,12 +1046,12 @@ pub fn equivalent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // If we have both True and False, it's False
   if has_true && has_false {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // If all are known and the same value, it's True
   if remaining.is_empty() {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // If some symbolic: the presence of an explicit True or False reduces
@@ -1095,7 +1087,7 @@ pub fn equivalent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // No boolean literal: a single distinct operand (e.g. Equivalent[a, a]) is
   // vacuously True; otherwise keep the deduplicated chain symbolic.
   if remaining.len() <= 1 {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
   Ok(Expr::FunctionCall {
     name: "Equivalent".to_string(),
@@ -1142,9 +1134,9 @@ pub fn boolean_table_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for (j, var_name) in vars.iter().enumerate() {
       let bit = (i >> (n - 1 - j)) & 1;
       let val = if bit == 0 {
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       } else {
-        Expr::Identifier("False".to_string())
+        bool_expr(false)
       };
       substituted =
         crate::syntax::substitute_variable(&substituted, var_name, &val);
@@ -1268,7 +1260,7 @@ fn canonicalize_dnf(expr: &Expr) -> Expr {
       Some(lits) => {
         if lits.is_empty() {
           // An empty conjunction is `True`, which absorbs the whole Or.
-          return Expr::Identifier("True".to_string());
+          return bool_expr(true);
         }
         clauses.push(
           lits
@@ -1280,7 +1272,7 @@ fn canonicalize_dnf(expr: &Expr) -> Expr {
     }
   }
   if clauses.is_empty() {
-    return Expr::Identifier("False".to_string());
+    return bool_expr(false);
   }
 
   // Signature for dedup/subset tests: the (variable, sign) pairs.
@@ -1594,8 +1586,8 @@ fn apply_not_inward(inner: &Expr) -> Expr {
       }
     }
     // Not[True] → False, Not[False] → True
-    Expr::Identifier(s) if s == "True" => Expr::Identifier("False".to_string()),
-    Expr::Identifier(s) if s == "False" => Expr::Identifier("True".to_string()),
+    Expr::Identifier(s) if s == "True" => bool_expr(false),
+    Expr::Identifier(s) if s == "False" => bool_expr(true),
     // Not[other] → Not[other] (keep as-is, recurse into inner)
     other => {
       let recurse = push_not_inward(other);
@@ -1767,7 +1759,7 @@ fn simplify_cnf(expr: &Expr) -> Expr {
         .filter(|clause| !is_tautological_clause(clause))
         .collect();
       if simplified.is_empty() {
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       } else if simplified.len() == 1 {
         simplified.into_iter().next().unwrap()
       } else {
@@ -2160,9 +2152,9 @@ pub fn tautology_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut substituted = expr.clone();
     for (i, var_name) in var_list.iter().enumerate() {
       let val = if (bits >> i) & 1 == 1 {
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       } else {
-        Expr::Identifier("False".to_string())
+        bool_expr(false)
       };
       substituted =
         crate::syntax::substitute_variable(&substituted, var_name, &val);
@@ -2183,9 +2175,7 @@ pub fn tautology_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::Identifier(
-    if has_false { "False" } else { "True" }.to_string(),
-  ))
+  Ok(bool_expr(!has_false))
 }
 
 /// BooleanMinimize[expr] - Find the minimal sum-of-products form.
@@ -2198,10 +2188,10 @@ pub fn boolean_minimize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Handle trivial cases
   if matches!(expr, Expr::Identifier(s) if s == "True") {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
   if matches!(expr, Expr::Identifier(s) if s == "False") {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // Collect all boolean variables
@@ -2225,9 +2215,9 @@ pub fn boolean_minimize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut substituted = expr.clone();
     for (i, var_name) in var_list.iter().enumerate() {
       let val = if (bits >> i) & 1 == 1 {
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       } else {
-        Expr::Identifier("False".to_string())
+        bool_expr(false)
       };
       substituted =
         crate::syntax::substitute_variable(&substituted, var_name, &val);
@@ -2239,10 +2229,10 @@ pub fn boolean_minimize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   if minterms.is_empty() {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
   if minterms.len() == (1usize << n) {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Quine-McCluskey: find prime implicants
@@ -2377,7 +2367,7 @@ fn implicants_to_expr(
   vars: &[String],
 ) -> Result<Expr, InterpreterError> {
   if implicants.is_empty() {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   let mut terms: Vec<Expr> = Vec::new();
@@ -2398,7 +2388,7 @@ fn implicants_to_expr(
       }
     }
     let term = if literals.is_empty() {
-      Expr::Identifier("True".to_string())
+      bool_expr(true)
     } else if literals.len() == 1 {
       literals.remove(0)
     } else {
@@ -2472,10 +2462,10 @@ pub fn boolean_counting_function_ast(
 
   // Trivial extremes.
   if count_set.is_empty() {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
   if count_set.len() == n + 1 {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // "Exactly k" — natural sum-of-minterms in lex order over which
@@ -2587,7 +2577,7 @@ fn detect_at_most(count_set: &[usize]) -> Option<usize> {
 fn exactly_k_dnf(vars: &[String], k: usize) -> Expr {
   let n = vars.len();
   if k > n {
-    return Expr::Identifier("False".to_string());
+    return bool_expr(false);
   }
   let subsets = subsets_in_lex_order(n, k);
   let mut terms: Vec<Expr> = Vec::with_capacity(subsets.len());
@@ -2622,7 +2612,7 @@ fn at_most_k_dnf(vars: &[String], kmax: usize) -> Expr {
   let n = vars.len();
   let neg_count = n.saturating_sub(kmax);
   if neg_count == 0 {
-    return Expr::Identifier("True".to_string());
+    return bool_expr(true);
   }
   let subsets = subsets_in_lex_order(n, neg_count);
   let mut terms: Vec<Expr> = Vec::with_capacity(subsets.len());
@@ -2721,7 +2711,7 @@ fn subsets_in_lex_order(n: usize, k: usize) -> Vec<Vec<usize>> {
 /// Wrap `terms` in an `Or` head, or unwrap if there's only one.
 fn or_of(mut terms: Vec<Expr>) -> Expr {
   if terms.is_empty() {
-    return Expr::Identifier("False".to_string());
+    return bool_expr(false);
   }
   if terms.len() == 1 {
     return terms.remove(0);
@@ -2775,7 +2765,7 @@ fn vector_compare_ast(
       (Expr::List(args_a), Expr::List(args_b)) => {
         // Mismatched lengths → False
         if args_a.len() != args_b.len() {
-          return Ok(Expr::Identifier("False".to_string()));
+          return Ok(bool_expr(false));
         }
         // Empty vectors → True (vacuously), continue to next pair
         for (ea, eb) in args_a.iter().zip(args_b.iter()) {
@@ -2793,10 +2783,10 @@ fn vector_compare_ast(
           };
           if allow_equal {
             if na > nb {
-              return Ok(Expr::Identifier("False".to_string()));
+              return Ok(bool_expr(false));
             }
           } else if na >= nb {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
         }
       }
@@ -2816,16 +2806,16 @@ fn vector_compare_ast(
         };
         if allow_equal {
           if na > nb {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
         } else if na >= nb {
-          return Ok(Expr::Identifier("False".to_string()));
+          return Ok(bool_expr(false));
         }
       }
     }
   }
 
-  Ok(Expr::Identifier("True".to_string()))
+  Ok(bool_expr(true))
 }
 
 // ---------------------------------------------------------------------------
@@ -2970,7 +2960,7 @@ fn count_satisfying(
       (0..n).map(|j| (idx >> (n - 1 - j)) & 1 == 0).collect();
     let mut substituted = expr.clone();
     for (var, &b) in vars.iter().zip(&assignment) {
-      let val = Expr::Identifier(if b { "True" } else { "False" }.to_string());
+      let val = bool_expr(b);
       substituted = substitute_boolean_var(&substituted, var, &val);
     }
     let result = evaluate_expr_to_expr(&substituted)?;
@@ -2997,22 +2987,20 @@ pub fn satisfiable_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       (0..n).map(|j| (idx >> (n - 1 - j)) & 1 == 0).collect();
     let mut substituted = args[0].clone();
     for (var, &b) in vars.iter().zip(&assignment) {
-      let val = Expr::Identifier(if b { "True" } else { "False" }.to_string());
+      let val = bool_expr(b);
       substituted = substitute_boolean_var(&substituted, var, &val);
     }
     let result = evaluate_expr_to_expr(&substituted)?;
     match &result {
       Expr::Identifier(s) if s == "True" => {
-        return Ok(Expr::Identifier("True".to_string()));
+        return Ok(bool_expr(true));
       }
       Expr::Identifier(s) if s == "False" => {}
       _ => {
         let shown = Expr::List(
           assignment
             .iter()
-            .map(|&b| {
-              Expr::Identifier(if b { "True" } else { "False" }.to_string())
-            })
+            .map(|&b| bool_expr(b))
             .collect::<Vec<_>>()
             .into(),
         );
@@ -3025,7 +3013,7 @@ pub fn satisfiable_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
     }
   }
-  Ok(Expr::Identifier("False".to_string()))
+  Ok(bool_expr(false))
 }
 
 /// SatisfiabilityCount[expr] / SatisfiabilityCount[expr, vars]
@@ -3062,10 +3050,10 @@ pub fn majority_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unknowns = n - trues - falses;
   // Decided regardless of the unknowns
   if 2 * trues > n {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
   if 2 * (trues + unknowns) <= n {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
   // Cancel one True/False pair and re-evaluate
   if trues >= 1 && falses >= 1 {
@@ -3174,7 +3162,7 @@ pub fn boolean_minterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       );
     }
   } else if spec_items.is_empty() {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   } else {
     bspec();
     return Ok(unevaluated());
@@ -3197,7 +3185,7 @@ pub fn boolean_minterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // A specification covering every minterm simplifies to True
   let covered: u64 = rows.iter().map(|r| 1u64 << (nvars - r.len())).sum();
   if covered >= (1u64 << nvars) {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   let terms: Vec<Expr> = rows
@@ -3228,7 +3216,7 @@ pub fn boolean_minterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     })
     .collect();
   let result = match terms.len() {
-    0 => Expr::Identifier("False".to_string()),
+    0 => bool_expr(false),
     1 => terms.into_iter().next().unwrap(),
     _ => Expr::FunctionCall {
       name: "Or".to_string(),
@@ -3260,7 +3248,7 @@ pub fn unate_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => return unevaluated(),
   };
   if vars.is_empty() {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
   let n = vars.len();
   if n > 16 {
@@ -3313,11 +3301,11 @@ pub fn unate_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       let idx_false = idx_true | bit;
       if is_true(&table[idx_false]) && is_false(&table[idx_true]) {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
   }
-  Ok(Expr::Identifier("True".to_string()))
+  Ok(bool_expr(true))
 }
 
 /// BooleanMaxterms[spec, {vars}] — the conjunction of maxterms given as
@@ -3395,7 +3383,7 @@ pub fn boolean_maxterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       );
     }
   } else if spec_items.is_empty() {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   } else {
     bspec();
     return Ok(unevaluated());
@@ -3418,7 +3406,7 @@ pub fn boolean_maxterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Covering every maxterm collapses the conjunction to False.
   let covered: u64 = rows.iter().map(|r| 1u64 << (nvars - r.len())).sum();
   if covered >= (1u64 << nvars) {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   let terms: Vec<Expr> = rows
@@ -3449,7 +3437,7 @@ pub fn boolean_maxterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     })
     .collect();
   let result = match terms.len() {
-    0 => Expr::Identifier("True".to_string()),
+    0 => bool_expr(true),
     1 => terms.into_iter().next().unwrap(),
     _ => Expr::FunctionCall {
       name: "And".to_string(),

--- a/src/functions/country_data.rs
+++ b/src/functions/country_data.rs
@@ -14,7 +14,7 @@
 //! self-contained, reproducible country dataset.
 
 use crate::InterpreterError;
-use crate::syntax::{Expr, unevaluated};
+use crate::syntax::{Expr, bool_expr, unevaluated};
 
 /// A single sovereign country: a canonical display name, its population in
 /// number of people, and alternate spellings/abbreviations that should
@@ -353,8 +353,8 @@ fn interpret_scalar(ty: &str, val: &Expr) -> Option<Expr> {
         _ => return None,
       };
       match s.as_str() {
-        "true" => Some(Expr::Identifier("True".to_string())),
-        "false" => Some(Expr::Identifier("False".to_string())),
+        "true" => Some(bool_expr(true)),
+        "false" => Some(bool_expr(false)),
         _ => None,
       }
     }

--- a/src/functions/datetime_ast.rs
+++ b/src/functions/datetime_ast.rs
@@ -1,7 +1,7 @@
 //! AST-native date/time functions.
 
 use crate::InterpreterError;
-use crate::syntax::{Expr, unevaluated};
+use crate::syntax::{Expr, bool_expr, unevaluated};
 
 /// Parse an ISO-style date/time string into its integer components, e.g.
 /// `"2024-03-15"` → `{2024, 3, 15}` and `"2024-03-15 14:30:00"` →
@@ -2446,11 +2446,7 @@ pub fn day_match_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     "Sunday",
   ];
 
-  let boolean = |b: bool| {
-    Ok(Expr::Identifier(
-      if b { "True" } else { "False" }.to_string(),
-    ))
-  };
+  let boolean = |b: bool| Ok(bool_expr(b));
 
   match &args[1] {
     // A weekday name (symbol or string) matches that day of the week.
@@ -4006,9 +4002,7 @@ pub fn date_within_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return unevaluated();
   }
   let within = s2 >= s1 && e2 <= e1 && s2 < e1;
-  Ok(Expr::Identifier(
-    if within { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(within))
 }
 
 /// DateSelect[list, crit] — the dates of `list` for which `crit[date]` is
@@ -4228,9 +4222,7 @@ pub fn date_overlaps_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let overlaps = a
     .iter()
     .any(|&(s1, e1)| b.iter().any(|&(s2, e2)| s1.max(s2) < e1.min(e2)));
-  Ok(Expr::Identifier(
-    if overlaps { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(overlaps))
 }
 
 /// FromJulianDate[jd] — the DateObject instant of a Julian date (days

--- a/src/functions/function_range_ast.rs
+++ b/src/functions/function_range_ast.rs
@@ -7,7 +7,9 @@
 //! LessEqual, 1].
 
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, ComparisonOp, Expr, unevaluated};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, bool_expr, unevaluated,
+};
 
 pub fn function_range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = |args: &[Expr]| unevaluated("FunctionRange", args);
@@ -29,7 +31,7 @@ pub fn function_range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       operands,
       operators,
     };
-  let true_expr = || Expr::Identifier("True".to_string());
+  let true_expr = || bool_expr(true);
   let y_ge =
     |v: Expr| cmp(vec![y.clone(), v], vec![ComparisonOp::GreaterEqual]);
   let y_le = |v: Expr| cmp(vec![y.clone(), v], vec![ComparisonOp::LessEqual]);

--- a/src/functions/geometric_test_ast.rs
+++ b/src/functions/geometric_test_ast.rs
@@ -12,7 +12,7 @@
 //! unsupported cases elsewhere).
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{Expr, bool_expr};
 
 /// Absolute tolerance for orientation / sign tests (exact-zero comparisons on
 /// well-conditioned inputs).
@@ -52,8 +52,6 @@ fn perp_vec(a: Pt, b: Pt) -> bool {
 fn approx_eq(a: f64, b: f64) -> bool {
   (a - b).abs() <= REL * (1.0 + a.abs().max(b.abs()))
 }
-
-use crate::syntax::bool_expr;
 
 /// Parse a single 2D point `{x, y}` with numeric coordinates.
 fn extract_point(expr: &Expr) -> Option<Pt> {

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -1,7 +1,7 @@
 use crate::InterpreterError;
 use crate::functions::graphics::{Color, graphics_ast, parse_color};
 use crate::syntax::{
-  BinaryOperator, Expr, expr_to_output, expr_to_string, unevaluated,
+  BinaryOperator, Expr, bool_expr, expr_to_output, expr_to_string, unevaluated,
 };
 use petgraph::graph::{DiGraph, NodeIndex, UnGraph};
 use petgraph::visit::EdgeRef;
@@ -4632,8 +4632,6 @@ fn parse_graph_pairs(expr: &Expr) -> Option<(usize, Vec<(usize, usize)>)> {
   }
   Some((vkeys.len(), pairs))
 }
-
-use crate::syntax::bool_expr;
 
 pub fn graph_predicate_ast(
   name: &str,

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -3,7 +3,7 @@ use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{DEFAULT_HEIGHT, DEFAULT_WIDTH, parse_image_size};
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
   unevaluated,
 };
 
@@ -7141,7 +7141,7 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Enable axes
       let axes_rule = Expr::Rule {
         pattern: Box::new(Expr::Identifier("Axes".to_string())),
-        replacement: Box::new(Expr::Identifier("True".to_string())),
+        replacement: Box::new(bool_expr(true)),
       };
       merge_option(&mut merged_options, &axes_rule);
 

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -1,6 +1,6 @@
 use crate::InterpreterError;
 use crate::syntax::BinaryOperator;
-use crate::syntax::{Expr, ImageType, unevaluated};
+use crate::syntax::{Expr, ImageType, bool_expr, unevaluated};
 use std::sync::Arc;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -429,9 +429,7 @@ pub fn image_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let is_image =
     matches!(&args[0], Expr::Image { .. }) || is_valid_image3d(&args[0]);
-  Ok(Expr::Identifier(
-    if is_image { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(is_image))
 }
 
 /// Image3D[arg] is a valid Image when `arg` is a rank-3 or rank-4 nested
@@ -3360,9 +3358,7 @@ pub fn binary_image_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       ..
     }
   );
-  Ok(Expr::Identifier(
-    if result { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(result))
 }
 
 /// PixelValue[img, {x, y}] — pixel value at column x (1-indexed from the

--- a/src/functions/information_render.rs
+++ b/src/functions/information_render.rs
@@ -5,7 +5,7 @@
 //! Both use the existing `grid_svg_with_gaps` infrastructure so theming and
 //! layout stay consistent with `Grid[]` / `TableForm[]` output.
 
-use crate::syntax::Expr;
+use crate::syntax::{Expr, bool_expr};
 
 /// Build a `Style[content, Bold]` Expr.
 fn bold_style(text: &str) -> Expr {
@@ -129,10 +129,7 @@ pub fn render_information_card_svg(
 
   // Grid options: outer frame, left-aligned both columns with right-aligned
   // labels, modest spacing, alternating row backgrounds for readability.
-  let frame_opt = rule(
-    Expr::Identifier("Frame".to_string()),
-    Expr::Identifier("True".to_string()),
-  );
+  let frame_opt = rule(Expr::Identifier("Frame".to_string()), bool_expr(true));
   let alignment_opt = rule(
     Expr::Identifier("Alignment".to_string()),
     list(vec![list(vec![
@@ -198,10 +195,7 @@ pub fn render_information_grid_svg(
 
   let grid_data = list(rows);
 
-  let frame_opt = rule(
-    Expr::Identifier("Frame".to_string()),
-    Expr::Identifier("True".to_string()),
-  );
+  let frame_opt = rule(Expr::Identifier("Frame".to_string()), bool_expr(true));
   let alignment_opt = rule(
     Expr::Identifier("Alignment".to_string()),
     Expr::Identifier("Left".to_string()),

--- a/src/functions/interval_ast.rs
+++ b/src/functions/interval_ast.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
+use crate::syntax::{BinaryOperator, Expr, bool_expr, unevaluated};
 use std::cmp::Ordering;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -711,10 +711,10 @@ pub fn interval_member_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       if !contained {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
-    Ok(Expr::Identifier("True".to_string()))
+    Ok(bool_expr(true))
   } else {
     // Point membership
     let point = &args[1];
@@ -724,10 +724,10 @@ pub fn interval_member_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Some(Ordering::Less | Ordering::Equal),
       ) = (compare_numeric(lo, point), compare_numeric(point, hi))
       {
-        return Ok(Expr::Identifier("True".to_string()));
+        return Ok(bool_expr(true));
       }
     }
-    Ok(Expr::Identifier("False".to_string()))
+    Ok(bool_expr(false))
   }
 }
 

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -2,7 +2,9 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator, unevaluated};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, UnaryOperator, bool_expr, unevaluated,
+};
 
 /// Shared AllTrue/AnyTrue/NoneTrue implementation: apply the predicate
 /// to every element at exactly the requested level (default 1) and
@@ -110,10 +112,10 @@ pub fn all_match_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   for part in &parts {
     if !matches_pattern_ast(part, &args[1]) {
-      return Ok(bool_to_expr(false));
+      return Ok(bool_expr(false));
     }
   }
-  Ok(bool_to_expr(true))
+  Ok(bool_expr(true))
 }
 
 /// AnyMatch[list, pattern] - True if any element at level 1 matches pattern
@@ -140,10 +142,10 @@ pub fn any_match_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   for part in &parts {
     if matches_pattern_ast(part, &args[1]) {
-      return Ok(bool_to_expr(true));
+      return Ok(bool_expr(true));
     }
   }
-  Ok(bool_to_expr(false))
+  Ok(bool_expr(false))
 }
 
 /// AST-based GroupBy: group elements by the value of a function.
@@ -2817,17 +2819,17 @@ pub fn all_same_by_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   };
   if items.is_empty() {
-    return Ok(bool_to_expr(true));
+    return Ok(bool_expr(true));
   }
   let first_val = apply_func_ast(&args[1], &items[0])?;
   let first_str = crate::syntax::expr_to_string(&first_val);
   for item in &items[1..] {
     let val = apply_func_ast(&args[1], item)?;
     if crate::syntax::expr_to_string(&val) != first_str {
-      return Ok(bool_to_expr(false));
+      return Ok(bool_expr(false));
     }
   }
-  Ok(bool_to_expr(true))
+  Ok(bool_expr(true))
 }
 
 /// `ClusteringComponents[list]` — assign each element of a 1-D numeric list

--- a/src/functions/list_helpers_ast/filtering.rs
+++ b/src/functions/list_helpers_ast/filtering.rs
@@ -2,7 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, unevaluated};
+use crate::syntax::{BinaryOperator, bool_expr, unevaluated};
 
 /// AST-based Select: filter elements where predicate returns True.
 /// Select[{a, b, c}, pred] -> elements where pred[elem] is True
@@ -499,9 +499,9 @@ fn apply_test_bool(test: &Expr, elem: &Expr) -> bool {
       );
       crate::interpret(&call_str).ok().map(|r| {
         if r == "True" {
-          Expr::Identifier("True".to_string())
+          bool_expr(true)
         } else {
-          Expr::Identifier("False".to_string())
+          bool_expr(false)
         }
       })
     }
@@ -622,9 +622,9 @@ pub fn matches_pattern_ast(expr: &Expr, pattern: &Expr) -> bool {
           );
           crate::interpret(&call_str).ok().map(|r| {
             if r == "True" {
-              Expr::Identifier("True".to_string())
+              bool_expr(true)
             } else {
-              Expr::Identifier("False".to_string())
+              bool_expr(false)
             }
           })
         }
@@ -1969,10 +1969,10 @@ pub fn contains_only_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       if !found {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   use std::collections::HashSet;
@@ -1981,10 +1981,10 @@ pub fn contains_only_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   for item in list {
     if !allowed.contains(&crate::syntax::expr_to_string(item)) {
-      return Ok(Expr::Identifier("False".to_string()));
+      return Ok(bool_expr(false));
     }
   }
-  Ok(Expr::Identifier("True".to_string()))
+  Ok(bool_expr(true))
 }
 
 /// LengthWhile[list, crit] - gives the number of contiguous elements at the start that satisfy crit

--- a/src/functions/list_helpers_ast/properties.rs
+++ b/src/functions/list_helpers_ast/properties.rs
@@ -2,7 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::unevaluated;
+use crate::syntax::{bool_expr, unevaluated};
 
 /// AST-based ArrayDepth: compute depth of nested lists.
 /// Returns the depth to which the expression forms a rectangular array.
@@ -644,9 +644,9 @@ pub fn array_q_ast(expr: &Expr) -> Result<Expr, InterpreterError> {
     }
   }
   Ok(if is_full_array(expr) {
-    Expr::Identifier("True".to_string())
+    bool_expr(true)
   } else {
-    Expr::Identifier("False".to_string())
+    bool_expr(false)
   })
 }
 
@@ -675,12 +675,12 @@ pub fn vector_q_ast(expr: &Expr) -> Result<Expr, InterpreterError> {
   match expr {
     Expr::List(items) => {
       Ok(if items.iter().all(|i| !matches!(i, Expr::List(_))) {
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       } else {
-        Expr::Identifier("False".to_string())
+        bool_expr(false)
       })
     }
-    _ => Ok(Expr::Identifier("False".to_string())),
+    _ => Ok(bool_expr(false)),
   }
 }
 
@@ -692,9 +692,7 @@ pub fn vector_q_with_test_ast(
   test: &Expr,
 ) -> Result<Expr, InterpreterError> {
   let ok = matches!(expr, Expr::List(_)) && all_leaves_pass_test(expr, 1, test);
-  Ok(Expr::Identifier(
-    if ok { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(ok))
 }
 
 /// MatrixQ[expr] - True if expr is a list of equal-length lists (2D rectangular array).
@@ -702,7 +700,7 @@ pub fn matrix_q_ast(expr: &Expr) -> Result<Expr, InterpreterError> {
   match expr {
     Expr::List(rows) => {
       if rows.is_empty() {
-        return Ok(Expr::Identifier("True".to_string()));
+        return Ok(bool_expr(true));
       }
       // Each row must be a list
       let mut ncols = None;
@@ -711,22 +709,22 @@ pub fn matrix_q_ast(expr: &Expr) -> Result<Expr, InterpreterError> {
           Expr::List(cols) => {
             if let Some(expected) = ncols {
               if cols.len() != expected {
-                return Ok(Expr::Identifier("False".to_string()));
+                return Ok(bool_expr(false));
               }
             } else {
               ncols = Some(cols.len());
             }
             // Each element must not be a list (must be a scalar)
             if cols.iter().any(|c| matches!(c, Expr::List(_))) {
-              return Ok(Expr::Identifier("False".to_string()));
+              return Ok(bool_expr(false));
             }
           }
-          _ => return Ok(Expr::Identifier("False".to_string())),
+          _ => return Ok(bool_expr(false)),
         }
       }
-      Ok(Expr::Identifier("True".to_string()))
+      Ok(bool_expr(true))
     }
-    _ => Ok(Expr::Identifier("False".to_string())),
+    _ => Ok(bool_expr(false)),
   }
 }
 
@@ -754,8 +752,8 @@ pub fn matrix_q_with_test_ast(
   // First check if it's a valid matrix structure
   let rows = match expr {
     Expr::List(rows) if !rows.is_empty() => rows,
-    Expr::List(_) => return Ok(Expr::Identifier("True".to_string())),
-    _ => return Ok(Expr::Identifier("False".to_string())),
+    Expr::List(_) => return Ok(bool_expr(true)),
+    _ => return Ok(bool_expr(false)),
   };
 
   let mut ncols = None;
@@ -764,7 +762,7 @@ pub fn matrix_q_with_test_ast(
       Expr::List(cols) => {
         if let Some(expected) = ncols {
           if cols.len() != expected {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
         } else {
           ncols = Some(cols.len());
@@ -772,7 +770,7 @@ pub fn matrix_q_with_test_ast(
         // Check each element with the test function
         for elem in cols {
           if matches!(elem, Expr::List(_)) {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
           let test_call = Expr::FunctionCall {
             name: if let Expr::Identifier(n) = test {
@@ -796,14 +794,14 @@ pub fn matrix_q_with_test_ast(
           };
           match &result {
             Expr::Identifier(s) if s == "True" => {}
-            _ => return Ok(Expr::Identifier("False".to_string())),
+            _ => return Ok(bool_expr(false)),
           }
         }
       }
-      _ => return Ok(Expr::Identifier("False".to_string())),
+      _ => return Ok(bool_expr(false)),
     }
   }
-  Ok(Expr::Identifier("True".to_string()))
+  Ok(bool_expr(true))
 }
 
 /// SymmetricMatrixQ[m] - True if m is a symmetric square matrix (m[i][j] == m[j][i]).
@@ -812,7 +810,7 @@ pub fn symmetric_matrix_q_ast(expr: &Expr) -> Result<Expr, InterpreterError> {
     Expr::List(rows) => {
       let n = rows.len();
       if n == 0 {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
       // All rows must be lists of length n (square matrix)
       let mut grid: Vec<&crate::ExprList> = Vec::with_capacity(n);
@@ -820,11 +818,11 @@ pub fn symmetric_matrix_q_ast(expr: &Expr) -> Result<Expr, InterpreterError> {
         match row {
           Expr::List(cols) => {
             if cols.len() != n {
-              return Ok(Expr::Identifier("False".to_string()));
+              return Ok(bool_expr(false));
             }
             grid.push(cols);
           }
-          _ => return Ok(Expr::Identifier("False".to_string())),
+          _ => return Ok(bool_expr(false)),
         }
       }
       // Check symmetry: m[i][j] == m[j][i]
@@ -833,13 +831,13 @@ pub fn symmetric_matrix_q_ast(expr: &Expr) -> Result<Expr, InterpreterError> {
           let a = crate::syntax::expr_to_string(&grid[i][j]);
           let b = crate::syntax::expr_to_string(&grid[j][i]);
           if a != b {
-            return Ok(Expr::Identifier("False".to_string()));
+            return Ok(bool_expr(false));
           }
         }
       }
-      Ok(Expr::Identifier("True".to_string()))
+      Ok(bool_expr(true))
     }
-    _ => Ok(Expr::Identifier("False".to_string())),
+    _ => Ok(bool_expr(false)),
   }
 }
 

--- a/src/functions/list_helpers_ast/sorting.rs
+++ b/src/functions/list_helpers_ast/sorting.rs
@@ -2,7 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
+use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 
 /// Wolfram canonical ordering for expressions.
 /// For strings: case-insensitive first, then lowercase before uppercase for ties.
@@ -1028,14 +1028,14 @@ pub fn ordered_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   if let Expr::List(items) = &args[0] {
     if items.len() <= 1 {
-      return Ok(Expr::Identifier("True".to_string()));
+      return Ok(bool_expr(true));
     }
     for i in 0..items.len() - 1 {
       if !expr_le(&items[i], &items[i + 1]) {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
-    Ok(Expr::Identifier("True".to_string()))
+    Ok(bool_expr(true))
   } else {
     Ok(unevaluated("OrderedQ", args))
   }

--- a/src/functions/list_helpers_ast/utilities.rs
+++ b/src/functions/list_helpers_ast/utilities.rs
@@ -12,11 +12,6 @@ pub fn expr_to_bool(expr: &Expr) -> Option<bool> {
   }
 }
 
-/// Convert a boolean to an Expr.
-pub fn bool_to_expr(b: bool) -> Expr {
-  Expr::Identifier(if b { "True" } else { "False" }.to_string())
-}
-
 /// Apply a function/predicate to an argument and return the resulting Expr.
 /// Uses the existing apply_function_to_arg from evaluator.
 pub fn apply_func_ast(

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
   unevaluated,
 };
 
@@ -11617,7 +11617,7 @@ pub fn empirical_distribution_ast(
         vec![
           Expr::List(weights.into()),
           Expr::List(uniques.into()),
-          Expr::Identifier("False".to_string()),
+          bool_expr(false),
         ]
         .into(),
       ),

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
   unevaluated,
 };
 use num_bigint::BigInt;
@@ -2630,7 +2630,7 @@ fn factor_integer_gaussian(n_expr: &Expr) -> Result<Expr, InterpreterError> {
         n_expr.clone(),
         Expr::Rule {
           pattern: Box::new(Expr::Identifier("GaussianIntegers".to_string())),
-          replacement: Box::new(Expr::Identifier("True".to_string())),
+          replacement: Box::new(bool_expr(true)),
         },
       ]
       .into(),
@@ -4449,9 +4449,7 @@ pub fn coprime_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() == 1 {
     let is_unit =
       matches!(expr_to_i128(&args[0]), Some(n) if n.unsigned_abs() == 1);
-    return Ok(Expr::Identifier(
-      if is_unit { "True" } else { "False" }.to_string(),
-    ));
+    return Ok(bool_expr(is_unit));
   }
 
   // Gaussian-integer CoprimeQ: when at least one argument is a complex
@@ -4466,11 +4464,11 @@ pub fn coprime_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for i in 0..gs.len() {
       for j in (i + 1)..gs.len() {
         if gaussian_gcd(gs[i], gs[j]) != (1, 0) {
-          return Ok(Expr::Identifier("False".to_string()));
+          return Ok(bool_expr(false));
         }
       }
     }
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Extract all integer values
@@ -4496,12 +4494,12 @@ pub fn coprime_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         a = temp;
       }
       if a != 1 {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
   }
 
-  Ok(Expr::Identifier("True".to_string()))
+  Ok(bool_expr(true))
 }
 
 /// Binomial[n, k] - Binomial coefficient
@@ -5104,9 +5102,7 @@ pub fn mersenne_prime_exponent_q_ast(
     Some(n) => MERSENNE_EXPONENTS.contains(&n),
     None => false,
   };
-  Ok(Expr::Identifier(
-    if is_exponent { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(is_exponent))
 }
 
 // ─── PrimePi ───────────────────────────────────────────────────────

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -3,8 +3,8 @@ use super::*;
 use crate::InterpreterError;
 use crate::functions::math_ast::gcd;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, ExprForm, UnaryOperator, expr_to_output,
-  expr_to_string, format_expr, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, ExprForm, UnaryOperator, bool_expr,
+  expr_to_output, expr_to_string, format_expr, unevaluated,
 };
 
 /// If the first argument is a numeric scalar, emit
@@ -5815,9 +5815,7 @@ pub fn group_element_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(unevaluated());
   };
   let found = gelems.iter().any(|g| perms_equal(&args[1], g));
-  Ok(Expr::Identifier(
-    if found { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(found))
 }
 
 /// GroupElementPosition[group, perm] - the 1-based position of the permutation

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -23,7 +23,9 @@
 //! all give `MusicPitch["G3"]`. The conversions use the standard convention
 //! where middle C is MIDI 60 / C4 and A4 (MIDI 69) is 440 Hz.
 
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
+use crate::syntax::{
+  BinaryOperator, Expr, UnaryOperator, bool_expr, unevaluated,
+};
 
 /// Heads that the Wolfram Language classifies as music objects — the "Music
 /// Events", "Music Properties", and "Music Containers" of the
@@ -67,7 +69,7 @@ pub fn music_object_q(args: &[Expr]) -> Expr {
     [Expr::FunctionCall { name, .. }]
       if MUSIC_OBJECT_HEADS.contains(&name.as_str())
   );
-  Expr::Identifier(if is_object { "True" } else { "False" }.to_string())
+  bool_expr(is_object)
 }
 
 /// Chromatic note names (sharp spelling) indexed by pitch class `0..=11`,

--- a/src/functions/polynomial_ast/eliminate.rs
+++ b/src/functions/polynomial_ast/eliminate.rs
@@ -3,7 +3,7 @@ use super::together::negate_expr;
 use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, expr_to_string, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, bool_expr, expr_to_string, unevaluated,
 };
 
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
@@ -53,7 +53,7 @@ pub fn eliminate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for var in &vars_to_eliminate {
     eqs = eliminate_one_variable(&eqs, var)?;
     if eqs.is_empty() {
-      return Ok(Expr::Identifier("True".to_string()));
+      return Ok(bool_expr(true));
     }
   }
 

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::InterpreterError;
 use crate::functions::calculus_ast::simplify;
 use crate::syntax::{
-  BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
+  BinaryOperator, Expr, UnaryOperator, bool_expr, expr_to_string, unevaluated,
 };
 
 // ─── Factor ─────────────────────────────────────────────────────────
@@ -1410,12 +1410,12 @@ pub fn irreducible_polynomial_q_ast(
   let list = match factor_list_ast(args) {
     Ok(l) => l,
     Err(_) => {
-      return Ok(Expr::Identifier("False".to_string()));
+      return Ok(bool_expr(false));
     }
   };
 
   let Expr::List(ref entries) = list else {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   };
 
   let mut non_constant_count = 0usize;
@@ -1434,9 +1434,7 @@ pub fn irreducible_polynomial_q_ast(
   }
 
   let irreducible = non_constant_count == 1 && !has_higher_power;
-  Ok(Expr::Identifier(
-    if irreducible { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(irreducible))
 }
 
 /// Decompose a factored expression into {factor, exponent} pairs.

--- a/src/functions/polynomial_ast/gf_factor.rs
+++ b/src/functions/polynomial_ast/gf_factor.rs
@@ -10,7 +10,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
+use crate::syntax::{BinaryOperator, Expr, bool_expr, unevaluated};
 
 /// Keep the c-sweep in Berlekamp splitting bounded.
 const MAX_MODULUS: i128 = 65_536;
@@ -482,9 +482,7 @@ pub fn irreducible_polynomial_q_modulus(
     Some((_, factors)) => factors.len() == 1 && factors[0].1 == 1,
     None => false,
   };
-  Ok(Some(Expr::Identifier(
-    if irreducible { "True" } else { "False" }.to_string(),
-  )))
+  Ok(Some(bool_expr(irreducible)))
 }
 
 /// PrimitivePolynomialQ[poly, p]: true when `poly` is primitive over GF(p),
@@ -506,9 +504,7 @@ pub fn primitive_polynomial_q_modulus(
     return Ok(None);
   };
   match is_primitive_over_gf(&coeffs, p) {
-    Some(primitive) => Ok(Some(Expr::Identifier(
-      if primitive { "True" } else { "False" }.to_string(),
-    ))),
+    Some(primitive) => Ok(Some(bool_expr(primitive))),
     None => Ok(None),
   }
 }

--- a/src/functions/polynomial_ast/helpers.rs
+++ b/src/functions/polynomial_ast/helpers.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, ComparisonOp, Expr, expr_to_string};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, bool_expr, expr_to_string,
+};
 
 // ─── helpers ────────────────────────────────────────────────────────
 
@@ -35,8 +37,6 @@ pub fn extract_exponent_map(var_factors: &[Expr]) -> HashMap<String, i128> {
   }
   map
 }
-
-pub use crate::syntax::bool_expr;
 
 /// Build a FunctionCall expression.
 pub fn mk_call(name: &str, args: Vec<Expr>) -> Expr {
@@ -157,7 +157,7 @@ pub fn build_or(mut terms: Vec<Expr>) -> Expr {
   terms.retain(|t| !matches!(t, Expr::Identifier(s) if s == "False"));
 
   if terms.is_empty() {
-    return Expr::Identifier("False".to_string());
+    return bool_expr(false);
   }
   if terms.len() == 1 {
     return terms.remove(0);
@@ -200,12 +200,8 @@ pub fn or_results(a: &Expr, b: &Expr) -> Expr {
   match (a, b) {
     (Expr::Identifier(s), _) if s == "False" => b.clone(),
     (_, Expr::Identifier(s)) if s == "False" => a.clone(),
-    (Expr::Identifier(s), _) if s == "True" => {
-      Expr::Identifier("True".to_string())
-    }
-    (_, Expr::Identifier(s)) if s == "True" => {
-      Expr::Identifier("True".to_string())
-    }
+    (Expr::Identifier(s), _) if s == "True" => bool_expr(true),
+    (_, Expr::Identifier(s)) if s == "True" => bool_expr(true),
     _ => Expr::BinaryOp {
       op: BinaryOperator::Or,
       left: Box::new(a.clone()),
@@ -219,12 +215,8 @@ pub fn and_results(a: &Expr, b: &Expr) -> Expr {
   match (a, b) {
     (Expr::Identifier(s), _) if s == "True" => b.clone(),
     (_, Expr::Identifier(s)) if s == "True" => a.clone(),
-    (Expr::Identifier(s), _) if s == "False" => {
-      Expr::Identifier("False".to_string())
-    }
-    (_, Expr::Identifier(s)) if s == "False" => {
-      Expr::Identifier("False".to_string())
-    }
+    (Expr::Identifier(s), _) if s == "False" => bool_expr(false),
+    (_, Expr::Identifier(s)) if s == "False" => bool_expr(false),
     _ => Expr::BinaryOp {
       op: BinaryOperator::And,
       left: Box::new(a.clone()),

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -4,7 +4,9 @@ use crate::InterpreterError;
 use crate::functions::math_ast::{
   expr_to_f64, expr_to_i128, expr_to_rational, gcd as gcd_i128, is_sqrt,
 };
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
+use crate::syntax::{
+  BinaryOperator, Expr, UnaryOperator, bool_expr, unevaluated,
+};
 
 /// MinimalPolynomial[α, x] - Computes the minimal polynomial of an algebraic number α
 /// in the variable x.
@@ -1552,9 +1554,7 @@ pub fn algebraic_unit_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(c) => *c.last().unwrap() == 1 && c[0].abs() == 1,
     None => false,
   };
-  Ok(Expr::Identifier(
-    if is_unit { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(is_unit))
 }
 
 /// AlgebraicNumberNorm[a] — the product of all conjugates of a over Q:

--- a/src/functions/polynomial_ast/polynomial_q.rs
+++ b/src/functions/polynomial_ast/polynomial_q.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::InterpreterError;
 use crate::evaluator::pattern_matching::expr_equal;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, bool_expr};
 
 use crate::functions::calculus_ast::is_constant_wrt;
 

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -3,7 +3,7 @@ use super::together::negate_expr;
 use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
   unevaluated,
 };
 
@@ -199,7 +199,7 @@ fn enumerate_integer_interval(result: &Expr, var: &str) -> Option<Expr> {
     _ => return None,
   };
   if upper < lower {
-    return Some(Expr::Identifier("False".to_string()));
+    return Some(bool_expr(false));
   }
   if (upper as i128 - lower as i128) > 100_000 {
     return None;
@@ -361,7 +361,7 @@ fn try_reduce_bounded_integer_filtered(expr: &Expr, var: &str) -> Option<Expr> {
     return None;
   }
   if upper < lower {
-    return Some(Expr::Identifier("False".to_string()));
+    return Some(bool_expr(false));
   }
   if (upper as i128 - lower as i128) > 100_000 {
     return None;
@@ -382,7 +382,7 @@ fn try_reduce_bounded_integer_filtered(expr: &Expr, var: &str) -> Option<Expr> {
     }
   }
   if terms.is_empty() {
-    return Some(Expr::Identifier("False".to_string()));
+    return Some(bool_expr(false));
   }
   Some(build_or(terms))
 }
@@ -466,7 +466,7 @@ fn try_reduce_bounded_trig(
     eqs.push(make_equality(&var_expr, replacement));
   }
   if eqs.is_empty() {
-    return Ok(Some(Expr::Identifier("False".to_string())));
+    return Ok(Some(bool_expr(false)));
   }
   Ok(Some(build_or(eqs)))
 }
@@ -508,20 +508,20 @@ fn reduce_expr(
   if let Expr::Identifier(s) = expr {
     if s == "True" {
       return Ok(if domain == Some("Reals") || domain == Some("Integers") {
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       } else {
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       });
     }
     if s == "False" {
-      return Ok(Expr::Identifier("False".to_string()));
+      return Ok(bool_expr(false));
     }
   }
 
   // Handle List of constraints → convert to And
   if let Expr::List(items) = expr {
     if items.is_empty() {
-      return Ok(Expr::Identifier("True".to_string()));
+      return Ok(bool_expr(true));
     }
     let and_expr =
       items
@@ -550,7 +550,7 @@ fn reduce_expr(
   // Handle FunctionCall Or
   if let Expr::FunctionCall { name, args: fargs } = expr {
     if name == "Or" {
-      let mut result = Expr::Identifier("False".to_string());
+      let mut result = bool_expr(false);
       for a in fargs {
         let r = reduce_expr(a, vars, domain)?;
         result = or_results(&result, &r);
@@ -939,9 +939,9 @@ fn reduce_equation(
     // No variable — check if constant is zero
     let simplified = simplify(expanded);
     return Ok(if matches!(simplified, Expr::Integer(0)) {
-      Expr::Identifier("True".to_string())
+      bool_expr(true)
     } else {
-      Expr::Identifier("False".to_string())
+      bool_expr(false)
     });
   }
 
@@ -960,7 +960,7 @@ fn reduce_equation(
   // Convert Solve result (list of rules) to Or of equalities
   if let Expr::List(solutions) = &solve_result {
     if solutions.is_empty() {
-      return Ok(Expr::Identifier("False".to_string()));
+      return Ok(bool_expr(false));
     }
 
     let mut equalities: Vec<Expr> = Vec::new();
@@ -968,7 +968,7 @@ fn reduce_equation(
       if let Expr::List(rules) = sol {
         if rules.is_empty() {
           // Solve returned {{}} meaning all values are solutions
-          return Ok(Expr::Identifier("True".to_string()));
+          return Ok(bool_expr(true));
         }
         for rule in rules {
           if let Expr::Rule {
@@ -993,7 +993,7 @@ fn reduce_equation(
     }
 
     if equalities.is_empty() {
-      return Ok(Expr::Identifier("False".to_string()));
+      return Ok(bool_expr(false));
     }
 
     // Sort equalities for canonical output
@@ -1069,9 +1069,9 @@ fn reduce_not_equal(
   if is_constant_wrt(&expanded, var) {
     let simplified = simplify(expanded);
     return Ok(if matches!(simplified, Expr::Integer(0)) {
-      Expr::Identifier("False".to_string())
+      bool_expr(false)
     } else {
-      Expr::Identifier("True".to_string())
+      bool_expr(true)
     });
   }
   // Return the not-equal condition as-is for now
@@ -1347,8 +1347,6 @@ fn try_reduce_abs_inequality(
   let neg_c = negate_expr(&c);
   let cval = expr_to_number(&c)?;
   let zero = Expr::Integer(0);
-  let truth =
-    |b: bool| Expr::Identifier(if b { "True" } else { "False" }.to_string());
   let and = |a: Expr, b: Expr| Expr::BinaryOp {
     op: BinaryOperator::And,
     left: Box::new(a),
@@ -1364,7 +1362,7 @@ fn try_reduce_abs_inequality(
     CompOp::Less => {
       // |f| < c : empty when c <= 0, else -c < f < c.
       if cval <= 0.0 {
-        return Some(Ok(truth(false)));
+        return Some(Ok(bool_expr(false)));
       }
       and(
         make_comparison(&inner, &neg_c, CompOp::Greater),
@@ -1374,7 +1372,7 @@ fn try_reduce_abs_inequality(
     CompOp::LessEqual => {
       // |f| <= c : empty for c < 0, the point f == 0 for c == 0, else band.
       if cval < 0.0 {
-        return Some(Ok(truth(false)));
+        return Some(Ok(bool_expr(false)));
       }
       if cval == 0.0 {
         make_comparison(&inner, &zero, CompOp::Equal)
@@ -1389,7 +1387,7 @@ fn try_reduce_abs_inequality(
       // |f| > c : all reals for c < 0, else two open rays. At c == 0 this is
       // `f < 0 || f > 0` (Wolfram does not collapse it to `f != 0`).
       if cval < 0.0 {
-        return Some(Ok(truth(true)));
+        return Some(Ok(bool_expr(true)));
       }
       or(
         make_comparison(&inner, &neg_c, CompOp::Less),
@@ -1399,7 +1397,7 @@ fn try_reduce_abs_inequality(
     CompOp::GreaterEqual => {
       // |f| >= c : all reals when c <= 0, else two closed rays.
       if cval <= 0.0 {
-        return Some(Ok(truth(true)));
+        return Some(Ok(bool_expr(true)));
       }
       or(
         make_comparison(&inner, &neg_c, CompOp::LessEqual),
@@ -1446,7 +1444,7 @@ fn try_reduce_abs_not_equal(
 
   // |f| != c is vacuously true when c < 0 (Abs is never negative).
   if cval < 0.0 {
-    return Some(Ok(Expr::Identifier("True".to_string())));
+    return Some(Ok(bool_expr(true)));
   }
   // |f| != 0 is the two open rays `f < 0 || f > 0` (Wolfram keeps it split
   // rather than folding back to `f != 0`).
@@ -1489,10 +1487,10 @@ fn evaluate_constant_ineq(val: &Expr, op: CompOp) -> Expr {
       CompOp::Equal => n == 0.0,
       CompOp::NotEqual => n != 0.0,
     };
-    return Expr::Identifier(if result { "True" } else { "False" }.to_string());
+    return bool_expr(result);
   }
   // Can't evaluate
-  Expr::Identifier("True".to_string())
+  bool_expr(true)
 }
 
 /// Try to extract a numeric value from an expression.
@@ -1624,7 +1622,7 @@ fn reduce_quadratic_inequality(
       return Ok(if result {
         // Always true over reals
         if domain == Some("Reals") {
-          Expr::Identifier("True".to_string())
+          bool_expr(true)
         } else {
           Expr::FunctionCall {
             name: "Element".to_string(),
@@ -1636,7 +1634,7 @@ fn reduce_quadratic_inequality(
           }
         }
       } else {
-        Expr::Identifier("False".to_string())
+        bool_expr(false)
       });
     }
 
@@ -1651,7 +1649,7 @@ fn reduce_quadratic_inequality(
         }
         CompOp::GreaterEqual if ai > 0 => {
           if domain == Some("Reals") {
-            Ok(Expr::Identifier("True".to_string()))
+            Ok(bool_expr(true))
           } else {
             Ok(Expr::FunctionCall {
               name: "Element".to_string(),
@@ -1670,10 +1668,10 @@ fn reduce_quadratic_inequality(
         CompOp::LessEqual if ai > 0 => {
           Ok(make_equality(&Expr::Identifier(var.to_string()), &root))
         }
-        CompOp::Less if ai > 0 => Ok(Expr::Identifier("False".to_string())),
+        CompOp::Less if ai > 0 => Ok(bool_expr(false)),
         CompOp::LessEqual if ai < 0 => {
           if domain == Some("Reals") {
-            Ok(Expr::Identifier("True".to_string()))
+            Ok(bool_expr(true))
           } else {
             Ok(Expr::FunctionCall {
               name: "Element".to_string(),
@@ -1692,8 +1690,8 @@ fn reduce_quadratic_inequality(
         CompOp::GreaterEqual if ai < 0 => {
           Ok(make_equality(&Expr::Identifier(var.to_string()), &root))
         }
-        CompOp::Greater if ai < 0 => Ok(Expr::Identifier("False".to_string())),
-        _ => Ok(Expr::Identifier("False".to_string())),
+        CompOp::Greater if ai < 0 => Ok(bool_expr(false)),
+        _ => Ok(bool_expr(false)),
       };
     }
 
@@ -1770,7 +1768,7 @@ fn reduce_quadratic_inequality(
           &r2,
         ))
       }
-      _ => Ok(Expr::Identifier("False".to_string())),
+      _ => Ok(bool_expr(false)),
     }
   } else {
     // Non-integer coefficients — return unevaluated
@@ -1985,7 +1983,7 @@ fn try_factor_and_reduce_inequality(
     }
 
     if intervals.is_empty() {
-      return Some(Expr::Identifier("False".to_string()));
+      return Some(bool_expr(false));
     }
 
     return Some(build_or(intervals));
@@ -2034,11 +2032,11 @@ fn reduce_and(
     .iter()
     .any(|c| matches!(c, Expr::Identifier(s) if s == "False"))
   {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   if constraints.is_empty() {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Separate equations from inequalities
@@ -2065,7 +2063,7 @@ fn reduce_and(
       let eq_result = reduce_equation(&eq.0, &eq.1, var, domain)?;
 
       if matches!(&eq_result, Expr::Identifier(s) if s == "False") {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
       if matches!(&eq_result, Expr::Identifier(s) if s == "True") {
         // Equation is trivially true, reduce remaining
@@ -2076,7 +2074,7 @@ fn reduce_and(
           .chain(other.iter().cloned())
           .collect();
         if remaining.is_empty() {
-          return Ok(Expr::Identifier("True".to_string()));
+          return Ok(bool_expr(true));
         }
         let combined =
           remaining
@@ -2141,7 +2139,7 @@ fn reduce_and(
       }
 
       if valid_solutions.is_empty() {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
       return Ok(build_or(valid_solutions));
     }
@@ -2256,7 +2254,7 @@ fn reduce_combined_inequalities(
     }
 
     return if valid_branches.is_empty() {
-      Ok(Expr::Identifier("False".to_string()))
+      Ok(bool_expr(false))
     } else {
       Ok(build_or(valid_branches))
     };
@@ -2376,7 +2374,7 @@ fn reduce_combined_inequalities(
         && (low_val > high_val
           || (low_val == high_val && (!low_inc || !high_inc)))
       {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
       let low_op = if *low_inc {
         CompOp::LessEqual
@@ -2474,7 +2472,7 @@ pub fn reduce_multi_var_and(
   domain: Option<&str>,
 ) -> Result<Expr, InterpreterError> {
   if vars.is_empty() || constraints.is_empty() {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Find the best (equation, variable) pair: prefer last variable in the list
@@ -2626,7 +2624,7 @@ pub fn reduce_multi_var_and(
       }
 
       if all_results.is_empty() {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
       return Ok(build_or(all_results));
     }
@@ -2842,7 +2840,7 @@ fn try_reduce_exists_quadratic_linear(
   let k = mul_q(&lhs, &delta_sq_inv);
 
   if k.is_zero() || k.is_negative() {
-    return Some(Expr::Identifier("True".to_string()));
+    return Some(bool_expr(true));
   }
   let bound = inv_q(&k)?;
   Some(Expr::Comparison {

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
 };
 
 use crate::functions::calculus_ast::simplify;
@@ -918,15 +918,11 @@ fn refine_expr(expr: &Expr, info: &AssumptionInfo, assumption: &Expr) -> Expr {
       if let Some(result) =
         check_comparison_under_assumption(expr, info, assumption)
       {
-        return Expr::Identifier(
-          if result { "True" } else { "False" }.to_string(),
-        );
+        return bool_expr(result);
       }
       // Try algebraic reasoning for equations/inequalities
       if let Some(result) = check_algebraic_comparison(expr, info, assumption) {
-        return Expr::Identifier(
-          if result { "True" } else { "False" }.to_string(),
-        );
+        return bool_expr(result);
       }
       expr.clone()
     }
@@ -1395,9 +1391,7 @@ fn refine_expr(expr: &Expr, info: &AssumptionInfo, assumption: &Expr) -> Expr {
         _ => None,
       };
       match verdict {
-        Some(b) => {
-          Expr::Identifier(if b { "True" } else { "False" }.to_string())
-        }
+        Some(b) => bool_expr(b),
         None => Expr::FunctionCall {
           name: name.clone(),
           args: vec![a].into(),
@@ -2727,10 +2721,10 @@ fn refine_element(
   if let Expr::Identifier(dom) = domain {
     match dom.as_str() {
       "Reals" if is_known_real(expr, info) => {
-        return Some(Expr::Identifier("True".to_string()));
+        return Some(bool_expr(true));
       }
       "Integers" if is_known_integer(expr, info) => {
-        return Some(Expr::Identifier("True".to_string()));
+        return Some(bool_expr(true));
       }
       _ => {}
     }
@@ -6483,18 +6477,18 @@ fn simplify_expr_inner(expr: &Expr) -> Expr {
       };
       let expanded_diff = super::expand_and_combine(&diff);
       if matches!(&expanded_diff, Expr::Integer(0)) {
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       } else if matches!(&expanded_diff, Expr::Integer(n) if *n != 0)
         || matches!(&expanded_diff, Expr::Real(f) if *f != 0.0)
       {
         // Nonzero constant difference means the equation is always False
-        Expr::Identifier("False".to_string())
+        bool_expr(false)
       } else if is_zero_constant(&simplify_expr_with_together(&diff)) {
         // Rational-function case: `Expand` alone can't cancel two fractions
         // over different denominators (e.g. a partial-fraction sum vs its
         // closed form). Combine over a common denominator with the full
         // simplifier and check whether the difference vanishes.
-        Expr::Identifier("True".to_string())
+        bool_expr(true)
       } else {
         Expr::Comparison {
           operands: vec![lhs, rhs],
@@ -6583,7 +6577,7 @@ fn simplify_conditional_expression(value: &Expr, cond: &Expr) -> Expr {
       }
     }
     let new_cond = match residual.len() {
-      0 => Expr::Identifier("True".to_string()),
+      0 => bool_expr(true),
       1 => residual.into_iter().next().unwrap(),
       _ => Expr::FunctionCall {
         name: "And".to_string(),

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -3,7 +3,7 @@ use super::together::negate_expr;
 use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
   unevaluated,
 };
 
@@ -416,7 +416,7 @@ pub fn roots_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Expr::List(inner) = item {
           if inner.is_empty() {
             // {{}} means all values (identity)
-            return Ok(Expr::Identifier("True".to_string()));
+            return Ok(bool_expr(true));
           }
           for rule in inner {
             if let Expr::Rule { replacement, .. } = rule {
@@ -452,7 +452,7 @@ pub fn roots_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
 
       if conditions.is_empty() {
-        Ok(Expr::Identifier("False".to_string()))
+        Ok(bool_expr(false))
       } else if conditions.len() == 1 {
         Ok(conditions.into_iter().next().unwrap())
       } else {

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -4,10 +4,8 @@
 
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
-
-use crate::syntax::bool_expr;
 
 /// NumberQ[expr] - Tests if the expression is a number
 pub fn number_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -1414,9 +1412,7 @@ pub fn free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let any = parts.iter().any(|p| {
         crate::functions::list_helpers_ast::matches_pattern_ast(p, &args[1])
       });
-      return Ok(Expr::Identifier(
-        if any { "False" } else { "True" }.to_string(),
-      ));
+      return Ok(bool_expr(!any));
     }
     return Ok(unevaluated("FreeQ", args));
   }
@@ -2539,10 +2535,10 @@ pub fn subset_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         )
       });
       if !found {
-        return Ok(Expr::Identifier("False".to_string()));
+        return Ok(bool_expr(false));
       }
     }
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
   // Default: structural membership.
   let superset_strs: Vec<String> =
@@ -2550,10 +2546,10 @@ pub fn subset_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for elem in subset {
     let s = crate::syntax::expr_to_string(elem);
     if !superset_strs.contains(&s) {
-      return Ok(Expr::Identifier("False".to_string()));
+      return Ok(bool_expr(false));
     }
   }
-  Ok(Expr::Identifier("True".to_string()))
+  Ok(bool_expr(true))
 }
 
 /// Extract the function `f` from a `SameTest -> f` rule, or from a singleton

--- a/src/functions/quantity_ast.rs
+++ b/src/functions/quantity_ast.rs
@@ -1,6 +1,6 @@
 use crate::InterpreterError;
 use crate::functions::math_ast::{is_sqrt, make_sqrt};
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
+use crate::syntax::{BinaryOperator, Expr, bool_expr, unevaluated};
 use std::collections::BTreeMap;
 
 // ─── Unit dimension system ──────────────────────────────────────────────────
@@ -1930,9 +1930,7 @@ pub fn quantity_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some((_mag, unit)) => known_unit_q_recursive(unit),
     None => false,
   };
-  Ok(Expr::Identifier(
-    if result { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(result))
 }
 
 // ─── CompatibleUnitQ ────────────────────────────────────────────────────────
@@ -1977,9 +1975,7 @@ pub fn known_unit_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
   let ok = known_unit_q_recursive(&args[0]);
-  Ok(Expr::Identifier(
-    if ok { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(ok))
 }
 
 pub fn compatible_unit_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -1999,9 +1995,7 @@ pub fn compatible_unit_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     &args[1]
   };
   let result = units_compatible(u1, u2);
-  Ok(Expr::Identifier(
-    if result { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(result))
 }
 
 // ─── UnitConvert ────────────────────────────────────────────────────────────

--- a/src/functions/resolve_ast.rs
+++ b/src/functions/resolve_ast.rs
@@ -7,7 +7,7 @@
 
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
 
 pub fn resolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -59,11 +59,7 @@ pub fn resolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let var = vars[0].clone();
 
-  let truth = |b: bool| {
-    Ok(Expr::Identifier(
-      if b { "True" } else { "False" }.to_string(),
-    ))
-  };
+  let truth = |b: bool| Ok(bool_expr(b));
 
   // Parametrized templates
   if let Some(result) = parametric_template(head, &var, &cond) {
@@ -369,9 +365,6 @@ fn resolve_multivar(
   cond: &Expr,
   over_reals: bool,
 ) -> Option<Expr> {
-  let truth =
-    |b: bool| Expr::Identifier(if b { "True" } else { "False" }.to_string());
-
   // Only single (non-chained) comparisons are supported.
   let (operands, op) = match cond {
     Expr::Comparison {
@@ -407,11 +400,11 @@ fn resolve_multivar(
   // polynomial has zeros and a non-empty complement over the complexes, so
   // `Exists` is True and `ForAll` is False for both `==` and `!=`.
   if is_equation && !use_reals && contains_any_bound_var(&expanded, vars) {
-    return Some(truth(head == "Exists"));
+    return Some(bool_expr(head == "Exists"));
   }
 
   let range = separable_range(&expanded, vars)?;
-  Some(truth(decide(head, op, &range)))
+  Some(bool_expr(decide(head, op, &range)))
 }
 
 /// Range of an additively separable polynomial over the reals, as a single

--- a/src/functions/root_ast.rs
+++ b/src/functions/root_ast.rs
@@ -43,7 +43,7 @@
 //! LZMA (`XZ`) and ZSTD (`ZS`) records produce a descriptive error.
 
 use crate::InterpreterError;
-use crate::syntax::Expr;
+use crate::syntax::{Expr, bool_expr};
 
 /// Flag bit marking a 4-byte length prefix ("byte count") in streamed data.
 const K_BYTE_COUNT_MASK: u32 = 0x4000_0000;
@@ -1304,9 +1304,7 @@ impl BasicKind {
       BasicKind::U64 => Expr::Integer(r.read_i64()? as u64 as i128),
       BasicKind::F32 => Expr::Real(r.read_f32()? as f64),
       BasicKind::F64 => Expr::Real(r.read_f64()?),
-      BasicKind::Bool => Expr::Identifier(
-        if r.read_u8()? != 0 { "True" } else { "False" }.to_string(),
-      ),
+      BasicKind::Bool => bool_expr(r.read_u8()? != 0),
     })
   }
 }

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -4,7 +4,7 @@
 
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
 
 use std::cell::RefCell;
@@ -998,9 +998,7 @@ pub fn string_starts_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     s.starts_with(&prefix)
   };
-  Ok(Expr::Identifier(
-    if result { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(result))
 }
 
 /// StringEndsQ[s, suffix] - checks if string ends with suffix
@@ -1053,9 +1051,7 @@ pub fn string_ends_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     s.ends_with(&suffix)
   };
-  Ok(Expr::Identifier(
-    if result { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(result))
 }
 
 /// StringContainsQ[s, sub] - checks if string contains substring
@@ -1085,7 +1081,7 @@ pub fn string_contains_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // StringContainsQ["ab", ""] are True (wolframscript-verified;
   // differential fuzzer, seed 11333804031743244357).
   if matches!(&args[1], Expr::String(sub) if sub.is_empty()) {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
   // Try regex-based pattern first
@@ -1093,9 +1089,7 @@ pub fn string_contains_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let (re, constraints) = compiled?;
     let present =
       !find_constraint_spans(&re, &constraints, &s, false).is_empty();
-    return Ok(Expr::Identifier(
-      if present { "True" } else { "False" }.to_string(),
-    ));
+    return Ok(bool_expr(present));
   }
 
   let sub = expr_to_str(&args[1])?;
@@ -1104,9 +1098,7 @@ pub fn string_contains_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     s.contains(&sub)
   };
-  Ok(Expr::Identifier(
-    if result { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(result))
 }
 
 /// Check if args contain IgnoreCase -> True option
@@ -2056,9 +2048,7 @@ pub fn string_match_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let re = compile_regex(&full_regex).map_err(|e| {
       InterpreterError::EvaluationError(format!("Invalid regex: {}", e))
     })?;
-    return Ok(Expr::Identifier(
-      if re.is_match(&s) { "True" } else { "False" }.to_string(),
-    ));
+    return Ok(bool_expr(re.is_match(&s)));
   }
 
   // Fall back to string-based wildcard matching
@@ -2068,9 +2058,7 @@ pub fn string_match_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     expr_to_str(&args[1])?
   };
   let matches = wildcard_match(&s, &pattern_str);
-  Ok(Expr::Identifier(
-    if matches { "True" } else { "False" }.to_string(),
-  ))
+  Ok(bool_expr(matches))
 }
 
 /// Simple wildcard matching
@@ -7801,7 +7789,7 @@ pub fn string_free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // No string is free of the empty pattern: StringFreeQ["", ""] is False
   // (wolframscript-verified).
   if matches!(&args[1], Expr::String(sub) if sub.is_empty()) {
-    return Ok(Expr::Identifier("False".to_string()));
+    return Ok(bool_expr(false));
   }
 
   // Try regex-based pattern first
@@ -7809,9 +7797,7 @@ pub fn string_free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let (re, constraints) = compiled?;
     let present =
       !find_constraint_spans(&re, &constraints, &s, false).is_empty();
-    return Ok(Expr::Identifier(
-      if present { "False" } else { "True" }.to_string(),
-    ));
+    return Ok(bool_expr(!present));
   }
 
   let sub = expr_to_str(&args[1])?;
@@ -7820,9 +7806,7 @@ pub fn string_free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     s.contains(&sub)
   };
-  Ok(Expr::Identifier(
-    if contains { "False" } else { "True" }.to_string(),
-  ))
+  Ok(bool_expr(!contains))
 }
 
 /// ToCharacterCode[s] - converts a string to a list of character codes
@@ -8550,11 +8534,9 @@ pub fn letter_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::String(s) => {
       let result = s.chars().all(|c| c.is_alphabetic());
-      Ok(Expr::Identifier(
-        if result { "True" } else { "False" }.to_string(),
-      ))
+      Ok(bool_expr(result))
     }
-    _ => Ok(Expr::Identifier("False".to_string())),
+    _ => Ok(bool_expr(false)),
   }
 }
 
@@ -8570,11 +8552,9 @@ pub fn upper_case_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::String(s) => {
       let result = s.chars().all(|c| c.is_alphabetic() && c.is_uppercase());
-      Ok(Expr::Identifier(
-        if result { "True" } else { "False" }.to_string(),
-      ))
+      Ok(bool_expr(result))
     }
-    _ => Ok(Expr::Identifier("False".to_string())),
+    _ => Ok(bool_expr(false)),
   }
 }
 
@@ -8590,11 +8570,9 @@ pub fn lower_case_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::String(s) => {
       let result = s.chars().all(|c| c.is_alphabetic() && c.is_lowercase());
-      Ok(Expr::Identifier(
-        if result { "True" } else { "False" }.to_string(),
-      ))
+      Ok(bool_expr(result))
     }
-    _ => Ok(Expr::Identifier("False".to_string())),
+    _ => Ok(bool_expr(false)),
   }
 }
 
@@ -8616,8 +8594,6 @@ pub fn printable_ascii_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       )
     ));
   };
-  let bool_expr =
-    |b: bool| Expr::Identifier(if b { "True" } else { "False" }.to_string());
   let is_printable =
     |s: &str| s.chars().all(|c| (32..=126).contains(&(c as u32)));
 
@@ -9070,11 +9046,9 @@ pub fn digit_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::String(s) => {
       let result = s.chars().all(|c| c.is_ascii_digit());
-      Ok(Expr::Identifier(
-        if result { "True" } else { "False" }.to_string(),
-      ))
+      Ok(bool_expr(result))
     }
-    _ => Ok(Expr::Identifier("False".to_string())),
+    _ => Ok(bool_expr(false)),
   }
 }
 
@@ -11783,9 +11757,7 @@ pub fn dictionary_word_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::String(s) => {
       let result = s.is_empty() || DICTIONARY_WORDS.contains(&s.to_lowercase());
-      Ok(Expr::Identifier(
-        if result { "True" } else { "False" }.to_string(),
-      ))
+      Ok(bool_expr(result))
     }
     _ => Ok(unevaluated("DictionaryWordQ", args)),
   }

--- a/src/functions/sum_convergence_ast.rs
+++ b/src/functions/sum_convergence_ast.rs
@@ -9,7 +9,7 @@
 
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
 
 pub fn sum_convergence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -76,26 +76,23 @@ pub fn sum_convergence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // 1/n! decay dominates any polynomial factor
   if inv_factorial {
-    return Ok(Expr::Identifier("True".to_string()));
+    return Ok(bool_expr(true));
   }
 
-  let verdict = |converges: bool| {
-    Expr::Identifier(if converges { "True" } else { "False" }.to_string())
-  };
   match geo_ratio {
     Some((r_abs, alternating)) => {
       if r_abs < 1.0 {
-        Ok(verdict(true))
+        Ok(bool_expr(true))
       } else if r_abs > 1.0 {
-        Ok(verdict(false))
+        Ok(bool_expr(false))
       } else if alternating {
         // |r| == 1 with sign alternation: alternating series test
-        Ok(verdict(net_degree <= -1))
+        Ok(bool_expr(net_degree <= -1))
       } else {
-        Ok(verdict(net_degree <= -2))
+        Ok(bool_expr(net_degree <= -2))
       }
     }
-    None => Ok(verdict(net_degree <= -2)),
+    None => Ok(bool_expr(net_degree <= -2)),
   }
 }
 

--- a/src/functions/xlsx_ast.rs
+++ b/src/functions/xlsx_ast.rs
@@ -1,6 +1,6 @@
 use crate::InterpreterError;
 use crate::functions::math_ast::try_eval_to_f64;
-use crate::syntax::Expr;
+use crate::syntax::{Expr, bool_expr};
 use calamine::{Data, Reader, open_workbook_auto, open_workbook_auto_from_rs};
 use rust_xlsxwriter::Workbook;
 use std::io::Cursor;
@@ -14,9 +14,7 @@ fn cell_to_expr(cell: &Data) -> Expr {
     Data::Int(n) => Expr::Real(*n as f64),
     Data::Float(f) => Expr::Real(*f),
     Data::String(s) => Expr::String(s.clone()),
-    Data::Bool(b) => {
-      Expr::Identifier(if *b { "True" } else { "False" }.to_string())
-    }
+    Data::Bool(b) => bool_expr(*b),
     Data::DateTime(dt) => Expr::Real(dt.as_f64()),
     Data::DateTimeIso(s) => Expr::String(s.clone()),
     Data::DurationIso(s) => Expr::String(s.clone()),


### PR DESCRIPTION
This PR applies bool_expr from syntax.rs more broadly to woxi. It handles "True", "False", "True||False" and "False||True" cases.