### PR TITLE
Fix ListPlot x positions for Labeled scalar entries

### DIFF
--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -254,23 +254,34 @@ fn unwrap_labeled(expr: &Expr) -> Option<(Expr, String)> {
 /// One parsed series per dataset plus one optional dataset label per series.
 type LabeledSeries = (Vec<Vec<(f64, f64)>>, Vec<Option<String>>);
 
-/// Like [`LabeledSeries`], but keeping the `Around` uncertainties.
-type LabeledErrSeries = (Vec<Vec<ErrPoint>>, Vec<Option<String>>);
+/// Like [`LabeledSeries`], but keeping the `Around` uncertainties plus
+/// per-point labels (parallel to each series' points) from `Labeled`
+/// wrappers around scalar data entries.
+type LabeledErrSeries = (
+  Vec<Vec<ErrPoint>>,
+  Vec<Option<String>>,
+  Vec<Vec<Option<String>>>,
+);
 
-/// Like [`parse_list_data_err_labeled`], with the uncertainties stripped.
+/// Like [`parse_list_data_err_labeled`], with the uncertainties and
+/// per-point labels stripped.
 fn parse_list_data_labeled(
   arg: &Expr,
 ) -> Result<LabeledSeries, InterpreterError> {
-  let (series, labels) = parse_list_data_err_labeled(arg)?;
+  let (series, labels, _) = parse_list_data_err_labeled(arg)?;
   Ok((strip_errors(&series), labels))
 }
 
 /// Parse list data that may carry `Labeled[data, label]` wrappers around the
 /// whole argument or around individual datasets. Returns one series per
 /// dataset plus one optional label per series (empty when no wrapper was
-/// present). A Labeled wrapper on any entry of the outer list marks that
-/// list as a list of datasets, so `{Labeled[{1, 2}, "a"], Labeled[{3, 4},
-/// "b"]}` parses as two 2-point series rather than as a list of x/y pairs.
+/// present) plus per-point labels (empty when no point is labeled).
+///
+/// A Labeled wrapper on a list entry of the outer list marks that list as a
+/// list of datasets, so `{Labeled[{1, 2}, "a"], Labeled[{3, 4}, "b"]}`
+/// parses as two 2-point series rather than as a list of x/y pairs. When
+/// every entry is a scalar, the Labeled wrappers instead label individual
+/// points of a single series: `{Labeled[2, "a"], 3}` plots at x = 1, 2.
 fn parse_list_data_err_labeled(
   arg: &Expr,
 ) -> Result<LabeledErrSeries, InterpreterError> {
@@ -280,25 +291,46 @@ fn parse_list_data_err_labeled(
   if let Some((content, label)) = unwrap_labeled(&data) {
     let series = parse_list_data_err(&content)?;
     let labels = vec![Some(label); series.len()];
-    return Ok((series, labels));
+    return Ok((series, labels, Vec::new()));
   }
 
   if let Expr::List(items) = &data
     && items.iter().any(|item| unwrap_labeled(item).is_some())
   {
-    let mut all_series = Vec::with_capacity(items.len());
-    let mut labels = Vec::with_capacity(items.len());
-    for item in items {
-      let (content, label) = match unwrap_labeled(item) {
-        Some((content, label)) => (content, Some(label)),
-        None => (item.clone(), None),
-      };
-      let content = evaluate_expr_to_expr(&content).unwrap_or(content);
+    let unwrapped: Vec<(Expr, Option<String>)> = items
+      .iter()
+      .map(|item| {
+        let (content, label) = match unwrap_labeled(item) {
+          Some((content, label)) => (content, Some(label)),
+          None => (item.clone(), None),
+        };
+        let content = evaluate_expr_to_expr(&content).unwrap_or(content);
+        (content, label)
+      })
+      .collect();
+
+    // All entries scalar: one series with sequential x values and the
+    // labels attached to the individual points.
+    if unwrapped.iter().all(|(c, _)| !matches!(c, Expr::List(_))) {
+      let mut points = Vec::with_capacity(unwrapped.len());
+      let mut point_labels = Vec::with_capacity(unwrapped.len());
+      for (i, (content, label)) in unwrapped.iter().enumerate() {
+        if let Some(y) = eval_to_value_err(content) {
+          points.push(ErrPoint::from_y((i + 1) as f64, y));
+          point_labels.push(label.clone());
+        }
+      }
+      return Ok((vec![points], Vec::new(), vec![point_labels]));
+    }
+
+    let mut all_series = Vec::with_capacity(unwrapped.len());
+    let mut labels = Vec::with_capacity(unwrapped.len());
+    for (content, label) in unwrapped {
       match &content {
         Expr::List(series_items) => {
           all_series.push(parse_single_series(series_items)?);
         }
-        // A labeled scalar contributes a one-point series.
+        // A labeled scalar among datasets contributes a one-point series.
         other => match eval_to_value_err(other) {
           Some(y) => all_series.push(vec![ErrPoint::from_y(1.0, y)]),
           None => all_series.push(Vec::new()),
@@ -306,10 +338,10 @@ fn parse_list_data_err_labeled(
       }
       labels.push(label);
     }
-    return Ok((all_series, labels));
+    return Ok((all_series, labels, Vec::new()));
   }
 
-  Ok((parse_list_data_err(&data)?, Vec::new()))
+  Ok((parse_list_data_err(&data)?, Vec::new(), Vec::new()))
 }
 
 /// Panel arrangement from the PlotLayout option.
@@ -633,10 +665,12 @@ fn apply_dataset_labels(opts: &mut PlotOptions, labels: &[Option<String>]) {
 
 /// ListPlot[{y1, y2, ...}] or ListPlot[{{x1,y1}, ...}]
 pub fn list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let (err_series, labels) = parse_list_data_err_labeled(&args[0])?;
+  let (err_series, labels, point_labels) =
+    parse_list_data_err_labeled(&args[0])?;
   let all_series = strip_errors(&err_series);
   let mut parsed = parse_plot_options(args);
   apply_dataset_labels(&mut parsed.opts, &labels);
+  parsed.opts.point_labels = point_labels;
   parsed.opts.error_bars = collect_error_bars(&err_series);
   if parsed.layout != PanelLayout::Overlaid && all_series.len() > 1 {
     return render_panel_layout(
@@ -752,10 +786,12 @@ pub fn complex_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// ListLinePlot[{y1, y2, ...}]
 pub fn list_line_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let (err_series, labels) = parse_list_data_err_labeled(&args[0])?;
+  let (err_series, labels, point_labels) =
+    parse_list_data_err_labeled(&args[0])?;
   let all_series = strip_errors(&err_series);
   let mut parsed = parse_plot_options(args);
   apply_dataset_labels(&mut parsed.opts, &labels);
+  parsed.opts.point_labels = point_labels;
   parsed.opts.error_bars = collect_error_bars(&err_series);
   if parsed.layout != PanelLayout::Overlaid && all_series.len() > 1 {
     return render_panel_layout(

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -1138,6 +1138,10 @@ pub(crate) struct PlotOptions {
   pub log_y: bool,
   /// Callout labels for each series (None = no callout for that series)
   pub callout_labels: Vec<Option<String>>,
+  /// Per-point labels from `Labeled[y, label]` data entries, parallel to
+  /// each series' points (None = no label for that point). Empty when no
+  /// point is labeled.
+  pub point_labels: Vec<Vec<Option<String>>>,
   /// Stacked mode (StackedListPlot): fill each series down to the previous
   /// series' curve instead of to a constant baseline, producing opaque
   /// stacked bands. The `all_points` passed in are the cumulative curves.
@@ -1179,6 +1183,7 @@ impl Default for PlotOptions {
       frame_label_right: None,
       date_axis: false,
       callout_labels: Vec::new(),
+      point_labels: Vec::new(),
       log_x: false,
       log_y: false,
       stacked: false,
@@ -2264,6 +2269,14 @@ fn generate_svg_with_options(
       (y_min, y_max),
       (plot_x0, margin_top_f, plot_w, plot_h),
     );
+    inject_point_labels(
+      &mut buf,
+      opts,
+      all_points,
+      (x_min, x_max),
+      (y_min, y_max),
+      (plot_x0, margin_top_f, plot_w, plot_h),
+    );
   }
 
   inject_legend(&mut buf, opts);
@@ -2349,6 +2362,70 @@ fn inject_callout_labels(
   }
 
   buf.insert_str(insert_pos, &callout_svg);
+}
+
+/// Inject per-point labels (from `Labeled[y, label]` data entries) into a
+/// finished SVG buffer as text next to each labeled point. `plot_area` is
+/// the drawing region in render-space pixels: (left, top, width, height).
+fn inject_point_labels(
+  buf: &mut String,
+  opts: &PlotOptions,
+  all_points: &[Vec<(f64, f64)>],
+  x_range: (f64, f64),
+  y_range: (f64, f64),
+  plot_area: (f64, f64, f64, f64),
+) {
+  if !opts
+    .point_labels
+    .iter()
+    .any(|series| series.iter().any(|l| l.is_some()))
+  {
+    return;
+  }
+  let (x_min, x_max) = x_range;
+  let (y_min, y_max) = y_range;
+  let (plot_x0, plot_top, plot_w, plot_h) = plot_area;
+  let sf = RESOLUTION_SCALE as f64;
+  let font_size = sf * 16.0;
+  let (_, _, _, _, text_fill) = plot_theme();
+
+  let Some(insert_pos) = buf.rfind("</svg>") else {
+    return;
+  };
+  let mut label_svg = String::new();
+
+  for (series_idx, labels) in opts.point_labels.iter().enumerate() {
+    let Some(points) = all_points.get(series_idx) else {
+      continue;
+    };
+    for (&(data_x, data_y), label) in points.iter().zip(labels) {
+      let Some(label_text) = label else { continue };
+      if !(data_x.is_finite() && data_y.is_finite()) {
+        continue;
+      }
+      let frac_x = (data_x - x_min) / (x_max - x_min);
+      let frac_y = (data_y - y_min) / (y_max - y_min);
+      let px = plot_x0 + frac_x * plot_w;
+      let py = plot_top + plot_h * (1.0 - frac_y);
+      // Place the label above-right of the point, flipping to above-left
+      // near the right edge so it stays inside the plot area.
+      let (label_px, anchor) = if frac_x > 0.92 {
+        (px - sf * 4.0, "end")
+      } else {
+        (px + sf * 4.0, "start")
+      };
+      // Keep the label inside the image when the point sits near the top.
+      let label_py = (py - sf * 8.0).max(font_size);
+      label_svg.push_str(&format!(
+        "<text x=\"{label_px:.1}\" y=\"{label_py:.1}\" \
+         font-family=\"sans-serif\" font-size=\"{font_size:.0}\" \
+         fill=\"{text_fill}\" text-anchor=\"{anchor}\">{}</text>\n",
+        crate::functions::graphics::box_string_to_svg(label_text)
+      ));
+    }
+  }
+
+  buf.insert_str(insert_pos, &label_svg);
 }
 
 /// Build a `PlotSource` from sampled plot data so that `Show` can later
@@ -2613,6 +2690,14 @@ pub(crate) fn generate_scatter_svg_with_options(
     let plot_w = render_width as f64 - 2.0 * margin - 65.0 * sf;
     let plot_h = render_height as f64 - 2.0 * margin - 40.0 * sf;
     inject_callout_labels(
+      &mut buf,
+      opts,
+      all_series,
+      (x_min, x_max),
+      (y_min, y_max),
+      (plot_x0, margin, plot_w, plot_h),
+    );
+    inject_point_labels(
       &mut buf,
       opts,
       all_series,

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_line_plot_labeled_scalar_points.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_line_plot_labeled_scalar_points.snap
@@ -1,0 +1,143 @@
+---
+source: tests/interpreter_tests/graphics.rs
+expression: "export_svg(r#\"ListLinePlot[{Labeled[1, \"start\"], 4, 9, Labeled[16, \"end\"]}]\"#)"
+---
+<svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1688" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1688 749,1688 "/>
+<text x="670" y="1587" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1587 749,1587 "/>
+<text x="670" y="1485" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1485 749,1485 "/>
+<text x="670" y="1383" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1383 749,1383 "/>
+<text x="670" y="1281" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1281 749,1281 "/>
+<text x="670" y="1179" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1179 749,1179 "/>
+<text x="670" y="1078" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1078 749,1078 "/>
+<text x="670" y="976" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,976 749,976 "/>
+<text x="670" y="874" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,874 749,874 "/>
+<text x="670" y="772" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+10
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,772 749,772 "/>
+<text x="670" y="671" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,671 749,671 "/>
+<text x="670" y="569" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,569 749,569 "/>
+<text x="670" y="467" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,467 749,467 "/>
+<text x="670" y="365" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,365 749,365 "/>
+<text x="670" y="263" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+15
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,263 749,263 "/>
+<text x="670" y="162" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,162 749,162 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
+<text x="851" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+1
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="851,1750 851,1790 "/>
+<text x="1021" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1021,1750 1021,1790 "/>
+<text x="1191" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1191,1750 1191,1790 "/>
+<text x="1360" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1360,1750 1360,1790 "/>
+<text x="1530" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1530,1750 1530,1790 "/>
+<text x="1700" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1700,1750 1700,1790 "/>
+<text x="1869" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1869,1750 1869,1790 "/>
+<text x="2039" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2039,1750 2039,1790 "/>
+<text x="2209" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2209,1750 2209,1790 "/>
+<text x="2379" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2379,1750 2379,1790 "/>
+<text x="2548" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+3
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2548,1750 2548,1790 "/>
+<text x="2718" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2718,1750 2718,1790 "/>
+<text x="2888" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2888,1750 2888,1790 "/>
+<text x="3057" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3057,1750 3057,1790 "/>
+<text x="3227" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3227,1750 3227,1790 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1688 1700,1383 2548,874 3397,162 "/>
+<line x1="851.9" y1="1790.0" x2="851.9" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="1700.6" y1="1790.0" x2="1700.6" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2549.4" y1="1790.0" x2="2549.4" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="3398.1" y1="1790.0" x2="3398.1" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1281.5" x2="680.0" y2="1281.5" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="772.2" x2="680.0" y2="772.2" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="263.0" x2="680.0" y2="263.0" stroke="#666" stroke-width="10"/>
+<text x="891.9" y="1608.9" font-family="sans-serif" font-size="160" fill="#333" text-anchor="start">start</text>
+<text x="3358.1" y="160.0" font-family="sans-serif" font-size="160" fill="#333" text-anchor="end">end</text>
+</svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_plot_labeled_scalar_points.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_plot_labeled_scalar_points.snap
@@ -1,0 +1,163 @@
+---
+source: tests/interpreter_tests/graphics.rs
+expression: "export_svg(r#\"ListPlot[{Labeled[2, \"a\"], 3, Labeled[5, \"b\"]}]\"#)"
+---
+<svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1688" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1688 749,1688 "/>
+<text x="670" y="1587" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1587 749,1587 "/>
+<text x="670" y="1485" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1485 749,1485 "/>
+<text x="670" y="1383" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1383 749,1383 "/>
+<text x="670" y="1281" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1281 749,1281 "/>
+<text x="670" y="1179" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+3
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1179 749,1179 "/>
+<text x="670" y="1078" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1078 749,1078 "/>
+<text x="670" y="976" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,976 749,976 "/>
+<text x="670" y="874" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,874 749,874 "/>
+<text x="670" y="772" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,772 749,772 "/>
+<text x="670" y="671" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+4
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,671 749,671 "/>
+<text x="670" y="569" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,569 749,569 "/>
+<text x="670" y="467" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,467 749,467 "/>
+<text x="670" y="365" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,365 749,365 "/>
+<text x="670" y="263" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,263 749,263 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
+<text x="851" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+1
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="851,1750 851,1790 "/>
+<text x="979" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="979,1750 979,1790 "/>
+<text x="1106" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1106,1750 1106,1790 "/>
+<text x="1233" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1233,1750 1233,1790 "/>
+<text x="1360" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1360,1750 1360,1790 "/>
+<text x="1488" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+1.5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1488,1750 1488,1790 "/>
+<text x="1615" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1615,1750 1615,1790 "/>
+<text x="1742" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1742,1750 1742,1790 "/>
+<text x="1869" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1869,1750 1869,1790 "/>
+<text x="1997" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1997,1750 1997,1790 "/>
+<text x="2124" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2124,1750 2124,1790 "/>
+<text x="2251" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2251,1750 2251,1790 "/>
+<text x="2379" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2379,1750 2379,1790 "/>
+<text x="2506" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2506,1750 2506,1790 "/>
+<text x="2633" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2633,1750 2633,1790 "/>
+<text x="2760" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+2.5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2760,1750 2760,1790 "/>
+<text x="2888" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2888,1750 2888,1790 "/>
+<text x="3015" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3015,1750 3015,1790 "/>
+<text x="3142" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3142,1750 3142,1790 "/>
+<text x="3269" y="1830" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3269,1750 3269,1790 "/>
+<circle cx="851" cy="1688" r="30" opacity="1" fill="#5E81B5" stroke="none" stroke-width="1"/>
+<circle cx="2124" cy="1179" r="30" opacity="1" fill="#5E81B5" stroke="none" stroke-width="1"/>
+<circle cx="3397" cy="162" r="30" opacity="1" fill="#5E81B5" stroke="none" stroke-width="1"/>
+<line x1="851.9" y1="1790.0" x2="851.9" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="1488.4" y1="1790.0" x2="1488.4" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2125.0" y1="1790.0" x2="2125.0" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="2761.6" y1="1790.0" x2="2761.6" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="3398.1" y1="1790.0" x2="3398.1" y2="1820.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1688.9" x2="680.0" y2="1688.9" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1179.6" x2="680.0" y2="1179.6" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="670.4" x2="680.0" y2="670.4" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="161.1" x2="680.0" y2="161.1" stroke="#666" stroke-width="10"/>
+<text x="891.9" y="1608.9" font-family="sans-serif" font-size="160" fill="#333" text-anchor="start">a</text>
+<text x="3358.1" y="160.0" font-family="sans-serif" font-size="160" fill="#333" text-anchor="end">b</text>
+</svg>


### PR DESCRIPTION
`ListPlot[{Labeled[2, "a"], Labeled[3, "b"], ...}]` used to turn every labeled scalar into its own one-point series at x = 1, stacking all points on the same x value. So

```wolfram
ListPlot[Labeled[#, #] & /@ Table[Prime[n], {n, 10}]]
```

rendered all ten primes at x = 1 instead of x = 1..10.

## Changes

- **Parsing** (`src/functions/list_plot.rs`): when all entries of the data list are scalars, `Labeled` wrappers now label individual points of a single series with sequential x = 1, 2, … — the same x assignment a plain `{y1, y2, ...}` list gets. Mixed plain and labeled scalars work too (`{Labeled[2, "a"], 3, 5}`). `Labeled` around *list* entries keeps its existing meaning of labeled datasets, so dataset labels and `PlotLayout` panels behave as before.
- **Rendering** (`src/functions/plot.rs`): added a per-point `point_labels` channel to `PlotOptions` (the existing `callout_labels` are one label per series) and an injection pass that draws each label next to its point — above-right, flipping to above-left near the right edge, clamped so top-most labels aren't clipped. Wired into both the scatter and line generators, so `ListLinePlot` gets the same behavior.

## Tests

- Regression test asserting the ten prime points have strictly increasing x positions and every prime value appears as a point label.
- Snapshot tests for labeled scalars in `ListPlot` and `ListLinePlot`.
- Full suite passes: 22,566 unit tests plus snapshot and CLI suites, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkdwfWFTBHAxnHNY2gai5

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAkdwfWFTBHAxnHNY2gai5)_