### PR TITLE
Add pub fn rat_reduce to numeric_utils

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::{
-  expr_to_rational, gcd_i128, is_sqrt, make_sqrt,
+  expr_to_rational, is_sqrt, make_sqrt, rat_reduce,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
@@ -12109,37 +12109,20 @@ fn find_sequence_function(
 
 /// Convert a rational (n, d) back to an Expr.
 fn rational_to_expr(n: i128, d: i128) -> Expr {
-  if d == 1 {
-    Expr::Integer(n)
-  } else {
-    let g = gcd_i128(n.abs(), d.abs());
-    let (n, d) = (n / g, d / g);
-    if d < 0 {
-      rational_to_expr(-n, -d)
-    } else if d == 1 {
-      Expr::Integer(n)
-    } else {
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(n), Expr::Integer(d)].into(),
-      }
-    }
-  }
+  crate::functions::math_ast::make_rational(n, d)
 }
 
 /// Rational arithmetic helpers
+fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
+  rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
+}
+
 fn rat_sub(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  let n = a.0 * b.1 - b.0 * a.1;
-  let d = a.1 * b.1;
-  let g = gcd_i128(n.abs(), d.abs());
-  (n / g, d / g)
+  rat_reduce(a.0 * b.1 - b.0 * a.1, a.1 * b.1)
 }
 
 fn rat_mul(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  let n = a.0 * b.0;
-  let d = a.1 * b.1;
-  let g = gcd_i128(n.abs(), d.abs());
-  (n / g, d / g)
+  rat_reduce(a.0 * b.0, a.1 * b.1)
 }
 
 fn rat_div(a: (i128, i128), b: (i128, i128)) -> Option<(i128, i128)> {
@@ -12147,13 +12130,6 @@ fn rat_div(a: (i128, i128), b: (i128, i128)) -> Option<(i128, i128)> {
     return None;
   }
   Some(rat_mul(a, (b.1, b.0)))
-}
-
-fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  let n = a.0 * b.1 + b.0 * a.1;
-  let d = a.1 * b.1;
-  let g = gcd_i128(n.abs(), d.abs());
-  (n / g, d / g)
 }
 
 /// Check if the sequence is n! (starting from n=1)

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::{
-  expr_to_rational, gcd_i128, gcd_u64, make_sqrt,
+  expr_to_rational, gcd_i128, gcd_u64, make_rational, make_sqrt, rat_reduce,
 };
 use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator, unevaluated};
 
@@ -161,7 +161,7 @@ pub fn dispatch_math_functions(
         let mut results = Vec::with_capacity(3);
         let mut all_ok = true;
         for (qn, qd) in qs {
-          let q_expr = crate::functions::math_ast::make_rational(qn, qd);
+          let q_expr = make_rational(qn, qd);
           let call = Expr::FunctionCall {
             name: "Quantile".to_string(),
             args: vec![args[0].clone(), q_expr].into(),
@@ -249,9 +249,7 @@ pub fn dispatch_math_functions(
               if !any_real && lo_i as f64 == lo_v && hi_i as f64 == hi_v {
                 // Exact rational: (w_lo*lo_i + w_hi*hi_i) / pos_den
                 let num = w_lo * lo_i + w_hi * hi_i;
-                results.push(crate::functions::math_ast::make_rational(
-                  num, pos_den,
-                ));
+                results.push(make_rational(num, pos_den));
               } else {
                 let v =
                   (w_lo as f64 * lo_v + w_hi as f64 * hi_v) / pos_den as f64;
@@ -2661,7 +2659,7 @@ pub fn dispatch_math_functions(
         if base_int >= 2 {
           let denom = (base_int as f64).powi(e as i32) as i128;
           if denom > 0 {
-            let mantissa = crate::functions::math_ast::make_rational(*n, denom);
+            let mantissa = make_rational(*n, denom);
             return Some(Ok(Expr::List(
               vec![mantissa, Expr::Integer(e)].into(),
             )));
@@ -5855,7 +5853,6 @@ fn cantor_staircase_ast(arg: &Expr) -> Result<Expr, InterpreterError> {
 
 /// Compute cantor staircase for exact rational p/q where 0 < p/q < 1
 fn cantor_staircase_rational(p: i128, q: i128) -> Expr {
-  use crate::functions::math_ast::make_rational;
   use std::collections::HashMap;
 
   // Use the ternary digit algorithm with cycle detection.
@@ -6131,7 +6128,7 @@ fn find_linear_recurrence_impl(seq: &[Expr]) -> Result<Expr, InterpreterError> {
       if valid {
         let result: Vec<Expr> = coeffs
           .iter()
-          .map(|&(num, den)| rational_to_expr_local(num, den))
+          .map(|&(num, den)| make_rational(num, den))
           .collect();
         return Ok(Expr::List(result.into()));
       }
@@ -6146,17 +6143,23 @@ fn find_linear_recurrence_impl(seq: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  let n = a.0 * b.1 + b.0 * a.1;
-  let d = a.1 * b.1;
-  let g = gcd_i128(n.abs(), d.abs());
-  (n / g, d / g)
+  rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
 }
 
 fn rat_mul(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  let n = a.0 * b.0;
-  let d = a.1 * b.1;
-  let g = gcd_i128(n.abs(), d.abs());
-  (n / g, d / g)
+  rat_reduce(a.0 * b.0, a.1 * b.1)
+}
+
+fn rat_sub(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
+  rat_add(a, (-b.0, b.1))
+}
+
+fn rat_div(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
+  if b.0 < 0 {
+    rat_mul(a, (-b.1, -b.0))
+  } else {
+    rat_mul(a, (b.1, b.0))
+  }
 }
 
 fn solve_rational_system(
@@ -6207,33 +6210,6 @@ fn solve_rational_system(
   }
 
   Some(solution)
-}
-
-fn rat_sub(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  rat_add(a, (-b.0, b.1))
-}
-
-fn rat_div(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  if b.0 < 0 {
-    rat_mul(a, (-b.1, -b.0))
-  } else {
-    rat_mul(a, (b.1, b.0))
-  }
-}
-
-fn rational_to_expr_local(n: i128, d: i128) -> Expr {
-  let g = gcd_i128(n.abs(), d.abs());
-  let (n, d) = (n / g, d / g);
-  if d < 0 {
-    rational_to_expr_local(-n, -d)
-  } else if d == 1 {
-    Expr::Integer(n)
-  } else {
-    Expr::FunctionCall {
-      name: "Rational".to_string(),
-      args: vec![Expr::Integer(n), Expr::Integer(d)].into(),
-    }
-  }
 }
 
 /// Substitute each variable named in `vars` with `Re[v] + I*Im[v]` so that

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::{gcd_i128, rat_reduce};
 use crate::syntax::bool_expr;
 
 // Re-export crate types/functions for submodules (used by submodules via `use super::*`)
@@ -10922,8 +10922,7 @@ fn rational_to_expr(num: i128, den: i128) -> Expr {
   } else if num == 0 {
     Expr::Integer(0)
   } else {
-    let g = gcd_i128(num.abs(), den.abs());
-    let (n, d) = (num / g, den / g);
+    let (n, d) = rat_reduce(num, den);
     if d == 1 {
       Expr::Integer(n)
     } else {

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -4,7 +4,7 @@
 //! and integration.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::{gcd_i128, is_sqrt, make_sqrt};
+use crate::functions::math_ast::{gcd_i128, is_sqrt, make_sqrt, rat_reduce};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -6264,9 +6264,7 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
     // Constant term: C(n,m) / 2^n * x
     let binom_mid = crate::functions::binomial_coeff(n, m);
     let denom = 1i128 << n; // 2^n
-    let g = gcd_i128(binom_mid, denom);
-    let const_num = binom_mid / g;
-    let const_den = denom / g;
+    let (const_num, const_den) = rat_reduce(binom_mid, denom);
     let numer_term = if const_num == 1 {
       Expr::Identifier(var.to_string())
     } else {
@@ -6336,9 +6334,7 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
     // Total coefficient: coeff_num / (freq * 4^m)
     let power_2n = 1i128 << n; // 2^n
     let denom = freq * power_2n; // freq * 2^n
-    let g = gcd_i128(coeff_num, denom);
-    let num = coeff_num / g;
-    let den = denom / g;
+    let (num, den) = rat_reduce(coeff_num, denom);
 
     let term = if matches!(&coeff, Expr::Integer(1)) {
       make_fraction_term(num, den, integrated_trig)
@@ -6866,7 +6862,7 @@ fn try_integrate_rational(
 ) -> Option<Expr> {
   use crate::functions::polynomial_ast::{
     build_sum, coeffs_to_expr, divide_by_root, evaluate_poly,
-    expand_and_combine, extract_poly_coeffs, find_integer_root, gcd_i128,
+    expand_and_combine, extract_poly_coeffs, find_integer_root,
     poly_long_divide,
   };
 
@@ -6989,13 +6985,7 @@ fn try_integrate_rational(
     }
 
     // A_i = num_at_root / den_product as reduced fraction
-    let g = gcd_i128(num_at_root.abs(), den_product.abs());
-    let (mut an, mut ad) = (num_at_root / g, den_product / g);
-    if ad < 0 {
-      an = -an;
-      ad = -ad;
-    }
-
+    let (an, ad) = rat_reduce(num_at_root, den_product);
     if an == 0 {
       continue;
     }
@@ -7299,12 +7289,7 @@ fn try_integrate_rational(
       if den_prod == 0 {
         return None;
       }
-      let g = gcd_i128(num_at_root.abs(), den_prod.abs());
-      let (mut an, mut ad) = (num_at_root / g, den_prod / g);
-      if ad < 0 {
-        an = -an;
-        ad = -ad;
-      }
+      let (an, ad) = rat_reduce(num_at_root, den_prod);
       residues.push((an, ad));
     }
 
@@ -15175,9 +15160,7 @@ pub fn compose_series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Rational arithmetic helpers for coefficient-based series computation
 /// Represents a rational number as (numerator, denominator) with denominator > 0
 fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  let num = a.0 * b.1 + b.0 * a.1;
-  let den = a.1 * b.1;
-  rat_reduce(num, den)
+  rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
 }
 
 fn rat_mul(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
@@ -15190,15 +15173,6 @@ fn rat_div(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
   } else {
     rat_reduce(a.0 * b.1, a.1 * b.0)
   }
-}
-
-fn rat_reduce(num: i128, den: i128) -> (i128, i128) {
-  if num == 0 {
-    return (0, 1);
-  }
-  let g = gcd_i128(num, den);
-  let (n, d) = (num / g, den / g);
-  if d < 0 { (-n, -d) } else { (n, d) }
 }
 
 fn rat_to_expr(r: (i128, i128)) -> Expr {
@@ -15533,17 +15507,6 @@ fn multiplicative_factors(expr: &Expr) -> Vec<Expr> {
   }
 }
 
-/// Reduce a fraction `(num, den)` (den > 0) to lowest terms with positive den.
-fn reduce_frac(num: i128, den: i128) -> (i128, i128) {
-  let g = gcd_i128(num.abs(), den.abs()).max(1);
-  let (mut n, mut d) = (num / g, den / g);
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
-  (n, d)
-}
-
 /// If `f` has a leading non-integer rational power of the shift `(var - x0)`
 /// (so that its expansion about `x0` is a genuine Puiseux series), return the
 /// reduced exponent `(p, q)` with `q > 1` together with the analytic cofactor
@@ -15629,14 +15592,14 @@ fn leading_fractional_power(
         // num/den += p/q
         num = num * q + p * den;
         den *= q;
-        let (rn, rd) = reduce_frac(num, den);
+        let (rn, rd) = rat_reduce(num, den);
         num = rn;
         den = rd;
       }
       None => g_factors.push(fac.clone()),
     }
   }
-  let (p, q) = reduce_frac(num, den);
+  let (p, q) = rat_reduce(num, den);
   if q <= 1 {
     return None; // integer total exponent — not a Puiseux case.
   }

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -6,7 +6,7 @@ use crate::syntax::{
   unevaluated,
 };
 use num_bigint::BigInt;
-use num_traits::Signed;
+use num_traits::{Signed, Zero};
 
 fn nth_prime(n: i128) -> i128 {
   if n == 0 {
@@ -231,7 +231,6 @@ pub fn gcd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Extended Euclidean algorithm: returns (gcd, s, t) where a*s + b*t = gcd
 fn extended_gcd_bigint(a: &BigInt, b: &BigInt) -> (BigInt, BigInt, BigInt) {
-  use num_traits::Zero;
   if b.is_zero() {
     if a.is_zero() {
       return (BigInt::from(0), BigInt::from(0), BigInt::from(0));
@@ -1007,23 +1006,23 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Represent each Bernoulli number as a reduced (numerator, denominator)
   // pair in BigInt, so large numerators (e.g. BernoulliB[60]) don't overflow
   // i128.
-  fn reduce(num: BigInt, den: BigInt) -> (BigInt, BigInt) {
+  fn rat_reduce(num: BigInt, den: BigInt) -> (BigInt, BigInt) {
     let mut g = gcd_bigint(&num, &den);
-    if g == BigInt::from(0) {
+    if g.is_zero() {
       g = BigInt::from(1);
     }
-    let (mut num, mut den) = (num / &g, den / &g);
+    let (num, den) = (num / &g, den / &g);
     if den < BigInt::from(0) {
-      num = -num;
-      den = -den;
+      (-num, -den)
+    } else {
+      (num, den)
     }
-    (num, den)
   }
   fn rat_add(a: &(BigInt, BigInt), b: &(BigInt, BigInt)) -> (BigInt, BigInt) {
-    reduce(&a.0 * &b.1 + &b.0 * &a.1, &a.1 * &b.1)
+    rat_reduce(&a.0 * &b.1 + &b.0 * &a.1, &a.1 * &b.1)
   }
   fn rat_mul(a: &(BigInt, BigInt), b: &(BigInt, BigInt)) -> (BigInt, BigInt) {
-    reduce(&a.0 * &b.0, &a.1 * &b.1)
+    rat_reduce(&a.0 * &b.0, &a.1 * &b.1)
   }
 
   let mut b: Vec<(BigInt, BigInt)> = Vec::with_capacity(n + 1);
@@ -1054,25 +1053,10 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Compute the nth Bernoulli polynomial B_n(z) = sum_{k=0}^{n} C(n,k) * B_k * z^(n-k)
 fn bernoulli_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
   fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-    let num = a.0 * b.1 + b.0 * a.1;
-    let den = a.1 * b.1;
-    let g = gcd_i128(num, den);
-    if den < 0 {
-      (-num / g, -den / g)
-    } else {
-      (num / g, den / g)
-    }
+    rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
   }
-
   fn rat_mul(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-    let num = a.0 * b.0;
-    let den = a.1 * b.1;
-    let g = gcd_i128(num, den);
-    if den < 0 {
-      (-num / g, -den / g)
-    } else {
-      (num / g, den / g)
-    }
+    rat_reduce(a.0 * b.0, a.1 * b.1)
   }
 
   // First compute all Bernoulli numbers B_0 through B_n as rationals
@@ -1112,14 +1096,7 @@ fn bernoulli_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
     let (z_num, z_den) = z_val;
     let mut result = (0i128, 1i128);
     for k in (0..=n).rev() {
-      let rn = result.0 * z_num;
-      let rd = result.1 * z_den;
-      let g = gcd_i128(rn, rd);
-      let (rn, rd) = if rd < 0 {
-        (-rn / g, -rd / g)
-      } else {
-        (rn / g, rd / g)
-      };
+      let (rn, rd) = rat_reduce(result.0 * z_num, result.1 * z_den);
       result = rat_add((rn, rd), coeffs[k]);
     }
     return Ok(make_rational(result.0, result.1));
@@ -1252,14 +1229,7 @@ pub fn euler_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Compute the nth Euler polynomial and either evaluate at a point or return symbolic expression
 fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
   fn rat_add(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-    let num = a.0 * b.1 + b.0 * a.1;
-    let den = a.1 * b.1;
-    let g = gcd_i128(num, den);
-    if den < 0 {
-      (-num / g, -den / g)
-    } else {
-      (num / g, den / g)
-    }
+    rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
   }
 
   // Build polynomial coefficients using recurrence
@@ -1278,12 +1248,7 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
       let (cn, cd) = coeffs[k];
       let num = degree as i128 * cn;
       let den = cd * (k as i128 + 1);
-      let g = gcd_i128(num, den);
-      let (num, den) = if den < 0 {
-        (-num / g, -den / g)
-      } else {
-        (num / g, den / g)
-      };
+      let (num, den) = rat_reduce(num, den);
       new_coeffs.push((num, den));
     }
 
@@ -1299,12 +1264,7 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
     // C = -sum_at_1 / 2
     let c_num = -sum_at_1.0;
     let c_den = sum_at_1.1 * 2;
-    let g = gcd_i128(c_num, c_den);
-    let (c_num, c_den) = if c_den < 0 {
-      (-c_num / g, -c_den / g)
-    } else {
-      (c_num / g, c_den / g)
-    };
+    let (c_num, c_den) = rat_reduce(c_num, c_den);
     new_coeffs[0] = (c_num, c_den);
 
     coeffs = new_coeffs;
@@ -1320,12 +1280,7 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
       // result = result * z + coeffs[k]
       let rn = result.0 * z_num;
       let rd = result.1 * z_den;
-      let g = gcd_i128(rn, rd);
-      let (rn, rd) = if rd < 0 {
-        (-rn / g, -rd / g)
-      } else {
-        (rn / g, rd / g)
-      };
+      let (rn, rd) = rat_reduce(rn, rd);
       result = rat_add((rn, rd), coeffs[k]);
     }
     return Ok(make_rational(result.0, result.1));
@@ -5788,7 +5743,6 @@ pub fn frobenius_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Compute GCD of all elements
-
   let mut g = nums[0];
   for &n in &nums[1..] {
     g = gcd_i128(g, n);

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -743,6 +743,13 @@ pub fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
   a
 }
 
+/// Reduce n/d to lowest terms with a positive denominator.
+pub fn rat_reduce(n: i128, d: i128) -> (i128, i128) {
+  let g = gcd_i128(n, d).max(1);
+  let (n, d) = (n / g, d / g);
+  if d < 0 { (-n, -d) } else { (n, d) }
+}
+
 /// Extract the largest easily-found perfect-square factor from a positive
 /// i128: returns `(outside, inside)` with `n == outside^2 * inside`, so
 /// `Sqrt[n] = outside * Sqrt[inside]`. Square factors of primes below a
@@ -790,16 +797,8 @@ pub fn make_rational(numer: i128, denom: i128) -> Expr {
     };
   }
 
-  // Handle sign: put sign in numerator
-  let (numer, denom) = if denom < 0 {
-    (-numer, -denom)
-  } else {
-    (numer, denom)
-  };
-
-  // Simplify by GCD
-  let g = gcd_i128(numer, denom);
-  let (numer, denom) = (numer / g, denom / g);
+  // Simplify
+  let (numer, denom) = rat_reduce(numer, denom);
 
   if denom == 1 {
     Expr::Integer(numer)
@@ -1239,13 +1238,11 @@ pub fn build_complex_expr(
   im_den: i128,
 ) -> Expr {
   let re = make_rational(re_num, re_den);
-  let g_i = gcd_i128(im_num.abs(), im_den.abs());
-  let (in_s, id_s) = if im_den < 0 {
-    (-im_num / g_i, -im_den / g_i)
-  } else {
-    (im_num / g_i, im_den / g_i)
-  };
+  if im_num == 0 {
+    return re; // Pure real
+  }
 
+  let (in_s, id_s) = rat_reduce(im_num, im_den);
   let i_expr = Expr::Identifier("I".to_string());
 
   // Build the imaginary term with correct sign handling
@@ -1253,9 +1250,7 @@ pub fn build_complex_expr(
   let im_positive = in_s > 0;
 
   // Build |im| * I
-  let im_term = if im_abs_num == 0 {
-    return re; // Pure real
-  } else if im_abs_num == 1 && id_s == 1 {
+  let im_term = if im_abs_num == 1 && id_s == 1 {
     i_expr
   } else {
     let coeff = make_rational(im_abs_num, id_s);
@@ -1267,9 +1262,7 @@ pub fn build_complex_expr(
   };
 
   // Check if real part is zero
-  let g_r = gcd_i128(re_num.abs(), re_den.abs());
-  let re_simplified = if re_den == 0 { re_num } else { re_num / g_r };
-  if re_simplified == 0 {
+  if re_num == 0 {
     // Pure imaginary
     return if im_positive {
       im_term

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -23,7 +23,7 @@
 //! all give `MusicPitch["G3"]`. The conversions use the standard convention
 //! where middle C is MIDI 60 / C4 and A4 (MIDI 69) is 440 Hz.
 
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::{make_rational, rat_reduce};
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, bool_expr, unevaluated,
 };
@@ -1032,14 +1032,6 @@ pub fn music_pitch_midi(expr: &Expr) -> Option<i128> {
 //                "Root" -> MusicPitch[<|"Key" -> "G", "Accidental" -> 0|>]|>]
 // ```
 
-/// A small `Rational[n, d]` builder (Woxi stores rationals as `Rational[n, d]`).
-fn rational(n: i128, d: i128) -> Expr {
-  Expr::FunctionCall {
-    name: "Rational".to_string(),
-    args: vec![Expr::Integer(n), Expr::Integer(d)].into(),
-  }
-}
-
 /// A `MusicPitch[<|…|>]` / `MusicDuration[<|…|>]` / … object wrapping a
 /// key-ordered association.
 fn music_assoc(head: &str, pairs: Vec<(&str, Expr)>) -> Expr {
@@ -1174,7 +1166,7 @@ fn named_duration_value(name: &str) -> Option<Expr> {
     "SixtyFourth" => 64,
     _ => return None,
   };
-  Some(rational(1, denom))
+  Some(make_rational(1, denom))
 }
 
 /// Extract the rhythmic value from any duration specification: a bare number,
@@ -1803,7 +1795,7 @@ pub fn music_duration_plus_terms(args: &[Expr]) -> Option<Vec<Expr>> {
 pub fn music_duration_from_value(value: Expr) -> Expr {
   music_assoc(
     "MusicDuration",
-    vec![("Duration", value), ("BeatDuration", rational(1, 4))],
+    vec![("Duration", value), ("BeatDuration", make_rational(1, 4))],
   )
 }
 
@@ -1842,44 +1834,21 @@ pub fn music_rest(args: &[Expr]) -> Option<Expr> {
   }
 }
 
-/// Reduce `n/d` to lowest terms with a positive denominator, returning an
-/// `Integer` when the denominator is 1 and a `Rational[n, d]` otherwise.
-fn rational_reduced(mut n: i128, mut d: i128) -> Expr {
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
-  let g = gcd_i128(n.abs(), d).max(1);
-  n /= g;
-  d /= g;
-  if d == 1 {
-    Expr::Integer(n)
-  } else {
-    rational(n, d)
-  }
-}
-
 /// A rational number as a reduced `(numerator, denominator)` pair with a
 /// positive denominator.
 type Ratio = (i128, i128);
 
 /// Reduce a `(numerator, denominator)` pair.
-fn reduce(n: i128, d: i128) -> Ratio {
-  let (n, d) = if d < 0 { (-n, -d) } else { (n, d) };
-  let g = gcd_i128(n.abs(), d).max(1);
-  (n / g, d / g)
-}
-
 fn ratio_mul((an, ad): Ratio, (bn, bd): Ratio) -> Ratio {
-  reduce(an * bn, ad * bd)
+  rat_reduce(an * bn, ad * bd)
 }
 
 fn ratio_add((an, ad): Ratio, (bn, bd): Ratio) -> Ratio {
-  reduce(an * bd + bn * ad, ad * bd)
+  rat_reduce(an * bd + bn * ad, ad * bd)
 }
 
 fn ratio_sub((an, ad): Ratio, (bn, bd): Ratio) -> Ratio {
-  reduce(an * bd - bn * ad, ad * bd)
+  rat_reduce(an * bd - bn * ad, ad * bd)
 }
 
 fn ratio_cmp((an, ad): Ratio, (bn, bd): Ratio) -> std::cmp::Ordering {
@@ -1888,7 +1857,7 @@ fn ratio_cmp((an, ad): Ratio, (bn, bd): Ratio) -> std::cmp::Ordering {
 
 /// Render a `Ratio` as the `Expr` the Wolfram Language prints for it.
 fn ratio_expr((n, d): Ratio) -> Expr {
-  rational_reduced(n, d)
+  make_rational(n, d)
 }
 
 /// Parse a bare rhythmic value (`Integer` or `Rational`) into a `Ratio`.
@@ -1897,7 +1866,9 @@ fn duration_ratio(expr: &Expr) -> Option<Ratio> {
     Expr::Integer(n) => Some((*n, 1)),
     Expr::FunctionCall { name, args } if name == "Rational" => {
       match &args[..] {
-        [Expr::Integer(n), Expr::Integer(d)] if *d != 0 => Some(reduce(*n, *d)),
+        [Expr::Integer(n), Expr::Integer(d)] if *d != 0 => {
+          Some(rat_reduce(*n, *d))
+        }
         _ => None,
       }
     }
@@ -2072,12 +2043,12 @@ pub fn music_measure(args: &[Expr]) -> Option<Expr> {
   // Simple vs. compound meter fixes the beat unit and the beats per measure.
   let compound = numer % 3 == 0 && (numer >= 6 || denom >= 8);
   let beat_duration: Ratio = if compound {
-    reduce(3, denom)
+    rat_reduce(3, denom)
   } else {
-    reduce(1, denom)
+    rat_reduce(1, denom)
   };
   let capacity: Ratio = if compound {
-    reduce(numer, 3)
+    rat_reduce(numer, 3)
   } else {
     (numer, 1)
   };

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -1,6 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
+use crate::functions::math_ast::{gcd_i128, rat_reduce};
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 // ─── Apart ──────────────────────────────────────────────────────────
@@ -361,12 +362,7 @@ fn apart_proper_fraction(
 
     // A_i = num_at_root / den_product
     // Term = A_i / (x - root) which in canonical form is A_i / (-root + x)
-    let g = gcd_i128(num_at_root.abs(), den_product.abs());
-    let (mut an, mut ad) = (num_at_root / g, den_product / g);
-    if ad < 0 {
-      an = -an;
-      ad = -ad;
-    }
+    let (an, ad) = rat_reduce(num_at_root, den_product);
 
     // A zero residue contributes nothing — skip it rather than emitting a
     // spurious `0/(...)` term (e.g. Apart[(x + 1)/(x^2 + x)] is just 1/x).
@@ -512,12 +508,7 @@ fn normalize_irreducible_quotient(
   }
   let num_prim: Vec<i128> = num_coeffs.iter().map(|c| c / cn).collect();
   let den_prim: Vec<i128> = den_coeffs.iter().map(|c| c / cd).collect();
-  let g = gcd_i128(cn.abs(), cd.abs()).max(1);
-  let (mut n_c, mut d_c) = (cn / g, cd / g);
-  if d_c < 0 {
-    n_c = -n_c;
-    d_c = -d_c;
-  }
+  let (n_c, d_c) = rat_reduce(cn, cd);
   // A ±1 numerator over an unscaled denominator displays as (den)^(-1) /
   // -(den)^(-1): Apart[2/(-2-2x-4x^2)] → -(1+x+2x^2)^(-1).
   if num_prim == [1] && n_c.abs() == 1 && d_c == 1 {
@@ -794,13 +785,9 @@ struct Rat {
 }
 
 impl Rat {
-  fn new(mut n: i128, mut d: i128) -> Rat {
-    if d < 0 {
-      n = -n;
-      d = -d;
-    }
-    let g = gcd_i128(n.abs(), d.abs()).max(1);
-    Rat { n: n / g, d: d / g }
+  fn new(n: i128, d: i128) -> Rat {
+    let (n, d) = rat_reduce(n, d);
+    Rat { n: n, d: d }
   }
   fn int(n: i128) -> Rat {
     Rat { n, d: 1 }
@@ -997,17 +984,6 @@ fn apart_repeated_roots(
     return None;
   }
   Some(build_sum(terms))
-}
-
-/// Reduce n/d to lowest terms with a positive denominator.
-fn rat_reduce(n: i128, d: i128) -> (i128, i128) {
-  let g = gcd_i128(n, d).max(1);
-  let (mut n, mut d) = (n / g, d / g);
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
-  (n, d)
 }
 
 /// a - b*c over i128 fractions, reduced; None on overflow.

--- a/src/functions/polynomial_ast/decompose.rs
+++ b/src/functions/polynomial_ast/decompose.rs
@@ -58,15 +58,9 @@ pub fn decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 type Rat = (i128, i128); // (numerator, denominator), always reduced
 
 fn rat_reduce(n: i128, d: i128) -> Rat {
-  if d == 0 {
-    return (n, d);
-  }
-  let g = gcd_i128(n, d);
-  if d < 0 {
-    (-n / g, -d / g)
-  } else {
-    (n / g, d / g)
-  }
+  let g = gcd_i128(n, d).max(1);
+  let (n, d) = (n / g, d / g);
+  if d < 0 { (-n, -d) } else { (n, d) }
 }
 
 fn rat_add(a: Rat, b: Rat) -> Rat {

--- a/src/functions/polynomial_ast/exponent.rs
+++ b/src/functions/polynomial_ast/exponent.rs
@@ -4,7 +4,7 @@ use crate::InterpreterError;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 use crate::functions::calculus_ast::is_constant_wrt;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 
 // ─── Rational exponent helpers ─────────────────────────────────────
 
@@ -18,14 +18,8 @@ pub struct Rat {
 impl Rat {
   fn new(n: i128, d: i128) -> Self {
     assert!(d != 0);
-    let g = gcd_i128(n, d);
-    let (n2, d2) = (n / g, d / g);
-    // Keep denominator positive
-    if d2 < 0 {
-      Rat { n: -n2, d: -d2 }
-    } else {
-      Rat { n: n2, d: d2 }
-    }
+    let (n, d) = rat_reduce(n, d);
+    Rat { n: n, d: d }
   }
 
   fn zero() -> Self {

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -1119,18 +1119,18 @@ fn poly_sub_i128(a: &[i128], b: &[i128]) -> Vec<i128> {
 /// Exact rational as a normalized (numerator, positive denominator) pair.
 type Rat = (i128, i128);
 
-fn rat_norm(n: i128, d: i128) -> Rat {
+fn rat_reduce(n: i128, d: i128) -> Rat {
   let g = gcd_i128(n, d).max(1);
-  let s = if d < 0 { -1 } else { 1 };
-  (s * n / g, d.abs() / g)
+  let (n, d) = (n / g, d / g);
+  if d < 0 { (-n, -d) } else { (n, d) }
 }
 
 fn rat_add(a: Rat, b: Rat) -> Rat {
-  rat_norm(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
+  rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
 }
 
 fn rat_mul(a: Rat, b: Rat) -> Rat {
-  rat_norm(a.0 * b.0, a.1 * b.1)
+  rat_reduce(a.0 * b.0, a.1 * b.1)
 }
 
 /// A rational polynomial in r = base^(1/q); `base: None` means no radical
@@ -1337,7 +1337,7 @@ fn collect_rad_poly(expr: &Expr, depth: usize) -> Option<RadPoly> {
       if name == "Rational" && args.len() == 2 =>
     {
       if let (Expr::Integer(p), Expr::Integer(q)) = (&args[0], &args[1]) {
-        Some(rad_const(rat_norm(*p, *q)))
+        Some(rad_const(rat_reduce(*p, *q)))
       } else {
         None
       }
@@ -1480,7 +1480,7 @@ fn single_radical_minpoly(
         if name == "Rational" && args.len() == 2 =>
       {
         if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
-          rats.push(rat_norm(*n, *d));
+          rats.push(rat_reduce(*n, *d));
         } else {
           return Ok(None);
         }

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -2898,25 +2898,20 @@ impl Rat {
   }
 }
 
-fn rat_simplify(num: i128, den: i128) -> Rat {
-  if den == 0 {
-    return Rat { num, den };
+fn rat_reduce(n: i128, d: i128) -> Rat {
+  if d == 0 {
+    return Rat { num: n, den: d };
   }
-  let g = gcd_i128(num, den).max(1);
-  let (mut n, mut d) = (num / g, den / g);
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
+  let (n, d) = crate::functions::math_ast::rat_reduce(n, d);
   Rat { num: n, den: d }
 }
 
 fn mul_q(a: &Rat, b: &Rat) -> Rat {
-  rat_simplify(a.num * b.num, a.den * b.den)
+  rat_reduce(a.num * b.num, a.den * b.den)
 }
 
 fn sub_q(a: &Rat, b: &Rat) -> Rat {
-  rat_simplify(a.num * b.den - b.num * a.den, a.den * b.den)
+  rat_reduce(a.num * b.den - b.num * a.den, a.den * b.den)
 }
 
 fn inv_q(a: &Rat) -> Option<Rat> {
@@ -2953,7 +2948,7 @@ fn simplify_to_rational(e: &Expr) -> Option<Rat> {
         if *d == 0 {
           None
         } else {
-          Some(rat_simplify(*n, *d))
+          Some(rat_reduce(*n, *d))
         }
       } else {
         None
@@ -2971,7 +2966,7 @@ fn simplify_to_rational(e: &Expr) -> Option<Rat> {
       let mut acc = Rat::from_int(0);
       for arg in args {
         let r = simplify_to_rational(arg)?;
-        acc = rat_simplify(acc.num * r.den + r.num * acc.den, acc.den * r.den);
+        acc = rat_reduce(acc.num * r.den + r.num * acc.den, acc.den * r.den);
       }
       Some(acc)
     }

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -8,7 +8,7 @@ use crate::syntax::{
 };
 
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
-use crate::functions::math_ast::{is_sqrt, make_sqrt};
+use crate::functions::math_ast::{gcd_i128, is_sqrt, make_sqrt, rat_reduce};
 
 /// In Solve context, simplify Sqrt[expr^(2n)] → expr^n since ± handles the sign.
 /// Also simplifies products containing such terms.
@@ -3675,22 +3675,7 @@ pub fn solve_divide(num: &Expr, den: &Expr) -> Expr {
     (Expr::Integer(0), _) => Expr::Integer(0),
     (_, Expr::Integer(1)) => num.clone(),
     (Expr::Integer(n), Expr::Integer(d)) if *d != 0 => {
-      let g = gcd_i128(*n, *d).abs();
-      let mut rn = n / g;
-      let mut rd = d / g;
-      // Normalize sign: denominator always positive
-      if rd < 0 {
-        rn = -rn;
-        rd = -rd;
-      }
-      if rd == 1 {
-        Expr::Integer(rn)
-      } else {
-        Expr::FunctionCall {
-          name: "Rational".to_string(),
-          args: vec![Expr::Integer(rn), Expr::Integer(rd)].into(),
-        }
-      }
+      crate::functions::math_ast::make_rational(*n, *d)
     }
     // Non-integer denominator (a rational such as -1/2, or a symbolic
     // expression): evaluate the quotient so it is fully simplified
@@ -5522,14 +5507,7 @@ fn reduce_fraction(n: i128, d: i128) -> (i128, i128) {
   if d == 0 {
     return (n, d);
   }
-  let g = gcd_i128(n.abs(), d.abs()).abs();
-  let mut rn = n / g;
-  let mut rd = d / g;
-  if rd < 0 {
-    rn = -rn;
-    rd = -rd;
-  }
-  (rn, rd)
+  rat_reduce(n, d)
 }
 
 /// Extract integer polynomial coefficients of `poly` in `var`.


### PR DESCRIPTION
There's a fair amount of duplication of code to reduce rationals in Woxi. This PR introduces a pub fn rat_reduce to consolidate this logic and starts to use it.

In addition, there are a number of naming changes for consistency. rat_norm, reduce, rat_simplify, reduce_frac => rat_reduce.