### PR TITLE
Fix log axis padding to use multiplicative scaling

### DIFF
--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -295,6 +295,17 @@ fn apply_plot_range_override(
 
 /// Compute x/y ranges from data with 4% padding.
 fn compute_ranges(all_series: &[Vec<(f64, f64)>]) -> ((f64, f64), (f64, f64)) {
+  compute_ranges_scaled(all_series, false, false)
+}
+
+/// Compute x/y ranges from data with 4% padding. Log axes are padded
+/// multiplicatively in log space (4% of the log range, matching LogPlot),
+/// so the padded range stays positive.
+fn compute_ranges_scaled(
+  all_series: &[Vec<(f64, f64)>],
+  log_x: bool,
+  log_y: bool,
+) -> ((f64, f64), (f64, f64)) {
   let mut x_min = f64::INFINITY;
   let mut x_max = f64::NEG_INFINITY;
   let mut y_min = f64::INFINITY;
@@ -314,30 +325,42 @@ fn compute_ranges(all_series: &[Vec<(f64, f64)>]) -> ((f64, f64), (f64, f64)) {
   }
 
   if !x_min.is_finite() || !x_max.is_finite() {
-    x_min = 0.0;
-    x_max = 1.0;
+    (x_min, x_max) = if log_x { (1.0, 10.0) } else { (0.0, 1.0) };
   }
   if !y_min.is_finite() || !y_max.is_finite() {
-    y_min = 0.0;
-    y_max = 1.0;
+    (y_min, y_max) = if log_y { (1.0, 10.0) } else { (0.0, 1.0) };
   }
 
-  let x_range = x_max - x_min;
-  let y_range = y_max - y_min;
-  let x_pad = if x_range.abs() < f64::EPSILON {
-    1.0
-  } else {
-    x_range * 0.04
+  let pad_linear = |min: f64, max: f64| {
+    let range = max - min;
+    let pad = if range.abs() < f64::EPSILON {
+      1.0
+    } else {
+      range * 0.04
+    };
+    (min - pad, max + pad)
   };
-  let y_pad = if y_range.abs() < f64::EPSILON {
-    1.0
-  } else {
-    y_range * 0.04
+  let pad_log = |min: f64, max: f64| {
+    let log_range = (max / min).ln();
+    let factor = if log_range.abs() < f64::EPSILON {
+      std::f64::consts::E
+    } else {
+      (log_range * 0.04).exp()
+    };
+    (min / factor, max * factor)
   };
 
   (
-    (x_min - x_pad, x_max + x_pad),
-    (y_min - y_pad, y_max + y_pad),
+    if log_x {
+      pad_log(x_min, x_max)
+    } else {
+      pad_linear(x_min, x_max)
+    },
+    if log_y {
+      pad_log(y_min, y_max)
+    } else {
+      pad_linear(y_min, y_max)
+    },
   )
 }
 
@@ -462,7 +485,7 @@ pub fn list_log_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     .map(|series| series.iter().filter(|&&(_, y)| y > 0.0).copied().collect())
     .collect();
 
-  let (x_range, y_range) = compute_ranges(&filtered);
+  let (x_range, y_range) = compute_ranges_scaled(&filtered, false, true);
   let y_range = adjust_y_range_for_filling(parsed.opts.filling, y_range);
   let (x_range, y_range) = apply_plot_range_override(&parsed, x_range, y_range);
   let svg =
@@ -489,7 +512,7 @@ pub fn list_log_log_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     })
     .collect();
 
-  let (x_range, y_range) = compute_ranges(&filtered);
+  let (x_range, y_range) = compute_ranges_scaled(&filtered, true, true);
   let y_range = adjust_y_range_for_filling(parsed.opts.filling, y_range);
   let (x_range, y_range) = apply_plot_range_override(&parsed, x_range, y_range);
   let svg =
@@ -511,7 +534,7 @@ pub fn list_log_linear_plot_ast(
     .map(|series| series.iter().filter(|&&(x, _)| x > 0.0).copied().collect())
     .collect();
 
-  let (x_range, y_range) = compute_ranges(&filtered);
+  let (x_range, y_range) = compute_ranges_scaled(&filtered, true, false);
   let y_range = adjust_y_range_for_filling(parsed.opts.filling, y_range);
   let (x_range, y_range) = apply_plot_range_override(&parsed, x_range, y_range);
   let svg =

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -659,6 +659,15 @@ fn inject_log_axis_labels(
   fill: &str,
   orientation: LogAxisOrientation,
 ) {
+  // A log axis needs positive, finite bounds; otherwise no labels can be
+  // placed (log10 would yield NaN positions).
+  if data_min <= 0.0
+    || !data_min.is_finite()
+    || !data_max.is_finite()
+    || data_max <= data_min
+  {
+    return;
+  }
   let log_min = data_min.log10();
   let log_max = data_max.log10();
   let decades = (log_max - log_min).abs();

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_log_linear_plot.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_log_linear_plot.snap
@@ -58,11 +58,24 @@ expression: "export_svg(\"ListLogLinearPlot[{{1, 2}, {10, 5}, {100, 8}}]\")"
 </text>
 <polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,162 749,162 "/>
 <polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
-<polyline fill="none" opacity="1" stroke="#CCCCCC" stroke-width="10" points="750,1749 750,100 "/>
-<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="750,1688 750,925 750,162 "/>
+<text x="851" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="851,1750 851,1790 "/>
+<text x="2124" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2124,1750 2124,1790 "/>
+<text x="3397" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3397,1750 3397,1790 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1688 2124,925 3397,162 "/>
 <line x1="710.0" y1="1688.9" x2="680.0" y2="1688.9" stroke="#666" stroke-width="10"/>
 <line x1="710.0" y1="1179.6" x2="680.0" y2="1179.6" stroke="#666" stroke-width="10"/>
 <line x1="710.0" y1="670.4" x2="680.0" y2="670.4" stroke="#666" stroke-width="10"/>
 <line x1="710.0" y1="161.1" x2="680.0" y2="161.1" stroke="#666" stroke-width="10"/>
-<text x="NaN" y="1938.7" text-anchor="middle" font-family="sans-serif" font-size="145" fill="#666">1</text>
+<text x="851.9" y="1938.7" text-anchor="middle" font-family="sans-serif" font-size="145" fill="#666">1</text>
+<text x="2125.0" y="1938.7" text-anchor="middle" font-family="sans-serif" font-size="145" fill="#666">10</text>
+<text x="3398.1" y="1938.7" text-anchor="middle" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">2</tspan></text>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_log_log_plot.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_log_log_plot.snap
@@ -5,11 +5,36 @@ expression: "export_svg(\"ListLogLogPlot[{{1, 10}, {10, 100}, {100, 1000}}]\")"
 <svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
 <rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
 <polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1688" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1688 749,1688 "/>
+<text x="670" y="925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,925 749,925 "/>
+<text x="670" y="162" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,162 749,162 "/>
 <polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
-<polyline fill="none" opacity="1" stroke="#CCCCCC" stroke-width="10" points="750,1749 750,1749 "/>
-<polyline fill="none" opacity="1" stroke="#CCCCCC" stroke-width="10" points="750,1749 750,1749 "/>
-<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="750,1749 750,1749 750,1749 "/>
-<text x="670.2" y="NaN" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">1</text>
-<text x="670.2" y="NaN" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">3</tspan></text>
-<text x="NaN" y="1938.7" text-anchor="middle" font-family="sans-serif" font-size="145" fill="#666">1</text>
+<text x="851" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="851,1750 851,1790 "/>
+<text x="2124" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2124,1750 2124,1790 "/>
+<text x="3397" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3397,1750 3397,1790 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1688 2124,925 3397,162 "/>
+<text x="670.2" y="1688.9" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10</text>
+<text x="670.2" y="925.0" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">2</tspan></text>
+<text x="670.2" y="161.1" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">3</tspan></text>
+<text x="851.9" y="1938.7" text-anchor="middle" font-family="sans-serif" font-size="145" fill="#666">1</text>
+<text x="2125.0" y="1938.7" text-anchor="middle" font-family="sans-serif" font-size="145" fill="#666">10</text>
+<text x="3398.1" y="1938.7" text-anchor="middle" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">2</tspan></text>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_log_plot.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_log_plot.snap
@@ -5,6 +5,22 @@ expression: "export_svg(\"ListLogPlot[{1, 10, 100, 1000}]\")"
 <svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
 <rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
 <polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1688" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1688 749,1688 "/>
+<text x="670" y="1179" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1179 749,1179 "/>
+<text x="670" y="671" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,671 749,671 "/>
+<text x="670" y="162" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,162 749,162 "/>
 <polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
 <text x="851" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
 1
@@ -66,12 +82,13 @@ expression: "export_svg(\"ListLogPlot[{1, 10, 100, 1000}]\")"
 
 </text>
 <polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3227,1750 3227,1790 "/>
-<polyline fill="none" opacity="1" stroke="#CCCCCC" stroke-width="10" points="750,1749 3499,1749 "/>
-<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1749 1700,1749 2548,1749 3397,1749 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1688 1700,1179 2548,671 3397,162 "/>
 <line x1="851.9" y1="1790.0" x2="851.9" y2="1820.0" stroke="#666" stroke-width="10"/>
 <line x1="1700.6" y1="1790.0" x2="1700.6" y2="1820.0" stroke="#666" stroke-width="10"/>
 <line x1="2549.4" y1="1790.0" x2="2549.4" y2="1820.0" stroke="#666" stroke-width="10"/>
 <line x1="3398.1" y1="1790.0" x2="3398.1" y2="1820.0" stroke="#666" stroke-width="10"/>
-<text x="670.2" y="NaN" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">1</text>
-<text x="670.2" y="NaN" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">3</tspan></text>
+<text x="670.2" y="1688.9" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">1</text>
+<text x="670.2" y="1179.6" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10</text>
+<text x="670.2" y="670.4" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">2</tspan></text>
+<text x="670.2" y="161.1" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">3</tspan></text>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_log_plot_binomial_joined.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_log_plot_binomial_joined.snap
@@ -1,0 +1,104 @@
+---
+source: tests/interpreter_tests/graphics.rs
+expression: svg
+---
+<svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1688" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1688 749,1688 "/>
+<text x="670" y="1461" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1461 749,1461 "/>
+<text x="670" y="1234" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1234 749,1234 "/>
+<text x="670" y="1006" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1006 749,1006 "/>
+<text x="670" y="779" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,779 749,779 "/>
+<text x="670" y="552" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,552 749,552 "/>
+<text x="670" y="324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,324 749,324 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
+<text x="750" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 750,1790 "/>
+<text x="953" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="953,1750 953,1790 "/>
+<text x="1157" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1157,1750 1157,1790 "/>
+<text x="1360" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1360,1750 1360,1790 "/>
+<text x="1564" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1564,1750 1564,1790 "/>
+<text x="1768" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+10
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1768,1750 1768,1790 "/>
+<text x="1971" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1971,1750 1971,1790 "/>
+<text x="2175" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2175,1750 2175,1790 "/>
+<text x="2379" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2379,1750 2379,1790 "/>
+<text x="2582" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2582,1750 2582,1790 "/>
+<text x="2786" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+20
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2786,1750 2786,1790 "/>
+<text x="2989" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2989,1750 2989,1790 "/>
+<text x="3193" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3193,1750 3193,1790 "/>
+<text x="3397" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3397,1750 3397,1790 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1688 953,1371 1055,1125 1157,924 1259,756 1360,614 1462,495 1564,397 1666,317 1768,254 1869,207 1971,177 2073,162 2175,162 2277,177 2379,207 2480,254 2582,317 2684,397 2786,495 2888,614 2989,756 3091,924 3193,1125 3295,1371 3397,1688 "/>
+<line x1="750.0" y1="1790.0" x2="750.0" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="1768.5" y1="1790.0" x2="1768.5" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2787.0" y1="1790.0" x2="2787.0" y2="1820.0" stroke="#666" stroke-width="10"/>
+<text x="670.2" y="1688.9" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">1</text>
+<text x="670.2" y="1461.4" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10</text>
+<text x="670.2" y="1233.9" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">2</tspan></text>
+<text x="670.2" y="1006.4" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">3</tspan></text>
+<text x="670.2" y="779.0" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">4</tspan></text>
+<text x="670.2" y="551.5" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">5</tspan></text>
+<text x="670.2" y="324.0" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">6</tspan></text>
+</svg>


### PR DESCRIPTION
## Summary
Fixed a bug where logarithmic axes were using linear padding (4% of the range), which could push the lower bound negative and cause NaN label positions. Log axes now use multiplicative padding in log space, matching the behavior of `LogPlot`.

## Changes
- Refactored `compute_ranges()` into `compute_ranges_scaled()` that accepts `log_x` and `log_y` parameters
- Implemented separate padding strategies:
  - **Linear padding**: `range * 0.04` (for linear axes)
  - **Logarithmic padding**: multiplicative factor of `e^(log_range * 0.04)` (for log axes)
- Updated `list_log_plot_ast()`, `list_log_log_plot_ast()`, and `list_log_linear_plot_ast()` to use the new function with appropriate flags
- Added validation in `inject_log_axis_labels()` to skip label injection if bounds are non-positive or invalid (prevents NaN positions)
- Added regression test `list_log_plot_binomial_joined()` to ensure log axis labels have valid positions

## Implementation Details
The logarithmic padding uses the formula: `(min / factor, max * factor)` where `factor = e^(log_range * 0.04)`. This ensures:
- Padded range stays positive (critical for log axes)
- Padding is proportional to the log range, not the linear range
- Behavior is consistent with Wolfram Language's `LogPlot`

Updated snapshots show correct axis labels and proper curve rendering for log plots.

https://claude.ai/code/session_01VgWQpYJmLHyfKjYWyFo9HF