### PR TITLE
Add NumberPadding option and BaseForm support to PaddedForm

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -889,7 +889,7 @@ SetterBar,Setter bar control (stays symbolic in script mode),✅,unevaluated,6.0
 StyleBox,Low-level box construct for styled content display,✅,pure,3.0,896
 PadLeft,Pads a list on the left to a specified length,✅,pure,4.0,897
 Counts,Returns association of element counts (on an association counts the values),✅,pure,10.0,898
-PaddedForm,Pads numbers (or a list of numbers) to fixed width via ToString rendering,✅,pure,2.0,900
+PaddedForm,"Pads numbers (or a list of numbers) to fixed width via ToString rendering; supports NumberPadding -> {p1; p2} pad characters and BaseForm[x; b] inner values (padded base-b digits with a subscript base)",✅,pure,2.0,900
 TrigToExp,Convert trigonometric and hyperbolic functions to exponentials and inverse functions to logarithms,✅,pure,3.0,900
 Triangle,Geometric primitive representing a triangle,✅,none,10.0,901
 ListContourPlot,Creates a contour plot from a list of values or {x y z} triples,✅,pure,1.0,902
@@ -1022,7 +1022,7 @@ AppearanceElements,Option specifying which interface elements appear,✅,pure,6.
 TimesBy,Multiplies a variable by a value,✅,stateful,1.0,1032
 Merge,Merges associations using a combining function,✅,pure,10.0,1033
 Colorize,Colorize a label matrix or image,✅,,8.0,1035
-NumberPadding,,🚫,,2.0,1035
+NumberPadding,Option specifying the padding characters used by NumberForm and PaddedForm,✅,pure,2.0,1035
 NonNegative,Tests if a number is non-negative,✅,pure,1.0,1036
 ImageMultiply,Multiplies pixel values of two images pointwise,✅,pure,7.0,1038
 TimeSeries,Represents a time series of values paired with time stamps,✅,pure,10.0,1038

--- a/src/evaluator/dispatch/string_functions.rs
+++ b/src/evaluator/dispatch/string_functions.rs
@@ -106,8 +106,10 @@ pub fn dispatch_string_functions(
       return Some(crate::functions::string_ast::to_string_ast(args));
     }
     // Display wrapper: stays unevaluated in script-mode echo (rendering
-    // happens through ToString), without the not-yet-implemented warning
-    "PaddedForm" if args.len() == 2 => {
+    // happens through ToString), without the not-yet-implemented warning.
+    // Trailing arguments beyond the spec carry options such as
+    // NumberPadding -> {"0", ""}.
+    "PaddedForm" if args.len() >= 2 => {
       return Some(Ok(unevaluated("PaddedForm", args)));
     }
     "ToExpression" if !args.is_empty() && args.len() <= 3 => {

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -6354,6 +6354,29 @@ pub fn expr_to_svg_markup(expr: &Expr) -> String {
           }
         }
 
+        // PaddedForm[BaseForm[x, b], n, opts…] → the base-b digits padded to
+        // the n+1 field with the NumberPadding character, with a subscript
+        // base (e.g. 00000101₂). Leading spaces from the default padding are
+        // dropped (the grid handles alignment); visible pad characters such
+        // as "0" are kept.
+        "PaddedForm"
+          if crate::functions::string_ast::padded_form_base_parts(args)
+            .is_some() =>
+        {
+          let (digits, base) =
+            crate::functions::string_ast::padded_form_base_parts(args).unwrap();
+          let shown = digits.trim_start_matches(' ');
+          if base == 10 {
+            svg_escape(shown)
+          } else {
+            format!(
+              "{}<tspan baseline-shift=\"sub\" font-size=\"70%\">{}</tspan>",
+              svg_escape(shown),
+              base
+            )
+          }
+        }
+
         // NumberForm / PaddedForm / AccountingForm → the formatted number text
         // (padding/grouping is folded into the string; the grid handles
         // alignment). Multi-line 2-D forms are flattened to a single line. When
@@ -6634,6 +6657,22 @@ pub fn estimate_display_width(expr: &Expr) -> f64 {
           }
           None => estimate_display_width(&args[0]),
         }
+      }
+      // Padded base-b digits + subscript base at 70% width, mirroring the
+      // markup branch above (leading space padding is not rendered).
+      "PaddedForm"
+        if crate::functions::string_ast::padded_form_base_parts(args)
+          .is_some() =>
+      {
+        let (digits, base) =
+          crate::functions::string_ast::padded_form_base_parts(args).unwrap();
+        let shown = digits.trim_start_matches(' ');
+        let base_len = if base == 10 {
+          0
+        } else {
+          base.to_string().len()
+        };
+        shown.chars().count() as f64 + base_len as f64 * 0.7
       }
       "NumberForm" | "PaddedForm" | "AccountingForm" if !args.is_empty() => {
         let s = crate::functions::string_ast::to_string_default_form(expr);

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -4539,18 +4539,42 @@ pub fn to_string_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // PaddedForm[expr, n] / PaddedForm[expr, {n, f}] — right-aligned
   // number rendering (width n+1 for the integer spec, n+2 for {n, f},
-  // reserving sign/decimal-point columns like wolframscript)
+  // reserving sign/decimal-point columns like wolframscript). The
+  // NumberPadding -> {p1, p2} option replaces the left padding character
+  // (e.g. "0" for zero-padded fields), with the sign column filling like
+  // the NumberForm NumberPadding handling above. A BaseForm[x, b] inner
+  // value pads the base-b digit string and keeps the subscript base line.
   if let Expr::FunctionCall {
     name,
     args: inner_args,
   } = &args[0]
     && name == "PaddedForm"
     && !is_input_form
-    && inner_args.len() == 2
-    && let Some(rendered) =
-      padded_form_to_string(&inner_args[0], &inner_args[1])
+    && inner_args.len() >= 2
   {
-    return Ok(Expr::String(rendered));
+    let positional: Vec<&Expr> = inner_args
+      .iter()
+      .filter(|a| !matches!(a, Expr::Rule { .. }))
+      .collect();
+    if positional.len() == 2 {
+      let lpad = number_padding_left(inner_args);
+      if let Some((digits, base)) =
+        padded_base_form_digits(positional[0], positional[1], &lpad)
+      {
+        let rendered = if base == 10 {
+          digits
+        } else {
+          let indent = " ".repeat(digits.chars().count());
+          format!("{}\n{}{}", digits, indent, base)
+        };
+        return Ok(Expr::String(rendered));
+      }
+      if let Some(rendered) =
+        padded_form_to_string(positional[0], positional[1], &lpad)
+      {
+        return Ok(Expr::String(rendered));
+      }
+    }
   }
 
   // If the expression is MathMLForm[inner], produce MathML regardless of form argument
@@ -12146,36 +12170,116 @@ fn is_abbreviation(before: &[char], after: &[char]) -> bool {
 /// Integer spec n: right-aligned to width n + 1. List spec {n, f}:
 /// rounded to f decimals (with trailing zeros) and right-aligned to
 /// width n + 2. None for non-numeric values or malformed specs.
-/// Right-align an integer's digit string into a padded field. A column is always
-/// reserved for the sign, and the digit field widens past `n` when the number
-/// has more digits, so e.g. `123` with n=2 renders as ` 123` (width 4).
-fn pad_integer_body(body: &str, n: usize) -> String {
-  let num_digits = body.trim_start_matches('-').chars().count();
-  let width = n.max(num_digits) + 1;
-  format!("{body:>width$}")
+/// The left NumberPadding string of a display-form argument list: the first
+/// element of a `NumberPadding -> {p1, p2}` rule, or " " when absent.
+pub fn number_padding_left(args: &[Expr]) -> String {
+  for a in args {
+    if let Expr::Rule {
+      pattern,
+      replacement,
+    } = a
+      && matches!(pattern.as_ref(), Expr::Identifier(s) if s == "NumberPadding")
+      && let Expr::List(pad) = replacement.as_ref()
+      && let Some(Expr::String(p1)) = pad.first()
+    {
+      return p1.clone();
+    }
+  }
+  " ".to_string()
 }
 
-fn padded_form_to_string(value: &Expr, spec: &Expr) -> Option<String> {
+/// Left-pad `body` to `width` columns with the padding string `lpad`
+/// (one copy per missing column, so an empty `lpad` disables padding).
+fn pad_left(body: &str, width: usize, lpad: &str) -> String {
+  let count = width.saturating_sub(body.chars().count());
+  format!("{}{}", lpad.repeat(count), body)
+}
+
+/// Right-align an integer's digit string into a padded field. A column is always
+/// reserved for the sign (filled by the pad character, matching the verified
+/// NumberForm NumberPadding behavior), and the digit field widens past `n`
+/// when the number has more digits, so e.g. `123` with n=2 renders as ` 123`
+/// (width 4).
+fn pad_integer_body(body: &str, n: usize, lpad: &str) -> String {
+  let num_digits = body.trim_start_matches('-').chars().count();
+  pad_left(body, n.max(num_digits) + 1, lpad)
+}
+
+/// Padded digits of `PaddedForm[BaseForm[x, b], n]`: the base-b digit string
+/// of the integer `x`, left-padded to n + 1 columns with `lpad` exactly like
+/// the decimal integer field. Returns `(padded_digits, base)`; None when the
+/// value is not an integer BaseForm or the spec is malformed. A `{n, f}` spec
+/// pads to its integer part (integers ignore the fractional spec).
+pub fn padded_base_form_digits(
+  value: &Expr,
+  spec: &Expr,
+  lpad: &str,
+) -> Option<(String, i128)> {
+  let Expr::FunctionCall { name, args } = value else {
+    return None;
+  };
+  if name != "BaseForm" || args.len() != 2 {
+    return None;
+  }
+  let (Expr::Integer(x), Expr::Integer(b)) = (&args[0], &args[1]) else {
+    return None;
+  };
+  if !(2..=36).contains(b) {
+    return None;
+  }
+  let n = match spec {
+    Expr::Integer(n) if *n >= 0 => *n,
+    Expr::List(parts) if parts.len() == 2 => match &parts[0] {
+      Expr::Integer(n) if *n >= 0 => *n,
+      _ => return None,
+    },
+    _ => return None,
+  };
+  let digits = integer_to_base_string(*x, *b);
+  Some((pad_integer_body(&digits, n as usize, lpad), *b))
+}
+
+/// Padded digits of a full `PaddedForm[BaseForm[x, b], spec, opts…]` argument
+/// list, honoring a `NumberPadding` option. Returns `(padded_digits, base)`;
+/// None when the arguments are not the BaseForm-in-PaddedForm shape.
+pub fn padded_form_base_parts(args: &[Expr]) -> Option<(String, i128)> {
+  let positional: Vec<&Expr> = args
+    .iter()
+    .filter(|a| !matches!(a, Expr::Rule { .. }))
+    .collect();
+  if positional.len() != 2 {
+    return None;
+  }
+  let lpad = number_padding_left(args);
+  padded_base_form_digits(positional[0], positional[1], &lpad)
+}
+
+fn padded_form_to_string(
+  value: &Expr,
+  spec: &Expr,
+  lpad: &str,
+) -> Option<String> {
   // A list pads each element with the same spec and renders as `{e1, e2, ...}`.
   if let Expr::List(items) = value {
     let parts: Option<Vec<String>> = items
       .iter()
-      .map(|e| padded_form_to_string(e, spec))
+      .map(|e| padded_form_to_string(e, spec, lpad))
       .collect();
     return Some(format!("{{{}}}", parts?.join(", ")));
   }
   match spec {
     Expr::Integer(n) if *n >= 0 => match value {
-      Expr::Integer(i) => Some(pad_integer_body(&i.to_string(), *n as usize)),
+      Expr::Integer(i) => {
+        Some(pad_integer_body(&i.to_string(), *n as usize, lpad))
+      }
       Expr::BigInteger(i) => {
-        Some(pad_integer_body(&i.to_string(), *n as usize))
+        Some(pad_integer_body(&i.to_string(), *n as usize, lpad))
       }
       _ => {
         // Reals/rationals: render via output form, padded to width n+1.
         crate::functions::math_ast::expr_to_num(value)?;
         let body = crate::syntax::expr_to_output(value);
-        let width = (*n as usize) + 1;
-        Some(format!("{body:>width$}"))
+        Some(pad_left(&body, (*n as usize) + 1, lpad))
       }
     },
     Expr::List(parts) if parts.len() == 2 => {
@@ -12187,16 +12291,15 @@ fn padded_form_to_string(value: &Expr, spec: &Expr) -> Option<String> {
           // An integer ignores the fractional spec: it is shown as an integer
           // padded to width n+1, never with a spurious decimal part.
           Expr::Integer(i) => {
-            Some(pad_integer_body(&i.to_string(), *n as usize))
+            Some(pad_integer_body(&i.to_string(), *n as usize, lpad))
           }
           Expr::BigInteger(i) => {
-            Some(pad_integer_body(&i.to_string(), *n as usize))
+            Some(pad_integer_body(&i.to_string(), *n as usize, lpad))
           }
           _ => {
             let v = crate::functions::math_ast::expr_to_num(value)?;
             let body = format!("{v:.prec$}", prec = *f as usize);
-            let width = (*n as usize) + 2;
-            Some(format!("{body:>width$}"))
+            Some(pad_left(&body, (*n as usize) + 2, lpad))
           }
         }
       } else {

--- a/tests/miscellaneous_tests/high_level_functions.rs
+++ b/tests/miscellaneous_tests/high_level_functions.rs
@@ -3070,6 +3070,91 @@ mod high_level_functions {
     }
 
     #[test]
+    fn test_padded_form_number_padding() {
+      // NumberPadding -> {p1, p2} replaces the left padding character; the
+      // pad fills the whole n+1 field (sign column included), matching the
+      // NumberForm NumberPadding behavior.
+      assert_eq!(
+        interpret(
+          "ToString[PaddedForm[123, 6, NumberPadding -> {\"0\", \"\"}]]"
+        )
+        .unwrap(),
+        "0000123"
+      );
+      // The sign occupies a pad slot.
+      assert_eq!(
+        interpret(
+          "ToString[PaddedForm[-7, 4, NumberPadding -> {\"0\", \"\"}]]"
+        )
+        .unwrap(),
+        "000-7"
+      );
+      // A {n, f} spec pads the fixed-decimal rendering to width n+2.
+      assert_eq!(
+        interpret(
+          "ToString[PaddedForm[1.5, {4, 2}, NumberPadding -> {\"0\", \"\"}]]"
+        )
+        .unwrap(),
+        "001.50"
+      );
+      // Lists thread the option over every element.
+      assert_eq!(
+        interpret(
+          "ToString[PaddedForm[{1, 22}, 4, NumberPadding -> {\"0\", \"\"}]]"
+        )
+        .unwrap(),
+        "{00001, 00022}"
+      );
+      // InputForm keeps the symbolic head, options included.
+      assert_eq!(
+        interpret(
+          "ToString[PaddedForm[7, 4, NumberPadding -> {\"0\", \"\"}], InputForm]"
+        )
+        .unwrap(),
+        "PaddedForm[7, 4, NumberPadding -> {\"0\", \"\"}]"
+      );
+    }
+
+    #[test]
+    fn test_padded_form_base_form() {
+      // PaddedForm[BaseForm[x, b], n] pads the base-b digit string to the
+      // n+1 field and keeps the subscript base on the line below.
+      assert_eq!(
+        interpret(
+          "ToString[PaddedForm[BaseForm[5, 2], 8, NumberPadding -> {\"0\", \"\"}]]"
+        )
+        .unwrap(),
+        "000000101\n         2"
+      );
+      // Zero pads to a full field of the pad character.
+      assert_eq!(
+        interpret(
+          "ToString[PaddedForm[BaseForm[0, 2], 8, NumberPadding -> {\"0\", \"\"}]]"
+        )
+        .unwrap(),
+        "000000000\n         2"
+      );
+      // Negatives keep the sign within the padded digit line.
+      assert_eq!(
+        interpret(
+          "ToString[PaddedForm[BaseForm[-5, 2], 6, NumberPadding -> {\"0\", \"\"}]]"
+        )
+        .unwrap(),
+        "000-101\n       2"
+      );
+      // Default padding is spaces, like the decimal field.
+      assert_eq!(
+        interpret("ToString[PaddedForm[BaseForm[255, 16], 4]]").unwrap(),
+        "   ff\n     16"
+      );
+      // Base 10 shows no subscript.
+      assert_eq!(
+        interpret("ToString[PaddedForm[BaseForm[5, 10], 3]]").unwrap(),
+        "   5"
+      );
+    }
+
+    #[test]
     fn test_divide_canonical_form() {
       // 1/(a*b) should produce canonical Times[Power[...]] form matching (a*b)^-1
       assert_eq!(interpret("(a*b)^-1 === 1/(a*b)").unwrap(), "True");

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -98,6 +98,78 @@ mod tests {
     );
   }
 
+  // ── PaddedForm[BaseForm[…]] grid cells ──
+
+  fn padded_base_form_expr(value: i128, spec: i128, zero_pad: bool) -> Expr {
+    let mut args = vec![
+      Expr::FunctionCall {
+        name: "BaseForm".to_string(),
+        args: vec![Expr::Integer(value), Expr::Integer(2)].into(),
+      },
+      Expr::Integer(spec),
+    ];
+    if zero_pad {
+      args.push(Expr::Rule {
+        pattern: Box::new(Expr::Identifier("NumberPadding".to_string())),
+        replacement: Box::new(Expr::List(
+          vec![Expr::String("0".to_string()), Expr::String(String::new())]
+            .into(),
+        )),
+      });
+    }
+    Expr::FunctionCall {
+      name: "PaddedForm".to_string(),
+      args: args.into(),
+    }
+  }
+
+  #[test]
+  fn test_svg_padded_base_form_zero_padded() {
+    // PaddedForm[BaseForm[8, 2], 8, NumberPadding -> {"0", ""}] — binary
+    // digits zero-padded to the n+1 field, with the subscript base.
+    let markup = expr_to_svg_markup(&padded_base_form_expr(8, 8, true));
+    assert_eq!(
+      markup,
+      "000001000<tspan baseline-shift=\"sub\" font-size=\"70%\">2</tspan>"
+    );
+    // Width: 9 digit columns + the subscript base at 70%.
+    let width = estimate_display_width(&padded_base_form_expr(8, 8, true));
+    assert!(
+      (width - 9.7).abs() < 1e-9,
+      "expected width 9.7, got {width}"
+    );
+  }
+
+  #[test]
+  fn test_svg_padded_base_form_default_space_padding_trimmed() {
+    // Without NumberPadding the pad is spaces, which the grid drops (cells
+    // are aligned by position, not by literal spaces).
+    let markup = expr_to_svg_markup(&padded_base_form_expr(8, 8, false));
+    assert_eq!(
+      markup,
+      "1000<tspan baseline-shift=\"sub\" font-size=\"70%\">2</tspan>"
+    );
+  }
+
+  #[test]
+  fn test_svg_padded_base_form_table_pipeline() {
+    // End-to-end: the wrapper distributes over TableForm cells and every
+    // cell comes out zero-padded.
+    let svg = woxi::interpret(
+      r#"ExportString[PaddedForm[BaseForm[TableForm[{{8, 49}, {123, 5}}], 2], 8,
+        NumberPadding -> {"0", ""}], "SVG"]"#,
+    )
+    .expect("interpret should succeed");
+    for cell in ["000001000", "000110001", "001111011", "000000101"] {
+      assert!(
+        svg.contains(&format!(
+          "{cell}<tspan baseline-shift=\"sub\" font-size=\"70%\">2</tspan>"
+        )),
+        "zero-padded cell {cell} missing from SVG"
+      );
+    }
+  }
+
   // ── Implicit multiplication (no * symbol) ──
 
   #[test]


### PR DESCRIPTION
## Summary

Extends `PaddedForm` to support the `NumberPadding` option for customizing the left padding character, and adds support for `PaddedForm[BaseForm[x, b], spec]` to render base-b digit strings with proper padding and subscript notation.

## Key Changes

- **NumberPadding option support**: `PaddedForm` now accepts `NumberPadding -> {p1, p2}` to replace the default space padding character (e.g., `"0"` for zero-padding), matching the behavior of `NumberForm`
- **BaseForm integration**: `PaddedForm[BaseForm[x, b], n]` pads the base-b digit string to width n+1 and renders the base as a subscript on the line below (except for base 10)
- **Refactored padding logic**: 
  - Extracted `pad_left()` helper for consistent left-padding with custom characters
  - Updated `pad_integer_body()` to accept and use the padding character
  - Added `number_padding_left()` to extract the NumberPadding option from argument lists
  - Added `padded_base_form_digits()` to compute padded base-b digits
  - Added `padded_form_base_parts()` as a public helper for SVG rendering
- **SVG rendering**: Updated `expr_to_svg_markup()` and `estimate_display_width()` to handle `PaddedForm[BaseForm[…]]` with proper subscript rendering and width estimation
- **Dispatcher update**: Modified `PaddedForm` dispatcher to accept variable argument counts (≥2) to support options
- **Tests**: Added comprehensive tests for NumberPadding behavior, BaseForm padding, and SVG rendering of padded base forms
- **Documentation**: Updated function description in functions.csv

## Implementation Details

- The padding character fills the entire n+1 field (including the sign column), consistent with NumberForm behavior
- For `{n, f}` specs with integers, the fractional part is ignored and the value is padded to width n+1
- Leading space padding is trimmed in SVG output (grid handles alignment), but visible characters like "0" are preserved
- Base 10 BaseForm values render without a subscript, matching standard decimal notation

https://claude.ai/code/session_01FvM4XnX76tCFiPUZ336z8T