### PR TITLE
Fix three more differential-fuzzer divergences against wolframscript

### DIFF
--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -8206,7 +8206,32 @@ fn direct_real_divide(a: &Expr, b: &Expr) -> Option<Expr> {
       use num_traits::ToPrimitive;
       n.to_f64()?
     }
-    _ => return None,
+    // An EXACT symbolic numeric numerator ((42 + Pi)/(Pi - 10)) folds
+    // through N first, then one IEEE division — wolframscript rounds
+    // once, never through a reciprocal multiply (differential fuzzer,
+    // seed 15033838239546239488). N of the exact part is correctly
+    // rounded: 25 digits is comfortably past double precision, so the
+    // final parse rounds once to the true machine value (10π(84+π)/(π-10)
+    // differs by 1 ulp when folded structurally in doubles).
+    _ => {
+      if contains_real(a) {
+        return None;
+      }
+      let hi = super::numerical::n_eval_arbitrary(a, 25.0).ok().and_then(
+        |e| match &e {
+          Expr::BigFloat(digits, _) => digits.parse::<f64>().ok(),
+          Expr::Real(x) => Some(*x),
+          _ => None,
+        },
+      );
+      match hi {
+        Some(x) if x.is_finite() => x,
+        _ => match super::numerical::n_eval(a) {
+          Ok(Expr::Real(x)) => x,
+          _ => return None,
+        },
+      }
+    }
   };
   Some(Expr::Real(x / y))
 }

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -4698,7 +4698,18 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
     // The square-free rule is decoded for POLYNOMIAL sums; sums carrying
     // other functions (trig etc.) keep the full Factor candidate, whose
     // numeric-content extraction the pipeline relies on.
-    let factored = if is_sum && polynomial_like(&best) {
+    // Sums of c·x^e monomials with negative exponents skip Factor
+    // entirely — the decoded recombine/extraction rules in candidate 5
+    // own them (Factor would rebuild -4/5 - 2/(5x) as the unreduced
+    // (-10*(1 + 2*x))/(25*x)).
+    let neg_power_sum = is_sum
+      && parse_neg_power_mono_sum(&super::coefficient::collect_additive_terms(
+        &best,
+      ))
+      .is_some();
+    let factored = if neg_power_sum {
+      Err(crate::InterpreterError::EvaluationError(String::new()))
+    } else if is_sum && polynomial_like(&best) {
       super::factor::factor_square_free_ast(&[best.clone()])
     } else {
       super::factor::factor_ast(&[best.clone()])
@@ -4841,6 +4852,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
           // content NEVER extracts (-4 - 2/x stays split, never
           // -2*(2 + x^(-1)); wolframscript-verified).
           let accept = match parse_neg_power_mono_sum(&terms) {
+            Some(_) if all_negative => false,
             Some(parsed) => {
               let has_const = parsed.iter().any(|&(_, _, e)| e == 0);
               let plain_cost = quotient_cost::sc_sum(&parsed);
@@ -7757,6 +7769,33 @@ fn simplify_quotient_select(
   let d_terms = terms_of(&d_coeffs);
   if n_terms.is_empty() || d_terms.is_empty() {
     return None;
+  }
+  // An unreduced quotient — shared integer content between numerator and
+  // denominator, like the (-10 - 20*x)/(25*x) an internal sum-combine
+  // can hand over — reduces before candidate selection so the built
+  // displays never show the shared factor.
+  {
+    let ng = n_terms
+      .iter()
+      .fold(0i128, |g, &(n, _, _)| gcd_i128(g, n).abs());
+    let dg = d_terms
+      .iter()
+      .fold(0i128, |g, &(n, _, _)| gcd_i128(g, n).abs());
+    let shared = gcd_i128(ng, dg).abs();
+    if shared > 1 {
+      let rn: Vec<(i128, i128, i128)> =
+        n_terms.iter().map(|&(n, d, e)| (n / shared, d, e)).collect();
+      let rd: Vec<(i128, i128, i128)> =
+        d_terms.iter().map(|&(n, d, e)| (n / shared, d, e)).collect();
+      let num2 = coeffs_from_terms(&rn, &var);
+      let den2 = coeffs_from_terms(&rd, &var);
+      let basic2 = Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(num2.clone()),
+        right: Box::new(den2.clone()),
+      };
+      return simplify_quotient_select(&basic2, &num2, &den2);
+    }
   }
   // A literal -1 numerator keeps the older reciprocal handling
   // (Simplify[-1/(1+x)] → -(1+x)^(-1), -1/(1-x) → (-1+x)^(-1)).

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -103,13 +103,67 @@ fn canonicalize_together_result(expr: &Expr) -> Expr {
     if matches!(&rd, Expr::Integer(1)) {
       return rn;
     }
-    return distribute_unit_negative_numerator(&Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(rn),
-      right: Box::new(rd),
-    });
+    return hoist_numerator_content(&distribute_unit_negative_numerator(
+      &Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(rn),
+        right: Box::new(rd),
+      },
+    ));
   }
-  distribute_unit_negative_numerator(&result)
+  hoist_numerator_content(&distribute_unit_negative_numerator(&result))
+}
+
+/// A combined quotient presents its numerator with the integer content
+/// extracted (FactorTerms sign rule): Together[-4/5 - 2/(5*x)] →
+/// (-2*(1 + 2*x))/(5*x) and Together[-2/5 - 2/(5*x)] →
+/// (-2*(1 + x))/(5*x). Direct quotient inputs already factor through the
+/// cancel path; this covers the sum-combine path
+/// (wolframscript-verified).
+fn hoist_numerator_content(expr: &Expr) -> Expr {
+  let (num, den) = extract_num_den(expr);
+  if matches!(&den, Expr::Integer(1)) {
+    return expr.clone();
+  }
+  if !super::simplify::polynomial_like(&num) {
+    return expr.clone();
+  }
+  let terms = collect_additive_terms(&num);
+  if terms.len() < 2 {
+    return expr.clone();
+  }
+  let Some((content, content_den, _)) = super::factor::rational_content(&terms)
+  else {
+    return expr.clone();
+  };
+  if content_den != 1 || content.abs() <= 1 {
+    return expr.clone();
+  }
+  let divided: Result<Vec<Expr>, _> = terms
+    .iter()
+    .map(|t| {
+      crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(t.clone()),
+        right: Box::new(Expr::Integer(content)),
+      })
+    })
+    .collect();
+  let Ok(divided) = divided else {
+    return expr.clone();
+  };
+  let prim = Expr::FunctionCall {
+    name: "Plus".to_string(),
+    args: divided.into(),
+  };
+  Expr::BinaryOp {
+    op: BinaryOperator::Divide,
+    left: Box::new(Expr::FunctionCall {
+      name: "Times".to_string(),
+      args: vec![Expr::Integer(content), prim].into(),
+    }),
+    right: Box::new(den),
+  }
 }
 
 /// A unit-negative numerator coefficient distributes into a single sum

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -592,6 +592,121 @@ mod simplify {
     assert_eq!(interpret("Simplify[x + x]").unwrap(), "2*x");
   }
 
+  // On a SimplifyCount tie the sign-only -(…) pull beats the numeric
+  // content extraction (both count 16), while a strict win keeps the
+  // extraction; wolframscript-verified (differential fuzzer, seed
+  // 5520550946540289960).
+  #[test]
+  fn sign_pull_beats_extraction_on_tie() {
+    assert_eq!(
+      interpret("Simplify[(-2 - 4 x)/(1 + 5 x)]").unwrap(),
+      "-((2 + 4*x)/(1 + 5*x))"
+    );
+    assert_eq!(
+      interpret("Simplify[(-3 - 6 x)/(1 + 5 x)]").unwrap(),
+      "-((3 + 6*x)/(1 + 5*x))"
+    );
+    assert_eq!(
+      interpret("Simplify[(-4 - 8 x)/(1 + 5 x)]").unwrap(),
+      "-((4 + 8*x)/(1 + 5*x))"
+    );
+    // Strict count wins keep the extraction.
+    assert_eq!(
+      interpret("Simplify[(-5 - 10 x)/(1 + 7 x)]").unwrap(),
+      "(-5*(1 + 2*x))/(1 + 7*x)"
+    );
+    assert_eq!(
+      interpret("Simplify[(-10 - 20 x)/(1 + 5 x)]").unwrap(),
+      "(-10*(1 + 2*x))/(1 + 5*x)"
+    );
+    // Positive content and mixed signs stay plain.
+    assert_eq!(
+      interpret("Simplify[(2 + 4 x)/(1 + 5 x)]").unwrap(),
+      "(2 + 4*x)/(1 + 5*x)"
+    );
+    assert_eq!(
+      interpret("Simplify[(-2 + 4 x)/(1 + 5 x)]").unwrap(),
+      "(-2 + 4*x)/(1 + 5*x)"
+    );
+  }
+
+  // A monomial denominator with a coefficient displays the pull as a
+  // rational prefactor; a coefficient-free monomial splits termwise
+  // (wolframscript-verified).
+  #[test]
+  fn mono_denominator_pull_prefactor() {
+    assert_eq!(
+      interpret("Simplify[(-2 - 4 x)/(5 x)]").unwrap(),
+      "-1/5*(2 + 4*x)/x"
+    );
+    assert_eq!(
+      interpret("Simplify[(-1 - 4 x)/(5 x)]").unwrap(),
+      "-1/5*(1 + 4*x)/x"
+    );
+    assert_eq!(
+      interpret("Simplify[(-2 - 4 x)/(5 x^2)]").unwrap(),
+      "-1/5*(2 + 4*x)/x^2"
+    );
+    assert_eq!(interpret("Simplify[(-2 - 4 x)/x]").unwrap(), "-4 - 2/x");
+  }
+
+  // Sums of c·x^e monomials with negative exponents: ALL-NEGATIVE
+  // content never split-extracts; the recombined quotient over the
+  // common x^k competes instead — full content out on unit cofactors,
+  // sign and denominator lcm only otherwise. Positive content keeps the
+  // split-extract with a strict-win, has-constant gate; all
+  // wolframscript-verified.
+  #[test]
+  fn reciprocal_sum_recombination() {
+    assert_eq!(interpret("Simplify[-4 - 2/x]").unwrap(), "-4 - 2/x");
+    assert_eq!(interpret("Simplify[-4 - 2/x^2]").unwrap(), "-4 - 2/x^2");
+    assert_eq!(interpret("Simplify[-2 - 2/x]").unwrap(), "(-2*(1 + x))/x");
+    assert_eq!(
+      interpret("Simplify[-2 - 2/x - 2 x]").unwrap(),
+      "(-2*(1 + x + x^2))/x"
+    );
+    assert_eq!(
+      interpret("Simplify[-2/5 - 2/(5 x)]").unwrap(),
+      "(-2*(1 + x))/(5*x)"
+    );
+    assert_eq!(
+      interpret("Simplify[-4/5 - 2/(5 x)]").unwrap(),
+      "-1/5*(2 + 4*x)/x"
+    );
+    assert_eq!(
+      interpret("Simplify[-4/3 - 2/(3 x)]").unwrap(),
+      "-1/3*(2 + 4*x)/x"
+    );
+    assert_eq!(
+      interpret("Simplify[-4/5 - 2/(5 x^2)]").unwrap(),
+      "-4/5 - 2/(5*x^2)"
+    );
+    // Positive/mixed content split-extracts on a strict win with a
+    // constant term present.
+    assert_eq!(
+      interpret("Simplify[-2 + 2/x + 2 x]").unwrap(),
+      "2*(-1 + x^(-1) + x)"
+    );
+    assert_eq!(
+      interpret("Simplify[-4 + 2/x + 2 x]").unwrap(),
+      "2*(-2 + x^(-1) + x)"
+    );
+    assert_eq!(
+      interpret("Simplify[4 + 2/x + 2 x]").unwrap(),
+      "2*(2 + x^(-1) + x)"
+    );
+    // Ties and constant-free sums keep their form.
+    assert_eq!(interpret("Simplify[4 + 2/x]").unwrap(), "4 + 2/x");
+    assert_eq!(interpret("Simplify[-2 + 2/x]").unwrap(), "-2 + 2/x");
+    assert_eq!(interpret("Simplify[2 - 2/x]").unwrap(), "2 - 2/x");
+    assert_eq!(interpret("Simplify[2/x + 2 x]").unwrap(), "2/x + 2*x");
+    assert_eq!(interpret("Simplify[-4 + 6/x]").unwrap(), "-4 + 6/x");
+    assert_eq!(
+      interpret("Simplify[-4/5 + 6/(5 x)]").unwrap(),
+      "-4/5 + 6/(5*x)"
+    );
+  }
+
   // Simplify minimizes a Boolean expression when that reduces the leaf count
   // (idempotence/complementarity/absorption), but keeps Xor/Implies whose DNF
   // expansion is larger — matching wolframscript's cost model.


### PR DESCRIPTION
A fresh 400-case `woxi-diff-fuzz` batch (seed `1784234939556239488`) found seven divergences; four had already been fixed by work since landed on main, three are new and fixed here. Rebased onto latest main as a single commit. All fixes are byte-verified against wolframscript.

## Together

The **sum-combine path hoists numerator integer content** (FactorTerms sign rule) like the direct-quotient path already did: `Together[-4/5 - 2/(5x)]` → `(-2*(1 + 2*x))/(5*x)` and `Together[-2/5 - 2/(5x)]` → `(-2*(1 + x))/(5*x)`.

## Simplify

- **All-negative sums of `c·x^e` monomials with negative exponents never split-extract** (`Simplify[-4 - 2/x]` keeps its form even though the split-extract counts 9 < 10); the recombined-quotient candidate competes instead, and the Factor candidate skips these sums entirely — it would rebuild `-4/5 - 2/(5x)` as the unreduced `(-10*(1 + 2*x))/(25*x)`.
- **Unreduced quotients reduce shared integer content before candidate selection**, so an internal sum-combine handing over `(-10 - 20*x)/(25*x)` still selects and displays the reduced `-1/5*(2 + 4*x)/x`.

## Machine floats

`Divide[exact, Real]` numericizes the exact numerator **once** (25-digit arbitrary-precision N, one parse to double) and performs a **single IEEE division** instead of a reciprocal multiply, matching wolframscript's rounding: `((42+Pi)/(Pi-10))/(-92.7)` and `(10π(84+π)/(π-10))/(-92.7)` now match to the last ulp.

## Verification

- Full suite passes: 24498 tests, 0 failures.
- Fuzzer replay: 400/400 clean on seed `1784234939556239488` (verified pre-rebase; the rebased probes all reproduce the oracle outputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt