### PR TITLE
More gcd_i128 simplifications

### DIFF
--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -4850,12 +4850,6 @@ fn lyapunov_solve_common(
     n: i128,
     d: i128,
   }
-  fn qgcd(mut a: i128, mut b: i128) -> i128 {
-    while b != 0 {
-      (a, b) = (b, a % b);
-    }
-    a.max(1)
-  }
   impl Q {
     fn new(mut n: i128, mut d: i128) -> Option<Q> {
       if d == 0 {
@@ -4865,8 +4859,8 @@ fn lyapunov_solve_common(
         n = n.checked_neg()?;
         d = d.checked_neg()?;
       }
-      let g = qgcd(n.abs(), d);
-      Some(Q { n: n / g, d: d / g })
+      (n, d) = rat_reduce(n, d);
+      Some(Q { n: n, d: d })
     }
     fn zero() -> Q {
       Q { n: 0, d: 1 }

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -893,17 +893,9 @@ fn factor_logarithmic_antiderivative(expr: &Expr, var: &str) -> Option<Expr> {
   if split.iter().any(|(_, _, p, _)| *p != common_power) {
     return None;
   }
-  let gcd = |mut a: i128, mut b: i128| {
-    while b != 0 {
-      let t = b;
-      b = a % b;
-      a = t;
-    }
-    a.abs()
-  };
   let denominator = split
     .iter()
-    .fold(1i128, |acc, (_, d, _, _)| acc / gcd(acc, *d) * d);
+    .fold(1i128, |acc, (_, d, _, _)| acc / gcd_i128(acc, *d) * d);
   if denominator == 1 {
     return None;
   }
@@ -7376,7 +7368,7 @@ fn try_integrate_rational(
       // than `4 + 2*Sqrt[3] - 2x`. The outer denominator stays at the
       // unsimplified `k * Sqrt[m]` (the Log[g] terms cancel between the two
       // arguments).
-      let g_bk = gcd_i128(b.abs(), k);
+      let g_bk = gcd_i128(b, k);
       let g = gcd_i128(g_bk, 2);
       let neg_b_g = -b / g;
       let b_g = b / g;
@@ -7634,9 +7626,9 @@ fn try_integrate_rational(
     let bc_b_scaled = if bc_scaled.len() < 2 { 0 } else { bc_scaled[1] };
 
     // Divide by lcm to get B and C as rationals
-    let g_b = gcd_i128(bc_b_scaled.abs(), lcm);
+    let g_b = gcd_i128(bc_b_scaled, lcm);
     let (big_b_num, big_b_den) = (bc_b_scaled / g_b, lcm / g_b);
-    let g_c = gcd_i128(bc_c_scaled.abs(), lcm);
+    let g_c = gcd_i128(bc_c_scaled, lcm);
     let (big_c_num, big_c_den) = (bc_c_scaled / g_c, lcm / g_c);
 
     // Convert to common B and C as integers (if possible) or rationals
@@ -7716,7 +7708,7 @@ fn try_integrate_rational(
 
       // Simplify ArcTan argument: (b + 2*x) / (k * sqrt(m))
       // The numerator coefficients are b and 2; divide both and k by their common factor.
-      let inner_gcd = if b == 0 { 2 } else { gcd_i128(b.abs(), 2) };
+      let inner_gcd = gcd_i128(b, 2);
       let g = gcd_i128(inner_gcd, k);
       let k_reduced = k / g;
       let b_simplified = b / g;

--- a/src/functions/geo_math.rs
+++ b/src/functions/geo_math.rs
@@ -7,7 +7,7 @@
 
 use crate::InterpreterError;
 use crate::functions::geographics::{position_to_latlon, positions_from_arg};
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::{Expr, UnaryOperator, unevaluated};
 use geographiclib_rs::{DirectGeodesic, Geodesic, InverseGeodesic};
 use std::sync::OnceLock;
@@ -312,8 +312,7 @@ impl AngleVal {
 fn rat_add(a: (i128, i128), b: (i128, i128)) -> Option<(i128, i128)> {
   let num = a.0.checked_mul(b.1)?.checked_add(b.0.checked_mul(a.1)?)?;
   let den = a.1.checked_mul(b.1)?;
-  let g = gcd_i128(num.abs().max(1), den);
-  Some((num / g, den / g))
+  Some(rat_reduce(num, den))
 }
 
 /// Convert a numeric scalar expression to an `AngleVal`. Exactness is

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -2930,7 +2930,7 @@ fn matrix_to_scaled_i128(
       if den != 1 {
         any_rational = true;
       }
-      scale = scale.checked_mul(den / gcd_i128(scale, den.abs()))?;
+      scale = scale.checked_mul(den / gcd_i128(scale, den))?;
       out_row.push((num, den));
     }
     entries.push(out_row);
@@ -3074,7 +3074,7 @@ fn quadratic_eigenvalues(b_coeff: i128, c_coeff: i128) -> Vec<Expr> {
 
   // Factor out GCD of neg_b and outer from the numerator:
   // (neg_b ± outer*Sqrt[inner]) / 2  =  common * (reduced_b ± reduced_outer*Sqrt[inner]) / 2
-  let common = gcd_i128(neg_b.abs(), outer as i128);
+  let common = gcd_i128(neg_b, outer as i128);
   let (reduced_b, reduced_outer) = (neg_b / common, outer as i128 / common);
 
   let sqrt_expr = make_sqrt(Expr::Integer(inner as i128));
@@ -3610,9 +3610,7 @@ fn int_poly_derivative(p: &[i128]) -> Vec<i128> {
 
 /// Content (gcd of all coefficients) of a nonzero integer polynomial.
 fn int_poly_content(p: &[i128]) -> i128 {
-  p.iter()
-    .fold(0i128, |acc, &c| gcd_i128(acc, c.abs()))
-    .max(1)
+  p.iter().fold(0i128, |acc, &c| gcd_i128(acc, c)).max(1)
 }
 
 /// Primitive part: divide out the content and drop leading zeros.
@@ -4061,7 +4059,7 @@ fn scale_to_integers(vec: &[Expr]) -> Vec<Expr> {
 
   // Find LCM of denominators
   let lcm_den = rats.iter().fold(1i128, |acc, &(_, d)| {
-    let g = gcd_i128(acc.abs(), d.abs());
+    let g = gcd_i128(acc, d);
     if g == 0 { acc } else { (acc / g) * d.abs() }
   });
 
@@ -4070,9 +4068,7 @@ fn scale_to_integers(vec: &[Expr]) -> Vec<Expr> {
     rats.iter().map(|&(n, d)| n * (lcm_den / d)).collect();
 
   // Find GCD of all entries
-  let g = scaled
-    .iter()
-    .fold(0i128, |acc, &x| gcd_i128(acc.abs(), x.abs()));
+  let g = scaled.iter().fold(0i128, |acc, &x| gcd_i128(acc, x));
 
   if g == 0 || g == 1 {
     scaled.iter().map(|&x| Expr::Integer(x)).collect()
@@ -4238,7 +4234,7 @@ fn eigenvectors_2x2_symbolic(int_matrix: &[Vec<i128>]) -> Vec<Vec<Expr>> {
     let build_v1 = |sign: i128| -> Expr {
       let signed_outer = sign * outer as i128;
       // Simplify: GCD of |diff|, |signed_outer|, |denom|
-      let g = gcd_i128(gcd_i128(diff.abs(), signed_outer.abs()), denom.abs());
+      let g = gcd_i128(gcd_i128(diff, signed_outer), denom);
       let rd = diff / g;
       let ro = (signed_outer / g).abs();
       let rden = denom / g;
@@ -4401,9 +4397,7 @@ fn normalize_symbolic_eigenvector(v: Vec<Expr>) -> Vec<Expr> {
         }
       })
       .collect();
-    let g = ints
-      .iter()
-      .fold(0i128, |acc, &x| gcd_i128(acc.abs(), x.abs()));
+    let g = ints.iter().fold(0i128, |acc, &x| gcd_i128(acc, x));
     if g == 0 {
       return v;
     }

--- a/src/functions/list_helpers_ast/aggregation.rs
+++ b/src/functions/list_helpers_ast/aggregation.rs
@@ -2,7 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::{gcd_i128, rat_reduce};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, UnaryOperator, bool_expr, unevaluated,
 };
@@ -909,13 +909,7 @@ fn hypoexponential_median(arg: &Expr) -> Option<Expr> {
     let new_num =
       sum_num.checked_mul(term_den)? + term_num.checked_mul(sum_den)?;
     let new_den = sum_den.checked_mul(term_den)?;
-    let g = gcd_i128(new_num.abs(), new_den.abs()).max(1);
-    sum_num = new_num / g;
-    sum_den = new_den / g;
-    if sum_den < 0 {
-      sum_num = -sum_num;
-      sum_den = -sum_den;
-    }
+    (sum_num, sum_den) = rat_reduce(new_num, new_den);
   }
 
   // sum equals 1/2 iff 2 * sum_num == sum_den.
@@ -1099,10 +1093,9 @@ pub fn median_ast(list: &Expr) -> Result<Expr, InterpreterError> {
         Ok(Expr::Integer(sum / 2))
       } else {
         // Return as Rational
-        let g = gcd_i128(sum.abs(), 2);
         Ok(Expr::FunctionCall {
           name: "Rational".to_string(),
-          args: vec![Expr::Integer(sum / g), Expr::Integer(2 / g)].into(),
+          args: vec![Expr::Integer(sum), Expr::Integer(2)].into(),
         })
       }
     }

--- a/src/functions/list_helpers_ast/construction.rs
+++ b/src/functions/list_helpers_ast/construction.rs
@@ -2,7 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::{BinaryOperator, unevaluated};
 
 /// AST-based Table: generate a table of values.
@@ -594,11 +594,7 @@ pub fn range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       cur_d *= step_d;
 
       // Simplify to avoid overflow
-      let g = gcd_i128(cur_n.abs(), cur_d.abs());
-      if g > 1 {
-        cur_n /= g;
-        cur_d /= g;
-      }
+      (cur_n, cur_d) = rat_reduce(cur_n, cur_d);
 
       if results.len() > 1_000_000 {
         return Err(InterpreterError::EvaluationError(
@@ -900,11 +896,7 @@ pub fn power_range_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       cur_d *= fac_d;
 
       // Simplify
-      let g = gcd_i128(cur_n.abs(), cur_d.abs());
-      if g > 1 {
-        cur_n /= g;
-        cur_d /= g;
-      }
+      (cur_n, cur_d) = rat_reduce(cur_n, cur_d);
 
       if results.len() > 1_000_000 {
         return Err(InterpreterError::EvaluationError(

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -2,7 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::{gcd_i128, rat_reduce};
 use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
 
 /// AnglePath[{θ1, θ2, ...}] - path with unit steps and cumulative turning angles.
@@ -5315,9 +5315,7 @@ fn zeta_even(s: i64) -> Result<Expr, InterpreterError> {
   let coeff_den = factorial * b_den.abs();
 
   // Simplify the fraction
-  let g = gcd_i128(coeff_num.abs(), coeff_den.abs());
-  let final_num = coeff_num / g;
-  let final_den = coeff_den / g;
+  let (final_num, final_den) = rat_reduce(coeff_num, coeff_den);
 
   // Build the expression: (final_num / final_den) * Pi^s
   let pi_power = if s == 1 {

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -2462,7 +2462,7 @@ fn norlund_b_poly(n: usize) -> Vec<(i128, i128)> {
       factorial *= j as i128;
     }
     if let Some((bn, bd)) = bernoulli_number(j) {
-      let g = gcd_i128(bn.abs(), factorial.abs());
+      let g = gcd_i128(bn, factorial);
       s.push((bn / g, bd * (factorial / g)));
     } else {
       s.push((0, 1));

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -235,12 +235,8 @@ fn extended_gcd_bigint(a: &BigInt, b: &BigInt) -> (BigInt, BigInt, BigInt) {
     if a.is_zero() {
       return (BigInt::from(0), BigInt::from(0), BigInt::from(0));
     }
-    let sign = if a >= &BigInt::from(0) {
-      BigInt::from(1)
-    } else {
-      BigInt::from(-1)
-    };
-    return (a.abs(), sign, BigInt::from(0));
+    let sign = if a.is_negative() { -1 } else { 1 };
+    return (a.abs(), BigInt::from(sign), BigInt::from(0));
   }
   let (mut old_r, mut r) = (a.clone(), b.clone());
   let (mut old_s, mut s) = (BigInt::from(1), BigInt::from(0));
@@ -249,21 +245,16 @@ fn extended_gcd_bigint(a: &BigInt, b: &BigInt) -> (BigInt, BigInt, BigInt) {
   while !r.is_zero() {
     let q = &old_r / &r;
     let new_r = &old_r - &q * &r;
-    old_r = r;
-    r = new_r;
+    (old_r, r) = (r, new_r);
     let new_s = &old_s - &q * &s;
-    old_s = s;
-    s = new_s;
+    (old_s, s) = (s, new_s);
     let new_t = &old_t - &q * &t;
-    old_t = t;
-    t = new_t;
+    (old_t, t) = (t, new_t);
   }
 
   // Ensure gcd is positive
   if old_r < BigInt::from(0) {
-    old_r = -old_r;
-    old_s = -old_s;
-    old_t = -old_t;
+    (old_r, old_s, old_t) = (-old_r, -old_s, -old_t);
   }
   (old_r, old_s, old_t)
 }
@@ -5439,8 +5430,8 @@ pub fn modular_inverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Extended Euclidean algorithm. `a` and the modulus must be coprime.
-  let (gcd, x, _) = extended_gcd(&a, &m_abs);
-  if !gcd.abs().is_one() {
+  let (gcd, x, _) = extended_gcd_bigint(&a, &m_abs);
+  if !gcd.is_one() {
     crate::emit_message(&format!(
       "ModularInverse::ninv: {} is not invertible modulo {}.",
       expr_to_string(&args[0]),
@@ -5456,16 +5447,6 @@ pub fn modular_inverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     result -= &m_abs;
   }
   Ok(bigint_to_expr(result))
-}
-
-/// Extended GCD: returns (gcd, x, y) such that a*x + b*y = gcd
-fn extended_gcd(a: &BigInt, b: &BigInt) -> (BigInt, BigInt, BigInt) {
-  use num_traits::Zero;
-  if a.is_zero() {
-    return (b.clone(), BigInt::zero(), BigInt::from(1));
-  }
-  let (g, x, y) = extended_gcd(&(b % a), a);
-  (g, y - (b / a) * &x, x)
 }
 
 // ─── BitLength ─────────────────────────────────────────────────────

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1268,12 +1268,7 @@ fn imaginary_pi_coeff(term: &Expr) -> Option<(i128, i128)> {
   if !(has_pi && has_imag) {
     return None;
   }
-  if den < 0 {
-    num = -num;
-    den = -den;
-  }
-  let g = gcd_i128(num.abs().max(1), den).max(1);
-  Some((num / g, den / g))
+  Some(rat_reduce(num, den))
 }
 
 /// If `arg` is a sum `rest + c Pi I` whose imaginary-`Pi` coefficient `c` is a
@@ -1332,8 +1327,7 @@ fn extract_imaginary_pi_shift(arg: &Expr) -> Option<((i128, i128), Expr)> {
     num = -num;
     den = -den;
   }
-  let g = gcd_i128(num.abs().max(1), den).max(1);
-  let (num, den) = (num / g, den / g);
+  let (num, den) = rat_reduce(num, den);
   let rest_expr = if rest.len() == 1 {
     rest.into_iter().next().unwrap()
   } else {

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -477,7 +477,7 @@ fn solve_rat_system(
 /// coefficient (the FactorTerms sign convention). Returns 0 for the zero
 /// polynomial.
 fn signed_content(coeffs: &[i128]) -> i128 {
-  let g = coeffs.iter().fold(0i128, |acc, &c| gcd_i128(acc, c.abs()));
+  let g = coeffs.iter().fold(0i128, |acc, &c| gcd_i128(acc, c));
   if coeffs
     .iter()
     .rev()
@@ -569,7 +569,7 @@ fn build_apart_term(
   let mut inum: Vec<i128> = pnum.iter().map(|r| r.n * (l / r.d)).collect();
   let mut g = l.abs();
   for &c in &inum {
-    g = gcd_i128(g, c.abs());
+    g = gcd_i128(g, c);
   }
   if g > 1 {
     for c in inum.iter_mut() {
@@ -651,7 +651,7 @@ fn apart_general(
       // (-19 + 16*x)/(5*(-1 - x + 5*x^2)), not (19-16*x)/(5+5*x-25*x^2).
       // Content and sign are absorbed by `scale` (= den / prod of factors)
       // below, and the content resurfaces as the term's scalar multiplier.
-      let content = c.iter().fold(0i128, |acc, &v| gcd_i128(acc, v.abs()));
+      let content = c.iter().fold(0i128, |acc, &v| gcd_i128(acc, v));
       if content > 1 {
         for v in c.iter_mut() {
           *v /= content;

--- a/src/functions/polynomial_ast/cancel.rs
+++ b/src/functions/polynomial_ast/cancel.rs
@@ -799,16 +799,10 @@ pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
   // Cancel numeric GCD
   let mut numeric_changed = false;
   if num_coeff != 0 && den_coeff != 0 {
-    let g = gcd_i128(num_coeff.abs(), den_coeff.abs());
-    if g > 1 {
-      num_coeff /= g;
-      den_coeff /= g;
+    let (n, d) = rat_reduce(num_coeff, den_coeff);
+    if n != num_coeff {
       numeric_changed = true;
-    }
-    // Keep signs normalized: negative in numerator
-    if den_coeff < 0 {
-      num_coeff = -num_coeff;
-      den_coeff = -den_coeff;
+      (num_coeff, den_coeff) = (n, d);
     }
   }
 

--- a/src/functions/polynomial_ast/eliminate.rs
+++ b/src/functions/polynomial_ast/eliminate.rs
@@ -3,7 +3,7 @@ use super::together::negate_expr;
 use super::*;
 use crate::InterpreterError;
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
-use crate::functions::math_ast::gcd_i128;
+use crate::functions::math_ast::rat_reduce;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, bool_expr, expr_to_string, unevaluated,
 };
@@ -680,17 +680,7 @@ fn normalize_eliminate_result(eq: &Expr, _eliminated_vars: &[String]) -> Expr {
     // rather than solving for the variable: `2 x == 3`, not `x == 3/2`. Only
     // when the content divides the constant evenly does it become `x == k`.
     if let (Expr::Integer(c), Expr::Integer(r)) = (&coeff, &rest) {
-      let (mut c, mut r) = (*c, *r);
-      if c < 0 {
-        c = -c;
-        r = -r;
-      }
-      let g = {
-        let g = gcd_i128(c.abs(), r.abs());
-        if g == 0 { 1 } else { g }
-      };
-      let c = c / g;
-      let r = r / g;
+      let (r, c) = rat_reduce(*r, *c);
       // c*var + r == 0  =>  c*var == -r
       let lhs = if c == 1 {
         Expr::Identifier(var.clone())

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -3026,7 +3026,7 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
     .iter()
     .copied()
     .filter(|&c| c != 0)
-    .fold(0i128, |a, b| gcd_i128(a, b.abs()));
+    .fold(0i128, |a, b| gcd_i128(a, b));
   if abs_gcd == 0 {
     return Expr::List(vec![Expr::Integer(1), expanded.clone()].into());
   }

--- a/src/functions/polynomial_ast/polynomial_mod.rs
+++ b/src/functions/polynomial_ast/polynomial_mod.rs
@@ -1,5 +1,6 @@
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
+use crate::functions::math_ast::gcd_i128;
 use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// PolynomialMod[poly, m] — reduce poly modulo m.
@@ -36,7 +37,7 @@ pub fn polynomial_mod_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     match &modulus {
       // A zero modulus reduces nothing.
       Expr::Integer(0) => {}
-      Expr::Integer(n) => numeric_gcd = gcd_i128(numeric_gcd, n.abs()),
+      Expr::Integer(n) => numeric_gcd = gcd_i128(numeric_gcd, *n),
       _ => {
         if crate::functions::math_ast::expr_to_f64(&modulus).is_some() {
           // A non-integer numeric modulus is not supported.
@@ -72,16 +73,6 @@ pub fn polynomial_mod_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     result = reduce_coefficients(&result, numeric_gcd)?;
   }
   evaluate_expr_to_expr(&result)
-}
-
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  let (mut a, mut b) = (a.abs(), b.abs());
-  while b != 0 {
-    let t = a % b;
-    a = b;
-    b = t;
-  }
-  a
 }
 
 /// Reduce every integer coefficient of an expanded polynomial modulo `m`,

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -1803,7 +1803,7 @@ fn reduce_quadratic_inequality(
 
 /// Make a quadratic root expression: (nb + so*Sqrt[si]) / den
 fn make_quadratic_root(nb: i128, so: i128, si: i128, den: i128) -> Expr {
-  let g = gcd_i128(gcd_i128(nb, so).abs(), den.abs()).abs();
+  let g = gcd_i128(gcd_i128(nb, so), den);
   let nb = nb / g;
   let so = so / g;
   let den = den / g;

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -5354,7 +5354,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
         .map(term_sqrt_radicand)
         .collect::<Option<Vec<i128>>>()
     {
-      let g = radicands.iter().fold(0i128, |a, &b| gcd_i128(a, b).abs());
+      let g = radicands.iter().fold(0i128, |a, &b| gcd_i128(a, b));
       // A MIXED-SIGN sum whose integer coefficients share |content| > 1
       // with unit cofactors extracts BOTH the content and the radical —
       // wolframscript's true SimplifyCount ties the content-only and
@@ -5374,7 +5374,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
             .iter()
             .map(|(n, _)| *n)
             .filter(|&n| n != 0)
-            .fold(0i128, |a, b| gcd_i128(a, b).abs());
+            .fold(0i128, |a, b| gcd_i128(a, b));
           if content <= 1 {
             return None;
           }
@@ -8070,13 +8070,9 @@ fn simplify_quotient_select(
   // can hand over — reduces before candidate selection so the built
   // displays never show the shared factor.
   {
-    let ng = n_terms
-      .iter()
-      .fold(0i128, |g, &(n, _, _)| gcd_i128(g, n).abs());
-    let dg = d_terms
-      .iter()
-      .fold(0i128, |g, &(n, _, _)| gcd_i128(g, n).abs());
-    let shared = gcd_i128(ng, dg).abs();
+    let ng = n_terms.iter().fold(0i128, |g, &(n, _, _)| gcd_i128(g, n));
+    let dg = d_terms.iter().fold(0i128, |g, &(n, _, _)| gcd_i128(g, n));
+    let shared = gcd_i128(ng, dg);
     if shared > 1 {
       let rn: Vec<(i128, i128, i128)> = n_terms
         .iter()
@@ -8288,7 +8284,7 @@ fn simplify_quotient_select(
   // through: Simplify[(2-4x+8x^2)/(2x^2+4x^3)] → (1-2x+4x^2)/(x^2+2x^3)
   // (wolframscript-verified).
   if !den_is_mono {
-    let shared = gcd_i128(n_content.abs(), d_content.abs());
+    let shared = gcd_i128(n_content, d_content);
     if shared > 1 {
       let sn = scale(&n_terms, shared);
       let sd = scale(&d_terms, shared);
@@ -8730,7 +8726,7 @@ fn radical_quotient_num_content(num: &Expr, den: &Expr) -> Option<Expr> {
     .iter()
     .map(|(n, _)| *n)
     .filter(|&n| n != 0)
-    .fold(0i128, |a, b| gcd_i128(a, b).abs());
+    .fold(0i128, |a, b| gcd_i128(a, b));
   if content <= 1 {
     return None;
   }
@@ -8756,7 +8752,7 @@ fn radical_quotient_num_content(num: &Expr, den: &Expr) -> Option<Expr> {
     },
     _ => 1,
   };
-  if gcd_i128(content, den_int).abs() > 1 {
+  if gcd_i128(content, den_int) > 1 {
     return None;
   }
   let signed = if coeffs.last()?.0 < 0 {

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2093,8 +2093,7 @@ pub fn solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           } else {
             // Irrational roots: (-bi ± sqrt_out*Sqrt[sqrt_in]) / (2*ai)
             // Simplify by dividing common factors
-            let g =
-              gcd_i128(gcd_i128(-bi, sqrt_out).abs(), (2 * ai).abs()).abs();
+            let g = gcd_i128(gcd_i128(-bi, sqrt_out), 2 * ai);
             let nb = -bi / g;
             let so = sqrt_out / g;
             let den = 2 * ai / g;
@@ -2237,8 +2236,7 @@ pub fn solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             ));
           } else {
             // Complex roots with irrational imaginary part
-            let g =
-              gcd_i128(gcd_i128(-bi, sqrt_out).abs(), (2 * ai).abs()).abs();
+            let g = gcd_i128(gcd_i128(-bi, sqrt_out), 2 * ai);
             let nb = -bi / g;
             let so = sqrt_out / g;
             let den = 2 * ai / g;
@@ -3801,9 +3799,7 @@ fn try_solve_factoring_powers(
               // New exponent = (pf.exp_num/pf.exp_den) - (min_n/min_d)
               let new_num = pf.exp_num * min_d - min_n * pf.exp_den;
               let new_den = pf.exp_den * min_d;
-              let g = gcd_i128(new_num.abs(), new_den.abs());
-              let new_num = new_num / g;
-              let new_den = new_den / g;
+              let (new_num, new_den) = rat_reduce(new_num, new_den);
 
               // Get the base expression
               let base_expr =
@@ -5618,9 +5614,7 @@ fn minimize_poly_roots_int(coeffs: &[i128], var: &str) -> Vec<Expr> {
             }
           } else {
             // Irrational roots: (-b ± sqrt_out * √sqrt_in) / (2a)
-            let g =
-              gcd_i128(gcd_i128((-b).abs(), sqrt_out.abs()), (2 * a).abs())
-                .abs();
+            let g = gcd_i128(gcd_i128(-b, sqrt_out), 2 * a);
             let nb = -b / g;
             let so = sqrt_out / g;
             let den = 2 * a / g;

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -442,7 +442,7 @@ pub(super) fn reduce_shared_integer_content(
       _ => None,
     })
   {
-    let g = gcd_i128(c.abs(), den_int);
+    let g = gcd_i128(c, den_int);
     if g <= 1 {
       return None;
     }
@@ -487,7 +487,7 @@ pub(super) fn reduce_shared_integer_content(
   if d != 1 || n.abs() <= 1 {
     return None;
   }
-  let g = gcd_i128(n.abs(), den_int);
+  let g = gcd_i128(n, den_int);
   if g <= 1 {
     return None;
   }
@@ -1671,7 +1671,7 @@ fn shares_cancelable_factor(num: &Expr, den: &Expr) -> bool {
   };
   let (num_content, num_bases) = side(num);
   let (den_content, den_bases) = side(den);
-  if gcd_i128(num_content, den_content).abs() > 1 {
+  if gcd_i128(num_content, den_content) > 1 {
     return true;
   }
   num_bases.iter().any(|b| den_bases.contains(b))
@@ -1863,7 +1863,7 @@ pub fn together_expr(expr: &Expr) -> Expr {
         && exp.0 > 0
         && let Ok(e) = u32::try_from(exp.0)
         && let Some(p) = n.checked_pow(e)
-        && let Some(l) = int_lcm.checked_mul(p / gcd_i128(int_lcm, p).abs())
+        && let Some(l) = int_lcm.checked_mul(p / gcd_i128(int_lcm, p))
       {
         int_lcm = l;
         merged += 1;


### PR DESCRIPTION
It's not necessary to call abs() on the arguments or return value of gcd_i128. Also gcd_i128(a.abs().max(1), b) <=> gcd_i128(a, b).max(1). These invariants lead to a fair number of code simplifications in Woxi.

This PR also consolidates extended_gcd and extended_gcd_bigint.  Another recursive extended_gcd_i128 will need to be replaced/updated later.