### PR TITLE
Implement ListPlay for playground and studio

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -2310,7 +2310,7 @@ RankedMax,k-th largest element,✅,pure,8.0,2355
 WindowFrame,notebook UI,🚫,None,3.0,2355
 FindProcessParameters,stochastic process fitting,🚫,None,9.0,2360
 KirchhoffMatrix,Builds the Kirchhoff (Laplacian) matrix of a graph,✅,none,8.0,2360
-ListPlay,audio playback,🚫,None,2.0,2360
+ListPlay,Plays a list of amplitude levels as a sound,✅,None,2.0,2360
 SmoothHistogram3D,3D visualization,🚫,None,8.0,2360
 SyntaxQ,Test if a string is valid Wolfram Language syntax,✅,1,2.0,2360
 SurfaceArea,Total boundary area of a 3D solid region,✅,pure,12.0,2361

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -10465,6 +10465,18 @@ pub fn evaluate_function_call_ast_inner(
     });
   }
 
+  // ListPlay[{a1, a2, …}, opts…] plays a list of amplitude levels as a sound.
+  // wolframscript normalizes the amplitudes into [-1, 1] and wraps them in a
+  // Sound[SampledSoundList[…]] object (sampled at 8000 Hz by default). Building
+  // that same object makes the result render as -Sound-, report Head -> Sound,
+  // and — in the visual hosts — play the normalized waveform.
+  if name == "ListPlay"
+    && !args.is_empty()
+    && let Some(sound) = crate::functions::sound::list_play(args)
+  {
+    return Ok(sound);
+  }
+
   // Check if the function is a known but unimplemented Wolfram Language function.
   // Some symbolic CAS objects (Root, RootSum, …) intentionally stay
   // unevaluated as their canonical form, so flagging them as

--- a/src/functions/sound.rs
+++ b/src/functions/sound.rs
@@ -22,24 +22,60 @@ use crate::syntax::Expr;
 /// `SampleRate` wolframscript uses for `Play` (8000 samples per second).
 const SAMPLE_RATE: u32 = 8000;
 
-/// Collect every `Play[f, {t, tmin, tmax}]` segment reachable inside a `Sound`
-/// expression, recursing through nested lists (so `Sound[{Play[…], Play[…]}]`
-/// yields both segments in order).
-fn collect_play_segments<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
+/// Collect every playable segment reachable inside a `Sound` expression into
+/// concrete amplitude samples plus a sample rate, recursing through nested
+/// lists (so `Sound[{Play[…], Play[…]}]` yields both segments in order).
+/// Recognizes `Play[f, {t, tmin, tmax}]` (synthesized) and
+/// `SampledSoundList[{samples…}, rate]` (produced by `ListPlay`).
+fn collect_segments(expr: &Expr, out: &mut Vec<(Vec<f64>, u32)>) {
   match expr {
-    Expr::FunctionCall { name, .. } if name == "Play" => out.push(expr),
+    Expr::FunctionCall { name, .. } if name == "Play" => {
+      if let Some(seg) = sample_play(expr) {
+        out.push((seg, SAMPLE_RATE));
+      }
+    }
+    Expr::FunctionCall { name, args } if name == "SampledSoundList" => {
+      if let Some(seg) = sample_sampled_sound_list(args) {
+        out.push(seg);
+      }
+    }
     Expr::FunctionCall { args, .. } => {
       for a in args.iter() {
-        collect_play_segments(a, out);
+        collect_segments(a, out);
       }
     }
     Expr::List(items) => {
       for a in items.iter() {
-        collect_play_segments(a, out);
+        collect_segments(a, out);
       }
     }
     _ => {}
   }
+}
+
+/// Extract amplitude samples and a sample rate from a
+/// `SampledSoundList[{s1, s2, …}, rate]` primitive. The samples are the final
+/// amplitudes (already normalized by `ListPlay`); they are only clipped to
+/// [-1, 1] before quantizing. The rate defaults to 8000 Hz when absent or
+/// non-positive. Returns `None` for an empty or non-numeric sample list.
+fn sample_sampled_sound_list(args: &[Expr]) -> Option<(Vec<f64>, u32)> {
+  let Expr::List(items) = args.first()? else {
+    return None;
+  };
+  if items.is_empty() {
+    return None;
+  }
+  let mut samples = Vec::with_capacity(items.len());
+  for it in items.iter() {
+    samples.push(try_eval_to_f64(it)?.clamp(-1.0, 1.0));
+  }
+  let rate = args
+    .get(1)
+    .and_then(try_eval_to_f64)
+    .filter(|r| *r > 0.0)
+    .map(|r| r.round() as u32)
+    .unwrap_or(SAMPLE_RATE);
+  Some((samples, rate))
 }
 
 /// Sample a single `Play[f, {t, tmin, tmax}]` segment into amplitude values
@@ -97,15 +133,19 @@ fn sample_play(play: &Expr) -> Option<Vec<f64>> {
 /// the samples together with the sample rate in Hz, or `None` when the
 /// expression contains no samplable `Play` segment.
 pub fn sound_to_samples(sound_expr: &Expr) -> Option<(Vec<f64>, u32)> {
-  let mut plays = Vec::new();
-  collect_play_segments(sound_expr, &mut plays);
-  let mut samples = Vec::new();
-  for play in plays {
-    if let Some(seg) = sample_play(play) {
-      samples.extend(seg);
-    }
+  let mut segments = Vec::new();
+  collect_segments(sound_expr, &mut segments);
+  if segments.is_empty() {
+    return None;
   }
-  (!samples.is_empty()).then_some((samples, SAMPLE_RATE))
+  // Use the first segment's sample rate for the whole sound (the common case
+  // is a single segment; mixed-rate Sound objects are rare).
+  let rate = segments[0].1;
+  let mut samples = Vec::new();
+  for (seg, _) in &segments {
+    samples.extend_from_slice(seg);
+  }
+  (!samples.is_empty()).then_some((samples, rate))
 }
 
 /// Encode interleaved 16-bit PCM samples as a little-endian WAV byte stream.
@@ -189,10 +229,10 @@ pub fn expr_to_wav_bytes(expr: &Expr) -> Option<Vec<u8>> {
 /// from raw sample data (Hz).
 pub(crate) const AUDIO_SAMPLE_RATE: f64 = 44100.0;
 
-/// Extract the sample rate from an `Audio[data, opts…]` argument list
-/// (`SampleRate -> r`), falling back to the 44100 Hz default.
-pub(crate) fn audio_sample_rate(args: &[Expr]) -> f64 {
-  for opt in args.iter().skip(1) {
+/// Find a positive `SampleRate -> r` option in an option list, falling back to
+/// `default` when absent or non-positive.
+fn option_sample_rate(opts: &[Expr], default: f64) -> f64 {
+  for opt in opts.iter() {
     if let Expr::Rule {
       pattern,
       replacement,
@@ -208,7 +248,59 @@ pub(crate) fn audio_sample_rate(args: &[Expr]) -> f64 {
       }
     }
   }
-  AUDIO_SAMPLE_RATE
+  default
+}
+
+/// Extract the sample rate from an `Audio[data, opts…]` argument list
+/// (`SampleRate -> r`), falling back to the 44100 Hz default.
+pub(crate) fn audio_sample_rate(args: &[Expr]) -> f64 {
+  option_sample_rate(args.get(1..).unwrap_or(&[]), AUDIO_SAMPLE_RATE)
+}
+
+/// Sample rate `wolframscript` uses for `ListPlay` sampled sounds (Hz).
+const LIST_PLAY_SAMPLE_RATE: f64 = 8000.0;
+
+/// Build the `Sound[SampledSoundList[{samples…}, rate]]` object that
+/// `ListPlay[data, opts…]` produces. `data` is a list of amplitude levels;
+/// wolframscript normalizes them linearly so the minimum maps to -1 and the
+/// maximum to +1 — capped at 0.99999 to stay inside the asymmetric 16-bit
+/// positive range — then samples at `SampleRate` (default 8000 Hz). A constant
+/// (or single-element) signal is silent, yielding all-zero samples. Building
+/// this object makes `ListPlay` render as `-Sound-`, report `Head -> Sound`,
+/// and play the normalized waveform in the visual hosts. Returns `None` when
+/// the first argument is not a non-empty numeric list (so `ListPlay` stays
+/// unevaluated).
+pub fn list_play(args: &[Expr]) -> Option<Expr> {
+  let Expr::List(items) = args.first()? else {
+    return None;
+  };
+  if items.is_empty() {
+    return None;
+  }
+  let mut data = Vec::with_capacity(items.len());
+  for it in items.iter() {
+    data.push(try_eval_to_f64(it)?);
+  }
+  let min = data.iter().copied().fold(f64::INFINITY, f64::min);
+  let max = data.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+  let normalized: Vec<Expr> = if max > min {
+    data
+      .iter()
+      .map(|&x| Expr::Real((2.0 * (x - min) / (max - min) - 1.0).min(0.99999)))
+      .collect()
+  } else {
+    vec![Expr::Real(0.0); data.len()]
+  };
+  let rate =
+    option_sample_rate(&args[1..], LIST_PLAY_SAMPLE_RATE).round() as i128;
+  Some(Expr::FunctionCall {
+    name: "Sound".to_string(),
+    args: vec![Expr::FunctionCall {
+      name: "SampledSoundList".to_string(),
+      args: vec![Expr::List(normalized.into()), Expr::Integer(rate)].into(),
+    }]
+    .into(),
+  })
 }
 
 /// File extensions recognized as audio sources for `Audio["path.ext"]`

--- a/tests/cli/ListPlay.md
+++ b/tests/cli/ListPlay.md
@@ -1,0 +1,17 @@
+# `ListPlay`
+
+Plays a list of amplitude levels as a sound. The amplitudes are normalized so
+the minimum maps to `-1` and the maximum to `+1`, then sampled at `SampleRate`
+(8000 Hz by default). The result is a `Sound` object, so it reports
+`Head -> Sound` and — in the visual hosts (the Woxi Playground and Woxi Studio)
+— renders a playable audio widget.
+
+```scrut
+$ wo 'Head[ListPlay[{0.1, 0.2, 0.3, -0.1}]]'
+Sound
+```
+
+```scrut
+$ wo 'Head[ListPlay[Table[Sin[2 Pi 50 t], {t, 0, 1, 1./2000}]]]'
+Sound
+```

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -942,6 +942,50 @@ mod interpreter_tests {
     assert_eq!(bytes.len(), 44 + (8000 * 7 / 10) * 2);
   }
 
+  #[test]
+  fn test_list_play_synthesizes_audio_in_visual_mode() {
+    // In visual mode (playground / woxi-studio), ListPlay[{levels…}] is
+    // normalized, encoded as a WAV, and exposed via the `sound` channel so the
+    // hosts render a playable audio widget instead of the -Sound- echo.
+    clear_state();
+    let r = interpret_with_stdout("ListPlay[{0.1, 0.2, 0.3, -0.1}]").unwrap();
+    let audio = r.sound.expect("ListPlay should produce synthesized audio");
+    let bytes = base64::engine::Engine::decode(
+      &base64::engine::general_purpose::STANDARD,
+      &audio.base64,
+    )
+    .expect("sound should be valid base64");
+    assert_eq!(&bytes[0..4], b"RIFF");
+    assert_eq!(&bytes[8..12], b"WAVE");
+    // Default ListPlay sample rate is 8000 Hz.
+    assert_eq!(u32::from_le_bytes(bytes[24..28].try_into().unwrap()), 8000);
+    // Four normalized samples, 16-bit mono, byte-verified against wolframscript.
+    assert_eq!(bytes.len(), 44 + 4 * 2);
+    assert_eq!(&bytes[44..52], &[0, 0, 0, 64, 255, 127, 0, 128]);
+  }
+
+  #[test]
+  fn test_list_play_target_waveform_in_visual_mode() {
+    // The motivating example: a 50 Hz sine sampled at 2000 Hz over 1 second
+    // (2001 samples) plays as a Sound in the visual hosts.
+    clear_state();
+    let r = interpret_with_stdout(
+      "ListPlay[Table[Sin[2 Pi 50 t], {t, 0, 1, 1./2000}]]",
+    )
+    .unwrap();
+    assert_eq!(r.result, "-Sound-");
+    let audio = r.sound.expect("ListPlay should produce synthesized audio");
+    let bytes = base64::engine::Engine::decode(
+      &base64::engine::general_purpose::STANDARD,
+      &audio.base64,
+    )
+    .expect("sound should be valid base64");
+    assert_eq!(&bytes[0..4], b"RIFF");
+    assert_eq!(u32::from_le_bytes(bytes[24..28].try_into().unwrap()), 8000);
+    // 2001 samples, 16-bit mono.
+    assert_eq!(bytes.len(), 44 + 2001 * 2);
+  }
+
   /// Decode the base64 WAV payload of a captured audio output.
   fn decode_wav_bytes(audio: &woxi::AudioOutput) -> Vec<u8> {
     assert_eq!(audio.mime, "audio/wav");

--- a/tests/miscellaneous_tests/high_level_functions.rs
+++ b/tests/miscellaneous_tests/high_level_functions.rs
@@ -4701,6 +4701,55 @@ mod high_level_functions {
     }
 
     #[test]
+    fn test_list_play_renders_as_sound() {
+      // ListPlay builds a Sound object: it renders as -Sound- and reports
+      // Head -> Sound, matching wolframscript.
+      assert_eq!(
+        interpret("ListPlay[{0.1, 0.2, 0.3, -0.1}]").unwrap(),
+        "-Sound-"
+      );
+      assert_eq!(
+        interpret("Head[ListPlay[{0.1, 0.2, 0.3, -0.1}]]").unwrap(),
+        "Sound"
+      );
+    }
+
+    #[test]
+    fn test_export_wav_list_play() {
+      // ListPlay normalizes the amplitudes so the minimum maps to -1 and the
+      // maximum to +1 (capped at 0.99999), then samples at 8000 Hz. Every byte
+      // below is verified against wolframscript's WAV export of the same call:
+      //   {0.1, 0.2, 0.3, -0.1} -> {~0, 0.5, 0.99999, -1.} -> PCM
+      //   0x0000, 0x4000, 0x7FFF, 0x8000.
+      let tmp = std::env::temp_dir().join("woxi_test_list_play.wav");
+      let path = tmp.display().to_string();
+      let result = interpret(&format!(
+        "Export[\"{path}\", ListPlay[{{0.1, 0.2, 0.3, -0.1}}]]"
+      ))
+      .unwrap();
+      assert_eq!(result, path);
+      let frames = assert_wav(&tmp, 8000);
+      assert_eq!(frames, 4, "four samples");
+      let bytes = std::fs::read(&tmp).unwrap();
+      assert_eq!(&bytes[44..52], &[0, 0, 0, 64, 255, 127, 0, 128]);
+      std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn test_export_wav_list_play_sample_rate() {
+      // The SampleRate option flows into the sampled sound.
+      let tmp = std::env::temp_dir().join("woxi_test_list_play_rate.wav");
+      let path = tmp.display().to_string();
+      let result = interpret(&format!(
+        "Export[\"{path}\", ListPlay[{{0.5, -0.5}}, SampleRate -> 44100]]"
+      ))
+      .unwrap();
+      assert_eq!(result, path);
+      assert_wav(&tmp, 44100);
+      std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
     fn test_export_wav_explicit_format() {
       // The format can be given explicitly instead of via the extension.
       let tmp = std::env::temp_dir().join("woxi_test_explicit_wav.bin");


### PR DESCRIPTION
## Summary

Implements `ListPlay[{levels…}, opts]` — plays a list of amplitude levels as a sound, matching the motivating example:

```wolfram
ListPlay[Table[Sin[2 Pi 50 t], {t, 0, 1, 1./2000}]]
```

## Behavior (verified against wolframscript)

- Normalizes amplitudes linearly so `min -> -1`, `max -> +1`, capped at `0.99999` to stay inside the asymmetric 16-bit positive range (matching WS's `SampledSoundList` output).
- Wraps the samples in `Sound[SampledSoundList[{samples…}, rate]]`, sampled at **8000 Hz** by default; the `SampleRate` option is honored.
- Constant data yields silence (all-zero samples).
- Renders as `-Sound-` in the CLI and reports `Head -> Sound`.

## Playground & Studio

Because the result is a `Sound` object, it flows through the existing
`render_sound_if_needed -> sound_to_wav_base64 -> sound_to_samples` pipeline.
`sound_to_samples` now samples `SampledSoundList` segments in addition to `Play`,
so `ListPlay` plays a WAV in both the **Woxi Playground** (`<audio>` element) and
**Woxi Studio** (external player) with **no host-side changes** — both already
consume `InterpretResult.sound`.

## Tests

- Byte-verified WAV export against wolframscript's own export (`{0.1,0.2,0.3,-0.1} -> PCM 0x0000,0x4000,0x7FFF,0x8000`).
- `SampleRate` option flow-through.
- Visual-mode capture path (`InterpretResult.sound`) for both the simple case and the target waveform.
- `-Sound-` rendering + `Head -> Sound`.
- CLI doc test (`tests/cli/ListPlay.md`).
- Full suite: 24,739 tests pass, 0 failures.

`functions.csv`: `ListPlay` flipped 🚫 -> ✅.