### PR TITLE
Force LF endings on checkout for nightly build-windows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,10 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
+    - name: Set git to use LF
+      run: |
+        git config --global core.autocrlf input
+        git config --global core.eol lf
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Currently Woxi expects notebooks and other files to have LF endings. If the files have CRLF endings, test failures will appear such as test_parse_layout_typography_no_backslashes.  For now, rather than try to fix all the bugs associated with endings, we should force git to checkout with LF endings.