### PR TITLE
Fix file_exists_q::existing_path test on Windows

### DIFF
--- a/tests/interpreter_tests/functions.rs
+++ b/tests/interpreter_tests/functions.rs
@@ -2871,7 +2871,11 @@ mod file_exists_q {
 
   #[test]
   fn existing_path() {
-    assert_eq!(interpret("FileExistsQ[\"/tmp\"]").unwrap(), "True");
+    let path = temp_file("");
+    assert_eq!(
+      interpret(&format!("FileExistsQ[\"{path}\"]")).unwrap(),
+      "True"
+    );
   }
 
   #[test]


### PR DESCRIPTION
Another case of Windows not having a /tmp directory.