### PR TITLE
Support Manipulate annotation rows and compound control variables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,28 @@
 # Changelog
 
+# Unreleased
+
+- Symbol names may contain `$` anywhere (`a$b`, `signal$1`), matching Wolfram.
+- `PlotRange` bounds given in reversed order (e.g. `{3, -3}`) normalize to
+    the same plot as the sorted form, matching Wolfram.
+- Manipulate improvements (driven by the "Oscilloscope with Two Signal
+    Inputs" Wolfram Demonstration):
+    - `Style[…]`, bare-string, and `Delimiter` arguments are treated as
+        static annotation rows between controls (no more spurious
+        `Manipulate::vsform` messages) and render as headings/separators
+        in Woxi Studio and the Playground.
+    - Compound control variables such as `Subscript[signal, 1]` work: they
+        are bound through synthesized symbols and keep a typeset label
+        (`signal₁`).
+    - Control specs may carry trailing options (`ControlType -> PopupMenu`,
+        `ImageSize -> Tiny`, …); `ControlType -> PopupMenu` always renders
+        a dropdown.
+    - A `Manipulate` whose body is an `Animate[…]` renders as one combined
+        widget, `AnimationRunning -> False` builds the widget paused, and
+        an `Infinity` animation bound gets a finite looping window.
+- Woxi Studio re-instantiates stored `Manipulate` widgets when opening a
+    notebook (instead of showing the saved `DynamicModuleBox[…]` text dump).
+
 # 2026-07-16 - 0.2.0
 
 Between 0.1.0 and 0.2.0 Woxi grew from a minimal interpreter into a broad

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -12181,6 +12181,15 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::FunctionCall { name, .. } if name == "Dynamic" => {
         out_args.push(spec.clone());
       }
+      // `Delimiter`, a bare string, and `Style[…]` are static annotation
+      // rows between controls (Wolfram tags them
+      // Manipulate`Dump`ThisIsNotAControl), not malformed variable specs —
+      // they pass through with no message, matching wolframscript.
+      Expr::Identifier(s) if s == "Delimiter" => out_args.push(spec.clone()),
+      Expr::String(_) => out_args.push(spec.clone()),
+      Expr::FunctionCall { name, .. } if name == "Style" => {
+        out_args.push(spec.clone());
+      }
       _ => {
         // Non-list variable specification: emit Manipulate::vsform
         // message but still return the expression unchanged, matching
@@ -12315,6 +12324,9 @@ pub enum ManipulateControl {
     initial_index: usize,
     label: String,
     label_runs: Vec<LabelRun>,
+    /// `ControlType -> PopupMenu`: always render a dropdown, even when the
+    /// choice count is small enough for a SetterBar.
+    popup: bool,
   },
   /// A 2D control (`ControlType -> Slider2D`, or a 2D range spec
   /// `{u, {xmin, ymin}, {xmax, ymax}}`). Binds its variable to a 2-vector
@@ -12341,16 +12353,29 @@ pub enum ManipulateControl {
     high_initial: f64,
     label: String,
   },
+  /// A static heading row between controls: a bare string or `Style[…]`
+  /// Manipulate argument (Wolfram's `ThisIsNotAControl` annotations, e.g.
+  /// the "signal 1" / "signal 2" captions of the oscilloscope
+  /// demonstration). Binds no variable.
+  Heading {
+    label: String,
+    label_runs: Vec<LabelRun>,
+  },
+  /// A `Delimiter` argument: a horizontal separator row between control
+  /// groups. Binds no variable.
+  Divider,
 }
 
 impl ManipulateControl {
-  /// The bound variable name for this control.
+  /// The bound variable name for this control. Annotation rows
+  /// (`Heading` / `Divider`) bind no variable and return `""`.
   pub fn name(&self) -> &str {
     match self {
       ManipulateControl::Continuous { name, .. }
       | ManipulateControl::Discrete { name, .. }
       | ManipulateControl::Slider2D { name, .. }
       | ManipulateControl::IntervalSlider { name, .. } => name,
+      ManipulateControl::Heading { .. } | ManipulateControl::Divider => "",
     }
   }
 }
@@ -12393,6 +12418,10 @@ pub struct ManipulateSpec {
   /// until the user drags a slider. Plain `Manipulate`/`Control` widgets leave
   /// this `false`.
   pub animated: bool,
+  /// Whether an animated widget starts playing. Wolfram's default is
+  /// `AnimationRunning -> True`; `AnimationRunning -> False` builds the
+  /// widget paused until the user presses play.
+  pub animation_running: bool,
   /// `Appearance -> None`: the widget shows no visible control rows (the
   /// animation just runs), matching Wolfram's control-free appearance.
   pub appearance_none: bool,
@@ -12430,18 +12459,63 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   if (name != "Manipulate" && name != "Animate") || args.len() < 2 {
     return None;
   }
-  let animated = name == "Animate";
+  let mut animated = name == "Animate";
+  let mut animation_running = true;
 
-  let body_code = crate::syntax::expr_to_input_form(&args[0]);
-  let mut controls = Vec::with_capacity(args.len() - 1);
+  // A Manipulate whose body is itself an `Animate[…]` (the Demonstrations
+  // "oscilloscope" pattern) nests an auto-playing animation inside the outer
+  // control panel. A single widget can render both: flatten the inner
+  // Animate into this spec — its body becomes the combined body and its
+  // animation variable becomes the leading (animated) control, followed by
+  // the outer controls.
+  let inner = if name == "Manipulate" {
+    match &args[0] {
+      Expr::FunctionCall { name: n, .. } if n == "Animate" => {
+        extract_manipulate_spec(&args[0])
+      }
+      _ => None,
+    }
+  } else {
+    None
+  };
+  let (
+    body_code,
+    mut controls,
+    mut state,
+    mut displays,
+    mut initialization,
+    mut control_enabled,
+  ) = match inner {
+    Some(inner) => {
+      animated = true;
+      animation_running = inner.animation_running;
+      (
+        inner.body_code,
+        inner.controls,
+        inner.state,
+        inner.displays,
+        inner.initialization,
+        inner.control_enabled,
+      )
+    }
+    None => (
+      crate::syntax::expr_to_input_form(&args[0]),
+      Vec::with_capacity(args.len() - 1),
+      Vec::new(),
+      Vec::new(),
+      None,
+      Vec::new(),
+    ),
+  };
   // `Locator` bindings are baked into the body (never rewritten by a
   // display); `ControlType -> None` bindings become live mutable state.
   let mut fixed: Vec<(String, String)> = Vec::new();
-  let mut state: Vec<(String, String)> = Vec::new();
-  let mut displays: Vec<String> = Vec::new();
-  let mut initialization: Option<String> = None;
-  let mut control_enabled: Vec<(String, String)> = Vec::new();
   let mut appearance_none = false;
+  // Compound (non-symbol) control variables such as `Subscript[signal, 1]`
+  // cannot be bound by name; each is renamed to a synthesized plain symbol,
+  // and every occurrence in the body (and related code fragments) is
+  // rewritten below via `(original InputForm, synthesized name)` pairs.
+  let mut renames: Vec<(String, String)> = Vec::new();
   for spec in &args[1..] {
     // Options such as `Initialization :> …` or `TrackedSymbols :> …`
     // are not variable specs; extract what we understand and ignore
@@ -12466,7 +12540,39 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       {
         appearance_none = true;
       }
+      // `AnimationRunning -> False` builds the widget paused.
+      if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "AnimationRunning")
+        && matches!(replacement.as_ref(), Expr::Identifier(s) if s == "False")
+      {
+        animation_running = false;
+      }
       continue;
+    }
+    // `Delimiter` and string / `Style[…]` arguments are static annotation
+    // rows between controls (Wolfram's `ThisIsNotAControl`), keeping their
+    // position among the control rows.
+    match spec {
+      Expr::Identifier(s) if s == "Delimiter" => {
+        controls.push(ManipulateControl::Divider);
+        continue;
+      }
+      Expr::String(_) => {
+        let label_runs = manipulate_label_runs(spec, false);
+        controls.push(ManipulateControl::Heading {
+          label: flatten_label_runs(&label_runs),
+          label_runs,
+        });
+        continue;
+      }
+      Expr::FunctionCall { name, .. } if name == "Style" => {
+        let label_runs = manipulate_label_runs(spec, false);
+        controls.push(ManipulateControl::Heading {
+          label: flatten_label_runs(&label_runs),
+          label_runs,
+        });
+        continue;
+      }
+      _ => {}
     }
     // Only list-shaped arguments are control specs. Any other trailing
     // argument (e.g. a `Dynamic[Panel[…]]` of checkboxes) is an extra
@@ -12475,23 +12581,70 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       displays.push(crate::syntax::expr_to_input_form(spec));
       continue;
     }
-    match parse_manipulate_control(spec)? {
-      ParsedControl::Visible(c, enabled) => {
+    let (spec, rename) = rewrite_compound_control_var(spec);
+    match parse_manipulate_control(&spec)? {
+      ParsedControl::Visible(mut c, enabled) => {
+        if let Some((orig, orig_form, synth)) = &rename {
+          patch_default_label(&mut c, orig, synth);
+          renames.push((orig_form.clone(), synth.clone()));
+        }
         if let Some(cond) = enabled {
           control_enabled.push((c.name().to_string(), cond));
         }
         controls.push(c);
       }
-      ParsedControl::Fixed { name, value } => fixed.push((name, value)),
-      ParsedControl::State { name, value } => state.push((name, value)),
+      ParsedControl::Fixed { name, value } => {
+        if let Some((_, orig_form, synth)) = &rename {
+          renames.push((orig_form.clone(), synth.clone()));
+        }
+        fixed.push((name, value));
+      }
+      ParsedControl::State { name, value } => {
+        if let Some((_, orig_form, synth)) = &rename {
+          renames.push((orig_form.clone(), synth.clone()));
+        }
+        state.push((name, value));
+      }
     }
   }
 
   // A Manipulate with no controls or state at all (e.g. `Manipulate[x^2,
   // badspec]`, where `badspec` is neither a spec nor an option) isn't
   // renderable as an interactive widget — fall back to the plain path.
-  if controls.is_empty() && fixed.is_empty() && state.is_empty() {
+  // Annotation rows alone don't make a widget either.
+  if !controls.iter().any(|c| !c.name().is_empty())
+    && fixed.is_empty()
+    && state.is_empty()
+  {
     return None;
+  }
+
+  // Rewrite every occurrence of a renamed compound variable in the code
+  // fragments that reference it. All fragments were printed by
+  // `expr_to_input_form`, so the original variable appears verbatim
+  // (including as a call head: `Subscript[signal, 1][x]`). Longest
+  // original first so no rename can match inside a longer one.
+  let mut body_code = body_code;
+  if !renames.is_empty() {
+    renames.sort_by_key(|(orig, _)| std::cmp::Reverse(orig.len()));
+    let rewrite = |code: &mut String| {
+      for (orig, synth) in &renames {
+        *code = code.replace(orig.as_str(), synth.as_str());
+      }
+    };
+    rewrite(&mut body_code);
+    for d in &mut displays {
+      rewrite(d);
+    }
+    if let Some(init) = &mut initialization {
+      rewrite(init);
+    }
+    for (_, cond) in &mut control_enabled {
+      rewrite(cond);
+    }
+    for (_, value) in fixed.iter_mut().chain(state.iter_mut()) {
+      rewrite(value);
+    }
   }
 
   // Bake fixed (Locator) bindings into the body so they remain in scope on
@@ -12511,8 +12664,124 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization,
     control_enabled,
     animated,
+    animation_running,
     appearance_none,
   })
+}
+
+/// Synthesize a plain symbol name for a compound (non-Identifier) control
+/// variable. `Subscript[signal, 1]` → `signal$1`; any other compound head
+/// sanitizes its whole InputForm, mapping non-symbol characters to `$`.
+/// Returns `None` for heads that already are plain symbols (or head lists).
+fn synthesize_var_name(expr: &Expr) -> Option<String> {
+  if !matches!(expr, Expr::FunctionCall { .. }) {
+    return None;
+  }
+  let sanitize = |s: &str| -> String {
+    s.chars()
+      .map(|c| {
+        if c.is_alphanumeric() || c == '_' {
+          c
+        } else {
+          '$'
+        }
+      })
+      .collect::<String>()
+      .split('$')
+      .filter(|p| !p.is_empty())
+      .collect::<Vec<_>>()
+      .join("$")
+  };
+  let mut name = match expr {
+    Expr::FunctionCall { name, args } if name == "Subscript" => args
+      .iter()
+      .map(|a| sanitize(&crate::syntax::expr_to_input_form(a)))
+      .collect::<Vec<_>>()
+      .join("$"),
+    other => sanitize(&crate::syntax::expr_to_input_form(other)),
+  };
+  if name.is_empty() || name.starts_with(|c: char| c.is_ascii_digit()) {
+    name.insert(0, '$');
+  }
+  Some(name)
+}
+
+/// If the control spec's variable is a compound expression (e.g.
+/// `{{Subscript[signal, 1], SquareWave, ""}, …}`), return the spec with the
+/// variable replaced by a synthesized plain symbol, together with
+/// `(original expr, original InputForm, synthesized name)` so the caller can
+/// rewrite the body and patch the default label. Specs with plain symbol
+/// variables come back unchanged.
+fn rewrite_compound_control_var(
+  spec: &Expr,
+) -> (Expr, Option<(Expr, String, String)>) {
+  let Expr::List(items) = spec else {
+    return (spec.clone(), None);
+  };
+  let Some(head) = items.first() else {
+    return (spec.clone(), None);
+  };
+  // The variable is either the head itself or the first element of a
+  // `{var, init, lbl}` head list.
+  let var = match head {
+    Expr::List(head_items) => match head_items.first() {
+      Some(v) => v,
+      None => return (spec.clone(), None),
+    },
+    other => other,
+  };
+  let Some(synth) = synthesize_var_name(var) else {
+    return (spec.clone(), None);
+  };
+  let orig_form = crate::syntax::expr_to_input_form(var);
+  let replacement = Expr::Identifier(synth.clone());
+  let new_head = match head {
+    Expr::List(head_items) => {
+      let mut new_items: Vec<Expr> = head_items.iter().cloned().collect();
+      new_items[0] = replacement;
+      Expr::List(new_items.into())
+    }
+    _ => replacement,
+  };
+  let mut new_spec: Vec<Expr> = items.iter().cloned().collect();
+  new_spec[0] = new_head;
+  (
+    Expr::List(new_spec.into()),
+    Some((var.clone(), orig_form, synth)),
+  )
+}
+
+/// After renaming a compound control variable, a control that fell back to
+/// the default label (the bare synthesized name) gets a pretty label
+/// rendered from the original expression instead — `Subscript[signal, 1]`
+/// shows as `signal₁`, not `signal$1`.
+fn patch_default_label(
+  control: &mut ManipulateControl,
+  original: &Expr,
+  synth: &str,
+) {
+  let pretty_runs = manipulate_label_runs(original, false);
+  let pretty = flatten_label_runs(&pretty_runs);
+  match control {
+    ManipulateControl::Continuous {
+      label, label_runs, ..
+    }
+    | ManipulateControl::Discrete {
+      label, label_runs, ..
+    } => {
+      if label == synth {
+        *label = pretty;
+        *label_runs = pretty_runs;
+      }
+    }
+    ManipulateControl::Slider2D { label, .. }
+    | ManipulateControl::IntervalSlider { label, .. } => {
+      if label == synth {
+        *label = pretty;
+      }
+    }
+    ManipulateControl::Heading { .. } | ManipulateControl::Divider => {}
+  }
 }
 
 /// Attempt to extract a `ManipulateSpec` from a held `ListAnimate[{e1, …, en}]`
@@ -12559,6 +12828,7 @@ pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled: Vec::new(),
     animated: true,
+    animation_running: true,
     appearance_none: false,
   })
 }
@@ -12630,6 +12900,7 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled: Vec::new(),
     animated: true,
+    animation_running: true,
     appearance_none: false,
   })
 }
@@ -12699,6 +12970,7 @@ pub fn extract_locator_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled: Vec::new(),
     animated: false,
+    animation_running: true,
     appearance_none: false,
   })
 }
@@ -12744,6 +13016,7 @@ pub fn extract_click_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled: Vec::new(),
     animated: false,
+    animation_running: true,
     appearance_none: false,
   })
 }
@@ -12789,6 +13062,7 @@ pub fn extract_control_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled,
     animated: false,
+    animation_running: true,
     appearance_none: false,
   })
 }
@@ -13187,11 +13461,13 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
     ));
   }
 
-  // Discrete form: `{u, {u1, u2, …}}` or `{{u, uinit, …}, {u1, u2, …}}`.
+  // Discrete form: `{u, {u1, u2, …}}` or `{{u, uinit, …}, {u1, u2, …}}`,
+  // possibly with trailing options (`{{u, uinit, ""}, {u1, …},
+  // ControlType -> PopupMenu}`) — hence matched on the option-free `bounds`.
   // The value list may also be given as an expression that evaluates to a
   // list (e.g. `{g, PolyhedronData[All]}`), so evaluate a non-literal.
-  if items.len() == 2 {
-    let value_items: Option<Vec<Expr>> = match &items[1] {
+  if bounds.len() == 1 {
+    let value_items: Option<Vec<Expr>> = match bounds[0] {
       Expr::List(vs) => Some(vs.iter().cloned().collect()),
       other => match crate::evaluator::evaluate_expr_to_expr(other) {
         Ok(Expr::List(ref vs)) => Some(vs.iter().cloned().collect()),
@@ -13235,6 +13511,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
           initial_index,
           label,
           label_runs,
+          popup: control_type.as_deref() == Some("PopupMenu"),
         },
         enabled,
       ));
@@ -13242,14 +13519,31 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
   }
 
   // Continuous form: {u, umin, umax} or {u, umin, umax, du}
-  // (or with labelled head: {{u, uinit, ulbl}, umin, umax, …})
-  if items.len() < 3 {
+  // (or with labelled head: {{u, uinit, ulbl}, umin, umax, …}),
+  // possibly with trailing options (`ImageSize -> Tiny`, …) — hence
+  // matched on the option-free `bounds`.
+  if bounds.len() < 2 {
     return None;
   }
-  let min = crate::functions::math_ast::try_eval_to_f64(&items[1])?;
-  let max = crate::functions::math_ast::try_eval_to_f64(&items[2])?;
-  let step = items
-    .get(3)
+  let mut min =
+    crate::functions::math_ast::try_eval_to_f64_with_infinity(bounds[0])?;
+  let mut max =
+    crate::functions::math_ast::try_eval_to_f64_with_infinity(bounds[1])?;
+  // An infinite bound (`Animate[…, {ϕ, 0, Infinity}]` runs forever in
+  // Wolfram) cannot drive a finite slider; substitute a 2π looping window
+  // so the default sine-based demonstrations wrap seamlessly.
+  match (min.is_finite(), max.is_finite()) {
+    (true, false) => max = min + 2.0 * std::f64::consts::PI,
+    (false, true) => min = max - 2.0 * std::f64::consts::PI,
+    (false, false) => {
+      min = 0.0;
+      max = 2.0 * std::f64::consts::PI;
+    }
+    (true, true) => {}
+  }
+  let step = bounds
+    .get(2)
+    .copied()
     .and_then(crate::functions::math_ast::try_eval_to_f64);
   let initial = match explicit_initial.as_ref() {
     Some(init) => {
@@ -13307,48 +13601,50 @@ pub fn manipulate_initial_bindings(
   spec
     .controls
     .iter()
-    .map(|c| match c {
+    .filter_map(|c| match c {
+      // Annotation rows bind no variable.
+      ManipulateControl::Heading { .. } | ManipulateControl::Divider => None,
       ManipulateControl::Continuous { name, initial, .. } => {
-        (name.clone(), format_f64_input(*initial))
+        Some((name.clone(), format_f64_input(*initial)))
       }
       ManipulateControl::Discrete {
         name,
         values,
         initial_index,
         ..
-      } => (
+      } => Some((
         name.clone(),
         values
           .get(*initial_index)
           .cloned()
           .unwrap_or_else(|| "Null".to_string()),
-      ),
+      )),
       ManipulateControl::Slider2D {
         name,
         x_initial,
         y_initial,
         ..
-      } => (
+      } => Some((
         name.clone(),
         format!(
           "{{{}, {}}}",
           format_f64_input(*x_initial),
           format_f64_input(*y_initial)
         ),
-      ),
+      )),
       ManipulateControl::IntervalSlider {
         name,
         low_initial,
         high_initial,
         ..
-      } => (
+      } => Some((
         name.clone(),
         format!(
           "{{{}, {}}}",
           format_f64_input(*low_initial),
           format_f64_input(*high_initial)
         ),
-      ),
+      )),
     })
     // Mutable `ControlType -> None` state variables travel in the binding
     // set alongside the visible controls so displays can read/write them.
@@ -13732,6 +14028,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
         initial_index,
         label,
         label_runs,
+        popup,
       } => {
         let value_parts: Vec<String> = values
           .iter()
@@ -13741,14 +14038,16 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           .iter()
           .map(|v| format!(r#""{}""#, json_escape_manipulate(v)))
           .collect();
+        let popup_json = if *popup { r#","popup":true"# } else { "" };
         ctrl_parts.push(format!(
-          r#"{{"kind":"discrete","name":"{}","label":"{}","labelRuns":{},"values":[{}],"valueLabels":[{}],"initialIndex":{}}}"#,
+          r#"{{"kind":"discrete","name":"{}","label":"{}","labelRuns":{},"values":[{}],"valueLabels":[{}],"initialIndex":{}{}}}"#,
           json_escape_manipulate(name),
           json_escape_manipulate(label),
           label_runs_to_json(label_runs),
           value_parts.join(","),
           label_parts.join(","),
           initial_index,
+          popup_json,
         ));
       }
       ManipulateControl::Slider2D {
@@ -13797,6 +14096,16 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           step_json,
         ));
       }
+      ManipulateControl::Heading { label, label_runs } => {
+        ctrl_parts.push(format!(
+          r#"{{"kind":"heading","label":"{}","labelRuns":{}}}"#,
+          json_escape_manipulate(label),
+          label_runs_to_json(label_runs),
+        ));
+      }
+      ManipulateControl::Divider => {
+        ctrl_parts.push(r#"{"kind":"delimiter"}"#.to_string());
+      }
     }
   }
 
@@ -13833,7 +14142,12 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
     .collect();
 
   let animated_json = if spec.animated {
-    r#","animated":true"#
+    if spec.animation_running {
+      r#","animated":true"#
+    } else {
+      // Animated but built paused (`AnimationRunning -> False`).
+      r#","animated":true,"animationRunning":false"#
+    }
   } else {
     ""
   };

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -6366,7 +6366,10 @@ pub(crate) fn parse_plot_range(
       let b = try_eval_to_f64(
         &evaluate_expr_to_expr(&items[1]).unwrap_or_else(|_| items[1].clone()),
       )?;
-      Some((a, b))
+      // Wolfram normalizes a reversed range: `PlotRange -> {3, -3}` plots
+      // exactly like `{-3, 3}` (verified against a FrontEnd-saved raster
+      // of the oscilloscope Demonstration, which uses the reversed form).
+      Some(if a <= b { (a, b) } else { (b, a) })
     } else {
       None
     }

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -110,8 +110,8 @@ NamedCharIdentifier = @{ NamedCharBase ~ (NamedCharBase | ASCII_ALPHANUMERIC | L
 // with a letter/_/$ so numeric precision tags like `1`30`/`Pi`30` aren't
 // accidentally absorbed.
 Identifier = @{
-  ("`" ~ (ASCII_ALPHA | LETTER | "_" | "$") ~ (ASCII_ALPHANUMERIC | LETTER | "_" | NamedCharBase)* ~ ("`" ~ (ASCII_ALPHA | LETTER | "_" | "$") ~ (ASCII_ALPHANUMERIC | LETTER | "_" | NamedCharBase)*)*)
-  | ((ASCII_ALPHA | LETTER | "_" | "$") ~ (ASCII_ALPHANUMERIC | LETTER | "_" | NamedCharBase)* ~ ("`" ~ (ASCII_ALPHA | LETTER | "_" | "$") ~ (ASCII_ALPHANUMERIC | LETTER | "_" | NamedCharBase)*)*)
+  ("`" ~ (ASCII_ALPHA | LETTER | "_" | "$") ~ (ASCII_ALPHANUMERIC | LETTER | "_" | "$" | NamedCharBase)* ~ ("`" ~ (ASCII_ALPHA | LETTER | "_" | "$") ~ (ASCII_ALPHANUMERIC | LETTER | "_" | "$" | NamedCharBase)*)*)
+  | ((ASCII_ALPHA | LETTER | "_" | "$") ~ (ASCII_ALPHANUMERIC | LETTER | "_" | "$" | NamedCharBase)* ~ ("`" ~ (ASCII_ALPHA | LETTER | "_" | "$") ~ (ASCII_ALPHANUMERIC | LETTER | "_" | "$" | NamedCharBase)*)*)
 }
 String = @{ "\"" ~ ("\\\\" | "\\\"" | "\\n" | "\\t" | "\\r" | (!"\"" ~ !"\\" ~ ANY) | ("\\" ~ ANY))* ~ "\"" }
 

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -691,6 +691,21 @@ mod graphics {
     }
 
     #[test]
+    fn plot_range_reversed_bounds_normalize() {
+      // Wolfram normalizes a reversed range: `PlotRange -> {3, -3}` plots
+      // exactly like `{-3, 3}` (the oscilloscope Demonstration uses the
+      // reversed form; its FrontEnd-saved raster shows the normal axis).
+      let normal =
+        export_svg("Plot[Sin[x], {x, 0, 10}, PlotRange -> {{0, 10}, {-3, 3}}]");
+      let reversed =
+        export_svg("Plot[Sin[x], {x, 0, 10}, PlotRange -> {{0, 10}, {3, -3}}]");
+      assert_eq!(normal, reversed);
+      let x_reversed =
+        export_svg("Plot[Sin[x], {x, 0, 10}, PlotRange -> {{10, 0}, {-3, 3}}]");
+      assert_eq!(normal, x_reversed);
+    }
+
+    #[test]
     fn background() {
       insta::assert_snapshot!(export_svg(
         "Graphics[{Circle[]}, Background -> LightGray]"
@@ -11170,6 +11185,274 @@ mod manipulate {
     let json = manipulate_spec_to_json(&spec);
     assert!(json.contains(r#""values":["True","False"]"#));
     assert!(json.contains(r#""valueLabels":["on","off"]"#));
+  }
+
+  #[test]
+  fn spec_style_and_delimiter_are_annotation_rows() {
+    // `Style["…", …]` and `Delimiter` arguments are static annotation rows
+    // between controls (Wolfram's ThisIsNotAControl), keeping their
+    // position among the control rows and binding no variable.
+    let expr = interpret_to_expr(
+      "Manipulate[a + b, Style[\"first\", Bold], {a, 0, 1}, Delimiter, \
+       \"second\", {b, 0, 1}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).unwrap();
+    let kinds: Vec<&str> = spec
+      .controls
+      .iter()
+      .map(|c| match c {
+        ManipulateControl::Heading { .. } => "heading",
+        ManipulateControl::Divider => "divider",
+        ManipulateControl::Continuous { .. } => "continuous",
+        _ => "other",
+      })
+      .collect();
+    assert_eq!(
+      kinds,
+      vec!["heading", "continuous", "divider", "heading", "continuous"]
+    );
+    match &spec.controls[0] {
+      ManipulateControl::Heading { label, .. } => assert_eq!(label, "first"),
+      _ => panic!("expected heading row"),
+    }
+    // Annotation rows contribute no bindings.
+    let bindings = manipulate_initial_bindings(&spec);
+    assert_eq!(
+      bindings,
+      vec![
+        ("a".to_string(), "0".to_string()),
+        ("b".to_string(), "0".to_string()),
+      ]
+    );
+    // JSON carries the annotation rows for the Playground frontend.
+    let json = manipulate_spec_to_json(&spec);
+    assert!(json.contains(r#""kind":"heading""#));
+    assert!(json.contains(r#""kind":"delimiter""#));
+  }
+
+  #[test]
+  fn spec_style_and_delimiter_emit_no_vsform_message() {
+    // wolframscript accepts Style[…]/Delimiter/string arguments silently —
+    // no Manipulate::vsform message.
+    let result = woxi::interpret_with_stdout(
+      "Manipulate[a, Style[\"s\", Bold], Delimiter, \"t\", {a, 0, 1}];",
+    )
+    .unwrap();
+    assert!(
+      result.warnings.iter().all(|w| !w.contains("vsform")),
+      "unexpected vsform warnings: {:?}",
+      result.warnings
+    );
+  }
+
+  #[test]
+  fn spec_subscript_variables_are_renamed() {
+    // Compound control variables like `Subscript[signal, 1]` cannot be
+    // bound by name; they are renamed to synthesized plain symbols and
+    // every occurrence in the body is rewritten (including call heads).
+    let expr = interpret_to_expr(
+      "Manipulate[Subscript[r, 1] Subscript[signal, 1][x], \
+       {{Subscript[signal, 1], SquareWave, \"\"}, {Sin -> \"sine\", \
+       SquareWave -> \"square wave\"}, ControlType -> PopupMenu}, \
+       {{Subscript[r, 1], 1, \"amplitude\"}, 0, 3}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).unwrap();
+    assert_eq!(spec.body_code, "r$1*signal$1[x]");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete {
+        name,
+        values,
+        value_labels,
+        initial_index,
+        popup,
+        ..
+      } => {
+        assert_eq!(name, "signal$1");
+        assert_eq!(values, &["Sin".to_string(), "SquareWave".to_string()]);
+        assert_eq!(
+          value_labels,
+          &["sine".to_string(), "square wave".to_string()]
+        );
+        // Explicit initial SquareWave matches values[1].
+        assert_eq!(*initial_index, 1);
+        // `ControlType -> PopupMenu` always renders a dropdown.
+        assert!(*popup);
+      }
+      other => panic!("expected discrete control, got {other:?}"),
+    }
+    match &spec.controls[1] {
+      ManipulateControl::Continuous {
+        name,
+        label,
+        min,
+        max,
+        initial,
+        ..
+      } => {
+        assert_eq!(name, "r$1");
+        assert_eq!(label, "amplitude");
+        assert_eq!((*min, *max, *initial), (0.0, 3.0, 1.0));
+      }
+      other => panic!("expected continuous control, got {other:?}"),
+    }
+    // The synthesized names must survive a full Block round-trip: the
+    // rewritten body evaluates with the initial bindings.
+    let bindings = manipulate_initial_bindings(&spec);
+    let code = manipulate_block_code(&spec.body_code, &bindings);
+    assert_eq!(interpret(&format!("{} /. x -> 0.3", code)).unwrap(), "1");
+  }
+
+  #[test]
+  fn spec_subscript_variable_default_label_is_pretty() {
+    // A renamed compound variable with no explicit label shows the
+    // original subscripted form (signal₁), not the synthesized symbol.
+    let expr = interpret_to_expr(
+      "Manipulate[Subscript[m, 1] x, {Subscript[m, 1], 0, 5}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).unwrap();
+    match &spec.controls[0] {
+      ManipulateControl::Continuous { name, label, .. } => {
+        assert_eq!(name, "m$1");
+        assert_eq!(label, "m₁");
+      }
+      other => panic!("expected continuous control, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn spec_continuous_ignores_trailing_options() {
+    // Options such as `ImageSize -> Tiny` in a control spec are not bounds.
+    let expr = interpret_to_expr(
+      "Manipulate[a x, {{a, 0, \"phase lag\"}, 0, 2 Pi, ImageSize -> Tiny}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).unwrap();
+    match &spec.controls[0] {
+      ManipulateControl::Continuous {
+        name,
+        label,
+        min,
+        max,
+        step,
+        ..
+      } => {
+        assert_eq!(name, "a");
+        assert_eq!(label, "phase lag");
+        assert_eq!(*min, 0.0);
+        assert!((*max - 2.0 * std::f64::consts::PI).abs() < 1e-12);
+        // The trailing option must not be misread as a step.
+        assert!(step.is_none());
+      }
+      other => panic!("expected continuous control, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn spec_nested_animate_body_flattens() {
+    // A Manipulate whose body is an `Animate[…]` renders as one combined
+    // widget: the inner body becomes the body, the animation variable
+    // becomes the leading control, and `AnimationRunning -> False` builds
+    // the widget paused.
+    let expr = interpret_to_expr(
+      "Manipulate[Animate[Plot[Sin[a x + p], {x, 0, 6}], {p, 0, Infinity}, \
+       AnimationRunning -> False], {a, 1, 5}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).unwrap();
+    assert!(spec.animated);
+    assert!(!spec.animation_running);
+    assert!(spec.body_code.starts_with("Plot["));
+    match &spec.controls[0] {
+      ManipulateControl::Continuous { name, min, max, .. } => {
+        assert_eq!(name, "p");
+        // The infinite animation range becomes a finite 2π looping window.
+        assert_eq!(*min, 0.0);
+        assert!((*max - 2.0 * std::f64::consts::PI).abs() < 1e-12);
+      }
+      other => panic!("expected continuous control, got {other:?}"),
+    }
+    match &spec.controls[1] {
+      ManipulateControl::Continuous { name, .. } => assert_eq!(name, "a"),
+      other => panic!("expected continuous control, got {other:?}"),
+    }
+    // Paused-at-build still serializes as animated for the Playground.
+    let json = manipulate_spec_to_json(&spec);
+    assert!(json.contains(r#""animated":true"#));
+    assert!(json.contains(r#""animationRunning":false"#));
+  }
+
+  #[test]
+  fn spec_oscilloscope_demonstration_manipulate() {
+    // End-to-end regression for the "Oscilloscope with Two Signal Inputs"
+    // Wolfram Demonstration: nested Animate body, Style/Delimiter
+    // annotation rows, Subscript control variables, popup menus with
+    // rule-form choices, ImageSize options, and an infinite animation
+    // range — all in one expression.
+    let expr = interpret_to_expr(
+      "Manipulate[\
+       Animate[Plot[{Subscript[r, 1] Subscript[signal, 1][Subscript[\
+       β, 1] ω+ϕ+Subscript[α, 1]],Subscript[r, 2] Subscript[signal, 2][\
+       Subscript[β, 2] ω+ϕ+Subscript[α, 2]]},{ω,0,10},ExclusionsStyle->\
+       Automatic,PlotRange->{{0,10},{3,-3}}],{ϕ,0,Infinity},\
+       AnimationRunning->False],\
+       Style[\"signal 1\",Bold,Medium],\
+       {{Subscript[signal, 1], SquareWave,\"\"},{Sin->\"sine\",\
+       SquareWave->\"square wave\",SawtoothWave->\"sawtooth wave\",\
+       TriangleWave->\"triangle wave\"},ControlType->PopupMenu},\
+       {{Subscript[α, 1],0,\"phase lag\"},0,2π, ImageSize-> Tiny},\
+       {{Subscript[r, 1],1,\"amplitude\"},0,3,ImageSize-> Tiny},\
+       {{Subscript[β, 1],1,\"frequency\"},0,5,ImageSize-> Tiny},\
+       Delimiter,\
+       Style[\"signal 2\",Bold,Medium],\
+       {{Subscript[signal, 2], Sin,\"\"},{Sin->\"sine\",\
+       SquareWave->\"square wave\",SawtoothWave->\"sawtooth wave\",\
+       TriangleWave->\"triangle wave\"},ControlType->PopupMenu},\
+       {{Subscript[α, 2],0,\"phase lag\"},0,2π,ImageSize-> Tiny},\
+       {{Subscript[r, 2],1,\"amplitude\"},0,3,ImageSize-> Tiny},\
+       {{Subscript[β, 2],1,\"frequency\"},0,5,ImageSize-> Tiny}\
+       ]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).unwrap();
+    assert!(spec.animated);
+    assert!(!spec.animation_running);
+    // Rows: animation slider, then per-signal heading + 4 controls,
+    // separated by a divider.
+    let kinds: Vec<&str> = spec
+      .controls
+      .iter()
+      .map(|c| match c {
+        ManipulateControl::Heading { .. } => "heading",
+        ManipulateControl::Divider => "divider",
+        ManipulateControl::Continuous { .. } => "continuous",
+        ManipulateControl::Discrete { .. } => "discrete",
+        _ => "other",
+      })
+      .collect();
+    assert_eq!(
+      kinds,
+      vec![
+        "continuous", // ϕ (animation)
+        "heading",    // signal 1
+        "discrete",
+        "continuous",
+        "continuous",
+        "continuous",
+        "divider",
+        "heading", // signal 2
+        "discrete",
+        "continuous",
+        "continuous",
+        "continuous",
+      ]
+    );
+    // The body with the initial bindings must evaluate to a Graphics.
+    let bindings = manipulate_initial_bindings(&spec);
+    let code = manipulate_block_code(&spec.body_code, &bindings);
+    assert_eq!(interpret(&format!("Head[{}]", code)).unwrap(), "Graphics");
   }
 
   #[test]

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -12,6 +12,35 @@ mod errors {
   }
 }
 
+mod dollar_in_symbol_names {
+  use super::*;
+
+  #[test]
+  fn dollar_sign_inside_symbol() {
+    // Wolfram allows `$` anywhere in a symbol name, not just at the start:
+    // `a$b` is one symbol (the form Module's renamed locals and Manipulate's
+    // synthesized control variables take).
+    assert_eq!(interpret("a$b = 7; a$b * 2").unwrap(), "14");
+  }
+
+  #[test]
+  fn dollar_sign_with_trailing_digits() {
+    assert_eq!(interpret("signal$1 = 5; signal$1 + 1").unwrap(), "6");
+  }
+
+  #[test]
+  fn dollar_symbol_used_as_function() {
+    assert_eq!(interpret("f$1[x_] := x^2; f$1[3]").unwrap(), "9");
+  }
+
+  #[test]
+  fn dollar_symbol_stays_symbolic() {
+    // An undefined `a$b` is a single symbol, not `a * $b`.
+    assert_eq!(interpret("Head[a$b]").unwrap(), "Symbol");
+    assert_eq!(interpret("a$b").unwrap(), "a$b");
+  }
+}
+
 mod char_escapes {
   use super::*;
 

--- a/tests/playground/script.js
+++ b/tests/playground/script.js
@@ -430,6 +430,8 @@ function renderManipulate(item) {
   function buildBindings() {
     const bindings = {}
     for (const ctrl of item.controls) {
+      // Annotation rows (headings / delimiters) bind no variable.
+      if (ctrl.kind === "heading" || ctrl.kind === "delimiter") continue
       const v = current[ctrl.name]
       if (ctrl.kind === "slider2d") {
         bindings[ctrl.name] = `{${v.x}, ${v.y}}`
@@ -595,6 +597,33 @@ function renderManipulate(item) {
   }
 
   for (const ctrl of item.controls) {
+    // Annotation rows between controls: a heading (a string or `Style[…]`
+    // Manipulate argument, e.g. "signal 1") or a `Delimiter` separator.
+    // They bind no variable and span the full row.
+    if (ctrl.kind === "heading") {
+      const heading = document.createElement("div")
+      heading.className = "manipulate-heading"
+      const runs = ctrl.labelRuns
+      if (Array.isArray(runs) && runs.length > 0) {
+        for (const run of runs) {
+          const part = document.createElement("span")
+          part.textContent = run.text
+          if (run.italic) part.style.fontStyle = "italic"
+          heading.appendChild(part)
+        }
+      } else {
+        heading.textContent = ctrl.label || ""
+      }
+      controlsEl.appendChild(heading)
+      continue
+    }
+    if (ctrl.kind === "delimiter") {
+      const hr = document.createElement("hr")
+      hr.className = "manipulate-delimiter"
+      controlsEl.appendChild(hr)
+      continue
+    }
+
     const row = document.createElement("label")
     row.className = "manipulate-control-row"
 
@@ -662,7 +691,9 @@ function renderManipulate(item) {
       // choice, else the value itself).
       const labels = ctrl.valueLabels ?? ctrl.values
       const values = ctrl.values
-      if (values.length <= SETTER_BAR_MAX_CHOICES) {
+      // `ControlType -> PopupMenu` always renders a dropdown, matching
+      // Wolfram; a small anonymous set defaults to a SetterBar.
+      if (values.length <= SETTER_BAR_MAX_CHOICES && !ctrl.popup) {
         // A small enumerated set renders as a segmented SetterBar: a row of
         // adjacent toggle buttons with the active choice highlighted, matching
         // Wolfram's SetterBar.
@@ -886,8 +917,9 @@ function renderManipulate(item) {
 
     bar.appendChild(btn)
     controlsEl.appendChild(bar)
-    // Start playing immediately (Wolfram's default AnimationRunning -> True).
-    play()
+    // Start playing immediately (Wolfram's default AnimationRunning -> True)
+    // unless the widget was built paused (`AnimationRunning -> False`).
+    if (item.animationRunning !== false) play()
   }
 
   box.appendChild(controlsEl)

--- a/tests/playground/style.css
+++ b/tests/playground/style.css
@@ -473,6 +473,23 @@ pre.output-box {
   color: var(--text);
 }
 
+/* A static heading row between controls (a string or Style[…] Manipulate
+   argument, e.g. "signal 1"). Spans the whole control grid. */
+.manipulate-heading {
+  grid-column: 1 / -1;
+  font-weight: 700;
+  color: var(--text);
+}
+
+/* A Delimiter argument: a horizontal separator between control groups. */
+.manipulate-delimiter {
+  grid-column: 1 / -1;
+  width: 100%;
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 0.15rem 0;
+}
+
 .manipulate-control-row input[type="range"] {
   width: 100%;
 }

--- a/woxi-studio/examples/dump_notebook.rs
+++ b/woxi-studio/examples/dump_notebook.rs
@@ -1,0 +1,32 @@
+//! Dump every parsed cell of a notebook file (style + content snippet) so
+//! rendering problems can be spotted without launching the GUI.
+//!
+//! Usage: cargo run --example dump_notebook -- path/to/notebook.nb
+
+use std::path::PathBuf;
+
+use woxi::notebook::{CellEntry, parse_notebook};
+
+fn main() {
+  let path: PathBuf = std::env::args()
+    .nth(1)
+    .expect("notebook path required")
+    .into();
+  let src = std::fs::read_to_string(&path).expect("read file");
+  let nb = parse_notebook(&src).expect("parse notebook");
+
+  let mut idx = 0;
+  for entry in &nb.cells {
+    let cells: Vec<_> = match entry {
+      CellEntry::Single(c) => vec![c],
+      CellEntry::Group(g) => g.cells.iter().collect(),
+    };
+    for cell in cells {
+      idx += 1;
+      let content = cell.content.replace('\n', "\\n");
+      let snippet: String = content.chars().take(200).collect();
+      let len = cell.content.chars().count();
+      println!("#{idx:3} [{:12}] ({len:6} chars) {snippet}", cell.style);
+    }
+  }
+}

--- a/woxi-studio/examples/rasterize_svg.rs
+++ b/woxi-studio/examples/rasterize_svg.rs
@@ -1,0 +1,32 @@
+//! Rasterize an SVG file to PNG (debugging aid).
+//! Usage: cargo run --example rasterize_svg -- in.svg out.png [scale]
+
+fn main() {
+  let mut args = std::env::args().skip(1);
+  let input = args.next().expect("input svg path");
+  let output = args.next().expect("output png path");
+  let scale: f32 = args.next().and_then(|s| s.parse().ok()).unwrap_or(2.0);
+
+  let data = std::fs::read(&input).expect("read svg");
+  let mut fontdb = resvg::usvg::fontdb::Database::new();
+  fontdb.load_system_fonts();
+  let opts = resvg::usvg::Options {
+    fontdb: std::sync::Arc::new(fontdb),
+    ..Default::default()
+  };
+  let tree = resvg::usvg::Tree::from_data(&data, &opts).expect("parse svg");
+  let size = tree.size();
+  let (w, h) = (
+    (size.width() * scale).ceil() as u32,
+    (size.height() * scale).ceil() as u32,
+  );
+  let mut pixmap = tiny_skia::Pixmap::new(w, h).expect("pixmap");
+  pixmap.fill(tiny_skia::Color::WHITE);
+  resvg::render(
+    &tree,
+    tiny_skia::Transform::from_scale(scale, scale),
+    &mut pixmap.as_mut(),
+  );
+  pixmap.save_png(&output).expect("write png");
+  println!("wrote {output} ({w}x{h})");
+}

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -549,7 +549,20 @@ impl WoxiStudio {
                 }
                 j += 1;
               }
+              // A stored FrontEnd widget dump (`DynamicModuleBox[…]`, the
+              // saved form of a live Manipulate) is meaningless as text —
+              // drop it and instantiate the interactive widget from the
+              // input instead, so the notebook opens with its Manipulate
+              // live (as Mathematica would show it).
+              let is_widget_dump =
+                output.as_deref().is_some_and(is_dynamic_box_dump);
+              let manipulate_state = if is_widget_dump {
+                instantiate_stored_manipulate(&cell.content)
+              } else {
+                None
+              };
               let output_content = match &output {
+                Some(_) if is_widget_dump => text_editor::Content::new(),
                 Some(s) => {
                   let d = s
                     .replace("-Graphics-", "")
@@ -571,7 +584,7 @@ impl WoxiStudio {
               editors.push(CellEditor {
                 content: text_editor::Content::with_text(&cell.content),
                 style: cell.style,
-                output,
+                output: if is_widget_dump { None } else { output },
                 stdout,
                 graphics_svg: None,
                 graphics_handle: None,
@@ -586,7 +599,7 @@ impl WoxiStudio {
                 redo_stack: Vec::new(),
                 output_stale: false,
                 is_collapsed: false,
-                manipulate_state: None,
+                manipulate_state,
                 hyperlinks: Vec::new(),
                 output_content,
                 stdout_content,
@@ -762,10 +775,11 @@ impl WoxiStudio {
           Ok((path, contents)) => match notebook::parse_notebook(&contents) {
             Ok(nb) => {
               self.stop_playback();
-              self.cell_editors = Self::editors_from_notebook(&nb);
-              self.notebook = nb;
               self.status = format!("Opened: {}", path.display());
               save_last_file_path(&path);
+              // Install the notebook's environment (directory, file name,
+              // theme) before building the editors: loading may instantiate
+              // stored Manipulate widgets, which evaluate their bodies.
               if let Some(dir) = path.parent() {
                 woxi::set_notebook_directory(Some(
                   dir.to_string_lossy().into_owned(),
@@ -775,6 +789,9 @@ impl WoxiStudio {
                 "$InputFileName",
                 &format!("\"{}\"", path.to_string_lossy()),
               );
+              woxi::set_dark_mode(!matches!(self.theme, Theme::Light));
+              self.cell_editors = Self::editors_from_notebook(&nb);
+              self.notebook = nb;
               self.file_path = Some(path);
               self.is_dirty = false;
               self.show_toc = self
@@ -3492,6 +3509,10 @@ fn manipulate_label_char_count(ctrl: &manipulate::ControlState) -> usize {
     | manipulate::ControlState::IntervalSlider { label, name, .. } => {
       (label, name)
     }
+    // Heading/divider rows span the full row instead of sitting in the
+    // label column, so they don't widen it.
+    manipulate::ControlState::Heading { .. }
+    | manipulate::ControlState::Divider => return 0,
   };
   let text = if label.is_empty() { name } else { label };
   text.chars().count()
@@ -3616,6 +3637,7 @@ fn render_manipulate_widget<'a>(
         label_runs,
         value_labels,
         current_index,
+        popup,
         ..
       } => {
         let label_widget = manipulate_label_widget(
@@ -3628,49 +3650,51 @@ fn render_manipulate_widget<'a>(
         let count = value_labels.len();
         // A small enumerated set renders as a segmented SetterBar (a row of
         // adjacent toggle buttons with the active choice highlighted), matching
-        // Wolfram's SetterBar; a larger set falls back to a dropdown so the
-        // row can't grow unbounded. The button labels are the display labels
+        // Wolfram's SetterBar; a larger set — or an explicit
+        // `ControlType -> PopupMenu` — renders a dropdown so the row can't
+        // grow unbounded. The button labels are the display labels
         // (rule right-hand sides); pressing one sends its label, which the
         // update handler maps back to an index. A disabled control drops its
         // press handlers so it can't be changed.
-        let control: Element<Message> = if count <= SETTER_BAR_MAX_CHOICES {
-          let mut bar = Row::new().spacing(0).align_y(Center);
-          for (i, choice_label) in value_labels.iter().enumerate() {
-            let is_selected = i == *current_index;
-            let choice = choice_label.clone();
-            let mut btn = button(text(choice_label.clone()).size(12))
-              .padding([3, 10])
-              .style(move |theme: &Theme, status| {
-                setter_button_style(
-                  theme,
-                  status,
-                  is_selected,
-                  i,
-                  count,
-                  enabled,
-                )
-              });
-            if enabled {
-              btn = btn.on_press(Message::ManipulateDiscreteChanged(
-                cell_idx, ctrl_idx, choice,
-              ));
+        let control: Element<Message> =
+          if count <= SETTER_BAR_MAX_CHOICES && !*popup {
+            let mut bar = Row::new().spacing(0).align_y(Center);
+            for (i, choice_label) in value_labels.iter().enumerate() {
+              let is_selected = i == *current_index;
+              let choice = choice_label.clone();
+              let mut btn = button(text(choice_label.clone()).size(12))
+                .padding([3, 10])
+                .style(move |theme: &Theme, status| {
+                  setter_button_style(
+                    theme,
+                    status,
+                    is_selected,
+                    i,
+                    count,
+                    enabled,
+                  )
+                });
+              if enabled {
+                btn = btn.on_press(Message::ManipulateDiscreteChanged(
+                  cell_idx, ctrl_idx, choice,
+                ));
+              }
+              bar = bar.push(btn);
             }
-            bar = bar.push(btn);
-          }
-          bar.into()
-        } else {
-          let selected = value_labels.get(*current_index).cloned();
-          let on_select = move |choice: String| {
-            if enabled {
-              Message::ManipulateDiscreteChanged(cell_idx, ctrl_idx, choice)
-            } else {
-              Message::Noop
-            }
+            bar.into()
+          } else {
+            let selected = value_labels.get(*current_index).cloned();
+            let on_select = move |choice: String| {
+              if enabled {
+                Message::ManipulateDiscreteChanged(cell_idx, ctrl_idx, choice)
+              } else {
+                Message::Noop
+              }
+            };
+            pick_list(value_labels.clone(), selected, on_select)
+              .width(iced::Length::Shrink)
+              .into()
           };
-          pick_list(value_labels.clone(), selected, on_select)
-            .width(iced::Length::Shrink)
-            .into()
-        };
         let control_row =
           row![label_widget, control].align_y(Center).spacing(8);
         controls_col = controls_col.push(control_row);
@@ -3785,6 +3809,34 @@ fn render_manipulate_widget<'a>(
         .align_y(Center)
         .spacing(8);
         controls_col = controls_col.push(control_row);
+      }
+      manipulate::ControlState::Heading { label, label_runs } => {
+        // A static heading row (a string or `Style[…]` Manipulate argument,
+        // e.g. "signal 1"). Rendered bold across the full row.
+        let spans: Vec<iced::widget::text::Span<Message>> = label_runs
+          .iter()
+          .map(|run| {
+            let mut font = Font::MONOSPACE;
+            font.weight = iced::font::Weight::Bold;
+            if run.italic {
+              font.style = iced::font::Style::Italic;
+            }
+            iced::widget::span(run.text.clone()).font(font)
+          })
+          .collect();
+        let heading: Element<Message> = if spans.is_empty() {
+          let mut font = Font::MONOSPACE;
+          font.weight = iced::font::Weight::Bold;
+          text(label.clone()).size(12).font(font).into()
+        } else {
+          rich_text(spans).size(12).into()
+        };
+        controls_col = controls_col.push(heading);
+      }
+      manipulate::ControlState::Divider => {
+        // A `Delimiter` argument: a horizontal separator between control
+        // groups.
+        controls_col = controls_col.push(rule::horizontal(1));
       }
     }
   }
@@ -4188,6 +4240,32 @@ fn play_audio(
 /// Evaluate all statements in a cell and collect their results.
 /// When a cell contains multiple newline-separated expressions,
 /// each expression's output is included (matching Mathematica behavior).
+/// Whether a stored Output cell holds a FrontEnd dynamic-widget dump — the
+/// `DynamicModuleBox[…]` box form Mathematica saves for a live Manipulate.
+/// Such text is meaningless outside the Wolfram FrontEnd.
+fn is_dynamic_box_dump(output: &str) -> bool {
+  let t = output.trim_start();
+  t.starts_with("DynamicModuleBox[")
+    || t.starts_with("TagBox[DynamicModuleBox[")
+    || t.starts_with("DynamicBox[")
+}
+
+/// Rebuild the interactive widget for a loaded Input cell whose stored
+/// output was a dynamic-widget dump. Only a cell that is exactly one held
+/// interactive expression (`Manipulate[…]`, `Animate[…]`, …) is
+/// instantiated on load; anything else (definitions, side effects) waits
+/// for an explicit evaluation.
+fn instantiate_stored_manipulate(
+  code: &str,
+) -> Option<manipulate::ManipulateState> {
+  let statements = woxi::split_into_statements(code);
+  if statements.len() != 1 {
+    return None;
+  }
+  let expr = woxi::interpret_to_expr(&statements[0]).ok()?;
+  manipulate::ManipulateState::from_expr(&expr)
+}
+
 fn evaluate_cell_statements(
   editor: &mut CellEditor,
   code: &str,
@@ -5991,6 +6069,148 @@ mod tests {
     let state = manipulate::ManipulateState::from_expr(&expr).unwrap();
     assert!(!state.appearance_none);
     assert!(!state.animated && !state.playing);
+  }
+
+  #[test]
+  fn animation_running_false_builds_widget_paused() {
+    // `AnimationRunning -> False` keeps the play/pause toggle but starts
+    // the widget paused until the user presses play.
+    let expr = woxi::interpret_to_expr(
+      "Animate[x, {x, 0, 1}, AnimationRunning -> False]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    assert!(state.animated);
+    assert!(!state.playing);
+  }
+
+  #[test]
+  fn dynamic_box_dump_is_recognized() {
+    // The saved box form of a live Manipulate (what Mathematica writes
+    // into the Output cell) must be recognized so Studio hides the dump
+    // and re-instantiates the widget instead.
+    assert!(is_dynamic_box_dump(
+      "DynamicModuleBox[{$CellContext`x$$ = 1}, …]"
+    ));
+    assert!(is_dynamic_box_dump("TagBox[DynamicModuleBox[{…}, …], …]"));
+    assert!(is_dynamic_box_dump("DynamicBox[…]"));
+    // Ordinary outputs are untouched.
+    assert!(!is_dynamic_box_dump("42"));
+    assert!(!is_dynamic_box_dump("{1, 2, 3}"));
+    assert!(!is_dynamic_box_dump("GraphicsBox[…]"));
+  }
+
+  #[test]
+  fn stored_manipulate_is_instantiated_on_load() {
+    let state =
+      instantiate_stored_manipulate("Manipulate[x^2, {x, 0, 10}]").unwrap();
+    assert_eq!(state.controls.len(), 1);
+    // A cell with side effects (multiple statements) is never auto-run.
+    assert!(
+      instantiate_stored_manipulate("y = 1;\nManipulate[x y, {x, 0, 10}]")
+        .is_none()
+    );
+    // A non-Manipulate cell yields no widget.
+    assert!(instantiate_stored_manipulate("1 + 1").is_none());
+  }
+
+  #[test]
+  fn oscilloscope_manipulate_builds_full_widget() {
+    // End-to-end regression for the "Oscilloscope with Two Signal Inputs"
+    // Demonstration: the loaded Input cell must build a live widget with
+    // the animation slider, per-signal headings, popup menus, a divider,
+    // and a rendered plot.
+    let code = "Manipulate[\n\
+      Animate[Plot[{Subscript[r, 1] Subscript[signal, 1][Subscript[β, 1] \
+      ω+ϕ+Subscript[α, 1]],Subscript[r, 2] Subscript[signal, 2][Subscript[\
+      β, 2] ω+ϕ+Subscript[α, 2]]},{ω,0,10},ExclusionsStyle->Automatic,\
+      PlotRange->{{0,10},{3,-3}}],{ϕ,0,Infinity},AnimationRunning->False],\n\
+      Style[\"signal 1\",Bold,Medium],\n\
+      {{Subscript[signal, 1], SquareWave,\"\"},{Sin->\"sine\",SquareWave->\
+      \"square wave\",SawtoothWave->\"sawtooth wave\",TriangleWave->\
+      \"triangle wave\"},ControlType->PopupMenu},\n\
+      {{Subscript[α, 1],0,\"phase lag\"},0,2π, ImageSize-> Tiny},\n\
+      {{Subscript[r, 1],1,\"amplitude\"},0,3,ImageSize-> Tiny},\n\
+      {{Subscript[β, 1],1,\"frequency\"},0,5,ImageSize-> Tiny},\n\
+      Delimiter,\n\
+      Style[\"signal 2\",Bold,Medium],\n\
+      {{Subscript[signal, 2], Sin,\"\"},{Sin->\"sine\",SquareWave->\
+      \"square wave\",SawtoothWave->\"sawtooth wave\",TriangleWave->\
+      \"triangle wave\"},ControlType->PopupMenu},\n\
+      {{Subscript[α, 2],0,\"phase lag\"},0,2π,ImageSize-> Tiny},\n\
+      {{Subscript[r, 2],1,\"amplitude\"},0,3,ImageSize-> Tiny},\n\
+      {{Subscript[β, 2],1,\"frequency\"},0,5,ImageSize-> Tiny}\n\
+      ]";
+    let state = instantiate_stored_manipulate(code)
+      .expect("oscilloscope Manipulate must build a widget");
+    assert!(
+      state.animated,
+      "nested Animate body must animate the widget"
+    );
+    assert!(!state.playing, "AnimationRunning -> False starts paused");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "initial rendering must produce the plot"
+    );
+    // Row layout: animation slider, then heading + popup + 3 sliders per
+    // signal, separated by a divider.
+    let kinds: Vec<&str> = state
+      .controls
+      .iter()
+      .map(|c| match c {
+        manipulate::ControlState::Continuous { .. } => "continuous",
+        manipulate::ControlState::Discrete { .. } => "discrete",
+        manipulate::ControlState::Heading { .. } => "heading",
+        manipulate::ControlState::Divider => "divider",
+        _ => "other",
+      })
+      .collect();
+    assert_eq!(
+      kinds,
+      vec![
+        "continuous",
+        "heading",
+        "discrete",
+        "continuous",
+        "continuous",
+        "continuous",
+        "divider",
+        "heading",
+        "discrete",
+        "continuous",
+        "continuous",
+        "continuous",
+      ]
+    );
+    // The popup menus keep their dropdown form and rule-form labels.
+    match &state.controls[2] {
+      manipulate::ControlState::Discrete {
+        value_labels,
+        current_index,
+        popup,
+        ..
+      } => {
+        assert!(popup);
+        assert_eq!(value_labels[*current_index], "square wave");
+      }
+      other => panic!("expected popup menu, got {other:?}"),
+    }
+    // Changing a signal re-renders without error (regression: symbol-valued
+    // popup bindings must substitute as function heads).
+    let mut state = state;
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[2]
+    {
+      *current_index = 3; // triangle wave
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
   }
 
   #[test]

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -43,6 +43,9 @@ pub enum ControlState {
     /// for plain choices; the rule's right side for rule-form choices.
     value_labels: Vec<String>,
     current_index: usize,
+    /// `ControlType -> PopupMenu`: always render a dropdown, even when the
+    /// choice count is small enough for a SetterBar.
+    popup: bool,
   },
   /// A 2D slider binding its variable to a `{x, y}` pair.
   Slider2D {
@@ -65,6 +68,14 @@ pub enum ControlState {
     low: f64,
     high: f64,
   },
+  /// A static heading row between controls (a string or `Style[…]`
+  /// Manipulate argument). Binds no variable.
+  Heading {
+    label: String,
+    label_runs: Vec<LabelRun>,
+  },
+  /// A `Delimiter` argument: a horizontal separator row. Binds no variable.
+  Divider,
 }
 
 impl ControlState {
@@ -74,7 +85,13 @@ impl ControlState {
       ControlState::Discrete { name, .. } => name,
       ControlState::Slider2D { name, .. } => name,
       ControlState::IntervalSlider { name, .. } => name,
+      ControlState::Heading { .. } | ControlState::Divider => "",
     }
+  }
+
+  /// Whether this row binds a variable (annotation rows don't).
+  pub fn binds_variable(&self) -> bool {
+    !matches!(self, ControlState::Heading { .. } | ControlState::Divider)
   }
 
   /// InputForm fragment for the *current* value, for use inside a
@@ -95,6 +112,10 @@ impl ControlState {
       }
       ControlState::IntervalSlider { low, high, .. } => {
         format!("{{{}, {}}}", format_f64(*low), format_f64(*high))
+      }
+      // Annotation rows bind no variable; never substituted.
+      ControlState::Heading { .. } | ControlState::Divider => {
+        "Null".to_string()
       }
     }
   }
@@ -192,8 +213,9 @@ impl ManipulateState {
       text_output: None,
       error: None,
       animated: spec.animated,
-      // Auto-play immediately (Wolfram's default AnimationRunning -> True).
-      playing: spec.animated,
+      // Auto-play immediately (Wolfram's default AnimationRunning -> True)
+      // unless the spec was built paused (`AnimationRunning -> False`).
+      playing: spec.animated && spec.animation_running,
       appearance_none: spec.appearance_none,
       control_enabled,
       control_is_enabled,
@@ -211,6 +233,7 @@ impl ManipulateState {
     let mut b: Vec<(String, String)> = self
       .controls
       .iter()
+      .filter(|c| c.binds_variable())
       .map(|c| (c.name().to_string(), c.current_code()))
       .collect();
     b.extend(self.state.iter().cloned());
@@ -418,6 +441,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         values,
         value_labels,
         initial_index,
+        popup,
       } => ControlState::Discrete {
         name: name.clone(),
         label: label.clone(),
@@ -425,6 +449,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         values: values.clone(),
         value_labels: value_labels.clone(),
         current_index: *initial_index,
+        popup: *popup,
       },
       ManipulateControl::Slider2D {
         name,
@@ -468,6 +493,13 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
           high: *high_initial,
         }
       }
+      ManipulateControl::Heading { label, label_runs } => {
+        ControlState::Heading {
+          label: label.clone(),
+          label_runs: label_runs.clone(),
+        }
+      }
+      ManipulateControl::Divider => ControlState::Divider,
     })
     .collect()
 }


### PR DESCRIPTION
## Summary

This PR adds support for static annotation rows in `Manipulate` expressions and enables compound (non-symbol) control variables like `Subscript[signal, 1]`. These features are driven by compatibility with the "Oscilloscope with Two Signal Inputs" Wolfram Demonstration.

## Key Changes

### Annotation Rows
- `Style[…]`, bare strings, and `Delimiter` arguments are now recognized as static annotation rows between controls (Wolfram's `ThisIsNotAControl` pattern)
- These rows render as headings and separators in both Woxi Studio and the Playground
- No spurious `Manipulate::vsform` messages are emitted for these arguments
- Annotation rows bind no variables and span the full control width

### Compound Control Variables
- Control variables that are compound expressions (e.g., `Subscript[signal, 1]`) are now supported
- Such variables are renamed to synthesized plain symbols (`signal$1`) internally
- All occurrences in the body, displays, initialization, and control conditions are rewritten to use the synthesized name
- Default labels are patched to show the pretty-printed original form (`signal₁`) instead of the synthesized name
- Longest original names are rewritten first to prevent partial matches

### Additional Features
- `AnimationRunning -> False` option now builds animated widgets in a paused state
- Nested `Animate` bodies in `Manipulate` expressions are flattened into a single combined widget
- `ControlType -> PopupMenu` option forces dropdown rendering even for small choice sets
- `PlotRange` bounds given in reversed order (e.g., `{3, -3}`) now normalize to match the sorted form
- Symbol names may now contain `$` anywhere (e.g., `a$b`, `signal$1`), matching Wolfram

### UI/Frontend Updates
- Woxi Studio renders heading and divider rows in the Manipulate widget
- The Playground frontend renders annotation rows with proper styling
- Stored `DynamicModuleBox` widget dumps are recognized and replaced with live widget instantiation on notebook load
- Notebook environment (directory, filename, theme) is installed before building editors to support widget evaluation

### Implementation Details
- New `ManipulateControl` variants: `Heading` and `Divider`
- New `ControlState` variants: `Heading` and `Divider`
- `ManipulateSpec` gains `animation_running` field to track pause state
- `synthesize_var_name()` generates plain symbol names from compound expressions
- `rewrite_compound_control_var()` rewrites control specs with compound variables
- `patch_default_label()` restores pretty-printed labels after renaming
- Added helper functions: `is_dynamic_box_dump()`, `instantiate_stored_manipulate()`
- Added example utilities: `dump_notebook.rs`, `rasterize_svg.rs`

### Tests
- Comprehensive tests for annotation rows, compound variables, and nested Animate
- End-to-end regression test for the oscilloscope Demonstration
- Tests for `AnimationRunning -> False` behavior
- Tests for dynamic box dump recognition and widget instantiation
- Tests for symbol names with `$` characters
- Tests for `PlotRange` normalization

https://claude.ai/code/session_01CNzAkYXn7b5jmh1mcQ8kag