### PR TITLE
Another round of gcd cleanups

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -1,6 +1,8 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::{expr_to_rational, is_sqrt, make_sqrt};
+use crate::functions::math_ast::{
+  expr_to_rational, gcd as gcd_i128, is_sqrt, make_sqrt,
+};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
@@ -12106,8 +12108,6 @@ fn rational_to_expr(n: i128, d: i128) -> Expr {
     }
   }
 }
-
-use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Rational arithmetic helpers
 fn rat_sub(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {

--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::make_sqrt;
+use crate::functions::math_ast::{gcd as gcd_i128, make_sqrt};
 use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 
 pub fn dispatch_linear_algebra_functions(
@@ -3862,8 +3862,6 @@ fn kronecker_product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   Ok(acc_owned)
 }
-
-use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Binary dissimilarity functions for binary (0/1) vectors.
 fn binary_dissimilarity_ast(

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -4,7 +4,7 @@
 //! and integration.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::{gcd, gcd as gcd_i128, is_sqrt, make_sqrt};
+use crate::functions::math_ast::{gcd as gcd_i128, is_sqrt, make_sqrt};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -5129,7 +5129,7 @@ fn try_integrate_trig_quotient(
       for j in 1..=k {
         let binom = crate::functions::binomial_coeff(k as i128, j as i128);
         let sign = if j % 2 == 1 { 1 } else { -1 };
-        let g = gcd_i128_calc(binom.abs(), 2 * j as i128);
+        let g = gcd_i128(binom, 2 * j as i128).max(1);
         terms.push(coeff_term(
           sign * binom / g,
           2 * j as i128 / g,
@@ -5172,7 +5172,7 @@ fn try_integrate_trig_quotient(
       for j in 1..=k {
         let binom = crate::functions::binomial_coeff(k as i128, j as i128);
         let sign = if j % 2 == 1 { -1 } else { 1 };
-        let g = gcd_i128_calc(binom.abs(), 2 * j as i128);
+        let g = gcd_i128(binom, 2 * j as i128).max(1);
         terms.push(coeff_term(
           sign * binom / g,
           2 * j as i128 / g,
@@ -5225,15 +5225,6 @@ fn collect_times_factor_refs<'a>(
     }
     _ => num.push(expr),
   }
-}
-
-fn gcd_i128_calc(mut a: i128, mut b: i128) -> i128 {
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a.max(1)
 }
 
 /// Build the antiderivative of Exp[-a*x^2] (`erf_name` = "Erf") or of
@@ -14641,7 +14632,7 @@ fn rat_reduce(num: i128, den: i128) -> (i128, i128) {
   if num == 0 {
     return (0, 1);
   }
-  let g = gcd(num.abs(), den.abs());
+  let g = gcd_i128(num, den);
   let (n, d) = (num / g, den / g);
   if d < 0 { (-n, -d) } else { (n, d) }
 }
@@ -15902,7 +15893,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // value / factorial
       match &value {
         Expr::Integer(n) => {
-          let g = gcd(n.abs(), factorial);
+          let g = gcd_i128(*n, factorial);
           let (num, den) = (n / g, factorial / g);
           if den == 1 {
             Expr::Integer(num)

--- a/src/functions/count_roots_ast.rs
+++ b/src/functions/count_roots_ast.rs
@@ -13,6 +13,7 @@
 //! Real-valued bounds) returns the call unevaluated.
 
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd_bigint;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 use num_bigint::BigInt;
 use num_traits::{One, Signed, Zero};
@@ -26,8 +27,6 @@ struct Rat {
   n: BigInt,
   d: BigInt, // invariant: d > 0, gcd(|n|, d) == 1
 }
-
-use crate::functions::math_ast::gcd_bigint;
 
 impl Rat {
   fn new(mut n: BigInt, mut d: BigInt) -> Rat {

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -12,7 +12,7 @@
 //! (1, -1, I, -I, or E^((a*I)/b*Pi) forms on the principal branch).
 
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd_bigint;
+use crate::functions::math_ast::{gcd as gcd_i128, gcd_bigint};
 use crate::syntax::Expr;
 use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
 
@@ -53,8 +53,8 @@ pub fn dirichlet_character_ast(
     _ => return Ok(unevaluated(args)),
   };
 
-  if gcd(n, k) != 1 {
-    // k = 1 has gcd(n, 1) = 1 for every n, so this is unreachable there
+  if gcd_i128(n, k) > 1 {
+    // k = 1 has gcd_i128(n, 1) = 0 or 1 for every n, so this is unreachable there
     return Ok(Expr::Integer(0));
   }
 
@@ -78,7 +78,7 @@ pub fn dirichlet_character_ast(
   for (f, e) in factors.iter().zip(&exps) {
     let t = f.dlog(n);
     let (mut p, mut q) = (e * t, f.order);
-    let g = gcd(p, q);
+    let g = gcd_i128(p, q).max(1);
     p = (p / g).rem_euclid(q / g);
     q /= g;
     if q == 1 || q == 2 || q == 4 {
@@ -86,13 +86,13 @@ pub fn dirichlet_character_ast(
     } else {
       num = num * q + p * den;
       den *= q;
-      let g = gcd(num, den);
+      let g = gcd_i128(num, den).max(1);
       num /= g;
       den /= g;
     }
   }
   num = num.rem_euclid(den);
-  let g = gcd(num, den);
+  let g = gcd_i128(num, den).max(1);
   num /= g;
   den /= g;
   // A combined exponential that lands on a fourth root folds into the
@@ -215,7 +215,7 @@ fn character_factors(k: i128) -> Vec<Factor> {
 /// Smallest primitive root modulo the odd prime power pe.
 fn primitive_root(pe: i128, order: i128) -> i128 {
   'g: for g in 2..pe {
-    if gcd(g, pe) != 1 {
+    if gcd_i128(g, pe) > 1 {
       continue;
     }
     // g is a primitive root iff g^(order/q) != 1 for every prime q | order
@@ -257,10 +257,6 @@ fn pow_mod(mut b: i128, mut e: i128, m: i128) -> i128 {
   r
 }
 
-fn gcd(a: i128, b: i128) -> i128 {
-  crate::functions::math_ast::gcd(a, b).max(1)
-}
-
 fn euler_phi(k: i128) -> i128 {
   let mut result = k;
   let mut n = k;
@@ -299,12 +295,12 @@ fn assemble_value(quarter: i128, num: i128, den: i128) -> Expr {
   // Principal branch: the printed multiple of Pi is m = a/b = 2*num/den
   // reduced into (-1, 1]
   let (mut a, mut b) = (2 * num, den);
-  let g = gcd(a, b);
+  let g = gcd_i128(a, b).max(1);
   a /= g;
   b /= g;
   if a > b {
     a -= 2 * b;
-    let g = gcd(a, b);
+    let g = gcd_i128(a, b).max(1);
     a /= g;
     b /= g;
   }
@@ -341,12 +337,12 @@ fn total_rotation(factors: &[Factor], exps: &[i128], a: i128) -> (i128, i128) {
     let (p, q) = (e * t, f.order);
     num = num * q + p * den;
     den *= q;
-    let g = gcd(num, den);
+    let g = gcd_i128(num, den).max(1);
     num /= g;
     den /= g;
   }
   num = num.rem_euclid(den);
-  let g = gcd(num, den);
+  let g = gcd_i128(num, den).max(1);
   (num / g, den / g)
 }
 
@@ -420,7 +416,7 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // chi(a) for a = 1..k as rotations; None where chi vanishes
   let rotations: Vec<Option<(i128, i128)>> = (1..=k)
     .map(|a| {
-      if gcd(a, k) == 1 {
+      if gcd_i128(a, k) <= 1 {
         Some(total_rotation(&factors, &exps, a))
       } else {
         None

--- a/src/functions/geo_math.rs
+++ b/src/functions/geo_math.rs
@@ -7,6 +7,7 @@
 
 use crate::InterpreterError;
 use crate::functions::geographics::{position_to_latlon, positions_from_arg};
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{Expr, UnaryOperator, unevaluated};
 use geographiclib_rs::{DirectGeodesic, Geodesic, InverseGeodesic};
 use std::sync::OnceLock;
@@ -314,8 +315,6 @@ fn rat_add(a: (i128, i128), b: (i128, i128)) -> Option<(i128, i128)> {
   let g = gcd_i128(num.abs().max(1), den);
   Some((num / g, den / g))
 }
-
-use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Convert a numeric scalar expression to an `AngleVal`. Exactness is
 /// preserved for Integer/Rational; Reals and exact-but-irrational numerics

--- a/src/functions/groebner_ast.rs
+++ b/src/functions/groebner_ast.rs
@@ -8,6 +8,7 @@
 //! unevaluated.
 
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 use std::collections::BTreeMap;
 
@@ -52,8 +53,6 @@ fn mod_inverse(a: i128, p: i128) -> Option<i128> {
   }
   Some(old_s.rem_euclid(p))
 }
-
-use crate::functions::math_ast::gcd;
 
 fn norm(f: Frac) -> Option<Frac> {
   if f.1 == 0 {

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -5,7 +5,7 @@
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::{
-  expr_to_rational, make_sqrt, try_eval_to_f64,
+  expr_to_rational, gcd as gcd_i128, make_sqrt, try_eval_to_f64,
 };
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
@@ -1342,8 +1342,6 @@ fn eval_divide(a: &Expr, b: &Expr) -> Expr {
     }
   }
 }
-
-use crate::functions::math_ast::gcd as gcd_i128;
 
 /// The rectangular shape of a nested-List array, found by descending through
 /// the first element of each level. A non-list has an empty shape; `{a, b}`
@@ -7289,7 +7287,7 @@ pub fn singular_value_decomposition_ast(
 /// extracted (e.g. `Sqrt[20/7]` → `2*Sqrt[5/7]`). Other expression shapes
 /// pass through unchanged.
 fn simplify_radical_factor(expr: &Expr) -> Expr {
-  use crate::functions::math_ast::{gcd, make_rational, sqrt_ast, times_ast};
+  use crate::functions::math_ast::{make_rational, sqrt_ast, times_ast};
   let extract_int = |e: &Expr| -> Option<i128> {
     if let Expr::Integer(n) = e {
       Some(*n)
@@ -7517,7 +7515,7 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
   if inner_den == 0 {
     return expr.clone();
   }
-  let g = gcd(inner_num.abs(), inner_den.abs());
+  let g = gcd_i128(inner_num, inner_den);
   if g == 0 {
     return expr.clone();
   }
@@ -10247,14 +10245,6 @@ fn la_mod_inv(a: i128, m: i128) -> i128 {
   old_s.rem_euclid(m)
 }
 
-fn la_gcd(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    (a, b) = (b, a % b);
-  }
-  a
-}
-
 /// Fraction-free integer determinant (Bareiss).
 fn la_int_det(mat: &[Vec<i128>]) -> i128 {
   let n = mat.len();
@@ -10322,7 +10312,7 @@ fn la_rref(mat: &mut [Vec<i128>], m: i128) -> Option<Vec<usize>> {
     if rank == rows {
       break;
     }
-    let Some(pr) = (rank..rows).find(|&r| la_gcd(mat[r][col], m) == 1) else {
+    let Some(pr) = (rank..rows).find(|&r| gcd_i128(mat[r][col], m) == 1) else {
       if (rank..rows).any(|r| mat[r][col] != 0) {
         return None;
       }
@@ -10387,7 +10377,7 @@ pub fn inverse_modulus_ast(
     .map(|r| r.iter().map(|c| c.rem_euclid(m)).collect())
     .collect();
   let det = la_int_det(&reduced).rem_euclid(m);
-  let g = la_gcd(det, m);
+  let g = gcd_i128(det, m);
   if g != 1 {
     if la_is_prime(m) {
       crate::emit_message(&format!(

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
 
 /// AnglePath[{θ1, θ2, ...}] - path with unit steps and cumulative turning angles.
@@ -3663,24 +3664,12 @@ fn match_exponential_base(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
   Some((coeff, base))
 }
 
-/// gcd of two non-negative integers.
-fn tr_gcd(mut a: i128, mut b: i128) -> i128 {
-  a = a.abs();
-  b = b.abs();
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
-
 /// Reduce a rational (num, den) to lowest terms with a positive denominator.
 fn tr_reduce(n: i128, d: i128) -> (i128, i128) {
   if d == 0 {
     return (n, 0);
   }
-  let g = tr_gcd(n, d).max(1);
+  let g = gcd_i128(n, d).max(1);
   let (mut n, mut d) = (n / g, d / g);
   if d < 0 {
     n = -n;
@@ -3823,7 +3812,7 @@ fn try_telescoping_rational_sum(
   let mut roots: Vec<i128> = Vec::new();
   // Strip integer denominators so the candidate search works on integers.
   let lcm_den = den.iter().fold(1i128, |acc, &(_, d)| {
-    let g = tr_gcd(acc, d);
+    let g = gcd_i128(acc, d);
     acc / g * d
   });
   let int_coeffs: Vec<i128> =
@@ -3968,7 +3957,7 @@ fn try_rational_pole_telescoping_sum(
 
   // Integer-clear the denominator for the rational-root search.
   let lcm_den = den.iter().fold(1i128, |acc, &(_, d)| {
-    let g = tr_gcd(acc, d);
+    let g = gcd_i128(acc, d);
     acc / g * d
   });
   let mut int_coeffs: Vec<i128> =

--- a/src/functions/list_helpers_ast/utilities.rs
+++ b/src/functions/list_helpers_ast/utilities.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+pub(crate) use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
 
 /// Convert an Expr to a boolean value.
@@ -258,8 +259,6 @@ pub fn f64_to_expr(n: f64) -> Expr {
     Expr::Real(n)
   }
 }
-
-pub(crate) use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Identity[x] - returns x unchanged
 pub fn identity_ast(arg: &Expr) -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -286,7 +286,7 @@ fn try_series_data_plus(
           "SeriesData denom must be Integer".into(),
         )
       })?;
-      let g = numeric_utils::gcd(common_denom.abs(), d.abs());
+      let g = gcd_i128(common_denom, d);
       if g == 0 {
         return Ok(None);
       }
@@ -455,7 +455,7 @@ fn try_series_data_times(
           "SeriesData denom must be Integer".into(),
         )
       })?;
-      let g = numeric_utils::gcd(common_denom.abs(), d.abs());
+      let g = gcd_i128(common_denom, d);
       if g == 0 {
         return Ok(None);
       }
@@ -1606,7 +1606,7 @@ impl Coeff {
         {
           let mut sd = c;
           let mut sn = sn;
-          let g = gcd(sn, sd);
+          let g = gcd_i128(sn, sd);
           sn /= g;
           sd /= g;
           if sd < 0 {
@@ -1668,7 +1668,7 @@ impl Coeff {
         {
           let mut sn = sn;
           let mut sd = sd;
-          let g = gcd(sn, sd);
+          let g = gcd_i128(sn, sd);
           sn /= g;
           sd /= g;
           if sd < 0 {
@@ -6245,7 +6245,7 @@ fn try_series_data_times_var_power(
   };
 
   // Lift to the common denominator d = lcm(denom, q).
-  let g = numeric_utils::gcd(denom.abs(), q.abs());
+  let g = gcd_i128(denom, q);
   if g == 0 {
     return Ok(None);
   }
@@ -8018,7 +8018,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         .and_then(|c2| c2.checked_mul(rn))
         .zip(cd.checked_mul(cd).and_then(|d2| d2.checked_mul(rd)));
       if let Some((mut num, mut den)) = merged {
-        let g = gcd(num.abs(), den).max(1);
+        let g = gcd_i128(num, den).max(1);
         num /= g;
         den /= g;
         let (s, p1) = extract_square_factor_i128(num.abs());
@@ -8681,7 +8681,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
     && *n > 0
   {
     let denom = d * d;
-    let g = gcd(*n, denom);
+    let g = gcd_i128(*n, denom);
     let reduced_d = (denom / g) as u64;
     // Check that the reduced denominator has no perfect square factors
     let mut has_sq_factor = false;
@@ -8972,7 +8972,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
               _ => None,
             })
             .unwrap_or(1);
-          if gcd(num_int as i128, den_int as i128) > 1 {
+          if gcd_i128(num_int as i128, den_int as i128) > 1 {
             let mut all_factors = num_factors;
             for df in den_factors {
               all_factors.push(power_two(&df, &Expr::Integer(-1))?);
@@ -9316,7 +9316,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     // Reduce mod 2*y_den (since y mod 2 means y_num mod 2*y_den).
     let modulus = 2 * y_den;
     y_num = y_num.rem_euclid(modulus);
-    let g = crate::functions::math_ast::gcd(y_num.abs(), y_den);
+    let g = gcd_i128(y_num, y_den);
     let (yn, yd) = (y_num / g, y_den / g);
     // Build -(-1)^Rational[yn, yd]. If yn == 0, (-1)^0 = 1, so result = -1.
     if yn == 0 {
@@ -9354,14 +9354,14 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     // y = p / (2q), reduced mod 2 into [0, 2).
     let y_den = 2 * q;
     let y_num = p.rem_euclid(2 * y_den);
-    let g = crate::functions::math_ast::gcd(y_num.abs(), y_den);
+    let g = gcd_i128(y_num, y_den);
     let (mut yn, mut yd) = (y_num / g, y_den / g);
     let mut sign = 1i128;
     if yn >= yd {
       // y in [1, 2): (-1)^y = -(-1)^(y-1).
       yn -= yd;
       sign = -1;
-      let g2 = crate::functions::math_ast::gcd(yn.abs(), yd);
+      let g2 = gcd_i128(yn, yd);
       if g2 > 1 {
         yn /= g2;
         yd /= g2;

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -400,12 +400,10 @@ impl BigUint {
   }
 
   fn gcd(a: &Self, b: &Self) -> Self {
-    let mut a = a.clone();
-    let mut b = b.clone();
+    let (mut a, mut b) = (a.clone(), b.clone());
     while !b.is_zero() {
       let (_, r) = a.divmod(&b);
-      a = b;
-      b = r;
+      (a, b) = (b, r);
     }
     a
   }
@@ -3907,9 +3905,6 @@ pub fn number_decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
     }
   } else {
-    let gcd_i128 = |a: i128, b: i128| -> i128 {
-      crate::functions::math_ast::gcd(a, b).max(1)
-    };
     let (mut rn, mut rd) = match value {
       Num::Exact(p, q) => (p, q),
       Num::Real(_) => unreachable!(),
@@ -3930,7 +3925,7 @@ pub fn number_decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // rem -= q_int * u
         rn = rn * ud - q_int * un * rd;
         rd *= ud;
-        let g = gcd_i128(rn, rd);
+        let g = gcd_i128(rn, rd).max(1);
         rn /= g;
         rd /= g;
       }

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::functions::math_ast::expr_to_rational;
+use crate::functions::math_ast::{expr_to_rational, gcd as gcd_i128};
 use crate::syntax::{
   BinaryOperator, Expr, ExprForm, UnaryOperator, expr_to_string, unevaluated,
 };
@@ -166,13 +166,13 @@ pub fn abs_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Handle exact complex numbers and rationals: Abs[a + b*I] = Sqrt[a^2 + b^2]
   if let Some(((rn, rd), (in_, id))) = try_extract_complex_exact(&args[0]) {
-    let g_r = gcd(rn, rd);
+    let g_r = gcd_i128(rn, rd);
     let (rn, rd) = if rd < 0 {
       (-rn / g_r, -rd / g_r)
     } else {
       (rn / g_r, rd / g_r)
     };
-    let g_i = gcd(in_, id);
+    let g_i = gcd_i128(in_, id);
     let (in_, id) = if id < 0 {
       (-in_ / g_i, -id / g_i)
     } else {
@@ -607,13 +607,13 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Handle complex numbers: Sign[a + b*I] = (a + b*I) / Abs[a + b*I]
   if let Some(((rn, rd), (in_, id))) = try_extract_complex_exact(&args[0]) {
-    let g_r = gcd(rn, rd);
+    let g_r = gcd_i128(rn, rd);
     let (rn, rd) = if rd < 0 {
       (-rn / g_r, -rd / g_r)
     } else {
       (rn / g_r, rd / g_r)
     };
-    let g_i = gcd(in_, id);
+    let g_i = gcd_i128(in_, id);
     let (in_, id) = if id < 0 {
       (-in_ / g_i, -id / g_i)
     } else {
@@ -643,7 +643,7 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         .and_then(|a| id.checked_mul(id).and_then(|b| a.checked_mul(b))),
     ) {
       // Simplify |z|^2 fraction
-      let g_abs = gcd(abs2_num.abs(), abs2_den.abs());
+      let g_abs = gcd_i128(abs2_num, abs2_den);
       let (abs2_n, abs2_d) = (abs2_num / g_abs, abs2_den / g_abs);
 
       // Check if |z|^2 is a perfect square (so |z| is rational)
@@ -1290,8 +1290,6 @@ fn extract_int_coeff(term: &Expr) -> Option<(i128, Expr)> {
 /// If the GCD is a perfect square, factor it out.
 /// E.g. Sqrt[4 + 36*t^2 + 36*t^4] → 2*Sqrt[1 + 9*t^2 + 9*t^4]
 fn try_sqrt_plus_gcd(expr: &Expr) -> Option<Expr> {
-  use crate::functions::math_ast::numeric_utils::gcd;
-
   let terms = match expr {
     Expr::FunctionCall { name, args } if name == "Plus" => args,
     _ => return None,
@@ -1313,7 +1311,7 @@ fn try_sqrt_plus_gcd(expr: &Expr) -> Option<Expr> {
   // Compute GCD of absolute values of all coefficients
   let mut g = pairs[0].0.abs();
   for &(c, _) in &pairs[1..] {
-    g = gcd(g, c.abs()).unsigned_abs() as i128;
+    g = gcd_i128(g, c);
     if g <= 1 {
       return None;
     }
@@ -1389,9 +1387,9 @@ fn try_sqrt_gaussian(expr: &Expr) -> Option<Expr> {
   let ((rn, rd), (in_, id)) = try_extract_complex_exact(expr)?;
   // Normalize to integers a and b where z = a + b*I
   // Require both parts to be integers (denominator 1 after reducing)
-  let g_r = crate::functions::math_ast::numeric_utils::gcd(rn, rd).abs();
+  let g_r = gcd_i128(rn, rd);
   let (rn, rd) = (rn / g_r, rd / g_r);
-  let g_i = crate::functions::math_ast::numeric_utils::gcd(in_, id).abs();
+  let g_i = gcd_i128(in_, id);
   let (in_, id) = (in_ / g_i, id / g_i);
   // Pure real cases are handled by existing code; skip to avoid duplication
   if in_ == 0 {
@@ -3453,8 +3451,6 @@ fn nice_step_rational(raw: f64) -> Option<(i128, i128)> {
   let g = gcd_i128(sn.abs(), sd.abs()).max(1);
   Some((sn / g, sd / g))
 }
-
-use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Reduce a (numerator, denominator) pair to lowest terms with a positive
 /// denominator.

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{BinaryOperator, Expr, expr_to_string, unevaluated};
 
 /// Hypergeometric0F1[a, z] - confluent hypergeometric limit function
@@ -961,8 +962,6 @@ fn hypergeometric_2f1_regularized_non_positive_c(
   };
   Ok(Some(crate::evaluator::evaluate_expr_to_expr(&product)?))
 }
-
-use crate::functions::math_ast::gcd as gcd_i128;
 
 /// Hypergeometric1F1[a, b, z] - Kummer's confluent hypergeometric function
 fn is_half(expr: &Expr) -> bool {
@@ -2483,7 +2482,6 @@ fn hypergeometric2f1_1_b_c(
   c: i128,
   z: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  use crate::functions::math_ast::numeric_utils::gcd;
   use std::collections::BTreeMap;
 
   let m = c - b; // >= 2
@@ -2508,7 +2506,7 @@ fn hypergeometric2f1_1_b_c(
     }
     let n = sign * prefactor;
     let d = j_fact * mj_fact;
-    let g = gcd(n.abs(), d);
+    let g = gcd_i128(n, d);
     cj.push((n / g, d / g));
   }
 
@@ -2523,14 +2521,13 @@ fn hypergeometric2f1_1_b_c(
     num: i128,
     den: i128,
   ) {
-    use crate::functions::math_ast::numeric_utils::gcd;
     let entry = map.entry(key).or_insert((0, 1));
     let new_num = entry.0 * den + num * entry.1;
     let new_den = entry.1 * den;
     if new_num == 0 {
       *entry = (0, 1);
     } else {
-      let g = gcd(new_num.abs(), new_den.abs());
+      let g = gcd_i128(new_num, new_den);
       *entry = (new_num / g, new_den / g);
     }
   }
@@ -2545,7 +2542,7 @@ fn hypergeometric2f1_1_b_c(
     for i in 1..(b + j) {
       let num = -cn;
       let den = cd * i;
-      let g = gcd(num.abs(), den.abs());
+      let g = gcd_i128(num, den);
       add_rational(&mut collected, (false, m - 1 - j + i), num / g, den / g);
     }
   }
@@ -2555,7 +2552,7 @@ fn hypergeometric2f1_1_b_c(
 
   // Find common denominator across all terms
   let common_den: i128 = collected.values().fold(1i128, |acc, &(_, d)| {
-    let g = gcd(acc, d.abs());
+    let g = gcd_i128(acc, d);
     acc / g * d.abs()
   });
 
@@ -2566,7 +2563,7 @@ fn hypergeometric2f1_1_b_c(
     .collect();
 
   // Find GCD of all scaled numerators
-  let num_gcd = scaled.iter().map(|(_, n)| n.abs()).fold(0i128, gcd);
+  let num_gcd = scaled.iter().map(|(_, n)| n.abs()).fold(0i128, gcd_i128);
 
   if num_gcd == 0 {
     return Ok(Expr::Integer(0));
@@ -2586,7 +2583,7 @@ fn hypergeometric2f1_1_b_c(
   // Overall factor = sign_adjust * num_gcd / common_den
   let factor_num = sign_adjust * num_gcd;
   let factor_den = common_den;
-  let fg = gcd(factor_num.abs(), factor_den);
+  let fg = gcd_i128(factor_num, factor_den);
   let (factor_n, factor_d) = (factor_num / fg, factor_den / fg);
 
   // Build Log[1-z]
@@ -2613,7 +2610,7 @@ fn hypergeometric2f1_1_b_c(
     // Factored coefficient: scaled_num / (sign_adjust * num_gcd)
     let cn = scaled_num * sign_adjust;
     let cd = num_gcd;
-    let cg = gcd(cn.abs(), cd);
+    let cg = gcd_i128(cn, cd);
     let (cn, cd) = (cn / cg, cd / cg);
 
     let mut factors: Vec<Expr> = Vec::new();

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -23,6 +23,7 @@
 //! all give `MusicPitch["G3"]`. The conversions use the standard convention
 //! where middle C is MIDI 60 / C4 and A4 (MIDI 69) is 440 Hz.
 
+use crate::functions::math_ast::gcd;
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, bool_expr, unevaluated,
 };
@@ -1840,8 +1841,6 @@ pub fn music_rest(args: &[Expr]) -> Option<Expr> {
     _ => None,
   }
 }
-
-use crate::functions::math_ast::gcd;
 
 /// Reduce `n/d` to lowest terms with a positive denominator, returning an
 /// `Integer` when the denominator is 1 and a `Rational[n, d]` otherwise.

--- a/src/functions/polynomial_ast/decompose.rs
+++ b/src/functions/polynomial_ast/decompose.rs
@@ -1,4 +1,5 @@
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 use super::coefficient::collect_additive_terms;
@@ -56,13 +57,11 @@ pub fn decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 type Rat = (i128, i128); // (numerator, denominator), always reduced
 
-use crate::functions::math_ast::gcd as rat_gcd;
-
 fn rat_reduce(n: i128, d: i128) -> Rat {
   if d == 0 {
     return (n, d);
   }
-  let g = rat_gcd(n, d);
+  let g = gcd_i128(n, d);
   if d < 0 {
     (-n / g, -d / g)
   } else {

--- a/src/functions/polynomial_ast/linear_programming.rs
+++ b/src/functions/polynomial_ast/linear_programming.rs
@@ -11,6 +11,7 @@
 //! generous iteration budget so it can never cycle on degenerate problems.
 
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd_bigint;
 use crate::syntax::{Expr, unevaluated};
 use num_bigint::BigInt;
 use num_traits::{One, Signed, Zero};
@@ -46,7 +47,7 @@ impl Rat {
       self.num = -&self.num;
       self.den = -&self.den;
     }
-    let g = gcd_big(&self.num.abs(), &self.den.abs());
+    let g = gcd_bigint(&self.num, &self.den);
     if !g.is_zero() && !g.is_one() {
       self.num /= &g;
       self.den /= &g;
@@ -93,17 +94,6 @@ impl Rat {
       }
     }
   }
-}
-
-fn gcd_big(a: &BigInt, b: &BigInt) -> BigInt {
-  let mut a = a.clone();
-  let mut b = b.clone();
-  while !b.is_zero() {
-    let t = &a % &b;
-    a = b;
-    b = t;
-  }
-  a
 }
 
 fn bigint_to_expr(n: &BigInt) -> Expr {

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -2,8 +2,10 @@
 use super::*;
 use crate::InterpreterError;
 use crate::functions::math_ast::{
-  expr_to_f64, expr_to_i128, expr_to_rational, gcd as gcd_i128, is_sqrt,
+  expr_to_f64, expr_to_i128, expr_to_rational, gcd as gcd_i128, gcd_bigint,
+  is_sqrt,
 };
+
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, bool_expr, unevaluated,
 };
@@ -345,7 +347,7 @@ fn factor_int_coeffs(factor: &Expr, var: &str) -> Option<Vec<i128>> {
   }
   let mut g = 0i128;
   for &c in &coeffs {
-    g = gcd_i128(g, c.abs());
+    g = gcd_i128(g, c);
   }
   if g > 1 {
     for c in coeffs.iter_mut() {
@@ -1918,8 +1920,6 @@ fn sturm_real_root_count(coeffs: &[i128]) -> usize {
     }
     v
   }
-
-  use crate::functions::math_ast::gcd_bigint;
 
   fn content_reduce(v: &[BigInt]) -> Vec<BigInt> {
     let mut g = BigInt::ZERO;

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -8,7 +8,7 @@ use crate::syntax::{
 };
 
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
-use crate::functions::math_ast::make_sqrt;
+use crate::functions::math_ast::{gcd as gcd_i128, make_sqrt};
 
 // ─── Reduce ──────────────────────────────────────────────────────────
 
@@ -2870,15 +2870,11 @@ impl Rat {
   }
 }
 
-fn rat_gcd(a: i128, b: i128) -> i128 {
-  crate::functions::math_ast::gcd(a, b).max(1)
-}
-
 fn rat_simplify(num: i128, den: i128) -> Rat {
   if den == 0 {
     return Rat { num, den };
   }
-  let g = rat_gcd(num, den);
+  let g = gcd_i128(num, den).max(1);
   let (mut n, mut d) = (num / g, den / g);
   if d < 0 {
     n = -n;

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -1,11 +1,11 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
+use crate::functions::calculus_ast::simplify;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
 };
-
-use crate::functions::calculus_ast::simplify;
 
 // ─── Refine ─────────────────────────────────────────────────────────
 
@@ -10062,17 +10062,6 @@ fn try_trig_polynomial_simplify(expr: &Expr) -> Option<Expr> {
   best
 }
 
-fn integer_gcd(mut a: i128, mut b: i128) -> i128 {
-  a = a.abs();
-  b = b.abs();
-  while b != 0 {
-    let t = b;
-    b = a % b;
-    a = t;
-  }
-  a
-}
-
 /// Perform Pythagorean substitution and power reduction using integer arithmetic.
 /// If `sub_sin`: substitute Sin²=1-Cos², producing polynomial in Cos.
 /// If `!sub_sin`: substitute Cos²=1-Sin², producing polynomial in Sin.
@@ -10180,7 +10169,7 @@ fn try_trig_sub_and_reduce(
   // Step 3: Simplify - find GCD of all numerators and denominator
   let mut g = common_denom;
   for &v in angle_coeffs.values() {
-    g = integer_gcd(g, v);
+    g = gcd_i128(g, v);
   }
   let final_denom = common_denom / g;
 
@@ -10191,7 +10180,7 @@ fn try_trig_sub_and_reduce(
   // Factor out GCD of all simplified numerators
   let mut num_gcd = 0i128;
   for &v in simplified_coeffs.values() {
-    num_gcd = integer_gcd(num_gcd, v);
+    num_gcd = gcd_i128(num_gcd, v);
   }
   if num_gcd == 0 {
     return None;

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -3,6 +3,7 @@
 //! These functions work directly with `Expr` AST nodes.
 
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
@@ -179,21 +180,11 @@ struct QuadNum {
   d: i128,         // square-free radicand > 1 (only meaningful when b != 0)
 }
 
-fn qi_gcd(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = a % b;
-    a = b;
-    b = t;
-  }
-  a.max(1)
-}
-
 fn qi_reduce(n: i128, d: i128) -> (i128, i128) {
   if d == 0 {
     return (n, 0);
   }
-  let g = qi_gcd(n, d);
+  let g = gcd_i128(n, d).max(1);
   let (mut n, mut d) = (n / g, d / g);
   if d < 0 {
     n = -n;

--- a/src/functions/quantity_ast.rs
+++ b/src/functions/quantity_ast.rs
@@ -1,5 +1,5 @@
 use crate::InterpreterError;
-use crate::functions::math_ast::{is_sqrt, make_sqrt};
+use crate::functions::math_ast::{gcd as gcd_i128, is_sqrt, make_sqrt};
 use crate::syntax::{BinaryOperator, Expr, bool_expr, unevaluated};
 use std::collections::BTreeMap;
 
@@ -720,8 +720,6 @@ fn resolve_lowercase_unit(name: &str) -> Option<String> {
   None
 }
 
-use crate::functions::math_ast::gcd;
-
 // ─── Compound unit decomposition ────────────────────────────────────────────
 
 /// A decomposed compound unit: list of (base_unit_name, exponent) pairs
@@ -1023,7 +1021,7 @@ fn decompose_unit_expr(expr: &Expr) -> Option<CompoundUnitInfo> {
             *dims.entry(*dim).or_insert(0) += dim_exp * exp;
           }
         }
-        let g = gcd(si_numer, si_denom);
+        let g = gcd_i128(si_numer, si_denom);
         return Some(CompoundUnitInfo {
           components,
           si_numer: si_numer / g,
@@ -1078,7 +1076,7 @@ fn decompose_unit_expr(expr: &Expr) -> Option<CompoundUnitInfo> {
           // SI factor: left / right
           left_info.si_numer *= right_info.si_denom;
           left_info.si_denom *= right_info.si_numer;
-          let g = gcd(left_info.si_numer, left_info.si_denom);
+          let g = gcd_i128(left_info.si_numer, left_info.si_denom);
           left_info.si_numer /= g;
           left_info.si_denom /= g;
           // Merge dimensions
@@ -1096,7 +1094,7 @@ fn decompose_unit_expr(expr: &Expr) -> Option<CompoundUnitInfo> {
           }
           left_info.si_numer *= right_info.si_numer;
           left_info.si_denom *= right_info.si_denom;
-          let g = gcd(left_info.si_numer, left_info.si_denom);
+          let g = gcd_i128(left_info.si_numer, left_info.si_denom);
           left_info.si_numer /= g;
           left_info.si_denom /= g;
           for (dim, exp) in &right_info.dimensions {
@@ -1118,7 +1116,7 @@ fn decompose_unit_expr(expr: &Expr) -> Option<CompoundUnitInfo> {
             .collect();
           let (pn, pd) =
             rational_pow(base_info.si_numer, base_info.si_denom, exp_val);
-          let g = gcd(pn, pd);
+          let g = gcd_i128(pn, pd);
           let dims: BTreeMap<Dimension, i64> = base_info
             .dimensions
             .iter()
@@ -1147,7 +1145,7 @@ fn decompose_unit_expr(expr: &Expr) -> Option<CompoundUnitInfo> {
             }
             r.si_numer *= info.si_numer;
             r.si_denom *= info.si_denom;
-            let g = gcd(r.si_numer, r.si_denom);
+            let g = gcd_i128(r.si_numer, r.si_denom);
             r.si_numer /= g;
             r.si_denom /= g;
             for (dim, exp) in &info.dimensions {
@@ -1175,7 +1173,7 @@ fn decompose_unit_expr(expr: &Expr) -> Option<CompoundUnitInfo> {
         .collect();
       let (pn, pd) =
         rational_pow(base_info.si_numer, base_info.si_denom, exp_val);
-      let g = gcd(pn, pd);
+      let g = gcd_i128(pn, pd);
       let dims: BTreeMap<Dimension, i64> = base_info
         .dimensions
         .iter()
@@ -1237,7 +1235,7 @@ fn simplify_compound_unit(
         let (pn, pd) = rational_pow(unit_conv_n, unit_conv_d, *exp);
         conv_numer *= pn;
         conv_denom *= pd;
-        let g = gcd(conv_numer, conv_denom);
+        let g = gcd_i128(conv_numer, conv_denom);
         conv_numer /= g;
         conv_denom /= g;
         total_exp += exp;
@@ -1717,7 +1715,7 @@ fn multiply_magnitude_by_rational(
   denom: i128,
 ) -> Result<Expr, InterpreterError> {
   // Simplify the conversion factor
-  let g = gcd(numer, denom);
+  let g = gcd_i128(numer, denom);
   let numer = numer / g;
   let denom = denom / g;
 
@@ -1729,7 +1727,7 @@ fn multiply_magnitude_by_rational(
     Expr::Integer(m) => {
       let result_numer = m * numer;
       let result_denom = denom;
-      let g2 = gcd(result_numer, result_denom);
+      let g2 = gcd_i128(result_numer, result_denom);
       let rn = result_numer / g2;
       let rd = result_denom / g2;
       if rd == 1 {
@@ -2703,7 +2701,7 @@ fn power_unit_expr(unit: &Expr, p: i128, q: i128) -> Option<Expr> {
     if new_n == 0 {
       continue;
     }
-    let g = gcd(new_n.abs(), new_d.abs());
+    let g = gcd_i128(new_n, new_d);
     let (rn, rd) = (new_n / g, new_d / g);
     // Ensure positive denominator
     let (rn, rd) = if rd < 0 { (-rn, -rd) } else { (rn, rd) };

--- a/src/functions/resolve_ast.rs
+++ b/src/functions/resolve_ast.rs
@@ -6,6 +6,7 @@
 //! c > 0 return their conditions.
 
 use crate::InterpreterError;
+use crate::functions::math_ast::gcd as gcd_i128;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
@@ -291,8 +292,6 @@ fn contains_imaginary(expr: &Expr) -> bool {
 //    complexes a non-constant polynomial always has zeros (and a non-empty
 //    complement), so those collapse without needing separability.
 
-use crate::functions::math_ast::gcd;
-
 /// Extract a rational literal (`Integer` or `Rational[n, d]`) from a leaf.
 fn expr_to_rational(e: &Expr) -> Option<(i128, i128)> {
   match e {
@@ -322,7 +321,7 @@ impl Q {
   }
   fn new(n: i128, d: i128) -> Q {
     let (mut n, mut d) = if d < 0 { (-n, -d) } else { (n, d) };
-    let g = gcd(n, d);
+    let g = gcd_i128(n, d);
     if g != 0 {
       n /= g;
       d /= g;

--- a/src/functions/ztransform_ast.rs
+++ b/src/functions/ztransform_ast.rs
@@ -14,6 +14,7 @@
 
 use crate::InterpreterError;
 use crate::functions::calculus_ast::is_constant_wrt;
+use crate::functions::math_ast::gcd;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -389,8 +390,6 @@ fn as_power(expr: &Expr) -> Option<(Expr, Expr)> {
     _ => None,
   }
 }
-
-use crate::functions::math_ast::gcd;
 
 fn plus(terms: Vec<Expr>) -> Expr {
   Expr::FunctionCall {


### PR DESCRIPTION
More gcd function removal.  Also remove unneeded abs() calls to the arguments or return value, regularize the name to gcd_i128 in more places, remove numeric_utils:: namespace usage for gcd.