### PR TITLE
Fix panic with FactorInteger[2^64-6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ checksum = "08bc795bdbccdbd461736fb163930a009da6597b226d6f6fce33e7a8eb6ec519"
 dependencies = [
  "cosmic-text",
  "etagere",
- "lru 0.16.3",
+ "lru",
  "rustc-hash 2.1.1",
  "wgpu",
 ]
@@ -2133,8 +2133,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2144,6 +2142,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2937,18 +2937,12 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lz4_flex"
@@ -3217,9 +3211,9 @@ dependencies = [
 
 [[package]]
 name = "num-modular"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -3228,13 +3222,13 @@ dependencies = [
 
 [[package]]
 name = "num-prime"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e238432a7881ec7164503ccc516c014bf009be7984cde1ba56837862543bdec3"
+checksum = "b285c575532a33ef6fdd3a57640d0b1c70e6ca48644d6df7bbd4b7a0cfbbb12d"
 dependencies = [
  "bitvec",
  "either",
- "lru 0.12.5",
+ "lru",
  "num-bigint",
  "num-integer",
  "num-modular",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ geographiclib-rs = "0.2"
 # at .5 boundaries and breaks the SVG snapshots across platforms.
 libm = "0.2"
 num-bigint = "0.4.6"
-num-prime = "0.4"
+num-prime = "0.5"
 plotters = { version = "0.3", default-features = false, features = ["svg_backend", "line_series", "area_series"] }
 num-traits = "0.2.19"
 pest = "2.5"

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -8,7 +8,7 @@ use crate::syntax::{
 use num_bigint::BigInt;
 use num_traits::Signed;
 
-fn nth_prime(n: usize) -> usize {
+fn nth_prime(n: i128) -> i128 {
   if n == 0 {
     return 0; // Return 0 for invalid input
   }
@@ -16,34 +16,11 @@ fn nth_prime(n: usize) -> usize {
   let mut num = 1;
   while count < n {
     num += 1;
-    if is_prime(num) {
+    if is_prime_i128(num) {
       count += 1;
     }
   }
   num
-}
-
-pub fn is_prime(n: usize) -> bool {
-  if n < 2 {
-    // 0 or 1
-    return false;
-  }
-  if n < 4 {
-    // 2 or 3
-    return true;
-  }
-  if n.is_multiple_of(2) || n.is_multiple_of(3) {
-    return false;
-  }
-  let mut i = 5usize;
-  while i * i <= n {
-    // (5 + 6k) + [1,3,4,5] -> (6 + 6k) + [0,2,3,4] -> multiple of 2 or 3, already tested
-    if n.is_multiple_of(i) || n.is_multiple_of(i + 2) {
-      return false;
-    }
-    i += 6;
-  }
-  true
 }
 
 /// True if `e` denotes a concrete number (an integer, real, big-float, or
@@ -51,16 +28,33 @@ pub fn is_prime(n: usize) -> bool {
 /// decide whether a "not a valid index" message should fire: a concrete
 /// non-integer argument is an error, but a symbolic one stays unevaluated.
 
-/// Primality test for i128 values (Miller-Rabin via BigInt beyond usize).
+/// Primality test for i128 values (Miller-Rabin via BigInt beyond 1u128 << 53).
 pub fn is_prime_i128(n: i128) -> bool {
   if n < 2 {
     return false;
   }
-  if n <= usize::MAX as i128 {
-    return is_prime(n as usize);
+  if n < 4 {
+    return true;
   }
-  let big = num_bigint::BigInt::from(n);
-  is_prime_bigint(&big)
+
+  if n.unsigned_abs() >= (1u128 << 53) {
+    // For large integers, use Miller-Rabin instead of trial division
+    let big = BigInt::from(n);
+    is_prime_bigint(&big)
+  } else {
+    if n % 2 == 0 || n % 3 == 0 {
+      return false;
+    }
+
+    let sqrt_n = (n as f64).sqrt() as i128;
+    for i in (5..=sqrt_n).step_by(6) {
+      // (5 + 6k) + [1,3,4,5] -> (6 + 6k) + [0,2,3,4] -> multiple of 2 or 3, already tested
+      if n % i == 0 || n % (i + 2) == 0 {
+        return false;
+      }
+    }
+    true
+  }
 }
 
 /// GCD[a, b, ...] - Greatest common divisor.
@@ -2416,7 +2410,7 @@ pub fn prime_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // every Real argument with Prime::intpp, even an integer-valued one like
   // 3.0, so do NOT coerce Reals to integers here.
   match expr_to_i128(&args[0]) {
-    Some(n) if n >= 1 => Ok(Expr::Integer(nth_prime(n as usize) as i128)),
+    Some(n) if n >= 1 => Ok(Expr::Integer(nth_prime(n))),
     Some(_) => {
       // Concrete non-positive integer: emit message like wolframscript
       let arg_str = expr_to_string(&args[0]);
@@ -5123,10 +5117,9 @@ pub fn prime_pi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if n < 2 {
         return Ok(Expr::Integer(0));
       }
-      let n_usize = n as usize;
       let mut count: i128 = 0;
-      for i in 2..=n_usize {
-        if is_prime(i) {
+      for i in 2..=n {
+        if is_prime_i128(i) {
           count += 1;
         }
       }
@@ -5141,10 +5134,10 @@ pub fn prime_pi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if f < 2.0 {
         return Ok(Expr::Integer(0));
       }
-      let n = f.floor() as usize;
+      let n = f.floor() as i128;
       let mut count: i128 = 0;
       for i in 2..=n {
-        if is_prime(i) {
+        if is_prime_i128(i) {
           count += 1;
         }
       }
@@ -5156,10 +5149,10 @@ pub fn prime_pi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if f < 2.0 {
           return Ok(Expr::Integer(0));
         }
-        let n = f.floor() as usize;
+        let n = f.floor() as i128;
         let mut count: i128 = 0;
         for i in 2..=n {
-          if is_prime(i) {
+          if is_prime_i128(i) {
             count += 1;
           }
         }
@@ -5311,7 +5304,7 @@ fn next_prime_after(n: i128) -> i128 {
   // For n >= 1: search upward from n+1
   if n >= 1 {
     let mut candidate = n + 1;
-    while !is_prime(candidate as usize) {
+    while !is_prime_i128(candidate) {
       candidate += 1;
     }
     return candidate;
@@ -5321,7 +5314,7 @@ fn next_prime_after(n: i128) -> i128 {
   // Search from n+1 upward: for each candidate c, check if |c| is prime.
   if n < -2 {
     for c in (n + 1)..=-2 {
-      if c < 0 && is_prime((-c) as usize) {
+      if c < 0 && is_prime_i128(-c) {
         return c;
       }
     }
@@ -5337,7 +5330,7 @@ fn prev_prime_before(n: i128) -> i128 {
   if n > 2 {
     let mut candidate = n - 1;
     while candidate >= 2 {
-      if is_prime(candidate as usize) {
+      if is_prime_i128(candidate) {
         return candidate;
       }
       candidate -= 1;
@@ -5353,7 +5346,7 @@ fn prev_prime_before(n: i128) -> i128 {
   // For n < -2: search downward among negative primes
   let mut candidate = n - 1;
   loop {
-    if is_prime((-candidate) as usize) {
+    if is_prime_i128(-candidate) {
       return candidate;
     }
     candidate -= 1;

--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -1649,7 +1649,7 @@ fn collect_primes_in_range(min: i128, max: i128) -> Vec<i128> {
   let start = if min < 2 { 2 } else { min };
   let mut primes = Vec::new();
   for n in start..=max {
-    if is_prime(n as usize) {
+    if is_prime_i128(n) {
       primes.push(n);
     }
   }

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -1135,27 +1135,7 @@ pub fn prime_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => return Ok(bool_expr(false)),
   };
 
-  let is_prime = if n <= 1 {
-    false
-  } else if n <= 3 {
-    true
-  } else if n % 2 == 0 || n % 3 == 0 {
-    false
-  } else if n.unsigned_abs() > (1u128 << 53) {
-    // For large integers, use Miller-Rabin instead of trial division
-    crate::functions::math_ast::is_prime_bigint(&num_bigint::BigInt::from(n))
-  } else {
-    let mut i = 5i128;
-    let mut result = true;
-    while i * i <= n {
-      if n % i == 0 || n % (i + 2) == 0 {
-        result = false;
-        break;
-      }
-      i += 6;
-    }
-    result
-  };
+  let is_prime = crate::functions::math_ast::is_prime_i128(n);
   Ok(bool_expr(is_prime))
 }
 

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -761,6 +761,11 @@ mod big_integer {
       interpret("FactorInteger[2^67 - 1]").unwrap(),
       "{{193707721, 1}, {761838257287, 1}}"
     );
+    // This would panic with num-prime 0.4.4
+    assert_eq!(
+      interpret("FactorInteger[2^64 - 6]").unwrap(),
+      "{{2, 1}, {5, 1}, {23, 1}, {53301701, 1}, {1504703107, 1}}"
+    );
   }
 
   #[test]

--- a/tests/interpreter_tests/math/number_theory.rs
+++ b/tests/interpreter_tests/math/number_theory.rs
@@ -4051,7 +4051,7 @@ mod arithmetic_geometric_mean {
 
 mod random_prime {
   use super::*;
-  use woxi::functions::math_ast::is_prime;
+  use woxi::functions::math_ast::is_prime_i128;
 
   #[test]
   fn with_max() {
@@ -4059,7 +4059,7 @@ mod random_prime {
     interpret("SeedRandom[42]").unwrap();
     let result: i128 = interpret("RandomPrime[100]").unwrap().parse().unwrap();
     assert!(result >= 2 && result <= 100);
-    assert!(is_prime(result as usize));
+    assert!(is_prime_i128(result));
   }
 
   #[test]
@@ -4068,7 +4068,7 @@ mod random_prime {
     let result: i128 =
       interpret("RandomPrime[{10, 30}]").unwrap().parse().unwrap();
     assert!(result >= 10 && result <= 30);
-    assert!(is_prime(result as usize));
+    assert!(is_prime_i128(result));
   }
 
   #[test]


### PR DESCRIPTION
While investigating whether i * i <= n would overflow for n near 2^64, I triggered a panic while doing "FactorInteger[2^64-6]".  Fixed by updating num-prime to 0.5.

And yes, i * i <= n can overflow for large n, so route all is_prime calls to is_prime_i128 which now switches to BigInt at 2^53 (instead of 2^64).  This eliminates another is_prime code duplication in predicate_ast.rs.