### PR TITLE
Fix some more tests on Windows using /tmp paths

### DIFF
--- a/tests/interpreter_tests/functions.rs
+++ b/tests/interpreter_tests/functions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::interpreter_tests::io::temp_file;
 
 mod unique {
   use super::*;
@@ -2871,7 +2872,11 @@ mod file_exists_q {
 
   #[test]
   fn existing_path() {
-    assert_eq!(interpret("FileExistsQ[\"/tmp\"]").unwrap(), "True");
+    let path = temp_file("");
+    assert_eq!(
+      interpret(&format!("FileExistsQ[\"{path}\"]")).unwrap(),
+      "True"
+    );
   }
 
   #[test]
@@ -2996,9 +3001,10 @@ mod delete_file {
 
   #[test]
   fn delete_existing() {
+    let file = temp_file("woxi_test_delete.txt");
     assert_eq!(
       interpret(
-        "WriteString[\"/tmp/test_delete_woxi.txt\", \"hello\"]; DeleteFile[\"/tmp/test_delete_woxi.txt\"]; FileExistsQ[\"/tmp/test_delete_woxi.txt\"]"
+        &format!("WriteString[\"{file}\", \"hello\"]; DeleteFile[\"{file}\"]; FileExistsQ[\"{file}\"]")
       )
       .unwrap(),
       "False"

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::interpreter_tests::io::temp_file;
 
 /// Helper: wraps an expression with ExportString[..., "SVG"], evaluates it,
 /// and returns the SVG string. Panics if evaluation fails or if the result
@@ -1152,14 +1153,15 @@ mod plot3d {
 
     #[test]
     fn export_svg() {
-      let result = interpret(
-        "Export[\"/tmp/test_plot3d.svg\", Plot3D[x + y, {x, -1, 1}, {y, -1, 1}]]",
-      );
+      let file = temp_file("woxi_test_plot3d.svg");
+      let result = interpret(&format!(
+        "Export[\"{file}\", Plot3D[x + y, {{x, -1, 1}}, {{y, -1, 1}}]]"
+      ));
       assert!(result.is_ok());
-      let content = std::fs::read_to_string("/tmp/test_plot3d.svg").unwrap();
+      let content = std::fs::read_to_string(&file).unwrap();
       assert!(content.starts_with("<svg"));
       assert!(content.contains("<polygon"));
-      std::fs::remove_file("/tmp/test_plot3d.svg").ok();
+      std::fs::remove_file(file).ok();
     }
 
     /// Regression test: Export["foo.png", Plot[...]] used to write the raw
@@ -1168,12 +1170,12 @@ mod plot3d {
     /// dropped because "sans-serif" had no matching font in the db).
     #[test]
     fn export_png_from_plot() {
-      let path = "/tmp/test_plot_export.png";
+      let path = temp_file("woxi_test_plot_export.png");
       let result = interpret(&format!(
         "Export[\"{path}\", Plot[Sin[x], {{x, -2 Pi, 2 Pi}}]]"
       ));
       assert!(result.is_ok(), "Export returned error: {result:?}");
-      let bytes = std::fs::read(path).unwrap();
+      let bytes = std::fs::read(&path).unwrap();
       // PNG magic: 89 50 4E 47 0D 0A 1A 0A
       assert_eq!(
         &bytes[..8],
@@ -1217,8 +1219,8 @@ mod plot3d {
     /// with ImageSize -> 800 at 300 DPI should come out at 2500 px wide.
     #[test]
     fn export_png_with_image_resolution() {
-      let path_hi = "/tmp/test_plot_export_hi.png";
-      let path_lo = "/tmp/test_plot_export_lo.png";
+      let path_hi = temp_file("woxi_test_plot_export_hi.png");
+      let path_lo = temp_file("woxi_test_plot_export_lo.png");
       let result_hi = interpret(&format!(
         "Export[\"{path_hi}\", \
          Plot[Sin[x], {{x, -3 Pi, 3 Pi}}, ImageSize -> 800], \
@@ -1231,8 +1233,8 @@ mod plot3d {
       ));
       assert!(result_lo.is_ok(), "Export returned error: {result_lo:?}");
 
-      let bytes_hi = std::fs::read(path_hi).unwrap();
-      let bytes_lo = std::fs::read(path_lo).unwrap();
+      let bytes_hi = std::fs::read(&path_hi).unwrap();
+      let bytes_lo = std::fs::read(&path_lo).unwrap();
       // PNG magic
       assert_eq!(
         &bytes_hi[..8],
@@ -1253,11 +1255,11 @@ mod plot3d {
 
     #[test]
     fn export_jpeg_from_plot() {
-      let path = "/tmp/test_plot_export.jpg";
+      let path = temp_file("woxi_test_plot_export.jpg");
       let result =
         interpret(&format!("Export[\"{path}\", Plot[Cos[x], {{x, 0, 2 Pi}}]]"));
       assert!(result.is_ok(), "Export returned error: {result:?}");
-      let bytes = std::fs::read(path).unwrap();
+      let bytes = std::fs::read(&path).unwrap();
       // JPEG SOI marker: FF D8 FF
       assert_eq!(
         &bytes[..3],
@@ -1274,8 +1276,8 @@ mod plot3d {
       // harness hit ARG_MAX before the image could even reach Export;
       // pin the behaviour here from a Rust test so the full path is
       // exercised.
-      let path = "/tmp/test_export_image_numericarray.jpg";
-      let _ = std::fs::remove_file(path);
+      let path = temp_file("woxi_test_export_image_numericarray.jpg");
+      let _ = std::fs::remove_file(&path);
       let code = format!(
         "Export[\"{path}\", Image[NumericArray[\
          {{{{{{62, 91, 147}}, {{69, 99, 160}}, {{74, 106, 167}}}}, \
@@ -1285,7 +1287,7 @@ mod plot3d {
       );
       let result = interpret(&code).unwrap();
       assert_eq!(result, path);
-      let bytes = std::fs::read(path).unwrap();
+      let bytes = std::fs::read(&path).unwrap();
       assert_eq!(
         &bytes[..3],
         &[0xFF, 0xD8, 0xFF],
@@ -1300,7 +1302,7 @@ mod plot3d {
     /// GIF (1504×15 px) of the textual list representation.
     #[test]
     fn export_animated_gif_from_graphics_list() {
-      let path = "/tmp/test_animated.gif";
+      let path = temp_file("woxi_test_animated.gif");
       let result = interpret(&format!(
         "Export[\"{path}\", \
          Table[Graphics[{{Disk[{{0, 0}}, r/10]}}, \
@@ -1309,12 +1311,12 @@ mod plot3d {
       ));
       assert!(result.is_ok(), "Export returned error: {result:?}");
 
-      let bytes = std::fs::read(path).unwrap();
+      let bytes = std::fs::read(&path).unwrap();
       // GIF magic: "GIF89a"
       assert_eq!(&bytes[..6], b"GIF89a", "file at {path} is not a GIF");
 
       // Decode and verify it's actually multi-frame.
-      let file = std::io::BufReader::new(std::fs::File::open(path).unwrap());
+      let file = std::io::BufReader::new(std::fs::File::open(&path).unwrap());
       let decoder = ::image::codecs::gif::GifDecoder::new(file).unwrap();
       use ::image::AnimationDecoder;
       let frames: Vec<_> = decoder
@@ -3287,9 +3289,10 @@ mod plot3d {
     // player only appears in visual hosts).
     #[test]
     fn audio_file_object_stays_symbolic() {
+      let path = temp_file("woxi_missing.flac");
       assert_eq!(
-        interpret("Audio[File[\"/tmp/missing.flac\"]]").unwrap(),
-        "Audio[File[/tmp/missing.flac]]"
+        interpret(&format!("Audio[File[\"{path}\"]]")).unwrap(),
+        format!("Audio[File[{path}]]")
       );
     }
 

--- a/tests/interpreter_tests/image.rs
+++ b/tests/interpreter_tests/image.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::interpreter_tests::io::temp_file;
 
 mod image_core {
   use super::*;
@@ -3298,15 +3299,16 @@ mod image_io {
   #[test]
   fn export_image() {
     clear_state();
-    let result = interpret(
-      "Export[\"/tmp/woxi_test_export.png\", Image[{{0, 0.5, 1}, {1, 0.5, 0}}]]",
-    )
+    let file = temp_file("woxi_test_export.png");
+    let result = interpret(&format!(
+      "Export[\"{file}\", Image[{{{{0, 0.5, 1}}, {{1, 0.5, 0}}}}]]"
+    ))
     .unwrap();
-    assert_eq!(result, "/tmp/woxi_test_export.png");
+    assert_eq!(result, file);
     // Verify file was created
-    assert!(std::path::Path::new("/tmp/woxi_test_export.png").exists());
+    assert!(std::path::Path::new(&file).exists());
     // Clean up
-    std::fs::remove_file("/tmp/woxi_test_export.png").ok();
+    std::fs::remove_file(file).ok();
   }
 
   #[test]
@@ -3329,16 +3331,14 @@ mod image_io {
   #[test]
   fn export_and_reimport() {
     clear_state();
-    let _ = interpret(
-      "Export[\"/tmp/woxi_test_roundtrip.png\", Image[{{0, 0.5, 1}}]]",
-    )
-    .unwrap();
+    let file = temp_file("woxi_test_roundtrip.png");
+    let _ = interpret(&format!("Export[\"{file}\", Image[{{{{0, 0.5, 1}}}}]]"))
+      .unwrap();
     let result =
-      interpret("ImageDimensions[Import[\"/tmp/woxi_test_roundtrip.png\"]]")
-        .unwrap();
+      interpret(&format!("ImageDimensions[Import[\"{file}\"]]")).unwrap();
     assert_eq!(result, "{3, 1}");
     // Clean up
-    std::fs::remove_file("/tmp/woxi_test_roundtrip.png").ok();
+    std::fs::remove_file(file).ok();
   }
 }
 

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -17,7 +17,7 @@ fn unixify(path: String) -> String {
   path.replace("\\", "/")
 }
 
-fn temp_file(file: &str) -> String {
+pub(crate) fn temp_file(file: &str) -> String {
   let tmp = std::env::temp_dir().join(file);
   unixify(tmp.display().to_string())
 }


### PR DESCRIPTION
Change more tests to get the tmp path rather than hardcode "/tmp" (which likely won't exist on Windows).