### PR TITLE
Refactor nested conditionals and improve code formatting

### DIFF
--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -392,11 +392,13 @@ fn parse_single_series(
 }
 
 /// Reinterpret list data according to an explicit `DataRange` option, the
-/// way Wolfram does: an explicit range forces value rows to be read as
+/// way Wolfram does: `DataRange -> All` forces value rows to be read as
 /// separate datasets of y-values rather than as (x, y) coordinates. So
 /// `ListPlot[{{1, 1}, {2, 2}, {3, 3}}, DataRange -> All]` plots three
 /// 2-point datasets, not the three points (1,1), (2,2), (3,3). `All` keeps
-/// x = 1, 2, …; `{xmin, xmax}` spaces the x-values evenly over the span.
+/// x = 1, 2, …; `{xmin, xmax}` spaces the x-values evenly over the span,
+/// but leaves a list of (x, y) pairs untouched — pairs keep their explicit
+/// x-coordinates, so the option has no effect there.
 ///
 /// Returns the rewritten data (y-values paired with explicit x-coordinates)
 /// or `None` when the option doesn't change the interpretation (data with
@@ -446,6 +448,16 @@ fn apply_data_range(data: &Expr, spec: &DataRangeSpec) -> Option<Expr> {
     matches!(it, Expr::List(row)
       if row.iter().all(|e| !matches!(e, Expr::List(_))))
   }) {
+    // Rows of exactly two scalars are (x, y) pairs. They keep their
+    // explicit x-coordinates under `DataRange -> {xmin, xmax}`; only
+    // `DataRange -> All` forces the separate-dataset reading.
+    if matches!(spec, DataRangeSpec::Span(..))
+      && items
+        .iter()
+        .all(|it| matches!(it, Expr::List(row) if row.len() == 2))
+    {
+      return None;
+    }
     return Some(Expr::List(
       items
         .iter()

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -8217,13 +8217,13 @@ fn direct_real_divide(a: &Expr, b: &Expr) -> Option<Expr> {
       if contains_real(a) {
         return None;
       }
-      let hi = super::numerical::n_eval_arbitrary(a, 25.0).ok().and_then(
-        |e| match &e {
+      let hi = super::numerical::n_eval_arbitrary(a, 25.0)
+        .ok()
+        .and_then(|e| match &e {
           Expr::BigFloat(digits, _) => digits.parse::<f64>().ok(),
           Expr::Real(x) => Some(*x),
           _ => None,
-        },
-      );
+        });
       match hi {
         Some(x) if x.is_finite() => x,
         _ => match super::numerical::n_eval(a) {

--- a/src/functions/memory.rs
+++ b/src/functions/memory.rs
@@ -153,11 +153,11 @@ pub fn memory_physical() -> i128 {
     // Parse /proc/meminfo for MemTotal (kB) and convert to bytes
     let contents = std::fs::read_to_string("/proc/meminfo").unwrap_or_default();
     for line in contents.lines() {
-      if let Some(rest) = line.strip_prefix("MemTotal:") {
-        if let Some(value) = rest.split_whitespace().next() {
-          let kb: u64 = value.parse().unwrap_or_default();
-          return (kb * 1024) as i128;
-        }
+      if let Some(rest) = line.strip_prefix("MemTotal:")
+        && let Some(value) = rest.split_whitespace().next()
+      {
+        let kb: u64 = value.parse().unwrap_or_default();
+        return (kb * 1024) as i128;
       }
     }
     -1
@@ -240,12 +240,11 @@ pub fn memory_available() -> i128 {
   {
     if let Ok(contents) = std::fs::read_to_string("/proc/meminfo") {
       for line in contents.lines() {
-        if let Some(rest) = line.strip_prefix("MemAvailable:") {
-          if let Some(tok) = rest.split_whitespace().next() {
-            if let Ok(kb) = tok.parse::<i128>() {
-              return kb * 1024;
-            }
-          }
+        if let Some(rest) = line.strip_prefix("MemAvailable:")
+          && let Some(tok) = rest.split_whitespace().next()
+          && let Ok(kb) = tok.parse::<i128>()
+        {
+          return kb * 1024;
         }
       }
     }

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -2994,7 +2994,7 @@ pub(crate) fn generate_scatter_svg_with_options(
               finite_pts
                 .iter()
                 .filter_map(|&(x, y)| {
-                  interp_polyline_y(target, x).map(|ty| (((x, y)), ty))
+                  interp_polyline_y(target, x).map(|ty| ((x, y), ty))
                 })
                 .collect()
             } else {

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -7783,10 +7783,14 @@ fn simplify_quotient_select(
       .fold(0i128, |g, &(n, _, _)| gcd_i128(g, n).abs());
     let shared = gcd_i128(ng, dg).abs();
     if shared > 1 {
-      let rn: Vec<(i128, i128, i128)> =
-        n_terms.iter().map(|&(n, d, e)| (n / shared, d, e)).collect();
-      let rd: Vec<(i128, i128, i128)> =
-        d_terms.iter().map(|&(n, d, e)| (n / shared, d, e)).collect();
+      let rn: Vec<(i128, i128, i128)> = n_terms
+        .iter()
+        .map(|&(n, d, e)| (n / shared, d, e))
+        .collect();
+      let rd: Vec<(i128, i128, i128)> = d_terms
+        .iter()
+        .map(|&(n, d, e)| (n / shared, d, e))
+        .collect();
       let num2 = coeffs_from_terms(&rn, &var);
       let den2 = coeffs_from_terms(&rd, &var);
       let basic2 = Expr::BinaryOp {


### PR DESCRIPTION
## Summary
This PR refactors nested conditional patterns throughout the codebase to use Rust's `&&` guard syntax for improved readability, and applies consistent formatting to multi-line expressions.

## Key Changes

- **Memory functions** (`src/functions/memory.rs`):
  - Refactored nested `if let` statements in `memory_physical()` to use `&&` guards
  - Refactored triple-nested `if let` statements in `memory_available()` to use `&&` guards
  - Improves readability by flattening deeply nested conditionals

- **List plot functionality** (`src/functions/list_plot.rs`):
  - Added regression test `list_plot_data_range_span_ignores_pairs()` to verify that `DataRange -> {xmin, xmax}` does not affect explicit (x, y) coordinate pairs
  - Updated documentation to clarify that `DataRange -> {xmin, xmax}` only affects y-value rows, not coordinate pairs
  - Implemented fix to preserve explicit x-coordinates when data contains (x, y) pairs, preventing incorrect reinterpretation as separate datasets

- **Graphics tests** (`tests/interpreter_tests/graphics.rs`):
  - Reformatted long line in `list_plot_data_range_span_maps_x()` for consistency
  - Added new regression test for DataRange behavior with coordinate pairs

- **Polynomial simplification** (`src/functions/polynomial_ast/simplify.rs`):
  - Reformatted multi-line iterator chains for improved readability

- **Arithmetic operations** (`src/functions/math_ast/arithmetic.rs`):
  - Reformatted chained method calls in `direct_real_divide()` for consistency

- **Plot generation** (`src/functions/plot.rs`):
  - Fixed tuple syntax: removed extra parentheses in `((x, y))` → `(x, y)`

## Notable Implementation Details

The DataRange fix ensures that when users provide explicit (x, y) coordinate pairs to `ListPlot`, the `DataRange` option correctly leaves them untouched rather than attempting to reinterpret them as separate y-value datasets. This aligns with Wolfram Language behavior where `DataRange -> All` forces separate-dataset reading, but `DataRange -> {xmin, xmax}` only affects y-value rows.

https://claude.ai/code/session_01JeikPJY2oGoiQo5hQYzxHp