### PR TITLE
Fix complex value tests

### DIFF
--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -10331,7 +10331,7 @@ mod function_expand {
     );
     // Numeric argument still evaluates to the same value as the direct call.
     let r = interpret("FunctionExpand[InverseGudermannian[0.5]]").unwrap();
-    let m = "0.522238103278440[23]";
+    let m = "^0.522238103278440[23]$";
     assert!(regex::Regex::new(m).unwrap().is_match(&r));
   }
 

--- a/tests/interpreter_tests/math/complex.rs
+++ b/tests/interpreter_tests/math/complex.rs
@@ -1039,10 +1039,9 @@ mod im_tests {
   fn e_to_quarter_i_pi_real_exponent() {
     // With a machine-real exponent (.25), E^(.25 I Pi) evaluates to the
     // complex machine-real Cos[Pi/4] + I*Sin[Pi/4].
-    assert_eq!(
-      interpret("E^(.25 I Pi)").unwrap(),
-      "0.7071067811865476 + 0.7071067811865475*I"
-    );
+    let r = interpret("E^(.25 I Pi)").unwrap();
+    let m = "^0.707106781186547[56] \\+ 0.707106781186547[56]\\*I$";
+    assert!(regex::Regex::new(m).unwrap().is_match(&r));
   }
 
   #[test]
@@ -1260,18 +1259,16 @@ mod complex_power_numeric {
 
   #[test]
   fn n_sqrt_i() {
-    assert_eq!(
-      interpret("N[Sqrt[I]]").unwrap(),
-      "0.7071067811865476 + 0.7071067811865475*I"
-    );
+    let r = interpret("N[Sqrt[I]]").unwrap();
+    let m = "^0.707106781186547[56] \\+ 0.707106781186547[56]\\*I$";
+    assert!(regex::Regex::new(m).unwrap().is_match(&r));
   }
 
   #[test]
   fn n_i_to_the_one_half() {
-    assert_eq!(
-      interpret("N[I^(1/2)]").unwrap(),
-      "0.7071067811865476 + 0.7071067811865475*I"
-    );
+    let r = interpret("N[I^(1/2)]").unwrap();
+    let m = "^0.707106781186547[56] \\+ 0.707106781186547[56]\\*I$";
+    assert!(regex::Regex::new(m).unwrap().is_match(&r));
   }
 
   #[test]
@@ -1285,10 +1282,9 @@ mod complex_power_numeric {
   #[test]
   fn i_to_float_exponent() {
     // Direct float exponent (no N wrapper needed)
-    assert_eq!(
-      interpret("I^0.5").unwrap(),
-      "0.7071067811865476 + 0.7071067811865475*I"
-    );
+    let r = interpret("I^0.5").unwrap();
+    let m = "^0.707106781186547[56] \\+ 0.707106781186547[56]\\*I$";
+    assert!(regex::Regex::new(m).unwrap().is_match(&r));
   }
 
   #[test]

--- a/tests/interpreter_tests/math/special_functions.rs
+++ b/tests/interpreter_tests/math/special_functions.rs
@@ -135,11 +135,11 @@ mod inverse_gudermannian {
     );
     // And the individual values should be exact negatives of one another.
     let r = interpret("InverseGudermannian[0.5]").unwrap();
-    let m = "0.522238103278440[23]";
+    let m = "^0.522238103278440[23]$";
     assert!(regex::Regex::new(m).unwrap().is_match(&r));
 
     let r = interpret("InverseGudermannian[-0.5]").unwrap();
-    let m = "\\-0.522238103278440[23]";
+    let m = "^\\-0.522238103278440[23]$";
     assert!(regex::Regex::new(m).unwrap().is_match(&r));
   }
 }

--- a/tests/miscellaneous_tests/high_level_functions.rs
+++ b/tests/miscellaneous_tests/high_level_functions.rs
@@ -6376,11 +6376,10 @@ mod high_level_functions {
     #[test]
     fn test_geodestination_returns_geoposition() {
       // GeoDestination[pos, {distance_meters, azimuth_degrees}].
-      let result =
-        interpret("GeoDestination[{40, -100}, {100000, 45}]").unwrap();
-      let regex =
-        "GeoPosition\\[\\{40.63380067529133, -99.164172238688(8|79)\\}\\]";
-      assert!(regex::Regex::new(regex).unwrap().is_match(&result));
+      let r = interpret("GeoDestination[{40, -100}, {100000, 45}]").unwrap();
+      let m =
+        "^GeoPosition\\[\\{40.63380067529133, -99.164172238688(8|79)\\}\\]$";
+      assert!(regex::Regex::new(m).unwrap().is_match(&r));
     }
 
     #[test]


### PR DESCRIPTION
Four more tests on my machine show slight numerical variances in the last digits, so use regexes to accept the variances.  Also add missing anchor tags in past fixes so the matches are more specific.