### PR TITLE
Fix inverse_gudermannian tests on Windows

### DIFF
--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -10278,10 +10278,9 @@ mod function_expand {
       "Log[Tan[Pi/4 + y/2]]"
     );
     // Numeric argument still evaluates to the same value as the direct call.
-    assert_eq!(
-      interpret("FunctionExpand[InverseGudermannian[0.5]]").unwrap(),
-      "0.5222381032784403"
-    );
+    let r = interpret("FunctionExpand[InverseGudermannian[0.5]]").unwrap();
+    let m = "0.522238103278440[23]";
+    assert!(regex::Regex::new(m).unwrap().is_match(&r));
   }
 
   #[test]

--- a/tests/interpreter_tests/math/special_functions.rs
+++ b/tests/interpreter_tests/math/special_functions.rs
@@ -134,14 +134,13 @@ mod inverse_gudermannian {
       "True"
     );
     // And the individual values should be exact negatives of one another.
-    assert_eq!(
-      interpret("InverseGudermannian[0.5]").unwrap(),
-      "0.5222381032784403"
-    );
-    assert_eq!(
-      interpret("InverseGudermannian[-0.5]").unwrap(),
-      "-0.5222381032784403"
-    );
+    let r = interpret("InverseGudermannian[0.5]").unwrap();
+    let m = "0.522238103278440[23]";
+    assert!(regex::Regex::new(m).unwrap().is_match(&r));
+
+    let r = interpret("InverseGudermannian[-0.5]").unwrap();
+    let m = "\\-0.522238103278440[23]";
+    assert!(regex::Regex::new(m).unwrap().is_match(&r));
   }
 }
 


### PR DESCRIPTION
Whether due to being Windows, or just my CPU, two
inverse_gudermannian test cases fail because the values are slightly different in the last digits.  Make the tests tolerate this variance.