### PR TITLE
Add Background option support to Framed and SVG export

### DIFF
--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -3384,6 +3384,16 @@ fn is_inline_graphic(expr: &Expr) -> bool {
   }
 }
 
+/// True if the expression is (or, within nested lists, contains) a `Framed`
+/// or `Highlighted` display wrapper.
+fn contains_framed_or_highlighted(expr: &Expr) -> bool {
+  match expr {
+    Expr::FunctionCall { name, .. } => name == "Framed" || name == "Highlighted",
+    Expr::List(items) => items.iter().any(contains_framed_or_highlighted),
+    _ => false,
+  }
+}
+
 pub(crate) fn expr_to_svg(expr: &Expr) -> String {
   match expr {
     Expr::Graphics { svg: svg_data, .. } => svg_data.clone(),
@@ -3562,6 +3572,26 @@ pub(crate) fn expr_to_svg(expr: &Expr) -> String {
       } else {
         expr_text_svg(expr)
       }
+    }
+    Expr::FunctionCall {
+      name: fr_name,
+      args: fr_args,
+    } if fr_name == "Framed" && !fr_args.is_empty() => {
+      crate::functions::graphics::framed_to_svg(fr_args)
+        .unwrap_or_else(|| expr_text_svg(expr))
+    }
+    Expr::FunctionCall {
+      name: hl_name,
+      args: hl_args,
+    } if hl_name == "Highlighted" && !hl_args.is_empty() => {
+      crate::functions::graphics::highlighted_to_svg(hl_args)
+        .unwrap_or_else(|| expr_text_svg(expr))
+    }
+    // A list with Framed/Highlighted elements renders as a row `{1, |2|, …}`
+    // with the wrapped items drawn as boxes, matching the inline display path.
+    Expr::List(items) if items.iter().any(contains_framed_or_highlighted) => {
+      crate::functions::graphics::row_with_framed_to_svg(items)
+        .unwrap_or_else(|| expr_text_svg(expr))
     }
     Expr::FunctionCall {
       name: ds_name,

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -10673,6 +10673,15 @@ pub fn framed_to_svg(args: &[Expr]) -> Option<String> {
 
   let content = &args[0];
 
+  // Optional `Background -> color` option fills the inside of the frame.
+  let bg_fill = args[1..]
+    .iter()
+    .filter_map(option_kv)
+    .find(|(k, _)| *k == "Background")
+    .and_then(|(_, v)| parse_color(v))
+    .map(|c| c.to_svg_rgb());
+  let rect_fill = bg_fill.as_deref().unwrap_or("none");
+
   // Layout constants
   let char_width: f64 = 8.4;
   let font_size: f64 = 14.0;
@@ -10719,7 +10728,7 @@ pub fn framed_to_svg(args: &[Expr]) -> Option<String> {
     // Border rectangle
     let framed_border = theme().framed_border;
     svg.push_str(&format!(
-      "<rect x=\"{:.1}\" y=\"{:.1}\" width=\"{:.1}\" height=\"{:.1}\" rx=\"{rounding:.1}\" fill=\"none\" stroke=\"{framed_border}\" stroke-width=\"{stroke_width}\"/>\n",
+      "<rect x=\"{:.1}\" y=\"{:.1}\" width=\"{:.1}\" height=\"{:.1}\" rx=\"{rounding:.1}\" fill=\"{rect_fill}\" stroke=\"{framed_border}\" stroke-width=\"{stroke_width}\"/>\n",
       stroke_width / 2.0, stroke_width / 2.0,
       total_w - stroke_width, total_h - stroke_width,
     ));
@@ -10751,7 +10760,7 @@ pub fn framed_to_svg(args: &[Expr]) -> Option<String> {
     // Border rectangle
     let framed_border = theme().framed_border;
     svg.push_str(&format!(
-      "<rect x=\"{:.1}\" y=\"{:.1}\" width=\"{:.1}\" height=\"{:.1}\" rx=\"{rounding:.1}\" fill=\"none\" stroke=\"{framed_border}\" stroke-width=\"{stroke_width}\"/>\n",
+      "<rect x=\"{:.1}\" y=\"{:.1}\" width=\"{:.1}\" height=\"{:.1}\" rx=\"{rounding:.1}\" fill=\"{rect_fill}\" stroke=\"{framed_border}\" stroke-width=\"{stroke_width}\"/>\n",
       stroke_width / 2.0, stroke_width / 2.0,
       total_w - stroke_width, total_h - stroke_width,
     ));


### PR DESCRIPTION
## Summary
Adds support for the `Background` option in `Framed` expressions and enables proper SVG rendering of `Framed` and `Highlighted` elements when exported via `ExportString`. Previously, `Framed` with a background color would not render the fill, and lists containing `Framed`/`Highlighted` items would dump the unevaluated expression as text instead of rendering the boxes.

## Key Changes
- **Framed background support**: Parse the `Background -> color` option in `Framed` and apply it as the fill color of the frame rectangle
- **SVG export for display wrappers**: Add `framed_to_svg()` and `highlighted_to_svg()` handling in `expr_to_svg()` to properly render these elements when exported
- **List rendering with wrapped items**: Implement `row_with_framed_to_svg()` to handle lists containing `Framed`/`Highlighted` elements, rendering them as boxes within a row layout instead of dumping the unevaluated expression
- **Helper function**: Add `contains_framed_or_highlighted()` to detect when a list contains display wrapper elements that need special SVG rendering

## Implementation Details
- The `Background` option is extracted from the arguments using the existing `option_kv()` helper and parsed with `parse_color()`
- When no background is specified, the frame fill defaults to `"none"` (transparent)
- The frame rectangle's `fill` attribute is now dynamic instead of hardcoded to `"none"`
- Lists with mixed content (plain items and wrapped items) are detected and routed to special rendering logic to maintain proper visual representation

## Tests Added
- `framed_background_option_fills_frame`: Verifies yellow background fills the frame
- `framed_without_background_has_unfilled_frame`: Ensures default behavior remains transparent
- `export_string_svg_framed_renders_frame`: Tests SVG export of `Framed` with background
- `export_string_svg_list_with_framed_renders_row`: Regression test for lists with mixed `Framed` and plain items
- `export_string_svg_highlighted_renders_box`: Tests SVG export of `Highlighted` elements

https://claude.ai/code/session_01PNarfqKS75yyhv6e1zFUHv