### PR TITLE
Fix fuzzer-found Plus ordering, Simplify, and Together divergences

### DIFF
--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -829,16 +829,34 @@ fn machine_tree_fold(xs: &[f64], op: fn(f64, f64) -> f64) -> f64 {
   }
 }
 
-/// Machine-precision Plus over the numeric terms, in input order. Every
-/// exact term converts to f64 individually — Wolfram does NOT coalesce
-/// exact terms into a rational sum first: Plus[2^60, 1, -2^60, 0.5] is
-/// 0. (the 1 is absorbed into 2^60 in f64) and Plus[22, -59, 34, 14.6]
-/// is 11.600000000000001, not (-3 + 14.6) = 11.6.
-fn machine_sum(terms: &[f64]) -> f64 {
+/// Machine-precision Plus over the numeric terms, in input order, as the
+/// balanced machine tree (see `coeff_tree_fold`): Plus[2^60, 1, -2^60, 0.5]
+/// is 0. and Plus[22, -59, 34, 14.6] is 11.600000000000001, not
+/// (-3 + 14.6) = 11.6, while adjacent exact terms combine exactly
+/// (Plus[19/27, 49/3, 0.1, 0.2] is 17.33703703703704, one ulp away from
+/// the per-term f64 sum).
+fn machine_sum(terms: &[Coeff]) -> f64 {
   if terms.is_empty() {
     return 0.0;
   }
-  machine_tree_fold(terms, |a, b| a + b)
+  coeff_tree_fold(terms, Coeff::add).to_f64()
+}
+
+/// Balanced machine tree fold over numeric Plus/Times operands in input
+/// order: the left half takes ceil(n/2) operands. A node whose two sides
+/// are both exact combines exactly (with BigInt promotion); a node mixing
+/// exact and Real converts the exact side to f64. Mirrors wolframscript's
+/// n-ary numeric folding (verified over random batches by the
+/// differential fuzzer).
+fn coeff_tree_fold(xs: &[Coeff], op: fn(&Coeff, &Coeff) -> Coeff) -> Coeff {
+  match xs.len() {
+    1 => xs[0].clone(),
+    2 => op(&xs[0], &xs[1]),
+    n => {
+      let m = n.div_ceil(2);
+      op(&coeff_tree_fold(&xs[..m], op), &coeff_tree_fold(&xs[m..], op))
+    }
+  }
 }
 
 pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -1180,16 +1198,15 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return bigfloat_plus(&flat_args);
   }
 
-  // If all numeric but has Reals, use f64: every term (exact or real)
-  // converts to f64 individually, in input order, and folds as the
-  // balanced machine tree (see machine_sum).
+  // If all numeric but has Reals, fold to f64 as the balanced machine
+  // tree over the terms in input order (see machine_sum).
   if all_numeric && !has_bigfloat {
-    let mut terms: Vec<f64> = Vec::new();
+    let mut terms: Vec<Coeff> = Vec::new();
     for arg in &flat_args {
       if let Expr::Real(f) = arg {
-        terms.push(*f);
+        terms.push(Coeff::Real(*f));
       } else if let Some(c) = expr_to_coeff(arg) {
-        terms.push(c.to_f64());
+        terms.push(c);
       }
     }
     return Ok(Expr::Real(machine_sum(&terms)));
@@ -1212,17 +1229,17 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut symbolic_args: Vec<Expr> = Vec::new();
     let mut has_exact = false;
     let mut exact_sum = Coeff::Exact(0, 1);
-    let mut numeric_terms: Vec<f64> = Vec::new();
+    let mut numeric_terms: Vec<Coeff> = Vec::new();
     let mut has_real_term = false;
 
     for arg in &flat_args {
       if let Some(c) = expr_to_coeff(arg) {
-        numeric_terms.push(c.to_f64());
         // Coeff::add promotes to BigInt on i128 overflow.
         exact_sum = exact_sum.add(&c);
         has_exact = true;
+        numeric_terms.push(c);
       } else if let Expr::Real(f) = arg {
-        numeric_terms.push(*f);
+        numeric_terms.push(Coeff::Real(*f));
         has_real_term = true;
       } else {
         symbolic_args.push(arg.clone());
@@ -7778,28 +7795,20 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Separate into: integers, rationals, reals, and symbolic arguments.
-  // real_factors keeps the machine Reals in input order, and
-  // first_numeric_exact records whether the first numeric factor was
-  // exact — Wolfram coalesces the exact factors into ONE exact product
-  // which seeds the machine fold when it comes first and multiplies
-  // after the reals otherwise (Times[3, 1/7, 0.1, 0.2, 0.3] →
-  // 0.002571428571428571 but Times[0.1, 0.2, 3, 1/7, 0.3] →
-  // 0.0025714285714285717).
+  // num_factors keeps EVERY numeric factor in input order (exact ones as
+  // exact Coeffs) — when a machine Real is present the product folds as
+  // the balanced machine tree over these factors (see coeff_tree_fold):
+  // Times[68, 63.599999999999994, 57] is (68*63.6)*57 =
+  // 246513.59999999995, one ulp away from the coalesced (68*57)*63.6
+  // (wolframscript-verified; differential fuzzer).
   let mut int_product: i128 = 1;
   let mut int_overflow = false;
   let mut has_int = false;
   let mut rat_numer: i128 = 1;
   let mut rat_denom: i128 = 1;
   let mut has_rational = false;
-  let mut real_factors: Vec<f64> = Vec::new();
   let mut any_real = false;
-  let mut first_numeric_exact: Option<bool> = None;
-  // Each exact factor's f64 value in input order — when the FIRST numeric
-  // factor is a Real, wolframscript multiplies the exact factors one at a
-  // time in input order rather than folding them into one coefficient:
-  // Times[r, -10, -3] is (r*-10)*-3, one ulp away from r*30
-  // (wolframscript-verified; differential fuzzer follow-up case).
-  let mut exact_factor_seq: Vec<f64> = Vec::new();
+  let mut num_factors: Vec<Coeff> = Vec::new();
   let mut symbolic_args: Vec<Expr> = Vec::new();
 
   // Pre-check: is there an explicit Rational or non-unity Integer coefficient among the args?
@@ -7820,13 +7829,11 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           int_overflow = true;
         }
         has_int = true;
-        first_numeric_exact.get_or_insert(true);
-        exact_factor_seq.push(*n as f64);
+        num_factors.push(Coeff::Exact(*n, 1));
       }
       Expr::Real(f) => {
-        real_factors.push(*f);
         any_real = true;
-        first_numeric_exact.get_or_insert(false);
+        num_factors.push(Coeff::Real(*f));
       }
       Expr::FunctionCall { name, args: rargs }
         if name == "Rational" && rargs.len() == 2 =>
@@ -7841,10 +7848,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             int_overflow = true;
           }
           has_rational = true;
-          first_numeric_exact.get_or_insert(true);
-          if let Some(v) = try_eval_to_f64(arg) {
-            exact_factor_seq.push(v);
-          }
+          num_factors.push(Coeff::Exact(*n, *d));
         } else {
           symbolic_args.push(arg.clone());
         }
@@ -7866,8 +7870,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             if let Some(rd) = rat_denom.checked_mul(pow) {
               rat_denom = rd;
               has_rational = true;
-              first_numeric_exact.get_or_insert(true);
-              exact_factor_seq.push(1.0 / pow as f64);
+              num_factors.push(Coeff::Exact(1, pow));
             } else {
               int_overflow = true;
             }
@@ -7894,14 +7897,14 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           if let Some(rd) = rat_denom.checked_mul(*d) {
             rat_denom = rd;
             has_rational = true;
+            num_factors.push(Coeff::Exact(1, *d));
             symbolic_args.push(*num_expr.clone());
           } else {
             symbolic_args.push(arg.clone());
           }
         } else if let Some(n) = expr_to_num(arg) {
-          real_factors.push(n);
           any_real = true;
-          first_numeric_exact.get_or_insert(false);
+          num_factors.push(Coeff::Real(n));
         } else {
           symbolic_args.push(arg.clone());
         }
@@ -7957,36 +7960,15 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     symbolic_args = remaining_symbolic;
 
-    // Machine fold in Wolfram's order: the coalesced exact coefficient
-    // joins the tree fold as the leading factor when the first numeric
-    // factor was exact, and multiplies after the reals otherwise; the
-    // numerified constants come last.
-    let has_exact_coeff = has_int || has_rational;
-    let exact_f = Coeff::Exact(int_product, 1)
-      .mul(&Coeff::Exact(rat_numer, rat_denom))
-      .to_f64();
-    let mut fold_factors: Vec<f64> = Vec::new();
-    if has_exact_coeff && first_numeric_exact == Some(true) {
-      fold_factors.push(exact_f);
-    }
-    fold_factors.extend_from_slice(&real_factors);
-    let mut total = if fold_factors.is_empty() {
+    // Machine fold in Wolfram's order: the balanced machine tree over
+    // every numeric factor in input order (exact subtrees combine
+    // exactly — see coeff_tree_fold); the numerified constants come
+    // last, one at a time.
+    let mut total = if num_factors.is_empty() {
       1.0
     } else {
-      machine_tree_fold(&fold_factors, |a, b| a * b)
+      coeff_tree_fold(&num_factors, Coeff::mul).to_f64()
     };
-    if has_exact_coeff && first_numeric_exact != Some(true) {
-      // Per-factor sequential multiply in input order (see
-      // exact_factor_seq above); the coalesced coefficient remains the
-      // fallback for factors that escaped tracking (overflow paths).
-      if exact_factor_seq.is_empty() {
-        total *= exact_f;
-      } else {
-        for f in &exact_factor_seq {
-          total *= f;
-        }
-      }
-    }
     for f in &numerified_tail {
       total *= f;
     }
@@ -11383,7 +11365,14 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
 
   match (expr_to_num(base), expr_to_num(exp)) {
     (Some(a), Some(b)) => {
-      let result = a.powf(b);
+      // A machine-real base with an exact Integer exponent must use
+      // wolframscript's multiplication chains rather than libm pow — the
+      // two round differently in the last ULP.
+      let result = if let (true, Expr::Integer(e)) = (has_real, exp) {
+        crate::functions::math_ast::numeric_utils::wolfram_powi(a, *e)
+      } else {
+        a.powf(b)
+      };
       if result.is_nan() && a < 0.0 {
         // Negative base with fractional exponent: use complex arithmetic
         // (-x)^r = x^r * e^(i*pi*r) = x^r * (cos(pi*r) + i*sin(pi*r))
@@ -11431,23 +11420,21 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
       }
     }
     _ => {
-      // Small positive integer exponent on a complex float: compute by
-      // repeated multiplication for better precision than the log/exp
-      // path below. (a+bI)^2 this way loses no ULPs, whereas
-      // exp(2 log(z)) can drift by one.
+      // Exact Integer exponent on a complex float: wolframscript uses the
+      // same multiplication chains as for real bases (and a Smith-style
+      // reciprocal for negative exponents), which the log/exp path below
+      // misses by a ULP.
       if let Expr::Integer(n) = exp
-        && (2..=16).contains(n)
+        && *n != 0
+        && *n != 1
         && let Some((a, b)) = try_extract_complex_float(base)
         && b != 0.0
         && contains_real(base)
       {
-        let (mut re, mut im) = (a, b);
-        for _ in 1..*n {
-          let new_re = re * a - im * b;
-          let new_im = re * b + im * a;
-          re = new_re;
-          im = new_im;
-        }
+        let (re, im) =
+          crate::functions::math_ast::numeric_utils::wolfram_powi_complex(
+            a, b, *n,
+          );
         return Ok(build_complex_float_expr(re, im));
       }
       // Try complex float evaluation: z^w = exp(w * log(z))

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -3585,8 +3585,8 @@ fn quotient_sum_terms_vector_order(
         },
         other => (other, 1),
       };
-      let (v, coeffs, is_sum) = if let Expr::Identifier(v) = fb {
-        (v.clone(), vec![0, 1], false)
+      let (v, coeffs, is_sum) = if let Some(v) = sym_var_name(fb) {
+        (v.to_string(), vec![0, 1], false)
       } else if cmp_is_sum_base(fb) {
         let (v, c) = univar_int_coeffs(fb)?;
         (v, c, true)
@@ -3685,36 +3685,38 @@ fn quotient_sum_terms_vector_order(
 fn sum_recip_vs_univar_order(a: &Expr, b: &Expr) -> Option<std::cmp::Ordering> {
   use std::cmp::Ordering;
   // (var, ascending base-polynomial coeffs, is_sum_reciprocal).
-  fn base_info(e: &Expr) -> Option<(String, Vec<i128>, bool)> {
+  fn base_info(e: &Expr) -> Option<(String, Vec<(i128, i128)>, bool)> {
     let (_, base) = decompose_term(e);
     if let Some((inner, _)) = cmp_neg_pow(&base) {
       if cmp_is_sum_base(inner) {
-        let (v, c) = univar_int_coeffs(inner)?;
+        let (v, c) = univar_rat_coeffs(inner)?;
         return Some((v, c, true));
       }
-      if let Expr::Identifier(v) = inner {
-        return Some((v.clone(), vec![0, 1], false));
+      if let Some(v) = sym_var_name(inner) {
+        return Some((v.to_string(), vec![(0, 1), (1, 1)], false));
       }
       return None;
     }
     let var_power = |b: &Expr, e: &Expr| -> Option<String> {
-      match (b, e) {
-        (Expr::Identifier(v), Expr::Integer(n)) if *n > 0 => Some(v.clone()),
+      match (sym_var_name(b), e) {
+        (Some(v), Expr::Integer(n)) if *n > 0 => Some(v.to_string()),
         _ => None,
       }
     };
+    if let Some(v) = sym_var_name(&base) {
+      return Some((v.to_string(), vec![(0, 1), (1, 1)], false));
+    }
     match &base {
-      Expr::Identifier(v) => Some((v.clone(), vec![0, 1], false)),
       Expr::FunctionCall { name, args }
         if name == "Power" && args.len() == 2 =>
       {
-        var_power(&args[0], &args[1]).map(|v| (v, vec![0, 1], false))
+        var_power(&args[0], &args[1]).map(|v| (v, vec![(0, 1), (1, 1)], false))
       }
       Expr::BinaryOp {
         op: BinaryOperator::Power,
         left,
         right,
-      } => var_power(left, right).map(|v| (v, vec![0, 1], false)),
+      } => var_power(left, right).map(|v| (v, vec![(0, 1), (1, 1)], false)),
       _ => None,
     }
   }
@@ -3723,15 +3725,16 @@ fn sum_recip_vs_univar_order(a: &Expr, b: &Expr) -> Option<std::cmp::Ordering> {
   if (!ra && !rb) || va != vb {
     return None;
   }
-  let degree = |c: &[i128]| c.iter().rposition(|&k| k != 0).unwrap_or(0);
+  let degree =
+    |c: &[(i128, i128)]| c.iter().rposition(|&(n, _)| n != 0).unwrap_or(0);
   let (da, db) = (degree(&ca), degree(&cb));
   if da != db {
     return Some(da.cmp(&db));
   }
   for i in (0..=da).rev() {
-    let x = ca.get(i).copied().unwrap_or(0);
-    let y = cb.get(i).copied().unwrap_or(0);
-    match x.cmp(&y) {
+    let x = ca.get(i).copied().unwrap_or((0, 1));
+    let y = cb.get(i).copied().unwrap_or((0, 1));
+    match rat_cmp(x, y) {
       Ordering::Equal => {}
       ord => return Some(ord),
     }
@@ -3913,20 +3916,57 @@ fn cmp_is_sum_base(e: &Expr) -> bool {
     )
 }
 
-/// Ascending integer coefficients of a univariate polynomial with number
-/// coefficients (sums of Integer / k*var / k*var^n terms, or a bare
-/// monomial). Returns (var, coeffs) or None for anything else.
-fn univar_int_coeffs(e: &Expr) -> Option<(String, Vec<i128>)> {
-  fn monomial(e: &Expr) -> Option<(Option<String>, usize, i128)> {
+/// The name of a symbol-like atom for univariate polynomial ordering: a
+/// bare Identifier or a named constant (Pi, E, …), which Wolfram orders
+/// exactly like a symbol (`Pi + (1 + Pi)^(-1)` keeps Pi first just as
+/// `x + (1 + x)^(-1)` keeps x first). The imaginary unit is excluded —
+/// sums containing I are complex numbers, not univariate polynomials.
+fn sym_var_name(e: &Expr) -> Option<&str> {
+  match e {
+    Expr::Identifier(v) => Some(v),
+    Expr::Constant(v) if v != "I" => Some(v),
+    _ => None,
+  }
+}
+
+/// A rational number literal as (numerator, denominator > 0), covering
+/// Integer and evaluated Rational[a, b] atoms.
+fn rat_literal(e: &Expr) -> Option<(i128, i128)> {
+  match e {
+    Expr::Integer(n) => Some((*n, 1)),
+    Expr::FunctionCall { name, args }
+      if name == "Rational" && args.len() == 2 =>
+    {
+      match (&args[0], &args[1]) {
+        (Expr::Integer(a), Expr::Integer(b)) if *b != 0 => {
+          Some(if *b < 0 { (-a, -b) } else { (*a, *b) })
+        }
+        _ => None,
+      }
+    }
+    _ => None,
+  }
+}
+
+/// Ascending rational coefficients (numerator, denominator > 0, reduced) of
+/// a univariate polynomial with number coefficients (sums of number /
+/// k*var / k*var^n terms, or a bare monomial). Returns (var, coeffs) or
+/// None for anything else.
+fn univar_rat_coeffs(e: &Expr) -> Option<(String, Vec<(i128, i128)>)> {
+  fn monomial(e: &Expr) -> Option<(Option<String>, usize, (i128, i128))> {
+    if let Some(c) = rat_literal(e) {
+      return Some((None, 0, c));
+    }
     match e {
-      Expr::Integer(n) => Some((None, 0, *n)),
-      Expr::Identifier(v) => Some((Some(v.clone()), 1, 1)),
+      _ if sym_var_name(e).is_some() => {
+        Some((Some(sym_var_name(e)?.to_string()), 1, (1, 1)))
+      }
       Expr::FunctionCall { name, args }
         if name == "Power" && args.len() == 2 =>
       {
-        match (&args[0], &args[1]) {
-          (Expr::Identifier(v), Expr::Integer(n)) if *n > 0 => {
-            Some((Some(v.clone()), *n as usize, 1))
+        match (sym_var_name(&args[0]), &args[1]) {
+          (Some(v), Expr::Integer(n)) if *n > 0 => {
+            Some((Some(v.to_string()), *n as usize, (1, 1)))
           }
           _ => None,
         }
@@ -3935,19 +3975,21 @@ fn univar_int_coeffs(e: &Expr) -> Option<(String, Vec<i128>)> {
         op: BinaryOperator::Power,
         left,
         right,
-      } => match (left.as_ref(), right.as_ref()) {
-        (Expr::Identifier(v), Expr::Integer(n)) if *n > 0 => {
-          Some((Some(v.clone()), *n as usize, 1))
+      } => match (sym_var_name(left), right.as_ref()) {
+        (Some(v), Expr::Integer(n)) if *n > 0 => {
+          Some((Some(v.to_string()), *n as usize, (1, 1)))
         }
         _ => None,
       },
       Expr::FunctionCall { name, args }
         if name == "Times" && args.len() == 2 =>
       {
-        match (&args[0], monomial(&args[1])) {
-          (Expr::Integer(k), Some((v, d, c))) => {
-            Some((v, d, k.checked_mul(c)?))
-          }
+        match (rat_literal(&args[0]), monomial(&args[1])) {
+          (Some((kn, kd)), Some((v, d, (cn, cd)))) => Some((
+            v,
+            d,
+            (kn.checked_mul(cn)?, kd.checked_mul(cd)?),
+          )),
           _ => None,
         }
       }
@@ -3955,19 +3997,40 @@ fn univar_int_coeffs(e: &Expr) -> Option<(String, Vec<i128>)> {
         op: BinaryOperator::Times,
         left,
         right,
-      } => match (left.as_ref(), monomial(right)) {
-        (Expr::Integer(k), Some((v, d, c))) => Some((v, d, k.checked_mul(c)?)),
+      } => match (rat_literal(left), monomial(right)) {
+        (Some((kn, kd)), Some((v, d, (cn, cd)))) => {
+          Some((v, d, (kn.checked_mul(cn)?, kd.checked_mul(cd)?)))
+        }
         _ => None,
       },
       Expr::UnaryOp {
         op: UnaryOperator::Minus,
         operand,
       } => {
-        let (v, d, c) = monomial(operand)?;
-        Some((v, d, c.checked_neg()?))
+        let (v, d, (cn, cd)) = monomial(operand)?;
+        Some((v, d, (cn.checked_neg()?, cd)))
       }
       _ => None,
     }
+  }
+  fn gcd(mut a: i128, mut b: i128) -> i128 {
+    while b != 0 {
+      (a, b) = (b, a % b);
+    }
+    a.abs().max(1)
+  }
+  // Reduced form with denominator > 0, so coefficient vectors compare
+  // consistently by value.
+  fn rat_norm((n, d): (i128, i128)) -> (i128, i128) {
+    let g = gcd(n, d);
+    let (n, d) = (n / g, d / g);
+    if d < 0 { (-n, -d) } else { (n, d) }
+  }
+  fn rat_add(a: (i128, i128), b: (i128, i128)) -> Option<(i128, i128)> {
+    Some(rat_norm((
+      a.0.checked_mul(b.1)?.checked_add(b.0.checked_mul(a.1)?)?,
+      a.1.checked_mul(b.1)?,
+    )))
   }
   let terms: Vec<&Expr> = match e {
     Expr::FunctionCall { name, args } if name == "Plus" => {
@@ -3976,7 +4039,7 @@ fn univar_int_coeffs(e: &Expr) -> Option<(String, Vec<i128>)> {
     other => vec![other],
   };
   let mut var: Option<String> = None;
-  let mut coeffs: Vec<i128> = Vec::new();
+  let mut coeffs: Vec<(i128, i128)> = Vec::new();
   for t in terms {
     let (v, d, c) = monomial(t)?;
     if let Some(v) = v {
@@ -3987,11 +4050,29 @@ fn univar_int_coeffs(e: &Expr) -> Option<(String, Vec<i128>)> {
       }
     }
     if coeffs.len() <= d {
-      coeffs.resize(d + 1, 0);
+      coeffs.resize(d + 1, (0, 1));
     }
-    coeffs[d] = coeffs[d].checked_add(c)?;
+    coeffs[d] = rat_add(coeffs[d], rat_norm(c))?;
   }
   Some((var?, coeffs))
+}
+
+/// Compare two rationals in (numerator, denominator > 0) form by value.
+fn rat_cmp(a: (i128, i128), b: (i128, i128)) -> std::cmp::Ordering {
+  (a.0 * b.1).cmp(&(b.0 * a.1))
+}
+
+/// Ascending integer coefficients of a univariate polynomial with number
+/// coefficients (sums of Integer / k*var / k*var^n terms, or a bare
+/// monomial). Returns (var, coeffs) or None for anything else (including
+/// polynomials with non-integer rational coefficients).
+fn univar_int_coeffs(e: &Expr) -> Option<(String, Vec<i128>)> {
+  let (var, rats) = univar_rat_coeffs(e)?;
+  let ints: Option<Vec<i128>> = rats
+    .iter()
+    .map(|&(n, d)| if d == 1 { Some(n) } else { None })
+    .collect();
+  Some((var, ints?))
 }
 
 /// WL polynomial term order for two univariate polynomials in the same
@@ -5037,6 +5118,40 @@ fn order_factor_vs_additive(
   use std::cmp::Ordering;
   let top = plus_args.last().unwrap();
   let (fb, fe) = times_term_base_exp(factor);
+  // A variable-power factor against a univariate polynomial sum in the
+  // SAME variable compares by coefficient vector, the factor flattening
+  // to plain-x coefficients [0, 1] whatever its positive exponent:
+  // degree ascending, then coefficients from the leading term down, a
+  // full tie keeping the factor first. All wolframscript-verified:
+  // x^2*(1 + x), x^3*(-1 + x^2), (-1 + x)*x^2, x^2*(-1 + x^2),
+  // (-2 + x)*x^2, x^2*(-1 + 2*x), (-1/2 + x)*x^2, Pi^2*(-1 + Pi^2).
+  if let Some(v) = sym_var_name(&fb)
+    && fe.is_some_and(|e| e > 0.0)
+  {
+    let sum_expr = Expr::FunctionCall {
+      name: "Plus".to_string(),
+      args: plus_args.to_vec().into(),
+    };
+    if let Some((sv, coeffs)) = univar_rat_coeffs(&sum_expr)
+      && sv == v
+    {
+      let deg = coeffs.iter().rposition(|&(n, _)| n != 0).unwrap_or(0);
+      match 1.cmp(&deg) {
+        Ordering::Equal => {}
+        ord => return ord,
+      }
+      let fvec = [(0i128, 1i128), (1, 1)];
+      for i in (0..=deg).rev() {
+        let x = fvec.get(i).copied().unwrap_or((0, 1));
+        let y = coeffs.get(i).copied().unwrap_or((0, 1));
+        match rat_cmp(x, y) {
+          Ordering::Equal => {}
+          ord => return ord,
+        }
+      }
+      return Ordering::Less;
+    }
+  }
   let (hb, he) = times_term_base_exp(top);
   // Atom bases compare by name only — compare_exprs would evaluate
   // constants numerically and order Pi (numeric) before I (non-numeric),

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -854,7 +854,10 @@ fn coeff_tree_fold(xs: &[Coeff], op: fn(&Coeff, &Coeff) -> Coeff) -> Coeff {
     2 => op(&xs[0], &xs[1]),
     n => {
       let m = n.div_ceil(2);
-      op(&coeff_tree_fold(&xs[..m], op), &coeff_tree_fold(&xs[m..], op))
+      op(
+        &coeff_tree_fold(&xs[..m], op),
+        &coeff_tree_fold(&xs[m..], op),
+      )
     }
   }
 }
@@ -3985,11 +3988,9 @@ fn univar_rat_coeffs(e: &Expr) -> Option<(String, Vec<(i128, i128)>)> {
         if name == "Times" && args.len() == 2 =>
       {
         match (rat_literal(&args[0]), monomial(&args[1])) {
-          (Some((kn, kd)), Some((v, d, (cn, cd)))) => Some((
-            v,
-            d,
-            (kn.checked_mul(cn)?, kd.checked_mul(cd)?),
-          )),
+          (Some((kn, kd)), Some((v, d, (cn, cd)))) => {
+            Some((v, d, (kn.checked_mul(cn)?, kd.checked_mul(cd)?)))
+          }
           _ => None,
         }
       }

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -5644,6 +5644,21 @@ fn pdf_power(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     ));
   }
   let (k, a) = (dargs[0].clone(), dargs[1].clone());
+  // wolframscript's compiled numeric PDF evaluates a*k^a*x^(a-1) as
+  // exp(log a + a log k + (a-1) log x), which rounds differently from the
+  // top-level Power chains for machine reals — mirror it exactly.
+  if let Expr::Real(xf) = x
+    && let (Some(kf), Some(af)) = (try_eval_to_f64(&k), try_eval_to_f64(&a))
+    && kf > 0.0
+    && af > 0.0
+  {
+    let v = if xf > 0.0 && xf <= 1.0 / kf {
+      (af.ln() + af * kf.ln() + (af - 1.0) * xf.ln()).exp()
+    } else {
+      0.0
+    };
+    return Ok(Expr::Real(v));
+  }
   let value = times(
     times(a.clone(), power(k.clone(), a.clone())),
     power(x.clone(), minus(a, int(1))),
@@ -5674,6 +5689,21 @@ fn cdf_power(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     ));
   }
   let (k, a) = (dargs[0].clone(), dargs[1].clone());
+  // As in pdf_power: wolframscript's compiled numeric CDF computes (k*x)^a
+  // with libm pow, not the top-level Power multiplication chains.
+  if let Expr::Real(xf) = x
+    && let (Some(kf), Some(af)) = (try_eval_to_f64(&k), try_eval_to_f64(&a))
+    && kf > 0.0
+  {
+    let v = if xf <= 0.0 {
+      0.0
+    } else if xf <= 1.0 / kf {
+      (kf * xf).powf(af)
+    } else {
+      1.0
+    };
+    return Ok(Expr::Real(v));
+  }
   let value = power(times(k.clone(), x.clone()), a.clone());
   let cond1 = comparison3(
     int(0),

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -3228,7 +3228,21 @@ pub fn fractional_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         && let Ok(floor_val) =
           crate::functions::math_ast::floor_ast(&[args[0].clone()])
       {
-        if let Expr::Integer(n) = &floor_val {
+        // IntegerPart truncates toward zero: Floor for x >= 0, Ceiling
+        // for x < 0 (FractionalPart[81*(Pi - 29/2)] = 920 + 81*(-29/2 + Pi),
+        // not 921 + ...).
+        let x_negative = match &floor_val {
+          Expr::Integer(n) => *n < 0,
+          Expr::BigInteger(b) => b.sign() == Sign::Minus,
+          _ => false,
+        };
+        let int_val = if x_negative {
+          crate::functions::math_ast::ceiling_ast(&[args[0].clone()])
+            .unwrap_or(floor_val)
+        } else {
+          floor_val
+        };
+        if let Expr::Integer(n) = &int_val {
           if *n == 0 {
             return Ok(args[0].clone());
           }
@@ -3237,14 +3251,14 @@ pub fn fractional_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             &[args[0].clone(), Expr::Integer(-*n)],
           );
         }
-        if let Expr::BigInteger(_) = &floor_val {
+        if let Expr::BigInteger(_) = &int_val {
           return crate::evaluator::evaluate_function_call_ast(
             "Plus",
             &[
               args[0].clone(),
               Expr::FunctionCall {
                 name: "Times".to_string(),
-                args: vec![Expr::Integer(-1), floor_val].into(),
+                args: vec![Expr::Integer(-1), int_val].into(),
               },
             ],
           );

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -32,6 +32,117 @@ pub fn expr_to_num(expr: &Expr) -> Option<f64> {
   }
 }
 
+/// Machine-real `x^n` for an exact `Integer` exponent `n`, reproducing the
+/// multiplication chains wolframscript uses so results agree to the last ULP
+/// (libm `pow` rounds differently, e.g. `7.488095238095239^-2`).
+///
+/// Empirically reverse-engineered from wolframscript by matching the exact
+/// f64 products over thousands of random bases and exponents:
+/// - exponents 2..=15 use a fixed chain table,
+/// - larger exponents peel a base-4 digit while the remaining exponent has
+///   an odd bit length and a binary digit while it has an even bit length
+///   (squaring the half-power when the digit is 0),
+/// - negative exponents are the reciprocal of the positive power.
+pub fn wolfram_powi(x: f64, n: i128) -> f64 {
+  if n == 0 {
+    return 1.0;
+  }
+  let m = n.unsigned_abs();
+  let r = if m == 1 {
+    x
+  } else {
+    wolfram_pow_chain(x, x * x, m, &|a, b| a * b)
+  };
+  if n < 0 { 1.0 / r } else { r }
+}
+
+/// The multiplication chain shared by real and complex machine integer
+/// powers (see `wolfram_powi` for the empirically derived structure).
+fn wolfram_pow_chain<T: Copy>(x: T, x2: T, k: u128, mul: &impl Fn(T, T) -> T) -> T {
+  let chain = |k| wolfram_pow_chain(x, x2, k, mul);
+  match k {
+    1 => x,
+    2 => x2,
+    3 => mul(x, x2),
+    4 => mul(x2, x2),
+    6 => {
+      let x3 = mul(x, x2);
+      mul(x3, x3)
+    }
+    8 => {
+      let x4 = mul(x2, x2);
+      mul(x4, x4)
+    }
+    10 => {
+      let x5 = chain(5);
+      mul(x5, x5)
+    }
+    12 => {
+      let x6 = mul(x2, mul(x2, x2));
+      mul(x6, x6)
+    }
+    14 => {
+      let x7 = mul(mul(x, x2), mul(x2, x2));
+      mul(x7, x7)
+    }
+    5 | 7 | 9 | 11 | 13 | 15 => mul(x, chain(k - 1)),
+    _ => {
+      let odd_bit_length = (128 - k.leading_zeros()) % 2 == 1;
+      if odd_bit_length {
+        match k % 4 {
+          0 => {
+            let h = chain(k / 2);
+            mul(h, h)
+          }
+          1 => mul(x, chain(k - 1)),
+          2 => mul(x2, chain(k - 2)),
+          _ => mul(mul(x, x2), chain(k - 3)),
+        }
+      } else if k % 2 == 0 {
+        let h = chain(k / 2);
+        mul(h, h)
+      } else {
+        mul(x, chain(k - 1))
+      }
+    }
+  }
+}
+
+/// Machine-complex `z^n` for an exact `Integer` exponent: the same
+/// multiplication chains as `wolfram_powi` with complex multiplications,
+/// and — for negative exponents — the reciprocal of the positive power via
+/// Smith's complex-division algorithm, both matching wolframscript
+/// bit-for-bit (verified over random batches by the differential fuzzer).
+/// Returns `(re, im)`.
+pub fn wolfram_powi_complex(re: f64, im: f64, n: i128) -> (f64, f64) {
+  if n == 0 {
+    return (1.0, 0.0);
+  }
+  let cmul = |a: (f64, f64), b: (f64, f64)| -> (f64, f64) {
+    (a.0 * b.0 - a.1 * b.1, a.0 * b.1 + a.1 * b.0)
+  };
+  let z = (re, im);
+  let m = n.unsigned_abs();
+  let (c, d) = if m == 1 {
+    z
+  } else {
+    wolfram_pow_chain(z, cmul(z, z), m, &cmul)
+  };
+  if n > 0 {
+    return (c, d);
+  }
+  // 1/(c + d*I) via Smith's algorithm.
+  if c.abs() >= d.abs() {
+    let r = d / c;
+    let den = c + d * r;
+    (1.0 / den, -r / den)
+  } else {
+    let r = c / d;
+    let den = c * r + d;
+    (r / den, -1.0 / den)
+  }
+}
+
 /// Compute the error function erf(x) using the Taylor series.
 /// erf(x) = (2/sqrt(pi)) * sum_{n=0}^{inf} (-1)^n * x^(2n+1) / (n! * (2n+1))
 pub fn erf_f64(x: f64) -> f64 {

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -58,7 +58,12 @@ pub fn wolfram_powi(x: f64, n: i128) -> f64 {
 
 /// The multiplication chain shared by real and complex machine integer
 /// powers (see `wolfram_powi` for the empirically derived structure).
-fn wolfram_pow_chain<T: Copy>(x: T, x2: T, k: u128, mul: &impl Fn(T, T) -> T) -> T {
+fn wolfram_pow_chain<T: Copy>(
+  x: T,
+  x2: T,
+  k: u128,
+  mul: &impl Fn(T, T) -> T,
+) -> T {
   let chain = |k| wolfram_pow_chain(x, x2, k, mul);
   match k {
     1 => x,
@@ -98,7 +103,7 @@ fn wolfram_pow_chain<T: Copy>(x: T, x2: T, k: u128, mul: &impl Fn(T, T) -> T) ->
           2 => mul(x2, chain(k - 2)),
           _ => mul(mul(x, x2), chain(k - 3)),
         }
-      } else if k % 2 == 0 {
+      } else if k.is_multiple_of(2) {
         let h = chain(k / 2);
         mul(h, h)
       } else {

--- a/src/functions/polynomial_ast/cancel.rs
+++ b/src/functions/polynomial_ast/cancel.rs
@@ -878,7 +878,7 @@ pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
 }
 
 /// Find the single variable that appears in either or both expressions
-fn find_single_variable_both(a: &Expr, b: &Expr) -> Option<String> {
+pub(super) fn find_single_variable_both(a: &Expr, b: &Expr) -> Option<String> {
   let mut vars = std::collections::HashSet::new();
   collect_variables(a, &mut vars);
   collect_variables(b, &mut vars);

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -5076,7 +5076,6 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
         super::together::extract_quotient_minus(&n, &d)
       {
         best = signed;
-      } else {
       }
     }
   }
@@ -7816,7 +7815,11 @@ pub(crate) fn simplify_division_impl(
         // accepted no-op.
         Some(r) => {
           settled_display = true;
-          if exprs_equal(&r, &basic) { None } else { Some(r) }
+          if exprs_equal(&r, &basic) {
+            None
+          } else {
+            Some(r)
+          }
         }
         None => Some(f),
       },
@@ -8177,9 +8180,8 @@ fn simplify_quotient_select(
     }
     Some(non_numeric)
   };
-  let simple_part = |e: &Expr| -> bool {
-    count_parts(e).map(|n| n <= 1).unwrap_or(false)
-  };
+  let simple_part =
+    |e: &Expr| -> bool { count_parts(e).map(|n| n <= 1).unwrap_or(false) };
   // The numerator must be plain (a sum, monomial, or content-wrapped sum)
   // — factored numerators like 2x(-1+2x) are Factor-pipeline displays
   // that a re-analysis would destroy. The DENOMINATOR may additionally
@@ -9741,7 +9743,9 @@ fn complexity_digits(expr: &Expr) -> usize {
         op: BinaryOperator::Minus,
         left,
         right,
-      } if !negated => plus_term_cost(left, false) + plus_term_cost(right, true),
+      } if !negated => {
+        plus_term_cost(left, false) + plus_term_cost(right, true)
+      }
       Expr::UnaryOp {
         op: UnaryOperator::Minus,
         operand,

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -4879,29 +4879,35 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
       None => raw,
     }
   };
-  let tc = leaf_count(&togethered);
-  if tc < best_c {
+  // Acceptance counts Wolfram's FullForm tree (complexity_digits), not the
+  // display tree: leaf_count rated the content-extracted den display
+  // (1+3x)/(-2*(-x+x^2)) below the expanded (1+3x)/(2x-2x^2) Wolfram
+  // keeps, because -x costs 2 display nodes but 3 FullForm nodes
+  // (differential fuzzer, seed 1785246333519574598 follow-up).
+  let tc = complexity_digits(&togethered);
+  if tc < complexity_digits(&best) {
     // Re-run simplify_expr to absorb any cancellations Together exposed.
     let resimplified = simplify_expr(&togethered);
-    let rc = leaf_count(&resimplified);
+    let rc = complexity_digits(&resimplified);
     if rc <= tc {
       best = resimplified;
-      best_c = rc;
     } else {
       best = togethered;
-      best_c = tc;
     }
+    best_c = leaf_count(&best);
   }
 
   // Candidate 2: Together sub-expressions (leaves outer structure alone).
   // This helps cases like `1 + 1/(1 + 1/x)` where the whole-expression Together
   // is tied with the original, but combining only the inner fraction is
   // strictly better.
+  // Same FullForm-based acceptance as candidate 1: the display-tree
+  // leaf count rated a den content extraction ((1+3x)/(-2*(-x+x^2)))
+  // below the expanded form Wolfram keeps.
   let sub_togethered = together_subexpressions(&simplified);
-  let sc = leaf_count(&sub_togethered);
-  if sc < best_c {
+  if complexity_digits(&sub_togethered) < complexity_digits(&best) {
+    best_c = leaf_count(&sub_togethered);
     best = sub_togethered;
-    best_c = sc;
   }
 
   // Candidate 3: Expand — wolframscript prefers `-1 + x^2` over
@@ -5030,8 +5036,12 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
           // of distinct factors: Simplify[1/(4x+3x^2)] stays
           // (4x+3x^2)^(-1), not 1/(x(4+3x)). Powers still collapse
           // (x^2/(1-3x+3x^2-x^3) → -(x^2/(-1+x)^3)). The squarefree
-          // redisplay above gates its own denominator.
-          leaf_count(&factored) <= best_c
+          // redisplay above gates its own denominator. The FullForm cost
+          // key (not the display-tree leaf count) decides, so a den
+          // content extraction like (1+3x)/(-2*(-x+x^2)) loses its tie
+          // against the expanded (1+3x)/(2x-2x^2) on the negative-leaf
+          // tie-break, matching wolframscript.
+          simplify_cost_key(&factored) <= simplify_cost_key(&best)
             && (den_gated || factored_den_acceptable(&best, &factored))
         };
       if accept && !exprs_equal(&factored, &best) {
@@ -5066,6 +5076,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
         super::together::extract_quotient_minus(&n, &d)
       {
         best = signed;
+      } else {
       }
     }
   }
@@ -7723,8 +7734,46 @@ pub(crate) fn simplify_division_impl(
     if matches!(&bd, Expr::Integer(1)) {
       basic
     } else if extract_minus
-      && let Some((chosen, terminal)) =
-        simplify_quotient_select(&basic, &bn, &bd)
+      && let Some((chosen, terminal)) = {
+        // Analyze the INPUT display pair first: the selection expands
+        // internally, but its plain candidate keeps the given
+        // denominator verbatim, so an already-canonical factored
+        // quotient like (2+x)/((-1+x)*x) survives Simplify unchanged
+        // just as in wolframscript, while a flip still normalizes
+        // (-1-3x)/(2*(-1+x)*x) → (1+3x)/(2x-2x^2). Shapes the
+        // selection cannot hold (multivariate, radicals, factored
+        // numerators) fall back to the expanded pair.
+        //
+        // One exception: a content-wrapped den whose primitive part has
+        // no constant term (2*(-x+x^2) — the sum pipeline's operand
+        // display) is not a Wolfram quotient display; hand the
+        // selection its expanded polynomial so the plain candidate
+        // rebuilds (1+3x)/(2x-2x^2).
+        let den_for_select = {
+          let factors =
+            super::together::flatten_times_args(std::slice::from_ref(den));
+          let non_numeric: Vec<&Expr> = factors
+            .iter()
+            .filter(|f| !matches!(f, Expr::Integer(_)))
+            .collect();
+          let content_wrapped_sum = factors.len() >= 2
+            && non_numeric.len() == 1
+            && super::coefficient::collect_additive_terms(non_numeric[0]).len()
+              > 1;
+          if content_wrapped_sum {
+            let expanded = expand_and_combine(den);
+            let no_constant = find_single_variable(&expanded)
+              .and_then(|v| extract_poly_coeffs(&expanded, &v))
+              .map(|c| c.first().copied() == Some(0))
+              .unwrap_or(false);
+            if no_constant { expanded } else { den.clone() }
+          } else {
+            den.clone()
+          }
+        };
+        simplify_quotient_select(&basic, num, &den_for_select)
+          .or_else(|| simplify_quotient_select(&basic, &bn, &bd))
+      }
     {
       if terminal {
         return chosen;
@@ -8095,7 +8144,7 @@ fn simplify_quotient_select(
   // here would rebuild expanded displays and destroy x^2/(-1+x)^3-style
   // forms. Only a plain sum, a monomial, or a content-wrapped sum
   // (Times[c, Plus[…]]) may pass.
-  let simple_part = |e: &Expr| -> bool {
+  let count_parts = |e: &Expr| -> Option<usize> {
     let factors = super::together::flatten_times_args(std::slice::from_ref(e));
     let mut non_numeric = 0usize;
     for f in &factors {
@@ -8122,13 +8171,24 @@ fn simplify_quotient_select(
         _ => false,
       };
       if power_sum_base {
-        return false;
+        return None;
       }
       non_numeric += 1;
     }
-    non_numeric <= 1
+    Some(non_numeric)
   };
-  if !simple_part(num) || !simple_part(den) {
+  let simple_part = |e: &Expr| -> bool {
+    count_parts(e).map(|n| n <= 1).unwrap_or(false)
+  };
+  // The numerator must be plain (a sum, monomial, or content-wrapped sum)
+  // — factored numerators like 2x(-1+2x) are Factor-pipeline displays
+  // that a re-analysis would destroy. The DENOMINATOR may additionally
+  // be a power-free product of sums/monomials (2*(-1+x)*x from a
+  // cancelled quotient): the plain candidate keeps its display verbatim
+  // while the flip normalizes Simplify[(-1-3x)/(2(-1+x)x)] to
+  // (1+3x)/(2x-2x^2) like wolframscript (differential fuzzer, seed
+  // 1785246333519574598).
+  if !simple_part(num) || count_parts(den).is_none() {
     return None;
   }
   let var = vars.into_iter().next().unwrap();
@@ -8269,12 +8329,17 @@ fn simplify_quotient_select(
   // keeps the extraction (Simplify[(-5-10x)/(1+7x)] → (-5*(1+2x))/(1+7x));
   // wolframscript-verified (differential fuzzer, seed 5520550946540289960).
   let num_pullable = !den_gate_open && n_terms.len() > 1 && n_content < 0;
-  let den_extractable = !den_gate_open && !den_is_mono && d_content > 1;
   // A denominator sum with monomial content x^k (k >= 1) can split it out
   // as its own reciprocal power factor: 1/(-3x^2+5x^3) → 1/(x^2*(-3+5x))
   // (15 < 17), while 1/(4x+3x^2) stays expanded (13 > 12);
   // wolframscript-verified (differential fuzzer, seed 862368627941598145).
   let den_min_exp = d_terms.iter().map(|&(_, _, e)| e).min().unwrap_or(0);
+  // Integer content only extracts from a den whose primitive part has a
+  // constant term; a den divisible by x belongs to the x^k split or the
+  // plain display, never the content-only form — wolframscript keeps
+  // (1+3x)/(-2x+2x^2), never showing (1+3x)/(2*(-x+x^2)).
+  let den_extractable =
+    !den_gate_open && !den_is_mono && d_content > 1 && den_min_exp == 0;
   // With a negative LEADING coefficient the split only applies to a
   // mixed-sign denominator (1/(3x^2-5x^3) → 1/((3-5x)*x^2)); an
   // all-nonpositive one pulls the minus out instead
@@ -8496,6 +8561,23 @@ fn simplify_quotient_select(
       } else {
         (1, fd)
       };
+      // Like the unflipped side, the content form only exists for a
+      // primitive part with a constant term; a flipped den divisible by
+      // x splits its x^k out instead — Simplify[(-1-3x)/(2x-2x^2)] →
+      // (1+3x)/(2*(-1+x)*x), never (1+3x)/(2*(-x+x^2))
+      // (wolframscript-verified).
+      let fd_min_exp = fdt.iter().map(|&(_, _, e)| e).min().unwrap_or(0);
+      let (fd_mono, fdt) = if fd_min_exp >= 1 {
+        (
+          fd_min_exp,
+          fdt
+            .iter()
+            .map(|&(n, d, e)| (n, d, e - fd_min_exp))
+            .collect::<Vec<_>>(),
+        )
+      } else {
+        (0, fdt)
+      };
       let mut flip_opts: Vec<(i128, Vec<(i128, i128, i128)>)> = Vec::new();
       if fn_terms.len() > 1 && fn_content.abs() > 1 {
         flip_opts.push((fn_content, scale(&fn_terms, fn_content)));
@@ -8504,14 +8586,19 @@ fn simplify_quotient_select(
       for (nc, nt) in flip_opts {
         let (coeff_n, coeff_d) = rat_reduce(nc, fdc);
         cands.push(Cand {
-          cost: sc_quotient((coeff_n, coeff_d), &nt, Some(&fdt), None),
+          cost: sc_quotient(
+            (coeff_n, coeff_d),
+            &nt,
+            Some(&fdt),
+            (fd_mono > 0).then_some(fd_mono),
+          ),
           class: 3,
           minus_pull: false,
           num_content: nc,
           num_terms: nt,
           den_content: fdc,
           den_terms: fdt.clone(),
-          den_mono: 0,
+          den_mono: fd_mono,
           split: false,
           terminal: false,
         });
@@ -8638,14 +8725,12 @@ fn simplify_quotient_select(
     if chosen.den_content > 1 {
       factors.push(Expr::Integer(chosen.den_content));
     }
-    // wolframscript orders a negative-LEADING primitive sum before the
-    // power (1/((3 - 5*x)*x^2)) but a positive-leading one after it
-    // (1/(x^2*(-3 + 5*x))).
-    if chosen
-      .den_terms
-      .last()
-      .map(|&(n, _, _)| n < 0)
-      .unwrap_or(false)
+    // Canonical Times order between the power and the primitive sum:
+    // 1/((3 - 5*x)*x^2) but 1/(x^2*(-3 + 5*x)), and (-1 + x) precedes a
+    // bare x (2*(-1+x)*x) — the coefficient-vector rule decides
+    // (wolframscript-verified).
+    if crate::functions::math_ast::order_monomial_vs_sum(&var_pow, &den_body)
+      == Some(std::cmp::Ordering::Greater)
     {
       factors.push(den_body);
       factors.push(var_pow);

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -4974,6 +4974,22 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
       super::factor::factor_ast(&[best.clone()])
     };
     if let Ok(factored) = factored {
+      // A univariate integer-polynomial quotient keeps Factor's
+      // CANCELLATION but not its display — wolframscript shows the
+      // reduced parts in FactorSquareFree form (squarefree numerators
+      // stay expanded: (2+3x+x^2)/(2+3x) keeps its form, x/(x-3x^2) →
+      // (1-3x)^(-1); perfect powers and monomial content still come
+      // out: (1+2x+x^2)/(2x+3x^2) → (1+x)^2/(x*(2+3x)));
+      // wolframscript-verified (differential fuzzer seed
+      // 1785082426573174375).
+      let (factored, den_gated) = if !is_sum {
+        match settled_quotient_factor_display(&best, &factored) {
+          Some(r) => (r, true),
+          None => (factored, false),
+        }
+      } else {
+        (factored, false)
+      };
       // Wolfram never factors a reciprocal INTO a sum factor:
       // Simplify[-4 - 2/x] keeps the split form (never -2*(2 + x^(-1)))
       // and Simplify[(-2-4x)/(5x)] keeps -1/5*(2+4x)/x;
@@ -4985,9 +5001,10 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
           // Wolfram never factors a quotient's DENOMINATOR into a product
           // of distinct factors: Simplify[1/(4x+3x^2)] stays
           // (4x+3x^2)^(-1), not 1/(x(4+3x)). Powers still collapse
-          // (x^2/(1-3x+3x^2-x^3) → -(x^2/(-1+x)^3)).
+          // (x^2/(1-3x+3x^2-x^3) → -(x^2/(-1+x)^3)). The squarefree
+          // redisplay above gates its own denominator.
           leaf_count(&factored) <= best_c
-            && factored_den_acceptable(&best, &factored)
+            && (den_gated || factored_den_acceptable(&best, &factored))
         };
       if accept && !exprs_equal(&factored, &best) {
         // Canonicalize a factored POLYNOMIAL product's factor order
@@ -7701,8 +7718,37 @@ pub(crate) fn simplify_division_impl(
   // (power of a) single factor — Simplify[1/(4x+3x^2)] stays
   // (4x+3x^2)^(-1), never 1/(x(4+3x)) — while quotient numerators factor
   // freely (Simplify[(4x^2-2x)/(2+3x)] → (2x(-1+2x))/(2+3x)).
-  if let Ok(factored) = super::factor::factor_ast(std::slice::from_ref(&basic))
-  {
+  //
+  // Once the SimplifyCount candidate selection has settled the quotient,
+  // the display factoring is FactorSquareFree, not Factor: a squarefree
+  // numerator stays expanded (Simplify[(-4-5x-5x^2-4x^3)/(-2x-3x^2)] →
+  // (4+5x+5x^2+4x^3)/(2x+3x^2), (2+3x+x^2)/(2+3x) keeps its form) while
+  // monomial content and perfect powers still come out ((4x^2-2x)/(2+3x)
+  // → (2x(-1+2x))/(2+3x)); the denominator follows the numerator into
+  // squarefree form when the numerator changed ((1+2x+x^2)/(2x+3x^2) →
+  // (1+x)^2/(x*(2+3x))) or when it collapses to a single factor
+  // (x^2/(1-3x+3x^2-x^3) → -(x^2/(-1+x)^3), but 1/(4x+3x^2) and
+  // Simplify[x/(x-3x^2)] = (1-3x)^(-1) keep their denominators);
+  // wolframscript-verified (differential fuzzer seed 1785082426573174375).
+  let mut settled_display = false;
+  let factored_display = if sign_settled {
+    match super::factor::factor_ast(std::slice::from_ref(&basic)) {
+      Ok(f) => match settled_quotient_factor_display(&basic, &f) {
+        // A "keep the input" decision must fall through to the
+        // numerator-only handling below, not short-circuit as an
+        // accepted no-op.
+        Some(r) => {
+          settled_display = true;
+          if exprs_equal(&r, &basic) { None } else { Some(r) }
+        }
+        None => Some(f),
+      },
+      Err(_) => None,
+    }
+  } else {
+    super::factor::factor_ast(std::slice::from_ref(&basic)).ok()
+  };
+  if let Some(factored) = factored_display {
     let fc = leaf_count(&factored);
     let bc = leaf_count(&basic);
     let num_ok = factor_num || {
@@ -7760,7 +7806,7 @@ pub(crate) fn simplify_division_impl(
     if fc <= bc
       && num_ok
       && !content_only_rewrite
-      && factored_den_acceptable(&basic, &factored)
+      && (settled_display || factored_den_acceptable(&basic, &factored))
     {
       // A factored quotient (den collapsed to a power / real numerator
       // factorization) was never among the candidate-selection forms, so
@@ -7787,6 +7833,23 @@ pub(crate) fn simplify_division_impl(
           super::factor::factor_ast(std::slice::from_ref(&bn))
           && leaf_count(&factored_num) <= leaf_count(&bn)
           && !exprs_equal(&factored_num, &bn)
+          // A settled quotient's numerator never splits into two or more
+          // SUM factors — that is Factor's display, not Simplify's
+          // ((-4-5x-5x^2-4x^3)/(-2x-3x^2) keeps its numerator expanded
+          // instead of becoming ((1+x)*(4+x+4x^2))/…). Monomial/content
+          // extraction with a single sum factor ((4x^2-2x)/(5-5x) →
+          // (2*(1-2x)*x)/(5*(-1+x))) and perfect powers still apply.
+          && !(sign_settled && {
+            super::together::flatten_times_args(std::slice::from_ref(
+              &factored_num,
+            ))
+            .iter()
+            .filter(|f| {
+              super::coefficient::collect_additive_terms(f).len() > 1
+            })
+            .count()
+              >= 2
+          })
         {
           // Once the SimplifyCount candidate selection has settled the
           // quotient's form, a content-only rewrite (Times[c, Plus[…]])
@@ -8850,6 +8913,151 @@ fn finish_quotient_sign(e: Expr, canonicalize_sign: bool) -> Expr {
     return e;
   }
   super::together::extract_quotient_minus(&n, &d).unwrap_or(e)
+}
+
+/// Display decision for a univariate integer-polynomial quotient given
+/// Factor's output, following wolframscript's Simplify (differential
+/// fuzzer seed 1785082426573174375; all cases wolframscript-verified):
+/// - the numerator never splits into two or more SUM factors — a
+///   squarefree sum stays expanded ((2+3x+x^2)/(2+3x) and
+///   (-4-5x-5x^2-4x^3)/(-2x-3x^2) keep their numerators) — while
+///   content/monomial extraction with at most one sum factor and
+///   perfect powers keep Factor's display ((4x^2-2x)/(5-5x) →
+///   (2*(1-2x)*x)/(5*(-1+x)), (1+2x+x^2)/(2x+3x^2) →
+///   (1+x)^2/(x*(2+3x)));
+/// - a rejected numerator still adopts a same-orientation collapsed
+///   denominator ((2+3x+x^2)/(1-2x+x^2) → (2+3x+x^2)/(-1+x)^2);
+/// - a denominator that neither collapses nor accompanies a factored
+///   numerator keeps the input display (1/(4x+3x^2) stays expanded);
+/// - a cancellation leaving a negative constant over a plain
+///   negative-constant-led denominator re-orients the pair
+///   (x/(x-3x^2) → (1-3x)^(-1)).
+/// Returns None when the quotient is not univariate integer-polynomial
+/// (or the input numerator is itself a negative constant) — the caller
+/// keeps its legacy handling of the Factor output.
+fn settled_quotient_factor_display(
+  basic: &Expr,
+  factored: &Expr,
+) -> Option<Expr> {
+  let (fn_, fd) = super::together::extract_num_den(factored);
+  if matches!(&fd, Expr::Integer(1)) {
+    return None;
+  }
+  let mut vars = std::collections::HashSet::new();
+  collect_variables(&fn_, &mut vars);
+  collect_variables(&fd, &mut vars);
+  if vars.len() != 1 {
+    return None;
+  }
+  let var = vars.into_iter().next().unwrap();
+  let fn_e = expand_and_combine(&fn_);
+  let fd_e = expand_and_combine(&fd);
+  let n_c = extract_poly_coeffs(&fn_e, &var)?;
+  let d_c = extract_poly_coeffs(&fd_e, &var)?;
+  let (bn0, bd0) = super::together::extract_num_den(basic);
+  let bn0_e = expand_and_combine(&bn0);
+  let bd0_e = expand_and_combine(&bd0);
+  let bn_c = extract_poly_coeffs(&bn0_e, &var)?;
+  let bd_c = extract_poly_coeffs(&bd0_e, &var)?;
+
+  // A part is "shaped" when Factor gave it structure beyond a plain
+  // sum: a negation wrapper, a multi-factor product, or a power of a
+  // sum. Unshaped parts are only re-orientations of the input.
+  let shaped = |e: &Expr| -> bool {
+    if matches!(
+      e,
+      Expr::UnaryOp {
+        op: UnaryOperator::Minus,
+        ..
+      }
+    ) {
+      return true;
+    }
+    let factors = super::together::flatten_times_args(std::slice::from_ref(e));
+    factors.len() > 1
+      || factors.iter().any(|f| {
+        let power_of_sum_base = |base: &Expr, exp: &Expr| {
+          matches!(exp, Expr::Integer(k) if *k >= 2)
+            && super::coefficient::collect_additive_terms(base).len() > 1
+        };
+        match f {
+          Expr::BinaryOp {
+            op: BinaryOperator::Power,
+            left,
+            right,
+          } => power_of_sum_base(left, right),
+          Expr::FunctionCall { name, args }
+            if name == "Power" && args.len() == 2 =>
+          {
+            power_of_sum_base(&args[0], &args[1])
+          }
+          _ => false,
+        }
+      })
+  };
+  let sum_factor_count = |e: &Expr| {
+    super::together::flatten_times_args(std::slice::from_ref(e))
+      .iter()
+      .filter(|f| super::coefficient::collect_additive_terms(f).len() > 1)
+      .count()
+  };
+
+  // A constant numerator out of Factor (the input numerator cancelled
+  // away, or Factor re-canonicalized a reciprocal's sign).
+  if n_c.len() == 1 {
+    if bn_c.len() == 1 && bn_c[0] < 0 {
+      // The input numerator is itself a negative constant — the legacy
+      // reciprocal handling owns those (-1/(1+x) → -(1+x)^(-1)).
+      return None;
+    }
+    if n_c[0] < 0
+      && !shaped(&fd)
+      && d_c.iter().find(|&&c| c != 0).is_some_and(|&c| c < 0)
+    {
+      let terms: Vec<(i128, i128, i128)> = d_c
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| **c != 0)
+        .map(|(e, c)| (-*c, 1, e as i128))
+        .collect();
+      return Some(Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(Expr::Integer(-n_c[0])),
+        right: Box::new(coeffs_from_terms(&terms, &var)),
+      });
+    }
+    return Some(if factored_den_acceptable(basic, factored) {
+      factored.clone()
+    } else {
+      basic.clone()
+    });
+  }
+
+  if sum_factor_count(&fn_) >= 2 {
+    // The numerator split is rejected; a same-orientation collapsed
+    // denominator still applies over the input numerator.
+    if shaped(&fd)
+      && factored_den_acceptable(basic, factored)
+      && d_c == bd_c
+      && n_c == bn_c
+      && !exprs_equal(&fd, &bd0)
+    {
+      return Some(Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(bn0),
+        right: Box::new(fd),
+      });
+    }
+    return Some(basic.clone());
+  }
+
+  if !shaped(&fn_) && !shaped(&fd) {
+    return Some(basic.clone());
+  }
+  if factored_den_acceptable(basic, factored) || shaped(&fn_) {
+    return Some(factored.clone());
+  }
+  Some(basic.clone())
 }
 
 /// Accept a factored quotient only when its denominator stayed unchanged

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -8561,23 +8561,28 @@ fn simplify_quotient_select(
       } else {
         (1, fd)
       };
-      // Like the unflipped side, the content form only exists for a
-      // primitive part with a constant term; a flipped den divisible by
-      // x splits its x^k out instead — Simplify[(-1-3x)/(2x-2x^2)] →
-      // (1+3x)/(2*(-1+x)*x), never (1+3x)/(2*(-x+x^2))
-      // (wolframscript-verified).
+      // Like the unflipped side, a flipped den divisible by x offers the
+      // x^k-split variant, competing by cost with the plain flipped
+      // display — Simplify[(-1-3x)/(2x-2x^2)] → (1+3x)/(2*(-1+x)*x)
+      // (split wins) but (-4-5x-5x^2-4x^3)/(-2x-3x^2) →
+      // (4+5x+5x^2+4x^3)/(2x+3x^2) (plain wins); the content-only form
+      // ((1+3x)/(2*(-x+x^2))) is never a Wolfram display, so a
+      // content-carrying fd with no constant term only competes split
+      // (all wolframscript-verified).
       let fd_min_exp = fdt.iter().map(|&(_, _, e)| e).min().unwrap_or(0);
-      let (fd_mono, fdt) = if fd_min_exp >= 1 {
-        (
+      let mut den_variants: Vec<(i128, Vec<(i128, i128, i128)>)> = Vec::new();
+      if fd_min_exp == 0 || fdc == 1 {
+        den_variants.push((0, fdt.clone()));
+      }
+      if fd_min_exp >= 1 {
+        den_variants.push((
           fd_min_exp,
           fdt
             .iter()
             .map(|&(n, d, e)| (n, d, e - fd_min_exp))
             .collect::<Vec<_>>(),
-        )
-      } else {
-        (0, fdt)
-      };
+        ));
+      }
       let mut flip_opts: Vec<(i128, Vec<(i128, i128, i128)>)> = Vec::new();
       if fn_terms.len() > 1 && fn_content.abs() > 1 {
         flip_opts.push((fn_content, scale(&fn_terms, fn_content)));
@@ -8585,23 +8590,25 @@ fn simplify_quotient_select(
       flip_opts.push((1, fn_terms));
       for (nc, nt) in flip_opts {
         let (coeff_n, coeff_d) = rat_reduce(nc, fdc);
-        cands.push(Cand {
-          cost: sc_quotient(
-            (coeff_n, coeff_d),
-            &nt,
-            Some(&fdt),
-            (fd_mono > 0).then_some(fd_mono),
-          ),
-          class: 3,
-          minus_pull: false,
-          num_content: nc,
-          num_terms: nt,
-          den_content: fdc,
-          den_terms: fdt.clone(),
-          den_mono: fd_mono,
-          split: false,
-          terminal: false,
-        });
+        for (fd_mono, fdt) in &den_variants {
+          cands.push(Cand {
+            cost: sc_quotient(
+              (coeff_n, coeff_d),
+              &nt,
+              Some(fdt),
+              (*fd_mono > 0).then_some(*fd_mono),
+            ),
+            class: 3,
+            minus_pull: false,
+            num_content: nc,
+            num_terms: nt.clone(),
+            den_content: fdc,
+            den_terms: fdt.clone(),
+            den_mono: *fd_mono,
+            split: false,
+            terminal: false,
+          });
+        }
       }
     } else {
       if n_terms.first().map(|&(n, _, _)| n < 0).unwrap_or(false) {

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -4946,14 +4946,42 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
     // For a top-level sum the negative-count tie-break applies (keep
     // `3 - 3x` over `-3*(-1 + x)`); other shapes (fractions, lists)
     // keep the plain leaf-count preference for factored forms.
-    let is_sum = matches!(&best, Expr::FunctionCall { name, .. } if name == "Plus")
-      || matches!(
-        &best,
-        Expr::BinaryOp {
-          op: BinaryOperator::Plus | BinaryOperator::Minus,
-          ..
+    let is_sum_shape = |e: &Expr| {
+      matches!(e, Expr::FunctionCall { name, .. } if name == "Plus")
+        || matches!(
+          e,
+          Expr::BinaryOp {
+            op: BinaryOperator::Plus | BinaryOperator::Minus,
+            ..
+          }
+        )
+    };
+    let is_sum = is_sum_shape(&best);
+    // A numeric content times a polynomial sum — simplify_expr's
+    // content-extracted form of a sum, e.g. -2*(-x + x^3) — follows the
+    // SUM rules below: the square-free candidate must compete
+    // (Simplify[2x - 2x^3] → -2*x*(-1 + x^2), wolframscript-verified)
+    // while the full Factor split -2*(-1+x)*x*(1+x) must not.
+    let content_sum = !is_sum && {
+      let numeric_lit = |e: &Expr| {
+        matches!(e, Expr::Integer(_))
+          || matches!(e, Expr::FunctionCall { name, .. } if name == "Rational")
+      };
+      match &best {
+        Expr::FunctionCall { name, args }
+          if name == "Times" && args.len() == 2 =>
+        {
+          numeric_lit(&args[0]) && is_sum_shape(&args[1])
         }
-      );
+        Expr::BinaryOp {
+          op: BinaryOperator::Times,
+          left,
+          right,
+        } => numeric_lit(left) && is_sum_shape(right),
+        _ => false,
+      }
+    };
+    let is_sum = is_sum || content_sum;
     // The square-free rule is decoded for POLYNOMIAL sums; sums carrying
     // other functions (trig etc.) keep the full Factor candidate, whose
     // numeric-content extraction the pipeline relies on.
@@ -9561,8 +9589,85 @@ fn leaf_count(expr: &Expr) -> usize {
 /// `Log[1048576]` is considered *more* complex than `20*Log[2]` even though it
 /// has fewer nodes. Used to decide whether folding `c*Log[n]` → `Log[n^c]`
 /// actually simplifies.
+///
+/// The count follows Wolfram's FullForm tree, not woxi's display tree:
+/// Times/Plus chains count ONE head however the display nests them, `-x`
+/// counts as `Times[-1, x]` (3 nodes), and `a - b` as
+/// `Plus[a, Times[-1, b]]`. Counting display shapes literally rated
+/// `-2*(-x + x^3)` (8) below `-2*x*(-1 + x^2)` (9) where Wolfram's
+/// FullForm has them 9 and 8, so Simplify picked the wrong form
+/// (differential fuzzer, seed 1785246333519574598).
 fn complexity_digits(expr: &Expr) -> usize {
-  let digits = |s: String| s.trim_start_matches('-').len().max(1);
+  fn digits(s: String) -> usize {
+    s.trim_start_matches('-').len().max(1)
+  }
+  fn is_number(e: &Expr) -> bool {
+    matches!(e, Expr::Integer(_) | Expr::BigInteger(_) | Expr::Real(_))
+  }
+  /// Cost of `e` inside an enclosing Times' flat factor list (no
+  /// additional Times head of its own).
+  fn times_factor_cost(e: &Expr) -> usize {
+    match e {
+      Expr::FunctionCall { name, args } if name == "Times" => {
+        args.iter().map(times_factor_cost).sum()
+      }
+      Expr::BinaryOp {
+        op: BinaryOperator::Times,
+        left,
+        right,
+      } => times_factor_cost(left) + times_factor_cost(right),
+      Expr::UnaryOp {
+        op: UnaryOperator::Minus,
+        operand,
+      } => {
+        if is_number(operand) {
+          // A negative literal factor: the sign folds into the number.
+          complexity_digits(operand)
+        } else {
+          // The -1 joins the enclosing factor list as one extra leaf.
+          1 + times_factor_cost(operand)
+        }
+      }
+      other => complexity_digits(other),
+    }
+  }
+  /// Cost of `e` inside an enclosing Plus' flat term list. `negated`
+  /// accounts for a leading minus from `a - b` / `-x` display forms.
+  fn plus_term_cost(e: &Expr, negated: bool) -> usize {
+    match e {
+      Expr::FunctionCall { name, args } if name == "Plus" && !negated => {
+        args.iter().map(|t| plus_term_cost(t, false)).sum()
+      }
+      Expr::BinaryOp {
+        op: BinaryOperator::Plus,
+        left,
+        right,
+      } if !negated => {
+        plus_term_cost(left, false) + plus_term_cost(right, false)
+      }
+      Expr::BinaryOp {
+        op: BinaryOperator::Minus,
+        left,
+        right,
+      } if !negated => plus_term_cost(left, false) + plus_term_cost(right, true),
+      Expr::UnaryOp {
+        op: UnaryOperator::Minus,
+        operand,
+      } => plus_term_cost(operand, !negated),
+      _ if !negated => complexity_digits(e),
+      _ if is_number(e) => complexity_digits(e),
+      // A negated product keeps its Times head; the -1 is one more leaf.
+      Expr::FunctionCall { name, .. } if name == "Times" => {
+        1 + complexity_digits(e)
+      }
+      Expr::BinaryOp {
+        op: BinaryOperator::Times,
+        ..
+      } => 1 + complexity_digits(e),
+      // Anything else gains the full Times[-1, …] wrapper.
+      _ => 2 + complexity_digits(e),
+    }
+  }
   match expr {
     Expr::Integer(n) => digits(n.to_string()),
     Expr::BigInteger(n) => digits(n.to_string()),
@@ -9570,6 +9675,39 @@ fn complexity_digits(expr: &Expr) -> usize {
     | Expr::String(_)
     | Expr::Constant(_)
     | Expr::Identifier(_) => 1,
+    Expr::FunctionCall { name, args } if name == "Times" => {
+      1 + args.iter().map(times_factor_cost).sum::<usize>()
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Times,
+      left,
+      right,
+    } => 1 + times_factor_cost(left) + times_factor_cost(right),
+    Expr::FunctionCall { name, args } if name == "Plus" => {
+      1 + args.iter().map(|t| plus_term_cost(t, false)).sum::<usize>()
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Plus,
+      left,
+      right,
+    } => 1 + plus_term_cost(left, false) + plus_term_cost(right, false),
+    Expr::BinaryOp {
+      op: BinaryOperator::Minus,
+      left,
+      right,
+    } => 1 + plus_term_cost(left, false) + plus_term_cost(right, true),
+    Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      operand,
+    } => {
+      if is_number(operand) {
+        complexity_digits(operand)
+      } else {
+        // Times[-1, …]: a Times head, the -1 leaf, and the operand's
+        // factors flattened into that head.
+        2 + times_factor_cost(operand)
+      }
+    }
     Expr::BinaryOp { left, right, .. } => {
       1 + complexity_digits(left) + complexity_digits(right)
     }

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -9054,6 +9054,7 @@ fn finish_quotient_sign(e: Expr, canonicalize_sign: bool) -> Expr {
 /// - a cancellation leaving a negative constant over a plain
 ///   negative-constant-led denominator re-orients the pair
 ///   (x/(x-3x^2) → (1-3x)^(-1)).
+///
 /// Returns None when the quotient is not univariate integer-polynomial
 /// (or the input numerator is itself a negative constant) — the caller
 /// keeps its legacy handling of the Factor output.

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -1769,6 +1769,31 @@ pub fn together_expr(expr: &Expr) -> Expr {
           return cancelled;
         }
       }
+      // A FACTORED denominator (e.g. the preprocessed -2*(-x + x^3), or
+      // x*(-1 + x^2)) can still share a polynomial factor with the
+      // numerator that string-level factor matching can't see —
+      // (1+x)*(1+3x) over 2x - 2x^3 shares 1+x. wolframscript's Together
+      // always divides out the polynomial GCD:
+      // Together[((1+x)*(1+3x))/(2x - 2x^3)] → (-1 - 3*x)/(2*(-1 + x)*x).
+      // Only a non-trivial (degree ≥ 1) GCD triggers the rewrite, so
+      // factored quotients with nothing to cancel keep their form
+      // ((5*x*(1+x))/((1-x)*(2+x)) stays put).
+      if !is_plus_polynomial(&ed)
+        && single_variable_fraction(&en, &ed)
+        && fraction_has_polynomial_gcd(&en, &ed)
+      {
+        let frac = Expr::BinaryOp {
+          op: BinaryOperator::Divide,
+          left: Box::new(en.clone()),
+          right: Box::new(
+            crate::functions::polynomial_ast::expand::expand_and_combine(&ed),
+          ),
+        };
+        let cancelled = super::cancel::cancel_expr_keep_quotient_sign(&frac);
+        if expr_to_string(&cancelled) != expr_to_string(&frac) {
+          return cancelled;
+        }
+      }
       // A numeric-content wrapper on the denominator (x/(4*(x^2 + x^3)),
       // the canonical form of x/(4*x^2 + 4*x^3)) hides the polynomial from
       // the GCD cancellation above. Expand the content back through and
@@ -2027,6 +2052,28 @@ pub fn together_expr(expr: &Expr) -> Expr {
         return cancelled;
       }
     }
+    // A FACTORED single-variable denominator can still share a polynomial
+    // factor with the numerator ((1+x)*(1+3x) over 2*x*(-1+x^2) shares
+    // 1+x — string-level factor matching can't see it). wolframscript's
+    // Together always divides out the polynomial GCD:
+    // Together[((1+x)*(1+3x))/(2x - 2x^3)] → (-1 - 3*x)/(2*(-1 + x)*x).
+    // Only a non-trivial (degree ≥ 1) GCD triggers the rewrite, so
+    // factored quotients with nothing to cancel keep their form
+    // ((5*x*(1+x))/((1-x)*(2+x)) stays put).
+    if !is_plus_polynomial(&simplified_den)
+      && single_variable_fraction(&simplified_num, &simplified_den)
+      && fraction_has_polynomial_gcd(&simplified_num, &simplified_den)
+    {
+      let frac = Expr::BinaryOp {
+        op: BinaryOperator::Divide,
+        left: Box::new(simplified_num.clone()),
+        right: Box::new(simplified_den.clone()),
+      };
+      let cancelled = super::cancel::cancel_expr_keep_quotient_sign(&frac);
+      if expr_to_string(&cancelled) != expr_to_string(&frac) {
+        return cancelled;
+      }
+    }
     if matches!(&simplified_den, Expr::Integer(1)) {
       simplified_num
     } else {
@@ -2080,6 +2127,29 @@ fn expand_numeric_content_denominator(den: &Expr) -> Option<Expr> {
     Expr::Integer(int_content),
     plus,
   ])))
+}
+
+/// True when expanded `num` and `den` are univariate integer-coefficient
+/// polynomials in the same variable with a non-trivial (degree ≥ 1)
+/// polynomial GCD — the cases where wolframscript's Together cancels even
+/// a factored denominator. Integer-content-only GCDs don't count (they
+/// are handled by the content reductions).
+fn fraction_has_polynomial_gcd(num: &Expr, den: &Expr) -> bool {
+  let Some(var) = super::cancel::find_single_variable_both(num, den) else {
+    return false;
+  };
+  let n = crate::functions::polynomial_ast::expand::expand_and_combine(num);
+  let d = crate::functions::polynomial_ast::expand::expand_and_combine(den);
+  let (Some(cn), Some(cd)) = (
+    super::simplify::extract_poly_coeffs(&n, &var),
+    super::simplify::extract_poly_coeffs(&d, &var),
+  ) else {
+    return false;
+  };
+  match super::cancel::poly_gcd(&cn, &cd) {
+    Some(g) => g.iter().rposition(|&c| c != 0).unwrap_or(0) >= 1,
+    None => false,
+  }
 }
 
 /// True when `num`/`den` together involve exactly one symbolic variable, the

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -623,15 +623,9 @@ mod simplify {
     assert_eq!(interpret("Simplify[3 - 3*x]").unwrap(), "3 - 3*x");
     assert_eq!(interpret("Simplify[9 - 9*x]").unwrap(), "9 - 9*x");
     // … and the fully factored linear split still wins where it should.
-    assert_eq!(
-      interpret("Simplify[2*x - 2*x^2]").unwrap(),
-      "-2*(-1 + x)*x"
-    );
+    assert_eq!(interpret("Simplify[2*x - 2*x^2]").unwrap(), "-2*(-1 + x)*x");
     assert_eq!(interpret("Simplify[-2*x - 2]").unwrap(), "-2*(1 + x)");
-    assert_eq!(
-      interpret("Simplify[100 - 100*x]").unwrap(),
-      "-100*(-1 + x)"
-    );
+    assert_eq!(interpret("Simplify[100 - 100*x]").unwrap(), "-100*(-1 + x)");
   }
 
   // A rational function whose numerator and denominator share a
@@ -3402,8 +3396,7 @@ mod apart {
     );
     // The full fuzzer case.
     assert_eq!(
-      interpret("Pi + Divide[Plus[14, -73], Plus[Pi, Divide[9, 2]]]")
-        .unwrap(),
+      interpret("Pi + Divide[Plus[14, -73], Plus[Pi, Divide[9, 2]]]").unwrap(),
       "Pi - 59/(9/2 + Pi)"
     );
   }
@@ -16046,10 +16039,7 @@ mod fuzz_diff_round_2026_07_26 {
       "(1 - 3*x)^(-1)",
     );
     // Sign handling around the squarefree display is unchanged.
-    assert_case(
-      "Simplify[x^2/(1 - 3*x + 3*x^2 - x^3)]",
-      "-(x^2/(-1 + x)^3)",
-    );
+    assert_case("Simplify[x^2/(1 - 3*x + 3*x^2 - x^3)]", "-(x^2/(-1 + x)^3)");
     assert_case("Simplify[1/(1 - 3*x + 3*x^2 - x^3)]", "-(-1 + x)^(-3)");
     assert_case("Simplify[-1/(2 - 4*x)]", "(-2 + 4*x)^(-1)");
     assert_case(

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -592,6 +592,60 @@ mod simplify {
     assert_eq!(interpret("Simplify[x + x]").unwrap(), "2*x");
   }
 
+  // Simplify prefers the square-free factored form when its FullForm node
+  // count wins: -2*x*(-1 + x^2) is 8 nodes vs 9 for 2*x - 2*x^3 and for
+  // -2*(-x + x^3). The count follows Wolfram's FullForm (Times/Plus
+  // chains flat, -x as Times[-1, x]), not the display tree
+  // (differential fuzzer, seed 1785246333519574598;
+  // all wolframscript-verified).
+  #[test]
+  fn square_free_factored_form_wins_on_node_count() {
+    assert_eq!(
+      interpret("Simplify[2*x - 2*x^3]").unwrap(),
+      "-2*x*(-1 + x^2)"
+    );
+    assert_eq!(
+      interpret("Simplify[3*x - 3*x^3]").unwrap(),
+      "-3*x*(-1 + x^2)"
+    );
+    assert_eq!(
+      interpret("Simplify[6*x - 6*x^3]").unwrap(),
+      "-6*x*(-1 + x^2)"
+    );
+    assert_eq!(
+      interpret("Simplify[3*x^2 - 3*x^4]").unwrap(),
+      "-3*x^2*(-1 + x^2)"
+    );
+    // The content-only extraction stays when it is cheaper …
+    assert_eq!(interpret("Simplify[2*x + 2*x^3]").unwrap(), "2*(x + x^3)");
+    // … the plain sum stays when everything else is more complex …
+    assert_eq!(interpret("Simplify[x - x^3]").unwrap(), "x - x^3");
+    assert_eq!(interpret("Simplify[3 - 3*x]").unwrap(), "3 - 3*x");
+    assert_eq!(interpret("Simplify[9 - 9*x]").unwrap(), "9 - 9*x");
+    // … and the fully factored linear split still wins where it should.
+    assert_eq!(
+      interpret("Simplify[2*x - 2*x^2]").unwrap(),
+      "-2*(-1 + x)*x"
+    );
+    assert_eq!(interpret("Simplify[-2*x - 2]").unwrap(), "-2*(1 + x)");
+    assert_eq!(
+      interpret("Simplify[100 - 100*x]").unwrap(),
+      "-100*(-1 + x)"
+    );
+  }
+
+  // A rational function whose numerator and denominator share a
+  // polynomial factor cancels it, and the surviving denominator is
+  // displayed expanded (differential fuzzer, seed 1785246333519574598;
+  // wolframscript-verified).
+  #[test]
+  fn rational_function_cancels_shared_factor() {
+    assert_eq!(
+      interpret("Simplify[(1 + 4*x + 3*x^2)/(2*x - 2*x^3)]").unwrap(),
+      "(1 + 3*x)/(2*x - 2*x^2)"
+    );
+  }
+
   // On a SimplifyCount tie the sign-only -(…) pull beats the numeric
   // content extraction (both count 16), while a strict win keeps the
   // extraction; wolframscript-verified (differential fuzzer, seed
@@ -2513,6 +2567,29 @@ mod together {
     assert_eq!(interpret("Together[1/x + 1/y]").unwrap(), "(x + y)/(x*y)");
   }
 
+  // Together divides out the polynomial GCD even when the denominator is
+  // held in factored/content-extracted form, where string-level factor
+  // matching can't see the shared factor ((1+x) divides -1+x^2). A
+  // quotient with nothing to cancel keeps its factored form. All
+  // wolframscript-verified (differential fuzzer, seed
+  // 1785246333519574598).
+  #[test]
+  fn together_cancels_gcd_behind_factored_denominator() {
+    assert_eq!(
+      interpret("Together[((1 + x)*(1 + 3*x))/(2*x - 2*x^3)]").unwrap(),
+      "(-1 - 3*x)/(2*(-1 + x)*x)"
+    );
+    assert_eq!(
+      interpret("Together[(1 + 4*x + 3*x^2)/(2*x - 2*x^3)]").unwrap(),
+      "(-1 - 3*x)/(2*(-1 + x)*x)"
+    );
+    // No shared polynomial factor: the factored quotient stays put.
+    assert_eq!(
+      interpret("Together[(5*x*(1 + x))/((1 - x)*(2 + x))]").unwrap(),
+      "(-5*x*(1 + x))/((-1 + x)*(2 + x))"
+    );
+  }
+
   // A negative numeric factor produced by denominator factoring flips
   // out of the quotient: sum numerators negate termwise with the content
   // staying in the denominator; monomial/unit numerators get a rational
@@ -3219,6 +3296,61 @@ mod apart {
     assert_eq!(
       interpret("1/x + 1/(1 + x)").unwrap(),
       "x^(-1) + (1 + x)^(-1)"
+    );
+  }
+
+  // Named constants (Pi, E, …) order exactly like symbols in the
+  // reciprocal-of-sum rule, and base polynomials may carry rational
+  // coefficients (differential fuzzer, seed 1785246333519574598:
+  // Pi - 59/(9/2 + Pi) put Pi last). All wolframscript-verified.
+  #[test]
+  fn sum_reciprocal_term_order_constants_and_rationals() {
+    assert_eq!(interpret("Pi + 1/(1 + Pi)").unwrap(), "Pi + (1 + Pi)^(-1)");
+    assert_eq!(interpret("E + 1/(1 + E)").unwrap(), "E + (1 + E)^(-1)");
+    assert_eq!(
+      interpret("Pi + 1/(-1 + Pi)").unwrap(),
+      "(-1 + Pi)^(-1) + Pi"
+    );
+    assert_eq!(
+      interpret("Pi + 1/(1 - 2 Pi)").unwrap(),
+      "(1 - 2*Pi)^(-1) + Pi"
+    );
+    assert_eq!(interpret("Pi + 2/(-1 + Pi)").unwrap(), "2/(-1 + Pi) + Pi");
+    assert_eq!(
+      interpret("Pi^2 + 1/(1 + Pi)").unwrap(),
+      "Pi^2 + (1 + Pi)^(-1)"
+    );
+    assert_eq!(
+      interpret("Pi + 1/(1 + Pi^2)").unwrap(),
+      "Pi + (1 + Pi^2)^(-1)"
+    );
+    // Mixed variables fall back to the general rules unchanged.
+    assert_eq!(interpret("Pi + 1/(1 + x)").unwrap(), "Pi + (1 + x)^(-1)");
+    assert_eq!(interpret("x + 1/(1 + Pi)").unwrap(), "(1 + Pi)^(-1) + x");
+    // Rational coefficients in the base compare by value.
+    assert_eq!(
+      interpret("Pi + 1/(9/2 + Pi)").unwrap(),
+      "Pi + (9/2 + Pi)^(-1)"
+    );
+    assert_eq!(interpret("x + 1/(9/2 + x)").unwrap(), "x + (9/2 + x)^(-1)");
+    assert_eq!(
+      interpret("x + 1/(-1/2 + x)").unwrap(),
+      "(-1/2 + x)^(-1) + x"
+    );
+    assert_eq!(interpret("x + 1/(1/2 - x)").unwrap(), "(1/2 - x)^(-1) + x");
+    assert_eq!(
+      interpret("x + 1/(3/2 + 2 x)").unwrap(),
+      "x + (3/2 + 2*x)^(-1)"
+    );
+    assert_eq!(
+      interpret("x^2 + 2/(-1/2 + x)").unwrap(),
+      "2/(-1/2 + x) + x^2"
+    );
+    // The full fuzzer case.
+    assert_eq!(
+      interpret("Pi + Divide[Plus[14, -73], Plus[Pi, Divide[9, 2]]]")
+        .unwrap(),
+      "Pi - 59/(9/2 + Pi)"
     );
   }
 

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -646,6 +646,60 @@ mod simplify {
     );
   }
 
+  // Quotient displays around sign normalization and factored
+  // denominators, all wolframscript-verified (differential fuzzer, seed
+  // 1785246333519574598 follow-up):
+  // - an already-canonical quotient is a fixed point, keeping even a
+  //   factored denominator verbatim;
+  // - a negative-content numerator flips both parts, the rebuilt
+  //   denominator showing expanded when its leading coefficient ends up
+  //   negative and in x^k-split form when positive;
+  // - integer content never extracts from a denominator divisible by x
+  //   ((1+3x)/(2*(-x+x^2)) is not a Wolfram display).
+  #[test]
+  fn quotient_sign_normalization_displays() {
+    assert_eq!(
+      interpret("Simplify[(1 + 3*x)/(2*(-1 + x)*x)]").unwrap(),
+      "(1 + 3*x)/(2*(-1 + x)*x)"
+    );
+    assert_eq!(
+      interpret("Simplify[(2 + x)/((-1 + x)*x)]").unwrap(),
+      "(2 + x)/((-1 + x)*x)"
+    );
+    assert_eq!(
+      interpret("Simplify[(1 + 3*x)/(2*x - 2*x^2)]").unwrap(),
+      "(1 + 3*x)/(2*x - 2*x^2)"
+    );
+    assert_eq!(
+      interpret("Simplify[(1 + 3*x)/(2*x^2 - 2*x)]").unwrap(),
+      "(1 + 3*x)/(-2*x + 2*x^2)"
+    );
+    assert_eq!(
+      interpret("Simplify[(-1 - 3*x)/(2*x^2 - 2*x)]").unwrap(),
+      "(1 + 3*x)/(2*x - 2*x^2)"
+    );
+    assert_eq!(
+      interpret("Simplify[(-1 - 3*x)/(2*(-1 + x)*x)]").unwrap(),
+      "(1 + 3*x)/(2*x - 2*x^2)"
+    );
+    assert_eq!(
+      interpret("Simplify[(-1 - 3*x)/(2*x - 2*x^2)]").unwrap(),
+      "(1 + 3*x)/(2*(-1 + x)*x)"
+    );
+    assert_eq!(
+      interpret("Simplify[(5*x)/((1 - x)*(2 + x))]").unwrap(),
+      "(-5*x)/(-2 + x + x^2)"
+    );
+    assert_eq!(
+      interpret("Simplify[(1 + x)/((1 - x)*(2 + x))]").unwrap(),
+      "-((1 + x)/(-2 + x + x^2))"
+    );
+    assert_eq!(
+      interpret("Simplify[1/(x^2*(-3 + 5*x))]").unwrap(),
+      "1/(x^2*(-3 + 5*x))"
+    );
+  }
+
   // On a SimplifyCount tie the sign-only -(…) pull beats the numeric
   // content extraction (both count 16), while a strict win keeps the
   // extraction; wolframscript-verified (differential fuzzer, seed

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -15816,3 +15816,59 @@ mod refine_bounded_variables {
     );
   }
 }
+
+mod fuzz_diff_round_2026_07_26 {
+  use super::super::case_helpers::assert_case;
+
+  // Simplify displays a univariate polynomial quotient's parts in
+  // FactorSquareFree form, never fully factored: a squarefree numerator
+  // stays expanded even when the factored form has a lower SimplifyCount
+  // (case seed 13512828096256521534; wolframscript-verified).
+  #[test]
+  fn simplify_squarefree_quotient_numerator_stays_expanded() {
+    assert_case(
+      "Simplify[Divide[Plus[-4, Times[-5, x], Times[-5, Power[x, 2]], Times[-4, Power[x, 3]]], Plus[0, Times[-2, x], Times[-3, Power[x, 2]]]]]",
+      "(4 + 5*x + 5*x^2 + 4*x^3)/(2*x + 3*x^2)",
+    );
+    assert_case(
+      "Simplify[(-4 - 5*x - 5*x^2 - 4*x^3)/(2*x + 3*x^2)]",
+      "-((4 + 5*x + 5*x^2 + 4*x^3)/(2*x + 3*x^2))",
+    );
+    assert_case(
+      "Simplify[(2 + 3*x + x^2)/(2 + 3*x)]",
+      "(2 + 3*x + x^2)/(2 + 3*x)",
+    );
+    assert_case(
+      "Simplify[(2 + 3*x + x^2)/(1 - 2*x + x^2)]",
+      "(2 + 3*x + x^2)/(-1 + x)^2",
+    );
+    // Monomial content and perfect powers still come out, and the
+    // denominator follows into squarefree form when the numerator
+    // changed.
+    assert_case(
+      "Simplify[(4*x^2 - 2*x)/(2 + 3*x)]",
+      "(2*x*(-1 + 2*x))/(2 + 3*x)",
+    );
+    assert_case(
+      "Simplify[(1 + 2*x + x^2)/(2*x + 3*x^2)]",
+      "(1 + x)^2/(x*(2 + 3*x))",
+    );
+    // Full cancellation keeps the reduced pair's own orientation:
+    // x/(x*(1-3x)) leaves a positive constant numerator.
+    assert_case(
+      "Simplify[Divide[x, Plus[0, x, Times[-3, Power[x, 2]]]]]",
+      "(1 - 3*x)^(-1)",
+    );
+    // Sign handling around the squarefree display is unchanged.
+    assert_case(
+      "Simplify[x^2/(1 - 3*x + 3*x^2 - x^3)]",
+      "-(x^2/(-1 + x)^3)",
+    );
+    assert_case("Simplify[1/(1 - 3*x + 3*x^2 - x^3)]", "-(-1 + x)^(-3)");
+    assert_case("Simplify[-1/(2 - 4*x)]", "(-2 + 4*x)^(-1)");
+    assert_case(
+      "Simplify[(2 + 3*x + x^2)/(4 + 5*x + 5*x^2 + 4*x^3)]",
+      "(2 + x)/(4 + x + 4*x^2)",
+    );
+  }
+}

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -341,6 +341,40 @@ mod arithmetic {
       assert_eq!(interpret("D[Sin[x]^2, x]").unwrap(), "2*Cos[x]*Sin[x]");
     }
 
+    // A variable-power factor against a univariate polynomial sum in the
+    // same variable compares by coefficient vector, the power flattening
+    // to plain-x coefficients [0, 1] whatever its exponent: degree
+    // ascending, then coefficients from the leading term down, a full
+    // tie keeping the factor first. All wolframscript-verified
+    // (differential fuzzer, seed 1785246333519574598 follow-up).
+    #[test]
+    fn var_power_vs_univar_sum_orders_by_coefficients() {
+      assert_eq!(interpret("x^2*(1 + x)").unwrap(), "x^2*(1 + x)");
+      assert_eq!(interpret("x^2*(2 + x)").unwrap(), "x^2*(2 + x)");
+      assert_eq!(interpret("x^2*(1/2 + x)").unwrap(), "x^2*(1/2 + x)");
+      assert_eq!(interpret("x^2*(-1 + 2*x)").unwrap(), "x^2*(-1 + 2*x)");
+      assert_eq!(interpret("x^3*(-1 + x^2)").unwrap(), "x^3*(-1 + x^2)");
+      assert_eq!(interpret("x^2*(-1 + x^2)").unwrap(), "x^2*(-1 + x^2)");
+      assert_eq!(interpret("x^2*(-1 + x - x^2)").unwrap(), "x^2*(-1 + x - x^2)");
+      assert_eq!(interpret("Pi^2*(-1 + Pi^2)").unwrap(), "Pi^2*(-1 + Pi^2)");
+      assert_eq!(
+        interpret("x^2*y*(-1 + x^2)").unwrap(),
+        "x^2*(-1 + x^2)*y"
+      );
+      assert_eq!(
+        interpret("x^2*(-1 + x^2)*(1 + x^2)").unwrap(),
+        "x^2*(-1 + x^2)*(1 + x^2)"
+      );
+      // Negative constants / leading coefficients pull the sum forward.
+      assert_eq!(interpret("x^2*(-1 + x)").unwrap(), "(-1 + x)*x^2");
+      assert_eq!(interpret("x^2*(-2 + x)").unwrap(), "(-2 + x)*x^2");
+      assert_eq!(interpret("x^2*(-1/2 + x)").unwrap(), "(-1/2 + x)*x^2");
+      assert_eq!(interpret("x^3*(-1 + x)").unwrap(), "(-1 + x)*x^3");
+      // Bare x keeps its existing behaviour.
+      assert_eq!(interpret("x*(1 + x)").unwrap(), "x*(1 + x)");
+      assert_eq!(interpret("x*(-1 + x^2)").unwrap(), "x*(-1 + x^2)");
+    }
+
     // When two reciprocal factors share the same sort key (e.g. y vs (x-y)),
     // the additive base sorts FIRST when it contains the negation of the
     // bare identifier — matching Wolfram. Regression for `Apart` output.

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -355,12 +355,12 @@ mod arithmetic {
       assert_eq!(interpret("x^2*(-1 + 2*x)").unwrap(), "x^2*(-1 + 2*x)");
       assert_eq!(interpret("x^3*(-1 + x^2)").unwrap(), "x^3*(-1 + x^2)");
       assert_eq!(interpret("x^2*(-1 + x^2)").unwrap(), "x^2*(-1 + x^2)");
-      assert_eq!(interpret("x^2*(-1 + x - x^2)").unwrap(), "x^2*(-1 + x - x^2)");
-      assert_eq!(interpret("Pi^2*(-1 + Pi^2)").unwrap(), "Pi^2*(-1 + Pi^2)");
       assert_eq!(
-        interpret("x^2*y*(-1 + x^2)").unwrap(),
-        "x^2*(-1 + x^2)*y"
+        interpret("x^2*(-1 + x - x^2)").unwrap(),
+        "x^2*(-1 + x - x^2)"
       );
+      assert_eq!(interpret("Pi^2*(-1 + Pi^2)").unwrap(), "Pi^2*(-1 + Pi^2)");
+      assert_eq!(interpret("x^2*y*(-1 + x^2)").unwrap(), "x^2*(-1 + x^2)*y");
       assert_eq!(
         interpret("x^2*(-1 + x^2)*(1 + x^2)").unwrap(),
         "x^2*(-1 + x^2)*(1 + x^2)"
@@ -10087,10 +10087,7 @@ mod bigfloat_trig {
         "17.33703703703704"
       );
       // The rational tail sums exactly to 1.
-      assert_eq!(
-        interpret("Plus[0.1, 1/3, 1/3, 1/3]").unwrap(),
-        "1.1"
-      );
+      assert_eq!(interpret("Plus[0.1, 1/3, 1/3, 1/3]").unwrap(), "1.1");
       // But exact terms in separate subtrees still convert individually.
       assert_eq!(
         interpret("Plus[22, -59, 34, 14.6]").unwrap(),

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -9889,6 +9889,182 @@ mod bigfloat_trig {
     );
     assert!(r.contains("`30.192402324441726"), "precision tag: {r}");
   }
+
+  // Machine-real base with an exact Integer exponent: wolframscript computes
+  // these by multiplication chains, not libm pow, and the two can differ in
+  // the last ULP. Every expected value below is wolframscript's exact output.
+  mod real_integer_power_chains {
+    use super::*;
+
+    #[test]
+    fn negative_exponent_uses_reciprocal_of_positive_power() {
+      // libm pow gives 0.017834349827242368 — one ULP off. Found by
+      // differential fuzzing (make fuzz-diff).
+      assert_eq!(
+        interpret("7.488095238095239^-2").unwrap(),
+        "0.01783434982724237"
+      );
+      assert_eq!(
+        interpret(
+          "Power[Plus[Times[Divide[-5, 4], Times[-13, Divide[1, 7]]], \
+           Subtract[Divide[7, 6], -4.0]], -2]"
+        )
+        .unwrap(),
+        "0.01783434982724237"
+      );
+    }
+
+    #[test]
+    fn small_exponent_chain_table() {
+      // n < 16 uses a fixed chain table (x^6 = ((x·x²))² here, not pow).
+      assert_eq!(
+        interpret("12.23936521647462^6").unwrap(),
+        "3.3616567340954533*^6"
+      );
+      assert_eq!(
+        interpret("8.6806365087523^6").unwrap(),
+        "427867.62481567793"
+      );
+      assert_eq!(interpret("1.855199^14").unwrap(), "5720.935105931365");
+      assert_eq!(interpret("1.855199^15").unwrap(), "10613.473087588762");
+    }
+
+    #[test]
+    fn real_typed_exponent_still_uses_libm_pow() {
+      // A Real exponent (even integer-valued) goes through libm pow in
+      // wolframscript — note the different last digit vs the `^6` case.
+      assert_eq!(
+        interpret("12.23936521647462^6.").unwrap(),
+        "3.3616567340954538*^6"
+      );
+    }
+
+    #[test]
+    fn medium_exponent_radix4_digit_peeling() {
+      // 16 <= |n| < 32 peels base-4 digits (x^-13 = 1/(x·(x²·x⁴)²)).
+      assert_eq!(
+        interpret("23.138004741^-13").unwrap(),
+        "1.8355373479186956*^-18"
+      );
+    }
+
+    #[test]
+    fn large_exponent_alternating_binary_and_radix4() {
+      assert_eq!(interpret("1.0346322539^122").unwrap(), "63.66395247925368");
+      assert_eq!(
+        interpret("1.0609804891^2127").unwrap(),
+        "4.782274689686765*^54"
+      );
+      assert_eq!(
+        interpret("0.96602143336^-2127").unwrap(),
+        "8.573468150695504*^31"
+      );
+    }
+
+    #[test]
+    fn negative_base_keeps_chain_semantics() {
+      assert_eq!(
+        interpret("(-7.488095238095239)^-2").unwrap(),
+        "0.01783434982724237"
+      );
+      assert_eq!(
+        interpret("(-7.488095238095239)^3").unwrap(),
+        "-419.869258516899"
+      );
+    }
+
+    #[test]
+    fn complex_float_integer_powers_use_chains() {
+      // Complex machine bases use the same chains, with a Smith-style
+      // reciprocal for negative exponents (the log/exp path is a ULP off).
+      assert_eq!(
+        interpret("(1.5 + 2.5 I)^-2").unwrap(),
+        "-0.05536332179930796 - 0.10380622837370243*I"
+      );
+      assert_eq!(
+        interpret("(1.5 + 2.5 I)^-1").unwrap(),
+        "0.17647058823529413 - 0.29411764705882354*I"
+      );
+      assert_eq!(
+        interpret("(-0.46872406 + 2.28458072 I)^9").unwrap(),
+        "-1977.3101018669993 - 505.83083638499534*I"
+      );
+      assert_eq!(
+        interpret("(-2.914 - 3.775221291 I)^-10").unwrap(),
+        "-1.57443249348989*^-7 - 4.704549167242218*^-8*I"
+      );
+    }
+  }
+
+  // N-ary numeric Times/Plus fold as a balanced machine tree over the
+  // arguments in input order (left half takes ceil(n/2)); exact subtrees
+  // combine exactly, and mixed nodes convert the exact side to f64. Every
+  // expected value below is wolframscript's exact output.
+  mod nary_machine_fold {
+    use super::*;
+
+    #[test]
+    fn times_folds_input_order_not_exact_first() {
+      // (68*63.6)*57, one ulp away from the coalesced (68*57)*63.6.
+      // Found by differential fuzzing (make fuzz-diff).
+      assert_eq!(
+        interpret("Times[68, 63.599999999999994, 57]").unwrap(),
+        "246513.59999999995"
+      );
+      assert_eq!(
+        interpret("Times[68, 63.599999999999994, 54]").unwrap(),
+        "233539.19999999995"
+      );
+      // Same product with the real last coalesces the exact pair first.
+      assert_eq!(
+        interpret("Times[68, 54, 63.599999999999994]").unwrap(),
+        "233539.19999999998"
+      );
+    }
+
+    #[test]
+    fn times_balanced_tree_with_exact_subtrees() {
+      // 4 args: (0.7*3)*(0.9*N[1/7]).
+      assert_eq!(
+        interpret("Times[0.7, 3, 0.9, 1/7]").unwrap(),
+        "0.2699999999999999"
+      );
+      // The right pair 1/3*3 combines exactly to 1.
+      assert_eq!(
+        interpret("Times[0.1, 1/3, 1/3, 3]").unwrap(),
+        "0.03333333333333333"
+      );
+      assert_eq!(
+        interpret("Times[3, 1/7, 0.1, 0.2, 0.3]").unwrap(),
+        "0.0025714285714285713"
+      );
+      assert_eq!(
+        interpret("Times[0.1, 0.2, 3, 1/7, 0.3]").unwrap(),
+        "0.0025714285714285717"
+      );
+    }
+
+    #[test]
+    fn plus_balanced_tree_with_exact_subtrees() {
+      // The adjacent rationals 19/27 + 49/3 combine exactly; converting
+      // each to f64 first would be one ulp lower.
+      assert_eq!(
+        interpret("Plus[19/27, 49/3, 0.1, 0.2]").unwrap(),
+        "17.33703703703704"
+      );
+      // The rational tail sums exactly to 1.
+      assert_eq!(
+        interpret("Plus[0.1, 1/3, 1/3, 1/3]").unwrap(),
+        "1.1"
+      );
+      // But exact terms in separate subtrees still convert individually.
+      assert_eq!(
+        interpret("Plus[22, -59, 34, 14.6]").unwrap(),
+        "11.600000000000001"
+      );
+      assert_eq!(interpret("Plus[2^60, 1, -2^60, 0.5]").unwrap(), "0.");
+    }
+  }
 }
 
 // Powers with an infinite base or exponent follow the direction and the

--- a/tests/interpreter_tests/math/rounding.rs
+++ b/tests/interpreter_tests/math/rounding.rs
@@ -85,6 +85,26 @@ mod fractional_part {
       "EulerGamma"
     );
   }
+
+  // FractionalPart truncates toward zero, so a NEGATIVE symbolic value
+  // subtracts its Ceiling, not its Floor: 81*(Pi - 29/2) ≈ -920.03 keeps
+  // integer part -920 (differential fuzzer seed 228602237882039336;
+  // wolframscript-verified).
+  #[test]
+  fn symbolic_negative_truncates_toward_zero() {
+    assert_eq!(
+      interpret("FractionalPart[Times[Subtract[Pi, Plus[7, Divide[15, 2]]], 81]]")
+        .unwrap(),
+      "920 + 81*(-29/2 + Pi)"
+    );
+    assert_eq!(interpret("FractionalPart[-Pi]").unwrap(), "3 - Pi");
+    assert_eq!(interpret("FractionalPart[-E]").unwrap(), "2 - E");
+    // Positive values still subtract their Floor.
+    assert_eq!(
+      interpret("FractionalPart[Pi^20]").unwrap(),
+      "-8769956796 + Pi^20"
+    );
+  }
 }
 
 mod mixed_fraction_parts {

--- a/tests/interpreter_tests/math/rounding.rs
+++ b/tests/interpreter_tests/math/rounding.rs
@@ -93,8 +93,10 @@ mod fractional_part {
   #[test]
   fn symbolic_negative_truncates_toward_zero() {
     assert_eq!(
-      interpret("FractionalPart[Times[Subtract[Pi, Plus[7, Divide[15, 2]]], 81]]")
-        .unwrap(),
+      interpret(
+        "FractionalPart[Times[Subtract[Pi, Plus[7, Divide[15, 2]]], 81]]"
+      )
+      .unwrap(),
       "920 + 81*(-29/2 + Pi)"
     );
     assert_eq!(interpret("FractionalPart[-Pi]").unwrap(), "3 - Pi");


### PR DESCRIPTION
`make fuzz-diff` (seed 1785246333519574598) found two divergences from wolframscript; fixing them properly surfaced and fixed several adjacent display divergences, all byte-verified against wolframscript.

## Plus canonical ordering

- Named constants (Pi, E) now order like symbols in the reciprocal-of-sum rule: `Pi + 1/(1 + Pi)` prints `Pi + (1 + Pi)^(-1)`, not `(1 + Pi)^(-1) + Pi`.
- The rule's base polynomials may carry rational coefficients (`univar_rat_coeffs`), so the original fuzz case `Pi + (14 - 73)/(Pi + 9/2)` prints `Pi - 59/(9/2 + Pi)`.

## Simplify

- `complexity_digits` now counts Wolfram's FullForm tree (flat Times/Plus chains, `-x` as `Times[-1, x]`) instead of woxi's display tree. This makes `Simplify[2x - 2x^3]` pick `-2*x*(-1 + x^2)` like wolframscript.
- The square-free factor candidate also competes for content-extracted sums (`Times[c, Plus[…]]`), and a var-power Times factor orders against a same-variable polynomial sum by coefficient vector (`x^2*(1 + x)` but `(-1 + x)*x^2`).
- Quotient displays around sign normalization: an already-canonical quotient is a fixed point (`(1+3x)/(2*(-1+x)*x)` survives verbatim); a negative-content numerator flips both parts, the rebuilt denominator showing expanded or x^k-split form exactly as wolframscript does; integer content never extracts from a denominator divisible by x.

## Together

- Together now cancels a polynomial GCD hidden behind a factored or content-extracted denominator: `Together[((1+x)(1+3x))/(2x - 2x^3)]` → `(-1 - 3*x)/(2*(-1 + x)*x)`. This also lets `Simplify[(1+4x+3x^2)/(2x-2x^3)]` reach `(1 + 3*x)/(2*x - 2*x^2)` (the second fuzz divergence).

## Also included (rebased from this branch's previous round)

- `FractionalPart` negative truncation fix and Simplify quotient FactorSquareFree display rules (seed 1785082426573174375).
- Machine-arithmetic rounding matched bit-for-bit to wolframscript.

## Tests

- New unit tests: `sum_reciprocal_term_order_constants_and_rationals`, `square_free_factored_form_wins_on_node_count`, `rational_function_cancels_shared_factor`, `quotient_sign_normalization_displays`, `together_cancels_gcd_behind_factored_denominator`, `var_power_vs_univar_sum_orders_by_coefficients` — every expectation wolframscript-verified.
- Full `make test` run in progress; will report status on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt

---
_Generated by [Claude Code](https://claude.ai/code/session_012vy7BLqUrZXvnap2eRHGtt)_