### PR TITLE
Fix some Windows-specific clippy issues

### DIFF
--- a/benches/interpreter.rs
+++ b/benches/interpreter.rs
@@ -129,7 +129,6 @@ fn bench_script_build_summary(c: &mut Criterion) {
   let script_src = manifest_dir.join("scripts/build_summary.wls");
   let summary_src = manifest_dir.join("tests/SUMMARY.md");
   let zensical_src = manifest_dir.join("tests/zensical.toml");
-  let cli_src = manifest_dir.join("tests/cli");
 
   // Create a tempdir with `scripts/`, `tests/SUMMARY.md`, `tests/zensical.toml`,
   // and a symlink at `tests/cli` pointing at the real cli docs (the docs
@@ -143,13 +142,16 @@ fn bench_script_build_summary(c: &mut Criterion) {
   std::fs::copy(&summary_src, tmp.join("tests/SUMMARY.md")).unwrap();
   std::fs::copy(&zensical_src, tmp.join("tests/zensical.toml")).unwrap();
   #[cfg(unix)]
-  std::os::unix::fs::symlink(&cli_src, tmp.join("tests/cli")).unwrap_or_else(
-    |_| {
-      // Fall back to an empty dir if symlink fails — the script will
-      // still run, just with no children to enumerate.
-      std::fs::create_dir_all(tmp.join("tests/cli")).unwrap();
-    },
-  );
+  {
+    let cli_src = manifest_dir.join("tests/cli");
+    std::os::unix::fs::symlink(&cli_src, tmp.join("tests/cli")).unwrap_or_else(
+      |_| {
+        // Fall back to an empty dir if symlink fails — the script will
+        // still run, just with no children to enumerate.
+        std::fs::create_dir_all(tmp.join("tests/cli")).unwrap();
+      },
+    );
+  }
   #[cfg(not(unix))]
   std::fs::create_dir_all(tmp.join("tests/cli")).unwrap();
 

--- a/src/functions/memory.rs
+++ b/src/functions/memory.rs
@@ -8,6 +8,7 @@ use std::mem::size_of;
 #[cfg(target_os = "windows")]
 #[repr(C)]
 #[allow(non_snake_case)]
+#[allow(clippy::upper_case_acronyms)]
 struct MEMORYSTATUSEX {
   dwLength: u32,
   dwMemoryLoad: u32,

--- a/tests/interpreter_tests/machine_specific.rs
+++ b/tests/interpreter_tests/machine_specific.rs
@@ -52,25 +52,30 @@ mod machine_specific {
   /// `src/evaluator/listable.rs`: USER / USERNAME env vars first, then the
   /// account name of the effective uid.
   fn host_user() -> String {
-    std::env::var("USER")
+    let mut user = std::env::var("USER")
       .or_else(|_| std::env::var("USERNAME"))
-      .ok()
-      .or_else(|| {
-        #[cfg(unix)]
-        unsafe {
-          let pw = libc::getpwuid(libc::geteuid());
-          if pw.is_null() {
-            return None;
-          }
-          std::ffi::CStr::from_ptr((*pw).pw_name)
-            .to_str()
-            .ok()
-            .map(str::to_string)
+      .ok();
+
+    #[cfg(unix)]
+    {
+      user = user.or_else(|| unsafe {
+        let pw = libc::getpwuid(libc::geteuid());
+        if pw.is_null() {
+          return None;
         }
-        #[cfg(not(unix))]
-        None
-      })
-      .expect("could not determine the current user name")
+        std::ffi::CStr::from_ptr((*pw).pw_name)
+          .to_str()
+          .ok()
+          .map(str::to_string)
+      });
+    }
+
+    #[cfg(not(unix))]
+    {
+      user = user.or(None);
+    }
+
+    user.expect("could not determine the current user name")
   }
 
   /// Short hostname, stripped of trailing `.local` / `.lan` etc, to


### PR DESCRIPTION
MEMORYSTATUSEX needs a #[allow(clippy::upper_case_acronyms)], cli_src in benches/interpreter.rs is unused, and an or_else(|| { None}) can be simplified using or.