### PR TITLE
Add interactive Locator controls and PlotLabel support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,26 @@
         an `Infinity` animation bound gets a finite looping window.
 - Woxi Studio re-instantiates stored `Manipulate` widgets when opening a
     notebook (instead of showing the saved `DynamicModuleBox[…]` text dump).
+- Manipulate improvements (driven by the "Center of Mass of a Polygon"
+    Wolfram Demonstration):
+    - `Locator` controls are interactive: a single point binds as a 2D
+        slider, a point list becomes a per-point X/Y control (with
+        add/remove when `LocatorAutoCreate -> True`, and a multi-handle
+        drag pad in the Playground), instead of freezing the variable at
+        its initial value.
+    - Discrete choices whose rule label is a graphic (`"+" -> myIcon[2]`)
+        render the icon in the SetterBar instead of dumping the label's
+        InputForm.
+    - A bare control-type shorthand in the range position
+        (`{{p, init}, Locator}`) is no longer misread as a `Dynamic[…]`
+        range.
+- InputForm keeps required parentheses around loose operands of `@@`, `/@`,
+    `@@@`, and `.` (`Plus @@ (x*y)/2`, `a . (b - c)`); previously the
+    printed form re-parsed to a different expression, silently corrupting
+    re-evaluated Manipulate bodies.
+- `PlotLabel` works on plain `Graphics[…]` (rendered as a centered title),
+    and labels may be arbitrary expressions such as
+    `Row[{"center of mass: ", CM}]` on all plot types.
 
 # 2026-07-16 - 0.2.0
 

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -95,7 +95,11 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
       let text = match &args[0] {
         Expr::String(s) => s.clone(),
         Expr::Identifier(s) => s.clone(),
-        _ => return None,
+        // Any other content (`Row[…]`, a number, …) labels with its
+        // OutputForm text, matching wolframscript.
+        other => {
+          crate::syntax::format_expr(other, crate::syntax::ExprForm::Output)
+        }
       };
       let mut bold = false;
       let mut italic = false;
@@ -122,7 +126,23 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
         font_size,
       })
     }
-    _ => None,
+    // Any other expression (`Row[{"a: ", val}]`, a number, …) labels the
+    // plot with its OutputForm text, matching wolframscript.
+    other => {
+      let text =
+        crate::syntax::format_expr(other, crate::syntax::ExprForm::Output);
+      if text.is_empty() {
+        None
+      } else {
+        Some(StyledLabel {
+          text,
+          bold: false,
+          italic: false,
+          color: None,
+          font_size: None,
+        })
+      }
+    }
   }
 }
 

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -12265,6 +12265,33 @@ fn process_manipulate_var_spec(items: &[Expr]) -> Expr {
       // A trailing control option such as `ControlType -> None` is not a
       // range, so it must not be wrapped in Dynamic[…].
       Expr::Rule { .. } | Expr::RuleDelayed { .. } => false,
+      // A bare control-type shorthand in the range position (`{{p, init},
+      // Locator}`, `{u, Slider}` …) selects the control; it is not a range.
+      Expr::Identifier(s)
+        if matches!(
+          s.as_str(),
+          "Locator"
+            | "Slider"
+            | "Slider2D"
+            | "VerticalSlider"
+            | "Manipulator"
+            | "InputField"
+            | "PopupMenu"
+            | "SetterBar"
+            | "RadioButtonBar"
+            | "TogglerBar"
+            | "Checkbox"
+            | "ColorSlider"
+            | "ColorSetter"
+            | "IntervalSlider"
+            | "Animator"
+            | "Trigger"
+            | "None"
+            | "Automatic"
+        ) =>
+      {
+        false
+      }
       _ => true,
     }
     && needs_dynamic
@@ -12348,8 +12375,14 @@ pub enum ManipulateControl {
     values: Vec<String>,
     /// The display label for each choice, parallel to `values`. For a plain
     /// choice this equals the value's InputForm; for a rule-form choice it is
-    /// the (unquoted) right side of the rule.
+    /// the (unquoted) right side of the rule. A rule label that is itself a
+    /// graphic falls back to the value's display text here (the rendered
+    /// icon travels in `value_label_svgs`).
     value_labels: Vec<String>,
+    /// Rendered SVG for each choice whose rule label is a `Graphics[…]`
+    /// icon (e.g. the crosshair pickers of the Demonstrations site),
+    /// parallel to `values`. `None` for plain text labels.
+    value_label_svgs: Vec<Option<String>>,
     initial_index: usize,
     label: String,
     label_runs: Vec<LabelRun>,
@@ -12382,6 +12415,20 @@ pub enum ManipulateControl {
     high_initial: f64,
     label: String,
   },
+  /// A `Locator` control bound to a *list* of draggable 2D points (e.g.
+  /// the vertices of a polygon). Rendered as one X/Y slider pair per
+  /// point; `auto_create` (`LocatorAutoCreate -> True`) additionally
+  /// offers adding and removing points.
+  Locator {
+    name: String,
+    points: Vec<(f64, f64)>,
+    x_min: f64,
+    x_max: f64,
+    y_min: f64,
+    y_max: f64,
+    auto_create: bool,
+    label: String,
+  },
   /// A static heading row between controls: a bare string or `Style[…]`
   /// Manipulate argument (Wolfram's `ThisIsNotAControl` annotations, e.g.
   /// the "signal 1" / "signal 2" captions of the oscilloscope
@@ -12403,7 +12450,8 @@ impl ManipulateControl {
       ManipulateControl::Continuous { name, .. }
       | ManipulateControl::Discrete { name, .. }
       | ManipulateControl::Slider2D { name, .. }
-      | ManipulateControl::IntervalSlider { name, .. } => name,
+      | ManipulateControl::IntervalSlider { name, .. }
+      | ManipulateControl::Locator { name, .. } => name,
       ManipulateControl::Heading { .. } | ManipulateControl::Divider => "",
     }
   }
@@ -12804,7 +12852,8 @@ fn patch_default_label(
       }
     }
     ManipulateControl::Slider2D { label, .. }
-    | ManipulateControl::IntervalSlider { label, .. } => {
+    | ManipulateControl::IntervalSlider { label, .. }
+    | ManipulateControl::Locator { label, .. } => {
       if label == synth {
         *label = pretty;
       }
@@ -13121,6 +13170,46 @@ fn list2_f64(e: &Expr) -> Option<(f64, f64)> {
   }
 }
 
+/// Interpret an expression as a non-empty list of 2D numeric points
+/// `{{x1, y1}, {x2, y2}, …}`. Returns `None` when any element isn't a
+/// numeric 2-vector.
+fn point_list_f64(e: &Expr) -> Option<Vec<(f64, f64)>> {
+  match e {
+    Expr::List(items) if !items.is_empty() => {
+      items.iter().map(list2_f64).collect()
+    }
+    _ => None,
+  }
+}
+
+/// Coordinate range for a Locator control: the explicit
+/// `{xmin, ymin}, {xmax, ymax}` corner bounds when the spec gives both,
+/// otherwise the bounding box of the initial points padded by half its
+/// span per axis (at least 1), so every point stays draggable.
+fn locator_range(
+  corner_bounds: &[(f64, f64)],
+  points: &[(f64, f64)],
+) -> (f64, f64, f64, f64) {
+  if corner_bounds.len() >= 2 {
+    let (x0, y0) = corner_bounds[0];
+    let (x1, y1) = corner_bounds[1];
+    return (x0.min(x1), x0.max(x1), y0.min(y1), y0.max(y1));
+  }
+  let mut x_min = f64::INFINITY;
+  let mut x_max = f64::NEG_INFINITY;
+  let mut y_min = f64::INFINITY;
+  let mut y_max = f64::NEG_INFINITY;
+  for (x, y) in points {
+    x_min = x_min.min(*x);
+    x_max = x_max.max(*x);
+    y_min = y_min.min(*y);
+    y_max = y_max.max(*y);
+  }
+  let x_pad = ((x_max - x_min) / 2.0).max(1.0);
+  let y_pad = ((y_max - y_min) / 2.0).max(1.0);
+  (x_min - x_pad, x_max + x_pad, y_min - y_pad, y_max + y_pad)
+}
+
 /// Render a control-label expression into styled runs for the interactive
 /// widget. Wolfram labels are frequently wrapped in presentation heads
 /// (`Style[…, Italic]`, `Text[…]`) or use `Subscript`, none of which should
@@ -13361,13 +13450,19 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
     _ => None,
   });
 
-  // Hidden controls: a `Locator` marker (`{{p, init}, pmin, pmax, Locator}`)
-  // or `ControlType -> None` (`{{v, init}, ControlType -> None}`). Neither
-  // renders a UI element in the static widget; both bind their variable to
-  // the (evaluated) initial value so the body can reference it.
-  let is_locator = items
-    .iter()
-    .any(|it| matches!(it, Expr::Identifier(s) if s == "Locator"));
+  // `Locator` controls (`{{p, init}, pmin, pmax, Locator}`, as a bare
+  // marker or `ControlType -> Locator`) and hidden `ControlType -> None`
+  // variables (`{{v, init}, ControlType -> None}`).
+  let is_locator = items.iter().any(|it| {
+    matches!(it, Expr::Identifier(s) if s == "Locator")
+      || matches!(
+        it,
+        Expr::Rule { pattern, replacement }
+        | Expr::RuleDelayed { pattern, replacement }
+          if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "ControlType")
+            && matches!(replacement.as_ref(), Expr::Identifier(s) if s == "Locator")
+      )
+  });
   let is_hidden = items.iter().any(|it| {
     matches!(
       it,
@@ -13382,15 +13477,76 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
       .clone()
       .or_else(|| items.get(1).cloned())
       .unwrap_or(Expr::Identifier("Null".to_string()));
-    let value = manipulate_value_to_input_form(&value_expr);
-    // A Locator's initial point list is baked into the body (it is never
-    // rewritten by a display); a `ControlType -> None` variable stays a
-    // live, mutable binding so an interactive display can rewrite it.
-    return Some(if is_locator {
-      ParsedControl::Fixed { name, value }
-    } else {
-      ParsedControl::State { name, value }
+    if is_hidden {
+      // A `ControlType -> None` variable stays a live, mutable binding so
+      // an interactive display can rewrite it.
+      let value = manipulate_value_to_input_form(&value_expr);
+      return Some(ParsedControl::State { name, value });
+    }
+    // A Locator drives its variable interactively: a single `{x, y}` point
+    // becomes a 2D slider (like `LocatorPane`), a list of points becomes a
+    // multi-point Locator control (one X/Y pair per point, with add/remove
+    // when `LocatorAutoCreate -> True`). The coordinate range comes from
+    // the `{xmin, ymin}, {xmax, ymax}` bounds when given, else from the
+    // points' bounding box. A non-numeric initial value keeps the previous
+    // behavior: a fixed binding baked into the body.
+    let evaluated = crate::evaluator::evaluate_expr_to_expr(&value_expr)
+      .unwrap_or_else(|_| value_expr.clone());
+    let corner_bounds: Vec<(f64, f64)> = items[1..]
+      .iter()
+      .filter(|it| {
+        !matches!(it, Expr::Rule { .. } | Expr::RuleDelayed { .. })
+          && !matches!(it, Expr::Identifier(s) if s == "Locator")
+      })
+      .filter_map(list2_f64)
+      .collect();
+    let auto_create = items.iter().any(|it| {
+      matches!(
+        it,
+        Expr::Rule { pattern, replacement }
+        | Expr::RuleDelayed { pattern, replacement }
+          if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "LocatorAutoCreate")
+            && matches!(
+              replacement.as_ref(),
+              Expr::Identifier(s) if s == "True" || s == "Automatic" || s == "All"
+            )
+      )
     });
+    if let Some((x, y)) = list2_f64(&evaluated) {
+      let (x_min, x_max, y_min, y_max) =
+        locator_range(&corner_bounds, &[(x, y)]);
+      return Some(ParsedControl::Visible(
+        ManipulateControl::Slider2D {
+          name,
+          x_min,
+          x_max,
+          y_min,
+          y_max,
+          x_initial: x,
+          y_initial: y,
+          label,
+        },
+        enabled,
+      ));
+    }
+    if let Some(points) = point_list_f64(&evaluated) {
+      let (x_min, x_max, y_min, y_max) = locator_range(&corner_bounds, &points);
+      return Some(ParsedControl::Visible(
+        ManipulateControl::Locator {
+          name,
+          points,
+          x_min,
+          x_max,
+          y_min,
+          y_max,
+          auto_create,
+          label,
+        },
+        enabled,
+      ));
+    }
+    let value = manipulate_value_to_input_form(&value_expr);
+    return Some(ParsedControl::Fixed { name, value });
   }
 
   // A `ControlType -> Slider2D` / `ControlType -> IntervalSlider` option
@@ -13509,19 +13665,32 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
       // case the left side is the value bound to the variable and the right
       // side is only the display label. Split the two so the binding sees the
       // real value, not the whole rule.
-      let (values, value_labels): (Vec<String>, Vec<String>) = value_items
-        .iter()
-        .map(|item| match discrete_choice_rule(item) {
-          Some((value, label)) => (
-            crate::syntax::expr_to_input_form(value),
-            discrete_choice_label(label),
-          ),
-          None => (
-            crate::syntax::expr_to_input_form(item),
-            discrete_choice_label(item),
-          ),
-        })
-        .unzip();
+      let mut values = Vec::with_capacity(value_items.len());
+      let mut value_labels = Vec::with_capacity(value_items.len());
+      let mut value_label_svgs = Vec::with_capacity(value_items.len());
+      for item in value_items.iter() {
+        match discrete_choice_rule(item) {
+          Some((value, label)) => {
+            values.push(crate::syntax::expr_to_input_form(value));
+            // A rule label that is itself a graphic (the crosshair icons
+            // of the Demonstrations site) renders as an SVG icon; its text
+            // column falls back to the bound value so a non-graphical
+            // frontend still shows something short and meaningful.
+            let svg = discrete_choice_label_svg(label);
+            value_labels.push(if svg.is_some() {
+              discrete_choice_label(value)
+            } else {
+              discrete_choice_label(label)
+            });
+            value_label_svgs.push(svg);
+          }
+          None => {
+            values.push(crate::syntax::expr_to_input_form(item));
+            value_labels.push(discrete_choice_label(item));
+            value_label_svgs.push(None);
+          }
+        }
+      }
       if values.is_empty() {
         return None;
       }
@@ -13537,6 +13706,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
           name,
           values,
           value_labels,
+          value_label_svgs,
           initial_index,
           label,
           label_runs,
@@ -13621,6 +13791,27 @@ fn discrete_choice_label(expr: &Expr) -> String {
   }
 }
 
+/// Rendered SVG for a discrete-choice label that is a graphic (e.g.
+/// `"+" -> myIcon[2]` in a Demonstrations crosshair picker). A held
+/// `Graphics[…]` call or a call producing one is evaluated; anything
+/// text-like yields `None`.
+fn discrete_choice_label_svg(label: &Expr) -> Option<String> {
+  match label {
+    Expr::Graphics { svg, .. } => Some(svg.clone()),
+    // Evaluating through the interpreter (not `evaluate_expr_to_expr`)
+    // is what renders a held `Graphics[…]` call — or a user-defined icon
+    // function like `myIcon[2]` — to SVG.
+    Expr::FunctionCall { .. } => {
+      let code = crate::syntax::expr_to_input_form(label);
+      match crate::interpret_with_stdout(&code) {
+        Ok(result) => result.graphics,
+        Err(_) => None,
+      }
+    }
+    _ => None,
+  }
+}
+
 /// Pick a reasonable current value for each control. For continuous
 /// controls this is the `initial`; for discrete controls it is the value
 /// at `initial_index`. Returns `(variable_name, input_form_value)` pairs.
@@ -13674,6 +13865,9 @@ pub fn manipulate_initial_bindings(
           format_f64_input(*high_initial)
         ),
       )),
+      ManipulateControl::Locator { name, points, .. } => {
+        Some((name.clone(), format_point_list_input(points)))
+      }
     })
     // Mutable `ControlType -> None` state variables travel in the binding
     // set alongside the visible controls so displays can read/write them.
@@ -13687,6 +13881,30 @@ pub fn manipulate_initial_bindings(
 fn format_f64_input(v: f64) -> String {
   if v.is_finite() && v.fract() == 0.0 && v.abs() < 1e15 {
     format!("{}", v as i64)
+  } else {
+    format!("{}", v)
+  }
+}
+
+/// Format a list of 2D points as Wolfram input code, e.g.
+/// `{{2., 2.}, {8., 2.}, {8., 8.}}`. The binding value for a `Locator`
+/// control. Locator positions are machine reals (dragging produces
+/// fractional coordinates), so integral values keep a trailing dot.
+pub fn format_point_list_input(points: &[(f64, f64)]) -> String {
+  let parts: Vec<String> = points
+    .iter()
+    .map(|(x, y)| {
+      format!("{{{}, {}}}", format_f64_real(*x), format_f64_real(*y))
+    })
+    .collect();
+  format!("{{{}}}", parts.join(", "))
+}
+
+/// Format an f64 as a Wolfram machine-real literal: integral values keep a
+/// trailing dot (`2.`) so they substitute as Real, not Integer.
+fn format_f64_real(v: f64) -> String {
+  if v.is_finite() && v.fract() == 0.0 && v.abs() < 1e15 {
+    format!("{}.", v as i64)
   } else {
     format!("{}", v)
   }
@@ -14054,6 +14272,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
         name,
         values,
         value_labels,
+        value_label_svgs,
         initial_index,
         label,
         label_runs,
@@ -14068,8 +14287,24 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           .map(|v| format!(r#""{}""#, json_escape_manipulate(v)))
           .collect();
         let popup_json = if *popup { r#","popup":true"# } else { "" };
+        // Icon labels (rule right sides that are graphics) ride along as
+        // rendered SVG, parallel to `values`; omitted when all-text.
+        let svg_json = if value_label_svgs.iter().any(Option::is_some) {
+          let svg_parts: Vec<String> = value_label_svgs
+            .iter()
+            .map(|s| match s {
+              Some(svg) => {
+                format!(r#""{}""#, json_escape_manipulate(svg))
+              }
+              None => "null".to_string(),
+            })
+            .collect();
+          format!(r#","valueLabelSvgs":[{}]"#, svg_parts.join(","))
+        } else {
+          String::new()
+        };
         ctrl_parts.push(format!(
-          r#"{{"kind":"discrete","name":"{}","label":"{}","labelRuns":{},"values":[{}],"valueLabels":[{}],"initialIndex":{}{}}}"#,
+          r#"{{"kind":"discrete","name":"{}","label":"{}","labelRuns":{},"values":[{}],"valueLabels":[{}],"initialIndex":{}{}{}}}"#,
           json_escape_manipulate(name),
           json_escape_manipulate(label),
           label_runs_to_json(label_runs),
@@ -14077,6 +14312,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           label_parts.join(","),
           initial_index,
           popup_json,
+          svg_json,
         ));
       }
       ManipulateControl::Slider2D {
@@ -14123,6 +14359,32 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           low_initial,
           high_initial,
           step_json,
+        ));
+      }
+      ManipulateControl::Locator {
+        name,
+        points,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        auto_create,
+        label,
+      } => {
+        let point_parts: Vec<String> = points
+          .iter()
+          .map(|(x, y)| format!("[{},{}]", x, y))
+          .collect();
+        ctrl_parts.push(format!(
+          r#"{{"kind":"locator","name":"{}","label":"{}","xMin":{},"xMax":{},"yMin":{},"yMax":{},"points":[{}],"autoCreate":{}}}"#,
+          json_escape_manipulate(name),
+          json_escape_manipulate(label),
+          x_min,
+          x_max,
+          y_min,
+          y_max,
+          point_parts.join(","),
+          auto_create,
         ));
       }
       ManipulateControl::Heading { label, label_runs } => {

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -4518,6 +4518,7 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut plot_range_x: Option<(f64, f64)> = None;
   let mut plot_range_y: Option<(f64, f64)> = None;
   let mut background: Option<Color> = None;
+  let mut plot_label: Option<String> = None;
   let mut axes = (false, false);
   let mut frame = false;
   let mut grid_x = GridSpec::None;
@@ -4556,6 +4557,22 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           if let Some((xr, yr)) = parse_plot_range(replacement) {
             plot_range_x = xr;
             plot_range_y = yr;
+          }
+        }
+        "PlotLabel" => {
+          // Any expression can label the plot (`Row[…]`, a string, a
+          // symbol); its OutputForm text becomes the centered title.
+          match replacement.as_ref() {
+            Expr::Identifier(s) if s == "None" => {}
+            other => {
+              let text = crate::syntax::format_expr(
+                other,
+                crate::syntax::ExprForm::Output,
+              );
+              if !text.is_empty() {
+                plot_label = Some(text);
+              }
+            }
           }
         }
         "Background" => {
@@ -4696,11 +4713,13 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  // Compute margins for axis/frame tick labels.
+  // Compute margins for axis/frame tick labels. A PlotLabel reserves an
+  // extra strip above the drawing area for its centered title text.
   let margin_left: f64 = if frame || axes.1 { 50.0 } else { 0.0 };
   let margin_bottom: f64 = if frame || axes.0 { 25.0 } else { 0.0 };
   let margin_right: f64 = if frame { 10.0 } else { 0.0 };
-  let margin_top: f64 = if frame { 10.0 } else { 0.0 };
+  let label_strip: f64 = if plot_label.is_some() { 26.0 } else { 0.0 };
+  let margin_top: f64 = if frame { 10.0 } else { 0.0 } + label_strip;
   let total_width = svg_w + margin_left + margin_right;
   let total_height = svg_h + margin_bottom + margin_top;
 
@@ -4742,6 +4761,16 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     svg.push_str(&format!(
       "<rect width=\"{total_width:.0}\" height=\"{total_height:.0}\" fill=\"{}\"/>\n",
       bg.to_svg_rgb(),
+    ));
+  }
+
+  // PlotLabel: centered above the drawing area, in the reserved strip.
+  if let Some(label) = &plot_label {
+    let cx = margin_left + svg_w / 2.0;
+    svg.push_str(&format!(
+      "<text x=\"{cx:.1}\" y=\"17\" text-anchor=\"middle\" \
+       font-family=\"sans-serif\" font-size=\"16\" fill=\"#333333\">{}</text>\n",
+      crate::functions::svg_escape(label)
     ));
   }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -6718,6 +6718,81 @@ fn prints_as_not(e: &Expr) -> bool {
     if name == "Not" && args.len() == 1)
 }
 
+/// Parse-side precedence (the `operator_precedence` scale) of the operator an
+/// expression prints with at top level, or `None` for forms that print
+/// self-delimiting (atoms, `f[…]`, `{…}`). Used to decide whether an operand
+/// of an infix shorthand (`@@`, `/@`, `@@@`, `.`) needs parentheses so the
+/// printed form re-parses to the same tree — e.g. `Plus @@ (x*y)` must not
+/// print as `Plus @@ x*y`, which re-parses as `(Plus @@ x)*y`.
+fn printed_infix_precedence(e: &Expr) -> Option<u8> {
+  match e {
+    Expr::BinaryOp { op, .. } => Some(match op {
+      BinaryOperator::Or => 15,
+      BinaryOperator::And => 18,
+      BinaryOperator::Alternatives => 27,
+      BinaryOperator::Plus
+      | BinaryOperator::Minus
+      | BinaryOperator::StringJoin => 30,
+      BinaryOperator::Times | BinaryOperator::Divide => 33,
+      BinaryOperator::Power => 48,
+    }),
+    Expr::Comparison { .. } => Some(21),
+    Expr::Rule { .. } | Expr::RuleDelayed { .. } => Some(12),
+    Expr::ReplaceAll { .. } | Expr::ReplaceRepeated { .. } => Some(7),
+    Expr::CompoundExpr(_) => Some(1),
+    // `body &` binds looser than every operator shorthand.
+    Expr::Function { .. } => Some(5),
+    Expr::Map { .. } => Some(44),
+    Expr::Apply { .. } | Expr::MapApply { .. } => Some(43),
+    // ` !x` sits between `&&` and the application shorthands.
+    Expr::UnaryOp {
+      op: UnaryOperator::Not,
+      ..
+    } => Some(20),
+    Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      ..
+    } => Some(45),
+    Expr::FunctionCall { name, args } => match name.as_str() {
+      "Not" if args.len() == 1 => Some(20),
+      "Dot" if args.len() == 2 => Some(40),
+      "Plus" if args.len() >= 2 => Some(30),
+      "Times" if args.len() >= 2 => Some(33),
+      _ => None,
+    },
+    _ => None,
+  }
+}
+
+/// Render an application shorthand (`f /@ list`, `f @@ list`, `f @@@ list`)
+/// in InputForm, parenthesizing either operand when it would otherwise bind
+/// differently on re-parse. `prec` is the shorthand's own parse precedence
+/// (`operator_precedence`): the left operand needs parens at equal precedence
+/// too (the shorthands are right-associative), the right one only below it.
+fn format_map_apply_shorthand(
+  func: &Expr,
+  list: &Expr,
+  op: &str,
+  prec: u8,
+) -> String {
+  let func_str = format_expr(func, ExprForm::Input);
+  let func_needs_parens = matches!(func, Expr::NamedFunction { .. })
+    || printed_infix_precedence(func).is_some_and(|p| p <= prec);
+  let func_display = if func_needs_parens {
+    format!("({})", func_str)
+  } else {
+    func_str
+  };
+  let list_str = format_expr(list, ExprForm::Input);
+  let list_display = if printed_infix_precedence(list).is_some_and(|p| p < prec)
+  {
+    format!("({})", list_str)
+  } else {
+    list_str
+  };
+  format!("{} {} {}", func_display, op, list_display)
+}
+
 fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
   let fmt = |e: &Expr| -> String { format_expr(e, form) };
   let fmt_fn: fn(&Expr) -> String = match form {
@@ -7509,9 +7584,19 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
       if name == "ReverseElement" && args.len() == 2 {
         return format!("{} \u{220B} {}", fmt(&args[0]), fmt(&args[1]));
       }
-      // Special case: Dot[a, b] displays as a . b (infix notation)
+      // Special case: Dot[a, b] displays as a . b (infix notation).
+      // Operands that bind looser than `.` (Plus, Times, …) keep their
+      // parens so e.g. `a . (b - c)` doesn't re-parse as `(a . b) - c`.
       if name == "Dot" && args.len() == 2 {
-        return format!("{} . {}", fmt(&args[0]), fmt(&args[1]));
+        let operand = |a: &Expr| {
+          let s = fmt(a);
+          if printed_infix_precedence(a).is_some_and(|p| p < 40) {
+            format!("({})", s)
+          } else {
+            s
+          }
+        };
+        return format!("{} . {}", operand(&args[0]), operand(&args[1]));
       }
       if name == "Composition" && args.len() >= 2 {
         let parts: Vec<String> = args.iter().map(&fmt).collect();
@@ -9828,36 +9913,13 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
       )
     }
     Expr::Map { func, list } => {
-      let func_str = format_expr(func, ExprForm::Input);
-      // Parenthesize func if it's a Function or NamedFunction (lower precedence than /@ )
-      let func_display = match func.as_ref() {
-        Expr::Function { .. } | Expr::NamedFunction { .. } => {
-          format!("({})", func_str)
-        }
-        head if prints_as_not(head) => format!("({})", func_str),
-        _ => func_str,
-      };
-      let list_str = format_expr(list, ExprForm::Input);
-      let list_display = if prints_as_not(list) {
-        format!("({})", list_str)
-      } else {
-        list_str
-      };
-      format!("{} /@ {}", func_display, list_display)
+      format_map_apply_shorthand(func, list, "/@", 44)
     }
     Expr::Apply { func, list } => {
-      format!(
-        "{} @@ {}",
-        format_expr(func, ExprForm::Input),
-        format_expr(list, ExprForm::Input)
-      )
+      format_map_apply_shorthand(func, list, "@@", 43)
     }
     Expr::MapApply { func, list } => {
-      format!(
-        "{} @@@ {}",
-        format_expr(func, ExprForm::Input),
-        format_expr(list, ExprForm::Input)
-      )
+      format_map_apply_shorthand(func, list, "@@@", 43)
     }
     Expr::PrefixApply { func, arg } => {
       // f @ g is displayed as f[g] (Wolfram converts @ to function call notation)

--- a/tests/cli/studio.md
+++ b/tests/cli/studio.md
@@ -92,7 +92,11 @@ widget with sliders and pick lists.  Option values such as
 `Initialization :> …` are preserved and prepended to every
 re-evaluation.  Discrete pick lists may be given as an expression that
 evaluates to a list (e.g. `{g, PolyhedronData[All]}`).  A `Locator`
-control binds its variable to a (frozen) initial value.  A
+control binds its variable to a draggable point (or list of points),
+rendered as one X/Y slider pair per point; `LocatorAutoCreate -> True`
+additionally offers adding and removing points.  Discrete choices whose
+rule label is a graphic (`"+" -> myIcon[2]`) show the rendered icon in
+the SetterBar.  A
 `ControlType -> None` variable has no slider but stays live, mutable
 state: extra display arguments such as a trailing
 `Dynamic[Panel[Grid[… Checkbox …]]]` are rendered as interactive

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -11567,13 +11567,14 @@ mod manipulate {
     Range[h], Range[w]]]]]]";
 
   #[test]
-  fn spec_locator_control_is_hidden_and_bound() {
-    // A `Locator` control renders no slider; its initial point list is
-    // baked into the body as a fixed binding. `q1`/`q2` stay as sliders,
-    // and the trailing `Deployed -> True` option is ignored.
+  fn spec_locator_control_is_interactive() {
+    // A `Locator` control with a point list binds its variable as a live
+    // multi-point control (one draggable point per entry) with the range
+    // taken from the `{-1, -1}, {1, 1}` corner bounds. `q1`/`q2` stay as
+    // sliders, and the trailing `Deployed -> True` option is ignored.
     let expr = interpret_to_expr(LOCATOR_EXAMPLE).unwrap();
     let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
-    assert_eq!(spec.controls.len(), 2, "only q1/q2 are visible controls");
+    assert_eq!(spec.controls.len(), 3, "q1, q2, and the locator");
     assert!(matches!(
       &spec.controls[0],
       ManipulateControl::Continuous { name, initial, .. }
@@ -11584,10 +11585,195 @@ mod manipulate {
       ManipulateControl::Continuous { name, initial, .. }
         if name == "q2" && *initial == 1.0
     ));
+    match &spec.controls[2] {
+      ManipulateControl::Locator {
+        name,
+        points,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        auto_create,
+        ..
+      } => {
+        assert_eq!(name, "p");
+        assert_eq!(points, &[(-1.0, 0.0), (1.0, 0.0)]);
+        assert_eq!((*x_min, *x_max, *y_min, *y_max), (-1.0, 1.0, -1.0, 1.0));
+        assert!(!auto_create, "no LocatorAutoCreate in this spec");
+      }
+      other => panic!("expected a Locator control, got {other:?}"),
+    }
+    // The point list travels as a live binding, not a baked-in Block.
     assert!(
-      spec.body_code.contains("Block[{p = {{-1, 0}, {1, 0}}}"),
-      "locator initial should be baked in: {}",
+      !spec.body_code.contains("Block["),
+      "locator must not be baked in: {}",
       spec.body_code
+    );
+    // Locator positions bind as machine reals (dragging produces
+    // fractional coordinates).
+    let bindings = manipulate_initial_bindings(&spec);
+    assert!(
+      bindings
+        .iter()
+        .any(|(n, v)| n == "p" && v == "{{-1., 0.}, {1., 0.}}"),
+      "locator points must be in the binding set: {bindings:?}"
+    );
+  }
+
+  #[test]
+  fn spec_locator_single_point_is_a_2d_slider() {
+    // A Locator bound to a single `{x, y}` point renders as a 2D slider
+    // (like `LocatorPane`), with the range from the corner bounds.
+    let expr = interpret_to_expr(
+      "Manipulate[Graphics[Point[p]], \
+       {{p, {0.5, 0.5}}, {0, 0}, {2, 2}, Locator}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert_eq!(spec.controls.len(), 1);
+    assert!(matches!(
+      &spec.controls[0],
+      ManipulateControl::Slider2D {
+        name,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        x_initial,
+        y_initial,
+        ..
+      } if name == "p"
+        && (*x_min, *x_max, *y_min, *y_max) == (0.0, 2.0, 0.0, 2.0)
+        && (*x_initial, *y_initial) == (0.5, 0.5)
+    ));
+  }
+
+  #[test]
+  fn spec_locator_non_numeric_initial_stays_fixed() {
+    // A Locator whose initial value doesn't resolve to points keeps the
+    // previous behavior: a fixed binding baked into the body.
+    let expr = interpret_to_expr(
+      "Manipulate[Graphics[Point[p]], {x, 0, 1}, {{p, q}, Locator}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert_eq!(spec.controls.len(), 1, "only the x slider is visible");
+    assert!(
+      spec.body_code.contains("Block[{p = q}"),
+      "non-numeric locator initial should be baked in: {}",
+      spec.body_code
+    );
+  }
+
+  // The Manipulate of the "Center of Mass of a Polygon" Wolfram
+  // Demonstration (02584428): a multi-point auto-create Locator driving a
+  // polygon, and a SetterBar whose rule labels are Graphics icons.
+  const CENTER_OF_MASS_EXAMPLE: &str = "Manipulate[\
+    Module[{area, moments, CM}, \
+    If[Length[pts] == 0, CM = \"none -- add some points!\", \
+    area = Plus @@ (ListCorrelate[{1, 1}, First /@ pts, 1]*\
+    ListCorrelate[{-1, 1}, Last /@ pts, 1])/2; \
+    moments = (1/6) {\
+    Plus @@ ((#1^2 + #1 #2 + #2^2 & @@ ({RotateLeft[#], #} &@(First /@ pts)))\
+    ListCorrelate[{-1, 1}, Last /@ pts, 1]), \
+    Plus @@ ((#1^2 + #1 #2 + #2^2 & @@ ({RotateLeft[#], #} &@(Last /@ pts)))\
+    ListCorrelate[{-1, 1}, First /@ pts, 1])}; \
+    CM = If[area == 0.0, Mean[pts], Abs[moments/area]];]; \
+    Graphics[{EdgeForm[Black], RGBColor[0.77, 0.44, 0.77], Polygon[pts], \
+    Black, If[Head[CM] === String, {}, {PointSize[0.02], Point[CM]}]}, \
+    PlotRange -> {{0, 10}, {0, 10}}, Frame -> True, \
+    PlotLabel -> Row[{\"center of mass: \", CM}]]], \
+    {{pts, 1.0 {{2, 2}, {8, 2}, {8, 8}}}, {0, 0}, {10, 10}, Locator, \
+    LocatorAutoCreate -> True}, \
+    {crosshairs, {\"none\", \"+\" -> myIcon[2], \"*\" -> myIcon[1]}, \
+    ControlType -> SetterBar, Appearance -> \"Horizontal\"}, \
+    \"The result is not valid for self-intersecting polygons!\", \
+    SaveDefinitions -> True, AutorunSequencing -> {1}]";
+
+  #[test]
+  fn spec_center_of_mass_demonstration() {
+    // The icon helper from the notebook's initialization cell.
+    interpret(
+      "myIcon[n_] := Graphics[Line[{#, -#}] & /@ \
+       ({Cos[#], Sin[#]} & /@ (n Range[0, 3] Pi/4)), \
+       ImageSize -> {24, 12}];",
+    )
+    .unwrap();
+    let expr = interpret_to_expr(CENTER_OF_MASS_EXAMPLE).unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    // Locator (auto-create), SetterBar, and the annotation heading.
+    assert_eq!(spec.controls.len(), 3);
+    match &spec.controls[0] {
+      ManipulateControl::Locator {
+        name,
+        points,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        auto_create,
+        ..
+      } => {
+        assert_eq!(name, "pts");
+        assert_eq!(points, &[(2.0, 2.0), (8.0, 2.0), (8.0, 8.0)]);
+        assert_eq!((*x_min, *x_max, *y_min, *y_max), (0.0, 10.0, 0.0, 10.0));
+        assert!(auto_create, "LocatorAutoCreate -> True");
+      }
+      other => panic!("expected a Locator control, got {other:?}"),
+    }
+    match &spec.controls[1] {
+      ManipulateControl::Discrete {
+        name,
+        values,
+        value_labels,
+        value_label_svgs,
+        ..
+      } => {
+        assert_eq!(name, "crosshairs");
+        assert_eq!(
+          values,
+          &[
+            "\"none\"".to_string(),
+            "\"+\"".to_string(),
+            "\"*\"".to_string()
+          ]
+        );
+        // Icon labels fall back to the value text and carry rendered SVG.
+        assert_eq!(
+          value_labels,
+          &["none".to_string(), "+".to_string(), "*".to_string()]
+        );
+        assert!(value_label_svgs[0].is_none(), "plain text choice");
+        assert!(
+          value_label_svgs[1]
+            .as_deref()
+            .is_some_and(|s| s.contains("<svg")),
+          "the + icon renders to SVG"
+        );
+        assert!(
+          value_label_svgs[2]
+            .as_deref()
+            .is_some_and(|s| s.contains("<svg")),
+          "the * icon renders to SVG"
+        );
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+    assert!(matches!(
+      &spec.controls[2],
+      ManipulateControl::Heading { label, .. }
+        if label == "The result is not valid for self-intersecting polygons!"
+    ));
+
+    // The initial frame must render the polygon with the correct center
+    // of mass — the centroid {6., 4.} of the initial triangle.
+    let bindings = manipulate_initial_bindings(&spec);
+    let code = manipulate_block_code(&spec.body_code, &bindings);
+    let result = woxi::interpret_with_stdout(&code).unwrap();
+    let svg = result.graphics.expect("polygon graphic should render");
+    assert!(
+      svg.contains("center of mass: {6., 4.}"),
+      "plot label must show the centroid"
     );
   }
 

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1996,6 +1996,25 @@ mod plot3d {
     }
 
     #[test]
+    fn plot_plot_label_expression() {
+      // A non-string label (`Row[…]`) titles the plot with its OutputForm
+      // text (the Demonstrations "center of mass: {6., 4.}" pattern).
+      let svg = export_svg(
+        r#"Plot[x, {x, 0, 1}, PlotLabel -> Row[{"cm: ", {6., 4.}}]]"#,
+      );
+      assert!(svg.contains("cm: {6., 4.}"), "Row label must render: {svg}");
+    }
+
+    #[test]
+    fn graphics_plot_label() {
+      // PlotLabel also works on plain Graphics, as a centered title.
+      let svg = export_svg(
+        r#"Graphics[{Disk[]}, PlotLabel -> "A Disk", Frame -> True]"#,
+      );
+      assert!(svg.contains(">A Disk</text>"), "label must render: {svg}");
+    }
+
+    #[test]
     fn plot_axes_label() {
       insta::assert_snapshot!(export_svg(
         r#"Plot[x^2, {x, -2, 2}, AxesLabel -> {"x", "y"}]"#

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -447,6 +447,60 @@ mod implicit_times_with_strings {
   }
 }
 
+mod operator_shorthand_parens {
+  use super::*;
+
+  // `@@`, `/@`, `@@@`, and `.` bind tighter than arithmetic; an operand
+  // that prints with a looser operator must keep its parens or the printed
+  // form re-parses to a different expression. (Woxi Studio re-evaluates
+  // Manipulate bodies from their InputForm, so a paren lost here silently
+  // changes the math — e.g. the polygon-area formula of the "Center of
+  // Mass of a Polygon" Demonstration.)
+  #[test]
+  fn held_apply_map_dot_keep_operand_parens() {
+    assert_eq!(interpret("Hold[a . (b - c)]").unwrap(), "Hold[a . (b - c)]");
+    assert_eq!(
+      interpret("Hold[f @@ (a + b)]").unwrap(),
+      "Hold[f @@ (a + b)]"
+    );
+    assert_eq!(
+      interpret("Hold[f @@@ (a + b)]").unwrap(),
+      "Hold[f @@@ (a + b)]"
+    );
+    assert_eq!(interpret("Hold[f /@ (a*b)]").unwrap(), "Hold[f /@ (a*b)]");
+    assert_eq!(
+      interpret("Hold[Plus @@ (x*y)/2]").unwrap(),
+      "Hold[Plus @@ (x*y)/2]"
+    );
+    // Higher-precedence operands stay unparenthesized.
+    assert_eq!(interpret("Hold[f /@ a + b]").unwrap(), "Hold[f /@ a + b]");
+    assert_eq!(interpret("Hold[f @@ a^2]").unwrap(), "Hold[f @@ a^2]");
+  }
+
+  // The InputForm of a held expression must re-parse to the very same
+  // expression (checked via FullForm equality).
+  #[test]
+  fn input_form_reparses_to_the_same_expression() {
+    for src in [
+      "Plus @@ (x*y)/2",
+      "a . (b - c)",
+      "Plus @@ ((#1^2 + #1*#2 + #2^2 & ) @@ x*y)",
+      "x /. p:{_?NumericQ, _?NumericQ} :> c + RotationMatrix[Pi/4] . (p - c)",
+      "(f & ) @@ (a + b)",
+      "f /@ a + b",
+    ] {
+      let full = interpret(&format!("FullForm[Hold[{src}]]")).unwrap();
+      let printed =
+        interpret(&format!("ToString[InputForm[Hold[{src}]]]")).unwrap();
+      let reparsed_full = interpret(&format!("FullForm[{printed}]")).unwrap();
+      assert_eq!(
+        full, reparsed_full,
+        "InputForm of `{src}` re-parses differently: `{printed}`"
+      );
+    }
+  }
+}
+
 mod plus_formatting {
   use super::*;
 

--- a/tests/playground/script.js
+++ b/tests/playground/script.js
@@ -360,6 +360,8 @@ function renderManipulate(item) {
       current[ctrl.name] = { x: ctrl.xInit, y: ctrl.yInit }
     } else if (ctrl.kind === "interval") {
       current[ctrl.name] = { low: ctrl.lowInit, high: ctrl.highInit }
+    } else if (ctrl.kind === "locator") {
+      current[ctrl.name] = { points: ctrl.points.map((p) => [p[0], p[1]]) }
     }
   }
   // Mutable state variables (ControlType -> None) carry an InputForm value
@@ -437,6 +439,12 @@ function renderManipulate(item) {
         bindings[ctrl.name] = `{${v.x}, ${v.y}}`
       } else if (ctrl.kind === "interval") {
         bindings[ctrl.name] = `{${v.low}, ${v.high}}`
+      } else if (ctrl.kind === "locator") {
+        // Locator positions are machine reals: integral coordinates keep a
+        // trailing dot so they substitute as Real, not Integer.
+        const real = (n) => (Number.isInteger(n) ? `${n}.` : String(n))
+        bindings[ctrl.name] =
+          `{${v.points.map(([x, y]) => `{${real(x)}, ${real(y)}}`).join(", ")}}`
       } else {
         bindings[ctrl.name] = String(v)
       }
@@ -704,7 +712,15 @@ function renderManipulate(item) {
           const btn = document.createElement("button")
           btn.type = "button"
           btn.className = "setter-btn"
-          btn.textContent = labels[idx] ?? val
+          // A choice whose rule label is a graphic (`"+" -> myIcon[2]`)
+          // shows the rendered SVG icon; text choices show their label.
+          const iconSvg = ctrl.valueLabelSvgs?.[idx]
+          if (iconSvg) {
+            btn.innerHTML = iconSvg
+            btn.classList.add("setter-btn-icon")
+          } else {
+            btn.textContent = labels[idx] ?? val
+          }
           if (idx === ctrl.initialIndex) btn.classList.add("active")
           btn.addEventListener("click", () => {
             current[ctrl.name] = val
@@ -803,6 +819,117 @@ function renderManipulate(item) {
       })
       pad.addEventListener("pointerup", () => {
         dragging = false
+      })
+
+      row.appendChild(pad)
+      row.appendChild(display)
+      widget.enabledControls.push({
+        condition: ctrl.enabledWhen || "",
+        apply: (on) => {
+          pad.style.pointerEvents = on ? "" : "none"
+          row.classList.toggle("disabled", !on)
+        },
+      })
+    } else if (ctrl.kind === "locator") {
+      // A list of draggable points on a 2D pad (e.g. polygon vertices).
+      // Dragging moves the nearest handle. With `LocatorAutoCreate`,
+      // clicking empty pad space adds a point there and double-clicking a
+      // handle removes it, mirroring Wolfram's locators.
+      const pad = document.createElement("div")
+      pad.className = "manipulate-pad manipulate-locator-pad"
+      const display = document.createElement("span")
+      display.className = "manipulate-value"
+
+      const xSpan = ctrl.xMax - ctrl.xMin
+      const ySpan = ctrl.yMax - ctrl.yMin
+      let handles = []
+
+      function refreshDisplay() {
+        const pts = current[ctrl.name].points
+        display.textContent =
+          pts.map(([x, y]) => `{${fmt(x)}, ${fmt(y)}}`).join(" ")
+      }
+      function rebuildHandles() {
+        for (const h of handles) h.remove()
+        handles = []
+        current[ctrl.name].points.forEach((pt, idx) => {
+          const handle = document.createElement("div")
+          handle.className = "manipulate-pad-handle"
+          const fx = xSpan !== 0 ? (pt[0] - ctrl.xMin) / xSpan : 0.5
+          const fy = ySpan !== 0 ? (pt[1] - ctrl.yMin) / ySpan : 0.5
+          handle.style.left = `${fx * 100}%`
+          handle.style.bottom = `${fy * 100}%`
+          if (ctrl.autoCreate) {
+            handle.addEventListener("dblclick", () => {
+              current[ctrl.name].points.splice(idx, 1)
+              rebuildHandles()
+              refreshDisplay()
+              requestUpdate()
+            })
+          }
+          pad.appendChild(handle)
+          handles.push(handle)
+        })
+      }
+      rebuildHandles()
+      refreshDisplay()
+
+      function padCoords(ev) {
+        const rect = pad.getBoundingClientRect()
+        let fx = rect.width !== 0 ? (ev.clientX - rect.left) / rect.width : 0
+        let fy =
+          rect.height !== 0 ? 1 - (ev.clientY - rect.top) / rect.height : 0
+        fx = Math.max(0, Math.min(1, fx))
+        fy = Math.max(0, Math.min(1, fy))
+        return [ctrl.xMin + fx * xSpan, ctrl.yMin + fy * ySpan]
+      }
+      let dragIndex = -1
+      pad.addEventListener("pointerdown", (ev) => {
+        const [x, y] = padCoords(ev)
+        const pts = current[ctrl.name].points
+        // Pick the handle nearest the pointer (within 8% of the pad).
+        let best = -1
+        let bestD = Infinity
+        pts.forEach(([px, py], i) => {
+          const d = Math.hypot(
+            xSpan !== 0 ? (px - x) / xSpan : 0,
+            ySpan !== 0 ? (py - y) / ySpan : 0,
+          )
+          if (d < bestD) {
+            bestD = d
+            best = i
+          }
+        })
+        if (best >= 0 && bestD <= 0.08) {
+          dragIndex = best
+        } else if (ctrl.autoCreate) {
+          pts.push([x, y])
+          dragIndex = pts.length - 1
+          rebuildHandles()
+          refreshDisplay()
+          requestUpdate()
+        } else {
+          dragIndex = best
+        }
+        if (dragIndex >= 0) pad.setPointerCapture(ev.pointerId)
+        ev.preventDefault()
+      })
+      pad.addEventListener("pointermove", (ev) => {
+        if (dragIndex < 0) return
+        const [x, y] = padCoords(ev)
+        current[ctrl.name].points[dragIndex] = [x, y]
+        const handle = handles[dragIndex]
+        if (handle) {
+          const fx = xSpan !== 0 ? (x - ctrl.xMin) / xSpan : 0.5
+          const fy = ySpan !== 0 ? (y - ctrl.yMin) / ySpan : 0.5
+          handle.style.left = `${fx * 100}%`
+          handle.style.bottom = `${fy * 100}%`
+        }
+        refreshDisplay()
+        requestUpdate()
+      })
+      pad.addEventListener("pointerup", () => {
+        dragIndex = -1
       })
 
       row.appendChild(pad)

--- a/tests/playground/style.css
+++ b/tests/playground/style.css
@@ -625,6 +625,21 @@ pre.output-box {
   pointer-events: none;
 }
 
+/* Multi-point locator pad (ControlType -> Locator): the handles receive
+   pointer events themselves so a double-click can remove a point. */
+.manipulate-locator-pad .manipulate-pad-handle {
+  pointer-events: auto;
+  cursor: grab;
+}
+
+/* SetterBar buttons whose label is a rendered Graphics icon */
+.manipulate-setterbar .setter-btn-icon svg {
+  display: block;
+  width: 24px;
+  height: 14px;
+  pointer-events: none;
+}
+
 /* Interval slider (ControlType -> IntervalSlider) */
 .manipulate-interval {
   display: flex;

--- a/woxi-studio/examples/dump_manipulate.rs
+++ b/woxi-studio/examples/dump_manipulate.rs
@@ -1,0 +1,89 @@
+//! Run every Input cell of a notebook through the exact pipeline Woxi
+//! Studio uses for interactive cells (evaluate, detect a Manipulate,
+//! build the widget state, re-evaluate the body once) and dump the
+//! resulting widget structure. This makes "does this notebook's
+//! Manipulate work in the Studio?" checkable without launching the GUI.
+//!
+//! Usage: cargo run --example dump_manipulate -- path/to/notebook.nb
+
+use std::path::PathBuf;
+
+// The full ControlState API is only partially exercised here; the unused
+// remainder is fine for a diagnostic example.
+#[allow(dead_code)]
+#[path = "../src/manipulate.rs"]
+mod manipulate;
+
+use woxi::notebook::{CellEntry, CellStyle, parse_notebook};
+
+fn main() {
+  let path: PathBuf = std::env::args()
+    .nth(1)
+    .expect("notebook path required")
+    .into();
+  let src = std::fs::read_to_string(&path).expect("read file");
+  let nb = parse_notebook(&src).expect("parse notebook");
+
+  let mut all_cells = Vec::new();
+  for entry in &nb.cells {
+    match entry {
+      CellEntry::Single(c) => all_cells.push(c.clone()),
+      CellEntry::Group(g) => {
+        for c in &g.cells {
+          all_cells.push(c.clone());
+        }
+      }
+    }
+  }
+
+  let mut widget_count = 0;
+  for cell in &all_cells {
+    if !matches!(cell.style, CellStyle::Input | CellStyle::Code) {
+      continue;
+    }
+    let code = cell.content.trim();
+    for stmt in woxi::split_into_statements(code) {
+      // Evaluate for side effects (definitions) exactly like the studio.
+      let eval = woxi::interpret_with_stdout(&stmt);
+      let Ok(expr) = woxi::interpret_to_expr(&stmt) else {
+        continue;
+      };
+      let Some(state) = manipulate::ManipulateState::from_expr(&expr) else {
+        if let Ok(res) = &eval
+          && res.result.starts_with("Manipulate[")
+        {
+          println!("!! Manipulate did NOT build a widget:");
+          let snippet: String = stmt.chars().take(160).collect();
+          println!("   {snippet}");
+        }
+        continue;
+      };
+      widget_count += 1;
+      println!("=== Interactive widget #{widget_count} ===");
+      println!("animated: {}", state.animated);
+      println!("controls:");
+      for c in &state.controls {
+        println!("  {c:?}");
+      }
+      if !state.state.is_empty() {
+        println!("state vars:");
+        for (n, v) in &state.state {
+          let snippet: String = v.chars().take(100).collect();
+          println!("  {n} = {snippet}");
+        }
+      }
+      println!("body:");
+      for line in state.body.lines() {
+        println!("  {line}");
+      }
+      println!(
+        "render: graphics={} text={:?} error={:?}",
+        state.graphics_handle.is_some(),
+        state.text_output,
+        state.error
+      );
+      println!();
+    }
+  }
+  println!("Interactive widgets built: {widget_count}");
+}

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -305,6 +305,15 @@ enum Message {
   ManipulateSlider2DChanged(usize, usize, u8, f64),
   /// (cell_idx, ctrl_idx, endpoint 0=low/1=high, value)
   ManipulateIntervalChanged(usize, usize, u8, f64),
+  /// One coordinate of a Locator point moved.
+  /// (cell_idx, ctrl_idx, point_idx, axis 0=x/1=y, value)
+  ManipulateLocatorChanged(usize, usize, usize, u8, f64),
+  /// Add a point to a `LocatorAutoCreate` locator (at the range centre).
+  /// (cell_idx, ctrl_idx)
+  ManipulateLocatorAdded(usize, usize),
+  /// Remove a point from a `LocatorAutoCreate` locator.
+  /// (cell_idx, ctrl_idx, point_idx)
+  ManipulateLocatorRemoved(usize, usize, usize),
   /// A checkbox in a Manipulate display element was toggled.
   /// (cell_idx, write-back assignment, e.g. `data[[3, 5]] = 1`)
   ManipulateDisplayToggled(usize, String),
@@ -1655,6 +1664,68 @@ impl WoxiStudio {
           } else {
             *high = value.max(*low);
           }
+          if state.request_reeval() {
+            return manipulate_reeval_task(cell_idx);
+          }
+        }
+        Task::none()
+      }
+
+      Message::ManipulateLocatorChanged(
+        cell_idx,
+        ctrl_idx,
+        point_idx,
+        axis,
+        value,
+      ) => {
+        if let Some(editor) = self.cell_editors.get_mut(cell_idx)
+          && let Some(state) = editor.manipulate_state.as_mut()
+          && let Some(control) = state.controls.get_mut(ctrl_idx)
+          && let manipulate::ControlState::Locator { points, .. } = control
+          && let Some(point) = points.get_mut(point_idx)
+        {
+          if axis == 0 {
+            point.0 = value;
+          } else {
+            point.1 = value;
+          }
+          if state.request_reeval() {
+            return manipulate_reeval_task(cell_idx);
+          }
+        }
+        Task::none()
+      }
+
+      Message::ManipulateLocatorAdded(cell_idx, ctrl_idx) => {
+        if let Some(editor) = self.cell_editors.get_mut(cell_idx)
+          && let Some(state) = editor.manipulate_state.as_mut()
+          && let Some(control) = state.controls.get_mut(ctrl_idx)
+          && let manipulate::ControlState::Locator {
+            points,
+            x_min,
+            x_max,
+            y_min,
+            y_max,
+            ..
+          } = control
+        {
+          // New points appear at the range centre, ready to drag.
+          points.push(((*x_min + *x_max) / 2.0, (*y_min + *y_max) / 2.0));
+          if state.request_reeval() {
+            return manipulate_reeval_task(cell_idx);
+          }
+        }
+        Task::none()
+      }
+
+      Message::ManipulateLocatorRemoved(cell_idx, ctrl_idx, point_idx) => {
+        if let Some(editor) = self.cell_editors.get_mut(cell_idx)
+          && let Some(state) = editor.manipulate_state.as_mut()
+          && let Some(control) = state.controls.get_mut(ctrl_idx)
+          && let manipulate::ControlState::Locator { points, .. } = control
+          && point_idx < points.len()
+        {
+          points.remove(point_idx);
           if state.request_reeval() {
             return manipulate_reeval_task(cell_idx);
           }
@@ -3506,9 +3577,8 @@ fn manipulate_label_char_count(ctrl: &manipulate::ControlState) -> usize {
     manipulate::ControlState::Continuous { label, name, .. }
     | manipulate::ControlState::Discrete { label, name, .. }
     | manipulate::ControlState::Slider2D { label, name, .. }
-    | manipulate::ControlState::IntervalSlider { label, name, .. } => {
-      (label, name)
-    }
+    | manipulate::ControlState::IntervalSlider { label, name, .. }
+    | manipulate::ControlState::Locator { label, name, .. } => (label, name),
     // Heading/divider rows span the full row instead of sitting in the
     // label column, so they don't widen it.
     manipulate::ControlState::Heading { .. }
@@ -3636,6 +3706,7 @@ fn render_manipulate_widget<'a>(
         label,
         label_runs,
         value_labels,
+        value_label_svgs,
         current_index,
         popup,
         ..
@@ -3662,9 +3733,18 @@ fn render_manipulate_widget<'a>(
             for (i, choice_label) in value_labels.iter().enumerate() {
               let is_selected = i == *current_index;
               let choice = choice_label.clone();
-              let mut btn = button(text(choice_label.clone()).size(12))
-                .padding([3, 10])
-                .style(move |theme: &Theme, status| {
+              // A choice whose rule label is a graphic (`"+" -> myIcon[2]`)
+              // shows the rendered icon; text choices show their label.
+              let btn_content: Element<Message> =
+                match value_label_svgs.get(i).and_then(|s| s.as_ref()) {
+                  Some(icon) => svg::Svg::new(icon.clone())
+                    .width(iced::Length::Fixed(24.0))
+                    .height(iced::Length::Fixed(14.0))
+                    .into(),
+                  None => text(choice_label.clone()).size(12).into(),
+                };
+              let mut btn = button(btn_content).padding([3, 10]).style(
+                move |theme: &Theme, status| {
                   setter_button_style(
                     theme,
                     status,
@@ -3673,7 +3753,8 @@ fn render_manipulate_widget<'a>(
                     count,
                     enabled,
                   )
-                });
+                },
+              );
               if enabled {
                 btn = btn.on_press(Message::ManipulateDiscreteChanged(
                   cell_idx, ctrl_idx, choice,
@@ -3808,6 +3889,94 @@ fn render_manipulate_widget<'a>(
         ]
         .align_y(Center)
         .spacing(8);
+        controls_col = controls_col.push(control_row);
+      }
+      manipulate::ControlState::Locator {
+        name,
+        label,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        points,
+        auto_create,
+      } => {
+        // A list of draggable 2D points (e.g. polygon vertices): one X/Y
+        // slider pair per point, plus add/remove buttons when the spec
+        // allows `LocatorAutoCreate`.
+        let x_span = (*x_max - *x_min).abs();
+        let y_span = (*y_max - *y_min).abs();
+        let x_step = if x_span > 0.0 { x_span / 100.0 } else { 1.0 };
+        let y_step = if y_span > 0.0 { y_span / 100.0 } else { 1.0 };
+        let label_widget =
+          manipulate_label_widget(&[], label, name, label_col_width, enabled);
+        let mut points_col = Column::new().spacing(4);
+        for (point_idx, (x, y)) in points.iter().enumerate() {
+          let mut x_slider = slider(*x_min..=*x_max, *x, move |v| {
+            if enabled {
+              Message::ManipulateLocatorChanged(
+                cell_idx, ctrl_idx, point_idx, 0, v,
+              )
+            } else {
+              Message::Noop
+            }
+          })
+          .step(x_step)
+          .width(Fill);
+          let mut y_slider = slider(*y_min..=*y_max, *y, move |v| {
+            if enabled {
+              Message::ManipulateLocatorChanged(
+                cell_idx, ctrl_idx, point_idx, 1, v,
+              )
+            } else {
+              Message::Noop
+            }
+          })
+          .step(y_step)
+          .width(Fill);
+          if !enabled {
+            x_slider = x_slider.style(disabled_slider_style);
+            y_slider = y_slider.style(disabled_slider_style);
+          }
+          let value_widget = text(format!(
+            "{{{}, {}}}",
+            format_manipulate_number(*x),
+            format_manipulate_number(*y)
+          ))
+          .size(11)
+          .font(Font::MONOSPACE)
+          .width(iced::Length::Fixed(96.0));
+          let mut point_row = row![
+            text(format!("{}", point_idx + 1))
+              .size(11)
+              .font(Font::MONOSPACE),
+            column![x_slider, y_slider].spacing(2),
+            value_widget
+          ]
+          .align_y(Center)
+          .spacing(8);
+          if *auto_create {
+            let mut remove_btn = button(text("−").size(11)).padding([1, 6]);
+            if enabled {
+              remove_btn =
+                remove_btn.on_press(Message::ManipulateLocatorRemoved(
+                  cell_idx, ctrl_idx, point_idx,
+                ));
+            }
+            point_row = point_row.push(remove_btn);
+          }
+          points_col = points_col.push(point_row);
+        }
+        if *auto_create {
+          let mut add_btn = button(text("+ point").size(11)).padding([1, 6]);
+          if enabled {
+            add_btn = add_btn
+              .on_press(Message::ManipulateLocatorAdded(cell_idx, ctrl_idx));
+          }
+          points_col = points_col.push(row![add_btn]);
+        }
+        let control_row =
+          row![label_widget, points_col].align_y(Center).spacing(8);
         controls_col = controls_col.push(control_row);
       }
       manipulate::ControlState::Heading { label, label_runs } => {
@@ -6031,6 +6200,86 @@ mod tests {
       0.0,
       "animation must loop back to the start"
     );
+  }
+
+  #[test]
+  fn locator_manipulate_builds_a_draggable_widget() {
+    // The "Center of Mass of a Polygon" Demonstration pattern: a Locator
+    // bound to a point list drives the polygon, with icon-labelled
+    // SetterBar choices. The widget must expose the points as a live
+    // Locator control, render the graphic, and re-render after a point
+    // moves or is added/removed (the LocatorAutoCreate interactions).
+    woxi::interpret(
+      "myIcon[n_] := Graphics[Line[{#, -#}] & /@ \
+       ({Cos[#], Sin[#]} & /@ (n Range[0, 3] Pi/4)), \
+       ImageSize -> {24, 12}];",
+    )
+    .unwrap();
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[Graphics[{Polygon[pts]}, PlotRange -> {{0, 10}, {0, 10}}], \
+       {{pts, 1.0 {{2, 2}, {8, 2}, {8, 8}}}, {0, 0}, {10, 10}, Locator, \
+       LocatorAutoCreate -> True}, \
+       {crosshairs, {\"none\", \"+\" -> myIcon[2]}, ControlType -> SetterBar}]",
+    )
+    .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    assert!(
+      state.graphics_handle.is_some(),
+      "initial frame should render the polygon: {:?}",
+      state.error
+    );
+    match &state.controls[0] {
+      manipulate::ControlState::Locator {
+        points,
+        auto_create,
+        ..
+      } => {
+        assert_eq!(points, &[(2.0, 2.0), (8.0, 2.0), (8.0, 8.0)]);
+        assert!(auto_create);
+      }
+      other => panic!("expected a locator control, got {other:?}"),
+    }
+    assert_eq!(
+      state.controls[0].current_code(),
+      "{{2., 2.}, {8., 2.}, {8., 8.}}",
+      "locator points bind as machine reals"
+    );
+    // The icon-labelled SetterBar choice carries its rendered SVG.
+    match &state.controls[1] {
+      manipulate::ControlState::Discrete {
+        value_labels,
+        value_label_svgs,
+        ..
+      } => {
+        assert_eq!(value_labels, &["none".to_string(), "+".to_string()]);
+        assert!(value_label_svgs[0].is_none());
+        assert!(value_label_svgs[1].is_some());
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+    // Drag a vertex, then add and remove a point — each re-render keeps
+    // producing a graphic.
+    if let manipulate::ControlState::Locator { points, .. } =
+      &mut state.controls[0]
+    {
+      points[0] = (3.5, 2.5);
+      points.push((5.0, 5.0));
+    }
+    state.reevaluate();
+    assert!(state.graphics_handle.is_some(), "re-render after drag/add");
+    if let manipulate::ControlState::Locator { points, .. } =
+      &mut state.controls[0]
+    {
+      points.remove(3);
+      points.remove(2);
+      points.remove(1);
+      points.remove(0);
+    }
+    state.reevaluate();
+    // With every point removed the binding is the empty list; the body
+    // must still evaluate (the Demonstration shows its "add some points"
+    // message) rather than error out.
+    assert!(state.error.is_none(), "empty point list must not error");
   }
 
   #[test]

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -42,6 +42,9 @@ pub enum ControlState {
     /// The label shown for each choice, parallel to `values`. Equals `values`
     /// for plain choices; the rule's right side for rule-form choices.
     value_labels: Vec<String>,
+    /// A rendered SVG icon per choice for rule labels that are graphics
+    /// (`"+" -> myIcon[2]`), parallel to `values`. `None` = text label.
+    value_label_svgs: Vec<Option<svg::Handle>>,
     current_index: usize,
     /// `ControlType -> PopupMenu`: always render a dropdown, even when the
     /// choice count is small enough for a SetterBar.
@@ -68,6 +71,19 @@ pub enum ControlState {
     low: f64,
     high: f64,
   },
+  /// A `Locator` control binding its variable to a list of 2D points
+  /// (e.g. draggable polygon vertices). Rendered as one X/Y slider pair
+  /// per point; `auto_create` additionally offers add/remove buttons.
+  Locator {
+    name: String,
+    label: String,
+    x_min: f64,
+    x_max: f64,
+    y_min: f64,
+    y_max: f64,
+    points: Vec<(f64, f64)>,
+    auto_create: bool,
+  },
   /// A static heading row between controls (a string or `Style[…]`
   /// Manipulate argument). Binds no variable.
   Heading {
@@ -85,6 +101,7 @@ impl ControlState {
       ControlState::Discrete { name, .. } => name,
       ControlState::Slider2D { name, .. } => name,
       ControlState::IntervalSlider { name, .. } => name,
+      ControlState::Locator { name, .. } => name,
       ControlState::Heading { .. } | ControlState::Divider => "",
     }
   }
@@ -112,6 +129,11 @@ impl ControlState {
       }
       ControlState::IntervalSlider { low, high, .. } => {
         format!("{{{}, {}}}", format_f64(*low), format_f64(*high))
+      }
+      // Locator positions are machine reals (dragging produces fractional
+      // coordinates); delegate so integral values keep their trailing dot.
+      ControlState::Locator { points, .. } => {
+        woxi::functions::graphics::format_point_list_input(points)
       }
       // Annotation rows bind no variable; never substituted.
       ControlState::Heading { .. } | ControlState::Divider => {
@@ -440,6 +462,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         label_runs,
         values,
         value_labels,
+        value_label_svgs,
         initial_index,
         popup,
       } => ControlState::Discrete {
@@ -448,6 +471,13 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         label_runs: label_runs.clone(),
         values: values.clone(),
         value_labels: value_labels.clone(),
+        value_label_svgs: value_label_svgs
+          .iter()
+          .map(|s| {
+            s.as_ref()
+              .map(|svg| svg::Handle::from_memory(svg.as_bytes().to_vec()))
+          })
+          .collect(),
         current_index: *initial_index,
         popup: *popup,
       },
@@ -493,6 +523,25 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
           high: *high_initial,
         }
       }
+      ManipulateControl::Locator {
+        name,
+        points,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        auto_create,
+        label,
+      } => ControlState::Locator {
+        name: name.clone(),
+        label: label.clone(),
+        x_min: *x_min,
+        x_max: *x_max,
+        y_min: *y_min,
+        y_max: *y_max,
+        points: points.clone(),
+        auto_create: *auto_create,
+      },
       ManipulateControl::Heading { label, label_runs } => {
         ControlState::Heading {
           label: label.clone(),


### PR DESCRIPTION
## Summary

This PR adds support for interactive `Locator` controls in Manipulate and implements `PlotLabel` for graphics, enabling interactive polygon editing and other multi-point dragging workflows. It also improves operator shorthand formatting to preserve parentheses for correct re-parsing.

## Key Changes

### Locator Controls (Interactive Multi-Point Dragging)
- **Single-point Locators** render as 2D sliders (like `LocatorPane`), with coordinate range from explicit bounds or auto-computed from initial position
- **Multi-point Locators** (point lists) render as one X/Y slider pair per point, enabling interactive polygon vertex editing
- **LocatorAutoCreate support**: When enabled, provides UI buttons to add points at the range center and remove points via double-click
- Points are stored as machine reals (coordinates keep trailing `.` when integral) to ensure correct substitution during re-evaluation
- Non-numeric initial values fall back to the previous behavior (fixed binding baked into the body)

### PlotLabel Implementation
- Added `PlotLabel` option support for both `Plot` and `Graphics`
- Accepts any expression; its `OutputForm` text becomes the centered title above the drawing area
- Reserves a 26-pixel strip above the plot for the label, properly accounting for margins
- Supports complex labels like `Row[{"center of mass: ", {6., 4.}}]`

### Discrete Choices with Graphic Icons
- Rule-form choices whose label is a `Graphics[…]` expression now render as SVG icons instead of text
- Enables icon-labelled SetterBar controls (e.g., crosshair pickers in Demonstrations)
- Falls back to value text display when icon rendering fails

### Operator Shorthand Parenthesization
- Fixed `@@`, `/@`, `@@@`, and `.` formatting to preserve parentheses when operands bind looser than the shorthand
- Ensures InputForm output re-parses to the same expression (critical for Manipulate body re-evaluation)
- Example: `Plus @@ (x*y)/2` now correctly prints with parens instead of losing them

### Supporting Infrastructure
- New `point_list_f64()` helper to parse `{{x1, y1}, {x2, y2}, …}` point lists
- New `locator_range()` function to compute coordinate bounds from explicit corners or point bounding box
- Added `dump_manipulate` example tool for diagnosing Manipulate widget issues in notebooks
- Extended `ManipulateControl` enum with `Locator` variant and `value_label_svgs` field for discrete choices

## Implementation Details

- Locator controls are parsed from specs like `{{p, init}, {xmin, ymin}, {xmax, ymax}, Locator}` or `{{p, init}, ControlType -> Locator}`
- The coordinate range is determined by: explicit `{xmin, ymin}, {xmax, ymax}` bounds if provided, otherwise the bounding box of initial points padded by half the span per axis (minimum 1 unit)
- Point list evaluation happens at parse time to distinguish numeric from non-numeric initial values
- SVG rendering for graphic choice labels uses the existing `svg_escape()` and graphics pipeline
- Playground and Studio both support the new Locator interactions with proper event handling and state management

## Tests Added

- `spec_locator_control_is_interactive`: Verifies multi-point Locator parsing and live binding
- `spec_locator_single_point_is_a_2d_slider`: Confirms single-point Locators render as 2D sliders
- `spec_locator_non_numeric_initial_stays_fixed`: Ensures fallback behavior for non-numeric values
- `spec_center_of_mass_demonstration`: Full integration test of the "Center of Mass of a Polygon" Demonstration pattern
- `plot_plot_label_expression`: Tests non-string labels like `Row[…]`
- `graphics_plot_label`: Tests PlotLabel on plain Graphics
- `held_apply_map_dot_keep_operand_parens`: Validates operator shorthand parenthesization
- `input_form_reparses_to_the_same_

https://claude.ai/code/session_011Qaji5A9qccdhSogajyizN