### PR TITLE
Support equation form of ContourPlot and improve Show/Solve

### DIFF
--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1504,6 +1504,61 @@ pub fn evaluate_expr_to_expr_inner(
           crate::evaluator::assignment::set_ast(&args[0], &new_val)?;
           return Ok(new_val);
         }
+        // AppendTo/PrependTo on an indexed (DownValue) target:
+        // AppendTo[f[1], v] after `f[1] = {…}`. Evaluate the stored value,
+        // extend it, and write it back through the same indexed-assignment
+        // path `f[1] = …` takes. A target with no stored value evaluates
+        // to itself — that is the rvalue error case.
+        if (name == "AppendTo" || name == "PrependTo")
+          && args.len() == 2
+          && matches!(&args[0], Expr::FunctionCall { .. })
+        {
+          let is_append = name == "AppendTo";
+          let mut current = evaluate_expr_to_expr(&args[0])?;
+          let has_value = crate::syntax::expr_to_string(&current)
+            != crate::syntax::expr_to_string(&args[0]);
+          if has_value {
+            let elem = evaluate_expr_to_expr(&args[1])?;
+            let new_val = match &mut current {
+              Expr::List(items) => {
+                let mut items = std::mem::take(items);
+                if is_append {
+                  items.push(elem);
+                } else {
+                  items.insert(0, elem);
+                }
+                Expr::List(items)
+              }
+              Expr::FunctionCall {
+                name: head,
+                args: fa,
+              } => {
+                let head = std::mem::take(head);
+                let mut fa = std::mem::take(fa);
+                if is_append {
+                  fa.push(elem);
+                } else {
+                  fa.insert(0, elem);
+                }
+                Expr::FunctionCall {
+                  name: head,
+                  args: fa,
+                }
+              }
+              _ => {
+                crate::emit_message(&format!(
+                  "{}::normal: Nonatomic expression expected at position 1 \
+                   in {}.",
+                  name,
+                  crate::syntax::expr_to_output(&unevaluated(name, args))
+                ));
+                return Ok(unevaluated(name, args));
+              }
+            };
+            crate::evaluator::assignment::set_ast(&args[0], &new_val)?;
+            return Ok(new_val);
+          }
+        }
         // A target that is neither a symbol nor a Part cannot hold a value.
         if (name == "AppendTo" || name == "PrependTo")
           && args.len() == 2

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -4681,6 +4681,39 @@ fn apply_replace_all_multi_ast_impl(
         .collect();
       Ok(Expr::Association(new_pairs?))
     }
+    // Symbolic comparisons (`y == x`, `a < b < c`) stay unevaluated, so
+    // `y == x /. {x -> 2, y -> 3}` must descend into every operand.
+    Expr::Comparison {
+      operands,
+      operators,
+    } => {
+      let new_operands: Result<Vec<Expr>, _> = operands
+        .iter()
+        .map(|o| apply_replace_all_multi_ast_impl(o, rules, held))
+        .collect();
+      Ok(Expr::Comparison {
+        operands: new_operands?,
+        operators: operators.clone(),
+      })
+    }
+    // A symbolic part extraction (`m[[1]]` with `m` undefined) keeps its
+    // expression and index as ordinary subexpressions.
+    Expr::Part { expr: part, index } => {
+      let new_expr = apply_replace_all_multi_ast_impl(part, rules, held)?;
+      let new_index = apply_replace_all_multi_ast_impl(index, rules, held)?;
+      Ok(Expr::Part {
+        expr: Box::new(new_expr),
+        index: Box::new(new_index),
+      })
+    }
+    // `(a; b) /. rules` descends into every statement.
+    Expr::CompoundExpr(stmts) => {
+      let new_stmts: Result<Vec<Expr>, _> = stmts
+        .iter()
+        .map(|s| apply_replace_all_multi_ast_impl(s, rules, held))
+        .collect();
+      Ok(Expr::CompoundExpr(new_stmts?))
+    }
     // Atoms and other nodes without children — return unchanged
     _ => Ok(expr.clone()),
   }

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -780,8 +780,48 @@ pub fn density_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// ContourPlot[f, {x, xmin, xmax}, {y, ymin, ymax}]
 /// Uses marching squares to draw contour lines.
+/// Rewrite an equation `lhs == rhs` into `lhs - rhs`, whose zero contour
+/// is the equation's implicit curve. Returns `None` for non-equations.
+fn equation_zero_body(e: &Expr) -> Option<Expr> {
+  let (lhs, rhs) = match e {
+    Expr::Comparison {
+      operands,
+      operators,
+    } if operands.len() == 2
+      && operators.len() == 1
+      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+    {
+      (&operands[0], &operands[1])
+    }
+    Expr::FunctionCall { name, args } if name == "Equal" && args.len() == 2 => {
+      (&args[0], &args[1])
+    }
+    _ => return None,
+  };
+  Some(Expr::BinaryOp {
+    op: crate::syntax::BinaryOperator::Minus,
+    left: Box::new(lhs.clone()),
+    right: Box::new(rhs.clone()),
+  })
+}
+
 pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let body = &args[0];
+  // `ContourPlot[lhs == rhs, …]` (or a list of equations) plots each
+  // equation's implicit curve — the zero contour of `lhs - rhs` — with no
+  // band shading, matching Wolfram.
+  let eq_bodies: Option<Vec<Expr>> = match body {
+    Expr::List(items)
+      if !items.is_empty()
+        && items.iter().all(|i| equation_zero_body(i).is_some()) =>
+    {
+      Some(items.iter().filter_map(equation_zero_body).collect())
+    }
+    _ => equation_zero_body(body).map(|b| vec![b]),
+  };
+  if let Some(bodies) = eq_bodies {
+    return contour_plot_equations(&bodies, args);
+  }
   let (xvar, x_min, x_max) = parse_iterator(&args[1], "ContourPlot")?;
   let (yvar, y_min, y_max) = parse_iterator(&args[2], "ContourPlot")?;
   let opts = parse_density_contour_options(args, 3);
@@ -866,6 +906,111 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   svg.push_str("</svg>");
   Ok(crate::graphics_result(svg))
+}
+
+/// The equation form of ContourPlot: draw each body's zero contour as an
+/// implicit curve. No bands are shaded — Wolfram renders equation contours
+/// as bare curves on an unshaded background.
+fn contour_plot_equations(
+  bodies: &[Expr],
+  args: &[Expr],
+) -> Result<Expr, InterpreterError> {
+  let (xvar, x_min, x_max) = parse_iterator(&args[1], "ContourPlot")?;
+  let (yvar, y_min, y_max) = parse_iterator(&args[2], "ContourPlot")?;
+  let opts = parse_density_contour_options(args, 3);
+
+  let n = FIELD_GRID + 1;
+  let area = generate_axes_only(
+    (x_min, x_max),
+    (y_min, y_max),
+    opts.svg_width,
+    opts.svg_height,
+    opts.full_width,
+  )?;
+
+  let mut svg = area.svg;
+  if let Some(pos) = svg.rfind("</svg>") {
+    svg.truncate(pos);
+  }
+
+  let cell_w = area.plot_w / FIELD_GRID as f64;
+  let cell_h = area.plot_h / FIELD_GRID as f64;
+
+  // Alongside the standalone SVG, collect every contour chain in *data*
+  // coordinates as a line series, so `Show[{ContourPlot[…], Graphics[…]}]`
+  // can merge the curve with other primitives. The chains are traced in a
+  // scaled 0‥1000 space — `chain_segments` keys points on a 1/16 grid,
+  // which would glue distinct points together in small data ranges.
+  let mut series: Vec<crate::syntax::PlotSeriesData> = Vec::new();
+
+  for body in bodies {
+    let mut grid = vec![vec![f64::NAN; n]; n];
+    let mut any_finite = false;
+    for (i, row) in grid.iter_mut().enumerate() {
+      let x = x_min + i as f64 / FIELD_GRID as f64 * (x_max - x_min);
+      for (j, cell) in row.iter_mut().enumerate() {
+        let y = y_min + j as f64 / FIELD_GRID as f64 * (y_max - y_min);
+        if let Some(v) = evaluate_at_xy(body, &xvar, &yvar, x, y)
+          && v.is_finite()
+        {
+          *cell = v;
+          any_finite = true;
+        }
+      }
+    }
+    if !any_finite {
+      continue;
+    }
+    render_contour_lines(
+      &mut svg,
+      &grid,
+      &[0.0],
+      area.plot_x0,
+      area.plot_y0,
+      cell_w,
+      cell_h,
+      area.render_width,
+    );
+    let scaled_cell = 1000.0 / FIELD_GRID as f64;
+    let segments =
+      marching_squares_segments(&grid, 0.0, 0.0, 0.0, scaled_cell, scaled_cell);
+    for chain in chain_segments(&segments) {
+      let points: Vec<(f64, f64)> = chain
+        .iter()
+        .map(|&(u, v)| {
+          (
+            x_min + u / 1000.0 * (x_max - x_min),
+            y_min + v / 1000.0 * (y_max - y_min),
+          )
+        })
+        .collect();
+      if points.len() >= 2 {
+        series.push(crate::syntax::PlotSeriesData {
+          points,
+          color: (0x40, 0x40, 0x40),
+          is_scatter: false,
+          filling: crate::syntax::SeriesFilling::None,
+        });
+      }
+    }
+  }
+
+  push_frame(
+    &mut svg,
+    area.plot_x0,
+    area.plot_y0,
+    area.plot_w,
+    area.plot_h,
+  );
+
+  svg.push_str("</svg>");
+  let source = crate::syntax::PlotSource {
+    series,
+    x_range: (x_min, x_max),
+    y_range: (y_min, y_max),
+    image_size: (opts.svg_width, opts.svg_height),
+  };
+  Ok(crate::graphics_result_with_source(svg, source))
 }
 
 /// RegionPlot[cond, {x, xmin, xmax}, {y, ymin, ymax}]

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -6511,6 +6511,27 @@ pub fn expr_to_svg_markup(expr: &Expr) -> String {
         // HoldForm[expr] → render content
         "HoldForm" if args.len() == 1 => expr_to_svg_markup(&args[0]),
 
+        // Presentation wrappers display their content only.
+        "Text" | "TraditionalForm" | "DisplayForm" | "StandardForm"
+          if args.len() == 1 =>
+        {
+          expr_to_svg_markup(&args[0])
+        }
+
+        // Row[{a, b, …}] concatenates its parts; Row[{…}, sep] joins
+        // them with the separator.
+        "Row" if !args.is_empty() => match &args[0] {
+          Expr::List(parts) => {
+            let sep = args.get(1).map(expr_to_svg_markup).unwrap_or_default();
+            parts
+              .iter()
+              .map(expr_to_svg_markup)
+              .collect::<Vec<_>>()
+              .join(&sep)
+          }
+          other => expr_to_svg_markup(other),
+        },
+
         // General FunctionCall: name[arg1, arg2, ...]
         _ => {
           let parts: Vec<String> =
@@ -7637,22 +7658,32 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     args
   };
 
-  for arg in args {
+  // Walk the args with an explicit work list: an argument that evaluates
+  // to a *list* of graphics (e.g. `Show[{g, {h1, h2}}]`, or a variable
+  // holding a collected list of Graphics) is spliced in place so its
+  // elements merge like ordinary arguments instead of being dropped.
+  let mut pending: Vec<Expr> = args.to_vec();
+  let mut idx = 0;
+  while idx < pending.len() {
+    let arg = pending[idx].clone();
     // If the arg is not already a Graphics/Graphics3D expression,
     // try evaluating it (e.g. it could be a variable or function call)
-    let evaled;
-    let expr_ref = match arg {
+    let expr_owned = match &arg {
       Expr::FunctionCall { name, .. }
         if name == "Graphics" || name == "Graphics3D" =>
       {
-        arg
+        arg.clone()
       }
-      Expr::Rule { .. } => arg,
-      _ => {
-        evaled = evaluate_expr_to_expr(arg).unwrap_or_else(|_| arg.clone());
-        &evaled
-      }
+      Expr::Rule { .. } => arg.clone(),
+      _ => evaluate_expr_to_expr(&arg).unwrap_or_else(|_| arg.clone()),
     };
+    if let Expr::List(items) = &expr_owned {
+      let items: Vec<Expr> = items.iter().cloned().collect();
+      pending.splice(idx..idx + 1, items);
+      continue;
+    }
+    idx += 1;
+    let expr_ref = &expr_owned;
 
     match expr_ref {
       Expr::FunctionCall { name, args: gargs } if name == "Graphics" => {

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -1698,6 +1698,67 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => args,
   };
 
+  // Pre-pass: thread equations whose two sides are equal-length lists into
+  // their component equations ({xx, yy} == {a, b} → xx == a, yy == b,
+  // recursively), matching Wolfram. Vector equations like
+  // `{xx, yy} == t*v + pos` (parametric-intersection systems) otherwise
+  // carry no solvable content for the scalar equation paths below.
+  fn thread_list_equations(eq: &Expr, out: &mut Vec<Expr>) -> bool {
+    let sides: Option<(&Expr, &Expr)> = match eq {
+      Expr::Comparison {
+        operands,
+        operators,
+      } if operands.len() == 2
+        && operators.len() == 1
+        && operators[0] == ComparisonOp::Equal =>
+      {
+        Some((&operands[0], &operands[1]))
+      }
+      Expr::FunctionCall { name, args }
+        if name == "Equal" && args.len() == 2 =>
+      {
+        Some((&args[0], &args[1]))
+      }
+      _ => None,
+    };
+    if let Some((Expr::List(l), Expr::List(r))) = sides
+      && l.len() == r.len()
+    {
+      for (li, ri) in l.iter().zip(r.iter()) {
+        thread_list_equations(
+          &Expr::Comparison {
+            operands: vec![li.clone(), ri.clone()],
+            operators: vec![ComparisonOp::Equal],
+          },
+          out,
+        );
+      }
+      return true;
+    }
+    out.push(eq.clone());
+    false
+  }
+  let threaded_args_owned: Vec<Expr>;
+  let args = {
+    let eqns: Vec<Expr> = match &args[0] {
+      Expr::List(items) => items.to_vec(),
+      other => vec![other.clone()],
+    };
+    let mut threaded = Vec::new();
+    let mut any_threaded = false;
+    for eq in &eqns {
+      any_threaded |= thread_list_equations(eq, &mut threaded);
+    }
+    if any_threaded {
+      let mut new_args = args.to_vec();
+      new_args[0] = Expr::List(threaded.into());
+      threaded_args_owned = new_args;
+      threaded_args_owned.as_slice()
+    } else {
+      args
+    }
+  };
+
   // Pre-pass: normalize a bare-symbol variable to a single-element list when
   // the first argument is a list of equations. Solve[{x == 1, x == 2}, x]
   // behaves like Solve[{x == 1, x == 2}, {x}], which the system path handles;

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -569,8 +569,25 @@ fn render_text_element(s: &str) -> String {
     }
   }
 
-  // Inline `Cell[...]` elements are the attached "more info" opener buttons in
-  // Demonstrations templates — they carry no textual content, so drop them.
+  // Inline `Cell[...]` elements: math cells (`Cell[BoxData[…],
+  // "InlineMath"]` and friends) carry real content — render their boxes as
+  // text so prose like "the equation of a parabola is y^2 = 2p x" keeps its
+  // formulas. All other inline cells are the attached "more info" opener
+  // buttons in Demonstrations templates — they carry no textual content,
+  // so drop them.
+  if let Some(rest) = s.strip_prefix("Cell[")
+    && let Ok((inner, _)) = find_matching_bracket(rest)
+  {
+    let args = split_top_level_commas(inner);
+    let is_inline_math = args.iter().skip(1).any(|a| {
+      let t = a.trim().trim_matches('"');
+      matches!(t, "InlineMath" | "InlineFormula" | "InlineCell")
+    });
+    if is_inline_math && let Some(first) = args.first() {
+      return extract_cell_content(first.trim());
+    }
+    return String::new();
+  }
   if s.starts_with("Cell[") {
     return String::new();
   }
@@ -2007,6 +2024,42 @@ Cell["Chapter 2", "Chapter"]
       extract_cell_content(s),
       "If you provide initialization code, include a SaveDefinitions->True \
        option in the Manipulate."
+    );
+  }
+
+  #[test]
+  fn test_extract_textdata_inline_math_cell() {
+    // Inline `Cell[BoxData[…], "InlineMath"]` elements hold real formulas
+    // (unlike the "more info" opener buttons) and must render as text.
+    let s = r#"TextData[{
+ "Given a point F (the focus) and a line ",
+ Cell[BoxData[
+  FormBox["d", TraditionalForm]], "InlineMath",ExpressionUUID->
+  "23d75367-0ed4-44ff-ba06-4d9bdc71d1e9"],
+ " (the directrix)."
+}]"#;
+    assert_eq!(
+      extract_cell_content(s),
+      "Given a point F (the focus) and a line d (the directrix)."
+    );
+  }
+
+  #[test]
+  fn test_extract_textdata_inline_math_formula() {
+    // A boxed formula inside prose converts to InputForm-style text.
+    let s = r#"TextData[{
+ "One form of the equation of a parabola is ",
+ Cell[BoxData[
+  FormBox[
+   RowBox[{
+    SuperscriptBox["y", "2"], "=",
+    RowBox[{"2", "p", " ", "x"}]}], TraditionalForm]], "InlineMath",
+  ExpressionUUID->"9efcaa42-0dc4-43ec-a2b4-2e1f21a58f50"],
+ "."
+}]"#;
+    assert_eq!(
+      extract_cell_content(s),
+      "One form of the equation of a parabola is (y)^(2)=2p x."
     );
   }
 

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -4692,6 +4692,33 @@ mod solve {
     );
   }
 
+  /// Equations between equal-length lists thread componentwise:
+  /// `{xx, yy} == {a, b}` contributes `xx == a` and `yy == b`.
+  /// (Regression: the vector equation was silently dropped, so
+  /// parametric-intersection systems like the parabolic-mirror
+  /// Demonstration solved only the scalar equations.)
+  #[test]
+  fn solve_threads_list_equations() {
+    assert_eq!(
+      interpret("Solve[{xx, yy} == {1, 2}, {xx, yy}]").unwrap(),
+      "{{xx -> 1, yy -> 2}}"
+    );
+    assert_eq!(
+      interpret(
+        "Solve[{yy^2 == 20 xx, {xx, yy} == t*{0.6, 0.8} + {5, 0}}, \
+         {t, xx, yy}]"
+      )
+      .unwrap(),
+      "{{t -> -6.249999999999999, xx -> 1.2499999999999998, yy -> -5.}, \
+       {t -> 24.999999999999996, xx -> 19.999999999999996, yy -> 20.}}"
+    );
+    // Threading composes with And-of-equations flattening.
+    assert_eq!(
+      interpret("Solve[{x, y} == {1, 2} && x + z == 3, {x, y, z}]").unwrap(),
+      "{{x -> 1, y -> 2, z -> 2}}"
+    );
+  }
+
   #[test]
   fn solve_pure_cubic_symbolic() {
     assert_eq!(

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -2214,6 +2214,31 @@ f[x_] := x^2"#,
       r#"f[x]"#,
     );
   }
+  /// AppendTo/PrependTo on an indexed (DownValue) target `f[1]`, both
+  /// global and Module-local, including the chained-assignment seed
+  /// `f[1] = f[2] = {}` used by the parabolic-mirror Demonstration.
+  #[test]
+  fn append_to_indexed_downvalue() {
+    assert_case(
+      r#"f[1] = {}; AppendTo[f[1], 5]; AppendTo[f[1], 7]; f[1]"#,
+      r#"{5, 7}"#,
+    );
+    assert_case(
+      r#"g1[1] = g1[2] = {}; AppendTo[g1[2], 1]; {g1[1], g1[2]}"#,
+      r#"{{}, {1}}"#,
+    );
+    assert_case(
+      r#"Module[{h}, h[1] = {}; AppendTo[h[1], 3]; h[1]]"#,
+      r#"{3}"#,
+    );
+    assert_case(r#"k[1] = {2, 3}; PrependTo[k[1], 1]; k[1]"#, r#"{1, 2, 3}"#);
+  }
+  /// An indexed target with no stored value still reports rvalue and
+  /// leaves the call unevaluated.
+  #[test]
+  fn append_to_indexed_without_value_stays_unevaluated() {
+    assert_case(r#"AppendTo[noval[1], 5]"#, r#"AppendTo[noval[1], 5]"#);
+  }
   #[test]
   fn symbol_literal_27() {
     assert_case(

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -5734,6 +5734,54 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       ));
     }
 
+    /// `ContourPlot[lhs == rhs, …]` draws the equation's implicit curve
+    /// (the zero contour of `lhs - rhs`) instead of an empty plot.
+    #[test]
+    fn contour_plot_equation_draws_curve() {
+      let svg =
+        export_svg("ContourPlot[x^2 + y^2 == 4, {x, -2, 2}, {y, -2, 2}]");
+      assert!(
+        svg.contains("<polyline"),
+        "expected the implicit circle as contour polylines, got: {}",
+        &svg[..svg.len().min(200)]
+      );
+    }
+
+    /// A pre-rendered equation ContourPlot must merge with other graphics
+    /// inside Show — the curve is carried along as plot-source line series.
+    #[test]
+    fn show_merges_equation_contour_plot_with_graphics() {
+      let svg = export_svg(
+        "Show[{ContourPlot[y^2 == 20 x, {x, -20, 20}, {y, -20, 20}], \
+         Graphics[Point[{5, 0}]]}, PlotRange -> All]",
+      );
+      assert!(
+        svg.contains("<polyline"),
+        "expected the parabola curve inside Show"
+      );
+      assert!(
+        svg.contains("<circle"),
+        "expected the merged Point inside Show"
+      );
+    }
+
+    /// Show must splice a *list* of Graphics (e.g. a collected list of
+    /// per-ray line graphics) instead of silently dropping it.
+    #[test]
+    fn show_flattens_nested_graphics_lists() {
+      let svg = export_svg(
+        "Show[{Graphics[Point[{5, 0}]], \
+         {Graphics[Line[{{0, 0}, {10, 10}}]], \
+          Graphics[Line[{{0, 0}, {10, -10}}]]}}, PlotRange -> All]",
+      );
+      let lines = svg.matches("<polyline").count();
+      assert_eq!(
+        lines, 2,
+        "expected both nested-list Lines to merge, got {lines}"
+      );
+      assert!(svg.contains("<circle"), "expected the Point to survive");
+    }
+
     #[test]
     fn region_plot_basic() {
       insta::assert_snapshot!(export_svg(

--- a/tests/interpreter_tests/patterns.rs
+++ b/tests/interpreter_tests/patterns.rs
@@ -678,6 +678,30 @@ mod pattern_matching {
   mod multiple_rules {
     use super::*;
 
+    /// A rule list must descend into symbolic comparisons: `y == x` stays
+    /// unevaluated, and every operand is an ordinary subexpression.
+    /// (Regression: multi-rule ReplaceAll returned Comparison nodes
+    /// unchanged, so `curveExp /. {x -> xx, y -> yy}` never substituted.)
+    #[test]
+    fn list_of_rules_replaces_inside_equation() {
+      assert_eq!(interpret("y == x /. {x -> 2, y -> 3}").unwrap(), "False");
+      assert_eq!(
+        interpret("(y^2 == 20 x) /. {x -> xx, y -> yy}").unwrap(),
+        "yy^2 == 20*xx"
+      );
+      assert_eq!(
+        interpret("f[x] == g[y] /. {x -> 1, y -> 2}").unwrap(),
+        "f[1] == g[2]"
+      );
+      assert_eq!(interpret("a < b /. {a -> 1, b -> 2}").unwrap(), "True");
+    }
+
+    /// A rule list must descend into a symbolic Part extraction.
+    #[test]
+    fn list_of_rules_replaces_inside_part() {
+      assert_eq!(interpret("m[[1]] /. {m -> {5, 6}}").unwrap(), "5");
+    }
+
     #[test]
     fn list_of_rules_applied_in_order() {
       // First matching rule wins

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -500,12 +500,20 @@ impl WoxiStudio {
   /// preceding Input/Code cell rather than shown separately.
   fn editors_from_notebook(notebook: &Notebook) -> Vec<CellEditor> {
     let mut editors = Vec::new();
+    // Input/Code cell sources seen so far, in document order. A stored
+    // Manipulate further down may call helpers defined in them (the
+    // Demonstrations "Initialization Code" section) — they are replayed
+    // before the widget is instantiated so the notebook opens live.
+    let mut prior_inputs: Vec<String> = Vec::new();
 
     for entry in &notebook.cells {
       match entry {
         CellEntry::Single(cell) => {
           if matches!(cell.style, CellStyle::Output | CellStyle::Print) {
             continue;
+          }
+          if matches!(cell.style, CellStyle::Input | CellStyle::Code) {
+            prior_inputs.push(cell.content.clone());
           }
           editors.push(CellEditor {
             content: text_editor::Content::with_text(&cell.content),
@@ -566,6 +574,15 @@ impl WoxiStudio {
               let is_widget_dump =
                 output.as_deref().is_some_and(is_dynamic_box_dump);
               let manipulate_state = if is_widget_dump {
+                // Replay the preceding Input/Code cells first: the widget
+                // body typically calls helpers from the notebook's
+                // "Initialization Code" section (what `SaveDefinitions ->
+                // True` captures in Mathematica), and without them the
+                // first render would fail.
+                woxi::clear_state();
+                for code in &prior_inputs {
+                  let _ = woxi::interpret_with_stdout(code);
+                }
                 instantiate_stored_manipulate(&cell.content)
               } else {
                 None
@@ -613,6 +630,7 @@ impl WoxiStudio {
                 output_content,
                 stdout_content,
               });
+              prior_inputs.push(cell.content.clone());
               i = j;
             } else if matches!(cell.style, CellStyle::Output | CellStyle::Print)
             {
@@ -6361,6 +6379,37 @@ mod tests {
     );
     // A non-Manipulate cell yields no widget.
     assert!(instantiate_stored_manipulate("1 + 1").is_none());
+  }
+
+  /// A stored Manipulate whose body calls helpers from earlier Input
+  /// cells (the Demonstrations "Initialization Code" section) must open
+  /// live: `editors_from_notebook` replays the preceding inputs before
+  /// instantiating the widget.
+  #[test]
+  fn stored_manipulate_replays_initialization_cells_on_load() {
+    let nb_src = r#"Notebook[{
+Cell[BoxData["initPlot[z_] := Plot[Sin[z x], {x, 0, 5}]"], "Input"],
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[initPlot[a], {a, 1, 3}]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`a$$ = 1}, \"…\"]"], "Output"]
+}, Open]]
+}]"#;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .iter()
+      .find_map(|e| e.manipulate_state.as_ref())
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "initPlot from the initialization cell must be in scope, \
+       so the first render produces the plot"
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Summary

This PR adds support for plotting equations in `ContourPlot`, improves `Show` to properly merge nested graphics lists, enhances `Solve` to handle vector equations, and extends `AppendTo`/`PrependTo` to work with indexed targets. It also fixes pattern matching in `ReplaceAll` for symbolic comparisons and improves notebook rendering of inline math cells.

## Key Changes

### ContourPlot Equation Support
- Added `equation_zero_body()` helper to convert equations (`lhs == rhs`) into their implicit form (`lhs - rhs`)
- Implemented `contour_plot_equations()` to render equation contours as bare curves (matching Wolfram behavior)
- `ContourPlot[lhs == rhs, ...]` now draws the implicit curve instead of an empty plot
- Supports both single equations and lists of equations
- Equation contours are collected as plot-source line series for merging with other graphics in `Show`

### Show Graphics Merging
- Fixed `show_ast()` to properly splice nested lists of Graphics instead of silently dropping them
- Uses explicit work list to handle evaluated arguments that produce lists
- Enables `Show[{g1, {g2, g3}}]` to merge all graphics correctly

### Solve Vector Equations
- Added `thread_list_equations()` pre-pass to decompose vector equations
- `{xx, yy} == {a, b}` now threads into component equations `xx == a` and `yy == b`
- Enables solving parametric-intersection systems like parabolic-mirror demonstrations
- Threading composes with And-of-equations flattening

### AppendTo/PrependTo on Indexed Targets
- Extended `AppendTo` and `PrependTo` to work with indexed (DownValue) targets like `f[1]`
- Evaluates the stored value, extends it, and writes back through the same indexed-assignment path
- Supports both global and Module-local indexed targets
- Properly handles chained assignments like `f[1] = f[2] = {}`

### Pattern Matching Improvements
- Fixed `apply_replace_all_multi_ast_impl()` to descend into `Comparison` nodes
- Added support for `Part` extraction in multi-rule `ReplaceAll`
- Added support for `CompoundExpr` (semicolon-separated statements)
- Enables `y == x /. {x -> 2, y -> 3}` and similar substitutions to work correctly

### Graphics Rendering
- Added support for presentation wrappers: `Text`, `TraditionalForm`, `DisplayForm`, `StandardForm`
- Implemented `Row[{a, b, ...}]` and `Row[{...}, sep]` for concatenating parts with optional separator

### Notebook Rendering
- Enhanced `render_text_element()` to recognize and render inline math cells (`Cell[BoxData[...], "InlineMath"]`)
- Distinguishes between math cells (which carry real content) and "more info" opener buttons
- Supports `InlineMath`, `InlineFormula`, and `InlineCell` cell types

### Woxi Studio
- Modified `editors_from_notebook()` to replay preceding Input/Code cells before instantiating stored Manipulate widgets
- Ensures helpers from the notebook's "Initialization Code" section are in scope when the widget first renders
- Enables Demonstrations with initialization cells to open live without errors

## Notable Implementation Details

- Equation contours use the same marching squares algorithm as regular contour plots but render only the zero contour
- The `chain_segments()` function is reused to trace contour chains in scaled 0‥1000 space for accurate merging
- Vector equation threading is recursive to handle nested list structures
- The Show graphics flattening uses a work-list approach to handle arbitrary nesting depth

https://claude.ai/code/session_01MBbHeq6JdKseNTh8z363WE