### PR TITLE
Add Translate and Scale graphics functions

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1397,6 +1397,63 @@ fn collect_primitives(
             None => prims.extend(inner),
           }
         }
+        // Translate[g, {dx, dy}] translates g by the given vector;
+        // Translate[g, {{dx1, dy1}, {dx2, dy2}, …}] draws one translated
+        // copy of g per vector.
+        "Translate" if args.len() >= 2 => {
+          let mut inner_style = style.clone();
+          let mut inner = Vec::new();
+          collect_primitives(&args[0], &mut inner_style, &mut inner, errors);
+          let offsets: Vec<(f64, f64)> =
+            if let Some(v) = expr_to_point(&args[1]) {
+              vec![v]
+            } else {
+              expr_to_point_list(&args[1]).unwrap_or_default()
+            };
+          if offsets.is_empty() {
+            // Non-numeric offset: draw the content untranslated as a fallback.
+            prims.extend(inner);
+          } else {
+            for &(dx, dy) in &offsets {
+              for p in &inner {
+                prims.push(translate_primitive(p, dx, dy));
+              }
+            }
+          }
+        }
+        // Scale[g, s] scales g by s about the center of its bounding box;
+        // Scale[g, {sx, sy}] scales each axis separately and
+        // Scale[g, s, {x, y}] scales about the point {x, y}.
+        "Scale" if args.len() >= 2 => {
+          let mut inner_style = style.clone();
+          let mut inner = Vec::new();
+          collect_primitives(&args[0], &mut inner_style, &mut inner, errors);
+          let factors = match &args[1] {
+            Expr::List(_) => expr_to_point(&args[1]),
+            other => expr_to_f64(other).map(|s| (s, s)),
+          };
+          match factors {
+            Some((sx, sy)) => {
+              let (cx, cy) =
+                args.get(2).and_then(expr_to_point).unwrap_or_else(|| {
+                  let mut bb = BBox::empty();
+                  for p in &inner {
+                    bb.merge(&primitive_bbox(p));
+                  }
+                  if bb.is_empty() {
+                    (0.0, 0.0)
+                  } else {
+                    ((bb.x_min + bb.x_max) / 2.0, (bb.y_min + bb.y_max) / 2.0)
+                  }
+                });
+              for p in &inner {
+                prims.push(scale_primitive(p, cx, cy, sx, sy));
+              }
+            }
+            // Non-numeric factor: draw the content unscaled as a fallback.
+            None => prims.extend(inner),
+          }
+        }
 
         _ => {
           // Try as directive first
@@ -2555,6 +2612,326 @@ fn rotate_primitive(
       p: rp(p.0, p.1),
       v: rv(v.0, v.1),
       w: rv(w.0, w.1),
+      full: *full,
+      style: style.clone(),
+    },
+  }
+}
+
+/// Return a copy of `prim` translated by (dx, dy).
+fn translate_primitive(prim: &Primitive, dx: f64, dy: f64) -> Primitive {
+  let tp = |x: f64, y: f64| (x + dx, y + dy);
+  match prim {
+    Primitive::PointSingle { x, y, style } => Primitive::PointSingle {
+      x: x + dx,
+      y: y + dy,
+      style: style.clone(),
+    },
+    Primitive::PointMulti { points, style } => Primitive::PointMulti {
+      points: points.iter().map(|&(x, y)| tp(x, y)).collect(),
+      style: style.clone(),
+    },
+    Primitive::Line { segments, style } => Primitive::Line {
+      segments: segments
+        .iter()
+        .map(|seg| seg.iter().map(|&(x, y)| tp(x, y)).collect())
+        .collect(),
+      style: style.clone(),
+    },
+    Primitive::PolygonPrim { points, style } => Primitive::PolygonPrim {
+      points: points.iter().map(|&(x, y)| tp(x, y)).collect(),
+      style: style.clone(),
+    },
+    Primitive::ArrowPrim {
+      points,
+      setback,
+      style,
+    } => Primitive::ArrowPrim {
+      points: points.iter().map(|&(x, y)| tp(x, y)).collect(),
+      setback: *setback,
+      style: style.clone(),
+    },
+    Primitive::BezierCurvePrim { points, style } => {
+      Primitive::BezierCurvePrim {
+        points: points.iter().map(|&(x, y)| tp(x, y)).collect(),
+        style: style.clone(),
+      }
+    }
+    Primitive::RectPrim {
+      x_min,
+      y_min,
+      x_max,
+      y_max,
+      style,
+    } => Primitive::RectPrim {
+      x_min: x_min + dx,
+      y_min: y_min + dy,
+      x_max: x_max + dx,
+      y_max: y_max + dy,
+      style: style.clone(),
+    },
+    Primitive::Disk {
+      cx,
+      cy,
+      rx,
+      ry,
+      style,
+    } => Primitive::Disk {
+      cx: cx + dx,
+      cy: cy + dy,
+      rx: *rx,
+      ry: *ry,
+      style: style.clone(),
+    },
+    Primitive::CircleArc {
+      cx,
+      cy,
+      rx,
+      ry,
+      angles,
+      style,
+    } => Primitive::CircleArc {
+      cx: cx + dx,
+      cy: cy + dy,
+      rx: *rx,
+      ry: *ry,
+      angles: *angles,
+      style: style.clone(),
+    },
+    Primitive::DiskSector {
+      cx,
+      cy,
+      rx,
+      ry,
+      angle1,
+      angle2,
+      style,
+    } => Primitive::DiskSector {
+      cx: cx + dx,
+      cy: cy + dy,
+      rx: *rx,
+      ry: *ry,
+      angle1: *angle1,
+      angle2: *angle2,
+      style: style.clone(),
+    },
+    Primitive::TextPrim { text, x, y, style } => Primitive::TextPrim {
+      text: text.clone(),
+      x: x + dx,
+      y: y + dy,
+      style: style.clone(),
+    },
+    Primitive::RasterPrim {
+      data,
+      x_min,
+      y_min,
+      x_max,
+      y_max,
+    } => Primitive::RasterPrim {
+      data: data.clone(),
+      x_min: x_min + dx,
+      y_min: y_min + dy,
+      x_max: x_max + dx,
+      y_max: y_max + dy,
+    },
+    Primitive::HalfPlanePrim {
+      p,
+      v,
+      w,
+      full,
+      style,
+    } => Primitive::HalfPlanePrim {
+      p: tp(p.0, p.1),
+      v: *v,
+      w: *w,
+      full: *full,
+      style: style.clone(),
+    },
+  }
+}
+
+/// Return a copy of `prim` scaled by (sx, sy) about the fixed point (cx, cy).
+///
+/// Ellipse radii scale per-axis by |sx| and |sy| (a radius cannot be
+/// negative); for negative factors the arc angles are mirrored accordingly.
+/// Point sizes, stroke widths, and text sizes are absolute (not part of the
+/// coordinate system) and stay unchanged.
+fn scale_primitive(
+  prim: &Primitive,
+  cx: f64,
+  cy: f64,
+  sx: f64,
+  sy: f64,
+) -> Primitive {
+  let sp = |x: f64, y: f64| (cx + (x - cx) * sx, cy + (y - cy) * sy);
+  // Map an ellipse angle through the axis scaling: a point at angle θ on the
+  // ellipse lands at angle θ' on the scaled ellipse with
+  // cos θ' = sign(sx)·cos θ and sin θ' = sign(sy)·sin θ.
+  let sa = |a: f64| -> f64 {
+    match (sx < 0.0, sy < 0.0) {
+      (false, false) => a,
+      (true, false) => std::f64::consts::PI - a,
+      (false, true) => -a,
+      (true, true) => a + std::f64::consts::PI,
+    }
+  };
+  // A single mirror flips the sweep direction, so the endpoints swap to keep
+  // the arc's counterclockwise orientation.
+  let sr = |a1: f64, a2: f64| -> (f64, f64) {
+    if (sx < 0.0) != (sy < 0.0) {
+      (sa(a2), sa(a1))
+    } else {
+      (sa(a1), sa(a2))
+    }
+  };
+  match prim {
+    Primitive::PointSingle { x, y, style } => {
+      let (nx, ny) = sp(*x, *y);
+      Primitive::PointSingle {
+        x: nx,
+        y: ny,
+        style: style.clone(),
+      }
+    }
+    Primitive::PointMulti { points, style } => Primitive::PointMulti {
+      points: points.iter().map(|&(x, y)| sp(x, y)).collect(),
+      style: style.clone(),
+    },
+    Primitive::Line { segments, style } => Primitive::Line {
+      segments: segments
+        .iter()
+        .map(|seg| seg.iter().map(|&(x, y)| sp(x, y)).collect())
+        .collect(),
+      style: style.clone(),
+    },
+    Primitive::PolygonPrim { points, style } => Primitive::PolygonPrim {
+      points: points.iter().map(|&(x, y)| sp(x, y)).collect(),
+      style: style.clone(),
+    },
+    Primitive::ArrowPrim {
+      points,
+      setback,
+      style,
+    } => Primitive::ArrowPrim {
+      points: points.iter().map(|&(x, y)| sp(x, y)).collect(),
+      setback: *setback,
+      style: style.clone(),
+    },
+    Primitive::BezierCurvePrim { points, style } => {
+      Primitive::BezierCurvePrim {
+        points: points.iter().map(|&(x, y)| sp(x, y)).collect(),
+        style: style.clone(),
+      }
+    }
+    Primitive::RectPrim {
+      x_min,
+      y_min,
+      x_max,
+      y_max,
+      style,
+    } => {
+      // Negative factors swap the corners; renormalize to min/max form.
+      let (x1, y1) = sp(*x_min, *y_min);
+      let (x2, y2) = sp(*x_max, *y_max);
+      Primitive::RectPrim {
+        x_min: x1.min(x2),
+        y_min: y1.min(y2),
+        x_max: x1.max(x2),
+        y_max: y1.max(y2),
+        style: style.clone(),
+      }
+    }
+    Primitive::Disk {
+      cx: dcx,
+      cy: dcy,
+      rx,
+      ry,
+      style,
+    } => {
+      let (nx, ny) = sp(*dcx, *dcy);
+      Primitive::Disk {
+        cx: nx,
+        cy: ny,
+        rx: rx * sx.abs(),
+        ry: ry * sy.abs(),
+        style: style.clone(),
+      }
+    }
+    Primitive::CircleArc {
+      cx: dcx,
+      cy: dcy,
+      rx,
+      ry,
+      angles,
+      style,
+    } => {
+      let (nx, ny) = sp(*dcx, *dcy);
+      Primitive::CircleArc {
+        cx: nx,
+        cy: ny,
+        rx: rx * sx.abs(),
+        ry: ry * sy.abs(),
+        angles: angles.map(|(a1, a2)| sr(a1, a2)),
+        style: style.clone(),
+      }
+    }
+    Primitive::DiskSector {
+      cx: dcx,
+      cy: dcy,
+      rx,
+      ry,
+      angle1,
+      angle2,
+      style,
+    } => {
+      let (nx, ny) = sp(*dcx, *dcy);
+      let (a1, a2) = sr(*angle1, *angle2);
+      Primitive::DiskSector {
+        cx: nx,
+        cy: ny,
+        rx: rx * sx.abs(),
+        ry: ry * sy.abs(),
+        angle1: a1,
+        angle2: a2,
+        style: style.clone(),
+      }
+    }
+    Primitive::TextPrim { text, x, y, style } => {
+      let (nx, ny) = sp(*x, *y);
+      Primitive::TextPrim {
+        text: text.clone(),
+        x: nx,
+        y: ny,
+        style: style.clone(),
+      }
+    }
+    Primitive::RasterPrim {
+      data,
+      x_min,
+      y_min,
+      x_max,
+      y_max,
+    } => {
+      let (x1, y1) = sp(*x_min, *y_min);
+      let (x2, y2) = sp(*x_max, *y_max);
+      Primitive::RasterPrim {
+        data: data.clone(),
+        x_min: x1.min(x2),
+        y_min: y1.min(y2),
+        x_max: x1.max(x2),
+        y_max: y1.max(y2),
+      }
+    }
+    Primitive::HalfPlanePrim {
+      p,
+      v,
+      w,
+      full,
+      style,
+    } => Primitive::HalfPlanePrim {
+      p: sp(p.0, p.1),
+      v: (v.0 * sx, v.1 * sy),
+      w: (w.0 * sx, w.1 * sy),
       full: *full,
       style: style.clone(),
     },

--- a/tests/miscellaneous_tests/high_level_functions.rs
+++ b/tests/miscellaneous_tests/high_level_functions.rs
@@ -3746,6 +3746,168 @@ mod high_level_functions {
     }
   }
 
+  mod graphics_translate_scale_tests {
+    use super::*;
+
+    // Extract (x, y, width, height) for every <rect> element.
+    fn rects(svg: &str) -> Vec<(f64, f64, f64, f64)> {
+      fn attr(seg: &str, name: &str) -> f64 {
+        let key = format!("{name}=\"");
+        let start = seg.find(&key).expect("missing attr") + key.len();
+        seg[start..].split('"').next().unwrap().parse().unwrap()
+      }
+      svg
+        .match_indices("<rect ")
+        .map(|(i, _)| {
+          let seg = &svg[i..i + svg[i..].find("/>").unwrap()];
+          (
+            attr(seg, "x"),
+            attr(seg, "y"),
+            attr(seg, "width"),
+            attr(seg, "height"),
+          )
+        })
+        .collect()
+    }
+
+    // Extract (cx, cy, rx, ry) for every <ellipse> element.
+    fn ellipses(svg: &str) -> Vec<(f64, f64, f64, f64)> {
+      fn attr(seg: &str, name: &str) -> f64 {
+        let key = format!("{name}=\"");
+        let start = seg.find(&key).expect("missing attr") + key.len();
+        seg[start..].split('"').next().unwrap().parse().unwrap()
+      }
+      svg
+        .match_indices("<ellipse ")
+        .map(|(i, _)| {
+          let seg = &svg[i..i + svg[i..].find("/>").unwrap()];
+          (
+            attr(seg, "cx"),
+            attr(seg, "cy"),
+            attr(seg, "rx"),
+            attr(seg, "ry"),
+          )
+        })
+        .collect()
+    }
+
+    // Extract the x coordinates of every <polyline> element's points.
+    fn polyline_xs(svg: &str) -> Vec<Vec<f64>> {
+      svg
+        .match_indices("<polyline")
+        .map(|(i, _)| {
+          let seg = &svg[i..];
+          let s = seg.find("points=\"").unwrap() + 8;
+          let e = seg[s..].find('"').unwrap() + s;
+          seg[s..e]
+            .split_whitespace()
+            .map(|p| p.split_once(',').unwrap().0.parse::<f64>().unwrap())
+            .collect()
+        })
+        .collect()
+    }
+
+    #[test]
+    fn test_translate_rectangle_shifts_by_vector() {
+      // The translated copy keeps its size and shifts by {3, 0}: for a
+      // 2-wide rectangle the pixel offset is 1.5x the rectangle's width.
+      let svg = interpret(
+        "ExportString[Graphics[{Rectangle[{0, 0}, {2, 1}], Translate[Rectangle[{0, 0}, {2, 1}], {3, 0}]}], \"SVG\"]",
+      )
+      .unwrap();
+      let rs = rects(&svg);
+      assert_eq!(rs.len(), 2, "expected two rects: {svg}");
+      let (x1, y1, w1, h1) = rs[0];
+      let (x2, y2, w2, h2) = rs[1];
+      assert!(
+        (w1 - w2).abs() < 1e-3 && (h1 - h2).abs() < 1e-3,
+        "translation must not resize: {svg}"
+      );
+      assert!((y1 - y2).abs() < 1e-3, "no vertical shift: {svg}");
+      assert!(
+        (x2 - x1 - 1.5 * w1).abs() < 1e-2,
+        "shift must be 3 units (= 1.5 widths): {svg}"
+      );
+    }
+
+    #[test]
+    fn test_translate_with_vector_list_draws_copies() {
+      // Translate[g, {v1, v2, …}] draws one copy of g per vector.
+      let svg = interpret(
+        "ExportString[Graphics[Translate[Disk[{0, 0}, 0.3], {{0, 0}, {1, 0}, {2, 0}}]], \"SVG\"]",
+      )
+      .unwrap();
+      let es = ellipses(&svg);
+      assert_eq!(es.len(), 3, "one copy per vector: {svg}");
+      let step1 = es[1].0 - es[0].0;
+      let step2 = es[2].0 - es[1].0;
+      assert!(step1 > 1.0, "copies must be spread out: {svg}");
+      assert!((step1 - step2).abs() < 1e-2, "even spacing: {svg}");
+      assert!((es[0].1 - es[2].1).abs() < 1e-3, "no vertical shift: {svg}");
+    }
+
+    #[test]
+    fn test_scale_rectangle_about_bbox_center() {
+      // Scale[g, 0.5] halves the size but keeps the bounding-box center.
+      let svg = interpret(
+        "ExportString[Graphics[{Rectangle[{0, 0}, {2, 1}], Scale[Rectangle[{0, 0}, {2, 1}], 0.5]}], \"SVG\"]",
+      )
+      .unwrap();
+      let rs = rects(&svg);
+      assert_eq!(rs.len(), 2, "expected two rects: {svg}");
+      let (x1, y1, w1, h1) = rs[0];
+      let (x2, y2, w2, h2) = rs[1];
+      assert!(
+        (w2 - w1 / 2.0).abs() < 1e-2 && (h2 - h1 / 2.0).abs() < 1e-2,
+        "scaled copy must be half size: {svg}"
+      );
+      assert!(
+        ((x2 + w2 / 2.0) - (x1 + w1 / 2.0)).abs() < 1e-2,
+        "x center must be fixed: {svg}"
+      );
+      assert!(
+        ((y2 + h2 / 2.0) - (y1 + h1 / 2.0)).abs() < 1e-2,
+        "y center must be fixed: {svg}"
+      );
+    }
+
+    #[test]
+    fn test_scale_about_explicit_point() {
+      // Scaling {{1,0},{2,0}} by 2 about the origin gives {{2,0},{4,0}}:
+      // the image starts where the original ends and is twice as long.
+      let svg = interpret(
+        "ExportString[Graphics[{Line[{{1, 0}, {2, 0}}], Scale[Line[{{1, 0}, {2, 0}}], 2, {0, 0}]}], \"SVG\"]",
+      )
+      .unwrap();
+      let ls = polyline_xs(&svg);
+      assert_eq!(ls.len(), 2, "expected two polylines: {svg}");
+      let len0 = ls[0][1] - ls[0][0];
+      let len1 = ls[1][1] - ls[1][0];
+      assert!(
+        (ls[1][0] - ls[0][1]).abs() < 1e-2,
+        "scaled line must start at {{2,0}}: {svg}"
+      );
+      assert!(
+        (len1 - 2.0 * len0).abs() < 1e-2,
+        "scaled line must be twice as long: {svg}"
+      );
+    }
+
+    #[test]
+    fn test_scale_disk_per_axis_gives_ellipse() {
+      // Scale[g, {sx, sy}] scales each axis separately: a unit disk scaled
+      // by {2, 1} becomes an ellipse with rx = 2 ry.
+      let svg = interpret(
+        "ExportString[Graphics[Scale[Disk[{0, 0}, 1], {2, 1}, {0, 0}]], \"SVG\"]",
+      )
+      .unwrap();
+      let es = ellipses(&svg);
+      assert_eq!(es.len(), 1, "expected one ellipse: {svg}");
+      let (_, _, rx, ry) = es[0];
+      assert!((rx - 2.0 * ry).abs() < 0.5, "rx must be twice ry: {svg}");
+    }
+  }
+
   mod string_split_delimiter_tests {
     use super::*;
 


### PR DESCRIPTION
Implement `Translate` and `Scale` graphics transformation functions for the graphics system.

## Summary
This PR adds support for two fundamental graphics transformations:
- `Translate[g, {dx, dy}]` - translates graphics by a vector
- `Translate[g, {{dx1, dy1}, ...}]` - draws multiple translated copies
- `Scale[g, s]` - scales graphics uniformly about bounding box center
- `Scale[g, {sx, sy}]` - scales each axis separately
- `Scale[g, s, {x, y}]` - scales about an explicit point

## Key Changes
- Added `Translate` and `Scale` expression handlers in `collect_primitives()` that parse arguments and apply transformations to collected primitives
- Implemented `translate_primitive()` function that translates all primitive types by (dx, dy), handling points, lines, polygons, curves, rectangles, disks, arcs, sectors, text, rasters, and half-planes
- Implemented `scale_primitive()` function that scales primitives about a fixed point (cx, cy) with per-axis factors (sx, sy):
  - Coordinates scale linearly: `x' = cx + (x - cx) * sx`
  - Ellipse radii scale by absolute values: `rx' = rx * |sx|`
  - Arc angles are transformed to account for axis mirroring when factors are negative
  - Point sizes, stroke widths, and text sizes remain unchanged (absolute coordinates)
- Added comprehensive test suite covering:
  - Translation of rectangles by vectors
  - Multiple copies via vector lists
  - Scaling rectangles about bounding box center
  - Scaling about explicit points
  - Per-axis scaling converting disks to ellipses

## Implementation Details
- Fallback behavior: non-numeric offsets/factors draw content untranslated
- Negative scale factors mirror the geometry and swap arc endpoints to maintain counterclockwise orientation
- Rectangle and raster bounds are renormalized after scaling to maintain min/max form
- Half-plane normal vectors are scaled to maintain geometric correctness

https://claude.ai/code/session_01PkQpzPPfvV4wBLqPay8kGL