### PR TITLE
Consolidate binop helper to syntax.rs

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -4,16 +4,9 @@ use crate::functions::math_ast::{
   expr_to_rational, is_sqrt, make_sqrt, rat_reduce,
 };
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, binop, bool_expr,
+  unevaluated,
 };
-
-fn binop(op: BinaryOperator, left: Expr, right: Expr) -> Expr {
-  Expr::BinaryOp {
-    op,
-    left: Box::new(left),
-    right: Box::new(right),
-  }
-}
 
 pub fn dispatch_complex_and_special(
   name: &str,

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -3,7 +3,9 @@ use super::*;
 use crate::functions::math_ast::{
   expr_to_rational, gcd_i128, gcd_u64, make_rational, make_sqrt, rat_reduce,
 };
-use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator, unevaluated};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, UnaryOperator, binop, unevaluated,
+};
 
 /// Columnwise quartile-family statistic for a matrix argument.
 ///
@@ -18,14 +20,6 @@ use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator, unevaluated};
 fn is_numeric_literal(e: &Expr) -> bool {
   matches!(e, Expr::Integer(_) | Expr::Real(_) | Expr::BigInteger(_))
     || matches!(e, Expr::FunctionCall { name, .. } if name == "Rational")
-}
-
-fn binop(op: BinaryOperator, left: Expr, right: Expr) -> Expr {
-  Expr::BinaryOp {
-    op,
-    left: Box::new(left),
-    right: Box::new(right),
-  }
 }
 
 /// True if `param` is a usable Quantile parameter specification: the 2 x 2
@@ -415,11 +409,7 @@ pub fn dispatch_math_functions(
             name: "Log".to_string(),
             args: vec![Expr::Integer(3)].into(),
           };
-          let iqr = Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(log3),
-            right: Box::new(lambda),
-          };
+          let iqr = binop(BinaryOperator::Divide, log3, lambda);
           return Some(crate::evaluator::evaluate_expr_to_expr(&iqr));
         }
       }
@@ -433,11 +423,7 @@ pub fn dispatch_math_functions(
         dispatch_math_functions("Quartiles", args)
         && qs.len() == 3
       {
-        let diff = Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(qs[2].clone()),
-          right: Box::new(qs[0].clone()),
-        };
+        let diff = binop(BinaryOperator::Minus, qs[2].clone(), qs[0].clone());
         return Some(crate::evaluator::evaluate_expr_to_expr(&diff));
       }
     }
@@ -450,15 +436,11 @@ pub fn dispatch_math_functions(
         dispatch_math_functions("Quartiles", args)
         && qs.len() == 3
       {
-        let half_iqr = Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Minus,
-            left: Box::new(qs[2].clone()),
-            right: Box::new(qs[0].clone()),
-          }),
-          right: Box::new(Expr::Integer(2)),
-        };
+        let half_iqr = binop(
+          BinaryOperator::Divide,
+          binop(BinaryOperator::Minus, qs[2].clone(), qs[0].clone()),
+          Expr::Integer(2),
+        );
         return Some(crate::evaluator::evaluate_expr_to_expr(&half_iqr));
       }
     }
@@ -474,29 +456,17 @@ pub fn dispatch_math_functions(
       {
         use BinaryOperator as B;
         // numerator = Q1 - 2*Q2 + Q3
-        let numerator = Expr::BinaryOp {
-          op: B::Plus,
-          left: Box::new(Expr::BinaryOp {
-            op: B::Minus,
-            left: Box::new(qs[0].clone()),
-            right: Box::new(Expr::BinaryOp {
-              op: B::Times,
-              left: Box::new(Expr::Integer(2)),
-              right: Box::new(qs[1].clone()),
-            }),
-          }),
-          right: Box::new(qs[2].clone()),
-        };
-        let denominator = Expr::BinaryOp {
-          op: B::Minus,
-          left: Box::new(qs[2].clone()),
-          right: Box::new(qs[0].clone()),
-        };
-        let skew = Expr::BinaryOp {
-          op: B::Divide,
-          left: Box::new(numerator),
-          right: Box::new(denominator),
-        };
+        let numerator = binop(
+          B::Plus,
+          binop(
+            B::Minus,
+            qs[0].clone(),
+            binop(B::Times, Expr::Integer(2), qs[1].clone()),
+          ),
+          qs[2].clone(),
+        );
+        let denominator = binop(B::Minus, qs[2].clone(), qs[0].clone());
+        let skew = binop(B::Divide, numerator, denominator);
         return Some(crate::evaluator::evaluate_expr_to_expr(&skew));
       }
     }
@@ -1090,11 +1060,11 @@ pub fn dispatch_math_functions(
           });
           let trimmed = &sorted[trim_lo..n - trim_hi];
           let sum_expr = unevaluated("Plus", trimmed);
-          let result = Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(sum_expr),
-            right: Box::new(Expr::Integer(trimmed.len() as i128)),
-          };
+          let result = binop(
+            BinaryOperator::Divide,
+            sum_expr,
+            Expr::Integer(trimmed.len() as i128),
+          );
           return Some(evaluate_expr_to_expr(&result));
         }
       }
@@ -1164,11 +1134,8 @@ pub fn dispatch_math_functions(
             name: "Plus".to_string(),
             args: winsorized.into(),
           };
-          let result = Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(sum_expr),
-            right: Box::new(Expr::Integer(n as i128)),
-          };
+          let result =
+            binop(BinaryOperator::Divide, sum_expr, Expr::Integer(n as i128));
           return Some(evaluate_expr_to_expr(&result));
         }
       }
@@ -1702,11 +1669,7 @@ pub fn dispatch_math_functions(
           name: "BetaRegularized".to_string(),
           args: vec![z.clone(), args[2].clone(), args[3].clone()].into(),
         };
-        let diff = Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(f(&args[1])),
-          right: Box::new(f(&args[0])),
-        };
+        let diff = binop(BinaryOperator::Minus, f(&args[1]), f(&args[0]));
         return Some(crate::evaluator::evaluate_expr_to_expr(&diff));
       }
       return Some(Ok(unevaluated("BetaRegularized", args)));
@@ -1743,11 +1706,7 @@ pub fn dispatch_math_functions(
           name: "GammaRegularized".to_string(),
           args: vec![args[0].clone(), z.clone()].into(),
         };
-        let diff = Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(g(&args[1])),
-          right: Box::new(g(&args[2])),
-        };
+        let diff = binop(BinaryOperator::Minus, g(&args[1]), g(&args[2]));
         return Some(crate::evaluator::evaluate_expr_to_expr(&diff));
       }
       if matches!(&args[0], Expr::Integer(1)) {
@@ -1762,11 +1721,8 @@ pub fn dispatch_math_functions(
           ]
           .into(),
         };
-        let diff = Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(exp_neg(&args[1])),
-          right: Box::new(exp_neg(&args[2])),
-        };
+        let diff =
+          binop(BinaryOperator::Minus, exp_neg(&args[1]), exp_neg(&args[2]));
         return Some(crate::evaluator::evaluate_expr_to_expr(&diff));
       }
       return Some(Ok(unevaluated("GammaRegularized", args)));
@@ -1917,11 +1873,7 @@ pub fn dispatch_math_functions(
           name: "Beta".to_string(),
           args: vec![z.clone(), args[2].clone(), args[3].clone()].into(),
         };
-        let diff = Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(f(&args[1])),
-          right: Box::new(f(&args[0])),
-        };
+        let diff = binop(BinaryOperator::Minus, f(&args[1]), f(&args[0]));
         return Some(crate::evaluator::evaluate_expr_to_expr(&diff));
       }
       return Some(Ok(unevaluated("Beta", args)));
@@ -2358,11 +2310,8 @@ pub fn dispatch_math_functions(
       match sin_result {
         Ok(ref sin_val) => {
           if !not_a_value(sin_val) {
-            let div_expr = Expr::BinaryOp {
-              op: BinaryOperator::Divide,
-              left: Box::new(sin_val.clone()),
-              right: Box::new(args[0].clone()),
-            };
+            let div_expr =
+              binop(BinaryOperator::Divide, sin_val.clone(), args[0].clone());
             return Some(crate::evaluator::evaluate_expr_to_expr(&div_expr));
           }
         }
@@ -2392,20 +2341,13 @@ pub fn dispatch_math_functions(
         }
       }
       if contains_real(&args[0]) {
-        let half = Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(args[0].clone()),
-          right: Box::new(Expr::Integer(2)),
-        };
+        let half =
+          binop(BinaryOperator::Divide, args[0].clone(), Expr::Integer(2));
         let sin_expr = Expr::FunctionCall {
           name: "Sin".to_string(),
           args: vec![half].into(),
         };
-        let expr = Expr::BinaryOp {
-          op: BinaryOperator::Power,
-          left: Box::new(sin_expr),
-          right: Box::new(Expr::Integer(2)),
-        };
+        let expr = binop(BinaryOperator::Power, sin_expr, Expr::Integer(2));
         return Some(crate::evaluator::evaluate_expr_to_expr(&expr));
       }
       // Exact args: Haversine[x] = (1 - Cos[x])/2. wolframscript evaluates the
@@ -2417,15 +2359,11 @@ pub fn dispatch_math_functions(
         name: "Cos".to_string(),
         args: vec![args[0].clone()].into(),
       };
-      let half = Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(Expr::Integer(1)),
-          right: Box::new(cos_x),
-        }),
-        right: Box::new(Expr::Integer(2)),
-      };
+      let half = binop(
+        BinaryOperator::Divide,
+        binop(BinaryOperator::Minus, Expr::Integer(1), cos_x),
+        Expr::Integer(2),
+      );
       if let Ok(result) = crate::evaluator::evaluate_expr_to_expr(&half) {
         let is_rational = matches!(&result, Expr::Integer(_))
           || matches!(&result, Expr::FunctionCall { name, args }
@@ -2543,11 +2481,7 @@ pub fn dispatch_math_functions(
         name: "ArcSin".to_string(),
         args: vec![sqrt_expr].into(),
       };
-      let expr = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(2)),
-        right: Box::new(asin_expr),
-      };
+      let expr = binop(BinaryOperator::Times, Expr::Integer(2), asin_expr);
       let result = match crate::evaluator::evaluate_expr_to_expr(&expr) {
         Ok(r) => r,
         Err(e) => return Some(Err(e)),
@@ -3639,19 +3573,11 @@ pub fn dispatch_math_functions(
         if elems.len() == 2 {
           let x = &elems[0];
           let y = &elems[1];
-          let r = make_sqrt(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(x.clone()),
-              right: Box::new(Expr::Integer(2)),
-            }),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(y.clone()),
-              right: Box::new(Expr::Integer(2)),
-            }),
-          });
+          let r = make_sqrt(binop(
+            BinaryOperator::Plus,
+            binop(BinaryOperator::Power, x.clone(), Expr::Integer(2)),
+            binop(BinaryOperator::Power, y.clone(), Expr::Integer(2)),
+          ));
           let theta = Expr::FunctionCall {
             name: "ArcTan".to_string(),
             args: vec![x.clone(), y.clone()].into(),
@@ -3667,10 +3593,8 @@ pub fn dispatch_math_functions(
         // Helper: Sqrt[Σ_{i=start..n} x_i^2].
         let radical = |start: usize| -> Expr {
           let squares: Vec<Expr> = (start..n)
-            .map(|i| Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(elems[i].clone()),
-              right: Box::new(Expr::Integer(2)),
+            .map(|i| {
+              binop(BinaryOperator::Power, elems[i].clone(), Expr::Integer(2))
             })
             .collect();
           let sum = if squares.len() == 1 {
@@ -3692,11 +3616,7 @@ pub fn dispatch_math_functions(
         result.push(r);
         for k in 0..(n - 2) {
           let denom = radical(k);
-          let frac = Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(elems[k].clone()),
-            right: Box::new(denom),
-          };
+          let frac = binop(BinaryOperator::Divide, elems[k].clone(), denom);
           result.push(Expr::FunctionCall {
             name: "ArcCos".to_string(),
             args: vec![frac].into(),
@@ -3767,41 +3687,21 @@ pub fn dispatch_math_functions(
         let x = &elems[0];
         let y = &elems[1];
         let z = &elems[2];
-        let sum_sq = Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(x.clone()),
-              right: Box::new(Expr::Integer(2)),
-            }),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(y.clone()),
-              right: Box::new(Expr::Integer(2)),
-            }),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(z.clone()),
-            right: Box::new(Expr::Integer(2)),
-          }),
-        };
+        let sum_sq = binop(
+          BinaryOperator::Plus,
+          binop(
+            BinaryOperator::Plus,
+            binop(BinaryOperator::Power, x.clone(), Expr::Integer(2)),
+            binop(BinaryOperator::Power, y.clone(), Expr::Integer(2)),
+          ),
+          binop(BinaryOperator::Power, z.clone(), Expr::Integer(2)),
+        );
         let r = make_sqrt(sum_sq);
-        let xy_sq = Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(x.clone()),
-            right: Box::new(Expr::Integer(2)),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(y.clone()),
-            right: Box::new(Expr::Integer(2)),
-          }),
-        };
+        let xy_sq = binop(
+          BinaryOperator::Plus,
+          binop(BinaryOperator::Power, x.clone(), Expr::Integer(2)),
+          binop(BinaryOperator::Power, y.clone(), Expr::Integer(2)),
+        );
         let theta = Expr::FunctionCall {
           name: "ArcTan".to_string(),
           args: vec![z.clone(), make_sqrt(xy_sq)].into(),
@@ -3859,16 +3759,8 @@ pub fn dispatch_math_functions(
             );
             let fk_eval =
               crate::evaluator::evaluate_expr_to_expr(&fk).unwrap_or(fk);
-            let denom = Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(fk_eval),
-              right: Box::new(acc),
-            };
-            acc = Expr::BinaryOp {
-              op: BinaryOperator::Divide,
-              left: Box::new(Expr::Integer(1)),
-              right: Box::new(denom),
-            };
+            let denom = binop(BinaryOperator::Plus, fk_eval, acc);
+            acc = binop(BinaryOperator::Divide, Expr::Integer(1), denom);
             acc = crate::evaluator::evaluate_expr_to_expr(&acc).unwrap_or(acc);
           }
           return Some(Ok(acc));
@@ -3915,16 +3807,8 @@ pub fn dispatch_math_functions(
             let gk_eval =
               crate::evaluator::evaluate_expr_to_expr(&gk).unwrap_or(gk);
             // acc = fk / (gk + acc)
-            let denom = Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(gk_eval),
-              right: Box::new(acc),
-            };
-            acc = Expr::BinaryOp {
-              op: BinaryOperator::Divide,
-              left: Box::new(fk_eval),
-              right: Box::new(denom),
-            };
+            let denom = binop(BinaryOperator::Plus, gk_eval, acc);
+            acc = binop(BinaryOperator::Divide, fk_eval, denom);
             acc = crate::evaluator::evaluate_expr_to_expr(&acc).unwrap_or(acc);
           }
           return Some(Ok(acc));
@@ -3952,59 +3836,35 @@ pub fn dispatch_math_functions(
       let b = &args[1];
       let c = &args[2];
       // cos(A) = (b^2 + c^2 - a^2) / (2*b*c)
-      let cos_a = Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(b.clone()),
-              right: Box::new(Expr::Integer(2)),
-            }),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(c.clone()),
-              right: Box::new(Expr::Integer(2)),
-            }),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(a.clone()),
-            right: Box::new(Expr::Integer(2)),
-          }),
-        }),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(2)),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(b.clone()),
-            right: Box::new(c.clone()),
-          }),
-        }),
-      };
+      let cos_a = binop(
+        BinaryOperator::Divide,
+        binop(
+          BinaryOperator::Minus,
+          binop(
+            BinaryOperator::Plus,
+            binop(BinaryOperator::Power, b.clone(), Expr::Integer(2)),
+            binop(BinaryOperator::Power, c.clone(), Expr::Integer(2)),
+          ),
+          binop(BinaryOperator::Power, a.clone(), Expr::Integer(2)),
+        ),
+        binop(
+          BinaryOperator::Times,
+          Expr::Integer(2),
+          binop(BinaryOperator::Times, b.clone(), c.clone()),
+        ),
+      );
       // cx = b * cos(A)
-      let cx = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(b.clone()),
-        right: Box::new(cos_a.clone()),
-      };
+      let cx = binop(BinaryOperator::Times, b.clone(), cos_a.clone());
       // cy = b * sin(A) = b * sqrt(1 - cos(A)^2)
-      let cy = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(b.clone()),
-        right: Box::new(make_sqrt(Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(Expr::Integer(1)),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(cos_a),
-            right: Box::new(Expr::Integer(2)),
-          }),
-        })),
-      };
+      let cy = binop(
+        BinaryOperator::Times,
+        b.clone(),
+        make_sqrt(binop(
+          BinaryOperator::Minus,
+          Expr::Integer(1),
+          binop(BinaryOperator::Power, cos_a, Expr::Integer(2)),
+        )),
+      );
       let cx_eval = crate::evaluator::evaluate_expr_to_expr(&cx).unwrap_or(cx);
       let cy_eval = crate::evaluator::evaluate_expr_to_expr(&cy).unwrap_or(cy);
       let c_eval = crate::evaluator::evaluate_expr_to_expr(c)
@@ -4029,11 +3889,8 @@ pub fn dispatch_math_functions(
         && !elems.is_empty()
       {
         let alpha = &args[1];
-        let one_minus_alpha = Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(Expr::Integer(1)),
-          right: Box::new(alpha.clone()),
-        };
+        let one_minus_alpha =
+          binop(BinaryOperator::Minus, Expr::Integer(1), alpha.clone());
         let one_minus_alpha_eval =
           crate::evaluator::evaluate_expr_to_expr(&one_minus_alpha)
             .unwrap_or(one_minus_alpha);
@@ -4041,19 +3898,11 @@ pub fn dispatch_math_functions(
         let mut result = vec![ema.clone()];
         for elem in &elems[1..] {
           // ema = alpha * x + (1 - alpha) * ema
-          let new_ema = Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(alpha.clone()),
-              right: Box::new(elem.clone()),
-            }),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(one_minus_alpha_eval.clone()),
-              right: Box::new(ema),
-            }),
-          };
+          let new_ema = binop(
+            BinaryOperator::Plus,
+            binop(BinaryOperator::Times, alpha.clone(), elem.clone()),
+            binop(BinaryOperator::Times, one_minus_alpha_eval.clone(), ema),
+          );
           ema = crate::evaluator::evaluate_expr_to_expr(&new_ema)
             .unwrap_or(new_ema);
           result.push(ema.clone());
@@ -4084,159 +3933,101 @@ pub fn dispatch_math_functions(
           let (x3, y3) = coords[2];
           // Build the circumcenter formula as AST and evaluate
           // D = 2*(x1*(y2-y3) + x2*(y3-y1) + x3*(y1-y2))
-          let d_expr = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(2)),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(x1.clone()),
-                  right: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Minus,
-                    left: Box::new(y2.clone()),
-                    right: Box::new(y3.clone()),
-                  }),
-                }),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(x2.clone()),
-                  right: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Minus,
-                    left: Box::new(y3.clone()),
-                    right: Box::new(y1.clone()),
-                  }),
-                }),
-              }),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(x3.clone()),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Minus,
-                  left: Box::new(y1.clone()),
-                  right: Box::new(y2.clone()),
-                }),
-              }),
-            }),
-          };
+          let d_expr = binop(
+            BinaryOperator::Times,
+            Expr::Integer(2),
+            binop(
+              BinaryOperator::Plus,
+              binop(
+                BinaryOperator::Plus,
+                binop(
+                  BinaryOperator::Times,
+                  x1.clone(),
+                  binop(BinaryOperator::Minus, y2.clone(), y3.clone()),
+                ),
+                binop(
+                  BinaryOperator::Times,
+                  x2.clone(),
+                  binop(BinaryOperator::Minus, y3.clone(), y1.clone()),
+                ),
+              ),
+              binop(
+                BinaryOperator::Times,
+                x3.clone(),
+                binop(BinaryOperator::Minus, y1.clone(), y2.clone()),
+              ),
+            ),
+          );
           // sq(p) = x^2 + y^2
-          let sq = |x: &Expr, y: &Expr| Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(x.clone()),
-              right: Box::new(Expr::Integer(2)),
-            }),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(y.clone()),
-              right: Box::new(Expr::Integer(2)),
-            }),
+          let sq = |x: &Expr, y: &Expr| {
+            binop(
+              BinaryOperator::Plus,
+              binop(BinaryOperator::Power, x.clone(), Expr::Integer(2)),
+              binop(BinaryOperator::Power, y.clone(), Expr::Integer(2)),
+            )
           };
           // h_num = sq1*(y2-y3) + sq2*(y3-y1) + sq3*(y1-y2)
-          let h_num = Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(sq(x1, y1)),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Minus,
-                  left: Box::new(y2.clone()),
-                  right: Box::new(y3.clone()),
-                }),
-              }),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(sq(x2, y2)),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Minus,
-                  left: Box::new(y3.clone()),
-                  right: Box::new(y1.clone()),
-                }),
-              }),
-            }),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(sq(x3, y3)),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Minus,
-                left: Box::new(y1.clone()),
-                right: Box::new(y2.clone()),
-              }),
-            }),
-          };
+          let h_num = binop(
+            BinaryOperator::Plus,
+            binop(
+              BinaryOperator::Plus,
+              binop(
+                BinaryOperator::Times,
+                sq(x1, y1),
+                binop(BinaryOperator::Minus, y2.clone(), y3.clone()),
+              ),
+              binop(
+                BinaryOperator::Times,
+                sq(x2, y2),
+                binop(BinaryOperator::Minus, y3.clone(), y1.clone()),
+              ),
+            ),
+            binop(
+              BinaryOperator::Times,
+              sq(x3, y3),
+              binop(BinaryOperator::Minus, y1.clone(), y2.clone()),
+            ),
+          );
           // k_num = sq1*(x3-x2) + sq2*(x1-x3) + sq3*(x2-x1)
-          let k_num = Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(sq(x1, y1)),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Minus,
-                  left: Box::new(x3.clone()),
-                  right: Box::new(x2.clone()),
-                }),
-              }),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(sq(x2, y2)),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Minus,
-                  left: Box::new(x1.clone()),
-                  right: Box::new(x3.clone()),
-                }),
-              }),
-            }),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(sq(x3, y3)),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Minus,
-                left: Box::new(x2.clone()),
-                right: Box::new(x1.clone()),
-              }),
-            }),
-          };
-          let h = Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(h_num),
-            right: Box::new(d_expr.clone()),
-          };
-          let k = Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(k_num),
-            right: Box::new(d_expr),
-          };
+          let k_num = binop(
+            BinaryOperator::Plus,
+            binop(
+              BinaryOperator::Plus,
+              binop(
+                BinaryOperator::Times,
+                sq(x1, y1),
+                binop(BinaryOperator::Minus, x3.clone(), x2.clone()),
+              ),
+              binop(
+                BinaryOperator::Times,
+                sq(x2, y2),
+                binop(BinaryOperator::Minus, x1.clone(), x3.clone()),
+              ),
+            ),
+            binop(
+              BinaryOperator::Times,
+              sq(x3, y3),
+              binop(BinaryOperator::Minus, x2.clone(), x1.clone()),
+            ),
+          );
+          let h = binop(BinaryOperator::Divide, h_num, d_expr.clone());
+          let k = binop(BinaryOperator::Divide, k_num, d_expr);
           let h_eval = crate::evaluator::evaluate_expr_to_expr(&h).unwrap_or(h);
           let k_eval = crate::evaluator::evaluate_expr_to_expr(&k).unwrap_or(k);
           // r = sqrt((x1-h)^2 + (y1-k)^2)
-          let r = make_sqrt(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Minus,
-                left: Box::new(x1.clone()),
-                right: Box::new(h_eval.clone()),
-              }),
-              right: Box::new(Expr::Integer(2)),
-            }),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Minus,
-                left: Box::new(y1.clone()),
-                right: Box::new(k_eval.clone()),
-              }),
-              right: Box::new(Expr::Integer(2)),
-            }),
-          });
+          let r = make_sqrt(binop(
+            BinaryOperator::Plus,
+            binop(
+              BinaryOperator::Power,
+              binop(BinaryOperator::Minus, x1.clone(), h_eval.clone()),
+              Expr::Integer(2),
+            ),
+            binop(
+              BinaryOperator::Power,
+              binop(BinaryOperator::Minus, y1.clone(), k_eval.clone()),
+              Expr::Integer(2),
+            ),
+          ));
           let r_eval = crate::evaluator::evaluate_expr_to_expr(&r).unwrap_or(r);
           return Some(Ok(Expr::FunctionCall {
             name: "Circle".to_string(),
@@ -4315,11 +4106,11 @@ pub fn dispatch_math_functions(
         // Per-dimension widths: maxs[d] - mins[d]
         let widths: Vec<Expr> = (0..dim)
           .map(|d| {
-            evaluate_expr_to_expr(&Expr::BinaryOp {
-              op: BinaryOperator::Minus,
-              left: Box::new(maxs[d].clone()),
-              right: Box::new(mins[d].clone()),
-            })
+            evaluate_expr_to_expr(&binop(
+              BinaryOperator::Minus,
+              maxs[d].clone(),
+              mins[d].clone(),
+            ))
             .unwrap_or_else(|_| Expr::Integer(0))
           })
           .collect();
@@ -4356,17 +4147,17 @@ pub fn dispatch_math_functions(
         if let Some(pads) = pad_pairs {
           let bounds: Vec<Expr> = (0..dim)
             .map(|d| {
-              let new_min = evaluate_expr_to_expr(&Expr::BinaryOp {
-                op: BinaryOperator::Minus,
-                left: Box::new(mins[d].clone()),
-                right: Box::new(pads[d].0.clone()),
-              })
+              let new_min = evaluate_expr_to_expr(&binop(
+                BinaryOperator::Minus,
+                mins[d].clone(),
+                pads[d].0.clone(),
+              ))
               .unwrap_or_else(|_| mins[d].clone());
-              let new_max = evaluate_expr_to_expr(&Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(maxs[d].clone()),
-                right: Box::new(pads[d].1.clone()),
-              })
+              let new_max = evaluate_expr_to_expr(&binop(
+                BinaryOperator::Plus,
+                maxs[d].clone(),
+                pads[d].1.clone(),
+              ))
               .unwrap_or_else(|_| maxs[d].clone());
               Expr::List(vec![new_min, new_max].into())
             })
@@ -4419,15 +4210,11 @@ pub fn dispatch_math_functions(
           .zip(b.iter())
           .map(|(ai, bi)| Expr::FunctionCall {
             name: "Abs".to_string(),
-            args: vec![Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(ai.clone()),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(Expr::Integer(-1)),
-                right: Box::new(bi.clone()),
-              }),
-            }]
+            args: vec![binop(
+              BinaryOperator::Plus,
+              ai.clone(),
+              binop(BinaryOperator::Times, Expr::Integer(-1), bi.clone()),
+            )]
             .into(),
           })
           .collect();
@@ -4443,15 +4230,11 @@ pub fn dispatch_math_functions(
       {
         let abs_expr = Expr::FunctionCall {
           name: "Abs".to_string(),
-          args: vec![Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(args[0].clone()),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Integer(-1)),
-              right: Box::new(args[1].clone()),
-            }),
-          }]
+          args: vec![binop(
+            BinaryOperator::Plus,
+            args[0].clone(),
+            binop(BinaryOperator::Times, Expr::Integer(-1), args[1].clone()),
+          )]
           .into(),
         };
         return Some(evaluate_expr_to_expr(&abs_expr));
@@ -4465,31 +4248,23 @@ pub fn dispatch_math_functions(
       {
         let num = Expr::FunctionCall {
           name: "Abs".to_string(),
-          args: vec![Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(args[0].clone()),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Integer(-1)),
-              right: Box::new(args[1].clone()),
-            }),
-          }]
+          args: vec![binop(
+            BinaryOperator::Plus,
+            args[0].clone(),
+            binop(BinaryOperator::Times, Expr::Integer(-1), args[1].clone()),
+          )]
           .into(),
         };
         let den = Expr::FunctionCall {
           name: "Abs".to_string(),
-          args: vec![Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(args[0].clone()),
-            right: Box::new(args[1].clone()),
-          }]
+          args: vec![binop(
+            BinaryOperator::Plus,
+            args[0].clone(),
+            args[1].clone(),
+          )]
           .into(),
         };
-        let result = Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(num),
-          right: Box::new(den),
-        };
+        let result = binop(BinaryOperator::Divide, num, den);
         return Some(evaluate_expr_to_expr(&result));
       }
       if let (Expr::List(a), Expr::List(b)) = (&args[0], &args[1])
@@ -4501,25 +4276,17 @@ pub fn dispatch_math_functions(
         for (ai, bi) in a.iter().zip(b.iter()) {
           num_terms.push(Expr::FunctionCall {
             name: "Abs".to_string(),
-            args: vec![Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(ai.clone()),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(Expr::Integer(-1)),
-                right: Box::new(bi.clone()),
-              }),
-            }]
+            args: vec![binop(
+              BinaryOperator::Plus,
+              ai.clone(),
+              binop(BinaryOperator::Times, Expr::Integer(-1), bi.clone()),
+            )]
             .into(),
           });
           den_terms.push(Expr::FunctionCall {
             name: "Abs".to_string(),
-            args: vec![Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(ai.clone()),
-              right: Box::new(bi.clone()),
-            }]
-            .into(),
+            args: vec![binop(BinaryOperator::Plus, ai.clone(), bi.clone())]
+              .into(),
           });
         }
         let num = Expr::FunctionCall {
@@ -4530,11 +4297,7 @@ pub fn dispatch_math_functions(
           name: "Plus".to_string(),
           args: den_terms.into(),
         };
-        let result = Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(num),
-          right: Box::new(den),
-        };
+        let result = binop(BinaryOperator::Divide, num, den);
         return Some(evaluate_expr_to_expr(&result));
       }
     }
@@ -4546,15 +4309,11 @@ pub fn dispatch_math_functions(
       {
         let num = Expr::FunctionCall {
           name: "Abs".to_string(),
-          args: vec![Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(args[0].clone()),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Integer(-1)),
-              right: Box::new(args[1].clone()),
-            }),
-          }]
+          args: vec![binop(
+            BinaryOperator::Plus,
+            args[0].clone(),
+            binop(BinaryOperator::Times, Expr::Integer(-1), args[1].clone()),
+          )]
           .into(),
         };
         let den = Expr::BinaryOp {
@@ -4568,11 +4327,7 @@ pub fn dispatch_math_functions(
             args: vec![args[1].clone()].into(),
           }),
         };
-        let result = Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(num),
-          right: Box::new(den),
-        };
+        let result = binop(BinaryOperator::Divide, num, den);
         return Some(evaluate_expr_to_expr(&result));
       }
       if let (Expr::List(a), Expr::List(b)) = (&args[0], &args[1])
@@ -4583,15 +4338,11 @@ pub fn dispatch_math_functions(
         for (ai, bi) in a.iter().zip(b.iter()) {
           let num = Expr::FunctionCall {
             name: "Abs".to_string(),
-            args: vec![Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(ai.clone()),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(Expr::Integer(-1)),
-                right: Box::new(bi.clone()),
-              }),
-            }]
+            args: vec![binop(
+              BinaryOperator::Plus,
+              ai.clone(),
+              binop(BinaryOperator::Times, Expr::Integer(-1), bi.clone()),
+            )]
             .into(),
           };
           let den = Expr::BinaryOp {
@@ -4605,11 +4356,7 @@ pub fn dispatch_math_functions(
               args: vec![bi.clone()].into(),
             }),
           };
-          terms.push(Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(num),
-            right: Box::new(den),
-          });
+          terms.push(binop(BinaryOperator::Divide, num, den));
         }
         let sum = Expr::FunctionCall {
           name: "Plus".to_string(),
@@ -4675,30 +4422,16 @@ pub fn dispatch_math_functions(
           name: "Conjugate".to_string(),
           args: vec![args[1].clone()].into(),
         };
-        let u_over_abs_u = Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(args[0].clone()),
-          right: Box::new(abs_u),
-        };
-        let conj_v_over_abs_v = Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(conj_v),
-          right: Box::new(abs_v),
-        };
-        let ratio = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(u_over_abs_u),
-          right: Box::new(conj_v_over_abs_v),
-        };
-        let result = Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::Integer(1)),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(-1)),
-            right: Box::new(ratio),
-          }),
-        };
+        let u_over_abs_u =
+          binop(BinaryOperator::Divide, args[0].clone(), abs_u);
+        let conj_v_over_abs_v = binop(BinaryOperator::Divide, conj_v, abs_v);
+        let ratio =
+          binop(BinaryOperator::Times, u_over_abs_u, conj_v_over_abs_v);
+        let result = binop(
+          BinaryOperator::Plus,
+          Expr::Integer(1),
+          binop(BinaryOperator::Times, Expr::Integer(-1), ratio),
+        );
         return Some(evaluate_expr_to_expr(&result));
       }
       if let (Expr::List(a), Expr::List(b)) = (&args[0], &args[1])
@@ -4739,23 +4472,19 @@ pub fn dispatch_math_functions(
           name: "Norm".to_string(),
           args: vec![args[1].clone()].into(),
         };
-        let result = Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::Integer(1)),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(-1)),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Divide,
-              left: Box::new(dot),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(norm_a),
-                right: Box::new(norm_b),
-              }),
-            }),
-          }),
-        };
+        let result = binop(
+          BinaryOperator::Plus,
+          Expr::Integer(1),
+          binop(
+            BinaryOperator::Times,
+            Expr::Integer(-1),
+            binop(
+              BinaryOperator::Divide,
+              dot,
+              binop(BinaryOperator::Times, norm_a, norm_b),
+            ),
+          ),
+        );
         return Some(evaluate_expr_to_expr(&result));
       }
     }
@@ -6119,11 +5848,7 @@ fn midpoint_ast(arg: &Expr) -> Result<Expr, InterpreterError> {
     name: "Plus".to_string(),
     args: vec![p1.clone(), p2.clone()].into(),
   };
-  let result = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(sum),
-    right: Box::new(Expr::Integer(2)),
-  };
+  let result = binop(BinaryOperator::Divide, sum, Expr::Integer(2));
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
 
@@ -6164,26 +5889,15 @@ fn qfactorial_ast(
   let mut factors = Vec::new();
   for k in 1..=n {
     // [k]_q = (1 - q^k) / (1 - q)
-    let q_k = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(q_expr.clone()),
-      right: Box::new(Expr::Integer(k as i128)),
-    };
-    let numerator = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(q_k),
-    };
-    let denominator = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(q_expr.clone()),
-    };
-    let factor = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numerator),
-      right: Box::new(denominator),
-    };
+    let q_k = binop(
+      BinaryOperator::Power,
+      q_expr.clone(),
+      Expr::Integer(k as i128),
+    );
+    let numerator = binop(BinaryOperator::Minus, Expr::Integer(1), q_k);
+    let denominator =
+      binop(BinaryOperator::Minus, Expr::Integer(1), q_expr.clone());
+    let factor = binop(BinaryOperator::Divide, numerator, denominator);
     factors.push(factor);
   }
 
@@ -6404,11 +6118,11 @@ fn substitute_complex_vars(expr: &Expr, vars: &[String]) -> Expr {
         .map(|a| substitute_complex_vars(a, vars))
         .collect(),
     },
-    Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
-      op: *op,
-      left: Box::new(substitute_complex_vars(left, vars)),
-      right: Box::new(substitute_complex_vars(right, vars)),
-    },
+    Expr::BinaryOp { op, left, right } => binop(
+      *op,
+      substitute_complex_vars(left, vars),
+      substitute_complex_vars(right, vars),
+    ),
     Expr::UnaryOp { op, operand } => Expr::UnaryOp {
       op: *op,
       operand: Box::new(substitute_complex_vars(operand, vars)),
@@ -6515,11 +6229,11 @@ fn expand_log_in_complex_expand(expr: &Expr) -> Expr {
           name: "Log".to_string(),
           args: vec![x.clone()].into(),
         };
-        return ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(log_x),
-          right: Box::new(Expr::Integer(2)),
-        });
+        return ce_simplify(binop(
+          BinaryOperator::Divide,
+          log_x,
+          Expr::Integer(2),
+        ));
       }
       // Log[Times[positive_const, …]] → Log[positive_const] + Log[Times[…]]
       if let Expr::FunctionCall {
@@ -6573,11 +6287,7 @@ fn expand_log_in_complex_expand(expr: &Expr) -> Expr {
             name: "Log".to_string(),
             args: vec![rest].into(),
           });
-          return ce_simplify(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(log_pos),
-            right: Box::new(log_rest),
-          });
+          return ce_simplify(binop(BinaryOperator::Plus, log_pos, log_rest));
         }
       }
       Expr::FunctionCall {
@@ -6589,11 +6299,11 @@ fn expand_log_in_complex_expand(expr: &Expr) -> Expr {
       name: name.clone(),
       args: args.iter().map(expand_log_in_complex_expand).collect(),
     },
-    Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
-      op: *op,
-      left: Box::new(expand_log_in_complex_expand(left)),
-      right: Box::new(expand_log_in_complex_expand(right)),
-    },
+    Expr::BinaryOp { op, left, right } => binop(
+      *op,
+      expand_log_in_complex_expand(left),
+      expand_log_in_complex_expand(right),
+    ),
     Expr::UnaryOp { op, operand } => Expr::UnaryOp {
       op: *op,
       operand: Box::new(expand_log_in_complex_expand(operand)),
@@ -6819,16 +6529,8 @@ fn split_real_imag(expr: &Expr) -> Option<(Expr, Expr)> {
       let (lr, li) = split_real_imag(left)?;
       let (rr, ri) = split_real_imag(right)?;
       Some((
-        ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(lr),
-          right: Box::new(rr),
-        }),
-        ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(li),
-          right: Box::new(ri),
-        }),
+        ce_simplify(binop(BinaryOperator::Plus, lr, rr)),
+        ce_simplify(binop(BinaryOperator::Plus, li, ri)),
       ))
     }
     // a - b
@@ -6840,16 +6542,8 @@ fn split_real_imag(expr: &Expr) -> Option<(Expr, Expr)> {
       let (lr, li) = split_real_imag(left)?;
       let (rr, ri) = split_real_imag(right)?;
       Some((
-        ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(lr),
-          right: Box::new(rr),
-        }),
-        ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(li),
-          right: Box::new(ri),
-        }),
+        ce_simplify(binop(BinaryOperator::Minus, lr, rr)),
+        ce_simplify(binop(BinaryOperator::Minus, li, ri)),
       ))
     }
     // c * expr — split each side and combine via complex multiplication.
@@ -6862,32 +6556,16 @@ fn split_real_imag(expr: &Expr) -> Option<(Expr, Expr)> {
       let (rr, ri) = split_real_imag(right)?;
       // (lr + li i) * (rr + ri i) = (lr*rr - li*ri) + (lr*ri + li*rr) i
       Some((
-        ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(lr.clone()),
-            right: Box::new(rr.clone()),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(li.clone()),
-            right: Box::new(ri.clone()),
-          }),
-        }),
-        ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(lr),
-            right: Box::new(ri),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(li),
-            right: Box::new(rr),
-          }),
-        }),
+        ce_simplify(binop(
+          BinaryOperator::Minus,
+          binop(BinaryOperator::Times, lr.clone(), rr.clone()),
+          binop(BinaryOperator::Times, li.clone(), ri.clone()),
+        )),
+        ce_simplify(binop(
+          BinaryOperator::Plus,
+          binop(BinaryOperator::Times, lr, ri),
+          binop(BinaryOperator::Times, li, rr),
+        )),
       ))
     }
     // I itself
@@ -6903,32 +6581,16 @@ fn split_real_imag(expr: &Expr) -> Option<(Expr, Expr)> {
       for arg in &args[1..] {
         let (rr, ri) = split_real_imag(arg)?;
         // (acc_re + acc_im*I) * (rr + ri*I)
-        let new_re = ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(acc_re.clone()),
-            right: Box::new(rr.clone()),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(acc_im.clone()),
-            right: Box::new(ri.clone()),
-          }),
-        });
-        let new_im = ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(acc_re.clone()),
-            right: Box::new(ri),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(acc_im),
-            right: Box::new(rr),
-          }),
-        });
+        let new_re = ce_simplify(binop(
+          BinaryOperator::Minus,
+          binop(BinaryOperator::Times, acc_re.clone(), rr.clone()),
+          binop(BinaryOperator::Times, acc_im.clone(), ri.clone()),
+        ));
+        let new_im = ce_simplify(binop(
+          BinaryOperator::Plus,
+          binop(BinaryOperator::Times, acc_re.clone(), ri),
+          binop(BinaryOperator::Times, acc_im, rr),
+        ));
         acc_re = new_re;
         acc_im = new_im;
       }
@@ -6995,11 +6657,7 @@ fn split_real_imag(expr: &Expr) -> Option<(Expr, Expr)> {
     } => {
       let (r, i) = split_real_imag(operand)?;
       let neg = |e: Expr| {
-        ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(-1)),
-          right: Box::new(e),
-        })
+        ce_simplify(binop(BinaryOperator::Times, Expr::Integer(-1), e))
       };
       Some((neg(r), neg(i)))
     }
@@ -7012,43 +6670,27 @@ fn split_real_imag(expr: &Expr) -> Option<(Expr, Expr)> {
     } => {
       let (nr, ni) = split_real_imag(left)?;
       let (dr, di) = split_real_imag(right)?;
-      let div = |a: Expr, b: Expr| {
-        ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(a),
-          right: Box::new(b),
-        })
-      };
+      let div =
+        |a: Expr, b: Expr| ce_simplify(binop(BinaryOperator::Divide, a, b));
       if is_expr_zero(&di) {
         Some((div(nr, dr.clone()), div(ni, dr)))
       } else {
         // denom = dr^2 + di^2; result = (n * conj(d)) / denom
-        let sq = |e: Expr| Expr::BinaryOp {
-          op: BinaryOperator::Power,
-          left: Box::new(e),
-          right: Box::new(Expr::Integer(2)),
-        };
-        let denom = ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(sq(dr.clone())),
-          right: Box::new(sq(di.clone())),
-        });
-        let mul = |a: Expr, b: Expr| Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(a),
-          right: Box::new(b),
-        };
+        let sq = |e: Expr| binop(BinaryOperator::Power, e, Expr::Integer(2));
+        let denom = ce_simplify(binop(
+          BinaryOperator::Plus,
+          sq(dr.clone()),
+          sq(di.clone()),
+        ));
+        let mul = |a: Expr, b: Expr| binop(BinaryOperator::Times, a, b);
         // (nr + ni i)(dr - di i) = (nr*dr + ni*di) + (ni*dr - nr*di) i
-        let re_num = ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(mul(nr.clone(), dr.clone())),
-          right: Box::new(mul(ni.clone(), di.clone())),
-        });
-        let im_num = ce_simplify(Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(mul(ni, dr)),
-          right: Box::new(mul(nr, di)),
-        });
+        let re_num = ce_simplify(binop(
+          BinaryOperator::Plus,
+          mul(nr.clone(), dr.clone()),
+          mul(ni.clone(), di.clone()),
+        ));
+        let im_num =
+          ce_simplify(binop(BinaryOperator::Minus, mul(ni, dr), mul(nr, di)));
         Some((div(re_num, denom.clone()), div(im_num, denom)))
       }
     }
@@ -7097,11 +6739,7 @@ fn power_split_real_imag(base: &Expr, exp: &Expr) -> Option<(Expr, Expr)> {
     && let Some((re_e, im_e)) = split_real_imag(exp)
     && !is_expr_zero(&im_e)
   {
-    let exp_a = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(base.clone()),
-      right: Box::new(re_e),
-    };
+    let exp_a = binop(BinaryOperator::Power, base.clone(), re_e);
     let inner_arg = if matches!(base, Expr::Identifier(s) | Expr::Constant(s) if s == "E")
     {
       im_e.clone()
@@ -7123,16 +6761,9 @@ fn power_split_real_imag(base: &Expr, exp: &Expr) -> Option<(Expr, Expr)> {
       name: "Sin".to_string(),
       args: vec![inner_arg].into(),
     };
-    let real = ce_simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(exp_a.clone()),
-      right: Box::new(cos_part),
-    });
-    let imag = ce_simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(exp_a),
-      right: Box::new(sin_part),
-    });
+    let real =
+      ce_simplify(binop(BinaryOperator::Times, exp_a.clone(), cos_part));
+    let imag = ce_simplify(binop(BinaryOperator::Times, exp_a, sin_part));
     return Some((real, imag));
   }
   // Exponent must be a non-negative integer literal.
@@ -7175,22 +6806,14 @@ fn make_term(coef: i128, a: &Expr, ai: i128, b: &Expr, bi: i128) -> Expr {
     if ai == 1 {
       factors.push(a.clone());
     } else {
-      factors.push(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(a.clone()),
-        right: Box::new(Expr::Integer(ai)),
-      });
+      factors.push(binop(BinaryOperator::Power, a.clone(), Expr::Integer(ai)));
     }
   }
   if bi > 0 {
     if bi == 1 {
       factors.push(b.clone());
     } else {
-      factors.push(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(b.clone()),
-        right: Box::new(Expr::Integer(bi)),
-      });
+      factors.push(binop(BinaryOperator::Power, b.clone(), Expr::Integer(bi)));
     }
   }
   if factors.is_empty() {
@@ -7316,24 +6939,11 @@ fn abs_complex_expand_rewrite(arg: &Expr) -> Option<Expr> {
       args: vec![w.clone()].into(),
     };
     let arg_w = complex_expand_recursive(&arg_w);
-    let log_sq = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(log_abs_w),
-      right: Box::new(Expr::Integer(2)),
-    };
-    let arg_sq = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(arg_w),
-      right: Box::new(Expr::Integer(2)),
-    };
+    let log_sq = binop(BinaryOperator::Power, log_abs_w, Expr::Integer(2));
+    let arg_sq = binop(BinaryOperator::Power, arg_w, Expr::Integer(2));
     return Some(Expr::FunctionCall {
       name: "Sqrt".to_string(),
-      args: vec![Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(log_sq),
-        right: Box::new(arg_sq),
-      }]
-      .into(),
+      args: vec![binop(BinaryOperator::Plus, log_sq, arg_sq)].into(),
     });
   }
   None
@@ -7379,23 +6989,15 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
                 name: "Sinh".to_string(),
                 args: vec![im].into(),
               };
-              return ce_simplify(Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(sin_a),
-                  right: Box::new(cosh_b),
-                }),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(Expr::Identifier("I".to_string())),
-                  right: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Times,
-                    left: Box::new(cos_a),
-                    right: Box::new(sinh_b),
-                  }),
-                }),
-              });
+              return ce_simplify(binop(
+                BinaryOperator::Plus,
+                binop(BinaryOperator::Times, sin_a, cosh_b),
+                binop(
+                  BinaryOperator::Times,
+                  Expr::Identifier("I".to_string()),
+                  binop(BinaryOperator::Times, cos_a, sinh_b),
+                ),
+              ));
             }
             // Cos[a + I*b] = Cos[a]*Cosh[b] - I*Sin[a]*Sinh[b]
             "Cos" => {
@@ -7415,23 +7017,15 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
                 name: "Sinh".to_string(),
                 args: vec![im].into(),
               };
-              return ce_simplify(Expr::BinaryOp {
-                op: BinaryOperator::Minus,
-                left: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(cos_a),
-                  right: Box::new(cosh_b),
-                }),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(Expr::Identifier("I".to_string())),
-                  right: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Times,
-                    left: Box::new(sin_a),
-                    right: Box::new(sinh_b),
-                  }),
-                }),
-              });
+              return ce_simplify(binop(
+                BinaryOperator::Minus,
+                binop(BinaryOperator::Times, cos_a, cosh_b),
+                binop(
+                  BinaryOperator::Times,
+                  Expr::Identifier("I".to_string()),
+                  binop(BinaryOperator::Times, sin_a, sinh_b),
+                ),
+              ));
             }
             // Sinh[a + I*b] = Sinh[a]*Cos[b] + I*Cosh[a]*Sin[b]
             "Sinh" => {
@@ -7451,39 +7045,25 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
                 name: "Sin".to_string(),
                 args: vec![im].into(),
               };
-              return ce_simplify(Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(sinh_a),
-                  right: Box::new(cos_b),
-                }),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(Expr::Identifier("I".to_string())),
-                  right: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Times,
-                    left: Box::new(cosh_a),
-                    right: Box::new(sin_b),
-                  }),
-                }),
-              });
+              return ce_simplify(binop(
+                BinaryOperator::Plus,
+                binop(BinaryOperator::Times, sinh_a, cos_b),
+                binop(
+                  BinaryOperator::Times,
+                  Expr::Identifier("I".to_string()),
+                  binop(BinaryOperator::Times, cosh_a, sin_b),
+                ),
+              ));
             }
             // Tanh[a + I*b] = (Sinh[2a] + I*Sin[2b]) / (Cos[2b] + Cosh[2a]).
             // The split-into-real-and-imag form Wolfram emits keeps the
             // shared denominator Cos[2b] + Cosh[2a] under both numerators
             // — emit it the same way so display matches `ComplexExpand`'s.
             "Tanh" => {
-              let two_a = Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(Expr::Integer(2)),
-                right: Box::new(re.clone()),
-              };
-              let two_b = Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(Expr::Integer(2)),
-                right: Box::new(im.clone()),
-              };
+              let two_a =
+                binop(BinaryOperator::Times, Expr::Integer(2), re.clone());
+              let two_b =
+                binop(BinaryOperator::Times, Expr::Integer(2), im.clone());
               let sinh_2a = Expr::FunctionCall {
                 name: "Sinh".to_string(),
                 args: vec![two_a.clone()].into(),
@@ -7500,30 +7080,19 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
                 name: "Cosh".to_string(),
                 args: vec![two_a].into(),
               };
-              let denom = Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(cos_2b),
-                right: Box::new(cosh_2a),
-              };
-              let real_part = Expr::BinaryOp {
-                op: BinaryOperator::Divide,
-                left: Box::new(sinh_2a),
-                right: Box::new(denom.clone()),
-              };
-              let imag_part = Expr::BinaryOp {
-                op: BinaryOperator::Divide,
-                left: Box::new(sin_2b),
-                right: Box::new(denom),
-              };
-              return ce_simplify(Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(real_part),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(Expr::Identifier("I".to_string())),
-                  right: Box::new(imag_part),
-                }),
-              });
+              let denom = binop(BinaryOperator::Plus, cos_2b, cosh_2a);
+              let real_part =
+                binop(BinaryOperator::Divide, sinh_2a, denom.clone());
+              let imag_part = binop(BinaryOperator::Divide, sin_2b, denom);
+              return ce_simplify(binop(
+                BinaryOperator::Plus,
+                real_part,
+                binop(
+                  BinaryOperator::Times,
+                  Expr::Identifier("I".to_string()),
+                  imag_part,
+                ),
+              ));
             }
             // Cosh[a + I*b] = Cosh[a]*Cos[b] + I*Sinh[a]*Sin[b]
             "Cosh" => {
@@ -7543,23 +7112,15 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
                 name: "Sin".to_string(),
                 args: vec![im].into(),
               };
-              return ce_simplify(Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(cosh_a),
-                  right: Box::new(cos_b),
-                }),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(Expr::Identifier("I".to_string())),
-                  right: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Times,
-                    left: Box::new(sinh_a),
-                    right: Box::new(sin_b),
-                  }),
-                }),
-              });
+              return ce_simplify(binop(
+                BinaryOperator::Plus,
+                binop(BinaryOperator::Times, cosh_a, cos_b),
+                binop(
+                  BinaryOperator::Times,
+                  Expr::Identifier("I".to_string()),
+                  binop(BinaryOperator::Times, sinh_a, sin_b),
+                ),
+              ));
             }
             // Exp[a + I*b] = E^a*Cos[b] + I*E^a*Sin[b]
             "Exp" => {
@@ -7575,41 +7136,25 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
                 name: "Sin".to_string(),
                 args: vec![im].into(),
               };
-              return ce_simplify(Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(exp_a.clone()),
-                  right: Box::new(cos_b),
-                }),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(Expr::Identifier("I".to_string())),
-                  right: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Times,
-                    left: Box::new(exp_a),
-                    right: Box::new(sin_b),
-                  }),
-                }),
-              });
+              return ce_simplify(binop(
+                BinaryOperator::Plus,
+                binop(BinaryOperator::Times, exp_a.clone(), cos_b),
+                binop(
+                  BinaryOperator::Times,
+                  Expr::Identifier("I".to_string()),
+                  binop(BinaryOperator::Times, exp_a, sin_b),
+                ),
+              ));
             }
             // Abs[a + I*b] = Sqrt[a^2 + b^2]
             "Abs" => {
               return ce_simplify(Expr::FunctionCall {
                 name: "Sqrt".to_string(),
-                args: vec![Expr::BinaryOp {
-                  op: BinaryOperator::Plus,
-                  left: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Power,
-                    left: Box::new(re),
-                    right: Box::new(Expr::Integer(2)),
-                  }),
-                  right: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Power,
-                    left: Box::new(im),
-                    right: Box::new(Expr::Integer(2)),
-                  }),
-                }]
+                args: vec![binop(
+                  BinaryOperator::Plus,
+                  binop(BinaryOperator::Power, re, Expr::Integer(2)),
+                  binop(BinaryOperator::Power, im, Expr::Integer(2)),
+                )]
                 .into(),
               });
             }
@@ -7625,19 +7170,11 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
           // Log[z] = Log[Re[z]^2 + Im[z]^2]/2 + I Arg[z]. Holds whether or not
           // the imaginary part is zero (e.g. Log[x] = I Arg[x] + Log[x^2]/2).
           "Log" => {
-            let mag_sq = Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Power,
-                left: Box::new(re),
-                right: Box::new(Expr::Integer(2)),
-              }),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Power,
-                left: Box::new(im),
-                right: Box::new(Expr::Integer(2)),
-              }),
-            };
+            let mag_sq = binop(
+              BinaryOperator::Plus,
+              binop(BinaryOperator::Power, re, Expr::Integer(2)),
+              binop(BinaryOperator::Power, im, Expr::Integer(2)),
+            );
             let log_term = Expr::BinaryOp {
               op: BinaryOperator::Divide,
               left: Box::new(Expr::FunctionCall {
@@ -7654,11 +7191,11 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
                 args: vec![arg.clone()].into(),
               }),
             };
-            return ce_simplify(Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(log_term),
-              right: Box::new(arg_term),
-            });
+            return ce_simplify(binop(
+              BinaryOperator::Plus,
+              log_term,
+              arg_term,
+            ));
           }
           // Real argument (im == 0): Abs[u] = Sqrt[u^2]. The im != 0 case is
           // handled in the block above. wolframscript treats every symbol as
@@ -7668,32 +7205,24 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
           "Abs" => {
             return ce_simplify(Expr::FunctionCall {
               name: "Sqrt".to_string(),
-              args: vec![Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Power,
-                  left: Box::new(re),
-                  right: Box::new(Expr::Integer(2)),
-                }),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Power,
-                  left: Box::new(im),
-                  right: Box::new(Expr::Integer(2)),
-                }),
-              }]
+              args: vec![binop(
+                BinaryOperator::Plus,
+                binop(BinaryOperator::Power, re, Expr::Integer(2)),
+                binop(BinaryOperator::Power, im, Expr::Integer(2)),
+              )]
               .into(),
             });
           }
           "Conjugate" => {
-            return ce_simplify(Expr::BinaryOp {
-              op: BinaryOperator::Minus,
-              left: Box::new(re),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(Expr::Identifier("I".to_string())),
-                right: Box::new(im),
-              }),
-            });
+            return ce_simplify(binop(
+              BinaryOperator::Minus,
+              re,
+              binop(
+                BinaryOperator::Times,
+                Expr::Identifier("I".to_string()),
+                im,
+              ),
+            ));
           }
           _ => {}
         }
@@ -7745,37 +7274,29 @@ fn complex_expand_recursive(expr: &Expr) -> Expr {
             name: "Sin".to_string(),
             args: vec![inner_arg].into(),
           };
-          return ce_simplify(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(exp_a.clone()),
-              right: Box::new(cos_b),
-            }),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Identifier("I".to_string())),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(exp_a),
-                right: Box::new(sin_b),
-              }),
-            }),
-          });
+          return ce_simplify(binop(
+            BinaryOperator::Plus,
+            binop(BinaryOperator::Times, exp_a.clone(), cos_b),
+            binop(
+              BinaryOperator::Times,
+              Expr::Identifier("I".to_string()),
+              binop(BinaryOperator::Times, exp_a, sin_b),
+            ),
+          ));
         }
       }
-      Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(complex_expand_recursive(base)),
-        right: Box::new(complex_expand_recursive(exp)),
-      }
+      binop(
+        BinaryOperator::Power,
+        complex_expand_recursive(base),
+        complex_expand_recursive(exp),
+      )
     }
     // Recurse into binary ops
-    Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
-      op: *op,
-      left: Box::new(complex_expand_recursive(left)),
-      right: Box::new(complex_expand_recursive(right)),
-    },
+    Expr::BinaryOp { op, left, right } => binop(
+      *op,
+      complex_expand_recursive(left),
+      complex_expand_recursive(right),
+    ),
     Expr::UnaryOp { op, operand } => Expr::UnaryOp {
       op: *op,
       operand: Box::new(complex_expand_recursive(operand)),
@@ -7826,11 +7347,11 @@ fn exp_to_trig_recursive(expr: &Expr) -> Expr {
       args: args.iter().map(exp_to_trig_recursive).collect(),
     },
     // Recurse into binary ops
-    Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
-      op: *op,
-      left: Box::new(exp_to_trig_recursive(left)),
-      right: Box::new(exp_to_trig_recursive(right)),
-    },
+    Expr::BinaryOp { op, left, right } => binop(
+      *op,
+      exp_to_trig_recursive(left),
+      exp_to_trig_recursive(right),
+    ),
     // Recurse into unary ops
     Expr::UnaryOp { op, operand } => Expr::UnaryOp {
       op: *op,
@@ -8214,11 +7735,11 @@ fn trig_to_exp_recursive(expr: &Expr) -> Expr {
       name: name.clone(),
       args: args.iter().map(trig_to_exp_recursive).collect(),
     },
-    Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
-      op: *op,
-      left: Box::new(trig_to_exp_recursive(left)),
-      right: Box::new(trig_to_exp_recursive(right)),
-    },
+    Expr::BinaryOp { op, left, right } => binop(
+      *op,
+      trig_to_exp_recursive(left),
+      trig_to_exp_recursive(right),
+    ),
     Expr::UnaryOp { op, operand } => Expr::UnaryOp {
       op: *op,
       operand: Box::new(trig_to_exp_recursive(operand)),

--- a/src/functions/math_ast/carlson.rs
+++ b/src/functions/math_ast/carlson.rs
@@ -8,7 +8,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{Expr, unevaluated};
+use crate::syntax::{Expr, binop, unevaluated};
 
 /// True if `e` contains an inexact (machine) number anywhere.
 use crate::functions::math_ast::contains_inexact_real as is_inexact;
@@ -299,14 +299,6 @@ fn is_exact_num(e: &Expr) -> bool {
     || matches!(e, Expr::FunctionCall { name, .. } if name == "Rational")
 }
 
-fn bin(op: BinaryOperator, a: Expr, b: Expr) -> Expr {
-  Expr::BinaryOp {
-    op,
-    left: Box::new(a),
-    right: Box::new(b),
-  }
-}
-
 fn sqrt_of(x: &Expr) -> Expr {
   make_sqrt(x.clone())
 }
@@ -321,19 +313,19 @@ fn cinf() -> Expr {
 
 /// `1 / Sqrt[x]`.
 fn recip_sqrt(x: &Expr) -> Result<Expr, InterpreterError> {
-  eval_expr(&bin(BinaryOperator::Divide, Expr::Integer(1), sqrt_of(x)))
+  eval_expr(&binop(BinaryOperator::Divide, Expr::Integer(1), sqrt_of(x)))
 }
 
 /// `x^(-3/2)`.
 fn recip_sqrt_cubed(x: &Expr) -> Result<Expr, InterpreterError> {
-  let exp = bin(BinaryOperator::Divide, Expr::Integer(-3), Expr::Integer(2));
-  eval_expr(&bin(BinaryOperator::Power, x.clone(), exp))
+  let exp = binop(BinaryOperator::Divide, Expr::Integer(-3), Expr::Integer(2));
+  eval_expr(&binop(BinaryOperator::Power, x.clone(), exp))
 }
 
 /// `Pi / (2 Sqrt[y])`.
 fn pi_over_2sqrt(y: &Expr) -> Result<Expr, InterpreterError> {
-  let den = bin(BinaryOperator::Times, Expr::Integer(2), sqrt_of(y));
-  eval_expr(&bin(BinaryOperator::Divide, pi(), den))
+  let den = binop(BinaryOperator::Times, Expr::Integer(2), sqrt_of(y));
+  eval_expr(&binop(BinaryOperator::Divide, pi(), den))
 }
 
 fn rc_exact(x: &Expr, y: &Expr) -> Option<Result<Expr, InterpreterError>> {
@@ -433,7 +425,7 @@ fn rg_exact(
   if zeros >= 2 {
     // R_G(0, 0, z) = Sqrt[z]/2.
     let nz = args.iter().copied().find(|e| !is_zero(e)).unwrap();
-    return Some(eval_expr(&bin(
+    return Some(eval_expr(&binop(
       BinaryOperator::Divide,
       sqrt_of(nz),
       Expr::Integer(2),
@@ -444,8 +436,8 @@ fn rg_exact(
       args.iter().copied().filter(|e| !is_zero(e)).collect();
     // R_G(0, y, y) = Pi Sqrt[y]/4.
     if expr_equal(others[0], others[1]) {
-      let num = bin(BinaryOperator::Times, pi(), sqrt_of(others[0]));
-      return Some(eval_expr(&bin(
+      let num = binop(BinaryOperator::Times, pi(), sqrt_of(others[0]));
+      return Some(eval_expr(&binop(
         BinaryOperator::Divide,
         num,
         Expr::Integer(4),

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -3,18 +3,9 @@ use super::*;
 use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
-  unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, binop, bool_expr,
+  expr_to_string, unevaluated,
 };
-
-/// Helper to build a binary operation expression
-fn binop(op: BinaryOperator, left: Expr, right: Expr) -> Expr {
-  Expr::BinaryOp {
-    op,
-    left: Box::new(left),
-    right: Box::new(right),
-  }
-}
 
 fn plus(a: Expr, b: Expr) -> Expr {
   binop(BinaryOperator::Plus, a, b)
@@ -6581,11 +6572,9 @@ fn failure_read_once_form(bexpr: &Expr) -> Option<Expr> {
       return r;
     }
     match e {
-      Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
-        op: *op,
-        left: Box::new(map_leaves(left, f)),
-        right: Box::new(map_leaves(right, f)),
-      },
+      Expr::BinaryOp { op, left, right } => {
+        binop(*op, map_leaves(left, f), map_leaves(right, f))
+      }
       Expr::UnaryOp { op, operand } => Expr::UnaryOp {
         op: *op,
         operand: Box::new(map_leaves(operand, f)),

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, expr_to_string, unevaluated};
+use crate::syntax::{BinaryOperator, Expr, binop, expr_to_string, unevaluated};
 
 /// Collect the factors of a product into `out`, descending through nested
 /// `Times` (both spellings) so that factors from separately evaluated parts
@@ -930,18 +930,18 @@ pub fn hypergeometric_pfq_regularized_ast(
   let mut gamma_product = Expr::Integer(1);
   for b_expr in &b_list {
     let gamma_val = gamma_ast(&[b_expr.clone()])?;
-    gamma_product = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(gamma_product),
-      right: Box::new(gamma_val),
-    })?;
+    gamma_product = crate::evaluator::evaluate_expr_to_expr(&binop(
+      BinaryOperator::Times,
+      gamma_product,
+      gamma_val,
+    ))?;
   }
 
-  crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(pfq_result),
-    right: Box::new(gamma_product),
-  })
+  crate::evaluator::evaluate_expr_to_expr(&binop(
+    BinaryOperator::Divide,
+    pfq_result,
+    gamma_product,
+  ))
 }
 
 /// Hypergeometric2F1Regularized[a, b, c, z] = HypergeometricPFQRegularized[{a,b},{c},z]
@@ -1011,11 +1011,7 @@ fn hypergeometric_2f1_regularized_non_positive_c(
         if k == 0 {
           x.clone()
         } else {
-          Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(x.clone()),
-            right: Box::new(Expr::Integer(k)),
-          }
+          binop(BinaryOperator::Plus, x.clone(), Expr::Integer(k))
         }
       })
       .collect();
@@ -1042,23 +1038,11 @@ fn hypergeometric_2f1_regularized_non_positive_c(
   };
 
   // z^{m+1}
-  let z_pow = Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(z.clone()),
-    right: Box::new(Expr::Integer(shift)),
-  };
+  let z_pow = binop(BinaryOperator::Power, z.clone(), Expr::Integer(shift));
 
   // 2F1(a + m + 1, b + m + 1; m + 2; z)
-  let inner_a = Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(a.clone()),
-    right: Box::new(Expr::Integer(shift)),
-  };
-  let inner_b = Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(b.clone()),
-    right: Box::new(Expr::Integer(shift)),
-  };
+  let inner_a = binop(BinaryOperator::Plus, a.clone(), Expr::Integer(shift));
+  let inner_b = binop(BinaryOperator::Plus, b.clone(), Expr::Integer(shift));
   let inner_c = Expr::Integer(shift + 1);
   let inner_2f1 = Expr::FunctionCall {
     name: "Hypergeometric2F1".to_string(),
@@ -1134,16 +1118,12 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Kummer identity: 1F1[1/2, 1, z] = E^(z/2) * BesselI[0, z/2].
   if is_half(&args[0]) && matches!(&args[1], Expr::Integer(1)) {
     let z = &args[2];
-    let half_z = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(z.clone()),
-      right: Box::new(Expr::Integer(2)),
-    };
-    let exp_part = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(Expr::Constant("E".to_string())),
-      right: Box::new(half_z.clone()),
-    };
+    let half_z = binop(BinaryOperator::Divide, z.clone(), Expr::Integer(2));
+    let exp_part = binop(
+      BinaryOperator::Power,
+      Expr::Constant("E".to_string()),
+      half_z.clone(),
+    );
     let bessel = Expr::FunctionCall {
       name: "BesselI".to_string(),
       args: vec![Expr::Integer(0), half_z].into(),
@@ -1162,11 +1142,11 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && !matches!(&args[2], Expr::Real(_) | Expr::BigFloat(_, _))
   {
     let z = &args[2];
-    let exp_z = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(Expr::Constant("E".to_string())),
-      right: Box::new(z.clone()),
-    };
+    let exp_z = binop(
+      BinaryOperator::Power,
+      Expr::Constant("E".to_string()),
+      z.clone(),
+    );
     let sqrt_pi = Expr::FunctionCall {
       name: "Sqrt".to_string(),
       args: vec![Expr::Constant("Pi".to_string())].into(),
@@ -1347,20 +1327,12 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: "Plus".to_string(),
       args: vec![Expr::Integer(b_int), z.clone()].into(),
     };
-    let ratio = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(plus),
-      right: Box::new(Expr::Integer(b_int)),
-    };
+    let ratio = binop(BinaryOperator::Divide, plus, Expr::Integer(b_int));
     let exp_z = Expr::FunctionCall {
       name: "Power".to_string(),
       args: vec![Expr::Identifier("E".to_string()), z.clone()].into(),
     };
-    let prod = Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(ratio),
-      right: Box::new(exp_z),
-    };
+    let prod = binop(BinaryOperator::Times, ratio, exp_z);
     return crate::evaluator::evaluate_expr_to_expr(&prod);
   }
 
@@ -1408,9 +1380,9 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let n_idx = (a - 1 + k) as usize;
       let scale_pow = (max_pow - 1 - n_idx as i128) as u32;
       let scale = z.pow(scale_pow);
-      let bin = crate::functions::binomial_coeff_big(b - a - 1, k);
+      let binom = crate::functions::binomial_coeff_big(b - a - 1, k);
       let sign: i128 = if k.rem_euclid(2) == 0 { 1 } else { -1 };
-      let coeff = BigInt::from(sign) * &bin;
+      let coeff = BigInt::from(sign) * &binom;
       e_num += &coeff * &scale * &p_vec[n_idx];
       const_num += &coeff * &scale * &q_vec[n_idx];
     }

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -2,7 +2,7 @@
 use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
+  BinaryOperator, Expr, UnaryOperator, binop, expr_to_string, unevaluated,
 };
 use num_bigint::BigInt;
 
@@ -1064,21 +1064,16 @@ fn struve_half_integer_closed_form(
   z: &Expr,
 ) -> Option<Result<Expr, InterpreterError>> {
   use BinaryOperator as B;
-  let bin = |op, a: Expr, b: Expr| Expr::BinaryOp {
-    op,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
   let call1 = |name: &str, e: Expr| Expr::FunctionCall {
     name: name.to_string(),
     args: vec![e].into(),
   };
   let i = Expr::Integer;
-  let plus = |a, b| bin(B::Plus, a, b);
-  let minus = |a, b| bin(B::Minus, a, b);
-  let times = |a, b| bin(B::Times, a, b);
-  let div = |a, b| bin(B::Divide, a, b);
-  let neg = |a| bin(B::Times, i(-1), a);
+  let plus = |a, b| binop(B::Plus, a, b);
+  let minus = |a, b| binop(B::Minus, a, b);
+  let times = |a, b| binop(B::Times, a, b);
+  let div = |a, b| binop(B::Divide, a, b);
+  let neg = |a| binop(B::Times, i(-1), a);
   let pi = || Expr::Constant("Pi".to_string());
   let sqrt = |e: Expr| call1("Sqrt", e);
   let z = || z.clone();
@@ -1090,7 +1085,7 @@ fn struve_half_integer_closed_form(
   let cz = || call1(if is_l { "Cosh" } else { "Cos" }, z());
   let sz = || call1(if is_l { "Sinh" } else { "Sin" }, z());
   // z^(3/2)
-  let z_32 = || bin(B::Power, z(), make_rational(3, 2));
+  let z_32 = || binop(B::Power, z(), make_rational(3, 2));
 
   let expr = match two_nu {
     1 => {
@@ -1756,11 +1751,7 @@ fn weber_e_integer_closed_form(
     r
   };
   let pi = Expr::Constant("Pi".to_string());
-  let pi_inv = Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(pi),
-    right: Box::new(Expr::Integer(-1)),
-  };
+  let pi_inv = binop(BinaryOperator::Power, pi, Expr::Integer(-1));
 
   // Polynomial terms: c_k * z^(m-2k-1) / Pi with
   //   c_k = (2k)! (m-k)! 2^(m-2k+1) / [ (2(m-k))! k! ].
@@ -1809,44 +1800,24 @@ fn weber_e_integer_closed_form(
 /// AngerJ[ν, 0] closed form: Sin[ν*Pi] / (ν*Pi).
 fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
   let pi = Expr::Constant("Pi".to_string());
-  let nu_pi = Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(nu.clone()),
-    right: Box::new(pi.clone()),
-  };
+  let nu_pi = binop(BinaryOperator::Times, nu.clone(), pi.clone());
   let sin_nu_pi = Expr::FunctionCall {
     name: "Sin".to_string(),
     args: vec![nu_pi.clone()].into(),
   };
-  Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(sin_nu_pi),
-    right: Box::new(nu_pi),
-  }
+  binop(BinaryOperator::Divide, sin_nu_pi, nu_pi)
 }
 
 /// WeberE[ν, 0] closed form: (1 - Cos[ν*Pi]) / (ν*Pi).
 fn weber_e_at_zero_symbolic(nu: &Expr) -> Expr {
   let pi = Expr::Constant("Pi".to_string());
-  let nu_pi = Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(nu.clone()),
-    right: Box::new(pi.clone()),
-  };
+  let nu_pi = binop(BinaryOperator::Times, nu.clone(), pi.clone());
   let cos_nu_pi = Expr::FunctionCall {
     name: "Cos".to_string(),
     args: vec![nu_pi.clone()].into(),
   };
-  let one_minus_cos = Expr::BinaryOp {
-    op: BinaryOperator::Minus,
-    left: Box::new(Expr::Integer(1)),
-    right: Box::new(cos_nu_pi),
-  };
-  Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(one_minus_cos),
-    right: Box::new(nu_pi),
-  }
+  let one_minus_cos = binop(BinaryOperator::Minus, Expr::Integer(1), cos_nu_pi);
+  binop(BinaryOperator::Divide, one_minus_cos, nu_pi)
 }
 
 /// Compute WeberE[nu, z] numerically using Gauss-Legendre quadrature.
@@ -2573,16 +2544,10 @@ pub fn appell_f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Symbolic reduction: F1(a, b1, b2; a; x, y) = 1 / ((1-x)^b1 * (1-y)^b2)
   if exprs_structurally_equal(&args[0], &args[3]) {
     let one = Expr::Integer(1);
-    let one_minus_x = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(one.clone()),
-      right: Box::new(args[4].clone()),
-    };
-    let one_minus_y = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(one.clone()),
-      right: Box::new(args[5].clone()),
-    };
+    let one_minus_x =
+      binop(BinaryOperator::Minus, one.clone(), args[4].clone());
+    let one_minus_y =
+      binop(BinaryOperator::Minus, one.clone(), args[5].clone());
     let factor_x = Expr::FunctionCall {
       name: "Power".to_string(),
       args: vec![one_minus_x, args[1].clone()].into(),
@@ -2591,16 +2556,8 @@ pub fn appell_f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: "Power".to_string(),
       args: vec![one_minus_y, args[2].clone()].into(),
     };
-    let denom = Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(factor_x),
-      right: Box::new(factor_y),
-    };
-    let result = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(one),
-      right: Box::new(denom),
-    };
+    let denom = binop(BinaryOperator::Times, factor_x, factor_y);
+    let result = binop(BinaryOperator::Divide, one, denom);
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
 

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -2,8 +2,8 @@
 use super::*;
 use crate::InterpreterError;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, ExprForm, UnaryOperator, bool_expr,
-  expr_to_output, expr_to_string, format_expr, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, ExprForm, UnaryOperator, binop,
+  bool_expr, expr_to_output, expr_to_string, format_expr, unevaluated,
 };
 
 /// If the first argument is a numeric scalar, emit
@@ -589,11 +589,11 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // like (a + b)/2 stays as-is (Plus does not distribute over Times),
         // while a Quantity sum collapses (Quantity[6, Meters]/2 →
         // Quantity[3, Meters]), matching wolframscript.
-        crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(evaluated_sum),
-          right: Box::new(Expr::Integer(n)),
-        })
+        crate::evaluator::evaluate_expr_to_expr(&binop(
+          BinaryOperator::Divide,
+          evaluated_sum,
+          Expr::Integer(n),
+        ))
       }
     }
     Expr::FunctionCall {
@@ -1240,11 +1240,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Variance[BinormalDistribution[…, {s1, s2}, …]] = {s1^2, s2^2}.
       match super::distributions::binormal_params(dargs) {
         Some((_, _, s1, s2, _)) => {
-          let sq = |s: Expr| Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(s),
-            right: Box::new(Expr::Integer(2)),
-          };
+          let sq = |s: Expr| binop(BinaryOperator::Power, s, Expr::Integer(2));
           crate::evaluator::evaluate_expr_to_expr(&Expr::List(
             vec![sq(s1), sq(s2)].into(),
           ))
@@ -1258,11 +1254,8 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } if dist_name == "QuantityDistribution" && dargs.len() == 2 => {
       // Variance[QuantityDistribution[dist, unit]] = Quantity[Variance[dist], unit^2]
       let inner_var = variance_ast(&[dargs[0].clone()])?;
-      let unit_sq = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(dargs[1].clone()),
-        right: Box::new(Expr::Integer(2)),
-      };
+      let unit_sq =
+        binop(BinaryOperator::Power, dargs[1].clone(), Expr::Integer(2));
       Ok(Expr::FunctionCall {
         name: "Quantity".to_string(),
         args: vec![inner_var, unit_sq].into(),
@@ -1572,11 +1565,7 @@ fn try_sqrt_extract_denom_factors(
     if half == 1 {
       base
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(base),
-        right: Box::new(Expr::Integer(half)),
-      }
+      binop(BinaryOperator::Power, base, Expr::Integer(half))
     }
   };
 
@@ -1662,11 +1651,7 @@ fn try_sqrt_extract_denom_factors(
     build_product(denominator_factors)
   };
 
-  Ok(Some(Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(numerator),
-    right: Box::new(denom_expr),
-  }))
+  Ok(Some(binop(BinaryOperator::Divide, numerator, denom_expr)))
 }
 
 /// GeometricMean[list] - Geometric mean: (product of elements)^(1/n)
@@ -1874,22 +1859,18 @@ fn harmonic_mean_symbolic(items: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let recips: Vec<Expr> = items
     .iter()
-    .map(|x| Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(x.clone()),
-    })
+    .map(|x| binop(BinaryOperator::Divide, Expr::Integer(1), x.clone()))
     .collect();
   let sum = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
     name: "Plus".to_string(),
     args: recips.into(),
   })?;
   let n = items.len() as i128;
-  crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(Expr::Integer(n)),
-    right: Box::new(sum),
-  })
+  crate::evaluator::evaluate_expr_to_expr(&binop(
+    BinaryOperator::Divide,
+    Expr::Integer(n),
+    sum,
+  ))
 }
 
 /// Column-wise HarmonicMean for a list-of-lists (matrix) input.
@@ -2086,25 +2067,13 @@ fn covariance_pair(xs: &[Expr], ys: &[Expr]) -> Result<Expr, InterpreterError> {
   let n = xs.len();
   let mut terms = Vec::with_capacity(n);
   for (x, y) in xs.iter().zip(ys.iter()) {
-    let dx = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(x.clone()),
-      right: Box::new(mean_x.clone()),
-    };
-    let dy = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(y.clone()),
-      right: Box::new(mean_y.clone()),
-    };
+    let dx = binop(BinaryOperator::Minus, x.clone(), mean_x.clone());
+    let dy = binop(BinaryOperator::Minus, y.clone(), mean_y.clone());
     let conj_dy = Expr::FunctionCall {
       name: "Conjugate".to_string(),
       args: vec![dy].into(),
     };
-    let product = Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(dx),
-      right: Box::new(conj_dy),
-    };
+    let product = binop(BinaryOperator::Times, dx, conj_dy);
     let val = crate::evaluator::evaluate_expr_to_expr(&product)?;
     terms.push(val);
   }
@@ -2114,11 +2083,11 @@ fn covariance_pair(xs: &[Expr], ys: &[Expr]) -> Result<Expr, InterpreterError> {
     args: terms.into(),
   };
   let sum_val = crate::evaluator::evaluate_expr_to_expr(&sum_expr)?;
-  let result = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(sum_val),
-    right: Box::new(Expr::Integer((n - 1) as i128)),
-  };
+  let result = binop(
+    BinaryOperator::Divide,
+    sum_val,
+    Expr::Integer((n - 1) as i128),
+  );
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
 
@@ -2144,43 +2113,19 @@ fn symbolic_covariance(
     args: vec![e.clone()].into(),
   };
   let result = if n == 2 {
-    let dx = Expr::BinaryOp {
-      op: B::Minus,
-      left: Box::new(xs[0].clone()),
-      right: Box::new(xs[1].clone()),
-    };
-    let dy = Expr::BinaryOp {
-      op: B::Minus,
-      left: Box::new(conj(&ys[0])),
-      right: Box::new(conj(&ys[1])),
-    };
-    Expr::BinaryOp {
-      op: B::Divide,
-      left: Box::new(Expr::BinaryOp {
-        op: B::Times,
-        left: Box::new(dx),
-        right: Box::new(dy),
-      }),
-      right: Box::new(Expr::Integer(2)),
-    }
+    let dx = binop(B::Minus, xs[0].clone(), xs[1].clone());
+    let dy = binop(B::Minus, conj(&ys[0]), conj(&ys[1]));
+    binop(B::Divide, binop(B::Times, dx, dy), Expr::Integer(2))
   } else {
     let sum_x = unevaluated("Plus", xs);
     let mut terms = Vec::with_capacity(n);
     for (x, y) in xs.iter().zip(ys.iter()) {
-      let coeff = Expr::BinaryOp {
-        op: B::Minus,
-        left: Box::new(Expr::BinaryOp {
-          op: B::Times,
-          left: Box::new(Expr::Integer(n as i128)),
-          right: Box::new(x.clone()),
-        }),
-        right: Box::new(sum_x.clone()),
-      };
-      terms.push(Expr::BinaryOp {
-        op: B::Times,
-        left: Box::new(coeff),
-        right: Box::new(conj(y)),
-      });
+      let coeff = binop(
+        B::Minus,
+        binop(B::Times, Expr::Integer(n as i128), x.clone()),
+        sum_x.clone(),
+      );
+      terms.push(binop(B::Times, coeff, conj(y)));
     }
     Expr::BinaryOp {
       op: B::Divide,
@@ -2235,20 +2180,8 @@ pub fn covariance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       super::distributions::binormal_params(dargs)
   {
     use BinaryOperator as B;
-    let sq = |s: Expr| Expr::BinaryOp {
-      op: B::Power,
-      left: Box::new(s),
-      right: Box::new(Expr::Integer(2)),
-    };
-    let off = Expr::BinaryOp {
-      op: B::Times,
-      left: Box::new(rho),
-      right: Box::new(Expr::BinaryOp {
-        op: B::Times,
-        left: Box::new(s1.clone()),
-        right: Box::new(s2.clone()),
-      }),
-    };
+    let sq = |s: Expr| binop(B::Power, s, Expr::Integer(2));
+    let off = binop(B::Times, rho, binop(B::Times, s1.clone(), s2.clone()));
     let matrix = Expr::List(
       vec![
         Expr::List(vec![sq(s1.clone()), off.clone()].into()),
@@ -3062,11 +2995,8 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let v1 = xs[1].clone();
       let w0 = ys[0].clone();
       let w1 = ys[1].clone();
-      let diff = |a: &Expr, b: &Expr| Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(a.clone()),
-        right: Box::new(b.clone()),
-      };
+      let diff =
+        |a: &Expr, b: &Expr| binop(BinaryOperator::Minus, a.clone(), b.clone());
       let conj = |e: &Expr| Expr::FunctionCall {
         name: "Conjugate".to_string(),
         args: vec![e.clone()].into(),
@@ -3075,11 +3005,8 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         name: "Times".to_string(),
         args: vec![a, b].into(),
       };
-      let conj_diff = |a: &Expr, b: &Expr| Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(conj(a)),
-        right: Box::new(conj(b)),
-      };
+      let conj_diff =
+        |a: &Expr, b: &Expr| binop(BinaryOperator::Minus, conj(a), conj(b));
       let v_diff = diff(&v0, &v1);
       let w_diff = diff(&w0, &w1);
       let v_conj_diff = conj_diff(&v0, &v1);
@@ -3097,11 +3024,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Return without re-evaluating to preserve the Times factor order
       // inside each Sqrt (which Woxi's canonical sort would otherwise
       // reorder differently than wolframscript for some variable names).
-      return Ok(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(numer),
-        right: Box::new(denom),
-      });
+      return Ok(binop(BinaryOperator::Divide, numer, denom));
     }
     return Ok(unevaluated("Correlation", args));
   }
@@ -3147,20 +3070,12 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     return Ok(unevaluated("Correlation", args));
   }
-  let var_product = Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(var_x),
-    right: Box::new(var_y),
-  };
+  let var_product = binop(BinaryOperator::Times, var_x, var_y);
   let denom = Expr::FunctionCall {
     name: "Sqrt".to_string(),
     args: vec![var_product].into(),
   };
-  let result = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(cov_xy),
-    right: Box::new(denom),
-  };
+  let result = binop(BinaryOperator::Divide, cov_xy, denom);
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
 
@@ -3207,11 +3122,11 @@ fn distribution_raw_moment(
   n: i128,
   var: &str,
 ) -> Result<Option<Expr>, InterpreterError> {
-  let powered = Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(Expr::Identifier(var.to_string())),
-    right: Box::new(Expr::Integer(n)),
-  };
+  let powered = binop(
+    BinaryOperator::Power,
+    Expr::Identifier(var.to_string()),
+    Expr::Integer(n),
+  );
   let distributed = Expr::FunctionCall {
     name: "Distributed".to_string(),
     args: vec![Expr::Identifier(var.to_string()), dist.clone()].into(),
@@ -3306,17 +3221,9 @@ fn skellam_central_moment(a: &Expr, b: &Expr, n: i128) -> Expr {
   }
   let kappa = |j: usize| -> Expr {
     if j.is_multiple_of(2) {
-      Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(a.clone()),
-        right: Box::new(b.clone()),
-      }
+      binop(BinaryOperator::Plus, a.clone(), b.clone())
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(a.clone()),
-        right: Box::new(b.clone()),
-      }
+      binop(BinaryOperator::Minus, a.clone(), b.clone())
     }
   };
   let mut terms: Vec<Expr> = Vec::new();
@@ -3388,11 +3295,7 @@ fn distribution_moment(
         name: "Times".to_string(),
         args: vec![
           Expr::Integer(fact_i128(n)),
-          Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(b),
-            right: Box::new(Expr::Integer(n)),
-          },
+          binop(BinaryOperator::Power, b, Expr::Integer(n)),
         ]
         .into(),
       }
@@ -3417,11 +3320,7 @@ fn distribution_moment(
   // not close, so give the closed form directly; this lets Skewness reduce to
   // 0 and Kurtosis to 21/5.
   if let Some((_, b)) = two_params_of(dist, "LogisticDistribution") {
-    let power = |base: Expr, exp: Expr| Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(base),
-      right: Box::new(exp),
-    };
+    let power = |base: Expr, exp: Expr| binop(BinaryOperator::Power, base, exp);
     let result = if n.rem_euclid(2) == 1 {
       Expr::Integer(0)
     } else {
@@ -3478,29 +3377,17 @@ fn distribution_moment(
         ]
         .into(),
       };
-      let num = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(diff),
-        right: Box::new(Expr::Integer(n)),
-      };
+      let num = binop(BinaryOperator::Power, diff, Expr::Integer(n));
       // 2^n * (n + 1), kept symbolic so large n does not overflow.
       let denom = Expr::FunctionCall {
         name: "Times".to_string(),
         args: vec![
-          Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(Expr::Integer(2)),
-            right: Box::new(Expr::Integer(n)),
-          },
+          binop(BinaryOperator::Power, Expr::Integer(2), Expr::Integer(n)),
           Expr::Integer(n + 1),
         ]
         .into(),
       };
-      Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(num),
-        right: Box::new(denom),
-      }
+      binop(BinaryOperator::Divide, num, denom)
     };
     return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
   }
@@ -3510,11 +3397,7 @@ fn distribution_moment(
   // (the even moments are the Euler numbers). This gives Skewness 0 and
   // Kurtosis 5.
   if let Some((_, s)) = two_params_of(dist, "SechDistribution") {
-    let power = |base: Expr, exp: Expr| Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(base),
-      right: Box::new(exp),
-    };
+    let power = |base: Expr, exp: Expr| binop(BinaryOperator::Power, base, exp);
     let result = if n.rem_euclid(2) == 1 {
       Expr::Integer(0)
     } else {
@@ -3653,16 +3536,8 @@ pub fn central_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut terms = Vec::with_capacity(n);
   for item in items {
     // (item - mean)^r
-    let diff = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(item.clone()),
-      right: Box::new(mean_expr.clone()),
-    };
-    let powered = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(diff),
-      right: Box::new(Expr::Integer(r as i128)),
-    };
+    let diff = binop(BinaryOperator::Minus, item.clone(), mean_expr.clone());
+    let powered = binop(BinaryOperator::Power, diff, Expr::Integer(r as i128));
     let val = crate::evaluator::evaluate_expr_to_expr(&powered)?;
     terms.push(val);
   }
@@ -3673,11 +3548,7 @@ pub fn central_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     args: terms.into(),
   };
   let sum_val = crate::evaluator::evaluate_expr_to_expr(&sum_expr)?;
-  let result = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(sum_val),
-    right: Box::new(Expr::Integer(n as i128)),
-  };
+  let result = binop(BinaryOperator::Divide, sum_val, Expr::Integer(n as i128));
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
 
@@ -3731,22 +3602,18 @@ pub fn cumulant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let raw_moment = |j: usize| -> Result<Expr, InterpreterError> {
     let mut terms = Vec::with_capacity(items.len());
     for item in items {
-      let powered = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(item.clone()),
-        right: Box::new(Expr::Integer(j as i128)),
-      };
+      let powered = binop(
+        BinaryOperator::Power,
+        item.clone(),
+        Expr::Integer(j as i128),
+      );
       terms.push(crate::evaluator::evaluate_expr_to_expr(&powered)?);
     }
     let sum_expr = Expr::FunctionCall {
       name: "Plus".to_string(),
       args: terms.into(),
     };
-    let div = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(sum_expr),
-      right: Box::new(Expr::Integer(n)),
-    };
+    let div = binop(BinaryOperator::Divide, sum_expr, Expr::Integer(n));
     crate::evaluator::evaluate_expr_to_expr(&div)
   };
 
@@ -3779,11 +3646,7 @@ fn cumulant_from_raw_moments(
         args: vec![Expr::Integer(binom), k[m].clone(), mu[nn - m].clone()]
           .into(),
       };
-      acc = Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(acc),
-        right: Box::new(term),
-      };
+      acc = binop(BinaryOperator::Minus, acc, term);
       acc = crate::evaluator::evaluate_expr_to_expr(&acc)?;
     }
     k.push(acc);
@@ -3799,101 +3662,78 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Skellam: Kurtosis = 3 + 1/(a+b). Built directly because the generic
   // moment-ratio Expand mangles the multi-parameter denominator.
   if let Some((a, b)) = skellam_params(&args[0]) {
-    let a_plus_b = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(a),
-      right: Box::new(b),
-    };
-    let result = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(3)),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(a_plus_b),
-      }),
-    };
+    let a_plus_b = binop(BinaryOperator::Plus, a, b);
+    let result = binop(
+      BinaryOperator::Plus,
+      Expr::Integer(3),
+      binop(BinaryOperator::Divide, Expr::Integer(1), a_plus_b),
+    );
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
   // PolyaAeppli: Kurtosis = 3 + (1 + 10 p + p^2)/((1 + p) t).
   if let Some((t, p)) = two_params_of(&args[0], "PolyaAeppliDistribution") {
     use BinaryOperator as B;
-    let bin = |op, l, r| Expr::BinaryOp {
-      op,
-      left: Box::new(l),
-      right: Box::new(r),
-    };
-    let num = bin(
+    let num = binop(
       B::Plus,
-      bin(
+      binop(
         B::Plus,
         Expr::Integer(1),
-        bin(B::Times, Expr::Integer(10), p.clone()),
+        binop(B::Times, Expr::Integer(10), p.clone()),
       ),
-      bin(B::Power, p.clone(), Expr::Integer(2)),
+      binop(B::Power, p.clone(), Expr::Integer(2)),
     );
-    let den = bin(B::Times, bin(B::Plus, Expr::Integer(1), p), t);
-    let result = bin(B::Plus, Expr::Integer(3), bin(B::Divide, num, den));
+    let den = binop(B::Times, binop(B::Plus, Expr::Integer(1), p), t);
+    let result = binop(B::Plus, Expr::Integer(3), binop(B::Divide, num, den));
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
   // Geometric: Kurtosis = 3 + (6 - 6 p + p^2)/(1 - p).
   if let Some(p) = one_param_of(&args[0], "GeometricDistribution") {
     use BinaryOperator as B;
-    let bin = |op, l, r| Expr::BinaryOp {
-      op,
-      left: Box::new(l),
-      right: Box::new(r),
-    };
-    let num = bin(
+    let num = binop(
       B::Plus,
-      bin(
+      binop(
         B::Plus,
         Expr::Integer(6),
-        bin(B::Times, Expr::Integer(-6), p.clone()),
+        binop(B::Times, Expr::Integer(-6), p.clone()),
       ),
-      bin(B::Power, p.clone(), Expr::Integer(2)),
+      binop(B::Power, p.clone(), Expr::Integer(2)),
     );
-    let den = bin(B::Minus, Expr::Integer(1), p);
-    let result = bin(B::Plus, Expr::Integer(3), bin(B::Divide, num, den));
+    let den = binop(B::Minus, Expr::Integer(1), p);
+    let result = binop(B::Plus, Expr::Integer(3), binop(B::Divide, num, den));
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
   // Negative-binomial family: Kurtosis = 3 + (6 - 6 p + p^2)/(scale (1 - p)),
   // scale = r (NegativeBinomial) or n (Pascal). Binomial has its own numerator.
   {
     use BinaryOperator as B;
-    let bin = |op, l, r| Expr::BinaryOp {
-      op,
-      left: Box::new(l),
-      right: Box::new(r),
-    };
-    let one_minus_p = |p: &Expr| bin(B::Minus, Expr::Integer(1), p.clone());
+    let one_minus_p = |p: &Expr| binop(B::Minus, Expr::Integer(1), p.clone());
     // 6 - 6 p + p^2
     let nb_num = |p: &Expr| {
-      bin(
+      binop(
         B::Plus,
-        bin(
+        binop(
           B::Plus,
           Expr::Integer(6),
-          bin(B::Times, Expr::Integer(-6), p.clone()),
+          binop(B::Times, Expr::Integer(-6), p.clone()),
         ),
-        bin(B::Power, p.clone(), Expr::Integer(2)),
+        binop(B::Power, p.clone(), Expr::Integer(2)),
       )
     };
     let three_plus =
-      |num, den| bin(B::Plus, Expr::Integer(3), bin(B::Divide, num, den));
+      |num, den| binop(B::Plus, Expr::Integer(3), binop(B::Divide, num, den));
     if let Some((r, p)) =
       two_params_of(&args[0], "NegativeBinomialDistribution")
     {
-      let result = three_plus(nb_num(&p), bin(B::Times, one_minus_p(&p), r));
+      let result = three_plus(nb_num(&p), binop(B::Times, one_minus_p(&p), r));
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
     if let Some((n, p)) = two_params_of(&args[0], "PascalDistribution") {
-      let result = three_plus(nb_num(&p), bin(B::Times, n, one_minus_p(&p)));
+      let result = three_plus(nb_num(&p), binop(B::Times, n, one_minus_p(&p)));
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
     if let Some((n, p)) = two_params_of(&args[0], "BinomialDistribution") {
       // 3 + (1 - 6 (1 - p) p)/(n (1 - p) p)
-      let num = bin(
+      let num = binop(
         B::Minus,
         Expr::Integer(1),
         Expr::FunctionCall {
@@ -3912,16 +3752,8 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let m4 = central_moment_ast(&[args[0].clone(), Expr::Integer(4)])?;
   let m2 = central_moment_ast(&[args[0].clone(), Expr::Integer(2)])?;
   // Compute m4 / m2^2 symbolically
-  let m2_squared = Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(m2),
-    right: Box::new(Expr::Integer(2)),
-  };
-  let result = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(m4),
-    right: Box::new(m2_squared),
-  };
+  let m2_squared = binop(BinaryOperator::Power, m2, Expr::Integer(2));
+  let result = binop(BinaryOperator::Divide, m4, m2_squared);
   let result = maybe_expand_for_distribution(&args[0], result);
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
@@ -3948,69 +3780,47 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Skellam: Skewness = (a-b)/(a+b)^(3/2). Built directly so the compact form
   // is preserved (the generic moment-ratio Expand would distribute it).
   if let Some((a, b)) = skellam_params(&args[0]) {
-    let result = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(a.clone()),
-        right: Box::new(b.clone()),
-      }),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(a),
-          right: Box::new(b),
-        }),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(Expr::Integer(3)),
-          right: Box::new(Expr::Integer(2)),
-        }),
-      }),
-    };
+    let result = binop(
+      BinaryOperator::Divide,
+      binop(BinaryOperator::Minus, a.clone(), b.clone()),
+      binop(
+        BinaryOperator::Power,
+        binop(BinaryOperator::Plus, a, b),
+        binop(BinaryOperator::Divide, Expr::Integer(3), Expr::Integer(2)),
+      ),
+    );
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
   // PolyaAeppli: Skewness = (1 + 4 p + p^2)/((1 + p) Sqrt[(1 + p) t]).
   if let Some((t, p)) = two_params_of(&args[0], "PolyaAeppliDistribution") {
     use BinaryOperator as B;
-    let bin = |op, l, r| Expr::BinaryOp {
-      op,
-      left: Box::new(l),
-      right: Box::new(r),
-    };
-    let one_plus_p = bin(B::Plus, Expr::Integer(1), p.clone());
-    let num = bin(
+    let one_plus_p = binop(B::Plus, Expr::Integer(1), p.clone());
+    let num = binop(
       B::Plus,
-      bin(
+      binop(
         B::Plus,
         Expr::Integer(1),
-        bin(B::Times, Expr::Integer(4), p.clone()),
+        binop(B::Times, Expr::Integer(4), p.clone()),
       ),
-      bin(B::Power, p, Expr::Integer(2)),
+      binop(B::Power, p, Expr::Integer(2)),
     );
     let sqrt = Expr::FunctionCall {
       name: "Sqrt".to_string(),
-      args: vec![bin(B::Times, one_plus_p.clone(), t)].into(),
+      args: vec![binop(B::Times, one_plus_p.clone(), t)].into(),
     };
-    let den = bin(B::Times, one_plus_p, sqrt);
-    let result = bin(B::Divide, num, den);
+    let den = binop(B::Times, one_plus_p, sqrt);
+    let result = binop(B::Divide, num, den);
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
   // Geometric: Skewness = (2 - p)/Sqrt[1 - p]. Built directly to preserve the
   // compact form (the generic moment ratio leaves CentralMoment unevaluated).
   if let Some(p) = one_param_of(&args[0], "GeometricDistribution") {
     use BinaryOperator as B;
-    let bin = |op, l, r| Expr::BinaryOp {
-      op,
-      left: Box::new(l),
-      right: Box::new(r),
-    };
     let sqrt = Expr::FunctionCall {
       name: "Sqrt".to_string(),
-      args: vec![bin(B::Minus, Expr::Integer(1), p.clone())].into(),
+      args: vec![binop(B::Minus, Expr::Integer(1), p.clone())].into(),
     };
-    let result = bin(B::Divide, bin(B::Minus, Expr::Integer(2), p), sqrt);
+    let result = binop(B::Divide, binop(B::Minus, Expr::Integer(2), p), sqrt);
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
   // Negative-binomial family: Skewness = (2 - p)/Sqrt[scale (1 - p)], with the
@@ -4018,45 +3828,40 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // form. Built directly so the compact shapes are preserved.
   {
     use BinaryOperator as B;
-    let bin = |op, l, r| Expr::BinaryOp {
-      op,
-      left: Box::new(l),
-      right: Box::new(r),
-    };
     let sqrt = |e| Expr::FunctionCall {
       name: "Sqrt".to_string(),
       args: vec![e].into(),
     };
-    let one_minus_p = |p: &Expr| bin(B::Minus, Expr::Integer(1), p.clone());
+    let one_minus_p = |p: &Expr| binop(B::Minus, Expr::Integer(1), p.clone());
     if let Some((r, p)) =
       two_params_of(&args[0], "NegativeBinomialDistribution")
     {
-      let result = bin(
+      let result = binop(
         B::Divide,
-        bin(B::Minus, Expr::Integer(2), p.clone()),
-        sqrt(bin(B::Times, one_minus_p(&p), r)),
+        binop(B::Minus, Expr::Integer(2), p.clone()),
+        sqrt(binop(B::Times, one_minus_p(&p), r)),
       );
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
     if let Some((n, p)) = two_params_of(&args[0], "PascalDistribution") {
-      let result = bin(
+      let result = binop(
         B::Divide,
-        bin(B::Minus, Expr::Integer(2), p.clone()),
-        sqrt(bin(B::Times, n, one_minus_p(&p))),
+        binop(B::Minus, Expr::Integer(2), p.clone()),
+        sqrt(binop(B::Times, n, one_minus_p(&p))),
       );
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
     if let Some((n, p)) = two_params_of(&args[0], "BinomialDistribution") {
-      let num = bin(
+      let num = binop(
         B::Minus,
         Expr::Integer(1),
-        bin(B::Times, Expr::Integer(2), p.clone()),
+        binop(B::Times, Expr::Integer(2), p.clone()),
       );
       let scale = Expr::FunctionCall {
         name: "Times".to_string(),
         args: vec![n, one_minus_p(&p), p.clone()].into(),
       };
-      let result = bin(B::Divide, num, sqrt(scale));
+      let result = binop(B::Divide, num, sqrt(scale));
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
   }
@@ -4079,29 +3884,17 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         args: vec![Expr::Integer(-3), Expr::Integer(2)].into(),
       }),
     };
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(m3),
-      right: Box::new(m2_pow),
-    }
+    binop(BinaryOperator::Times, m3, m2_pow)
   } else {
     // Compute m3 / m2^(3/2) symbolically
-    let m2_pow = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(m2),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::Integer(3)),
-        right: Box::new(Expr::Integer(2)),
-      }),
-    };
+    let m2_pow = binop(
+      BinaryOperator::Power,
+      m2,
+      binop(BinaryOperator::Divide, Expr::Integer(3), Expr::Integer(2)),
+    );
     maybe_expand_for_distribution(
       &args[0],
-      Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(m3),
-        right: Box::new(m2_pow),
-      },
+      binop(BinaryOperator::Divide, m3, m2_pow),
     )
   };
   crate::evaluator::evaluate_expr_to_expr(&result)
@@ -4607,11 +4400,7 @@ fn factorial_moment_of_distribution(
   dargs: &[Expr],
   r: i128,
 ) -> Option<Expr> {
-  let pow = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(b),
-    right: Box::new(e),
-  };
+  let pow = |b: Expr, e: Expr| binop(BinaryOperator::Power, b, e);
   let times = |fs: Vec<Expr>| Expr::FunctionCall {
     name: "Times".to_string(),
     args: fs.into(),
@@ -4874,11 +4663,7 @@ pub fn mean_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let n = items.len() as i128;
     let mut abs_devs = Vec::new();
     for item in items {
-      let diff = Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(item.clone()),
-        right: Box::new(mean_expr.clone()),
-      };
+      let diff = binop(BinaryOperator::Minus, item.clone(), mean_expr.clone());
       let abs_diff = Expr::FunctionCall {
         name: "Abs".to_string(),
         args: vec![diff].into(),
@@ -4889,11 +4674,7 @@ pub fn mean_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: "Plus".to_string(),
       args: abs_devs.into(),
     };
-    let result = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(sum),
-      right: Box::new(Expr::Integer(n)),
-    };
+    let result = binop(BinaryOperator::Divide, sum, Expr::Integer(n));
     crate::evaluator::evaluate_expr_to_expr(&result)
   } else {
     Ok(unevaluated("MeanDeviation", args))
@@ -4913,11 +4694,8 @@ pub fn median_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Compute absolute deviations |xi - median|
     let mut abs_devs = Vec::new();
     for item in items {
-      let diff = Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(item.clone()),
-        right: Box::new(median_expr.clone()),
-      };
+      let diff =
+        binop(BinaryOperator::Minus, item.clone(), median_expr.clone());
       let abs_diff = Expr::FunctionCall {
         name: "Abs".to_string(),
         args: vec![diff].into(),
@@ -6657,11 +6435,7 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
     } => {
       let l = discrete_asymptotic_leading(left, var)?;
       let r = discrete_asymptotic_leading(right, var)?;
-      Some(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(l),
-        right: Box::new(r),
-      })
+      Some(binop(BinaryOperator::Divide, l, r))
     }
 
     // Sqrt[expr]
@@ -6988,29 +6762,21 @@ pub fn covariance_function_data(
     Ok(m) => m,
     Err(e) => return Some(Err(e)),
   };
-  let dev = |x: &Expr| Expr::BinaryOp {
-    op: BinaryOperator::Minus,
-    left: Box::new(x.clone()),
-    right: Box::new(mean.clone()),
-  };
+  let dev = |x: &Expr| binop(BinaryOperator::Minus, x.clone(), mean.clone());
   let h_us = h.unsigned_abs() as usize;
   let mut terms = Vec::new();
   for t in 0..(n - h_us) {
-    terms.push(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(dev(&items[t])),
-      right: Box::new(dev(&items[t + h_us])),
-    });
+    terms.push(binop(
+      BinaryOperator::Times,
+      dev(&items[t]),
+      dev(&items[t + h_us]),
+    ));
   }
   let sum = Expr::FunctionCall {
     name: "Plus".to_string(),
     args: terms.into(),
   };
-  let result = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(sum),
-    right: Box::new(Expr::Integer(n as i128)),
-  };
+  let result = binop(BinaryOperator::Divide, sum, Expr::Integer(n as i128));
   Some(crate::evaluator::evaluate_expr_to_expr(&result))
 }
 
@@ -7042,10 +6808,12 @@ pub fn absolute_correlation_function_ast(
   let single = |h: i128| -> Result<Expr, InterpreterError> {
     let h_us = h.unsigned_abs() as usize;
     let terms: Vec<Expr> = (0..(n - h_us))
-      .map(|t| Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(items[t].clone()),
-        right: Box::new(items[t + h_us].clone()),
+      .map(|t| {
+        binop(
+          BinaryOperator::Times,
+          items[t].clone(),
+          items[t + h_us].clone(),
+        )
       })
       .collect();
     crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
@@ -7122,22 +6890,10 @@ fn process_covariance(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
     name: n.to_string(),
     args: a.into(),
   };
-  let times2 = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
-  let plus2 = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
+  let times2 = |a: Expr, b: Expr| binop(BinaryOperator::Times, a, b);
+  let plus2 = |a: Expr, b: Expr| binop(BinaryOperator::Plus, a, b);
   let neg = |a: Expr| times2(Expr::Integer(-1), a);
-  let sq = |a: &Expr| Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(a.clone()),
-    right: Box::new(Expr::Integer(2)),
-  };
+  let sq = |a: &Expr| binop(BinaryOperator::Power, a.clone(), Expr::Integer(2));
   let min = call("Min", vec![t1.clone(), t2.clone()]);
   let max = call("Max", vec![t1.clone(), t2.clone()]);
   match (name.as_str(), args.as_slice()) {
@@ -7182,11 +6938,11 @@ fn process_covariance(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
           call("Abs", vec![plus2(t1.clone(), neg(t2.clone()))]),
         )),
       };
-      Some(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(sq(sp)),
-        right: Box::new(times2(times2(Expr::Integer(2), decay), th.clone())),
-      })
+      Some(binop(
+        BinaryOperator::Divide,
+        sq(sp),
+        times2(times2(Expr::Integer(2), decay), th.clone()),
+      ))
     }
     // Brownian bridge: s^2 (tb - Max)(Min - ta)/(tb - ta).
     ("BrownianBridgeProcess", [sp, Expr::List(p1), Expr::List(p2)])
@@ -7205,18 +6961,18 @@ fn process_covariance(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
     // Geometric Brownian motion:
     // x0^2 E^(m (t1 + t2)) (E^(s^2 Min) - 1).
     ("GeometricBrownianMotionProcess", [m, sp, x0]) => {
-      let growth = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::Constant("E".to_string())),
-        right: Box::new(times2(m.clone(), plus2(t1.clone(), t2.clone()))),
-      };
+      let growth = binop(
+        BinaryOperator::Power,
+        Expr::Constant("E".to_string()),
+        times2(m.clone(), plus2(t1.clone(), t2.clone())),
+      );
       let bump = plus2(
         Expr::Integer(-1),
-        Expr::BinaryOp {
-          op: BinaryOperator::Power,
-          left: Box::new(Expr::Constant("E".to_string())),
-          right: Box::new(times2(sq(sp), min)),
-        },
+        binop(
+          BinaryOperator::Power,
+          Expr::Constant("E".to_string()),
+          times2(sq(sp), min),
+        ),
       );
       Some(times2(times2(growth, bump), sq(x0)))
     }
@@ -7255,18 +7011,13 @@ pub fn biweight_midvariance_ast(
     name: n.to_string(),
     args: a.into(),
   };
-  let bin = |op: BinaryOperator, a: Expr, b: Expr| Expr::BinaryOp {
-    op,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
   let median = ev(&call("Median", vec![args[0].clone()]))?;
   let deviations: Vec<Expr> = items
     .iter()
     .map(|x| {
       call(
         "Abs",
-        vec![bin(BinaryOperator::Minus, x.clone(), median.clone())],
+        vec![binop(BinaryOperator::Minus, x.clone(), median.clone())],
       )
     })
     .collect();
@@ -7276,32 +7027,32 @@ pub fn biweight_midvariance_ast(
     Some(_) => return Ok(Expr::Identifier("Indeterminate".to_string())),
     None => return unevaluated(),
   }
-  let scale = bin(BinaryOperator::Times, c, mad);
+  let scale = binop(BinaryOperator::Times, c, mad);
   let mut num_terms: Vec<Expr> = Vec::new();
   let mut den_terms: Vec<Expr> = Vec::new();
   for x in items.iter() {
-    let dev = bin(BinaryOperator::Minus, x.clone(), median.clone());
-    let u = ev(&bin(BinaryOperator::Divide, dev.clone(), scale.clone()))?;
+    let dev = binop(BinaryOperator::Minus, x.clone(), median.clone());
+    let u = ev(&binop(BinaryOperator::Divide, dev.clone(), scale.clone()))?;
     let Some(u_f) = crate::functions::math_ast::try_eval_to_f64(&u) else {
       return unevaluated();
     };
     if u_f.abs() >= 1.0 {
       continue;
     }
-    let u2 = bin(BinaryOperator::Power, u.clone(), Expr::Integer(2));
-    let one_minus = bin(BinaryOperator::Minus, Expr::Integer(1), u2.clone());
-    num_terms.push(bin(
+    let u2 = binop(BinaryOperator::Power, u.clone(), Expr::Integer(2));
+    let one_minus = binop(BinaryOperator::Minus, Expr::Integer(1), u2.clone());
+    num_terms.push(binop(
       BinaryOperator::Times,
-      bin(BinaryOperator::Power, dev, Expr::Integer(2)),
-      bin(BinaryOperator::Power, one_minus.clone(), Expr::Integer(4)),
+      binop(BinaryOperator::Power, dev, Expr::Integer(2)),
+      binop(BinaryOperator::Power, one_minus.clone(), Expr::Integer(4)),
     ));
-    den_terms.push(bin(
+    den_terms.push(binop(
       BinaryOperator::Times,
       one_minus,
-      bin(
+      binop(
         BinaryOperator::Minus,
         Expr::Integer(1),
-        bin(BinaryOperator::Times, Expr::Integer(5), u2),
+        binop(BinaryOperator::Times, Expr::Integer(5), u2),
       ),
     ));
   }
@@ -7312,14 +7063,14 @@ pub fn biweight_midvariance_ast(
     name: "Plus".to_string(),
     args: ts.into(),
   };
-  ev(&bin(
+  ev(&binop(
     BinaryOperator::Divide,
-    bin(
+    binop(
       BinaryOperator::Times,
       Expr::Integer(items.len() as i128),
       total(num_terms),
     ),
-    bin(BinaryOperator::Power, total(den_terms), Expr::Integer(2)),
+    binop(BinaryOperator::Power, total(den_terms), Expr::Integer(2)),
   ))
 }
 
@@ -7333,26 +7084,21 @@ pub fn process_correlation(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
     name: n.to_string(),
     args: a.into(),
   };
-  let bin = |op: BinaryOperator, a: Expr, b: Expr| Expr::BinaryOp {
-    op,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
-  let times2 = |a: Expr, b: Expr| bin(BinaryOperator::Times, a, b);
-  let plus2 = |a: Expr, b: Expr| bin(BinaryOperator::Plus, a, b);
+  let times2 = |a: Expr, b: Expr| binop(BinaryOperator::Times, a, b);
+  let plus2 = |a: Expr, b: Expr| binop(BinaryOperator::Plus, a, b);
   let neg = |a: Expr| times2(Expr::Integer(-1), a);
-  let sq = |a: &Expr| bin(BinaryOperator::Power, a.clone(), Expr::Integer(2));
+  let sq = |a: &Expr| binop(BinaryOperator::Power, a.clone(), Expr::Integer(2));
   let min = call("Min", vec![t1.clone(), t2.clone()]);
   match (name.as_str(), args.as_slice()) {
     // The scale cancels for all three counting/Brownian cases.
     ("WienerProcess", [_, _])
     | ("PoissonProcess", [_])
-    | ("BinomialProcess", [_]) => Some(bin(
+    | ("BinomialProcess", [_]) => Some(binop(
       BinaryOperator::Divide,
       min,
       call("Sqrt", vec![times2(t1.clone(), t2.clone())]),
     )),
-    ("OrnsteinUhlenbeckProcess", [_, _, th]) => Some(bin(
+    ("OrnsteinUhlenbeckProcess", [_, _, th]) => Some(binop(
       BinaryOperator::Power,
       Expr::Constant("E".to_string()),
       neg(times2(
@@ -7392,20 +7138,24 @@ pub fn process_correlation(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
           )],
         )
       };
-      Some(bin(BinaryOperator::Divide, numer, times2(leg(t1), leg(t2))))
+      Some(binop(
+        BinaryOperator::Divide,
+        numer,
+        times2(leg(t1), leg(t2)),
+      ))
     }
     ("GeometricBrownianMotionProcess", [_, sp, _]) => {
       let bump = |arg: Expr| {
         plus2(
           Expr::Integer(-1),
-          bin(
+          binop(
             BinaryOperator::Power,
             Expr::Constant("E".to_string()),
             times2(sq(sp), arg),
           ),
         )
       };
-      Some(bin(
+      Some(binop(
         BinaryOperator::Divide,
         bump(min),
         times2(
@@ -7432,15 +7182,10 @@ pub fn process_absolute_correlation(
     name: n.to_string(),
     args: a.into(),
   };
-  let bin = |op: BinaryOperator, a: Expr, b: Expr| Expr::BinaryOp {
-    op,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
-  let times2 = |a: Expr, b: Expr| bin(BinaryOperator::Times, a, b);
-  let plus2 = |a: Expr, b: Expr| bin(BinaryOperator::Plus, a, b);
+  let times2 = |a: Expr, b: Expr| binop(BinaryOperator::Times, a, b);
+  let plus2 = |a: Expr, b: Expr| binop(BinaryOperator::Plus, a, b);
   let neg = |a: Expr| times2(Expr::Integer(-1), a);
-  let sq = |a: &Expr| bin(BinaryOperator::Power, a.clone(), Expr::Integer(2));
+  let sq = |a: &Expr| binop(BinaryOperator::Power, a.clone(), Expr::Integer(2));
   let min = call("Min", vec![t1.clone(), t2.clone()]);
   match (name.as_str(), args.as_slice()) {
     ("WienerProcess", [m, sp]) => Some(plus2(
@@ -7459,7 +7204,7 @@ pub fn process_absolute_correlation(
       ),
     )),
     ("OrnsteinUhlenbeckProcess", [m, sp, th]) => {
-      let decay = bin(
+      let decay = binop(
         BinaryOperator::Power,
         Expr::Constant("E".to_string()),
         times2(
@@ -7469,7 +7214,7 @@ pub fn process_absolute_correlation(
       );
       Some(plus2(
         sq(m),
-        bin(
+        binop(
           BinaryOperator::Divide,
           sq(sp),
           times2(times2(Expr::Integer(2), decay), th.clone()),
@@ -7512,7 +7257,7 @@ pub fn process_absolute_correlation(
       ))
     }
     ("GeometricBrownianMotionProcess", [m, sp, x0]) => Some(times2(
-      bin(
+      binop(
         BinaryOperator::Power,
         Expr::Constant("E".to_string()),
         plus2(
@@ -7531,7 +7276,7 @@ pub fn process_absolute_correlation(
       let mean_at = |t: &Expr| {
         plus2(
           a.clone(),
-          bin(
+          binop(
             BinaryOperator::Divide,
             times2(
               plus2(neg(a.clone()), b.clone()),
@@ -7545,7 +7290,7 @@ pub fn process_absolute_correlation(
       let cov = times2(
         sq(sp),
         plus2(
-          bin(
+          binop(
             BinaryOperator::Divide,
             plus2(
               neg(times2(t1.clone(), t2.clone())),
@@ -7633,11 +7378,7 @@ fn cf_pow(b: Expr, e: Expr) -> Expr {
   fc("Power", vec![b, e])
 }
 fn cf_div(n: Expr, d: Expr) -> Expr {
-  Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(n),
-    right: Box::new(d),
-  }
+  binop(BinaryOperator::Divide, n, d)
 }
 fn cf_neg(x: Expr) -> Expr {
   cf_times(vec![Expr::Integer(-1), x])
@@ -7791,16 +7532,8 @@ pub fn characteristic_function_ast(
     op: UnaryOperator::Minus,
     operand: Box::new(e),
   };
-  let pow = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(b),
-    right: Box::new(e),
-  };
-  let div = |n: Expr, d: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(n),
-    right: Box::new(d),
-  };
+  let pow = |b: Expr, e: Expr| binop(BinaryOperator::Power, b, e);
+  let div = |n: Expr, d: Expr| binop(BinaryOperator::Divide, n, d);
   // E^(I*t) and E^(I*c*t)
   let e_it = |factors: Vec<Expr>| {
     let mut f = vec![i_unit()];
@@ -8244,16 +7977,8 @@ pub fn moment_generating_function_ast(
     op: UnaryOperator::Minus,
     operand: Box::new(e),
   };
-  let pow = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(b),
-    right: Box::new(e),
-  };
-  let div = |n: Expr, d: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(n),
-    right: Box::new(d),
-  };
+  let pow = |b: Expr, e: Expr| binop(BinaryOperator::Power, b, e);
+  let div = |n: Expr, d: Expr| binop(BinaryOperator::Divide, n, d);
   // E^t and E^(c*t)
   let e_t = |factors: Vec<Expr>| {
     if factors.is_empty() {
@@ -8673,16 +8398,8 @@ pub fn cumulant_generating_function_ast(
     op: UnaryOperator::Minus,
     operand: Box::new(e),
   };
-  let pow = |b: Expr, e: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(b),
-    right: Box::new(e),
-  };
-  let div = |n: Expr, d: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(n),
-    right: Box::new(d),
-  };
+  let pow = |b: Expr, e: Expr| binop(BinaryOperator::Power, b, e);
+  let div = |n: Expr, d: Expr| binop(BinaryOperator::Divide, n, d);
   let log = |e: Expr| Expr::FunctionCall {
     name: "Log".to_string(),
     args: vec![e].into(),
@@ -8820,11 +8537,7 @@ pub fn factorial_moment_generating_function_ast(
       name: "Times".to_string(),
       args: f.into(),
     };
-    let sq = |e: Expr| Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(e),
-      right: Box::new(Expr::Integer(2)),
-    };
+    let sq = |e: Expr| binop(BinaryOperator::Power, e, Expr::Integer(2));
     return Ok(Expr::BinaryOp {
       op: BinaryOperator::Power,
       left: Box::new(Expr::Identifier("E".to_string())),
@@ -8832,11 +8545,11 @@ pub fn factorial_moment_generating_function_ast(
         name: "Plus".to_string(),
         args: vec![
           times(vec![m, log_t.clone()]),
-          Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(times(vec![sq(sd), sq(log_t)])),
-            right: Box::new(Expr::Integer(2)),
-          },
+          binop(
+            BinaryOperator::Divide,
+            times(vec![sq(sd), sq(log_t)]),
+            Expr::Integer(2),
+          ),
         ]
         .into(),
       }),
@@ -8893,10 +8606,8 @@ pub fn central_moment_generating_function_ast(
       name: "Times".to_string(),
       args: f.into(),
     };
-    let e_pow = |e: Expr| Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(Expr::Identifier("E".to_string())),
-      right: Box::new(e),
+    let e_pow = |e: Expr| {
+      binop(BinaryOperator::Power, Expr::Identifier("E".to_string()), e)
     };
     let half = Expr::FunctionCall {
       name: "Rational".to_string(),
@@ -8990,17 +8701,17 @@ pub fn central_moment_generating_function_ast(
     } else {
       raw
     };
-    return Ok(Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(Expr::Identifier("E".to_string())),
-      right: Box::new(exponent),
-    });
+    return Ok(binop(
+      BinaryOperator::Power,
+      Expr::Identifier("E".to_string()),
+      exponent,
+    ));
   }
-  let damp = Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(Expr::Identifier("E".to_string())),
-    right: Box::new(damp_exponent),
-  };
+  let damp = binop(
+    BinaryOperator::Power,
+    Expr::Identifier("E".to_string()),
+    damp_exponent,
+  );
   crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
     name: "Times".to_string(),
     args: vec![damp, mgf].into(),
@@ -9090,11 +8801,11 @@ pub fn correlation_function_ast(
     return Ok(Expr::Identifier("Indeterminate".to_string()));
   }
 
-  crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(numerator),
-    right: Box::new(denominator),
-  })
+  crate::evaluator::evaluate_expr_to_expr(&binop(
+    BinaryOperator::Divide,
+    numerator,
+    denominator,
+  ))
 }
 
 /// ZTest[data] / ZTest[data, var] / ZTest[data, var, mu0] /
@@ -9402,11 +9113,7 @@ pub fn cycle_index_polynomial_ast(
         factors.push(if m == 1 {
           base
         } else {
-          Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(base),
-            right: Box::new(Expr::Integer(m as i128)),
-          }
+          binop(BinaryOperator::Power, base, Expr::Integer(m as i128))
         });
       }
       Expr::FunctionCall {

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
+use crate::syntax::{BinaryOperator, Expr, UnaryOperator, binop, unevaluated};
 
 /// Try to express a symbolic expression as a rational multiple of Pi: k*Pi/n.
 /// Returns Some((k, n)) in lowest terms, None if not recognized.
@@ -513,47 +513,47 @@ fn exact_sin(k: i64, n: i64) -> Option<Expr> {
   let val = match (kr, nr) {
     (0, _) => Expr::Integer(0),
     // sin(Pi/12) = (-1 + Sqrt[3]) / (2*Sqrt[2])
-    (1, 12) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(make_sqrt(Expr::Integer(3))),
-      }),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(2)),
-        right: Box::new(make_sqrt(Expr::Integer(2))),
-      }),
-    },
+    (1, 12) => binop(
+      BinaryOperator::Divide,
+      binop(
+        BinaryOperator::Plus,
+        Expr::Integer(-1),
+        make_sqrt(Expr::Integer(3)),
+      ),
+      binop(
+        BinaryOperator::Times,
+        Expr::Integer(2),
+        make_sqrt(Expr::Integer(2)),
+      ),
+    ),
     // sin(Pi/6) = 1/2
     (1, 6) => make_rational(1, 2),
     // sin(Pi/4) = 1/Sqrt[2]
-    (1, 4) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(make_sqrt(Expr::Integer(2))),
-    },
+    (1, 4) => binop(
+      BinaryOperator::Divide,
+      Expr::Integer(1),
+      make_sqrt(Expr::Integer(2)),
+    ),
     // sin(Pi/3) = Sqrt[3]/2
-    (1, 3) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(make_sqrt(Expr::Integer(3))),
-      right: Box::new(Expr::Integer(2)),
-    },
+    (1, 3) => binop(
+      BinaryOperator::Divide,
+      make_sqrt(Expr::Integer(3)),
+      Expr::Integer(2),
+    ),
     // sin(5*Pi/12) = (1 + Sqrt[3]) / (2*Sqrt[2])
-    (5, 12) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(make_sqrt(Expr::Integer(3))),
-      }),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(2)),
-        right: Box::new(make_sqrt(Expr::Integer(2))),
-      }),
-    },
+    (5, 12) => binop(
+      BinaryOperator::Divide,
+      binop(
+        BinaryOperator::Plus,
+        Expr::Integer(1),
+        make_sqrt(Expr::Integer(3)),
+      ),
+      binop(
+        BinaryOperator::Times,
+        Expr::Integer(2),
+        make_sqrt(Expr::Integer(2)),
+      ),
+    ),
     // sin(Pi/5) = Sqrt[5/8 - Sqrt[5]/8]
     (1, 5) => lit("Sqrt[5/8 - Sqrt[5]/8]"),
     // sin(2*Pi/5) = Sqrt[5/8 + Sqrt[5]/8]
@@ -604,47 +604,47 @@ fn exact_cos(k: i64, n: i64) -> Option<Expr> {
   let val = match (kr, nr) {
     (0, _) => Expr::Integer(1),
     // cos(Pi/12) = (1 + Sqrt[3]) / (2*Sqrt[2])
-    (1, 12) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(make_sqrt(Expr::Integer(3))),
-      }),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(2)),
-        right: Box::new(make_sqrt(Expr::Integer(2))),
-      }),
-    },
+    (1, 12) => binop(
+      BinaryOperator::Divide,
+      binop(
+        BinaryOperator::Plus,
+        Expr::Integer(1),
+        make_sqrt(Expr::Integer(3)),
+      ),
+      binop(
+        BinaryOperator::Times,
+        Expr::Integer(2),
+        make_sqrt(Expr::Integer(2)),
+      ),
+    ),
     // cos(Pi/6) = Sqrt[3]/2
-    (1, 6) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(make_sqrt(Expr::Integer(3))),
-      right: Box::new(Expr::Integer(2)),
-    },
+    (1, 6) => binop(
+      BinaryOperator::Divide,
+      make_sqrt(Expr::Integer(3)),
+      Expr::Integer(2),
+    ),
     // cos(Pi/4) = 1/Sqrt[2]
-    (1, 4) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(make_sqrt(Expr::Integer(2))),
-    },
+    (1, 4) => binop(
+      BinaryOperator::Divide,
+      Expr::Integer(1),
+      make_sqrt(Expr::Integer(2)),
+    ),
     // cos(Pi/3) = 1/2
     (1, 3) => make_rational(1, 2),
     // cos(5*Pi/12) = (-1 + Sqrt[3]) / (2*Sqrt[2])
-    (5, 12) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(make_sqrt(Expr::Integer(3))),
-      }),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(2)),
-        right: Box::new(make_sqrt(Expr::Integer(2))),
-      }),
-    },
+    (5, 12) => binop(
+      BinaryOperator::Divide,
+      binop(
+        BinaryOperator::Plus,
+        Expr::Integer(-1),
+        make_sqrt(Expr::Integer(3)),
+      ),
+      binop(
+        BinaryOperator::Times,
+        Expr::Integer(2),
+        make_sqrt(Expr::Integer(2)),
+      ),
+    ),
     // cos(Pi/5) = (1 + Sqrt[5])/4
     (1, 5) => lit("(1 + Sqrt[5])/4"),
     // cos(2*Pi/5) = (-1 + Sqrt[5])/4
@@ -696,27 +696,27 @@ fn exact_tan(k: i64, n: i64) -> Option<Expr> {
   let val = match (kr, nr) {
     (0, _) => Expr::Integer(0),
     // tan(Pi/12) = 2 - Sqrt[3]
-    (1, 12) => Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(Expr::Integer(2)),
-      right: Box::new(make_sqrt(Expr::Integer(3))),
-    },
+    (1, 12) => binop(
+      BinaryOperator::Minus,
+      Expr::Integer(2),
+      make_sqrt(Expr::Integer(3)),
+    ),
     // tan(Pi/6) = 1/Sqrt[3]
-    (1, 6) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(make_sqrt(Expr::Integer(3))),
-    },
+    (1, 6) => binop(
+      BinaryOperator::Divide,
+      Expr::Integer(1),
+      make_sqrt(Expr::Integer(3)),
+    ),
     // tan(Pi/4) = 1
     (1, 4) => Expr::Integer(1),
     // tan(Pi/3) = Sqrt[3]
     (1, 3) => make_sqrt(Expr::Integer(3)),
     // tan(5*Pi/12) = 2 + Sqrt[3]
-    (5, 12) => Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(2)),
-      right: Box::new(make_sqrt(Expr::Integer(3))),
-    },
+    (5, 12) => binop(
+      BinaryOperator::Plus,
+      Expr::Integer(2),
+      make_sqrt(Expr::Integer(3)),
+    ),
     // tan(Pi/5) = Sqrt[5 - 2*Sqrt[5]]
     (1, 5) => lit("Sqrt[5 - 2*Sqrt[5]]"),
     // tan(2*Pi/5) = Sqrt[5 + 2*Sqrt[5]]
@@ -763,11 +763,11 @@ fn exact_sec(k: i64, n: i64) -> Option<Expr> {
   let val = match (kr, nr) {
     (0, _) => Expr::Integer(1),
     // Sec(Pi/6) = 2/Sqrt[3]
-    (1, 6) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(2)),
-      right: Box::new(make_sqrt(Expr::Integer(3))),
-    },
+    (1, 6) => binop(
+      BinaryOperator::Divide,
+      Expr::Integer(2),
+      make_sqrt(Expr::Integer(3)),
+    ),
     // Sec(Pi/4) = Sqrt[2]
     (1, 4) => make_sqrt(Expr::Integer(2)),
     // Sec(Pi/3) = 2
@@ -824,11 +824,11 @@ fn exact_csc(k: i64, n: i64) -> Option<Expr> {
     // Csc(Pi/4) = Sqrt[2]
     (1, 4) => make_sqrt(Expr::Integer(2)),
     // Csc(Pi/3) = 2/Sqrt[3]
-    (1, 3) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(2)),
-      right: Box::new(make_sqrt(Expr::Integer(3))),
-    },
+    (1, 3) => binop(
+      BinaryOperator::Divide,
+      Expr::Integer(2),
+      make_sqrt(Expr::Integer(3)),
+    ),
     // Csc(Pi/5) = 1/Sqrt[5/8 - Sqrt[5]/8]
     (1, 5) => lit("1/Sqrt[5/8 - Sqrt[5]/8]"),
     // Csc(2*Pi/5) = 1/Sqrt[5/8 + Sqrt[5]/8]
@@ -877,27 +877,27 @@ fn exact_cot(k: i64, n: i64) -> Option<Expr> {
 
   let val = match (kr, nr) {
     // Cot(Pi/12) = 2 + Sqrt[3]
-    (1, 12) => Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(2)),
-      right: Box::new(make_sqrt(Expr::Integer(3))),
-    },
+    (1, 12) => binop(
+      BinaryOperator::Plus,
+      Expr::Integer(2),
+      make_sqrt(Expr::Integer(3)),
+    ),
     // Cot(Pi/6) = Sqrt[3]
     (1, 6) => make_sqrt(Expr::Integer(3)),
     // Cot(Pi/4) = 1
     (1, 4) => Expr::Integer(1),
     // Cot(Pi/3) = 1/Sqrt[3]
-    (1, 3) => Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(make_sqrt(Expr::Integer(3))),
-    },
+    (1, 3) => binop(
+      BinaryOperator::Divide,
+      Expr::Integer(1),
+      make_sqrt(Expr::Integer(3)),
+    ),
     // Cot(5*Pi/12) = 2 - Sqrt[3]
-    (5, 12) => Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(Expr::Integer(2)),
-      right: Box::new(make_sqrt(Expr::Integer(3))),
-    },
+    (5, 12) => binop(
+      BinaryOperator::Minus,
+      Expr::Integer(2),
+      make_sqrt(Expr::Integer(3)),
+    ),
     // Cot(Pi/5) = Sqrt[1 + 2/Sqrt[5]]
     (1, 5) => lit("Sqrt[1 + 2/Sqrt[5]]"),
     // Cot(2*Pi/5) = Sqrt[1 - 2/Sqrt[5]]
@@ -941,11 +941,11 @@ fn canonicalize_exact_trig_value(
       right,
     } = operand.as_ref()
   {
-    let distributed = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(negate_expr((**left).clone())),
-      right: Box::new(negate_expr((**right).clone())),
-    };
+    let distributed = binop(
+      BinaryOperator::Plus,
+      negate_expr((**left).clone()),
+      negate_expr((**right).clone()),
+    );
     return crate::evaluator::evaluate_expr_to_expr(&distributed);
   }
   crate::evaluator::evaluate_expr_to_expr(&exact)
@@ -1051,22 +1051,18 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
     Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Plus => {
       let left = std::mem::replace(left, Box::new(Expr::Integer(0)));
       let right = std::mem::replace(right, Box::new(Expr::Integer(0)));
-      return Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(negate_expr(*left)),
-        right: Box::new(negate_expr(*right)),
-      };
+      return binop(
+        BinaryOperator::Plus,
+        negate_expr(*left),
+        negate_expr(*right),
+      );
     }
     // -(a - b) => (-a) + b: likewise distribute over a difference so the
     // result keeps the additive form (e.g. -(2 - Sqrt[3]) => -2 + Sqrt[3]).
     Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Minus => {
       let left = std::mem::replace(left, Box::new(Expr::Integer(0)));
       let right = std::mem::replace(right, Box::new(Expr::Integer(0)));
-      return Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(negate_expr(*left)),
-        right: Box::new(*right),
-      };
+      return binop(BinaryOperator::Plus, negate_expr(*left), *right);
     }
     // -(a/b) => Times[-1, a/b] to match Wolfram output style
     Expr::BinaryOp { op, left, right } if *op == BinaryOperator::Divide => {
@@ -1091,11 +1087,7 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
           (**left).clone(),
         ];
         if let Some(rest) = rest {
-          factors.push(Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(rest),
-            right: Box::new(Expr::Integer(-1)),
-          });
+          factors.push(binop(BinaryOperator::Power, rest, Expr::Integer(-1)));
         }
         return Expr::FunctionCall {
           name: "Times".to_string(),
@@ -1556,11 +1548,7 @@ fn imaginary_arg_reduction(
 /// `Sqrt[1 +- x^2]` with the inner `1 +- x^2` evaluated so that a compound
 /// argument's square expands (e.g. `(2 y)^2 -> 4 y^2`), matching wolframscript.
 fn sqrt_one_pm_sq(x: &Expr, plus: bool) -> Expr {
-  let x_sq = Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(x.clone()),
-    right: Box::new(Expr::Integer(2)),
-  };
+  let x_sq = binop(BinaryOperator::Power, x.clone(), Expr::Integer(2));
   let inner = Expr::BinaryOp {
     op: if plus {
       BinaryOperator::Plus
@@ -1592,11 +1580,7 @@ fn sqrt_one_plus_sq(x: &Expr) -> Expr {
 }
 
 fn divide(num: Expr, den: Expr) -> Expr {
-  let quotient = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(num),
-    right: Box::new(den),
-  };
+  let quotient = binop(BinaryOperator::Divide, num, den);
   // Evaluate so a rational numerator/denominator collapses, e.g.
   // Tan[ArcSin[3/5]] = (3/5)/(4/5) -> 3/4; a symbolic quotient such as
   // x/Sqrt[1 - x^2] is left in its canonical printed form.
@@ -1645,23 +1629,16 @@ fn reciprocal_trig_of_inverse(outer: &str, inner: &Expr) -> Option<Expr> {
 /// `Sqrt[(-1 + x)/(1 + x)] * (1 + x)` — wolframscript's branch-cut form for
 /// the hyperbolic-of-ArcCosh identities.
 fn arccosh_branch_form(x: &Expr) -> Expr {
-  let one_plus = Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(Expr::Integer(1)),
-    right: Box::new(x.clone()),
-  };
-  let minus_one_plus = Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(Expr::Integer(-1)),
-    right: Box::new(x.clone()),
-  };
+  let one_plus = binop(BinaryOperator::Plus, Expr::Integer(1), x.clone());
+  let minus_one_plus =
+    binop(BinaryOperator::Plus, Expr::Integer(-1), x.clone());
   let sqrt = Expr::FunctionCall {
     name: "Sqrt".to_string(),
-    args: vec![Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(minus_one_plus),
-      right: Box::new(one_plus.clone()),
-    }]
+    args: vec![binop(
+      BinaryOperator::Divide,
+      minus_one_plus,
+      one_plus.clone(),
+    )]
     .into(),
   };
   Expr::FunctionCall {
@@ -3202,11 +3179,11 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let result = Expr::FunctionCall {
           name: "Plus".to_string(),
           args: vec![
-            Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Identifier("I".to_string())),
-              right: Box::new(Expr::Constant("Pi".to_string())),
-            },
+            binop(
+              BinaryOperator::Times,
+              Expr::Identifier("I".to_string()),
+              Expr::Constant("Pi".to_string()),
+            ),
             Expr::FunctionCall {
               name: "Log".to_string(),
               args: vec![make_rational(p.abs(), q.abs())].into(),
@@ -3222,11 +3199,11 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       {
         let abs_n = -*n;
         // I*Pi
-        let i_pi = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Identifier("I".to_string())),
-          right: Box::new(Expr::Constant("Pi".to_string())),
-        };
+        let i_pi = binop(
+          BinaryOperator::Times,
+          Expr::Identifier("I".to_string()),
+          Expr::Constant("Pi".to_string()),
+        );
         if abs_n == 1 {
           return Ok(i_pi);
         }
@@ -3260,11 +3237,11 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           _ => None,
         };
         if let Some(inner_expr) = inner {
-          let i_pi = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Identifier("I".to_string())),
-            right: Box::new(Expr::Constant("Pi".to_string())),
-          };
+          let i_pi = binop(
+            BinaryOperator::Times,
+            Expr::Identifier("I".to_string()),
+            Expr::Constant("Pi".to_string()),
+          );
           let log_x =
             crate::evaluator::evaluate_function_call_ast("Log", &[inner_expr])?;
           return crate::evaluator::evaluate_function_call_ast(
@@ -3301,11 +3278,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           name: "Log".to_string(),
           args: vec![inverted].into(),
         };
-        return Ok(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(-1)),
-          right: Box::new(log_inv),
-        });
+        return Ok(binop(BinaryOperator::Times, Expr::Integer(-1), log_inv));
       }
       // Arbitrary-precision argument: compute ln(x) at the tracked precision
       // instead of leaving `Log[2.`30.]` unevaluated.
@@ -3609,11 +3582,11 @@ pub fn arcsin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::Integer(0) => return Ok(Expr::Integer(0)),
     Expr::Integer(1) => {
-      return Ok(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::Constant("Pi".to_string())),
-        right: Box::new(Expr::Integer(2)),
-      });
+      return Ok(binop(
+        BinaryOperator::Divide,
+        Expr::Constant("Pi".to_string()),
+        Expr::Integer(2),
+      ));
     }
     Expr::Integer(-1) => {
       // -1/2*Pi = Times[Rational[-1, 2], Pi]
@@ -3752,11 +3725,11 @@ pub fn arccos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::Integer(1) => return Ok(Expr::Integer(0)),
     Expr::Integer(0) => {
-      return Ok(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::Constant("Pi".to_string())),
-        right: Box::new(Expr::Integer(2)),
-      });
+      return Ok(binop(
+        BinaryOperator::Divide,
+        Expr::Constant("Pi".to_string()),
+        Expr::Integer(2),
+      ));
     }
     Expr::Integer(-1) => return Ok(Expr::Constant("Pi".to_string())),
     Expr::Real(f) if (-1.0..=1.0).contains(f) => {
@@ -3779,11 +3752,11 @@ pub fn arccos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some(sign) = imaginary_infinity_sign(&args[0]) {
     let direction = if sign > 0 {
       // Negate I: Times[-1, I]
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(Expr::Identifier("I".to_string())),
-      }
+      binop(
+        BinaryOperator::Times,
+        Expr::Integer(-1),
+        Expr::Identifier("I".to_string()),
+      )
     } else {
       Expr::Identifier("I".to_string())
     };
@@ -3811,27 +3784,23 @@ fn arccos_special_value(v: f64) -> Option<Expr> {
       if num == 1 {
         Expr::Constant("Pi".to_string())
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(num)),
-          right: Box::new(Expr::Constant("Pi".to_string())),
-        }
+        binop(
+          BinaryOperator::Times,
+          Expr::Integer(num),
+          Expr::Constant("Pi".to_string()),
+        )
       }
     } else {
       let numerator = if num == 1 {
         Expr::Constant("Pi".to_string())
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(num)),
-          right: Box::new(Expr::Constant("Pi".to_string())),
-        }
+        binop(
+          BinaryOperator::Times,
+          Expr::Integer(num),
+          Expr::Constant("Pi".to_string()),
+        )
       };
-      Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(numerator),
-        right: Box::new(Expr::Integer(den)),
-      }
+      binop(BinaryOperator::Divide, numerator, Expr::Integer(den))
     }
   };
 
@@ -3881,11 +3850,11 @@ fn arcsin_special_value(v: f64) -> Option<Expr> {
       } else if den == 1 {
         return Some(Expr::Constant("Pi".to_string()));
       } else {
-        return Some(Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(Expr::Constant("Pi".to_string())),
-          right: Box::new(Expr::Integer(den)),
-        });
+        return Some(binop(
+          BinaryOperator::Divide,
+          Expr::Constant("Pi".to_string()),
+          Expr::Integer(den),
+        ));
       }
     }
   }
@@ -3930,11 +3899,11 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::Integer(0) => return Ok(Expr::Integer(0)),
     Expr::Integer(1) => {
-      return Ok(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::Constant("Pi".to_string())),
-        right: Box::new(Expr::Integer(4)),
-      });
+      return Ok(binop(
+        BinaryOperator::Divide,
+        Expr::Constant("Pi".to_string()),
+        Expr::Integer(4),
+      ));
     }
     Expr::Integer(-1) => {
       // -1/4*Pi = Times[Rational[-1, 4], Pi]
@@ -3949,11 +3918,11 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     Expr::Identifier(s) if s == "Infinity" => {
       // ArcTan[Infinity] = Pi/2
-      return Ok(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::Constant("Pi".to_string())),
-        right: Box::new(Expr::Integer(2)),
-      });
+      return Ok(binop(
+        BinaryOperator::Divide,
+        Expr::Constant("Pi".to_string()),
+        Expr::Integer(2),
+      ));
     }
     Expr::Real(f) => return Ok(Expr::Real(f.atan())),
     _ => {}
@@ -3980,11 +3949,11 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let eps = 1e-12;
     if (val - sqrt3).abs() < eps {
       // ArcTan[Sqrt[3]] = Pi/3
-      return Ok(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::Constant("Pi".to_string())),
-        right: Box::new(Expr::Integer(3)),
-      });
+      return Ok(binop(
+        BinaryOperator::Divide,
+        Expr::Constant("Pi".to_string()),
+        Expr::Integer(3),
+      ));
     }
     if (val + sqrt3).abs() < eps {
       // ArcTan[-Sqrt[3]] = -Pi/3
@@ -4003,11 +3972,11 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let inv_sqrt3 = 1.0 / sqrt3;
     if (val - inv_sqrt3).abs() < eps {
       // ArcTan[1/Sqrt[3]] = Pi/6
-      return Ok(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::Constant("Pi".to_string())),
-        right: Box::new(Expr::Integer(6)),
-      });
+      return Ok(binop(
+        BinaryOperator::Divide,
+        Expr::Constant("Pi".to_string()),
+        Expr::Integer(6),
+      ));
     }
     if (val + inv_sqrt3).abs() < eps {
       // ArcTan[-1/Sqrt[3]] = -Pi/6
@@ -4027,11 +3996,11 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Tan[5 Pi/12] = 2 + Sqrt[3]). `k_over_12_pi(k)` builds k*Pi/12.
     let k_over_12_pi = |k: i128| -> Expr {
       if k == 1 {
-        Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(Expr::Constant("Pi".to_string())),
-          right: Box::new(Expr::Integer(12)),
-        }
+        binop(
+          BinaryOperator::Divide,
+          Expr::Constant("Pi".to_string()),
+          Expr::Integer(12),
+        )
       } else {
         Expr::FunctionCall {
           name: "Times".to_string(),
@@ -4110,11 +4079,11 @@ pub fn arctan2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if num == 1 {
         Expr::Constant("Pi".to_string())
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(num)),
-          right: Box::new(Expr::Constant("Pi".to_string())),
-        }
+        binop(
+          BinaryOperator::Times,
+          Expr::Integer(num),
+          Expr::Constant("Pi".to_string()),
+        )
       }
     } else {
       Expr::BinaryOp {
@@ -4174,11 +4143,11 @@ pub fn arctan2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let pi_term = if yf >= 0.0 {
       Expr::Constant("Pi".to_string())
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(Expr::Constant("Pi".to_string())),
-      }
+      binop(
+        BinaryOperator::Times,
+        Expr::Integer(-1),
+        Expr::Constant("Pi".to_string()),
+      )
     };
     return crate::evaluator::evaluate_function_call_ast(
       "Plus",
@@ -4428,22 +4397,17 @@ fn hyperbolic_of_log(
   {
     return None;
   }
-  let bin = |op: B, a: Expr, b: Expr| Expr::BinaryOp {
-    op,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
-  let u2 = bin(B::Power, u.clone(), Expr::Integer(2));
-  let u2_minus_1 = bin(B::Minus, u2.clone(), Expr::Integer(1));
-  let u2_plus_1 = bin(B::Plus, u2, Expr::Integer(1));
-  let two_u = bin(B::Times, Expr::Integer(2), u.clone());
+  let u2 = binop(B::Power, u.clone(), Expr::Integer(2));
+  let u2_minus_1 = binop(B::Minus, u2.clone(), Expr::Integer(1));
+  let u2_plus_1 = binop(B::Plus, u2, Expr::Integer(1));
+  let two_u = binop(B::Times, Expr::Integer(2), u.clone());
   let result = match name {
-    "Sinh" => bin(B::Divide, u2_minus_1, two_u),
-    "Cosh" => bin(B::Divide, u2_plus_1, two_u),
-    "Tanh" => bin(B::Divide, u2_minus_1, u2_plus_1),
-    "Coth" => bin(B::Divide, u2_plus_1, u2_minus_1),
-    "Sech" => bin(B::Divide, two_u, u2_plus_1),
-    "Csch" => bin(B::Divide, two_u, u2_minus_1),
+    "Sinh" => binop(B::Divide, u2_minus_1, two_u),
+    "Cosh" => binop(B::Divide, u2_plus_1, two_u),
+    "Tanh" => binop(B::Divide, u2_minus_1, u2_plus_1),
+    "Coth" => binop(B::Divide, u2_plus_1, u2_minus_1),
+    "Sech" => binop(B::Divide, two_u, u2_plus_1),
+    "Csch" => binop(B::Divide, two_u, u2_minus_1),
     _ => return None,
   };
   Some(crate::evaluator::evaluate_expr_to_expr(&result))
@@ -4491,10 +4455,12 @@ fn circular_at_infinity(
     return None;
   }
   let inf = || Expr::Identifier("Infinity".to_string());
-  let neg_inf = || Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(Expr::Integer(-1)),
-    right: Box::new(Expr::Identifier("Infinity".to_string())),
+  let neg_inf = || {
+    binop(
+      BinaryOperator::Times,
+      Expr::Integer(-1),
+      Expr::Identifier("Infinity".to_string()),
+    )
   };
   let span = |lo: Expr, hi: Expr| Expr::List(vec![lo, hi].into());
   let interval = |spans: Vec<Expr>| Expr::FunctionCall {
@@ -5368,23 +5334,19 @@ pub fn arccsch_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Helper to construct -Pi/2 matching wolframscript output format
 /// Construct Pi/n as an AST expression
 fn pi_over_n(n: i128) -> Expr {
-  Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(Expr::Constant("Pi".to_string())),
-    right: Box::new(Expr::Integer(n)),
-  }
+  binop(
+    BinaryOperator::Divide,
+    Expr::Constant("Pi".to_string()),
+    Expr::Integer(n),
+  )
 }
 
 fn negative_pi_over_2() -> Expr {
-  Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(-1)),
-      right: Box::new(Expr::Integer(2)),
-    }),
-    right: Box::new(Expr::Constant("Pi".to_string())),
-  }
+  binop(
+    BinaryOperator::Times,
+    binop(BinaryOperator::Divide, Expr::Integer(-1), Expr::Integer(2)),
+    Expr::Constant("Pi".to_string()),
+  )
 }
 
 /// Gudermannian[x] - the Gudermannian function: 2 ArcTan[Tanh[x/2]]
@@ -5564,11 +5526,11 @@ pub fn gudermannian_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     Expr::Identifier(name) if name == "Infinity" => {
       // Gudermannian[Infinity] = Pi/2
-      return Ok(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::Constant("Pi".to_string())),
-        right: Box::new(Expr::Integer(2)),
-      });
+      return Ok(binop(
+        BinaryOperator::Divide,
+        Expr::Constant("Pi".to_string()),
+        Expr::Integer(2),
+      ));
     }
     Expr::Identifier(name) if name == "ComplexInfinity" => {
       // Gudermannian[ComplexInfinity] is unevaluated in Wolfram
@@ -5883,11 +5845,11 @@ fn trig_expand_recursive(expr: &Expr) -> Expr {
       name: name.clone(),
       args: args.iter().map(trig_expand_recursive).collect(),
     },
-    Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
-      op: *op,
-      left: Box::new(trig_expand_recursive(left)),
-      right: Box::new(trig_expand_recursive(right)),
-    },
+    Expr::BinaryOp { op, left, right } => binop(
+      *op,
+      trig_expand_recursive(left),
+      trig_expand_recursive(right),
+    ),
     Expr::List(items) => {
       Expr::List(items.iter().map(trig_expand_recursive).collect())
     }
@@ -6379,22 +6341,18 @@ fn trig_reduce_recursive(expr: &Expr) -> Expr {
       {
         return result;
       }
-      Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(base),
-        right: Box::new(trig_reduce_recursive(right)),
-      }
+      binop(BinaryOperator::Power, base, trig_reduce_recursive(right))
     }
     // Recurse into other structures
     Expr::FunctionCall { name, args } => Expr::FunctionCall {
       name: name.clone(),
       args: args.iter().map(trig_reduce_recursive).collect(),
     },
-    Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
-      op: *op,
-      left: Box::new(trig_reduce_recursive(left)),
-      right: Box::new(trig_reduce_recursive(right)),
-    },
+    Expr::BinaryOp { op, left, right } => binop(
+      *op,
+      trig_reduce_recursive(left),
+      trig_reduce_recursive(right),
+    ),
     Expr::UnaryOp { op, operand } => Expr::UnaryOp {
       op: *op,
       operand: Box::new(trig_reduce_recursive(operand)),
@@ -6460,11 +6418,7 @@ fn reduce_two_factor_product(a: &Expr, b: &Expr) -> Expr {
   if let Some(result) = try_reduce_with_power(b, a) {
     return result;
   }
-  Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(a.clone()),
-    right: Box::new(b.clone()),
-  }
+  binop(BinaryOperator::Times, a.clone(), b.clone())
 }
 
 /// Try product-to-sum for Sin[a]*Cos[b], Sin[a]*Sin[b], Cos[a]*Cos[b].
@@ -6472,24 +6426,11 @@ fn try_reduce_trig_pair(a: &Expr, b: &Expr) -> Option<Expr> {
   let (a_name, a_arg) = extract_trig(a)?;
   let (b_name, b_arg) = extract_trig(b)?;
 
-  let sum = Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(a_arg.clone()),
-    right: Box::new(b_arg.clone()),
-  };
-  let diff = Expr::BinaryOp {
-    op: BinaryOperator::Minus,
-    left: Box::new(a_arg.clone()),
-    right: Box::new(b_arg.clone()),
-  };
+  let sum = binop(BinaryOperator::Plus, a_arg.clone(), b_arg.clone());
+  let diff = binop(BinaryOperator::Minus, a_arg.clone(), b_arg.clone());
 
-  let half = |e: Expr| -> Expr {
-    Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(e),
-      right: Box::new(Expr::Integer(2)),
-    }
-  };
+  let half =
+    |e: Expr| -> Expr { binop(BinaryOperator::Divide, e, Expr::Integer(2)) };
 
   let sin = |e: Expr| -> Expr {
     Expr::FunctionCall {
@@ -6524,39 +6465,19 @@ fn try_reduce_trig_pair(a: &Expr, b: &Expr) -> Option<Expr> {
       } else {
         (b_arg, a_arg)
       };
-      let s = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(sin_arg.clone()),
-        right: Box::new(cos_arg.clone()),
-      };
-      let d = Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(sin_arg),
-        right: Box::new(cos_arg),
-      };
-      let result = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(sin(s)),
-        right: Box::new(sin(d)),
-      };
+      let s = binop(BinaryOperator::Plus, sin_arg.clone(), cos_arg.clone());
+      let d = binop(BinaryOperator::Minus, sin_arg, cos_arg);
+      let result = binop(BinaryOperator::Plus, sin(s), sin(d));
       Some(half(result))
     }
     // Cos[a]*Cos[b] = (Cos[a-b] + Cos[a+b])/2
     ("Cos", "Cos") => {
-      let result = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(cos(diff)),
-        right: Box::new(cos(sum)),
-      };
+      let result = binop(BinaryOperator::Plus, cos(diff), cos(sum));
       Some(half(result))
     }
     // Sin[a]*Sin[b] = (Cos[a-b] - Cos[a+b])/2
     ("Sin", "Sin") => {
-      let result = Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(cos(diff)),
-        right: Box::new(cos(sum)),
-      };
+      let result = binop(BinaryOperator::Minus, cos(diff), cos(sum));
       Some(half(result))
     }
     // Sinh[a]*Cosh[b] = (Sinh[a+b] + Sinh[a-b])/2
@@ -6566,39 +6487,19 @@ fn try_reduce_trig_pair(a: &Expr, b: &Expr) -> Option<Expr> {
       } else {
         (b_arg, a_arg)
       };
-      let s = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(sinh_arg.clone()),
-        right: Box::new(cosh_arg.clone()),
-      };
-      let d = Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(sinh_arg),
-        right: Box::new(cosh_arg),
-      };
-      let result = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(sinh(s)),
-        right: Box::new(sinh(d)),
-      };
+      let s = binop(BinaryOperator::Plus, sinh_arg.clone(), cosh_arg.clone());
+      let d = binop(BinaryOperator::Minus, sinh_arg, cosh_arg);
+      let result = binop(BinaryOperator::Plus, sinh(s), sinh(d));
       Some(half(result))
     }
     // Cosh[a]*Cosh[b] = (Cosh[a-b] + Cosh[a+b])/2
     ("Cosh", "Cosh") => {
-      let result = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(cosh(diff)),
-        right: Box::new(cosh(sum)),
-      };
+      let result = binop(BinaryOperator::Plus, cosh(diff), cosh(sum));
       Some(half(result))
     }
     // Sinh[a]*Sinh[b] = (Cosh[a+b] - Cosh[a-b])/2
     ("Sinh", "Sinh") => {
-      let result = Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(cosh(sum)),
-        right: Box::new(cosh(diff)),
-      };
+      let result = binop(BinaryOperator::Minus, cosh(sum), cosh(diff));
       Some(half(result))
     }
     _ => None,
@@ -6631,11 +6532,7 @@ fn reduce_trig_power(base: &Expr, n: i128) -> Option<Expr> {
     if m == 1 {
       arg.clone()
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(coeff)),
-        right: Box::new(arg.clone()),
-      }
+      binop(BinaryOperator::Times, Expr::Integer(coeff), arg.clone())
     }
   };
 
@@ -6701,17 +6598,17 @@ fn reduce_trig_power(base: &Expr, n: i128) -> Option<Expr> {
         if reduced_c == 1 {
           terms.push(trig_call);
         } else if reduced_c == -1 {
-          terms.push(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(-1)),
-            right: Box::new(trig_call),
-          });
+          terms.push(binop(
+            BinaryOperator::Times,
+            Expr::Integer(-1),
+            trig_call,
+          ));
         } else {
-          terms.push(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(reduced_c)),
-            right: Box::new(trig_call),
-          });
+          terms.push(binop(
+            BinaryOperator::Times,
+            Expr::Integer(reduced_c),
+            trig_call,
+          ));
         }
       }
     }
@@ -6729,11 +6626,11 @@ fn reduce_trig_power(base: &Expr, n: i128) -> Option<Expr> {
   if reduced_denom == 1 {
     Some(numerator)
   } else {
-    Some(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numerator),
-      right: Box::new(Expr::Integer(reduced_denom)),
-    })
+    Some(binop(
+      BinaryOperator::Divide,
+      numerator,
+      Expr::Integer(reduced_denom),
+    ))
   }
 }
 

--- a/src/functions/quantity_ast.rs
+++ b/src/functions/quantity_ast.rs
@@ -1,15 +1,7 @@
 use crate::InterpreterError;
 use crate::functions::math_ast::{is_sqrt, make_sqrt, rat_reduce};
-use crate::syntax::{BinaryOperator, Expr, bool_expr, unevaluated};
+use crate::syntax::{BinaryOperator, Expr, binop, bool_expr, unevaluated};
 use std::collections::BTreeMap;
-
-fn binop(op: BinaryOperator, left: Expr, right: Expr) -> Expr {
-  Expr::BinaryOp {
-    op,
-    left: Box::new(left),
-    right: Box::new(right),
-  }
-}
 
 // ─── Unit dimension system ──────────────────────────────────────────────────
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -14262,3 +14262,12 @@ pub fn unevaluated(name: &str, args: &[Expr]) -> Expr {
     args: args.to_vec().into(),
   }
 }
+
+/// Helper to build a binary operation expression
+pub fn binop(op: BinaryOperator, a: Expr, b: Expr) -> Expr {
+  Expr::BinaryOp {
+    op: op,
+    left: Box::new(a),
+    right: Box::new(b),
+  }
+}


### PR DESCRIPTION
The binop helper is called bin and binop and defined in multiple places. Consolidate the implementation to syntax.rs, and rename and apply as appropriate. Most of the changes were generated by script.