### PR TITLE
Add and apply rat_reduce_bigint

### DIFF
--- a/src/functions/count_roots_ast.rs
+++ b/src/functions/count_roots_ast.rs
@@ -13,7 +13,7 @@
 //! Real-valued bounds) returns the call unevaluated.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd_bigint;
+use crate::functions::math_ast::rat_reduce_bigint;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 use num_bigint::BigInt;
 use num_traits::{One, Signed, Zero};
@@ -31,15 +31,7 @@ struct Rat {
 impl Rat {
   fn new(mut n: BigInt, mut d: BigInt) -> Rat {
     debug_assert!(!d.is_zero());
-    if d.is_negative() {
-      n = -n;
-      d = -d;
-    }
-    let g = gcd_bigint(&n, &d);
-    if !g.is_zero() && !g.is_one() {
-      n /= &g;
-      d /= &g;
-    }
+    (n, d) = rat_reduce_bigint(&n, &d);
     Rat { n, d }
   }
 

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -12,7 +12,7 @@
 //! (1, -1, I, -I, or E^((a*I)/b*Pi) forms on the principal branch).
 
 use crate::InterpreterError;
-use crate::functions::math_ast::{gcd_bigint, gcd_i128, rat_reduce};
+use crate::functions::math_ast::{gcd_i128, rat_reduce, rat_reduce_bigint};
 use crate::syntax::Expr;
 use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
 
@@ -347,7 +347,6 @@ fn total_rotation(factors: &[Factor], exps: &[i128], a: i128) -> (i128, i128) {
 /// with higher-order values stay unevaluated.
 pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   use num_bigint::BigInt;
-  use num_traits::Zero;
   let unevaluated = |args: &[Expr]| unevaluated("DirichletL", args);
   if args.len() != 3 {
     return Ok(unevaluated(args));
@@ -487,18 +486,8 @@ pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Fraction helpers over BigInt
   type Frac = (BigInt, BigInt);
-  let reduce = |num: BigInt, den: BigInt| -> Frac {
-    let mut g = gcd_bigint(&num, &den);
-    if g.is_zero() {
-      g = BigInt::from(1);
-    }
-    let (mut n, mut d) = (num / &g, den / g);
-    if d < BigInt::from(0) {
-      n = -n;
-      d = -d;
-    }
-    (n, d)
-  };
+  let reduce =
+    |num: BigInt, den: BigInt| -> Frac { rat_reduce_bigint(&num, &den) };
   let add = |a: &Frac, b: &Frac| reduce(&a.0 * &b.1 + &b.0 * &a.1, &a.1 * &b.1);
   let mul = |a: &Frac, b: &Frac| reduce(&a.0 * &b.0, &a.1 * &b.1);
 

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1620,27 +1620,13 @@ impl Coeff {
         // Overflow: promote to BigInt
         let (n1, d1) = Self::to_big(*n1, *d1);
         let (n2, d2) = Self::to_big(*n2, *d2);
-        let mut sn = &n1 * &d2 + &n2 * &d1;
-        let mut sd = d1 * d2;
-        let g = gcd_bigint(&sn, &sd);
-        sn /= &g;
-        sd /= g;
-        if sd < BigInt::from(0) {
-          sn = -sn;
-          sd = -sd;
-        }
+        let (mut sn, mut sd) = (&n1 * &d2 + &n2 * &d1, d1 * d2);
+        (sn, sd) = rat_reduce_bigint(&sn, &sd);
         Self::BigExact(sn, sd)
       }
       (Self::BigExact(n1, d1), Self::BigExact(n2, d2)) => {
-        let mut sn = n1 * d2 + n2 * d1;
-        let mut sd = d1 * d2;
-        let g = gcd_bigint(&sn, &sd);
-        sn /= &g;
-        sd /= g;
-        if sd < BigInt::from(0) {
-          sn = -sn;
-          sd = -sd;
-        }
+        let (mut sn, mut sd) = (n1 * d2 + n2 * d1, d1 * d2);
+        (sn, sd) = rat_reduce_bigint(&sn, &sd);
         Self::BigExact(sn, sd)
       }
       (Self::Exact(n, d), Self::BigExact(..))
@@ -1673,27 +1659,13 @@ impl Coeff {
         }
         let (n1, d1) = Self::to_big(*n1, *d1);
         let (n2, d2) = Self::to_big(*n2, *d2);
-        let mut sn = &n1 * &n2;
-        let mut sd = d1 * d2;
-        let g = gcd_bigint(&sn, &sd);
-        sn /= &g;
-        sd /= g;
-        if sd < BigInt::from(0) {
-          sn = -sn;
-          sd = -sd;
-        }
+        let (mut sn, mut sd) = (&n1 * &n2, d1 * d2);
+        (sn, sd) = rat_reduce_bigint(&sn, &sd);
         Self::BigExact(sn, sd)
       }
       (Self::BigExact(n1, d1), Self::BigExact(n2, d2)) => {
-        let mut sn = n1 * n2;
-        let mut sd = d1 * d2;
-        let g = gcd_bigint(&sn, &sd);
-        sn /= &g;
-        sd /= g;
-        if sd < BigInt::from(0) {
-          sn = -sn;
-          sd = -sd;
-        }
+        let (mut sn, mut sd) = (n1 * n2, d1 * d2);
+        (sn, sd) = rat_reduce_bigint(&sn, &sd);
         Self::BigExact(sn, sd)
       }
       (Self::Exact(n, d), Self::BigExact(..))
@@ -7543,17 +7515,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
 
     // Reduce the fraction by gcd and fix the sign onto the numerator.
-    {
-      let g = gcd_bigint(&big_numer, &big_denom);
-      if g != BigInt::from(0) {
-        big_numer /= &g;
-        big_denom /= &g;
-      }
-      if big_denom < BigInt::from(0) {
-        big_numer = -big_numer;
-        big_denom = -big_denom;
-      }
-    }
+    (big_numer, big_denom) = rat_reduce_bigint(&big_numer, &big_denom);
     let coeff_is_int = big_denom == BigInt::from(1);
 
     if all_int && coeff_is_int {
@@ -7886,13 +7848,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     None => {
       let big_numer = BigInt::from(int_product) * BigInt::from(rat_numer);
       let big_denom = BigInt::from(rat_denom);
-      let g = gcd_bigint(&big_numer, &big_denom);
-      let mut sn = big_numer / &g;
-      let mut sd = big_denom / g;
-      if sd < BigInt::from(0) {
-        sn = -sn;
-        sd = -sd;
-      }
+      let (sn, sd) = rat_reduce_bigint(&big_numer, &big_denom);
       let coeff_expr = {
         use num_traits::One;
         if sd.is_one() {
@@ -8809,14 +8765,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
       if denom.is_zero() {
         return Ok(divide_by_zero_result(a));
       }
-      let g = gcd_bigint(&numer, &denom);
-      let mut rn = &numer / &g;
-      let mut rd = &denom / &g;
-      // Normalize sign: put sign in numerator
-      if rd < BigInt::from(0) {
-        rn = -rn;
-        rd = -rd;
-      }
+      let (rn, rd) = rat_reduce_bigint(&numer, &denom);
       if rd == BigInt::from(1) {
         return Ok(bigint_to_expr(rn));
       }
@@ -9068,13 +9017,7 @@ pub fn divide_two(a: &Expr, b: &Expr) -> Result<Expr, InterpreterError> {
         if denom.is_zero() {
           return Ok(divide_by_zero_result(a));
         }
-        let g = gcd_bigint(&numer, &denom);
-        let mut rn = &numer / &g;
-        let mut rd = &denom / &g;
-        if rd < BigInt::from(0) {
-          rn = -rn;
-          rd = -rd;
-        }
+        let (rn, rd) = rat_reduce_bigint(&numer, &denom);
         if rd == BigInt::from(1) {
           return Ok(bigint_to_expr(rn));
         }
@@ -10586,12 +10529,8 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     let k_n = num_traits::pow::pow(k_big, *n as usize);
 
     // Reduce fractions
-    let g_re = gcd_bigint(&result_re, &k_n);
-    let final_re_n = &result_re / &g_re;
-    let final_re_d = &k_n / &g_re;
-    let g_im = gcd_bigint(&result_im, &k_n);
-    let final_im_n = &result_im / &g_im;
-    let final_im_d = &k_n / &g_im;
+    let (final_re_n, final_re_d) = rat_reduce_bigint(&result_re, &k_n);
+    let (final_im_n, final_im_d) = rat_reduce_bigint(&result_im, &k_n);
 
     // Try to convert back to i128
     if let (Some(rn), Some(rd), Some(imn), Some(imd)) = (

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -2576,9 +2576,7 @@ pub fn from_digits_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       // Need a rational: int_val / base^(-shift)
       let denom = big_base.pow((-shift) as u32);
-      let g = gcd_bigint(&int_val, &denom);
-      let num = &int_val / &g;
-      let den = &denom / &g;
+      let (num, den) = rat_reduce_bigint(&int_val, &denom);
       if den == BigInt::from(1) {
         return Ok(bigint_to_expr(num));
       } else {
@@ -4077,18 +4075,8 @@ pub fn minkowski_question_mark_ast(
   };
 
   // Exact fraction arithmetic over BigInt
-  let gcd_bigint = |a: &BigInt, b: &BigInt| -> BigInt {
-    let g = crate::functions::math_ast::gcd_bigint(a, b);
-    if g.is_zero() { BigInt::from(1) } else { g }
-  };
   let reduce = |num: BigInt, den: BigInt| -> (BigInt, BigInt) {
-    let g = gcd_bigint(&num, &den);
-    let (mut n, mut d) = (num / &g, den / g);
-    if d < BigInt::from(0) {
-      n = -n;
-      d = -d;
-    }
-    (n, d)
+    rat_reduce_bigint(&num, &den)
   };
   let add = |a: &(BigInt, BigInt), b: &(BigInt, BigInt)| -> (BigInt, BigInt) {
     reduce(&a.0 * &b.1 + &b.0 * &a.1, &a.1 * &b.1)

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -452,9 +452,7 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 fn gamma_half_expr(numer: BigInt, denom: BigInt, is_neg: bool) -> Expr {
   // Simplify the rational part
-  let g = gcd_bigint(&numer, &denom);
-  let num_simplified = &numer / &g;
-  let den_simplified = &denom / &g;
+  let (num_simplified, den_simplified) = rat_reduce_bigint(&numer, &denom);
   let coeff_num = if is_neg {
     -num_simplified.clone()
   } else {

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1292,9 +1292,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       let denom = fact(n - k) * &b_pochhammer * &k_fact;
       // coeff = n! / denom (reduce GCD).
-      let g = gcd_bigint(&n_fact, &denom);
-      let cn = &n_fact / &g;
-      let cd = &denom / &g;
+      let (cn, cd) = rat_reduce_bigint(&n_fact, &denom);
       let z_pow = if k == 0 {
         Expr::Integer(1)
       } else if k == 1 {

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -428,19 +428,13 @@ fn lcm_bigint(a: BigInt, b: BigInt) -> BigInt {
 /// Reduce numerator/denominator and emit either an Integer (when the
 /// denominator is 1) or a `Rational[p, q]` Expr.
 pub fn make_rational_expr(num: BigInt, den: BigInt) -> Expr {
-  use num_traits::{One, Zero};
+  use num_traits::One;
   if den.is_zero() {
     // Wolfram returns ComplexInfinity for 1/0 — preserve that here so
     // callers see the same surface behaviour.
     return Expr::Identifier("ComplexInfinity".to_string());
   }
-  let g = gcd_bigint(&num, &den);
-  let mut n = num / &g;
-  let mut d = den / g;
-  if d < BigInt::from(0) {
-    n = -n;
-    d = -d;
-  }
+  let (n, d) = rat_reduce_bigint(&num, &den);
   if d.is_one() {
     return bigint_to_expr(n);
   }
@@ -1013,16 +1007,7 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // pair in BigInt, so large numerators (e.g. BernoulliB[60]) don't overflow
   // i128.
   fn rat_reduce(num: BigInt, den: BigInt) -> (BigInt, BigInt) {
-    let mut g = gcd_bigint(&num, &den);
-    if g.is_zero() {
-      g = BigInt::from(1);
-    }
-    let (num, den) = (num / &g, den / &g);
-    if den < BigInt::from(0) {
-      (-num, -den)
-    } else {
-      (num, den)
-    }
+    rat_reduce_bigint(&num, &den)
   }
   fn rat_add(a: &(BigInt, BigInt), b: &(BigInt, BigInt)) -> (BigInt, BigInt) {
     rat_reduce(&a.0 * &b.1 + &b.0 * &a.1, &a.1 * &b.1)
@@ -1896,23 +1881,16 @@ pub fn harmonic_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Compute as exact rational: sum of 1/k^r for k = 1 to n
   // Use BigInt numerator and denominator
-  let mut num = BigInt::from(0);
-  let mut den = BigInt::from(1);
+  let (mut num, mut den) = (BigInt::from(0), BigInt::from(1));
   if r >= 0 {
     // Standard case: sum of 1/k^r
     for k in 1..=n {
       let k_big = BigInt::from(k);
       let k_pow = num_traits::pow::pow(k_big, r as usize);
       // Add 1/k_pow to num/den: num/den + 1/k_pow = (num*k_pow + den) / (den*k_pow)
-      num = &num * &k_pow + &den;
-      den = &den * &k_pow;
+      (num, den) = (&num * &k_pow + &den, &den * &k_pow);
       // Reduce
-      let g = gcd_bigint(&num, &den);
-      use num_traits::One;
-      if g > BigInt::one() {
-        num /= &g;
-        den /= &g;
-      }
+      (num, den) = rat_reduce_bigint(&num, &den);
     }
   } else {
     // Negative r: sum of k^|r| (each term is an integer, result is integer)
@@ -2181,8 +2159,7 @@ pub fn alternating_harmonic_number_ast(
 
     if let Some(r) = expr_to_i128(&r_expr) {
       // Exact rational alternating sum, mirroring harmonic_number_ast.
-      let mut num = BigInt::from(0);
-      let mut den = BigInt::from(1);
+      let (mut num, mut den) = (BigInt::from(0), BigInt::from(1));
       if r >= 0 {
         for k in 1..=n {
           let k_pow = num_traits::pow::pow(BigInt::from(k), r as usize);
@@ -2191,14 +2168,8 @@ pub fn alternating_harmonic_number_ast(
           } else {
             den.clone()
           };
-          num = &num * &k_pow + signed;
-          den = &den * &k_pow;
-          let g = gcd_bigint(&num, &den);
-          use num_traits::One;
-          if g > BigInt::one() {
-            num /= &g;
-            den /= &g;
-          }
+          (num, den) = (&num * &k_pow + signed, &den * &k_pow);
+          (num, den) = rat_reduce_bigint(&num, &den);
         }
       } else {
         // Negative order: alternating power sum, always an integer.
@@ -9147,17 +9118,12 @@ fn extract_perfect_square_bigint(n: &BigInt) -> (BigInt, BigInt) {
 }
 
 fn bigint_rational_to_expr(num: BigInt, den: BigInt) -> Expr {
-  use num_traits::Zero;
+  use num_traits::One;
   if den.is_zero() {
     return Expr::Identifier("ComplexInfinity".to_string());
   }
-  let g = gcd_bigint(&num, &den);
-  let (mut n, mut d) = (num / &g, den / &g);
-  if d < BigInt::from(0) {
-    n = -n;
-    d = -d;
-  }
-  if d == BigInt::from(1) {
+  let (n, d) = rat_reduce_bigint(&num, &den);
+  if d.is_one() {
     return bigint_to_expr(n);
   }
   Expr::FunctionCall {

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -3,6 +3,7 @@ use super::*;
 use crate::InterpreterError;
 use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 use num_bigint::BigInt;
+use num_traits::{Signed, Zero};
 
 /// Helper - constants are kept symbolic, no direct f64 conversion in expr_to_num.
 pub fn constant_to_f64(_name: &str) -> Option<f64> {
@@ -562,7 +563,7 @@ pub fn expr_to_bigint(e: &Expr) -> Option<BigInt> {
 /// `num.to_f64() / den.to_f64()` would compute `inf / inf = NaN` there.
 /// Returns None when `den` is zero.
 fn big_rational_to_f64(num: &BigInt, den: &BigInt) -> Option<f64> {
-  use num_traits::{Signed, ToPrimitive, Zero};
+  use num_traits::ToPrimitive;
   if den.is_zero() {
     return None;
   }
@@ -734,7 +735,6 @@ pub fn lcm_i128(a: i128, b: i128) -> i128 {
 
 /// Compute the (non-negative) GCD of two BigInts.
 pub fn gcd_bigint(a: &BigInt, b: &BigInt) -> BigInt {
-  use num_traits::{Signed, Zero};
   let (mut a, mut b) = (a.abs(), b.abs());
   while !b.is_zero() {
     let r = &a % &b;
@@ -748,6 +748,15 @@ pub fn rat_reduce(n: i128, d: i128) -> (i128, i128) {
   let g = gcd_i128(n, d).max(1);
   let (n, d) = (n / g, d / g);
   if d < 0 { (-n, -d) } else { (n, d) }
+}
+
+pub fn rat_reduce_bigint(n: &BigInt, d: &BigInt) -> (BigInt, BigInt) {
+  let mut g = gcd_bigint(n, d);
+  if g.is_zero() {
+    g = BigInt::from(1);
+  }
+  let (n, d) = (n / &g, d / g);
+  if d.is_negative() { (-n, -d) } else { (n, d) }
 }
 
 /// Extract the largest easily-found perfect-square factor from a positive

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -826,10 +826,8 @@ fn legendre_eval_rational(n: usize, x: (BigInt, BigInt)) -> (BigInt, BigInt) {
     return (xn, xd);
   }
 
-  let mut prev_n = BigInt::from(1); // P_0 = 1/1
-  let mut prev_d = BigInt::from(1);
-  let mut curr_n = xn.clone(); // P_1 = x
-  let mut curr_d = xd.clone();
+  let (mut prev_n, mut prev_d) = (BigInt::from(1), BigInt::from(1)); // P_0 = 1/1
+  let (mut curr_n, mut curr_d) = (xn.clone(), xd.clone()); // P_1 = x
 
   for m in 1..n {
     // P_{m+1} = ((2m+1)*x*P_m - m*P_{m-1}) / (m+1)
@@ -843,15 +841,10 @@ fn legendre_eval_rational(n: usize, x: (BigInt, BigInt)) -> (BigInt, BigInt) {
 
     let diff_n = &term1_n * &term2_d - &term2_n * &term1_d;
     let diff_d = &term1_d * &term2_d * (&m_i + BigInt::from(1));
+    let (next_n, next_d) = rat_reduce_bigint(&diff_n, &diff_d);
 
-    let g = gcd_bigint(&diff_n, &diff_d);
-    let next_n = &diff_n / &g;
-    let next_d = &diff_d / &g;
-
-    prev_n = curr_n;
-    prev_d = curr_d;
-    curr_n = next_n;
-    curr_d = next_d;
+    (prev_n, prev_d) = (curr_n, curr_d);
+    (curr_n, curr_d) = (next_n, next_d);
   }
 
   (curr_n, curr_d)
@@ -2317,13 +2310,8 @@ fn chebyshev_t_eval_rational(
     let a_d = &xd * &t.1;
     let new_n = &a_n * &tm1.1 - &tm1.0 * &a_d;
     let new_d = &a_d * &tm1.1;
-    let g = gcd_bigint(&new_n, &new_d);
     tm1 = t;
-    t = if g != BigInt::from(0) {
-      (&new_n / &g, &new_d / &g)
-    } else {
-      (new_n, new_d)
-    };
+    t = rat_reduce_bigint(&new_n, &new_d);
   }
   t
 }
@@ -2535,13 +2523,8 @@ fn chebyshev_u_eval_rational(
     let a_d = &xd * &u.1;
     let new_n = &a_n * &um1.1 - &um1.0 * &a_d;
     let new_d = &a_d * &um1.1;
-    let g = gcd_bigint(&new_n, &new_d);
     um1 = u;
-    u = if g != BigInt::from(0) {
-      (&new_n / &g, &new_d / &g)
-    } else {
-      (new_n, new_d)
-    };
+    u = rat_reduce_bigint(&new_n, &new_d);
   }
   u
 }
@@ -2909,12 +2892,7 @@ fn gegenbauer_eval_rational(
   // C_1 = 2λx = (2*lam_n*x_n, lam_d*x_d)
   let c1_n = BigInt::from(2) * &lam.0 * &x.0;
   let c1_d = &lam.1 * &x.1;
-  let g = gcd_bigint(&c1_n, &c1_d);
-  let c1 = if g != BigInt::from(0) {
-    (&c1_n / &g, &c1_d / &g)
-  } else {
-    (c1_n, c1_d)
-  };
+  let c1 = rat_reduce_bigint(&c1_n, &c1_d);
   if n == 1 {
     return c1;
   }
@@ -2948,13 +2926,8 @@ fn gegenbauer_eval_rational(
     let new_n = diff_n;
     let new_d = diff_d * (&kk + BigInt::from(1));
 
-    let g = gcd_bigint(&new_n, &new_d);
     cm1 = c;
-    c = if g != BigInt::from(0) {
-      (&new_n / &g, &new_d / &g)
-    } else {
-      (new_n, new_d)
-    };
+    c = rat_reduce_bigint(&new_n, &new_d);
   }
   c
 }
@@ -3579,13 +3552,8 @@ fn laguerre_eval_rational(n: usize, x: (BigInt, BigInt)) -> (BigInt, BigInt) {
     let sub_n = &a_n * b_d - &b_n * &a_d;
     let sub_d = &a_d * b_d * (&kf + BigInt::from(1));
 
-    let g = gcd_bigint(&sub_n, &sub_d);
     lm1 = l;
-    l = if g != BigInt::from(0) {
-      (&sub_n / &g, &sub_d / &g)
-    } else {
-      (sub_n, sub_d)
-    };
+    l = rat_reduce_bigint(&sub_n, &sub_d);
   }
   l
 }

--- a/src/functions/polynomial_ast/linear_programming.rs
+++ b/src/functions/polynomial_ast/linear_programming.rs
@@ -11,7 +11,7 @@
 //! generous iteration budget so it can never cycle on degenerate problems.
 
 use crate::InterpreterError;
-use crate::functions::math_ast::gcd_bigint;
+use crate::functions::math_ast::rat_reduce_bigint;
 use crate::syntax::{Expr, unevaluated};
 use num_bigint::BigInt;
 use num_traits::{One, Signed, Zero};
@@ -43,15 +43,7 @@ impl Rat {
     Rat::from_int(BigInt::one())
   }
   fn reduce(&mut self) {
-    if self.den.is_negative() {
-      self.num = -&self.num;
-      self.den = -&self.den;
-    }
-    let g = gcd_bigint(&self.num, &self.den);
-    if !g.is_zero() && !g.is_one() {
-      self.num /= &g;
-      self.den /= &g;
-    }
+    (self.num, self.den) = rat_reduce_bigint(&self.num, &self.den);
   }
   fn is_zero(&self) -> bool {
     self.num.is_zero()

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::InterpreterError;
 use crate::functions::calculus_ast::simplify;
-use crate::functions::math_ast::{gcd_i128, rat_reduce};
+use crate::functions::math_ast::{gcd_i128, rat_reduce, rat_reduce_bigint};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
 };
@@ -9383,9 +9383,7 @@ fn try_merge_logs(expr: &Expr) -> Option<Expr> {
         den *= n.pow((-c) as u32);
       }
     }
-    let g = crate::functions::math_ast::gcd_bigint(&num, &den);
-    let num = &num / &g;
-    let den = &den / &g;
+    let (num, den) = rat_reduce_bigint(&num, &den);
     let q = if den.is_one() {
       crate::functions::math_ast::bigint_to_expr(num)
     } else {


### PR DESCRIPTION
Like rat_reduce, the rat_reduce_bigint helper replaces many uses of gcd_bigint with less code.