### PR TITLE
Use rat_reduce where appropriate

### DIFF
--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::{gcd_i128, make_sqrt};
+use crate::functions::math_ast::{make_sqrt, rat_reduce};
 use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 
 pub fn dispatch_linear_algebra_functions(
@@ -3023,11 +3023,7 @@ pub fn dispatch_linear_algebra_functions(
             } else {
               // angle = 2*Pi*exp/n, compute (Cos[angle] + I*Sin[angle]) / Sqrt[n]
               // Simplify the fraction 2*exp/n
-              let num = 2 * exp;
-              let den = n as i128;
-              let g = gcd_i128(num.abs(), den);
-              let snum = num / g;
-              let sden = den / g;
+              let (snum, sden) = rat_reduce(2 * exp, n as i128);
               let angle = if sden == 1 {
                 Expr::FunctionCall {
                   name: "Times".to_string(),

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -5165,8 +5165,7 @@ pub fn dispatch_math_functions(
             .checked_add(sn.checked_mul(dd)?.checked_mul(md)?)?;
           let den: i128 =
             dd.checked_mul(md)?.checked_mul(sd)?.checked_mul(3600)?;
-          let g = gcd_i128(num.abs(), den.abs()).max(1);
-          let (num, den) = (num / g, den / g);
+          let (num, den) = rat_reduce(num, den);
           // Now emit via the same logic as the scalar-rational path below.
           let d = num / den;
           let remainder = num - d * den;
@@ -5181,18 +5180,14 @@ pub fn dispatch_math_functions(
               vec![Expr::Integer(d), Expr::Integer(m), Expr::Integer(s)].into(),
             )));
           } else {
-            let g2 = gcd_i128(sec_num.abs(), den.abs());
+            let (sec_num, den) = rat_reduce(sec_num, den);
             return Some(Ok(Expr::List(
               vec![
                 Expr::Integer(d),
                 Expr::Integer(m),
                 Expr::FunctionCall {
                   name: "Rational".to_string(),
-                  args: vec![
-                    Expr::Integer(sec_num / g2),
-                    Expr::Integer(den / g2),
-                  ]
-                  .into(),
+                  args: vec![Expr::Integer(sec_num), Expr::Integer(den)].into(),
                 },
               ]
               .into(),
@@ -5215,15 +5210,14 @@ pub fn dispatch_math_functions(
             vec![Expr::Integer(d), Expr::Integer(m), Expr::Integer(s)].into(),
           )));
         } else {
-          let g = gcd_i128(sec_num.abs(), den.abs());
+          let (sec_num, den) = rat_reduce(sec_num, den);
           return Some(Ok(Expr::List(
             vec![
               Expr::Integer(d),
               Expr::Integer(m),
               Expr::FunctionCall {
                 name: "Rational".to_string(),
-                args: vec![Expr::Integer(sec_num / g), Expr::Integer(den / g)]
-                  .into(),
+                args: vec![Expr::Integer(sec_num), Expr::Integer(den)].into(),
               },
             ]
             .into(),

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 
-use crate::functions::math_ast::{gcd_i128, rat_reduce};
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::bool_expr;
 
 // Re-export crate types/functions for submodules (used by submodules via `use super::*`)
@@ -6469,20 +6469,17 @@ fn evaluate_function_call_ast_inner(
             }
           }
         }
-        let possible = (k * (k - 1) / 2) as i128;
+        let mut possible = (k * (k - 1) / 2) as i128;
         if triangles == possible {
           Expr::Integer(1)
         } else if triangles == 0 {
           Expr::Integer(0)
         } else {
-          let g = gcd_i128(triangles, possible);
+          (triangles, possible) = rat_reduce(triangles, possible);
           Expr::FunctionCall {
             name: "Rational".to_string(),
-            args: vec![
-              Expr::Integer(triangles / g),
-              Expr::Integer(possible / g),
-            ]
-            .into(),
+            args: vec![Expr::Integer(triangles), Expr::Integer(possible)]
+              .into(),
           }
         }
       })
@@ -11106,9 +11103,9 @@ fn expr_to_rational(expr: &Expr) -> Option<(i128, i128)> {
         Some((1, 1))
       } else {
         // For other floats, use denominator 1000 and simplify
-        let n = (*f * 1000.0).round() as i128;
-        let g = gcd_i128(n.abs(), 1000);
-        Some((n / g, 1000 / g))
+        let (n, d) = ((*f * 1000.0).round() as i128, 1000i128);
+        let (n, d) = rat_reduce(n, d);
+        Some((n, d))
       }
     }
     _ => None,

--- a/src/evaluator/dispatch/polynomial_functions.rs
+++ b/src/evaluator/dispatch/polynomial_functions.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::{BinaryOperator, ComparisonOp, bool_expr, unevaluated};
 
 pub fn dispatch_polynomial_functions(
@@ -1434,16 +1434,7 @@ fn try_constrained_linear_disk_symbolic(
 fn sinusoid_extremum(expr: &Expr, var: &str, maximize: bool) -> Option<Expr> {
   type Frac = (i128, i128);
   fn add(a: Frac, b: Frac) -> Frac {
-    norm((a.0 * b.1 + b.0 * a.1, a.1 * b.1))
-  }
-  fn norm(f: Frac) -> Frac {
-    let g = gcd_i128(f.0, f.1).max(1);
-    let (mut n, mut d) = (f.0 / g, f.1 / g);
-    if d < 0 {
-      n = -n;
-      d = -d;
-    }
-    (n, d)
+    rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
   }
   fn as_frac(e: &Expr) -> Option<Frac> {
     match e {
@@ -1452,7 +1443,7 @@ fn sinusoid_extremum(expr: &Expr, var: &str, maximize: bool) -> Option<Expr> {
         if name == "Rational" && args.len() == 2 =>
       {
         if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
-          Some(norm((*n, *d)))
+          Some(rat_reduce(*n, *d))
         } else {
           None
         }

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -5521,11 +5521,12 @@ fn try_integrate_trig_quotient(
       ));
       for j in 1..=k {
         let binom = crate::functions::binomial_coeff(k as i128, j as i128);
+        let denom = 2 * j as i128;
         let sign = if j % 2 == 1 { 1 } else { -1 };
-        let g = gcd_i128(binom, 2 * j as i128).max(1);
+        let (binom, denom) = rat_reduce(binom, denom);
         terms.push(coeff_term(
-          sign * binom / g,
-          2 * j as i128 / g,
+          sign * binom,
+          denom,
           trig_pow("Cos", 2 * j),
           &coeff,
         ));
@@ -5564,11 +5565,12 @@ fn try_integrate_trig_quotient(
       ));
       for j in 1..=k {
         let binom = crate::functions::binomial_coeff(k as i128, j as i128);
+        let denom = 2 * j as i128;
         let sign = if j % 2 == 1 { -1 } else { 1 };
-        let g = gcd_i128(binom, 2 * j as i128).max(1);
+        let (binom, denom) = rat_reduce(binom, denom);
         terms.push(coeff_term(
-          sign * binom / g,
-          2 * j as i128 / g,
+          sign * binom,
+          denom,
           trig_pow("Sin", 2 * j),
           &coeff,
         ));
@@ -7480,8 +7482,7 @@ fn try_integrate_rational(
     // = big_b_int / (2 * common_den)
     let log_total_num = big_b_int;
     let log_total_den = 2 * common_den;
-    let g_log = gcd_i128(log_total_num.abs(), log_total_den);
-    let (log_num, log_den) = (log_total_num / g_log, log_total_den / g_log);
+    let (log_num, log_den) = rat_reduce(log_total_num, log_total_den);
 
     if log_num != 0 {
       let log_expr = Expr::FunctionCall {
@@ -7583,9 +7584,7 @@ fn try_integrate_rational(
 
       // Full coefficient: arctan_coeff_num / (common_den * k_reduced * sqrt(m))
       // Reduce: arctan_coeff_num / common_den first
-      let g_at = gcd_i128(arctan_coeff_num.abs(), common_den);
-      let at_num = arctan_coeff_num / g_at;
-      let at_den_int = common_den / g_at;
+      let (at_num, at_den_int) = rat_reduce(arctan_coeff_num, common_den);
 
       // Build effective sqrt expression combining at_den_int, k_reduced, and sqrt(m)
       let int_factor = at_den_int * k_reduced;
@@ -7640,9 +7639,7 @@ fn build_arctan_term(
 
   let term = if let Expr::Integer(s) = sqrt_expr {
     // sqrt is an integer - can simplify
-    let g = gcd_i128(abs_coeff, *s);
-    let reduced_num = abs_coeff / g;
-    let reduced_den = *s / g;
+    let (reduced_num, reduced_den) = rat_reduce(abs_coeff, *s);
 
     if reduced_den == 1 {
       if reduced_num == 1 {
@@ -16625,8 +16622,7 @@ pub fn series_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // value / factorial
       match &value {
         Expr::Integer(n) => {
-          let g = gcd_i128(*n, factorial);
-          let (num, den) = (n / g, factorial / g);
+          let (num, den) = rat_reduce(*n, factorial);
           if den == 1 {
             Expr::Integer(num)
           } else {

--- a/src/functions/convolve_ast.rs
+++ b/src/functions/convolve_ast.rs
@@ -11,19 +11,13 @@
 //! (e.g. Sqrt[Pi/2]/E^(y^2/2), (y*UnitStep[y])/E^(2*y)).
 
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 type Frac = (i128, i128);
 
 fn frac(n: i128, d: i128) -> Frac {
-  let g = gcd_i128(n, d).max(1);
-  let (mut n, mut d) = (n / g, d / g);
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
-  (n, d)
+  rat_reduce(n, d)
 }
 
 fn frac_to_expr(f: Frac) -> Expr {

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -12,7 +12,7 @@
 //! (1, -1, I, -I, or E^((a*I)/b*Pi) forms on the principal branch).
 
 use crate::InterpreterError;
-use crate::functions::math_ast::{gcd_bigint, gcd_i128};
+use crate::functions::math_ast::{gcd_bigint, gcd_i128, rat_reduce};
 use crate::syntax::Expr;
 use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
 
@@ -86,15 +86,11 @@ pub fn dirichlet_character_ast(
     } else {
       num = num * q + p * den;
       den *= q;
-      let g = gcd_i128(num, den).max(1);
-      num /= g;
-      den /= g;
+      (num, den) = rat_reduce(num, den);
     }
   }
   num = num.rem_euclid(den);
-  let g = gcd_i128(num, den).max(1);
-  num /= g;
-  den /= g;
+  (num, den) = rat_reduce(num, den);
   // A combined exponential that lands on a fourth root folds into the
   // coefficient too
   if den == 1 || den == 2 || den == 4 {
@@ -294,15 +290,10 @@ fn assemble_value(quarter: i128, num: i128, den: i128) -> Expr {
   }
   // Principal branch: the printed multiple of Pi is m = a/b = 2*num/den
   // reduced into (-1, 1]
-  let (mut a, mut b) = (2 * num, den);
-  let g = gcd_i128(a, b).max(1);
-  a /= g;
-  b /= g;
+  let (mut a, mut b) = rat_reduce(2 * num, den);
   if a > b {
     a -= 2 * b;
-    let g = gcd_i128(a, b).max(1);
-    a /= g;
-    b /= g;
+    (a, b) = rat_reduce(a, b);
   }
   let exp_form = |a: i128, b: i128| -> String {
     let inner = if a == 1 {
@@ -337,13 +328,10 @@ fn total_rotation(factors: &[Factor], exps: &[i128], a: i128) -> (i128, i128) {
     let (p, q) = (e * t, f.order);
     num = num * q + p * den;
     den *= q;
-    let g = gcd_i128(num, den).max(1);
-    num /= g;
-    den /= g;
+    (num, den) = rat_reduce(num, den);
   }
   num = num.rem_euclid(den);
-  let g = gcd_i128(num, den).max(1);
-  (num / g, den / g)
+  rat_reduce(num, den)
 }
 
 /// DirichletL[k, j, s] - Dirichlet L-function of the j-th character

--- a/src/functions/expr_form.rs
+++ b/src/functions/expr_form.rs
@@ -1,4 +1,4 @@
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::{BinaryOperator, ComparisonOp, Expr, UnaryOperator};
 
 /// Result of decomposing an expression into its canonical form.
@@ -417,14 +417,9 @@ pub fn decompose_expr(expr: &Expr) -> ExprForm {
 }
 
 /// Helper: render a rational (num, denom) pair in FullForm notation.
-fn render_rational_full_form(num: i128, denom: i128) -> String {
+fn render_rational_full_form(numer: i128, denom: i128) -> String {
   // Reduce to lowest terms
-  let g = gcd_i128(num, denom);
-  let (n, d) = if g > 0 {
-    (num / g, denom / g)
-  } else {
-    (num, denom)
-  };
+  let (n, d) = rat_reduce(numer, denom);
   if d == 1 {
     n.to_string()
   } else {

--- a/src/functions/function_range_ast.rs
+++ b/src/functions/function_range_ast.rs
@@ -7,7 +7,7 @@
 //! LessEqual, 1].
 
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, bool_expr, unevaluated,
 };
@@ -126,7 +126,7 @@ pub fn function_range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // v = c - b^2/(4a) computed exactly
       let num = c.0 * 4 * a.0 * b.1 * b.1 - b.0 * b.0 * c.1 * a.1;
       let den = c.1 * 4 * a.0 * b.1 * b.1;
-      let v = simplify_frac(num, den);
+      let v = rat_reduce(num, den);
       let v_expr = if v.1 == 1 {
         Expr::Integer(v.0)
       } else {
@@ -168,16 +168,6 @@ fn as_power(expr: &Expr) -> Option<(Expr, Expr)> {
     } => Some(((**left).clone(), (**right).clone())),
     _ => None,
   }
-}
-
-fn simplify_frac(n: i128, d: i128) -> (i128, i128) {
-  let g = gcd_i128(n, d).max(1);
-  let (mut n, mut d) = (n / g, d / g);
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
-  (n, d)
 }
 
 /// Ascending rational coefficients of a polynomial in `var`; None for

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -1,5 +1,5 @@
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::BinaryOperator;
 use crate::syntax::{Expr, ImageType, bool_expr, unevaluated};
 use std::sync::Arc;
@@ -568,8 +568,7 @@ pub fn image_aspect_ratio_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
   fn ratio(h: i128, w: i128) -> Expr {
-    let g = gcd_i128(h, w);
-    let (num, den) = (h / g, w / g);
+    let (num, den) = rat_reduce(h, w);
     if den == 1 {
       Expr::Integer(num)
     } else {

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -5,7 +5,7 @@
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::{
-  expr_to_rational, gcd_i128, make_sqrt, try_eval_to_f64,
+  expr_to_rational, gcd_i128, make_sqrt, rat_reduce, try_eval_to_f64,
 };
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
@@ -1320,14 +1320,8 @@ fn eval_divide(a: &Expr, b: &Expr) -> Expr {
         Expr::Integer(x / y)
       } else {
         // Simplify the fraction
-        let g = gcd_i128(x.abs(), y.abs());
-        let (n, d) = (x / g, y / g);
-        if d < 0 {
-          // Keep denominator positive
-          crate::functions::math_ast::make_rational(-n, -d)
-        } else {
-          crate::functions::math_ast::make_rational(n, d)
-        }
+        let (n, d) = rat_reduce(*x, *y);
+        crate::functions::math_ast::make_rational(n, d)
       }
     }
     _ => {
@@ -2780,8 +2774,7 @@ fn quadratic_eigenvalues(b_coeff: i128, c_coeff: i128) -> Vec<Expr> {
   // Factor out GCD of neg_b and outer from the numerator:
   // (neg_b ± outer*Sqrt[inner]) / 2  =  common * (reduced_b ± reduced_outer*Sqrt[inner]) / 2
   let common = gcd_i128(neg_b.abs(), outer as i128);
-  let reduced_b = neg_b / common;
-  let reduced_outer = outer as i128 / common;
+  let (reduced_b, reduced_outer) = (neg_b / common, outer as i128 / common);
 
   let sqrt_expr = make_sqrt(Expr::Integer(inner as i128));
 
@@ -2824,9 +2817,7 @@ fn quadratic_eigenvalues(b_coeff: i128, c_coeff: i128) -> Vec<Expr> {
 
 /// Simplify fraction n/d, returning Expr::Integer or Expr::Rational.
 fn simplify_fraction(n: i128, d: i128) -> Expr {
-  let g = gcd_i128(n.abs(), d.abs());
-  let (n, d) = (n / g, d / g);
-  let (n, d) = if d < 0 { (-n, -d) } else { (n, d) };
+  let (n, d) = rat_reduce(n, d);
   if d == 1 {
     Expr::Integer(n)
   } else {
@@ -9312,8 +9303,8 @@ impl QNum {
     } else {
       (n, d)
     };
-    let g = gcd_i128(n.abs(), d).max(1);
-    Some(QNum { n: n / g, d: d / g })
+    let (n, d) = rat_reduce(n, d);
+    Some(QNum { n: n, d: d })
   }
   fn zero() -> QNum {
     QNum { n: 0, d: 1 }

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::functions::math_ast::gcd_i128;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, UnaryOperator, bool_expr, unevaluated,
 };

--- a/src/functions/list_helpers_ast/construction.rs
+++ b/src/functions/list_helpers_ast/construction.rs
@@ -2,6 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
+use crate::functions::math_ast::gcd_i128;
 use crate::syntax::{BinaryOperator, unevaluated};
 
 /// AST-based Table: generate a table of values.

--- a/src/functions/list_helpers_ast/utilities.rs
+++ b/src/functions/list_helpers_ast/utilities.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-pub(crate) use crate::functions::math_ast::gcd_i128;
 use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
 
 /// Convert an Expr to a boolean value.

--- a/src/functions/math_ast/coordinate_arrays.rs
+++ b/src/functions/math_ast/coordinate_arrays.rs
@@ -37,8 +37,7 @@ impl Num {
     match self {
       Num::Exact(0, _) => Expr::Integer(0),
       Num::Exact(p, q) => {
-        let g = gcd_i128(p.abs(), q).max(1);
-        let (p, q) = (p / g, q / g);
+        let (p, q) = rat_reduce(p, q);
         if q == 1 {
           Expr::Integer(p)
         } else {

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -1200,18 +1200,7 @@ impl Rat {
     Rat { num: n, den: 1 }
   }
   fn reduce(&mut self) {
-    if self.den < 0 {
-      self.num = -self.num;
-      self.den = -self.den;
-    }
-    let g = gcd_i128(self.num, self.den);
-    if g > 1 {
-      self.num /= g;
-      self.den /= g;
-    }
-    if self.num == 0 {
-      self.den = 1;
-    }
+    (self.num, self.den) = rat_reduce(self.num, self.den);
   }
   fn add(self, o: Rat) -> Rat {
     Rat::new(self.num * o.den + o.num * self.den, self.den * o.den)
@@ -1301,8 +1290,7 @@ fn periodic_continued_fraction(
   let rn = acc_b.num * (q / acc_b.den);
   if rn == 0 {
     // Degenerate to a rational (shouldn't happen for a genuine periodic CF).
-    let g = gcd_i128(pn, q);
-    let (pn, q) = (pn / g, q / g);
+    let (pn, q) = rat_reduce(pn, q);
     return Some(if q == 1 {
       Expr::Integer(pn)
     } else {
@@ -1319,8 +1307,7 @@ fn periodic_continued_fraction(
   if d == 1 {
     // Perfect square under the root: the value is rational.
     let total = pn + s;
-    let g = gcd_i128(total, q);
-    let (total, q) = (total / g, q / g);
+    let (total, q) = rat_reduce(total, q);
     return Some(if q == 1 {
       Expr::Integer(total)
     } else {
@@ -1450,17 +1437,7 @@ pub fn from_continued_fraction_ast(
   }
 
   // Simplify by GCD
-
-  let g = gcd_i128(num, den);
-  num /= g;
-  den /= g;
-
-  // Normalize sign: keep denominator positive
-  if den < 0 {
-    num = -num;
-    den = -den;
-  }
-
+  (num, den) = rat_reduce(num, den);
   if den == 1 {
     Ok(Expr::Integer(num))
   } else {
@@ -3452,8 +3429,7 @@ fn make_rational_expr(num: i128, den: i128) -> Expr {
   } else if den == -1 {
     Expr::Integer(-num)
   } else {
-    let g = gcd_i128(num, den);
-    let (n, d) = (num / g, den / g);
+    let (n, d) = rat_reduce(num, den);
     if d < 0 {
       if -d == 1 {
         Expr::Integer(-n)
@@ -3924,9 +3900,7 @@ pub fn number_decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // rem -= q_int * u
         rn = rn * ud - q_int * un * rd;
         rd *= ud;
-        let g = gcd_i128(rn, rd).max(1);
-        rn /= g;
-        rd /= g;
+        (rn, rd) = rat_reduce(rn, rd);
       }
     }
   }

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1516,8 +1516,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         denom /= (n - k + 1) as i128;
         denom *= k as i128;
       }
-      let g = gcd_i128(numer, denom);
-      let coeff = (numer / g, denom / g);
+      let coeff = rat_reduce(numer, denom);
       let z_pow = if k == 0 {
         Expr::Integer(1)
       } else if k == 1 {
@@ -2645,10 +2644,8 @@ fn hypergeometric2f1_1_b_c(
     for k in 1..=(m - 1 - j) {
       mj_fact *= k;
     }
-    let n = sign * prefactor;
-    let d = j_fact * mj_fact;
-    let g = gcd_i128(n, d);
-    cj.push((n / g, d / g));
+    let (n, d) = (sign * prefactor, j_fact * mj_fact);
+    cj.push(rat_reduce(n, d));
   }
 
   // Collect all distributed terms into (has_log, z_power) -> (num, den)
@@ -2668,8 +2665,7 @@ fn hypergeometric2f1_1_b_c(
     if new_num == 0 {
       *entry = (0, 1);
     } else {
-      let g = gcd_i128(new_num, new_den);
-      *entry = (new_num / g, new_den / g);
+      *entry = rat_reduce(new_num, new_den);
     }
   }
 
@@ -2681,10 +2677,8 @@ fn hypergeometric2f1_1_b_c(
 
     // Poly terms: -C_j/i * z^{m-1-j+i} for i = 1..b+j-1
     for i in 1..(b + j) {
-      let num = -cn;
-      let den = cd * i;
-      let g = gcd_i128(num, den);
-      add_rational(&mut collected, (false, m - 1 - j + i), num / g, den / g);
+      let (num, den) = rat_reduce(-cn, cd * i);
+      add_rational(&mut collected, (false, m - 1 - j + i), num, den);
     }
   }
 
@@ -2724,8 +2718,7 @@ fn hypergeometric2f1_1_b_c(
   // Overall factor = sign_adjust * num_gcd / common_den
   let factor_num = sign_adjust * num_gcd;
   let factor_den = common_den;
-  let fg = gcd_i128(factor_num, factor_den);
-  let (factor_n, factor_d) = (factor_num / fg, factor_den / fg);
+  let (factor_n, factor_d) = rat_reduce(factor_num, factor_den);
 
   // Build Log[1-z]
   let one_minus_z = Expr::FunctionCall {
@@ -2749,10 +2742,8 @@ fn hypergeometric2f1_1_b_c(
 
   for &((has_log, power), scaled_num) in &scaled {
     // Factored coefficient: scaled_num / (sign_adjust * num_gcd)
-    let cn = scaled_num * sign_adjust;
-    let cd = num_gcd;
-    let cg = gcd_i128(cn, cd);
-    let (cn, cd) = (cn / cg, cd / cg);
+    let (cn, cd) = (scaled_num * sign_adjust, num_gcd);
+    let (cn, cd) = rat_reduce(cn, cd);
 
     let mut factors: Vec<Expr> = Vec::new();
 

--- a/src/functions/math_ast/polylog.rs
+++ b/src/functions/math_ast/polylog.rs
@@ -369,18 +369,14 @@ fn polylog_at_neg1(s: i128) -> Result<Expr, InterpreterError> {
           Some(v) => v,
           None => return Ok(unevaluated_polylog(s, -1)),
         };
-        let g = gcd_i128(znum, zden);
-        znum /= g;
-        zden /= g;
+        (znum, zden) = rat_reduce(znum, zden);
       }
       for k in 1..=s_usize {
         zden = match zden.checked_mul(k as i128) {
           Some(v) => v,
           None => return Ok(unevaluated_polylog(s, -1)),
         };
-        let g = gcd_i128(znum, zden);
-        znum /= g;
-        zden /= g;
+        (znum, zden) = rat_reduce(znum, zden);
       }
 
       // Multiply by -(1 - 2^{1-s}) = (1 - 2^{s-1}) / 2^{s-1}
@@ -400,9 +396,7 @@ fn polylog_at_neg1(s: i128) -> Result<Expr, InterpreterError> {
         final_num = -final_num;
         final_den = -final_den;
       }
-      let g = gcd_i128(final_num.abs(), final_den);
-      final_num /= g;
-      final_den /= g;
+      (final_num, final_den) = rat_reduce(final_num, final_den);
 
       // Build coefficient * Pi^s
       let pi_power = Expr::BinaryOp {
@@ -451,9 +445,7 @@ fn polylog_at_neg1(s: i128) -> Result<Expr, InterpreterError> {
     let pow2 = 1_i128 << (s_usize - 1);
     let coeff_num = 1 - pow2;
     let coeff_den = pow2;
-    let g = gcd_i128(coeff_num.abs(), coeff_den);
-    let cn = coeff_num / g;
-    let cd = coeff_den / g;
+    let (cn, cd) = rat_reduce(coeff_num, coeff_den);
 
     let zeta_expr = Expr::FunctionCall {
       name: "Zeta".to_string(),

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -557,9 +557,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Ok(Expr::Integer(sum / count))
         } else {
           // Return as Rational
-          let g = gcd_i128(sum.abs(), count);
-          let num = sum / g;
-          let denom = count / g;
+          let (num, denom) = rat_reduce(sum, count);
           Ok(Expr::FunctionCall {
             name: "Rational".to_string(),
             args: vec![Expr::Integer(num), Expr::Integer(denom)].into(),
@@ -1829,9 +1827,7 @@ pub fn harmonic_mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           sum_numer = sum_numer * x + sum_denom;
           sum_denom *= x;
           // Simplify to avoid overflow
-          let g = gcd_i128(sum_numer.abs(), sum_denom.abs());
-          sum_numer /= g;
-          sum_denom /= g;
+          (sum_numer, sum_denom) = rat_reduce(sum_numer, sum_denom);
         }
         // HarmonicMean = n / (sum_numer/sum_denom) = n * sum_denom / sum_numer
         let result_numer = n * sum_denom;
@@ -4175,9 +4171,7 @@ pub fn root_mean_square_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let n = int_vals.len() as i128;
         let sum_sq: i128 = int_vals.iter().map(|x| x * x).sum();
         // RMS = Sqrt[sum_sq / n]
-        let g = gcd_i128(sum_sq.abs(), n);
-        let numer = sum_sq / g;
-        let denom = n / g;
+        let (numer, denom) = rat_reduce(sum_sq, n);
         // Check if numer/denom is a perfect square
         if denom == 1 {
           let root = (numer as f64).sqrt() as i128;

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -4,7 +4,7 @@
 //! NDSolve solves initial-value problems numerically using RK4.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::{gcd_i128, make_sqrt};
+use crate::functions::math_ast::{make_sqrt, rat_reduce};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -1537,11 +1537,8 @@ fn f64_to_nice_expr(f: f64) -> Expr {
   for denom in 2..=12 {
     let numer = f * denom as f64;
     if (numer - numer.round()).abs() < 1e-10 {
-      let n = numer.round() as i128;
-      let d = denom as i128;
-      let g = gcd_i128(n, d);
-      let nn = n / g;
-      let dd = d / g;
+      let (n, d) = (numer.round() as i128, denom as i128);
+      let (nn, dd) = rat_reduce(n, d);
       if dd == 1 {
         return Expr::Integer(nn);
       }
@@ -3137,10 +3134,7 @@ fn try_direct_linear_pde_body(
 /// `Rational` literal. Sign is folded into the numerator.
 fn make_neg_b_over_a(b: i128, a: i128) -> Expr {
   use crate::functions::math_ast::make_rational;
-  let g = gcd_i128(b.abs(), a.abs());
-  let g = if g == 0 { 1 } else { g };
-  let (num, den) = (-b / g, a / g);
-  let (num, den) = if den < 0 { (-num, -den) } else { (num, den) };
+  let (num, den) = rat_reduce(-b, a);
   if den == 1 {
     Expr::Integer(num)
   } else {
@@ -3150,10 +3144,7 @@ fn make_neg_b_over_a(b: i128, a: i128) -> Expr {
 
 fn make_c_over_a(c: i128, a: i128) -> Expr {
   use crate::functions::math_ast::make_rational;
-  let g = gcd_i128(c.abs(), a.abs());
-  let g = if g == 0 { 1 } else { g };
-  let (num, den) = (c / g, a / g);
-  let (num, den) = if den < 0 { (-num, -den) } else { (num, den) };
+  let (num, den) = rat_reduce(c, a);
   if den == 1 {
     Expr::Integer(num)
   } else {

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::functions::math_ast::{gcd_i128, rat_reduce};
+use crate::functions::math_ast::{gcd_i128, lcm_i128, rat_reduce};
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 // ─── Apart ──────────────────────────────────────────────────────────

--- a/src/functions/polynomial_ast/cancel.rs
+++ b/src/functions/polynomial_ast/cancel.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::functions::math_ast::{is_sqrt, make_sqrt};
+use crate::functions::math_ast::{gcd_i128, is_sqrt, make_sqrt, rat_reduce};
 use crate::syntax::{BinaryOperator, Expr, expr_to_string};
 
 // ─── Cancel ─────────────────────────────────────────────────────────
@@ -757,14 +757,7 @@ pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
 
   // Subtract two rational exponents: (a/b) - (c/d)
   fn rat_sub(a: RatExp, b: RatExp) -> RatExp {
-    let num = a.0 * b.1 - b.0 * a.1;
-    let den = a.1 * b.1;
-    let g = gcd_i128(num.abs(), den.abs());
-    if g > 0 {
-      (num / g, den / g)
-    } else {
-      (num, den)
-    }
+    rat_reduce(a.0 * b.1 - b.0 * a.1, a.1 * b.1)
   }
 
   // Check if rational exponent is positive

--- a/src/functions/polynomial_ast/eliminate.rs
+++ b/src/functions/polynomial_ast/eliminate.rs
@@ -2,11 +2,11 @@ use super::together::negate_expr;
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
+use crate::functions::calculus_ast::{is_constant_wrt, simplify};
+use crate::functions::math_ast::gcd_i128;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, bool_expr, expr_to_string, unevaluated,
 };
-
-use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 
 /// Eliminate[{eq1, eq2, ...}, var]  or  Eliminate[{eq1, eq2, ...}, {v1, v2, ...}]
 /// Eliminates variables from a system of equations.

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -2,6 +2,7 @@
 use super::*;
 use crate::InterpreterError;
 use crate::functions::calculus_ast::simplify;
+use crate::functions::math_ast::{gcd_i128, lcm_i128, rat_reduce};
 use crate::syntax::{
   BinaryOperator, Expr, UnaryOperator, bool_expr, expr_to_string, unevaluated,
 };
@@ -2500,13 +2501,7 @@ fn product_square_free(expr: &Expr) -> Result<Option<Expr>, InterpreterError> {
     }
   }
 
-  if cden < 0 {
-    cnum = -cnum;
-    cden = -cden;
-  }
-  let g = gcd_i128(cnum, cden).max(1);
-  cnum /= g;
-  cden /= g;
+  (cnum, cden) = rat_reduce(cnum, cden);
 
   // A pure sign flip around one untouched square-free sum is not a
   // factorization: FactorSquareFree[-x - y] (Times[-1, x + y]) stays

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -34,8 +34,6 @@ mod to_radicals;
 pub mod together;
 mod zassenhaus;
 
-pub(crate) use crate::functions::math_ast::{gcd_i128, lcm_i128};
-
 pub use apart::*;
 pub use cancel::*;
 pub use coefficient::*;

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::{gcd_i128, rat_reduce};
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
 
 // ─── Together ───────────────────────────────────────────────────────
@@ -2334,10 +2334,7 @@ fn rat_max(a: RatExp, b: RatExp) -> RatExp {
 
 /// Subtract two rational exponents: a - b
 fn rat_sub((an, ad): RatExp, (bn, bd): RatExp) -> RatExp {
-  let n = an * bd - bn * ad;
-  let d = ad * bd;
-  let g = gcd_i128(n, d);
-  (n / g, d / g)
+  rat_reduce(an * bd - bn * ad, ad * bd)
 }
 
 /// Extract base and exponent from a denominator expression.
@@ -2380,8 +2377,7 @@ fn compute_missing_factor(
     if let Some(entry) = den_map.iter_mut().find(|(k, _)| *k == key) {
       // Add exponents for same base
       entry.1 = (entry.1.0 * exp.1 + exp.0 * entry.1.1, entry.1.1 * exp.1);
-      let g = gcd_i128(entry.1.0, entry.1.1);
-      entry.1 = (entry.1.0 / g, entry.1.1 / g);
+      entry.1 = rat_reduce(entry.1.0, entry.1.1);
     } else {
       den_map.push((key, *exp));
     }

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -3,7 +3,7 @@
 //! These functions work directly with `Expr` AST nodes.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
@@ -184,13 +184,7 @@ fn qi_reduce(n: i128, d: i128) -> (i128, i128) {
   if d == 0 {
     return (n, 0);
   }
-  let g = gcd_i128(n, d).max(1);
-  let (mut n, mut d) = (n / g, d / g);
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
-  (n, d)
+  rat_reduce(n, d)
 }
 
 fn qi_add(x: (i128, i128), y: (i128, i128)) -> (i128, i128) {

--- a/src/functions/resolve_ast.rs
+++ b/src/functions/resolve_ast.rs
@@ -6,7 +6,7 @@
 //! c > 0 return their conditions.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
@@ -320,12 +320,7 @@ impl Q {
     Q { n, d: 1 }
   }
   fn new(n: i128, d: i128) -> Q {
-    let (mut n, mut d) = if d < 0 { (-n, -d) } else { (n, d) };
-    let g = gcd_i128(n, d);
-    if g != 0 {
-      n /= g;
-      d /= g;
-    }
+    let (n, d) = rat_reduce(n, d);
     Q { n, d }
   }
   fn add(self, o: Q) -> Q {

--- a/src/functions/rsolve_ast.rs
+++ b/src/functions/rsolve_ast.rs
@@ -913,12 +913,7 @@ fn rat_reduce(n: i128, d: i128) -> Option<(i128, i128)> {
   if d == 0 {
     return None;
   }
-  let g = gcd_i128(n, d);
-  let (mut n, mut d) = if g == 0 { (0, 1) } else { (n / g, d / g) };
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
+  let (n, d) = crate::functions::math_ast::rat_reduce(n, d);
   Some((n, d))
 }
 
@@ -1681,23 +1676,11 @@ fn solve_initial_conditions(
         // new = an/ad - (fn/fd)/(pn/pd) * bn/bd
         //     = an/ad - (fn*pd)/(fd*pn) * bn/bd
         //     = an/ad - (fn*pd*bn)/(fd*pn*bd)
-        let lhs_n = an * fd * pn * bd;
-        let lhs_d = ad * fd * pn * bd;
+        let (lhs_n, lhs_d) = (an * fd * pn * bd, ad * fd * pn * bd);
         let rhs_n = fn_ * pd * bn * ad;
-        let new_n = lhs_n - rhs_n;
-        let new_d = lhs_d;
-        let g = gcd_i128(new_n, new_d);
-        aug[row][j] = if g == 0 {
-          (0, 1)
-        } else {
-          let mut nn = new_n / g;
-          let mut nd = new_d / g;
-          if nd < 0 {
-            nn = -nn;
-            nd = -nd;
-          }
-          (nn, nd)
-        };
+        let (new_n, new_d) = (lhs_n - rhs_n, lhs_d);
+        let (nn, nd) = crate::functions::math_ast::rat_reduce(new_n, new_d);
+        aug[row][j] = (nn, nd);
       }
     }
   }
@@ -1715,29 +1698,13 @@ fn solve_initial_conditions(
       // sn/sd - sub_n/sub_d
       sn = sn * sub_d - sub_n * sd;
       sd *= sub_d;
-      let g = gcd_i128(sn, sd);
-      if g != 0 {
-        sn /= g;
-        sd /= g;
-      }
-      if sd < 0 {
-        sn = -sn;
-        sd = -sd;
-      }
+      (sn, sd) = crate::functions::math_ast::rat_reduce(sn, sd);
     }
     // solution[i] = (sn/sd) / aug[i][i]
     let (pn, pd) = aug[i][i];
     sn *= pd;
     sd *= pn;
-    let g = gcd_i128(sn, sd);
-    if g != 0 {
-      sn /= g;
-      sd /= g;
-    }
-    if sd < 0 {
-      sn = -sn;
-      sd = -sd;
-    }
+    (sn, sd) = crate::functions::math_ast::rat_reduce(sn, sd);
     solution[i] = (sn, sd);
   }
 

--- a/src/functions/ztransform_ast.rs
+++ b/src/functions/ztransform_ast.rs
@@ -14,7 +14,7 @@
 
 use crate::InterpreterError;
 use crate::functions::calculus_ast::is_constant_wrt;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::{gcd_i128, rat_reduce};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
@@ -370,11 +370,7 @@ fn collect_factors(
 }
 
 fn reduce_base(parts: &mut TermParts) {
-  let g = gcd_i128(parts.base_num, parts.base_den);
-  if g > 1 {
-    parts.base_num /= g;
-    parts.base_den /= g;
-  }
+  (parts.base_num, parts.base_den) = rat_reduce(parts.base_num, parts.base_den);
 }
 
 fn as_power(expr: &Expr) -> Option<(Expr, Expr)> {
@@ -468,13 +464,7 @@ fn linear_coeff_in_n(arg: &Expr, n_var: &str) -> Option<Expr> {
 type Frac = (i128, i128); // (numerator, denominator), denominator > 0
 
 fn frac(n: i128, d: i128) -> Frac {
-  let g = gcd_i128(n, d);
-  let (mut n, mut d) = if g == 0 { (0, 1) } else { (n / g, d / g) };
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
-  (n, d)
+  rat_reduce(n, d)
 }
 
 fn frac_add(a: Frac, b: Frac) -> Frac {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1729,9 +1729,8 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
         match denom {
           Some(d) => {
             // Simplify the fraction
-            let g = crate::functions::math_ast::gcd_i128(mantissa, d);
-            let num = mantissa / g;
-            let den = d / g;
+            let (num, den) =
+              crate::functions::math_ast::rat_reduce(mantissa, d);
             if den == 1 {
               Expr::Integer(num)
             } else {


### PR DESCRIPTION
This should cover the majority of the remaining cases where rat_reduce is a better choice than calling gcd_i128 directly.