### PR TITLE
Support Thread with List head and Dynamic in graphics/visual mode

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -140,7 +140,7 @@ Mod,Returns the remainder on division (m - n Floor[m/n]; Gaussian integers use m
 Arg,Returns the argument (phase angle) of a complex number,✅,pure,1.0,135
 Or,Checks if at least one condition is true,✅,pure,1.0,136
 BaseStyle,Option specifying the base style for elements in a graphic or other output,✅,none,6.0,137
-Dynamic,Dynamic display wrapper (stays symbolic in script mode),✅,unevaluated,6.0,138
+Dynamic,Dynamic display wrapper (shows the current value in visual mode; stays symbolic in script mode),✅,unevaluated,6.0,138
 Not,Logical negation of an expression — written with the ! operator and bracketed inside anything that binds tighter than it,✅,pure,1.0,139
 Last,Returns the last element of a list or the given default which is only evaluated when used,✅,pure,1.0,140
 AdministrativeDivisionData,,🚫,,10.0,141

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1455,6 +1455,20 @@ fn collect_primitives(
           }
         }
 
+        // `Dynamic[expr]` inside graphics displays the current value of
+        // its held expression (the front end re-evaluates it as its
+        // dependencies change; Woxi's hosts re-render wholesale, so the
+        // current value is the correct snapshot). Dynamic is HoldFirst —
+        // the content arrives unevaluated, so release the hold before
+        // collecting, otherwise computed primitives (e.g. the
+        // `Dynamic[colorSlice[#+a] & /@ clrCases]` highlight overlay in
+        // the Demonstrations color-wheel notebook) silently vanish.
+        "Dynamic" if !args.is_empty() => {
+          if let Ok(inner) = evaluate_expr_to_expr(&args[0]) {
+            collect_primitives(&inner, style, prims, errors);
+          }
+        }
+
         _ => {
           // Try as directive first
           if !apply_directive(expr, style) {
@@ -11058,8 +11072,9 @@ pub fn column_to_svg(args: &[Expr]) -> Option<String> {
     return None;
   }
 
-  // Parse optional alignment from second arg (default: Left)
-  let alignment = if args.len() >= 2 {
+  // Parse optional alignment: positional (`Column[{…}, Center]`) or the
+  // option form (`Column[{…}, Alignment -> Center]`). Default: Left.
+  let mut alignment = if args.len() >= 2 {
     match &args[1] {
       Expr::Identifier(s) if s == "Center" => "middle",
       Expr::Identifier(s) if s == "Right" => "end",
@@ -11068,6 +11083,21 @@ pub fn column_to_svg(args: &[Expr]) -> Option<String> {
   } else {
     "start"
   };
+  for arg in &args[1..] {
+    if let Expr::Rule {
+      pattern,
+      replacement,
+    } = arg
+      && matches!(pattern.as_ref(), Expr::Identifier(s) if s == "Alignment")
+      && let Expr::Identifier(spec) = replacement.as_ref()
+    {
+      alignment = match spec.as_str() {
+        "Center" => "middle",
+        "Right" => "end",
+        _ => "start",
+      };
+    }
+  }
 
   // Parse optional spacing from third arg in ems (default: 0)
   let spacing_ems: f64 = if args.len() >= 3 {

--- a/src/functions/list_helpers_ast/mapping.rs
+++ b/src/functions/list_helpers_ast/mapping.rs
@@ -1578,6 +1578,80 @@ pub fn thread_ast_positions(
   positions: Option<&[usize]>,
 ) -> Result<Expr, InterpreterError> {
   match expr {
+    // The threaded expression's head can itself be List:
+    // Thread[{{a, b}, {c, d}}] -> {{a, c}, {b, d}} (a transpose), with
+    // non-list elements repeated: Thread[{{a, b}, x}] -> {{a, x}, {b, x}}.
+    Expr::List(elements) => {
+      let mut list_indices: Vec<usize> = Vec::new();
+      let mut list_len: Option<usize> = None;
+
+      for (i, el) in elements.iter().enumerate() {
+        if let Some(pos) = positions
+          && !pos.contains(&(i + 1))
+        {
+          continue;
+        }
+        let matching_len: Option<usize> = match thread_head {
+          None => match el {
+            Expr::List(items) => Some(items.len()),
+            _ => None,
+          },
+          Some(head) => match el {
+            Expr::FunctionCall {
+              name: el_name,
+              args: el_args,
+            } if el_name == head => Some(el_args.len()),
+            Expr::List(items) if head == "List" => Some(items.len()),
+            _ => None,
+          },
+        };
+        if let Some(n) = matching_len {
+          if let Some(len) = list_len {
+            if n != len {
+              return Err(InterpreterError::EvaluationError(
+                "Thread: all lists must have the same length".into(),
+              ));
+            }
+          } else {
+            list_len = Some(n);
+          }
+          list_indices.push(i);
+        }
+      }
+
+      let Some(len) = list_len else {
+        return Ok(expr.clone());
+      };
+
+      let mut results = Vec::with_capacity(len);
+      for j in 0..len {
+        let new_elements: Vec<Expr> = elements
+          .iter()
+          .enumerate()
+          .map(|(i, el)| {
+            if list_indices.contains(&i) {
+              match el {
+                Expr::List(items) => items[j].clone(),
+                Expr::FunctionCall { args: el_args, .. } => el_args[j].clone(),
+                _ => el.clone(),
+              }
+            } else {
+              el.clone()
+            }
+          })
+          .collect();
+        results.push(Expr::List(new_elements.into()));
+      }
+
+      // Wrap the result in the thread head (List by default).
+      match thread_head {
+        None => Ok(Expr::List(results.into())),
+        Some("List") => Ok(Expr::List(results.into())),
+        Some(head) => {
+          crate::evaluator::evaluate_function_call_ast(head, &results)
+        }
+      }
+    }
     Expr::FunctionCall { name, args } => {
       // Find which args contain the target head (List by default, or specified head)
       let mut list_indices: Vec<usize> = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1982,6 +1982,7 @@ fn format_top_level_result(result_expr: syntax::Expr) -> String {
   let result_expr = render_tabular_if_needed(result_expr);
   // In visual mode, render TableForm[list], MatrixForm[list], and Column[list] as SVGs
   let result_expr = if VISUAL_MODE.with(|v| *v.borrow()) {
+    let result_expr = render_dynamic_if_needed(result_expr);
     let result_expr = render_color_if_needed(result_expr);
     let result_expr = render_tableform_if_needed(result_expr);
     let result_expr = render_matrixform_if_needed(result_expr);
@@ -2718,6 +2719,7 @@ fn render_inline_display_wrapper(expr: syntax::Expr) -> syntax::Expr {
   // The top-level pipeline transformations don't recurse into nested
   // wrapper arguments, so we apply the relevant ones here for a single
   // sub-expression.
+  let expr = render_dynamic_if_needed(expr);
   let expr = render_grid_if_needed(expr);
   let expr = render_dataset_if_needed(expr);
   let expr = render_tabular_if_needed(expr);
@@ -2733,6 +2735,32 @@ fn render_inline_display_wrapper(expr: syntax::Expr) -> syntax::Expr {
   // PolyhedronData) are rendered to embedded SVG so a `Column[{plot, …}]`
   // shows the actual graphic instead of a `-Graphics-` text placeholder.
   render_graphics_fc_if_needed(expr)
+}
+
+/// In visual (notebook) display mode, `Dynamic[expr, …]` displays the
+/// current value of `expr` — the front end re-evaluates it as its
+/// dependencies change, and Woxi's visual hosts (Playground, Studio)
+/// re-evaluate the whole cell on any control change, so the current value
+/// is the correct rendering. Script/CLI mode keeps the symbolic
+/// `Dynamic[…]` echo to match wolframscript.
+fn render_dynamic_if_needed(expr: syntax::Expr) -> syntax::Expr {
+  if !is_visual_mode() {
+    return expr;
+  }
+  match &expr {
+    syntax::Expr::FunctionCall { name, args }
+      if name == "Dynamic" && !args.is_empty() =>
+    {
+      // Dynamic is HoldFirst: its content arrives unevaluated. Release
+      // the hold; on error keep the symbolic form rather than failing
+      // the whole rendering pipeline.
+      match evaluator::evaluate_expr_to_expr(&args[0]) {
+        Ok(inner) => inner,
+        Err(_) => expr,
+      }
+    }
+    _ => expr,
+  }
 }
 
 /// If `expr` is `Column[{…}]`, render it as an SVG column and return `-Graphics-`.

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -1878,6 +1878,69 @@ Cell["Chapter 2", "Chapter"]
   }
 
   #[test]
+  fn test_parse_real_demonstration_nb() {
+    // Reduced Wolfram Demonstrations "definition notebook" (the
+    // ColorRelationships template): deeply nested cell groups, Section
+    // headers carrying inline MoreInfo opener cells, an Input +
+    // DynamicModuleBox-dump Output pair, a RasterBox snapshot Output,
+    // and Item keyword cells.
+    let contents = std::fs::read_to_string(concat!(
+      env!("CARGO_MANIFEST_DIR"),
+      "/tests/notebooks/demonstration.nb"
+    ))
+    .unwrap();
+    let nb = parse_notebook(&contents).unwrap();
+    let flat = nb.flat_cells();
+    let cells: Vec<&Cell> = flat.iter().map(|(_, c)| *c).collect();
+
+    assert_eq!(cells[0].style, CellStyle::Title);
+    assert_eq!(cells[0].content, "Color Relationships");
+
+    // Section headers render just their label — the trailing inline
+    // `Cell[BoxData[PaneSelectorBox[…]]]` opener button carries no text.
+    assert_eq!(cells[1].style, CellStyle::Section);
+    assert_eq!(cells[1].content, "Initialization Code");
+
+    // The initialization Input cell reconstructs evaluable InputForm.
+    assert_eq!(cells[2].style, CellStyle::Input);
+    assert_eq!(
+      cells[2].content,
+      "swatch[clr_]:=Graphics[{clr,Rectangle[]}]"
+    );
+
+    assert_eq!(cells[3].style, CellStyle::Section);
+    assert_eq!(cells[3].content, "Manipulate");
+
+    // The Manipulate input keeps ASCII `->` (from `\[Rule]`) and its
+    // stored output is recognizable as a FrontEnd widget dump (TagBox/
+    // StyleBox wrappers unwrap to the DynamicModuleBox).
+    assert_eq!(cells[4].style, CellStyle::Input);
+    assert!(cells[4].content.starts_with("Manipulate["));
+    assert!(cells[4].content.contains("SaveDefinitions->True"));
+    assert_eq!(cells[5].style, CellStyle::Output);
+    assert!(
+      cells[5]
+        .content
+        .trim_start()
+        .starts_with("DynamicModuleBox[")
+    );
+
+    // Snapshot outputs and keyword items parse with their styles.
+    assert!(
+      cells.iter().any(
+        |c| c.style == CellStyle::Output && c.content.contains("RasterBox")
+      ),
+      "expected a RasterBox snapshot output"
+    );
+    let items: Vec<&str> = cells
+      .iter()
+      .filter(|c| c.style == CellStyle::Item)
+      .map(|c| c.content.as_str())
+      .collect();
+    assert_eq!(items, vec!["hue", "color wheel"]);
+  }
+
+  #[test]
   fn test_unescape_wolfram_string_delimiters() {
     // \< and \> are Wolfram string delimiters in box expressions
     assert_eq!(unescape_string(r#"\<"Hello"\>"#), r#""Hello""#);

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1676,7 +1676,11 @@ mod interpreter_tests {
       ("Editable[x]", "Editable[x]"),
       ("Selectable[x]", "Selectable[x]"),
       ("DynamicWrapper[a, b]", "DynamicWrapper[a, b]"),
-      ("Dynamic[x]", "Dynamic[x]"),
+      // Dynamic displays the current value of its content in visual mode
+      // (interpret_with_stdout), like a notebook front end — for an
+      // undefined symbol that value is the symbol itself. The script-mode
+      // echo `Dynamic[x]` is covered by dynamic_stays_symbolic_in_text_mode.
+      ("Dynamic[x]", "x"),
       ("Setter[a, b]", "Setter[a, b]"),
       ("Slider[0.5]", "Slider[0.5]"),
       ("Toggler[a, b]", "Toggler[a, b]"),

--- a/tests/interpreter_tests/column.rs
+++ b/tests/interpreter_tests/column.rs
@@ -231,4 +231,47 @@ mod column_visual_mode {
     assert!(svg.contains(">bbb</text>"));
     assert!(svg.contains(">ccccc</text>"));
   }
+
+  #[test]
+  fn column_alignment_option_rule() {
+    clear_state();
+    // The option form `Alignment -> Center` must center like the
+    // positional `Column[{…}, Center]` form.
+    let result =
+      interpret_with_stdout("Column[{1, 2, 3}, Alignment -> Center]").unwrap();
+    assert_eq!(result.result, "-Graphics-");
+    let svg = result.graphics.unwrap();
+    assert!(svg.contains("text-anchor=\"middle\""));
+  }
+
+  #[test]
+  fn column_dynamic_item_shows_value() {
+    clear_state();
+    // In visual mode `Dynamic[expr]` displays the current value of `expr`
+    // (the front end re-evaluates it as dependencies change). A Column
+    // item must therefore render the value, not the literal `Dynamic[…]`
+    // text — the Demonstrations color-wheel notebook stacks
+    // `Dynamic[Row[…]]` above its wheel graphic.
+    let result = interpret_with_stdout("Column[{Dynamic[1 + 1], 3}]").unwrap();
+    assert_eq!(result.result, "-Graphics-");
+    let svg = result.graphics.unwrap();
+    assert!(svg.contains(">2</text>"), "expected value 2, got: {svg}");
+    assert!(svg.contains(">3</text>"));
+    assert!(!svg.contains("Dynamic"));
+  }
+
+  #[test]
+  fn dynamic_top_level_shows_value_in_visual_mode() {
+    clear_state();
+    let result = interpret_with_stdout("Dynamic[1 + 1]").unwrap();
+    assert_eq!(result.result, "2");
+  }
+
+  #[test]
+  fn dynamic_stays_symbolic_in_text_mode() {
+    clear_state();
+    // Script/CLI mode matches wolframscript: no front end, so Dynamic
+    // echoes verbatim.
+    assert_eq!(interpret("Dynamic[1 + 1]").unwrap(), "Dynamic[1 + 1]");
+  }
 }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -14953,4 +14953,36 @@ mod color_data_indexed {
     assert_eq!(interpret("Head[ColorData[1, 1]]").unwrap(), "RGBColor");
     assert_eq!(interpret("Head[ColorData[2, 1]]").unwrap(), "RGBColor");
   }
+
+  mod dynamic_content {
+    use super::*;
+
+    #[test]
+    fn dynamic_literal_primitives_render() {
+      clear_state();
+      let svg = export_svg(
+        "Graphics[{Dynamic[{Hue[0.5, 1, 1], \
+         Polygon[{{0, 0}, {1, 0}, {1, 1}}]}], Circle[{0, 0}, 1]}]",
+      );
+      assert!(svg.contains("<polygon"), "polygon missing: {svg}");
+      assert!(svg.contains("rgb(0,255,255)"), "hue fill missing: {svg}");
+    }
+
+    #[test]
+    fn dynamic_computed_primitives_render() {
+      clear_state();
+      // Dynamic is HoldFirst: a computed content expression (here a Map
+      // over a helper function, as in the Demonstrations color-wheel
+      // notebook's highlight overlay) must be evaluated before its
+      // primitives are collected.
+      let _ = interpret(
+        "slice[s_] := {Hue[s, 1, 1], Polygon[{{0, 0}, {1, 0}, {1, 1}}]}",
+      );
+      let svg = export_svg(
+        "Graphics[{Dynamic[slice[#] & /@ {0.5}], Circle[{0, 0}, 1]}]",
+      );
+      assert!(svg.contains("<polygon"), "polygon missing: {svg}");
+      assert!(svg.contains("rgb(0,255,255)"), "hue fill missing: {svg}");
+    }
+  }
 }

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -9098,6 +9098,55 @@ mod join_non_list {
   }
 
   #[test]
+  fn thread_list_head_transposes() {
+    // Thread over an expression whose head is List transposes:
+    // Thread[{{a, b}, {c, d}}] -> {{a, c}, {b, d}}. The Demonstrations
+    // color-wheel notebook relies on Thread[List[{colors}, {polygons}]]
+    // pairing each color directive with its primitive.
+    assert_eq!(
+      interpret("Thread[{{1, 2}, {3, 4}}]").unwrap(),
+      "{{1, 3}, {2, 4}}"
+    );
+    assert_eq!(
+      interpret("Thread[List[{a, b}, {c, d}]]").unwrap(),
+      "{{a, c}, {b, d}}"
+    );
+  }
+
+  #[test]
+  fn thread_list_head_repeats_non_list() {
+    // Non-list elements are repeated across the threaded results.
+    assert_eq!(
+      interpret("Thread[{{1, 2}, x}]").unwrap(),
+      "{{1, x}, {2, x}}"
+    );
+  }
+
+  #[test]
+  fn thread_list_head_without_sublists_unchanged() {
+    assert_eq!(interpret("Thread[{a, b}]").unwrap(), "{a, b}");
+  }
+
+  #[test]
+  fn thread_list_head_unequal_lengths_returns_unchanged() {
+    // Wolfram emits Thread::tdlen and returns the expression unchanged.
+    assert_eq!(
+      interpret("Thread[{{1, 2}, {3, 4, 5}}]").unwrap(),
+      "{{1, 2}, {3, 4, 5}}"
+    );
+  }
+
+  #[test]
+  fn thread_list_head_with_explicit_thread_head() {
+    // Thread[{f[1, 2], f[3, 4]}, f] -> f[{1, 3}, {2, 4}]: elements with
+    // the given head thread, and the result is wrapped in that head.
+    assert_eq!(
+      interpret("Thread[{f[1, 2], f[3, 4]}, f]").unwrap(),
+      "f[{1, 3}, {2, 4}]"
+    );
+  }
+
+  #[test]
   fn thread_comparison_geq() {
     // Thread[{a, b, c} >= 0] should produce {a >= 0, b >= 0, c >= 0}
     assert_eq!(

--- a/tests/notebooks/demonstration.nb
+++ b/tests/notebooks/demonstration.nb
@@ -1,0 +1,145 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+
+Cell[CellGroupData[{
+Cell["Color Relationships", "Title",
+ TaggingRules->{},
+ CellTags->{"Name", "Title"},
+ CellID->700863240,ExpressionUUID->"b0d3674c-39dc-442d-9bee-57d641d9d2e8"],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Initialization Code",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"InitializationCode"},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "Hover"}, False]]]]]
+}], "Section",
+ CellTags->{"Initialization Code", "InitializationCode", "TemplateCellGroup"},
+ CellID->352434337,ExpressionUUID->"29506df2-8461-449d-b5cd-42e156604772"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"swatch", "[", "clr_", "]"}], ":=",
+  RowBox[{"Graphics", "[",
+   RowBox[{"{",
+    RowBox[{"clr", ",",
+     RowBox[{"Rectangle", "[", "]"}]}], "}"}], "]"}]}]], "Input",
+ CellID->1932241304,ExpressionUUID->"a698b810-4e70-4907-92cf-b81a09ea9711"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Manipulate",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"ManipulateGroup"},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "Hover"}, False]]]]]
+}], "Section",
+ CellTags->{"Manipulate", "ManipulateGroup", "TemplateCellGroup"},
+ CellID->737824434,ExpressionUUID->"07a26aaa-49dd-42d6-a7ae-9a25c9de3823"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"Manipulate", "[",
+  RowBox[{
+   RowBox[{"swatch", "[",
+    RowBox[{"Hue", "[",
+     RowBox[{"a", "/", "36"}], "]"}], "]"}], ",",
+   RowBox[{"{",
+    RowBox[{
+     RowBox[{"{",
+      RowBox[{"a", ",", "1", ",", "\"angle\""}], "}"}], ",", "1", ",",
+     "36", ",", "1"}], "}"}], ",",
+   RowBox[{"SaveDefinitions", "\[Rule]", "True"}]}], "]"}]], "Input",
+ CellID->842528087,ExpressionUUID->"15dbcf6b-4980-4f52-92e4-79391878e73b"],
+
+Cell[BoxData[
+ TagBox[
+  StyleBox[
+   DynamicModuleBox[{$CellContext`a$$ = 1, Typeset`show$$ = True},
+    "\"widget dump placeholder\""],
+   ShowSpecialCharacters->False],
+  "Manipulate",
+  Deployed->True]], "Output",
+ CellID->432552542,ExpressionUUID->"6a44866e-0043-46ff-990a-1a80793168e5"]
+}, Open]]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Snapshots",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"Snapshots"},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "Hover"}, False]]]]]
+}], "Section",
+ CellTags->{"SnapshotGroup", "Snapshots", "TemplateCellGroup"},
+ CellID->158391975,ExpressionUUID->"87565683-3a86-4d63-8dc2-6423c491d5bb"],
+
+Cell[BoxData[
+ PaneBox[
+  GraphicsBox[TagBox[
+    RasterBox[CompressedData["
+1:eJzs3QlcVOe9//GTpkm6pPtNmtvbpm3a2yy9vUvTf/f2pkuatGlvt7RJb9s0
+     "], {{0, 116}, {175, 0}}, {0, 255}, ColorFunction->RGBColor],
+    BoxForm`ImageTag["Byte", ColorSpace -> "RGB", Interleaving -> True],
+    Selectable->False],
+   DefaultBaseStyle->"ImageGraphics"],
+  BaselinePosition->Baseline,
+  ImageSize->{175, 116}]], "Output",
+ CellTags->"Snapshot",
+ CellID->27615341,ExpressionUUID->"b3200392-31a2-4d70-b34a-15963f57f4d7"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Source & Additional Information", "Section",
+ CellID->27038220,ExpressionUUID->"e2971563-8f97-475f-93c3-64eec3b7ec84"],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Keywords",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"Keywords"},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "Hover"}, False]]]]]
+}], "Subsection",
+ CellID->146574570,ExpressionUUID->"e2b98692-2764-42b0-b93d-8022ee39d635"],
+
+Cell["hue", "Item",
+ TaggingRules->{},
+ CellID->586845895,ExpressionUUID->"07b32e6c-e18b-43cd-83b6-3059aa4e6f80"],
+
+Cell["color wheel", "Item",
+ TaggingRules->{},
+ CellID->588807008,ExpressionUUID->"32d6ba05-4a94-4dd4-b355-e4bfc25dd1a2"]
+}, Open]]
+}, Closed]]
+}, Open]]
+},
+WindowSize->{808, 911},
+WindowMargins->{{Automatic, 188}, {Automatic, 0}},
+FrontEndVersion->"14.1 for Mac OS X ARM (64-bit) (July 16, 2024)",
+StyleDefinitions->"Default.nb",
+ExpressionUUID->"3865fea5-4d10-45db-93bd-01e37d20e504"
+]
+(* End of Notebook Content *)

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -500,12 +500,23 @@ impl WoxiStudio {
   /// preceding Input/Code cell rather than shown separately.
   fn editors_from_notebook(notebook: &Notebook) -> Vec<CellEditor> {
     let mut editors = Vec::new();
+    // Input cells seen so far that have not been evaluated yet. A stored
+    // interactive widget (Manipulate saved with `SaveDefinitions -> True`)
+    // depends on helper functions defined in earlier Input cells — the
+    // Demonstrations "Initialization Code" section. Mathematica embeds
+    // those definitions in the saved DynamicModuleBox dump; Woxi drops the
+    // dump and re-instantiates from the input, so the earlier cells must
+    // run first for the widget's body to evaluate.
+    let mut pending_init: Vec<String> = Vec::new();
 
     for entry in &notebook.cells {
       match entry {
         CellEntry::Single(cell) => {
           if matches!(cell.style, CellStyle::Output | CellStyle::Print) {
             continue;
+          }
+          if matches!(cell.style, CellStyle::Input | CellStyle::Code) {
+            pending_init.push(cell.content.clone());
           }
           editors.push(CellEditor {
             content: text_editor::Content::with_text(&cell.content),
@@ -566,8 +577,12 @@ impl WoxiStudio {
               let is_widget_dump =
                 output.as_deref().is_some_and(is_dynamic_box_dump);
               let manipulate_state = if is_widget_dump {
+                // Run the earlier Input cells (helper definitions) before
+                // the widget's body first evaluates.
+                evaluate_pending_initialization(&mut pending_init);
                 instantiate_stored_manipulate(&cell.content)
               } else {
+                pending_init.push(cell.content.clone());
                 None
               };
               let output_content = match &output {
@@ -4417,6 +4432,20 @@ fn is_dynamic_box_dump(output: &str) -> bool {
   t.starts_with("DynamicModuleBox[")
     || t.starts_with("TagBox[DynamicModuleBox[")
     || t.starts_with("DynamicBox[")
+}
+
+/// Evaluate (and drain) the Input-cell code accumulated ahead of a stored
+/// interactive widget, so helper definitions from the notebook's
+/// initialization cells (e.g. the Wolfram Demonstrations "Initialization
+/// Code" section) are in scope when the widget's body evaluates. Results
+/// and errors are discarded — the cells keep their stored outputs until
+/// the user explicitly evaluates them.
+fn evaluate_pending_initialization(pending: &mut Vec<String>) {
+  for code in pending.drain(..) {
+    for stmt in woxi::split_into_statements(&code) {
+      let _ = woxi::interpret_with_stdout(&stmt);
+    }
+  }
 }
 
 /// Rebuild the interactive widget for a loaded Input cell whose stored


### PR DESCRIPTION
## Summary

This PR adds support for the `Thread` function when its head is `List` (enabling matrix transposition), improves handling of `Dynamic` expressions in visual mode, and enhances `Column` to support the `Alignment -> value` option form. These changes enable proper rendering of Wolfram Demonstrations notebooks, particularly the color-wheel example.

## Key Changes

- **Thread with List head**: Implemented `Thread[{{a, b}, {c, d}}]` → `{{a, c}, {b, d}}` transposition behavior, with non-list elements repeated across results. Supports both implicit List head and explicit head specification via `Thread[expr, head]`.

- **Dynamic in visual mode**: 
  - `Dynamic[expr]` now displays the current value of `expr` in notebook/visual mode (matching front-end behavior), while remaining symbolic in script/CLI mode
  - Evaluates held Dynamic content in graphics primitives, enabling computed overlays like `Dynamic[colorSlice[#+a] & /@ clrCases]`
  - Integrated into top-level rendering pipeline and inline display wrappers

- **Column alignment option**: Extended `Column` to accept `Alignment -> Center|Right|Left` option form in addition to positional argument

- **Studio widget support**: Added initialization cell evaluation before stored interactive widgets (Manipulate with `SaveDefinitions -> True`), ensuring helper definitions from "Initialization Code" sections are in scope

- **Notebook parsing**: Added comprehensive test for real Wolfram Demonstrations notebook structure (deeply nested cell groups, Section headers with inline MoreInfo openers, DynamicModuleBox outputs, RasterBox snapshots, Item keywords)

## Implementation Details

- Thread implementation handles mixed list/non-list elements and validates equal lengths across threaded lists
- Dynamic rendering respects HoldFirst semantics by explicitly evaluating held arguments
- Column alignment parsing checks both positional and Rule-form arguments
- Studio's widget instantiation now pre-evaluates accumulated Input cells to populate symbol tables before widget body evaluation

https://claude.ai/code/session_01SfAbC8Kk6D1TxTbm292L3C