### PR TITLE
Add Euler log-trig definite integrals and constant-factor linearity

### DIFF
--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -1163,7 +1163,141 @@ fn try_definite_integral(
     });
   }
 
+  // Euler's log-trig integrals:
+  //   ∫_0^{Pi/2} Log[Sin[x]] dx = ∫_0^{Pi/2} Log[Cos[x]] dx = -(Pi·Log[2])/2
+  //   ∫_0^{Pi/2} Log[Tan[x]] dx = ∫_0^{Pi/2} Log[Cot[x]] dx = 0
+  //   ∫_0^{Pi}   Log[Sin[x]] dx = -Pi·Log[2]
+  if matches!(lo, Expr::Integer(0))
+    && let Expr::FunctionCall {
+      name: log_name,
+      args: log_args,
+    } = integrand
+    && log_name == "Log"
+    && log_args.len() == 1
+    && let Expr::FunctionCall {
+      name: trig_name,
+      args: trig_args,
+    } = &log_args[0]
+    && trig_args.len() == 1
+    && matches!(&trig_args[0], Expr::Identifier(n) if n == var)
+  {
+    let pi_log2 = Expr::FunctionCall {
+      name: "Times".to_string(),
+      args: vec![
+        Expr::Constant("Pi".to_string()),
+        Expr::FunctionCall {
+          name: "Log".to_string(),
+          args: vec![Expr::Integer(2)].into(),
+        },
+      ]
+      .into(),
+    };
+    if is_pi_over_two(hi) {
+      match trig_name.as_str() {
+        "Sin" | "Cos" => {
+          let result = Expr::FunctionCall {
+            name: "Times".to_string(),
+            args: vec![
+              Expr::FunctionCall {
+                name: "Rational".to_string(),
+                args: vec![Expr::Integer(-1), Expr::Integer(2)].into(),
+              },
+              pi_log2,
+            ]
+            .into(),
+          };
+          return Some(
+            crate::evaluator::evaluate_expr_to_expr(&result).unwrap_or(result),
+          );
+        }
+        // The Tan/Cot integrands are antisymmetric about Pi/4 (Tan and Cot
+        // swap under x -> Pi/2 - x), so the two halves cancel exactly.
+        "Tan" | "Cot" => return Some(Expr::Integer(0)),
+        _ => {}
+      }
+    } else if is_pi(hi) && trig_name == "Sin" {
+      let result = Expr::FunctionCall {
+        name: "Times".to_string(),
+        args: vec![Expr::Integer(-1), pi_log2].into(),
+      };
+      return Some(
+        crate::evaluator::evaluate_expr_to_expr(&result).unwrap_or(result),
+      );
+    }
+  }
+
+  // Linearity in constant factors: ∫ c·f(x) dx = c·∫ f(x) dx for any factor
+  // c independent of the integration variable. Recursing on the var-dependent
+  // part lets every known-integral rule above compose with constant
+  // multiples. Runs last so rules with their own coefficient handling (e.g.
+  // DiracDelta sifting, Gaussian moments) keep their specialised results.
+  {
+    let (negated, base) = match integrand {
+      Expr::UnaryOp {
+        op: UnaryOperator::Minus,
+        operand,
+      } => (true, operand.as_ref()),
+      _ => (false, integrand),
+    };
+    let factors = flatten_times_factors(base);
+    if negated || factors.len() > 1 {
+      let (mut consts, dependent): (Vec<Expr>, Vec<Expr>) = factors
+        .into_iter()
+        .partition(|f| !expr_depends_on_var(f, var));
+      if negated {
+        consts.push(Expr::Integer(-1));
+      }
+      if !consts.is_empty() && !dependent.is_empty() {
+        let rest = if dependent.len() == 1 {
+          dependent.into_iter().next().unwrap()
+        } else {
+          Expr::FunctionCall {
+            name: "Times".to_string(),
+            args: dependent.into(),
+          }
+        };
+        if let Some(inner) = try_definite_integral(&rest, var, lo, hi) {
+          consts.push(inner);
+          let product = Expr::FunctionCall {
+            name: "Times".to_string(),
+            args: consts.into(),
+          };
+          return Some(
+            crate::evaluator::evaluate_expr_to_expr(&product)
+              .unwrap_or(product),
+          );
+        }
+      }
+    }
+  }
+
   None
+}
+
+/// Match the constant `Pi/2` in either its parsed (`Pi/2` division) or
+/// evaluated (`Times[Rational[1, 2], Pi]`) form.
+fn is_pi_over_two(e: &Expr) -> bool {
+  let is_half = |e: &Expr| {
+    matches!(
+      e,
+      Expr::FunctionCall { name, args }
+        if name == "Rational" && args.len() == 2
+           && matches!(&args[0], Expr::Integer(1))
+           && matches!(&args[1], Expr::Integer(2))
+    )
+  };
+  match e {
+    Expr::BinaryOp {
+      op: BinaryOperator::Divide,
+      left,
+      right,
+    } => is_pi(left) && matches!(right.as_ref(), Expr::Integer(2)),
+    Expr::FunctionCall { name, args } if name == "Times" && args.len() == 2 => {
+      (is_half(&args[0]) && is_pi(&args[1]))
+        || (is_pi(&args[0]) && is_half(&args[1]))
+    }
+    _ => false,
+  }
 }
 
 fn is_pi(e: &Expr) -> bool {

--- a/tests/cli/symbolic/Integrate.md
+++ b/tests/cli/symbolic/Integrate.md
@@ -18,3 +18,8 @@ $ wo 'Integrate[x^2, {x, 0, 1}]'
 $ wo 'Integrate[Sin[x], {x, 0, Pi}]'
 2
 ```
+
+```scrut
+$ wo 'Integrate[Log[Sin[x]], {x, 0, Pi/2}]'
+-1/2*(Pi*Log[2])
+```

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -814,6 +814,86 @@ mod definite_integrals {
   use super::*;
 
   #[test]
+  fn log_sin_over_half_period() {
+    // Euler: ∫_0^{π/2} Log[Sin[x]] dx = -(π Log[2])/2
+    assert_eq!(
+      interpret("Integrate[Log[Sin[x]], {x, 0, Pi/2}]").unwrap(),
+      "-1/2*(Pi*Log[2])"
+    );
+  }
+
+  #[test]
+  fn log_cos_over_half_period() {
+    assert_eq!(
+      interpret("Integrate[Log[Cos[x]], {x, 0, Pi/2}]").unwrap(),
+      "-1/2*(Pi*Log[2])"
+    );
+  }
+
+  #[test]
+  fn log_tan_and_log_cot_over_half_period() {
+    // Tan and Cot swap under x -> Pi/2 - x, so both integrals vanish.
+    assert_eq!(
+      interpret("Integrate[Log[Tan[x]], {x, 0, Pi/2}]").unwrap(),
+      "0"
+    );
+    assert_eq!(
+      interpret("Integrate[Log[Cot[x]], {x, 0, Pi/2}]").unwrap(),
+      "0"
+    );
+  }
+
+  #[test]
+  fn log_sin_over_full_period() {
+    // ∫_0^π Log[Sin[x]] dx = -π Log[2]
+    assert_eq!(
+      interpret("Integrate[Log[Sin[x]], {x, 0, Pi}]").unwrap(),
+      "-(Pi*Log[2])"
+    );
+  }
+
+  #[test]
+  fn log_sin_other_variable_name() {
+    assert_eq!(
+      interpret("Integrate[Log[Sin[y]], {y, 0, Pi/2}]").unwrap(),
+      "-1/2*(Pi*Log[2])"
+    );
+  }
+
+  #[test]
+  fn log_sin_wrong_bounds_stays_unevaluated() {
+    // The table entry must not misfire on other bounds. (wolframscript
+    // returns a PolyLog closed form here, which woxi doesn't support yet —
+    // falling through unevaluated is the safe behaviour.)
+    assert_eq!(
+      interpret("Integrate[Log[Sin[x]], {x, 0, 1}]").unwrap(),
+      "Integrate[Log[Sin[x]], {x, 0, 1}]"
+    );
+  }
+
+  #[test]
+  fn definite_integral_constant_factor_linearity() {
+    // Constant factors are pulled out of known definite integrals.
+    assert_eq!(
+      interpret("Integrate[3 Log[Sin[x]], {x, 0, Pi/2}]").unwrap(),
+      "(-3*Pi*Log[2])/2"
+    );
+    assert_eq!(
+      interpret("Integrate[Log[Sin[x]]/2, {x, 0, Pi/2}]").unwrap(),
+      "-1/4*(Pi*Log[2])"
+    );
+    assert_eq!(
+      interpret("Integrate[-Log[Sin[x]], {x, 0, Pi/2}]").unwrap(),
+      "(Pi*Log[2])/2"
+    );
+    // Symbolic constant factor times the Bessel integral representation.
+    assert_eq!(
+      interpret("Integrate[Pi Cos[Sin[x]], {x, 0, Pi}]").unwrap(),
+      "Pi^2*BesselJ[0, 1]"
+    );
+  }
+
+  #[test]
   fn gaussian_integral_full() {
     // ∫_{-∞}^{∞} E^(-x^2) dx = Sqrt[Pi]
     assert_eq!(


### PR DESCRIPTION
## Summary

`Integrate[Log[Sin[x]], {x, 0, Pi/2}]` previously returned unevaluated. It now returns `-1/2*(Pi*Log[2])`, exactly matching wolframscript.

Two additions to `try_definite_integral` in `src/functions/calculus_ast.rs`:

1. **Euler's log-trig integral table**
   - `∫₀^(π/2) Log[Sin[x]] dx = ∫₀^(π/2) Log[Cos[x]] dx = -1/2*(Pi*Log[2])`
   - `∫₀^(π/2) Log[Tan[x]] dx = ∫₀^(π/2) Log[Cot[x]] dx = 0`
   - `∫₀^π Log[Sin[x]] dx = -(Pi*Log[2])`

2. **Constant-factor linearity for definite integrals** — factors independent of the integration variable are pulled out and the known-integral table is retried on the var-dependent part, so constant multiples of every table entry compose:
   - `Integrate[3 Log[Sin[x]], {x, 0, Pi/2}]` → `(-3*Pi*Log[2])/2`
   - `Integrate[Log[Sin[x]]/2, {x, 0, Pi/2}]` → `-1/4*(Pi*Log[2])`
   - `Integrate[-Log[Sin[x]], {x, 0, Pi/2}]` → `(Pi*Log[2])/2`
   - `Integrate[Pi Cos[Sin[x]], {x, 0, Pi}]` → `Pi^2*BesselJ[0, 1]` (composes with the existing Bessel rule)

   It runs after the specialised rules (DiracDelta sifting, Gaussian moments) so their coefficient handling is unchanged, and falls through to the antiderivative path when no table entry matches.

All outputs above were verified character-for-character against `wolframscript`.

## Tests

- 8 new unit tests in `tests/interpreter_tests/calculus.rs`, including a guard that the table entry does not misfire on non-classic bounds (`{x, 0, 1}` stays unevaluated — wolframscript returns a PolyLog closed form there, which is not yet supported).
- New doc-test example in `tests/cli/symbolic/Integrate.md`.
- Full suite: `make test` — 24,490 tests passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt

---
_Generated by [Claude Code](https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt)_