### PR TITLE
Add FillingStyle option to customize plot fill appearance

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -4351,7 +4351,9 @@ fn parse_background(expr: &Expr) -> Option<Color> {
 fn parse_axes(expr: &Expr) -> Option<(bool, bool)> {
   fn parse_bool(expr: &Expr) -> Option<bool> {
     match expr {
-      Expr::Identifier(s) if s == "True" => Some(true),
+      // `Automatic` shows the axis (positioned automatically), e.g. the
+      // common `Axes -> {Automatic, False}` form.
+      Expr::Identifier(s) if s == "True" || s == "Automatic" => Some(true),
       Expr::Identifier(s) if s == "False" => Some(false),
       _ => None,
     }
@@ -7623,6 +7625,10 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut rendered_graphics: Vec<Expr> = Vec::new();
   // Plot source data for re-rendering via plotters
   let mut plot_sources: Vec<crate::syntax::PlotSource> = Vec::new();
+  // Whether the first graphic argument was a plot (carried a PlotSource).
+  // Wolfram takes the merged result's options from the first graphic, so
+  // plot defaults (axes, 1/GoldenRatio aspect) apply only in that case.
+  let mut first_graphic_is_plot: Option<bool> = None;
 
   // `Show[{g1, g2, …}, opts…]` — flatten a leading List argument into
   // multiple graphics args (Wolfram convention; not Listable but accepts
@@ -7656,6 +7662,7 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
     match expr_ref {
       Expr::FunctionCall { name, args: gargs } if name == "Graphics" => {
+        first_graphic_is_plot.get_or_insert(false);
         if !gargs.is_empty() {
           merged_primitives.push(gargs[0].clone());
         }
@@ -7667,6 +7674,7 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if name == "MeshRegion" && gargs.len() == 2 =>
       {
         // Convert MeshRegion to Graphics primitives for Show merging
+        first_graphic_is_plot.get_or_insert(false);
         if let Some(graphics_prims) =
           mesh_region_to_graphics_prims(&gargs[0], &gargs[1])
         {
@@ -7674,6 +7682,7 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       Expr::FunctionCall { name, args: gargs } if name == "Graphics3D" => {
+        first_graphic_is_plot.get_or_insert(false);
         is_3d = true;
         if !gargs.is_empty() {
           merged_primitives.push(gargs[0].clone());
@@ -7687,6 +7696,7 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         source,
         ..
       } => {
+        first_graphic_is_plot.get_or_insert(source.is_some());
         is_3d = *g_is_3d;
         if let Some(src) = source {
           plot_sources.push(src.as_ref().clone());
@@ -7747,6 +7757,56 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for ps in &plot_sources {
       let mut series_prims: Vec<Expr> = Vec::new();
       for sd in &ps.series {
+        // Filled region (Filling -> …) as a Polygon underneath the curve,
+        // wrapped in its own list so the fill color/opacity directives
+        // don't leak onto the line drawn after it. FillingStyle appearance
+        // travels on the series (fill_color/fill_opacity); the defaults
+        // match the standalone plot render (series color at 0.2 opacity).
+        if !sd.is_scatter
+          && let Some(ref_y) =
+            sd.filling.reference_y(ps.y_range.0, ps.y_range.1)
+        {
+          let (fr, fg, fb) = sd.fill_color.unwrap_or(sd.color);
+          let mut fill_prims: Vec<Expr> = vec![
+            Expr::FunctionCall {
+              name: "Opacity".to_string(),
+              args: vec![Expr::Real(sd.fill_opacity.unwrap_or(0.2))].into(),
+            },
+            Expr::FunctionCall {
+              name: "RGBColor".to_string(),
+              args: vec![
+                Expr::Real(fr as f64 / 255.0),
+                Expr::Real(fg as f64 / 255.0),
+                Expr::Real(fb as f64 / 255.0),
+              ]
+              .into(),
+            },
+          ];
+          for seg in &crate::functions::plot::split_into_segments(&sd.points) {
+            if seg.len() < 2 {
+              continue;
+            }
+            let mut coords: Vec<Expr> = seg
+              .iter()
+              .map(|&(x, y)| {
+                Expr::List(vec![Expr::Real(x), Expr::Real(y)].into())
+              })
+              .collect();
+            let (x_last, _) = seg[seg.len() - 1];
+            let (x_first, _) = seg[0];
+            coords.push(Expr::List(
+              vec![Expr::Real(x_last), Expr::Real(ref_y)].into(),
+            ));
+            coords.push(Expr::List(
+              vec![Expr::Real(x_first), Expr::Real(ref_y)].into(),
+            ));
+            fill_prims.push(Expr::FunctionCall {
+              name: "Polygon".to_string(),
+              args: vec![Expr::List(coords.into())].into(),
+            });
+          }
+          series_prims.push(Expr::List(fill_prims.into()));
+        }
         // Color directive
         series_prims.push(Expr::FunctionCall {
           name: "RGBColor".to_string(),
@@ -7807,20 +7867,34 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // range would crop any other Graphics primitives that extend beyond it
       // (e.g. a control polygon), whereas Wolfram shows the union of all
       // primitives. Leaving PlotRange unset yields that union.
+    }
 
-      // Enable axes
-      let axes_rule = Expr::Rule {
-        pattern: Box::new(Expr::Identifier("Axes".to_string())),
-        replacement: Box::new(bool_expr(true)),
-      };
-      merge_option(&mut merged_options, &axes_rule);
-
-      // AspectRatio -> Full for plot-style rendering
-      let ar_rule = Expr::Rule {
-        pattern: Box::new(Expr::Identifier("AspectRatio".to_string())),
-        replacement: Box::new(Expr::Identifier("Full".to_string())),
-      };
-      merge_option(&mut merged_options, &ar_rule);
+    // Defaults inherited from the plots when the *first* graphic was a plot
+    // (Wolfram takes the result's options from the first graphic): axes on,
+    // and the plot AspectRatio of 1/GoldenRatio. Explicit options passed to
+    // Show (already collected in `merged_options`) win — without the
+    // AspectRatio default a wide PlotRange collapses the render to a
+    // sliver, since the graphics renderer otherwise derives the height
+    // from the data aspect. When a raw Graphics comes first, its uniform
+    // scaling stays in charge (circles must render round).
+    let has_option = |opts: &[Expr], name: &str| {
+      opts.iter().any(|o| {
+        matches!(o, Expr::Rule { pattern, .. } if option_name(pattern) == Some(name))
+      })
+    };
+    if first_graphic_is_plot == Some(true) {
+      if !has_option(&merged_options, "Axes") {
+        merged_options.push(Expr::Rule {
+          pattern: Box::new(Expr::Identifier("Axes".to_string())),
+          replacement: Box::new(bool_expr(true)),
+        });
+      }
+      if !has_option(&merged_options, "AspectRatio") {
+        merged_options.push(Expr::Rule {
+          pattern: Box::new(Expr::Identifier("AspectRatio".to_string())),
+          replacement: Box::new(Expr::Real(1.0 / 1.618_033_988_749_895)),
+        });
+      }
     }
   }
 

--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -818,6 +818,10 @@ fn parse_plot_options(args: &[Expr]) -> ParsedOptions {
         "Filling" => {
           apply_filling_option(replacement, opts);
         }
+        "FillingStyle" => {
+          opts.filling_style =
+            crate::functions::plot::parse_filling_style(replacement);
+        }
         "Background" => {
           opts.background =
             crate::functions::plot::parse_background_option(replacement);
@@ -1263,6 +1267,7 @@ pub fn list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     (opts.svg_width, opts.svg_height),
     !joined,
     opts.filling,
+    opts.filling_style,
   );
   Ok(crate::graphics_result_with_source(svg, source))
 }
@@ -1341,6 +1346,7 @@ pub fn complex_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     (opts.svg_width, opts.svg_height),
     !joined,
     opts.filling,
+    opts.filling_style,
   );
   Ok(crate::graphics_result_with_source(svg, source))
 }

--- a/src/functions/parametric_plot.rs
+++ b/src/functions/parametric_plot.rs
@@ -279,6 +279,7 @@ pub fn parametric_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     (plot_opts.svg_width, plot_opts.svg_height),
     false,
     plot_opts.filling,
+    plot_opts.filling_style,
   );
   Ok(crate::graphics_result_with_source(svg, source))
 }
@@ -341,6 +342,7 @@ pub fn polar_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     (plot_opts.svg_width, plot_opts.svg_height),
     false,
     plot_opts.filling,
+    plot_opts.filling_style,
   );
   Ok(crate::graphics_result_with_source(svg, source))
 }

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -1001,6 +1001,107 @@ impl Filling {
   }
 }
 
+/// Parsed `FillingStyle -> …` value: an optional fill color override
+/// (`None` = use the series color) and an optional opacity (`None` = the
+/// default 0.2 translucency).
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) struct FillStyle {
+  pub color: Option<(u8, u8, u8)>,
+  pub opacity: Option<f64>,
+}
+
+/// Parse a `FillingStyle` option value. Supported forms: a color,
+/// `Opacity[a]`, `Opacity[a, color]`, `Directive[…]`, and a directive list
+/// `{Opacity[a], color}`. Returns `None` for `Automatic`/`None`/unrecognized
+/// values (keeping the default fill appearance).
+pub(crate) fn parse_filling_style(replacement: &Expr) -> Option<FillStyle> {
+  fn walk(e: &Expr, fs: &mut FillStyle) {
+    match e {
+      Expr::FunctionCall { name, args }
+        if name == "Opacity" && !args.is_empty() =>
+      {
+        if let Some(a) = try_eval_to_f64(&args[0]) {
+          fs.opacity = Some(a.clamp(0.0, 1.0));
+        }
+        if args.len() >= 2
+          && let Some(c) = parse_color(&args[1])
+        {
+          fs.color = Some(color_to_rgb8(c));
+        }
+      }
+      Expr::FunctionCall { name, args } if name == "Directive" => {
+        for a in args {
+          walk(a, fs);
+        }
+      }
+      Expr::List(items) => {
+        for item in items {
+          walk(item, fs);
+        }
+      }
+      Expr::Identifier(s) if s == "Automatic" || s == "None" => {}
+      other => {
+        if let Some(c) = parse_color(other) {
+          fs.color = Some(color_to_rgb8(c));
+          // An alpha channel on the color (`RGBColor[r, g, b, a]`) doubles
+          // as the fill opacity when no explicit Opacity[…] is given.
+          if c.a < 1.0 && fs.opacity.is_none() {
+            fs.opacity = Some(c.a);
+          }
+        }
+      }
+    }
+  }
+  let val = evaluate_expr_to_expr(replacement).unwrap_or(replacement.clone());
+  let mut fs = FillStyle {
+    color: None,
+    opacity: None,
+  };
+  walk(&val, &mut fs);
+  if fs.color.is_none() && fs.opacity.is_none() {
+    None
+  } else {
+    Some(fs)
+  }
+}
+
+/// Convert a parsed `Color` (float channels) to 8-bit RGB.
+fn color_to_rgb8(c: WoxiColor) -> (u8, u8, u8) {
+  (
+    (c.r.clamp(0.0, 1.0) * 255.0).round() as u8,
+    (c.g.clamp(0.0, 1.0) * 255.0).round() as u8,
+    (c.b.clamp(0.0, 1.0) * 255.0).round() as u8,
+  )
+}
+
+/// Resolve the fill paint for a series: the `FillingStyle` color override
+/// (else the series color) at the `FillingStyle` opacity (else 0.2).
+fn fill_paint(
+  filling_style: Option<FillStyle>,
+  series_rgb: (u8, u8, u8),
+) -> plotters::style::RGBAColor {
+  let fs = filling_style.unwrap_or(FillStyle {
+    color: None,
+    opacity: None,
+  });
+  let (r, g, b) = fs.color.unwrap_or(series_rgb);
+  RGBColor(r, g, b).mix(fs.opacity.unwrap_or(0.2))
+}
+
+/// [`fill_paint`] for a stored `PlotSeriesData` (the `Show` merge path,
+/// where the `FillingStyle` appearance travels on the series itself).
+fn series_fill_paint(
+  sd: &crate::syntax::PlotSeriesData,
+) -> plotters::style::RGBAColor {
+  fill_paint(
+    Some(FillStyle {
+      color: sd.fill_color,
+      opacity: sd.fill_opacity,
+    }),
+    sd.color,
+  )
+}
+
 impl crate::syntax::SeriesFilling {
   /// Reference y-value for the fill, given the current y-range.
   pub fn reference_y(self, y_min: f64, y_max: f64) -> Option<f64> {
@@ -1307,6 +1408,10 @@ pub(crate) struct PlotOptions {
   /// index → target). When non-empty this replaces the global `filling`:
   /// series without a rule are not filled.
   pub filling_rules: Vec<(usize, FillTarget)>,
+  /// `FillingStyle -> …`: color/opacity for the filled regions (applies to
+  /// every filled series). `None` keeps the default appearance (series
+  /// color at 0.2 opacity).
+  pub filling_style: Option<FillStyle>,
   pub mesh: Mesh,
   pub plot_label: Option<StyledLabel>,
   pub axes_label: Option<(String, String)>,
@@ -1384,6 +1489,7 @@ impl Default for PlotOptions {
       full_width: false,
       filling: Filling::None,
       filling_rules: Vec::new(),
+      filling_style: None,
       mesh: Mesh::None,
       plot_label: None,
       axes_label: None,
@@ -2115,6 +2221,7 @@ fn generate_svg_with_options(
                 })?;
             }
           } else {
+            let paint = fill_paint(opts.filling_style, (r, g, b));
             match series_fill_target(opts, series_idx) {
               FillTarget::Level(level) => {
                 if let Some(ref_y) = level.reference_y(y_min, y_max) {
@@ -2126,7 +2233,7 @@ fn generate_svg_with_options(
                       .draw_series(AreaSeries::new(
                         segment.iter().copied(),
                         ref_y,
-                        RGBColor(r, g, b).mix(0.2),
+                        paint,
                       ))
                       .map_err(|e| {
                         InterpreterError::EvaluationError(format!("Plot: {e}"))
@@ -2142,10 +2249,7 @@ fn generate_svg_with_options(
                   && let Some(polygon) = fill_between_polygon(points, target)
                 {
                   chart
-                    .draw_series(std::iter::once(Polygon::new(
-                      polygon,
-                      RGBColor(r, g, b).mix(0.2),
-                    )))
+                    .draw_series(std::iter::once(Polygon::new(polygon, paint)))
                     .map_err(|e| {
                       InterpreterError::EvaluationError(format!("Plot: {e}"))
                     })?;
@@ -2786,8 +2890,13 @@ pub(crate) fn build_plot_source(
   image_size: (u32, u32),
   is_scatter: bool,
   filling: Filling,
+  filling_style: Option<FillStyle>,
 ) -> crate::syntax::PlotSource {
   let series_filling = filling.to_series_filling();
+  let (fill_color, fill_opacity) = match filling_style {
+    Some(fs) => (fs.color, fs.opacity),
+    None => (None, None),
+  };
   let series = all_points
     .iter()
     .enumerate()
@@ -2798,6 +2907,8 @@ pub(crate) fn build_plot_source(
         color,
         is_scatter,
         filling: series_filling,
+        fill_color,
+        fill_opacity,
       }
     })
     .collect();
@@ -2976,8 +3087,8 @@ pub(crate) fn generate_scatter_svg_with_options(
       // level for Axis/Bottom/Top/value, or — for `Filling -> {i -> {j}}` —
       // the other series, linearly interpolated at this point's x so
       // irregularly spaced datasets fill correctly.
-      let stem_style =
-        RGBColor(r, g, b).mix(0.2).stroke_width(RESOLUTION_SCALE);
+      let stem_style = fill_paint(opts.filling_style, (r, g, b))
+        .stroke_width(RESOLUTION_SCALE);
       let stem_targets: Vec<((f64, f64), f64)> =
         match series_fill_target(opts, series_idx) {
           FillTarget::Level(level) => level
@@ -3211,7 +3322,7 @@ pub(crate) fn render_merged_plot_source(
 
         // Stem lines from each point to the fill reference level
         if let Some(ref_y) = sd.filling.reference_y(y_min, y_max) {
-          let stem_style = color.mix(0.2).stroke_width(RESOLUTION_SCALE);
+          let stem_style = series_fill_paint(sd).stroke_width(RESOLUTION_SCALE);
           for &(x, y) in &finite_pts {
             chart
               .draw_series(std::iter::once(PathElement::new(
@@ -3247,7 +3358,7 @@ pub(crate) fn render_merged_plot_source(
               .draw_series(AreaSeries::new(
                 segment.iter().copied(),
                 ref_y,
-                color.mix(0.2),
+                series_fill_paint(sd),
               ))
               .map_err(|e| {
                 InterpreterError::EvaluationError(format!("Plot: {e}"))
@@ -5264,6 +5375,8 @@ pub(crate) fn histogram_plot_source(
       color,
       is_scatter: false,
       filling: crate::syntax::SeriesFilling::Axis,
+      fill_color: None,
+      fill_opacity: None,
     });
   }
 
@@ -6630,6 +6743,9 @@ pub(crate) fn apply_common_plot_option(
     "Filling" => {
       apply_filling_option(replacement, plot_opts);
     }
+    "FillingStyle" => {
+      plot_opts.filling_style = parse_filling_style(replacement);
+    }
     "Background" => {
       plot_opts.background = parse_background_option(replacement);
     }
@@ -7086,6 +7202,7 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     (plot_opts.svg_width, plot_opts.svg_height),
     false,
     plot_opts.filling,
+    plot_opts.filling_style,
   );
 
   // Return -Graphics- as the text representation
@@ -7206,6 +7323,9 @@ fn log_scale_plot_ast(
         }
         "Filling" => {
           apply_filling_option(replacement, &mut plot_opts);
+        }
+        "FillingStyle" => {
+          plot_opts.filling_style = parse_filling_style(replacement);
         }
         "Background" => {
           plot_opts.background = parse_background_option(replacement);

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -569,10 +569,33 @@ fn render_text_element(s: &str) -> String {
     }
   }
 
-  // Inline `Cell[...]` elements are the attached "more info" opener buttons in
-  // Demonstrations templates — they carry no textual content, so drop them.
-  if s.starts_with("Cell[") {
-    return String::new();
+  // Inline `Cell[...]` elements inside a TextData run come in two kinds.
+  // Styled inline content — `Cell[BoxData[FormBox[…]], "InlineMath"]` and
+  // friends — carries real prose (math embedded in a sentence) and must be
+  // rendered, otherwise the surrounding text is left with holes. Unstyled
+  // inline cells are the attached "more info" opener buttons in
+  // Demonstrations templates (PaneSelectorBox/TemplateBox chrome) — they
+  // carry no textual content, so drop them.
+  if let Some(rest) = s.strip_prefix("Cell[")
+    && let Ok((inner, _)) = find_matching_bracket(rest)
+  {
+    let parts = split_top_level_commas(inner);
+    let style = parts.iter().skip(1).find_map(|p| {
+      let t = p.trim();
+      let is_option = t.contains("->") || t.contains(":>");
+      (!is_option && t.starts_with('"') && t.ends_with('"') && t.len() >= 2)
+        .then(|| &t[1..t.len() - 1])
+    });
+    return match style {
+      Some(
+        "InlineMath" | "InlineFormula" | "InlineCode" | "InlineInput"
+        | "InlineOutput",
+      ) => parts
+        .first()
+        .map(|c| extract_cell_content(c.trim()))
+        .unwrap_or_default(),
+      _ => String::new(),
+    };
   }
 
   // Nested RowBox / typeset boxes.
@@ -1676,6 +1699,63 @@ Cell["A subitem", "Subitem"]
 
     let reparsed = parse_notebook(&serialized).unwrap();
     assert_eq!(reparsed.cells.len(), 4);
+  }
+
+  #[test]
+  fn test_textdata_inline_math_cell_renders_content() {
+    // Inline `Cell[…, "InlineMath"]` elements inside a TextData run carry
+    // real prose (math embedded in a sentence) and must be rendered, not
+    // dropped like the Demonstrations "more info" chrome buttons.
+    let nb = r#"Notebook[{
+Cell[TextData[{
+ "To find ",
+ Cell[BoxData[
+  FormBox[
+   RowBox[{"P", "(",
+    RowBox[{"X", "\[LessEqual]", "x"}], ")"}], TraditionalForm]],
+  "InlineMath",ExpressionUUID->"c04c6311-9407-4855-8351-984bf610bb65"],
+ " with mean ",
+ Cell[BoxData[
+  FormBox["\[Mu]", TraditionalForm]], "InlineMath",ExpressionUUID->
+  "2769c287-5751-4749-947c-fcdd1da9d653"],
+ "."
+}], "Text"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    match &parsed.cells[0] {
+      CellEntry::Single(cell) => {
+        assert_eq!(cell.style, CellStyle::Text);
+        assert_eq!(cell.content, "To find P(X<=x) with mean \u{03bc}.");
+      }
+      _ => panic!("Expected single cell"),
+    }
+  }
+
+  #[test]
+  fn test_textdata_chrome_button_cell_still_dropped() {
+    // Unstyled inline cells (the Demonstrations "more info" opener
+    // buttons) carry no textual content and stay dropped.
+    let nb = r#"Notebook[{
+Cell[TextData[{
+ "Caption",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"CaptionCells"},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "4c32c08b-d967-45c6-8920-0c21a5734cd7"]
+}], "Section"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    match &parsed.cells[0] {
+      CellEntry::Single(cell) => {
+        assert_eq!(cell.style, CellStyle::Section);
+        assert_eq!(cell.content, "Caption");
+      }
+      _ => panic!("Expected single cell"),
+    }
   }
 
   #[test]

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -175,6 +175,10 @@ pub struct PlotSeriesData {
   pub color: (u8, u8, u8),
   pub is_scatter: bool,
   pub filling: SeriesFilling,
+  /// Fill color override from `FillingStyle` (`None` = use `color`).
+  pub fill_color: Option<(u8, u8, u8)>,
+  /// Fill opacity override from `FillingStyle` (`None` = the 0.2 default).
+  pub fill_opacity: Option<f64>,
 }
 
 /// Convert a Wolfram named character name (e.g. "Pi", "Alpha", "Sum") to its
@@ -9079,7 +9083,16 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
       let mut parts: Vec<Expr> = Vec::new();
       collect_string_join(left, &mut parts);
       collect_string_join(right, &mut parts);
-      let rendered: Vec<String> = parts.iter().map(&fmt).collect();
+      // Inside a genuine InputForm render (`expr_to_input_form`, which
+      // routes some nodes through the OutputForm path) the operands must
+      // keep their quotes — `StringJoin["z = ", ToString[z]]` — or the
+      // result doesn't re-parse. Display forms keep the unquoted operands
+      // (`StringJoin[z = , ToString[z]]`, matching wolframscript).
+      let rendered: Vec<String> = if in_true_input_form() {
+        parts.iter().map(expr_to_input_form).collect()
+      } else {
+        parts.iter().map(&fmt).collect()
+      };
       format!("StringJoin[{}]", rendered.join(", "))
     }
     // All other BinaryOps in OutputForm fall through to InputForm

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -6839,6 +6839,123 @@ mod show {
     clear_state();
     assert_eq!(interpret("Show[1, 2, 3]").unwrap(), "Show[1, 2, 3]");
   }
+
+  #[test]
+  fn show_plot_with_graphics_keeps_plot_aspect() {
+    // Merging a Plot with raw Graphics primitives inherits the plot's
+    // 1/GoldenRatio aspect (Wolfram takes the options from the first
+    // graphic). Regression: the render used to collapse to a sliver whose
+    // height came from the wide PlotRange's data aspect.
+    clear_state();
+    let svg = export_svg(
+      "Show[{Plot[Sin[x], {x, 0, 6}], Graphics[{Text[\"hi\", {1, 1}]}]}, \
+       PlotRange -> {{-7, 24}, {-0.15, 0.75}}, ImageSize -> 480]",
+    );
+    let dim = |attr: &str| -> f64 {
+      let start = svg.find(&format!("{attr}=\"")).unwrap() + attr.len() + 2;
+      svg[start..svg[start..].find('"').unwrap() + start]
+        .parse()
+        .unwrap()
+    };
+    let (w, h) = (dim("width"), dim("height"));
+    assert!(
+      (250.0..=450.0).contains(&h) && w >= 480.0,
+      "expected ~480 x ~300 (1/GoldenRatio of the plotting area), got {w} x {h}"
+    );
+  }
+
+  #[test]
+  fn show_plot_with_graphics_keeps_filling() {
+    // The plot-source series merged into a Graphics render keep their
+    // Filling regions (as polygons) and FillingStyle appearance.
+    clear_state();
+    let svg = export_svg(
+      "Show[Plot[Sin[x], {x, 0, 6}, Filling -> Axis, \
+       FillingStyle -> {Opacity[0.8], RGBColor[0.33, 0.36, 0.78]}], \
+       Graphics[{Text[\"hi\", {1, 1}]}]]",
+    );
+    assert!(
+      svg.contains("fill=\"rgb(84,92,199)\" fill-opacity=\"0.8\""),
+      "expected a filled polygon with the FillingStyle color/opacity"
+    );
+  }
+
+  #[test]
+  fn show_respects_explicit_axes_option() {
+    // `Axes -> {Automatic, False}` passed to Show must survive the merge
+    // (the mixed path used to overwrite it with Axes -> True) and hide the
+    // y-axis while keeping the x-axis. With the y-axis hidden the render
+    // reserves no left tick-label margin, so the total width equals the
+    // ImageSize exactly; the x-axis still adds its bottom margin.
+    clear_state();
+    let svg = export_svg(
+      "Show[{Plot[Sin[x], {x, 0, 6}], Graphics[{Point[{1, 1}]}]}, \
+       Axes -> {Automatic, False}, ImageSize -> 400]",
+    );
+    assert!(
+      svg.starts_with("<svg width=\"400\""),
+      "expected no left axis margin (y-axis hidden), got: {}",
+      &svg[..60.min(svg.len())]
+    );
+  }
+}
+
+mod filling_style {
+  use super::*;
+
+  #[test]
+  fn plot_filling_style_opacity_and_color() {
+    // FillingStyle -> {Opacity[a], color} overrides the default fill
+    // appearance (series color at 0.2 opacity).
+    clear_state();
+    let svg = export_svg(
+      "Plot[Sin[x], {x, 0, 6}, Filling -> Axis, \
+       FillingStyle -> {Opacity[0.8], RGBColor[0.33, 0.36, 0.78]}]",
+    );
+    assert!(
+      svg.contains("opacity=\"0.8\" fill=\"#545CC7\""),
+      "expected fill polygon with FillingStyle color at opacity 0.8"
+    );
+  }
+
+  #[test]
+  fn plot_filling_style_color_only() {
+    // A bare color keeps the default 0.2 opacity but recolors the fill.
+    clear_state();
+    let svg = export_svg(
+      "Plot[Sin[x], {x, 0, 6}, Filling -> Axis, FillingStyle -> Red]",
+    );
+    assert!(
+      svg.contains("opacity=\"0.2\" fill=\"#FF0000\""),
+      "expected red fill polygon at the default 0.2 opacity"
+    );
+  }
+
+  #[test]
+  fn plot_filling_style_opacity_only() {
+    // A bare Opacity keeps the series color but changes the translucency.
+    clear_state();
+    let svg = export_svg(
+      "Plot[Sin[x], {x, 0, 6}, Filling -> Axis, FillingStyle -> Opacity[0.5]]",
+    );
+    assert!(
+      svg.contains("opacity=\"0.5\" fill=\"#5E81B5\""),
+      "expected series-colored fill polygon at opacity 0.5"
+    );
+  }
+
+  #[test]
+  fn list_line_plot_filling_style() {
+    clear_state();
+    let svg = export_svg(
+      "ListLinePlot[{1, 4, 2, 5, 3}, Filling -> Axis, \
+       FillingStyle -> Directive[Opacity[0.6], RGBColor[0.12, 0.61, 0.78]]]",
+    );
+    assert!(
+      svg.contains("opacity=\"0.6\" fill=\"#1F9CC7\""),
+      "expected fill polygon with the Directive color at opacity 0.6"
+    );
+  }
 }
 
 mod list_plot_3d {

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -445,6 +445,23 @@ mod implicit_times_with_strings {
       r#"Hold["a" + "b"]"#
     );
   }
+
+  // A held `<>` renders as `StringJoin[a, b]` with the operands unquoted in
+  // OutputForm but quoted in genuine InputForm — Woxi Studio re-evaluates
+  // Manipulate bodies from their InputForm, and an unquoted operand
+  // (`StringJoin[z = , ToString[z]]`) doesn't re-parse (regression from the
+  // "Area of a Normal Distribution" Demonstration).
+  #[test]
+  fn held_string_join_input_form_quoted() {
+    assert_eq!(
+      interpret(r#"Hold["z = " <> ToString[z]]"#).unwrap(),
+      "Hold[StringJoin[z = , ToString[z]]]"
+    );
+    assert_eq!(
+      interpret(r#"ToString[Hold["z = " <> ToString[z]], InputForm]"#).unwrap(),
+      r#"Hold[StringJoin["z = ", ToString[z]]]"#
+    );
+  }
 }
 
 mod operator_shorthand_parens {


### PR DESCRIPTION
## Summary
Adds support for the `FillingStyle` option in plot functions, allowing users to customize the color and opacity of filled regions in plots. This option works with `Filling` to override the default appearance (series color at 0.2 opacity).

## Key Changes

- **New `FillStyle` struct and parser**: Added `FillStyle` to represent parsed fill color/opacity, with `parse_filling_style()` function that handles multiple input forms:
  - Bare colors: `FillingStyle -> Red`
  - Opacity only: `FillingStyle -> Opacity[0.5]`
  - Color + opacity: `FillingStyle -> {Opacity[0.8], RGBColor[...]}` or `Opacity[a, color]`
  - Directive lists: `FillingStyle -> Directive[Opacity[...], color]`
  - Color alpha channels double as fill opacity when no explicit `Opacity` is given

- **Plot rendering updates**: 
  - Added `filling_style` field to `PlotOptions` and `PlotSeriesData`
  - Updated fill paint calculation to use `FillingStyle` color/opacity instead of hardcoded defaults
  - Applied to both direct plot rendering and merged plot sources in `Show`

- **Show/Graphics merging improvements**:
  - Plot series now render their filled regions as `Polygon` primitives when merged into `Graphics`
  - Fill appearance (color/opacity) travels with the series data
  - Fixed aspect ratio handling: plots now correctly apply 1/GoldenRatio aspect when they're the first graphic in `Show`
  - Fixed `Axes` option handling: explicit `Axes -> {Automatic, False}` now survives the merge (previously overwritten)

- **Parser improvements**:
  - `parse_axes()` now treats `Automatic` as equivalent to `True` for axis display

- **Notebook rendering fix**: Inline `Cell[..., "InlineMath"]` and similar styled cells now render their content instead of being dropped, while unstyled chrome buttons (Demonstrations "more info" openers) remain dropped

- **StringJoin InputForm fix**: Held `<>` expressions now properly quote operands in `InputForm` to ensure re-parsing works correctly in Manipulate bodies

## Testing
Added comprehensive test coverage for `FillingStyle` with various input forms, and regression tests for `Show` merging behavior with plots and graphics.

https://claude.ai/code/session_01C972BGkGis7grUwsnw5yNw