### PR TITLE
Add support for Around values in ListPlot and ListLinePlot

### DIFF
--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -10,6 +10,100 @@ use crate::functions::plot::{
 use crate::functions::sound::audio_sample_rate;
 use crate::syntax::{Expr, unevaluated};
 
+/// One parsed data point: coordinates plus asymmetric x/y uncertainties.
+/// The uncertainties are (minus, plus) half-widths taken from
+/// `Around[value, err]` / `Around[value, {minus, plus}]` entries and are
+/// `(0, 0)` for exact values.
+#[derive(Clone, Copy)]
+struct ErrPoint {
+  x: f64,
+  y: f64,
+  dx: (f64, f64),
+  dy: (f64, f64),
+}
+
+impl ErrPoint {
+  fn from_y(x: f64, (y, dy): (f64, (f64, f64))) -> Self {
+    ErrPoint {
+      x,
+      y,
+      dx: (0.0, 0.0),
+      dy,
+    }
+  }
+
+  fn from_xy((x, dx): (f64, (f64, f64)), (y, dy): (f64, (f64, f64))) -> Self {
+    ErrPoint { x, y, dx, dy }
+  }
+}
+
+/// Evaluate an expression to a plottable value with uncertainty: a plain
+/// number carries zero uncertainty, `Around[v, u]` / `Around[v, {m, p}]`
+/// carry (minus, plus) error-bar half-widths.
+fn eval_to_value_err(expr: &Expr) -> Option<(f64, (f64, f64))> {
+  let e = evaluate_expr_to_expr(expr).unwrap_or_else(|_| expr.clone());
+  if let Expr::FunctionCall { name, args } = &e
+    && name == "Around"
+    && args.len() == 2
+  {
+    let v = try_eval_to_f64(&args[0])?;
+    let err = match &args[1] {
+      Expr::List(items) if items.len() == 2 => (
+        try_eval_to_f64(&items[0])?.abs(),
+        try_eval_to_f64(&items[1])?.abs(),
+      ),
+      u => {
+        let u = try_eval_to_f64(u)?.abs();
+        (u, u)
+      }
+    };
+    return Some((v, err));
+  }
+  try_eval_to_f64(&e).map(|v| (v, (0.0, 0.0)))
+}
+
+/// Strip the uncertainties from parsed series, leaving plain (x, y) points.
+fn strip_errors(all_series: &[Vec<ErrPoint>]) -> Vec<Vec<(f64, f64)>> {
+  all_series
+    .iter()
+    .map(|series| series.iter().map(|p| (p.x, p.y)).collect())
+    .collect()
+}
+
+/// Per-series error bars parallel to the series' points, in the
+/// `PlotOptions::error_bars` layout. Empty when no point has an uncertainty.
+fn collect_error_bars(
+  all_series: &[Vec<ErrPoint>],
+) -> Vec<Vec<((f64, f64), (f64, f64))>> {
+  let has_any = all_series
+    .iter()
+    .flatten()
+    .any(|p| p.dx.0 > 0.0 || p.dx.1 > 0.0 || p.dy.0 > 0.0 || p.dy.1 > 0.0);
+  if !has_any {
+    return Vec::new();
+  }
+  all_series
+    .iter()
+    .map(|series| series.iter().map(|p| (p.dx, p.dy)).collect())
+    .collect()
+}
+
+/// Expand each point to the extremes of its error bars so that range
+/// computation covers the full uncertainty intervals.
+fn error_extremes(all_series: &[Vec<ErrPoint>]) -> Vec<Vec<(f64, f64)>> {
+  all_series
+    .iter()
+    .map(|series| {
+      series
+        .iter()
+        .flat_map(|p| {
+          [(p.x - p.dx.0, p.y - p.dy.0), (p.x + p.dx.1, p.y + p.dy.1)]
+        })
+        .collect()
+    })
+    .collect()
+}
+
 /// Parse list data from the first argument.
 /// Returns a vector of series, each series being a vector of (x, y) points.
 ///
@@ -17,9 +111,19 @@ use crate::syntax::{Expr, unevaluated};
 /// - `{y1, y2, y3}` → single series with x = 1,2,3,...
 /// - `{{x1,y1}, {x2,y2}}` → single series with explicit coordinates
 /// - `{{y1, y2}, {y3, y4}}` → multiple series (if inner lists don't look like points)
+///
+/// Any value (y or x/y pair element) may be an `Around[...]`, whose central
+/// value becomes the coordinate and whose uncertainty an error bar.
 fn parse_list_data(
   arg: &Expr,
 ) -> Result<Vec<Vec<(f64, f64)>>, InterpreterError> {
+  parse_list_data_err(arg).map(|series| strip_errors(&series))
+}
+
+/// Like [`parse_list_data`], but keeps the `Around` uncertainties.
+fn parse_list_data_err(
+  arg: &Expr,
+) -> Result<Vec<Vec<ErrPoint>>, InterpreterError> {
   let data = evaluate_expr_to_expr(arg)?;
 
   // A TimeSeries / multi-path TemporalData becomes one (x, y) series per path.
@@ -32,7 +136,10 @@ fn parse_list_data(
           .filter_map(|(t, v)| {
             let te = evaluate_expr_to_expr(&t).unwrap_or(t);
             let ve = evaluate_expr_to_expr(&v).unwrap_or(v);
-            Some((try_eval_to_f64(&te)?, try_eval_to_f64(&ve)?))
+            Some(ErrPoint::from_xy(
+              (try_eval_to_f64(&te)?, (0.0, 0.0)),
+              eval_to_value_err(&ve)?,
+            ))
           })
           .collect()
       })
@@ -56,32 +163,18 @@ fn parse_list_data(
   // Check if it's a list of {x, y} pairs
   if let Expr::List(first_inner) = &items[0] {
     if first_inner.len() == 2
-      && try_eval_to_f64(
-        &evaluate_expr_to_expr(&first_inner[0])
-          .unwrap_or(first_inner[0].clone()),
-      )
-      .is_some()
-      && try_eval_to_f64(
-        &evaluate_expr_to_expr(&first_inner[1])
-          .unwrap_or(first_inner[1].clone()),
-      )
-      .is_some()
+      && eval_to_value_err(&first_inner[0]).is_some()
+      && eval_to_value_err(&first_inner[1]).is_some()
     {
       // {{x1,y1}, {x2,y2}, ...} → single series with explicit coords
       let mut points = Vec::with_capacity(items.len());
       for item in items {
         if let Expr::List(pair) = item
           && pair.len() == 2
+          && let (Some(x), Some(y)) =
+            (eval_to_value_err(&pair[0]), eval_to_value_err(&pair[1]))
         {
-          let x_expr =
-            evaluate_expr_to_expr(&pair[0]).unwrap_or(pair[0].clone());
-          let y_expr =
-            evaluate_expr_to_expr(&pair[1]).unwrap_or(pair[1].clone());
-          if let (Some(x), Some(y)) =
-            (try_eval_to_f64(&x_expr), try_eval_to_f64(&y_expr))
-          {
-            points.push((x, y));
-          }
+          points.push(ErrPoint::from_xy(x, y));
         }
       }
       return Ok(vec![points]);
@@ -110,9 +203,8 @@ fn parse_list_data(
   // Simple list: {y1, y2, y3} → single series with x = 1,2,3,...
   let mut points = Vec::with_capacity(items.len());
   for (i, item) in items.iter().enumerate() {
-    let v_expr = evaluate_expr_to_expr(item).unwrap_or(item.clone());
-    if let Some(y) = try_eval_to_f64(&v_expr) {
-      points.push(((i + 1) as f64, y));
+    if let Some(y) = eval_to_value_err(item) {
+      points.push(ErrPoint::from_y((i + 1) as f64, y));
     }
   }
   Ok(vec![points])
@@ -121,7 +213,7 @@ fn parse_list_data(
 /// Parse a single series: either plain y-values or {x, y} pairs.
 fn parse_single_series(
   series_items: &[Expr],
-) -> Result<Vec<(f64, f64)>, InterpreterError> {
+) -> Result<Vec<ErrPoint>, InterpreterError> {
   // Check if items are {x, y} pairs
   let is_xy_pairs = !series_items.is_empty()
     && series_items
@@ -133,21 +225,16 @@ fn parse_single_series(
     for item in series_items {
       if let Expr::List(pair) = item
         && pair.len() == 2
+        && let (Some(x), Some(y)) =
+          (eval_to_value_err(&pair[0]), eval_to_value_err(&pair[1]))
       {
-        let x_expr = evaluate_expr_to_expr(&pair[0]).unwrap_or(pair[0].clone());
-        let y_expr = evaluate_expr_to_expr(&pair[1]).unwrap_or(pair[1].clone());
-        if let (Some(x), Some(y)) =
-          (try_eval_to_f64(&x_expr), try_eval_to_f64(&y_expr))
-        {
-          points.push((x, y));
-        }
+        points.push(ErrPoint::from_xy(x, y));
       }
     }
   } else {
     for (i, val) in series_items.iter().enumerate() {
-      let v_expr = evaluate_expr_to_expr(val).unwrap_or(val.clone());
-      if let Some(y) = try_eval_to_f64(&v_expr) {
-        points.push(((i + 1) as f64, y));
+      if let Some(y) = eval_to_value_err(val) {
+        points.push(ErrPoint::from_y((i + 1) as f64, y));
       }
     }
   }
@@ -343,9 +430,12 @@ fn compute_ranges(all_series: &[Vec<(f64, f64)>]) -> ((f64, f64), (f64, f64)) {
 
 /// ListPlot[{y1, y2, ...}] or ListPlot[{{x1,y1}, ...}]
 pub fn list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let all_series = parse_list_data(&args[0])?;
-  let parsed = parse_plot_options(args);
-  let (x_range, y_range) = compute_ranges(&all_series);
+  let err_series = parse_list_data_err(&args[0])?;
+  let all_series = strip_errors(&err_series);
+  let mut parsed = parse_plot_options(args);
+  parsed.opts.error_bars = collect_error_bars(&err_series);
+  // The plot range must cover the full extent of any error bars.
+  let (x_range, y_range) = compute_ranges(&error_extremes(&err_series));
   let y_range = adjust_y_range_for_filling(parsed.opts.filling, y_range);
   let (x_range, y_range) = apply_plot_range_override(&parsed, x_range, y_range);
   let joined = parsed.joined;
@@ -371,9 +461,11 @@ pub fn list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// ListLinePlot[{y1, y2, ...}]
 pub fn list_line_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let all_series = parse_list_data(&args[0])?;
-  let parsed = parse_plot_options(args);
-  let (x_range, mut y_range) = compute_ranges(&all_series);
+  let err_series = parse_list_data_err(&args[0])?;
+  let all_series = strip_errors(&err_series);
+  let mut parsed = parse_plot_options(args);
+  parsed.opts.error_bars = collect_error_bars(&err_series);
+  let (x_range, mut y_range) = compute_ranges(&error_extremes(&err_series));
 
   y_range = adjust_y_range_for_filling(parsed.opts.filling, y_range);
   let (x_range, y_range) = apply_plot_range_override(&parsed, x_range, y_range);

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -1135,6 +1135,10 @@ pub(crate) struct PlotOptions {
   /// `Epilog -> {…}` graphics primitives (already evaluated), drawn on top
   /// of the plotted data in data coordinates.
   pub epilog: Vec<Expr>,
+  /// Per-series error bars from `Around` data values, parallel to the
+  /// series' points: each entry is ((dx_minus, dx_plus), (dy_minus,
+  /// dy_plus)) in data units. Empty when the data has no uncertainties.
+  pub error_bars: Vec<Vec<((f64, f64), (f64, f64))>>,
 }
 
 impl Default for PlotOptions {
@@ -1166,8 +1170,55 @@ impl Default for PlotOptions {
       log_y: false,
       stacked: false,
       epilog: Vec::new(),
+      error_bars: Vec::new(),
     }
   }
+}
+
+/// Draw `Around`-style error bars for one series: a bar spanning each
+/// point's uncertainty interval, with short caps at both ends, in the
+/// series color. `bars` is parallel to `points` and holds the
+/// ((dx_minus, dx_plus), (dy_minus, dy_plus)) half-widths in data units;
+/// zero widths draw nothing for that direction.
+fn draw_error_bars<
+  DB: plotters::prelude::DrawingBackend,
+  CT: plotters::prelude::CoordTranslate<From = (f64, f64)>,
+>(
+  chart: &mut plotters::prelude::ChartContext<DB, CT>,
+  points: &[(f64, f64)],
+  bars: &[((f64, f64), (f64, f64))],
+  color: RGBColor,
+  x_span: f64,
+  y_span: f64,
+) -> Result<(), InterpreterError> {
+  // Cap half-lengths: a small fixed fraction of the plotted span.
+  let cap_x = x_span * 0.012;
+  let cap_y = y_span * 0.012;
+  let style = color.stroke_width(RESOLUTION_SCALE);
+  let mut segments: Vec<[(f64, f64); 2]> = Vec::new();
+  for (&(x, y), &(dx, dy)) in points.iter().zip(bars) {
+    if !(x.is_finite() && y.is_finite()) {
+      continue;
+    }
+    if dy.0 > 0.0 || dy.1 > 0.0 {
+      let (lo, hi) = (y - dy.0, y + dy.1);
+      segments.push([(x, lo), (x, hi)]);
+      segments.push([(x - cap_x, lo), (x + cap_x, lo)]);
+      segments.push([(x - cap_x, hi), (x + cap_x, hi)]);
+    }
+    if dx.0 > 0.0 || dx.1 > 0.0 {
+      let (lo, hi) = (x - dx.0, x + dx.1);
+      segments.push([(lo, y), (hi, y)]);
+      segments.push([(lo, y - cap_y), (lo, y + cap_y)]);
+      segments.push([(hi, y - cap_y), (hi, y + cap_y)]);
+    }
+  }
+  for seg in segments {
+    chart
+      .draw_series(std::iter::once(PathElement::new(seg.to_vec(), style)))
+      .map_err(|e| InterpreterError::EvaluationError(format!("Plot: {e}")))?;
+  }
+  Ok(())
 }
 
 /// Draw a dashed/dotted line on a chart.
@@ -1798,6 +1849,18 @@ fn generate_svg_with_options(
                   InterpreterError::EvaluationError(format!("Plot: {e}"))
                 })?;
             }
+          }
+
+          // Error bars from Around data values, on top of the line.
+          if let Some(bars) = opts.error_bars.get(series_idx) {
+            draw_error_bars(
+              &mut chart,
+              points,
+              bars,
+              color,
+              x_max - x_min,
+              y_max - y_min,
+            )?;
           }
 
           // Draw mesh dots at each data point when Mesh -> All
@@ -2435,6 +2498,18 @@ pub(crate) fn generate_scatter_svg_with_options(
               InterpreterError::EvaluationError(format!("Plot: {e}"))
             })?;
         }
+      }
+
+      // Error bars from Around data values, under the point markers.
+      if let Some(bars) = opts.error_bars.get(series_idx) {
+        draw_error_bars(
+          &mut chart,
+          points,
+          bars,
+          color,
+          x_max - x_min,
+          y_max - y_min,
+        )?;
       }
 
       chart

--- a/tests/cli/plotting/ListPlot.md
+++ b/tests/cli/plotting/ListPlot.md
@@ -11,3 +11,11 @@ Accepts the same core options as `Plot`, plus:
 
 - **`Joined`** — `True` connects the points with a line.
 - **`PlotMarkers`** — shape spec for the markers.
+
+Values wrapped in `Around` are plotted at their central value
+with error bars spanning the uncertainty:
+
+```scrut
+$ wo 'Head[ListPlot[{Around[2.2, 1.2], Around[3.3, 1.1], Around[5.9, 0.6]}]]'
+Graphics
+```

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_plot_around_snapshot.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_plot_around_snapshot.snap
@@ -1,0 +1,200 @@
+---
+source: tests/interpreter_tests/graphics.rs
+assertion_line: 2297
+expression: "export_svg(\"ListPlot[{Around[2, 1], Around[3, 0.5], Around[5, 0.25]}]\")"
+---
+<svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1688" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+1
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1688 749,1688 "/>
+<text x="670" y="1617" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1617 749,1617 "/>
+<text x="670" y="1545" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1545 749,1545 "/>
+<text x="670" y="1473" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1473 749,1473 "/>
+<text x="670" y="1401" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1401 749,1401 "/>
+<text x="670" y="1329" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1329 749,1329 "/>
+<text x="670" y="1257" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1257 749,1257 "/>
+<text x="670" y="1185" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1185 749,1185 "/>
+<text x="670" y="1114" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1114 749,1114 "/>
+<text x="670" y="1042" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1042 749,1042 "/>
+<text x="670" y="970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+3
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,970 749,970 "/>
+<text x="670" y="898" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,898 749,898 "/>
+<text x="670" y="826" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,826 749,826 "/>
+<text x="670" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,754 749,754 "/>
+<text x="670" y="682" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,682 749,682 "/>
+<text x="670" y="611" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+4
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,611 749,611 "/>
+<text x="670" y="539" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,539 749,539 "/>
+<text x="670" y="467" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,467 749,467 "/>
+<text x="670" y="395" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,395 749,395 "/>
+<text x="670" y="323" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,323 749,323 "/>
+<text x="670" y="251" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,251 749,251 "/>
+<text x="670" y="180" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,180 749,180 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
+<text x="851" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+1
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="851,1750 851,1790 "/>
+<text x="979" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="979,1750 979,1790 "/>
+<text x="1106" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1106,1750 1106,1790 "/>
+<text x="1233" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1233,1750 1233,1790 "/>
+<text x="1360" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1360,1750 1360,1790 "/>
+<text x="1488" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+1.5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1488,1750 1488,1790 "/>
+<text x="1615" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1615,1750 1615,1790 "/>
+<text x="1742" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1742,1750 1742,1790 "/>
+<text x="1869" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1869,1750 1869,1790 "/>
+<text x="1997" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1997,1750 1997,1790 "/>
+<text x="2124" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2124,1750 2124,1790 "/>
+<text x="2251" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2251,1750 2251,1790 "/>
+<text x="2379" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2379,1750 2379,1790 "/>
+<text x="2506" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2506,1750 2506,1790 "/>
+<text x="2633" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2633,1750 2633,1790 "/>
+<text x="2760" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+2.5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2760,1750 2760,1790 "/>
+<text x="2888" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2888,1750 2888,1790 "/>
+<text x="3015" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3015,1750 3015,1790 "/>
+<text x="3142" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3142,1750 3142,1790 "/>
+<text x="3269" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3269,1750 3269,1790 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="10" points="851,1688 851,970 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="10" points="818,1688 884,1688 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="10" points="818,970 884,970 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="10" points="2124,1150 2124,790 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="10" points="2091,1150 2157,1150 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="10" points="2091,790 2157,790 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="10" points="3397,341 3397,162 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="10" points="3364,341 3430,341 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="10" points="3364,162 3430,162 "/>
+<circle cx="851" cy="1329" r="30" opacity="1" fill="#5E81B5" stroke="none" stroke-width="1"/>
+<circle cx="2124" cy="970" r="30" opacity="1" fill="#5E81B5" stroke="none" stroke-width="1"/>
+<circle cx="3397" cy="251" r="30" opacity="1" fill="#5E81B5" stroke="none" stroke-width="1"/>
+<line x1="851.9" y1="1790.0" x2="851.9" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="1488.4" y1="1790.0" x2="1488.4" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2125.0" y1="1790.0" x2="2125.0" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2761.6" y1="1790.0" x2="2761.6" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="3398.1" y1="1790.0" x2="3398.1" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1688.9" x2="680.0" y2="1688.9" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1329.4" x2="680.0" y2="1329.4" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="969.9" x2="680.0" y2="969.9" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="610.5" x2="680.0" y2="610.5" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="251.0" x2="680.0" y2="251.0" stroke="#666" stroke-width="10"/>
+</svg>


### PR DESCRIPTION
## Summary

Add support for plotting `Around[value, uncertainty]` expressions in `ListPlot` and `ListLinePlot`. Values wrapped in `Around` are now plotted at their central value with error bars spanning the uncertainty interval.

## Changes

- **New `ErrPoint` struct**: Represents a data point with asymmetric x/y uncertainties extracted from `Around` expressions
- **`eval_to_value_err` function**: Evaluates expressions to plottable values with uncertainty, handling both symmetric `Around[v, u]` and asymmetric `Around[v, {minus, plus}]` forms
- **Updated data parsing**: Modified `parse_list_data_err` to preserve uncertainty information while parsing, with `parse_list_data` now stripping errors for backward compatibility
- **Error bar rendering**: New `draw_error_bars` function renders vertical/horizontal error bars with caps in the series color, integrated into both line and scatter plot rendering paths
- **Range computation**: Plot ranges now account for the full extent of error bars via `error_extremes` helper
- **Test coverage**: Added comprehensive tests for y-value uncertainties, x/y pair uncertainties, asymmetric uncertainties, and mixed exact/uncertain values, plus a snapshot test

## Implementation Details

- Error bars are stored in `PlotOptions::error_bars` as per-series vectors of `((dx_minus, dx_plus), (dy_minus, dy_plus))` tuples in data units
- Cap lengths are computed as 1.2% of the plotted span for visual consistency
- Both `ListPlot` (scatter) and `ListLinePlot` (line) support error bars
- Exact values (non-`Around`) coexist with uncertain values in the same plot with no error bar

https://claude.ai/code/session_017ZQ3QTJqLWD8tewbSoCos4