### PR TITLE
Fix Simplify of radical-times-radical-sum products

### DIFF
--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -4893,13 +4893,28 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
             // → 9*(1 + Sqrt[19]) at 10 = 10, but 4*Sqrt[2] - 8*Sqrt[30]
             // stays expanded at 17 = 17 — differential fuzzer, seed
             // 12449481718952209155; all wolframscript-verified).
+            //
+            // One extra guard for a sum whose EVERY term is a pure Sqrt:
+            // on the unit-cofactor tie the content-factored and distributed
+            // forms cost the same, and WL keeps the factored form only when
+            // it avoids a leading minus (6*Sqrt[399] - 6*Sqrt[2261] →
+            // 6*(Sqrt[399] - Sqrt[2261]) but -6*Sqrt[399] + 6*Sqrt[2261]
+            // stays distributed). A bare-constant term (9 + 9*Sqrt[19],
+            // -9 + 9*Sqrt[19] → 9*(-1 + Sqrt[19])) is exempt — the constant
+            // makes the factored form a genuine win regardless of sign.
+            // Differential fuzzer, seed 14323847961001369104;
+            // wolframscript-verified.
             None => {
               let cand_cost = wl_simplify_count(&candidate);
               let best_cost = wl_simplify_count(&best);
               let all_unit = coeffs
                 .iter()
                 .all(|(n, d)| n.abs() * g_den == d.abs() * g_num);
-              cand_cost < best_cost || (cand_cost == best_cost && all_unit)
+              let all_sqrt =
+                terms.iter().all(|t| term_sqrt_radicand(t).is_some());
+              let first_negative = coeffs.first().is_some_and(|(n, _)| *n < 0);
+              let tie_ok = all_unit && !(all_sqrt && first_negative);
+              cand_cost < best_cost || (cand_cost == best_cost && tie_ok)
             }
           };
           if accept {
@@ -5143,7 +5158,18 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
       } else {
         None
       };
-      if let Some(full) = full_extraction {
+      // The full radical+content extraction only wins when pulling the
+      // common Sqrt[g] out collapses a cofactor to a bare integer — i.e.
+      // some radicand equals g (Sqrt[8] - Sqrt[24] → -2*Sqrt[2]*(-1 +
+      // Sqrt[3]): radicand 2 == g, dropping a whole Sqrt). When every
+      // cofactor stays a Sqrt (2*Sqrt[57] - 2*Sqrt[323], g = 19: 57/19 = 3
+      // and 323/19 = 17 both survive) pulling Sqrt[19] out costs MORE than
+      // the content-only 2*(Sqrt[57] - Sqrt[323]) that candidate 5 already
+      // built, so keep that instead. Differential fuzzer, seed
+      // 14323847961001369104; wolframscript-verified.
+      if let Some(full) = full_extraction
+        && radicands.contains(&g)
+      {
         best = full;
       } else if g > 1 {
         let divided: Result<Vec<Expr>, _> = terms

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -14509,6 +14509,44 @@ mod fuzz_diff_round_2026_07_17 {
     assert_case("Simplify[8 - 2*Sqrt[3]]", "8 - 2*Sqrt[3]");
     assert_case("Simplify[-3*Sqrt[2] + Sqrt[10]]", "Sqrt[2]*(-3 + Sqrt[5])");
     assert_case("Simplify[4*Sqrt[2] - 8*Sqrt[30]]", "4*Sqrt[2] - 8*Sqrt[30]");
+
+    // case seed 14323847961001369104: a radical times a sum of radicals.
+    // Pulling the shared Sqrt out only wins when a cofactor collapses to a
+    // bare integer; here every cofactor stays a Sqrt, so the content-only
+    // form is kept, and on the unit-cofactor cost tie WL keeps it factored
+    // only when the leading term stays positive.
+    assert_case(
+      "Simplify[Times[Subtract[Sqrt[3], Sqrt[17]], Times[Sqrt[19], Times[-3, Sqrt[28]]]]]",
+      "-6*Sqrt[399] + 6*Sqrt[2261]",
+    );
+    assert_case(
+      "Simplify[2*Sqrt[19]*(Sqrt[3] - Sqrt[17])]",
+      "2*(Sqrt[57] - Sqrt[323])",
+    );
+    assert_case(
+      "Simplify[6*Sqrt[133]*(Sqrt[3] - Sqrt[17])]",
+      "6*(Sqrt[399] - Sqrt[2261])",
+    );
+    assert_case(
+      "Simplify[Sqrt[19]*(Sqrt[3] - Sqrt[17])]",
+      "Sqrt[57] - Sqrt[323]",
+    );
+    // unit-cofactor cost tie: factored only when the leading term is positive
+    assert_case("Simplify[2*Sqrt[3] - 2*Sqrt[5]]", "2*(Sqrt[3] - Sqrt[5])");
+    assert_case(
+      "Simplify[6*Sqrt[399] - 6*Sqrt[2261]]",
+      "6*(Sqrt[399] - Sqrt[2261])",
+    );
+    // non-unit cofactor: strict cost win keeps the content form even with a
+    // negative leading term
+    assert_case(
+      "Simplify[-12*Sqrt[5] + 3*Sqrt[19]]",
+      "3*(-4*Sqrt[5] + Sqrt[19])",
+    );
+    assert_case(
+      "Simplify[12*Sqrt[5] - 3*Sqrt[19]]",
+      "12*Sqrt[5] - 3*Sqrt[19]",
+    );
   }
 
   #[test]


### PR DESCRIPTION
## What

`make fuzz-diff` (differential fuzzer vs wolframscript, seed `1784750589790375000`, case seed `14323847961001369104`) flagged one divergence:

```
Simplify[(Sqrt[3] - Sqrt[17]) * Sqrt[19] * -3 * Sqrt[28]]
  woxi:   6*Sqrt[133]*(-Sqrt[3] + Sqrt[17])
  oracle: -6*Sqrt[399] + 6*Sqrt[2261]
```

Value-correct, but the form diverged. Two decoded rules in the radical-sum branch of Simplify's candidate selection:

1. **Full radical extraction was unconditional.** Candidate 6 always pulled the shared `Sqrt[g]` out of a sum of radicals. That only wins when a cofactor collapses to a bare integer (some radicand `== g`, e.g. `Sqrt[8] - Sqrt[24] -> -2*Sqrt[2]*(-1 + Sqrt[3])`); otherwise it costs *more* than the content-only form (`2*Sqrt[57] - 2*Sqrt[323]` should stay `2*(Sqrt[57] - Sqrt[323])`, not `2*Sqrt[19]*(Sqrt[3] - Sqrt[17])`). Now gated on `radicands.contains(&g)`.

2. **Unit-cofactor SimplifyCount tie leading-sign rule.** On the tie between the content-factored and distributed forms, WL keeps the factored form only when it avoids a leading minus: `6*Sqrt[399] - 6*Sqrt[2261]` factors, but `-6*Sqrt[399] + 6*Sqrt[2261]` stays distributed. A bare-constant term exempts the sum (`-9 + 9*Sqrt[19] -> 9*(-1 + Sqrt[19])`).

## Verification

- Full fuzzer batch replayed with the original seed: **200/200 clean** (was 1 divergence).
- `cargo nextest run`: **24734/24734 pass**, including new regression cases in `simplify_radical_and_content_extraction`.

## Known pre-existing (not addressed)

`Simplify[-6*Sqrt[399] + 6*Sqrt[2261]]` given the *already-distributed* sum directly still returns `-6*(Sqrt[399] - Sqrt[2261])` (a negative-content extraction produced upstream in `simplify_expr_inner`). This is input-form-dependent, predates this change, and belongs to the documented radical-canonicalization class; the fuzzer's product-form input is fixed.