### PR TITLE
Remove some math_ast wrapper functions

### DIFF
--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1947,7 +1947,7 @@ pub fn dispatch_math_functions(
         name: pname,
         args: dargs,
       } = &args[0]
-        && let Some(slice) = crate::functions::math_ast::distributions_slice(
+        && let Some(slice) = crate::functions::math_ast::process_slice_distribution(
           pname, dargs, &args[1],
         )
       {
@@ -1957,7 +1957,7 @@ pub fn dispatch_math_functions(
     }
     "CorrelationFunction" if args.len() == 3 => {
       if let Some(result) =
-        crate::functions::math_ast::statistics_process_correlation(
+        crate::functions::math_ast::process_correlation(
           &args[0], &args[1], &args[2],
         )
       {
@@ -1967,7 +1967,7 @@ pub fn dispatch_math_functions(
     }
     "AbsoluteCorrelationFunction" if args.len() == 3 => {
       if let Some(result) =
-        crate::functions::math_ast::statistics_process_absolute_correlation(
+        crate::functions::math_ast::process_absolute_correlation(
           &args[0], &args[1], &args[2],
         )
       {
@@ -1980,7 +1980,7 @@ pub fn dispatch_math_functions(
     }
     "BiweightMidvariance" => {
       return Some(
-        crate::functions::math_ast::statistics_biweight_midvariance(args),
+        crate::functions::math_ast::biweight_midvariance_ast(args),
       );
     }
     // StieltjesGamma[0] is EulerGamma; positive integers and symbols stay

--- a/src/functions/math_ast/mod.rs
+++ b/src/functions/math_ast/mod.rs
@@ -2,8 +2,6 @@
 //!
 //! These functions work directly with `Expr` AST nodes.
 
-use crate::syntax::Expr;
-
 mod airy;
 mod arithmetic;
 mod bessel;
@@ -60,37 +58,3 @@ pub use triangles::*;
 pub use trigonometric::*;
 pub use weierstrass::*;
 pub use zeta_functions::*;
-
-/// Public accessor for the process time-slice distribution (used by
-/// SliceDistribution).
-pub fn distributions_slice(
-  proc_name: &str,
-  dargs: &[Expr],
-  t: &Expr,
-) -> Option<Expr> {
-  distributions::process_slice_distribution(proc_name, dargs, t)
-}
-
-/// Public accessors for the process correlation closed forms.
-pub fn statistics_process_correlation(
-  proc: &Expr,
-  t1: &Expr,
-  t2: &Expr,
-) -> Option<Expr> {
-  statistics::process_correlation(proc, t1, t2)
-}
-
-pub fn statistics_process_absolute_correlation(
-  proc: &Expr,
-  t1: &Expr,
-  t2: &Expr,
-) -> Option<Expr> {
-  statistics::process_absolute_correlation(proc, t1, t2)
-}
-
-/// Public accessor for BiweightMidvariance.
-pub fn statistics_biweight_midvariance(
-  args: &[Expr],
-) -> Result<Expr, crate::InterpreterError> {
-  statistics::biweight_midvariance_ast(args)
-}


### PR DESCRIPTION
statistics_process_correlation, statistics_process_absolute_correlation, statistics_biweight_midvariance and distributions_slice are wrapper functions but their underlying functions are already public.  Remove them to to make math_ast/mod.rs only contain modules and exports.