### PR TITLE
Fix ListPlot to treat wrapped {x,y} pairs as single series

### DIFF
--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -533,6 +533,29 @@ fn parse_list_data_err_labeled(
       return Ok((vec![points], Vec::new(), vec![point_labels]));
     }
 
+    // All entries {x, y} pairs (e.g. `Callout[{x, y}, label]` /
+    // `Labeled[{x, y}, label]` around individual coordinates): the wrappers
+    // label individual points of a single series, not separate datasets.
+    let is_numeric_pair = |c: &Expr| {
+      matches!(c, Expr::List(pair) if pair.len() == 2
+        && eval_to_value_err(&pair[0]).is_some()
+        && eval_to_value_err(&pair[1]).is_some())
+    };
+    if unwrapped.iter().all(|(c, _)| is_numeric_pair(c)) {
+      let mut points = Vec::with_capacity(unwrapped.len());
+      let mut point_labels = Vec::with_capacity(unwrapped.len());
+      for (content, label) in &unwrapped {
+        if let Expr::List(pair) = content
+          && let (Some(x), Some(y)) =
+            (eval_to_value_err(&pair[0]), eval_to_value_err(&pair[1]))
+        {
+          points.push(ErrPoint::from_xy(x, y));
+          point_labels.push(label.clone());
+        }
+      }
+      return Ok((vec![points], Vec::new(), vec![point_labels]));
+    }
+
     let mut all_series = Vec::with_capacity(unwrapped.len());
     let mut labels = Vec::with_capacity(unwrapped.len());
     for (content, label) in unwrapped {


### PR DESCRIPTION
## Summary

Fix a regression in `ListPlot` where `Callout` and `Labeled` wrappers around individual `{x, y}` coordinate pairs were incorrectly interpreted as separate two-point datasets, causing doubled markers, incorrect palette cycling, and misplaced labels. These wrappers now correctly label points within a single series.

## Changes

- **src/functions/list_plot.rs**: Added logic to detect when all entries in a wrapped list are individual `{x, y}` pairs. When detected, they are now parsed as a single series of labeled points at their explicit coordinates, rather than being treated as separate datasets.

- **tests/interpreter_tests/graphics.rs**: 
  - Added three new regression tests for `ListPlot` with wrapped coordinate pairs:
    - `list_plot_callout_xy_points_form_single_series`: Verifies that three `Callout`-wrapped points form one series with correct markers and labels
    - `list_plot_callout_many_xy_points`: Tests a larger dataset of 20 `Callout`-wrapped points
    - `list_plot_callout_mixed_with_plain_points`: Tests mixing plain and `Callout`-wrapped points in one series
  - Updated `list_plot_labeled_two_point_pairs` test (formerly `list_plot_labeled_two_point_datasets`) to reflect the corrected behavior: two labeled pairs now form a single series with one palette color, not two separate series with different colors

## Implementation Details

The fix checks if all unwrapped entries are numeric `{x, y}` pairs before attempting to parse them as datasets. When this condition is met, the pairs are collected into a single series with their associated labels, matching the behavior of wolframscript.

https://claude.ai/code/session_01Cr4Ch8Z5U7Mn3HUgRrQfTW