### PR TITLE
Add 3D affine transforms (Translate, Rotate, Scale) for Graphics3D

### DIFF
--- a/src/evaluator/part_extraction.rs
+++ b/src/evaluator/part_extraction.rs
@@ -356,6 +356,17 @@ pub fn extract_part_ast(
     });
   }
 
+  // A rendered graphic that remembers its symbolic form (e.g. a plot's
+  // `Graphics3D[GraphicsComplex[…], opts]`) indexes that form, matching
+  // Wolfram where `SphericalPlot3D[…][[1]]` yields the GraphicsComplex.
+  if let Expr::Graphics {
+    structure: Some(symbolic),
+    ..
+  } = expr
+  {
+    return extract_part_ast(symbolic, index);
+  }
+
   // A tree is an atom: Part cannot reach inside it, so the call stays
   // unevaluated and the caller reports Part::partd.
   if matches!(expr, Expr::FunctionCall { name, .. } if name == "Tree") {

--- a/src/functions/geographics.rs
+++ b/src/functions/geographics.rs
@@ -1563,6 +1563,7 @@ pub fn geo_histogram_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       is_3d: *is_3d,
       source: source.clone(),
       head: Some("GeoGraphics".to_string()),
+      structure: None,
     })
   } else {
     Ok(result)
@@ -1590,6 +1591,7 @@ pub fn geographics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       is_3d: *is_3d,
       source: source.clone(),
       head: Some("GeoGraphics".to_string()),
+      structure: None,
     })
   } else {
     Ok(result)

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -2136,6 +2136,7 @@ pub fn polar_curve_to_graphics(name: &str, args: &[Expr]) -> Option<Expr> {
       is_3d: *is_3d,
       source: source.clone(),
       head: Some(name.to_string()),
+      structure: None,
     })
   } else {
     None

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -1512,6 +1512,7 @@ impl Default for StyleState3D {
   }
 }
 
+#[derive(Clone)]
 enum Primitive3D {
   Sphere {
     center: Point3D,
@@ -1647,6 +1648,277 @@ fn apply_3d_directive(expr: &Expr, style: &mut StyleState3D) -> bool {
 }
 
 /// Collect 3D primitives from an expression.
+/// An affine 3D transform (`p ↦ m·p + t`) built from `Translate`, `Rotate`,
+/// or `Scale` wrappers and applied to already-collected primitives.
+struct Affine3 {
+  m: [[f64; 3]; 3],
+  t: [f64; 3],
+}
+
+impl Affine3 {
+  fn apply(&self, p: Point3D) -> Point3D {
+    Point3D {
+      x: self.m[0][0] * p.x
+        + self.m[0][1] * p.y
+        + self.m[0][2] * p.z
+        + self.t[0],
+      y: self.m[1][0] * p.x
+        + self.m[1][1] * p.y
+        + self.m[1][2] * p.z
+        + self.t[1],
+      z: self.m[2][0] * p.x
+        + self.m[2][1] * p.y
+        + self.m[2][2] * p.z
+        + self.t[2],
+    }
+  }
+
+  /// Uniform length-scale factor of the linear part (cube root of |det|),
+  /// used to scale the radii of Sphere/Cylinder/Cone primitives.
+  fn length_scale(&self) -> f64 {
+    let m = &self.m;
+    let det = m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+      - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+      + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+    det.abs().cbrt()
+  }
+
+  fn translation(v: [f64; 3]) -> Self {
+    Affine3 {
+      m: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+      t: v,
+    }
+  }
+
+  /// Rotation by `angle` around the axis direction `w` through `anchor`
+  /// (Rodrigues' formula).
+  fn rotation(angle: f64, w: [f64; 3], anchor: [f64; 3]) -> Option<Self> {
+    let len = (w[0] * w[0] + w[1] * w[1] + w[2] * w[2]).sqrt();
+    if !len.is_finite() || len < 1e-12 {
+      return None;
+    }
+    let (ux, uy, uz) = (w[0] / len, w[1] / len, w[2] / len);
+    let (s, c) = angle.sin_cos();
+    let ic = 1.0 - c;
+    let m = [
+      [
+        c + ux * ux * ic,
+        ux * uy * ic - uz * s,
+        ux * uz * ic + uy * s,
+      ],
+      [
+        uy * ux * ic + uz * s,
+        c + uy * uy * ic,
+        uy * uz * ic - ux * s,
+      ],
+      [
+        uz * ux * ic - uy * s,
+        uz * uy * ic + ux * s,
+        c + uz * uz * ic,
+      ],
+    ];
+    // Conjugate with the anchor so the axis passes through it:
+    // p ↦ m·(p - anchor) + anchor.
+    let t = [
+      anchor[0]
+        - (m[0][0] * anchor[0] + m[0][1] * anchor[1] + m[0][2] * anchor[2]),
+      anchor[1]
+        - (m[1][0] * anchor[0] + m[1][1] * anchor[1] + m[1][2] * anchor[2]),
+      anchor[2]
+        - (m[2][0] * anchor[0] + m[2][1] * anchor[1] + m[2][2] * anchor[2]),
+    ];
+    Some(Affine3 { m, t })
+  }
+
+  fn scaling(factors: [f64; 3], center: [f64; 3]) -> Self {
+    Affine3 {
+      m: [
+        [factors[0], 0.0, 0.0],
+        [0.0, factors[1], 0.0],
+        [0.0, 0.0, factors[2]],
+      ],
+      t: [
+        center[0] * (1.0 - factors[0]),
+        center[1] * (1.0 - factors[1]),
+        center[2] * (1.0 - factors[2]),
+      ],
+    }
+  }
+}
+
+/// Numeric `{x, y, z}` from an expression, evaluating each component.
+fn eval_vec3(expr: &Expr) -> Option<[f64; 3]> {
+  let Expr::List(items) = &evaluate_expr_to_expr(expr).ok()? else {
+    return None;
+  };
+  if items.len() != 3 {
+    return None;
+  }
+  let mut v = [0.0; 3];
+  for (slot, item) in v.iter_mut().zip(items.iter()) {
+    *slot = try_eval_to_f64(item)?;
+  }
+  Some(v)
+}
+
+/// Build the transform list for a `Translate`/`Rotate`/`Scale` wrapper from
+/// its arguments (past the wrapped graphics). `Translate` with a list of
+/// offset vectors produces one transform per copy; the others produce one.
+fn parse_3d_transforms(name: &str, args: &[Expr]) -> Option<Vec<Affine3>> {
+  match name {
+    "Translate" if args.len() == 1 => {
+      // Either a single {dx, dy, dz} or a list of offset vectors.
+      if let Some(v) = eval_vec3(&args[0]) {
+        return Some(vec![Affine3::translation(v)]);
+      }
+      if let Ok(Expr::List(ref rows)) = evaluate_expr_to_expr(&args[0]) {
+        let offsets: Option<Vec<[f64; 3]>> =
+          rows.iter().map(eval_vec3).collect();
+        return offsets
+          .map(|os| os.into_iter().map(Affine3::translation).collect());
+      }
+      None
+    }
+    "Rotate" if !args.is_empty() => {
+      let angle = try_eval_to_f64(&evaluate_expr_to_expr(&args[0]).ok()?)?;
+      match args.len() {
+        // Rotate[g, θ, w]: axis direction w through the origin.
+        // Rotate[g, θ, {p1, p2}]: axis through the points p1 and p2.
+        2 => {
+          if let Some(w) = eval_vec3(&args[1]) {
+            return Affine3::rotation(angle, w, [0.0; 3]).map(|a| vec![a]);
+          }
+          if let Ok(Expr::List(ref pts)) = evaluate_expr_to_expr(&args[1])
+            && pts.len() == 2
+            && let (Some(p1), Some(p2)) =
+              (eval_vec3(&pts[0]), eval_vec3(&pts[1]))
+          {
+            let w = [p2[0] - p1[0], p2[1] - p1[1], p2[2] - p1[2]];
+            return Affine3::rotation(angle, w, p1).map(|a| vec![a]);
+          }
+          None
+        }
+        _ => None,
+      }
+    }
+    "Scale" if !args.is_empty() => {
+      let factors = if let Some(f) = eval_vec3(&args[0]) {
+        f
+      } else {
+        let s = try_eval_to_f64(&evaluate_expr_to_expr(&args[0]).ok()?)?;
+        [s, s, s]
+      };
+      let center = args.get(1).and_then(eval_vec3).unwrap_or([0.0; 3]);
+      Some(vec![Affine3::scaling(factors, center)])
+    }
+    _ => None,
+  }
+}
+
+/// Apply an affine transform to a collected primitive in place.
+fn transform_primitive3d(prim: &mut Primitive3D, xf: &Affine3) {
+  let scale = xf.length_scale();
+  match prim {
+    Primitive3D::Sphere { center, radius, .. } => {
+      *center = xf.apply(*center);
+      *radius *= scale;
+    }
+    Primitive3D::Cuboid { p_min, p_max, .. } => {
+      // Transform both corners and re-normalize; the box stays
+      // axis-aligned, so rotations are only approximated.
+      let a = xf.apply(*p_min);
+      let b = xf.apply(*p_max);
+      *p_min = Point3D {
+        x: a.x.min(b.x),
+        y: a.y.min(b.y),
+        z: a.z.min(b.z),
+      };
+      *p_max = Point3D {
+        x: a.x.max(b.x),
+        y: a.y.max(b.y),
+        z: a.z.max(b.z),
+      };
+    }
+    Primitive3D::Polygon3D { points, .. }
+    | Primitive3D::Point3DPrim { points, .. }
+    | Primitive3D::Arrow3D { points, .. } => {
+      for p in points {
+        *p = xf.apply(*p);
+      }
+    }
+    Primitive3D::Line3D { segments, .. } => {
+      for seg in segments {
+        for p in seg {
+          *p = xf.apply(*p);
+        }
+      }
+    }
+    Primitive3D::Cylinder { p1, p2, radius, .. }
+    | Primitive3D::Cone { p1, p2, radius, .. } => {
+      *p1 = xf.apply(*p1);
+      *p2 = xf.apply(*p2);
+      *radius *= scale;
+    }
+    Primitive3D::Surface3D { tris, .. } => {
+      for (a, b, c) in tris {
+        *a = xf.apply(*a);
+        *b = xf.apply(*b);
+        *c = xf.apply(*c);
+      }
+    }
+  }
+}
+
+/// Replace the 1-based vertex indices inside a `GraphicsComplex` primitive
+/// (`Polygon`/`Line`/`Point`/`Arrow` arguments) with the coordinates they
+/// refer to, leaving everything else untouched.
+fn resolve_complex_indices(expr: &Expr, points: &[Expr]) -> Expr {
+  fn substitute(expr: &Expr, points: &[Expr]) -> Expr {
+    match expr {
+      Expr::Integer(i) if *i >= 1 && (*i as usize) <= points.len() => {
+        points[*i as usize - 1].clone()
+      }
+      Expr::List(items) => Expr::List(
+        items
+          .iter()
+          .map(|e| substitute(e, points))
+          .collect::<Vec<_>>()
+          .into(),
+      ),
+      other => other.clone(),
+    }
+  }
+  match expr {
+    Expr::FunctionCall { name, args }
+      if matches!(name.as_str(), "Polygon" | "Line" | "Point" | "Arrow")
+        && !args.is_empty() =>
+    {
+      let mut new_args = args.to_vec();
+      new_args[0] = substitute(&args[0], points);
+      Expr::FunctionCall {
+        name: name.clone(),
+        args: new_args.into(),
+      }
+    }
+    Expr::List(items) => Expr::List(
+      items
+        .iter()
+        .map(|e| resolve_complex_indices(e, points))
+        .collect::<Vec<_>>()
+        .into(),
+    ),
+    Expr::FunctionCall { name, args } => Expr::FunctionCall {
+      name: name.clone(),
+      args: args
+        .iter()
+        .map(|e| resolve_complex_indices(e, points))
+        .collect::<Vec<_>>()
+        .into(),
+    },
+    other => other.clone(),
+  }
+}
+
 fn collect_3d_primitives(
   expr: &Expr,
   style: &mut StyleState3D,
@@ -1732,6 +2004,17 @@ fn collect_3d_primitives(
               points: pts,
               style: style.clone(),
             });
+          } else if let Expr::List(poly_exprs) = &args[0] {
+            // Polygon[{{p1, p2, …}, {q1, q2, …}, …}]: a collection of
+            // polygons in one primitive.
+            for poly in poly_exprs.iter() {
+              if let Some(pts) = parse_point3d_list(poly) {
+                prims.push(Primitive3D::Polygon3D {
+                  points: pts,
+                  style: style.clone(),
+                });
+              }
+            }
           }
         }
         "Line" if !args.is_empty() => {
@@ -1740,6 +2023,19 @@ fn collect_3d_primitives(
               segments: vec![pts],
               style: style.clone(),
             });
+          } else if let Expr::List(seg_exprs) = &args[0] {
+            // Line[{{p1, p2, …}, {q1, q2, …}, …}]: a collection of
+            // polylines in one primitive.
+            let segments: Option<Vec<Vec<Point3D>>> =
+              seg_exprs.iter().map(parse_point3d_list).collect();
+            if let Some(segments) = segments
+              && !segments.is_empty()
+            {
+              prims.push(Primitive3D::Line3D {
+                segments,
+                style: style.clone(),
+              });
+            }
           }
         }
         "Point" if !args.is_empty() => {
@@ -1945,6 +2241,39 @@ fn collect_3d_primitives(
         }
         "Raster3D" if !args.is_empty() => {
           collect_raster3d(&args[0], style, prims);
+        }
+        // GraphicsComplex[points, prims]: primitives reference the shared
+        // coordinate list by 1-based index.
+        "GraphicsComplex" if args.len() >= 2 => {
+          if let Ok(Expr::List(ref points)) = evaluate_expr_to_expr(&args[0]) {
+            let resolved = resolve_complex_indices(&args[1], points);
+            let saved = style.clone();
+            collect_3d_primitives(&resolved, style, prims);
+            *style = saved;
+          }
+        }
+        // Geometric transforms: collect the wrapped graphics, then map the
+        // primitives through the affine transform (per copy for the
+        // multi-offset Translate form).
+        "Translate" | "Rotate" | "Scale" if args.len() >= 2 => {
+          let mut sub = Vec::new();
+          let saved = style.clone();
+          collect_3d_primitives(&args[0], style, &mut sub);
+          *style = saved;
+          match parse_3d_transforms(name, &args[1..]) {
+            Some(transforms) => {
+              for xf in &transforms {
+                for prim in &sub {
+                  let mut copy = prim.clone();
+                  transform_primitive3d(&mut copy, xf);
+                  prims.push(copy);
+                }
+              }
+            }
+            // Unrecognized transform spec: keep the primitives untransformed
+            // rather than dropping them.
+            None => prims.extend(sub),
+          }
         }
         _ => {
           // Try as directive first
@@ -2447,6 +2776,11 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut full_width = false;
   let mut show_box = true;
   let mut background: Option<(u8, u8, u8)> = None;
+  let mut camera = Camera::default();
+  // `PlotRange -> r` (a single number): the displayed region is the fixed
+  // cube [-r, r]³, so the framing stays put while contents move (as in a
+  // Manipulate re-render).
+  let mut plot_range: Option<f64> = None;
   for opt in &args[1..] {
     let opt_eval = evaluate_expr_to_expr(opt).unwrap_or(opt.clone());
     if let Expr::Rule {
@@ -2480,6 +2814,23 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             background = Some((r, g, b));
           }
         }
+        "ViewPoint" => {
+          if let Some(vp) = eval_vec3(replacement) {
+            camera = Camera {
+              azimuth: vp[1].atan2(vp[0]),
+              elevation: vp[2].atan2(vp[0].hypot(vp[1])),
+            };
+          }
+        }
+        "PlotRange" => {
+          if let Some(r) = try_eval_to_f64(
+            &evaluate_expr_to_expr(replacement)
+              .unwrap_or_else(|_| replacement.as_ref().clone()),
+          ) && r > 0.0
+          {
+            plot_range = Some(r);
+          }
+        }
         _ => {}
       }
     }
@@ -2490,16 +2841,27 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut style3d = StyleState3D::default();
   collect_3d_primitives(&content, &mut style3d, &mut prims);
 
+  // The symbolic form carried on the rendered result so that Part can
+  // index it (`Graphics3D[…][[1]]` → the content).
+  let structure = Expr::FunctionCall {
+    name: "Graphics3D".to_string(),
+    args: std::iter::once(content.clone())
+      .chain(args[1..].iter().cloned())
+      .collect::<Vec<_>>()
+      .into(),
+  };
+
   if prims.is_empty() {
     // Even with no primitives, return the marker
     let empty_svg = format!(
       "<svg width=\"{svg_width}\" height=\"{svg_height}\" xmlns=\"http://www.w3.org/2000/svg\"></svg>"
     );
-    return Ok(crate::graphics3d_result(empty_svg));
+    return Ok(crate::graphics3d_result_with_structure(
+      empty_svg, structure,
+    ));
   }
 
   // Tessellate all primitives into triangles
-  let camera = Camera::default();
   let mut all_triangles: Vec<Triangle> = Vec::new();
   let base_color = (0x5E_u8, 0x81_u8, 0xB5_u8); // Default blue
 
@@ -2757,6 +3119,17 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   z3_min -= pad_z;
   z3_max += pad_z;
 
+  // An explicit PlotRange pins the displayed region to [-r, r]³ regardless
+  // of the content's extent, keeping the framing stable across re-renders.
+  if let Some(r) = plot_range {
+    x3_min = -r;
+    x3_max = r;
+    y3_min = -r;
+    y3_max = r;
+    z3_min = -r;
+    z3_max = r;
+  }
+
   // Build box corners
   let box_corners = [
     Point3D {
@@ -2844,8 +3217,10 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  // Include box corners in projected bounding box
-  if show_box {
+  // Include box corners in the projected bounding box — always when the
+  // box is drawn, and also for a fixed PlotRange so the zoom level does
+  // not follow the contents.
+  if show_box || plot_range.is_some() {
     for &corner in &box_corners {
       let (px, py) = project(corner, &camera);
       px_min = px_min.min(px);
@@ -2880,9 +3255,26 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     (cx + (px - p_cx) * scale, cy - (py - p_cy) * scale)
   };
 
-  // Build depth-sorted box-edge segments for interleaving with triangles
+  let (_, axis_rgb, _, _, _) = crate::functions::plot::plot_theme();
+  let axis_color = format!("rgb({},{},{})", axis_rgb.0, axis_rgb.1, axis_rgb.2);
+  let default_prim_color = crate::functions::graphics::theme().text_primary;
+
+  // A depth-sorted line segment interleaved with the surface triangles
+  // (painter's algorithm) so lines behind a surface are hidden by it.
+  struct SceneEdge {
+    endpoints: [Point3D; 2],
+    depth: f64,
+    color: String,
+    width: f64,
+    opacity: f64,
+  }
+
+  // Build depth-sorted segments: the bounding-box edges plus all Line
+  // primitives. Each is subdivided so per-segment depth sorting produces
+  // correct occlusion against the surface.
   const EDGE_SUBDIVISIONS: usize = 20;
-  let sorted_edges = if show_box {
+  let mut sorted_edges: Vec<SceneEdge> = Vec::new();
+  if show_box {
     let edge_pairs: [(usize, usize); 12] = [
       (0, 1),
       (0, 2),
@@ -2897,7 +3289,6 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       (2, 6),
       (3, 7),
     ];
-    let mut segments: Vec<BoxEdge> = Vec::with_capacity(12 * EDGE_SUBDIVISIONS);
     for &(i, j) in &edge_pairs {
       let a = box_corners[i];
       let b = box_corners[j];
@@ -2910,24 +3301,64 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           y: a.y + (b.y - a.y) * t,
           z: a.z + (b.z - a.z) * t,
         };
-        segments.push(BoxEdge {
+        sorted_edges.push(SceneEdge {
           endpoints: [lerp(t0), lerp(t1)],
           depth: depth(lerp(tm), &camera),
+          color: axis_color.clone(),
+          width: 0.5,
+          opacity: 0.4,
         });
       }
     }
-    segments.sort_by(|a, b| {
-      b.depth
-        .partial_cmp(&a.depth)
-        .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    segments
-  } else {
-    Vec::new()
-  };
-
-  let (_, axis_rgb, _, _, _) = crate::functions::plot::plot_theme();
-  let axis_color = format!("rgb({},{},{})", axis_rgb.0, axis_rgb.1, axis_rgb.2);
+  }
+  {
+    // Lines sit exactly on the surfaces they outline, so nudge them
+    // toward the viewer by a fraction of the scene size: a face's own
+    // outline stays visible while lines behind other faces are hidden.
+    let diag = ((x3_max - x3_min).powi(2)
+      + (y3_max - y3_min).powi(2)
+      + (z3_max - z3_min).powi(2))
+    .sqrt();
+    let bias = diag * 1e-3;
+    const LINE_SUBDIVISIONS: usize = 8;
+    for prim in &prims {
+      let Primitive3D::Line3D { segments, style } = prim else {
+        continue;
+      };
+      let color = match style.color {
+        Some((r, g, b)) => format!("rgb({r},{g},{b})"),
+        None => default_prim_color.to_string(),
+      };
+      let width = style.thickness.unwrap_or(1.5);
+      for seg in segments {
+        for pair in seg.windows(2) {
+          let (a, b) = (pair[0], pair[1]);
+          for s in 0..LINE_SUBDIVISIONS {
+            let t0 = s as f64 / LINE_SUBDIVISIONS as f64;
+            let t1 = (s + 1) as f64 / LINE_SUBDIVISIONS as f64;
+            let tm = (t0 + t1) * 0.5;
+            let lerp = |t: f64| Point3D {
+              x: a.x + (b.x - a.x) * t,
+              y: a.y + (b.y - a.y) * t,
+              z: a.z + (b.z - a.z) * t,
+            };
+            sorted_edges.push(SceneEdge {
+              endpoints: [lerp(t0), lerp(t1)],
+              depth: depth(lerp(tm), &camera) - bias,
+              color: color.clone(),
+              width,
+              opacity: style.opacity,
+            });
+          }
+        }
+      }
+    }
+  }
+  sorted_edges.sort_by(|a, b| {
+    b.depth
+      .partial_cmp(&a.depth)
+      .unwrap_or(std::cmp::Ordering::Equal)
+  });
 
   let mut svg = String::with_capacity(all_triangles.len() * 120 + 1000);
   if full_width {
@@ -2952,23 +3383,30 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Render triangles interleaved with box edges (painter's algorithm)
   {
+    let emit_edge = |svg: &mut String, edge: &SceneEdge| {
+      let (ex0, ey0) = to_svg(
+        project(edge.endpoints[0], &camera).0,
+        project(edge.endpoints[0], &camera).1,
+      );
+      let (ex1, ey1) = to_svg(
+        project(edge.endpoints[1], &camera).0,
+        project(edge.endpoints[1], &camera).1,
+      );
+      let opacity_attr = if edge.opacity < 1.0 {
+        format!(" opacity=\"{}\"", edge.opacity)
+      } else {
+        String::new()
+      };
+      svg.push_str(&format!(
+        "<line x1=\"{:.1}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" stroke=\"{}\" stroke-width=\"{:.1}\" stroke-linecap=\"round\"{}/>\n",
+        ex0, ey0, ex1, ey1, edge.color, edge.width, opacity_attr
+      ));
+    };
     let mut ei = 0;
     for tri in &all_triangles {
-      // Emit any box edges further from camera than this triangle
+      // Emit any edge segments further from the camera than this triangle
       while ei < sorted_edges.len() && sorted_edges[ei].depth >= tri.depth {
-        let edge = &sorted_edges[ei];
-        let (ex0, ey0) = to_svg(
-          project(edge.endpoints[0], &camera).0,
-          project(edge.endpoints[0], &camera).1,
-        );
-        let (ex1, ey1) = to_svg(
-          project(edge.endpoints[1], &camera).0,
-          project(edge.endpoints[1], &camera).1,
-        );
-        svg.push_str(&format!(
-          "<line x1=\"{:.1}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" stroke=\"{}\" stroke-width=\"0.5\" opacity=\"0.4\"/>\n",
-          ex0, ey0, ex1, ey1, axis_color
-        ));
+        emit_edge(&mut svg, &sorted_edges[ei]);
         ei += 1;
       }
       // Emit triangle
@@ -2986,56 +3424,17 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         x0, y0, x1, y1, x2, y2, r, g, b, opacity_attr
       ));
     }
-    // Emit remaining box edges (closest to viewer)
+    // Emit remaining edge segments (closest to viewer)
     while ei < sorted_edges.len() {
-      let edge = &sorted_edges[ei];
-      let (ex0, ey0) = to_svg(
-        project(edge.endpoints[0], &camera).0,
-        project(edge.endpoints[0], &camera).1,
-      );
-      let (ex1, ey1) = to_svg(
-        project(edge.endpoints[1], &camera).0,
-        project(edge.endpoints[1], &camera).1,
-      );
-      svg.push_str(&format!(
-        "<line x1=\"{:.1}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" stroke=\"{}\" stroke-width=\"0.5\" opacity=\"0.4\"/>\n",
-        ex0, ey0, ex1, ey1, axis_color
-      ));
+      emit_edge(&mut svg, &sorted_edges[ei]);
       ei += 1;
     }
   }
 
-  // Render lines and points
-  let default_prim_color = crate::functions::graphics::theme().text_primary;
+  // Render points and arrows on top (lines are depth-sorted with the
+  // triangles above so surfaces occlude them correctly)
   for prim in &prims {
     match prim {
-      Primitive3D::Line3D { segments, style } => {
-        let stroke_color = if let Some((r, g, b)) = style.color {
-          format!("rgb({r},{g},{b})")
-        } else {
-          default_prim_color.to_string()
-        };
-        let opacity_attr = if style.opacity < 1.0 {
-          format!(" opacity=\"{}\"", style.opacity)
-        } else {
-          String::new()
-        };
-        let stroke_width = style.thickness.unwrap_or(1.5);
-        for seg in segments {
-          let pts: Vec<String> = seg
-            .iter()
-            .map(|p| {
-              let (sx, sy) =
-                to_svg(project(*p, &camera).0, project(*p, &camera).1);
-              format!("{:.1},{:.1}", sx, sy)
-            })
-            .collect();
-          svg.push_str(&format!(
-            "<polyline points=\"{}\" fill=\"none\" stroke=\"{}\" stroke-width=\"{:.1}\"{}/>\n",
-            pts.join(" "), stroke_color, stroke_width, opacity_attr
-          ));
-        }
-      }
       Primitive3D::Point3DPrim { points, style } => {
         let fill_color = if let Some((r, g, b)) = style.color {
           format!("rgb({r},{g},{b})")
@@ -3112,7 +3511,7 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   svg.push_str("</svg>");
-  Ok(crate::graphics3d_result(svg))
+  Ok(crate::graphics3d_result_with_structure(svg, structure))
 }
 
 /// Implementation of ListPlot3D[data, opts...].
@@ -4981,6 +5380,11 @@ const SPHERICAL_GRID: usize = 50;
 
 /// SphericalPlot3D[r, {theta, t0, t1}, {phi, p0, p1}]
 /// Plots r(theta, phi) in spherical coordinates.
+///
+/// The rendered result carries its symbolic form —
+/// `Graphics3D[GraphicsComplex[points, {Polygon[…], …}], opts]` — so that
+/// `plot[[1]]` yields the surface mesh for reuse inside other graphics
+/// (as Wolfram Demonstrations do).
 pub fn spherical_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() < 3 {
     return Err(InterpreterError::EvaluationError(
@@ -5003,6 +5407,17 @@ pub fn spherical_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut full_width = false;
   let mut _mesh_mode = MeshMode::Default;
   let mut show_axes = true;
+  // `PlotPoints -> n`: number of samples per direction (n - 1 grid cells),
+  // as in Wolfram. Low values matter: Demonstrations use PlotPoints -> 2
+  // with MaxRecursion -> 0 to get intentionally flat facets.
+  let mut plot_points: Option<usize> = None;
+  // `RegionFunction -> f`: keep only surface parts where
+  // f[x, y, z, theta, phi, r] is True; cells crossing the boundary are
+  // clipped to it.
+  let mut region_fn: Option<Expr> = None;
+  // `BoundaryStyle -> style`: draw the boundary edges of the (possibly
+  // region-clipped) surface with this color.
+  let mut boundary_color: Option<(u8, u8, u8)> = None;
 
   for opt in &args[3..] {
     if let Expr::Rule {
@@ -5033,38 +5448,327 @@ pub fn spherical_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             show_axes = false;
           }
         }
+        Expr::Identifier(name) if name == "PlotPoints" => {
+          let n = match evaluate_expr_to_expr(replacement) {
+            Ok(Expr::Integer(n)) => Some(n),
+            Ok(Expr::List(ref items)) => match items.first() {
+              Some(Expr::Integer(n)) => Some(*n),
+              _ => None,
+            },
+            _ => None,
+          };
+          if let Some(n) = n
+            && n >= 2
+          {
+            plot_points = Some(n as usize);
+          }
+        }
+        Expr::Identifier(name) if name == "RegionFunction" => {
+          region_fn = Some(
+            evaluate_expr_to_expr(replacement)
+              .unwrap_or_else(|_| replacement.as_ref().clone()),
+          );
+        }
+        Expr::Identifier(name) if name == "BoundaryStyle" => {
+          if !matches!(replacement.as_ref(), Expr::Identifier(n) if n == "None")
+            && let Some(color) =
+              crate::functions::graphics::parse_color(replacement)
+          {
+            boundary_color = Some((
+              (color.r.clamp(0.0, 1.0) * 255.0).round() as u8,
+              (color.g.clamp(0.0, 1.0) * 255.0).round() as u8,
+              (color.b.clamp(0.0, 1.0) * 255.0).round() as u8,
+            ));
+          }
+        }
         _ => {}
       }
     }
   }
 
-  let n_theta = SPHERICAL_GRID;
-  let n_phi = SPHERICAL_GRID;
+  let n_theta = plot_points.map(|p| p - 1).unwrap_or(SPHERICAL_GRID);
+  let n_phi = plot_points.map(|p| p - 1).unwrap_or(SPHERICAL_GRID);
   let theta_range = theta_max - theta_min;
   let phi_range = phi_max - phi_min;
+
+  // Evaluate the surface point at arbitrary (theta, phi) parameters.
+  let surface_at = |theta: f64, phi: f64| -> Option<(Point3D, f64)> {
+    let r = evaluate_at_t_theta(body, &theta_var, theta, &phi_var, phi)?;
+    if !r.is_finite() {
+      return None;
+    }
+    let p = Point3D {
+      x: r * theta.sin() * phi.cos(),
+      y: r * theta.sin() * phi.sin(),
+      z: r * theta.cos(),
+    };
+    (p.x.is_finite() && p.y.is_finite() && p.z.is_finite()).then_some((p, r))
+  };
+
+  // Whether the surface point at (theta, phi) exists and satisfies the
+  // region function (which receives x, y, z, theta, phi, r as in Wolfram).
+  let inside_at = |theta: f64, phi: f64| -> bool {
+    let Some((p, r)) = surface_at(theta, phi) else {
+      return false;
+    };
+    let Some(region) = &region_fn else {
+      return true;
+    };
+    let call = Expr::CurriedCall {
+      func: Box::new(region.clone()),
+      args: vec![
+        Expr::Real(p.x),
+        Expr::Real(p.y),
+        Expr::Real(p.z),
+        Expr::Real(theta),
+        Expr::Real(phi),
+        Expr::Real(r),
+      ],
+    };
+    matches!(
+      evaluate_expr_to_expr(&call),
+      Ok(Expr::Identifier(ref s)) if s == "True"
+    )
+  };
 
   // Sample the function on a theta x phi grid
   let mut grid_pts: Vec<Vec<Option<Point3D>>> =
     vec![vec![None; n_phi + 1]; n_theta + 1];
+  let mut grid_inside: Vec<Vec<bool>> =
+    vec![vec![false; n_phi + 1]; n_theta + 1];
+
+  let param_at = |i: usize, j: usize| -> (f64, f64) {
+    (
+      theta_min + (i as f64 / n_theta as f64) * theta_range,
+      phi_min + (j as f64 / n_phi as f64) * phi_range,
+    )
+  };
 
   for i in 0..=n_theta {
-    let theta = theta_min + (i as f64 / n_theta as f64) * theta_range;
     for j in 0..=n_phi {
-      let phi = phi_min + (j as f64 / n_phi as f64) * phi_range;
-      if let Some(r) =
-        evaluate_at_t_theta(body, &theta_var, theta, &phi_var, phi)
-        && r.is_finite()
-      {
-        let x = r * theta.sin() * phi.cos();
-        let y = r * theta.sin() * phi.sin();
-        let z = r * theta.cos();
-        if x.is_finite() && y.is_finite() && z.is_finite() {
-          grid_pts[i][j] = Some(Point3D { x, y, z });
+      let (theta, phi) = param_at(i, j);
+      if let Some((p, _)) = surface_at(theta, phi) {
+        grid_pts[i][j] = Some(p);
+        grid_inside[i][j] = if region_fn.is_some() {
+          inside_at(theta, phi)
+        } else {
+          true
+        };
+      }
+    }
+  }
+
+  // Clip a triangle (given in parameter space with per-vertex inside
+  // flags) against the region boundary, bisecting crossing edges so cut
+  // points land on the boundary. Returns the surviving polygon.
+  let clip_triangle = |verts: [((f64, f64), bool); 3]| -> Vec<(f64, f64)> {
+    if verts.iter().all(|(_, inside)| *inside) {
+      return verts.iter().map(|(p, _)| *p).collect();
+    }
+    if verts.iter().all(|(_, inside)| !inside) {
+      return Vec::new();
+    }
+    let bisect = |a: (f64, f64), b: (f64, f64)| -> (f64, f64) {
+      // `a` inside, `b` outside; converge onto the boundary.
+      let (mut lo, mut hi) = (a, b);
+      for _ in 0..24 {
+        let mid = ((lo.0 + hi.0) / 2.0, (lo.1 + hi.1) / 2.0);
+        if inside_at(mid.0, mid.1) {
+          lo = mid;
+        } else {
+          hi = mid;
+        }
+      }
+      ((lo.0 + hi.0) / 2.0, (lo.1 + hi.1) / 2.0)
+    };
+    let mut out = Vec::new();
+    for k in 0..3 {
+      let (a, a_in) = verts[k];
+      let (b, b_in) = verts[(k + 1) % 3];
+      if a_in {
+        out.push(a);
+      }
+      if a_in != b_in {
+        out.push(if a_in { bisect(a, b) } else { bisect(b, a) });
+      }
+    }
+    out
+  };
+
+  // Build the world-space triangles, clipping cells that cross the
+  // region boundary.
+  let mut world_tris: Vec<[Point3D; 3]> = Vec::new();
+  for i in 0..n_theta {
+    for j in 0..n_phi {
+      // The cell's two triangles in grid corners:
+      // (i,j), (i+1,j), (i,j+1) and (i+1,j+1), (i,j+1), (i+1,j).
+      for corner_set in [
+        [(i, j), (i + 1, j), (i, j + 1)],
+        [(i + 1, j + 1), (i, j + 1), (i + 1, j)],
+      ] {
+        if corner_set
+          .iter()
+          .any(|&(ci, cj)| grid_pts[ci][cj].is_none())
+        {
+          continue;
+        }
+        let verts =
+          corner_set.map(|(ci, cj)| (param_at(ci, cj), grid_inside[ci][cj]));
+        let polygon = if region_fn.is_some() {
+          clip_triangle(verts)
+        } else {
+          verts.iter().map(|(p, _)| *p).collect()
+        };
+        if polygon.len() < 3 {
+          continue;
+        }
+        // Fan-triangulate the clipped polygon back into world space.
+        let points: Vec<Point3D> = polygon
+          .iter()
+          .filter_map(|&(th, ph)| surface_at(th, ph).map(|(p, _)| p))
+          .collect();
+        if points.len() < 3 {
+          continue;
+        }
+        for k in 1..points.len() - 1 {
+          let (a, b, c) = (points[0], points[k], points[k + 1]);
+          // Skip degenerate slivers (e.g. the collapsed pole edge).
+          let n = triangle_normal(a, b, c);
+          let ab =
+            ((b.x - a.x).powi(2) + (b.y - a.y).powi(2) + (b.z - a.z).powi(2))
+              .sqrt();
+          let ac =
+            ((c.x - a.x).powi(2) + (c.y - a.y).powi(2) + (c.z - a.z).powi(2))
+              .sqrt();
+          let area2 = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+          if area2 < 1e-12 * (ab * ac).max(1e-300) {
+            continue;
+          }
+          world_tris.push([a, b, c]);
         }
       }
     }
   }
 
+  if world_tris.is_empty() {
+    return Err(InterpreterError::EvaluationError(
+      "SphericalPlot3D: no renderable triangles".into(),
+    ));
+  }
+
+  // ── Symbolic structure: GraphicsComplex[points, {Polygon[…], …}] ──
+  // Deduplicate shared vertices into an indexed coordinate list.
+  let mut point_index: std::collections::HashMap<(i64, i64, i64), usize> =
+    std::collections::HashMap::new();
+  let mut points: Vec<Point3D> = Vec::new();
+  let mut index_of = |p: Point3D| -> usize {
+    let key = (
+      (p.x * 1e9).round() as i64,
+      (p.y * 1e9).round() as i64,
+      (p.z * 1e9).round() as i64,
+    );
+    *point_index.entry(key).or_insert_with(|| {
+      points.push(p);
+      points.len() - 1
+    })
+  };
+  let mut tri_indices: Vec<[usize; 3]> = Vec::new();
+  for tri in &world_tris {
+    tri_indices.push([index_of(tri[0]), index_of(tri[1]), index_of(tri[2])]);
+  }
+
+  // Boundary edges (used by BoundaryStyle): edges belonging to exactly
+  // one triangle of the mesh.
+  let mut edge_count: std::collections::HashMap<(usize, usize), usize> =
+    std::collections::HashMap::new();
+  for tri in &tri_indices {
+    for k in 0..3 {
+      let (a, b) = (tri[k], tri[(k + 1) % 3]);
+      if a != b {
+        *edge_count.entry((a.min(b), a.max(b))).or_insert(0) += 1;
+      }
+    }
+  }
+  let mut boundary_edges: Vec<(usize, usize)> = edge_count
+    .iter()
+    .filter(|&(_, &count)| count == 1)
+    .map(|(&edge, _)| edge)
+    .collect();
+  boundary_edges.sort_unstable();
+
+  let point_exprs: Vec<Expr> = points
+    .iter()
+    .map(|p| {
+      Expr::List(vec![Expr::Real(p.x), Expr::Real(p.y), Expr::Real(p.z)].into())
+    })
+    .collect();
+  let polygon_expr = Expr::FunctionCall {
+    name: "Polygon".to_string(),
+    args: vec![Expr::List(
+      tri_indices
+        .iter()
+        .map(|tri| {
+          Expr::List(
+            tri
+              .iter()
+              .map(|&idx| Expr::Integer(idx as i128 + 1))
+              .collect::<Vec<_>>()
+              .into(),
+          )
+        })
+        .collect::<Vec<_>>()
+        .into(),
+    )]
+    .into(),
+  };
+  let mut gc_content = vec![polygon_expr];
+  if let Some((r, g, b)) = boundary_color
+    && !boundary_edges.is_empty()
+  {
+    let line_expr = Expr::FunctionCall {
+      name: "Line".to_string(),
+      args: vec![Expr::List(
+        boundary_edges
+          .iter()
+          .map(|&(a, b)| {
+            Expr::List(
+              vec![Expr::Integer(a as i128 + 1), Expr::Integer(b as i128 + 1)]
+                .into(),
+            )
+          })
+          .collect::<Vec<_>>()
+          .into(),
+      )]
+      .into(),
+    };
+    let color_expr = Expr::FunctionCall {
+      name: "RGBColor".to_string(),
+      args: vec![
+        Expr::Real(r as f64 / 255.0),
+        Expr::Real(g as f64 / 255.0),
+        Expr::Real(b as f64 / 255.0),
+      ]
+      .into(),
+    };
+    gc_content.push(Expr::List(vec![color_expr, line_expr].into()));
+  }
+  let graphics_complex = Expr::FunctionCall {
+    name: "GraphicsComplex".to_string(),
+    args: vec![
+      Expr::List(point_exprs.into()),
+      Expr::List(gc_content.into()),
+    ]
+    .into(),
+  };
+  let structure = Expr::FunctionCall {
+    name: "Graphics3D".to_string(),
+    args: std::iter::once(graphics_complex)
+      .chain(args[3..].iter().cloned())
+      .collect::<Vec<_>>()
+      .into(),
+  };
+
+  // ── Standalone rendering (the plot's own SVG) ──
   // Find coordinate ranges
   let mut x_min = f64::INFINITY;
   let mut x_max = f64::NEG_INFINITY;
@@ -5073,8 +5777,8 @@ pub fn spherical_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut z_min = f64::INFINITY;
   let mut z_max = f64::NEG_INFINITY;
 
-  for row in &grid_pts {
-    for p in row.iter().flatten() {
+  for tri in &world_tris {
+    for p in tri {
       x_min = x_min.min(p.x);
       x_max = x_max.max(p.x);
       y_min = y_min.min(p.y);
@@ -5106,82 +5810,35 @@ pub fn spherical_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   };
 
-  // Build triangles from grid
-  for i in 0..n_theta {
-    for j in 0..n_phi {
-      let p00 = grid_pts[i][j];
-      let p10 = grid_pts[i + 1][j];
-      let p01 = grid_pts[i][j + 1];
-      let p11 = grid_pts[i + 1][j + 1];
+  for tri in &world_tris {
+    let [a, b, c] = *tri;
+    let na = normalize(a);
+    let nb = normalize(b);
+    let nc = normalize(c);
 
-      // Triangle 1: (i,j), (i+1,j), (i,j+1)
-      if let (Some(a), Some(b), Some(c)) = (p00, p10, p01) {
-        let na = normalize(a);
-        let nb = normalize(b);
-        let nc = normalize(c);
+    let avg_z = ((a.z - z_min) / z_range_v
+      + (b.z - z_min) / z_range_v
+      + (c.z - z_min) / z_range_v)
+      / 3.0;
+    let base_color = height_color(avg_z);
+    let normal = triangle_normal(na, nb, nc);
+    let color = apply_lighting(base_color, normal);
 
-        let avg_z = ((a.z - z_min) / z_range_v
-          + (b.z - z_min) / z_range_v
-          + (c.z - z_min) / z_range_v)
-          / 3.0;
-        let base_color = height_color(avg_z);
-        let normal = triangle_normal(na, nb, nc);
-        let color = apply_lighting(base_color, normal);
+    let pa = project(na, &camera);
+    let pb = project(nb, &camera);
+    let pc = project(nc, &camera);
+    let center = Point3D {
+      x: (na.x + nb.x + nc.x) / 3.0,
+      y: (na.y + nb.y + nc.y) / 3.0,
+      z: (na.z + nb.z + nc.z) / 3.0,
+    };
 
-        let pa = project(na, &camera);
-        let pb = project(nb, &camera);
-        let pc = project(nc, &camera);
-        let center = Point3D {
-          x: (na.x + nb.x + nc.x) / 3.0,
-          y: (na.y + nb.y + nc.y) / 3.0,
-          z: (na.z + nb.z + nc.z) / 3.0,
-        };
-
-        all_triangles.push(Triangle {
-          projected: [pa, pb, pc],
-          depth: depth(center, &camera),
-          color,
-          opacity: 1.0,
-        });
-      }
-
-      // Triangle 2: (i+1,j+1), (i,j+1), (i+1,j)
-      if let (Some(a), Some(b), Some(c)) = (p11, p01, p10) {
-        let na = normalize(a);
-        let nb = normalize(b);
-        let nc = normalize(c);
-
-        let avg_z = ((a.z - z_min) / z_range_v
-          + (b.z - z_min) / z_range_v
-          + (c.z - z_min) / z_range_v)
-          / 3.0;
-        let base_color = height_color(avg_z);
-        let normal = triangle_normal(na, nb, nc);
-        let color = apply_lighting(base_color, normal);
-
-        let pa = project(na, &camera);
-        let pb = project(nb, &camera);
-        let pc = project(nc, &camera);
-        let center = Point3D {
-          x: (na.x + nb.x + nc.x) / 3.0,
-          y: (na.y + nb.y + nc.y) / 3.0,
-          z: (na.z + nb.z + nc.z) / 3.0,
-        };
-
-        all_triangles.push(Triangle {
-          projected: [pa, pb, pc],
-          depth: depth(center, &camera),
-          color,
-          opacity: 1.0,
-        });
-      }
-    }
-  }
-
-  if all_triangles.is_empty() {
-    return Err(InterpreterError::EvaluationError(
-      "SphericalPlot3D: no renderable triangles".into(),
-    ));
+    all_triangles.push(Triangle {
+      projected: [pa, pb, pc],
+      depth: depth(center, &camera),
+      color,
+      opacity: 1.0,
+    });
   }
 
   all_triangles.sort_by(|a, b| {
@@ -5210,7 +5867,7 @@ pub fn spherical_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     show_axes,
   )?;
 
-  Ok(crate::graphics3d_result(svg))
+  Ok(crate::graphics3d_result_with_structure(svg, structure))
 }
 
 /// DiscretePlot3D[f, {x, xmin, xmax}, {y, ymin, ymax}]

--- a/src/functions/polyhedron_data.rs
+++ b/src/functions/polyhedron_data.rs
@@ -15,76 +15,11 @@ struct PolyhedronInfo {
   surface_area: &'static str,
   circumradius: &'static str,
   inradius: &'static str,
-  /// Vertex coordinates for unit edge length (used for rendering).
-  vertices: fn() -> Vec<[f64; 3]>,
-}
-
-const PHI: f64 = 1.618_033_988_749_895; // golden ratio (1 + Sqrt[5])/2
-
-fn tetrahedron_vertices() -> Vec<[f64; 3]> {
-  // Edge length of {±1, ±1, ±1} alternated corners is 2 Sqrt[2].
-  let s = 1.0 / (2.0 * std::f64::consts::SQRT_2);
-  vec![[s, s, s], [s, -s, -s], [-s, s, -s], [-s, -s, s]]
-}
-
-fn cube_vertices() -> Vec<[f64; 3]> {
-  let mut v = Vec::with_capacity(8);
-  for &x in &[-0.5, 0.5] {
-    for &y in &[-0.5, 0.5] {
-      for &z in &[-0.5, 0.5] {
-        v.push([x, y, z]);
-      }
-    }
-  }
-  v
-}
-
-fn octahedron_vertices() -> Vec<[f64; 3]> {
-  let s = 1.0 / std::f64::consts::SQRT_2;
-  vec![
-    [s, 0.0, 0.0],
-    [-s, 0.0, 0.0],
-    [0.0, s, 0.0],
-    [0.0, -s, 0.0],
-    [0.0, 0.0, s],
-    [0.0, 0.0, -s],
-  ]
-}
-
-fn dodecahedron_vertices() -> Vec<[f64; 3]> {
-  // The classic (±1, ±1, ±1) / (0, ±1/φ, ±φ) / … coordinates have edge
-  // length 2/φ; scale by φ/2 for a unit edge.
-  let s = PHI / 2.0;
-  let a = 1.0 / PHI;
-  let mut v = Vec::with_capacity(20);
-  for &x in &[-1.0, 1.0] {
-    for &y in &[-1.0, 1.0] {
-      for &z in &[-1.0, 1.0] {
-        v.push([s * x, s * y, s * z]);
-      }
-    }
-  }
-  for &p in &[-1.0f64, 1.0] {
-    for &q in &[-1.0f64, 1.0] {
-      v.push([0.0, s * p * a, s * q * PHI]);
-      v.push([s * p * a, s * q * PHI, 0.0]);
-      v.push([s * p * PHI, 0.0, s * q * a]);
-    }
-  }
-  v
-}
-
-fn icosahedron_vertices() -> Vec<[f64; 3]> {
-  // Cyclic permutations of (0, ±1, ±φ) have edge length 2; halve for unit.
-  let mut v = Vec::with_capacity(12);
-  for &p in &[-0.5f64, 0.5] {
-    for &q in &[-0.5f64, 0.5] {
-      v.push([0.0, p, q * PHI]);
-      v.push([p, q * PHI, 0.0]);
-      v.push([q * PHI, 0.0, p]);
-    }
-  }
-  v
+  /// Exact vertex coordinates for unit edge length, as WL source, in
+  /// Wolfram's canonical orientation and vertex order (the z axis is the
+  /// polar symmetry axis where there is one). Used both for the
+  /// "VertexCoordinates" property and (numerically) for rendering.
+  vertices_src: &'static str,
 }
 
 static POLYHEDRA: &[PolyhedronInfo] = &[
@@ -97,7 +32,12 @@ static POLYHEDRA: &[PolyhedronInfo] = &[
     surface_area: "Sqrt[3]",
     circumradius: "Sqrt[3/8]",
     inradius: "1/(2*Sqrt[6])",
-    vertices: tetrahedron_vertices,
+    // Base triangle in the z = -Inradius plane, apex on the +z axis.
+    vertices_src: "{\
+      {-1/(2*Sqrt[3]), -1/2, -1/(2*Sqrt[6])}, \
+      {-1/(2*Sqrt[3]), 1/2, -1/(2*Sqrt[6])}, \
+      {1/Sqrt[3], 0, -1/(2*Sqrt[6])}, \
+      {0, 0, Sqrt[3/8]}}",
   },
   PolyhedronInfo {
     name: "Cube",
@@ -108,7 +48,11 @@ static POLYHEDRA: &[PolyhedronInfo] = &[
     surface_area: "6",
     circumradius: "Sqrt[3]/2",
     inradius: "1/2",
-    vertices: cube_vertices,
+    vertices_src: "{\
+      {-1/2, -1/2, -1/2}, {-1/2, -1/2, 1/2}, \
+      {-1/2, 1/2, -1/2}, {-1/2, 1/2, 1/2}, \
+      {1/2, -1/2, -1/2}, {1/2, -1/2, 1/2}, \
+      {1/2, 1/2, -1/2}, {1/2, 1/2, 1/2}}",
   },
   PolyhedronInfo {
     name: "Octahedron",
@@ -119,7 +63,10 @@ static POLYHEDRA: &[PolyhedronInfo] = &[
     surface_area: "2*Sqrt[3]",
     circumradius: "1/Sqrt[2]",
     inradius: "1/Sqrt[6]",
-    vertices: octahedron_vertices,
+    vertices_src: "{\
+      {-1/Sqrt[2], 0, 0}, {1/Sqrt[2], 0, 0}, \
+      {0, -1/Sqrt[2], 0}, {0, 1/Sqrt[2], 0}, \
+      {0, 0, -1/Sqrt[2]}, {0, 0, 1/Sqrt[2]}}",
   },
   PolyhedronInfo {
     name: "Dodecahedron",
@@ -130,7 +77,29 @@ static POLYHEDRA: &[PolyhedronInfo] = &[
     surface_area: "3*Sqrt[5*(5 + 2*Sqrt[5])]",
     circumradius: "(Sqrt[15] + Sqrt[3])/4",
     inradius: "Sqrt[250 + 110*Sqrt[5]]/20",
-    vertices: dodecahedron_vertices,
+    // Two wide vertex rings around the equator (antipodal pairs first),
+    // then the two rings of the top and bottom faces; z is the C5 axis.
+    vertices_src: "{\
+      {-Sqrt[1 + 2/Sqrt[5]], 0, -Sqrt[1/8 - Sqrt[5]/40]}, \
+      {Sqrt[1 + 2/Sqrt[5]], 0, Sqrt[1/8 - Sqrt[5]/40]}, \
+      {-Sqrt[1/8 + Sqrt[5]/40], -(3 + Sqrt[5])/4, -Sqrt[1/8 - Sqrt[5]/40]}, \
+      {-Sqrt[1/8 + Sqrt[5]/40], (3 + Sqrt[5])/4, -Sqrt[1/8 - Sqrt[5]/40]}, \
+      {Sqrt[5/8 + 11*Sqrt[5]/40], -(1 + Sqrt[5])/4, -Sqrt[1/8 - Sqrt[5]/40]}, \
+      {Sqrt[5/8 + 11*Sqrt[5]/40], (1 + Sqrt[5])/4, -Sqrt[1/8 - Sqrt[5]/40]}, \
+      {-Sqrt[5/8 + 11*Sqrt[5]/40], -(1 + Sqrt[5])/4, Sqrt[1/8 - Sqrt[5]/40]}, \
+      {-Sqrt[5/8 + 11*Sqrt[5]/40], (1 + Sqrt[5])/4, Sqrt[1/8 - Sqrt[5]/40]}, \
+      {Sqrt[1/8 + Sqrt[5]/40], -(3 + Sqrt[5])/4, Sqrt[1/8 - Sqrt[5]/40]}, \
+      {Sqrt[1/8 + Sqrt[5]/40], (3 + Sqrt[5])/4, Sqrt[1/8 - Sqrt[5]/40]}, \
+      {-Sqrt[1/2 + Sqrt[5]/10], 0, -Sqrt[5/8 + 11*Sqrt[5]/40]}, \
+      {Sqrt[1/2 + Sqrt[5]/10], 0, Sqrt[5/8 + 11*Sqrt[5]/40]}, \
+      {-Sqrt[1/4 + Sqrt[5]/10], -1/2, Sqrt[5/8 + 11*Sqrt[5]/40]}, \
+      {-Sqrt[1/4 + Sqrt[5]/10], 1/2, Sqrt[5/8 + 11*Sqrt[5]/40]}, \
+      {Sqrt[1/4 + Sqrt[5]/10], -1/2, -Sqrt[5/8 + 11*Sqrt[5]/40]}, \
+      {Sqrt[1/4 + Sqrt[5]/10], 1/2, -Sqrt[5/8 + 11*Sqrt[5]/40]}, \
+      {-Sqrt[1/8 - Sqrt[5]/40], -(1 + Sqrt[5])/4, -Sqrt[5/8 + 11*Sqrt[5]/40]}, \
+      {-Sqrt[1/8 - Sqrt[5]/40], (1 + Sqrt[5])/4, -Sqrt[5/8 + 11*Sqrt[5]/40]}, \
+      {Sqrt[1/8 - Sqrt[5]/40], -(1 + Sqrt[5])/4, Sqrt[5/8 + 11*Sqrt[5]/40]}, \
+      {Sqrt[1/8 - Sqrt[5]/40], (1 + Sqrt[5])/4, Sqrt[5/8 + 11*Sqrt[5]/40]}}",
   },
   PolyhedronInfo {
     name: "Icosahedron",
@@ -141,7 +110,21 @@ static POLYHEDRA: &[PolyhedronInfo] = &[
     surface_area: "5*Sqrt[3]",
     circumradius: "Sqrt[10 + 2*Sqrt[5]]/4",
     inradius: "(3*Sqrt[3] + Sqrt[15])/12",
-    vertices: icosahedron_vertices,
+    // The two poles, then the two staggered vertex rings (antipodal
+    // pairs adjacent); z is the C5 axis through the poles.
+    vertices_src: "{\
+      {0, 0, -Sqrt[5/8 + Sqrt[5]/8]}, \
+      {0, 0, Sqrt[5/8 + Sqrt[5]/8]}, \
+      {-Sqrt[1/2 + Sqrt[5]/10], 0, -Sqrt[1/8 + Sqrt[5]/40]}, \
+      {Sqrt[1/2 + Sqrt[5]/10], 0, Sqrt[1/8 + Sqrt[5]/40]}, \
+      {Sqrt[1/4 + Sqrt[5]/10], -1/2, -Sqrt[1/8 + Sqrt[5]/40]}, \
+      {Sqrt[1/4 + Sqrt[5]/10], 1/2, -Sqrt[1/8 + Sqrt[5]/40]}, \
+      {-Sqrt[1/4 + Sqrt[5]/10], -1/2, Sqrt[1/8 + Sqrt[5]/40]}, \
+      {-Sqrt[1/4 + Sqrt[5]/10], 1/2, Sqrt[1/8 + Sqrt[5]/40]}, \
+      {-Sqrt[1/8 - Sqrt[5]/40], -(1 + Sqrt[5])/4, -Sqrt[1/8 + Sqrt[5]/40]}, \
+      {-Sqrt[1/8 - Sqrt[5]/40], (1 + Sqrt[5])/4, -Sqrt[1/8 + Sqrt[5]/40]}, \
+      {Sqrt[1/8 - Sqrt[5]/40], -(1 + Sqrt[5])/4, Sqrt[1/8 + Sqrt[5]/40]}, \
+      {Sqrt[1/8 - Sqrt[5]/40], (1 + Sqrt[5])/4, Sqrt[1/8 + Sqrt[5]/40]}}",
   },
 ];
 
@@ -159,6 +142,85 @@ pub fn unit_volume_src(name: &str) -> Option<&'static str> {
 /// The exact unit-edge surface area of a Platonic solid, as WL source.
 pub fn unit_surface_area_src(name: &str) -> Option<&'static str> {
   find_polyhedron(name).map(|p| p.surface_area)
+}
+
+/// Evaluate a polyhedron's exact vertex list to numeric `[x, y, z]` rows
+/// (for rendering and for deriving the edge list).
+fn numeric_vertices(
+  info: &PolyhedronInfo,
+) -> Result<Vec<[f64; 3]>, InterpreterError> {
+  let evaluated = eval_wl(&format!("N[{}]", info.vertices_src))?;
+  let Expr::List(rows) = &evaluated else {
+    return Err(InterpreterError::EvaluationError(format!(
+      "PolyhedronData: vertex data for {} did not evaluate to a list",
+      info.name
+    )));
+  };
+  let mut vertices = Vec::with_capacity(rows.len());
+  for row in rows.iter() {
+    let Expr::List(coords) = row else {
+      return Err(InterpreterError::EvaluationError(format!(
+        "PolyhedronData: vertex row for {} is not a coordinate triple",
+        info.name
+      )));
+    };
+    let mut point = [0.0; 3];
+    for (slot, coord) in point.iter_mut().zip(coords.iter()) {
+      *slot = match coord {
+        Expr::Real(r) => *r,
+        Expr::Integer(i) => *i as f64,
+        _ => {
+          return Err(InterpreterError::EvaluationError(format!(
+            "PolyhedronData: vertex coordinate for {} is not numeric",
+            info.name
+          )));
+        }
+      };
+    }
+    vertices.push(point);
+  }
+  Ok(vertices)
+}
+
+/// The edges of a polyhedron as 1-based vertex index pairs, in canonical
+/// (lexicographic) order: every vertex pair at minimal (= edge) distance.
+fn edge_indices(info: &PolyhedronInfo) -> Result<Expr, InterpreterError> {
+  let vertices = numeric_vertices(info)?;
+  let dist = |a: [f64; 3], b: [f64; 3]| -> f64 {
+    let d = [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+    (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt()
+  };
+  let mut min_dist = f64::INFINITY;
+  for i in 0..vertices.len() {
+    for j in i + 1..vertices.len() {
+      min_dist = min_dist.min(dist(vertices[i], vertices[j]));
+    }
+  }
+  let mut pairs = Vec::new();
+  for i in 0..vertices.len() {
+    for j in i + 1..vertices.len() {
+      if dist(vertices[i], vertices[j]) < min_dist * (1.0 + 1e-9) {
+        pairs.push(Expr::List(
+          vec![Expr::Integer(i as i128 + 1), Expr::Integer(j as i128 + 1)]
+            .into(),
+        ));
+      }
+    }
+  }
+  Ok(Expr::List(pairs.into()))
+}
+
+/// `Sphere[{0, 0, 0}, r]` with the polyhedron's exact inradius: the sphere
+/// inscribed in the (origin-centered) solid.
+fn insphere(info: &PolyhedronInfo) -> Result<Expr, InterpreterError> {
+  let center = Expr::List(
+    vec![Expr::Integer(0), Expr::Integer(0), Expr::Integer(0)].into(),
+  );
+  let radius = eval_wl(info.inradius)?;
+  Ok(Expr::FunctionCall {
+    name: "Sphere".to_string(),
+    args: vec![center, radius].into(),
+  })
 }
 
 /// Compute the faces of a convex polyhedron from its vertices: every plane
@@ -257,7 +319,7 @@ fn convex_faces(vertices: &[[f64; 3]]) -> Vec<Vec<usize>> {
 fn polyhedron_graphics(
   info: &PolyhedronInfo,
 ) -> Result<Expr, InterpreterError> {
-  let vertices = (info.vertices)();
+  let vertices = numeric_vertices(info)?;
   let faces = convex_faces(&vertices);
   let polygons: Vec<Expr> = faces
     .iter()
@@ -298,9 +360,12 @@ fn eval_wl(src: &str) -> Result<Expr, InterpreterError> {
 static PROPERTIES: &[&str] = &[
   "Circumradius",
   "EdgeCount",
+  "EdgeIndices",
   "FaceCount",
   "Inradius",
+  "Insphere",
   "SurfaceArea",
+  "VertexCoordinates",
   "VertexCount",
   "Volume",
 ];
@@ -370,6 +435,9 @@ pub fn polyhedron_data_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "SurfaceArea" => eval_wl(info.surface_area),
         "Circumradius" => eval_wl(info.circumradius),
         "Inradius" => eval_wl(info.inradius),
+        "VertexCoordinates" => eval_wl(info.vertices_src),
+        "EdgeIndices" => edge_indices(info),
+        "Insphere" => insphere(info),
         _ => unevaluated(),
       }
     }

--- a/src/functions/region.rs
+++ b/src/functions/region.rs
@@ -279,6 +279,7 @@ pub fn region_to_graphics(args: &[Expr]) -> Option<Expr> {
       is_3d: *is_3d,
       source: source.clone(),
       head: Some("Region".to_string()),
+      structure: None,
     })
   } else {
     None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -819,6 +819,7 @@ pub fn graphics_result(svg: String) -> syntax::Expr {
     is_3d: false,
     source: None,
     head: None,
+    structure: None,
   }
 }
 
@@ -831,6 +832,7 @@ fn graphics_result_with_head(svg: String, head: &str) -> syntax::Expr {
     is_3d: false,
     source: None,
     head: Some(head.to_string()),
+    structure: None,
   }
 }
 
@@ -847,6 +849,7 @@ pub fn graphics_result_with_source(
     is_3d: false,
     source: Some(Box::new(source)),
     head: None,
+    structure: None,
   }
 }
 
@@ -858,6 +861,24 @@ pub fn graphics3d_result(svg: String) -> syntax::Expr {
     is_3d: true,
     source: None,
     head: None,
+    structure: None,
+  }
+}
+
+/// Like `graphics3d_result` but remembers the symbolic expression the
+/// rendering came from, so `Part` can index into it (Wolfram's
+/// `Graphics3D[…][[1]]` returns the graphic's content).
+pub fn graphics3d_result_with_structure(
+  svg: String,
+  structure: syntax::Expr,
+) -> syntax::Expr {
+  capture_graphics(&svg);
+  syntax::Expr::Graphics {
+    svg,
+    is_3d: true,
+    source: None,
+    head: None,
+    structure: Some(Box::new(structure)),
   }
 }
 
@@ -2945,6 +2966,7 @@ fn render_graphics_fc_if_needed(expr: syntax::Expr) -> syntax::Expr {
           is_3d: false,
           source: None,
           head: None,
+          structure: None,
         }
       } else {
         expr

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -137,6 +137,12 @@ pub enum Expr {
     is_3d: bool,
     source: Option<Box<PlotSource>>,
     head: Option<String>,
+    /// The symbolic expression this rendering was produced from (e.g.
+    /// `Graphics3D[GraphicsComplex[…], opts]`), so structural operations
+    /// like `Part` can look inside a rendered graphic the way Wolfram's
+    /// `Graphics3D[…][[1]]` does. `None` for renderings with no useful
+    /// symbolic form.
+    structure: Option<Box<Expr>>,
   },
 }
 
@@ -758,12 +764,14 @@ impl Clone for Expr {
         is_3d,
         source,
         head,
+        structure,
       } => {
         return Self::Graphics {
           svg: svg.clone(),
           is_3d: *is_3d,
           source: source.clone(),
           head: head.clone(),
+          structure: structure.clone(),
         };
       }
       _ => {} // fall through to iterative clone
@@ -846,11 +854,13 @@ impl Clone for Expr {
             is_3d,
             source,
             head,
+            structure,
           } => results.push(Self::Graphics {
             svg: svg.clone(),
             is_3d: *is_3d,
             source: source.clone(),
             head: head.clone(),
+            structure: structure.clone(),
           }),
 
           // Vec<Expr> children
@@ -4796,10 +4806,12 @@ fn operator_precedence(op: &str) -> u8 {
     "<->" => 21, // TwoWayRule (same level as comparisons, tighter than Rule)
     "\\[Distributed]" | "\u{F3D2}" => 21, // Distributed (same level as comparisons)
     "\\[Conditioned]" | "\u{F3D3}" => 12, // Conditioned (looser than ||, like ;)
-    "\\[Cross]" | "\u{F3C4}" | "\u{2A2F}" => 36, // Cross (same level as Dot)
-    "\\[TensorProduct]" | "\u{F3DA}" => 36, // TensorProduct (same level as Dot)
-    "\\[Cap]" | "\u{2322}" => 36,         // Cap (⌢, infix → Cap[a, b])
-    "\\[Cup]" | "\u{2323}" => 36,         // Cup (⌣, infix → Cup[a, b])
+    // Cross and TensorProduct bind tighter than Dot in Wolfram
+    // (Precedence 500 and 495 vs Dot's 490): a.b\[Cross]c is a.(b\[Cross]c).
+    "\\[Cross]" | "\u{F3C4}" | "\u{2A2F}" => 42, // Cross (above TensorProduct)
+    "\\[TensorProduct]" | "\u{F3DA}" => 41, // TensorProduct (just above Dot)
+    "\\[Cap]" | "\u{2322}" => 36,           // Cap (⌢, infix → Cap[a, b])
+    "\\[Cup]" | "\u{2323}" => 36,           // Cup (⌣, infix → Cup[a, b])
     "\\[RightTee]" | "\u{22A2}" => 15, // RightTee (⊢, right-assoc, between -> and ==)
     "\\[DoubleRightTee]" | "\u{22A8}" => 15, // DoubleRightTee (⊨, right-assoc, same level)
     "\\[LeftTee]" | "\u{22A3}" => 15, // LeftTee (⊣, left-assoc, same level)
@@ -4827,19 +4839,19 @@ fn operator_precedence(op: &str) -> u8 {
     "\\[Diamond]" | "\u{22C4}" => 38,    // above Wedge, below Backslash
     "\\[Backslash]" | "\u{2216}" => 39,  // above Diamond, below Dot
     "." => 40,                           // Dot (higher than the ring ops)
-    "\\[CircleDot]" | "\u{2299}" => 41,  // above Dot, below SmallCircle
-    "\\[SmallCircle]" | "\u{2218}" => 42, // above CircleDot, below Apply
-    "@@@" | "@@" => 43,                  // Apply/MapApply
-    "/@" => 44,                          // Map (higher than Apply)
-    "NEGATE" => 45, // Unary minus (PreMinus): between Times/Dot and Power
-    "^" | "^_NEG" => 48, // Power (`^_NEG` is `a^-b` with negated right operand)
-    s if s.starts_with('~') && s.ends_with('~') && s.len() > 2 => 51, // Tilde infix: a ~f~ b (higher than ^, lower than @)
-    "@" => 54, // Prefix application
+    "\\[CircleDot]" | "\u{2299}" => 43,  // above Cross, below SmallCircle
+    "\\[SmallCircle]" | "\u{2218}" => 44, // above CircleDot, below Apply
+    "@@@" | "@@" => 45,                  // Apply/MapApply
+    "/@" => 46,                          // Map (higher than Apply)
+    "NEGATE" => 47, // Unary minus (PreMinus): between Times/Dot and Power
+    "^" | "^_NEG" => 50, // Power (`^_NEG` is `a^-b` with negated right operand)
+    s if s.starts_with('~') && s.ends_with('~') && s.len() > 2 => 53, // Tilde infix: a ~f~ b (higher than ^, lower than @)
+    "@" => 56, // Prefix application
     // Composition/RightComposition bind tighter than prefix application (so
     // `f @* g @ x` parses as `(f @* g) @ x`) and Map (`Length@*f /@ list`
     // parses as `(Length@*f) /@ list`), but looser than MessageName.
-    "@*" | "/*" => 55,
-    "::" => 57, // MessageName (highest — a::b binds tighter than everything)
+    "@*" | "/*" => 57,
+    "::" => 59, // MessageName (highest — a::b binds tighter than everything)
     _ => 0,
   }
 }

--- a/tests/interpreter_tests/functions.rs
+++ b/tests/interpreter_tests/functions.rs
@@ -5783,6 +5783,30 @@ mod boolean_minterms {
   }
 }
 
+mod cross_operator_precedence {
+  use super::*;
+
+  // \[Cross] binds tighter than Dot (Wolfram precedence 500 vs 490), so
+  // a.b\[Cross]c is a.(b\[Cross]c) — the form Demonstrations rely on for
+  // plane tests like {x,y,z}.v1\[Cross]v2 > 0.
+  #[test]
+  fn cross_binds_tighter_than_dot() {
+    assert_eq!(
+      interpret("Hold[a . b \\[Cross] c]").unwrap(),
+      "Hold[a . Cross[b, c]]"
+    );
+    assert_eq!(
+      interpret("{1, 0, 0} . {0, 1, 0} \\[Cross] {0, 0, 1}").unwrap(),
+      "1"
+    );
+    // Left of the dot: (a\[Cross]b).c likewise groups the cross first.
+    assert_eq!(
+      interpret("{0, 1, 0} \\[Cross] {0, 0, 1} . {1, 0, 0}").unwrap(),
+      "1"
+    );
+  }
+}
+
 mod cross_dot_shape_messages {
   use super::*;
 

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1591,6 +1591,66 @@ mod plot3d {
         assert!(interpret("SphericalPlot3D[1, 5, 6]").is_err());
       }
     }
+
+    // The rendered plot remembers its symbolic
+    // Graphics3D[GraphicsComplex[…]] form for Part extraction, the way
+    // Wolfram Demonstrations reuse a plot's mesh in other graphics.
+    mod structure {
+      use super::*;
+
+      #[test]
+      fn part_one_is_a_graphics_complex() {
+        assert_eq!(
+          interpret("Head[SphericalPlot3D[1, {t, 0, Pi}, {p, 0, 2 Pi}][[1]]]")
+            .unwrap(),
+          "GraphicsComplex"
+        );
+      }
+
+      // PlotPoints -> 2 samples a 2x2 grid: after dropping the collapsed
+      // pole edge a single facet triangle remains.
+      #[test]
+      fn plot_points_controls_grid_resolution() {
+        assert_eq!(
+          interpret(
+            "Length[SphericalPlot3D[1, {t, 0, Pi/3}, {p, 0, Pi/3}, \
+             PlotPoints -> 2][[1, 1]]]"
+          )
+          .unwrap(),
+          "3"
+        );
+      }
+
+      // RegionFunction receives x, y, z (then theta, phi, r); the mesh is
+      // clipped to where it is True, so a z > 0 region keeps no point
+      // meaningfully below the equator.
+      #[test]
+      fn region_function_clips_the_mesh() {
+        assert_eq!(
+          interpret(
+            "Min[SphericalPlot3D[1, {t, 0, Pi}, {p, 0, 2 Pi}, \
+             RegionFunction -> ({#1, #2, #3} . {0, 0, 1} > 0 &)][[1, 1]][[All, 3]]] \
+             > -1/1000"
+          )
+          .unwrap(),
+          "True"
+        );
+      }
+
+      // BoundaryStyle adds the mesh's boundary edges as styled lines in
+      // the GraphicsComplex content.
+      #[test]
+      fn boundary_style_adds_boundary_lines() {
+        assert_eq!(
+          interpret(
+            "Cases[SphericalPlot3D[1, {t, 0, Pi/2}, {p, 0, Pi}, \
+             BoundaryStyle -> Black][[1, 2]], _Line, Infinity] =!= {}"
+          )
+          .unwrap(),
+          "True"
+        );
+      }
+    }
   }
 
   mod list_point_plot3d {
@@ -1802,19 +1862,152 @@ mod plot3d {
         "Graphics3D[Polygon[{{0,0,0}, {0,1,1}, {1,0,0}}]]"
       ));
     }
+
+    // Part indexes the symbolic form of a rendered Graphics3D, as in
+    // Wolfram where Graphics3D[…][[1]] returns the content.
+    #[test]
+    fn graphics3d_part_returns_content() {
+      assert_eq!(
+        interpret(
+          "Graphics3D[GraphicsComplex[{{0,0,0},{1,0,0},{0,1,0}}, \
+           Polygon[{{1,2,3}}]]][[1]]"
+        )
+        .unwrap(),
+        "GraphicsComplex[{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}}, \
+         Polygon[{{1, 2, 3}}]]"
+      );
+    }
+
+    // GraphicsComplex primitives resolve their 1-based vertex indices,
+    // for both single- and multi-polygon/line forms.
+    #[test]
+    fn graphics3d_graphics_complex_renders() {
+      let svg = export_svg(
+        "Graphics3D[GraphicsComplex[{{0,0,0},{1,0,0},{0,1,0},{0,0,1}}, \
+         {Polygon[{{1,2,3},{1,2,4}}], Line[{{1,4},{2,4}}]}]]",
+      );
+      assert!(
+        svg.contains("<polygon") && svg.contains("<line"),
+        "expected polygons and lines from the GraphicsComplex, got: {}",
+        &svg[..300.min(svg.len())]
+      );
+    }
+
+    // Translate/Rotate/Scale wrap primitives with affine transforms. A
+    // unit polygon rotated by Pi around z and translated must still
+    // produce polygons (the transform used to be silently dropped).
+    #[test]
+    fn graphics3d_transforms_render() {
+      let svg = export_svg(
+        "Graphics3D[{Translate[Rotate[Scale[\
+           Polygon[{{0,0,0},{1,0,0},{0,1,0}}], {2,2,2}, {0,0,0}], \
+           Pi/3, {0,0,1}], {0,0,1}], \
+         Translate[Polygon[{{0,0,0},{1,0,0},{0,1,0}}], {{0,0,0},{0,0,2}}]}]",
+      );
+      let polygons = svg.matches("<polygon").count();
+      assert!(
+        polygons >= 3,
+        "expected the transformed polygon plus two translated copies, \
+         got {polygons} polygons"
+      );
+    }
+
+    // A numeric PlotRange pins the frame: with PlotRange -> 10 a unit
+    // sphere occupies a small part of the drawing, so its projected
+    // extent must be far smaller than with the fitted default.
+    #[test]
+    fn graphics3d_plot_range_fixes_the_frame() {
+      let fitted = export_svg("Graphics3D[Sphere[], Boxed -> False]");
+      let ranged =
+        export_svg("Graphics3D[Sphere[], Boxed -> False, PlotRange -> 10]");
+      let width = |svg: &str| -> f64 {
+        let mut min = f64::INFINITY;
+        let mut max = f64::NEG_INFINITY;
+        for cap in svg.split("<polygon points=\"").skip(1) {
+          let coords = cap.split('"').next().unwrap_or("");
+          for pair in coords.split_whitespace() {
+            if let Some(x) = pair.split(',').next()
+              && let Ok(x) = x.parse::<f64>()
+            {
+              min = min.min(x);
+              max = max.max(x);
+            }
+          }
+        }
+        max - min
+      };
+      assert!(
+        width(&ranged) < width(&fitted) / 2.0,
+        "PlotRange -> 10 must shrink the sphere's projected size \
+         (fitted {} vs ranged {})",
+        width(&fitted),
+        width(&ranged)
+      );
+    }
+
+    // ViewPoint moves the camera: looking straight down the z axis a
+    // point at +x projects to a different screen spot than the default
+    // oblique view, so the two renderings must differ.
+    #[test]
+    fn graphics3d_view_point_moves_the_camera() {
+      let default_view =
+        export_svg("Graphics3D[Polygon[{{0,0,0},{1,0,0},{0,1,0}}]]");
+      let top_view = export_svg(
+        "Graphics3D[Polygon[{{0,0,0},{1,0,0},{0,1,0}}], \
+         ViewPoint -> {0, 0, 10}]",
+      );
+      assert_ne!(default_view, top_view);
+    }
+
+    // Regression: the "Icosahedron Ball" Demonstration body — a
+    // SphericalPlot3D mesh reused via [[1]], transformed with
+    // Translate/Rotate copies, and combined with PolyhedronData's
+    // wireframe and insphere — must evaluate to a rendered graphic.
+    #[test]
+    fn icosahedron_ball_demonstration_body() {
+      assert_eq!(
+        interpret(
+          "Block[{conv = 2, dis = -3, icos = 1, sep = 0}, \
+           v = PolyhedronData[\"Icosahedron\", \"VertexCoordinates\"]; \
+           h1a = SphericalPlot3D[Norm[v[[2]]], \
+             {theta, 0, VectorAngle[v[[2]], v[[4]]]}, {phi, 0, (2 Pi)/5}, \
+             RegionFunction -> ({#1, #2, #3} . v[[4]] \\[Cross] v[[12]] > 0 &), \
+             MaxRecursion -> 0, PlotPoints -> conv, Mesh -> None, \
+             BoundaryStyle -> Black][[1]]; \
+           h1 = Translate[h1a, dis Mean[v[[{2, 4, 12}]]]]; \
+           h2 = Rotate[h1, -(1/5) (2 Pi), v[[4]]]; \
+           h3 = Translate[(Rotate[{h1, h2}, (2 Pi #1)/5, {0, 0, 1}] &) /@ \
+             Range[5], {0, 0, sep}]; \
+           h4 = {RGBColor[0.3, 1, 0.8], Rotate[h3, Pi, {0, 1, 0}]}; \
+           Graphics3D[{{RGBColor[0.9, 1, 0.5], \
+               PolyhedronData[\"Icosahedron\", \"Insphere\"]}, \
+             {Scale[GraphicsComplex[\
+               PolyhedronData[\"Icosahedron\", \"VertexCoordinates\"], \
+               Line[PolyhedronData[\"Icosahedron\", \"EdgeIndices\"]]], \
+               icos {1, 1, 1}, {0, 0, 0}]}, \
+             {RGBColor[0.7, 1, 1], h3}, h4}, \
+             Boxed -> False, SphericalRegion -> True, ViewAngle -> 0.09, \
+             ViewPoint -> {3.2, -10, 5.2}, PlotRange -> 1.7, \
+             ImageSize -> 380]]"
+        )
+        .unwrap(),
+        "-Graphics3D-"
+      );
+    }
   }
 
   mod parametric_plot3d_curve {
     use super::*;
 
-    /// 1-iterator form should sample the curve and render it as a polyline.
+    /// 1-iterator form should sample the curve and render it as line
+    /// segments (depth-sorted so surfaces can occlude them).
     #[test]
     fn curve_renders_polyline() {
       let svg =
         export_svg("ParametricPlot3D[{Cos[t], Sin[t], 0}, {t, 0, 2 Pi}]");
       assert!(
-        svg.contains("<polyline"),
-        "expected a <polyline> for the sampled curve, got: {}",
+        svg.contains("<polyline") || svg.contains("<line"),
+        "expected line segments for the sampled curve, got: {}",
         &svg[..200.min(svg.len())]
       );
     }
@@ -1847,8 +2040,8 @@ mod plot3d {
            PlotStyle -> Directive[{Thick, Red}]]]",
       );
       assert!(
-        svg.contains("<polyline"),
-        "expected polyline from the parametric ring inside Show"
+        svg.contains("<polyline") || svg.contains("<line"),
+        "expected line segments from the parametric ring inside Show"
       );
       assert!(
         svg.contains("rgb(255,0,0)"),

--- a/tests/interpreter_tests/polyhedron_data.rs
+++ b/tests/interpreter_tests/polyhedron_data.rs
@@ -85,6 +85,142 @@ mod polyhedron_data_tests {
     );
   }
 
+  // Exact vertex coordinates (unit edge length) in Wolfram's canonical
+  // orientation: z is the polar symmetry axis where there is one.
+  #[test]
+  fn polyhedron_data_vertex_coordinates_icosahedron() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Icosahedron", "VertexCoordinates"]"#)
+        .unwrap(),
+      "{{0, 0, -Sqrt[5/8 + Sqrt[5]/8]}, {0, 0, Sqrt[5/8 + Sqrt[5]/8]}, \
+       {-Sqrt[1/2 + 1/(2*Sqrt[5])], 0, -Sqrt[1/8 + 1/(8*Sqrt[5])]}, \
+       {Sqrt[1/2 + 1/(2*Sqrt[5])], 0, Sqrt[1/8 + 1/(8*Sqrt[5])]}, \
+       {Sqrt[1/4 + 1/(2*Sqrt[5])], -1/2, -Sqrt[1/8 + 1/(8*Sqrt[5])]}, \
+       {Sqrt[1/4 + 1/(2*Sqrt[5])], 1/2, -Sqrt[1/8 + 1/(8*Sqrt[5])]}, \
+       {-Sqrt[1/4 + 1/(2*Sqrt[5])], -1/2, Sqrt[1/8 + 1/(8*Sqrt[5])]}, \
+       {-Sqrt[1/4 + 1/(2*Sqrt[5])], 1/2, Sqrt[1/8 + 1/(8*Sqrt[5])]}, \
+       {-Sqrt[1/8 - 1/(8*Sqrt[5])], (-1 - Sqrt[5])/4, -Sqrt[1/8 + 1/(8*Sqrt[5])]}, \
+       {-Sqrt[1/8 - 1/(8*Sqrt[5])], (1 + Sqrt[5])/4, -Sqrt[1/8 + 1/(8*Sqrt[5])]}, \
+       {Sqrt[1/8 - 1/(8*Sqrt[5])], (-1 - Sqrt[5])/4, Sqrt[1/8 + 1/(8*Sqrt[5])]}, \
+       {Sqrt[1/8 - 1/(8*Sqrt[5])], (1 + Sqrt[5])/4, Sqrt[1/8 + 1/(8*Sqrt[5])]}}"
+    );
+  }
+
+  #[test]
+  fn polyhedron_data_vertex_coordinates_cube_and_octahedron() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube", "VertexCoordinates"]"#).unwrap(),
+      "{{-1/2, -1/2, -1/2}, {-1/2, -1/2, 1/2}, {-1/2, 1/2, -1/2}, \
+       {-1/2, 1/2, 1/2}, {1/2, -1/2, -1/2}, {1/2, -1/2, 1/2}, \
+       {1/2, 1/2, -1/2}, {1/2, 1/2, 1/2}}"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Octahedron", "VertexCoordinates"]"#)
+        .unwrap(),
+      "{{-(1/Sqrt[2]), 0, 0}, {1/Sqrt[2], 0, 0}, {0, -(1/Sqrt[2]), 0}, \
+       {0, 1/Sqrt[2], 0}, {0, 0, -(1/Sqrt[2])}, {0, 0, 1/Sqrt[2]}}"
+    );
+  }
+
+  // The stored coordinates must describe a unit-edge solid: every solid's
+  // shortest vertex-to-vertex distance is exactly 1, and the number of
+  // pairs at that distance is the edge count.
+  #[test]
+  fn polyhedron_data_vertex_coordinates_have_unit_edges() {
+    for name in [
+      "Tetrahedron",
+      "Cube",
+      "Octahedron",
+      "Dodecahedron",
+      "Icosahedron",
+    ] {
+      let result = interpret(&format!(
+        r#"With[{{v = N[PolyhedronData["{name}", "VertexCoordinates"]]}},
+             {{Length[v],
+               Round[1000000 * Min @@ Flatten[Table[
+                 Norm[v[[i]] - v[[j]]],
+                 {{i, Length[v] - 1}}, {{j, i + 1, Length[v]}}]]]}}]"#
+      ))
+      .unwrap();
+      let expected_counts = match name {
+        "Tetrahedron" => "{4, 1000000}",
+        "Cube" => "{8, 1000000}",
+        "Octahedron" => "{6, 1000000}",
+        "Dodecahedron" => "{20, 1000000}",
+        "Icosahedron" => "{12, 1000000}",
+        _ => unreachable!(),
+      };
+      assert_eq!(result, expected_counts, "solid: {name}");
+    }
+  }
+
+  // Edge lists as 1-based vertex index pairs in canonical order.
+  #[test]
+  fn polyhedron_data_edge_indices() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Tetrahedron", "EdgeIndices"]"#).unwrap(),
+      "{{1, 2}, {1, 3}, {1, 4}, {2, 3}, {2, 4}, {3, 4}}"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube", "EdgeIndices"]"#).unwrap(),
+      "{{1, 2}, {1, 3}, {1, 5}, {2, 4}, {2, 6}, {3, 4}, {3, 7}, {4, 8}, \
+       {5, 6}, {5, 7}, {6, 8}, {7, 8}}"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Icosahedron", "EdgeIndices"]"#).unwrap(),
+      "{{1, 3}, {1, 5}, {1, 6}, {1, 9}, {1, 10}, {2, 4}, {2, 7}, {2, 8}, \
+       {2, 11}, {2, 12}, {3, 7}, {3, 8}, {3, 9}, {3, 10}, {4, 5}, {4, 6}, \
+       {4, 11}, {4, 12}, {5, 6}, {5, 9}, {5, 11}, {6, 10}, {6, 12}, {7, 8}, \
+       {7, 9}, {7, 11}, {8, 10}, {8, 12}, {9, 11}, {10, 12}}"
+    );
+  }
+
+  // Every solid's edge list has exactly EdgeCount entries.
+  #[test]
+  fn polyhedron_data_edge_indices_match_edge_count() {
+    for name in [
+      "Tetrahedron",
+      "Cube",
+      "Octahedron",
+      "Dodecahedron",
+      "Icosahedron",
+    ] {
+      let result = interpret(&format!(
+        r#"Length[PolyhedronData["{name}", "EdgeIndices"]] ==
+           PolyhedronData["{name}", "EdgeCount"]"#
+      ))
+      .unwrap();
+      assert_eq!(result, "True", "solid: {name}");
+    }
+  }
+
+  // The insphere is a Sphere at the origin with the exact inradius.
+  #[test]
+  fn polyhedron_data_insphere() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Cube", "Insphere"]"#).unwrap(),
+      "Sphere[{0, 0, 0}, 1/2]"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Icosahedron", "Insphere"]"#).unwrap(),
+      "Sphere[{0, 0, 0}, (3*Sqrt[3] + Sqrt[15])/12]"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["Dodecahedron", "Insphere"]"#).unwrap(),
+      "Sphere[{0, 0, 0}, Sqrt[250 + 110*Sqrt[5]]/20]"
+    );
+  }
+
+  // The new data properties appear in the sorted "Properties" list.
+  #[test]
+  fn polyhedron_data_properties_include_data_properties() {
+    assert_eq!(
+      interpret(r#"PolyhedronData["Properties"]"#).unwrap(),
+      "{Circumradius, EdgeCount, EdgeIndices, FaceCount, Inradius, \
+       Insphere, SurfaceArea, VertexCoordinates, VertexCount, Volume}"
+    );
+  }
+
   // "Hexahedron" is an alternative name for the cube.
   #[test]
   fn polyhedron_data_hexahedron_alias() {

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d__graphics3d_arrow_with_background.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d__graphics3d_arrow_with_background.snap
@@ -4,246 +4,246 @@ expression: "export_svg(\"Graphics3D[{Arrow[{{0,0,0},{1,0,1}}]}, Background -> R
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,0,0)"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polyline points="55.7,254.4 304.3,105.6" fill="none" stroke="#333" stroke-width="1.5"/>
 <polygon points="304.3,105.6 298.9,112.3 295.9,107.1" fill="#333"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d__graphics3d_polygon.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d__graphics3d_polygon.snap
@@ -4,245 +4,245 @@ expression: "export_svg(\"Graphics3D[Polygon[{{0,0,0}, {0,1,1}, {1,0,0}}]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 141.8,25.5 218.2,334.5" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d__graphics3d_sphere.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d__graphics3d_sphere.snap
@@ -4,63 +4,63 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.9,177.4 178.5,194.9 178.2,176.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.2,176.1 178.5,194.9 160.9,196.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.0,157.4 178.2,176.1 157.6,178.0" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.9,177.4 196.1,196.0 178.5,194.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,176.1 160.9,196.5 157.6,178.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,158.9 198.9,177.4 178.2,176.1" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,158.9 178.2,176.1 178.0,157.4" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.1,196.0 178.8,213.1 178.5,194.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.0,157.4 157.6,178.0 155.1,159.5" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,194.9 165.0,214.4 160.9,196.5" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.4,181.8 196.1,196.0 198.9,177.4" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.5,194.9 178.8,213.1 165.0,214.4" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
@@ -76,21 +76,21 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="222.6,163.8 218.4,181.8 198.9,177.4" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,141.2 178.0,157.4 177.9,139.6" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,196.5 165.0,214.4 152.2,217.7" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,196.5 152.2,217.7 144.7,200.7" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,199.8 205.6,217.0 192.6,214.0" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="177.9,139.6 155.1,159.5 153.5,141.8" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,214.0 179.2,230.1 178.8,213.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,159.5 138.5,182.9 133.9,165.0" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.8,213.1 169.7,231.0 165.0,214.4" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.5,141.8 155.1,159.5 133.9,165.0" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.6,217.0 188.7,230.7 192.6,214.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="235.2,189.1 212.6,199.8 218.4,181.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.3,146.4 201.0,158.9 202.3,141.2" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.3,146.4 222.6,163.8 201.0,158.9" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.8,213.1 179.2,230.1 169.7,231.0" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,206.0 205.6,217.0 212.6,199.8" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,214.0 188.7,230.7 179.2,230.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -103,11 +103,11 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="241.4,171.9 218.4,181.8 222.6,163.8" fill="rgb(79,108,152)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.2,189.1 227.0,206.0 212.6,199.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.9,165.0 138.5,182.9 122.2,190.6" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,217.0 197.7,232.8 188.7,230.7" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.5,141.8 133.9,165.0 131.0,147.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,206.0 216.9,221.8 205.6,217.0" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,200.7 141.4,222.8 130.9,207.3" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,221.8 197.7,232.8 205.6,217.0" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,182.9 130.9,207.3 122.2,190.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
@@ -119,8 +119,8 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="188.7,230.7 179.6,245.1 179.2,230.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,217.7 153.4,236.8 141.4,222.8" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,230.1 174.7,245.6 169.7,231.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="226.2,130.3 225.3,146.4 202.3,141.2" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,221.8 205.4,236.1 197.7,232.8" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.0,147.7 133.9,165.0 115.8,173.6" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -130,9 +130,9 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="245.1,155.0 222.6,163.8 225.3,146.4" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.7,231.0 170.3,246.7 160.9,233.2" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,214.1 216.9,221.8 227.0,206.0" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="245.1,155.0 241.4,171.9 222.6,163.8" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.3,198.7 227.0,206.0 235.2,189.1" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,230.1 179.6,245.1 174.7,245.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,207.3 141.4,222.8 133.2,229.5" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
@@ -155,16 +155,16 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="225.6,228.2 211.4,240.5 205.4,236.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.0,147.7 115.8,173.6 111.8,156.8" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="255.9,182.5 235.2,189.1 241.4,171.9" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,173.6 122.2,190.6 109.9,200.5" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,236.1 193.0,248.2 189.0,246.5" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,240.5 193.0,248.2 205.4,236.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="130.0,131.6 131.0,147.7 111.8,156.8" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,110.9 177.8,123.4 177.9,109.3" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.2,190.6 120.4,215.7 109.9,200.5" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.5,111.5 153.0,125.6 130.0,131.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.4,236.8 163.5,250.9 147.7,241.4" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.4,139.1 225.3,146.4 226.2,130.3" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -189,13 +189,13 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="111.8,156.8 115.8,173.6 102.1,184.6" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,166.3 241.4,171.9 245.1,155.0" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,173.6 109.9,200.5 102.1,184.6" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,241.4 163.5,250.9 161.8,253.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,235.7 215.3,245.7 211.4,240.5" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.0,250.4 180.0,257.7 193.0,248.2" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="166.4,248.5 180.0,257.7 163.5,250.9" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.7,241.4 161.8,253.6 144.3,246.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.2,229.5 144.3,246.6 128.1,237.1" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
@@ -228,7 +228,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="161.8,253.6 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.7,255.9 180.0,257.7 198.0,253.1" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.8,253.6 180.0,257.7 161.3,256.4" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.7,255.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.8,251.3 198.7,255.9 198.0,253.1" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -237,16 +237,16 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="245.1,124.7 226.2,130.3 225.3,116.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.4,243.9 215.3,245.7 231.3,235.7" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,156.8 102.1,184.6 97.3,168.5" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,246.6 161.3,256.4 143.2,252.3" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="265.2,195.0 248.3,198.7 255.9,182.5" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,184.6 109.9,200.5 102.3,212.0" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="110.5,140.9 111.8,156.8 97.3,168.5" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.0,259.3 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 198.7,255.9" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 153.5,111.5 131.0,117.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,99.4 177.9,109.3 178.0,98.0" fill="rgb(56,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 162.0,259.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -269,7 +269,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="162.0,259.3 180.0,257.7 164.0,261.9" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,237.1 143.2,252.3 126.6,245.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="185.3,266.8 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.7,256.9 198.7,255.9 216.8,251.3" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.6,266.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -277,22 +277,22 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="215.7,256.9 198.2,258.8 198.7,255.9" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="222.6,104.4 202.3,110.9 201.0,99.4" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.6,263.8 180.0,257.7 196.5,261.5" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="131.0,117.4 110.5,140.9 111.8,126.5" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,261.9 180.0,257.7 167.0,264.2" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.0,234.0 233.4,243.9 231.3,235.7" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.2,252.3 162.0,259.3 144.7,257.8" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.7,265.6 180.0,257.7 193.6,263.8" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.0,264.2 180.0,257.7 171.0,265.9" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,257.8 162.0,259.3 164.0,261.9" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="97.3,168.5 102.1,184.6 93.7,197.3" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.5,179.6 255.9,182.5 260.6,166.3" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,245.3 143.2,252.3 144.7,257.8" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,184.6 102.3,212.0 93.7,197.3" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 131.0,117.4 133.9,105.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.3,266.8 180.0,257.7 189.7,265.6" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 175.6,266.9" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
@@ -310,24 +310,24 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="270.5,179.6 265.2,195.0 255.9,182.5" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,126.5 110.5,140.9 95.7,152.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.2,89.8 178.0,98.0 155.1,100.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 245.1,124.7 225.3,116.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="259.9,222.1 248.0,234.0 245.2,223.7" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.9,91.1 201.0,99.4 178.0,98.0" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.6,263.0 164.0,261.9 167.0,264.2" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,136.0 246.4,139.1 245.1,124.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,257.8 164.0,261.9 148.6,263.0" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 225.3,116.1 222.6,104.4" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.6,266.7 193.6,263.8 196.5,261.5" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,136.0 262.1,150.6 246.4,139.1" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,245.3 144.7,257.8 128.7,253.4" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.0,235.8 126.6,245.3 128.7,253.4" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.6,266.7 196.5,261.5 212.3,262.2" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.6,267.4 167.0,264.2 171.0,265.9" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.6,91.7 155.1,100.1 133.9,105.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,244.4 233.4,243.9 248.0,234.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
@@ -343,7 +343,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="272.3,164.1 260.6,166.3 262.1,150.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.6,263.0 167.0,264.2 154.6,267.4" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,244.4 231.9,252.0 233.4,243.9" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,89.8 155.1,100.1 157.6,91.7" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.8,259.7 212.3,262.2 215.7,256.9" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.3,270.8 171.0,265.9 175.6,266.9" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -351,9 +351,9 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="226.8,259.7 215.7,256.9 231.9,252.0" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.3,272.6 185.3,266.8 189.7,265.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.8,208.5 259.9,222.1 256.7,209.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="272.3,164.1 270.5,179.6 260.6,166.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="171.3,272.8 175.6,266.9 180.4,267.2" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.4,95.5 201.0,99.4 198.9,91.1" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,126.5 95.7,152.8 97.3,138.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -361,15 +361,15 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="199.1,270.3 193.6,263.8 206.6,266.7" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.6,267.4 171.0,265.9 162.3,270.8" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.0,235.8 128.7,253.4 114.8,246.2" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.7,253.4 148.6,263.0 134.4,260.9" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 111.8,126.5 97.3,138.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.6,91.7 133.9,105.6 138.5,96.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.1,224.2 112.0,235.8 114.8,246.2" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,272.6 189.7,265.6 199.1,270.3" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.4,260.9 148.6,263.0 154.6,267.4" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,96.6 133.9,105.6 115.8,114.1" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.3,270.8 175.6,266.9 171.3,272.8" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -386,29 +386,29 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="95.7,152.8 88.4,182.0 86.6,166.6" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,234.3 246.0,244.4 248.0,234.0" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,246.2 128.7,253.4 134.4,260.9" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,266.3 212.3,262.2 226.8,259.7" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.2,102.8 222.6,104.4 218.4,95.5" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.3,138.2 95.7,152.8 86.6,166.6" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="270.5,149.3 262.1,150.6 260.6,136.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,85.0 178.2,89.8 157.6,91.7" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="274.3,193.9 268.8,208.5 265.2,195.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.1,86.2 198.9,91.1 178.2,89.8" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,254.2 231.9,252.0 246.0,244.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,254.2 226.8,259.7 231.9,252.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.1,267.3 154.6,267.4 162.3,270.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.5,149.3 272.3,164.1 262.1,150.6" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.4,260.9 154.6,267.4 143.1,267.3" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.8,271.5 199.1,270.3 206.6,266.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.1,224.2 114.8,246.2 103.3,236.4" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,86.6 157.6,91.7 138.5,96.6" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 97.3,138.2 102.1,125.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,96.6 115.8,114.1 122.2,104.3" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,89.9 218.4,95.5 198.9,91.1" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -416,22 +416,22 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="196.1,86.2 178.2,89.8 178.5,85.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,222.1 259.9,222.1 268.8,208.5" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,246.2 134.4,260.9 121.9,255.7" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="207.8,271.5 206.6,266.7 218.6,266.3" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.4,272.2 162.3,270.8 171.3,272.8" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.4,182.0 91.2,210.9 85.7,196.4" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.5,85.0 157.6,91.7 160.9,86.6" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.6,166.6 88.4,182.0 85.7,196.4" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="195.0,274.8 190.3,272.6 199.1,270.3" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="276.1,178.7 270.5,179.6 272.3,164.1" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="122.2,104.3 115.8,114.1 102.1,125.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,222.1 257.7,234.3 259.9,222.1" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,89.9 198.9,91.1 196.1,86.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,255.7 134.4,260.9 143.1,267.3" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.1,267.3 162.3,270.8 154.4,272.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,275.2 171.3,272.8 180.8,273.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -443,29 +443,29 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="276.1,178.7 274.3,193.9 270.5,179.6" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,262.6 218.6,266.3 226.8,259.7" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,125.2 97.3,138.2 88.4,151.7" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 138.5,96.6 122.2,104.3" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.1,245.8 246.0,244.4 257.7,234.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,86.6 138.5,96.6 144.7,90.9" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="195.0,274.8 199.1,270.3 207.8,271.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="265.2,135.6 260.6,136.0 255.9,123.1" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,262.6 226.8,259.7 239.6,254.2" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="250.1,245.8 239.6,254.2 246.0,244.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,96.1 235.2,102.8 218.4,95.5" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.4,272.2 171.3,272.8 167.4,275.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="265.2,135.6 270.5,149.3 260.6,136.0" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,210.9 103.3,236.4 94.8,224.4" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.2,276.0 190.3,272.6 195.0,274.8" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,96.1 218.4,95.5 212.6,89.9" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,275.2 180.8,273.4 181.2,276.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,196.4 91.2,210.9 94.8,224.4" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="271.6,208.3 268.8,208.5 274.3,193.9" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.9,255.7 143.1,267.3 133.0,263.9" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.6,166.6 85.7,196.4 83.9,181.3" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -478,13 +478,13 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="103.3,236.4 121.9,255.7 111.7,247.6" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,208.3 266.3,222.1 268.8,208.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,269.1 207.8,271.5 218.6,266.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 122.2,104.3 130.9,97.4" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.1,125.2 88.4,151.7 93.7,137.9" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="274.3,163.6 276.1,178.7 272.3,164.1" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.0,85.2 160.9,86.6 144.7,90.9" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.8,224.4 103.3,236.4 111.7,247.6" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
@@ -494,12 +494,12 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="111.7,247.6 121.9,255.7 133.0,263.9" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.9,234.8 257.7,234.3 266.3,222.1" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.9,114.2 102.1,125.2 93.7,137.9" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.4,270.1 154.4,272.2 167.4,275.2" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,104.3 248.3,112.4 235.2,102.8" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,84.8 178.5,85.0 178.8,84.0" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="256.7,123.6 255.9,123.1 248.3,112.4" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.9,234.8 250.1,245.8 257.7,234.3" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,104.3 235.2,102.8 227.0,96.1" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
@@ -507,38 +507,38 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="178.8,84.0 160.9,86.6 165.0,85.2" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="237.8,255.7 229.1,262.6 239.6,254.2" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.0,263.9 154.4,272.2 147.4,270.1" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="237.8,255.7 239.6,254.2 250.1,245.8" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="256.7,123.6 265.2,135.6 255.9,123.1" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,196.4 94.8,224.4 89.5,210.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,87.8 196.1,86.2 192.6,84.8" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.9,181.3 85.7,196.4 89.5,210.7" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.4,193.4 274.3,193.9 276.1,178.7" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.9,273.8 167.4,275.2 181.2,276.0" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.5,275.0 181.2,276.0 195.0,274.8" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,88.5 144.7,90.9 130.9,97.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="88.4,151.7 83.9,181.3 85.7,166.1" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.9,92.7 227.0,96.1 212.6,89.9" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.0,85.2 144.7,90.9 152.2,88.5" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,273.4 207.8,271.5 215.3,269.1" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.7,137.9 88.4,151.7 85.7,166.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.8,149.1 270.5,149.3 265.2,135.6" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.4,193.4 271.6,208.3 274.3,193.9" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.8,224.4 111.7,247.6 104.1,236.9" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,97.4 109.9,114.2 120.4,105.8" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.4,270.1 167.4,275.2 163.9,273.8" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,92.7 212.6,89.9 205.6,87.8" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.7,247.6 133.0,263.9 124.8,257.2" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="268.8,149.1 274.3,163.6 270.5,149.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.9,114.2 93.7,137.9 102.3,125.7" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,275.0 195.0,274.8 199.1,273.4" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.8,257.2 133.0,263.9 147.4,270.1" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
@@ -547,10 +547,10 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="262.7,221.8 266.3,222.1 271.6,208.3" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,263.4 215.3,269.1 229.1,262.6" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,88.5 130.9,97.4 141.4,93.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 109.9,114.2 102.3,125.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.2,86.6 178.8,84.0 165.0,85.2" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="188.7,87.2 192.6,84.8 178.8,84.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.1,236.9 111.7,247.6 124.8,257.2" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
@@ -561,19 +561,19 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="221.5,263.4 229.1,262.6 237.8,255.7" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="245.2,113.8 256.7,123.6 248.3,112.4" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,166.1 83.9,181.3 87.7,195.9" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="225.6,99.1 238.1,104.3 227.0,96.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,178.0 276.1,178.7 274.3,163.6" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="169.7,87.4 165.0,85.2 152.2,88.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.2,245.9 250.1,245.8 257.9,234.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.2,245.9 237.8,255.7 250.1,245.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.7,89.2 205.6,87.8 192.6,84.8" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.7,137.9 85.7,166.1 91.2,151.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.6,99.1 227.0,96.1 216.9,92.7" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.3,125.7 93.7,137.9 91.2,151.5" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.9,135.8 265.2,135.6 256.7,123.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,178.0 273.4,193.4 276.1,178.7" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -583,19 +583,19 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="202.4,268.3 199.1,273.4 215.3,269.1" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.9,135.8 268.8,149.1 265.2,135.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,86.6 165.0,85.2 169.7,87.4" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 152.2,88.5 141.4,93.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.5,210.7 104.1,236.9 99.4,224.0" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.7,89.2 192.6,84.8 188.7,87.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.4,92.6 216.9,92.7 205.6,87.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 102.3,125.7 114.0,115.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.4,93.7 120.4,105.8 133.2,100.3" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,268.9 163.9,273.8 181.5,275.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,270.2 181.5,275.0 199.1,273.4" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.7,195.9 89.5,210.7 99.4,224.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.7,87.4 152.2,88.5 160.9,89.7" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -603,23 +603,23 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="202.4,268.3 215.3,269.1 221.5,263.4" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="264.3,207.2 271.6,208.3 273.4,193.4" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,92.6 205.6,87.8 197.7,89.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="85.7,166.1 87.7,195.9 89.5,180.4" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.2,100.3 120.4,105.8 114.0,115.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,162.7 274.3,163.6 268.8,149.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.2,151.5 85.7,166.1 89.5,180.4" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,264.5 163.9,273.8 161.1,268.9" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="264.3,207.2 262.7,221.8 271.6,208.3" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.6,247.6 124.8,257.2 141.6,264.5" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,106.6 245.2,113.8 238.1,104.3" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,106.6 238.1,104.3 225.6,99.1" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,125.7 91.2,151.5 100.1,137.9" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.4,224.0 104.1,236.9 118.6,247.6" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.4,93.3 141.4,93.7 133.2,100.3" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 141.4,93.7 153.4,93.3" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.0,115.6 102.3,125.7 100.1,137.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.8,270.2 199.1,273.4 202.4,268.3" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
@@ -627,14 +627,14 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="248.0,124.2 256.7,123.6 245.2,113.8" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,162.7 271.6,178.0 274.3,163.6" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="211.4,97.0 225.6,99.1 216.9,92.7" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="161.1,268.9 181.5,275.0 181.8,270.2" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,233.5 257.9,234.8 262.7,221.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.1,254.4 237.8,255.7 244.2,245.9" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.0,124.2 259.9,135.8 256.7,123.6" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,233.5 244.2,245.9 257.9,234.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,97.0 216.9,92.7 205.4,92.6" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.6,92.8 179.2,86.6 169.7,87.4" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,93.1 188.7,87.2 179.2,86.6" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
@@ -642,15 +642,15 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="87.7,195.9 99.4,224.0 97.9,209.4" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.7,93.2 169.7,87.4 160.9,89.7" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,94.1 197.7,89.2 188.7,87.2" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="89.5,180.4 87.7,195.9 97.9,209.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="262.7,191.5 273.4,193.4 271.6,178.0" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.4,93.3 133.2,100.3 147.7,97.8" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="118.6,247.6 141.6,264.5 137.4,255.6" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,148.0 268.8,149.1 259.9,135.8" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,151.5 89.5,180.4 94.8,165.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,255.6 141.6,264.5 161.1,268.9" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.1,137.9 91.2,151.5 94.8,165.0" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
@@ -663,18 +663,18 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="262.7,191.5 264.3,207.2 273.4,193.4" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,102.2 231.3,106.6 225.6,99.1" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,93.1 179.2,86.6 179.6,92.8" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.6,92.8 169.7,87.4 174.7,93.2" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,108.0 114.0,115.6 112.0,126.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,148.0 266.3,162.7 268.8,149.1" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,102.2 225.6,99.1 211.4,97.0" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="233.4,114.7 245.2,113.8 231.3,106.6" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,94.1 188.7,87.2 184.4,93.1" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.4,114.7 248.0,124.2 245.2,113.8" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.7,93.2 160.9,89.7 170.3,94.4" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="204.9,259.9 221.5,263.4 226.1,254.4" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="159.0,260.6 161.1,268.9 181.8,270.2" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.9,209.4 99.4,224.0 114.9,235.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.0,95.8 197.7,89.2 189.0,94.1" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
@@ -683,10 +683,10 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="196.0,98.1 211.4,97.0 205.4,92.6" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,235.3 118.6,247.6 137.4,255.6" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.5,219.1 262.7,221.8 264.3,207.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="170.3,94.4 153.4,93.3 166.4,96.2" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,97.8 128.1,108.0 144.3,103.1" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,255.6 161.1,268.9 159.0,260.6" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.5,219.1 248.2,233.5 262.7,221.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -700,12 +700,12 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="100.1,137.9 94.8,165.0 103.3,150.1" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.8,165.0 89.5,180.4 99.4,193.7" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,108.0 112.0,126.0 126.6,116.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.0,262.0 202.4,268.3 204.9,259.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,134.6 257.7,148.0 259.9,135.8" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,103.1 128.1,108.0 126.6,116.1" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.8,107.7 231.3,106.6 215.3,102.2" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.0,260.6 181.8,270.2 182.0,262.0" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="166.4,96.2 147.7,97.8 163.5,98.5" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
@@ -720,10 +720,10 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="180.0,102.3 174.7,93.2 170.3,94.4" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.9,209.4 114.9,235.3 113.6,220.9" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,235.3 137.4,255.6 134.7,243.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="231.9,122.9 248.0,124.2 233.4,114.7" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 193.0,95.8 189.0,94.1" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 170.3,94.4 166.4,96.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,116.1 112.0,126.0 114.8,136.3" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
@@ -733,12 +733,12 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="112.0,126.0 103.3,150.1 114.8,136.3" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.4,193.7 97.9,209.4 113.6,220.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.1,159.5 266.3,162.7 257.7,148.0" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.2,203.2 264.3,207.2 262.7,191.5" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 196.0,98.1 193.0,95.8" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,248.5 204.9,259.9 226.1,254.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.9,122.9 246.0,134.6 248.0,124.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 166.4,96.2 163.5,98.5" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.8,101.2 144.3,103.1 143.2,108.7" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.3,150.1 94.8,165.0 104.1,177.5" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
@@ -749,7 +749,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="180.0,102.3 184.4,93.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 174.7,93.2 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,203.2 249.5,219.1 264.3,207.2" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 189.0,94.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 196.0,98.1" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,248.5 226.1,254.4 229.0,242.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -771,21 +771,21 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="126.6,116.1 114.8,136.3 128.7,124.3" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.7,113.4 231.9,122.9 233.4,114.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.7,103.6 198.0,100.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 161.3,104.1" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,106.4 216.8,107.7 198.7,103.6" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,144.3 257.7,148.0 246.0,134.6" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.7,243.9 159.0,260.6 157.7,249.1" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.7,103.6 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,104.1 143.2,108.7 144.7,114.3" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,136.3 103.3,150.1 111.7,161.3" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,106.4 215.7,113.4 216.8,107.7" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.2,106.4 198.7,103.6" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 162.0,106.9" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.2,106.4 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -817,15 +817,15 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="180.0,102.3 175.6,114.6 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 180.4,114.9 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 193.6,111.5 196.5,109.1" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 164.0,109.6 167.0,111.8" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.8,229.7 134.7,243.9 157.7,249.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.8,130.5 239.6,144.3 246.0,134.6" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="162.0,106.9 144.7,114.3 148.6,119.5" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.5,109.1 212.3,118.6 215.7,113.4" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.8,136.3 111.7,161.3 121.9,145.9" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,114.3 128.7,124.3 134.4,131.8" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,205.0 113.6,220.9 133.8,229.7" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -850,7 +850,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="237.8,169.4 244.2,186.4 257.9,175.4" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.2,235.0 157.7,249.1 182.1,250.7" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,109.6 154.6,123.9 167.0,111.8" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.2,236.6 182.1,250.7 206.5,248.5" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,109.6 148.6,119.5 154.6,123.9" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.6,111.5 206.6,123.2 212.3,118.6" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
@@ -858,9 +858,9 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="229.1,152.7 250.1,159.5 239.6,144.3" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.6,123.2 226.8,130.5 212.3,118.6" fill="rgb(88,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.7,113.3 206.6,123.2 193.6,111.5" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,137.2 239.6,144.3 226.8,130.5" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.9,145.9 111.7,161.3 124.8,170.9" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,205.0 133.8,229.7 134.7,213.6" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -884,17 +884,17 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="180.4,114.9 190.3,129.0 185.3,114.4" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.1,195.0 229.0,212.3 248.2,203.2" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.6,114.6 180.8,129.9 180.4,114.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.5,218.2 207.0,234.4 230.0,228.4" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,145.9 124.8,170.9 133.0,154.0" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,218.2 230.0,228.4 229.0,212.3" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,126.8 218.6,137.2 206.6,123.2" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.4,131.8 133.0,154.0 143.1,138.2" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,113.5 162.3,127.2 171.3,129.3" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.3,114.4 190.3,129.0 199.1,126.8" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="175.6,114.6 171.3,129.3 180.8,129.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.4,114.9 180.8,129.9 190.3,129.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,177.1 244.2,186.4 237.8,169.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
@@ -909,9 +909,9 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="182.1,220.4 182.2,236.6 207.0,234.4" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,177.1 226.1,195.0 244.2,186.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,159.3 237.8,169.4 229.1,152.7" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,129.0 207.8,142.3 199.1,126.8" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.1,220.4 207.0,234.4 206.5,218.2" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.0,154.0 124.8,170.9 141.6,178.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.1,138.2 133.0,154.0 147.4,160.2" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
@@ -928,17 +928,17 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="162.3,127.2 154.4,143.0 167.4,146.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.3,129.0 195.0,145.6 207.8,142.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.3,129.3 181.2,146.9 180.8,129.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="133.0,154.0 141.6,178.2 147.4,160.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="195.0,145.6 215.3,159.3 207.8,142.3" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.3,129.3 167.4,146.0 181.2,146.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.8,129.9 181.2,146.9 195.0,145.6" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,196.2 157.7,218.8 159.0,201.1" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.4,182.0 226.1,195.0 221.5,177.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.0,201.1 157.7,218.8 182.1,220.4" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,178.2 137.4,196.2 159.0,201.1" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="182.0,202.6 182.1,220.4 206.5,218.2" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,163.5 221.5,177.1 215.3,159.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -954,62 +954,62 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="141.6,178.2 159.0,201.1 161.1,182.6" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,146.0 181.5,165.1 181.2,146.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.4,160.2 161.1,182.6 163.9,164.0" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,146.0 163.9,164.0 181.5,165.1" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.2,146.9 181.5,165.1 199.1,163.5" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,182.6 159.0,201.1 182.0,202.6" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,183.9 182.0,202.6 204.9,200.5" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.8,183.9 204.9,200.5 202.4,182.0" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,165.1 202.4,182.0 199.1,163.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="163.9,164.0 161.1,182.6 181.8,183.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,182.6 182.0,202.6 181.8,183.9" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.9,164.0 181.8,183.9 181.5,165.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,165.1 181.8,183.9 202.4,182.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_arrow.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_arrow.snap
@@ -4,246 +4,246 @@ expression: "export_svg(\"Graphics3D[Arrow[{{0,0,0},{1,0,1}}]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polyline points="55.7,254.4 304.3,105.6" fill="none" stroke="#333" stroke-width="1.5"/>
 <polygon points="304.3,105.6 298.9,112.3 295.9,107.1" fill="#333"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_background.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_background.snap
@@ -4,246 +4,246 @@ expression: "export_svg(\"Graphics3D[{Arrow[{{0,0,0},{1,0,1}}]}, Background -> R
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,0,0)"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="261.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="57.0" y2="266.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="261.8" x2="43.3" y2="249.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="266.2" x2="70.6" y2="270.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="249.2" x2="43.3" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="270.7" x2="84.3" y2="275.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="275.1" x2="98.0" y2="279.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="236.7" x2="43.3" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="279.5" x2="111.7" y2="283.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="224.1" x2="43.3" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="283.9" x2="125.3" y2="288.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="288.3" x2="139.0" y2="292.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="211.5" x2="43.3" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="292.7" x2="152.7" y2="297.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="198.9" x2="43.3" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="297.1" x2="166.3" y2="301.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="301.5" x2="180.0" y2="305.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="186.3" x2="43.3" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="305.9" x2="193.7" y2="310.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="173.7" x2="43.3" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="310.3" x2="207.3" y2="314.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="314.7" x2="221.0" y2="319.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="161.1" x2="43.3" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="319.1" x2="234.7" y2="323.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="148.5" x2="43.3" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="323.6" x2="248.3" y2="328.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="328.0" x2="262.0" y2="332.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="135.9" x2="43.3" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="332.4" x2="275.7" y2="336.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="123.3" x2="43.3" y2="110.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="336.8" x2="289.4" y2="341.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="341.2" x2="303.0" y2="345.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="110.7" x2="43.3" y2="98.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="345.6" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="98.1" x2="43.3" y2="85.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="350.0" x2="316.7" y2="337.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="85.6" x2="43.3" y2="73.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="337.4" x2="316.7" y2="324.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="73.0" x2="43.3" y2="60.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="324.8" x2="316.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="60.4" x2="43.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="312.2" x2="316.7" y2="299.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="47.8" x2="43.3" y2="35.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="299.6" x2="316.7" y2="287.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="35.2" x2="43.3" y2="22.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="287.0" x2="316.7" y2="274.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="22.6" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="274.4" x2="316.7" y2="261.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="43.3" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.3" y1="10.0" x2="57.0" y2="14.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="261.9" x2="316.7" y2="249.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.0" y1="14.4" x2="70.6" y2="18.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.6" y1="18.8" x2="84.3" y2="23.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="249.3" x2="316.7" y2="236.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.3" y1="23.2" x2="98.0" y2="27.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="236.7" x2="316.7" y2="224.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="27.6" x2="111.7" y2="32.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.7" y1="32.0" x2="125.3" y2="36.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="224.1" x2="316.7" y2="211.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.3" y1="36.4" x2="139.0" y2="40.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="211.5" x2="316.7" y2="198.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="139.0" y1="40.9" x2="152.7" y2="45.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.7" y1="45.3" x2="166.3" y2="49.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="198.9" x2="316.7" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="49.7" x2="180.0" y2="54.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="186.3" x2="316.7" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="54.1" x2="193.7" y2="58.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="58.5" x2="207.3" y2="62.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="173.7" x2="316.7" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.3" y1="62.9" x2="221.0" y2="67.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="161.1" x2="316.7" y2="148.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.0" y1="67.3" x2="234.7" y2="71.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="234.7" y1="71.7" x2="248.3" y2="76.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="148.5" x2="316.7" y2="135.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.3" y1="76.1" x2="262.0" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="135.9" x2="316.7" y2="123.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="80.5" x2="275.7" y2="84.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.7" y1="84.9" x2="289.4" y2="89.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="123.3" x2="316.7" y2="110.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.4" y1="89.3" x2="303.0" y2="93.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="110.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.0" y1="93.8" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="316.7" y1="98.2" x2="316.7" y2="98.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polyline points="55.7,254.4 304.3,105.6" fill="none" stroke="#333" stroke-width="1.5"/>
 <polygon points="304.3,105.6 298.9,112.3 295.9,107.1" fill="#333"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_boxed_true.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_boxed_true.snap
@@ -4,63 +4,63 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.9,177.4 178.5,194.9 178.2,176.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.2,176.1 178.5,194.9 160.9,196.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.0,157.4 178.2,176.1 157.6,178.0" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.9,177.4 196.1,196.0 178.5,194.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,176.1 160.9,196.5 157.6,178.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,158.9 198.9,177.4 178.2,176.1" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,158.9 178.2,176.1 178.0,157.4" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.1,196.0 178.8,213.1 178.5,194.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.0,157.4 157.6,178.0 155.1,159.5" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,194.9 165.0,214.4 160.9,196.5" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.4,181.8 196.1,196.0 198.9,177.4" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.5,194.9 178.8,213.1 165.0,214.4" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
@@ -76,21 +76,21 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="222.6,163.8 218.4,181.8 198.9,177.4" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,141.2 178.0,157.4 177.9,139.6" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,196.5 165.0,214.4 152.2,217.7" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,196.5 152.2,217.7 144.7,200.7" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,199.8 205.6,217.0 192.6,214.0" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="177.9,139.6 155.1,159.5 153.5,141.8" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,214.0 179.2,230.1 178.8,213.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,159.5 138.5,182.9 133.9,165.0" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.8,213.1 169.7,231.0 165.0,214.4" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.5,141.8 155.1,159.5 133.9,165.0" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.6,217.0 188.7,230.7 192.6,214.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="235.2,189.1 212.6,199.8 218.4,181.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.3,146.4 201.0,158.9 202.3,141.2" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.3,146.4 222.6,163.8 201.0,158.9" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.8,213.1 179.2,230.1 169.7,231.0" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,206.0 205.6,217.0 212.6,199.8" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,214.0 188.7,230.7 179.2,230.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -103,11 +103,11 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="241.4,171.9 218.4,181.8 222.6,163.8" fill="rgb(79,108,152)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.2,189.1 227.0,206.0 212.6,199.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.9,165.0 138.5,182.9 122.2,190.6" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,217.0 197.7,232.8 188.7,230.7" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.5,141.8 133.9,165.0 131.0,147.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,206.0 216.9,221.8 205.6,217.0" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,200.7 141.4,222.8 130.9,207.3" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,221.8 197.7,232.8 205.6,217.0" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,182.9 130.9,207.3 122.2,190.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
@@ -119,8 +119,8 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="188.7,230.7 179.6,245.1 179.2,230.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,217.7 153.4,236.8 141.4,222.8" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,230.1 174.7,245.6 169.7,231.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="226.2,130.3 225.3,146.4 202.3,141.2" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,221.8 205.4,236.1 197.7,232.8" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.0,147.7 133.9,165.0 115.8,173.6" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -130,9 +130,9 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="245.1,155.0 222.6,163.8 225.3,146.4" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.7,231.0 170.3,246.7 160.9,233.2" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,214.1 216.9,221.8 227.0,206.0" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="245.1,155.0 241.4,171.9 222.6,163.8" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.3,198.7 227.0,206.0 235.2,189.1" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,230.1 179.6,245.1 174.7,245.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,207.3 141.4,222.8 133.2,229.5" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
@@ -155,16 +155,16 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="225.6,228.2 211.4,240.5 205.4,236.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.0,147.7 115.8,173.6 111.8,156.8" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="255.9,182.5 235.2,189.1 241.4,171.9" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,173.6 122.2,190.6 109.9,200.5" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,236.1 193.0,248.2 189.0,246.5" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,240.5 193.0,248.2 205.4,236.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="130.0,131.6 131.0,147.7 111.8,156.8" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,110.9 177.8,123.4 177.9,109.3" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.2,190.6 120.4,215.7 109.9,200.5" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.5,111.5 153.0,125.6 130.0,131.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.4,236.8 163.5,250.9 147.7,241.4" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.4,139.1 225.3,146.4 226.2,130.3" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -189,13 +189,13 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="111.8,156.8 115.8,173.6 102.1,184.6" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,166.3 241.4,171.9 245.1,155.0" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,173.6 109.9,200.5 102.1,184.6" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,241.4 163.5,250.9 161.8,253.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,235.7 215.3,245.7 211.4,240.5" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.0,250.4 180.0,257.7 193.0,248.2" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="166.4,248.5 180.0,257.7 163.5,250.9" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.7,241.4 161.8,253.6 144.3,246.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.2,229.5 144.3,246.6 128.1,237.1" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
@@ -228,7 +228,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="161.8,253.6 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.7,255.9 180.0,257.7 198.0,253.1" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.8,253.6 180.0,257.7 161.3,256.4" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.7,255.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.8,251.3 198.7,255.9 198.0,253.1" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -237,16 +237,16 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="245.1,124.7 226.2,130.3 225.3,116.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.4,243.9 215.3,245.7 231.3,235.7" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,156.8 102.1,184.6 97.3,168.5" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,246.6 161.3,256.4 143.2,252.3" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="265.2,195.0 248.3,198.7 255.9,182.5" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,184.6 109.9,200.5 102.3,212.0" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="110.5,140.9 111.8,156.8 97.3,168.5" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.0,259.3 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 198.7,255.9" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 153.5,111.5 131.0,117.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,99.4 177.9,109.3 178.0,98.0" fill="rgb(56,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 162.0,259.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -269,7 +269,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="162.0,259.3 180.0,257.7 164.0,261.9" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,237.1 143.2,252.3 126.6,245.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="185.3,266.8 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.7,256.9 198.7,255.9 216.8,251.3" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.6,266.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -277,22 +277,22 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="215.7,256.9 198.2,258.8 198.7,255.9" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="222.6,104.4 202.3,110.9 201.0,99.4" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.6,263.8 180.0,257.7 196.5,261.5" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="131.0,117.4 110.5,140.9 111.8,126.5" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,261.9 180.0,257.7 167.0,264.2" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.0,234.0 233.4,243.9 231.3,235.7" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.2,252.3 162.0,259.3 144.7,257.8" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.7,265.6 180.0,257.7 193.6,263.8" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.0,264.2 180.0,257.7 171.0,265.9" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,257.8 162.0,259.3 164.0,261.9" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="97.3,168.5 102.1,184.6 93.7,197.3" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.5,179.6 255.9,182.5 260.6,166.3" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,245.3 143.2,252.3 144.7,257.8" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,184.6 102.3,212.0 93.7,197.3" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 131.0,117.4 133.9,105.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.3,266.8 180.0,257.7 189.7,265.6" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 175.6,266.9" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
@@ -310,24 +310,24 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="270.5,179.6 265.2,195.0 255.9,182.5" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,126.5 110.5,140.9 95.7,152.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.2,89.8 178.0,98.0 155.1,100.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 245.1,124.7 225.3,116.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="259.9,222.1 248.0,234.0 245.2,223.7" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.9,91.1 201.0,99.4 178.0,98.0" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.6,263.0 164.0,261.9 167.0,264.2" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,136.0 246.4,139.1 245.1,124.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,257.8 164.0,261.9 148.6,263.0" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 225.3,116.1 222.6,104.4" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.6,266.7 193.6,263.8 196.5,261.5" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,136.0 262.1,150.6 246.4,139.1" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,245.3 144.7,257.8 128.7,253.4" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.0,235.8 126.6,245.3 128.7,253.4" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.6,266.7 196.5,261.5 212.3,262.2" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.6,267.4 167.0,264.2 171.0,265.9" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.6,91.7 155.1,100.1 133.9,105.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,244.4 233.4,243.9 248.0,234.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
@@ -343,7 +343,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="272.3,164.1 260.6,166.3 262.1,150.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.6,263.0 167.0,264.2 154.6,267.4" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,244.4 231.9,252.0 233.4,243.9" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,89.8 155.1,100.1 157.6,91.7" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.8,259.7 212.3,262.2 215.7,256.9" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.3,270.8 171.0,265.9 175.6,266.9" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -351,9 +351,9 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="226.8,259.7 215.7,256.9 231.9,252.0" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.3,272.6 185.3,266.8 189.7,265.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.8,208.5 259.9,222.1 256.7,209.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="272.3,164.1 270.5,179.6 260.6,166.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="171.3,272.8 175.6,266.9 180.4,267.2" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.4,95.5 201.0,99.4 198.9,91.1" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,126.5 95.7,152.8 97.3,138.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -361,15 +361,15 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="199.1,270.3 193.6,263.8 206.6,266.7" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.6,267.4 171.0,265.9 162.3,270.8" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.0,235.8 128.7,253.4 114.8,246.2" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.7,253.4 148.6,263.0 134.4,260.9" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 111.8,126.5 97.3,138.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.6,91.7 133.9,105.6 138.5,96.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.1,224.2 112.0,235.8 114.8,246.2" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,272.6 189.7,265.6 199.1,270.3" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.4,260.9 148.6,263.0 154.6,267.4" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,96.6 133.9,105.6 115.8,114.1" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.3,270.8 175.6,266.9 171.3,272.8" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -386,29 +386,29 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="95.7,152.8 88.4,182.0 86.6,166.6" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,234.3 246.0,244.4 248.0,234.0" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,246.2 128.7,253.4 134.4,260.9" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,266.3 212.3,262.2 226.8,259.7" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.2,102.8 222.6,104.4 218.4,95.5" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.3,138.2 95.7,152.8 86.6,166.6" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="270.5,149.3 262.1,150.6 260.6,136.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,85.0 178.2,89.8 157.6,91.7" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="274.3,193.9 268.8,208.5 265.2,195.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.1,86.2 198.9,91.1 178.2,89.8" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,254.2 231.9,252.0 246.0,244.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,254.2 226.8,259.7 231.9,252.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.1,267.3 154.6,267.4 162.3,270.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.5,149.3 272.3,164.1 262.1,150.6" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.4,260.9 154.6,267.4 143.1,267.3" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.8,271.5 199.1,270.3 206.6,266.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.1,224.2 114.8,246.2 103.3,236.4" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,86.6 157.6,91.7 138.5,96.6" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 97.3,138.2 102.1,125.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,96.6 115.8,114.1 122.2,104.3" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,89.9 218.4,95.5 198.9,91.1" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -416,22 +416,22 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="196.1,86.2 178.2,89.8 178.5,85.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,222.1 259.9,222.1 268.8,208.5" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,246.2 134.4,260.9 121.9,255.7" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="207.8,271.5 206.6,266.7 218.6,266.3" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.4,272.2 162.3,270.8 171.3,272.8" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.4,182.0 91.2,210.9 85.7,196.4" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.5,85.0 157.6,91.7 160.9,86.6" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.6,166.6 88.4,182.0 85.7,196.4" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="195.0,274.8 190.3,272.6 199.1,270.3" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="276.1,178.7 270.5,179.6 272.3,164.1" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="122.2,104.3 115.8,114.1 102.1,125.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,222.1 257.7,234.3 259.9,222.1" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,89.9 198.9,91.1 196.1,86.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,255.7 134.4,260.9 143.1,267.3" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.1,267.3 162.3,270.8 154.4,272.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,275.2 171.3,272.8 180.8,273.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -443,29 +443,29 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="276.1,178.7 274.3,193.9 270.5,179.6" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,262.6 218.6,266.3 226.8,259.7" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,125.2 97.3,138.2 88.4,151.7" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 138.5,96.6 122.2,104.3" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.1,245.8 246.0,244.4 257.7,234.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,86.6 138.5,96.6 144.7,90.9" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="195.0,274.8 199.1,270.3 207.8,271.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="265.2,135.6 260.6,136.0 255.9,123.1" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,262.6 226.8,259.7 239.6,254.2" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="250.1,245.8 239.6,254.2 246.0,244.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,96.1 235.2,102.8 218.4,95.5" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.4,272.2 171.3,272.8 167.4,275.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="265.2,135.6 270.5,149.3 260.6,136.0" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,210.9 103.3,236.4 94.8,224.4" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.2,276.0 190.3,272.6 195.0,274.8" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,96.1 218.4,95.5 212.6,89.9" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,275.2 180.8,273.4 181.2,276.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,196.4 91.2,210.9 94.8,224.4" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="271.6,208.3 268.8,208.5 274.3,193.9" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.9,255.7 143.1,267.3 133.0,263.9" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.6,166.6 85.7,196.4 83.9,181.3" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -478,13 +478,13 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="103.3,236.4 121.9,255.7 111.7,247.6" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,208.3 266.3,222.1 268.8,208.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,269.1 207.8,271.5 218.6,266.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 122.2,104.3 130.9,97.4" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.1,125.2 88.4,151.7 93.7,137.9" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="274.3,163.6 276.1,178.7 272.3,164.1" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.0,85.2 160.9,86.6 144.7,90.9" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.8,224.4 103.3,236.4 111.7,247.6" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
@@ -494,12 +494,12 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="111.7,247.6 121.9,255.7 133.0,263.9" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.9,234.8 257.7,234.3 266.3,222.1" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.9,114.2 102.1,125.2 93.7,137.9" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.4,270.1 154.4,272.2 167.4,275.2" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,104.3 248.3,112.4 235.2,102.8" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,84.8 178.5,85.0 178.8,84.0" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="256.7,123.6 255.9,123.1 248.3,112.4" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.9,234.8 250.1,245.8 257.7,234.3" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,104.3 235.2,102.8 227.0,96.1" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
@@ -507,38 +507,38 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="178.8,84.0 160.9,86.6 165.0,85.2" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="237.8,255.7 229.1,262.6 239.6,254.2" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.0,263.9 154.4,272.2 147.4,270.1" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="237.8,255.7 239.6,254.2 250.1,245.8" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="256.7,123.6 265.2,135.6 255.9,123.1" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,196.4 94.8,224.4 89.5,210.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,87.8 196.1,86.2 192.6,84.8" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.9,181.3 85.7,196.4 89.5,210.7" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.4,193.4 274.3,193.9 276.1,178.7" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.9,273.8 167.4,275.2 181.2,276.0" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.5,275.0 181.2,276.0 195.0,274.8" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,88.5 144.7,90.9 130.9,97.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="88.4,151.7 83.9,181.3 85.7,166.1" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.9,92.7 227.0,96.1 212.6,89.9" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.0,85.2 144.7,90.9 152.2,88.5" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,273.4 207.8,271.5 215.3,269.1" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.7,137.9 88.4,151.7 85.7,166.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.8,149.1 270.5,149.3 265.2,135.6" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.4,193.4 271.6,208.3 274.3,193.9" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.8,224.4 111.7,247.6 104.1,236.9" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,97.4 109.9,114.2 120.4,105.8" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.4,270.1 167.4,275.2 163.9,273.8" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,92.7 212.6,89.9 205.6,87.8" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.7,247.6 133.0,263.9 124.8,257.2" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="268.8,149.1 274.3,163.6 270.5,149.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.9,114.2 93.7,137.9 102.3,125.7" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,275.0 195.0,274.8 199.1,273.4" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.8,257.2 133.0,263.9 147.4,270.1" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
@@ -547,10 +547,10 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="262.7,221.8 266.3,222.1 271.6,208.3" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,263.4 215.3,269.1 229.1,262.6" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,88.5 130.9,97.4 141.4,93.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 109.9,114.2 102.3,125.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.2,86.6 178.8,84.0 165.0,85.2" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="188.7,87.2 192.6,84.8 178.8,84.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.1,236.9 111.7,247.6 124.8,257.2" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
@@ -561,19 +561,19 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="221.5,263.4 229.1,262.6 237.8,255.7" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="245.2,113.8 256.7,123.6 248.3,112.4" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,166.1 83.9,181.3 87.7,195.9" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="225.6,99.1 238.1,104.3 227.0,96.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,178.0 276.1,178.7 274.3,163.6" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="169.7,87.4 165.0,85.2 152.2,88.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.2,245.9 250.1,245.8 257.9,234.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.2,245.9 237.8,255.7 250.1,245.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.7,89.2 205.6,87.8 192.6,84.8" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.7,137.9 85.7,166.1 91.2,151.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.6,99.1 227.0,96.1 216.9,92.7" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.3,125.7 93.7,137.9 91.2,151.5" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.9,135.8 265.2,135.6 256.7,123.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,178.0 273.4,193.4 276.1,178.7" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -583,19 +583,19 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="202.4,268.3 199.1,273.4 215.3,269.1" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.9,135.8 268.8,149.1 265.2,135.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,86.6 165.0,85.2 169.7,87.4" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 152.2,88.5 141.4,93.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.5,210.7 104.1,236.9 99.4,224.0" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.7,89.2 192.6,84.8 188.7,87.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.4,92.6 216.9,92.7 205.6,87.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 102.3,125.7 114.0,115.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.4,93.7 120.4,105.8 133.2,100.3" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,268.9 163.9,273.8 181.5,275.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,270.2 181.5,275.0 199.1,273.4" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.7,195.9 89.5,210.7 99.4,224.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.7,87.4 152.2,88.5 160.9,89.7" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -603,23 +603,23 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="202.4,268.3 215.3,269.1 221.5,263.4" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="264.3,207.2 271.6,208.3 273.4,193.4" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,92.6 205.6,87.8 197.7,89.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="85.7,166.1 87.7,195.9 89.5,180.4" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.2,100.3 120.4,105.8 114.0,115.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,162.7 274.3,163.6 268.8,149.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.2,151.5 85.7,166.1 89.5,180.4" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,264.5 163.9,273.8 161.1,268.9" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="264.3,207.2 262.7,221.8 271.6,208.3" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.6,247.6 124.8,257.2 141.6,264.5" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,106.6 245.2,113.8 238.1,104.3" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,106.6 238.1,104.3 225.6,99.1" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,125.7 91.2,151.5 100.1,137.9" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.4,224.0 104.1,236.9 118.6,247.6" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.4,93.3 141.4,93.7 133.2,100.3" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 141.4,93.7 153.4,93.3" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.0,115.6 102.3,125.7 100.1,137.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.8,270.2 199.1,273.4 202.4,268.3" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
@@ -627,14 +627,14 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="248.0,124.2 256.7,123.6 245.2,113.8" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,162.7 271.6,178.0 274.3,163.6" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="211.4,97.0 225.6,99.1 216.9,92.7" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="161.1,268.9 181.5,275.0 181.8,270.2" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,233.5 257.9,234.8 262.7,221.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.1,254.4 237.8,255.7 244.2,245.9" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.0,124.2 259.9,135.8 256.7,123.6" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,233.5 244.2,245.9 257.9,234.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,97.0 216.9,92.7 205.4,92.6" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.6,92.8 179.2,86.6 169.7,87.4" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,93.1 188.7,87.2 179.2,86.6" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
@@ -642,15 +642,15 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="87.7,195.9 99.4,224.0 97.9,209.4" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.7,93.2 169.7,87.4 160.9,89.7" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,94.1 197.7,89.2 188.7,87.2" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="89.5,180.4 87.7,195.9 97.9,209.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="262.7,191.5 273.4,193.4 271.6,178.0" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.4,93.3 133.2,100.3 147.7,97.8" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="118.6,247.6 141.6,264.5 137.4,255.6" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,148.0 268.8,149.1 259.9,135.8" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,151.5 89.5,180.4 94.8,165.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,255.6 141.6,264.5 161.1,268.9" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.1,137.9 91.2,151.5 94.8,165.0" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
@@ -663,18 +663,18 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="262.7,191.5 264.3,207.2 273.4,193.4" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,102.2 231.3,106.6 225.6,99.1" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,93.1 179.2,86.6 179.6,92.8" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.6,92.8 169.7,87.4 174.7,93.2" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,108.0 114.0,115.6 112.0,126.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,148.0 266.3,162.7 268.8,149.1" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,102.2 225.6,99.1 211.4,97.0" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="233.4,114.7 245.2,113.8 231.3,106.6" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,94.1 188.7,87.2 184.4,93.1" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.4,114.7 248.0,124.2 245.2,113.8" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.7,93.2 160.9,89.7 170.3,94.4" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="204.9,259.9 221.5,263.4 226.1,254.4" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="159.0,260.6 161.1,268.9 181.8,270.2" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.9,209.4 99.4,224.0 114.9,235.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.0,95.8 197.7,89.2 189.0,94.1" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
@@ -683,10 +683,10 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="196.0,98.1 211.4,97.0 205.4,92.6" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,235.3 118.6,247.6 137.4,255.6" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.5,219.1 262.7,221.8 264.3,207.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="170.3,94.4 153.4,93.3 166.4,96.2" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,97.8 128.1,108.0 144.3,103.1" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,255.6 161.1,268.9 159.0,260.6" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.5,219.1 248.2,233.5 262.7,221.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -700,12 +700,12 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="100.1,137.9 94.8,165.0 103.3,150.1" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.8,165.0 89.5,180.4 99.4,193.7" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,108.0 112.0,126.0 126.6,116.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.0,262.0 202.4,268.3 204.9,259.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,134.6 257.7,148.0 259.9,135.8" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,103.1 128.1,108.0 126.6,116.1" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.8,107.7 231.3,106.6 215.3,102.2" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.0,260.6 181.8,270.2 182.0,262.0" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="166.4,96.2 147.7,97.8 163.5,98.5" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
@@ -720,10 +720,10 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="180.0,102.3 174.7,93.2 170.3,94.4" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.9,209.4 114.9,235.3 113.6,220.9" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,235.3 137.4,255.6 134.7,243.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="231.9,122.9 248.0,124.2 233.4,114.7" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 193.0,95.8 189.0,94.1" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 170.3,94.4 166.4,96.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,116.1 112.0,126.0 114.8,136.3" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
@@ -733,12 +733,12 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="112.0,126.0 103.3,150.1 114.8,136.3" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.4,193.7 97.9,209.4 113.6,220.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.1,159.5 266.3,162.7 257.7,148.0" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.2,203.2 264.3,207.2 262.7,191.5" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 196.0,98.1 193.0,95.8" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,248.5 204.9,259.9 226.1,254.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.9,122.9 246.0,134.6 248.0,124.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 166.4,96.2 163.5,98.5" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.8,101.2 144.3,103.1 143.2,108.7" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.3,150.1 94.8,165.0 104.1,177.5" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
@@ -749,7 +749,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="180.0,102.3 184.4,93.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 174.7,93.2 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,203.2 249.5,219.1 264.3,207.2" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 189.0,94.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 196.0,98.1" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,248.5 226.1,254.4 229.0,242.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -771,21 +771,21 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="126.6,116.1 114.8,136.3 128.7,124.3" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.7,113.4 231.9,122.9 233.4,114.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.7,103.6 198.0,100.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 161.3,104.1" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,106.4 216.8,107.7 198.7,103.6" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,144.3 257.7,148.0 246.0,134.6" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.7,243.9 159.0,260.6 157.7,249.1" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.7,103.6 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,104.1 143.2,108.7 144.7,114.3" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,136.3 103.3,150.1 111.7,161.3" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,106.4 215.7,113.4 216.8,107.7" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.2,106.4 198.7,103.6" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 162.0,106.9" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.2,106.4 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -817,15 +817,15 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="180.0,102.3 175.6,114.6 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 180.4,114.9 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 193.6,111.5 196.5,109.1" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 164.0,109.6 167.0,111.8" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.8,229.7 134.7,243.9 157.7,249.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.8,130.5 239.6,144.3 246.0,134.6" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="162.0,106.9 144.7,114.3 148.6,119.5" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.5,109.1 212.3,118.6 215.7,113.4" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.8,136.3 111.7,161.3 121.9,145.9" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,114.3 128.7,124.3 134.4,131.8" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,205.0 113.6,220.9 133.8,229.7" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -850,7 +850,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="237.8,169.4 244.2,186.4 257.9,175.4" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.2,235.0 157.7,249.1 182.1,250.7" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,109.6 154.6,123.9 167.0,111.8" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.2,236.6 182.1,250.7 206.5,248.5" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,109.6 148.6,119.5 154.6,123.9" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.6,111.5 206.6,123.2 212.3,118.6" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
@@ -858,9 +858,9 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="229.1,152.7 250.1,159.5 239.6,144.3" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.6,123.2 226.8,130.5 212.3,118.6" fill="rgb(88,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.7,113.3 206.6,123.2 193.6,111.5" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,137.2 239.6,144.3 226.8,130.5" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.9,145.9 111.7,161.3 124.8,170.9" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,205.0 133.8,229.7 134.7,213.6" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -884,17 +884,17 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="180.4,114.9 190.3,129.0 185.3,114.4" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.1,195.0 229.0,212.3 248.2,203.2" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.6,114.6 180.8,129.9 180.4,114.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.5,218.2 207.0,234.4 230.0,228.4" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,145.9 124.8,170.9 133.0,154.0" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,218.2 230.0,228.4 229.0,212.3" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,126.8 218.6,137.2 206.6,123.2" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.4,131.8 133.0,154.0 143.1,138.2" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,113.5 162.3,127.2 171.3,129.3" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.3,114.4 190.3,129.0 199.1,126.8" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="175.6,114.6 171.3,129.3 180.8,129.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.4,114.9 180.8,129.9 190.3,129.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,177.1 244.2,186.4 237.8,169.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
@@ -909,9 +909,9 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="182.1,220.4 182.2,236.6 207.0,234.4" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,177.1 226.1,195.0 244.2,186.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,159.3 237.8,169.4 229.1,152.7" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,129.0 207.8,142.3 199.1,126.8" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.1,220.4 207.0,234.4 206.5,218.2" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.0,154.0 124.8,170.9 141.6,178.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.1,138.2 133.0,154.0 147.4,160.2" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
@@ -928,17 +928,17 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="162.3,127.2 154.4,143.0 167.4,146.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.3,129.0 195.0,145.6 207.8,142.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.3,129.3 181.2,146.9 180.8,129.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="133.0,154.0 141.6,178.2 147.4,160.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="195.0,145.6 215.3,159.3 207.8,142.3" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.3,129.3 167.4,146.0 181.2,146.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.8,129.9 181.2,146.9 195.0,145.6" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,196.2 157.7,218.8 159.0,201.1" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.4,182.0 226.1,195.0 221.5,177.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.0,201.1 157.7,218.8 182.1,220.4" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,178.2 137.4,196.2 159.0,201.1" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="182.0,202.6 182.1,220.4 206.5,218.2" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,163.5 221.5,177.1 215.3,159.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -954,62 +954,62 @@ expression: "export_svg(\"Graphics3D[Sphere[], Boxed -> True]\")"
 <polygon points="141.6,178.2 159.0,201.1 161.1,182.6" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,146.0 181.5,165.1 181.2,146.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.4,160.2 161.1,182.6 163.9,164.0" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,146.0 163.9,164.0 181.5,165.1" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.2,146.9 181.5,165.1 199.1,163.5" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,182.6 159.0,201.1 182.0,202.6" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,183.9 182.0,202.6 204.9,200.5" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.8,183.9 204.9,200.5 202.4,182.0" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,165.1 202.4,182.0 199.1,163.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="163.9,164.0 161.1,182.6 181.8,183.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,182.6 182.0,202.6 181.8,183.9" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.9,164.0 181.8,183.9 181.5,165.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,165.1 181.8,183.9 202.4,182.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_color_directive.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_color_directive.snap
@@ -4,76 +4,76 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.3,239.1 101.1,246.1 101.0,238.5" fill="rgb(249,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.0,238.5 101.1,246.1 94.1,246.7" fill="rgb(252,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,231.1 101.0,238.5 92.7,239.3" fill="rgb(243,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -89,7 +89,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="92.7,239.3 94.1,246.7 87.6,248.4" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.1,246.5 106.8,253.7 101.2,253.3" fill="rgb(252,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,223.9 100.9,231.1 91.7,231.9" fill="rgb(228,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.8,248.0 106.8,253.7 108.1,246.5" fill="rgb(245,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.7,231.9 92.7,239.3 85.1,241.3" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.8,233.6 109.3,239.1 110.1,231.7" fill="rgb(229,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -105,9 +105,9 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="106.8,253.7 101.4,260.1 101.2,253.3" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.7,231.9 85.1,241.3 83.3,234.1" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.2,253.3 97.6,260.5 95.7,253.9" fill="rgb(251,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.1,224.8 91.7,231.9 83.3,234.1" fill="rgb(225,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.0,254.9 105.2,260.4 106.8,253.7" fill="rgb(244,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="123.8,243.7 114.8,248.0 117.1,240.8" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.8,226.7 110.1,231.7 110.6,224.6" fill="rgb(213,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -130,11 +130,11 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="87.6,248.4 86.3,257.2 82.1,251.0" fill="rgb(247,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.5,256.8 108.8,261.2 112.0,254.9" fill="rgb(236,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.1,241.3 82.1,251.0 78.6,244.3" fill="rgb(242,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="110.8,218.1 100.9,223.9 100.8,217.5" fill="rgb(204,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="126.3,236.9 123.8,243.7 117.1,240.8" fill="rgb(214,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.8,217.5 91.1,224.8 90.9,218.4" fill="rgb(208,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.9,218.4 91.1,224.8 82.1,227.2" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.6,255.2 94.1,261.4 91.1,262.8" fill="rgb(245,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -174,16 +174,16 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="82.1,227.2 76.0,237.5 74.4,230.8" fill="rgb(215,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.1,241.1 123.8,243.7 126.3,236.9" fill="rgb(194,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="76.0,237.5 78.6,244.3 73.7,248.3" fill="rgb(217,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="111.9,262.5 106.9,267.4 105.3,266.7" fill="rgb(232,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.3,264.3 106.9,267.4 111.9,262.5" fill="rgb(226,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.7,220.7 82.1,227.2 74.4,230.8" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.6,212.4 100.8,217.5 100.9,211.8" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.6,244.3 77.9,254.4 73.7,248.3" fill="rgb(229,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.1,212.7 90.9,218.4 81.7,220.7" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.1,262.8 95.1,268.4 88.8,264.6" fill="rgb(233,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.3,223.7 119.8,226.7 120.2,220.2" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.1,241.1 129.0,247.6 123.8,243.7" fill="rgb(194,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,211.8 90.9,218.4 91.1,212.7" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -213,7 +213,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="88.8,264.6 94.4,269.5 87.4,266.8" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.0,259.9 87.4,266.8 81.0,263.0" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.8,257.6 122.2,262.4 120.0,259.4" fill="rgb(203,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.5,266.2 101.7,271.2 101.7,271.2" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,266.4 108.9,269.3 108.1,268.3" fill="rgb(218,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.7,220.7 74.4,230.8 73.9,224.4" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -225,11 +225,11 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="105.3,266.7 101.7,271.2 101.7,271.2" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="73.7,248.3 77.9,254.4 75.3,258.3" fill="rgb(212,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.8,266.8 101.7,271.2 101.7,271.2" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="108.9,269.3 101.7,271.2 108.1,268.3" fill="rgb(218,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.9,267.4 101.7,271.2 101.7,271.2" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.3,267.5 101.7,271.2 101.7,271.2" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="95.1,268.4 101.7,271.2 94.4,269.5" fill="rgb(221,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,207.3 100.9,211.8 91.1,212.7" fill="rgb(155,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.9,254.4 81.0,263.0 75.3,258.3" fill="rgb(222,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -264,7 +264,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="94.2,270.7 101.7,271.2 94.5,271.8" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.6,228.3 127.8,230.1 128.3,223.7" fill="rgb(153,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="73.7,248.3 75.3,258.3 70.7,252.9" fill="rgb(212,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="123.1,265.6 116.4,268.6 115.8,266.4" fill="rgb(200,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.3,272.7 101.7,271.2 101.7,271.2" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.3,272.9 101.7,271.2 101.7,271.2" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -292,9 +292,9 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="82.1,215.1 73.9,224.4 74.4,218.7" fill="rgb(170,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.3,272.9 101.7,271.2 96.5,273.8" fill="rgb(210,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.9,261.7 123.1,265.6 122.2,262.4" fill="rgb(186,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="87.0,269.0 94.5,271.8 87.6,271.2" fill="rgb(211,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="105.6,274.3 101.7,271.2 107.1,273.6" fill="rgb(206,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.5,273.8 101.7,271.2 98.1,274.4" fill="rgb(208,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.6,271.2 94.5,271.8 95.3,272.9" fill="rgb(203,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -325,23 +325,23 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="89.1,273.3 95.3,272.9 96.5,273.8" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.9,222.5 128.3,223.7 127.8,218.0" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.6,271.2 95.3,272.9 89.1,273.3" fill="rgb(203,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="126.3,213.1 119.8,214.5 118.8,209.8" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.4,274.8 107.1,273.6 108.3,272.7" fill="rgb(188,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.9,222.5 134.6,228.3 128.3,223.7" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="80.4,266.2 87.6,271.2 81.2,269.5" fill="rgb(202,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="74.5,262.4 80.4,266.2 81.2,269.5" fill="rgb(188,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.4,274.8 108.3,272.7 114.6,273.0" fill="rgb(188,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,275.1 96.5,273.8 98.1,274.4" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="92.7,204.8 91.7,208.1 83.3,210.3" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.1,265.9 123.1,265.6 128.9,261.7" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.2,269.5 87.6,271.2 89.1,273.3" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="70.7,252.9 74.5,262.4 69.8,257.8" fill="rgb(192,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.2,247.0 70.7,252.9 69.8,257.8" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.6,235.5 67.2,247.0 65.1,240.9" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="137.2,251.5 132.4,252.1 135.8,246.1" fill="rgb(147,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.4,276.2 105.6,274.3 107.1,273.6" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.1,206.3 118.8,209.8 110.1,207.9" fill="rgb(111,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -375,7 +375,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="94.6,276.4 99.9,274.9 98.2,277.2" fill="rgb(184,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.8,261.8 128.9,261.7 133.7,256.9" fill="rgb(146,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.1,217.3 127.8,218.0 126.3,213.1" fill="rgb(102,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="67.2,247.0 69.8,257.8 66.2,252.5" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.1,217.3 133.9,222.5 127.8,218.0" fill="rgb(102,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.1,240.9 67.2,247.0 66.2,252.5" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -383,14 +383,14 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="117.2,274.6 112.4,274.8 114.6,273.0" fill="rgb(164,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.4,245.7 135.8,246.1 137.9,239.9" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="123.8,209.2 126.3,213.1 118.8,209.8" fill="rgb(95,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="98.2,277.2 101.9,275.0 102.0,277.5" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.0,229.2 65.1,240.9 64.4,234.7" fill="rgb(157,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.8,261.8 128.1,265.9 128.9,261.7" fill="rgb(146,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.6,266.6 81.2,269.5 83.5,272.5" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.2,274.6 114.6,273.0 120.5,272.0" fill="rgb(164,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="123.8,209.2 118.8,209.8 117.1,206.3" fill="rgb(95,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="68.6,223.4 68.0,229.2 64.4,234.7" fill="rgb(132,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.9,227.8 134.6,228.3 133.9,222.5" fill="rgb(102,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.1,202.1 101.0,204.0 92.7,204.8" fill="rgb(92,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -398,13 +398,13 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="108.1,202.6 109.3,204.5 101.0,204.0" fill="rgb(90,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.6,269.8 122.5,268.9 128.1,265.9" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.6,269.8 120.5,272.0 122.5,268.9" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="87.0,275.0 91.5,275.1 94.6,276.4" fill="rgb(166,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.9,227.8 138.6,233.7 134.6,228.3" fill="rgb(102,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="83.5,272.5 91.5,275.1 87.0,275.0" fill="rgb(176,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.8,276.7 109.4,276.2 112.4,274.8" fill="rgb(156,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="69.8,257.8 75.6,266.6 71.0,262.6" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.1,202.8 92.7,204.8 85.1,206.7" fill="rgb(90,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="310.5,142.0 243.0,58.1 243.0,120.2" fill="rgb(0,0,173)" stroke="#00000018" stroke-width="0.5"/>
@@ -422,7 +422,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="64.4,234.7 65.1,240.9 64.0,246.7" fill="rgb(131,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.7,278.0 105.8,277.1 109.4,276.2" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="140.2,239.6 137.9,239.9 138.6,233.7" fill="rgb(99,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="78.6,209.8 76.0,213.7 70.6,218.2" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.2,256.9 132.8,261.8 133.7,256.9" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,204.1 109.3,204.5 108.1,202.6" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -430,7 +430,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="87.0,275.0 94.6,276.4 91.5,277.0" fill="rgb(166,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.7,278.2 98.2,277.2 102.0,277.5" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.6,223.4 64.4,234.7 65.1,228.8" fill="rgb(132,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.2,278.5 102.0,277.5 105.8,277.1" fill="rgb(150,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="71.0,262.6 75.6,266.6 78.5,270.4" fill="rgb(149,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.0,213.0 132.1,217.3 126.3,213.1" fill="rgb(103,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -450,29 +450,29 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="91.5,277.0 98.2,277.2 96.7,278.2" fill="rgb(157,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.8,222.3 137.9,227.8 133.9,222.5" fill="rgb(101,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="66.2,252.5 71.0,262.6 67.6,257.9" fill="rgb(151,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.2,278.5 105.8,277.1 107.7,278.0" fill="rgb(150,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.5,206.5 117.1,206.3 114.8,204.1" fill="rgb(112,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.7,278.2 102.0,277.5 102.2,278.5" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="64.0,246.7 66.2,252.5 67.6,257.9" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.4,251.4 137.2,251.5 139.4,245.7" fill="rgb(97,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.5,270.4 87.0,275.0 82.9,273.6" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="64.4,234.7 64.0,246.7 63.3,240.6" fill="rgb(131,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.6,209.8 70.6,218.2 73.7,213.8" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="82.9,273.6 87.0,275.0 91.5,277.0" fill="rgb(140,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="65.1,228.8 64.4,234.7 63.3,240.6" fill="rgb(107,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.2,201.7 101.1,202.1 94.1,202.8" fill="rgb(119,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.8,202.0 108.1,202.6 101.1,202.1" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.4,233.5 138.6,233.7 137.9,227.8" fill="rgb(104,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="71.0,262.6 78.5,270.4 74.4,267.1" fill="rgb(149,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="138.4,251.4 136.2,256.9 137.2,251.5" fill="rgb(97,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,275.8 112.8,276.7 117.2,274.6" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="87.6,204.4 78.6,209.8 82.1,207.1" fill="rgb(97,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="70.6,218.2 65.1,228.8 67.2,223.3" fill="rgb(106,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.4,233.5 140.2,239.6 138.6,233.7" fill="rgb(104,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.7,202.2 94.1,202.8 87.6,204.4" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -503,13 +503,13 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="95.3,277.6 96.7,278.2 102.2,278.5" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,278.1 102.2,278.5 107.7,278.0" fill="rgb(119,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.6,203.5 87.6,204.4 82.1,207.1" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="65.1,228.8 63.3,240.6 64.0,234.5" fill="rgb(107,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.5,205.2 120.5,206.5 114.8,204.1" fill="rgb(140,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.7,202.2 87.6,204.4 90.6,203.5" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.3,277.4 112.8,276.7 115.8,275.8" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.2,223.3 65.1,228.8 64.0,234.5" fill="rgb(97,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="137.2,227.7 137.9,227.8 135.8,222.3" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.1,245.5 138.4,251.4 139.4,245.7" fill="rgb(107,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.6,257.9 74.4,267.1 71.4,262.9" fill="rgb(126,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -518,14 +518,14 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="116.5,205.2 114.8,204.1 112.0,203.2" fill="rgb(140,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="74.4,267.1 82.9,273.6 79.6,271.0" fill="rgb(129,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.2,227.7 139.4,233.5 137.9,227.8" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="73.7,213.8 67.2,223.3 70.7,218.4" fill="rgb(100,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,278.1 107.7,278.0 109.3,277.4" fill="rgb(119,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="79.6,271.0 82.9,273.6 88.7,276.1" fill="rgb(112,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.3,277.6 102.2,278.5 102.3,278.1" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.5,252.4 67.6,257.9 71.4,262.9" fill="rgb(101,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.8,256.8 136.2,256.9 138.4,251.4" fill="rgb(106,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.3,273.5 115.8,275.8 121.4,273.1" fill="rgb(97,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.6,203.5 82.1,207.1 86.3,205.6" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -541,16 +541,16 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="127.8,213.6 132.4,217.5 129.0,213.0" fill="rgb(149,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="64.0,234.5 63.3,240.6 64.8,246.5" fill="rgb(99,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.0,207.7 124.9,209.8 120.5,206.5" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="138.4,239.3 140.2,239.6 139.4,233.5" fill="rgb(131,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.6,203.1 95.7,202.2 90.6,203.5" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.4,266.4 129.8,266.4 132.9,262.0" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.4,266.4 124.8,270.4 129.8,266.4" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.8,203.8 112.0,203.2 106.8,202.0" fill="rgb(157,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.2,223.3 64.0,234.5 66.2,228.7" fill="rgb(97,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.0,207.7 120.5,206.5 116.5,205.2" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="70.7,218.4 67.2,223.3 66.2,228.7" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.7,222.4 135.8,222.3 132.4,217.5" fill="rgb(151,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.4,239.3 139.1,245.5 140.2,239.6" fill="rgb(131,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -574,10 +574,10 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="110.7,275.4 115.8,275.8 118.3,273.5" fill="rgb(90,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.4,251.0 138.4,251.4 139.1,245.5" fill="rgb(132,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.9,205.1 112.0,203.2 108.8,203.8" fill="rgb(166,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="64.0,234.5 64.8,246.5 65.5,240.3" fill="rgb(99,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.0,208.2 77.9,210.4 75.3,214.3" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="136.2,233.2 139.4,233.5 137.2,227.7" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="66.2,228.7 64.0,234.5 65.5,240.3" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.4,273.9 95.3,277.6 94.1,275.7" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -585,9 +585,9 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="77.2,267.1 79.6,271.0 86.4,273.9" fill="rgb(95,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.2,210.7 127.8,213.6 124.9,209.8" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.2,210.7 124.9,209.8 120.0,207.7" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="70.7,218.4 66.2,228.7 69.8,223.3" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="69.5,257.7 71.4,262.9 77.2,267.1" fill="rgb(102,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.1,205.4 86.3,205.6 83.0,208.2" fill="rgb(164,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.1,204.0 86.3,205.6 91.1,205.4" fill="rgb(156,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -597,7 +597,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="128.9,217.8 132.4,217.5 127.8,213.6" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.2,233.2 138.4,239.3 139.4,233.5" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.3,206.9 120.0,207.7 116.5,205.2" fill="rgb(176,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.1,275.7 102.3,278.1 102.4,276.2" fill="rgb(90,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.0,261.5 132.9,262.0 134.8,256.8" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.2,269.9 124.8,270.4 127.4,266.4" fill="rgb(113,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -615,18 +615,18 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="91.1,205.4 83.0,208.2 88.8,207.2" fill="rgb(164,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.2,267.1 86.4,273.9 84.7,270.3" fill="rgb(95,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.8,227.3 137.2,227.7 133.7,222.4" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="66.2,228.7 65.5,240.3 67.6,234.1" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="84.7,270.3 86.4,273.9 94.1,275.7" fill="rgb(111,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="69.8,223.3 66.2,228.7 67.6,234.1" fill="rgb(147,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="75.3,214.3 69.8,223.3 74.5,218.5" fill="rgb(146,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.8,207.2 83.0,208.2 81.0,211.3" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.8,205.8 94.1,204.0 91.1,205.4" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.7,272.1 110.7,275.4 118.3,273.5" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.9,206.4 111.9,205.1 108.8,203.8" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="69.5,257.7 77.2,267.1 75.7,262.2" fill="rgb(102,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.8,244.7 135.4,251.0 139.1,245.5" fill="rgb(157,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,209.0 122.2,210.7 120.0,207.7" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.5,205.3 101.4,202.7 101.5,205.2" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -642,13 +642,13 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="93.3,272.3 94.1,275.7 102.4,276.2" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.9,251.9 69.5,257.7 75.7,262.2" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.9,206.4 108.8,203.8 105.3,205.7" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.5,272.9 102.4,276.2 110.7,275.4" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.3,206.6 91.1,205.4 88.8,207.2" fill="rgb(188,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.1,207.3 114.3,206.9 111.9,205.1" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.7,262.2 77.2,267.1 84.7,270.3" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.5,255.7 134.8,256.8 135.4,251.0" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="97.8,205.8 91.1,205.4 96.3,206.6" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.8,207.2 81.0,211.3 87.4,209.3" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="84.7,270.3 94.1,275.7 93.3,272.3" fill="rgb(111,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -665,7 +665,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="67.6,234.1 65.5,240.3 69.5,245.6" fill="rgb(150,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.0,211.3 74.5,218.5 80.4,214.6" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.5,272.9 110.7,275.4 111.7,272.1" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.1,221.9 132.8,227.3 133.7,222.4" fill="rgb(192,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.4,209.3 81.0,211.3 80.4,214.6" fill="rgb(187,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.4,211.2 122.2,210.7 115.8,209.0" fill="rgb(202,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -675,8 +675,8 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="108.9,208.4 115.8,209.0 114.3,206.9" fill="rgb(203,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.4,211.2 123.1,214.0 122.2,210.7" fill="rgb(202,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.9,238.3 134.8,244.7 138.4,239.3" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="108.9,208.4 114.3,206.9 108.1,207.3" fill="rgb(203,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 103.5,205.3 101.5,205.2" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 101.5,205.2 99.6,205.4" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -704,7 +704,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="109.2,209.5 115.8,209.0 108.9,208.4" fill="rgb(211,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.2,209.5 116.4,211.2 115.8,209.0" fill="rgb(211,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.6,234.1 69.5,245.6 71.4,239.1" fill="rgb(150,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.7,209.0 101.5,205.2 101.7,209.0" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 103.5,205.3 101.7,209.0" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 99.6,205.4 101.7,209.0" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -719,8 +719,8 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="129.8,231.9 132.9,238.3 136.2,233.2" fill="rgb(197,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 106.9,206.4 101.7,209.0" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 96.3,206.6 101.7,209.0" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="87.0,211.6 80.4,214.6 81.2,217.8" fill="rgb(200,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.4,208.6 87.0,211.6 94.2,209.7" fill="rgb(202,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 108.1,207.3 101.7,209.0" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -734,9 +734,9 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="101.7,209.0 109.2,209.5 108.9,208.4" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 94.4,208.6 94.2,209.7" fill="rgb(212,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 108.9,208.4 101.7,209.0" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.7,209.0 94.4,208.6 101.7,209.0" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.0,210.7 116.4,211.2 109.2,209.5" fill="rgb(219,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.6,225.8 132.8,227.3 128.1,221.9" fill="rgb(212,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.6,265.6 93.3,272.3 92.8,267.7" fill="rgb(140,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -784,12 +784,12 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="108.3,211.7 114.6,215.6 116.0,213.4" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.6,222.6 74.4,232.6 78.5,226.5" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.6,213.8 81.2,217.8 83.5,220.8" fill="rgb(213,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="75.7,250.1 75.2,256.5 83.3,260.0" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.5,261.8 112.3,267.5 121.3,265.1" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.5,210.9 89.1,215.9 95.3,211.9" fill="rgb(218,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 105.6,213.4 107.1,212.7" fill="rgb(225,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.6,215.6 120.5,220.3 122.5,217.2" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 96.5,212.8 98.1,213.5" fill="rgb(223,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.3,253.0 129.5,255.7 129.0,249.4" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -797,7 +797,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="112.5,261.8 121.3,265.1 121.7,259.5" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 103.8,213.9 105.6,213.4" fill="rgb(226,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.1,212.7 114.6,215.6 108.3,211.7" fill="rgb(233,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.7,209.0 98.1,213.5 99.9,213.9" fill="rgb(224,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.3,253.0 121.7,259.5 129.5,255.7" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.2,217.8 78.5,226.5 83.5,220.8" fill="rgb(203,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -814,13 +814,13 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="107.1,212.7 112.4,217.4 114.6,215.6" fill="rgb(233,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.3,260.0 92.8,267.7 92.6,262.1" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.4,229.2 129.8,231.9 125.6,225.8" fill="rgb(229,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.4,217.4 120.5,220.3 114.6,215.6" fill="rgb(237,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.6,213.4 112.4,217.4 107.1,212.7" fill="rgb(238,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="117.2,223.0 125.6,225.8 120.5,220.3" fill="rgb(236,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.5,226.5 74.4,232.6 79.6,236.5" fill="rgb(209,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="75.7,250.1 83.3,260.0 83.6,253.5" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.5,212.8 94.6,219.0 98.1,213.5" fill="rgb(232,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.6,262.7 112.3,267.5 112.5,261.8" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -838,14 +838,14 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="273.6,181.7 310.5,79.8 310.5,142.0" fill="rgb(0,0,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.1,215.9 87.0,223.4 91.5,217.7" fill="rgb(225,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="98.1,213.5 98.2,219.8 99.9,213.9" fill="rgb(237,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="117.2,223.0 121.4,229.2 125.6,225.8" fill="rgb(236,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.6,253.5 83.3,260.0 92.6,262.1" fill="rgb(193,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.9,214.0 105.8,219.7 103.8,213.9" fill="rgb(242,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.2,246.1 121.3,253.0 129.0,249.4" fill="rgb(215,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.9,213.9 102.0,220.1 101.9,214.0" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.3,255.4 112.5,261.8 121.7,259.5" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="78.5,226.5 79.6,236.5 82.9,229.7" fill="rgb(209,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.3,255.4 121.7,259.5 121.3,253.0" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.4,218.8 117.2,223.0 112.4,217.4" fill="rgb(245,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -871,7 +871,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="102.6,256.2 112.5,261.8 112.3,255.4" fill="rgb(208,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="82.9,229.7 79.6,236.5 86.4,239.4" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.0,223.4 82.9,229.7 88.7,232.2" fill="rgb(234,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="84.7,246.6 83.6,253.5 92.8,255.6" fill="rgb(213,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.6,219.0 96.7,226.5 98.2,219.8" fill="rgb(244,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.8,225.0 115.8,231.8 121.4,229.2" fill="rgb(247,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -882,14 +882,14 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="79.6,236.5 84.7,246.6 86.4,239.4" fill="rgb(214,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.0,220.1 107.7,226.3 105.8,219.7" fill="rgb(251,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.0,223.4 88.7,232.2 91.5,225.3" fill="rgb(234,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.6,219.0 91.5,225.3 96.7,226.5" fill="rgb(244,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.8,219.7 107.7,226.3 112.8,225.0" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="98.2,219.8 102.2,226.8 102.0,220.1" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="82.9,229.7 86.4,239.4 88.7,232.2" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="107.7,226.3 115.8,231.8 112.8,225.0" fill="rgb(253,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="98.2,219.8 96.7,226.5 102.2,226.8" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.0,220.1 102.2,226.8 107.7,226.3" fill="rgb(251,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -898,7 +898,7 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="93.3,248.5 92.8,255.6 102.6,256.2" fill="rgb(224,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.4,239.4 84.7,246.6 93.3,248.5" fill="rgb(229,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.5,249.1 102.6,256.2 112.3,255.4" fill="rgb(228,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.3,233.5 118.3,238.9 115.8,231.8" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,225.3 88.7,232.2 95.3,233.7" fill="rgb(245,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.7,240.9 111.7,248.3 120.2,246.1" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -918,110 +918,110 @@ expression: "export_svg(\"Graphics3D[{Red, Sphere[{0,0,0}, 0.5], Blue, Cuboid[{1
 <polygon points="102.4,241.7 102.5,249.1 111.7,248.3" fill="rgb(243,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.4,241.7 111.7,248.3 110.7,240.9" fill="rgb(243,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,234.1 110.7,240.9 109.3,233.5" fill="rgb(252,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="95.3,233.7 94.1,241.1 102.4,241.7" fill="rgb(249,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.1,241.1 102.5,249.1 102.4,241.7" fill="rgb(239,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.3,233.7 102.4,241.7 102.3,234.1" fill="rgb(249,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,234.1 102.4,241.7 110.7,240.9" fill="rgb(252,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.1,97.8 243.0,58.1 310.5,79.8" fill="rgb(0,0,216)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.1,160.0 273.6,119.6 273.6,181.7" fill="rgb(0,0,173)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.1,160.0 206.1,97.8 273.6,119.6" fill="rgb(0,0,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.6,181.7 273.6,119.6 310.5,79.8" fill="rgb(0,0,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.1,97.8 310.5,79.8 273.6,119.6" fill="rgb(0,0,216)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cone.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cone.snap
@@ -4,268 +4,268 @@ expression: "export_svg(\"Graphics3D[Cone[{{0,0,0},{0,0,1}}, 0.5]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="152.1" y1="237.5" x2="158.2" y2="239.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="148.7" y1="241.1" x2="152.1" y2="237.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.2" y1="239.4" x2="164.4" y2="241.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="237.5" x2="152.1" y2="226.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.4" y1="241.4" x2="170.6" y2="243.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="145.3" y1="244.7" x2="148.7" y2="241.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.6" y1="243.4" x2="176.7" y2="245.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.7" y1="245.4" x2="182.9" y2="247.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="226.1" x2="152.1" y2="214.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.9" y1="248.4" x2="145.3" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="182.9" y1="247.4" x2="189.1" y2="249.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="252.0" x2="141.9" y2="248.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.1" y1="249.4" x2="195.3" y2="251.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.3" y1="251.4" x2="201.4" y2="253.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="214.7" x2="152.1" y2="203.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="135.2" y1="255.6" x2="138.5" y2="252.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.4" y1="253.4" x2="207.6" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.6" y1="255.4" x2="213.8" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="131.8" y1="259.3" x2="135.2" y2="255.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="213.8" y1="257.4" x2="220.0" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="203.3" x2="152.1" y2="192.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="220.0" y1="259.3" x2="226.1" y2="261.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="128.4" y1="262.9" x2="131.8" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="226.1" y1="261.3" x2="232.3" y2="263.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.3" y1="263.3" x2="238.5" y2="265.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="192.0" x2="152.1" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.0" y1="266.5" x2="128.4" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.5" y1="265.3" x2="244.7" y2="267.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="244.7" y1="267.3" x2="250.8" y2="269.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.6" y1="270.2" x2="125.0" y2="266.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="250.8" y1="269.3" x2="257.0" y2="271.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="180.6" x2="152.1" y2="169.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="118.3" y1="273.8" x2="121.6" y2="270.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.0" y1="271.3" x2="263.2" y2="273.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="263.2" y1="273.3" x2="269.3" y2="275.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="114.9" y1="277.5" x2="118.3" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="269.3" y1="275.3" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="169.2" x2="152.1" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.1" y1="280.9" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.5" y1="281.1" x2="114.9" y2="277.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="277.3" x2="275.5" y2="265.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="268.8" y1="284.5" x2="272.1" y2="280.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="157.8" x2="152.1" y2="146.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.1" y1="284.7" x2="111.5" y2="281.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="265.9" x2="275.5" y2="254.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.4" y1="288.2" x2="268.8" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="104.8" y1="288.4" x2="108.1" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="146.5" x2="152.1" y2="135.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="291.8" x2="265.4" y2="288.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="292.0" x2="104.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="254.5" x2="275.5" y2="243.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="295.4" x2="262.0" y2="291.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="295.6" x2="101.4" y2="292.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="135.1" x2="152.1" y2="123.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="255.2" y1="299.1" x2="258.6" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.6" y1="299.3" x2="98.0" y2="295.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="243.1" x2="275.5" y2="231.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.9" y1="302.7" x2="255.2" y2="299.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="123.7" x2="152.1" y2="112.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="91.2" y1="302.9" x2="94.6" y2="299.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="231.8" x2="275.5" y2="220.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.5" y1="306.4" x2="251.9" y2="302.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.9" y1="306.6" x2="91.2" y2="302.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="112.4" x2="152.1" y2="101.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="245.1" y1="310.0" x2="248.5" y2="306.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="310.2" x2="87.9" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="220.4" x2="275.5" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="310.2" x2="90.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="241.7" y1="313.6" x2="245.1" y2="310.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="101.0" x2="152.1" y2="89.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="90.7" y1="312.2" x2="96.8" y2="314.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="310.2" x2="84.5" y2="298.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="96.8" y1="314.2" x2="103.0" y2="316.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.4" y1="317.3" x2="241.7" y2="313.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="209.0" x2="275.5" y2="197.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="103.0" y1="316.2" x2="109.2" y2="318.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="89.6" x2="152.1" y2="78.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="235.0" y1="320.9" x2="238.4" y2="317.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="109.2" y1="318.2" x2="115.3" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="298.8" x2="84.5" y2="287.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="237.5" x2="158.2" y2="239.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="148.7" y1="241.1" x2="152.1" y2="237.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.2" y1="239.4" x2="164.4" y2="241.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="237.5" x2="152.1" y2="226.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.4" y1="241.4" x2="170.6" y2="243.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="145.3" y1="244.7" x2="148.7" y2="241.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.6" y1="243.4" x2="176.7" y2="245.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.7" y1="245.4" x2="182.9" y2="247.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="226.1" x2="152.1" y2="214.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.9" y1="248.4" x2="145.3" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="182.9" y1="247.4" x2="189.1" y2="249.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="252.0" x2="141.9" y2="248.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.1" y1="249.4" x2="195.3" y2="251.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.3" y1="251.4" x2="201.4" y2="253.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="214.7" x2="152.1" y2="203.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="135.2" y1="255.6" x2="138.5" y2="252.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.4" y1="253.4" x2="207.6" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.6" y1="255.4" x2="213.8" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="131.8" y1="259.3" x2="135.2" y2="255.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="213.8" y1="257.4" x2="220.0" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="203.3" x2="152.1" y2="192.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="220.0" y1="259.3" x2="226.1" y2="261.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="128.4" y1="262.9" x2="131.8" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="226.1" y1="261.3" x2="232.3" y2="263.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.3" y1="263.3" x2="238.5" y2="265.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="192.0" x2="152.1" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.0" y1="266.5" x2="128.4" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.5" y1="265.3" x2="244.7" y2="267.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="244.7" y1="267.3" x2="250.8" y2="269.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.6" y1="270.2" x2="125.0" y2="266.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="250.8" y1="269.3" x2="257.0" y2="271.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="180.6" x2="152.1" y2="169.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="118.3" y1="273.8" x2="121.6" y2="270.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.0" y1="271.3" x2="263.2" y2="273.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="263.2" y1="273.3" x2="269.3" y2="275.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="114.9" y1="277.5" x2="118.3" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="269.3" y1="275.3" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="169.2" x2="152.1" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.1" y1="280.9" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.5" y1="281.1" x2="114.9" y2="277.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="277.3" x2="275.5" y2="265.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="268.8" y1="284.5" x2="272.1" y2="280.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="157.8" x2="152.1" y2="146.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.1" y1="284.7" x2="111.5" y2="281.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="265.9" x2="275.5" y2="254.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.4" y1="288.2" x2="268.8" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="104.8" y1="288.4" x2="108.1" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="146.5" x2="152.1" y2="135.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="291.8" x2="265.4" y2="288.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="292.0" x2="104.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="254.5" x2="275.5" y2="243.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="295.4" x2="262.0" y2="291.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="295.6" x2="101.4" y2="292.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="135.1" x2="152.1" y2="123.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="255.2" y1="299.1" x2="258.6" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.6" y1="299.3" x2="98.0" y2="295.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="243.1" x2="275.5" y2="231.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.9" y1="302.7" x2="255.2" y2="299.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="123.7" x2="152.1" y2="112.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="91.2" y1="302.9" x2="94.6" y2="299.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="231.8" x2="275.5" y2="220.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.5" y1="306.4" x2="251.9" y2="302.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.9" y1="306.6" x2="91.2" y2="302.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="112.4" x2="152.1" y2="101.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="245.1" y1="310.0" x2="248.5" y2="306.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="87.9" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="220.4" x2="275.5" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="90.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="241.7" y1="313.6" x2="245.1" y2="310.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="101.0" x2="152.1" y2="89.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="90.7" y1="312.2" x2="96.8" y2="314.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="84.5" y2="298.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="96.8" y1="314.2" x2="103.0" y2="316.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.4" y1="317.3" x2="241.7" y2="313.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="209.0" x2="275.5" y2="197.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="103.0" y1="316.2" x2="109.2" y2="318.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="89.6" x2="152.1" y2="78.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="235.0" y1="320.9" x2="238.4" y2="317.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="109.2" y1="318.2" x2="115.3" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="298.8" x2="84.5" y2="287.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 195.1,195.1 178.5,194.0" fill="rgb(46,63,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 178.5,194.0 162.0,195.5" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="115.3" y1="320.1" x2="121.5" y2="322.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="115.3" y1="320.1" x2="121.5" y2="322.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 210.7,198.6 195.1,195.1" fill="rgb(42,58,82)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 162.0,195.5 146.8,199.5" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="197.7" x2="275.5" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="231.6" y1="324.5" x2="235.0" y2="320.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.5" y1="322.1" x2="127.7" y2="324.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="197.7" x2="275.5" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="231.6" y1="324.5" x2="235.0" y2="320.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.5" y1="322.1" x2="127.7" y2="324.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 224.2,204.4 210.7,198.6" fill="rgb(37,50,70)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="78.2" x2="152.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.7" y1="324.1" x2="133.9" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="287.4" x2="84.5" y2="276.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="78.2" x2="152.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.7" y1="324.1" x2="133.9" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="287.4" x2="84.5" y2="276.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 146.8,199.5 133.7,205.7" fill="rgb(43,59,83)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="228.2" y1="328.2" x2="231.6" y2="324.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="133.9" y1="326.1" x2="140.0" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="186.3" x2="275.5" y2="174.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="140.0" y1="328.1" x2="146.2" y2="330.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="228.2" y1="328.2" x2="231.6" y2="324.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="133.9" y1="326.1" x2="140.0" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="186.3" x2="275.5" y2="174.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="140.0" y1="328.1" x2="146.2" y2="330.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 234.7,212.1 224.2,204.4" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="224.8" y1="331.8" x2="228.2" y2="328.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="224.8" y1="331.8" x2="228.2" y2="328.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 133.7,205.7 123.9,213.6" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="146.2" y1="330.1" x2="152.4" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="66.9" x2="152.1" y2="55.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="276.1" x2="84.5" y2="264.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.4" y1="332.1" x2="158.6" y2="334.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="335.5" x2="224.8" y2="331.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="174.9" x2="275.5" y2="163.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="146.2" y1="330.1" x2="152.4" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="66.9" x2="152.1" y2="55.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="276.1" x2="84.5" y2="264.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.4" y1="332.1" x2="158.6" y2="334.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="335.5" x2="224.8" y2="331.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="174.9" x2="275.5" y2="163.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 241.4,221.1 234.7,212.1" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="158.6" y1="334.1" x2="164.7" y2="336.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="158.6" y1="334.1" x2="164.7" y2="336.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 123.9,213.6 117.8,222.8" fill="rgb(35,49,68)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="164.7" y1="336.1" x2="170.9" y2="338.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="55.5" x2="152.1" y2="44.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.1" y1="339.1" x2="221.5" y2="335.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="264.7" x2="84.5" y2="253.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.9" y1="338.1" x2="177.1" y2="340.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="163.5" x2="275.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="214.7" y1="342.7" x2="218.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="177.1" y1="340.0" x2="183.3" y2="342.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="164.7" y1="336.1" x2="170.9" y2="338.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="55.5" x2="152.1" y2="44.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.1" y1="339.1" x2="221.5" y2="335.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="264.7" x2="84.5" y2="253.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.9" y1="338.1" x2="177.1" y2="340.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="163.5" x2="275.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="214.7" y1="342.7" x2="218.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="177.1" y1="340.0" x2="183.3" y2="342.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 244.0,230.8 241.4,221.1" fill="rgb(54,75,105)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 117.8,222.8 116.0,232.6" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="183.3" y1="342.0" x2="189.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="44.1" x2="152.1" y2="32.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="253.3" x2="84.5" y2="242.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="211.3" y1="346.4" x2="214.7" y2="342.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.4" y1="344.0" x2="195.6" y2="346.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="152.2" x2="275.5" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.6" y1="346.0" x2="201.8" y2="348.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="183.3" y1="342.0" x2="189.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="44.1" x2="152.1" y2="32.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="253.3" x2="84.5" y2="242.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="211.3" y1="346.4" x2="214.7" y2="342.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.4" y1="344.0" x2="195.6" y2="346.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="152.2" x2="275.5" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.6" y1="346.0" x2="201.8" y2="348.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 242.2,240.6 244.0,230.8" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="207.9" y1="350.0" x2="211.3" y2="346.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="207.9" y1="350.0" x2="211.3" y2="346.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 116.0,232.6 118.6,242.3" fill="rgb(53,73,102)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="201.8" y1="348.0" x2="207.9" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="32.7" x2="152.1" y2="21.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="242.0" x2="84.5" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="140.8" x2="275.5" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="350.0" x2="207.9" y2="338.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="201.8" y1="348.0" x2="207.9" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="32.7" x2="152.1" y2="21.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="242.0" x2="84.5" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="140.8" x2="275.5" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="350.0" x2="207.9" y2="338.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 236.1,249.8 242.2,240.6" fill="rgb(72,99,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 118.6,242.3 125.3,251.3" fill="rgb(62,85,120)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="21.4" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="230.6" x2="84.5" y2="219.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="129.4" x2="275.5" y2="118.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="338.6" x2="207.9" y2="327.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="10.0" x2="158.2" y2="12.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="21.4" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="230.6" x2="84.5" y2="219.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="129.4" x2="275.5" y2="118.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="338.6" x2="207.9" y2="327.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="10.0" x2="158.2" y2="12.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 226.3,257.7 236.1,249.8" fill="rgb(79,109,152)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="148.7" y1="13.6" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="148.7" y1="13.6" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 125.3,251.3 135.8,258.9" fill="rgb(71,97,136)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="158.2" y1="12.0" x2="164.4" y2="14.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="219.2" x2="84.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.4" y1="14.0" x2="170.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="145.3" y1="17.3" x2="148.7" y2="13.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="158.2" y1="12.0" x2="164.4" y2="14.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="219.2" x2="84.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.4" y1="14.0" x2="170.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="145.3" y1="17.3" x2="148.7" y2="13.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 213.2,263.9 226.3,257.7" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="118.0" x2="275.5" y2="106.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="327.3" x2="207.9" y2="315.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="118.0" x2="275.5" y2="106.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="327.3" x2="207.9" y2="315.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 135.8,258.9 149.3,264.8" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="170.6" y1="16.0" x2="176.7" y2="18.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.7" y1="18.0" x2="182.9" y2="20.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.9" y1="20.9" x2="145.3" y2="17.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="207.8" x2="84.5" y2="196.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="170.6" y1="16.0" x2="176.7" y2="18.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.7" y1="18.0" x2="182.9" y2="20.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.9" y1="20.9" x2="145.3" y2="17.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="207.8" x2="84.5" y2="196.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 198.0,267.9 213.2,263.9" fill="rgb(88,121,169)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 149.3,264.8 164.9,268.3" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="182.9" y1="20.0" x2="189.1" y2="21.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="182.9" y1="20.0" x2="189.1" y2="21.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 181.5,269.4 198.0,267.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 164.9,268.3 181.5,269.4" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="106.7" x2="275.5" y2="95.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="24.5" x2="141.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="315.9" x2="207.9" y2="304.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.1" y1="21.9" x2="195.3" y2="23.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.3" y1="23.9" x2="201.4" y2="25.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="196.5" x2="84.5" y2="185.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="135.2" y1="28.2" x2="138.5" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.4" y1="25.9" x2="207.6" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="95.3" x2="275.5" y2="83.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="304.5" x2="207.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.6" y1="27.9" x2="213.8" y2="29.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="131.8" y1="31.8" x2="135.2" y2="28.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="213.8" y1="29.9" x2="220.0" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="185.1" x2="84.5" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="220.0" y1="31.9" x2="226.1" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="128.4" y1="35.5" x2="131.8" y2="31.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="83.9" x2="275.5" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="226.1" y1="33.9" x2="232.3" y2="35.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="293.1" x2="207.9" y2="281.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.3" y1="35.9" x2="238.5" y2="37.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.0" y1="39.1" x2="128.4" y2="35.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="173.7" x2="84.5" y2="162.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.5" y1="37.9" x2="244.7" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="72.6" x2="275.5" y2="61.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="244.7" y1="39.9" x2="250.8" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.6" y1="42.7" x2="125.0" y2="39.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="281.8" x2="207.9" y2="270.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="250.8" y1="41.8" x2="257.0" y2="43.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="162.3" x2="84.5" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="118.3" y1="46.4" x2="121.6" y2="42.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.0" y1="43.8" x2="263.2" y2="45.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="61.2" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="263.2" y1="45.8" x2="269.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="270.4" x2="207.9" y2="259.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="114.9" y1="50.0" x2="118.3" y2="46.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="269.3" y1="47.8" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="151.0" x2="84.5" y2="139.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.1" y1="53.4" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.5" y1="53.6" x2="114.9" y2="50.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="259.0" x2="207.9" y2="247.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="268.8" y1="57.1" x2="272.1" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.1" y1="57.3" x2="111.5" y2="53.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="139.6" x2="84.5" y2="128.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.4" y1="60.7" x2="268.8" y2="57.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="247.6" x2="207.9" y2="236.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="104.8" y1="60.9" x2="108.1" y2="57.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="128.2" x2="84.5" y2="116.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="64.4" x2="265.4" y2="60.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="64.6" x2="104.8" y2="60.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="236.3" x2="207.9" y2="224.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="68.0" x2="262.0" y2="64.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="68.2" x2="101.4" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="116.9" x2="84.5" y2="105.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="255.2" y1="71.6" x2="258.6" y2="68.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.6" y1="71.8" x2="98.0" y2="68.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="224.9" x2="207.9" y2="213.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.9" y1="75.3" x2="255.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="91.2" y1="75.5" x2="94.6" y2="71.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="105.5" x2="84.5" y2="94.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.5" y1="78.9" x2="251.9" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="213.5" x2="207.9" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.9" y1="79.1" x2="91.2" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="94.1" x2="84.5" y2="82.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="245.1" y1="82.5" x2="248.5" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="82.7" x2="87.9" y2="79.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="202.2" x2="207.9" y2="190.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="82.7" x2="90.7" y2="84.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="241.7" y1="86.2" x2="245.1" y2="82.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="90.7" y1="84.7" x2="96.8" y2="86.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="96.8" y1="86.7" x2="103.0" y2="88.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.4" y1="89.8" x2="241.7" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="190.8" x2="207.9" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="103.0" y1="88.7" x2="109.2" y2="90.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="235.0" y1="93.5" x2="238.4" y2="89.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="109.2" y1="90.7" x2="115.3" y2="92.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="115.3" y1="92.7" x2="121.5" y2="94.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="231.6" y1="97.1" x2="235.0" y2="93.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="179.4" x2="207.9" y2="168.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.5" y1="94.7" x2="127.7" y2="96.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.7" y1="96.7" x2="133.9" y2="98.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="228.2" y1="100.7" x2="231.6" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="133.9" y1="98.7" x2="140.0" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="168.0" x2="207.9" y2="156.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="140.0" y1="100.7" x2="146.2" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="224.8" y1="104.4" x2="228.2" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="146.2" y1="102.6" x2="152.4" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.4" y1="104.6" x2="158.6" y2="106.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="108.0" x2="224.8" y2="104.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="156.7" x2="207.9" y2="145.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.6" y1="106.6" x2="164.7" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.7" y1="108.6" x2="170.9" y2="110.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.1" y1="111.6" x2="221.5" y2="108.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.9" y1="110.6" x2="177.1" y2="112.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="214.7" y1="115.3" x2="218.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="145.3" x2="207.9" y2="133.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="177.1" y1="112.6" x2="183.3" y2="114.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="183.3" y1="114.6" x2="189.4" y2="116.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="211.3" y1="118.9" x2="214.7" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.4" y1="116.6" x2="195.6" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="133.9" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.6" y1="118.6" x2="201.8" y2="120.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="122.5" x2="211.3" y2="118.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.8" y1="120.6" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="106.7" x2="275.5" y2="95.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="24.5" x2="141.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="315.9" x2="207.9" y2="304.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.1" y1="21.9" x2="195.3" y2="23.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.3" y1="23.9" x2="201.4" y2="25.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="196.5" x2="84.5" y2="185.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="135.2" y1="28.2" x2="138.5" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.4" y1="25.9" x2="207.6" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="95.3" x2="275.5" y2="83.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="304.5" x2="207.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.6" y1="27.9" x2="213.8" y2="29.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="131.8" y1="31.8" x2="135.2" y2="28.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="213.8" y1="29.9" x2="220.0" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="185.1" x2="84.5" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="220.0" y1="31.9" x2="226.1" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="128.4" y1="35.5" x2="131.8" y2="31.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="83.9" x2="275.5" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="226.1" y1="33.9" x2="232.3" y2="35.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="293.1" x2="207.9" y2="281.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.3" y1="35.9" x2="238.5" y2="37.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.0" y1="39.1" x2="128.4" y2="35.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="173.7" x2="84.5" y2="162.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.5" y1="37.9" x2="244.7" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="72.6" x2="275.5" y2="61.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="244.7" y1="39.9" x2="250.8" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.6" y1="42.7" x2="125.0" y2="39.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="281.8" x2="207.9" y2="270.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="250.8" y1="41.8" x2="257.0" y2="43.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="162.3" x2="84.5" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="118.3" y1="46.4" x2="121.6" y2="42.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.0" y1="43.8" x2="263.2" y2="45.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="61.2" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="263.2" y1="45.8" x2="269.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="270.4" x2="207.9" y2="259.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="114.9" y1="50.0" x2="118.3" y2="46.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="269.3" y1="47.8" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="151.0" x2="84.5" y2="139.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.1" y1="53.4" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.5" y1="53.6" x2="114.9" y2="50.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="259.0" x2="207.9" y2="247.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="268.8" y1="57.1" x2="272.1" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.1" y1="57.3" x2="111.5" y2="53.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="139.6" x2="84.5" y2="128.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.4" y1="60.7" x2="268.8" y2="57.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="247.6" x2="207.9" y2="236.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="104.8" y1="60.9" x2="108.1" y2="57.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="128.2" x2="84.5" y2="116.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="64.4" x2="265.4" y2="60.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="64.6" x2="104.8" y2="60.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="236.3" x2="207.9" y2="224.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="68.0" x2="262.0" y2="64.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="68.2" x2="101.4" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="116.9" x2="84.5" y2="105.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="255.2" y1="71.6" x2="258.6" y2="68.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.6" y1="71.8" x2="98.0" y2="68.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="224.9" x2="207.9" y2="213.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.9" y1="75.3" x2="255.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="91.2" y1="75.5" x2="94.6" y2="71.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="105.5" x2="84.5" y2="94.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.5" y1="78.9" x2="251.9" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="213.5" x2="207.9" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.9" y1="79.1" x2="91.2" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="94.1" x2="84.5" y2="82.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="245.1" y1="82.5" x2="248.5" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="82.7" x2="87.9" y2="79.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="202.2" x2="207.9" y2="190.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="82.7" x2="90.7" y2="84.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="241.7" y1="86.2" x2="245.1" y2="82.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="90.7" y1="84.7" x2="96.8" y2="86.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="96.8" y1="86.7" x2="103.0" y2="88.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.4" y1="89.8" x2="241.7" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="190.8" x2="207.9" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="103.0" y1="88.7" x2="109.2" y2="90.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="235.0" y1="93.5" x2="238.4" y2="89.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="109.2" y1="90.7" x2="115.3" y2="92.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="115.3" y1="92.7" x2="121.5" y2="94.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="231.6" y1="97.1" x2="235.0" y2="93.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="179.4" x2="207.9" y2="168.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.5" y1="94.7" x2="127.7" y2="96.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.7" y1="96.7" x2="133.9" y2="98.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="228.2" y1="100.7" x2="231.6" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="133.9" y1="98.7" x2="140.0" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="168.0" x2="207.9" y2="156.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="140.0" y1="100.7" x2="146.2" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="224.8" y1="104.4" x2="228.2" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="146.2" y1="102.6" x2="152.4" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.4" y1="104.6" x2="158.6" y2="106.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="108.0" x2="224.8" y2="104.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="156.7" x2="207.9" y2="145.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.6" y1="106.6" x2="164.7" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.7" y1="108.6" x2="170.9" y2="110.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.1" y1="111.6" x2="221.5" y2="108.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.9" y1="110.6" x2="177.1" y2="112.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="214.7" y1="115.3" x2="218.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="145.3" x2="207.9" y2="133.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="177.1" y1="112.6" x2="183.3" y2="114.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="183.3" y1="114.6" x2="189.4" y2="116.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="211.3" y1="118.9" x2="214.7" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.4" y1="116.6" x2="195.6" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="133.9" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.6" y1="118.6" x2="201.8" y2="120.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="122.5" x2="211.3" y2="118.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.8" y1="120.6" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cone_default.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cone_default.snap
@@ -4,268 +4,268 @@ expression: "export_svg(\"Graphics3D[Cone[]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="152.1" y1="237.5" x2="158.2" y2="239.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="148.7" y1="241.1" x2="152.1" y2="237.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.2" y1="239.4" x2="164.4" y2="241.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="237.5" x2="152.1" y2="226.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.4" y1="241.4" x2="170.6" y2="243.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="145.3" y1="244.7" x2="148.7" y2="241.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.6" y1="243.4" x2="176.7" y2="245.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.7" y1="245.4" x2="182.9" y2="247.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="226.1" x2="152.1" y2="214.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.9" y1="248.4" x2="145.3" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="182.9" y1="247.4" x2="189.1" y2="249.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="252.0" x2="141.9" y2="248.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.1" y1="249.4" x2="195.3" y2="251.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.3" y1="251.4" x2="201.4" y2="253.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="214.7" x2="152.1" y2="203.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="135.2" y1="255.6" x2="138.5" y2="252.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.4" y1="253.4" x2="207.6" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.6" y1="255.4" x2="213.8" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="131.8" y1="259.3" x2="135.2" y2="255.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="213.8" y1="257.4" x2="220.0" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="203.3" x2="152.1" y2="192.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="220.0" y1="259.3" x2="226.1" y2="261.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="128.4" y1="262.9" x2="131.8" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="226.1" y1="261.3" x2="232.3" y2="263.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.3" y1="263.3" x2="238.5" y2="265.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="192.0" x2="152.1" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.0" y1="266.5" x2="128.4" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.5" y1="265.3" x2="244.7" y2="267.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="244.7" y1="267.3" x2="250.8" y2="269.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.6" y1="270.2" x2="125.0" y2="266.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="250.8" y1="269.3" x2="257.0" y2="271.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="180.6" x2="152.1" y2="169.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="118.3" y1="273.8" x2="121.6" y2="270.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.0" y1="271.3" x2="263.2" y2="273.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="263.2" y1="273.3" x2="269.3" y2="275.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="114.9" y1="277.5" x2="118.3" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="269.3" y1="275.3" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="169.2" x2="152.1" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.1" y1="280.9" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.5" y1="281.1" x2="114.9" y2="277.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="277.3" x2="275.5" y2="265.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="268.8" y1="284.5" x2="272.1" y2="280.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="157.8" x2="152.1" y2="146.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.1" y1="284.7" x2="111.5" y2="281.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="265.9" x2="275.5" y2="254.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.4" y1="288.2" x2="268.8" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="104.8" y1="288.4" x2="108.1" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="146.5" x2="152.1" y2="135.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="291.8" x2="265.4" y2="288.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="292.0" x2="104.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="254.5" x2="275.5" y2="243.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="295.4" x2="262.0" y2="291.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="295.6" x2="101.4" y2="292.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="135.1" x2="152.1" y2="123.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="255.2" y1="299.1" x2="258.6" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.6" y1="299.3" x2="98.0" y2="295.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="243.1" x2="275.5" y2="231.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.9" y1="302.7" x2="255.2" y2="299.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="123.7" x2="152.1" y2="112.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="91.2" y1="302.9" x2="94.6" y2="299.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="231.8" x2="275.5" y2="220.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.5" y1="306.4" x2="251.9" y2="302.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.9" y1="306.6" x2="91.2" y2="302.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="112.4" x2="152.1" y2="101.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="245.1" y1="310.0" x2="248.5" y2="306.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="310.2" x2="87.9" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="220.4" x2="275.5" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="310.2" x2="90.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="241.7" y1="313.6" x2="245.1" y2="310.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="101.0" x2="152.1" y2="89.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="90.7" y1="312.2" x2="96.8" y2="314.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="310.2" x2="84.5" y2="298.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="96.8" y1="314.2" x2="103.0" y2="316.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.4" y1="317.3" x2="241.7" y2="313.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="209.0" x2="275.5" y2="197.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="103.0" y1="316.2" x2="109.2" y2="318.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="89.6" x2="152.1" y2="78.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="235.0" y1="320.9" x2="238.4" y2="317.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="109.2" y1="318.2" x2="115.3" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="298.8" x2="84.5" y2="287.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="237.5" x2="158.2" y2="239.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="148.7" y1="241.1" x2="152.1" y2="237.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.2" y1="239.4" x2="164.4" y2="241.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="237.5" x2="152.1" y2="226.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.4" y1="241.4" x2="170.6" y2="243.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="145.3" y1="244.7" x2="148.7" y2="241.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.6" y1="243.4" x2="176.7" y2="245.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.7" y1="245.4" x2="182.9" y2="247.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="226.1" x2="152.1" y2="214.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.9" y1="248.4" x2="145.3" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="182.9" y1="247.4" x2="189.1" y2="249.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="252.0" x2="141.9" y2="248.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.1" y1="249.4" x2="195.3" y2="251.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.3" y1="251.4" x2="201.4" y2="253.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="214.7" x2="152.1" y2="203.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="135.2" y1="255.6" x2="138.5" y2="252.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.4" y1="253.4" x2="207.6" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.6" y1="255.4" x2="213.8" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="131.8" y1="259.3" x2="135.2" y2="255.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="213.8" y1="257.4" x2="220.0" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="203.3" x2="152.1" y2="192.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="220.0" y1="259.3" x2="226.1" y2="261.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="128.4" y1="262.9" x2="131.8" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="226.1" y1="261.3" x2="232.3" y2="263.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.3" y1="263.3" x2="238.5" y2="265.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="192.0" x2="152.1" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.0" y1="266.5" x2="128.4" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.5" y1="265.3" x2="244.7" y2="267.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="244.7" y1="267.3" x2="250.8" y2="269.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.6" y1="270.2" x2="125.0" y2="266.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="250.8" y1="269.3" x2="257.0" y2="271.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="180.6" x2="152.1" y2="169.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="118.3" y1="273.8" x2="121.6" y2="270.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.0" y1="271.3" x2="263.2" y2="273.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="263.2" y1="273.3" x2="269.3" y2="275.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="114.9" y1="277.5" x2="118.3" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="269.3" y1="275.3" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="169.2" x2="152.1" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.1" y1="280.9" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.5" y1="281.1" x2="114.9" y2="277.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="277.3" x2="275.5" y2="265.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="268.8" y1="284.5" x2="272.1" y2="280.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="157.8" x2="152.1" y2="146.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.1" y1="284.7" x2="111.5" y2="281.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="265.9" x2="275.5" y2="254.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.4" y1="288.2" x2="268.8" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="104.8" y1="288.4" x2="108.1" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="146.5" x2="152.1" y2="135.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="291.8" x2="265.4" y2="288.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="292.0" x2="104.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="254.5" x2="275.5" y2="243.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="295.4" x2="262.0" y2="291.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="295.6" x2="101.4" y2="292.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="135.1" x2="152.1" y2="123.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="255.2" y1="299.1" x2="258.6" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.6" y1="299.3" x2="98.0" y2="295.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="243.1" x2="275.5" y2="231.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.9" y1="302.7" x2="255.2" y2="299.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="123.7" x2="152.1" y2="112.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="91.2" y1="302.9" x2="94.6" y2="299.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="231.8" x2="275.5" y2="220.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.5" y1="306.4" x2="251.9" y2="302.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.9" y1="306.6" x2="91.2" y2="302.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="112.4" x2="152.1" y2="101.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="245.1" y1="310.0" x2="248.5" y2="306.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="87.9" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="220.4" x2="275.5" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="90.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="241.7" y1="313.6" x2="245.1" y2="310.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="101.0" x2="152.1" y2="89.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="90.7" y1="312.2" x2="96.8" y2="314.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="84.5" y2="298.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="96.8" y1="314.2" x2="103.0" y2="316.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.4" y1="317.3" x2="241.7" y2="313.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="209.0" x2="275.5" y2="197.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="103.0" y1="316.2" x2="109.2" y2="318.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="89.6" x2="152.1" y2="78.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="235.0" y1="320.9" x2="238.4" y2="317.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="109.2" y1="318.2" x2="115.3" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="298.8" x2="84.5" y2="287.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 195.1,195.1 178.5,194.0" fill="rgb(46,63,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 178.5,194.0 162.0,195.5" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="115.3" y1="320.1" x2="121.5" y2="322.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="115.3" y1="320.1" x2="121.5" y2="322.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 210.7,198.6 195.1,195.1" fill="rgb(42,58,82)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 162.0,195.5 146.8,199.5" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="197.7" x2="275.5" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="231.6" y1="324.5" x2="235.0" y2="320.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.5" y1="322.1" x2="127.7" y2="324.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="197.7" x2="275.5" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="231.6" y1="324.5" x2="235.0" y2="320.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.5" y1="322.1" x2="127.7" y2="324.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 224.2,204.4 210.7,198.6" fill="rgb(37,50,70)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="78.2" x2="152.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.7" y1="324.1" x2="133.9" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="287.4" x2="84.5" y2="276.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="78.2" x2="152.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.7" y1="324.1" x2="133.9" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="287.4" x2="84.5" y2="276.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 146.8,199.5 133.7,205.7" fill="rgb(43,59,83)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="228.2" y1="328.2" x2="231.6" y2="324.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="133.9" y1="326.1" x2="140.0" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="186.3" x2="275.5" y2="174.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="140.0" y1="328.1" x2="146.2" y2="330.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="228.2" y1="328.2" x2="231.6" y2="324.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="133.9" y1="326.1" x2="140.0" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="186.3" x2="275.5" y2="174.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="140.0" y1="328.1" x2="146.2" y2="330.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 234.7,212.1 224.2,204.4" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="224.8" y1="331.8" x2="228.2" y2="328.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="224.8" y1="331.8" x2="228.2" y2="328.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 133.7,205.7 123.9,213.6" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="146.2" y1="330.1" x2="152.4" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="66.9" x2="152.1" y2="55.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="276.1" x2="84.5" y2="264.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.4" y1="332.1" x2="158.6" y2="334.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="335.5" x2="224.8" y2="331.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="174.9" x2="275.5" y2="163.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="146.2" y1="330.1" x2="152.4" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="66.9" x2="152.1" y2="55.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="276.1" x2="84.5" y2="264.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.4" y1="332.1" x2="158.6" y2="334.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="335.5" x2="224.8" y2="331.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="174.9" x2="275.5" y2="163.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 241.4,221.1 234.7,212.1" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="158.6" y1="334.1" x2="164.7" y2="336.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="158.6" y1="334.1" x2="164.7" y2="336.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 123.9,213.6 117.8,222.8" fill="rgb(35,49,68)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="164.7" y1="336.1" x2="170.9" y2="338.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="55.5" x2="152.1" y2="44.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.1" y1="339.1" x2="221.5" y2="335.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="264.7" x2="84.5" y2="253.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.9" y1="338.1" x2="177.1" y2="340.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="163.5" x2="275.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="214.7" y1="342.7" x2="218.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="177.1" y1="340.0" x2="183.3" y2="342.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="164.7" y1="336.1" x2="170.9" y2="338.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="55.5" x2="152.1" y2="44.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.1" y1="339.1" x2="221.5" y2="335.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="264.7" x2="84.5" y2="253.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.9" y1="338.1" x2="177.1" y2="340.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="163.5" x2="275.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="214.7" y1="342.7" x2="218.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="177.1" y1="340.0" x2="183.3" y2="342.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 244.0,230.8 241.4,221.1" fill="rgb(54,75,105)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 117.8,222.8 116.0,232.6" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="183.3" y1="342.0" x2="189.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="44.1" x2="152.1" y2="32.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="253.3" x2="84.5" y2="242.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="211.3" y1="346.4" x2="214.7" y2="342.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.4" y1="344.0" x2="195.6" y2="346.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="152.2" x2="275.5" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.6" y1="346.0" x2="201.8" y2="348.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="183.3" y1="342.0" x2="189.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="44.1" x2="152.1" y2="32.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="253.3" x2="84.5" y2="242.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="211.3" y1="346.4" x2="214.7" y2="342.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.4" y1="344.0" x2="195.6" y2="346.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="152.2" x2="275.5" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.6" y1="346.0" x2="201.8" y2="348.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 242.2,240.6 244.0,230.8" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="207.9" y1="350.0" x2="211.3" y2="346.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="207.9" y1="350.0" x2="211.3" y2="346.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 116.0,232.6 118.6,242.3" fill="rgb(53,73,102)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="201.8" y1="348.0" x2="207.9" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="32.7" x2="152.1" y2="21.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="242.0" x2="84.5" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="140.8" x2="275.5" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="350.0" x2="207.9" y2="338.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="201.8" y1="348.0" x2="207.9" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="32.7" x2="152.1" y2="21.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="242.0" x2="84.5" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="140.8" x2="275.5" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="350.0" x2="207.9" y2="338.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 236.1,249.8 242.2,240.6" fill="rgb(72,99,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 118.6,242.3 125.3,251.3" fill="rgb(62,85,120)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="21.4" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="230.6" x2="84.5" y2="219.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="129.4" x2="275.5" y2="118.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="338.6" x2="207.9" y2="327.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="10.0" x2="158.2" y2="12.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="21.4" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="230.6" x2="84.5" y2="219.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="129.4" x2="275.5" y2="118.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="338.6" x2="207.9" y2="327.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="10.0" x2="158.2" y2="12.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 226.3,257.7 236.1,249.8" fill="rgb(79,109,152)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="148.7" y1="13.6" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="148.7" y1="13.6" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 125.3,251.3 135.8,258.9" fill="rgb(71,97,136)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="158.2" y1="12.0" x2="164.4" y2="14.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="219.2" x2="84.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.4" y1="14.0" x2="170.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="145.3" y1="17.3" x2="148.7" y2="13.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="158.2" y1="12.0" x2="164.4" y2="14.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="219.2" x2="84.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.4" y1="14.0" x2="170.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="145.3" y1="17.3" x2="148.7" y2="13.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 213.2,263.9 226.3,257.7" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="118.0" x2="275.5" y2="106.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="327.3" x2="207.9" y2="315.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="118.0" x2="275.5" y2="106.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="327.3" x2="207.9" y2="315.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 135.8,258.9 149.3,264.8" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="170.6" y1="16.0" x2="176.7" y2="18.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.7" y1="18.0" x2="182.9" y2="20.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.9" y1="20.9" x2="145.3" y2="17.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="207.8" x2="84.5" y2="196.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="170.6" y1="16.0" x2="176.7" y2="18.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.7" y1="18.0" x2="182.9" y2="20.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.9" y1="20.9" x2="145.3" y2="17.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="207.8" x2="84.5" y2="196.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 198.0,267.9 213.2,263.9" fill="rgb(88,121,169)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 149.3,264.8 164.9,268.3" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="182.9" y1="20.0" x2="189.1" y2="21.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="182.9" y1="20.0" x2="189.1" y2="21.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 181.5,269.4 198.0,267.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 164.9,268.3 181.5,269.4" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="106.7" x2="275.5" y2="95.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="24.5" x2="141.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="315.9" x2="207.9" y2="304.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.1" y1="21.9" x2="195.3" y2="23.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.3" y1="23.9" x2="201.4" y2="25.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="196.5" x2="84.5" y2="185.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="135.2" y1="28.2" x2="138.5" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.4" y1="25.9" x2="207.6" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="95.3" x2="275.5" y2="83.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="304.5" x2="207.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.6" y1="27.9" x2="213.8" y2="29.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="131.8" y1="31.8" x2="135.2" y2="28.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="213.8" y1="29.9" x2="220.0" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="185.1" x2="84.5" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="220.0" y1="31.9" x2="226.1" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="128.4" y1="35.5" x2="131.8" y2="31.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="83.9" x2="275.5" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="226.1" y1="33.9" x2="232.3" y2="35.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="293.1" x2="207.9" y2="281.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.3" y1="35.9" x2="238.5" y2="37.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.0" y1="39.1" x2="128.4" y2="35.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="173.7" x2="84.5" y2="162.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.5" y1="37.9" x2="244.7" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="72.6" x2="275.5" y2="61.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="244.7" y1="39.9" x2="250.8" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.6" y1="42.7" x2="125.0" y2="39.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="281.8" x2="207.9" y2="270.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="250.8" y1="41.8" x2="257.0" y2="43.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="162.3" x2="84.5" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="118.3" y1="46.4" x2="121.6" y2="42.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.0" y1="43.8" x2="263.2" y2="45.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="61.2" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="263.2" y1="45.8" x2="269.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="270.4" x2="207.9" y2="259.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="114.9" y1="50.0" x2="118.3" y2="46.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="269.3" y1="47.8" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="151.0" x2="84.5" y2="139.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.1" y1="53.4" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.5" y1="53.6" x2="114.9" y2="50.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="259.0" x2="207.9" y2="247.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="268.8" y1="57.1" x2="272.1" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.1" y1="57.3" x2="111.5" y2="53.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="139.6" x2="84.5" y2="128.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.4" y1="60.7" x2="268.8" y2="57.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="247.6" x2="207.9" y2="236.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="104.8" y1="60.9" x2="108.1" y2="57.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="128.2" x2="84.5" y2="116.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="64.4" x2="265.4" y2="60.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="64.6" x2="104.8" y2="60.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="236.3" x2="207.9" y2="224.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="68.0" x2="262.0" y2="64.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="68.2" x2="101.4" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="116.9" x2="84.5" y2="105.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="255.2" y1="71.6" x2="258.6" y2="68.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.6" y1="71.8" x2="98.0" y2="68.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="224.9" x2="207.9" y2="213.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.9" y1="75.3" x2="255.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="91.2" y1="75.5" x2="94.6" y2="71.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="105.5" x2="84.5" y2="94.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.5" y1="78.9" x2="251.9" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="213.5" x2="207.9" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.9" y1="79.1" x2="91.2" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="94.1" x2="84.5" y2="82.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="245.1" y1="82.5" x2="248.5" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="82.7" x2="87.9" y2="79.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="202.2" x2="207.9" y2="190.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="82.7" x2="90.7" y2="84.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="241.7" y1="86.2" x2="245.1" y2="82.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="90.7" y1="84.7" x2="96.8" y2="86.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="96.8" y1="86.7" x2="103.0" y2="88.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.4" y1="89.8" x2="241.7" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="190.8" x2="207.9" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="103.0" y1="88.7" x2="109.2" y2="90.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="235.0" y1="93.5" x2="238.4" y2="89.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="109.2" y1="90.7" x2="115.3" y2="92.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="115.3" y1="92.7" x2="121.5" y2="94.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="231.6" y1="97.1" x2="235.0" y2="93.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="179.4" x2="207.9" y2="168.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.5" y1="94.7" x2="127.7" y2="96.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.7" y1="96.7" x2="133.9" y2="98.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="228.2" y1="100.7" x2="231.6" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="133.9" y1="98.7" x2="140.0" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="168.0" x2="207.9" y2="156.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="140.0" y1="100.7" x2="146.2" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="224.8" y1="104.4" x2="228.2" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="146.2" y1="102.6" x2="152.4" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.4" y1="104.6" x2="158.6" y2="106.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="108.0" x2="224.8" y2="104.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="156.7" x2="207.9" y2="145.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.6" y1="106.6" x2="164.7" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.7" y1="108.6" x2="170.9" y2="110.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.1" y1="111.6" x2="221.5" y2="108.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.9" y1="110.6" x2="177.1" y2="112.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="214.7" y1="115.3" x2="218.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="145.3" x2="207.9" y2="133.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="177.1" y1="112.6" x2="183.3" y2="114.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="183.3" y1="114.6" x2="189.4" y2="116.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="211.3" y1="118.9" x2="214.7" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.4" y1="116.6" x2="195.6" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="133.9" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.6" y1="118.6" x2="201.8" y2="120.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="122.5" x2="211.3" y2="118.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.8" y1="120.6" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="106.7" x2="275.5" y2="95.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="24.5" x2="141.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="315.9" x2="207.9" y2="304.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.1" y1="21.9" x2="195.3" y2="23.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.3" y1="23.9" x2="201.4" y2="25.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="196.5" x2="84.5" y2="185.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="135.2" y1="28.2" x2="138.5" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.4" y1="25.9" x2="207.6" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="95.3" x2="275.5" y2="83.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="304.5" x2="207.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.6" y1="27.9" x2="213.8" y2="29.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="131.8" y1="31.8" x2="135.2" y2="28.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="213.8" y1="29.9" x2="220.0" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="185.1" x2="84.5" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="220.0" y1="31.9" x2="226.1" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="128.4" y1="35.5" x2="131.8" y2="31.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="83.9" x2="275.5" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="226.1" y1="33.9" x2="232.3" y2="35.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="293.1" x2="207.9" y2="281.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.3" y1="35.9" x2="238.5" y2="37.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.0" y1="39.1" x2="128.4" y2="35.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="173.7" x2="84.5" y2="162.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.5" y1="37.9" x2="244.7" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="72.6" x2="275.5" y2="61.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="244.7" y1="39.9" x2="250.8" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.6" y1="42.7" x2="125.0" y2="39.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="281.8" x2="207.9" y2="270.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="250.8" y1="41.8" x2="257.0" y2="43.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="162.3" x2="84.5" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="118.3" y1="46.4" x2="121.6" y2="42.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.0" y1="43.8" x2="263.2" y2="45.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="61.2" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="263.2" y1="45.8" x2="269.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="270.4" x2="207.9" y2="259.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="114.9" y1="50.0" x2="118.3" y2="46.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="269.3" y1="47.8" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="151.0" x2="84.5" y2="139.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.1" y1="53.4" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.5" y1="53.6" x2="114.9" y2="50.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="259.0" x2="207.9" y2="247.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="268.8" y1="57.1" x2="272.1" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.1" y1="57.3" x2="111.5" y2="53.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="139.6" x2="84.5" y2="128.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.4" y1="60.7" x2="268.8" y2="57.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="247.6" x2="207.9" y2="236.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="104.8" y1="60.9" x2="108.1" y2="57.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="128.2" x2="84.5" y2="116.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="64.4" x2="265.4" y2="60.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="64.6" x2="104.8" y2="60.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="236.3" x2="207.9" y2="224.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="68.0" x2="262.0" y2="64.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="68.2" x2="101.4" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="116.9" x2="84.5" y2="105.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="255.2" y1="71.6" x2="258.6" y2="68.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.6" y1="71.8" x2="98.0" y2="68.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="224.9" x2="207.9" y2="213.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.9" y1="75.3" x2="255.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="91.2" y1="75.5" x2="94.6" y2="71.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="105.5" x2="84.5" y2="94.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.5" y1="78.9" x2="251.9" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="213.5" x2="207.9" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.9" y1="79.1" x2="91.2" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="94.1" x2="84.5" y2="82.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="245.1" y1="82.5" x2="248.5" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="82.7" x2="87.9" y2="79.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="202.2" x2="207.9" y2="190.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="82.7" x2="90.7" y2="84.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="241.7" y1="86.2" x2="245.1" y2="82.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="90.7" y1="84.7" x2="96.8" y2="86.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="96.8" y1="86.7" x2="103.0" y2="88.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.4" y1="89.8" x2="241.7" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="190.8" x2="207.9" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="103.0" y1="88.7" x2="109.2" y2="90.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="235.0" y1="93.5" x2="238.4" y2="89.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="109.2" y1="90.7" x2="115.3" y2="92.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="115.3" y1="92.7" x2="121.5" y2="94.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="231.6" y1="97.1" x2="235.0" y2="93.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="179.4" x2="207.9" y2="168.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.5" y1="94.7" x2="127.7" y2="96.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.7" y1="96.7" x2="133.9" y2="98.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="228.2" y1="100.7" x2="231.6" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="133.9" y1="98.7" x2="140.0" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="168.0" x2="207.9" y2="156.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="140.0" y1="100.7" x2="146.2" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="224.8" y1="104.4" x2="228.2" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="146.2" y1="102.6" x2="152.4" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.4" y1="104.6" x2="158.6" y2="106.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="108.0" x2="224.8" y2="104.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="156.7" x2="207.9" y2="145.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.6" y1="106.6" x2="164.7" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.7" y1="108.6" x2="170.9" y2="110.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.1" y1="111.6" x2="221.5" y2="108.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.9" y1="110.6" x2="177.1" y2="112.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="214.7" y1="115.3" x2="218.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="145.3" x2="207.9" y2="133.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="177.1" y1="112.6" x2="183.3" y2="114.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="183.3" y1="114.6" x2="189.4" y2="116.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="211.3" y1="118.9" x2="214.7" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.4" y1="116.6" x2="195.6" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="133.9" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.6" y1="118.6" x2="201.8" y2="120.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="122.5" x2="211.3" y2="118.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.8" y1="120.6" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cuboid.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cuboid.snap
@@ -4,256 +4,256 @@ expression: "export_svg(\"Graphics3D[Cuboid[{0, 0, 0}, {1, 1, 1}]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="310.5,235.2 141.8,25.5 141.8,180.8" fill="rgb(64,87,123)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 310.5,235.2 141.8,180.8" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 141.8,180.8 141.8,25.5" fill="rgb(57,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="310.5,235.2 310.5,79.8 141.8,25.5" fill="rgb(64,87,123)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 218.2,334.5 310.5,235.2" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.2,334.5 310.5,79.8 310.5,235.2" fill="rgb(57,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 141.8,25.5 49.5,124.8" fill="rgb(57,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,124.8 141.8,25.5 310.5,79.8" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 218.2,179.2 218.2,334.5" fill="rgb(64,87,123)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 49.5,124.8 218.2,179.2" fill="rgb(64,87,123)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.2,334.5 218.2,179.2 310.5,79.8" fill="rgb(57,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,124.8 310.5,79.8 218.2,179.2" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cylinder.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cylinder.snap
@@ -4,292 +4,292 @@ expression: "export_svg(\"Graphics3D[Cylinder[{{0,0,0},{0,0,1}}, 0.5]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="152.1" y1="237.5" x2="158.2" y2="239.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="148.7" y1="241.1" x2="152.1" y2="237.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.2" y1="239.4" x2="164.4" y2="241.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="237.5" x2="152.1" y2="226.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.4" y1="241.4" x2="170.6" y2="243.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="145.3" y1="244.7" x2="148.7" y2="241.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.6" y1="243.4" x2="176.7" y2="245.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.7" y1="245.4" x2="182.9" y2="247.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="226.1" x2="152.1" y2="214.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.9" y1="248.4" x2="145.3" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="182.9" y1="247.4" x2="189.1" y2="249.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="252.0" x2="141.9" y2="248.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.1" y1="249.4" x2="195.3" y2="251.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.3" y1="251.4" x2="201.4" y2="253.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="214.7" x2="152.1" y2="203.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="135.2" y1="255.6" x2="138.5" y2="252.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.4" y1="253.4" x2="207.6" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.6" y1="255.4" x2="213.8" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="131.8" y1="259.3" x2="135.2" y2="255.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="213.8" y1="257.4" x2="220.0" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="203.3" x2="152.1" y2="192.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="220.0" y1="259.3" x2="226.1" y2="261.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="128.4" y1="262.9" x2="131.8" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="226.1" y1="261.3" x2="232.3" y2="263.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.3" y1="263.3" x2="238.5" y2="265.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="192.0" x2="152.1" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.0" y1="266.5" x2="128.4" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.5" y1="265.3" x2="244.7" y2="267.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="244.7" y1="267.3" x2="250.8" y2="269.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.6" y1="270.2" x2="125.0" y2="266.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="250.8" y1="269.3" x2="257.0" y2="271.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="180.6" x2="152.1" y2="169.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="118.3" y1="273.8" x2="121.6" y2="270.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.0" y1="271.3" x2="263.2" y2="273.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="263.2" y1="273.3" x2="269.3" y2="275.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="114.9" y1="277.5" x2="118.3" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="269.3" y1="275.3" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="169.2" x2="152.1" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.1" y1="280.9" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.5" y1="281.1" x2="114.9" y2="277.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="277.3" x2="275.5" y2="265.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="268.8" y1="284.5" x2="272.1" y2="280.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="157.8" x2="152.1" y2="146.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.1" y1="284.7" x2="111.5" y2="281.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="265.9" x2="275.5" y2="254.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.4" y1="288.2" x2="268.8" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="104.8" y1="288.4" x2="108.1" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="146.5" x2="152.1" y2="135.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="291.8" x2="265.4" y2="288.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="292.0" x2="104.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="254.5" x2="275.5" y2="243.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="295.4" x2="262.0" y2="291.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="295.6" x2="101.4" y2="292.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="135.1" x2="152.1" y2="123.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="255.2" y1="299.1" x2="258.6" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.6" y1="299.3" x2="98.0" y2="295.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="243.1" x2="275.5" y2="231.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.9" y1="302.7" x2="255.2" y2="299.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="123.7" x2="152.1" y2="112.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="91.2" y1="302.9" x2="94.6" y2="299.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="231.8" x2="275.5" y2="220.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.5" y1="306.4" x2="251.9" y2="302.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.9" y1="306.6" x2="91.2" y2="302.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="112.4" x2="152.1" y2="101.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="237.5" x2="158.2" y2="239.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="148.7" y1="241.1" x2="152.1" y2="237.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.2" y1="239.4" x2="164.4" y2="241.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="237.5" x2="152.1" y2="226.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.4" y1="241.4" x2="170.6" y2="243.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="145.3" y1="244.7" x2="148.7" y2="241.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.6" y1="243.4" x2="176.7" y2="245.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.7" y1="245.4" x2="182.9" y2="247.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="226.1" x2="152.1" y2="214.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.9" y1="248.4" x2="145.3" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="182.9" y1="247.4" x2="189.1" y2="249.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="252.0" x2="141.9" y2="248.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.1" y1="249.4" x2="195.3" y2="251.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.3" y1="251.4" x2="201.4" y2="253.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="214.7" x2="152.1" y2="203.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="135.2" y1="255.6" x2="138.5" y2="252.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.4" y1="253.4" x2="207.6" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.6" y1="255.4" x2="213.8" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="131.8" y1="259.3" x2="135.2" y2="255.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="213.8" y1="257.4" x2="220.0" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="203.3" x2="152.1" y2="192.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="220.0" y1="259.3" x2="226.1" y2="261.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="128.4" y1="262.9" x2="131.8" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="226.1" y1="261.3" x2="232.3" y2="263.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.3" y1="263.3" x2="238.5" y2="265.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="192.0" x2="152.1" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.0" y1="266.5" x2="128.4" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.5" y1="265.3" x2="244.7" y2="267.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="244.7" y1="267.3" x2="250.8" y2="269.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.6" y1="270.2" x2="125.0" y2="266.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="250.8" y1="269.3" x2="257.0" y2="271.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="180.6" x2="152.1" y2="169.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="118.3" y1="273.8" x2="121.6" y2="270.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.0" y1="271.3" x2="263.2" y2="273.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="263.2" y1="273.3" x2="269.3" y2="275.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="114.9" y1="277.5" x2="118.3" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="269.3" y1="275.3" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="169.2" x2="152.1" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.1" y1="280.9" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.5" y1="281.1" x2="114.9" y2="277.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="277.3" x2="275.5" y2="265.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="268.8" y1="284.5" x2="272.1" y2="280.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="157.8" x2="152.1" y2="146.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.1" y1="284.7" x2="111.5" y2="281.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="265.9" x2="275.5" y2="254.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.4" y1="288.2" x2="268.8" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="104.8" y1="288.4" x2="108.1" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="146.5" x2="152.1" y2="135.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="291.8" x2="265.4" y2="288.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="292.0" x2="104.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="254.5" x2="275.5" y2="243.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="295.4" x2="262.0" y2="291.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="295.6" x2="101.4" y2="292.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="135.1" x2="152.1" y2="123.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="255.2" y1="299.1" x2="258.6" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.6" y1="299.3" x2="98.0" y2="295.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="243.1" x2="275.5" y2="231.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.9" y1="302.7" x2="255.2" y2="299.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="123.7" x2="152.1" y2="112.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="91.2" y1="302.9" x2="94.6" y2="299.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="231.8" x2="275.5" y2="220.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.5" y1="306.4" x2="251.9" y2="302.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.9" y1="306.6" x2="91.2" y2="302.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="112.4" x2="152.1" y2="101.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="195.1,195.1 178.5,90.6 178.5,194.0" fill="rgb(71,97,136)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="245.1" y1="310.0" x2="248.5" y2="306.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="245.1" y1="310.0" x2="248.5" y2="306.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,194.0 162.0,92.1 162.0,195.5" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="310.2" x2="87.9" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="87.9" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="210.7,198.6 195.1,91.7 195.1,195.1" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="220.4" x2="275.5" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="310.2" x2="90.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="220.4" x2="275.5" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="90.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="162.0,195.5 146.8,96.1 146.8,199.5" fill="rgb(71,98,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="241.7" y1="313.6" x2="245.1" y2="310.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="101.0" x2="152.1" y2="89.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="90.7" y1="312.2" x2="96.8" y2="314.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="310.2" x2="84.5" y2="298.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="241.7" y1="313.6" x2="245.1" y2="310.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="101.0" x2="152.1" y2="89.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="90.7" y1="312.2" x2="96.8" y2="314.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="84.5" y2="298.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="224.2,204.4 210.7,95.2 210.7,198.6" fill="rgb(60,83,116)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="96.8" y1="314.2" x2="103.0" y2="316.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.4" y1="317.3" x2="241.7" y2="313.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="209.0" x2="275.5" y2="197.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="96.8" y1="314.2" x2="103.0" y2="316.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.4" y1="317.3" x2="241.7" y2="313.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="209.0" x2="275.5" y2="197.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="146.8,199.5 133.7,102.3 133.7,205.7" fill="rgb(67,92,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="103.0" y1="316.2" x2="109.2" y2="318.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="89.6" x2="152.1" y2="78.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="235.0" y1="320.9" x2="238.4" y2="317.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="109.2" y1="318.2" x2="115.3" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="298.8" x2="84.5" y2="287.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="103.0" y1="316.2" x2="109.2" y2="318.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="89.6" x2="152.1" y2="78.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="235.0" y1="320.9" x2="238.4" y2="317.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="109.2" y1="318.2" x2="115.3" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="298.8" x2="84.5" y2="287.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="234.7,212.1 224.2,101.1 224.2,204.4" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="115.3" y1="320.1" x2="121.5" y2="322.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="197.7" x2="275.5" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="231.6" y1="324.5" x2="235.0" y2="320.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.5" y1="322.1" x2="127.7" y2="324.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="115.3" y1="320.1" x2="121.5" y2="322.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="197.7" x2="275.5" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="231.6" y1="324.5" x2="235.0" y2="320.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.5" y1="322.1" x2="127.7" y2="324.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="133.7,205.7 123.9,110.2 123.9,213.6" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="78.2" x2="152.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.7" y1="324.1" x2="133.9" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="287.4" x2="84.5" y2="276.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="78.2" x2="152.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.7" y1="324.1" x2="133.9" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="287.4" x2="84.5" y2="276.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,194.0 178.5,90.6 162.0,92.1" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="228.2" y1="328.2" x2="231.6" y2="324.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="228.2" y1="328.2" x2="231.6" y2="324.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="195.1,195.1 195.1,91.7 178.5,90.6" fill="rgb(71,97,136)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="133.9" y1="326.1" x2="140.0" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="133.9" y1="326.1" x2="140.0" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,221.1 234.7,108.7 234.7,212.1" fill="rgb(42,58,81)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.0,195.5 162.0,92.1 146.8,96.1" fill="rgb(71,98,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="186.3" x2="275.5" y2="174.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="186.3" x2="275.5" y2="174.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="210.7,198.6 210.7,95.2 195.1,91.7" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="140.0" y1="328.1" x2="146.2" y2="330.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="224.8" y1="331.8" x2="228.2" y2="328.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="146.2" y1="330.1" x2="152.4" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="66.9" x2="152.1" y2="55.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="276.1" x2="84.5" y2="264.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="140.0" y1="328.1" x2="146.2" y2="330.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="224.8" y1="331.8" x2="228.2" y2="328.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="146.2" y1="330.1" x2="152.4" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="66.9" x2="152.1" y2="55.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="276.1" x2="84.5" y2="264.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="123.9,213.6 117.8,119.4 117.8,222.8" fill="rgb(53,73,103)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.4" y1="332.1" x2="158.6" y2="334.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.4" y1="332.1" x2="158.6" y2="334.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="146.8,199.5 146.8,96.1 133.7,102.3" fill="rgb(67,92,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="221.5" y1="335.5" x2="224.8" y2="331.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="221.5" y1="335.5" x2="224.8" y2="331.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="224.2,204.4 224.2,101.1 210.7,95.2" fill="rgb(60,83,116)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="174.9" x2="275.5" y2="163.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.6" y1="334.1" x2="164.7" y2="336.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.7" y1="336.1" x2="170.9" y2="338.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="55.5" x2="152.1" y2="44.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.1" y1="339.1" x2="221.5" y2="335.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="264.7" x2="84.5" y2="253.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="174.9" x2="275.5" y2="163.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.6" y1="334.1" x2="164.7" y2="336.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.7" y1="336.1" x2="170.9" y2="338.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="55.5" x2="152.1" y2="44.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.1" y1="339.1" x2="221.5" y2="335.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="264.7" x2="84.5" y2="253.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="244.0,230.8 241.4,117.7 241.4,221.1" fill="rgb(34,46,65)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="170.9" y1="338.1" x2="177.1" y2="340.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="170.9" y1="338.1" x2="177.1" y2="340.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="133.7,205.7 133.7,102.3 123.9,110.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="163.5" x2="275.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="214.7" y1="342.7" x2="218.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="177.1" y1="340.0" x2="183.3" y2="342.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="163.5" x2="275.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="214.7" y1="342.7" x2="218.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="177.1" y1="340.0" x2="183.3" y2="342.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="234.7,212.1 234.7,108.7 224.2,101.1" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.8,222.8 116.0,129.2 116.0,232.6" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="183.3" y1="342.0" x2="189.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="44.1" x2="152.1" y2="32.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="253.3" x2="84.5" y2="242.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="211.3" y1="346.4" x2="214.7" y2="342.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.4" y1="344.0" x2="195.6" y2="346.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="152.2" x2="275.5" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.6" y1="346.0" x2="201.8" y2="348.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="183.3" y1="342.0" x2="189.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="44.1" x2="152.1" y2="32.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="253.3" x2="84.5" y2="242.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="211.3" y1="346.4" x2="214.7" y2="342.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.4" y1="344.0" x2="195.6" y2="346.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="152.2" x2="275.5" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.6" y1="346.0" x2="201.8" y2="348.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="242.2,240.6 244.0,127.4 244.0,230.8" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="207.9" y1="350.0" x2="211.3" y2="346.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="207.9" y1="350.0" x2="211.3" y2="346.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="123.9,213.6 123.9,110.2 117.8,119.4" fill="rgb(53,73,103)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="201.8" y1="348.0" x2="207.9" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="32.7" x2="152.1" y2="21.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="242.0" x2="84.5" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="201.8" y1="348.0" x2="207.9" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="32.7" x2="152.1" y2="21.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="242.0" x2="84.5" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,221.1 241.4,117.7 234.7,108.7" fill="rgb(42,58,81)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.0,232.6 118.6,138.9 118.6,242.3" fill="rgb(34,46,65)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="140.8" x2="275.5" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="350.0" x2="207.9" y2="338.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="21.4" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="230.6" x2="84.5" y2="219.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="140.8" x2="275.5" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="350.0" x2="207.9" y2="338.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="21.4" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="230.6" x2="84.5" y2="219.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="236.1,249.8 242.2,137.2 242.2,240.6" fill="rgb(53,73,103)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.8,222.8 117.8,119.4 116.0,129.2" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="129.4" x2="275.5" y2="118.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="338.6" x2="207.9" y2="327.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="129.4" x2="275.5" y2="118.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="338.6" x2="207.9" y2="327.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="244.0,230.8 244.0,127.4 241.4,117.7" fill="rgb(34,46,65)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="10.0" x2="158.2" y2="12.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="148.7" y1="13.6" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.2" y1="12.0" x2="164.4" y2="14.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="219.2" x2="84.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="10.0" x2="158.2" y2="12.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="148.7" y1="13.6" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.2" y1="12.0" x2="164.4" y2="14.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="219.2" x2="84.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="118.6,242.3 125.3,147.9 125.3,251.3" fill="rgb(42,58,81)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="164.4" y1="14.0" x2="170.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="145.3" y1="17.3" x2="148.7" y2="13.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="118.0" x2="275.5" y2="106.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="327.3" x2="207.9" y2="315.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.6" y1="16.0" x2="176.7" y2="18.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="164.4" y1="14.0" x2="170.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="145.3" y1="17.3" x2="148.7" y2="13.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="118.0" x2="275.5" y2="106.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="327.3" x2="207.9" y2="315.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.6" y1="16.0" x2="176.7" y2="18.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="226.3,257.7 236.1,146.4 236.1,249.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.7" y1="18.0" x2="182.9" y2="20.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.7" y1="18.0" x2="182.9" y2="20.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="116.0,232.6 116.0,129.2 118.6,138.9" fill="rgb(34,46,65)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="141.9" y1="20.9" x2="145.3" y2="17.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="207.8" x2="84.5" y2="196.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="141.9" y1="20.9" x2="145.3" y2="17.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="207.8" x2="84.5" y2="196.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="242.2,240.6 242.2,137.2 244.0,127.4" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="182.9" y1="20.0" x2="189.1" y2="21.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="182.9" y1="20.0" x2="189.1" y2="21.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="125.3,251.3 135.8,155.6 135.8,258.9" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="106.7" x2="275.5" y2="95.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="24.5" x2="141.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="315.9" x2="207.9" y2="304.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.1" y1="21.9" x2="195.3" y2="23.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="106.7" x2="275.5" y2="95.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="24.5" x2="141.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="315.9" x2="207.9" y2="304.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.1" y1="21.9" x2="195.3" y2="23.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="213.2,263.9 226.3,154.3 226.3,257.7" fill="rgb(67,92,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="195.3" y1="23.9" x2="201.4" y2="25.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="196.5" x2="84.5" y2="185.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="135.2" y1="28.2" x2="138.5" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.4" y1="25.9" x2="207.6" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="195.3" y1="23.9" x2="201.4" y2="25.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="196.5" x2="84.5" y2="185.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="135.2" y1="28.2" x2="138.5" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.4" y1="25.9" x2="207.6" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="135.8,258.9 149.3,161.4 149.3,264.8" fill="rgb(60,83,116)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.6,242.3 118.6,138.9 125.3,147.9" fill="rgb(42,58,81)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="95.3" x2="275.5" y2="83.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="304.5" x2="207.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.6" y1="27.9" x2="213.8" y2="29.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="131.8" y1="31.8" x2="135.2" y2="28.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="95.3" x2="275.5" y2="83.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="304.5" x2="207.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.6" y1="27.9" x2="213.8" y2="29.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="131.8" y1="31.8" x2="135.2" y2="28.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="236.1,249.8 236.1,146.4 242.2,137.2" fill="rgb(53,73,103)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.0,267.9 213.2,160.5 213.2,263.9" fill="rgb(71,98,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="213.8" y1="29.9" x2="220.0" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="185.1" x2="84.5" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="213.8" y1="29.9" x2="220.0" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="185.1" x2="84.5" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="149.3,264.8 164.9,164.9 164.9,268.3" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="220.0" y1="31.9" x2="226.1" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="220.0" y1="31.9" x2="226.1" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.5,269.4 198.0,164.5 198.0,267.9" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="128.4" y1="35.5" x2="131.8" y2="31.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="128.4" y1="35.5" x2="131.8" y2="31.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="164.9,268.3 181.5,166.0 181.5,269.4" fill="rgb(71,97,136)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="83.9" x2="275.5" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="226.1" y1="33.9" x2="232.3" y2="35.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="293.1" x2="207.9" y2="281.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.3" y1="35.9" x2="238.5" y2="37.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="83.9" x2="275.5" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="226.1" y1="33.9" x2="232.3" y2="35.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="293.1" x2="207.9" y2="281.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.3" y1="35.9" x2="238.5" y2="37.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="125.3,251.3 125.3,147.9 135.8,155.6" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="125.0" y1="39.1" x2="128.4" y2="35.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="173.7" x2="84.5" y2="162.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="125.0" y1="39.1" x2="128.4" y2="35.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="173.7" x2="84.5" y2="162.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="226.3,257.7 226.3,154.3 236.1,146.4" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="238.5" y1="37.9" x2="244.7" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="72.6" x2="275.5" y2="61.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="244.7" y1="39.9" x2="250.8" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.6" y1="42.7" x2="125.0" y2="39.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="281.8" x2="207.9" y2="270.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="250.8" y1="41.8" x2="257.0" y2="43.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="162.3" x2="84.5" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="238.5" y1="37.9" x2="244.7" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="72.6" x2="275.5" y2="61.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="244.7" y1="39.9" x2="250.8" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.6" y1="42.7" x2="125.0" y2="39.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="281.8" x2="207.9" y2="270.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="250.8" y1="41.8" x2="257.0" y2="43.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="162.3" x2="84.5" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="135.8,258.9 135.8,155.6 149.3,161.4" fill="rgb(60,83,116)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="118.3" y1="46.4" x2="121.6" y2="42.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.0" y1="43.8" x2="263.2" y2="45.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="118.3" y1="46.4" x2="121.6" y2="42.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.0" y1="43.8" x2="263.2" y2="45.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="213.2,263.9 213.2,160.5 226.3,154.3" fill="rgb(67,92,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="61.2" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="263.2" y1="45.8" x2="269.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="270.4" x2="207.9" y2="259.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="114.9" y1="50.0" x2="118.3" y2="46.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="269.3" y1="47.8" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="61.2" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="263.2" y1="45.8" x2="269.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="270.4" x2="207.9" y2="259.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="114.9" y1="50.0" x2="118.3" y2="46.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="269.3" y1="47.8" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="149.3,264.8 149.3,161.4 164.9,164.9" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="151.0" x2="84.5" y2="139.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="151.0" x2="84.5" y2="139.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.0,267.9 198.0,164.5 213.2,160.5" fill="rgb(71,98,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="272.1" y1="53.4" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.5" y1="53.6" x2="114.9" y2="50.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="272.1" y1="53.4" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.5" y1="53.6" x2="114.9" y2="50.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="164.9,268.3 164.9,164.9 181.5,166.0" fill="rgb(71,97,136)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,269.4 181.5,166.0 198.0,164.5" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="207.9" y1="259.0" x2="207.9" y2="247.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="268.8" y1="57.1" x2="272.1" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.1" y1="57.3" x2="111.5" y2="53.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="139.6" x2="84.5" y2="128.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.4" y1="60.7" x2="268.8" y2="57.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="247.6" x2="207.9" y2="236.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="104.8" y1="60.9" x2="108.1" y2="57.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="128.2" x2="84.5" y2="116.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="64.4" x2="265.4" y2="60.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="64.6" x2="104.8" y2="60.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="236.3" x2="207.9" y2="224.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="68.0" x2="262.0" y2="64.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="68.2" x2="101.4" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="116.9" x2="84.5" y2="105.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="255.2" y1="71.6" x2="258.6" y2="68.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.6" y1="71.8" x2="98.0" y2="68.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="224.9" x2="207.9" y2="213.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.9" y1="75.3" x2="255.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="91.2" y1="75.5" x2="94.6" y2="71.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="105.5" x2="84.5" y2="94.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.5" y1="78.9" x2="251.9" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="213.5" x2="207.9" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.9" y1="79.1" x2="91.2" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="94.1" x2="84.5" y2="82.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="245.1" y1="82.5" x2="248.5" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="82.7" x2="87.9" y2="79.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="202.2" x2="207.9" y2="190.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="82.7" x2="90.7" y2="84.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="241.7" y1="86.2" x2="245.1" y2="82.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="90.7" y1="84.7" x2="96.8" y2="86.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="96.8" y1="86.7" x2="103.0" y2="88.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.4" y1="89.8" x2="241.7" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="190.8" x2="207.9" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="103.0" y1="88.7" x2="109.2" y2="90.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="235.0" y1="93.5" x2="238.4" y2="89.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="109.2" y1="90.7" x2="115.3" y2="92.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="115.3" y1="92.7" x2="121.5" y2="94.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="231.6" y1="97.1" x2="235.0" y2="93.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="179.4" x2="207.9" y2="168.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.5" y1="94.7" x2="127.7" y2="96.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.7" y1="96.7" x2="133.9" y2="98.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="228.2" y1="100.7" x2="231.6" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="133.9" y1="98.7" x2="140.0" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="168.0" x2="207.9" y2="156.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="140.0" y1="100.7" x2="146.2" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="224.8" y1="104.4" x2="228.2" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="146.2" y1="102.6" x2="152.4" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.4" y1="104.6" x2="158.6" y2="106.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="108.0" x2="224.8" y2="104.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="156.7" x2="207.9" y2="145.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.6" y1="106.6" x2="164.7" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.7" y1="108.6" x2="170.9" y2="110.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.1" y1="111.6" x2="221.5" y2="108.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.9" y1="110.6" x2="177.1" y2="112.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="214.7" y1="115.3" x2="218.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="145.3" x2="207.9" y2="133.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="177.1" y1="112.6" x2="183.3" y2="114.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="183.3" y1="114.6" x2="189.4" y2="116.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="211.3" y1="118.9" x2="214.7" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.4" y1="116.6" x2="195.6" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="133.9" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.6" y1="118.6" x2="201.8" y2="120.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="122.5" x2="211.3" y2="118.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.8" y1="120.6" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="207.9" y1="259.0" x2="207.9" y2="247.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="268.8" y1="57.1" x2="272.1" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.1" y1="57.3" x2="111.5" y2="53.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="139.6" x2="84.5" y2="128.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.4" y1="60.7" x2="268.8" y2="57.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="247.6" x2="207.9" y2="236.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="104.8" y1="60.9" x2="108.1" y2="57.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="128.2" x2="84.5" y2="116.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="64.4" x2="265.4" y2="60.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="64.6" x2="104.8" y2="60.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="236.3" x2="207.9" y2="224.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="68.0" x2="262.0" y2="64.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="68.2" x2="101.4" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="116.9" x2="84.5" y2="105.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="255.2" y1="71.6" x2="258.6" y2="68.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.6" y1="71.8" x2="98.0" y2="68.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="224.9" x2="207.9" y2="213.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.9" y1="75.3" x2="255.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="91.2" y1="75.5" x2="94.6" y2="71.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="105.5" x2="84.5" y2="94.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.5" y1="78.9" x2="251.9" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="213.5" x2="207.9" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.9" y1="79.1" x2="91.2" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="94.1" x2="84.5" y2="82.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="245.1" y1="82.5" x2="248.5" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="82.7" x2="87.9" y2="79.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="202.2" x2="207.9" y2="190.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="82.7" x2="90.7" y2="84.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="241.7" y1="86.2" x2="245.1" y2="82.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="90.7" y1="84.7" x2="96.8" y2="86.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="96.8" y1="86.7" x2="103.0" y2="88.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.4" y1="89.8" x2="241.7" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="190.8" x2="207.9" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="103.0" y1="88.7" x2="109.2" y2="90.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="235.0" y1="93.5" x2="238.4" y2="89.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="109.2" y1="90.7" x2="115.3" y2="92.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="115.3" y1="92.7" x2="121.5" y2="94.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="231.6" y1="97.1" x2="235.0" y2="93.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="179.4" x2="207.9" y2="168.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.5" y1="94.7" x2="127.7" y2="96.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.7" y1="96.7" x2="133.9" y2="98.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="228.2" y1="100.7" x2="231.6" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="133.9" y1="98.7" x2="140.0" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="168.0" x2="207.9" y2="156.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="140.0" y1="100.7" x2="146.2" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="224.8" y1="104.4" x2="228.2" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="146.2" y1="102.6" x2="152.4" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.4" y1="104.6" x2="158.6" y2="106.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="108.0" x2="224.8" y2="104.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="156.7" x2="207.9" y2="145.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.6" y1="106.6" x2="164.7" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.7" y1="108.6" x2="170.9" y2="110.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.1" y1="111.6" x2="221.5" y2="108.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.9" y1="110.6" x2="177.1" y2="112.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="214.7" y1="115.3" x2="218.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="145.3" x2="207.9" y2="133.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="177.1" y1="112.6" x2="183.3" y2="114.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="183.3" y1="114.6" x2="189.4" y2="116.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="211.3" y1="118.9" x2="214.7" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.4" y1="116.6" x2="195.6" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="133.9" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.6" y1="118.6" x2="201.8" y2="120.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="122.5" x2="211.3" y2="118.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.8" y1="120.6" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_image_size.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_image_size.snap
@@ -4,63 +4,63 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 ---
 <svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
 <rect width="200" height="200" fill="rgb(255,255,255)"/>
-<line x1="77.8" y1="100.5" x2="82.7" y2="102.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="100.5" x2="77.8" y2="95.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="75.1" y1="103.4" x2="77.8" y2="100.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.7" y1="102.1" x2="87.6" y2="103.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="95.9" x2="77.8" y2="91.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.6" y1="103.6" x2="92.5" y2="105.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.4" y1="106.3" x2="75.1" y2="103.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.5" y1="105.2" x2="97.4" y2="106.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="91.4" x2="77.8" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="106.8" x2="102.3" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="69.7" y1="109.1" x2="72.4" y2="106.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="86.9" x2="77.8" y2="82.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.3" y1="108.4" x2="107.2" y2="110.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="67.0" y1="112.0" x2="69.7" y2="109.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.2" y1="110.0" x2="112.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="82.4" x2="77.8" y2="77.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.1" y1="111.6" x2="117.1" y2="113.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="114.9" x2="67.0" y2="112.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="77.9" x2="77.8" y2="73.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.1" y1="113.1" x2="122.0" y2="114.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.0" y1="114.7" x2="126.9" y2="116.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="73.3" x2="77.8" y2="68.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.6" y1="117.8" x2="64.3" y2="114.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="126.9" y1="116.3" x2="131.8" y2="117.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="68.8" x2="77.8" y2="64.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="131.8" y1="117.9" x2="136.7" y2="119.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="59.0" y1="120.7" x2="61.6" y2="117.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="136.7" y1="119.5" x2="141.6" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="64.3" x2="77.8" y2="59.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.6" y1="121.1" x2="146.5" y2="122.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.3" y1="123.6" x2="59.0" y2="120.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="59.8" x2="77.8" y2="55.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="146.5" y1="122.6" x2="151.4" y2="124.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="151.4" y1="124.2" x2="156.3" y2="125.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="53.6" y1="126.5" x2="56.3" y2="123.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="55.2" x2="77.8" y2="50.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.3" y1="125.8" x2="161.3" y2="127.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="50.9" y1="129.4" x2="53.6" y2="126.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="50.7" x2="77.8" y2="46.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="161.3" y1="127.4" x2="166.2" y2="129.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.2" y1="129.0" x2="171.1" y2="130.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.8" y1="46.2" x2="77.8" y2="41.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="48.2" y1="132.3" x2="50.9" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="171.1" y1="130.6" x2="176.0" y2="132.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.8" y1="100.5" x2="82.7" y2="102.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="100.5" x2="77.8" y2="95.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="75.1" y1="103.4" x2="77.8" y2="100.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.7" y1="102.1" x2="87.6" y2="103.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="95.9" x2="77.8" y2="91.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.6" y1="103.6" x2="92.5" y2="105.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.4" y1="106.3" x2="75.1" y2="103.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.5" y1="105.2" x2="97.4" y2="106.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="91.4" x2="77.8" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="106.8" x2="102.3" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="69.7" y1="109.1" x2="72.4" y2="106.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="86.9" x2="77.8" y2="82.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.3" y1="108.4" x2="107.2" y2="110.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="67.0" y1="112.0" x2="69.7" y2="109.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.2" y1="110.0" x2="112.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="82.4" x2="77.8" y2="77.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.1" y1="111.6" x2="117.1" y2="113.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="114.9" x2="67.0" y2="112.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="77.9" x2="77.8" y2="73.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.1" y1="113.1" x2="122.0" y2="114.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.0" y1="114.7" x2="126.9" y2="116.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="73.3" x2="77.8" y2="68.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.6" y1="117.8" x2="64.3" y2="114.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="126.9" y1="116.3" x2="131.8" y2="117.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="68.8" x2="77.8" y2="64.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="131.8" y1="117.9" x2="136.7" y2="119.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="59.0" y1="120.7" x2="61.6" y2="117.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="136.7" y1="119.5" x2="141.6" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="64.3" x2="77.8" y2="59.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.6" y1="121.1" x2="146.5" y2="122.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.3" y1="123.6" x2="59.0" y2="120.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="59.8" x2="77.8" y2="55.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="146.5" y1="122.6" x2="151.4" y2="124.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="151.4" y1="124.2" x2="156.3" y2="125.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="53.6" y1="126.5" x2="56.3" y2="123.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="55.2" x2="77.8" y2="50.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.3" y1="125.8" x2="161.3" y2="127.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="50.9" y1="129.4" x2="53.6" y2="126.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="50.7" x2="77.8" y2="46.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="161.3" y1="127.4" x2="166.2" y2="129.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.2" y1="129.0" x2="171.1" y2="130.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.8" y1="46.2" x2="77.8" y2="41.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="48.2" y1="132.3" x2="50.9" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="171.1" y1="130.6" x2="176.0" y2="132.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="110.0,98.6 99.2,107.9 99.0,97.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.0,97.9 99.2,107.9 89.9,108.7" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="98.9,88.0 99.0,97.9 88.1,98.9" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.0,98.6 108.5,108.5 99.2,107.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.8" y1="41.7" x2="77.8" y2="37.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.8" y1="41.7" x2="77.8" y2="37.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.0,97.9 89.9,108.7 88.1,98.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.1,88.8 110.0,98.6 99.0,97.9" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.1,88.8 99.0,97.9 98.9,88.0" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="132.1" x2="176.0" y2="127.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="132.1" x2="176.0" y2="127.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="108.5,108.5 99.4,117.5 99.2,107.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="173.3" y1="135.0" x2="176.0" y2="132.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="173.3" y1="135.0" x2="176.0" y2="132.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="98.9,88.0 88.1,98.9 86.8,89.2" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="45.5" y1="135.2" x2="48.2" y2="132.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="45.5" y1="135.2" x2="48.2" y2="132.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.2,107.9 92.1,118.2 89.9,108.7" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.3,101.0 108.5,108.5 110.0,98.6" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.2,107.9 99.4,117.5 92.1,118.2" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
@@ -76,21 +76,21 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="122.6,91.4 120.3,101.0 110.0,98.6" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,79.5 98.9,88.0 98.9,78.6" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.9,108.7 92.1,118.2 85.3,120.0" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.8" y1="37.1" x2="77.8" y2="32.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.8" y1="37.1" x2="77.8" y2="32.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="89.9,108.7 85.3,120.0 81.3,111.0" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.3,110.5 113.6,119.6 106.7,118.0" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="98.9,78.6 86.8,89.2 86.0,79.8" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.7,118.0 99.6,126.5 99.4,117.5" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="127.6" x2="176.0" y2="123.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="127.6" x2="176.0" y2="123.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.8,89.2 78.0,101.5 75.6,92.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.4,117.5 94.5,127.0 92.1,118.2" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.0,79.8 86.8,89.2 75.6,92.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="113.6,119.6 104.6,126.8 106.7,118.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="170.6" y1="137.9" x2="173.3" y2="135.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="170.6" y1="137.9" x2="173.3" y2="135.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="129.2,104.8 117.3,110.5 120.3,101.0" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.0,82.2 111.1,88.8 111.8,79.5" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.0,82.2 122.6,91.4 111.1,88.8" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="42.8" y1="138.1" x2="45.5" y2="135.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="42.8" y1="138.1" x2="45.5" y2="135.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.4,117.5 99.6,126.5 94.5,127.0" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.9,113.7 113.6,119.6 117.3,110.5" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.7,118.0 104.6,126.8 99.6,126.5" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -103,11 +103,11 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="132.5,95.7 120.3,101.0 122.6,91.4" fill="rgb(79,108,152)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.2,104.8 124.9,113.7 117.3,110.5" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.6,92.1 78.0,101.5 69.4,105.6" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.8" y1="32.6" x2="77.8" y2="28.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.8" y1="32.6" x2="77.8" y2="28.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="113.6,119.6 109.4,127.9 104.6,126.8" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.0,79.8 75.6,92.1 74.1,82.9" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.9,113.7 119.5,122.1 113.6,119.6" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="123.1" x2="176.0" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="123.1" x2="176.0" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="81.3,111.0 79.6,122.7 74.0,114.4" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.5,122.1 109.4,127.9 113.6,119.6" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.0,101.5 74.0,114.4 69.4,105.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
@@ -119,8 +119,8 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="104.6,126.8 99.8,134.5 99.6,126.5" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.3,120.0 85.9,130.1 79.6,122.7" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.6,126.5 97.2,134.7 94.5,127.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="167.9" y1="140.8" x2="170.6" y2="137.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="40.1" y1="141.0" x2="42.8" y2="138.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="167.9" y1="140.8" x2="170.6" y2="137.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="40.1" y1="141.0" x2="42.8" y2="138.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="124.4,73.7 124.0,82.2 111.8,79.5" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.5,122.1 113.5,129.7 109.4,127.9" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="74.1,82.9 75.6,92.1 66.0,96.6" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -130,9 +130,9 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="134.5,86.8 122.6,91.4 124.0,82.2" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.5,127.0 94.8,135.3 89.9,128.2" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.7,118.1 119.5,122.1 124.9,113.7" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.8" y1="28.1" x2="77.8" y2="23.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.8" y1="28.1" x2="77.8" y2="23.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.5,86.8 132.5,95.7 122.6,91.4" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="118.6" x2="176.0" y2="114.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="118.6" x2="176.0" y2="114.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="136.2,109.9 124.9,113.7 129.2,104.8" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.6,126.5 99.8,134.5 97.2,134.7" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="74.0,114.4 79.6,122.7 75.2,126.2" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
@@ -155,16 +155,16 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="124.2,125.5 116.6,132.0 113.5,129.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="74.1,82.9 66.0,96.6 63.9,87.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="140.2,101.3 129.2,104.8 132.5,95.7" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="165.2" y1="143.7" x2="167.9" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="165.2" y1="143.7" x2="167.9" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="66.0,96.6 69.4,105.6 62.9,110.9" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="113.5,129.7 106.9,136.1 104.8,135.2" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="37.5" y1="143.9" x2="40.1" y2="141.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="37.5" y1="143.9" x2="40.1" y2="141.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="116.6,132.0 106.9,136.1 113.5,129.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.8" y1="23.6" x2="77.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.8" y1="23.6" x2="77.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="73.6,74.4 74.1,82.9 63.9,87.7" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,63.4 98.8,70.0 98.9,62.6" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="69.4,105.6 68.4,118.9 62.9,110.9" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="114.0" x2="176.0" y2="109.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="114.0" x2="176.0" y2="109.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.0,63.8 85.7,71.2 73.6,74.4" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.9,130.1 91.3,137.5 82.9,132.5" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.2,78.3 124.0,82.2 124.4,73.7" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -189,13 +189,13 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="63.9,87.7 66.0,96.6 58.8,102.4" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="142.6,92.7 132.5,95.7 134.5,86.8" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="66.0,96.6 62.9,110.9 58.8,102.4" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.8" y1="19.0" x2="77.8" y2="14.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.8" y1="19.0" x2="77.8" y2="14.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="82.9,132.5 91.3,137.5 90.4,138.9" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.1,129.5 118.7,134.8 116.6,132.0" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="162.5" y1="146.6" x2="165.2" y2="143.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="162.5" y1="146.6" x2="165.2" y2="143.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="108.5,137.3 100.0,141.1 106.9,136.1" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="34.8" y1="146.8" x2="37.5" y2="143.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.0" y1="109.5" x2="176.0" y2="105.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="34.8" y1="146.8" x2="37.5" y2="143.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.0" y1="109.5" x2="176.0" y2="105.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="92.8,136.3 100.0,141.1 91.3,137.5" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="82.9,132.5 90.4,138.9 81.1,135.3" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.2,126.2 81.1,135.3 72.5,130.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
@@ -228,7 +228,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="90.4,138.9 100.0,141.1 100.0,141.1" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.9,140.2 100.0,141.1 109.5,138.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.4,138.9 100.0,141.1 90.1,140.5" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.8" y1="14.5" x2="77.8" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.8" y1="14.5" x2="77.8" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.9,140.2 100.0,141.1 100.0,141.1" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.5,137.7 109.9,140.2 109.5,138.7" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.1,140.5 100.0,141.1 100.0,141.1" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -237,16 +237,16 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="134.5,70.7 124.4,73.7 124.0,66.2" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.3,133.8 118.7,134.8 127.1,129.5" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="63.9,87.7 58.8,102.4 56.2,93.9" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="105.0" x2="176.0" y2="100.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="105.0" x2="176.0" y2="100.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="81.1,135.3 90.1,140.5 80.5,138.3" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.1,108.0 136.2,109.9 140.2,101.3" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="58.8,102.4 62.9,110.9 58.9,116.9" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.6,141.7 100.0,141.1 100.0,141.1" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="159.9" y1="149.5" x2="162.5" y2="146.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="159.9" y1="149.5" x2="162.5" y2="146.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="63.2,79.3 63.9,87.7 56.2,93.9" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.5,142.0 100.0,141.1 100.0,141.1" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.6,141.7 100.0,141.1 109.9,140.2" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="32.1" y1="149.7" x2="34.8" y2="146.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="32.1" y1="149.7" x2="34.8" y2="146.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.8,57.7 86.0,63.8 74.1,66.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.1,57.4 98.9,62.6 98.9,56.6" fill="rgb(56,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.1,140.5 100.0,141.1 90.5,142.0" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -269,7 +269,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="90.5,142.0 100.0,141.1 91.5,143.4" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.2,145.5 100.0,141.1 100.0,141.1" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="72.5,130.2 80.5,138.3 71.7,134.6" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.8" y1="10.0" x2="82.7" y2="11.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.8" y1="10.0" x2="82.7" y2="11.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.8,145.9 100.0,141.1 100.0,141.1" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.9,140.7 109.9,140.2 119.5,137.7" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.6,146.0 100.0,141.1 100.0,141.1" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -277,22 +277,22 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="118.9,140.7 109.6,141.7 109.9,140.2" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.6,60.0 111.8,63.4 111.1,57.4" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.2,144.4 100.0,141.1 108.7,143.1" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="75.1" y1="12.9" x2="77.8" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="75.1" y1="12.9" x2="77.8" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="74.1,66.9 63.2,79.3 63.9,71.7" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,143.4 100.0,141.1 93.1,144.6" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.0,128.6 128.3,133.8 127.1,129.5" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="100.5" x2="176.0" y2="96.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="100.5" x2="176.0" y2="96.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="80.5,138.3 90.5,142.0 81.3,141.2" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.2,145.3 100.0,141.1 107.2,144.4" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.1,144.6 100.0,141.1 95.2,145.5" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.3,141.2 90.5,142.0 91.5,143.4" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="82.7" y1="11.6" x2="87.6" y2="13.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.2" y1="152.4" x2="159.9" y2="149.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="82.7" y1="11.6" x2="87.6" y2="13.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.2" y1="152.4" x2="159.9" y2="149.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="56.2,93.9 58.8,102.4 54.3,109.2" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.9,99.8 140.2,101.3 142.6,92.7" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="71.7,134.6 80.5,138.3 81.3,141.2" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="58.8,102.4 58.9,116.9 54.3,109.2" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="29.4" y1="152.5" x2="32.1" y2="149.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="29.4" y1="152.5" x2="32.1" y2="149.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.8,57.7 74.1,66.9 75.6,60.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.8,145.9 100.0,141.1 105.2,145.3" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.2,145.5 100.0,141.1 97.6,146.0" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
@@ -310,24 +310,24 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="147.9,99.8 145.1,108.0 140.2,101.3" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="63.9,71.7 63.2,79.3 55.4,85.6" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.0,52.2 98.9,56.6 86.8,57.7" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="87.6" y1="13.2" x2="92.5" y2="14.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="87.6" y1="13.2" x2="92.5" y2="14.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="132.5,64.2 134.5,70.7 124.0,66.2" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="96.0" x2="176.0" y2="91.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="96.0" x2="176.0" y2="91.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="142.3,122.3 136.0,128.6 134.5,123.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.0,52.9 111.1,57.4 98.9,56.6" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.4,144.0 91.5,143.4 93.1,144.6" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="142.6,76.7 135.2,78.3 134.5,70.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.3,141.2 91.5,143.4 83.4,144.0" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.4" y1="15.8" x2="75.1" y2="12.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.4" y1="15.8" x2="75.1" y2="12.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="132.5,64.2 124.0,66.2 122.6,60.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.1,145.9 107.2,144.4 108.7,143.1" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="142.6,76.7 143.5,84.4 135.2,78.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="71.7,134.6 81.3,141.2 72.9,138.9" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="154.5" y1="155.3" x2="157.2" y2="152.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="154.5" y1="155.3" x2="157.2" y2="152.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="64.0,129.6 71.7,134.6 72.9,138.9" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="26.7" y1="155.4" x2="29.4" y2="152.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="26.7" y1="155.4" x2="29.4" y2="152.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.1,145.9 108.7,143.1 117.1,143.5" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="92.5" y1="14.8" x2="97.4" y2="16.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.5" y1="14.8" x2="97.4" y2="16.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.5,146.3 93.1,144.6 95.2,145.5" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.1,53.2 86.8,57.7 75.6,60.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.0,134.1 128.3,133.8 136.0,128.6" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
@@ -343,7 +343,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="148.8,91.6 142.6,92.7 143.5,84.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.4,144.0 93.1,144.6 86.5,146.3" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.0,134.1 127.5,138.1 128.3,133.8" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="91.4" x2="176.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="91.4" x2="176.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.0,52.2 86.8,57.7 88.1,53.2" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.8,142.2 117.1,143.5 118.9,140.7" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.6,148.1 95.2,145.5 97.6,146.0" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -351,9 +351,9 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="124.8,142.2 118.9,140.7 127.5,138.1" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.5,149.0 102.8,145.9 105.2,145.3" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.0,115.1 142.3,122.3 140.6,115.8" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="97.4" y1="16.3" x2="102.3" y2="17.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="97.4" y1="16.3" x2="102.3" y2="17.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="148.8,91.6 147.9,99.8 142.6,92.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="69.7" y1="18.7" x2="72.4" y2="15.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="69.7" y1="18.7" x2="72.4" y2="15.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="95.4,149.1 97.6,146.0 100.2,146.2" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.3,55.3 111.1,57.4 110.0,52.9" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="63.9,71.7 55.4,85.6 56.2,77.9" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -361,15 +361,15 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="110.1,147.8 107.2,144.4 114.1,145.9" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.5,146.3 95.2,145.5 90.6,148.1" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="64.0,129.6 72.9,138.9 65.5,135.0" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="151.8" y1="158.2" x2="154.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="151.8" y1="158.2" x2="154.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="72.9,138.9 83.4,144.0 75.8,142.8" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="158.3" x2="26.7" y2="155.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="158.3" x2="26.7" y2="155.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="66.0,65.1 63.9,71.7 56.2,77.9" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.1,53.2 75.6,60.6 78.0,55.9" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="57.7,123.4 64.0,129.6 65.5,135.0" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="102.3" y1="17.9" x2="107.2" y2="19.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="102.3" y1="17.9" x2="107.2" y2="19.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="105.5,149.0 105.2,145.3 110.1,147.8" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="86.9" x2="176.0" y2="82.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="86.9" x2="176.0" y2="82.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="75.8,142.8 83.4,144.0 86.5,146.3" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.0,55.9 75.6,60.6 66.0,65.1" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.6,148.1 97.6,146.0 95.4,149.1" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -386,29 +386,29 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="55.4,85.6 51.5,101.1 50.6,92.9" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="141.1,128.7 135.0,134.1 136.0,128.6" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.5,135.0 72.9,138.9 75.8,142.8" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="67.0" y1="21.6" x2="69.7" y2="18.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="67.0" y1="21.6" x2="69.7" y2="18.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,145.7 117.1,143.5 124.8,142.2" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.2,59.1 122.6,60.0 120.3,55.3" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="56.2,77.9 55.4,85.6 50.6,92.9" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="107.2" y1="19.5" x2="112.1" y2="21.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="107.2" y1="19.5" x2="112.1" y2="21.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.9,83.7 143.5,84.4 142.6,76.7" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="158.3" x2="28.9" y2="159.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="158.3" x2="28.9" y2="159.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.2,49.7 99.0,52.2 88.1,53.2" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="149.9,107.4 147.0,115.1 145.1,108.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.5,50.3 110.0,52.9 99.0,52.2" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.6,139.3 127.5,138.1 135.0,134.1" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.6,139.3 124.8,142.2 127.5,138.1" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="158.3" x2="24.0" y2="153.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="149.1" y1="161.1" x2="151.8" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.0" y1="82.4" x2="176.0" y2="77.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="158.3" x2="24.0" y2="153.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="149.1" y1="161.1" x2="151.8" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.0" y1="82.4" x2="176.0" y2="77.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="80.5,146.2 86.5,146.3 90.6,148.1" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.9,83.7 148.8,91.6 143.5,84.4" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.8,142.8 86.5,146.3 80.5,146.2" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.7,148.4 110.1,147.8 114.1,145.9" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="112.1" y1="21.1" x2="117.1" y2="22.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.1" y1="21.1" x2="117.1" y2="22.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="57.7,123.4 65.5,135.0 59.4,129.8" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.9,50.6 88.1,53.2 78.0,55.9" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="28.9" y1="159.9" x2="33.8" y2="161.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="28.9" y1="159.9" x2="33.8" y2="161.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="66.0,65.1 56.2,77.9 58.8,71.0" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.0,55.9 66.0,65.1 69.4,59.9" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.3,52.3 120.3,55.3 110.0,52.9" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -416,22 +416,22 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="108.5,50.3 99.0,52.2 99.2,49.7" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.7,122.3 142.3,122.3 147.0,115.1" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.5,135.0 75.8,142.8 69.3,140.1" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="64.3" y1="24.5" x2="67.0" y2="21.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="64.3" y1="24.5" x2="67.0" y2="21.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.7,148.4 114.1,145.9 120.4,145.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.4,148.8 90.6,148.1 95.4,149.1" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="51.5,101.1 53.0,116.4 50.1,108.7" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.2,49.7 88.1,53.2 89.9,50.6" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="153.8" x2="24.0" y2="149.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="153.8" x2="24.0" y2="149.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="50.6,92.9 51.5,101.1 50.1,108.7" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="117.1" y1="22.7" x2="122.0" y2="24.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="117.1" y1="22.7" x2="122.0" y2="24.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="107.9,150.2 105.5,149.0 110.1,147.8" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="150.9,99.3 147.9,99.8 148.8,91.6" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="77.9" x2="176.0" y2="73.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="33.8" y1="161.5" x2="38.7" y2="163.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="77.9" x2="176.0" y2="73.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="33.8" y1="161.5" x2="38.7" y2="163.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="69.4,59.9 66.0,65.1 58.8,71.0" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.7,122.3 141.1,128.7 142.3,122.3" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.3,52.3 110.0,52.9 108.5,50.3" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="146.4" y1="164.0" x2="149.1" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="146.4" y1="164.0" x2="149.1" y2="161.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="69.3,140.1 75.8,142.8 80.5,146.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="80.5,146.2 90.6,148.1 86.4,148.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.3,150.4 95.4,149.1 100.4,149.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -443,29 +443,29 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="150.9,99.3 149.9,107.4 147.9,99.8" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.0,143.7 120.4,145.7 124.8,142.2" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="58.8,71.0 56.2,77.9 51.5,85.0" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.0" y1="24.3" x2="126.9" y2="25.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.0" y1="24.3" x2="126.9" y2="25.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="81.3,52.8 78.0,55.9 69.4,59.9" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.1,134.8 135.0,134.1 141.1,128.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.9,50.6 78.0,55.9 81.3,52.8" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.9,150.2 110.1,147.8 114.7,148.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.1,76.5 142.6,76.7 140.2,69.9" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.0,143.7 124.8,142.2 131.6,139.3" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="38.7" y1="163.1" x2="43.7" y2="164.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="38.7" y1="163.1" x2="43.7" y2="164.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="137.1,134.8 131.6,139.3 135.0,134.1" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.9,55.6 129.2,59.1 120.3,55.3" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="149.3" x2="24.0" y2="144.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="149.3" x2="24.0" y2="144.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.4,148.8 95.4,149.1 93.3,150.4" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.6" y1="27.4" x2="64.3" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.6" y1="27.4" x2="64.3" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="145.1,76.5 147.9,83.7 142.6,76.7" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="73.3" x2="176.0" y2="68.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="73.3" x2="176.0" y2="68.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="53.0,116.4 59.4,129.8 54.9,123.5" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.6,150.8 105.5,149.0 107.9,150.2" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.9,55.6 120.3,55.3 117.3,52.3" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="126.9" y1="25.8" x2="131.8" y2="27.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="126.9" y1="25.8" x2="131.8" y2="27.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="93.3,150.4 100.4,149.5 100.6,150.8" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="50.1,108.7 53.0,116.4 54.9,123.5" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="143.7" y1="166.9" x2="146.4" y2="164.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.7" y1="164.7" x2="48.6" y2="166.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="143.7" y1="166.9" x2="146.4" y2="164.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.7" y1="164.7" x2="48.6" y2="166.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="148.5,115.0 147.0,115.1 149.9,107.4" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="69.3,140.1 80.5,146.2 75.1,144.4" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="50.6,92.9 50.1,108.7 49.1,100.7" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -478,13 +478,13 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="59.4,129.8 69.3,140.1 63.8,135.8" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.5,115.0 145.7,122.3 147.0,115.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.7,147.2 114.7,148.4 120.4,145.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="144.8" x2="24.0" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="131.8" y1="27.4" x2="136.7" y2="29.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="144.8" x2="24.0" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="131.8" y1="27.4" x2="136.7" y2="29.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="81.3,52.8 69.4,59.9 74.0,56.3" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="68.8" x2="176.0" y2="64.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="48.6" y1="166.2" x2="53.5" y2="167.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="68.8" x2="176.0" y2="64.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="48.6" y1="166.2" x2="53.5" y2="167.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="58.8,71.0 51.5,85.0 54.3,77.7" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="59.0" y1="30.3" x2="61.6" y2="27.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="59.0" y1="30.3" x2="61.6" y2="27.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="149.9,91.3 150.9,99.3 148.8,91.6" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="92.1,49.8 89.9,50.6 81.3,52.8" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="54.9,123.5 59.4,129.8 63.8,135.8" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
@@ -494,12 +494,12 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="63.8,135.8 69.3,140.1 75.1,144.4" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="141.2,129.0 141.1,128.7 145.7,122.3" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="62.9,65.2 58.8,71.0 54.3,77.7" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="141.0" y1="169.7" x2="143.7" y2="166.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="136.7" y1="29.0" x2="141.6" y2="30.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="141.0" y1="169.7" x2="143.7" y2="166.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="136.7" y1="29.0" x2="141.6" y2="30.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="82.7,147.7 86.4,148.8 93.3,150.4" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.7,59.9 136.2,64.2 129.2,59.1" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.7,49.6 99.2,49.7 99.4,49.2" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="53.5" y1="167.8" x2="58.4" y2="169.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="53.5" y1="167.8" x2="58.4" y2="169.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="140.6,70.2 140.2,69.9 136.2,64.2" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="141.2,129.0 137.1,134.8 141.1,128.7" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.7,59.9 129.2,59.1 124.9,55.6" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
@@ -507,38 +507,38 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="99.4,49.2 89.9,50.6 92.1,49.8" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.6,140.1 126.0,143.7 131.6,139.3" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.1,144.4 86.4,148.8 82.7,147.7" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="140.2" x2="24.0" y2="135.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="140.2" x2="24.0" y2="135.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="130.6,140.1 131.6,139.3 137.1,134.8" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="140.6,70.2 145.1,76.5 140.2,69.9" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="50.1,108.7 54.9,123.5 52.1,116.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="64.3" x2="176.0" y2="59.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="64.3" x2="176.0" y2="59.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="113.6,51.2 108.5,50.3 106.7,49.6" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="49.1,100.7 50.1,108.7 52.1,116.3" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="149.4,107.1 149.9,107.4 150.9,99.3" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,149.7 93.3,150.4 100.6,150.8" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="141.6" y1="30.6" x2="146.5" y2="32.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="141.6" y1="30.6" x2="146.5" y2="32.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.8,150.3 100.6,150.8 107.9,150.2" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.3,51.6 81.3,52.8 74.0,56.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="58.4" y1="169.4" x2="63.3" y2="171.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="58.4" y1="169.4" x2="63.3" y2="171.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="51.5,85.0 49.1,100.7 50.1,92.6" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="56.3" y1="33.1" x2="59.0" y2="30.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.3" y1="33.1" x2="59.0" y2="30.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.5,53.8 124.9,55.6 117.3,52.3" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="92.1,49.8 81.3,52.8 85.3,51.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.1,149.4 114.7,148.4 118.7,147.2" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="54.3,77.7 51.5,85.0 50.1,92.6" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.0,83.6 147.9,83.7 145.1,76.5" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="149.4,107.1 148.5,115.0 149.9,107.4" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.4" y1="172.6" x2="141.0" y2="169.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.4" y1="172.6" x2="141.0" y2="169.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="54.9,123.5 63.8,135.8 59.8,130.1" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="74.0,56.3 62.9,65.2 68.4,60.7" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="82.7,147.7 93.3,150.4 91.5,149.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.5,53.8 117.3,52.3 113.6,51.2" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="63.8,135.8 75.1,144.4 70.8,140.9" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="146.5" y1="32.2" x2="151.4" y2="33.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="24.0" y1="135.7" x2="24.0" y2="131.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="146.5" y1="32.2" x2="151.4" y2="33.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="24.0" y1="135.7" x2="24.0" y2="131.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.0,83.6 149.9,91.3 147.9,83.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="63.3" y1="171.0" x2="68.2" y2="172.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.0" y1="59.8" x2="176.0" y2="55.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="63.3" y1="171.0" x2="68.2" y2="172.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.0" y1="59.8" x2="176.0" y2="55.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="62.9,65.2 54.3,77.7 58.9,71.3" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.8,150.3 107.9,150.2 110.1,149.4" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="70.8,140.9 75.1,144.4 82.7,147.7" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
@@ -547,10 +547,10 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="143.8,122.1 145.7,122.3 148.5,115.0" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.0,144.1 118.7,147.2 126.0,143.7" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.3,51.6 74.0,56.3 79.6,54.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="151.4" y1="33.8" x2="156.3" y2="35.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="53.6" y1="36.0" x2="56.3" y2="33.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="151.4" y1="33.8" x2="156.3" y2="35.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="53.6" y1="36.0" x2="56.3" y2="33.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="68.4,60.7 62.9,65.2 58.9,71.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="68.2" y1="172.6" x2="73.1" y2="174.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="68.2" y1="172.6" x2="73.1" y2="174.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.6,50.5 99.4,49.2 92.1,49.8" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.6,50.9 106.7,49.6 99.4,49.2" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="59.8,130.1 63.8,135.8 70.8,140.9" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
@@ -561,19 +561,19 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="122.0,144.1 126.0,143.7 130.6,140.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.5,65.0 140.6,70.2 136.2,64.2" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="50.1,92.6 49.1,100.7 51.2,108.4" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="131.2" x2="24.0" y2="126.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="131.2" x2="24.0" y2="126.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="124.2,57.2 130.7,59.9 124.9,55.6" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.5,98.9 150.9,99.3 149.9,91.3" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="135.7" y1="175.5" x2="138.4" y2="172.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.0" y1="55.2" x2="176.0" y2="50.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="135.7" y1="175.5" x2="138.4" y2="172.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.0" y1="55.2" x2="176.0" y2="50.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.5,51.0 92.1,49.8 85.3,51.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.0,134.9 137.1,134.8 141.2,129.0" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.0,134.9 130.6,140.1 137.1,134.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.4,51.9 113.6,51.2 106.7,49.6" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="54.3,77.7 50.1,92.6 53.0,84.9" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.2,57.2 124.9,55.6 119.5,53.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="156.3" y1="35.3" x2="161.3" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.1" y1="174.2" x2="78.0" y2="175.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="156.3" y1="35.3" x2="161.3" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.1" y1="174.2" x2="78.0" y2="175.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="58.9,71.3 54.3,77.7 53.0,84.9" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="142.3,76.6 145.1,76.5 140.6,70.2" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.5,98.9 149.4,107.1 150.9,99.3" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -583,19 +583,19 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="111.9,146.8 110.1,149.4 118.7,147.2" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="142.3,76.6 147.0,83.6 145.1,76.5" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.6,50.5 92.1,49.8 94.5,51.0" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="50.9" y1="38.9" x2="53.6" y2="36.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="161.3" y1="36.9" x2="166.2" y2="38.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="50.9" y1="38.9" x2="53.6" y2="36.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="161.3" y1="36.9" x2="166.2" y2="38.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="89.9,52.2 85.3,51.6 79.6,54.3" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="52.1,116.3 59.8,130.1 57.4,123.3" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.4,51.9 106.7,49.6 104.6,50.9" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="126.7" x2="24.0" y2="122.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="126.7" x2="24.0" y2="122.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="113.5,53.7 119.5,53.8 113.6,51.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="78.0" y1="175.7" x2="82.9" y2="177.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="78.0" y1="175.7" x2="82.9" y2="177.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="68.4,60.7 58.9,71.3 65.0,65.9" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="50.7" x2="176.0" y2="46.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="50.7" x2="176.0" y2="46.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="79.6,54.3 68.4,60.7 75.2,57.8" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.0,147.1 91.5,149.7 100.8,150.3" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="133.0" y1="178.4" x2="135.7" y2="175.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="133.0" y1="178.4" x2="135.7" y2="175.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.0,147.8 100.8,150.3 110.1,149.4" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="51.2,108.4 52.1,116.3 57.4,123.3" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.5,51.0 85.3,51.6 89.9,52.2" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -603,23 +603,23 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="111.9,146.8 118.7,147.2 122.0,144.1" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.6,114.4 148.5,115.0 149.4,107.1" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="113.5,53.7 113.6,51.2 109.4,51.9" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="166.2" y1="38.5" x2="171.1" y2="40.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="166.2" y1="38.5" x2="171.1" y2="40.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="50.1,92.6 51.2,108.4 52.1,100.2" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.2,57.8 68.4,60.7 65.0,65.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.7,90.8 149.9,91.3 147.0,83.6" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="53.0,84.9 50.1,92.6 52.1,100.2" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="82.9" y1="177.3" x2="87.9" y2="178.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="82.9" y1="177.3" x2="87.9" y2="178.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="79.7,144.7 91.5,149.7 90.0,147.1" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.6,114.4 143.8,122.1 148.5,115.0" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.5,135.8 70.8,140.9 79.7,144.7" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.1,61.1 134.5,65.0 130.7,59.9" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.1,61.1 130.7,59.9 124.2,57.2" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="58.9,71.3 53.0,84.9 57.7,77.7" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="122.1" x2="24.0" y2="117.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="122.1" x2="24.0" y2="117.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="57.4,123.3 59.8,130.1 67.5,135.8" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="48.2" y1="41.8" x2="50.9" y2="38.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="48.2" y1="41.8" x2="50.9" y2="38.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="85.9,54.1 79.6,54.3 75.2,57.8" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.0" y1="46.2" x2="176.0" y2="41.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.0" y1="46.2" x2="176.0" y2="41.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="89.9,52.2 79.6,54.3 85.9,54.1" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.0,65.9 58.9,71.3 57.7,77.7" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.0,147.8 110.1,149.4 111.9,146.8" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
@@ -627,14 +627,14 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="136.0,70.4 140.6,70.2 134.5,65.0" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.7,90.8 148.5,98.9 149.9,91.3" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.6,56.0 124.2,57.2 119.5,53.8" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="171.1" y1="40.1" x2="176.0" y2="41.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="171.1" y1="40.1" x2="176.0" y2="41.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="90.0,147.1 100.8,150.3 101.0,147.8" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.1,128.3 141.2,129.0 143.8,122.1" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.4,139.4 130.6,140.1 134.0,134.9" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="87.9" y1="178.9" x2="92.8" y2="180.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="87.9" y1="178.9" x2="92.8" y2="180.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="136.0,70.4 142.3,76.6 140.6,70.2" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.1,128.3 134.0,134.9 141.2,129.0" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="130.3" y1="181.3" x2="133.0" y2="178.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="130.3" y1="181.3" x2="133.0" y2="178.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="116.6,56.0 119.5,53.8 113.5,53.7" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.8,53.8 99.6,50.5 94.5,51.0" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.4,54.0 104.6,50.9 99.6,50.5" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
@@ -642,15 +642,15 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="51.2,108.4 57.4,123.3 56.5,115.6" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.2,54.1 94.5,51.0 89.9,52.2" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.8,54.5 109.4,51.9 104.6,50.9" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="117.6" x2="24.0" y2="113.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.8" y1="180.5" x2="97.7" y2="182.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="117.6" x2="24.0" y2="113.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.8" y1="180.5" x2="97.7" y2="182.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="52.1,100.2 51.2,108.4 56.5,115.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.8,106.1 149.4,107.1 148.5,98.9" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.9,54.1 75.2,57.8 82.9,56.5" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="173.3" y1="44.6" x2="176.0" y2="41.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="173.3" y1="44.6" x2="176.0" y2="41.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="67.5,135.8 79.7,144.7 77.4,140.0" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="141.1,83.1 147.0,83.6 142.3,76.6" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="45.5" y1="44.7" x2="48.2" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="45.5" y1="44.7" x2="48.2" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="53.0,84.9 52.1,100.2 54.9,92.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.4,140.0 79.7,144.7 90.0,147.1" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="57.7,77.7 53.0,84.9 54.9,92.0" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
@@ -663,18 +663,18 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="143.8,106.1 144.6,114.4 149.4,107.1" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.7,58.8 127.1,61.1 124.2,57.2" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.4,54.0 99.6,50.5 99.8,53.8" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="127.6" y1="184.2" x2="130.3" y2="181.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="127.6" y1="184.2" x2="130.3" y2="181.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.8,53.8 94.5,51.0 97.2,54.1" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="72.5,61.9 65.0,65.9 64.0,71.4" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="141.1,83.1 145.7,90.8 147.0,83.6" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.7,58.8 124.2,57.2 116.6,56.0" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="97.7" y1="182.1" x2="102.6" y2="183.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="97.7" y1="182.1" x2="102.6" y2="183.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.3,65.4 134.5,65.0 127.1,61.1" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.8,54.5 104.6,50.9 102.4,54.0" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.3,65.4 136.0,70.4 134.5,65.0" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.2,54.1 89.9,52.2 94.8,54.7" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="113.2,142.3 122.0,144.1 124.4,139.4" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="113.1" x2="24.0" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="113.1" x2="24.0" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="88.9,142.6 90.0,147.1 101.0,147.8" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="56.5,115.6 57.4,123.3 65.5,129.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.9,55.4 109.4,51.9 104.8,54.5" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
@@ -683,10 +683,10 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="108.5,56.6 116.6,56.0 113.5,53.7" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.5,129.3 67.5,135.8 77.4,140.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.8,120.7 143.8,122.1 144.6,114.4" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="102.6" y1="183.7" x2="107.5" y2="185.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.6" y1="47.5" x2="173.3" y2="44.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="102.6" y1="183.7" x2="107.5" y2="185.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.6" y1="47.5" x2="173.3" y2="44.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.8,54.7 85.9,54.1 92.8,55.6" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="42.8" y1="47.6" x2="45.5" y2="44.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="42.8" y1="47.6" x2="45.5" y2="44.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="82.9,56.5 72.5,61.9 81.1,59.3" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.4,140.0 90.0,147.1 88.9,142.6" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.8,120.7 136.1,128.3 143.8,122.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -700,12 +700,12 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="57.7,77.7 54.9,92.0 59.4,84.2" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="54.9,92.0 52.1,100.2 57.4,107.3" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="72.5,61.9 64.0,71.4 71.7,66.2" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="124.9" y1="187.1" x2="127.6" y2="184.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="124.9" y1="187.1" x2="127.6" y2="184.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.1,143.4 111.9,146.8 113.2,142.3" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.0,75.9 141.1,83.1 142.3,76.6" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="108.6" x2="24.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="108.6" x2="24.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="81.1,59.3 72.5,61.9 71.7,66.2" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="107.5" y1="185.2" x2="112.4" y2="186.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="107.5" y1="185.2" x2="112.4" y2="186.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.5,61.7 127.1,61.1 118.7,58.8" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.9,142.6 101.0,147.8 101.1,143.4" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="92.8,55.6 82.9,56.5 91.3,56.9" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
@@ -720,10 +720,10 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="100.0,58.9 97.2,54.1 94.8,54.7" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="56.5,115.6 65.5,129.3 64.8,121.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.5,129.3 77.4,140.0 76.0,133.8" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="167.9" y1="50.3" x2="170.6" y2="47.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="167.9" y1="50.3" x2="170.6" y2="47.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="127.5,69.8 136.0,70.4 128.3,65.4" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="40.1" y1="50.5" x2="42.8" y2="47.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.4" y1="186.8" x2="117.3" y2="188.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="40.1" y1="50.5" x2="42.8" y2="47.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.4" y1="186.8" x2="117.3" y2="188.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.0,58.9 106.9,55.4 104.8,54.5" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 94.8,54.7 92.8,55.6" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="71.7,66.2 64.0,71.4 65.5,76.9" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
@@ -733,12 +733,12 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="64.0,71.4 59.4,84.2 65.5,76.9" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="57.4,107.3 56.5,115.6 64.8,121.7" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.1,89.1 145.7,90.8 141.1,83.1" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="104.0" x2="24.0" y2="99.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="104.0" x2="24.0" y2="99.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="136.1,112.3 144.6,114.4 143.8,106.1" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 108.5,56.6 106.9,55.4" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.0,136.2 113.2,142.3 124.4,139.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.5,69.8 135.0,75.9 136.0,70.4" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.2" y1="190.0" x2="124.9" y2="187.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.2" y1="190.0" x2="124.9" y2="187.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.0,58.9 92.8,55.6 91.3,56.9" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.4,58.3 81.1,59.3 80.5,62.3" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="59.4,84.2 54.9,92.0 59.8,98.7" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
@@ -749,7 +749,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="100.0,58.9 102.4,54.0 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 97.2,54.1 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.1,112.3 136.8,120.7 144.6,114.4" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="117.3" y1="188.4" x2="122.2" y2="190.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="117.3" y1="188.4" x2="122.2" y2="190.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.0,58.9 104.8,54.5 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 109.5,58.0 108.5,56.6" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.0,136.2 124.4,139.4 125.9,133.1" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -771,21 +771,21 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="71.7,66.2 65.5,76.9 72.9,70.5" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.9,64.7 127.5,69.8 128.3,65.4" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 109.9,59.5 109.5,58.0" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="165.2" y1="53.2" x2="167.9" y2="50.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="165.2" y1="53.2" x2="167.9" y2="50.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.0,58.9 90.4,58.3 90.1,59.8" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 109.5,58.0 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="37.5" y1="53.4" x2="40.1" y2="50.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="37.5" y1="53.4" x2="40.1" y2="50.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.0,58.9 90.4,58.3 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.6,61.1 119.5,61.7 109.9,59.5" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.6,81.1 141.1,83.1 135.0,75.9" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="76.0,133.8 88.9,142.6 88.2,136.6" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="99.5" x2="24.0" y2="95.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="99.5" x2="24.0" y2="95.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.0,58.9 109.9,59.5 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 90.1,59.8 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.1,59.8 80.5,62.3 81.3,65.2" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.5,76.9 59.4,84.2 63.8,90.1" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.6,61.1 118.9,64.7 119.5,61.7" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.2" y1="190.0" x2="122.2" y2="185.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.2" y1="190.0" x2="122.2" y2="185.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.0,58.9 109.6,61.1 109.9,59.5" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 90.1,59.8 90.5,61.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 109.6,61.1 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -817,15 +817,15 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="100.0,58.9 97.6,65.4 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 100.2,65.5 100.0,58.9" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.0,58.9 107.2,63.7 108.7,62.5" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="95.0" x2="24.0" y2="90.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="162.5" y1="56.1" x2="165.2" y2="53.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="95.0" x2="24.0" y2="90.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="162.5" y1="56.1" x2="165.2" y2="53.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.0,58.9 91.5,62.7 93.1,63.9" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.6,126.3 76.0,133.8 88.2,136.6" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.8,73.8 131.6,81.1 135.0,75.9" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="34.8" y1="56.3" x2="37.5" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="34.8" y1="56.3" x2="37.5" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="90.5,61.3 81.3,65.2 83.4,68.0" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.7,62.5 117.1,67.5 118.9,64.7" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.2" y1="185.5" x2="122.2" y2="181.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.2" y1="185.5" x2="122.2" y2="181.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="65.5,76.9 63.8,90.1 69.3,81.9" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.3,65.2 72.9,70.5 75.8,74.5" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.5,113.2 64.8,121.7 75.6,126.3" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -850,7 +850,7 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="130.6,94.4 134.0,103.4 141.2,97.6" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.0,129.1 88.2,136.6 101.1,137.4" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,62.7 86.5,70.3 93.1,63.9" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="90.5" x2="24.0" y2="86.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="90.5" x2="24.0" y2="86.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.2,130.0 101.1,137.4 114.0,136.2" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,62.7 83.4,68.0 86.5,70.3" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.2,63.7 114.1,69.9 117.1,67.5" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
@@ -858,9 +858,9 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="126.0,85.6 137.1,89.1 131.6,81.1" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.1,69.9 124.8,73.8 117.1,67.5" fill="rgb(88,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.2,64.7 114.1,69.9 107.2,63.7" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.2" y1="181.0" x2="122.2" y2="176.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="159.9" y1="59.0" x2="162.5" y2="56.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="32.1" y1="59.2" x2="34.8" y2="56.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.2" y1="181.0" x2="122.2" y2="176.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="159.9" y1="59.0" x2="162.5" y2="56.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="32.1" y1="59.2" x2="34.8" y2="56.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,77.3 131.6,81.1 124.8,73.8" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="69.3,81.9 63.8,90.1 70.8,95.2" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.5,113.2 75.6,126.3 76.0,117.8" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -884,17 +884,17 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="100.2,65.5 105.5,73.0 102.8,65.3" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.4,107.9 125.9,117.1 136.1,112.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.6,65.4 100.4,73.5 100.2,65.5" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="86.0" x2="24.0" y2="81.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="86.0" x2="24.0" y2="81.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.0,120.2 114.3,128.8 126.4,125.6" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.2" y1="176.4" x2="122.2" y2="171.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.2" y1="176.4" x2="122.2" y2="171.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="69.3,81.9 70.8,95.2 75.1,86.3" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.0,120.2 126.4,125.6 125.9,117.1" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.1,71.8 120.4,77.3 114.1,69.9" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.8,74.5 75.1,86.3 80.5,77.9" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.2,64.8 90.6,72.1 95.4,73.2" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.8,65.3 105.5,73.0 110.1,71.8" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="157.2" y1="61.9" x2="159.9" y2="59.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="29.4" y1="62.1" x2="32.1" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="157.2" y1="61.9" x2="159.9" y2="59.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="29.4" y1="62.1" x2="32.1" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="97.6,65.4 95.4,73.2 100.4,73.5" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.2,65.5 100.4,73.5 105.5,73.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.0,98.5 134.0,103.4 130.6,94.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
@@ -909,9 +909,9 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="101.1,121.4 101.2,130.0 114.3,128.8" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.0,98.5 124.4,107.9 134.0,103.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.7,89.0 130.6,94.4 126.0,85.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="81.4" x2="24.0" y2="76.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="81.4" x2="24.0" y2="76.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="105.5,73.0 114.7,80.0 110.1,71.8" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.2" y1="171.9" x2="122.2" y2="167.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.2" y1="171.9" x2="122.2" y2="167.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.1,121.4 114.3,128.8 114.0,120.2" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.1,86.3 70.8,95.2 79.7,99.0" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="80.5,77.9 75.1,86.3 82.7,89.5" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
@@ -928,17 +928,17 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="90.6,72.1 86.4,80.4 93.3,82.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.5,73.0 107.9,81.8 114.7,80.0" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.4,73.2 100.6,82.5 100.4,73.5" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="154.5" y1="64.8" x2="157.2" y2="61.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="26.7" y1="65.0" x2="29.4" y2="62.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="154.5" y1="64.8" x2="157.2" y2="61.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="26.7" y1="65.0" x2="29.4" y2="62.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="75.1,86.3 79.7,99.0 82.7,89.5" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.9,81.8 118.7,89.0 114.7,80.0" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.4,73.2 93.3,82.0 100.6,82.5" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="76.9" x2="24.0" y2="72.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="76.9" x2="24.0" y2="72.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.4,73.5 100.6,82.5 107.9,81.8" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.4,108.6 88.2,120.5 88.9,111.2" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.9,101.1 124.4,107.9 122.0,98.5" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.9,111.2 88.2,120.5 101.1,121.4" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.2" y1="167.4" x2="122.2" y2="162.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.2" y1="167.4" x2="122.2" y2="162.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="79.7,99.0 77.4,108.6 88.9,111.2" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.1,112.0 101.1,121.4 114.0,120.2" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.1,91.3 122.0,98.5 118.7,89.0" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -954,62 +954,62 @@ expression: "export_svg(\"Graphics3D[Sphere[], ImageSize -> 200]\")"
 <polygon points="79.7,99.0 88.9,111.2 90.0,101.4" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.3,82.0 100.8,92.1 100.6,82.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="82.7,89.5 90.0,101.4 91.5,91.5" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="151.8" y1="67.7" x2="154.5" y2="64.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="151.8" y1="67.7" x2="154.5" y2="64.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="93.3,82.0 91.5,91.5 100.8,92.1" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="67.9" x2="26.7" y2="65.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="67.9" x2="26.7" y2="65.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.6,82.5 100.8,92.1 110.1,91.3" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.0,101.4 88.9,111.2 101.1,112.0" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="72.4" x2="24.0" y2="67.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="72.4" x2="24.0" y2="67.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.0,102.1 101.1,112.0 113.2,110.8" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.0,102.1 113.2,110.8 111.9,101.1" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.8,92.1 111.9,101.1 110.1,91.3" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.2" y1="162.9" x2="122.2" y2="158.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.2" y1="162.9" x2="122.2" y2="158.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.5,91.5 90.0,101.4 101.0,102.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.0,101.4 101.1,112.0 101.0,102.1" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,91.5 101.0,102.1 100.8,92.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.8,92.1 101.0,102.1 111.9,101.1" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.0" y1="67.9" x2="28.9" y2="69.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="149.1" y1="70.6" x2="151.8" y2="67.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="158.3" x2="122.2" y2="153.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="28.9" y1="69.4" x2="33.8" y2="71.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="33.8" y1="71.0" x2="38.7" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="153.8" x2="122.2" y2="149.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="146.4" y1="73.5" x2="149.1" y2="70.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="38.7" y1="72.6" x2="43.7" y2="74.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="149.3" x2="122.2" y2="144.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="143.7" y1="76.4" x2="146.4" y2="73.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.7" y1="74.2" x2="48.6" y2="75.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="48.6" y1="75.8" x2="53.5" y2="77.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="144.8" x2="122.2" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.0" y1="79.3" x2="143.7" y2="76.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="53.5" y1="77.4" x2="58.4" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="140.2" x2="122.2" y2="135.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="58.4" y1="78.9" x2="63.3" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.4" y1="82.2" x2="141.0" y2="79.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="63.3" y1="80.5" x2="68.2" y2="82.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="135.7" x2="122.2" y2="131.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="68.2" y1="82.1" x2="73.1" y2="83.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="135.7" y1="85.1" x2="138.4" y2="82.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="131.2" x2="122.2" y2="126.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.1" y1="83.7" x2="78.0" y2="85.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="78.0" y1="85.3" x2="82.9" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="126.7" x2="122.2" y2="122.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="133.0" y1="88.0" x2="135.7" y2="85.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="86.9" x2="87.9" y2="88.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="122.1" x2="122.2" y2="117.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.9" y1="88.4" x2="92.8" y2="90.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="90.9" x2="133.0" y2="88.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.8" y1="90.0" x2="97.7" y2="91.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="117.6" x2="122.2" y2="113.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.6" y1="93.7" x2="130.3" y2="90.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.7" y1="91.6" x2="102.6" y2="93.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="113.1" x2="122.2" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.6" y1="93.2" x2="107.5" y2="94.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="124.9" y1="96.6" x2="127.6" y2="93.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.5" y1="94.8" x2="112.4" y2="96.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="108.6" x2="122.2" y2="104.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.4" y1="96.4" x2="117.3" y2="97.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="99.5" x2="124.9" y2="96.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.2" y1="104.1" x2="122.2" y2="99.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.3" y1="97.9" x2="122.2" y2="99.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.0" y1="67.9" x2="28.9" y2="69.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="149.1" y1="70.6" x2="151.8" y2="67.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="158.3" x2="122.2" y2="153.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="28.9" y1="69.4" x2="33.8" y2="71.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="33.8" y1="71.0" x2="38.7" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="153.8" x2="122.2" y2="149.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="146.4" y1="73.5" x2="149.1" y2="70.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="38.7" y1="72.6" x2="43.7" y2="74.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="149.3" x2="122.2" y2="144.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="143.7" y1="76.4" x2="146.4" y2="73.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.7" y1="74.2" x2="48.6" y2="75.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="48.6" y1="75.8" x2="53.5" y2="77.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="144.8" x2="122.2" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.0" y1="79.3" x2="143.7" y2="76.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="53.5" y1="77.4" x2="58.4" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="140.2" x2="122.2" y2="135.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="58.4" y1="78.9" x2="63.3" y2="80.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.4" y1="82.2" x2="141.0" y2="79.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="63.3" y1="80.5" x2="68.2" y2="82.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="135.7" x2="122.2" y2="131.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="68.2" y1="82.1" x2="73.1" y2="83.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="135.7" y1="85.1" x2="138.4" y2="82.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="131.2" x2="122.2" y2="126.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.1" y1="83.7" x2="78.0" y2="85.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="78.0" y1="85.3" x2="82.9" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="126.7" x2="122.2" y2="122.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="133.0" y1="88.0" x2="135.7" y2="85.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="86.9" x2="87.9" y2="88.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="122.1" x2="122.2" y2="117.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.9" y1="88.4" x2="92.8" y2="90.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="90.9" x2="133.0" y2="88.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.8" y1="90.0" x2="97.7" y2="91.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="117.6" x2="122.2" y2="113.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.6" y1="93.7" x2="130.3" y2="90.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.7" y1="91.6" x2="102.6" y2="93.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="113.1" x2="122.2" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.6" y1="93.2" x2="107.5" y2="94.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="124.9" y1="96.6" x2="127.6" y2="93.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.5" y1="94.8" x2="112.4" y2="96.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="108.6" x2="122.2" y2="104.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.4" y1="96.4" x2="117.3" y2="97.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="99.5" x2="124.9" y2="96.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.2" y1="104.1" x2="122.2" y2="99.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.3" y1="97.9" x2="122.2" y2="99.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_line.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_line.snap
@@ -4,245 +4,252 @@ expression: "export_svg(\"Graphics3D[Line[{{0,0,0}, {1,1,1}}]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<polyline points="49.5,280.2 310.5,79.8" fill="none" stroke="#333" stroke-width="1.5"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="49.5" y1="280.2" x2="82.1" y2="255.1" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.1" y1="255.1" x2="114.8" y2="230.1" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="114.8" y1="230.1" x2="147.4" y2="205.0" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.4" y1="205.0" x2="180.0" y2="180.0" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="212.6" y2="155.0" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.6" y1="155.0" x2="245.2" y2="129.9" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="245.2" y1="129.9" x2="277.9" y2="104.9" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.9" y1="104.9" x2="310.5" y2="79.8" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_line_color.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_line_color.snap
@@ -4,245 +4,252 @@ expression: "export_svg(\"Graphics3D[{Red, Line[{{0,0,0}, {1,1,1}}]}]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<polyline points="49.5,280.2 310.5,79.8" fill="none" stroke="rgb(255,0,0)" stroke-width="1.5"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="49.5" y1="280.2" x2="82.1" y2="255.1" stroke="rgb(255,0,0)" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.1" y1="255.1" x2="114.8" y2="230.1" stroke="rgb(255,0,0)" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="114.8" y1="230.1" x2="147.4" y2="205.0" stroke="rgb(255,0,0)" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.4" y1="205.0" x2="180.0" y2="180.0" stroke="rgb(255,0,0)" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="212.6" y2="155.0" stroke="rgb(255,0,0)" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.6" y1="155.0" x2="245.2" y2="129.9" stroke="rgb(255,0,0)" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="245.2" y1="129.9" x2="277.9" y2="104.9" stroke="rgb(255,0,0)" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.9" y1="104.9" x2="310.5" y2="79.8" stroke="rgb(255,0,0)" stroke-width="1.5" stroke-linecap="round"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_multiple_primitives.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_multiple_primitives.snap
@@ -4,76 +4,76 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.3,239.1 101.1,246.1 101.0,238.5" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.0,238.5 101.1,246.1 94.1,246.7" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,231.1 101.0,238.5 92.7,239.3" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
@@ -89,7 +89,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="92.7,239.3 94.1,246.7 87.6,248.4" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.1,246.5 106.8,253.7 101.2,253.3" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,223.9 100.9,231.1 91.7,231.9" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.8,248.0 106.8,253.7 108.1,246.5" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.7,231.9 92.7,239.3 85.1,241.3" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.8,233.6 109.3,239.1 110.1,231.7" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
@@ -105,9 +105,9 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="106.8,253.7 101.4,260.1 101.2,253.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.7,231.9 85.1,241.3 83.3,234.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.2,253.3 97.6,260.5 95.7,253.9" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.1,224.8 91.7,231.9 83.3,234.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.0,254.9 105.2,260.4 106.8,253.7" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="123.8,243.7 114.8,248.0 117.1,240.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.8,226.7 110.1,231.7 110.6,224.6" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
@@ -130,11 +130,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="87.6,248.4 86.3,257.2 82.1,251.0" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.5,256.8 108.8,261.2 112.0,254.9" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.1,241.3 82.1,251.0 78.6,244.3" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="110.8,218.1 100.9,223.9 100.8,217.5" fill="rgb(75,103,145)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="126.3,236.9 123.8,243.7 117.1,240.8" fill="rgb(79,108,152)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.8,217.5 91.1,224.8 90.9,218.4" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.9,218.4 91.1,224.8 82.1,227.2" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.6,255.2 94.1,261.4 91.1,262.8" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
@@ -174,16 +174,16 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="82.1,227.2 76.0,237.5 74.4,230.8" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.1,241.1 123.8,243.7 126.3,236.9" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="76.0,237.5 78.6,244.3 73.7,248.3" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="111.9,262.5 106.9,267.4 105.3,266.7" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.3,264.3 106.9,267.4 111.9,262.5" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.7,220.7 82.1,227.2 74.4,230.8" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.6,212.4 100.8,217.5 100.9,211.8" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.6,244.3 77.9,254.4 73.7,248.3" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.1,212.7 90.9,218.4 81.7,220.7" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.1,262.8 95.1,268.4 88.8,264.6" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.3,223.7 119.8,226.7 120.2,220.2" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.1,241.1 129.0,247.6 123.8,243.7" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,211.8 90.9,218.4 91.1,212.7" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -213,7 +213,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="88.8,264.6 94.4,269.5 87.4,266.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.0,259.9 87.4,266.8 81.0,263.0" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.8,257.6 122.2,262.4 120.0,259.4" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.5,266.2 101.7,271.2 101.7,271.2" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,266.4 108.9,269.3 108.1,268.3" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.7,220.7 74.4,230.8 73.9,224.4" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
@@ -225,11 +225,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="105.3,266.7 101.7,271.2 101.7,271.2" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="73.7,248.3 77.9,254.4 75.3,258.3" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.8,266.8 101.7,271.2 101.7,271.2" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="108.9,269.3 101.7,271.2 108.1,268.3" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.9,267.4 101.7,271.2 101.7,271.2" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.3,267.5 101.7,271.2 101.7,271.2" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="95.1,268.4 101.7,271.2 94.4,269.5" fill="rgb(81,112,157)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,207.3 100.9,211.8 91.1,212.7" fill="rgb(57,78,110)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.9,254.4 81.0,263.0 75.3,258.3" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5"/>
@@ -264,7 +264,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="94.2,270.7 101.7,271.2 94.5,271.8" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.6,228.3 127.8,230.1 128.3,223.7" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="73.7,248.3 75.3,258.3 70.7,252.9" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="123.1,265.6 116.4,268.6 115.8,266.4" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.3,272.7 101.7,271.2 101.7,271.2" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.3,272.9 101.7,271.2 101.7,271.2" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -292,9 +292,9 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="82.1,215.1 73.9,224.4 74.4,218.7" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.3,272.9 101.7,271.2 96.5,273.8" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.9,261.7 123.1,265.6 122.2,262.4" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="87.0,269.0 94.5,271.8 87.6,271.2" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="105.6,274.3 101.7,271.2 107.1,273.6" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.5,273.8 101.7,271.2 98.1,274.4" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.6,271.2 94.5,271.8 95.3,272.9" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
@@ -325,23 +325,23 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="89.1,273.3 95.3,272.9 96.5,273.8" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.9,222.5 128.3,223.7 127.8,218.0" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.6,271.2 95.3,272.9 89.1,273.3" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="126.3,213.1 119.8,214.5 118.8,209.8" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.4,274.8 107.1,273.6 108.3,272.7" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.9,222.5 134.6,228.3 128.3,223.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="80.4,266.2 87.6,271.2 81.2,269.5" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="74.5,262.4 80.4,266.2 81.2,269.5" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.4,274.8 108.3,272.7 114.6,273.0" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,275.1 96.5,273.8 98.1,274.4" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="92.7,204.8 91.7,208.1 83.3,210.3" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.1,265.9 123.1,265.6 128.9,261.7" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.2,269.5 87.6,271.2 89.1,273.3" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="70.7,252.9 74.5,262.4 69.8,257.8" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.2,247.0 70.7,252.9 69.8,257.8" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.6,235.5 67.2,247.0 65.1,240.9" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="137.2,251.5 132.4,252.1 135.8,246.1" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.4,276.2 105.6,274.3 107.1,273.6" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.1,206.3 118.8,209.8 110.1,207.9" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
@@ -375,7 +375,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="94.6,276.4 99.9,274.9 98.2,277.2" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.8,261.8 128.9,261.7 133.7,256.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.1,217.3 127.8,218.0 126.3,213.1" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="67.2,247.0 69.8,257.8 66.2,252.5" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.1,217.3 133.9,222.5 127.8,218.0" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.1,240.9 67.2,247.0 66.2,252.5" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -383,14 +383,14 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="117.2,274.6 112.4,274.8 114.6,273.0" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.4,245.7 135.8,246.1 137.9,239.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="123.8,209.2 126.3,213.1 118.8,209.8" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="98.2,277.2 101.9,275.0 102.0,277.5" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.0,229.2 65.1,240.9 64.4,234.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.8,261.8 128.1,265.9 128.9,261.7" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.6,266.6 81.2,269.5 83.5,272.5" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.2,274.6 114.6,273.0 120.5,272.0" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="123.8,209.2 118.8,209.8 117.1,206.3" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="68.6,223.4 68.0,229.2 64.4,234.7" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.9,227.8 134.6,228.3 133.9,222.5" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.1,202.1 101.0,204.0 92.7,204.8" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
@@ -398,13 +398,13 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="108.1,202.6 109.3,204.5 101.0,204.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.6,269.8 122.5,268.9 128.1,265.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.6,269.8 120.5,272.0 122.5,268.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="87.0,275.0 91.5,275.1 94.6,276.4" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.9,227.8 138.6,233.7 134.6,228.3" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="83.5,272.5 91.5,275.1 87.0,275.0" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.8,276.7 109.4,276.2 112.4,274.8" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="69.8,257.8 75.6,266.6 71.0,262.6" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.1,202.8 92.7,204.8 85.1,206.7" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="310.5,142.0 243.0,58.1 243.0,120.2" fill="rgb(64,87,123)" stroke="#00000018" stroke-width="0.5"/>
@@ -422,7 +422,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="64.4,234.7 65.1,240.9 64.0,246.7" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.7,278.0 105.8,277.1 109.4,276.2" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="140.2,239.6 137.9,239.9 138.6,233.7" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="78.6,209.8 76.0,213.7 70.6,218.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.2,256.9 132.8,261.8 133.7,256.9" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,204.1 109.3,204.5 108.1,202.6" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -430,7 +430,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="87.0,275.0 94.6,276.4 91.5,277.0" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.7,278.2 98.2,277.2 102.0,277.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.6,223.4 64.4,234.7 65.1,228.8" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.2,278.5 102.0,277.5 105.8,277.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="71.0,262.6 75.6,266.6 78.5,270.4" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.0,213.0 132.1,217.3 126.3,213.1" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
@@ -450,29 +450,29 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="91.5,277.0 98.2,277.2 96.7,278.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.8,222.3 137.9,227.8 133.9,222.5" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="66.2,252.5 71.0,262.6 67.6,257.9" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.2,278.5 105.8,277.1 107.7,278.0" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.5,206.5 117.1,206.3 114.8,204.1" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.7,278.2 102.0,277.5 102.2,278.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="64.0,246.7 66.2,252.5 67.6,257.9" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.4,251.4 137.2,251.5 139.4,245.7" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.5,270.4 87.0,275.0 82.9,273.6" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="64.4,234.7 64.0,246.7 63.3,240.6" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.6,209.8 70.6,218.2 73.7,213.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="82.9,273.6 87.0,275.0 91.5,277.0" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="65.1,228.8 64.4,234.7 63.3,240.6" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.2,201.7 101.1,202.1 94.1,202.8" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.8,202.0 108.1,202.6 101.1,202.1" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.4,233.5 138.6,233.7 137.9,227.8" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="71.0,262.6 78.5,270.4 74.4,267.1" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="138.4,251.4 136.2,256.9 137.2,251.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,275.8 112.8,276.7 117.2,274.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="87.6,204.4 78.6,209.8 82.1,207.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="70.6,218.2 65.1,228.8 67.2,223.3" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.4,233.5 140.2,239.6 138.6,233.7" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.7,202.2 94.1,202.8 87.6,204.4" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
@@ -503,13 +503,13 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="95.3,277.6 96.7,278.2 102.2,278.5" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,278.1 102.2,278.5 107.7,278.0" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.6,203.5 87.6,204.4 82.1,207.1" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="65.1,228.8 63.3,240.6 64.0,234.5" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.5,205.2 120.5,206.5 114.8,204.1" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.7,202.2 87.6,204.4 90.6,203.5" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.3,277.4 112.8,276.7 115.8,275.8" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.2,223.3 65.1,228.8 64.0,234.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="137.2,227.7 137.9,227.8 135.8,222.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.1,245.5 138.4,251.4 139.4,245.7" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.6,257.9 74.4,267.1 71.4,262.9" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
@@ -518,14 +518,14 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="116.5,205.2 114.8,204.1 112.0,203.2" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="74.4,267.1 82.9,273.6 79.6,271.0" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.2,227.7 139.4,233.5 137.9,227.8" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="73.7,213.8 67.2,223.3 70.7,218.4" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,278.1 107.7,278.0 109.3,277.4" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="79.6,271.0 82.9,273.6 88.7,276.1" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.3,277.6 102.2,278.5 102.3,278.1" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="65.5,252.4 67.6,257.9 71.4,262.9" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.8,256.8 136.2,256.9 138.4,251.4" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.3,273.5 115.8,275.8 121.4,273.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="90.6,203.5 82.1,207.1 86.3,205.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
@@ -541,16 +541,16 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="127.8,213.6 132.4,217.5 129.0,213.0" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="64.0,234.5 63.3,240.6 64.8,246.5" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.0,207.7 124.9,209.8 120.5,206.5" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="138.4,239.3 140.2,239.6 139.4,233.5" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.6,203.1 95.7,202.2 90.6,203.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.4,266.4 129.8,266.4 132.9,262.0" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="127.4,266.4 124.8,270.4 129.8,266.4" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.8,203.8 112.0,203.2 106.8,202.0" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.2,223.3 64.0,234.5 66.2,228.7" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.0,207.7 120.5,206.5 116.5,205.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="70.7,218.4 67.2,223.3 66.2,228.7" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.7,222.4 135.8,222.3 132.4,217.5" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.4,239.3 139.1,245.5 140.2,239.6" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -574,10 +574,10 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="110.7,275.4 115.8,275.8 118.3,273.5" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.4,251.0 138.4,251.4 139.1,245.5" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.9,205.1 112.0,203.2 108.8,203.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="64.0,234.5 64.8,246.5 65.5,240.3" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.0,208.2 77.9,210.4 75.3,214.3" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="136.2,233.2 139.4,233.5 137.2,227.7" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="66.2,228.7 64.0,234.5 65.5,240.3" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.4,273.9 95.3,277.6 94.1,275.7" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -585,9 +585,9 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="77.2,267.1 79.6,271.0 86.4,273.9" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.2,210.7 127.8,213.6 124.9,209.8" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.2,210.7 124.9,209.8 120.0,207.7" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="70.7,218.4 66.2,228.7 69.8,223.3" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="69.5,257.7 71.4,262.9 77.2,267.1" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.1,205.4 86.3,205.6 83.0,208.2" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.1,204.0 86.3,205.6 91.1,205.4" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
@@ -597,7 +597,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="128.9,217.8 132.4,217.5 127.8,213.6" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.2,233.2 138.4,239.3 139.4,233.5" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.3,206.9 120.0,207.7 116.5,205.2" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.1,275.7 102.3,278.1 102.4,276.2" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.0,261.5 132.9,262.0 134.8,256.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.2,269.9 124.8,270.4 127.4,266.4" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
@@ -615,18 +615,18 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="91.1,205.4 83.0,208.2 88.8,207.2" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.2,267.1 86.4,273.9 84.7,270.3" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.8,227.3 137.2,227.7 133.7,222.4" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="66.2,228.7 65.5,240.3 67.6,234.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="84.7,270.3 86.4,273.9 94.1,275.7" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="69.8,223.3 66.2,228.7 67.6,234.1" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="75.3,214.3 69.8,223.3 74.5,218.5" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.8,207.2 83.0,208.2 81.0,211.3" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.8,205.8 94.1,204.0 91.1,205.4" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.7,272.1 110.7,275.4 118.3,273.5" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.9,206.4 111.9,205.1 108.8,203.8" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="69.5,257.7 77.2,267.1 75.7,262.2" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.8,244.7 135.4,251.0 139.1,245.5" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,209.0 122.2,210.7 120.0,207.7" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.5,205.3 101.4,202.7 101.5,205.2" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
@@ -642,13 +642,13 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="93.3,272.3 94.1,275.7 102.4,276.2" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.9,251.9 69.5,257.7 75.7,262.2" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.9,206.4 108.8,203.8 105.3,205.7" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.5,272.9 102.4,276.2 110.7,275.4" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.3,206.6 91.1,205.4 88.8,207.2" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="108.1,207.3 114.3,206.9 111.9,205.1" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.7,262.2 77.2,267.1 84.7,270.3" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.5,255.7 134.8,256.8 135.4,251.0" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="97.8,205.8 91.1,205.4 96.3,206.6" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.8,207.2 81.0,211.3 87.4,209.3" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="84.7,270.3 94.1,275.7 93.3,272.3" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
@@ -665,7 +665,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="67.6,234.1 65.5,240.3 69.5,245.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.0,211.3 74.5,218.5 80.4,214.6" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.5,272.9 110.7,275.4 111.7,272.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.1,221.9 132.8,227.3 133.7,222.4" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.4,209.3 81.0,211.3 80.4,214.6" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.4,211.2 122.2,210.7 115.8,209.0" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
@@ -675,8 +675,8 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="108.9,208.4 115.8,209.0 114.3,206.9" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.4,211.2 123.1,214.0 122.2,210.7" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.9,238.3 134.8,244.7 138.4,239.3" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="108.9,208.4 114.3,206.9 108.1,207.3" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 103.5,205.3 101.5,205.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 101.5,205.2 99.6,205.4" fill="rgb(76,104,145)" stroke="#00000018" stroke-width="0.5"/>
@@ -704,7 +704,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="109.2,209.5 115.8,209.0 108.9,208.4" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.2,209.5 116.4,211.2 115.8,209.0" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="67.6,234.1 69.5,245.6 71.4,239.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.7,209.0 101.5,205.2 101.7,209.0" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 103.5,205.3 101.7,209.0" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 99.6,205.4 101.7,209.0" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -719,8 +719,8 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="129.8,231.9 132.9,238.3 136.2,233.2" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 106.9,206.4 101.7,209.0" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 96.3,206.6 101.7,209.0" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="87.0,211.6 80.4,214.6 81.2,217.8" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.4,208.6 87.0,211.6 94.2,209.7" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 108.1,207.3 101.7,209.0" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -734,9 +734,9 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="101.7,209.0 109.2,209.5 108.9,208.4" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 94.4,208.6 94.2,209.7" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 108.9,208.4 101.7,209.0" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.7,209.0 94.4,208.6 101.7,209.0" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.0,210.7 116.4,211.2 109.2,209.5" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.6,225.8 132.8,227.3 128.1,221.9" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.6,265.6 93.3,272.3 92.8,267.7" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
@@ -784,12 +784,12 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="108.3,211.7 114.6,215.6 116.0,213.4" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.6,222.6 74.4,232.6 78.5,226.5" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.6,213.8 81.2,217.8 83.5,220.8" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="75.7,250.1 75.2,256.5 83.3,260.0" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.5,261.8 112.3,267.5 121.3,265.1" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.5,210.9 89.1,215.9 95.3,211.9" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 105.6,213.4 107.1,212.7" fill="rgb(83,114,159)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.6,215.6 120.5,220.3 122.5,217.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 96.5,212.8 98.1,213.5" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.3,253.0 129.5,255.7 129.0,249.4" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
@@ -797,7 +797,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="112.5,261.8 121.3,265.1 121.7,259.5" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.7,209.0 103.8,213.9 105.6,213.4" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.1,212.7 114.6,215.6 108.3,211.7" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="101.7,209.0 98.1,213.5 99.9,213.9" fill="rgb(83,114,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.3,253.0 121.7,259.5 129.5,255.7" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="81.2,217.8 78.5,226.5 83.5,220.8" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
@@ -814,13 +814,13 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="107.1,212.7 112.4,217.4 114.6,215.6" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.3,260.0 92.8,267.7 92.6,262.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.4,229.2 129.8,231.9 125.6,225.8" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.4,217.4 120.5,220.3 114.6,215.6" fill="rgb(88,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.6,213.4 112.4,217.4 107.1,212.7" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="117.2,223.0 125.6,225.8 120.5,220.3" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="78.5,226.5 74.4,232.6 79.6,236.5" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="75.7,250.1 83.3,260.0 83.6,253.5" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.5,212.8 94.6,219.0 98.1,213.5" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.6,262.7 112.3,267.5 112.5,261.8" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -838,14 +838,14 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="273.6,181.7 310.5,79.8 310.5,142.0" fill="rgb(57,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.1,215.9 87.0,223.4 91.5,217.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="98.1,213.5 98.2,219.8 99.9,213.9" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="117.2,223.0 121.4,229.2 125.6,225.8" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.6,253.5 83.3,260.0 92.6,262.1" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.9,214.0 105.8,219.7 103.8,213.9" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.2,246.1 121.3,253.0 129.0,249.4" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.9,213.9 102.0,220.1 101.9,214.0" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.3,255.4 112.5,261.8 121.7,259.5" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="78.5,226.5 79.6,236.5 82.9,229.7" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.3,255.4 121.7,259.5 121.3,253.0" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.4,218.8 117.2,223.0 112.4,217.4" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
@@ -871,7 +871,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="102.6,256.2 112.5,261.8 112.3,255.4" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="82.9,229.7 79.6,236.5 86.4,239.4" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.0,223.4 82.9,229.7 88.7,232.2" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="84.7,246.6 83.6,253.5 92.8,255.6" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.6,219.0 96.7,226.5 98.2,219.8" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.8,225.0 115.8,231.8 121.4,229.2" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
@@ -882,14 +882,14 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="79.6,236.5 84.7,246.6 86.4,239.4" fill="rgb(79,108,152)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.0,220.1 107.7,226.3 105.8,219.7" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.0,223.4 88.7,232.2 91.5,225.3" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.6,219.0 91.5,225.3 96.7,226.5" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.8,219.7 107.7,226.3 112.8,225.0" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="98.2,219.8 102.2,226.8 102.0,220.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="82.9,229.7 86.4,239.4 88.7,232.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="107.7,226.3 115.8,231.8 112.8,225.0" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="98.2,219.8 96.7,226.5 102.2,226.8" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.0,220.1 102.2,226.8 107.7,226.3" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
@@ -898,7 +898,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="93.3,248.5 92.8,255.6 102.6,256.2" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.4,239.4 84.7,246.6 93.3,248.5" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.5,249.1 102.6,256.2 112.3,255.4" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.3,233.5 118.3,238.9 115.8,231.8" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,225.3 88.7,232.2 95.3,233.7" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.7,240.9 111.7,248.3 120.2,246.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
@@ -918,110 +918,110 @@ expression: "export_svg(\"Graphics3D[{Sphere[{0,0,0}, 0.5], Cuboid[{1,1,1}, {2,2
 <polygon points="102.4,241.7 102.5,249.1 111.7,248.3" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.4,241.7 111.7,248.3 110.7,240.9" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,234.1 110.7,240.9 109.3,233.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="95.3,233.7 94.1,241.1 102.4,241.7" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.1,241.1 102.5,249.1 102.4,241.7" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="95.3,233.7 102.4,241.7 102.3,234.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,234.1 102.4,241.7 110.7,240.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.1,97.8 243.0,58.1 310.5,79.8" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.1,160.0 273.6,119.6 273.6,181.7" fill="rgb(64,87,123)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.1,160.0 206.1,97.8 273.6,119.6" fill="rgb(64,87,123)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.6,181.7 273.6,119.6 310.5,79.8" fill="rgb(57,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.1,97.8 310.5,79.8 273.6,119.6" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_opacity.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_opacity.snap
@@ -4,63 +4,63 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.9,177.4 178.5,194.9 178.2,176.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="178.2,176.1 178.5,194.9 160.9,196.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="178.0,157.4 178.2,176.1 157.6,178.0" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="198.9,177.4 196.1,196.0 178.5,194.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,176.1 160.9,196.5 157.6,178.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="201.0,158.9 198.9,177.4 178.2,176.1" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="201.0,158.9 178.2,176.1 178.0,157.4" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.1,196.0 178.8,213.1 178.5,194.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.0,157.4 157.6,178.0 155.1,159.5" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,194.9 165.0,214.4 160.9,196.5" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="218.4,181.8 196.1,196.0 198.9,177.4" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="178.5,194.9 178.8,213.1 165.0,214.4" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -76,21 +76,21 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="222.6,163.8 218.4,181.8 198.9,177.4" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="202.3,141.2 178.0,157.4 177.9,139.6" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="160.9,196.5 165.0,214.4 152.2,217.7" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,196.5 152.2,217.7 144.7,200.7" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="212.6,199.8 205.6,217.0 192.6,214.0" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="177.9,139.6 155.1,159.5 153.5,141.8" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="192.6,214.0 179.2,230.1 178.8,213.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,159.5 138.5,182.9 133.9,165.0" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="178.8,213.1 169.7,231.0 165.0,214.4" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="153.5,141.8 155.1,159.5 133.9,165.0" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="205.6,217.0 188.7,230.7 192.6,214.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="235.2,189.1 212.6,199.8 218.4,181.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="225.3,146.4 201.0,158.9 202.3,141.2" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="225.3,146.4 222.6,163.8 201.0,158.9" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.8,213.1 179.2,230.1 169.7,231.0" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="227.0,206.0 205.6,217.0 212.6,199.8" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="192.6,214.0 188.7,230.7 179.2,230.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -103,11 +103,11 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="241.4,171.9 218.4,181.8 222.6,163.8" fill="rgb(79,108,152)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="235.2,189.1 227.0,206.0 212.6,199.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="133.9,165.0 138.5,182.9 122.2,190.6" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,217.0 197.7,232.8 188.7,230.7" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="153.5,141.8 133.9,165.0 131.0,147.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="227.0,206.0 216.9,221.8 205.6,217.0" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,200.7 141.4,222.8 130.9,207.3" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="216.9,221.8 197.7,232.8 205.6,217.0" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="138.5,182.9 130.9,207.3 122.2,190.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -119,8 +119,8 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="188.7,230.7 179.6,245.1 179.2,230.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="152.2,217.7 153.4,236.8 141.4,222.8" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="179.2,230.1 174.7,245.6 169.7,231.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="226.2,130.3 225.3,146.4 202.3,141.2" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="216.9,221.8 205.4,236.1 197.7,232.8" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="131.0,147.7 133.9,165.0 115.8,173.6" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -130,9 +130,9 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="245.1,155.0 222.6,163.8 225.3,146.4" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="169.7,231.0 170.3,246.7 160.9,233.2" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="238.1,214.1 216.9,221.8 227.0,206.0" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="245.1,155.0 241.4,171.9 222.6,163.8" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.3,198.7 227.0,206.0 235.2,189.1" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="179.2,230.1 179.6,245.1 174.7,245.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="130.9,207.3 141.4,222.8 133.2,229.5" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -155,16 +155,16 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="225.6,228.2 211.4,240.5 205.4,236.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="131.0,147.7 115.8,173.6 111.8,156.8" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="255.9,182.5 235.2,189.1 241.4,171.9" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,173.6 122.2,190.6 109.9,200.5" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="205.4,236.1 193.0,248.2 189.0,246.5" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,240.5 193.0,248.2 205.4,236.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="130.0,131.6 131.0,147.7 111.8,156.8" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="202.3,110.9 177.8,123.4 177.9,109.3" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="122.2,190.6 120.4,215.7 109.9,200.5" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.5,111.5 153.0,125.6 130.0,131.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="153.4,236.8 163.5,250.9 147.7,241.4" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="246.4,139.1 225.3,146.4 226.2,130.3" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -189,13 +189,13 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="111.8,156.8 115.8,173.6 102.1,184.6" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="260.6,166.3 241.4,171.9 245.1,155.0" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="115.8,173.6 109.9,200.5 102.1,184.6" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,241.4 163.5,250.9 161.8,253.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="231.3,235.7 215.3,245.7 211.4,240.5" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.0,250.4 180.0,257.7 193.0,248.2" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="166.4,248.5 180.0,257.7 163.5,250.9" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="147.7,241.4 161.8,253.6 144.3,246.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="133.2,229.5 144.3,246.6 128.1,237.1" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -228,7 +228,7 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="161.8,253.6 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="198.7,255.9 180.0,257.7 198.0,253.1" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="161.8,253.6 180.0,257.7 161.3,256.4" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.7,255.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="216.8,251.3 198.7,255.9 198.0,253.1" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -237,16 +237,16 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="245.1,124.7 226.2,130.3 225.3,116.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="233.4,243.9 215.3,245.7 231.3,235.7" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="111.8,156.8 102.1,184.6 97.3,168.5" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,246.6 161.3,256.4 143.2,252.3" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="265.2,195.0 248.3,198.7 255.9,182.5" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="102.1,184.6 109.9,200.5 102.3,212.0" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="110.5,140.9 111.8,156.8 97.3,168.5" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="162.0,259.3 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 198.7,255.9" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 153.5,111.5 131.0,117.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="201.0,99.4 177.9,109.3 178.0,98.0" fill="rgb(56,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 162.0,259.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -269,7 +269,7 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="162.0,259.3 180.0,257.7 164.0,261.9" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="128.1,237.1 143.2,252.3 126.6,245.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="185.3,266.8 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="215.7,256.9 198.7,255.9 216.8,251.3" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="175.6,266.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -277,22 +277,22 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="215.7,256.9 198.2,258.8 198.7,255.9" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="222.6,104.4 202.3,110.9 201.0,99.4" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="193.6,263.8 180.0,257.7 196.5,261.5" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="131.0,117.4 110.5,140.9 111.8,126.5" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="164.0,261.9 180.0,257.7 167.0,264.2" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="248.0,234.0 233.4,243.9 231.3,235.7" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.2,252.3 162.0,259.3 144.7,257.8" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="189.7,265.6 180.0,257.7 193.6,263.8" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="167.0,264.2 180.0,257.7 171.0,265.9" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="144.7,257.8 162.0,259.3 164.0,261.9" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="97.3,168.5 102.1,184.6 93.7,197.3" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="270.5,179.6 255.9,182.5 260.6,166.3" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="126.6,245.3 143.2,252.3 144.7,257.8" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="102.1,184.6 102.3,212.0 93.7,197.3" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 131.0,117.4 133.9,105.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="185.3,266.8 180.0,257.7 189.7,265.6" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 175.6,266.9" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -310,24 +310,24 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="270.5,179.6 265.2,195.0 255.9,182.5" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="111.8,126.5 110.5,140.9 95.7,152.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="178.2,89.8 178.0,98.0 155.1,100.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 245.1,124.7 225.3,116.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="259.9,222.1 248.0,234.0 245.2,223.7" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="198.9,91.1 201.0,99.4 178.0,98.0" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="148.6,263.0 164.0,261.9 167.0,264.2" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="260.6,136.0 246.4,139.1 245.1,124.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="144.7,257.8 164.0,261.9 148.6,263.0" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 225.3,116.1 222.6,104.4" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="206.6,266.7 193.6,263.8 196.5,261.5" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="260.6,136.0 262.1,150.6 246.4,139.1" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="126.6,245.3 144.7,257.8 128.7,253.4" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.0,235.8 126.6,245.3 128.7,253.4" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.6,266.7 196.5,261.5 212.3,262.2" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.6,267.4 167.0,264.2 171.0,265.9" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="157.6,91.7 155.1,100.1 133.9,105.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="246.0,244.4 233.4,243.9 248.0,234.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -343,7 +343,7 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="272.3,164.1 260.6,166.3 262.1,150.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="148.6,263.0 167.0,264.2 154.6,267.4" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="246.0,244.4 231.9,252.0 233.4,243.9" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,89.8 155.1,100.1 157.6,91.7" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="226.8,259.7 212.3,262.2 215.7,256.9" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="162.3,270.8 171.0,265.9 175.6,266.9" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -351,9 +351,9 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="226.8,259.7 215.7,256.9 231.9,252.0" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="190.3,272.6 185.3,266.8 189.7,265.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="268.8,208.5 259.9,222.1 256.7,209.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="272.3,164.1 270.5,179.6 260.6,166.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="171.3,272.8 175.6,266.9 180.4,267.2" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="218.4,95.5 201.0,99.4 198.9,91.1" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="111.8,126.5 95.7,152.8 97.3,138.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -361,15 +361,15 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="199.1,270.3 193.6,263.8 206.6,266.7" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="154.6,267.4 171.0,265.9 162.3,270.8" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="112.0,235.8 128.7,253.4 114.8,246.2" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.7,253.4 148.6,263.0 134.4,260.9" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 111.8,126.5 97.3,138.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="157.6,91.7 133.9,105.6 138.5,96.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="100.1,224.2 112.0,235.8 114.8,246.2" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,272.6 189.7,265.6 199.1,270.3" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.4,260.9 148.6,263.0 154.6,267.4" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="138.5,96.6 133.9,105.6 115.8,114.1" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="162.3,270.8 175.6,266.9 171.3,272.8" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -386,29 +386,29 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="95.7,152.8 88.4,182.0 86.6,166.6" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="257.7,234.3 246.0,244.4 248.0,234.0" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="114.8,246.2 128.7,253.4 134.4,260.9" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,266.3 212.3,262.2 226.8,259.7" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="235.2,102.8 222.6,104.4 218.4,95.5" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="97.3,138.2 95.7,152.8 86.6,166.6" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="270.5,149.3 262.1,150.6 260.6,136.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,85.0 178.2,89.8 157.6,91.7" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="274.3,193.9 268.8,208.5 265.2,195.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="196.1,86.2 198.9,91.1 178.2,89.8" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="239.6,254.2 231.9,252.0 246.0,244.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="239.6,254.2 226.8,259.7 231.9,252.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.1,267.3 154.6,267.4 162.3,270.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="270.5,149.3 272.3,164.1 262.1,150.6" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="134.4,260.9 154.6,267.4 143.1,267.3" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="207.8,271.5 199.1,270.3 206.6,266.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.1,224.2 114.8,246.2 103.3,236.4" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="160.9,86.6 157.6,91.7 138.5,96.6" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 97.3,138.2 102.1,125.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="138.5,96.6 115.8,114.1 122.2,104.3" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="212.6,89.9 218.4,95.5 198.9,91.1" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -416,22 +416,22 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="196.1,86.2 178.2,89.8 178.5,85.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="266.3,222.1 259.9,222.1 268.8,208.5" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="114.8,246.2 134.4,260.9 121.9,255.7" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="207.8,271.5 206.6,266.7 218.6,266.3" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="154.4,272.2 162.3,270.8 171.3,272.8" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="88.4,182.0 91.2,210.9 85.7,196.4" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="178.5,85.0 157.6,91.7 160.9,86.6" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.6,166.6 88.4,182.0 85.7,196.4" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="195.0,274.8 190.3,272.6 199.1,270.3" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="276.1,178.7 270.5,179.6 272.3,164.1" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="122.2,104.3 115.8,114.1 102.1,125.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="266.3,222.1 257.7,234.3 259.9,222.1" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="212.6,89.9 198.9,91.1 196.1,86.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,255.7 134.4,260.9 143.1,267.3" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="143.1,267.3 162.3,270.8 154.4,272.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="167.4,275.2 171.3,272.8 180.8,273.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -443,29 +443,29 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="276.1,178.7 274.3,193.9 270.5,179.6" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="229.1,262.6 218.6,266.3 226.8,259.7" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="102.1,125.2 97.3,138.2 88.4,151.7" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 138.5,96.6 122.2,104.3" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="250.1,245.8 246.0,244.4 257.7,234.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="160.9,86.6 138.5,96.6 144.7,90.9" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="195.0,274.8 199.1,270.3 207.8,271.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="265.2,135.6 260.6,136.0 255.9,123.1" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="229.1,262.6 226.8,259.7 239.6,254.2" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="250.1,245.8 239.6,254.2 246.0,244.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="227.0,96.1 235.2,102.8 218.4,95.5" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.4,272.2 171.3,272.8 167.4,275.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="265.2,135.6 270.5,149.3 260.6,136.0" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,210.9 103.3,236.4 94.8,224.4" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="181.2,276.0 190.3,272.6 195.0,274.8" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="227.0,96.1 218.4,95.5 212.6,89.9" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,275.2 180.8,273.4 181.2,276.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="85.7,196.4 91.2,210.9 94.8,224.4" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="271.6,208.3 268.8,208.5 274.3,193.9" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="121.9,255.7 143.1,267.3 133.0,263.9" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="86.6,166.6 85.7,196.4 83.9,181.3" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -478,13 +478,13 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="103.3,236.4 121.9,255.7 111.7,247.6" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="271.6,208.3 266.3,222.1 268.8,208.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="215.3,269.1 207.8,271.5 218.6,266.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 122.2,104.3 130.9,97.4" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.1,125.2 88.4,151.7 93.7,137.9" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="274.3,163.6 276.1,178.7 272.3,164.1" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="165.0,85.2 160.9,86.6 144.7,90.9" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="94.8,224.4 103.3,236.4 111.7,247.6" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -494,12 +494,12 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="111.7,247.6 121.9,255.7 133.0,263.9" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="257.9,234.8 257.7,234.3 266.3,222.1" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="109.9,114.2 102.1,125.2 93.7,137.9" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.4,270.1 154.4,272.2 167.4,275.2" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="238.1,104.3 248.3,112.4 235.2,102.8" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="192.6,84.8 178.5,85.0 178.8,84.0" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="256.7,123.6 255.9,123.1 248.3,112.4" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="257.9,234.8 250.1,245.8 257.7,234.3" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="238.1,104.3 235.2,102.8 227.0,96.1" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -507,38 +507,38 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="178.8,84.0 160.9,86.6 165.0,85.2" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="237.8,255.7 229.1,262.6 239.6,254.2" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="133.0,263.9 154.4,272.2 147.4,270.1" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="237.8,255.7 239.6,254.2 250.1,245.8" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="256.7,123.6 265.2,135.6 255.9,123.1" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="85.7,196.4 94.8,224.4 89.5,210.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,87.8 196.1,86.2 192.6,84.8" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="83.9,181.3 85.7,196.4 89.5,210.7" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="273.4,193.4 274.3,193.9 276.1,178.7" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="163.9,273.8 167.4,275.2 181.2,276.0" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.5,275.0 181.2,276.0 195.0,274.8" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="152.2,88.5 144.7,90.9 130.9,97.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="88.4,151.7 83.9,181.3 85.7,166.1" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.9,92.7 227.0,96.1 212.6,89.9" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="165.0,85.2 144.7,90.9 152.2,88.5" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="199.1,273.4 207.8,271.5 215.3,269.1" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="93.7,137.9 88.4,151.7 85.7,166.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="268.8,149.1 270.5,149.3 265.2,135.6" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="273.4,193.4 271.6,208.3 274.3,193.9" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.8,224.4 111.7,247.6 104.1,236.9" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="130.9,97.4 109.9,114.2 120.4,105.8" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="147.4,270.1 167.4,275.2 163.9,273.8" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="216.9,92.7 212.6,89.9 205.6,87.8" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="111.7,247.6 133.0,263.9 124.8,257.2" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="268.8,149.1 274.3,163.6 270.5,149.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.9,114.2 93.7,137.9 102.3,125.7" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="181.5,275.0 195.0,274.8 199.1,273.4" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="124.8,257.2 133.0,263.9 147.4,270.1" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -547,10 +547,10 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="262.7,221.8 266.3,222.1 271.6,208.3" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="221.5,263.4 215.3,269.1 229.1,262.6" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="152.2,88.5 130.9,97.4 141.4,93.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 109.9,114.2 102.3,125.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.2,86.6 178.8,84.0 165.0,85.2" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="188.7,87.2 192.6,84.8 178.8,84.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="104.1,236.9 111.7,247.6 124.8,257.2" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -561,19 +561,19 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="221.5,263.4 229.1,262.6 237.8,255.7" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="245.2,113.8 256.7,123.6 248.3,112.4" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="85.7,166.1 83.9,181.3 87.7,195.9" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="225.6,99.1 238.1,104.3 227.0,96.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="271.6,178.0 276.1,178.7 274.3,163.6" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="169.7,87.4 165.0,85.2 152.2,88.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="244.2,245.9 250.1,245.8 257.9,234.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="244.2,245.9 237.8,255.7 250.1,245.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="197.7,89.2 205.6,87.8 192.6,84.8" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="93.7,137.9 85.7,166.1 91.2,151.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="225.6,99.1 227.0,96.1 216.9,92.7" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.3,125.7 93.7,137.9 91.2,151.5" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="259.9,135.8 265.2,135.6 256.7,123.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="271.6,178.0 273.4,193.4 276.1,178.7" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -583,19 +583,19 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="202.4,268.3 199.1,273.4 215.3,269.1" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="259.9,135.8 268.8,149.1 265.2,135.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="179.2,86.6 165.0,85.2 169.7,87.4" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 152.2,88.5 141.4,93.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="89.5,210.7 104.1,236.9 99.4,224.0" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="197.7,89.2 192.6,84.8 188.7,87.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.4,92.6 216.9,92.7 205.6,87.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 102.3,125.7 114.0,115.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.4,93.7 120.4,105.8 133.2,100.3" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="161.1,268.9 163.9,273.8 181.5,275.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,270.2 181.5,275.0 199.1,273.4" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="87.7,195.9 89.5,210.7 99.4,224.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="169.7,87.4 152.2,88.5 160.9,89.7" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -603,23 +603,23 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="202.4,268.3 215.3,269.1 221.5,263.4" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="264.3,207.2 271.6,208.3 273.4,193.4" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="205.4,92.6 205.6,87.8 197.7,89.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="85.7,166.1 87.7,195.9 89.5,180.4" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="133.2,100.3 120.4,105.8 114.0,115.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="266.3,162.7 274.3,163.6 268.8,149.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="91.2,151.5 85.7,166.1 89.5,180.4" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,264.5 163.9,273.8 161.1,268.9" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="264.3,207.2 262.7,221.8 271.6,208.3" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="118.6,247.6 124.8,257.2 141.6,264.5" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="231.3,106.6 245.2,113.8 238.1,104.3" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="231.3,106.6 238.1,104.3 225.6,99.1" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="102.3,125.7 91.2,151.5 100.1,137.9" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.4,224.0 104.1,236.9 118.6,247.6" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.4,93.3 141.4,93.7 133.2,100.3" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 141.4,93.7 153.4,93.3" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="114.0,115.6 102.3,125.7 100.1,137.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="181.8,270.2 199.1,273.4 202.4,268.3" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -627,14 +627,14 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="248.0,124.2 256.7,123.6 245.2,113.8" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="266.3,162.7 271.6,178.0 274.3,163.6" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="211.4,97.0 225.6,99.1 216.9,92.7" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="161.1,268.9 181.5,275.0 181.8,270.2" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="248.2,233.5 257.9,234.8 262.7,221.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="226.1,254.4 237.8,255.7 244.2,245.9" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.0,124.2 259.9,135.8 256.7,123.6" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="248.2,233.5 244.2,245.9 257.9,234.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,97.0 216.9,92.7 205.4,92.6" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="179.6,92.8 179.2,86.6 169.7,87.4" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="184.4,93.1 188.7,87.2 179.2,86.6" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -642,15 +642,15 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="87.7,195.9 99.4,224.0 97.9,209.4" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="174.7,93.2 169.7,87.4 160.9,89.7" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="189.0,94.1 197.7,89.2 188.7,87.2" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="89.5,180.4 87.7,195.9 97.9,209.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="262.7,191.5 273.4,193.4 271.6,178.0" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="153.4,93.3 133.2,100.3 147.7,97.8" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="118.6,247.6 141.6,264.5 137.4,255.6" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="257.7,148.0 268.8,149.1 259.9,135.8" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,151.5 89.5,180.4 94.8,165.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="137.4,255.6 141.6,264.5 161.1,268.9" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="100.1,137.9 91.2,151.5 94.8,165.0" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -663,18 +663,18 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="262.7,191.5 264.3,207.2 273.4,193.4" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="215.3,102.2 231.3,106.6 225.6,99.1" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="184.4,93.1 179.2,86.6 179.6,92.8" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.6,92.8 169.7,87.4 174.7,93.2" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="128.1,108.0 114.0,115.6 112.0,126.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="257.7,148.0 266.3,162.7 268.8,149.1" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="215.3,102.2 225.6,99.1 211.4,97.0" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="233.4,114.7 245.2,113.8 231.3,106.6" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="189.0,94.1 188.7,87.2 184.4,93.1" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="233.4,114.7 248.0,124.2 245.2,113.8" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="174.7,93.2 160.9,89.7 170.3,94.4" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="204.9,259.9 221.5,263.4 226.1,254.4" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="159.0,260.6 161.1,268.9 181.8,270.2" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="97.9,209.4 99.4,224.0 114.9,235.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="193.0,95.8 197.7,89.2 189.0,94.1" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -683,10 +683,10 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="196.0,98.1 211.4,97.0 205.4,92.6" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="114.9,235.3 118.6,247.6 137.4,255.6" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="249.5,219.1 262.7,221.8 264.3,207.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="170.3,94.4 153.4,93.3 166.4,96.2" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,97.8 128.1,108.0 144.3,103.1" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="137.4,255.6 161.1,268.9 159.0,260.6" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="249.5,219.1 248.2,233.5 262.7,221.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -700,12 +700,12 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="100.1,137.9 94.8,165.0 103.3,150.1" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="94.8,165.0 89.5,180.4 99.4,193.7" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="128.1,108.0 112.0,126.0 126.6,116.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.0,262.0 202.4,268.3 204.9,259.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="246.0,134.6 257.7,148.0 259.9,135.8" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,103.1 128.1,108.0 126.6,116.1" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.8,107.7 231.3,106.6 215.3,102.2" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="159.0,260.6 181.8,270.2 182.0,262.0" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="166.4,96.2 147.7,97.8 163.5,98.5" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -720,10 +720,10 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="180.0,102.3 174.7,93.2 170.3,94.4" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="97.9,209.4 114.9,235.3 113.6,220.9" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="114.9,235.3 137.4,255.6 134.7,243.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="231.9,122.9 248.0,124.2 233.4,114.7" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 193.0,95.8 189.0,94.1" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 170.3,94.4 166.4,96.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="126.6,116.1 112.0,126.0 114.8,136.3" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -733,12 +733,12 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="112.0,126.0 103.3,150.1 114.8,136.3" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="99.4,193.7 97.9,209.4 113.6,220.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="250.1,159.5 266.3,162.7 257.7,148.0" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.2,203.2 264.3,207.2 262.7,191.5" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 196.0,98.1 193.0,95.8" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="206.5,248.5 204.9,259.9 226.1,254.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="231.9,122.9 246.0,134.6 248.0,124.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 166.4,96.2 163.5,98.5" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="161.8,101.2 144.3,103.1 143.2,108.7" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="103.3,150.1 94.8,165.0 104.1,177.5" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -749,7 +749,7 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="180.0,102.3 184.4,93.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 174.7,93.2 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="248.2,203.2 249.5,219.1 264.3,207.2" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 189.0,94.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 196.0,98.1" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="206.5,248.5 226.1,254.4 229.0,242.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -771,21 +771,21 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="126.6,116.1 114.8,136.3 128.7,124.3" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="215.7,113.4 231.9,122.9 233.4,114.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 198.7,103.6 198.0,100.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 161.3,104.1" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="198.2,106.4 216.8,107.7 198.7,103.6" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="239.6,144.3 257.7,148.0 246.0,134.6" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="134.7,243.9 159.0,260.6 157.7,249.1" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.7,103.6 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="161.3,104.1 143.2,108.7 144.7,114.3" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="114.8,136.3 103.3,150.1 111.7,161.3" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="198.2,106.4 215.7,113.4 216.8,107.7" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.2,106.4 198.7,103.6" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 162.0,106.9" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 198.2,106.4 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -817,15 +817,15 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="180.0,102.3 175.6,114.6 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 180.4,114.9 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.0,102.3 193.6,111.5 196.5,109.1" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 164.0,109.6 167.0,111.8" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="133.8,229.7 134.7,243.9 157.7,249.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="226.8,130.5 239.6,144.3 246.0,134.6" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="162.0,106.9 144.7,114.3 148.6,119.5" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="196.5,109.1 212.3,118.6 215.7,113.4" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.8,136.3 111.7,161.3 121.9,145.9" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="144.7,114.3 128.7,124.3 134.4,131.8" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="114.9,205.0 113.6,220.9 133.8,229.7" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -850,7 +850,7 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="237.8,169.4 244.2,186.4 257.9,175.4" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="157.2,235.0 157.7,249.1 182.1,250.7" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="164.0,109.6 154.6,123.9 167.0,111.8" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.2,236.6 182.1,250.7 206.5,248.5" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="164.0,109.6 148.6,119.5 154.6,123.9" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="193.6,111.5 206.6,123.2 212.3,118.6" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -858,9 +858,9 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="229.1,152.7 250.1,159.5 239.6,144.3" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="206.6,123.2 226.8,130.5 212.3,118.6" fill="rgb(88,120,168)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="189.7,113.3 206.6,123.2 193.6,111.5" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,137.2 239.6,144.3 226.8,130.5" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="121.9,145.9 111.7,161.3 124.8,170.9" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="114.9,205.0 133.8,229.7 134.7,213.6" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -884,17 +884,17 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="180.4,114.9 190.3,129.0 185.3,114.4" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="226.1,195.0 229.0,212.3 248.2,203.2" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="175.6,114.6 180.8,129.9 180.4,114.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.5,218.2 207.0,234.4 230.0,228.4" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,145.9 124.8,170.9 133.0,154.0" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="206.5,218.2 230.0,228.4 229.0,212.3" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="199.1,126.8 218.6,137.2 206.6,123.2" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="134.4,131.8 133.0,154.0 143.1,138.2" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="171.0,113.5 162.3,127.2 171.3,129.3" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="185.3,114.4 190.3,129.0 199.1,126.8" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="175.6,114.6 171.3,129.3 180.8,129.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="180.4,114.9 180.8,129.9 190.3,129.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="221.5,177.1 244.2,186.4 237.8,169.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -909,9 +909,9 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="182.1,220.4 182.2,236.6 207.0,234.4" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="221.5,177.1 226.1,195.0 244.2,186.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="215.3,159.3 237.8,169.4 229.1,152.7" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,129.0 207.8,142.3 199.1,126.8" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.1,220.4 207.0,234.4 206.5,218.2" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="133.0,154.0 124.8,170.9 141.6,178.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="143.1,138.2 133.0,154.0 147.4,160.2" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -928,17 +928,17 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="162.3,127.2 154.4,143.0 167.4,146.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="190.3,129.0 195.0,145.6 207.8,142.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="171.3,129.3 181.2,146.9 180.8,129.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="133.0,154.0 141.6,178.2 147.4,160.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="195.0,145.6 215.3,159.3 207.8,142.3" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="171.3,129.3 167.4,146.0 181.2,146.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.8,129.9 181.2,146.9 195.0,145.6" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="137.4,196.2 157.7,218.8 159.0,201.1" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="202.4,182.0 226.1,195.0 221.5,177.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="159.0,201.1 157.7,218.8 182.1,220.4" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,178.2 137.4,196.2 159.0,201.1" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="182.0,202.6 182.1,220.4 206.5,218.2" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="199.1,163.5 221.5,177.1 215.3,159.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
@@ -954,62 +954,62 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Sphere[]}]\")"
 <polygon points="141.6,178.2 159.0,201.1 161.1,182.6" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="167.4,146.0 181.5,165.1 181.2,146.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="147.4,160.2 161.1,182.6 163.9,164.0" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,146.0 163.9,164.0 181.5,165.1" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.2,146.9 181.5,165.1 199.1,163.5" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="161.1,182.6 159.0,201.1 182.0,202.6" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,183.9 182.0,202.6 204.9,200.5" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="181.8,183.9 204.9,200.5 202.4,182.0" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="181.5,165.1 202.4,182.0 199.1,163.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="163.9,164.0 161.1,182.6 181.8,183.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="161.1,182.6 182.0,202.6 181.8,183.9" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="163.9,164.0 181.8,183.9 181.5,165.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
 <polygon points="181.5,165.1 181.8,183.9 202.4,182.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5" opacity="0.5"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_opacity_with_color.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_opacity_with_color.snap
@@ -4,256 +4,256 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.3, Red], Cuboid[]}]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="310.5,235.2 141.8,25.5 141.8,180.8" fill="rgb(173,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 310.5,235.2 141.8,180.8" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 141.8,180.8 141.8,25.5" fill="rgb(156,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="310.5,235.2 310.5,79.8 141.8,25.5" fill="rgb(173,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 218.2,334.5 310.5,235.2" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.2,334.5 310.5,79.8 310.5,235.2" fill="rgb(156,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 141.8,25.5 49.5,124.8" fill="rgb(156,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,124.8 141.8,25.5 310.5,79.8" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 218.2,179.2 218.2,334.5" fill="rgb(173,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,280.2 49.5,124.8 218.2,179.2" fill="rgb(173,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.2,334.5 218.2,179.2 310.5,79.8" fill="rgb(156,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="49.5,124.8 310.5,79.8 218.2,179.2" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5" opacity="0.3"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_point.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_point.snap
@@ -4,245 +4,245 @@ expression: "export_svg(\"Graphics3D[Point[{0, 0, 0}]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <circle cx="180.0" cy="180.0" r="3" fill="#333"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_point_opacity.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_point_opacity.snap
@@ -4,245 +4,245 @@ expression: "export_svg(\"Graphics3D[{Opacity[0.5], Blue, Point[{0, 0, 0}]}]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="180.0" y1="180.0" x2="180.0" y2="180.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <circle cx="180.0" cy="180.0" r="3" fill="rgb(0,0,255)" opacity="0.5"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_polygon.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_polygon.snap
@@ -4,245 +4,245 @@ expression: "export_svg(\"Graphics3D[Polygon[{{0,0,0}, {1,0,0}, {0,1,0}}]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="141.3" y2="83.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.3" y1="79.8" x2="141.3" y2="83.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="124.3" y1="86.3" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="124.3" y1="86.3" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.3" y1="83.4" x2="152.2" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.3" y1="83.4" x2="152.2" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.2" y1="86.9" x2="163.2" y2="90.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.2" y1="86.9" x2="163.2" y2="90.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="118.2" y1="92.8" x2="124.3" y2="86.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="118.2" y1="92.8" x2="124.3" y2="86.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="163.2" y1="90.5" x2="174.2" y2="94.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="163.2" y1="90.5" x2="174.2" y2="94.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="174.2" y1="94.0" x2="185.2" y2="97.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="174.2" y1="94.0" x2="185.2" y2="97.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.2" y1="99.3" x2="118.2" y2="92.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.2" y1="99.3" x2="118.2" y2="92.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="185.2" y1="97.6" x2="196.2" y2="101.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="185.2" y1="97.6" x2="196.2" y2="101.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="106.2" y1="105.7" x2="112.2" y2="99.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="106.2" y1="105.7" x2="112.2" y2="99.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="196.2" y1="101.1" x2="207.2" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="196.2" y1="101.1" x2="207.2" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.2" y1="104.6" x2="218.2" y2="108.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.2" y1="104.6" x2="218.2" y2="108.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="100.2" y1="112.2" x2="106.2" y2="105.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="100.2" y1="112.2" x2="106.2" y2="105.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.2" y1="108.2" x2="229.1" y2="111.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.2" y1="108.2" x2="229.1" y2="111.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.1" y1="111.7" x2="240.1" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.1" y1="111.7" x2="240.1" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.2" y1="118.7" x2="100.2" y2="112.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.2" y1="118.7" x2="100.2" y2="112.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.1" y1="115.3" x2="251.1" y2="118.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.1" y1="115.3" x2="251.1" y2="118.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.1" y1="118.8" x2="262.1" y2="122.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.1" y1="118.8" x2="262.1" y2="122.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="88.2" y1="125.2" x2="94.2" y2="118.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="88.2" y1="125.2" x2="94.2" y2="118.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.1" y1="122.4" x2="273.1" y2="125.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.1" y1="122.4" x2="273.1" y2="125.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="273.1" y1="125.9" x2="284.1" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="273.1" y1="125.9" x2="284.1" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="131.6" x2="88.2" y2="125.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="131.6" x2="88.2" y2="125.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="284.1" y1="129.4" x2="295.1" y2="133.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="284.1" y1="129.4" x2="295.1" y2="133.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.1" y1="133.0" x2="306.1" y2="136.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.1" y1="133.0" x2="306.1" y2="136.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="76.1" y1="138.1" x2="82.2" y2="131.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="76.1" y1="138.1" x2="82.2" y2="131.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="306.1" y1="136.5" x2="317.0" y2="140.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="306.1" y1="136.5" x2="317.0" y2="140.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.1" y1="144.6" x2="76.1" y2="138.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="70.1" y1="144.6" x2="76.1" y2="138.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="317.0" y1="140.1" x2="328.0" y2="143.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="317.0" y1="140.1" x2="328.0" y2="143.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="328.0" y1="143.6" x2="339.0" y2="147.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="328.0" y1="143.6" x2="339.0" y2="147.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.1" y1="151.0" x2="70.1" y2="144.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.1" y1="151.0" x2="70.1" y2="144.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="339.0" y1="147.2" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="339.0" y1="147.2" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="344.0" y1="157.2" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="344.0" y1="157.2" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="58.1" y1="157.5" x2="64.1" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="58.1" y1="157.5" x2="64.1" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="338.0" y1="163.6" x2="344.0" y2="157.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="338.0" y1="163.6" x2="344.0" y2="157.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="52.1" y1="164.0" x2="58.1" y2="157.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="52.1" y1="164.0" x2="58.1" y2="157.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="332.0" y1="170.1" x2="338.0" y2="163.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="332.0" y1="170.1" x2="338.0" y2="163.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.1" y1="170.5" x2="52.1" y2="164.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.1" y1="170.5" x2="52.1" y2="164.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="325.9" y1="176.6" x2="332.0" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="325.9" y1="176.6" x2="332.0" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="40.1" y1="176.9" x2="46.1" y2="170.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="40.1" y1="176.9" x2="46.1" y2="170.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="319.9" y1="183.1" x2="325.9" y2="176.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="319.9" y1="183.1" x2="325.9" y2="176.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="34.1" y1="183.4" x2="40.1" y2="176.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="34.1" y1="183.4" x2="40.1" y2="176.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.9" y1="189.5" x2="319.9" y2="183.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.9" y1="189.5" x2="319.9" y2="183.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="28.0" y1="189.9" x2="34.1" y2="183.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="28.0" y1="189.9" x2="34.1" y2="183.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="141.3" y2="83.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.3" y1="79.8" x2="141.3" y2="83.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="124.3" y1="86.3" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="124.3" y1="86.3" x2="130.3" y2="79.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.3" y1="83.4" x2="152.2" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.3" y1="83.4" x2="152.2" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.2" y1="86.9" x2="163.2" y2="90.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.2" y1="86.9" x2="163.2" y2="90.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="118.2" y1="92.8" x2="124.3" y2="86.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="118.2" y1="92.8" x2="124.3" y2="86.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="163.2" y1="90.5" x2="174.2" y2="94.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="163.2" y1="90.5" x2="174.2" y2="94.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="174.2" y1="94.0" x2="185.2" y2="97.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="174.2" y1="94.0" x2="185.2" y2="97.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.2" y1="99.3" x2="118.2" y2="92.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.2" y1="99.3" x2="118.2" y2="92.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="185.2" y1="97.6" x2="196.2" y2="101.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="185.2" y1="97.6" x2="196.2" y2="101.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="106.2" y1="105.7" x2="112.2" y2="99.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="106.2" y1="105.7" x2="112.2" y2="99.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="196.2" y1="101.1" x2="207.2" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="196.2" y1="101.1" x2="207.2" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.2" y1="104.6" x2="218.2" y2="108.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.2" y1="104.6" x2="218.2" y2="108.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="100.2" y1="112.2" x2="106.2" y2="105.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="100.2" y1="112.2" x2="106.2" y2="105.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.2" y1="108.2" x2="229.1" y2="111.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.2" y1="108.2" x2="229.1" y2="111.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.1" y1="111.7" x2="240.1" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.1" y1="111.7" x2="240.1" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.2" y1="118.7" x2="100.2" y2="112.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.2" y1="118.7" x2="100.2" y2="112.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.1" y1="115.3" x2="251.1" y2="118.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.1" y1="115.3" x2="251.1" y2="118.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.1" y1="118.8" x2="262.1" y2="122.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.1" y1="118.8" x2="262.1" y2="122.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="88.2" y1="125.2" x2="94.2" y2="118.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="88.2" y1="125.2" x2="94.2" y2="118.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.1" y1="122.4" x2="273.1" y2="125.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.1" y1="122.4" x2="273.1" y2="125.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="273.1" y1="125.9" x2="284.1" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="273.1" y1="125.9" x2="284.1" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="131.6" x2="88.2" y2="125.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="131.6" x2="88.2" y2="125.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="284.1" y1="129.4" x2="295.1" y2="133.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="284.1" y1="129.4" x2="295.1" y2="133.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.1" y1="133.0" x2="306.1" y2="136.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.1" y1="133.0" x2="306.1" y2="136.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="76.1" y1="138.1" x2="82.2" y2="131.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="76.1" y1="138.1" x2="82.2" y2="131.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="306.1" y1="136.5" x2="317.0" y2="140.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="306.1" y1="136.5" x2="317.0" y2="140.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.1" y1="144.6" x2="76.1" y2="138.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="70.1" y1="144.6" x2="76.1" y2="138.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="317.0" y1="140.1" x2="328.0" y2="143.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="317.0" y1="140.1" x2="328.0" y2="143.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="328.0" y1="143.6" x2="339.0" y2="147.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="328.0" y1="143.6" x2="339.0" y2="147.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.1" y1="151.0" x2="70.1" y2="144.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.1" y1="151.0" x2="70.1" y2="144.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="339.0" y1="147.2" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="339.0" y1="147.2" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="150.7" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="344.0" y1="157.2" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="344.0" y1="157.2" x2="350.0" y2="150.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="58.1" y1="157.5" x2="64.1" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="58.1" y1="157.5" x2="64.1" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="338.0" y1="163.6" x2="344.0" y2="157.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="338.0" y1="163.6" x2="344.0" y2="157.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="52.1" y1="164.0" x2="58.1" y2="157.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="52.1" y1="164.0" x2="58.1" y2="157.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="332.0" y1="170.1" x2="338.0" y2="163.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="332.0" y1="170.1" x2="338.0" y2="163.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.1" y1="170.5" x2="52.1" y2="164.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.1" y1="170.5" x2="52.1" y2="164.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="325.9" y1="176.6" x2="332.0" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="325.9" y1="176.6" x2="332.0" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="40.1" y1="176.9" x2="46.1" y2="170.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="40.1" y1="176.9" x2="46.1" y2="170.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="319.9" y1="183.1" x2="325.9" y2="176.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="319.9" y1="183.1" x2="325.9" y2="176.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="34.1" y1="183.4" x2="40.1" y2="176.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="34.1" y1="183.4" x2="40.1" y2="176.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.9" y1="189.5" x2="319.9" y2="183.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.9" y1="189.5" x2="319.9" y2="183.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="28.0" y1="189.9" x2="34.1" y2="183.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="28.0" y1="189.9" x2="34.1" y2="183.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="25.5,206.6 225.2,271.0 134.8,89.0" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="307.9" y1="196.0" x2="313.9" y2="189.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="307.9" y1="196.0" x2="313.9" y2="189.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="22.0" y1="196.4" x2="28.0" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="22.0" y1="196.4" x2="28.0" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="301.9" y1="202.5" x2="307.9" y2="196.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="301.9" y1="202.5" x2="307.9" y2="196.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="16.0" y1="202.8" x2="22.0" y2="196.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="16.0" y1="202.8" x2="22.0" y2="196.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.9" y1="209.0" x2="301.9" y2="202.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.9" y1="209.0" x2="301.9" y2="202.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="16.0" y2="202.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="16.0" y2="202.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="21.0" y2="212.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="209.3" x2="21.0" y2="212.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.9" y1="215.4" x2="295.9" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="289.9" y1="215.4" x2="295.9" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="21.0" y1="212.8" x2="32.0" y2="216.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="21.0" y1="212.8" x2="32.0" y2="216.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="32.0" y1="216.4" x2="43.0" y2="219.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="32.0" y1="216.4" x2="43.0" y2="219.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="283.9" y1="221.9" x2="289.9" y2="215.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="283.9" y1="221.9" x2="289.9" y2="215.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.0" y1="219.9" x2="53.9" y2="223.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="43.0" y1="219.9" x2="53.9" y2="223.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="228.4" x2="283.9" y2="221.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.8" y1="228.4" x2="283.9" y2="221.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="53.9" y1="223.5" x2="64.9" y2="227.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="53.9" y1="223.5" x2="64.9" y2="227.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.9" y1="227.0" x2="75.9" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.9" y1="227.0" x2="75.9" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="271.8" y1="234.8" x2="277.8" y2="228.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="271.8" y1="234.8" x2="277.8" y2="228.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="75.9" y1="230.6" x2="86.9" y2="234.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="75.9" y1="230.6" x2="86.9" y2="234.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="86.9" y1="234.1" x2="97.9" y2="237.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="86.9" y1="234.1" x2="97.9" y2="237.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.8" y1="241.3" x2="271.8" y2="234.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.8" y1="241.3" x2="271.8" y2="234.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.9" y1="237.6" x2="108.9" y2="241.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.9" y1="237.6" x2="108.9" y2="241.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.9" y1="241.2" x2="119.9" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.9" y1="241.2" x2="119.9" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="259.8" y1="247.8" x2="265.8" y2="241.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="259.8" y1="247.8" x2="265.8" y2="241.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="119.9" y1="244.7" x2="130.9" y2="248.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="119.9" y1="244.7" x2="130.9" y2="248.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.9" y1="248.3" x2="141.8" y2="251.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.9" y1="248.3" x2="141.8" y2="251.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="253.8" y1="254.3" x2="259.8" y2="247.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="253.8" y1="254.3" x2="259.8" y2="247.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.8" y1="251.8" x2="152.8" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.8" y1="251.8" x2="152.8" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.8" y1="255.4" x2="163.8" y2="258.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.8" y1="255.4" x2="163.8" y2="258.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.8" y1="260.7" x2="253.8" y2="254.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.8" y1="260.7" x2="253.8" y2="254.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="163.8" y1="258.9" x2="174.8" y2="262.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="163.8" y1="258.9" x2="174.8" y2="262.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="241.8" y1="267.2" x2="247.8" y2="260.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="241.8" y1="267.2" x2="247.8" y2="260.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="174.8" y1="262.4" x2="185.8" y2="266.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="174.8" y1="262.4" x2="185.8" y2="266.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="185.8" y1="266.0" x2="196.8" y2="269.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="185.8" y1="266.0" x2="196.8" y2="269.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="235.7" y1="273.7" x2="241.8" y2="267.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="235.7" y1="273.7" x2="241.8" y2="267.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="196.8" y1="269.5" x2="207.8" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="196.8" y1="269.5" x2="207.8" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.8" y1="273.1" x2="218.7" y2="276.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.8" y1="273.1" x2="218.7" y2="276.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="235.7" y2="273.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="235.7" y2="273.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.7" y1="276.6" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.7" y1="276.6" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="307.9" y1="196.0" x2="313.9" y2="189.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="307.9" y1="196.0" x2="313.9" y2="189.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="22.0" y1="196.4" x2="28.0" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="22.0" y1="196.4" x2="28.0" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="301.9" y1="202.5" x2="307.9" y2="196.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="301.9" y1="202.5" x2="307.9" y2="196.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="16.0" y1="202.8" x2="22.0" y2="196.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="16.0" y1="202.8" x2="22.0" y2="196.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.9" y1="209.0" x2="301.9" y2="202.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.9" y1="209.0" x2="301.9" y2="202.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="16.0" y2="202.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="16.0" y2="202.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="10.0" y2="209.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="21.0" y2="212.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="209.3" x2="21.0" y2="212.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.9" y1="215.4" x2="295.9" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="289.9" y1="215.4" x2="295.9" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="21.0" y1="212.8" x2="32.0" y2="216.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="21.0" y1="212.8" x2="32.0" y2="216.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="32.0" y1="216.4" x2="43.0" y2="219.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="32.0" y1="216.4" x2="43.0" y2="219.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="283.9" y1="221.9" x2="289.9" y2="215.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="283.9" y1="221.9" x2="289.9" y2="215.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.0" y1="219.9" x2="53.9" y2="223.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="43.0" y1="219.9" x2="53.9" y2="223.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="228.4" x2="283.9" y2="221.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.8" y1="228.4" x2="283.9" y2="221.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="53.9" y1="223.5" x2="64.9" y2="227.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="53.9" y1="223.5" x2="64.9" y2="227.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.9" y1="227.0" x2="75.9" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.9" y1="227.0" x2="75.9" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="271.8" y1="234.8" x2="277.8" y2="228.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="271.8" y1="234.8" x2="277.8" y2="228.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="75.9" y1="230.6" x2="86.9" y2="234.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="75.9" y1="230.6" x2="86.9" y2="234.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="86.9" y1="234.1" x2="97.9" y2="237.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="86.9" y1="234.1" x2="97.9" y2="237.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.8" y1="241.3" x2="271.8" y2="234.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.8" y1="241.3" x2="271.8" y2="234.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.9" y1="237.6" x2="108.9" y2="241.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.9" y1="237.6" x2="108.9" y2="241.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.9" y1="241.2" x2="119.9" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.9" y1="241.2" x2="119.9" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="259.8" y1="247.8" x2="265.8" y2="241.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="259.8" y1="247.8" x2="265.8" y2="241.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="119.9" y1="244.7" x2="130.9" y2="248.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="119.9" y1="244.7" x2="130.9" y2="248.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.9" y1="248.3" x2="141.8" y2="251.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.9" y1="248.3" x2="141.8" y2="251.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="253.8" y1="254.3" x2="259.8" y2="247.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="253.8" y1="254.3" x2="259.8" y2="247.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.8" y1="251.8" x2="152.8" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.8" y1="251.8" x2="152.8" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.8" y1="255.4" x2="163.8" y2="258.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.8" y1="255.4" x2="163.8" y2="258.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.8" y1="260.7" x2="253.8" y2="254.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.8" y1="260.7" x2="253.8" y2="254.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="163.8" y1="258.9" x2="174.8" y2="262.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="163.8" y1="258.9" x2="174.8" y2="262.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="241.8" y1="267.2" x2="247.8" y2="260.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="241.8" y1="267.2" x2="247.8" y2="260.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="174.8" y1="262.4" x2="185.8" y2="266.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="174.8" y1="262.4" x2="185.8" y2="266.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="185.8" y1="266.0" x2="196.8" y2="269.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="185.8" y1="266.0" x2="196.8" y2="269.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="235.7" y1="273.7" x2="241.8" y2="267.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="235.7" y1="273.7" x2="241.8" y2="267.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="196.8" y1="269.5" x2="207.8" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="196.8" y1="269.5" x2="207.8" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.8" y1="273.1" x2="218.7" y2="276.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.8" y1="273.1" x2="218.7" y2="276.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="235.7" y2="273.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="235.7" y2="273.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.7" y1="276.6" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.7" y1="276.6" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="229.7" y1="280.2" x2="229.7" y2="280.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_rgbcolor.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_rgbcolor.snap
@@ -4,63 +4,63 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.9,177.4 178.5,194.9 178.2,176.1" fill="rgb(0,249,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.2,176.1 178.5,194.9 160.9,196.5" fill="rgb(0,252,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.0,157.4 178.2,176.1 157.6,178.0" fill="rgb(0,243,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.9,177.4 196.1,196.0 178.5,194.9" fill="rgb(0,249,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,176.1 160.9,196.5 157.6,178.0" fill="rgb(0,252,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,158.9 198.9,177.4 178.2,176.1" fill="rgb(0,239,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,158.9 178.2,176.1 178.0,157.4" fill="rgb(0,239,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.1,196.0 178.8,213.1 178.5,194.9" fill="rgb(0,252,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.0,157.4 157.6,178.0 155.1,159.5" fill="rgb(0,243,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,194.9 165.0,214.4 160.9,196.5" fill="rgb(0,255,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.4,181.8 196.1,196.0 198.9,177.4" fill="rgb(0,240,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.5,194.9 178.8,213.1 165.0,214.4" fill="rgb(0,255,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -76,21 +76,21 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="222.6,163.8 218.4,181.8 198.9,177.4" fill="rgb(0,229,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,141.2 178.0,157.4 177.9,139.6" fill="rgb(0,224,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,196.5 165.0,214.4 152.2,217.7" fill="rgb(0,253,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,196.5 152.2,217.7 144.7,200.7" fill="rgb(0,253,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,199.8 205.6,217.0 192.6,214.0" fill="rgb(0,245,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="177.9,139.6 155.1,159.5 153.5,141.8" fill="rgb(0,228,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,214.0 179.2,230.1 178.8,213.1" fill="rgb(0,250,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,159.5 138.5,182.9 133.9,165.0" fill="rgb(0,240,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.8,213.1 169.7,231.0 165.0,214.4" fill="rgb(0,251,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.5,141.8 155.1,159.5 133.9,165.0" fill="rgb(0,225,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.6,217.0 188.7,230.7 192.6,214.0" fill="rgb(0,244,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="235.2,189.1 212.6,199.8 218.4,181.8" fill="rgb(0,227,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.3,146.4 201.0,158.9 202.3,141.2" fill="rgb(0,213,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.3,146.4 222.6,163.8 201.0,158.9" fill="rgb(0,213,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.8,213.1 179.2,230.1 169.7,231.0" fill="rgb(0,251,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,206.0 205.6,217.0 212.6,199.8" fill="rgb(0,234,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,214.0 188.7,230.7 179.2,230.1" fill="rgb(0,250,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -103,11 +103,11 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="241.4,171.9 218.4,181.8 222.6,163.8" fill="rgb(0,214,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.2,189.1 227.0,206.0 212.6,199.8" fill="rgb(0,227,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.9,165.0 138.5,182.9 122.2,190.6" fill="rgb(0,231,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,217.0 197.7,232.8 188.7,230.7" fill="rgb(0,244,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.5,141.8 133.9,165.0 131.0,147.7" fill="rgb(0,225,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,206.0 216.9,221.8 205.6,217.0" fill="rgb(0,234,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,200.7 141.4,222.8 130.9,207.3" fill="rgb(0,247,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,221.8 197.7,232.8 205.6,217.0" fill="rgb(0,236,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,182.9 130.9,207.3 122.2,190.6" fill="rgb(0,242,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -119,8 +119,8 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="188.7,230.7 179.6,245.1 179.2,230.1" fill="rgb(0,240,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,217.7 153.4,236.8 141.4,222.8" fill="rgb(0,245,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,230.1 174.7,245.6 169.7,231.0" fill="rgb(0,242,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="226.2,130.3 225.3,146.4 202.3,141.2" fill="rgb(0,193,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,221.8 205.4,236.1 197.7,232.8" fill="rgb(0,236,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.0,147.7 133.9,165.0 115.8,173.6" fill="rgb(0,215,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -130,9 +130,9 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="245.1,155.0 222.6,163.8 225.3,146.4" fill="rgb(0,197,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.7,231.0 170.3,246.7 160.9,233.2" fill="rgb(0,241,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,214.1 216.9,221.8 227.0,206.0" fill="rgb(0,220,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="245.1,155.0 241.4,171.9 222.6,163.8" fill="rgb(0,197,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.3,198.7 227.0,206.0 235.2,189.1" fill="rgb(0,209,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,230.1 179.6,245.1 174.7,245.6" fill="rgb(0,242,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,207.3 141.4,222.8 133.2,229.5" fill="rgb(0,236,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -155,16 +155,16 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="225.6,228.2 211.4,240.5 205.4,236.1" fill="rgb(0,225,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.0,147.7 115.8,173.6 111.8,156.8" fill="rgb(0,215,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="255.9,182.5 235.2,189.1 241.4,171.9" fill="rgb(0,194,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,173.6 122.2,190.6 109.9,200.5" fill="rgb(0,217,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,236.1 193.0,248.2 189.0,246.5" fill="rgb(0,232,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,240.5 193.0,248.2 205.4,236.1" fill="rgb(0,226,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="130.0,131.6 131.0,147.7 111.8,156.8" fill="rgb(0,195,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,110.9 177.8,123.4 177.9,109.3" fill="rgb(0,179,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.2,190.6 120.4,215.7 109.9,200.5" fill="rgb(0,229,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.5,111.5 153.0,125.6 130.0,131.6" fill="rgb(0,180,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.4,236.8 163.5,250.9 147.7,241.4" fill="rgb(0,233,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.4,139.1 225.3,146.4 226.2,130.3" fill="rgb(0,175,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -189,13 +189,13 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="111.8,156.8 115.8,173.6 102.1,184.6" fill="rgb(0,200,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,166.3 241.4,171.9 245.1,155.0" fill="rgb(0,175,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,173.6 109.9,200.5 102.1,184.6" fill="rgb(0,217,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,241.4 163.5,250.9 161.8,253.6" fill="rgb(0,227,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,235.7 215.3,245.7 211.4,240.5" fill="rgb(0,213,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.0,250.4 180.0,257.7 193.0,248.2" fill="rgb(0,220,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="166.4,248.5 180.0,257.7 163.5,250.9" fill="rgb(0,223,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.7,241.4 161.8,253.6 144.3,246.6" fill="rgb(0,227,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.2,229.5 144.3,246.6 128.1,237.1" fill="rgb(0,227,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -228,7 +228,7 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="161.8,253.6 180.0,257.7 180.0,257.7" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.7,255.9 180.0,257.7 198.0,253.1" fill="rgb(0,215,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.8,253.6 180.0,257.7 161.3,256.4" fill="rgb(0,218,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.7,255.9 180.0,257.7 180.0,257.7" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.8,251.3 198.7,255.9 198.0,253.1" fill="rgb(0,210,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 180.0,257.7" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -237,16 +237,16 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="245.1,124.7 226.2,130.3 225.3,116.1" fill="rgb(0,151,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.4,243.9 215.3,245.7 231.3,235.7" fill="rgb(0,200,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,156.8 102.1,184.6 97.3,168.5" fill="rgb(0,200,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,246.6 161.3,256.4 143.2,252.3" fill="rgb(0,219,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="265.2,195.0 248.3,198.7 255.9,182.5" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,184.6 109.9,200.5 102.3,212.0" fill="rgb(0,197,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 180.0,257.7" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="110.5,140.9 111.8,156.8 97.3,168.5" fill="rgb(0,178,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.0,259.3 180.0,257.7 180.0,257.7" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 198.7,255.9" fill="rgb(0,212,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 153.5,111.5 131.0,117.4" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,99.4 177.9,109.3 178.0,98.0" fill="rgb(0,151,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 162.0,259.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -269,7 +269,7 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="162.0,259.3 180.0,257.7 164.0,261.9" fill="rgb(0,213,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 180.0,257.7" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,237.1 143.2,252.3 126.6,245.3" fill="rgb(0,215,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="185.3,266.8 180.0,257.7 180.0,257.7" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.7,256.9 198.7,255.9 216.8,251.3" fill="rgb(0,202,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.6,266.9 180.0,257.7 180.0,257.7" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -277,22 +277,22 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="215.7,256.9 198.2,258.8 198.7,255.9" fill="rgb(0,202,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="222.6,104.4 202.3,110.9 201.0,99.4" fill="rgb(0,140,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.6,263.8 180.0,257.7 196.5,261.5" fill="rgb(0,208,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="131.0,117.4 110.5,140.9 111.8,126.5" fill="rgb(0,170,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,261.9 180.0,257.7 167.0,264.2" fill="rgb(0,210,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.0,234.0 233.4,243.9 231.3,235.7" fill="rgb(0,186,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.2,252.3 162.0,259.3 144.7,257.8" fill="rgb(0,211,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.7,265.6 180.0,257.7 193.6,263.8" fill="rgb(0,206,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.0,264.2 180.0,257.7 171.0,265.9" fill="rgb(0,208,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,257.8 162.0,259.3 164.0,261.9" fill="rgb(0,203,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="97.3,168.5 102.1,184.6 93.7,197.3" fill="rgb(0,179,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.5,179.6 255.9,182.5 260.6,166.3" fill="rgb(0,150,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,245.3 143.2,252.3 144.7,257.8" fill="rgb(0,202,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,184.6 102.3,212.0 93.7,197.3" fill="rgb(0,197,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 131.0,117.4 133.9,105.6" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.3,266.8 180.0,257.7 189.7,265.6" fill="rgb(0,205,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 175.6,266.9" fill="rgb(0,206,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -310,24 +310,24 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="270.5,179.6 265.2,195.0 255.9,182.5" fill="rgb(0,150,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,126.5 110.5,140.9 95.7,152.8" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.2,89.8 178.0,98.0 155.1,100.1" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 245.1,124.7 225.3,116.1" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="259.9,222.1 248.0,234.0 245.2,223.7" fill="rgb(0,168,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.9,91.1 201.0,99.4 178.0,98.0" fill="rgb(0,121,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.6,263.0 164.0,261.9 167.0,264.2" fill="rgb(0,195,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,136.0 246.4,139.1 245.1,124.7" fill="rgb(0,128,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,257.8 164.0,261.9 148.6,263.0" fill="rgb(0,203,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 225.3,116.1 222.6,104.4" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.6,266.7 193.6,263.8 196.5,261.5" fill="rgb(0,188,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,136.0 262.1,150.6 246.4,139.1" fill="rgb(0,128,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,245.3 144.7,257.8 128.7,253.4" fill="rgb(0,202,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.0,235.8 126.6,245.3 128.7,253.4" fill="rgb(0,188,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.6,266.7 196.5,261.5 212.3,262.2" fill="rgb(0,188,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.6,267.4 167.0,264.2 171.0,265.9" fill="rgb(0,189,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.6,91.7 155.1,100.1 133.9,105.6" fill="rgb(0,122,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,244.4 233.4,243.9 248.0,234.0" fill="rgb(0,168,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -343,7 +343,7 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="272.3,164.1 260.6,166.3 262.1,150.6" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.6,263.0 167.0,264.2 154.6,267.4" fill="rgb(0,195,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,244.4 231.9,252.0 233.4,243.9" fill="rgb(0,168,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,89.8 155.1,100.1 157.6,91.7" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.8,259.7 212.3,262.2 215.7,256.9" fill="rgb(0,175,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.3,270.8 171.0,265.9 175.6,266.9" fill="rgb(0,184,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -351,9 +351,9 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="226.8,259.7 215.7,256.9 231.9,252.0" fill="rgb(0,175,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.3,272.6 185.3,266.8 189.7,265.6" fill="rgb(0,180,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.8,208.5 259.9,222.1 256.7,209.9" fill="rgb(0,147,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="272.3,164.1 270.5,179.6 260.6,166.3" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="171.3,272.8 175.6,266.9 180.4,267.2" fill="rgb(0,180,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.4,95.5 201.0,99.4 198.9,91.1" fill="rgb(0,111,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,126.5 95.7,152.8 97.3,138.2" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -361,15 +361,15 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="199.1,270.3 193.6,263.8 206.6,266.7" fill="rgb(0,183,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.6,267.4 171.0,265.9 162.3,270.8" fill="rgb(0,189,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.0,235.8 128.7,253.4 114.8,246.2" fill="rgb(0,188,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.7,253.4 148.6,263.0 134.4,260.9" fill="rgb(0,189,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 111.8,126.5 97.3,138.2" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.6,91.7 133.9,105.6 138.5,96.6" fill="rgb(0,122,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.1,224.2 112.0,235.8 114.8,246.2" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,272.6 189.7,265.6 199.1,270.3" fill="rgb(0,180,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.4,260.9 148.6,263.0 154.6,267.4" fill="rgb(0,176,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,96.6 133.9,105.6 115.8,114.1" fill="rgb(0,113,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.3,270.8 175.6,266.9 171.3,272.8" fill="rgb(0,184,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -386,29 +386,29 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="95.7,152.8 88.4,182.0 86.6,166.6" fill="rgb(0,157,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,234.3 246.0,244.4 248.0,234.0" fill="rgb(0,146,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,246.2 128.7,253.4 134.4,260.9" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,266.3 212.3,262.2 226.8,259.7" fill="rgb(0,164,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.2,102.8 222.6,104.4 218.4,95.5" fill="rgb(0,95,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.3,138.2 95.7,152.8 86.6,166.6" fill="rgb(0,132,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="270.5,149.3 262.1,150.6 260.6,136.0" fill="rgb(0,102,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,85.0 178.2,89.8 157.6,91.7" fill="rgb(0,92,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="274.3,193.9 268.8,208.5 265.2,195.0" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.1,86.2 198.9,91.1 178.2,89.8" fill="rgb(0,90,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,254.2 231.9,252.0 246.0,244.4" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,254.2 226.8,259.7 231.9,252.0" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.1,267.3 154.6,267.4 162.3,270.8" fill="rgb(0,166,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.5,149.3 272.3,164.1 262.1,150.6" fill="rgb(0,102,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.4,260.9 154.6,267.4 143.1,267.3" fill="rgb(0,176,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.8,271.5 199.1,270.3 206.6,266.7" fill="rgb(0,156,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.1,224.2 114.8,246.2 103.3,236.4" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,86.6 157.6,91.7 138.5,96.6" fill="rgb(0,90,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 97.3,138.2 102.1,125.2" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,96.6 115.8,114.1 122.2,104.3" fill="rgb(0,113,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,89.9 218.4,95.5 198.9,91.1" fill="rgb(0,98,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -416,22 +416,22 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="196.1,86.2 178.2,89.8 178.5,85.0" fill="rgb(0,90,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,222.1 259.9,222.1 268.8,208.5" fill="rgb(0,122,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,246.2 134.4,260.9 121.9,255.7" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="207.8,271.5 206.6,266.7 218.6,266.3" fill="rgb(0,156,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.4,272.2 162.3,270.8 171.3,272.8" fill="rgb(0,157,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.4,182.0 91.2,210.9 85.7,196.4" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.5,85.0 157.6,91.7 160.9,86.6" fill="rgb(0,92,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.6,166.6 88.4,182.0 85.7,196.4" fill="rgb(0,131,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="195.0,274.8 190.3,272.6 199.1,270.3" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="276.1,178.7 270.5,179.6 272.3,164.1" fill="rgb(0,99,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="122.2,104.3 115.8,114.1 102.1,125.2" fill="rgb(0,98,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,222.1 257.7,234.3 259.9,222.1" fill="rgb(0,122,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,89.9 198.9,91.1 196.1,86.2" fill="rgb(0,98,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,255.7 134.4,260.9 143.1,267.3" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.1,267.3 162.3,270.8 154.4,272.2" fill="rgb(0,166,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,275.2 171.3,272.8 180.8,273.4" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -443,29 +443,29 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="276.1,178.7 274.3,193.9 270.5,179.6" fill="rgb(0,99,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,262.6 218.6,266.3 226.8,259.7" fill="rgb(0,138,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,125.2 97.3,138.2 88.4,151.7" fill="rgb(0,106,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 138.5,96.6 122.2,104.3" fill="rgb(0,97,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.1,245.8 246.0,244.4 257.7,234.3" fill="rgb(0,126,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,86.6 138.5,96.6 144.7,90.9" fill="rgb(0,90,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="195.0,274.8 199.1,270.3 207.8,271.5" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="265.2,135.6 260.6,136.0 255.9,123.1" fill="rgb(0,101,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,262.6 226.8,259.7 239.6,254.2" fill="rgb(0,138,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="250.1,245.8 239.6,254.2 246.0,244.4" fill="rgb(0,126,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,96.1 235.2,102.8 218.4,95.5" fill="rgb(0,112,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.4,272.2 171.3,272.8 167.4,275.2" fill="rgb(0,157,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="265.2,135.6 270.5,149.3 260.6,136.0" fill="rgb(0,101,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,210.9 103.3,236.4 94.8,224.4" fill="rgb(0,151,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.2,276.0 190.3,272.6 195.0,274.8" fill="rgb(0,150,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,96.1 218.4,95.5 212.6,89.9" fill="rgb(0,112,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,275.2 180.8,273.4 181.2,276.0" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,196.4 91.2,210.9 94.8,224.4" fill="rgb(0,128,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="271.6,208.3 268.8,208.5 274.3,193.9" fill="rgb(0,97,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.9,255.7 143.1,267.3 133.0,263.9" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.6,166.6 85.7,196.4 83.9,181.3" fill="rgb(0,131,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -478,13 +478,13 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="103.3,236.4 121.9,255.7 111.7,247.6" fill="rgb(0,149,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,208.3 266.3,222.1 268.8,208.5" fill="rgb(0,97,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,269.1 207.8,271.5 218.6,266.3" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 122.2,104.3 130.9,97.4" fill="rgb(0,97,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.1,125.2 88.4,151.7 93.7,137.9" fill="rgb(0,106,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="274.3,163.6 276.1,178.7 272.3,164.1" fill="rgb(0,104,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.0,85.2 160.9,86.6 144.7,90.9" fill="rgb(0,121,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.8,224.4 103.3,236.4 111.7,247.6" fill="rgb(0,126,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -494,12 +494,12 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="111.7,247.6 121.9,255.7 133.0,263.9" fill="rgb(0,129,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.9,234.8 257.7,234.3 266.3,222.1" fill="rgb(0,100,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.9,114.2 102.1,125.2 93.7,137.9" fill="rgb(0,100,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.4,270.1 154.4,272.2 167.4,275.2" fill="rgb(0,129,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,104.3 248.3,112.4 235.2,102.8" fill="rgb(0,129,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,84.8 178.5,85.0 178.8,84.0" fill="rgb(0,121,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="256.7,123.6 255.9,123.1 248.3,112.4" fill="rgb(0,126,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.9,234.8 250.1,245.8 257.7,234.3" fill="rgb(0,100,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,104.3 235.2,102.8 227.0,96.1" fill="rgb(0,129,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -507,38 +507,38 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="178.8,84.0 160.9,86.6 165.0,85.2" fill="rgb(0,119,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="237.8,255.7 229.1,262.6 239.6,254.2" fill="rgb(0,110,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.0,263.9 154.4,272.2 147.4,270.1" fill="rgb(0,140,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="237.8,255.7 239.6,254.2 250.1,245.8" fill="rgb(0,110,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="256.7,123.6 265.2,135.6 255.9,123.1" fill="rgb(0,126,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,196.4 94.8,224.4 89.5,210.7" fill="rgb(0,128,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,87.8 196.1,86.2 192.6,84.8" fill="rgb(0,129,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.9,181.3 85.7,196.4 89.5,210.7" fill="rgb(0,104,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.4,193.4 274.3,193.9 276.1,178.7" fill="rgb(0,107,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.9,273.8 167.4,275.2 181.2,276.0" fill="rgb(0,121,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.5,275.0 181.2,276.0 195.0,274.8" fill="rgb(0,119,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,88.5 144.7,90.9 130.9,97.4" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="88.4,151.7 83.9,181.3 85.7,166.1" fill="rgb(0,107,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.9,92.7 227.0,96.1 212.6,89.9" fill="rgb(0,140,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.0,85.2 144.7,90.9 152.2,88.5" fill="rgb(0,121,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,273.4 207.8,271.5 215.3,269.1" fill="rgb(0,121,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.7,137.9 88.4,151.7 85.7,166.1" fill="rgb(0,97,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.8,149.1 270.5,149.3 265.2,135.6" fill="rgb(0,128,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.4,193.4 271.6,208.3 274.3,193.9" fill="rgb(0,107,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.8,224.4 111.7,247.6 104.1,236.9" fill="rgb(0,126,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,97.4 109.9,114.2 120.4,105.8" fill="rgb(0,110,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.4,270.1 167.4,275.2 163.9,273.8" fill="rgb(0,129,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,92.7 212.6,89.9 205.6,87.8" fill="rgb(0,140,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.7,247.6 133.0,263.9 124.8,257.2" fill="rgb(0,129,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="268.8,149.1 274.3,163.6 270.5,149.3" fill="rgb(0,128,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.9,114.2 93.7,137.9 102.3,125.7" fill="rgb(0,100,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,275.0 195.0,274.8 199.1,273.4" fill="rgb(0,119,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.8,257.2 133.0,263.9 147.4,270.1" fill="rgb(0,112,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -547,10 +547,10 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="262.7,221.8 266.3,222.1 271.6,208.3" fill="rgb(0,106,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,263.4 215.3,269.1 229.1,262.6" fill="rgb(0,97,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,88.5 130.9,97.4 141.4,93.7" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 109.9,114.2 102.3,125.7" fill="rgb(0,126,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.2,86.6 178.8,84.0 165.0,85.2" fill="rgb(0,150,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="188.7,87.2 192.6,84.8 178.8,84.0" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.1,236.9 111.7,247.6 124.8,257.2" fill="rgb(0,103,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -561,19 +561,19 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="221.5,263.4 229.1,262.6 237.8,255.7" fill="rgb(0,97,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="245.2,113.8 256.7,123.6 248.3,112.4" fill="rgb(0,149,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,166.1 83.9,181.3 87.7,195.9" fill="rgb(0,99,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="225.6,99.1 238.1,104.3 227.0,96.1" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,178.0 276.1,178.7 274.3,163.6" fill="rgb(0,131,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="169.7,87.4 165.0,85.2 152.2,88.5" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.2,245.9 250.1,245.8 257.9,234.8" fill="rgb(0,98,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.2,245.9 237.8,255.7 250.1,245.8" fill="rgb(0,98,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.7,89.2 205.6,87.8 192.6,84.8" fill="rgb(0,157,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.7,137.9 85.7,166.1 91.2,151.5" fill="rgb(0,97,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.6,99.1 227.0,96.1 216.9,92.7" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.3,125.7 93.7,137.9 91.2,151.5" fill="rgb(0,122,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.9,135.8 265.2,135.6 256.7,123.6" fill="rgb(0,151,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,178.0 273.4,193.4 276.1,178.7" fill="rgb(0,131,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -583,19 +583,19 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="202.4,268.3 199.1,273.4 215.3,269.1" fill="rgb(0,90,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.9,135.8 268.8,149.1 265.2,135.6" fill="rgb(0,151,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,86.6 165.0,85.2 169.7,87.4" fill="rgb(0,150,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 152.2,88.5 141.4,93.7" fill="rgb(0,156,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.5,210.7 104.1,236.9 99.4,224.0" fill="rgb(0,101,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.7,89.2 192.6,84.8 188.7,87.2" fill="rgb(0,157,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.4,92.6 216.9,92.7 205.6,87.8" fill="rgb(0,166,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 102.3,125.7 114.0,115.6" fill="rgb(0,126,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.4,93.7 120.4,105.8 133.2,100.3" fill="rgb(0,138,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,268.9 163.9,273.8 181.5,275.0" fill="rgb(0,90,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,270.2 181.5,275.0 199.1,273.4" fill="rgb(0,92,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.7,195.9 89.5,210.7 99.4,224.0" fill="rgb(0,102,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.7,87.4 152.2,88.5 160.9,89.7" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -603,23 +603,23 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="202.4,268.3 215.3,269.1 221.5,263.4" fill="rgb(0,90,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="264.3,207.2 271.6,208.3 273.4,193.4" fill="rgb(0,132,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,92.6 205.6,87.8 197.7,89.2" fill="rgb(0,166,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="85.7,166.1 87.7,195.9 89.5,180.4" fill="rgb(0,99,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.2,100.3 120.4,105.8 114.0,115.6" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,162.7 274.3,163.6 268.8,149.1" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.2,151.5 85.7,166.1 89.5,180.4" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,264.5 163.9,273.8 161.1,268.9" fill="rgb(0,98,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="264.3,207.2 262.7,221.8 271.6,208.3" fill="rgb(0,132,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.6,247.6 124.8,257.2 141.6,264.5" fill="rgb(0,95,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,106.6 245.2,113.8 238.1,104.3" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,106.6 238.1,104.3 225.6,99.1" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,125.7 91.2,151.5 100.1,137.9" fill="rgb(0,122,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.4,224.0 104.1,236.9 118.6,247.6" fill="rgb(0,102,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.4,93.3 141.4,93.7 133.2,100.3" fill="rgb(0,164,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 141.4,93.7 153.4,93.3" fill="rgb(0,156,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.0,115.6 102.3,125.7 100.1,137.9" fill="rgb(0,146,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.8,270.2 199.1,273.4 202.4,268.3" fill="rgb(0,92,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -627,14 +627,14 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="248.0,124.2 256.7,123.6 245.2,113.8" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,162.7 271.6,178.0 274.3,163.6" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="211.4,97.0 225.6,99.1 216.9,92.7" fill="rgb(0,176,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="161.1,268.9 181.5,275.0 181.8,270.2" fill="rgb(0,90,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,233.5 257.9,234.8 262.7,221.8" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.1,254.4 237.8,255.7 244.2,245.9" fill="rgb(0,113,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.0,124.2 259.9,135.8 256.7,123.6" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,233.5 244.2,245.9 257.9,234.8" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,97.0 216.9,92.7 205.4,92.6" fill="rgb(0,176,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.6,92.8 179.2,86.6 169.7,87.4" fill="rgb(0,179,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,93.1 188.7,87.2 179.2,86.6" fill="rgb(0,180,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -642,15 +642,15 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="87.7,195.9 99.4,224.0 97.9,209.4" fill="rgb(0,102,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.7,93.2 169.7,87.4 160.9,89.7" fill="rgb(0,180,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,94.1 197.7,89.2 188.7,87.2" fill="rgb(0,184,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="89.5,180.4 87.7,195.9 97.9,209.4" fill="rgb(0,127,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="262.7,191.5 273.4,193.4 271.6,178.0" fill="rgb(0,157,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.4,93.3 133.2,100.3 147.7,97.8" fill="rgb(0,164,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="118.6,247.6 141.6,264.5 137.4,255.6" fill="rgb(0,95,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,148.0 268.8,149.1 259.9,135.8" fill="rgb(0,175,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,151.5 89.5,180.4 94.8,165.0" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,255.6 141.6,264.5 161.1,268.9" fill="rgb(0,111,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.1,137.9 91.2,151.5 94.8,165.0" fill="rgb(0,147,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -663,18 +663,18 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="262.7,191.5 264.3,207.2 273.4,193.4" fill="rgb(0,157,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,102.2 231.3,106.6 225.6,99.1" fill="rgb(0,189,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,93.1 179.2,86.6 179.6,92.8" fill="rgb(0,180,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.6,92.8 169.7,87.4 174.7,93.2" fill="rgb(0,179,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,108.0 114.0,115.6 112.0,126.0" fill="rgb(0,168,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,148.0 266.3,162.7 268.8,149.1" fill="rgb(0,175,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,102.2 225.6,99.1 211.4,97.0" fill="rgb(0,189,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="233.4,114.7 245.2,113.8 231.3,106.6" fill="rgb(0,188,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,94.1 188.7,87.2 184.4,93.1" fill="rgb(0,184,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.4,114.7 248.0,124.2 245.2,113.8" fill="rgb(0,188,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.7,93.2 160.9,89.7 170.3,94.4" fill="rgb(0,180,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="204.9,259.9 221.5,263.4 226.1,254.4" fill="rgb(0,122,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="159.0,260.6 161.1,268.9 181.8,270.2" fill="rgb(0,121,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.9,209.4 99.4,224.0 114.9,235.3" fill="rgb(0,128,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.0,95.8 197.7,89.2 189.0,94.1" fill="rgb(0,189,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -683,10 +683,10 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="196.0,98.1 211.4,97.0 205.4,92.6" fill="rgb(0,195,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,235.3 118.6,247.6 137.4,255.6" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.5,219.1 262.7,221.8 264.3,207.2" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="170.3,94.4 153.4,93.3 166.4,96.2" fill="rgb(0,183,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,97.8 128.1,108.0 144.3,103.1" fill="rgb(0,175,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,255.6 161.1,268.9 159.0,260.6" fill="rgb(0,111,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.5,219.1 248.2,233.5 262.7,221.8" fill="rgb(0,154,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -700,12 +700,12 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="100.1,137.9 94.8,165.0 103.3,150.1" fill="rgb(0,147,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.8,165.0 89.5,180.4 99.4,193.7" fill="rgb(0,150,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,108.0 112.0,126.0 126.6,116.1" fill="rgb(0,168,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.0,262.0 202.4,268.3 204.9,259.9" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,134.6 257.7,148.0 259.9,135.8" fill="rgb(0,192,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,103.1 128.1,108.0 126.6,116.1" fill="rgb(0,187,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.8,107.7 231.3,106.6 215.3,102.2" fill="rgb(0,202,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.0,260.6 181.8,270.2 182.0,262.0" fill="rgb(0,121,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="166.4,96.2 147.7,97.8 163.5,98.5" fill="rgb(0,188,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -720,10 +720,10 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="180.0,102.3 174.7,93.2 170.3,94.4" fill="rgb(0,205,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.9,209.4 114.9,235.3 113.6,220.9" fill="rgb(0,128,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,235.3 137.4,255.6 134.7,243.9" fill="rgb(0,124,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="231.9,122.9 248.0,124.2 233.4,114.7" fill="rgb(0,206,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 193.0,95.8 189.0,94.1" fill="rgb(0,208,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 170.3,94.4 166.4,96.2" fill="rgb(0,206,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,116.1 112.0,126.0 114.8,136.3" fill="rgb(0,186,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -733,12 +733,12 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="112.0,126.0 103.3,150.1 114.8,136.3" fill="rgb(0,168,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.4,193.7 97.9,209.4 113.6,220.9" fill="rgb(0,153,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.1,159.5 266.3,162.7 257.7,148.0" fill="rgb(0,197,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.2,203.2 264.3,207.2 262.7,191.5" fill="rgb(0,178,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 196.0,98.1 193.0,95.8" fill="rgb(0,210,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,248.5 204.9,259.9 226.1,254.4" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.9,122.9 246.0,134.6 248.0,124.2" fill="rgb(0,206,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 166.4,96.2 163.5,98.5" fill="rgb(0,208,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.8,101.2 144.3,103.1 143.2,108.7" fill="rgb(0,202,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.3,150.1 94.8,165.0 104.1,177.5" fill="rgb(0,171,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -749,7 +749,7 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="180.0,102.3 184.4,93.1 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 174.7,93.2 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,203.2 249.5,219.1 264.3,207.2" fill="rgb(0,178,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 189.0,94.1 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 196.0,98.1" fill="rgb(0,213,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,248.5 226.1,254.4 229.0,242.6" fill="rgb(0,152,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -771,21 +771,21 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="126.6,116.1 114.8,136.3 128.7,124.3" fill="rgb(0,186,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.7,113.4 231.9,122.9 233.4,114.7" fill="rgb(0,215,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.7,103.6 198.0,100.7" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 161.3,104.1" fill="rgb(0,212,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,106.4 216.8,107.7 198.7,103.6" fill="rgb(0,219,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,144.3 257.7,148.0 246.0,134.6" fill="rgb(0,212,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.7,243.9 159.0,260.6 157.7,249.1" fill="rgb(0,140,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.7,103.6 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,104.1 143.2,108.7 144.7,114.3" fill="rgb(0,210,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,136.3 103.3,150.1 111.7,161.3" fill="rgb(0,189,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,106.4 215.7,113.4 216.8,107.7" fill="rgb(0,219,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.2,106.4 198.7,103.6" fill="rgb(0,218,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 162.0,106.9" fill="rgb(0,215,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.2,106.4 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -817,15 +817,15 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="180.0,102.3 175.6,114.6 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 180.4,114.9 180.0,102.3" fill="rgb(0,216,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 193.6,111.5 196.5,109.1" fill="rgb(0,223,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 164.0,109.6 167.0,111.8" fill="rgb(0,220,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.8,229.7 134.7,243.9 157.7,249.1" fill="rgb(0,168,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.8,130.5 239.6,144.3 246.0,134.6" fill="rgb(0,222,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="162.0,106.9 144.7,114.3 148.6,119.5" fill="rgb(0,218,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.5,109.1 212.3,118.6 215.7,113.4" fill="rgb(0,227,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.8,136.3 111.7,161.3 121.9,145.9" fill="rgb(0,189,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,114.3 128.7,124.3 134.4,131.8" fill="rgb(0,213,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,205.0 113.6,220.9 133.8,229.7" fill="rgb(0,175,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -850,7 +850,7 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="237.8,169.4 244.2,186.4 257.9,175.4" fill="rgb(0,217,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.2,235.0 157.7,249.1 182.1,250.7" fill="rgb(0,179,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,109.6 154.6,123.9 167.0,111.8" fill="rgb(0,226,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.2,236.6 182.1,250.7 206.5,248.5" fill="rgb(0,183,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,109.6 148.6,119.5 154.6,123.9" fill="rgb(0,226,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.6,111.5 206.6,123.2 212.3,118.6" fill="rgb(0,233,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -858,9 +858,9 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="229.1,152.7 250.1,159.5 239.6,144.3" fill="rgb(0,229,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.6,123.2 226.8,130.5 212.3,118.6" fill="rgb(0,237,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.7,113.3 206.6,123.2 193.6,111.5" fill="rgb(0,238,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,137.2 239.6,144.3 226.8,130.5" fill="rgb(0,236,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.9,145.9 111.7,161.3 124.8,170.9" fill="rgb(0,209,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,205.0 133.8,229.7 134.7,213.6" fill="rgb(0,175,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -884,17 +884,17 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="180.4,114.9 190.3,129.0 185.3,114.4" fill="rgb(0,242,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.1,195.0 229.0,212.3 248.2,203.2" fill="rgb(0,215,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.6,114.6 180.8,129.9 180.4,114.9" fill="rgb(0,240,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.5,218.2 207.0,234.4 230.0,228.4" fill="rgb(0,205,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,145.9 124.8,170.9 133.0,154.0" fill="rgb(0,209,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,218.2 230.0,228.4 229.0,212.3" fill="rgb(0,205,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,126.8 218.6,137.2 206.6,123.2" fill="rgb(0,245,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.4,131.8 133.0,154.0 143.1,138.2" fill="rgb(0,220,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,113.5 162.3,127.2 171.3,129.3" fill="rgb(0,237,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.3,114.4 190.3,129.0 199.1,126.8" fill="rgb(0,241,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="175.6,114.6 171.3,129.3 180.8,129.9" fill="rgb(0,240,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.4,114.9 180.8,129.9 190.3,129.0" fill="rgb(0,242,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,177.1 244.2,186.4 237.8,169.4" fill="rgb(0,231,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -909,9 +909,9 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="182.1,220.4 182.2,236.6 207.0,234.4" fill="rgb(0,208,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,177.1 226.1,195.0 244.2,186.4" fill="rgb(0,231,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,159.3 237.8,169.4 229.1,152.7" fill="rgb(0,242,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,129.0 207.8,142.3 199.1,126.8" fill="rgb(0,250,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.1,220.4 207.0,234.4 206.5,218.2" fill="rgb(0,208,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.0,154.0 124.8,170.9 141.6,178.2" fill="rgb(0,227,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.1,138.2 133.0,154.0 147.4,160.2" fill="rgb(0,234,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -928,17 +928,17 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="162.3,127.2 154.4,143.0 167.4,146.0" fill="rgb(0,244,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.3,129.0 195.0,145.6 207.8,142.3" fill="rgb(0,250,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.3,129.3 181.2,146.9 180.8,129.9" fill="rgb(0,250,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="133.0,154.0 141.6,178.2 147.4,160.2" fill="rgb(0,227,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="195.0,145.6 215.3,159.3 207.8,142.3" fill="rgb(0,253,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.3,129.3 167.4,146.0 181.2,146.9" fill="rgb(0,250,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.8,129.9 181.2,146.9 195.0,145.6" fill="rgb(0,251,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,196.2 157.7,218.8 159.0,201.1" fill="rgb(0,213,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.4,182.0 226.1,195.0 221.5,177.1" fill="rgb(0,240,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.0,201.1 157.7,218.8 182.1,220.4" fill="rgb(0,224,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,178.2 137.4,196.2 159.0,201.1" fill="rgb(0,229,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="182.0,202.6 182.1,220.4 206.5,218.2" fill="rgb(0,228,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,163.5 221.5,177.1 215.3,159.3" fill="rgb(0,250,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -954,62 +954,62 @@ expression: "export_svg(\"Graphics3D[{RGBColor[0, 1, 0], Sphere[]}]\")"
 <polygon points="141.6,178.2 159.0,201.1 161.1,182.6" fill="rgb(0,229,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,146.0 181.5,165.1 181.2,146.9" fill="rgb(0,252,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.4,160.2 161.1,182.6 163.9,164.0" fill="rgb(0,240,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,146.0 163.9,164.0 181.5,165.1" fill="rgb(0,252,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.2,146.9 181.5,165.1 199.1,163.5" fill="rgb(0,255,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,182.6 159.0,201.1 182.0,202.6" fill="rgb(0,239,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,183.9 182.0,202.6 204.9,200.5" fill="rgb(0,243,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.8,183.9 204.9,200.5 202.4,182.0" fill="rgb(0,243,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,165.1 202.4,182.0 199.1,163.5" fill="rgb(0,252,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="163.9,164.0 161.1,182.6 181.8,183.9" fill="rgb(0,249,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,182.6 182.0,202.6 181.8,183.9" fill="rgb(0,239,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.9,164.0 181.8,183.9 181.5,165.1" fill="rgb(0,249,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,165.1 181.8,183.9 202.4,182.0" fill="rgb(0,252,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_scoped_styles.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_scoped_styles.snap
@@ -4,43 +4,43 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="83.1" y1="159.1" x2="83.1" y2="153.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="79.4" y1="163.0" x2="83.1" y2="159.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="159.1" x2="96.4" y2="163.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="153.0" x2="83.1" y2="146.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="75.7" y1="167.0" x2="79.4" y2="163.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="96.4" y1="163.4" x2="109.7" y2="167.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="146.8" x2="83.1" y2="140.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="72.1" y1="170.9" x2="75.7" y2="167.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="109.7" y1="167.7" x2="123.1" y2="172.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="140.7" x2="83.1" y2="134.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="68.4" y1="174.8" x2="72.1" y2="170.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="134.5" x2="83.1" y2="128.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="123.1" y1="172.0" x2="136.4" y2="176.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.8" y1="178.8" x2="68.4" y2="174.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="128.4" x2="83.1" y2="122.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="136.4" y1="176.3" x2="149.8" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="122.2" x2="83.1" y2="116.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="61.1" y1="182.7" x2="64.8" y2="178.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="149.8" y1="180.6" x2="163.1" y2="184.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="116.1" x2="83.1" y2="109.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="57.5" y1="186.6" x2="61.1" y2="182.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="109.9" x2="83.1" y2="103.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="163.1" y1="184.9" x2="176.5" y2="189.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="53.8" y1="190.6" x2="57.5" y2="186.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="103.8" x2="83.1" y2="97.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.5" y1="189.2" x2="189.8" y2="193.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="50.2" y1="194.5" x2="53.8" y2="190.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="97.6" x2="83.1" y2="91.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.8" y1="193.5" x2="203.2" y2="197.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.5" y1="198.4" x2="50.2" y2="194.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="91.5" x2="83.1" y2="85.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="85.3" x2="83.1" y2="79.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.2" y1="197.9" x2="216.5" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="42.9" y1="202.4" x2="46.5" y2="198.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="79.2" x2="83.1" y2="73.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="216.5" y1="202.2" x2="229.9" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="39.2" y1="206.3" x2="42.9" y2="202.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="83.1" y1="159.1" x2="83.1" y2="153.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="79.4" y1="163.0" x2="83.1" y2="159.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="159.1" x2="96.4" y2="163.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="153.0" x2="83.1" y2="146.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="75.7" y1="167.0" x2="79.4" y2="163.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="96.4" y1="163.4" x2="109.7" y2="167.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="146.8" x2="83.1" y2="140.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="72.1" y1="170.9" x2="75.7" y2="167.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="109.7" y1="167.7" x2="123.1" y2="172.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="140.7" x2="83.1" y2="134.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="68.4" y1="174.8" x2="72.1" y2="170.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="134.5" x2="83.1" y2="128.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="123.1" y1="172.0" x2="136.4" y2="176.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.8" y1="178.8" x2="68.4" y2="174.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="128.4" x2="83.1" y2="122.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="136.4" y1="176.3" x2="149.8" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="122.2" x2="83.1" y2="116.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="61.1" y1="182.7" x2="64.8" y2="178.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="149.8" y1="180.6" x2="163.1" y2="184.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="116.1" x2="83.1" y2="109.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="57.5" y1="186.6" x2="61.1" y2="182.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="109.9" x2="83.1" y2="103.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="163.1" y1="184.9" x2="176.5" y2="189.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="53.8" y1="190.6" x2="57.5" y2="186.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="103.8" x2="83.1" y2="97.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.5" y1="189.2" x2="189.8" y2="193.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="50.2" y1="194.5" x2="53.8" y2="190.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="97.6" x2="83.1" y2="91.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.8" y1="193.5" x2="203.2" y2="197.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.5" y1="198.4" x2="50.2" y2="194.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="91.5" x2="83.1" y2="85.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="85.3" x2="83.1" y2="79.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.2" y1="197.9" x2="216.5" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="42.9" y1="202.4" x2="46.5" y2="198.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="79.2" x2="83.1" y2="73.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="216.5" y1="202.2" x2="229.9" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="39.2" y1="206.3" x2="42.9" y2="202.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="132.9,158.6 118.2,171.1 118.0,157.6" fill="rgb(249,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.0,157.6 118.2,171.1 105.6,172.3" fill="rgb(252,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.9,144.2 118.0,157.6 103.2,159.0" fill="rgb(243,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -52,7 +52,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="117.9,144.2 103.2,159.0 101.4,145.7" fill="rgb(243,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.2,171.1 108.5,185.2 105.6,172.3" fill="rgb(255,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="146.9,161.8 130.9,172.0 132.9,158.6" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="83.1" y1="73.1" x2="83.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="83.1" y1="73.1" x2="83.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="118.2,171.1 118.5,184.3 108.5,185.2" fill="rgb(255,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.2,159.0 105.6,172.3 93.9,175.3" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,172.0 128.4,184.9 118.5,184.3" fill="rgb(252,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -66,16 +66,16 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="150.0,148.8 146.9,161.8 132.9,158.6" fill="rgb(229,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.4,132.5 117.9,144.2 117.8,131.4" fill="rgb(224,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.6,172.3 108.5,185.2 99.4,187.6" fill="rgb(253,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="35.6" y1="210.2" x2="39.2" y2="206.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="35.6" y1="210.2" x2="39.2" y2="206.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="105.6,172.3 99.4,187.6 93.9,175.3" fill="rgb(253,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="229.9" y1="206.5" x2="243.2" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="229.9" y1="206.5" x2="243.2" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="142.8,174.7 137.8,187.0 128.4,184.9" fill="rgb(245,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.8,131.4 101.4,145.7 100.3,133.0" fill="rgb(228,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.4,184.9 118.7,196.5 118.5,184.3" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.4,145.7 89.4,162.5 86.1,149.7" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.5,184.3 111.9,197.1 108.5,185.2" fill="rgb(251,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.3,133.0 101.4,145.7 86.1,149.7" fill="rgb(225,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="83.1" y1="66.9" x2="83.1" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="83.1" y1="66.9" x2="83.1" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="137.8,187.0 125.6,196.9 128.4,184.9" fill="rgb(244,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.1,167.0 142.8,174.7 146.9,161.8" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="151.9,136.3 134.5,145.2 135.4,132.5" fill="rgb(213,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -95,14 +95,14 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="137.8,187.0 132.0,198.4 125.6,196.9" fill="rgb(244,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.3,133.0 86.1,149.7 84.1,137.2" fill="rgb(225,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.1,179.1 145.9,190.5 137.8,187.0" fill="rgb(234,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="31.9" y1="214.2" x2="35.6" y2="210.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="31.9" y1="214.2" x2="35.6" y2="210.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="93.9,175.3 91.5,191.3 84.0,180.0" fill="rgb(247,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.9,190.5 132.0,198.4 137.8,187.0" fill="rgb(236,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.4,162.5 84.0,180.0 77.8,168.1" fill="rgb(242,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.7,120.8 117.8,131.4 117.8,119.7" fill="rgb(204,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.5,154.6 159.1,167.0 146.9,161.8" fill="rgb(214,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="243.2" y1="210.8" x2="256.6" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="83.1" y1="60.8" x2="83.1" y2="54.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="243.2" y1="210.8" x2="256.6" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="83.1" y1="60.8" x2="83.1" y2="54.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="117.8,119.7 100.3,133.0 99.9,121.3" fill="rgb(208,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.9,121.3 100.3,133.0 84.1,137.2" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.4,187.6 105.6,198.7 100.2,201.3" fill="rgb(245,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -126,9 +126,9 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="152.2,195.1 137.6,200.8 145.9,190.5" fill="rgb(225,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.6,200.8 125.8,208.3 132.0,198.4" fill="rgb(232,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.8,168.1 84.0,180.0 76.4,186.1" fill="rgb(229,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="28.3" y1="218.1" x2="31.9" y2="214.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="28.3" y1="218.1" x2="31.9" y2="214.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="111.9,197.1 115.5,207.6 112.3,208.5" fill="rgb(241,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="83.1" y1="54.6" x2="83.1" y2="48.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="83.1" y1="54.6" x2="83.1" y2="48.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="132.0,198.4 125.8,208.3 122.5,207.5" fill="rgb(237,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.8,109.6 117.8,119.7 99.9,121.3" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.9,121.3 84.1,137.2 83.4,125.6" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -136,7 +136,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="161.1,185.0 152.2,195.1 145.9,190.5" fill="rgb(220,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.5,191.3 100.2,201.3 96.1,204.6" fill="rgb(237,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.4,110.7 135.7,120.8 117.8,119.7" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="256.6" y1="215.1" x2="269.9" y2="219.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="256.6" y1="215.1" x2="269.9" y2="219.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="168.5,173.9 161.1,185.0 153.1,179.1" fill="rgb(209,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.6,198.7 112.3,208.5 109.6,209.8" fill="rgb(238,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="84.0,180.0 85.6,196.0 76.4,186.1" fill="rgb(236,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -156,12 +156,12 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="173.9,162.3 168.5,173.9 159.1,167.0" fill="rgb(194,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.8,109.6 99.9,121.3 100.3,111.2" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.2,201.3 109.6,209.8 107.5,211.4" fill="rgb(233,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="83.1" y1="48.5" x2="83.1" y2="42.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="83.1" y1="48.5" x2="83.1" y2="42.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.1,131.0 166.2,142.4 151.9,136.3" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="151.9,114.5 152.5,124.7 135.7,120.8" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="141.9,204.0 130.9,211.1 128.7,209.5" fill="rgb(226,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.5,207.5 119.3,216.3 119.0,207.3" fill="rgb(226,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.6" y1="222.0" x2="28.3" y2="218.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.6" y1="222.0" x2="28.3" y2="218.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.0,207.3 119.3,216.3 115.5,207.6" fill="rgb(226,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="156.2,200.5 141.9,204.0 152.2,195.1" fill="rgb(213,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.8,208.3 119.3,216.3 122.5,207.5" fill="rgb(224,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -176,7 +176,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="70.3,143.7 73.1,155.8 63.3,163.7" fill="rgb(200,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="177.3,150.6 163.5,154.6 166.2,142.4" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="73.1,155.8 68.9,175.2 63.3,163.7" fill="rgb(217,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="269.9" y1="219.4" x2="283.3" y2="223.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="269.9" y1="219.4" x2="283.3" y2="223.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="96.1,204.6 107.5,211.4 106.2,213.4" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="156.2,200.5 144.7,207.7 141.9,204.0" fill="rgb(213,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,211.1 119.3,216.3 128.7,209.5" fill="rgb(220,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -195,7 +195,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="125.8,208.3 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.9,175.2 76.4,186.1 71.8,193.1" fill="rgb(212,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.3,208.5 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="83.1" y1="42.3" x2="83.1" y2="36.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="83.1" y1="42.3" x2="83.1" y2="36.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="132.3,213.0 119.3,216.3 130.9,211.1" fill="rgb(218,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.7,209.5 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.6,209.8 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -205,7 +205,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="130.9,211.1 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.5,102.5 135.4,110.7 117.8,109.6" fill="rgb(151,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.5,211.4 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="21.0" y1="226.0" x2="24.6" y2="222.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="21.0" y1="226.0" x2="24.6" y2="222.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="84.1,115.4 83.4,125.6 69.3,132.3" fill="rgb(170,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.6,208.4 106.2,213.4 105.8,215.4" fill="rgb(219,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.5,182.0 166.3,191.9 161.1,185.0" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -228,7 +228,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="132.4,217.1 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="69.3,132.3 70.3,143.7 59.8,152.2" fill="rgb(178,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.4,217.5 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="283.3" y1="223.7" x2="296.6" y2="228.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="283.3" y1="223.7" x2="296.6" y2="228.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="132.4,217.1 119.3,216.3 132.8,215.1" fill="rgb(212,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.4,102.9 100.3,111.2 84.1,115.4" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.5,102.5 117.8,109.6 117.9,101.4" fill="rgb(151,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -237,10 +237,10 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="68.9,175.2 71.8,193.1 63.5,183.5" fill="rgb(212,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.7,206.4 145.8,211.7 144.7,207.7" fill="rgb(200,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.2,219.1 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="79.4" y1="40.1" x2="83.1" y2="36.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="79.4" y1="40.1" x2="83.1" y2="36.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="107.8,219.4 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="150.0,106.0 151.9,114.5 135.4,110.7" fill="rgb(140,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="83.1" y1="36.2" x2="96.4" y2="40.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="83.1" y1="36.2" x2="96.4" y2="40.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="117.9,101.4 100.3,111.2 101.4,102.9" fill="rgb(155,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.1,220.7 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="92.9,212.4 105.8,215.4 106.4,217.5" fill="rgb(211,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -259,7 +259,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="116.1,223.0 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.6,223.2 119.3,216.3 119.3,216.3" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.0,215.8 132.4,217.1 132.8,215.1" fill="rgb(202,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="17.3" y1="229.9" x2="21.0" y2="226.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="17.3" y1="229.9" x2="21.0" y2="226.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="150.0,106.0 135.4,110.7 134.5,102.5" fill="rgb(140,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.1,220.7 119.3,216.3 131.2,219.1" fill="rgb(208,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="84.1,115.4 69.3,132.3 70.3,121.9" fill="rgb(170,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -275,11 +275,11 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="63.3,163.7 63.5,183.5 57.2,172.9" fill="rgb(197,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="101.4,102.9 84.1,115.4 86.1,106.9" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="123.1,222.9 119.3,216.3 126.3,222.0" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="296.6" y1="228.0" x2="310.0" y2="232.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="296.6" y1="228.0" x2="310.0" y2="232.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.9,222.2 119.3,216.3 116.1,223.0" fill="rgb(206,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="63.5,183.5 71.8,193.1 70.4,200.6" fill="rgb(192,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="69.3,132.3 59.8,152.2 58.7,140.9" fill="rgb(178,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="75.7" y1="44.0" x2="79.4" y2="40.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="75.7" y1="44.0" x2="79.4" y2="40.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="142.5,219.6 131.2,219.1 132.4,217.1" fill="rgb(194,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.6,223.2 119.3,216.3 123.1,222.9" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="176.8,190.7 166.3,191.9 174.5,182.0" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -287,14 +287,14 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="156.7,212.3 145.8,211.7 157.7,206.4" fill="rgb(187,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.1,223.0 119.3,216.3 119.6,223.2" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="142.5,219.6 132.4,217.1 145.0,215.8" fill="rgb(194,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="96.4" y1="40.5" x2="109.7" y2="44.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="96.4" y1="40.5" x2="109.7" y2="44.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.1,106.9 84.1,115.4 70.3,121.9" fill="rgb(142,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="156.7,212.3 145.0,215.8 145.8,211.7" fill="rgb(187,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,160.1 180.7,171.3 173.9,162.3" fill="rgb(150,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="70.3,121.9 69.3,132.3 58.7,140.9" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.0,95.5 117.9,101.4 101.4,102.9" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.5,111.8 166.2,120.6 151.9,114.5" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="13.7" y1="233.8" x2="17.3" y2="229.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="13.7" y1="233.8" x2="17.3" y2="229.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="176.8,190.7 168.2,199.3 166.3,191.9" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.9,96.5 134.5,102.5 117.9,101.4" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.7,220.2 107.8,219.4 110.0,221.0" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -309,12 +309,12 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="101.0,223.3 110.0,221.0 112.9,222.2" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.2,96.9 101.4,102.9 86.1,106.9" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="166.8,206.8 157.7,206.4 168.2,199.3" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.1" y1="48.0" x2="75.7" y2="44.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.1" y1="48.0" x2="75.7" y2="44.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="82.5,213.3 93.9,216.4 96.7,220.2" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="63.5,183.5 70.4,200.6 61.8,192.3" fill="rgb(192,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="57.2,172.9 63.5,183.5 61.8,192.3" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="59.8,152.2 57.2,172.9 53.4,161.9" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="310.0" y1="232.3" x2="323.3" y2="236.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="310.0" y1="232.3" x2="323.3" y2="236.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="183.2,181.0 174.5,182.0 180.7,171.3" fill="rgb(147,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.1,225.4 126.3,222.0 129.1,220.7" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="146.9,99.7 150.0,106.0 134.5,102.5" fill="rgb(111,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -324,12 +324,12 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="96.7,220.2 110.0,221.0 101.0,223.3" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="166.8,206.8 156.7,212.3 157.7,206.4" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.0,95.5 101.4,102.9 103.2,96.9" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="109.7" y1="44.8" x2="123.1" y2="49.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="109.7" y1="44.8" x2="123.1" y2="49.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.0,217.8 142.5,219.6 145.0,215.8" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.6,225.7 112.9,222.2 116.1,223.0" fill="rgb(184,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.1,106.9 70.3,121.9 73.1,113.0" fill="rgb(142,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.0,217.8 145.0,215.8 156.7,212.3" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="237.8" x2="13.7" y2="233.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="237.8" x2="13.7" y2="233.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="126.8,227.0 123.1,222.9 126.3,222.0" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="183.2,181.0 176.8,190.7 174.5,182.0" fill="rgb(147,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.7,149.0 184.4,160.1 177.3,150.6" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -343,12 +343,12 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="82.5,213.3 96.7,220.2 86.5,218.7" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="73.1,113.0 70.3,121.9 59.8,130.3" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.2,96.9 86.1,106.9 89.4,100.4" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="68.4" y1="51.9" x2="72.1" y2="48.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="68.4" y1="51.9" x2="72.1" y2="48.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="61.8,192.3 70.4,200.6 72.4,208.0" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.8,227.0 126.3,222.0 133.1,225.4" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.5,218.7 96.7,220.2 101.0,223.3" fill="rgb(176,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.4,100.4 86.1,106.9 73.1,113.0" fill="rgb(113,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.3" y1="236.6" x2="336.7" y2="240.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.3" y1="236.6" x2="336.7" y2="240.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="106.6,225.7 116.1,223.0 113.1,227.2" fill="rgb(184,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.2,199.5 168.2,199.3 176.8,190.7" fill="rgb(146,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="173.9,119.5 166.2,120.6 163.5,111.8" fill="rgb(102,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -358,14 +358,14 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="119.9,227.7 123.1,222.9 126.8,227.0" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.1,222.5 138.5,222.8 142.5,219.6" fill="rgb(164,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="187.1,170.4 180.7,171.3 184.4,160.1" fill="rgb(124,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="237.8" x2="10.0" y2="231.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="237.8" x2="10.0" y2="231.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="159.1,104.9 163.5,111.8 150.0,106.0" fill="rgb(95,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="113.1,227.2 119.6,223.2 119.9,227.7" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="123.1" y1="49.1" x2="136.4" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="123.1" y1="49.1" x2="136.4" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="58.7,140.9 53.4,161.9 52.1,150.8" fill="rgb(157,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.2,199.5 166.8,206.8 168.2,199.3" fill="rgb(146,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="72.4,208.0 82.5,213.3 86.5,218.7" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="237.8" x2="23.3" y2="242.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="237.8" x2="23.3" y2="242.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.1,222.5 142.5,219.6 153.0,217.8" fill="rgb(164,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.1,104.9 150.0,106.0 146.9,99.7" fill="rgb(95,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="59.8,130.3 58.7,140.9 52.1,150.8" fill="rgb(132,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -378,23 +378,23 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="92.8,223.3 101.0,223.3 106.6,225.7" fill="rgb(166,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,138.3 185.7,149.0 178.4,139.3" fill="rgb(102,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.5,218.7 101.0,223.3 92.8,223.3" fill="rgb(176,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="64.8" y1="55.8" x2="68.4" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="64.8" y1="55.8" x2="68.4" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="139.3,226.2 133.1,225.4 138.5,222.8" fill="rgb(156,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="231.6" x2="10.0" y2="225.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="231.6" x2="10.0" y2="225.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="61.8,192.3 72.4,208.0 64.1,201.0" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.6,93.3 103.2,96.9 89.4,100.4" fill="rgb(90,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="73.1,113.0 59.8,130.3 63.3,121.0" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="336.7" y1="240.9" x2="350.0" y2="245.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="336.7" y1="240.9" x2="350.0" y2="245.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="89.4,100.4 73.1,113.0 77.8,106.0" fill="rgb(113,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="142.8,95.6 146.9,99.7 132.9,96.5" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="55.4,182.7 61.8,192.3 64.1,201.0" fill="rgb(151,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="136.4" y1="53.4" x2="149.8" y2="57.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="136.4" y1="53.4" x2="149.8" y2="57.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="254.3,197.7 239.6,210.3 239.4,196.7" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,92.9 118.0,95.5 118.2,92.1" fill="rgb(90,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.4,190.7 176.8,190.7 183.2,181.0" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="72.4,208.0 86.5,218.7 77.5,214.9" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.4,196.7 239.6,210.3 226.9,211.4" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="23.3" y1="242.1" x2="36.7" y2="246.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="23.3" y1="242.1" x2="36.7" y2="246.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="139.3,226.2 138.5,222.8 147.1,222.5" fill="rgb(156,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.2,183.3 239.4,196.7 224.5,198.1" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,226.8 106.6,225.7 113.1,227.2" fill="rgb(157,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -420,11 +420,11 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="59.8,130.3 52.1,150.8 53.4,140.1" fill="rgb(132,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.2,229.5 119.9,227.7 126.8,227.0" fill="rgb(150,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,210.3 239.8,223.4 229.9,224.3" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="225.5" x2="10.0" y2="219.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="225.5" x2="10.0" y2="219.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="64.1,201.0 72.4,208.0 77.5,214.9" fill="rgb(149,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="224.5,198.1 226.9,211.4 215.3,214.5" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="252.2,211.1 249.8,224.0 239.8,223.4" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.1" y1="59.8" x2="64.8" y2="55.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.1" y1="59.8" x2="64.8" y2="55.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="168.5,111.8 173.9,119.5 163.5,111.8" fill="rgb(103,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="168.5,111.8 163.5,111.8 159.1,104.9" fill="rgb(103,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.1,170.5 239.2,183.3 222.7,184.8" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
@@ -436,7 +436,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="268.3,200.9 264.2,213.8 252.2,211.1" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.7,219.9 147.1,222.5 153.0,217.8" fill="rgb(138,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="63.3,121.0 59.8,130.3 53.4,140.1" fill="rgb(106,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="245.2" x2="350.0" y2="239.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="245.2" x2="350.0" y2="239.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="93.9,96.3 89.4,100.4 77.8,106.0" fill="rgb(97,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.8,207.8 166.8,206.8 175.2,199.5" fill="rgb(126,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="224.5,198.1 215.3,214.5 210.8,201.7" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -444,7 +444,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="271.3,187.9 268.3,200.9 254.3,197.7" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.1,228.6 133.1,225.4 139.3,226.2" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.7,128.5 177.3,128.8 173.9,119.5" fill="rgb(101,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="346.3" y1="249.1" x2="350.0" y2="245.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="346.3" y1="249.1" x2="350.0" y2="245.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.7,219.9 153.0,217.8 162.2,213.8" fill="rgb(138,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="256.7,171.6 239.2,183.3 239.1,170.5" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.9,211.4 229.9,224.3 220.7,226.7" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
@@ -456,17 +456,17 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="100.9,226.8 113.1,227.2 110.2,228.9" fill="rgb(157,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.8,224.0 240.1,235.6 239.8,223.4" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.7,128.5 184.4,138.3 177.3,128.8" fill="rgb(101,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="149.8" y1="57.7" x2="163.1" y2="62.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="149.8" y1="57.7" x2="163.1" y2="62.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="222.7,184.8 210.8,201.7 207.5,188.8" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.8,223.4 233.2,236.2 229.9,224.3" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="55.4,182.7 64.1,201.0 58.0,192.4" fill="rgb(151,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.7" y1="246.4" x2="50.0" y2="250.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.7" y1="246.4" x2="50.0" y2="250.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="221.6,172.1 222.7,184.8 207.5,188.8" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.2,229.5 126.8,227.0 130.1,228.6" fill="rgb(150,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.1,100.1 146.9,99.7 142.8,95.6" fill="rgb(112,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.2,228.9 119.9,227.7 120.2,229.5" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.1,226.2 246.9,236.0 249.8,224.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="219.3" x2="10.0" y2="213.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="219.3" x2="10.0" y2="213.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="51.5,172.3 55.4,182.7 58.0,192.4" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="280.4,206.1 264.2,213.8 268.3,200.9" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.2,175.4 255.8,184.4 256.7,171.6" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
@@ -478,9 +478,9 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="210.8,201.7 215.3,214.5 205.3,219.2" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.5,214.9 92.8,223.3 85.5,220.8" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.9,224.3 226.9,237.9 220.7,226.7" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="57.5" y1="63.7" x2="61.1" y2="59.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="57.5" y1="63.7" x2="61.1" y2="59.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="52.1,150.8 51.5,172.3 50.2,161.4" fill="rgb(131,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="239.0" x2="350.0" y2="232.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="239.0" x2="350.0" y2="232.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="77.8,106.0 63.3,121.0 68.9,113.1" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.5,220.8 92.8,223.3 100.9,226.8" fill="rgb(140,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.1,158.8 239.1,170.5 221.6,172.1" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
@@ -498,7 +498,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="185.2,180.8 181.4,190.7 183.2,181.0" fill="rgb(97,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.1,226.2 253.4,237.5 246.9,236.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,224.6 139.3,226.2 147.1,222.5" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="342.7" y1="253.1" x2="346.3" y2="249.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="342.7" y1="253.1" x2="346.3" y2="249.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="221.6,172.1 207.5,188.8 205.4,176.3" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="274.5,218.2 267.2,229.7 259.1,226.2" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,214.5 212.9,230.4 205.3,219.2" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
@@ -513,21 +513,21 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="58.0,192.4 64.1,201.0 70.2,209.1" fill="rgb(126,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.1,158.8 221.6,172.1 221.3,160.5" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,224.6 147.1,222.5 154.7,219.9" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="163.1" y1="62.0" x2="176.5" y2="66.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="163.1" y1="62.0" x2="176.5" y2="66.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="137.8,94.1 142.8,95.6 130.9,92.9" fill="rgb(129,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="213.2" x2="10.0" y2="207.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="213.2" x2="10.0" y2="207.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="221.3,160.5 221.6,172.1 205.4,176.3" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="220.7,226.7 226.9,237.9 221.5,240.4" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="84.0,101.0 77.8,106.0 68.9,113.1" fill="rgb(110,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.9,236.0 240.4,246.4 240.1,235.6" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="50.0" y1="250.7" x2="63.4" y2="255.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="50.0" y1="250.7" x2="63.4" y2="255.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="220.7,226.7 221.5,240.4 212.9,230.4" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="70.2,209.1 77.5,214.9 85.5,220.8" fill="rgb(129,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.1,235.6 236.9,246.7 233.2,236.2" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.4,199.9 175.2,199.5 181.4,190.7" fill="rgb(100,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.9,113.1 63.3,121.0 57.2,130.1" fill="rgb(100,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.9,163.8 273.2,175.4 256.7,171.6" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="232.9" x2="350.0" y2="226.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="232.9" x2="350.0" y2="226.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="267.2,229.7 259.0,239.9 253.4,237.5" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,176.3 207.5,188.8 194.5,194.9" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.5,188.8 199.1,207.2 194.5,194.9" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
@@ -539,7 +539,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="287.5,181.6 271.3,187.9 273.2,175.4" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.5,119.9 173.9,119.5 168.5,111.8" fill="rgb(126,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.4,199.9 169.8,207.8 175.2,199.5" fill="rgb(100,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="53.8" y1="67.6" x2="57.5" y2="63.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="53.8" y1="67.6" x2="57.5" y2="63.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="161.1,105.9 159.1,104.9 153.1,100.1" fill="rgb(129,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.2,236.2 233.7,247.6 226.9,237.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.1,227.6 130.1,228.6 139.3,226.2" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -557,7 +557,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="137.8,94.1 130.9,92.9 128.4,92.0" fill="rgb(129,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.9,236.0 243.9,246.7 240.4,246.4" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.5,234.3 259.0,239.9 267.2,229.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="339.0" y1="257.0" x2="342.7" y2="253.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="339.0" y1="257.0" x2="342.7" y2="253.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="259.0,239.9 247.1,247.4 253.4,237.5" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="50.2,161.4 51.5,172.3 54.2,182.6" fill="rgb(104,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,207.2 205.3,219.2 197.8,225.2" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
@@ -568,7 +568,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="99.4,94.6 93.9,96.3 84.0,101.0" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="253.4,237.5 247.1,247.4 243.9,246.7" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.1,148.7 239.1,158.8 221.3,160.5" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="207.0" x2="10.0" y2="200.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="207.0" x2="10.0" y2="200.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="221.3,160.5 205.4,176.3 204.7,164.7" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.9,237.9 230.9,248.9 221.5,240.4" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="282.5,224.1 273.5,234.3 267.2,229.7" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
@@ -583,15 +583,15 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="183.2,138.2 184.4,138.3 180.7,128.5" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.9,237.9 233.7,247.6 230.9,248.9" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.3,219.2 207.0,235.2 197.8,225.2" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="226.8" x2="350.0" y2="220.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.5" y1="66.3" x2="189.8" y2="70.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="226.8" x2="350.0" y2="220.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.5" y1="66.3" x2="189.8" y2="70.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="212.9,230.4 217.5,243.7 207.0,235.2" fill="rgb(88,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="186.5,170.1 185.2,180.8 187.1,170.4" fill="rgb(107,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.5,234.3 263.3,243.1 259.0,239.9" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,176.3 194.5,194.9 191.6,182.9" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="295.3,201.4 280.4,206.1 284.8,193.7" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="194.5,194.9 199.1,207.2 190.2,214.3" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="63.4" y1="255.0" x2="76.7" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="63.4" y1="255.0" x2="76.7" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="259.0,239.9 250.0,248.6 247.1,247.4" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="263.3,243.1 250.0,248.6 259.0,239.9" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="58.0,192.4 70.2,209.1 64.7,201.4" fill="rgb(126,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -602,7 +602,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="204.7,164.7 205.4,176.3 191.6,182.9" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="256.7,149.8 239.1,158.8 239.1,148.7" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,207.2 197.8,225.2 190.2,214.3" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="50.2" y1="71.6" x2="53.8" y2="67.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="50.2" y1="71.6" x2="53.8" y2="67.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="183.2,138.2 187.1,148.6 184.4,138.3" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.6,150.3 221.3,160.5 204.7,164.7" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="68.9,113.1 57.2,130.1 63.5,121.4" fill="rgb(100,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -617,8 +617,8 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="107.8,227.9 120.2,229.5 120.4,228.8" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.2,153.6 273.9,163.8 257.0,160.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="54.2,182.6 58.0,192.4 64.7,201.4" fill="rgb(101,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="335.4" y1="260.9" x2="339.0" y2="257.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="10.0" y1="200.9" x2="10.0" y2="194.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="335.4" y1="260.9" x2="339.0" y2="257.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="10.0" y1="200.9" x2="10.0" y2="194.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="263.3,243.1 252.2,250.2 250.0,248.6" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="243.9,246.7 240.7,255.4 240.4,246.4" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.4,246.4 240.7,255.4 236.9,246.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
@@ -632,7 +632,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="207.0,235.2 217.5,243.7 215.0,247.5" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="287.6,231.0 273.5,234.3 282.5,224.1" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="76.4,107.1 68.9,113.1 63.5,121.4" fill="rgb(126,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="220.6" x2="350.0" y2="214.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="220.6" x2="350.0" y2="214.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="250.0,248.6 240.7,255.4 247.1,247.4" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.1,246.8 252.2,250.2 263.3,243.1" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.7,93.2 118.5,91.3 108.5,92.2" fill="rgb(150,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -654,11 +654,11 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="51.5,150.4 50.2,161.4 53.0,171.9" fill="rgb(99,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,102.2 161.1,105.9 153.1,100.1" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.2,159.0 188.5,159.5 187.1,148.6" fill="rgb(131,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="189.8" y1="70.6" x2="203.2" y2="74.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="189.8" y1="70.6" x2="203.2" y2="74.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="252.2,250.2 240.7,255.4 250.0,248.6" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="230.9,248.9 240.7,255.4 228.8,250.6" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="217.5,243.7 227.6,252.5 215.0,247.5" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="76.7" y1="259.3" x2="90.1" y2="263.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="76.7" y1="259.3" x2="90.1" y2="263.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="207.0,235.2 215.0,247.5 203.3,240.7" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="287.6,231.0 277.5,239.7 273.5,234.3" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.9,93.8 108.5,92.2 99.4,94.6" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -675,11 +675,11 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="57.2,130.1 51.5,150.4 55.4,139.9" fill="rgb(97,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,102.2 153.1,100.1 145.9,97.6" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.6,150.3 204.7,164.7 205.4,154.5" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="46.5" y1="75.5" x2="50.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="46.5" y1="75.5" x2="50.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="247.1,247.4 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.2,214.3 197.8,225.2 193.2,232.3" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.7,247.6 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="194.7" x2="10.0" y2="188.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="194.7" x2="10.0" y2="188.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="253.6,252.1 240.7,255.4 252.2,250.2" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.0,248.6 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="63.5,121.4 57.2,130.1 55.4,139.9" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -691,11 +691,11 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="91.7,221.2 95.8,225.2 107.8,227.9" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.8,225.2 203.3,240.7 193.2,232.3" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="252.2,250.2 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="331.7" y1="264.9" x2="335.4" y2="260.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="331.7" y1="264.9" x2="335.4" y2="260.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="255.8,141.6 256.7,149.8 239.1,148.7" fill="rgb(56,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="228.8,250.6 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="79.6,216.0 95.8,225.2 91.7,221.2" fill="rgb(112,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="214.5" x2="350.0" y2="208.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="214.5" x2="350.0" y2="208.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.4,154.5 204.7,164.7 190.7,171.4" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.6,93.7 118.5,91.3 118.7,93.2" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.0,247.5 227.6,252.5 227.2,254.6" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
@@ -740,15 +740,15 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="299.8,178.4 287.5,181.6 288.4,170.1" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.5,224.0 144.7,224.6 149.2,220.4" fill="rgb(90,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.2,214.3 193.2,232.3 184.8,222.6" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="203.2" y1="74.9" x2="216.5" y2="79.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="203.2" y1="74.9" x2="216.5" y2="79.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="279.1,245.5 267.1,250.8 266.1,246.8" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="252.5,258.2 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="188.6" x2="10.0" y2="182.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="188.6" x2="10.0" y2="182.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,180.0 185.2,180.8 186.5,170.1" fill="rgb(132,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,258.5 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="90.1" y1="263.6" x2="103.4" y2="267.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="90.1" y1="263.6" x2="103.4" y2="267.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="271.3,145.2 273.2,153.6 256.7,149.8" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="42.9" y1="79.4" x2="46.5" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="42.9" y1="79.4" x2="46.5" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="239.2,140.5 221.6,150.3 222.7,142.0" fill="rgb(57,78,110)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.4,259.9 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="214.2,251.6 227.2,254.6 227.7,256.6" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
@@ -760,7 +760,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="85.6,103.1 76.4,107.1 71.8,114.1" fill="rgb(152,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.2,232.3 203.3,240.7 202.3,246.5" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="302.0,210.4 295.9,221.1 289.8,213.0" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="208.3" x2="350.0" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="208.3" x2="350.0" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="289.6,238.4 277.5,239.7 287.6,231.0" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="247.7,261.2 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.4,148.0 187.1,148.6 183.2,138.2" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -773,7 +773,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="237.5,262.1 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.7,221.2 107.8,227.9 105.7,224.4" fill="rgb(98,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,180.0 178.8,190.5 185.2,180.8" fill="rgb(132,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="328.1" y1="268.8" x2="331.7" y2="264.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="328.1" y1="268.8" x2="331.7" y2="264.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.0,262.3 240.7,255.4 240.7,255.4" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.4,254.9 253.8,256.3 254.2,254.2" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.2,209.0 79.6,216.0 91.7,221.2" fill="rgb(95,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -801,7 +801,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="231.3,260.1 240.7,255.4 234.2,261.3" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.5,214.0 160.9,214.9 165.5,207.8" fill="rgb(113,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,255.6 227.7,256.6 229.1,258.5" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="182.4" x2="10.0" y2="176.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="182.4" x2="10.0" y2="176.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.2,191.3 184.6,202.9 178.6,212.0" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="305.8,199.2 295.3,201.4 298.6,189.7" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,246.5 214.2,251.6 215.3,255.6" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
@@ -820,12 +820,12 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="193.2,232.3 202.3,246.5 191.8,239.7" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="278.0,251.4 267.1,250.8 279.1,245.5" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="237.5,262.1 240.7,255.4 241.0,262.3" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="216.5" y1="79.2" x2="229.9" y2="83.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="39.2" y1="83.4" x2="42.9" y2="79.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="350.0" y1="202.2" x2="350.0" y2="196.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="216.5" y1="79.2" x2="229.9" y2="83.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="39.2" y1="83.4" x2="42.9" y2="79.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="350.0" y1="202.2" x2="350.0" y2="196.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.0,97.7 118.7,93.2 111.9,93.8" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.5,97.9 125.6,93.7 118.7,93.2" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="103.4" y1="267.9" x2="116.8" y2="272.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="103.4" y1="267.9" x2="116.8" y2="272.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="263.9,258.7 253.8,256.3 266.4,254.9" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.5,146.0 205.4,154.5 191.6,161.1" fill="rgb(52,72,101)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="278.0,251.4 266.4,254.9 267.1,250.8" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
@@ -835,7 +835,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="191.6,161.1 190.7,171.4 180.0,180.0" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.5,98.0 111.9,93.8 105.6,95.5" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.8,98.7 132.0,95.1 125.6,93.7" fill="rgb(184,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="324.4" y1="272.7" x2="328.1" y2="268.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="324.4" y1="272.7" x2="328.1" y2="268.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="239.4,134.6 239.2,140.5 222.7,142.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="284.8,151.0 287.5,159.8 273.2,153.6" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="298.2,229.8 289.6,238.4 287.6,231.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
@@ -855,7 +855,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="259.8,262.0 250.4,259.9 252.5,258.2" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="298.6,167.9 299.8,178.4 288.4,170.1" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,246.5 215.3,255.6 203.8,252.4" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="176.3" x2="10.0" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="176.3" x2="10.0" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="71.8,114.1 61.8,130.2 70.4,121.6" fill="rgb(146,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="96.1,101.3 85.6,103.1 82.0,108.6" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.3,98.8 105.6,95.5 100.2,98.0" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -866,7 +866,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="144.7,104.4 156.2,107.6 152.2,102.2" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.5,97.9 118.7,93.2 119.0,97.7" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="191.8,239.7 202.3,246.5 203.8,252.4" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="196.0" x2="350.0" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="196.0" x2="350.0" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.0,97.7 111.9,93.8 115.5,98.0" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="82.0,108.6 71.8,114.1 70.4,121.6" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.2,137.4 181.4,148.0 183.2,138.2" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -881,7 +881,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="184.8,222.6 191.8,239.7 183.2,231.4" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.6,212.0 184.8,222.6 183.2,231.4" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.2,191.3 178.6,212.0 174.8,201.0" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="35.6" y1="87.3" x2="39.2" y2="83.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="35.6" y1="87.3" x2="39.2" y2="83.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="304.6,220.1 295.9,221.1 302.0,210.4" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="254.4,264.5 247.7,261.2 250.4,259.9" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.3,138.8 271.3,145.2 255.8,141.6" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
@@ -890,12 +890,12 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="180.0,180.0 181.2,191.3 174.8,201.0" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.5,98.0 105.6,95.5 112.3,98.8" fill="rgb(180,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.3,218.0 149.2,220.4 152.5,214.0" fill="rgb(122,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="229.9" y1="83.5" x2="243.2" y2="87.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="229.9" y1="83.5" x2="243.2" y2="87.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="307.0,188.1 298.6,189.7 299.8,178.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.1,259.3 231.3,260.1 222.4,262.5" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="288.2,245.9 278.0,251.4 279.1,245.5" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.2,218.4 105.7,224.4 120.6,225.4" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="116.8" y1="272.2" x2="130.1" y2="276.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="116.8" y1="272.2" x2="130.1" y2="276.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="60.2,181.6 61.4,192.1 72.5,200.2" fill="rgb(128,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.4,134.6 222.7,142.0 224.5,136.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.7,99.9 132.0,95.1 125.8,98.7" fill="rgb(189,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -903,7 +903,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="274.4,256.9 263.9,258.7 266.4,254.9" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="228.0,264.9 234.2,261.3 237.5,262.1" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.5,146.0 191.6,161.1 194.5,152.2" fill="rgb(52,72,101)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="320.8" y1="276.6" x2="324.4" y2="272.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="320.8" y1="276.6" x2="324.4" y2="272.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.6,100.1 100.2,98.0 96.1,101.3" fill="rgb(188,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="274.4,256.9 266.4,254.9 278.0,251.4" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,101.5 141.9,100.7 137.6,97.5" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -911,7 +911,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="248.1,266.2 244.5,262.0 247.7,261.2" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.3,188.6 178.8,190.5 180.0,180.0" fill="rgb(154,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="304.6,220.1 298.2,229.8 295.9,221.1" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="170.1" x2="10.0" y2="164.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="170.1" x2="10.0" y2="164.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="307.0,188.1 305.8,199.2 298.6,189.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="234.4,266.3 237.5,262.1 241.0,262.3" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.3,138.8 255.8,141.6 254.3,135.6" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
@@ -927,7 +927,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="130.9,101.5 137.6,97.5 128.7,99.9" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="54.2,160.8 60.2,181.6 61.4,170.3" fill="rgb(127,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.6,205.5 165.5,207.8 168.4,198.9" fill="rgb(142,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="189.9" x2="350.0" y2="183.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="189.9" x2="350.0" y2="183.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="70.4,121.6 61.8,130.2 64.1,138.9" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.4,157.1 185.2,159.0 181.4,148.0" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="61.8,130.2 58.0,149.6 64.1,138.9" fill="rgb(147,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -945,7 +945,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="248.1,266.2 247.7,261.2 254.4,264.5" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.8,108.4 156.2,107.6 144.7,104.4" fill="rgb(202,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.2,218.4 120.6,225.4 120.8,219.5" fill="rgb(121,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="31.9" y1="91.2" x2="35.6" y2="87.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="31.9" y1="91.2" x2="35.6" y2="87.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="207.8,257.8 218.1,259.3 222.4,262.5" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.6,100.1 96.1,101.3 107.5,101.8" fill="rgb(188,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.5,101.8 96.1,101.3 93.6,105.1" fill="rgb(194,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -957,7 +957,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="296.5,238.6 289.6,238.4 298.2,229.8" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="295.3,158.6 287.5,159.8 284.8,151.0" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.6,212.0 183.2,231.4 176.8,221.8" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="243.2" y1="87.8" x2="256.6" y2="92.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="243.2" y1="87.8" x2="256.6" y2="92.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="295.3,158.6 298.6,167.9 287.5,159.8" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="132.3,103.4 141.9,100.7 130.9,101.5" fill="rgb(203,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.8,201.0 178.6,212.0 176.8,221.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -965,10 +965,10 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="268.5,261.7 259.8,262.0 263.9,258.7" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="308.5,209.6 302.0,210.4 305.8,199.2" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="280.4,144.0 284.8,151.0 271.3,145.2" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="164.0" x2="10.0" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="164.0" x2="10.0" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="234.4,266.3 241.0,262.3 241.3,266.8" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="317.1" y1="280.6" x2="320.8" y2="276.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.1" y1="276.5" x2="143.5" y2="280.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="317.1" y1="280.6" x2="320.8" y2="276.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.1" y1="276.5" x2="143.5" y2="280.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.3,104.6 122.5,97.9 119.0,97.7" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 119.0,97.7 115.5,98.0" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,180.0 174.8,201.0 173.5,189.9" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
@@ -981,7 +981,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="268.5,261.7 263.9,258.7 274.4,256.9" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="280.4,144.0 271.3,145.2 268.3,138.8" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="156.7,119.3 168.2,120.3 157.7,113.5" fill="rgb(206,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="183.7" x2="350.0" y2="177.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="183.7" x2="350.0" y2="177.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.2,169.5 180.0,180.0 173.5,189.9" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 128.7,99.9 125.8,98.7" fill="rgb(208,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 112.3,98.8 109.6,100.1" fill="rgb(206,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1012,7 +1012,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="58.0,149.6 61.4,170.3 64.7,158.6" fill="rgb(150,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.8,257.8 222.4,262.5 214.1,262.4" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 119.0,97.7 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="28.3" y1="95.1" x2="31.9" y2="91.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="28.3" y1="95.1" x2="31.9" y2="91.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.3,104.6 122.5,97.9 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 115.5,98.0 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="168.4,177.1 169.3,188.6 180.0,180.0" fill="rgb(178,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1023,7 +1023,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="183.2,231.4 193.7,247.2 185.5,240.1" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 112.3,98.8 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="71.6,189.9 72.5,200.2 86.8,206.4" fill="rgb(151,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="157.8" x2="10.0" y2="151.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="157.8" x2="10.0" y2="151.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="226.9,132.4 224.5,136.0 210.8,139.6" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 107.5,101.8 106.2,103.7" fill="rgb(210,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.0,112.5 157.7,113.5 145.8,108.4" fill="rgb(215,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1033,18 +1033,18 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="119.3,104.6 109.6,100.1 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="210.8,139.6 194.5,152.2 199.1,145.1" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="264.2,134.8 268.3,138.8 254.3,135.6" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="313.5" y1="284.5" x2="317.1" y2="280.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="256.6" y1="92.1" x2="269.9" y2="96.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="313.5" y1="284.5" x2="317.1" y2="280.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="256.6" y1="92.1" x2="269.9" y2="96.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="92.9,109.2 80.9,114.5 82.5,120.3" fill="rgb(200,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="176.8,221.8 183.2,231.4 185.5,240.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.2,103.7 92.9,109.2 105.8,105.8" fill="rgb(202,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 130.9,101.5 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.3,210.2 104.2,218.4 120.8,219.5" fill="rgb(151,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="177.6" x2="350.0" y2="171.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="177.6" x2="350.0" y2="171.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.3,104.6 107.5,101.8 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="155.3,195.3 168.4,198.9 169.3,188.6" fill="rgb(170,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="155.3,195.3 154.6,205.5 168.4,198.9" fill="rgb(170,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="143.5" y1="280.8" x2="156.8" y2="285.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="143.5" y1="280.8" x2="156.8" y2="285.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.9,211.3 120.8,219.5 137.3,218.0" fill="rgb(155,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="252.2,132.1 239.4,134.6 239.6,131.2" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="80.9,114.5 72.4,129.0 82.5,120.3" fill="rgb(186,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1087,14 +1087,14 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="64.1,138.9 64.7,158.6 70.2,147.0" fill="rgb(171,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.5,240.1 193.7,247.2 198.9,254.1" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.9,211.3 137.3,218.0 138.4,209.7" fill="rgb(155,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="151.7" x2="10.0" y2="145.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="151.7" x2="10.0" y2="145.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="165.5,165.1 178.8,168.7 175.4,157.1" fill="rgb(200,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.2,134.8 169.8,145.7 175.2,137.4" fill="rgb(212,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="64.7,158.6 61.4,170.3 72.5,178.4" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="289.8,150.9 295.3,158.6 284.8,151.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 131.2,109.4 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="289.8,150.9 284.8,151.0 280.4,144.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="24.6" y1="99.1" x2="28.3" y2="95.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="24.6" y1="99.1" x2="28.3" y2="95.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="105.8,105.8 93.9,113.2 106.4,107.9" fill="rgb(210,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 107.8,109.8 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="309.8,198.6 308.5,209.6 305.8,199.2" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
@@ -1106,7 +1106,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="119.3,104.6 129.1,111.1 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 110.0,111.4 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 106.4,107.9 107.8,109.8" fill="rgb(218,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="171.4" x2="350.0" y2="165.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="171.4" x2="350.0" y2="165.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="215.3,135.4 210.8,139.6 199.1,145.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="71.6,189.9 86.8,206.4 86.1,196.2" fill="rgb(151,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="291.1,246.9 288.2,245.9 296.5,238.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
@@ -1117,7 +1117,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="276.0,259.0 274.4,256.9 283.6,252.9" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 126.3,112.4 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 112.9,112.6 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="309.8" y1="288.4" x2="313.5" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="309.8" y1="288.4" x2="313.5" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="165.5,165.1 168.4,177.1 178.8,168.7" fill="rgb(200,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="291.1,246.9 283.6,252.9 288.2,245.9" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="142.5,116.3 156.7,119.3 145.0,112.5" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1126,12 +1126,12 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="119.3,104.6 116.1,113.3 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="274.5,139.2 280.4,144.0 268.3,138.8" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 119.6,113.6 119.3,104.6" fill="rgb(216,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="269.9" y1="96.4" x2="283.3" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="269.9" y1="96.4" x2="283.3" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.3,104.6 129.1,111.1 131.2,109.4" fill="rgb(223,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="222.2,265.9 234.4,266.3 231.6,268.0" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="302.0,167.6 305.8,177.4 298.6,167.9" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.3,104.6 107.8,109.8 110.0,111.4" fill="rgb(220,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="156.8" y1="285.1" x2="170.2" y2="289.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="156.8" y1="285.1" x2="170.2" y2="289.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.1,196.2 86.8,206.4 103.3,210.2" fill="rgb(168,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.0,124.8 162.2,134.8 166.8,127.7" fill="rgb(222,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.4,107.9 93.9,113.2 96.7,116.9" fill="rgb(218,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1149,7 +1149,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="119.3,104.6 110.0,111.4 112.9,112.6" fill="rgb(223,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.6,268.0 241.3,266.8 241.5,268.7" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="172.9,211.4 176.8,221.8 179.3,231.5" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="145.5" x2="10.0" y2="139.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="145.5" x2="10.0" y2="139.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.6,183.7 169.3,188.6 168.4,177.1" fill="rgb(195,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="306.6,219.9 304.6,220.1 308.5,209.6" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,152.8 175.4,157.1 169.8,145.7" fill="rgb(217,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1167,9 +1167,9 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="93.9,113.2 86.5,125.7 96.7,116.9" fill="rgb(213,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,145.1 184.6,160.1 190.2,152.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.9,259.9 214.1,262.4 222.2,265.9" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="165.3" x2="350.0" y2="159.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="165.3" x2="350.0" y2="159.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="64.7,158.6 72.5,178.4 75.2,166.3" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="21.0" y1="103.0" x2="24.6" y2="99.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="21.0" y1="103.0" x2="24.6" y2="99.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="174.8,179.2 173.5,189.9 171.5,200.5" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.8,130.5 239.6,131.2 226.9,132.4" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.8,131.1 252.2,132.1 239.6,131.2" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
@@ -1181,7 +1181,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="103.0,200.0 103.3,210.2 120.9,211.3" fill="rgb(179,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.8,109.8 101.0,120.1 110.0,111.4" fill="rgb(226,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.9,201.2 120.9,211.3 138.4,209.7" fill="rgb(183,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="306.2" y1="292.4" x2="309.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="306.2" y1="292.4" x2="309.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="107.8,109.8 96.7,116.9 101.0,120.1" fill="rgb(226,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.1,111.1 138.5,119.6 142.5,116.3" fill="rgb(233,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,135.4 199.1,145.1 205.3,140.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
@@ -1190,16 +1190,16 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="138.5,119.6 153.0,124.8 142.5,116.3" fill="rgb(237,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.3,112.4 138.5,119.6 129.1,111.1" fill="rgb(238,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.6,160.1 174.8,179.2 178.6,169.3" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="283.3" y1="100.7" x2="296.6" y2="105.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="283.3" y1="100.7" x2="296.6" y2="105.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="308.5,187.7 309.8,198.6 307.0,188.1" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.9,131.4 226.9,132.4 215.3,135.4" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.3,231.5 185.5,240.1 191.5,248.2" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.1,129.6 162.2,134.8 153.0,124.8" fill="rgb(236,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.1,263.7 268.5,261.7 276.0,259.0" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="170.2" y1="289.4" x2="183.5" y2="293.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="170.2" y1="289.4" x2="183.5" y2="293.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="259.1,133.2 264.2,134.8 252.2,132.1" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="77.5,135.9 70.2,147.0 79.6,153.9" fill="rgb(209,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="139.4" x2="10.0" y2="133.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="139.4" x2="10.0" y2="133.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="72.5,178.4 86.1,196.2 86.8,184.6" fill="rgb(175,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.3,140.1 199.1,145.1 190.2,152.2" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="110.0,111.4 106.6,122.5 112.9,112.6" fill="rgb(232,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1211,7 +1211,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="123.1,113.3 133.1,122.1 126.3,112.4" fill="rgb(241,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.7,140.8 160.9,152.8 169.8,145.7" fill="rgb(229,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="70.2,147.0 75.2,166.3 79.6,153.9" fill="rgb(194,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="159.1" x2="350.0" y2="153.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="159.1" x2="350.0" y2="153.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="217.2,264.4 222.2,265.9 231.6,268.0" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,119.6 147.1,129.6 153.0,124.8" fill="rgb(237,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="75.2,166.3 72.5,178.4 86.8,184.6" fill="rgb(197,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1230,7 +1230,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="254.4,266.7 251.5,267.8 260.6,265.4" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.8,130.5 226.9,132.4 229.9,131.4" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="282.2,254.0 276.0,259.0 283.6,252.9" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="17.3" y1="106.9" x2="21.0" y2="103.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="17.3" y1="106.9" x2="21.0" y2="103.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.1,129.6 154.7,140.8 162.2,134.8" fill="rgb(236,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.8,184.6 86.1,196.2 103.0,200.0" fill="rgb(193,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.6,113.6 126.8,123.8 123.1,113.3" fill="rgb(242,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1245,7 +1245,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="77.5,135.9 79.6,153.9 85.5,141.8" fill="rgb(209,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.5,200.5 172.9,211.4 175.6,221.7" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.4,187.9 155.3,195.3 154.6,183.7" fill="rgb(205,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="302.5" y1="296.3" x2="306.2" y2="292.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="302.5" y1="296.3" x2="306.2" y2="292.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="133.1,122.1 147.1,129.6 138.5,119.6" fill="rgb(245,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.5,125.7 85.5,141.8 92.8,130.3" fill="rgb(220,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="307.9,209.2 308.5,209.6 309.8,198.6" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
@@ -1254,19 +1254,19 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="123.1,113.3 126.8,123.8 133.1,122.1" fill="rgb(241,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="241.8,267.9 241.5,268.7 251.5,267.8" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="220.7,133.8 215.3,135.4 205.3,140.1" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="133.2" x2="10.0" y2="127.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="133.2" x2="10.0" y2="127.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="174.8,179.2 171.5,200.5 172.9,189.6" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="267.2,136.7 274.5,139.2 264.2,134.8" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.9,131.4 215.3,135.4 220.7,133.8" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="254.4,266.7 260.6,265.4 266.1,263.7" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="116.1,113.3 113.1,124.0 119.9,124.4" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.6,113.6 119.9,124.4 126.8,123.8" fill="rgb(242,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="296.6" y1="105.0" x2="310.0" y2="109.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="296.6" y1="105.0" x2="310.0" y2="109.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="149.2,158.3 165.5,165.1 160.9,152.8" fill="rgb(231,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.6,169.3 174.8,179.2 172.9,189.6" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="304.6,177.3 305.8,177.4 302.0,167.6" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="153.0" x2="350.0" y2="146.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="183.5" y1="293.7" x2="196.9" y2="298.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="153.0" x2="350.0" y2="146.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="183.5" y1="293.7" x2="196.9" y2="298.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="75.2,166.3 86.8,184.6 88.7,172.1" fill="rgb(197,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="79.6,153.9 75.2,166.3 88.7,172.1" fill="rgb(214,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="307.9,209.2 306.6,219.9 308.5,209.6" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
@@ -1286,7 +1286,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="144.7,145.5 160.9,152.8 154.7,140.8" fill="rgb(242,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.8,123.8 139.3,133.3 133.1,122.1" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="304.6,177.3 308.5,187.7 305.8,177.4" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="13.7" y1="110.9" x2="17.3" y2="106.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="13.7" y1="110.9" x2="17.3" y2="106.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.2,152.2 178.6,169.3 184.8,160.5" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="241.8,267.9 251.5,267.8 254.4,266.7" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.9,189.5 138.7,199.5 138.4,187.9" fill="rgb(208,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1298,10 +1298,10 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="175.6,221.7 179.3,231.5 186.1,240.5" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="106.6,122.5 110.2,136.0 113.1,124.0" fill="rgb(244,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.3,133.3 144.7,145.5 154.7,140.8" fill="rgb(247,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="127.1" x2="10.0" y2="121.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="127.1" x2="10.0" y2="121.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="137.3,175.2 154.6,183.7 152.5,171.2" fill="rgb(225,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,145.5 149.2,158.3 160.9,152.8" fill="rgb(242,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="298.9" y1="300.2" x2="302.5" y2="296.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="298.9" y1="300.2" x2="302.5" y2="296.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="103.3,188.4 120.9,201.2 120.9,189.5" fill="rgb(204,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.3,175.2 138.4,187.9 154.6,183.7" fill="rgb(225,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="79.6,153.9 88.7,172.1 91.7,159.1" fill="rgb(214,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1314,7 +1314,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="220.7,133.8 205.3,140.1 212.9,137.5" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="113.1,124.0 120.2,136.6 119.9,124.4" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.8,146.2 190.2,152.2 184.8,160.5" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="146.8" x2="350.0" y2="140.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="146.8" x2="350.0" y2="140.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="240.1,132.3 239.8,130.5 229.9,131.4" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.5,141.8 91.7,159.1 95.8,146.2" fill="rgb(227,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.9,132.8 249.8,131.1 239.8,130.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -1324,14 +1324,14 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="171.5,200.5 175.6,221.7 174.3,211.0" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="287.6,152.0 289.8,150.9 282.5,145.1" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.6,259.6 276.0,259.0 282.2,254.0" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="310.0" y1="109.3" x2="323.3" y2="113.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="310.0" y1="109.3" x2="323.3" y2="113.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="130.1,135.7 144.7,145.5 139.3,133.3" fill="rgb(253,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="287.6,152.0 295.9,159.0 289.8,150.9" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="172.9,189.6 171.5,200.5 174.3,211.0" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.5,141.3 282.5,145.1 274.5,139.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="306.6,198.1 309.8,198.6 308.5,187.7" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="113.1,124.0 110.2,136.0 120.2,136.6" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="196.9" y1="298.0" x2="210.2" y2="302.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="196.9" y1="298.0" x2="210.2" y2="302.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.9,124.4 120.2,136.6 130.1,135.7" fill="rgb(251,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.7,172.1 103.3,188.4 104.2,175.6" fill="rgb(213,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.5,161.9 152.5,171.2 149.2,158.3" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1344,14 +1344,14 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="178.6,169.3 172.9,189.6 176.8,179.0" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.5,141.3 274.5,139.2 267.2,136.7" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.8,176.7 120.9,189.5 138.4,187.9" fill="rgb(228,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="114.8" x2="13.7" y2="110.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="114.8" x2="13.7" y2="110.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="133.1,148.6 149.2,158.3 144.7,145.5" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,133.8 95.8,146.2 107.8,148.9" fill="rgb(245,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.5,161.9 137.3,175.2 152.5,171.2" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.9,133.8 107.8,148.9 110.2,136.0" fill="rgb(245,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.8,160.5 178.6,169.3 176.8,179.0" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.8,176.7 138.4,187.9 137.3,175.2" fill="rgb(228,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="121.0" x2="10.0" y2="114.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="121.0" x2="10.0" y2="114.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="130.1,135.7 133.1,148.6 144.7,145.5" fill="rgb(253,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="298.2,167.7 302.0,167.6 295.9,159.0" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="306.6,198.1 307.9,209.2 309.8,198.6" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -1359,10 +1359,10 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="95.8,146.2 91.7,159.1 105.7,162.3" fill="rgb(240,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.2,136.6 133.1,148.6 130.1,135.7" fill="rgb(255,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.2,175.6 120.9,189.5 120.8,176.7" fill="rgb(224,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="295.2" y1="304.2" x2="298.9" y2="300.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="295.2" y1="304.2" x2="298.9" y2="300.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="200.9,255.1 217.2,264.4 213.1,260.3" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.1,148.6 135.5,161.9 149.2,158.3" fill="rgb(250,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="140.7" x2="350.0" y2="134.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="140.7" x2="350.0" y2="134.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.7,159.1 104.2,175.6 105.7,162.3" fill="rgb(229,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.9,132.8 239.8,130.5 240.1,132.3" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="256.8,263.1 254.4,266.7 266.1,263.7" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
@@ -1382,7 +1382,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="197.8,146.2 184.8,160.5 193.2,153.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.9,137.5 197.8,146.2 207.0,142.2" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.4,149.7 135.5,161.9 133.1,148.6" fill="rgb(252,0,0)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.3" y1="113.6" x2="336.7" y2="117.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.3" y1="113.6" x2="336.7" y2="117.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="227.1,263.5 229.1,267.1 241.8,267.9" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="107.8,148.9 105.7,162.3 120.6,163.3" fill="rgb(249,0,0)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="105.7,162.3 120.8,176.7 120.6,163.3" fill="rgb(239,0,0)" stroke="#00000018" stroke-width="0.5"/>
@@ -1393,19 +1393,19 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="233.2,133.0 220.7,133.8 226.9,134.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="186.1,240.5 200.9,255.1 196.5,248.2" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="256.8,263.1 266.1,263.7 270.6,259.6" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="210.2" y1="302.3" x2="223.6" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="210.2" y1="302.3" x2="223.6" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="301.3,219.1 306.6,219.9 307.9,209.2" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="10.0" y1="114.8" x2="23.3" y2="119.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="10.0" y1="114.8" x2="23.3" y2="119.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="259.0,136.7 259.1,133.2 253.4,134.3" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="172.9,189.6 174.3,211.0 175.6,199.9" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.0,142.2 197.8,146.2 193.2,153.2" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="302.8,187.1 308.5,187.7 304.6,177.3" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="134.5" x2="350.0" y2="128.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="134.5" x2="350.0" y2="128.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="176.8,179.0 172.9,189.6 175.6,199.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="213.1,260.3 229.1,267.1 227.1,263.5" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="301.3,219.1 300.2,229.7 306.6,219.9" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.5,248.2 200.9,255.1 213.1,260.3" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="291.6" y1="308.1" x2="295.2" y2="304.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="291.6" y1="308.1" x2="295.2" y2="304.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="277.5,146.7 287.6,152.0 282.5,145.1" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="277.5,146.7 282.5,145.1 273.5,141.3" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.8,160.5 176.8,179.0 183.2,169.3" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
@@ -1424,17 +1424,17 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="289.6,159.4 298.2,167.7 295.9,159.0" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="289.7,238.1 286.9,247.0 296.7,239.0" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="263.3,139.8 267.2,136.7 259.0,136.7" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="336.7" y1="117.9" x2="350.0" y2="122.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="223.6" y1="306.6" x2="236.9" y2="310.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="336.7" y1="117.9" x2="350.0" y2="122.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="223.6" y1="306.6" x2="236.9" y2="310.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="240.4,136.8 240.1,132.3 233.2,133.0" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="243.9,137.0 246.9,132.8 240.1,132.3" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="350.0" y1="128.4" x2="350.0" y2="122.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="350.0" y1="128.4" x2="350.0" y2="122.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="207.0,142.2 193.2,153.2 203.3,147.7" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="23.3" y1="119.1" x2="36.7" y2="123.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="23.3" y1="119.1" x2="36.7" y2="123.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="174.3,211.0 182.7,231.2 181.6,220.7" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="236.9,137.1 233.2,133.0 226.9,134.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="247.1,137.8 253.4,134.3 246.9,132.8" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="287.9" y1="312.0" x2="291.6" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="287.9" y1="312.0" x2="291.6" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="175.6,199.9 174.3,211.0 181.6,220.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="300.2,207.8 307.9,209.2 306.6,198.1" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,137.2 207.0,142.2 217.5,140.4" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
@@ -1458,20 +1458,20 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="266.1,143.6 273.5,141.3 263.3,139.8" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="279.1,152.6 287.6,152.0 277.5,146.7" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="247.1,137.8 246.9,132.8 243.9,137.0" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="346.3" y1="126.2" x2="350.0" y2="122.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="346.3" y1="126.2" x2="350.0" y2="122.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="279.1,152.6 289.6,159.4 287.6,152.0" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="236.9,137.1 226.9,134.6 233.7,138.0" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="258.6,257.1 270.6,259.6 273.9,253.1" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="236.9" y1="310.9" x2="250.3" y2="315.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="236.9" y1="310.9" x2="250.3" y2="315.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="225.5,257.5 227.1,263.5 242.0,264.5" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.6,220.7 182.7,231.2 193.8,239.4" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.0,139.0 253.4,134.3 247.1,137.8" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="242.1,258.6 242.0,264.5 256.8,263.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="230.9,139.3 221.5,137.2 217.5,140.4" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.7" y1="123.4" x2="50.0" y2="127.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.7" y1="123.4" x2="50.0" y2="127.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="252.2,140.6 263.3,139.8 259.0,136.7" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.8,239.4 196.5,248.2 210.0,254.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="284.3" y1="316.0" x2="287.9" y2="312.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="284.3" y1="316.0" x2="287.9" y2="312.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="290.7,227.7 300.2,229.7 301.3,219.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.7,138.0 221.5,137.2 230.9,139.3" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="217.5,140.4 203.3,147.7 215.0,144.2" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -1489,7 +1489,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="203.3,147.7 191.8,160.7 202.3,153.6" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="242.1,258.6 256.8,263.1 258.6,257.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="288.2,166.9 296.5,176.5 298.2,167.7" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="342.7" y1="130.1" x2="346.3" y2="126.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="342.7" y1="130.1" x2="346.3" y2="126.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="215.0,144.2 203.3,147.7 202.3,153.6" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="267.1,147.6 277.5,146.7 266.1,143.6" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.5,257.5 242.0,264.5 242.1,258.6" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
@@ -1498,13 +1498,13 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="253.6,142.5 266.1,143.6 263.3,139.8" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="267.1,147.6 279.1,152.6 277.5,146.7" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="296.7,196.3 300.2,207.8 306.6,198.1" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="250.3" y1="315.2" x2="263.6" y2="319.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="250.3" y1="315.2" x2="263.6" y2="319.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="253.6,142.5 263.3,139.8 252.2,140.6" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 243.9,137.0 240.4,136.8" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 240.4,136.8 236.9,137.1" fill="rgb(76,104,145)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="280.6" y1="319.9" x2="284.3" y2="316.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="280.6" y1="319.9" x2="284.3" y2="316.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="240.7,143.7 247.1,137.8 243.9,137.0" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="50.0" y1="127.7" x2="63.4" y2="132.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="50.0" y1="127.7" x2="63.4" y2="132.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="240.7,143.7 236.9,137.1 233.7,138.0" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.6,220.7 193.8,239.4 192.9,229.0" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.8,239.4 210.0,254.0 208.1,245.5" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
@@ -1528,7 +1528,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="254.2,144.6 266.1,143.6 253.6,142.5" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="254.2,144.6 267.1,147.6 266.1,143.6" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.3,188.7 182.7,209.4 186.1,197.7" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="339.0" y1="134.0" x2="342.7" y2="130.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="339.0" y1="134.0" x2="342.7" y2="130.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="240.7,143.7 240.4,136.8 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 243.9,137.0 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 236.9,137.1 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -1543,11 +1543,11 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="291.1,184.8 296.7,196.3 302.8,187.1" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 250.0,139.0 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 230.9,139.3 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="263.6" y1="319.5" x2="276.9" y2="323.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="263.6" y1="319.5" x2="276.9" y2="323.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="214.2,148.3 202.3,153.6 203.8,159.5" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.6,142.9 214.2,148.3 227.2,144.9" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 252.2,140.6 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="276.9" y1="323.8" x2="280.6" y2="319.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="276.9" y1="323.8" x2="280.6" y2="319.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="224.6,249.3 225.5,257.5 242.1,258.6" fill="rgb(56,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 228.8,140.9 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="276.6,234.4 289.7,238.1 290.7,227.7" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
@@ -1557,7 +1557,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="266.4,151.6 278.0,158.5 279.1,152.6" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 254.2,144.6 253.6,142.5" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 227.6,142.9 227.2,144.9" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="63.4" y1="132.0" x2="76.7" y2="136.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="63.4" y1="132.0" x2="76.7" y2="136.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="240.7,143.7 253.6,142.5 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 227.6,142.9 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="253.8,146.6 267.1,147.6 254.2,144.6" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
@@ -1576,7 +1576,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="240.7,143.7 227.7,147.0 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.5,178.0 186.1,197.7 191.5,186.1" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="242.2,250.4 258.6,257.1 259.7,248.8" fill="rgb(57,78,110)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="335.4" y1="138.0" x2="339.0" y2="134.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="335.4" y1="138.0" x2="339.0" y2="134.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="286.9,204.2 300.2,207.8 296.7,196.3" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="283.6,173.9 291.1,184.8 296.5,176.5" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="186.1,197.7 182.7,209.4 193.8,217.6" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -1591,7 +1591,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="240.7,143.7 227.7,147.0 229.1,148.9" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.9,229.0 208.1,245.5 207.5,235.3" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="252.5,148.6 266.4,151.6 253.8,146.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="276.9" y1="323.8" x2="276.9" y2="317.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="276.9" y1="323.8" x2="276.9" y2="317.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="240.7,143.7 247.7,151.5 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 234.2,151.7 240.7,143.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="286.9,204.2 289.7,216.3 300.2,207.8" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
@@ -1607,7 +1607,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="227.7,147.0 215.3,152.3 218.1,156.0" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="252.5,148.6 263.9,155.4 266.4,151.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.7,168.1 191.5,186.1 198.9,175.0" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="76.7" y1="136.3" x2="90.1" y2="140.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="76.7" y1="136.3" x2="90.1" y2="140.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="215.3,152.3 203.8,159.5 207.8,164.9" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.8,217.6 192.9,229.0 207.5,235.3" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.1,238.7 259.7,248.8 275.9,244.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
@@ -1624,12 +1624,12 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="275.9,222.8 276.6,234.4 290.7,227.7" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="203.8,159.5 198.9,175.0 207.8,164.9" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 241.0,152.7 244.5,152.4" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="331.7" y1="141.9" x2="335.4" y2="138.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="331.7" y1="141.9" x2="335.4" y2="138.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="191.5,186.1 186.1,197.7 196.5,205.4" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.7,143.7 237.5,152.5 241.0,152.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,152.3 207.8,164.9 218.1,156.0" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="186.1,197.7 193.8,217.6 196.5,205.4" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="276.9" y1="317.7" x2="276.9" y2="311.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="276.9" y1="317.7" x2="276.9" y2="311.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="282.2,191.9 286.9,204.2 296.7,196.3" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="224.3,239.2 224.6,249.3 242.2,250.4" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,148.9 222.4,159.2 231.3,150.5" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
@@ -1643,7 +1643,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="268.5,168.7 283.6,173.9 274.4,164.0" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.9,175.0 191.5,186.1 200.9,193.0" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.8,217.6 207.5,235.3 208.1,223.7" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="90.1" y1="140.6" x2="103.4" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="90.1" y1="140.6" x2="103.4" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="231.3,150.5 228.0,161.6 234.2,151.7" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="242.2,240.3 259.7,248.8 260.1,238.7" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.1,156.0 207.8,164.9 214.1,169.5" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
@@ -1656,10 +1656,10 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="273.9,210.3 289.7,216.3 286.9,204.2" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="224.3,239.2 242.2,250.4 242.2,240.3" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,150.5 222.4,159.2 228.0,161.6" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="276.9" y1="311.5" x2="276.9" y2="305.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="276.9" y1="311.5" x2="276.9" y2="305.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="247.7,151.5 254.4,161.3 259.8,158.7" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.1,156.0 214.1,169.5 222.4,159.2" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="328.1" y1="145.8" x2="331.7" y2="141.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="328.1" y1="145.8" x2="331.7" y2="141.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="234.2,151.7 234.4,163.1 237.5,152.5" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.5,168.7 276.0,180.0 283.6,173.9" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="208.1,223.7 207.5,235.3 224.3,239.2" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
@@ -1680,16 +1680,16 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="200.9,193.0 196.5,205.4 210.0,211.2" fill="rgb(79,108,152)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="222.4,159.2 214.1,169.5 222.2,173.0" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="222.4,159.2 222.2,173.0 228.0,161.6" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="276.9" y1="305.4" x2="276.9" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="276.9" y1="305.4" x2="276.9" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="224.6,227.5 224.3,239.2 242.2,240.3" fill="rgb(75,103,145)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="103.4" y1="144.9" x2="116.8" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="103.4" y1="144.9" x2="116.8" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="208.1,223.7 224.3,239.2 224.6,227.5" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="254.4,161.3 260.6,172.4 268.5,168.7" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,172.4 276.0,180.0 268.5,168.7" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="242.2,228.6 242.2,240.3 260.1,238.7" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.6,197.5 273.9,210.3 286.9,204.2" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.1,184.7 282.2,191.9 276.0,180.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="324.4" y1="149.8" x2="328.1" y2="145.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="324.4" y1="149.8" x2="328.1" y2="145.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.1,162.9 260.6,172.4 254.4,161.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="242.2,228.6 260.1,238.7 259.7,227.0" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.9,180.9 200.9,193.0 213.1,198.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
@@ -1708,17 +1708,17 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="248.1,162.9 251.5,174.8 260.6,172.4" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="234.4,163.1 241.5,175.7 241.3,163.5" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.9,180.9 213.1,198.2 217.2,185.3" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="276.9" y1="299.2" x2="276.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="276.9" y1="299.2" x2="276.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="251.5,174.8 266.1,184.7 260.6,172.4" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="234.4,163.1 231.6,175.1 241.5,175.7" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="241.3,163.5 241.5,175.7 251.5,174.8" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="210.0,211.2 224.6,227.5 225.5,214.8" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="116.8" y1="149.2" x2="130.1" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="116.8" y1="149.2" x2="130.1" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="256.8,201.0 273.9,210.3 270.6,197.5" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.5,214.8 224.6,227.5 242.2,228.6" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="213.1,198.2 210.0,211.2 225.5,214.8" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="242.1,215.8 242.2,228.6 259.7,227.0" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="320.8" y1="153.7" x2="324.4" y2="149.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="320.8" y1="153.7" x2="324.4" y2="149.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="254.4,187.7 270.6,197.5 266.1,184.7" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="222.2,173.0 217.2,185.3 229.1,188.0" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="256.8,201.0 258.6,214.3 273.9,210.3" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
@@ -1731,7 +1731,7 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="254.4,187.7 256.8,201.0 270.6,197.5" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="213.1,198.2 225.5,214.8 227.1,201.4" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.6,175.1 241.8,188.9 241.5,175.7" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="276.9" y1="293.1" x2="276.9" y2="286.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="276.9" y1="293.1" x2="276.9" y2="286.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="217.2,185.3 227.1,201.4 229.1,188.0" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.6,175.1 229.1,188.0 241.8,188.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="241.5,175.7 241.8,188.9 254.4,187.7" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
@@ -1743,41 +1743,41 @@ expression: "export_svg(\"Graphics3D[{{Red, Sphere[{0,0,0}]}, Sphere[{2,0,0}]}]\
 <polygon points="227.1,201.4 242.1,215.8 242.0,202.4" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,188.0 242.0,202.4 241.8,188.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="241.8,188.9 242.0,202.4 256.8,201.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="317.1" y1="157.6" x2="320.8" y2="153.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="130.1" y1="153.5" x2="143.5" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="286.9" x2="276.9" y2="280.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.5" y1="161.6" x2="317.1" y2="157.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="143.5" y1="157.8" x2="156.8" y2="162.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="280.8" x2="276.9" y2="274.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="274.7" x2="276.9" y2="268.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="309.8" y1="165.5" x2="313.5" y2="161.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.8" y1="162.1" x2="170.2" y2="166.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="268.5" x2="276.9" y2="262.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="306.2" y1="169.4" x2="309.8" y2="165.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.2" y1="166.5" x2="183.5" y2="170.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="262.4" x2="276.9" y2="256.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="302.5" y1="173.4" x2="306.2" y2="169.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="183.5" y1="170.8" x2="196.9" y2="175.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="256.2" x2="276.9" y2="250.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.9" y1="177.3" x2="302.5" y2="173.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="250.1" x2="276.9" y2="243.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="196.9" y1="175.1" x2="210.2" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.2" y1="181.2" x2="298.9" y2="177.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="243.9" x2="276.9" y2="237.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="210.2" y1="179.4" x2="223.6" y2="183.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="237.8" x2="276.9" y2="231.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="291.6" y1="185.2" x2="295.2" y2="181.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="223.6" y1="183.7" x2="236.9" y2="188.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="231.6" x2="276.9" y2="225.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="287.9" y1="189.1" x2="291.6" y2="185.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="225.5" x2="276.9" y2="219.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="236.9" y1="188.0" x2="250.3" y2="192.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="284.3" y1="193.0" x2="287.9" y2="189.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="219.3" x2="276.9" y2="213.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="250.3" y1="192.3" x2="263.6" y2="196.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="280.6" y1="197.0" x2="284.3" y2="193.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="213.2" x2="276.9" y2="207.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="263.6" y1="196.6" x2="276.9" y2="200.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="200.9" x2="280.6" y2="197.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="276.9" y1="207.0" x2="276.9" y2="200.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="317.1" y1="157.6" x2="320.8" y2="153.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="130.1" y1="153.5" x2="143.5" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="286.9" x2="276.9" y2="280.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.5" y1="161.6" x2="317.1" y2="157.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="143.5" y1="157.8" x2="156.8" y2="162.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="280.8" x2="276.9" y2="274.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="274.7" x2="276.9" y2="268.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="309.8" y1="165.5" x2="313.5" y2="161.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.8" y1="162.1" x2="170.2" y2="166.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="268.5" x2="276.9" y2="262.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="306.2" y1="169.4" x2="309.8" y2="165.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.2" y1="166.5" x2="183.5" y2="170.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="262.4" x2="276.9" y2="256.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="302.5" y1="173.4" x2="306.2" y2="169.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="183.5" y1="170.8" x2="196.9" y2="175.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="256.2" x2="276.9" y2="250.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.9" y1="177.3" x2="302.5" y2="173.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="250.1" x2="276.9" y2="243.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="196.9" y1="175.1" x2="210.2" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.2" y1="181.2" x2="298.9" y2="177.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="243.9" x2="276.9" y2="237.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="210.2" y1="179.4" x2="223.6" y2="183.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="237.8" x2="276.9" y2="231.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="291.6" y1="185.2" x2="295.2" y2="181.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="223.6" y1="183.7" x2="236.9" y2="188.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="231.6" x2="276.9" y2="225.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="287.9" y1="189.1" x2="291.6" y2="185.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="225.5" x2="276.9" y2="219.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="236.9" y1="188.0" x2="250.3" y2="192.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="284.3" y1="193.0" x2="287.9" y2="189.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="219.3" x2="276.9" y2="213.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="250.3" y1="192.3" x2="263.6" y2="196.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="280.6" y1="197.0" x2="284.3" y2="193.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="213.2" x2="276.9" y2="207.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="263.6" y1="196.6" x2="276.9" y2="200.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="200.9" x2="280.6" y2="197.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="276.9" y1="207.0" x2="276.9" y2="200.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_sphere.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_sphere.snap
@@ -4,63 +4,63 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="147.3" y2="183.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="180.9" x2="138.0" y2="172.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="132.9" y1="186.3" x2="138.0" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.3" y1="183.9" x2="156.6" y2="186.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="172.3" x2="138.0" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="156.6" y1="186.9" x2="165.8" y2="189.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.9" y1="191.8" x2="132.9" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="165.8" y1="189.9" x2="175.1" y2="192.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="163.8" x2="138.0" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.1" y1="192.8" x2="184.4" y2="195.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="122.8" y1="197.3" x2="127.9" y2="191.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="155.3" x2="138.0" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.4" y1="195.8" x2="193.7" y2="198.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="117.7" y1="202.7" x2="122.8" y2="197.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="193.7" y1="198.8" x2="202.9" y2="201.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="146.7" x2="138.0" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="202.9" y1="201.8" x2="212.2" y2="204.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="112.6" y1="208.2" x2="117.7" y2="202.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="138.2" x2="138.0" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.2" y1="204.8" x2="221.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="207.8" x2="230.8" y2="210.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="129.6" x2="138.0" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="107.6" y1="213.7" x2="112.6" y2="208.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="230.8" y1="210.8" x2="240.0" y2="213.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="121.1" x2="138.0" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="213.8" x2="249.3" y2="216.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="102.5" y1="219.1" x2="107.6" y2="213.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="216.8" x2="258.6" y2="219.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="112.5" x2="138.0" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="219.8" x2="267.9" y2="222.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="97.4" y1="224.6" x2="102.5" y2="219.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="104.0" x2="138.0" y2="95.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.9" y1="222.8" x2="277.1" y2="225.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="277.1" y1="225.8" x2="286.4" y2="228.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="230.1" x2="97.4" y2="224.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="95.4" x2="138.0" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="286.4" y1="228.7" x2="295.7" y2="231.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.2" y1="235.5" x2="92.3" y2="230.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="86.9" x2="138.0" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="231.7" x2="305.0" y2="234.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="305.0" y1="234.7" x2="314.3" y2="237.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.0" y1="78.4" x2="138.0" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.2" y1="241.0" x2="87.2" y2="235.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="314.3" y1="237.7" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.9,177.4 178.5,194.9 178.2,176.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.2,176.1 178.5,194.9 160.9,196.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.0,157.4 178.2,176.1 157.6,178.0" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.9,177.4 196.1,196.0 178.5,194.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="69.8" x2="138.0" y2="61.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,176.1 160.9,196.5 157.6,178.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,158.9 198.9,177.4 178.2,176.1" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,158.9 178.2,176.1 178.0,157.4" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="240.7" x2="323.5" y2="232.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.1,196.0 178.8,213.1 178.5,194.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="246.2" x2="323.5" y2="240.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.0,157.4 157.6,178.0 155.1,159.5" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="246.5" x2="82.2" y2="241.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,194.9 165.0,214.4 160.9,196.5" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.4,181.8 196.1,196.0 198.9,177.4" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.5,194.9 178.8,213.1 165.0,214.4" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
@@ -76,21 +76,21 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="222.6,163.8 218.4,181.8 198.9,177.4" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,141.2 178.0,157.4 177.9,139.6" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,196.5 165.0,214.4 152.2,217.7" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="61.3" x2="138.0" y2="52.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,196.5 152.2,217.7 144.7,200.7" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,199.8 205.6,217.0 192.6,214.0" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="177.9,139.6 155.1,159.5 153.5,141.8" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,214.0 179.2,230.1 178.8,213.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="232.2" x2="323.5" y2="223.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,159.5 138.5,182.9 133.9,165.0" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.8,213.1 169.7,231.0 165.0,214.4" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.5,141.8 155.1,159.5 133.9,165.0" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.6,217.0 188.7,230.7 192.6,214.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="313.4" y1="251.6" x2="318.4" y2="246.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="235.2,189.1 212.6,199.8 218.4,181.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.3,146.4 201.0,158.9 202.3,141.2" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.3,146.4 222.6,163.8 201.0,158.9" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="251.9" x2="77.1" y2="246.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.8,213.1 179.2,230.1 169.7,231.0" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,206.0 205.6,217.0 212.6,199.8" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,214.0 188.7,230.7 179.2,230.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -103,11 +103,11 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="241.4,171.9 218.4,181.8 222.6,163.8" fill="rgb(79,108,152)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.2,189.1 227.0,206.0 212.6,199.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.9,165.0 138.5,182.9 122.2,190.6" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="52.7" x2="138.0" y2="44.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,217.0 197.7,232.8 188.7,230.7" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.5,141.8 133.9,165.0 131.0,147.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,206.0 216.9,221.8 205.6,217.0" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="223.6" x2="323.5" y2="215.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,200.7 141.4,222.8 130.9,207.3" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,221.8 197.7,232.8 205.6,217.0" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,182.9 130.9,207.3 122.2,190.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
@@ -119,8 +119,8 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="188.7,230.7 179.6,245.1 179.2,230.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,217.7 153.4,236.8 141.4,222.8" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,230.1 174.7,245.6 169.7,231.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="257.1" x2="313.4" y2="251.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="66.9" y1="257.4" x2="72.0" y2="251.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="226.2,130.3 225.3,146.4 202.3,141.2" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,221.8 205.4,236.1 197.7,232.8" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.0,147.7 133.9,165.0 115.8,173.6" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -130,9 +130,9 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="245.1,155.0 222.6,163.8 225.3,146.4" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.7,231.0 170.3,246.7 160.9,233.2" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,214.1 216.9,221.8 227.0,206.0" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="44.2" x2="138.0" y2="35.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="245.1,155.0 241.4,171.9 222.6,163.8" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="215.1" x2="323.5" y2="206.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.3,198.7 227.0,206.0 235.2,189.1" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,230.1 179.6,245.1 174.7,245.6" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,207.3 141.4,222.8 133.2,229.5" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
@@ -155,16 +155,16 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="225.6,228.2 211.4,240.5 205.4,236.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="131.0,147.7 115.8,173.6 111.8,156.8" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="255.9,182.5 235.2,189.1 241.4,171.9" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="262.6" x2="308.3" y2="257.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,173.6 122.2,190.6 109.9,200.5" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,236.1 193.0,248.2 189.0,246.5" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="262.9" x2="66.9" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,240.5 193.0,248.2 205.4,236.1" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="35.6" x2="138.0" y2="27.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="130.0,131.6 131.0,147.7 111.8,156.8" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.3,110.9 177.8,123.4 177.9,109.3" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.2,190.6 120.4,215.7 109.9,200.5" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="206.5" x2="323.5" y2="198.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.5,111.5 153.0,125.6 130.0,131.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.4,236.8 163.5,250.9 147.7,241.4" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.4,139.1 225.3,146.4 226.2,130.3" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -189,13 +189,13 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="111.8,156.8 115.8,173.6 102.1,184.6" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,166.3 241.4,171.9 245.1,155.0" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="115.8,173.6 109.9,200.5 102.1,184.6" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="27.1" x2="138.0" y2="18.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,241.4 163.5,250.9 161.8,253.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,235.7 215.3,245.7 211.4,240.5" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="298.1" y1="268.0" x2="303.2" y2="262.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="196.0,250.4 180.0,257.7 193.0,248.2" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="268.3" x2="61.9" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="198.0" x2="323.5" y2="189.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="166.4,248.5 180.0,257.7 163.5,250.9" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.7,241.4 161.8,253.6 144.3,246.6" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.2,229.5 144.3,246.6 128.1,237.1" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
@@ -228,7 +228,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="161.8,253.6 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.7,255.9 180.0,257.7 198.0,253.1" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.8,253.6 180.0,257.7 161.3,256.4" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="18.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.7,255.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.8,251.3 198.7,255.9 198.0,253.1" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -237,16 +237,16 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="245.1,124.7 226.2,130.3 225.3,116.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.4,243.9 215.3,245.7 231.3,235.7" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,156.8 102.1,184.6 97.3,168.5" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="189.4" x2="323.5" y2="180.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,246.6 161.3,256.4 143.2,252.3" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="265.2,195.0 248.3,198.7 255.9,182.5" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,184.6 109.9,200.5 102.3,212.0" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="293.1" y1="273.5" x2="298.1" y2="268.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="110.5,140.9 111.8,156.8 97.3,168.5" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.0,259.3 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,258.8 180.0,257.7 198.7,255.9" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="51.7" y1="273.8" x2="56.8" y2="268.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 153.5,111.5 131.0,117.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.0,99.4 177.9,109.3 178.0,98.0" fill="rgb(56,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,256.4 180.0,257.7 162.0,259.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -269,7 +269,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="162.0,259.3 180.0,257.7 164.0,261.9" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,237.1 143.2,252.3 126.6,245.3" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.0" y1="10.0" x2="147.3" y2="13.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="185.3,266.8 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.7,256.9 198.7,255.9 216.8,251.3" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.6,266.9 180.0,257.7 180.0,257.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -277,22 +277,22 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="215.7,256.9 198.2,258.8 198.7,255.9" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="222.6,104.4 202.3,110.9 201.0,99.4" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.6,263.8 180.0,257.7 196.5,261.5" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="132.9" y1="15.5" x2="138.0" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="131.0,117.4 110.5,140.9 111.8,126.5" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,261.9 180.0,257.7 167.0,264.2" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.0,234.0 233.4,243.9 231.3,235.7" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="180.9" x2="323.5" y2="172.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.2,252.3 162.0,259.3 144.7,257.8" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.7,265.6 180.0,257.7 193.6,263.8" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.0,264.2 180.0,257.7 171.0,265.9" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,257.8 162.0,259.3 164.0,261.9" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.3" y1="13.0" x2="156.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="288.0" y1="279.0" x2="293.1" y2="273.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="97.3,168.5 102.1,184.6 93.7,197.3" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.5,179.6 255.9,182.5 260.6,166.3" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,245.3 143.2,252.3 144.7,257.8" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,184.6 102.3,212.0 93.7,197.3" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="46.6" y1="279.2" x2="51.7" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="155.1,100.1 131.0,117.4 133.9,105.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.3,266.8 180.0,257.7 189.7,265.6" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,265.9 180.0,257.7 175.6,266.9" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
@@ -310,24 +310,24 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="270.5,179.6 265.2,195.0 255.9,182.5" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,126.5 110.5,140.9 95.7,152.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.2,89.8 178.0,98.0 155.1,100.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="156.6" y1="16.0" x2="165.8" y2="19.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 245.1,124.7 225.3,116.1" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="172.4" x2="323.5" y2="163.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="259.9,222.1 248.0,234.0 245.2,223.7" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.9,91.1 201.0,99.4 178.0,98.0" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.6,263.0 164.0,261.9 167.0,264.2" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,136.0 246.4,139.1 245.1,124.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,257.8 164.0,261.9 148.6,263.0" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="127.9" y1="20.9" x2="132.9" y2="15.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,112.4 225.3,116.1 222.6,104.4" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.6,266.7 193.6,263.8 196.5,261.5" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="260.6,136.0 262.1,150.6 246.4,139.1" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,245.3 144.7,257.8 128.7,253.4" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="284.4" x2="288.0" y2="279.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="112.0,235.8 126.6,245.3 128.7,253.4" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="41.6" y1="284.7" x2="46.6" y2="279.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.6,266.7 196.5,261.5 212.3,262.2" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="165.8" y1="19.0" x2="175.1" y2="22.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.6,267.4 167.0,264.2 171.0,265.9" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.6,91.7 155.1,100.1 133.9,105.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,244.4 233.4,243.9 248.0,234.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
@@ -343,7 +343,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="272.3,164.1 260.6,166.3 262.1,150.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.6,263.0 167.0,264.2 154.6,267.4" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,244.4 231.9,252.0 233.4,243.9" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="163.8" x2="323.5" y2="155.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.2,89.8 155.1,100.1 157.6,91.7" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.8,259.7 212.3,262.2 215.7,256.9" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.3,270.8 171.0,265.9 175.6,266.9" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -351,9 +351,9 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="226.8,259.7 215.7,256.9 231.9,252.0" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.3,272.6 185.3,266.8 189.7,265.6" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.8,208.5 259.9,222.1 256.7,209.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.1" y1="22.0" x2="184.4" y2="25.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="272.3,164.1 270.5,179.6 260.6,166.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="122.8" y1="26.4" x2="127.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="171.3,272.8 175.6,266.9 180.4,267.2" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.4,95.5 201.0,99.4 198.9,91.1" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.8,126.5 95.7,152.8 97.3,138.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -361,15 +361,15 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="199.1,270.3 193.6,263.8 206.6,266.7" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.6,267.4 171.0,265.9 162.3,270.8" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="112.0,235.8 128.7,253.4 114.8,246.2" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="289.9" x2="282.9" y2="284.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.7,253.4 148.6,263.0 134.4,260.9" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="41.6" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 111.8,126.5 97.3,138.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.6,91.7 133.9,105.6 138.5,96.6" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.1,224.2 112.0,235.8 114.8,246.2" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.4" y1="25.0" x2="193.7" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,272.6 189.7,265.6 199.1,270.3" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="155.3" x2="323.5" y2="146.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.4,260.9 148.6,263.0 154.6,267.4" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,96.6 133.9,105.6 115.8,114.1" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.3,270.8 175.6,266.9 171.3,272.8" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
@@ -386,29 +386,29 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="95.7,152.8 88.4,182.0 86.6,166.6" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,234.3 246.0,244.4 248.0,234.0" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,246.2 128.7,253.4 134.4,260.9" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="117.7" y1="31.9" x2="122.8" y2="26.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,266.3 212.3,262.2 226.8,259.7" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.2,102.8 222.6,104.4 218.4,95.5" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.3,138.2 95.7,152.8 86.6,166.6" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="193.7" y1="27.9" x2="202.9" y2="30.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="270.5,149.3 262.1,150.6 260.6,136.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="45.7" y2="293.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,85.0 178.2,89.8 157.6,91.7" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="274.3,193.9 268.8,208.5 265.2,195.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.1,86.2 198.9,91.1 178.2,89.8" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,254.2 231.9,252.0 246.0,244.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,254.2 226.8,259.7 231.9,252.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="290.2" x2="36.5" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="295.4" x2="277.8" y2="289.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="146.7" x2="323.5" y2="138.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="143.1,267.3 154.6,267.4 162.3,270.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="270.5,149.3 272.3,164.1 262.1,150.6" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.4,260.9 154.6,267.4 143.1,267.3" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.8,271.5 199.1,270.3 206.6,266.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="202.9" y1="30.9" x2="212.2" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="100.1,224.2 114.8,246.2 103.3,236.4" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,86.6 157.6,91.7 138.5,96.6" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="45.7" y1="293.2" x2="55.0" y2="296.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="115.8,114.1 97.3,138.2 102.1,125.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="138.5,96.6 115.8,114.1 122.2,104.3" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,89.9 218.4,95.5 198.9,91.1" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -416,22 +416,22 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="196.1,86.2 178.2,89.8 178.5,85.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,222.1 259.9,222.1 268.8,208.5" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,246.2 134.4,260.9 121.9,255.7" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="112.6" y1="37.3" x2="117.7" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="207.8,271.5 206.6,266.7 218.6,266.3" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.4,272.2 162.3,270.8 171.3,272.8" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="88.4,182.0 91.2,210.9 85.7,196.4" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.5,85.0 157.6,91.7 160.9,86.6" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="281.6" x2="36.5" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="86.6,166.6 88.4,182.0 85.7,196.4" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.2" y1="33.9" x2="221.5" y2="36.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="195.0,274.8 190.3,272.6 199.1,270.3" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="276.1,178.7 270.5,179.6 272.3,164.1" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="138.2" x2="323.5" y2="129.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="296.2" x2="64.3" y2="299.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="122.2,104.3 115.8,114.1 102.1,125.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,222.1 257.7,234.3 259.9,222.1" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,89.9 198.9,91.1 196.1,86.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.7" y1="300.8" x2="272.8" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,255.7 134.4,260.9 143.1,267.3" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.1,267.3 162.3,270.8 154.4,272.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,275.2 171.3,272.8 180.8,273.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -443,29 +443,29 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="276.1,178.7 274.3,193.9 270.5,179.6" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,262.6 218.6,266.3 226.8,259.7" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.1,125.2 97.3,138.2 88.4,151.7" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="221.5" y1="36.9" x2="230.8" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 138.5,96.6 122.2,104.3" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.1,245.8 246.0,244.4 257.7,234.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="160.9,86.6 138.5,96.6 144.7,90.9" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="195.0,274.8 199.1,270.3 207.8,271.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="265.2,135.6 260.6,136.0 255.9,123.1" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="229.1,262.6 226.8,259.7 239.6,254.2" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="64.3" y1="299.2" x2="73.6" y2="302.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="250.1,245.8 239.6,254.2 246.0,244.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,96.1 235.2,102.8 218.4,95.5" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="273.1" x2="36.5" y2="264.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.4,272.2 171.3,272.8 167.4,275.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="107.6" y1="42.8" x2="112.6" y2="37.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="265.2,135.6 270.5,149.3 260.6,136.0" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="129.6" x2="323.5" y2="121.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,210.9 103.3,236.4 94.8,224.4" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.2,276.0 190.3,272.6 195.0,274.8" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="227.0,96.1 218.4,95.5 212.6,89.9" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="230.8" y1="39.9" x2="240.0" y2="42.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,275.2 180.8,273.4 181.2,276.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,196.4 91.2,210.9 94.8,224.4" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="262.6" y1="306.3" x2="267.7" y2="300.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="302.1" x2="82.9" y2="305.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="271.6,208.3 268.8,208.5 274.3,193.9" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.9,255.7 143.1,267.3 133.0,263.9" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="86.6,166.6 85.7,196.4 83.9,181.3" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -478,13 +478,13 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="103.3,236.4 121.9,255.7 111.7,247.6" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,208.3 266.3,222.1 268.8,208.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,269.1 207.8,271.5 218.6,266.3" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="264.5" x2="36.5" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="240.0" y1="42.9" x2="249.3" y2="45.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.7,90.9 122.2,104.3 130.9,97.4" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="121.1" x2="323.5" y2="112.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="305.1" x2="92.1" y2="308.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.1,125.2 88.4,151.7 93.7,137.9" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="102.5" y1="48.3" x2="107.6" y2="42.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="274.3,163.6 276.1,178.7 272.3,164.1" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.0,85.2 160.9,86.6 144.7,90.9" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.8,224.4 103.3,236.4 111.7,247.6" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
@@ -494,12 +494,12 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="111.7,247.6 121.9,255.7 133.0,263.9" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.9,234.8 257.7,234.3 266.3,222.1" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="109.9,114.2 102.1,125.2 93.7,137.9" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.5" y1="311.7" x2="262.6" y2="306.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="249.3" y1="45.9" x2="258.6" y2="48.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.4,270.1 154.4,272.2 167.4,275.2" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,104.3 248.3,112.4 235.2,102.8" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,84.8 178.5,85.0 178.8,84.0" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="92.1" y1="308.1" x2="101.4" y2="311.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="256.7,123.6 255.9,123.1 248.3,112.4" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.9,234.8 250.1,245.8 257.7,234.3" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="238.1,104.3 235.2,102.8 227.0,96.1" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
@@ -507,38 +507,38 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="178.8,84.0 160.9,86.6 165.0,85.2" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="237.8,255.7 229.1,262.6 239.6,254.2" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.0,263.9 154.4,272.2 147.4,270.1" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="256.0" x2="36.5" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="237.8,255.7 239.6,254.2 250.1,245.8" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="256.7,123.6 265.2,135.6 255.9,123.1" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,196.4 94.8,224.4 89.5,210.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="112.5" x2="323.5" y2="104.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.6,87.8 196.1,86.2 192.6,84.8" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="83.9,181.3 85.7,196.4 89.5,210.7" fill="rgb(38,52,74)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.4,193.4 274.3,193.9 276.1,178.7" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.9,273.8 167.4,275.2 181.2,276.0" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="258.6" y1="48.9" x2="267.9" y2="51.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.5,275.0 181.2,276.0 195.0,274.8" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,88.5 144.7,90.9 130.9,97.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="101.4" y1="311.1" x2="110.7" y2="314.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="88.4,151.7 83.9,181.3 85.7,166.1" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="97.4" y1="53.7" x2="102.5" y2="48.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.9,92.7 227.0,96.1 212.6,89.9" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.0,85.2 144.7,90.9 152.2,88.5" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,273.4 207.8,271.5 215.3,269.1" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.7,137.9 88.4,151.7 85.7,166.1" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="268.8,149.1 270.5,149.3 265.2,135.6" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="273.4,193.4 271.6,208.3 274.3,193.9" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="252.4" y1="317.2" x2="257.5" y2="311.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="94.8,224.4 111.7,247.6 104.1,236.9" fill="rgb(46,64,89)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="130.9,97.4 109.9,114.2 120.4,105.8" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.4,270.1 167.4,275.2 163.9,273.8" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.9,92.7 212.6,89.9 205.6,87.8" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="111.7,247.6 133.0,263.9 124.8,257.2" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="267.9" y1="51.9" x2="277.1" y2="54.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="36.5" y1="247.5" x2="36.5" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="268.8,149.1 274.3,163.6 270.5,149.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="110.7" y1="314.1" x2="120.0" y2="317.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="104.0" x2="323.5" y2="95.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="109.9,114.2 93.7,137.9 102.3,125.7" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,275.0 195.0,274.8 199.1,273.4" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="124.8,257.2 133.0,263.9 147.4,270.1" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
@@ -547,10 +547,10 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="262.7,221.8 266.3,222.1 271.6,208.3" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,263.4 215.3,269.1 229.1,262.6" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.2,88.5 130.9,97.4 141.4,93.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.1" y1="54.9" x2="286.4" y2="57.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.3" y1="59.2" x2="97.4" y2="53.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 109.9,114.2 102.3,125.7" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="120.0" y1="317.1" x2="129.2" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.2,86.6 178.8,84.0 165.0,85.2" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="188.7,87.2 192.6,84.8 178.8,84.0" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="104.1,236.9 111.7,247.6 124.8,257.2" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
@@ -561,19 +561,19 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="221.5,263.4 229.1,262.6 237.8,255.7" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="245.2,113.8 256.7,123.6 248.3,112.4" fill="rgb(55,76,106)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="85.7,166.1 83.9,181.3 87.7,195.9" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="238.9" x2="36.5" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="225.6,99.1 238.1,104.3 227.0,96.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,178.0 276.1,178.7 274.3,163.6" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="247.4" y1="322.7" x2="252.4" y2="317.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="323.5" y1="95.5" x2="323.5" y2="86.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="169.7,87.4 165.0,85.2 152.2,88.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.2,245.9 250.1,245.8 257.9,234.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.2,245.9 237.8,255.7 250.1,245.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.7,89.2 205.6,87.8 192.6,84.8" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="93.7,137.9 85.7,166.1 91.2,151.5" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.6,99.1 227.0,96.1 216.9,92.7" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="286.4" y1="57.9" x2="295.7" y2="60.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="320.1" x2="138.5" y2="323.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="102.3,125.7 93.7,137.9 91.2,151.5" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.9,135.8 265.2,135.6 256.7,123.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="271.6,178.0 273.4,193.4 276.1,178.7" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
@@ -583,19 +583,19 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="202.4,268.3 199.1,273.4 215.3,269.1" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="259.9,135.8 268.8,149.1 265.2,135.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.2,86.6 165.0,85.2 169.7,87.4" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="87.2" y1="64.6" x2="92.3" y2="59.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="295.7" y1="60.8" x2="305.0" y2="63.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 152.2,88.5 141.4,93.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="89.5,210.7 104.1,236.9 99.4,224.0" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.7,89.2 192.6,84.8 188.7,87.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="230.4" x2="36.5" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.4,92.6 216.9,92.7 205.6,87.8" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.5" y1="323.1" x2="147.8" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.4,105.8 102.3,125.7 114.0,115.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="86.9" x2="323.5" y2="78.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.4,93.7 120.4,105.8 133.2,100.3" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,268.9 163.9,273.8 181.5,275.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="242.3" y1="328.1" x2="247.4" y2="322.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,270.2 181.5,275.0 199.1,273.4" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="87.7,195.9 89.5,210.7 99.4,224.0" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.7,87.4 152.2,88.5 160.9,89.7" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -603,23 +603,23 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="202.4,268.3 215.3,269.1 221.5,263.4" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="264.3,207.2 271.6,208.3 273.4,193.4" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.4,92.6 205.6,87.8 197.7,89.2" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="305.0" y1="63.8" x2="314.3" y2="66.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="85.7,166.1 87.7,195.9 89.5,180.4" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.2,100.3 120.4,105.8 114.0,115.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,162.7 274.3,163.6 268.8,149.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="91.2,151.5 85.7,166.1 89.5,180.4" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="147.8" y1="326.1" x2="157.1" y2="329.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,264.5 163.9,273.8 161.1,268.9" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="264.3,207.2 262.7,221.8 271.6,208.3" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.6,247.6 124.8,257.2 141.6,264.5" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,106.6 245.2,113.8 238.1,104.3" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.3,106.6 238.1,104.3 225.6,99.1" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="102.3,125.7 91.2,151.5 100.1,137.9" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="221.8" x2="36.5" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="99.4,224.0 104.1,236.9 118.6,247.6" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="82.2" y1="70.1" x2="87.2" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="153.4,93.3 141.4,93.7 133.2,100.3" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="323.5" y1="78.4" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="160.9,89.7 141.4,93.7 153.4,93.3" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.0,115.6 102.3,125.7 100.1,137.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.8,270.2 199.1,273.4 202.4,268.3" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
@@ -627,14 +627,14 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="248.0,124.2 256.7,123.6 245.2,113.8" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="266.3,162.7 271.6,178.0 274.3,163.6" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="211.4,97.0 225.6,99.1 216.9,92.7" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="314.3" y1="66.8" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="161.1,268.9 181.5,275.0 181.8,270.2" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,233.5 257.9,234.8 262.7,221.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.1,254.4 237.8,255.7 244.2,245.9" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="157.1" y1="329.1" x2="166.3" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.0,124.2 259.9,135.8 256.7,123.6" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,233.5 244.2,245.9 257.9,234.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="237.2" y1="333.6" x2="242.3" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="211.4,97.0 216.9,92.7 205.4,92.6" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.6,92.8 179.2,86.6 169.7,87.4" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,93.1 188.7,87.2 179.2,86.6" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
@@ -642,15 +642,15 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="87.7,195.9 99.4,224.0 97.9,209.4" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.7,93.2 169.7,87.4 160.9,89.7" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,94.1 197.7,89.2 188.7,87.2" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="213.3" x2="36.5" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="332.1" x2="175.6" y2="335.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="89.5,180.4 87.7,195.9 97.9,209.4" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="262.7,191.5 273.4,193.4 271.6,178.0" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="153.4,93.3 133.2,100.3 147.7,97.8" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="318.4" y1="75.3" x2="323.5" y2="69.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="118.6,247.6 141.6,264.5 137.4,255.6" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,148.0 268.8,149.1 259.9,135.8" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="77.1" y1="75.6" x2="82.2" y2="70.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="91.2,151.5 89.5,180.4 94.8,165.0" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,255.6 141.6,264.5 161.1,268.9" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="100.1,137.9 91.2,151.5 94.8,165.0" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
@@ -663,18 +663,18 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="262.7,191.5 264.3,207.2 273.4,193.4" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,102.2 231.3,106.6 225.6,99.1" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="184.4,93.1 179.2,86.6 179.6,92.8" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="232.1" y1="339.1" x2="237.2" y2="333.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.6,92.8 169.7,87.4 174.7,93.2" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,108.0 114.0,115.6 112.0,126.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="257.7,148.0 266.3,162.7 268.8,149.1" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,102.2 225.6,99.1 211.4,97.0" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="175.6" y1="335.0" x2="184.9" y2="338.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="233.4,114.7 245.2,113.8 231.3,106.6" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,94.1 188.7,87.2 184.4,93.1" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.4,114.7 248.0,124.2 245.2,113.8" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.7,93.2 160.9,89.7 170.3,94.4" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="204.9,259.9 221.5,263.4 226.1,254.4" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="204.7" x2="36.5" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="159.0,260.6 161.1,268.9 181.8,270.2" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.9,209.4 99.4,224.0 114.9,235.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.0,95.8 197.7,89.2 189.0,94.1" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
@@ -683,10 +683,10 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="196.0,98.1 211.4,97.0 205.4,92.6" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,235.3 118.6,247.6 137.4,255.6" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.5,219.1 262.7,221.8 264.3,207.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="184.9" y1="338.0" x2="194.2" y2="341.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="313.4" y1="80.8" x2="318.4" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="170.3,94.4 153.4,93.3 166.4,96.2" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="72.0" y1="81.0" x2="77.1" y2="75.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.7,97.8 128.1,108.0 144.3,103.1" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,255.6 161.1,268.9 159.0,260.6" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="249.5,219.1 248.2,233.5 262.7,221.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
@@ -700,12 +700,12 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="100.1,137.9 94.8,165.0 103.3,150.1" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="94.8,165.0 89.5,180.4 99.4,193.7" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.1,108.0 112.0,126.0 126.6,116.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="227.1" y1="344.5" x2="232.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.0,262.0 202.4,268.3 204.9,259.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="246.0,134.6 257.7,148.0 259.9,135.8" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="196.2" x2="36.5" y2="187.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="144.3,103.1 128.1,108.0 126.6,116.1" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="194.2" y1="341.0" x2="203.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="216.8,107.7 231.3,106.6 215.3,102.2" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.0,260.6 181.8,270.2 182.0,262.0" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="166.4,96.2 147.7,97.8 163.5,98.5" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
@@ -720,10 +720,10 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="180.0,102.3 174.7,93.2 170.3,94.4" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="97.9,209.4 114.9,235.3 113.6,220.9" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,235.3 137.4,255.6 134.7,243.9" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="308.3" y1="86.2" x2="313.4" y2="80.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="231.9,122.9 248.0,124.2 233.4,114.7" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="66.9" y1="86.5" x2="72.0" y2="81.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="344.0" x2="212.7" y2="347.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 193.0,95.8 189.0,94.1" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 170.3,94.4 166.4,96.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.6,116.1 112.0,126.0 114.8,136.3" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
@@ -733,12 +733,12 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="112.0,126.0 103.3,150.1 114.8,136.3" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="99.4,193.7 97.9,209.4 113.6,220.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="250.1,159.5 266.3,162.7 257.7,148.0" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="187.6" x2="36.5" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="248.2,203.2 264.3,207.2 262.7,191.5" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 196.0,98.1 193.0,95.8" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,248.5 204.9,259.9 226.1,254.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.9,122.9 246.0,134.6 248.0,124.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="227.1" y2="344.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 166.4,96.2 163.5,98.5" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.8,101.2 144.3,103.1 143.2,108.7" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="103.3,150.1 94.8,165.0 104.1,177.5" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
@@ -749,7 +749,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="180.0,102.3 184.4,93.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 174.7,93.2 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="248.2,203.2 249.5,219.1 264.3,207.2" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="212.7" y1="347.0" x2="222.0" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 189.0,94.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 196.0,98.1" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,248.5 226.1,254.4 229.0,242.6" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -771,21 +771,21 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="126.6,116.1 114.8,136.3 128.7,124.3" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.7,113.4 231.9,122.9 233.4,114.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.7,103.6 198.0,100.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="303.2" y1="91.7" x2="308.3" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 161.3,104.1" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.0,100.7 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="61.9" y1="92.0" x2="66.9" y2="86.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 161.8,101.2 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,106.4 216.8,107.7 198.7,103.6" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="239.6,144.3 257.7,148.0 246.0,134.6" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.7,243.9 159.0,260.6 157.7,249.1" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="179.1" x2="36.5" y2="170.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.7,103.6 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.3,104.1 143.2,108.7 144.7,114.3" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.8,136.3 103.3,150.1 111.7,161.3" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.2,106.4 215.7,113.4 216.8,107.7" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="350.0" x2="222.0" y2="341.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 198.2,106.4 198.7,103.6" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 161.3,104.1 162.0,106.9" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 198.2,106.4 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -817,15 +817,15 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="180.0,102.3 175.6,114.6 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 180.4,114.9 180.0,102.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,102.3 193.6,111.5 196.5,109.1" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="170.6" x2="36.5" y2="162.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="298.1" y1="97.1" x2="303.2" y2="91.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,102.3 164.0,109.6 167.0,111.8" fill="rgb(81,112,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.8,229.7 134.7,243.9 157.7,249.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.8,130.5 239.6,144.3 246.0,134.6" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="56.8" y1="97.4" x2="61.9" y2="92.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="162.0,106.9 144.7,114.3 148.6,119.5" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.5,109.1 212.3,118.6 215.7,113.4" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="341.5" x2="222.0" y2="332.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="114.8,136.3 111.7,161.3 121.9,145.9" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.7,114.3 128.7,124.3 134.4,131.8" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,205.0 113.6,220.9 133.8,229.7" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -850,7 +850,7 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="237.8,169.4 244.2,186.4 257.9,175.4" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="157.2,235.0 157.7,249.1 182.1,250.7" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,109.6 154.6,123.9 167.0,111.8" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="162.0" x2="36.5" y2="153.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.2,236.6 182.1,250.7 206.5,248.5" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.0,109.6 148.6,119.5 154.6,123.9" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="193.6,111.5 206.6,123.2 212.3,118.6" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
@@ -858,9 +858,9 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="229.1,152.7 250.1,159.5 239.6,144.3" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.6,123.2 226.8,130.5 212.3,118.6" fill="rgb(88,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.7,113.3 206.6,123.2 193.6,111.5" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="332.9" x2="222.0" y2="324.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="293.1" y1="102.6" x2="298.1" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="51.7" y1="102.9" x2="56.8" y2="97.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.6,137.2 239.6,144.3 226.8,130.5" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="121.9,145.9 111.7,161.3 124.8,170.9" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="114.9,205.0 133.8,229.7 134.7,213.6" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -884,17 +884,17 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="180.4,114.9 190.3,129.0 185.3,114.4" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.1,195.0 229.0,212.3 248.2,203.2" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="175.6,114.6 180.8,129.9 180.4,114.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="153.5" x2="36.5" y2="144.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="206.5,218.2 207.0,234.4 230.0,228.4" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="324.4" x2="222.0" y2="315.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="121.9,145.9 124.8,170.9 133.0,154.0" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="206.5,218.2 230.0,228.4 229.0,212.3" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,126.8 218.6,137.2 206.6,123.2" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.4,131.8 133.0,154.0 143.1,138.2" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,113.5 162.3,127.2 171.3,129.3" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.3,114.4 190.3,129.0 199.1,126.8" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="288.0" y1="108.1" x2="293.1" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="46.6" y1="108.4" x2="51.7" y2="102.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="175.6,114.6 171.3,129.3 180.8,129.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.4,114.9 180.8,129.9 190.3,129.0" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,177.1 244.2,186.4 237.8,169.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
@@ -909,9 +909,9 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="182.1,220.4 182.2,236.6 207.0,234.4" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="221.5,177.1 226.1,195.0 244.2,186.4" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.3,159.3 237.8,169.4 229.1,152.7" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="144.9" x2="36.5" y2="136.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.3,129.0 207.8,142.3 199.1,126.8" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="315.8" x2="222.0" y2="307.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="182.1,220.4 207.0,234.4 206.5,218.2" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.0,154.0 124.8,170.9 141.6,178.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.1,138.2 133.0,154.0 147.4,160.2" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
@@ -928,17 +928,17 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="162.3,127.2 154.4,143.0 167.4,146.0" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.3,129.0 195.0,145.6 207.8,142.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.3,129.3 181.2,146.9 180.8,129.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="282.9" y1="113.5" x2="288.0" y2="108.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="41.6" y1="113.8" x2="46.6" y2="108.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="133.0,154.0 141.6,178.2 147.4,160.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="195.0,145.6 215.3,159.3 207.8,142.3" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.3,129.3 167.4,146.0 181.2,146.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="136.4" x2="36.5" y2="127.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.8,129.9 181.2,146.9 195.0,145.6" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.4,196.2 157.7,218.8 159.0,201.1" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="202.4,182.0 226.1,195.0 221.5,177.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.0,201.1 157.7,218.8 182.1,220.4" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="307.3" x2="222.0" y2="298.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.6,178.2 137.4,196.2 159.0,201.1" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="182.0,202.6 182.1,220.4 206.5,218.2" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="199.1,163.5 221.5,177.1 215.3,159.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -954,62 +954,62 @@ expression: "export_svg(\"Graphics3D[Sphere[]]\")"
 <polygon points="141.6,178.2 159.0,201.1 161.1,182.6" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,146.0 181.5,165.1 181.2,146.9" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.4,160.2 161.1,182.6 163.9,164.0" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="277.8" y1="119.0" x2="282.9" y2="113.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.4,146.0 163.9,164.0 181.5,165.1" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="41.6" y2="113.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.2,146.9 181.5,165.1 199.1,163.5" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,182.6 159.0,201.1 182.0,202.6" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="127.8" x2="36.5" y2="119.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.8,183.9 182.0,202.6 204.9,200.5" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.8,183.9 204.9,200.5 202.4,182.0" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,165.1 202.4,182.0 199.1,163.5" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="222.0" y1="298.7" x2="222.0" y2="290.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="163.9,164.0 161.1,182.6 181.8,183.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.1,182.6 182.0,202.6 181.8,183.9" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.9,164.0 181.8,183.9 181.5,165.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,165.1 181.8,183.9 202.4,182.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="36.5" y1="119.3" x2="45.7" y2="122.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.8" y1="124.5" x2="277.8" y2="119.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="290.2" x2="222.0" y2="281.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="45.7" y1="122.3" x2="55.0" y2="125.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="55.0" y1="125.3" x2="64.3" y2="128.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="281.6" x2="222.0" y2="273.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="267.7" y1="129.9" x2="272.8" y2="124.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="64.3" y1="128.3" x2="73.6" y2="131.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="273.1" x2="222.0" y2="264.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.6" y1="135.4" x2="267.7" y2="129.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="73.6" y1="131.3" x2="82.9" y2="134.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="82.9" y1="134.2" x2="92.1" y2="137.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="264.6" x2="222.0" y2="256.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.5" y1="140.9" x2="262.6" y2="135.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="92.1" y1="137.2" x2="101.4" y2="140.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="256.0" x2="222.0" y2="247.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="140.2" x2="110.7" y2="143.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="252.4" y1="146.3" x2="257.5" y2="140.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="110.7" y1="143.2" x2="120.0" y2="146.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="247.5" x2="222.0" y2="238.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="120.0" y1="146.2" x2="129.2" y2="149.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="247.4" y1="151.8" x2="252.4" y2="146.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="238.9" x2="222.0" y2="230.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="129.2" y1="149.2" x2="138.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="152.2" x2="147.8" y2="155.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="230.4" x2="222.0" y2="221.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="242.3" y1="157.3" x2="247.4" y2="151.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="147.8" y1="155.2" x2="157.1" y2="158.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="221.8" x2="222.0" y2="213.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="157.1" y1="158.2" x2="166.3" y2="161.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="237.2" y1="162.7" x2="242.3" y2="157.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="166.3" y1="161.2" x2="175.6" y2="164.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="213.3" x2="222.0" y2="204.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.1" y1="168.2" x2="237.2" y2="162.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="175.6" y1="164.2" x2="184.9" y2="167.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="204.7" x2="222.0" y2="196.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="184.9" y1="167.2" x2="194.2" y2="170.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="227.1" y1="173.7" x2="232.1" y2="168.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="194.2" y1="170.1" x2="203.4" y2="173.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="196.2" x2="222.0" y2="187.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="203.4" y1="173.1" x2="212.7" y2="176.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="179.1" x2="227.1" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="222.0" y1="187.7" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="212.7" y1="176.1" x2="222.0" y2="179.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_sphere_and_cone.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_sphere_and_cone.snap
@@ -4,74 +4,74 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="360" fill="rgb(255,255,255)"/>
-<line x1="152.1" y1="237.5" x2="158.2" y2="239.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="148.7" y1="241.1" x2="152.1" y2="237.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.2" y1="239.4" x2="164.4" y2="241.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="237.5" x2="152.1" y2="226.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.4" y1="241.4" x2="170.6" y2="243.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="145.3" y1="244.7" x2="148.7" y2="241.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.6" y1="243.4" x2="176.7" y2="245.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="176.7" y1="245.4" x2="182.9" y2="247.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="226.1" x2="152.1" y2="214.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.9" y1="248.4" x2="145.3" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="182.9" y1="247.4" x2="189.1" y2="249.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="138.5" y1="252.0" x2="141.9" y2="248.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.1" y1="249.4" x2="195.3" y2="251.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.3" y1="251.4" x2="201.4" y2="253.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="214.7" x2="152.1" y2="203.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="135.2" y1="255.6" x2="138.5" y2="252.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.4" y1="253.4" x2="207.6" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.6" y1="255.4" x2="213.8" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="131.8" y1="259.3" x2="135.2" y2="255.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="213.8" y1="257.4" x2="220.0" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="203.3" x2="152.1" y2="192.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="220.0" y1="259.3" x2="226.1" y2="261.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="128.4" y1="262.9" x2="131.8" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="226.1" y1="261.3" x2="232.3" y2="263.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="232.3" y1="263.3" x2="238.5" y2="265.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="192.0" x2="152.1" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="125.0" y1="266.5" x2="128.4" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.5" y1="265.3" x2="244.7" y2="267.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="244.7" y1="267.3" x2="250.8" y2="269.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.6" y1="270.2" x2="125.0" y2="266.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="250.8" y1="269.3" x2="257.0" y2="271.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="180.6" x2="152.1" y2="169.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="118.3" y1="273.8" x2="121.6" y2="270.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="257.0" y1="271.3" x2="263.2" y2="273.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="263.2" y1="273.3" x2="269.3" y2="275.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="114.9" y1="277.5" x2="118.3" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="269.3" y1="275.3" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="169.2" x2="152.1" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="272.1" y1="280.9" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="111.5" y1="281.1" x2="114.9" y2="277.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="277.3" x2="275.5" y2="265.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="268.8" y1="284.5" x2="272.1" y2="280.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="157.8" x2="152.1" y2="146.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.1" y1="284.7" x2="111.5" y2="281.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="265.9" x2="275.5" y2="254.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.4" y1="288.2" x2="268.8" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="104.8" y1="288.4" x2="108.1" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="146.5" x2="152.1" y2="135.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="291.8" x2="265.4" y2="288.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="292.0" x2="104.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="254.5" x2="275.5" y2="243.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="295.4" x2="262.0" y2="291.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="295.6" x2="101.4" y2="292.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="135.1" x2="152.1" y2="123.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="255.2" y1="299.1" x2="258.6" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.6" y1="299.3" x2="98.0" y2="295.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="243.1" x2="275.5" y2="231.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.9" y1="302.7" x2="255.2" y2="299.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="123.7" x2="152.1" y2="112.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="91.2" y1="302.9" x2="94.6" y2="299.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="275.5" y1="231.8" x2="275.5" y2="220.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.5" y1="306.4" x2="251.9" y2="302.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.9" y1="306.6" x2="91.2" y2="302.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.1" y1="112.4" x2="152.1" y2="101.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="237.5" x2="158.2" y2="239.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="148.7" y1="241.1" x2="152.1" y2="237.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.2" y1="239.4" x2="164.4" y2="241.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="237.5" x2="152.1" y2="226.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.4" y1="241.4" x2="170.6" y2="243.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="145.3" y1="244.7" x2="148.7" y2="241.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.6" y1="243.4" x2="176.7" y2="245.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="176.7" y1="245.4" x2="182.9" y2="247.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="226.1" x2="152.1" y2="214.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.9" y1="248.4" x2="145.3" y2="244.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="182.9" y1="247.4" x2="189.1" y2="249.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="138.5" y1="252.0" x2="141.9" y2="248.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.1" y1="249.4" x2="195.3" y2="251.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.3" y1="251.4" x2="201.4" y2="253.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="214.7" x2="152.1" y2="203.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="135.2" y1="255.6" x2="138.5" y2="252.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.4" y1="253.4" x2="207.6" y2="255.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.6" y1="255.4" x2="213.8" y2="257.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="131.8" y1="259.3" x2="135.2" y2="255.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="213.8" y1="257.4" x2="220.0" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="203.3" x2="152.1" y2="192.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="220.0" y1="259.3" x2="226.1" y2="261.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="128.4" y1="262.9" x2="131.8" y2="259.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="226.1" y1="261.3" x2="232.3" y2="263.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="232.3" y1="263.3" x2="238.5" y2="265.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="192.0" x2="152.1" y2="180.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="125.0" y1="266.5" x2="128.4" y2="262.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.5" y1="265.3" x2="244.7" y2="267.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="244.7" y1="267.3" x2="250.8" y2="269.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.6" y1="270.2" x2="125.0" y2="266.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="250.8" y1="269.3" x2="257.0" y2="271.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="180.6" x2="152.1" y2="169.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="118.3" y1="273.8" x2="121.6" y2="270.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="257.0" y1="271.3" x2="263.2" y2="273.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="263.2" y1="273.3" x2="269.3" y2="275.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="114.9" y1="277.5" x2="118.3" y2="273.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="269.3" y1="275.3" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="169.2" x2="152.1" y2="157.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="272.1" y1="280.9" x2="275.5" y2="277.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="111.5" y1="281.1" x2="114.9" y2="277.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="277.3" x2="275.5" y2="265.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="268.8" y1="284.5" x2="272.1" y2="280.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="157.8" x2="152.1" y2="146.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.1" y1="284.7" x2="111.5" y2="281.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="265.9" x2="275.5" y2="254.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.4" y1="288.2" x2="268.8" y2="284.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="104.8" y1="288.4" x2="108.1" y2="284.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="146.5" x2="152.1" y2="135.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="291.8" x2="265.4" y2="288.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="292.0" x2="104.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="254.5" x2="275.5" y2="243.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="295.4" x2="262.0" y2="291.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="295.6" x2="101.4" y2="292.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="135.1" x2="152.1" y2="123.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="255.2" y1="299.1" x2="258.6" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.6" y1="299.3" x2="98.0" y2="295.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="243.1" x2="275.5" y2="231.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.9" y1="302.7" x2="255.2" y2="299.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="123.7" x2="152.1" y2="112.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="91.2" y1="302.9" x2="94.6" y2="299.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="275.5" y1="231.8" x2="275.5" y2="220.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.5" y1="306.4" x2="251.9" y2="302.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.9" y1="306.6" x2="91.2" y2="302.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.1" y1="112.4" x2="152.1" y2="101.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="192.6,178.3 179.0,189.9 178.8,177.4" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="245.1" y1="310.0" x2="248.5" y2="306.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="245.1" y1="310.0" x2="248.5" y2="306.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.8,177.4 179.0,189.9 167.3,191.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="310.2" x2="87.9" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="87.9" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.7,165.0 178.8,177.4 165.1,178.6" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.6,178.3 190.7,190.7 179.0,189.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.8,177.4 167.3,191.0 165.1,178.6" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
@@ -88,17 +88,17 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="201.7,193.2 188.4,202.6 190.7,190.7" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.4,166.4 165.1,178.6 152.4,181.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="208.4,169.2 192.6,178.3 194.0,166.0" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="220.4" x2="275.5" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="220.4" x2="275.5" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="194.9,154.2 194.0,166.0 178.7,165.0" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="205.5,181.2 201.7,193.2 190.7,190.7" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.1,178.6 156.5,193.8 152.4,181.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="208.4,169.2 205.5,181.2 192.6,178.3" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="310.2" x2="90.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="90.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="194.9,154.2 178.7,165.0 178.6,153.1" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.3,191.0 170.0,202.9 161.5,205.1" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.3,191.0 161.5,205.1 156.5,193.8" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.7,193.2 197.1,204.6 188.4,202.6" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="241.7" y1="313.6" x2="245.1" y2="310.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="241.7" y1="313.6" x2="245.1" y2="310.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.6,153.1 163.4,166.4 162.4,154.6" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="188.4,202.6 179.4,213.3 179.2,202.0" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.4,166.4 152.4,181.9 149.3,170.0" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
@@ -106,11 +106,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="162.4,154.6 163.4,166.4 149.3,170.0" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.1,204.6 185.8,213.7 188.4,202.6" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.7,186.1 201.7,193.2 205.5,181.2" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="101.0" x2="152.1" y2="89.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="101.0" x2="152.1" y2="89.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="210.1,157.7 194.0,166.0 194.9,154.2" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="210.1,157.7 208.4,169.2 194.0,166.0" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="90.7" y1="312.2" x2="96.8" y2="314.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="310.2" x2="84.5" y2="298.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="90.7" y1="312.2" x2="96.8" y2="314.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="310.2" x2="84.5" y2="298.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.2,202.0 179.4,213.3 173.1,213.9" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="211.2,197.3 197.1,204.6 201.7,193.2" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="188.4,202.6 185.8,213.7 179.4,213.3" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
@@ -128,24 +128,24 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="211.2,197.3 204.6,207.8 197.1,204.6" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="156.5,193.8 154.3,208.5 147.3,198.1" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="204.6,207.8 191.8,215.1 197.1,204.6" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="96.8" y1="314.2" x2="103.0" y2="316.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="96.8" y1="314.2" x2="103.0" y2="316.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="152.4,181.9 147.3,198.1 141.5,187.1" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="195.1,143.4 178.6,153.1 178.5,142.3" fill="rgb(75,103,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="220.8,174.6 216.7,186.1 205.5,181.2" fill="rgb(79,108,152)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="238.4" y1="317.3" x2="241.7" y2="313.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="238.4" y1="317.3" x2="241.7" y2="313.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.5,142.3 162.4,154.6 162.0,143.8" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.0,143.8 162.4,154.6 147.4,158.5" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.5,205.1 167.3,215.4 162.3,217.8" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.8,213.7 179.7,223.3 179.4,213.3" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.5,205.1 162.3,217.8 154.3,208.5" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.4,213.3 176.5,223.6 173.1,213.9" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="209.0" x2="275.5" y2="197.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="209.0" x2="275.5" y2="197.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="210.7,146.9 210.1,157.7 194.9,154.2" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="204.6,207.8 196.9,217.3 191.8,215.1" fill="rgb(87,119,167)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.4,158.5 149.3,170.0 137.3,175.7" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="149.3,170.0 141.5,187.1 137.3,175.7" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="191.8,215.1 183.0,223.6 185.8,213.7" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="103.0" y1="316.2" x2="109.2" y2="318.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="103.0" y1="316.2" x2="109.2" y2="318.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="210.7,146.9 194.9,154.2 195.1,143.4" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="223.3,163.4 208.4,169.2 210.1,157.7" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="173.1,213.9 173.5,224.4 167.3,215.4" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
@@ -161,15 +161,15 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="173.1,213.9 176.5,223.6 173.5,224.4" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="191.8,215.1 186.0,224.3 183.0,223.6" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="178.6,133.0 178.5,142.3 162.0,143.8" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="89.6" x2="152.1" y2="78.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="89.6" x2="152.1" y2="78.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="162.0,143.8 147.4,158.5 146.8,147.8" fill="rgb(75,104,145)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="235.0" y1="320.9" x2="238.4" y2="317.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="109.2" y1="318.2" x2="115.3" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="235.0" y1="320.9" x2="238.4" y2="317.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="109.2" y1="318.2" x2="115.3" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.3,215.4 171.0,225.6 162.3,217.8" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.7,202.7 210.4,212.1 204.6,207.8" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.3,208.5 162.3,217.8 158.5,220.8" fill="rgb(88,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="194.9,134.0 195.1,143.4 178.5,142.3" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="298.8" x2="84.5" y2="287.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="298.8" x2="84.5" y2="287.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="225.4,192.4 218.7,202.7 211.2,197.3" fill="rgb(77,106,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.3,215.4 173.5,224.4 171.0,225.6" fill="rgb(88,120,169)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.3,198.1 148.8,212.9 140.3,203.8" fill="rgb(87,119,168)" stroke="#00000018" stroke-width="0.5"/>
@@ -185,7 +185,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="146.8,147.8 147.4,158.5 134.6,164.5" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="194.9,134.0 178.5,142.3 178.6,133.0" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="141.5,187.1 140.3,203.8 133.3,193.7" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="115.3" y1="320.1" x2="121.5" y2="322.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="115.3" y1="320.1" x2="121.5" y2="322.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="162.4,134.4 162.0,143.8 146.8,147.8" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.3,217.8 169.1,227.2 158.5,220.8" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="224.2,152.7 210.1,157.7 210.7,146.9" fill="rgb(65,89,124)" stroke="#00000018" stroke-width="0.5"/>
@@ -201,13 +201,13 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="179.7,223.3 180.0,231.7 176.5,223.6" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="214.1,217.1 200.9,220.3 210.4,212.1" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="186.0,224.3 180.0,231.7 183.0,223.6" fill="rgb(83,114,159)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="197.7" x2="275.5" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="197.7" x2="275.5" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="176.5,223.6 180.0,231.7 173.5,224.4" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="231.6" y1="324.5" x2="235.0" y2="320.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="231.6" y1="324.5" x2="235.0" y2="320.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="210.1,137.5 195.1,143.4 194.9,134.0" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.8,212.9 158.5,220.8 156.2,224.3" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="223.4,209.1 210.4,212.1 218.7,202.7" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="121.5" y1="322.1" x2="127.7" y2="324.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="121.5" y1="322.1" x2="127.7" y2="324.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="188.6,225.4 180.0,231.7 186.0,224.3" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="203.5,223.7 190.7,226.9 200.9,220.3" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="140.3,203.8 148.8,212.9 145.5,218.0" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5"/>
@@ -236,11 +236,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="180.0,128.3 224.2,204.4 210.7,198.6" fill="rgb(37,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.0,228.6 180.0,231.7 190.7,226.9" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="188.6,225.4 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="78.2" x2="152.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.7" y1="324.1" x2="133.9" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="78.2" x2="152.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.7" y1="324.1" x2="133.9" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="171.0,225.6 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.1,227.2 180.0,231.7 167.9,229.0" fill="rgb(81,112,157)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="287.4" x2="84.5" y2="276.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="287.4" x2="84.5" y2="276.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.7,125.4 178.6,133.0 162.4,134.4" fill="rgb(57,78,110)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="140.3,203.8 145.5,218.0 136.0,210.2" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.7,226.9 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
@@ -254,7 +254,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="192.0,228.6 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.9,229.0 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.5,230.5 180.0,231.7 192.0,228.6" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="228.2" y1="328.2" x2="231.6" y2="324.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="228.2" y1="328.2" x2="231.6" y2="324.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.9,229.0 180.0,231.7 167.5,230.9" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.5,230.5 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="204.5,227.4 192.5,230.5 192.0,228.6" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
@@ -264,7 +264,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="223.3,143.2 210.7,146.9 210.1,137.5" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.5,222.5 203.5,223.7 214.1,217.1" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.6,164.5 128.2,183.1 125.0,172.3" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="133.9" y1="326.1" x2="140.0" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="133.9" y1="326.1" x2="140.0" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="156.2,224.3 167.5,230.9 155.5,228.1" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="236.7,190.0 225.4,192.4 230.5,181.7" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.2,183.1 133.3,193.7 128.3,201.3" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
@@ -285,7 +285,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="189.0,235.8 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="155.5,228.1 167.5,230.9 168.0,232.8" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.4,236.0 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="186.3" x2="275.5" y2="174.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="186.3" x2="275.5" y2="174.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="234.7,160.4 233.6,170.9 223.3,163.4" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.9,234.2 180.0,231.7 192.1,232.4" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.0,210.2 145.5,218.0 144.5,223.5" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
@@ -294,7 +294,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="186.5,237.0 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="168.0,232.8 180.0,231.7 169.3,234.5" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.0,237.2 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="140.0" y1="328.1" x2="146.2" y2="330.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="140.0" y1="328.1" x2="146.2" y2="330.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="145.5,218.0 155.5,228.1 144.5,223.5" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="183.5,237.8 180.0,231.7 180.0,231.7" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="203.8,231.2 192.5,230.5 204.5,227.4" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
@@ -304,7 +304,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="203.8,231.2 192.1,232.4 192.5,230.5" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="208.4,129.7 194.9,134.0 194.0,126.4" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,235.8 180.0,231.7 190.9,234.2" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="224.8" y1="331.8" x2="228.2" y2="328.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="224.8" y1="331.8" x2="228.2" y2="328.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="147.4,138.3 133.7,154.0 134.6,144.4" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.3,234.5 180.0,231.7 171.4,236.0" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.2,215.9 215.5,222.5 214.1,217.1" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
@@ -313,13 +313,13 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="186.5,237.0 180.0,231.7 189.0,235.8" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.4,236.0 180.0,231.7 174.0,237.2" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="156.5,231.8 168.0,232.8 169.3,234.5" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="146.2" y1="330.1" x2="152.4" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="146.2" y1="330.1" x2="152.4" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="125.0,172.3 128.2,183.1 122.6,191.5" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="66.9" x2="152.1" y2="55.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="66.9" x2="152.1" y2="55.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="240.2,179.7 230.5,181.7 233.6,170.9" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.5,223.5 155.5,228.1 156.5,231.8" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.2,183.1 128.3,201.3 122.6,191.5" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="276.1" x2="84.5" y2="264.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="276.1" x2="84.5" y2="264.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="163.4,126.8 147.4,138.3 149.3,130.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="183.5,237.8 180.0,231.7 186.5,237.0" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.0,237.2 180.0,231.7 177.0,237.8" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
@@ -336,7 +336,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="214.5,227.9 203.8,231.2 204.5,227.4" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.2,179.7 236.7,190.0 230.5,181.7" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.6,144.4 133.7,154.0 123.9,161.9" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.4" y1="332.1" x2="158.6" y2="334.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.4" y1="332.1" x2="158.6" y2="334.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="178.8,120.0 178.7,125.4 163.4,126.8" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="220.8,135.0 223.3,143.2 210.1,137.5" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.2,208.0 225.2,215.9 223.4,209.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
@@ -345,14 +345,14 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="233.6,150.7 224.2,152.7 223.3,143.2" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="156.5,231.8 169.3,234.5 159.1,235.3" fill="rgb(75,103,144)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="220.8,135.0 210.1,137.5 208.4,129.7" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="221.5" y1="335.5" x2="224.8" y2="331.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="221.5" y1="335.5" x2="224.8" y2="331.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="197.7,237.7 189.0,235.8 190.9,234.2" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="233.6,150.7 234.7,160.4 224.2,152.7" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.5,223.5 156.5,231.8 145.9,228.9" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="174.9" x2="275.5" y2="163.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="174.9" x2="275.5" y2="163.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.8,217.2 144.5,223.5 145.9,228.9" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 241.4,221.1 234.7,212.1" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="158.6" y1="334.1" x2="164.7" y2="336.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="158.6" y1="334.1" x2="164.7" y2="336.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="197.7,237.7 190.9,234.2 201.5,234.7" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.1,238.2 171.4,236.0 174.0,237.2" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.1,121.2 163.4,126.8 149.3,130.5" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
@@ -376,23 +376,23 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="149.3,130.5 134.6,144.4 137.3,136.2" fill="rgb(52,72,101)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="211.2,233.0 203.8,231.2 214.5,227.9" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="186.9,241.6 183.5,237.8 186.5,237.0" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="164.7" y1="336.1" x2="170.9" y2="338.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="164.7" y1="336.1" x2="170.9" y2="338.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="239.1,199.0 233.2,208.0 231.1,199.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="55.5" x2="152.1" y2="44.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="55.5" x2="152.1" y2="44.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.4,169.4 240.2,179.7 233.6,170.9" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.2,241.8 177.0,237.8 180.3,238.1" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="218.1" y1="339.1" x2="221.5" y2="335.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="218.1" y1="339.1" x2="221.5" y2="335.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.5,123.8 194.0,126.4 192.6,120.8" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.6,144.4 123.9,161.9 125.0,152.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.6,242.2 180.3,238.1 183.5,237.8" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="264.7" x2="84.5" y2="253.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="264.7" x2="84.5" y2="253.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="192.7,240.1 189.0,235.8 197.7,237.7" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="163.1,238.2 174.0,237.2 168.2,240.4" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.8,217.2 145.9,228.9 136.6,224.0" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.9,228.9 159.1,235.3 149.6,233.9" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="137.3,136.2 134.6,144.4 125.0,152.2" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.1,121.2 149.3,130.5 152.4,124.5" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="170.9" y1="338.1" x2="177.1" y2="340.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="170.9" y1="338.1" x2="177.1" y2="340.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="126.8,209.4 134.8,217.2 136.6,224.0" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="186.9,241.6 186.5,237.0 192.7,240.1" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="149.6,233.9 159.1,235.3 163.1,238.2" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
@@ -411,11 +411,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="123.9,161.9 119.0,181.3 117.8,171.1" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.7,216.1 224.0,222.9 225.2,215.9" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.6,224.0 145.9,228.9 149.6,233.9" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="163.5" x2="275.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="214.7" y1="342.7" x2="218.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="163.5" x2="275.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="214.7" y1="342.7" x2="218.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="205.7,237.4 201.5,234.7 211.2,233.0" fill="rgb(61,83,117)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="216.7,128.6 208.4,129.7 205.5,123.8" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="177.1" y1="340.0" x2="183.3" y2="342.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="177.1" y1="340.0" x2="183.3" y2="342.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="125.0,152.2 123.9,161.9 117.8,171.1" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 244.0,230.8 241.4,221.1" fill="rgb(54,75,105)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.2,159.5 234.7,160.4 233.6,150.7" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
@@ -428,12 +428,12 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="155.4,238.1 163.1,238.2 168.2,240.4" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="240.2,159.5 241.4,169.4 234.7,160.4" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="149.6,233.9 163.1,238.2 155.4,238.1" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="183.3" y1="342.0" x2="189.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="183.3" y1="342.0" x2="189.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.5,240.9 192.7,240.1 197.7,237.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="126.8,209.4 136.6,224.0 128.9,217.5" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="44.1" x2="152.1" y2="32.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="44.1" x2="152.1" y2="32.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="167.3,117.9 165.1,121.2 152.4,124.5" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="253.3" x2="84.5" y2="242.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="253.3" x2="84.5" y2="242.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="137.3,136.2 125.0,152.2 128.2,143.5" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="152.4,124.5 137.3,136.2 141.5,129.6" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.7,120.1 205.5,123.8 192.6,120.8" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -441,13 +441,13 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="190.7,117.6 178.8,120.0 179.0,116.8" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="237.4,208.0 233.2,208.0 239.1,199.0" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.6,224.0 149.6,233.9 141.3,230.4" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="211.3" y1="346.4" x2="214.7" y2="342.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="211.3" y1="346.4" x2="214.7" y2="342.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="198.5,240.9 197.7,237.7 205.7,237.4" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.9,241.3 168.2,240.4 174.2,241.8" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="119.0,181.3 120.9,200.6 117.3,190.9" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.0,116.8 165.1,121.2 167.3,117.9" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.8,171.1 119.0,181.3 117.3,190.9" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="189.4" y1="344.0" x2="195.6" y2="346.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="189.4" y1="344.0" x2="195.6" y2="346.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="190.0,243.1 186.9,241.6 192.7,240.1" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.0,179.1 240.2,179.7 241.4,169.4" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="141.5,129.6 137.3,136.2 128.2,143.5" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -463,9 +463,9 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="225.4,135.0 220.8,135.0 216.7,128.6" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="244.0,179.1 242.7,189.2 240.2,179.7" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.7,235.0 205.7,237.4 211.2,233.0" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="152.2" x2="275.5" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="152.2" x2="275.5" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="128.2,143.5 125.0,152.2 119.0,161.2" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="195.6" y1="346.0" x2="201.8" y2="348.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="195.6" y1="346.0" x2="201.8" y2="348.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="156.5,120.7 152.4,124.5 141.5,129.6" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.7,223.8 224.0,222.9 231.7,216.1" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.3,117.9 152.4,124.5 156.5,120.7" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
@@ -477,17 +477,17 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="180.0,128.3 242.2,240.6 244.0,230.8" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.9,241.3 174.2,241.8 171.6,243.3" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="236.7,150.4 240.2,159.5 233.6,150.7" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="207.9" y1="350.0" x2="211.3" y2="346.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="207.9" y1="350.0" x2="211.3" y2="346.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="120.9,200.6 128.9,217.5 123.3,209.6" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.8,243.9 186.9,241.6 190.0,243.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 116.0,232.6 118.6,242.3" fill="rgb(53,73,102)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="211.2,124.2 205.5,123.8 201.7,120.1" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="201.8" y1="348.0" x2="207.9" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="201.8" y1="348.0" x2="207.9" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="171.6,243.3 180.6,242.2 180.8,243.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.3,190.9 120.9,200.6 123.3,209.6" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="32.7" x2="152.1" y2="21.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="32.7" x2="152.1" y2="21.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="241.0,198.8 239.1,199.0 242.7,189.2" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="242.0" x2="84.5" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="242.0" x2="84.5" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="141.3,230.4 155.4,238.1 148.8,235.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="117.8,171.1 117.3,190.9 116.0,180.9" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="141.5,129.6 128.2,143.5 133.3,136.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -508,10 +508,10 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="197.1,118.7 201.7,120.1 190.7,117.6" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="147.3,125.0 141.5,129.6 133.3,136.2" fill="rgb(40,55,78)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="134.6,225.0 141.3,230.4 148.8,235.8" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="140.8" x2="275.5" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="140.8" x2="275.5" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="231.8,216.5 231.7,216.1 237.4,208.0" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="133.3,136.2 128.2,143.5 122.6,152.0" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="207.9" y1="350.0" x2="207.9" y2="338.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="207.9" y1="350.0" x2="207.9" y2="338.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="158.3,239.9 162.9,241.3 171.6,243.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="218.7,129.6 225.4,135.0 216.7,128.6" fill="rgb(48,65,92)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="188.4,116.7 179.0,116.8 179.2,116.1" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
@@ -533,10 +533,10 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="181.0,243.2 180.8,243.9 190.0,243.1" fill="rgb(44,60,84)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="161.5,119.1 156.5,120.7 147.3,125.0" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 118.6,242.3 125.3,251.3" fill="rgb(62,85,120)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="21.4" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="21.4" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.0,161.2 116.0,180.9 117.3,170.8" fill="rgb(39,54,76)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="204.6,121.9 211.2,124.2 201.7,120.1" fill="rgb(52,71,99)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="230.6" x2="84.5" y2="219.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="230.6" x2="84.5" y2="219.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="170.0,116.9 156.5,120.7 161.5,119.1" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.7,242.1 198.5,240.9 203.5,239.3" fill="rgb(45,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="122.6,152.0 119.0,161.2 117.3,170.8" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
@@ -555,11 +555,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="119.8,200.5 123.3,209.6 129.5,217.9" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.0,207.8 237.4,208.0 241.0,198.8" fill="rgb(39,53,75)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.6,235.5 203.5,239.3 212.7,235.0" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="129.4" x2="275.5" y2="118.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="129.4" x2="275.5" y2="118.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="161.5,119.1 147.3,125.0 154.3,122.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="207.9" y1="338.6" x2="207.9" y2="327.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="207.9" y1="338.6" x2="207.9" y2="327.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="140.3,130.7 133.3,136.2 128.3,143.9" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="152.1" y1="10.0" x2="158.2" y2="12.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="152.1" y1="10.0" x2="158.2" y2="12.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.4,117.8 179.2,116.1 170.0,116.9" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.8,118.2 188.4,116.7 179.2,116.1" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="129.5,217.9 134.6,225.0 143.3,231.4" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
@@ -573,7 +573,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="117.3,170.8 116.0,180.9 118.6,190.6" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="210.4,126.1 218.7,129.6 211.2,124.2" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="241.0,178.7 244.0,179.1 242.7,169.1" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="148.7" y1="13.6" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="148.7" y1="13.6" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="173.1,118.4 170.0,116.9 161.5,119.1" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 125.3,251.3 135.8,258.9" fill="rgb(71,97,136)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="222.7,223.8 226.7,223.8 231.8,216.5" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
@@ -582,10 +582,10 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="122.6,152.0 117.3,170.8 120.9,161.0" fill="rgb(36,49,69)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="210.4,126.1 211.2,124.2 204.6,121.9" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.3,143.9 122.6,152.0 120.9,161.0" fill="rgb(45,62,87)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="158.2" y1="12.0" x2="164.4" y2="14.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="158.2" y1="12.0" x2="164.4" y2="14.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="233.2,150.6 236.7,150.4 231.1,142.5" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="241.0,178.7 242.2,188.9 244.0,179.1" fill="rgb(48,66,93)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="219.2" x2="84.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="219.2" x2="84.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.5,236.2 158.3,239.9 169.3,242.4" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="143.3,231.4 158.3,239.9 154.5,236.2" fill="rgb(41,57,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="185.8,118.2 179.2,116.1 179.4,117.8" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -596,11 +596,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="119.8,200.5 129.5,217.9 126.4,209.3" fill="rgb(37,51,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="191.8,119.6 188.4,116.7 185.8,118.2" fill="rgb(58,80,112)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.9,121.8 204.6,121.9 197.1,118.7" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="164.4" y1="14.0" x2="170.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="164.4" y1="14.0" x2="170.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="140.3,130.7 128.3,143.9 136.0,137.1" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.3,122.6 140.3,130.7 148.8,127.0" fill="rgb(51,70,98)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,239.2 169.3,242.4 181.0,243.2" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="145.3" y1="17.3" x2="148.7" y2="13.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="145.3" y1="17.3" x2="148.7" y2="13.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.2,240.0 181.0,243.2 192.7,242.1" fill="rgb(34,47,65)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="118.6,190.6 119.8,200.5 126.4,209.3" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="173.1,118.4 161.5,119.1 167.3,119.9" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -609,14 +609,14 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="236.1,198.1 241.0,198.8 242.2,188.9" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 213.2,263.9 226.3,257.7" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="196.9,121.8 197.1,118.7 191.8,119.6" fill="rgb(61,84,118)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="118.0" x2="275.5" y2="106.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="118.0" x2="275.5" y2="106.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="117.3,170.8 118.6,190.6 119.8,180.3" fill="rgb(37,50,71)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.8,127.0 140.3,130.7 136.0,137.1" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="207.9" y1="327.3" x2="207.9" y2="315.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="207.9" y1="327.3" x2="207.9" y2="315.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 135.8,258.9 149.3,264.8" fill="rgb(78,107,150)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="237.4,168.5 242.7,169.1 239.1,159.4" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="120.9,161.0 117.3,170.8 119.8,180.3" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="170.6" y1="16.0" x2="176.7" y2="18.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="170.6" y1="16.0" x2="176.7" y2="18.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="154.5,236.2 169.3,242.4 167.4,239.2" fill="rgb(36,50,70)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="236.1,198.1 235.0,207.8 241.0,198.8" fill="rgb(49,67,94)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.2,225.0 143.3,231.4 154.5,236.2" fill="rgb(35,48,68)" stroke="#00000018" stroke-width="0.5"/>
@@ -635,11 +635,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="167.4,239.2 181.0,243.2 181.2,240.0" fill="rgb(33,45,64)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.4,215.6 231.8,216.5 235.0,207.8" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="210.7,229.5 218.5,230.4 222.7,223.8" fill="rgb(41,57,80)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="176.7" y1="18.0" x2="182.9" y2="20.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="141.9" y1="20.9" x2="145.3" y2="17.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="176.7" y1="18.0" x2="182.9" y2="20.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="141.9" y1="20.9" x2="145.3" y2="17.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="225.2,142.8 233.2,150.6 231.1,142.5" fill="rgb(63,86,121)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.4,215.6 222.7,223.8 231.8,216.5" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="207.8" x2="84.5" y2="196.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="207.8" x2="84.5" y2="196.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="200.9,124.7 204.6,121.9 196.9,121.8" fill="rgb(65,89,125)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 198.0,267.9 213.2,263.9" fill="rgb(88,121,169)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="179.7,121.9 179.4,117.8 173.1,118.4" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
@@ -649,7 +649,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="118.6,190.6 126.4,209.3 125.3,199.6" fill="rgb(38,52,73)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="176.5,122.2 173.1,118.4 167.3,119.9" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="186.0,122.8 191.8,119.6 185.8,118.2" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="182.9" y1="20.0" x2="189.1" y2="21.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="182.9" y1="20.0" x2="189.1" y2="21.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="119.8,180.3 118.6,190.6 125.3,199.6" fill="rgb(47,64,90)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.0,187.7 242.2,188.9 241.0,178.7" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 181.5,269.4 198.0,267.9" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
@@ -668,16 +668,16 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="126.4,209.3 139.2,225.0 136.7,216.8" fill="rgb(38,52,72)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="235.0,187.7 236.1,198.1 242.2,188.9" fill="rgb(58,79,111)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="203.5,128.2 214.1,131.1 210.4,126.1" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="106.7" x2="275.5" y2="95.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="106.7" x2="275.5" y2="95.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="183.0,122.2 179.4,117.8 179.7,121.9" fill="rgb(67,91,128)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="138.5" y1="24.5" x2="141.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="315.9" x2="207.9" y2="304.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="138.5" y1="24.5" x2="141.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="315.9" x2="207.9" y2="304.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="179.7,121.9 173.1,118.4 176.5,122.2" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.5,132.1 136.0,137.1 134.8,144.1" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="231.7,158.7 237.4,168.5 239.1,159.4" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="203.5,128.2 210.4,126.1 200.9,124.7" fill="rgb(70,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.5,136.5 223.4,136.0 214.1,131.1" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="189.1" y1="21.9" x2="195.3" y2="23.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="189.1" y1="21.9" x2="195.3" y2="23.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="186.0,122.8 185.8,118.2 183.0,122.2" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="215.5,136.5 225.2,142.8 223.4,136.0" fill="rgb(69,95,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="176.5,122.2 167.3,119.9 173.5,123.0" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
@@ -690,10 +690,10 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="190.7,125.5 200.9,124.7 196.9,121.8" fill="rgb(72,99,139)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.7,216.8 139.2,225.0 151.6,230.3" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.3,206.0 235.0,207.8 236.1,198.1" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="195.3" y1="23.9" x2="201.4" y2="25.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="195.3" y1="23.9" x2="201.4" y2="25.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="173.5,123.0 162.3,122.3 171.0,124.2" fill="rgb(67,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="158.5,125.3 145.5,132.1 156.2,128.8" fill="rgb(64,88,124)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="196.5" x2="84.5" y2="185.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="196.5" x2="84.5" y2="185.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="151.6,230.3 167.4,239.2 166.0,233.6" fill="rgb(41,56,79)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.3,206.0 225.4,215.6 235.0,207.8" fill="rgb(57,78,109)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,221.7 210.7,229.5 222.7,223.8" fill="rgb(52,72,101)" stroke="#00000018" stroke-width="0.5"/>
@@ -706,11 +706,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="126.8,152.0 123.3,170.0 128.9,160.1" fill="rgb(54,74,104)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="123.3,170.0 119.8,180.3 126.4,189.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="145.5,132.1 134.8,144.1 144.5,137.5" fill="rgb(62,85,119)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="135.2" y1="28.2" x2="138.5" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="135.2" y1="28.2" x2="138.5" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.3,234.6 194.9,238.8 196.6,233.2" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="224.0,149.8 231.7,158.7 233.2,150.6" fill="rgb(71,97,137)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="156.2,128.8 145.5,132.1 144.5,137.5" fill="rgb(69,94,133)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="201.4" y1="25.9" x2="207.6" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="201.4" y1="25.9" x2="207.6" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="204.5,131.9 214.1,131.1 203.5,128.2" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="166.0,233.6 181.2,240.0 181.3,234.6" fill="rgb(44,61,86)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="171.0,124.2 158.5,125.3 169.1,125.8" fill="rgb(69,95,133)" stroke="#00000018" stroke-width="0.5"/>
@@ -725,10 +725,10 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="180.0,128.3 176.5,122.2 173.5,123.0" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="125.3,199.6 136.7,216.8 135.8,207.3" fill="rgb(47,65,91)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.7,216.8 151.6,230.3 149.9,222.5" fill="rgb(46,63,88)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="95.3" x2="275.5" y2="83.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="95.3" x2="275.5" y2="83.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="214.5,142.0 225.2,142.8 215.5,136.5" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="207.9" y1="304.5" x2="207.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.6" y1="27.9" x2="213.8" y2="29.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="207.9" y1="304.5" x2="207.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.6" y1="27.9" x2="213.8" y2="29.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 188.6,124.0 186.0,122.8" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 173.5,123.0 171.0,124.2" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="144.5,137.5 134.8,144.1 136.6,150.9" fill="rgb(68,94,132)" stroke="#00000018" stroke-width="0.5"/>
@@ -742,7 +742,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="180.0,128.3 190.7,125.5 188.6,124.0" fill="rgb(78,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.6,225.6 196.6,233.2 210.7,229.5" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="214.5,142.0 224.0,149.8 225.2,142.8" fill="rgb(76,104,146)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="131.8" y1="31.8" x2="135.2" y2="28.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="131.8" y1="31.8" x2="135.2" y2="28.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 171.0,124.2 169.1,125.8" fill="rgb(77,105,147)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.9,127.6 156.2,128.8 155.5,132.6" fill="rgb(74,102,143)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="128.9,160.1 123.3,170.0 129.5,178.3" fill="rgb(63,87,122)" stroke="#00000018" stroke-width="0.5"/>
@@ -753,7 +753,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="180.0,128.3 183.0,122.2 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 176.5,122.2 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="225.4,195.5 226.3,206.0 236.1,198.1" fill="rgb(66,90,127)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="213.8" y1="29.9" x2="220.0" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="213.8" y1="29.9" x2="220.0" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 186.0,122.8 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 192.0,127.2 190.7,125.5" fill="rgb(78,108,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="197.6,225.6 210.7,229.5 212.6,221.7" fill="rgb(56,77,108)" stroke="#00000018" stroke-width="0.5"/>
@@ -762,7 +762,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="180.0,128.3 169.1,125.8 167.9,127.6" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="203.8,135.7 215.5,136.5 204.5,131.9" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="226.7,166.3 231.8,176.9 237.4,168.5" fill="rgb(73,100,140)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="185.1" x2="84.5" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="185.1" x2="84.5" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 188.6,124.0 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 171.0,124.2 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="155.5,132.6 144.5,137.5 145.9,142.9" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
@@ -782,14 +782,14 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="192.1,131.0 204.5,131.9 192.5,129.1" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="219.7,156.2 231.7,158.7 224.0,149.8" fill="rgb(78,107,151)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="149.9,222.5 166.0,233.6 165.1,226.0" fill="rgb(52,71,100)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="220.0" y1="31.9" x2="226.1" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="220.0" y1="31.9" x2="226.1" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 192.5,129.1 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 167.5,129.5 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.5,129.5 155.5,132.6 156.5,136.3" fill="rgb(77,106,149)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="136.6,150.9 128.9,160.1 134.6,167.6" fill="rgb(70,96,134)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="192.1,131.0 203.8,135.7 204.5,131.9" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 192.1,131.0 192.5,129.1" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="128.4" y1="35.5" x2="131.8" y2="31.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="128.4" y1="35.5" x2="131.8" y2="31.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 167.5,129.5 168.0,131.4" fill="rgb(79,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 192.1,131.0 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="155.5,132.6 145.9,142.9 156.5,136.3" fill="rgb(74,101,142)" stroke="#00000018" stroke-width="0.5"/>
@@ -805,11 +805,11 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="180.0,128.3 169.3,133.1 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="165.1,226.0 181.3,234.6 181.4,227.0" fill="rgb(56,76,107)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="211.2,147.1 224.0,149.8 214.5,142.0" fill="rgb(82,112,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="83.9" x2="275.5" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="83.9" x2="275.5" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 190.9,132.8 192.1,131.0" fill="rgb(81,112,157)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 189.0,134.4 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="226.1" y1="33.9" x2="232.3" y2="35.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="293.1" x2="207.9" y2="281.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="226.1" y1="33.9" x2="232.3" y2="35.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="293.1" x2="207.9" y2="281.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="180.0,128.3 171.4,134.6 180.0,128.3" fill="rgb(80,109,153)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 168.0,131.4 169.3,133.1" fill="rgb(80,110,155)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="135.8,207.3 149.9,222.5 149.3,213.1" fill="rgb(55,76,107)" stroke="#00000018" stroke-width="0.5"/>
@@ -836,13 +836,13 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="180.0,128.3 186.5,135.6 189.0,134.4" fill="rgb(83,114,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="201.5,139.2 211.2,147.1 214.5,142.0" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 171.4,134.6 174.0,135.7" fill="rgb(82,113,158)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="232.3" y1="35.9" x2="238.5" y2="37.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="232.3" y1="35.9" x2="238.5" y2="37.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="212.6,201.5 226.3,206.0 225.4,195.5" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="125.0" y1="39.1" x2="128.4" y2="35.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="125.0" y1="39.1" x2="128.4" y2="35.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="218.5,172.9 231.8,176.9 226.7,166.3" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.0,216.2 212.6,221.7 213.2,212.2" fill="rgb(66,91,128)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 183.5,136.4 186.5,135.6" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="173.7" x2="84.5" y2="162.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="173.7" x2="84.5" y2="162.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="189.0,134.4 201.5,139.2 190.9,132.8" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.0,128.3 174.0,135.7 177.0,136.4" fill="rgb(83,114,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.6,201.5 213.2,212.2 226.3,206.0" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
@@ -855,7 +855,7 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="218.5,172.9 222.7,184.3 231.8,176.9" fill="rgb(80,110,154)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="164.9,216.6 165.1,226.0 181.4,227.0" fill="rgb(66,91,127)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.3,133.1 163.1,142.7 171.4,134.6" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="238.5" y1="37.9" x2="244.7" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="238.5" y1="37.9" x2="244.7" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="181.5,217.7 181.4,227.0 197.6,225.6" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.3,133.1 159.1,139.7 163.1,142.7" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="189.0,134.4 197.7,142.2 201.5,139.2" fill="rgb(86,118,165)" stroke="#00000018" stroke-width="0.5"/>
@@ -869,13 +869,13 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="171.4,134.6 168.2,144.9 174.0,135.7" fill="rgb(86,117,165)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.5,217.7 197.6,225.6 198.0,216.2" fill="rgb(68,93,130)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="159.1,139.7 149.6,147.9 155.4,152.2" fill="rgb(83,114,160)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="72.6" x2="275.5" y2="61.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="72.6" x2="275.5" y2="61.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="183.5,136.4 192.7,144.6 186.5,135.6" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="212.7,161.9 218.5,172.9 226.7,166.3" fill="rgb(84,116,163)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="244.7" y1="39.9" x2="250.8" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="244.7" y1="39.9" x2="250.8" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="134.6,167.6 139.2,185.4 143.3,173.9" fill="rgb(72,98,138)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="121.6" y1="42.7" x2="125.0" y2="39.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="281.8" x2="207.9" y2="270.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="121.6" y1="42.7" x2="125.0" y2="39.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="281.8" x2="207.9" y2="270.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="197.7,142.2 205.7,151.5 211.2,147.1" fill="rgb(88,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="139.2,185.4 136.7,196.6 149.9,202.3" fill="rgb(72,99,140)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="149.6,147.9 141.3,157.3 148.8,162.7" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
@@ -897,8 +897,8 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="149.6,147.9 148.8,162.7 155.4,152.2" fill="rgb(81,111,156)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.0,135.7 168.2,144.9 174.2,146.3" fill="rgb(87,120,168)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="183.5,136.4 186.9,146.1 192.7,144.6" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="250.8" y1="41.8" x2="257.0" y2="43.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="162.3" x2="84.5" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="250.8" y1="41.8" x2="257.0" y2="43.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="162.3" x2="84.5" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="177.0,136.4 174.2,146.3 180.6,146.7" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.3,136.7 180.6,146.7 186.9,146.1" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="207.6,178.1 222.7,184.3 218.5,172.9" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
@@ -911,10 +911,10 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="192.7,144.6 198.5,154.9 205.7,151.5" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="198.5,154.9 212.7,161.9 205.7,151.5" fill="rgb(91,125,175)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.4,206.9 181.5,217.7 198.0,216.2" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="118.3" y1="46.4" x2="121.6" y2="42.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="118.3" y1="46.4" x2="121.6" y2="42.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="207.6,178.1 210.7,190.0 222.7,184.3" fill="rgb(85,117,164)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="203.5,166.2 218.5,172.9 212.7,161.9" fill="rgb(89,122,172)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="257.0" y1="43.8" x2="263.2" y2="45.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="257.0" y1="43.8" x2="263.2" y2="45.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="186.9,146.1 198.5,154.9 192.7,144.6" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.4,206.9 198.0,216.2 197.6,205.4" fill="rgb(77,105,148)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="148.8,162.7 143.3,173.9 154.5,178.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
@@ -930,29 +930,29 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="180.6,146.7 190.0,157.1 186.9,146.1" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="155.4,152.2 158.3,166.8 162.9,155.4" fill="rgb(86,118,166)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="168.2,144.9 162.9,155.4 171.6,157.4" fill="rgb(90,124,173)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="275.5" y1="61.2" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="275.5" y1="61.2" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="186.9,146.1 190.0,157.1 198.5,154.9" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.2,146.3 180.8,158.0 180.6,146.7" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="263.2" y1="45.8" x2="269.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="270.4" x2="207.9" y2="259.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="263.2" y1="45.8" x2="269.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="270.4" x2="207.9" y2="259.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="148.8,162.7 154.5,178.8 158.3,166.8" fill="rgb(84,115,161)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.0,157.1 203.5,166.2 198.5,154.9" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="174.2,146.3 171.6,157.4 180.8,158.0" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.6,146.7 180.8,158.0 190.0,157.1" fill="rgb(93,127,179)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="151.6,190.8 165.1,205.8 166.0,194.0" fill="rgb(79,108,151)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="114.9" y1="50.0" x2="118.3" y2="46.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="114.9" y1="50.0" x2="118.3" y2="46.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="194.9,181.4 210.7,190.0 207.6,178.1" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="166.0,194.0 165.1,205.8 181.4,206.9" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="154.5,178.8 151.6,190.8 166.0,194.0" fill="rgb(85,116,163)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.3,195.0 181.4,206.9 197.6,205.4" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="269.3" y1="47.8" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="269.3" y1="47.8" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="192.7,169.0 207.6,178.1 203.5,166.2" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.9,155.4 158.3,166.8 169.3,169.3" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="194.9,181.4 196.6,193.6 210.7,190.0" fill="rgb(89,122,171)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="162.9,155.4 169.3,169.3 171.6,157.4" fill="rgb(90,124,174)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.3,195.0 197.6,205.4 196.6,193.6" fill="rgb(84,115,162)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="190.0,157.1 192.7,169.0 203.5,166.2" fill="rgb(93,128,180)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="84.5" y1="151.0" x2="84.5" y2="139.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="84.5" y1="151.0" x2="84.5" y2="139.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="158.3,166.8 154.5,178.8 167.4,181.7" fill="rgb(89,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="180.8,158.0 192.7,169.0 190.0,157.1" fill="rgb(94,129,181)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="166.0,194.0 181.4,206.9 181.3,195.0" fill="rgb(83,113,159)" stroke="#00000018" stroke-width="0.5"/>
@@ -966,74 +966,74 @@ expression: "export_svg(\"Graphics3D[{Sphere[], Cone[]}]\")"
 <polygon points="181.2,182.6 181.3,195.0 196.6,193.6" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.2,182.6 196.6,193.6 194.9,181.4" fill="rgb(90,123,172)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.0,170.1 194.9,181.4 192.7,169.0" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="272.1" y1="53.4" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="272.1" y1="53.4" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <polygon points="169.3,169.3 167.4,181.7 181.2,182.6" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="167.4,181.7 181.3,195.0 181.2,182.6" fill="rgb(88,121,170)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="169.3,169.3 181.2,182.6 181.0,170.1" fill="rgb(92,126,177)" stroke="#00000018" stroke-width="0.5"/>
 <polygon points="181.0,170.1 181.2,182.6 194.9,181.4" fill="rgb(93,128,179)" stroke="#00000018" stroke-width="0.5"/>
-<line x1="111.5" y1="53.6" x2="114.9" y2="50.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="259.0" x2="207.9" y2="247.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="268.8" y1="57.1" x2="272.1" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="108.1" y1="57.3" x2="111.5" y2="53.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="139.6" x2="84.5" y2="128.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="265.4" y1="60.7" x2="268.8" y2="57.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="247.6" x2="207.9" y2="236.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="104.8" y1="60.9" x2="108.1" y2="57.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="128.2" x2="84.5" y2="116.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="262.0" y1="64.4" x2="265.4" y2="60.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="101.4" y1="64.6" x2="104.8" y2="60.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="236.3" x2="207.9" y2="224.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="258.6" y1="68.0" x2="262.0" y2="64.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="98.0" y1="68.2" x2="101.4" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="116.9" x2="84.5" y2="105.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="255.2" y1="71.6" x2="258.6" y2="68.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="94.6" y1="71.8" x2="98.0" y2="68.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="224.9" x2="207.9" y2="213.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="251.9" y1="75.3" x2="255.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="91.2" y1="75.5" x2="94.6" y2="71.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="105.5" x2="84.5" y2="94.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="248.5" y1="78.9" x2="251.9" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="213.5" x2="207.9" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="87.9" y1="79.1" x2="91.2" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="94.1" x2="84.5" y2="82.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="245.1" y1="82.5" x2="248.5" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="82.7" x2="87.9" y2="79.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="202.2" x2="207.9" y2="190.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="84.5" y1="82.7" x2="90.7" y2="84.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="241.7" y1="86.2" x2="245.1" y2="82.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="90.7" y1="84.7" x2="96.8" y2="86.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="96.8" y1="86.7" x2="103.0" y2="88.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="238.4" y1="89.8" x2="241.7" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="190.8" x2="207.9" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="103.0" y1="88.7" x2="109.2" y2="90.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="235.0" y1="93.5" x2="238.4" y2="89.8" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="109.2" y1="90.7" x2="115.3" y2="92.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="115.3" y1="92.7" x2="121.5" y2="94.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="231.6" y1="97.1" x2="235.0" y2="93.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="179.4" x2="207.9" y2="168.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="121.5" y1="94.7" x2="127.7" y2="96.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="127.7" y1="96.7" x2="133.9" y2="98.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="228.2" y1="100.7" x2="231.6" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="133.9" y1="98.7" x2="140.0" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="168.0" x2="207.9" y2="156.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="140.0" y1="100.7" x2="146.2" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="224.8" y1="104.4" x2="228.2" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="146.2" y1="102.6" x2="152.4" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="152.4" y1="104.6" x2="158.6" y2="106.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="221.5" y1="108.0" x2="224.8" y2="104.4" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="156.7" x2="207.9" y2="145.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="158.6" y1="106.6" x2="164.7" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="164.7" y1="108.6" x2="170.9" y2="110.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="218.1" y1="111.6" x2="221.5" y2="108.0" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="170.9" y1="110.6" x2="177.1" y2="112.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="214.7" y1="115.3" x2="218.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="145.3" x2="207.9" y2="133.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="177.1" y1="112.6" x2="183.3" y2="114.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="183.3" y1="114.6" x2="189.4" y2="116.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="211.3" y1="118.9" x2="214.7" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="189.4" y1="116.6" x2="195.6" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="133.9" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="195.6" y1="118.6" x2="201.8" y2="120.6" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="207.9" y1="122.5" x2="211.3" y2="118.9" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
-<line x1="201.8" y1="120.6" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" opacity="0.4"/>
+<line x1="111.5" y1="53.6" x2="114.9" y2="50.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="259.0" x2="207.9" y2="247.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="268.8" y1="57.1" x2="272.1" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="108.1" y1="57.3" x2="111.5" y2="53.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="139.6" x2="84.5" y2="128.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="265.4" y1="60.7" x2="268.8" y2="57.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="247.6" x2="207.9" y2="236.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="104.8" y1="60.9" x2="108.1" y2="57.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="128.2" x2="84.5" y2="116.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="262.0" y1="64.4" x2="265.4" y2="60.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="101.4" y1="64.6" x2="104.8" y2="60.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="236.3" x2="207.9" y2="224.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="258.6" y1="68.0" x2="262.0" y2="64.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="98.0" y1="68.2" x2="101.4" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="116.9" x2="84.5" y2="105.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="255.2" y1="71.6" x2="258.6" y2="68.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="94.6" y1="71.8" x2="98.0" y2="68.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="224.9" x2="207.9" y2="213.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="251.9" y1="75.3" x2="255.2" y2="71.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="91.2" y1="75.5" x2="94.6" y2="71.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="105.5" x2="84.5" y2="94.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="248.5" y1="78.9" x2="251.9" y2="75.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="213.5" x2="207.9" y2="202.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="87.9" y1="79.1" x2="91.2" y2="75.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="94.1" x2="84.5" y2="82.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="245.1" y1="82.5" x2="248.5" y2="78.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="82.7" x2="87.9" y2="79.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="202.2" x2="207.9" y2="190.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="84.5" y1="82.7" x2="90.7" y2="84.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="241.7" y1="86.2" x2="245.1" y2="82.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="90.7" y1="84.7" x2="96.8" y2="86.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="96.8" y1="86.7" x2="103.0" y2="88.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="238.4" y1="89.8" x2="241.7" y2="86.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="190.8" x2="207.9" y2="179.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="103.0" y1="88.7" x2="109.2" y2="90.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="235.0" y1="93.5" x2="238.4" y2="89.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="109.2" y1="90.7" x2="115.3" y2="92.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="115.3" y1="92.7" x2="121.5" y2="94.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="231.6" y1="97.1" x2="235.0" y2="93.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="179.4" x2="207.9" y2="168.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="121.5" y1="94.7" x2="127.7" y2="96.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="127.7" y1="96.7" x2="133.9" y2="98.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="228.2" y1="100.7" x2="231.6" y2="97.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="133.9" y1="98.7" x2="140.0" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="168.0" x2="207.9" y2="156.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="140.0" y1="100.7" x2="146.2" y2="102.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="224.8" y1="104.4" x2="228.2" y2="100.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="146.2" y1="102.6" x2="152.4" y2="104.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="152.4" y1="104.6" x2="158.6" y2="106.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="221.5" y1="108.0" x2="224.8" y2="104.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="156.7" x2="207.9" y2="145.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="158.6" y1="106.6" x2="164.7" y2="108.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="164.7" y1="108.6" x2="170.9" y2="110.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="218.1" y1="111.6" x2="221.5" y2="108.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="170.9" y1="110.6" x2="177.1" y2="112.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="214.7" y1="115.3" x2="218.1" y2="111.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="145.3" x2="207.9" y2="133.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="177.1" y1="112.6" x2="183.3" y2="114.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="183.3" y1="114.6" x2="189.4" y2="116.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="211.3" y1="118.9" x2="214.7" y2="115.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="189.4" y1="116.6" x2="195.6" y2="118.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="133.9" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="195.6" y1="118.6" x2="201.8" y2="120.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="207.9" y1="122.5" x2="211.3" y2="118.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<line x1="201.8" y1="120.6" x2="207.9" y2="122.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 </svg>

--- a/woxi-studio/examples/dump_notebook.rs
+++ b/woxi-studio/examples/dump_notebook.rs
@@ -1,7 +1,7 @@
 //! Dump every parsed cell of a notebook file (style + content snippet) so
 //! rendering problems can be spotted without launching the GUI.
 //!
-//! Usage: cargo run --example dump_notebook -- path/to/notebook.nb
+//! Usage: cargo run --example dump_notebook -- path/to/notebook.nb [max-chars]
 
 use std::path::PathBuf;
 
@@ -12,6 +12,10 @@ fn main() {
     .nth(1)
     .expect("notebook path required")
     .into();
+  let max_chars: usize = std::env::args()
+    .nth(2)
+    .map(|s| s.parse().expect("max-chars must be a number"))
+    .unwrap_or(200);
   let src = std::fs::read_to_string(&path).expect("read file");
   let nb = parse_notebook(&src).expect("parse notebook");
 
@@ -24,7 +28,7 @@ fn main() {
     for cell in cells {
       idx += 1;
       let content = cell.content.replace('\n', "\\n");
-      let snippet: String = content.chars().take(200).collect();
+      let snippet: String = content.chars().take(max_chars).collect();
       let len = cell.content.chars().count();
       println!("#{idx:3} [{:12}] ({len:6} chars) {snippet}", cell.style);
     }


### PR DESCRIPTION
## Summary

Implements support for `Translate`, `Rotate`, and `Scale` wrapper functions in 3D graphics, allowing geometric transformations to be applied to 3D primitives in `Graphics3D`. This enables users to position, orient, and resize 3D objects using standard Wolfram Language transformation syntax.

## Key Changes

- **Added `Affine3` struct** (`src/functions/plot3d.rs`): Represents affine 3D transformations (p ↦ m·p + t) with methods for:
  - Point transformation via matrix-vector multiplication
  - Uniform length-scale computation (cube root of determinant) for scaling radii of spheres/cylinders/cones
  - Factory methods for translation, rotation (via Rodrigues' formula), and scaling transformations

- **Added transform parsing** (`parse_3d_transforms` function): Parses `Translate`, `Rotate`, and `Scale` wrapper arguments:
  - `Translate` supports both single offset vectors and lists of offset vectors (producing multiple copies)
  - `Rotate` accepts angle and axis (with optional anchor point for rotation center)
  - `Scale` accepts scaling factors and optional center point

- **Integrated transforms into primitive collection**: Modified `collect_3d_primitives` to apply accumulated affine transformations to all collected 3D primitives (Sphere, Cylinder, Cone, Line, Point, Polygon, Cuboid)

- **Made `Primitive3D` cloneable**: Added `#[derive(Clone)]` to support transformation application

- **Added helper function `eval_vec3`**: Evaluates expressions to numeric 3D vectors for transform parameters

- **Updated polyhedron data** (`src/functions/polyhedron_data.rs`): Removed runtime vertex generation functions (now handled via transforms) and updated to use exact symbolic coordinates

- **Enhanced plot structure tracking** (`src/syntax.rs`): Added optional `structure` field to `Graphics` to preserve symbolic form of rendered plots (e.g., `Graphics3D[GraphicsComplex[…], opts]`) for Part extraction

- **Updated Part extraction** (`src/evaluator/part_extraction.rs`): Graphics with preserved structure now index the symbolic form, matching Wolfram behavior for plot reuse

- **Test coverage**: Added tests for transform parsing and plot structure preservation in `tests/interpreter_tests/graphics.rs` and `tests/interpreter_tests/polyhedron_data.rs`

## Implementation Details

- Rotation uses Rodrigues' formula with proper conjugation to ensure the rotation axis passes through the specified anchor point
- Scaling is centered at a specified point (default origin) using the formula: p ↦ center + factors ⊙ (p - center)
- Transform composition is handled by sequential application to primitives
- Determinant calculation for length-scale uses the standard 3×3 cofactor expansion
- Snapshot tests updated to reflect rendering changes from transform implementation

https://claude.ai/code/session_01HuCtzEJTZLtTd6i7tLzSRX