### PR TITLE
Fix eleven differential-fuzzer divergences against wolframscript

### DIFF
--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -579,6 +579,18 @@ pub fn evaluate_function_call_ast_inner(
     return result;
   }
 
+  // A machine Real times a NESTED exact-times-constant product folds in
+  // wolframscript's pre-flattening order (((outer * reals) * nested exact)
+  // * constants), one ulp away from the flattened fold — decide before the
+  // Flat attribute erases the nesting (differential fuzzer, seed
+  // 4134943276941009607).
+  if name == "Times"
+    && let Some(result) =
+      crate::functions::math_ast::nested_exact_const_machine_times(args)
+  {
+    return Ok(result);
+  }
+
   // Apply Flat attribute: flatten nested calls of the same function
   let has_flat = is_builtin_flat(name)
     || crate::FUNC_ATTRS.with(|m| {

--- a/src/functions/list_helpers_ast/set_operations.rs
+++ b/src/functions/list_helpers_ast/set_operations.rs
@@ -309,13 +309,11 @@ fn collect_set_subjects<'a>(
   Ok((slices, head, same_test))
 }
 
-/// Sort canonically via compare_exprs (1 = first argument precedes).
+/// Sort canonically. Union/Intersection/Complement follow Sort's canonical
+/// order (which differs from Order for same-base powers and sums):
+/// Union[{Pi}, {1/Pi}] = {Pi^(-1), Pi} even though Order[Pi, 1/Pi] = -1.
 fn sort_canonical(items: &mut [Expr]) {
-  items.sort_by(|a, b| match compare_exprs(a, b) {
-    n if n > 0 => std::cmp::Ordering::Less,
-    n if n < 0 => std::cmp::Ordering::Greater,
-    _ => std::cmp::Ordering::Equal,
-  });
+  items.sort_by(super::sorting::canonical_cmp);
 }
 
 /// If every argument is an Association, return their `(key, value)` pair

--- a/src/functions/list_helpers_ast/sorting.rs
+++ b/src/functions/list_helpers_ast/sorting.rs
@@ -288,13 +288,14 @@ pub fn canonical_cmp(a: &Expr, b: &Expr) -> std::cmp::Ordering {
           }
         }
       }
-      // Powers of integer bases order by base then exponent, ascending
-      // (Sort[{Sqrt[11], Sqrt[2]}] = {Sqrt[2], Sqrt[11]}); the
+      // Powers of integer or rational bases order by base then exponent,
+      // ascending (Sort[{Sqrt[11], Sqrt[2]}] = {Sqrt[2], Sqrt[11]},
+      // Sort[{Sqrt[3], Sqrt[5/3]}] = {Sqrt[5/3], Sqrt[3]}); the
       // head-name/argument comparison below would order 11 before 2.
       if let (Some((ba, ea)), Some((bb, eb))) =
         (int_base_power(a), int_base_power(b))
       {
-        match ba.cmp(&bb) {
+        match ratio_cmp(ba, bb) {
           std::cmp::Ordering::Equal => {}
           other => return other,
         }
@@ -306,6 +307,81 @@ pub fn canonical_cmp(a: &Expr, b: &Expr) -> std::cmp::Ordering {
           };
         }
         return std::cmp::Ordering::Equal;
+      }
+      // Same-base powers (or a power against its bare base) compare by
+      // exponent, ascending: Sort[{Pi, 1/Pi}] = {Pi^(-1), Pi},
+      // Sort[{x, Sqrt[x], x^2}] = {Sqrt[x], x, x^2} (wolframscript-verified).
+      {
+        let base_exp = |e: &Expr| -> Option<(String, f64)> {
+          if let Some((base, exp)) = power_parts(e) {
+            let v = crate::functions::math_ast::try_eval_to_f64(&exp)?;
+            Some((crate::syntax::expr_to_string(&base), v))
+          } else {
+            Some((crate::syntax::expr_to_string(e), 1.0))
+          }
+        };
+        let a_is_pow = power_parts(a).is_some();
+        let b_is_pow = power_parts(b).is_some();
+        if (a_is_pow || b_is_pow)
+          && let (Some((sa, ea)), Some((sb, eb))) = (base_exp(a), base_exp(b))
+          && sa == sb
+          && ea != eb
+        {
+          return if ea < eb {
+            std::cmp::Ordering::Less
+          } else {
+            std::cmp::Ordering::Greater
+          };
+        }
+      }
+      // Additive expressions (sums) hold a class-based place in canonical
+      // order (wolframscript-verified probe families in Pi and x):
+      //   {1, 1+x^(-1), 1+Sqrt[x], x^(-2), x^(-1), 93/x, Sqrt[x], x, 2*x,
+      //    x^2, x^3, 1+x, 2+x, 1+2*x, 1+x^2, x+x^2}
+      // A sum whose greatest (last canonical) term is sub-linear (exponent
+      // < 1), has a negative leading coefficient, or carries a negative
+      // lower-order term sorts BEFORE monomials and atoms; every other sum
+      // sorts AFTER them but before plain function calls
+      // (Sort[{Cos[x], 1+x}] = {1+x, Cos[x]}). Two sums compare termwise
+      // from the greatest term down.
+      {
+        let a_terms = sum_terms_list(a);
+        let b_terms = sum_terms_list(b);
+        let skip = matches!(a, Expr::List(_) | Expr::Pattern { .. })
+          || matches!(b, Expr::List(_) | Expr::Pattern { .. });
+        if !skip {
+          match (&a_terms, &b_terms) {
+            (Some(ta), Some(tb)) => {
+              let (ca, cb) = (sum_sorts_early(ta), sum_sorts_early(tb));
+              if ca != cb {
+                return if ca {
+                  std::cmp::Ordering::Less
+                } else {
+                  std::cmp::Ordering::Greater
+                };
+              }
+              let ord = cmp_sum_terms(ta, tb);
+              if ord != std::cmp::Ordering::Equal {
+                return ord;
+              }
+            }
+            (Some(ta), None) => {
+              return if sum_sorts_early(ta) || is_plain_call_non_power(b) {
+                std::cmp::Ordering::Less
+              } else {
+                std::cmp::Ordering::Greater
+              };
+            }
+            (None, Some(tb)) => {
+              return if sum_sorts_early(tb) || is_plain_call_non_power(a) {
+                std::cmp::Ordering::Greater
+              } else {
+                std::cmp::Ordering::Less
+              };
+            }
+            (None, None) => {}
+          }
+        }
       }
       // Handle compound expressions (lists, function calls) element-wise
       match (a, b) {
@@ -1195,16 +1271,18 @@ pub fn compare_exprs(a: &Expr, b: &Expr) -> i64 {
     }
   }
 
-  // Two powers of integer bases with numeric exponents compare by base
-  // ascending, then exponent ascending: Order[Sqrt[2], Sqrt[11]] = 1,
-  // Order[2^(1/3), Sqrt[2]] = 1, Order[Sqrt[2], 2^(2/3)] = 1 (all
+  // Two powers of integer or rational bases with numeric exponents compare
+  // by base ascending, then exponent ascending: Order[Sqrt[2], Sqrt[11]] = 1,
+  // Order[2^(1/3), Sqrt[2]] = 1, Order[Sqrt[5/3], Sqrt[3]] = 1 (all
   // wolframscript-verified). The string comparisons below would order
   // "11" before "2" lexicographically.
   if let (Some((ba, ea)), Some((bb, eb))) =
     (int_base_power(a), int_base_power(b))
   {
-    if ba != bb {
-      return if ba < bb { 1 } else { -1 };
+    match ratio_cmp(ba, bb) {
+      std::cmp::Ordering::Equal => {}
+      std::cmp::Ordering::Less => return 1,
+      std::cmp::Ordering::Greater => return -1,
     }
     if ea != eb {
       return if ea < eb { 1 } else { -1 };
@@ -1343,7 +1421,7 @@ pub fn compare_exprs(a: &Expr, b: &Expr) -> i64 {
 /// A power of an integer base with a numeric exponent — Sqrt[2],
 /// 2^(1/3), Power[5, -1] — as `(base, exponent)`. These compare by base
 /// ascending then exponent ascending in Wolfram's canonical order.
-fn int_base_power(e: &Expr) -> Option<(i128, f64)> {
+fn int_base_power(e: &Expr) -> Option<((i128, i128), f64)> {
   use crate::functions::math_ast::try_eval_to_f64_with_infinity;
   let (base, exp) = match e {
     Expr::FunctionCall { name, args } if name == "Sqrt" && args.len() == 1 => (
@@ -1363,9 +1441,53 @@ fn int_base_power(e: &Expr) -> Option<(i128, f64)> {
     } => ((**left).clone(), (**right).clone()),
     _ => return None,
   };
-  let Expr::Integer(b) = base else { return None };
+  // Bases may be integers or rationals — Sort[{Sqrt[3], Sqrt[5/3]}] =
+  // {Sqrt[5/3], Sqrt[3]} because 5/3 < 3. Normalized to den > 0.
+  let b = match &base {
+    Expr::Integer(b) => (*b, 1),
+    Expr::FunctionCall { name, args }
+      if name == "Rational" && args.len() == 2 =>
+    {
+      match (&args[0], &args[1]) {
+        (Expr::Integer(n), Expr::Integer(d)) if *d != 0 => {
+          if *d < 0 { (-n, -d) } else { (*n, *d) }
+        }
+        _ => return None,
+      }
+    }
+    _ => return None,
+  };
   let e = try_eval_to_f64_with_infinity(&exp)?;
   Some((b, e))
+}
+
+/// Order two powers of integer/rational bases with numeric exponents by
+/// base ascending, then exponent ascending — Wolfram's canonical order for
+/// numeric radicals (Order[Sqrt[5/3], Sqrt[3]] = 1, Order[2^(1/3),
+/// Sqrt[2]] = 1). None unless both expressions are such powers.
+pub fn numeric_base_power_cmp(
+  a: &Expr,
+  b: &Expr,
+) -> Option<std::cmp::Ordering> {
+  let (ba, ea) = int_base_power(a)?;
+  let (bb, eb) = int_base_power(b)?;
+  Some(
+    ratio_cmp(ba, bb)
+      .then(ea.partial_cmp(&eb).unwrap_or(std::cmp::Ordering::Equal)),
+  )
+}
+
+/// Compare two exact rationals `(num, den)` with positive denominators by
+/// cross-multiplication, falling back to f64 on i128 overflow.
+fn ratio_cmp(a: (i128, i128), b: (i128, i128)) -> std::cmp::Ordering {
+  match (a.0.checked_mul(b.1), b.0.checked_mul(a.1)) {
+    (Some(l), Some(r)) => l.cmp(&r),
+    _ => {
+      let l = a.0 as f64 / a.1 as f64;
+      let r = b.0 as f64 / b.1 as f64;
+      l.partial_cmp(&r).unwrap_or(std::cmp::Ordering::Equal)
+    }
+  }
 }
 
 /// Decompose a power expression — Power[b, e] (either Expr shape) or
@@ -1448,6 +1570,148 @@ fn numeric_coeff_and_rest_expr(e: &Expr) -> (f64, Option<Expr>) {
     }
     _ => (1.0, None),
   }
+}
+
+/// Flattened additive terms of a sum, in stored (canonical, ascending)
+/// order — the greatest term is last. Minus-chain right operands come back
+/// negated. Returns None unless `e` is an additive expression with at
+/// least two terms.
+fn sum_terms_list(e: &Expr) -> Option<Vec<Expr>> {
+  fn collect(e: &Expr, negate: bool, out: &mut Vec<Expr>) {
+    match e {
+      Expr::FunctionCall { name, args } if name == "Plus" => {
+        for a in args.iter() {
+          collect(a, negate, out);
+        }
+      }
+      Expr::BinaryOp {
+        op: BinaryOperator::Plus,
+        left,
+        right,
+      } => {
+        collect(left, negate, out);
+        collect(right, negate, out);
+      }
+      Expr::BinaryOp {
+        op: BinaryOperator::Minus,
+        left,
+        right,
+      } => {
+        collect(left, negate, out);
+        collect(right, !negate, out);
+      }
+      _ => out.push(if negate {
+        Expr::UnaryOp {
+          op: UnaryOperator::Minus,
+          operand: Box::new(e.clone()),
+        }
+      } else {
+        e.clone()
+      }),
+    }
+  }
+  if !matches!(e, Expr::FunctionCall { name, .. } if name == "Plus")
+    && !matches!(
+      e,
+      Expr::BinaryOp {
+        op: BinaryOperator::Plus | BinaryOperator::Minus,
+        ..
+      }
+    )
+  {
+    return None;
+  }
+  let mut out = Vec::new();
+  collect(e, false, &mut out);
+  if out.len() >= 2 { Some(out) } else { None }
+}
+
+/// The numeric exponent of a term with its literal coefficient stripped:
+/// `x` -> 1, `Sqrt[x]` -> 0.5, `x^n` -> n, `93/x` -> -1. None when the
+/// exponent is not numeric (e.g. `2^x`).
+fn term_exponent(t: &Expr) -> Option<f64> {
+  let (_, r) = numeric_coeff_and_rest_expr(t);
+  let rest = r.as_ref().unwrap_or(t);
+  if let Some((_, exp)) = power_parts(rest) {
+    crate::functions::math_ast::try_eval_to_f64(&exp)
+  } else {
+    Some(1.0)
+  }
+}
+
+/// True when `t` is a negative number literal or carries a negative literal
+/// coefficient (`-3`, `-x`, `-2*Sqrt[5]`).
+fn term_is_negative(t: &Expr) -> bool {
+  if matches!(
+    t,
+    Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      ..
+    }
+  ) {
+    return true;
+  }
+  if let Some(v) = crate::functions::math_ast::try_eval_to_f64(t) {
+    return v < 0.0;
+  }
+  let (c, r) = numeric_coeff_and_rest_expr(t);
+  r.is_some() && c < 0.0
+}
+
+/// Whether a sum sorts in the EARLY class — before monomials and atoms —
+/// in Wolfram's canonical Sort order. wolframscript-verified:
+///   Sort[{Pi, 1 + 1/Pi}]  = {1 + Pi^(-1), Pi}   (sub-linear lead)
+///   Sort[{x, 5 - x}]      = {5 - x, x}          (negative lead coeff)
+///   Sort[{1/x, -3 + x}]   = {-3 + x, x^(-1)}    (negative lower term)
+///   Sort[{x, 2 + x}]      = {x, 2 + x}          (late: all-positive linear)
+///   Sort[{1/x, x - x^2}]  = {x^(-1), x - x^2}   (late: super-linear lead)
+fn sum_sorts_early(terms: &[Expr]) -> bool {
+  let Some(lead) = terms.last() else {
+    return false;
+  };
+  let Some(exp) = term_exponent(lead) else {
+    return false;
+  };
+  if exp < 1.0 {
+    return true;
+  }
+  if exp == 1.0
+    && (term_is_negative(lead)
+      || terms[..terms.len() - 1].iter().any(term_is_negative))
+  {
+    return true;
+  }
+  false
+}
+
+/// Compare two sums termwise from the greatest (last canonical) term down;
+/// when one runs out, its missing terms count as 0 against the other's
+/// remaining greatest term (Sort[{2 + Pi, Pi}] = {Pi, 2 + Pi} but
+/// Sort[{-3 + x, x}] = {-3 + x, x}).
+fn cmp_sum_terms(ta: &[Expr], tb: &[Expr]) -> std::cmp::Ordering {
+  let (mut i, mut j) = (ta.len(), tb.len());
+  loop {
+    match (i, j) {
+      (0, 0) => return std::cmp::Ordering::Equal,
+      (0, _) => return canonical_cmp(&Expr::Integer(0), &tb[j - 1]),
+      (_, 0) => return canonical_cmp(&ta[i - 1], &Expr::Integer(0)),
+      _ => {
+        let ord = canonical_cmp(&ta[i - 1], &tb[j - 1]);
+        if ord != std::cmp::Ordering::Equal {
+          return ord;
+        }
+        i -= 1;
+        j -= 1;
+      }
+    }
+  }
+}
+
+/// A plain function call that is not itself a power (Sqrt/Power) — sums
+/// sort before these (Sort[{Cos[x], 1 + x}] = {1 + x, Cos[x]}).
+fn is_plain_call_non_power(e: &Expr) -> bool {
+  is_plain_func_call(e)
+    && !matches!(e, Expr::FunctionCall { name, args } if name == "Sqrt" && args.len() == 1)
 }
 
 /// True when `sum` is an additive expression whose highest (last) canonical

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -4027,6 +4027,17 @@ fn compare_expr_canonical(a: &Expr, b: &Expr) -> std::cmp::Ordering {
     return ord;
   }
 
+  // Numeric radicals compare by base ascending, then exponent ascending —
+  // Sqrt[5/3] + Sqrt[3] keeps Sqrt[5/3] first because 5/3 < 3
+  // (wolframscript-verified). The type-tag/argument comparison below would
+  // order the Integer-based Sqrt[3] ahead of the Rational-based Sqrt[5/3].
+  if let Some(ord) =
+    crate::functions::list_helpers_ast::sorting::numeric_base_power_cmp(a, b)
+    && ord != Ordering::Equal
+  {
+    return ord;
+  }
+
   // Assign a type tag for top-level ordering
   fn type_tag(e: &Expr) -> u8 {
     match e {
@@ -6292,6 +6303,189 @@ fn try_series_data_times_var_power(
 }
 
 /// Times[args...] - Product of arguments, with list threading
+/// Machine fold for a Times whose arguments include a machine Real and a
+/// NESTED exact-times-constant product (Times[-35, Pi]): wolframscript
+/// keeps the nested product out of the outer coefficient pool —
+/// Times[39, Times[-35, Pi], r] = ((39 * r) * -35) * N[Pi], one ulp away
+/// from the flat Times[39, -35, Pi, r] = (-1365 * r) * N[Pi]
+/// (wolframscript-verified; differential fuzzer, seed
+/// 4134943276941009607). Returns None unless the argument list is exactly
+/// this shape: only machine reals, exact numbers, numeric-constant
+/// expressions, and at least one real-free nested product carrying both an
+/// exact coefficient and a constant part.
+pub fn nested_exact_const_machine_times(args: &[Expr]) -> Option<Expr> {
+  use crate::functions::math_ast::try_eval_to_f64;
+  fn exact_val(e: &Expr) -> Option<(i128, i128)> {
+    match e {
+      Expr::Integer(n) => Some((*n, 1)),
+      Expr::FunctionCall { name, args }
+        if name == "Rational" && args.len() == 2 =>
+      {
+        match (&args[0], &args[1]) {
+          (Expr::Integer(n), Expr::Integer(d)) if *d != 0 => {
+            if *d < 0 { Some((-n, -d)) } else { Some((*n, *d)) }
+          }
+          _ => None,
+        }
+      }
+      _ => None,
+    }
+  }
+  fn contains_real(e: &Expr) -> bool {
+    match e {
+      Expr::Real(_) | Expr::BigFloat(..) => true,
+      Expr::BinaryOp { left, right, .. } => {
+        contains_real(left) || contains_real(right)
+      }
+      Expr::UnaryOp { operand, .. } => contains_real(operand),
+      Expr::FunctionCall { args, .. } | Expr::List(args) => {
+        args.iter().any(contains_real)
+      }
+      _ => false,
+    }
+  }
+  fn times_factors(e: &Expr) -> Option<Vec<Expr>> {
+    match e {
+      Expr::FunctionCall { name, args } if name == "Times" => {
+        Some(args.to_vec())
+      }
+      Expr::BinaryOp {
+        op: BinaryOperator::Times,
+        left,
+        right,
+      } => {
+        let mut v = times_factors(left)
+          .unwrap_or_else(|| vec![(**left).clone()]);
+        v.extend(
+          times_factors(right).unwrap_or_else(|| vec![(**right).clone()]),
+        );
+        Some(v)
+      }
+      _ => None,
+    }
+  }
+  let mul_exact = |a: (i128, i128), b: (i128, i128)| -> Option<(i128, i128)> {
+    let n = a.0.checked_mul(b.0)?;
+    let d = a.1.checked_mul(b.1)?;
+    let g = {
+      let (mut x, mut y) = (n.abs(), d.abs());
+      while y != 0 {
+        let t = x % y;
+        x = y;
+        y = t;
+      }
+      x.max(1)
+    };
+    Some((n / g, d / g))
+  };
+
+  let mut outer_exact: Option<(i128, i128)> = None;
+  let mut first_numeric_exact: Option<bool> = None;
+  let mut reals: Vec<f64> = Vec::new();
+  let mut nested_coeffs: Vec<f64> = Vec::new();
+  let mut const_tail: Vec<f64> = Vec::new();
+  let mut has_nested = false;
+
+  for arg in args {
+    if let Some(v) = exact_val(arg) {
+      first_numeric_exact.get_or_insert(true);
+      outer_exact = Some(mul_exact(outer_exact.unwrap_or((1, 1)), v)?);
+    } else if let Expr::Real(r) = arg {
+      first_numeric_exact.get_or_insert(false);
+      reals.push(*r);
+    } else if let Some(factors) = times_factors(arg) {
+      if contains_real(arg) {
+        return None;
+      }
+      let mut exact: Option<(i128, i128)> = None;
+      let mut consts: Vec<f64> = Vec::new();
+      for f in &factors {
+        if let Some(v) = exact_val(f) {
+          exact = Some(mul_exact(exact.unwrap_or((1, 1)), v)?);
+        } else {
+          consts.push(try_eval_to_f64(f)?);
+        }
+      }
+      if consts.is_empty() {
+        return None;
+      }
+      has_nested = true;
+      match exact {
+        Some(e) => {
+          nested_coeffs.push(e.0 as f64 / e.1 as f64);
+          const_tail.extend(consts);
+        }
+        // No exact coefficient — the factors multiply in wolframscript's
+        // canonical Times order, which stores reciprocal powers LAST
+        // ((21 - 22*Pi)/Pi is Times[Plus[21, -22*Pi], Power[Pi, -1]]),
+        // while woxi's factor order puts the reciprocal first. Reorder so
+        // Times[A, (21-22*Pi)/Pi, -14.9] folds ((r*A)*(21-22π))*(1/π)
+        // (differential fuzzer, seed 4125733669514322931).
+        None => {
+          let is_reciprocal = |e: &Expr| -> bool {
+            let exp = match e {
+              Expr::BinaryOp {
+                op: BinaryOperator::Power,
+                right,
+                ..
+              } => Some(right.as_ref()),
+              Expr::FunctionCall { name, args }
+                if name == "Power" && args.len() == 2 =>
+              {
+                Some(&args[1])
+              }
+              _ => None,
+            };
+            exp
+              .and_then(crate::functions::math_ast::try_eval_to_f64)
+              .map(|v| v < 0.0)
+              .unwrap_or(false)
+          };
+          let mut main: Vec<f64> = Vec::new();
+          let mut recip: Vec<f64> = Vec::new();
+          for (f, v) in factors.iter().zip(consts.iter()) {
+            if is_reciprocal(f) {
+              recip.push(*v);
+            } else {
+              main.push(*v);
+            }
+          }
+          const_tail.extend(main);
+          const_tail.extend(recip);
+        }
+      }
+    } else if !contains_real(arg)
+      && let Some(v) = try_eval_to_f64(arg)
+    {
+      const_tail.push(v);
+    } else {
+      return None;
+    }
+  }
+  if reals.is_empty() || !has_nested {
+    return None;
+  }
+
+  let exact_f =
+    outer_exact.map(|(n, d)| n as f64 / d as f64).unwrap_or(1.0);
+  let mut fold: Vec<f64> = Vec::new();
+  if outer_exact.is_some() && first_numeric_exact == Some(true) {
+    fold.push(exact_f);
+  }
+  fold.extend_from_slice(&reals);
+  let mut total = machine_tree_fold(&fold, |a, b| a * b);
+  if outer_exact.is_some() && first_numeric_exact != Some(true) {
+    total *= exact_f;
+  }
+  for c in &nested_coeffs {
+    total *= c;
+  }
+  for c in &const_tail {
+    total *= c;
+  }
+  Some(Expr::Real(total))
+}
+
 pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.is_empty() {
     return Ok(Expr::Integer(1));
@@ -6428,6 +6622,18 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Around (uncertain-value) error propagation.
   if let Some(result) = try_around_times(args) {
+    return Ok(result);
+  }
+
+  // A NESTED exact-times-constant product multiplying a machine Real does
+  // not flatten into the outer coefficient pool: wolframscript computes
+  // Times[39, Times[-35, Pi], -51.3 + Pi] as ((39 * real) * -35) * N[Pi]
+  // — the outer exacts fold with the reals first, each nested product's
+  // exact coefficient multiplies next, and the symbolic constants convert
+  // last — while the flat Times[39, -35, Pi, -51.3 + Pi] folds
+  // (-1365 * real) * N[Pi]. One ulp apart; wolframscript-verified
+  // (differential fuzzer, seed 4134943276941009607).
+  if let Some(result) = nested_exact_const_machine_times(args) {
     return Ok(result);
   }
 
@@ -7207,6 +7413,12 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut real_factors: Vec<f64> = Vec::new();
   let mut any_real = false;
   let mut first_numeric_exact: Option<bool> = None;
+  // Each exact factor's f64 value in input order — when the FIRST numeric
+  // factor is a Real, wolframscript multiplies the exact factors one at a
+  // time in input order rather than folding them into one coefficient:
+  // Times[r, -10, -3] is (r*-10)*-3, one ulp away from r*30
+  // (wolframscript-verified; differential fuzzer follow-up case).
+  let mut exact_factor_seq: Vec<f64> = Vec::new();
   let mut symbolic_args: Vec<Expr> = Vec::new();
 
   // Pre-check: is there an explicit Rational or non-unity Integer coefficient among the args?
@@ -7228,6 +7440,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         has_int = true;
         first_numeric_exact.get_or_insert(true);
+        exact_factor_seq.push(*n as f64);
       }
       Expr::Real(f) => {
         real_factors.push(*f);
@@ -7248,6 +7461,9 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }
           has_rational = true;
           first_numeric_exact.get_or_insert(true);
+          if let Some(v) = try_eval_to_f64(arg) {
+            exact_factor_seq.push(v);
+          }
         } else {
           symbolic_args.push(arg.clone());
         }
@@ -7270,6 +7486,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               rat_denom = rd;
               has_rational = true;
               first_numeric_exact.get_or_insert(true);
+              exact_factor_seq.push(1.0 / pow as f64);
             } else {
               int_overflow = true;
             }
@@ -7378,7 +7595,16 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       machine_tree_fold(&fold_factors, |a, b| a * b)
     };
     if has_exact_coeff && first_numeric_exact != Some(true) {
-      total *= exact_f;
+      // Per-factor sequential multiply in input order (see
+      // exact_factor_seq above); the coalesced coefficient remains the
+      // fallback for factors that escaped tracking (overflow paths).
+      if exact_factor_seq.is_empty() {
+        total *= exact_f;
+      } else {
+        for f in &exact_factor_seq {
+          total *= f;
+        }
+      }
     }
     for f in &numerified_tail {
       total *= f;

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -652,8 +652,25 @@ fn apart_general(
     if let Expr::Integer(_) = f {
       continue; // constant content — folded into the overall scale below
     }
-    let c = extract_poly_coeffs(f, var)?;
+    let mut c = extract_poly_coeffs(f, var)?;
     if c.len() >= 2 {
+      // Normalize each factor to its primitive, positive-leading form —
+      // wolframscript presents partial-fraction denominators content-hoisted
+      // and leading-positive: Apart[(4x-3x^2-x^3)/(x+x^2-5x^3)] = 1/5 +
+      // (-19 + 16*x)/(5*(-1 - x + 5*x^2)), not (19-16*x)/(5+5*x-25*x^2).
+      // Content and sign are absorbed by `scale` (= den / prod of factors)
+      // below, and the content resurfaces as the term's scalar multiplier.
+      let content = c.iter().fold(0i128, |acc, &v| gcd_i128(acc, v.abs()));
+      if content > 1 {
+        for v in c.iter_mut() {
+          *v /= content;
+        }
+      }
+      if c.last().map(|&l| l < 0).unwrap_or(false) {
+        for v in c.iter_mut() {
+          *v = -*v;
+        }
+      }
       factors.push(c);
     }
   }

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -1709,7 +1709,12 @@ fn extract_rational_coeff(term: &Expr) -> Option<(i128, i128)> {
 
 /// Total degree of a term's non-numeric part: each symbolic factor counts
 /// 1, an integer power counts its exponent. Sin[x]^2*y → 3.
-fn term_total_degree(term: &Expr) -> i128 {
+/// A term's exponent per symbolic factor (variables by name, other
+/// non-numeric factors like Sin[theta] by their display form) — the
+/// lex-order comparison key for the content-sign rule.
+fn term_lex_exponents(
+  term: &Expr,
+) -> std::collections::BTreeMap<String, i128> {
   let inner = match term {
     Expr::UnaryOp {
       op: UnaryOperator::Minus,
@@ -1717,36 +1722,62 @@ fn term_total_degree(term: &Expr) -> i128 {
     } => operand.as_ref(),
     other => other,
   };
-  let mut deg = 0i128;
+  let mut exps: std::collections::BTreeMap<String, i128> =
+    std::collections::BTreeMap::new();
   for f in collect_multiplicative_factors(inner) {
-    let is_numeric = matches!(
-      &f,
-      Expr::Integer(_) | Expr::BigInteger(_) | Expr::Real(_)
-    ) || matches!(&f, Expr::FunctionCall { name, args } if name == "Rational" && args.len() == 2);
-    if is_numeric {
-      continue;
-    }
-    deg += match &f {
+    let (base, e) = match &f {
       Expr::BinaryOp {
         op: BinaryOperator::Power,
+        left,
         right,
-        ..
-      } => match right.as_ref() {
-        Expr::Integer(n) => *n,
-        _ => 1,
-      },
+      } => (
+        left.as_ref().clone(),
+        match right.as_ref() {
+          Expr::Integer(n) => *n,
+          _ => 1,
+        },
+      ),
       Expr::FunctionCall { name, args }
         if name == "Power" && args.len() == 2 =>
       {
-        match &args[1] {
-          Expr::Integer(n) => *n,
-          _ => 1,
-        }
+        (
+          args[0].clone(),
+          match &args[1] {
+            Expr::Integer(n) => *n,
+            _ => 1,
+          },
+        )
       }
-      _ => 1,
+      other => ((*other).clone(), 1),
     };
+    let is_numeric = matches!(
+      &base,
+      Expr::Integer(_) | Expr::BigInteger(_) | Expr::Real(_)
+    ) || matches!(&base, Expr::FunctionCall { name, args } if name == "Rational" && args.len() == 2);
+    if !is_numeric {
+      *exps.entry(expr_to_string(&base)).or_insert(0) += e;
+    }
   }
-  deg
+  exps
+}
+
+/// Lexicographic order on exponent maps: variables compare alphabetically,
+/// missing exponents count as 0, and the first differing exponent decides.
+fn lex_exponents_greater(
+  a: &std::collections::BTreeMap<String, i128>,
+  b: &std::collections::BTreeMap<String, i128>,
+) -> bool {
+  let mut vars: Vec<&String> = a.keys().chain(b.keys()).collect();
+  vars.sort();
+  vars.dedup();
+  for v in vars {
+    let ea = a.get(v).copied().unwrap_or(0);
+    let eb = b.get(v).copied().unwrap_or(0);
+    if ea != eb {
+      return ea > eb;
+    }
+  }
+  false
 }
 
 /// Compute the rational content of additive terms: gcd of numerators over
@@ -1775,15 +1806,25 @@ pub(super) fn rational_content(
     .fold(0i128, gcd_i128);
   let den_lcm = coeffs.iter().map(|(_, d)| *d).fold(1i128, lcm_i128);
 
-  let mut best_deg = i128::MIN;
+  // Sign of the LEX-leading term (variables alphabetical, exponents
+  // descending — the same leading term FactorTerms keys its sign on):
+  // FactorTerms[2 - 4x - 4x^2] → -2*(-1 + 2x + 2x^2), but
+  // Factor[2*x^2 - 3*x*y^2] → x*(2*x - 3*y^2) because the x-major lex
+  // leading term is +2x^2, even though -3*x*y^2 has the higher total
+  // degree (wolframscript-verified; differential fuzzer follow-up case).
+  let mut best_key: Option<std::collections::BTreeMap<String, i128>> = None;
   let mut sign: i128 = 1;
   for (term, (n, _)) in terms.iter().zip(coeffs.iter()) {
     if *n == 0 {
       continue;
     }
-    let d = term_total_degree(term);
-    if d > best_deg {
-      best_deg = d;
+    let key = term_lex_exponents(term);
+    let better = match &best_key {
+      None => true,
+      Some(best) => lex_exponents_greater(&key, best),
+    };
+    if better {
+      best_key = Some(key);
       sign = if *n < 0 { -1 } else { 1 };
     }
   }
@@ -4350,16 +4391,25 @@ fn extract_multivar_content(expr: &Expr) -> i128 {
   if gcd == 0 {
     return 1;
   }
-  let mut best_deg = i128::MIN;
+  // Sign of the LEX-leading term (variables alphabetical, exponents
+  // descending): Factor[2*x^2 - 3*x*y^2] keeps x*(2*x - 3*y^2) because
+  // the x-major leading term is +2x^2, while Factor[5*y - 3*x*y^2]
+  // flips to -(y*(-5 + 3*x*y)) on its -3*x*y^2 lead
+  // (wolframscript-verified; differential fuzzer follow-up case).
+  let mut best_key: Option<std::collections::BTreeMap<String, i128>> = None;
   let mut sign = 1i128;
   for term in &terms {
     let c = term_integer_coeff(term);
     if c == 0 {
       continue;
     }
-    let d = term_total_degree(term);
-    if d > best_deg {
-      best_deg = d;
+    let key = term_lex_exponents(term);
+    let better = match &best_key {
+      None => true,
+      Some(best) => lex_exponents_greater(&key, best),
+    };
+    if better {
+      best_key = Some(key);
       sign = if c < 0 { -1 } else { 1 };
     }
   }

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -4413,6 +4413,39 @@ fn contains_zero_negative_power(expr: &Expr) -> bool {
 /// reciprocal's base must be a bare VARIABLE (possibly powered) — a sum
 /// base (Times[Rational[-2,5], 1-x+x^2, (-1+x)^(-1)], a Factor rewrite of
 /// a flipped quotient) is NOT this display and must keep re-simplifying.
+/// A settled minus-pull over a flipped denominator —
+/// -((4 - 3*x)/(4 + x + 3*x^2 - 5*x^3)) — whose denominator's LEADING
+/// (highest-degree) coefficient is negative. The SimplifyCount candidate
+/// selection chose this display; the Together candidate would distribute
+/// the sign back into the numerator, so it must be treated as final.
+fn is_minus_pull_neg_leading_quotient(e: &Expr) -> bool {
+  let Expr::UnaryOp {
+    op: UnaryOperator::Minus,
+    operand,
+  } = e
+  else {
+    return false;
+  };
+  let Expr::BinaryOp {
+    op: BinaryOperator::Divide,
+    right,
+    ..
+  } = operand.as_ref()
+  else {
+    return false;
+  };
+  let mut vars = std::collections::HashSet::new();
+  collect_variables(right, &mut vars);
+  if vars.len() != 1 {
+    return false;
+  }
+  let var = vars.into_iter().next().unwrap();
+  match extract_poly_coeffs(right, &var) {
+    Some(coeffs) => coeffs.last().map(|&c| c < 0).unwrap_or(false),
+    None => false,
+  }
+}
+
 fn is_rational_prefactor_quotient(e: &Expr) -> bool {
   let factors = super::together::flatten_times_args(std::slice::from_ref(e));
   if factors.len() != 3 {
@@ -4555,7 +4588,9 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
   // (-1/5*(2+4x)/x, Simplify[(-2-4x)/(5x)]) is FINAL: the leaf-count
   // candidates below would re-expand or re-combine it
   // (wolframscript-verified).
-  if is_rational_prefactor_quotient(&simplified) {
+  if is_rational_prefactor_quotient(&simplified)
+    || is_minus_pull_neg_leading_quotient(&simplified)
+  {
     return simplified;
   }
   let mut best = simplified.clone();
@@ -4688,6 +4723,8 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
     if !matches!(&d, Expr::Integer(1)) {
       if let Some((chosen, _)) = simplify_quotient_select(&best, &n, &d) {
         best = chosen;
+      } else if let Some(extracted) = radical_quotient_num_content(&n, &d) {
+        best = extracted;
       } else if let Some(signed) =
         super::together::extract_quotient_minus(&n, &d)
       {
@@ -4703,6 +4740,9 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
   // is), and Simplify[3/2 + (3/2)*Sqrt[2]] → (3*(1 + Sqrt[2]))/2.
   // Polynomial sums already go through the Factor candidate above.
   if !polynomial_like(&best) {
+    // Candidate 6 below needs the sum BEFORE candidate 5's content
+    // extraction wraps it in Times[c, Plus[…]].
+    let pre_content = best.clone();
     let terms = super::coefficient::collect_additive_terms(&best);
     if terms.len() >= 2
       && let Some((_, _, coeffs)) = super::factor::rational_content(&terms)
@@ -4840,7 +4880,57 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
     // Sqrt[g] out wins the exact SimplifyCount: Simplify[-3*Sqrt[2] +
     // Sqrt[10]] → Sqrt[2]*(-3 + Sqrt[5]) (14 < 15; differential fuzzer,
     // seed 14799314084710522344; wolframscript-verified).
-    let terms = super::coefficient::collect_additive_terms(&best);
+    let terms = {
+      let t = super::coefficient::collect_additive_terms(&pre_content);
+      if t.len() >= 2 {
+        t
+      } else {
+        // An earlier candidate (Factor) may have content-wrapped the sum
+        // as Times[c, Plus[…]] — distribute c back so the radical
+        // extraction still sees the raw terms.
+        let content_wrapped = match &pre_content {
+          Expr::FunctionCall { name, args }
+            if name == "Times" && args.len() == 2 =>
+          {
+            match (&args[0], &args[1]) {
+              (Expr::Integer(c), inner) => Some((*c, inner.clone())),
+              _ => None,
+            }
+          }
+          Expr::BinaryOp {
+            op: BinaryOperator::Times,
+            left,
+            right,
+          } => match left.as_ref() {
+            Expr::Integer(c) => Some((*c, (**right).clone())),
+            _ => None,
+          },
+          _ => None,
+        };
+        match content_wrapped {
+          Some((c, inner)) => {
+            let inner_terms =
+              super::coefficient::collect_additive_terms(&inner);
+            if inner_terms.len() >= 2 {
+              inner_terms
+                .iter()
+                .filter_map(|t| {
+                  crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
+                    op: BinaryOperator::Times,
+                    left: Box::new(Expr::Integer(c)),
+                    right: Box::new(t.clone()),
+                  })
+                  .ok()
+                })
+                .collect()
+            } else {
+              t
+            }
+          }
+          None => t,
+        }
+      }
+    };
     if terms.len() >= 2
       && let Some(radicands) = terms
         .iter()
@@ -4848,7 +4938,81 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
         .collect::<Option<Vec<i128>>>()
     {
       let g = radicands.iter().fold(0i128, |a, &b| gcd_i128(a, b).abs());
-      if g > 1 {
+      // A MIXED-SIGN sum whose integer coefficients share |content| > 1
+      // with unit cofactors extracts BOTH the content and the radical —
+      // wolframscript's true SimplifyCount ties the content-only and
+      // fully-extracted forms and Simplify picks the latter, signed so
+      // the greatest term stays positive: Sqrt[8] - Sqrt[24] →
+      // -2*Sqrt[2]*(-1 + Sqrt[3]), -Sqrt[8] + Sqrt[24] →
+      // 2*Sqrt[2]*(-1 + Sqrt[3]); the all-positive Sqrt[8] + Sqrt[24]
+      // keeps 2*(Sqrt[2] + Sqrt[6]) (wolframscript-verified; differential
+      // fuzzer, seed 16005587802477298591).
+      let full_extraction = if g > 1 {
+        (|| -> Option<Expr> {
+          let (_, _, coeffs) = super::factor::rational_content(&terms)?;
+          if coeffs.iter().any(|(_, d)| *d != 1) {
+            return None;
+          }
+          let content = coeffs
+            .iter()
+            .map(|(n, _)| *n)
+            .filter(|&n| n != 0)
+            .fold(0i128, |a, b| gcd_i128(a, b).abs());
+          if content <= 1 {
+            return None;
+          }
+          let has_pos = coeffs.iter().any(|(n, _)| *n > 0);
+          let has_neg = coeffs.iter().any(|(n, _)| *n < 0);
+          if !(has_pos && has_neg) {
+            return None;
+          }
+          if coeffs.iter().any(|(n, _)| (n / content).abs() != 1) {
+            return None;
+          }
+          let signed = if coeffs.last()?.0 < 0 {
+            -content
+          } else {
+            content
+          };
+          let sqrt_of = |n: i128| Expr::FunctionCall {
+            name: "Sqrt".to_string(),
+            args: vec![Expr::Integer(n)].into(),
+          };
+          let inner: Vec<Expr> = coeffs
+            .iter()
+            .zip(radicands.iter())
+            .map(|(&(n, _), &r)| {
+              let c = n / signed; // ±1 by the unit-cofactor gate
+              let rad = r / g;
+              match (c, rad) {
+                (_, 1) => Expr::Integer(c),
+                (1, _) => sqrt_of(rad),
+                _ => Expr::UnaryOp {
+                  op: UnaryOperator::Minus,
+                  operand: Box::new(sqrt_of(rad)),
+                },
+              }
+            })
+            .collect();
+          Some(Expr::FunctionCall {
+            name: "Times".to_string(),
+            args: vec![
+              Expr::Integer(signed),
+              sqrt_of(g),
+              Expr::FunctionCall {
+                name: "Plus".to_string(),
+                args: inner.into(),
+              },
+            ]
+            .into(),
+          })
+        })()
+      } else {
+        None
+      };
+      if let Some(full) = full_extraction {
+        best = full;
+      } else if g > 1 {
         let divided: Result<Vec<Expr>, _> = terms
           .iter()
           .map(|t| {
@@ -7522,7 +7686,12 @@ fn simplify_quotient_select(
     num_terms: Vec<(i128, i128, i128)>,
     den_content: i128,
     den_terms: Vec<(i128, i128, i128)>,
+    // x^k monomial content split out of a denominator SUM (0 = none):
+    // 1/(-3x^2+5x^3) → 1/(x^2*(-3+5x))
+    den_mono: i128,
     split: bool,
+    // display is final — later factoring would rebuild it
+    terminal: bool,
   }
   let mut cands: Vec<Cand> = Vec::new();
 
@@ -7540,7 +7709,9 @@ fn simplify_quotient_select(
     num_terms: n_terms.clone(),
     den_content: 1,
     den_terms: d_terms.clone(),
+    den_mono: 0,
     split: false,
+    terminal: false,
   });
 
   // extraction variants (unflipped): numerator signed content and/or a
@@ -7559,6 +7730,18 @@ fn simplify_quotient_select(
   // wolframscript-verified (differential fuzzer, seed 5520550946540289960).
   let num_pullable = !den_gate_open && n_terms.len() > 1 && n_content < 0;
   let den_extractable = !den_gate_open && !den_is_mono && d_content > 1;
+  // A denominator sum with monomial content x^k (k >= 1) can split it out
+  // as its own reciprocal power factor: 1/(-3x^2+5x^3) → 1/(x^2*(-3+5x))
+  // (15 < 17), while 1/(4x+3x^2) stays expanded (13 > 12);
+  // wolframscript-verified (differential fuzzer, seed 862368627941598145).
+  let den_min_exp = d_terms.iter().map(|&(_, _, e)| e).min().unwrap_or(0);
+  // With a negative LEADING coefficient the split only applies to a
+  // mixed-sign denominator (1/(3x^2-5x^3) → 1/((3-5x)*x^2)); an
+  // all-nonpositive one pulls the minus out instead
+  // (Simplify[(2+3x)/(-4x-3x^2)] → -((2+3x)/(4x+3x^2))).
+  let den_mono_extractable = !den_is_mono
+    && den_min_exp >= 1
+    && (!den_gate_open || d_terms.iter().any(|&(n, _, _)| n > 0));
   let num_opts: Vec<(i128, Vec<(i128, i128, i128)>, bool)> = {
     let mut v = Vec::new();
     if num_extractable {
@@ -7571,22 +7754,35 @@ fn simplify_quotient_select(
     v
   };
   for (nc, nt, pull) in &num_opts {
-    for de in [true, false] {
-      if de && (!den_extractable || *pull) {
+    for de in [2usize, 1, 0] {
+      if de == 1 && (!den_extractable || *pull) {
         // a -(…) pull keeps the denominator exactly as the input shows
         // it: Simplify[(2+x)/(-5-5x)] → -((2+x)/(5+5x))
         continue;
       }
-      if !de && *nc == 1 && !*pull {
+      if de == 2 && (!den_mono_extractable || *pull) {
+        continue;
+      }
+      if de == 0 && *nc == 1 && !*pull {
         continue; // that's the plain candidate
       }
-      let (dc, dt) = if de {
-        (d_content, scale(&d_terms, d_content))
-      } else {
-        (1, d_terms.clone())
+      let (dc, dt, dk) = match de {
+        1 => (d_content, scale(&d_terms, d_content), 0),
+        2 => {
+          let shifted: Vec<(i128, i128, i128)> = d_terms
+            .iter()
+            .map(|&(n, d, e)| (n, d, e - den_min_exp))
+            .collect();
+          if d_content > 1 {
+            (d_content, scale(&shifted, d_content), den_min_exp)
+          } else {
+            (1, shifted, den_min_exp)
+          }
+        }
+        _ => (1, d_terms.clone(), 0),
       };
       let mut coeff_n = *nc;
-      let mut coeff_d = if den_is_mono { den_mono_coeff } else { dc };
+      let coeff_d = if den_is_mono { den_mono_coeff } else { dc };
       if *pull {
         coeff_n = -coeff_n;
       }
@@ -7594,11 +7790,12 @@ fn simplify_quotient_select(
       if g > 1 {
         // shared content would have been cancelled upstream; skip
         // rather than construct a misleading display
-        coeff_n /= g;
-        coeff_d /= g;
+        continue;
       }
       let cost = if den_is_mono {
         sc_quotient((coeff_n, coeff_d), nt, None, Some(den_mono_exp))
+      } else if dk > 0 {
+        sc_quotient((coeff_n, coeff_d), nt, Some(&dt), Some(dk))
       } else {
         sc_quotient((coeff_n, coeff_d), nt, Some(&dt), None)
       };
@@ -7606,14 +7803,47 @@ fn simplify_quotient_select(
         cost,
         // the -(…) pull only beats plain on a tie when plain's first
         // numerator term is negative (Simplify[(2-x)/(-1+x)] keeps,
-        // (-2-3x)/(4x+3x^2) pulls) — same tie rule as a flip
-        class: if *pull { 2 } else { 1 },
+        // (-2-3x)/(4x+3x^2) pulls) — same tie rule as a flip. The
+        // denominator x^k split (class 4) needs a STRICT win:
+        // (2+3x)/(4x+3x^2) stays expanded on its 18=18 tie.
+        class: if *pull {
+          2
+        } else if dk > 0 {
+          4
+        } else {
+          1
+        },
         minus_pull: *pull,
         num_content: *nc,
         num_terms: nt.clone(),
         den_content: dc,
         den_terms: dt,
+        den_mono: dk,
         split: false,
+        terminal: false,
+      });
+    }
+  }
+
+  // Shared integer content between numerator and denominator cancels
+  // through: Simplify[(2-4x+8x^2)/(2x^2+4x^3)] → (1-2x+4x^2)/(x^2+2x^3)
+  // (wolframscript-verified).
+  if !den_is_mono {
+    let shared = gcd_i128(n_content.abs(), d_content.abs());
+    if shared > 1 {
+      let sn = scale(&n_terms, shared);
+      let sd = scale(&d_terms, shared);
+      cands.push(Cand {
+        cost: sc_quotient((1, 1), &sn, Some(&sd), None),
+        class: 1,
+        minus_pull: false,
+        num_content: 1,
+        num_terms: sn,
+        den_content: 1,
+        den_terms: sd,
+        den_mono: 0,
+        split: false,
+        terminal: false,
       });
     }
   }
@@ -7639,7 +7869,9 @@ fn simplify_quotient_select(
         num_terms: n_terms.clone(),
         den_content: dc,
         den_terms: dt,
+        den_mono: 0,
         split: false,
+        terminal: false,
       });
     }
   }
@@ -7692,7 +7924,9 @@ fn simplify_quotient_select(
       num_terms: n_terms.clone(),
       den_content: 1,
       den_terms: d_terms.clone(),
+      den_mono: 0,
       split: true,
+      terminal: false,
     });
   }
 
@@ -7743,19 +7977,43 @@ fn simplify_quotient_select(
           num_terms: nt,
           den_content: fdc,
           den_terms: fdt.clone(),
+          den_mono: 0,
           split: false,
+          terminal: false,
         });
       }
-    } else if n_terms.first().map(|&(n, _, _)| n < 0).unwrap_or(false) {
+    } else {
+      if n_terms.first().map(|&(n, _, _)| n < 0).unwrap_or(false) {
+        cands.push(Cand {
+          cost: sc_quotient((1, 1), &fn_terms, Some(&fd), None),
+          class: 3,
+          minus_pull: false,
+          num_content: 1,
+          num_terms: fn_terms,
+          den_content: 1,
+          den_terms: fd.clone(),
+          den_mono: 0,
+          split: false,
+          terminal: false,
+        });
+      }
+      // The flipped denominator keeps a negative leading coefficient, so
+      // a clean flip is out — but pulling the sign all the way out over
+      // the NEGATED denominator can still win: Simplify[(4-3x)/
+      // (-4-x-3x^2+5x^3)] → -((4-3x)/(4+x+3x^2-5x^3)) (29 < 30;
+      // wolframscript-verified, differential fuzzer seed
+      // 862368627941598145).
       cands.push(Cand {
-        cost: sc_quotient((1, 1), &fn_terms, Some(&fd), None),
+        cost: sc_quotient((-1, 1), &n_terms, Some(&fd), None),
         class: 3,
-        minus_pull: false,
+        minus_pull: true,
         num_content: 1,
-        num_terms: fn_terms,
+        num_terms: n_terms.clone(),
         den_content: 1,
         den_terms: fd,
+        den_mono: 0,
         split: false,
+        terminal: false,
       });
     }
   }
@@ -7830,7 +8088,37 @@ fn simplify_quotient_select(
     num_body
   };
   let den_body = coeffs_from_terms(&chosen.den_terms, &var);
-  let den_expr = if chosen.den_content > 1 {
+  let den_expr = if chosen.den_mono > 0 {
+    // x^k monomial content split out of the denominator sum:
+    // 1/(-3x^2+5x^3) → 1/(x^2*(-3+5x))
+    let var_pow = if chosen.den_mono == 1 {
+      Expr::Identifier(var.clone())
+    } else {
+      Expr::BinaryOp {
+        op: BinaryOperator::Power,
+        left: Box::new(Expr::Identifier(var.clone())),
+        right: Box::new(Expr::Integer(chosen.den_mono)),
+      }
+    };
+    let mut factors: Vec<Expr> = Vec::new();
+    if chosen.den_content > 1 {
+      factors.push(Expr::Integer(chosen.den_content));
+    }
+    // wolframscript orders a negative-LEADING primitive sum before the
+    // power (1/((3 - 5*x)*x^2)) but a positive-leading one after it
+    // (1/(x^2*(-3 + 5*x))).
+    if chosen.den_terms.last().map(|&(n, _, _)| n < 0).unwrap_or(false) {
+      factors.push(den_body);
+      factors.push(var_pow);
+    } else {
+      factors.push(var_pow);
+      factors.push(den_body);
+    }
+    Expr::FunctionCall {
+      name: "Times".to_string(),
+      args: factors.into(),
+    }
+  } else if chosen.den_content > 1 {
     Expr::FunctionCall {
       name: "Times".to_string(),
       args: vec![Expr::Integer(chosen.den_content), den_body].into(),
@@ -7873,6 +8161,9 @@ fn simplify_quotient_select(
         true,
       ));
     }
+    // Terminal: later pipeline stages would redistribute the pulled sign
+    // into the numerator when the kept denominator's leading coefficient
+    // is negative (-((4-3x)/(4+x+3x^2-5x^3)) → (-4+3x)/(…)).
     return Some((
       Expr::UnaryOp {
         op: UnaryOperator::Minus,
@@ -7882,11 +8173,23 @@ fn simplify_quotient_select(
           right: Box::new(den_expr),
         }),
       },
-      false,
+      true,
     ));
   }
-  // a numerator flipped to exactly 1 displays as a reciprocal power
+  // a numerator flipped to exactly 1 displays as a reciprocal power —
+  // except over a mono-content-extracted denominator, whose product base
+  // renders as 1/(x^2*(-3+5x)) via a plain Divide
   if matches!(&num_expr, Expr::Integer(1)) {
+    if chosen.den_mono > 0 {
+      return Some((
+        Expr::BinaryOp {
+          op: BinaryOperator::Divide,
+          left: Box::new(Expr::Integer(1)),
+          right: Box::new(den_expr),
+        },
+        true,
+      ));
+    }
     return Some((
       Expr::BinaryOp {
         op: BinaryOperator::Power,
@@ -7902,7 +8205,7 @@ fn simplify_quotient_select(
       left: Box::new(num_expr),
       right: Box::new(den_expr),
     },
-    false,
+    chosen.terminal,
   ))
 }
 
@@ -7937,6 +8240,97 @@ fn coeffs_from_terms(terms: &[(i128, i128, i128)], var: &str) -> Expr {
     coeffs[e as usize] = n;
   }
   coeffs_to_expr(&coeffs, var)
+}
+
+/// In a variable-free quotient, a numerator sum with integer content
+/// |c| > 1 extracts it, signed so the greatest (last canonical) term
+/// stays positive — wolframscript's SimplifyCount ties the plain and
+/// extracted forms in quotient context and Simplify extracts:
+/// (8 - 2*Sqrt[3])/Sqrt[13] → (-2*(-4 + Sqrt[3]))/Sqrt[13],
+/// (8 + 2*Sqrt[3])/Sqrt[13] → (2*(4 + Sqrt[3]))/Sqrt[13], while the
+/// bare Simplify[8 - 2*Sqrt[3]] keeps its form (wolframscript-verified;
+/// differential fuzzer, seed 16005587802477298591). The content must be
+/// coprime to the denominator's own integer factor — a shared factor
+/// would have cancelled upstream. None → no extraction applies.
+fn radical_quotient_num_content(num: &Expr, den: &Expr) -> Option<Expr> {
+  let mut vars = std::collections::HashSet::new();
+  collect_variables(num, &mut vars);
+  collect_variables(den, &mut vars);
+  vars.remove("I");
+  if !vars.is_empty() {
+    return None;
+  }
+  let terms = super::coefficient::collect_additive_terms(num);
+  if terms.len() < 2 {
+    return None;
+  }
+  let (_, _, coeffs) = super::factor::rational_content(&terms)?;
+  if coeffs.iter().any(|(_, d)| *d != 1) {
+    return None;
+  }
+  let content = coeffs
+    .iter()
+    .map(|(n, _)| *n)
+    .filter(|&n| n != 0)
+    .fold(0i128, |a, b| gcd_i128(a, b).abs());
+  if content <= 1 {
+    return None;
+  }
+  // The denominator's integer factor must not share a factor with the
+  // content (that quotient would reduce instead of extracting).
+  let den_int = match den {
+    Expr::Integer(k) => *k,
+    Expr::FunctionCall { name, args } if name == "Times" && !args.is_empty() =>
+    {
+      match &args[0] {
+        Expr::Integer(k) => *k,
+        _ => 1,
+      }
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Times,
+      left,
+      ..
+    } => match left.as_ref() {
+      Expr::Integer(k) => *k,
+      _ => 1,
+    },
+    _ => 1,
+  };
+  if gcd_i128(content, den_int).abs() > 1 {
+    return None;
+  }
+  let signed = if coeffs.last()?.0 < 0 {
+    -content
+  } else {
+    content
+  };
+  let divided: Result<Vec<Expr>, _> = terms
+    .iter()
+    .map(|t| {
+      crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(t.clone()),
+        right: Box::new(Expr::Integer(signed)),
+      })
+    })
+    .collect();
+  let divided = divided.ok()?;
+  Some(Expr::BinaryOp {
+    op: BinaryOperator::Divide,
+    left: Box::new(Expr::FunctionCall {
+      name: "Times".to_string(),
+      args: vec![
+        Expr::Integer(signed),
+        Expr::FunctionCall {
+          name: "Plus".to_string(),
+          args: divided.into(),
+        },
+      ]
+      .into(),
+    }),
+    right: Box::new(den.clone()),
+  })
 }
 
 /// Pull the integer content out of a sum, keeping the polynomial

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -13871,3 +13871,166 @@ mod number_field_signature_tests {
     );
   }
 }
+
+// Differential-fuzzer regression tests (seed 1784293790651335963):
+// canonical ordering, Apart normalization, Simplify extraction, and
+// machine-fold divergences against wolframscript 15.0. All expectations
+// wolframscript-verified.
+mod fuzz_diff_round_2026_07_17 {
+  use super::super::case_helpers::assert_case;
+
+  #[test]
+  fn rational_base_radicals_order_by_numeric_base() {
+    // case seed 3699346173710306347
+    assert_case(
+      "Numerator[Plus[Divide[Sqrt[10], Sqrt[6]], Sqrt[3]]]",
+      "Sqrt[5/3] + Sqrt[3]",
+    );
+    // case seed 320857114228749038
+    assert_case(
+      "Expand[Plus[Plus[Sqrt[9], Sqrt[11]], Divide[Times[4, Sqrt[10]], Sqrt[29]]]]",
+      "3 + 4*Sqrt[10/29] + Sqrt[11]",
+    );
+    // case seed 17866292230593708820
+    assert_case(
+      "Abs[Subtract[Divide[Sqrt[24], Sqrt[29]], Divide[Times[-2, Sqrt[27]], Sqrt[14]]]]",
+      "2*Sqrt[6/29] + 3*Sqrt[6/7]",
+    );
+    assert_case("Sort[{Sqrt[3], Sqrt[5/3]}]", "{Sqrt[5/3], Sqrt[3]}");
+    assert_case("Sort[{Sqrt[3], Sqrt[7/2]}]", "{Sqrt[3], Sqrt[7/2]}");
+    assert_case("Sort[{Sqrt[2], Sqrt[1/2]}]", "{1/Sqrt[2], Sqrt[2]}");
+  }
+
+  #[test]
+  fn sort_union_same_base_powers_and_sums() {
+    // case seed 16300912233182470467 (Union canonical order)
+    assert_case("Union[{Pi}, {1/Pi}]", "{Pi^(-1), Pi}");
+    assert_case("Sort[{Pi, 1/Pi}]", "{Pi^(-1), Pi}");
+    assert_case("Sort[{Pi, 1 + 1/Pi}]", "{1 + Pi^(-1), Pi}");
+    assert_case("Sort[{Pi, -3910 + 93/Pi}]", "{-3910 + 93/Pi, Pi}");
+    assert_case("Sort[{Pi, 2 + Pi}]", "{Pi, 2 + Pi}");
+    assert_case("Sort[{Pi^2, 1 + Pi}]", "{Pi^2, 1 + Pi}");
+    assert_case("Sort[{x, 5 - x}]", "{5 - x, x}");
+    assert_case("Sort[{x, -3 + x}]", "{-3 + x, x}");
+    assert_case("Sort[{1/x, x - x^2}]", "{x^(-1), x - x^2}");
+    assert_case("Sort[{Cos[x], 1 + x}]", "{1 + x, Cos[x]}");
+    assert_case(
+      "Union[{27, 5.7, Pi}, {Plus[Divide[18, 3], Times[81, Divide[-17, 3]]], Subtract[Times[85, -46], Divide[-93, Pi]], Divide[Subtract[8, Divide[6, 2]], Divide[17, 5]]}]",
+      "{-453, 25/17, 5.7, 27, -3910 + 93/Pi, Pi}",
+    );
+  }
+
+  #[test]
+  fn apart_denominator_leading_positive_with_content() {
+    // case seed 8021134854569802508
+    assert_case(
+      "Apart[Divide[Plus[0, Times[4, x], Times[-3, Power[x, 2]], Times[-1, Power[x, 3]]], Plus[0, Times[1, x], Times[1, Power[x, 2]], Times[-5, Power[x, 3]]]]]",
+      "1/5 + (-19 + 16*x)/(5*(-1 - x + 5*x^2))",
+    );
+    assert_case(
+      "Apart[1/(x + x^2 - 5*x^3)]",
+      "x^(-1) + (1 - 5*x)/(-1 - x + 5*x^2)",
+    );
+    assert_case(
+      "Apart[1/(2*x + x^2 - 5*x^3)]",
+      "1/(2*x) + (1 - 5*x)/(2*(-2 - x + 5*x^2))",
+    );
+    // unchanged conventions
+    assert_case(
+      "Apart[(5 + 3*x)/(-1 - 2*x + 3*x^2)]",
+      "2/(-1 + x) - 3/(1 + 3*x)",
+    );
+    assert_case("Apart[1/(x^2*(x + 1))]", "x^(-2) - x^(-1) + (1 + x)^(-1)");
+    assert_case("Apart[(2 - 4*x)/(2 - 5*x)]", "4/5 - 2/(5*(-2 + 5*x))");
+  }
+
+  #[test]
+  fn simplify_radical_and_content_extraction() {
+    // case seed 16005587802477298591
+    assert_case(
+      "Simplify[Times[Subtract[Sqrt[16], Sqrt[3]], Divide[Sqrt[8], Sqrt[26]]]]",
+      "(-2*(-4 + Sqrt[3]))/Sqrt[13]",
+    );
+    assert_case("Simplify[Sqrt[8] - Sqrt[24]]", "-2*Sqrt[2]*(-1 + Sqrt[3])");
+    assert_case("Simplify[-Sqrt[8] + Sqrt[24]]", "2*Sqrt[2]*(-1 + Sqrt[3])");
+    assert_case("Simplify[Sqrt[8] + Sqrt[24]]", "2*(Sqrt[2] + Sqrt[6])");
+    assert_case("Simplify[-Sqrt[8] - Sqrt[24]]", "-2*(Sqrt[2] + Sqrt[6])");
+    assert_case(
+      "Simplify[(8 + 2*Sqrt[3])/Sqrt[13]]",
+      "(2*(4 + Sqrt[3]))/Sqrt[13]",
+    );
+    assert_case(
+      "Simplify[(-8 - 2*Sqrt[3])/Sqrt[13]]",
+      "(-2*(4 + Sqrt[3]))/Sqrt[13]",
+    );
+    assert_case(
+      "Simplify[(5 - 3*Sqrt[3])/Sqrt[13]]",
+      "(5 - 3*Sqrt[3])/Sqrt[13]",
+    );
+    // bare sums keep their form on the SimplifyCount tie
+    assert_case("Simplify[8 - 2*Sqrt[3]]", "8 - 2*Sqrt[3]");
+    assert_case("Simplify[-3*Sqrt[2] + Sqrt[10]]", "Sqrt[2]*(-3 + Sqrt[5])");
+    assert_case("Simplify[4*Sqrt[2] - 8*Sqrt[30]]", "4*Sqrt[2] - 8*Sqrt[30]");
+  }
+
+  #[test]
+  fn simplify_quotient_sign_and_denominator_content() {
+    // case seed 862368627941598145
+    assert_case(
+      "Simplify[Divide[Plus[4, Times[-3, x]], Plus[-4, Times[-1, x], Times[-3, Power[x, 2]], Times[5, Power[x, 3]]]]]",
+      "-((4 - 3*x)/(4 + x + 3*x^2 - 5*x^3))",
+    );
+    assert_case("Simplify[1/(-3*x^2 + 5*x^3)]", "1/(x^2*(-3 + 5*x))");
+    assert_case("Simplify[1/(3*x^2 - 5*x^3)]", "1/((3 - 5*x)*x^2)");
+    assert_case("Simplify[1/(4*x + 3*x^2)]", "(4*x + 3*x^2)^(-1)");
+    assert_case("Simplify[1/(2*x^2 + 4*x^3)]", "(2*x^2 + 4*x^3)^(-1)");
+    assert_case(
+      "Simplify[(1 - 5*x - 3*x^2 - x^3)/(-1 - 2*x + 4*x^2)]",
+      "-((-1 + 5*x + 3*x^2 + x^3)/(-1 - 2*x + 4*x^2))",
+    );
+    assert_case(
+      "Simplify[(2 - 2*x + 2*x^2)/(1 - 2*x)]",
+      "(2 - 2*x + 2*x^2)/(1 - 2*x)",
+    );
+  }
+
+  #[test]
+  fn machine_times_nested_exact_const_fold() {
+    // case seed 4134943276941009607
+    assert_case(
+      "Times[39, Times[Plus[Divide[-63, -70], Plus[-83, Divide[4, 8]]], Pi], Subtract[Plus[Subtract[Pi, -19.5], -76], -5.2]]",
+      "481478.3397922004",
+    );
+    assert_case("Times[39, Times[-35, Pi], -51.3 + Pi]", "206516.44476381145");
+    assert_case("(-1365*Pi)*(-51.3 + Pi)", "206516.44476381148");
+    assert_case("Times[13, Times[-17, Pi], Plus[-51.3, Pi]]", "33435.995818902804");
+    assert_case("Times[7, Times[11, E], Plus[-51.3, Pi]]", "-10079.92551545021");
+    // case seed 4125733669514322931
+    assert_case(
+      "Times[Subtract[Divide[58, -60], Divide[-83, Plus[Divide[-4, 5], Pi]]], Divide[Plus[21, Times[Pi, -22]], Pi], -14.9]",
+      "7868.203629768974",
+    );
+    assert_case(
+      "Times[-14.9, Divide[Plus[21, Times[Pi, -22]], Pi]]",
+      "228.2008366130919",
+    );
+    // flat folds keep their order
+    assert_case("Times[2.7, Times[3, Pi]]", "25.44690049407733");
+    assert_case("Times[0.1, Pi, 0.3, -Pi]", "-0.2960881320326807");
+    // real-first exact factors multiply sequentially in input order
+    // (case seed 15183690236476585210)
+    assert_case(
+      "Times[Times[Plus[Pi, 51], Times[Plus[64, -7.3], Plus[16, Pi]]], -10, Divide[-15, 5]]",
+      "1.762842087037921*^6",
+    );
+  }
+
+  #[test]
+  fn factor_content_sign_follows_lex_leading_term() {
+    assert_case("Factor[2*x^2 - 3*x*y^2]", "x*(2*x - 3*y^2)");
+    assert_case("Factor[5*y - 3*x*y^2]", "-(y*(-5 + 3*x*y))");
+    assert_case("Factor[5*y - 3*x*y]", "-((-5 + 3*x)*y)");
+    assert_case("Factor[-2*x^2*y + 4*x*y^2]", "-2*x*(x - 2*y)*y");
+    assert_case("FactorTerms[2 - 4*x - 4*x^2]", "-2*(-1 + 2*x + 2*x^2)");
+  }
+}


### PR DESCRIPTION
An 800-case woxi-diff-fuzz batch (seed 1784293790651335963) found nine divergences; a follow-up batch surfaced two more. All fixes are byte-verified against wolframscript 15.0.

Canonical ordering:
- Powers of rational bases compare numerically by base, then exponent (Sqrt[5/3] + Sqrt[3] keeps Sqrt[5/3] first), in both comparators and the Plus-term fallback.
- Sort's canonical order (canonical_cmp): same-base powers order by exponent ascending (Sort[{Pi, 1/Pi}] = {Pi^(-1), Pi}); sums with a sub-linear or negatively-signed lead sort before monomials and atoms (Sort[{Pi, -3910 + 93/Pi}] puts the sum first) while other sums stay after them but before plain function calls; two sums compare termwise from the greatest term down. Union/Intersection/Complement now sort with canonical_cmp — wolframscript's Union follows Sort's order, which differs from Order for same-base powers.

Apart:
- apart_general normalizes each factor to its primitive positive-leading form, with content and sign absorbed by the overall scale: Apart[(4x-3x^2-x^3)/(x+x^2-5x^3)] = 1/5 + (-19+16x)/(5*(-1-x+5x^2)).

Simplify:
- Mixed-sign radical sums with unit cofactors extract content and the common radical together (Sqrt[8] - Sqrt[24] → -2*Sqrt[2]*(-1+Sqrt[3])), signed so the greatest term stays positive; all-positive sums keep the content-only form.
- Variable-free quotient numerators extract their integer content on the SimplifyCount tie ((8-2*Sqrt[3])/Sqrt[13] → (-2*(-4+Sqrt[3]))/Sqrt[13]) while bare sums keep their form.
- The quotient candidate selection gains a denominator x^k split (1/(-3x^2+5x^3) → 1/(x^2*(-3+5x)), strict-win only), a minus-pull over the negated mixed-sign denominator ((4-3x)/(-4-x-3x^2+5x^3) → -((4-3x)/(4+x+3x^2-5x^3))), and a shared-content cancellation candidate; minus-pull displays are terminal so later passes don't redistribute the sign.

Machine arithmetic (1-ulp):
- A nested exact-times-constant product multiplying a Real numericizes without joining the outer coefficient pool: Times[39, Times[-35, Pi], r] folds ((39*r)*-35)*N[Pi], and exact-free nested products multiply their constant factors with reciprocal powers last.
- With a Real as the first numeric factor, exact factors multiply sequentially in input order instead of coalescing (Times[r, -10, -3] is (r*-10)*-3).

Factor/FactorTerms:
- The content sign follows the LEX-leading term (factors alphabetical, exponents descending) instead of total degree: Factor[2x^2 - 3x*y^2] keeps x*(2x - 3y^2).

Full suite passes: 24329 tests (up from 24268). Fuzzer replays clean: 800/800 on the flagging seed plus two fresh 400-case batches.


Claude-Session: https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt