### PR TITLE
Add Trigger and Button controls, Row-grouped layouts, and ColorData gradients

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -225,7 +225,7 @@ While,Evaluates an expression repeatedly while a condition is true,✅,pure,1.0,
 FrameLabel,Axis labels for framed charts (alias for AxesLabel),✅,pure,2.0,221
 FindRoot,Numerically finds a root of an equation using a damped Newton iteration — honours MaxIterations and reports non-convergence or a singular derivative (WorkingPrecision and the accuracy goals are accepted but ignored),✅,pure,1.0,222
 Image,Constructs an image from pixel data,✅,pure,7.0,223
-ColorData,Named color data: the categories; the colors of indexed schemes 1 (generated) 2 3 and 97; the named gradients are not yet colors of their own,🚧,pure,6.0,224
+ColorData,"Named color data: the categories; the colors of indexed schemes 1 (generated) 2 3 and 97; named gradients give a ColorDataFunction sampling the scheme (e.g. ColorData[""TemperatureMap""][0.5])",✅,pure,6.0,224
 Binomial,Returns the binomial coefficient,✅,pure,1.0,225
 Which,Evaluates conditions and returns the value for the first true one,✅,pure,1.0,226
 Replace,Applies transformation rules to an expression,✅,pure,1.0,227
@@ -257,7 +257,7 @@ PDF,Probability density function,✅,pure,6.0,254
 TableForm,Formats data as a table,✅,pure,1.0,255
 Circle,Represents a circle graphics primitive,✅,pure,2.0,256
 AbsoluteTiming,Returns the time taken to evaluate an expression,✅,contextual,5.0,257
-Blend,Blend colors together using linear interpolation,✅,none,6.0,258
+Blend,Blend colors together using linear interpolation; also samples named ColorData gradient schemes,✅,none,6.0,258
 Tooltip,Tooltip display wrapper (stays symbolic in script mode),✅,unevaluated,6.0,260
 Spacings,Spacing specification for grids and layouts,✅,none,6.0,261
 Assumptions,Specify assumptions for symbolic computation,✅,none,3.0,262
@@ -1137,7 +1137,7 @@ NotebookSelection,,🚫,,3.0,1141
 CellTags,,🚫,,3.0,1142
 FractionBox,Low-level box construct for fraction display,✅,pure,3.0,1143
 Magnification,,🚫,,3.0,1145
-Refresh,,🚫,,6.0,1145
+Refresh,Returns its first argument evaluated; the update-interval options only matter in a Dynamic FrontEnd context,✅,pure,6.0,1145
 KelvinBer,Kelvin ber function (real part of BesselJ on a rotated argument),✅,pure,6.0,1146
 NetTrain,,🚫,,11.0,1147
 SinIntegral,Sine integral Si(z),✅,pure,2.0,1148
@@ -4099,7 +4099,7 @@ AcousticAbsorbingValue,,🚫,,12.2,4225
 AdjacentMeshCells,,,,12.1,4225
 AudioStream,,🚫,,11.2,4225
 BlomqvistBetaTest,,,,9.0,4225
-ColorDataFunction,,,,6.0,4225
+ColorDataFunction,Structured form returned by ColorData for a named gradient; applying it to a number samples the gradient,✅,pure,6.0,4225
 DiscreteRiccatiSolve,,,,8.0,4225
 EquirippleFilterKernel,,,,9.0,4225
 FormControl,,🚫,,11.0,4225

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -1910,6 +1910,13 @@ fn evaluate_function_call_ast_inner(
     return Ok(result);
   }
 
+  // Refresh[expr, opts…] — the FrontEnd refresh wrapper displays (and
+  // returns) its first argument; the update-interval options only matter
+  // inside a Dynamic FrontEnd context.
+  if name == "Refresh" && !args.is_empty() {
+    return Ok(args[0].clone());
+  }
+
   // DiffusionPDETerm[{u, x}, c] → 0 (PDE term evaluates to zero outside solver context)
   if name == "DiffusionPDETerm"
     && args.len() == 2
@@ -11638,6 +11645,19 @@ fn nd_eigenvalues_diffusion_line(args: &[Expr]) -> Option<Expr> {
 
 /// Evaluate Blend[{c1, c2, ...}] or Blend[{c1, c2, ...}, t].
 fn evaluate_blend(args: &[Expr]) -> Option<Expr> {
+  // Named-scheme form: Blend["TemperatureMap", t] interpolates the stored
+  // control points of the named ColorData gradient at t.
+  if let Expr::String(scheme) = &args[0]
+    && args.len() == 2
+    && let Some(t) = crate::functions::math_ast::try_eval_to_f64(&args[1])
+    && let Some((r, g, b)) =
+      crate::functions::chart::sample_named_gradient(scheme, t)
+  {
+    return Some(Expr::FunctionCall {
+      name: "RGBColor".to_string(),
+      args: vec![Expr::Real(r), Expr::Real(g), Expr::Real(b)].into(),
+    });
+  }
   let colors = match &args[0] {
     Expr::List(items) if items.len() >= 2 => items,
     _ => return None,

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -777,6 +777,31 @@ pub fn dispatch_image_functions(
             .collect(),
         )));
       }
+      // ColorData["scheme"]: the gradient's color function, echoed in
+      // wolframscript's structured form
+      //   ColorDataFunction[scheme, "Gradients", {0, 1}, Blend[scheme, #1] &].
+      // Applying it (ColorData["scheme"][t]) blends the stored control
+      // points at t (see apply_curried_call).
+      if let Expr::String(scheme) = &args[0]
+        && crate::functions::chart::named_color_scheme(scheme).is_some()
+      {
+        let blend = Expr::Function {
+          body: Box::new(Expr::FunctionCall {
+            name: "Blend".to_string(),
+            args: vec![Expr::String(scheme.clone()), Expr::Slot(1)].into(),
+          }),
+        };
+        return Some(Ok(Expr::FunctionCall {
+          name: "ColorDataFunction".to_string(),
+          args: vec![
+            Expr::String(scheme.clone()),
+            Expr::String("Gradients".to_string()),
+            Expr::List(vec![Expr::Integer(0), Expr::Integer(1)].into()),
+            blend,
+          ]
+          .into(),
+        }));
+      }
     }
     "ImageCompose" if args.len() == 2 => {
       return Some(crate::functions::image_ast::image_compose_ast(args));

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -1632,6 +1632,15 @@ pub fn apply_curried_call(
     Expr::FunctionCall {
       name,
       args: func_args,
+    } if name == "ColorDataFunction" && func_args.len() == 4 => {
+      // ColorDataFunction[scheme, "Gradients", range, blend][t] — apply the
+      // stored blend function (the structured form ColorData["scheme"]
+      // evaluates to) at t.
+      apply_curried_call(&func_args[3], args)
+    }
+    Expr::FunctionCall {
+      name,
+      args: func_args,
     } if name == "BezierFunction" && func_args.len() == 1 => {
       // BezierFunction[{{p1}, {p2}, ...}][t] — evaluate Bezier curve at t
       evaluate_bezier_function(func_args, args)

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -427,7 +427,9 @@ const CHERRY_TONES_GRADIENT: [(f64, f64, f64); 8] = [
 ];
 
 /// Resolve a named ChartStyle color scheme to its gradient control points.
-fn named_color_scheme(name: &str) -> Option<&'static [(f64, f64, f64)]> {
+pub(crate) fn named_color_scheme(
+  name: &str,
+) -> Option<&'static [(f64, f64, f64)]> {
   let scheme: &'static [(f64, f64, f64)] = match name {
     "Pastel" => &PASTEL_GRADIENT,
     "Rainbow" => &RAINBOW_GRADIENT,
@@ -461,6 +463,33 @@ fn scheme_name(val: &Expr) -> Option<String> {
     }
     _ => None,
   }
+}
+
+/// Sample a named `ColorData` gradient scheme at parameter `t` (clamped to
+/// [0, 1]) via a linear `Blend` of its control points — the same
+/// interpolation wolframscript applies for `ColorData[name][t]` /
+/// `Blend[name, t]`. Returns `None` for schemes without stored control
+/// points.
+pub(crate) fn sample_named_gradient(
+  name: &str,
+  t: f64,
+) -> Option<(f64, f64, f64)> {
+  let controls = named_color_scheme(name)?;
+  let m = controls.len();
+  if m == 0 {
+    return None;
+  }
+  let t = t.clamp(0.0, 1.0);
+  let p = t * (m - 1) as f64;
+  let idx = (p.floor() as usize).min(m - 1);
+  let frac = p - idx as f64;
+  let (r0, g0, b0) = controls[idx];
+  let (r1, g1, b1) = controls[(idx + 1).min(m - 1)];
+  Some((
+    r0 + frac * (r1 - r0),
+    g0 + frac * (g1 - g0),
+    b0 + frac * (b1 - b0),
+  ))
 }
 
 /// Sample a gradient (linear `Blend` of its control points) at `n` evenly

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -117,8 +117,8 @@ fn parse_density_contour_options(
     {
       match name.as_str() {
         "ColorFunction" => {
-          if let Expr::String(s) = replacement.as_ref() {
-            color_function = Some(s.clone());
+          if let Some(s) = color_function_scheme_name(replacement.as_ref()) {
+            color_function = Some(s);
           }
         }
         "Contours" => match replacement.as_ref() {
@@ -1624,9 +1624,41 @@ enum ArrayCell {
   Color(GfxColor),
 }
 
+/// The gradient scheme name of a `ColorFunction` option value: a bare
+/// string (`"TemperatureMap"`), a `ColorData["TemperatureMap"]` call, or
+/// the structured `ColorDataFunction["TemperatureMap", …]` form the call
+/// evaluates to.
+fn color_function_scheme_name(val: &Expr) -> Option<String> {
+  match val {
+    Expr::String(s) => Some(s.clone()),
+    Expr::FunctionCall { name, args }
+      if (name == "ColorData" || name == "ColorDataFunction")
+        && !args.is_empty() =>
+    {
+      match &args[0] {
+        Expr::String(s) => Some(s.clone()),
+        _ => None,
+      }
+    }
+    _ => None,
+  }
+}
+
 /// Apply a named color function (gradient) to a normalized value t in [0,1].
+/// Schemes with stored `ColorData` control points (see
+/// `chart::sample_named_gradient`) interpolate those — matching
+/// wolframscript exactly; the rest fall back to analytic approximations.
 fn apply_named_color_function(name: &str, t: f64) -> (u8, u8, u8) {
   let t = t.clamp(0.0, 1.0);
+  if let Some((r, g, b)) =
+    crate::functions::chart::sample_named_gradient(name, t)
+  {
+    return (
+      (r * 255.0).round() as u8,
+      (g * 255.0).round() as u8,
+      (b * 255.0).round() as u8,
+    );
+  }
   match name {
     "Rainbow" => {
       // Hue-based rainbow: red -> yellow -> green -> cyan -> blue -> violet
@@ -1760,8 +1792,8 @@ pub fn array_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           _ => {}
         },
         "ColorFunction" => {
-          if let Expr::String(s) = replacement.as_ref() {
-            color_function = Some(s.clone());
+          if let Some(s) = color_function_scheme_name(replacement.as_ref()) {
+            color_function = Some(s);
           }
         }
         _ => {}

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -12220,6 +12220,18 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::FunctionCall { name, .. } if name == "Style" => {
         out_args.push(spec.clone());
       }
+      // Control objects and layout containers grouping them — `Control[…]`,
+      // `Button[…]`, `Row[{Control[…], Spacer[…], …}]` and friends — are
+      // valid Manipulate arguments (the Demonstrations layout pattern), not
+      // malformed variable specs. They pass through with no message.
+      Expr::FunctionCall { name, .. }
+        if matches!(
+          name.as_str(),
+          "Row" | "Column" | "Grid" | "Control" | "Button" | "Spacer"
+        ) =>
+      {
+        out_args.push(spec.clone());
+      }
       _ => {
         // Non-list variable specification: emit Manipulate::vsform
         // message but still return the expression unchanged, matching
@@ -12430,6 +12442,31 @@ pub enum ManipulateControl {
     auto_create: bool,
     label: String,
   },
+  /// A `ControlType -> Trigger` control: a play/pause button pair that
+  /// sweeps its variable from `min` towards `max` in `step` increments
+  /// while running (the Demonstrations "run/stop simulation" control).
+  /// `max` may be `f64::INFINITY` (`{time, 0, Infinity, 1, …}`), in which
+  /// case the sweep never wraps.
+  Trigger {
+    name: String,
+    min: f64,
+    max: f64,
+    step: f64,
+    initial: f64,
+    /// `AnimationRunning -> True`: start sweeping immediately. Wolfram's
+    /// Trigger sits paused until pressed by default.
+    running: bool,
+    label: String,
+    label_runs: Vec<LabelRun>,
+  },
+  /// A `Button[label, action]` control row. Pressing it evaluates `action`
+  /// (InputForm) against the live bindings — typically resetting state
+  /// variables (`time = 0; {U, V} = {Uinit, Vinit}`). Binds no variable.
+  Button {
+    label: String,
+    label_runs: Vec<LabelRun>,
+    action: String,
+  },
   /// A static heading row between controls: a bare string or `Style[…]`
   /// Manipulate argument (Wolfram's `ThisIsNotAControl` annotations, e.g.
   /// the "signal 1" / "signal 2" captions of the oscilloscope
@@ -12452,8 +12489,11 @@ impl ManipulateControl {
       | ManipulateControl::Discrete { name, .. }
       | ManipulateControl::Slider2D { name, .. }
       | ManipulateControl::IntervalSlider { name, .. }
+      | ManipulateControl::Trigger { name, .. }
       | ManipulateControl::Locator { name, .. } => name,
-      ManipulateControl::Heading { .. } | ManipulateControl::Divider => "",
+      ManipulateControl::Button { .. }
+      | ManipulateControl::Heading { .. }
+      | ManipulateControl::Divider => "",
     }
   }
 }
@@ -12577,7 +12617,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       )
     }
     None => (
-      crate::syntax::expr_to_input_form(&args[0]),
+      crate::syntax::expr_to_input_form(unwrap_dynamic_body(&args[0])),
       Vec::with_capacity(args.len() - 1),
       Vec::new(),
       Vec::new(),
@@ -12594,7 +12634,28 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   // and every occurrence in the body (and related code fragments) is
   // rewritten below via `(original InputForm, synthesized name)` pairs.
   let mut renames: Vec<(String, String)> = Vec::new();
+  // Controls grouped in a `Row[…]`/`Column[…]`/`Grid[…]` argument (the
+  // Demonstrations layout pattern `Row[{Control[…], Spacer[20], Button[…]}]`)
+  // flatten into their items so each inner control becomes its own row.
+  let mut arg_items: Vec<Expr> =
+    Vec::with_capacity(args.len().saturating_sub(1));
   for spec in &args[1..] {
+    match control_group_items(spec) {
+      Some(items) => arg_items.extend(items),
+      None => arg_items.push(spec.clone()),
+    }
+  }
+  for spec in &arg_items {
+    // `Control[spec, opts…]` wraps an ordinary variable specification;
+    // unwrap it so the spec parses through the standard path.
+    let spec = match spec {
+      Expr::FunctionCall { name, args }
+        if name == "Control" && !args.is_empty() =>
+      {
+        &args[0]
+      }
+      other => other,
+    };
     // Options such as `Initialization :> …` or `TrackedSymbols :> …`
     // are not variable specs; extract what we understand and ignore
     // the rest rather than failing the whole extraction.
@@ -12650,6 +12711,21 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         });
         continue;
       }
+      // `Button[label, action, opts…]`: a pressable control row whose
+      // action code runs against the live bindings (e.g. a reset button).
+      Expr::FunctionCall { name, args }
+        if name == "Button" && args.len() >= 2 =>
+      {
+        let label_runs = manipulate_label_runs(&args[0], false);
+        controls.push(ManipulateControl::Button {
+          label: flatten_label_runs(&label_runs),
+          label_runs,
+          action: crate::syntax::expr_to_input_form(&args[1]),
+        });
+        continue;
+      }
+      // `Spacer[…]` is pure layout between grouped controls — skip it.
+      Expr::FunctionCall { name, .. } if name == "Spacer" => continue,
       _ => {}
     }
     // Only list-shaped arguments are control specs. Any other trailing
@@ -12734,6 +12810,17 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     manipulate_block_code(&body_code, &fixed)
   };
 
+  // A Trigger control makes the whole widget animated: the play/pause
+  // toggle sweeps the trigger variable. It starts paused unless the
+  // trigger asked for `AnimationRunning -> True`.
+  if let Some(ManipulateControl::Trigger { running, .. }) = controls
+    .iter()
+    .find(|c| matches!(c, ManipulateControl::Trigger { .. }))
+  {
+    animated = true;
+    animation_running = *running;
+  }
+
   Some(ManipulateSpec {
     body_code,
     controls,
@@ -12745,6 +12832,67 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animation_running,
     appearance_none,
   })
+}
+
+/// A Manipulate body wrapped in `Dynamic[…]` displays the Dynamic's first
+/// argument — the wrapper only adds FrontEnd tracking hints (a second
+/// update-function argument, `TrackedSymbols :> …`) — so evaluation uses
+/// that inner expression.
+fn unwrap_dynamic_body(body: &Expr) -> &Expr {
+  match body {
+    Expr::FunctionCall { name, args }
+      if name == "Dynamic" && !args.is_empty() =>
+    {
+      &args[0]
+    }
+    other => other,
+  }
+}
+
+/// The flattened control items of a `Row[…]`/`Column[…]`/`Grid[…]`
+/// Manipulate argument that lays several controls out in one row (the
+/// Wolfram Demonstrations pattern `Row[{Control[…], Spacer[20],
+/// Button[…]}]`). Returns `None` when the argument contains no
+/// `Control[…]`/`Button[…]` anywhere, so plain `Row[…]` display
+/// expressions keep flowing to the display path.
+fn control_group_items(spec: &Expr) -> Option<Vec<Expr>> {
+  fn contains_control(e: &Expr) -> bool {
+    match e {
+      Expr::FunctionCall { name, args } => {
+        name == "Control"
+          || name == "Button"
+          || args.iter().any(contains_control)
+      }
+      Expr::List(items) => items.iter().any(contains_control),
+      _ => false,
+    }
+  }
+  let Expr::FunctionCall { name, args } = spec else {
+    return None;
+  };
+  if !matches!(name.as_str(), "Row" | "Column" | "Grid") || args.is_empty() {
+    return None;
+  }
+  if !contains_control(spec) {
+    return None;
+  }
+  let Expr::List(items) = &args[0] else {
+    return None;
+  };
+  let mut out = Vec::new();
+  for item in items.iter() {
+    match item {
+      // A Grid's first level is its list of layout rows; their elements
+      // are the actual items.
+      Expr::List(row) if name == "Grid" => out.extend(row.iter().cloned()),
+      // Nested layout containers flatten recursively.
+      other => match control_group_items(other) {
+        Some(nested) => out.extend(nested),
+        None => out.push(other.clone()),
+      },
+    }
+  }
+  Some(out)
 }
 
 /// Synthesize a plain symbol name for a compound (non-Identifier) control
@@ -12846,6 +12994,9 @@ fn patch_default_label(
     }
     | ManipulateControl::Discrete {
       label, label_runs, ..
+    }
+    | ManipulateControl::Trigger {
+      label, label_runs, ..
     } => {
       if label == synth {
         *label = pretty;
@@ -12859,7 +13010,9 @@ fn patch_default_label(
         *label = pretty;
       }
     }
-    ManipulateControl::Heading { .. } | ManipulateControl::Divider => {}
+    ManipulateControl::Button { .. }
+    | ManipulateControl::Heading { .. }
+    | ManipulateControl::Divider => {}
   }
 }
 
@@ -13551,28 +13704,112 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
   }
 
   // A `ControlType -> Slider2D` / `ControlType -> IntervalSlider` option
-  // selects a compound control. The bounds are the non-option items after
-  // the head.
-  let control_type = items.iter().find_map(|it| match it {
-    Expr::Rule {
-      pattern,
-      replacement,
-    }
-    | Expr::RuleDelayed {
-      pattern,
-      replacement,
-    } if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "ControlType") => {
-      match replacement.as_ref() {
-        Expr::Identifier(s) => Some(s.clone()),
-        _ => None,
+  // selects a compound control. The control type may also appear as a bare
+  // identifier in the spec (`{u, {1, 2, 3}, SetterBar}`). The bounds are
+  // the non-option, non-control-type items after the head.
+  let is_control_type_name = |s: &str| {
+    matches!(
+      s,
+      "Locator"
+        | "Slider"
+        | "Slider2D"
+        | "VerticalSlider"
+        | "Manipulator"
+        | "InputField"
+        | "PopupMenu"
+        | "SetterBar"
+        | "RadioButtonBar"
+        | "TogglerBar"
+        | "Checkbox"
+        | "ColorSlider"
+        | "ColorSetter"
+        | "IntervalSlider"
+        | "Animator"
+        | "Trigger"
+        | "Automatic"
+    )
+  };
+  let control_type = items
+    .iter()
+    .find_map(|it| match it {
+      Expr::Rule {
+        pattern,
+        replacement,
       }
-    }
-    _ => None,
-  });
+      | Expr::RuleDelayed {
+        pattern,
+        replacement,
+      } if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "ControlType") => {
+        match replacement.as_ref() {
+          Expr::Identifier(s) => Some(s.clone()),
+          _ => None,
+        }
+      }
+      _ => None,
+    })
+    .or_else(|| {
+      items[1..].iter().find_map(|it| match it {
+        Expr::Identifier(s) if is_control_type_name(s) => Some(s.clone()),
+        _ => None,
+      })
+    });
   let bounds: Vec<&Expr> = items[1..]
     .iter()
-    .filter(|it| !matches!(it, Expr::Rule { .. } | Expr::RuleDelayed { .. }))
+    .filter(|it| {
+      !matches!(it, Expr::Rule { .. } | Expr::RuleDelayed { .. })
+        && !matches!(it, Expr::Identifier(s) if is_control_type_name(s))
+    })
     .collect();
+
+  // `ControlType -> Trigger` (or a bare `Trigger` marker): a play/pause
+  // control sweeping the variable over `{min, max, step}`. `max` may be
+  // `Infinity` (`{time, 0, Infinity, 1, …}` — sweep forever, never wrap).
+  if control_type.as_deref() == Some("Trigger") {
+    let min = bounds
+      .first()
+      .and_then(|e| {
+        crate::functions::math_ast::try_eval_to_f64_with_infinity(e)
+      })
+      .unwrap_or(0.0);
+    let max = bounds
+      .get(1)
+      .and_then(|e| {
+        crate::functions::math_ast::try_eval_to_f64_with_infinity(e)
+      })
+      .unwrap_or(f64::INFINITY);
+    let step = bounds
+      .get(2)
+      .and_then(|e| crate::functions::math_ast::try_eval_to_f64(e))
+      .unwrap_or(1.0);
+    let initial = explicit_initial
+      .as_ref()
+      .and_then(crate::functions::math_ast::try_eval_to_f64)
+      .unwrap_or(min);
+    // Wolfram's Trigger sits paused until pressed; only an explicit
+    // `AnimationRunning -> True` starts it sweeping immediately.
+    let running = items.iter().any(|it| {
+      matches!(
+        it,
+        Expr::Rule { pattern, replacement }
+        | Expr::RuleDelayed { pattern, replacement }
+          if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "AnimationRunning")
+            && matches!(replacement.as_ref(), Expr::Identifier(s) if s == "True")
+      )
+    });
+    return Some(ParsedControl::Visible(
+      ManipulateControl::Trigger {
+        name,
+        min,
+        max,
+        step,
+        initial,
+        running,
+        label,
+        label_runs,
+      },
+      enabled,
+    ));
+  }
 
   // 2D control: either an explicit `ControlType -> Slider2D`, or a range
   // given as two corner points `{u, {xmin, ymin}, {xmax, ymax}}`.
@@ -13823,9 +14060,12 @@ pub fn manipulate_initial_bindings(
     .controls
     .iter()
     .filter_map(|c| match c {
-      // Annotation rows bind no variable.
-      ManipulateControl::Heading { .. } | ManipulateControl::Divider => None,
-      ManipulateControl::Continuous { name, initial, .. } => {
+      // Annotation and button rows bind no variable.
+      ManipulateControl::Heading { .. }
+      | ManipulateControl::Divider
+      | ManipulateControl::Button { .. } => None,
+      ManipulateControl::Continuous { name, initial, .. }
+      | ManipulateControl::Trigger { name, initial, .. } => {
         Some((name.clone(), format_f64_input(*initial)))
       }
       ManipulateControl::Discrete {
@@ -14132,6 +14372,33 @@ pub fn apply_manipulate_mutations(
   }
 }
 
+/// Run a Manipulate `Button[…]` action against the current bindings and
+/// return the updated InputForm value of every bound variable. The action's
+/// writes to unbound globals (e.g. `{U, V} = {Uinit, Vinit}`) persist as
+/// ordinary global side effects; writes to the bound control variables are
+/// captured through the returned list so the caller can move its widgets
+/// (e.g. `time = 0` rewinds a Trigger control).
+pub fn apply_manipulate_button_action(
+  bindings: &[(String, String)],
+  action: &str,
+) -> Vec<(String, String)> {
+  if bindings.is_empty() {
+    let _ = crate::interpret_with_stdout(action);
+    return Vec::new();
+  }
+  let names: Vec<&str> = bindings.iter().map(|(n, _)| n.as_str()).collect();
+  let body = format!("{action}; {{{}}}", names.join(", "));
+  let code = manipulate_block_code(&body, bindings);
+  match crate::interpret_to_expr(&code) {
+    Ok(Expr::List(ref vals)) if vals.len() == names.len() => names
+      .into_iter()
+      .map(str::to_string)
+      .zip(vals.iter().map(crate::syntax::expr_to_input_form))
+      .collect(),
+    _ => Vec::new(),
+  }
+}
+
 /// The distinct target variables of a set of write-back assignments, in first-
 /// seen order. Used to read back the mutated state values after applying the
 /// assignments to the (globally-installed) bindings.
@@ -14386,6 +14653,47 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           y_max,
           point_parts.join(","),
           auto_create,
+        ));
+      }
+      ManipulateControl::Trigger {
+        name,
+        min,
+        max,
+        step,
+        initial,
+        running,
+        label,
+        label_runs,
+      } => {
+        // An infinite sweep end (`{time, 0, Infinity, 1}`) serializes as
+        // `null` — JSON has no Infinity literal.
+        let max_json = if max.is_finite() {
+          format!("{}", max)
+        } else {
+          "null".to_string()
+        };
+        ctrl_parts.push(format!(
+          r#"{{"kind":"trigger","name":"{}","label":"{}","labelRuns":{},"min":{},"max":{},"step":{},"initial":{},"running":{}}}"#,
+          json_escape_manipulate(name),
+          json_escape_manipulate(label),
+          label_runs_to_json(label_runs),
+          min,
+          max_json,
+          step,
+          initial,
+          running,
+        ));
+      }
+      ManipulateControl::Button {
+        label,
+        label_runs,
+        action,
+      } => {
+        ctrl_parts.push(format!(
+          r#"{{"kind":"button","label":"{}","labelRuns":{},"action":"{}"}}"#,
+          json_escape_manipulate(label),
+          label_runs_to_json(label_runs),
+          json_escape_manipulate(action),
         ));
       }
       ManipulateControl::Heading { label, label_runs } => {

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -569,9 +569,28 @@ fn render_text_element(s: &str) -> String {
     }
   }
 
-  // Inline `Cell[...]` elements are the attached "more info" opener buttons in
-  // Demonstrations templates — they carry no textual content, so drop them.
-  if s.starts_with("Cell[") {
+  // Inline `Cell[…]` elements: `Cell[BoxData[…], "InlineMath"]` (the
+  // Demonstrations template's inline formulas; standard notebooks use
+  // "InlineFormula") renders as display text so prose like "Here D_U and
+  // D_V are the diffusion coefficients" keeps its symbols. Any other
+  // inline cell is an attached "more info" opener button carrying no
+  // textual content — drop it.
+  if let Some(rest) = s.strip_prefix("Cell[")
+    && let Ok((inner, _)) = find_matching_bracket(rest)
+  {
+    let parts = split_top_level_commas(inner);
+    let is_inline_math = parts.iter().skip(1).any(|p| {
+      // A part may start with a `\`-newline line continuation left over
+      // from the .nb file's physical line wrapping — strip it before
+      // matching the style string.
+      let t = p.trim();
+      let t = t.strip_prefix('\\').map(str::trim_start).unwrap_or(t);
+      let t = t.trim_matches('"');
+      t == "InlineMath" || t == "InlineFormula"
+    });
+    if is_inline_math && let Some(first) = parts.first() {
+      return render_boxes_text(first.trim());
+    }
     return String::new();
   }
 
@@ -584,6 +603,164 @@ fn render_text_element(s: &str) -> String {
   }
 
   s.to_string()
+}
+
+/// Render a box expression as *display* text for a prose (Text) cell —
+/// the inline-formula counterpart of `extract_typeset_box`, preferring
+/// readable notation over evaluable InputForm: `SubscriptBox["D", "U"]` →
+/// `D_U`, `SuperscriptBox["V", "2"]` → `V²`, `FractionBox[a, b]` → `a/b`,
+/// and `GridBox` rows on separate lines. Named characters resolve to
+/// Unicode (`\[Del]` → `∇`), never to ASCII operator rewrites.
+fn render_boxes_text(s: &str) -> String {
+  let s = s.trim();
+
+  // Plain string literal.
+  if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+    return unescape_string(&s[1..s.len() - 1]);
+  }
+
+  // A bare `{…}` list of inline items.
+  if s.starts_with('{') && s.ends_with('}') {
+    return split_top_level_commas(&s[1..s.len() - 1])
+      .iter()
+      .map(|p| render_boxes_text(p.trim()))
+      .collect::<String>();
+  }
+
+  fn box_args(head: &str, s: &str) -> Option<Vec<String>> {
+    let rest = s.strip_prefix(head)?.strip_prefix('[')?;
+    let (inner, _) = find_matching_bracket(rest).ok()?;
+    Some(
+      split_top_level_commas(inner)
+        .into_iter()
+        .map(|p| p.trim().to_string())
+        .collect(),
+    )
+  }
+
+  // Superscripts of digits (and a leading minus) read best as Unicode
+  // superscript characters: `V²`, `∇²`, `10⁻³`.
+  fn superscript_unicode(s: &str) -> Option<String> {
+    s.chars()
+      .map(|c| match c {
+        '0' => Some('⁰'),
+        '1' => Some('¹'),
+        '2' => Some('²'),
+        '3' => Some('³'),
+        '4' => Some('⁴'),
+        '5' => Some('⁵'),
+        '6' => Some('⁶'),
+        '7' => Some('⁷'),
+        '8' => Some('⁸'),
+        '9' => Some('⁹'),
+        '-' => Some('⁻'),
+        '+' => Some('⁺'),
+        _ => None,
+      })
+      .collect()
+  }
+
+  for head in [
+    "BoxData",
+    "FormBox",
+    "StyleBox",
+    "TagBox",
+    "AdjustmentBox",
+    "FrameBox",
+    "ButtonBox",
+    "PaneBox",
+    "ItemBox",
+  ] {
+    if let Some(args) = box_args(head, s)
+      && let Some(first) = args.first()
+    {
+      // These wrappers only style/annotate their first argument.
+      return render_boxes_text(first);
+    }
+  }
+  if let Some(args) = box_args("InterpretationBox", s)
+    && !args.is_empty()
+  {
+    // The displayed form is the first argument (the second is the value).
+    return render_boxes_text(&args[0]);
+  }
+  if let Some(args) = box_args("RowBox", s)
+    && let Some(first) = args.first()
+  {
+    return render_boxes_text(first);
+  }
+  if let Some(args) = box_args("FractionBox", s)
+    && args.len() == 2
+  {
+    return format!(
+      "{}/{}",
+      render_boxes_text(&args[0]),
+      render_boxes_text(&args[1])
+    );
+  }
+  if let Some(args) = box_args("SubscriptBox", s)
+    && args.len() == 2
+  {
+    return format!(
+      "{}_{}",
+      render_boxes_text(&args[0]),
+      render_boxes_text(&args[1])
+    );
+  }
+  if let Some(args) = box_args("SuperscriptBox", s)
+    && args.len() == 2
+  {
+    let base = render_boxes_text(&args[0]);
+    let exp = render_boxes_text(&args[1]);
+    return match superscript_unicode(&exp) {
+      Some(sup) if !sup.is_empty() => format!("{base}{sup}"),
+      _ => format!("{base}^{exp}"),
+    };
+  }
+  if let Some(args) = box_args("SubsuperscriptBox", s)
+    && args.len() == 3
+  {
+    let base = render_boxes_text(&args[0]);
+    let sub = render_boxes_text(&args[1]);
+    let exp = render_boxes_text(&args[2]);
+    return match superscript_unicode(&exp) {
+      Some(sup) if !sup.is_empty() => format!("{base}_{sub}{sup}"),
+      _ => format!("{base}_{sub}^{exp}"),
+    };
+  }
+  if let Some(args) = box_args("SqrtBox", s)
+    && args.len() == 1
+  {
+    return format!("√{}", render_boxes_text(&args[0]));
+  }
+  if let Some(args) = box_args("GridBox", s)
+    && let Some(rows_text) = args.first()
+  {
+    // Rows on separate lines, columns separated by two spaces.
+    let rows_inner = rows_text
+      .strip_prefix('{')
+      .and_then(|r| r.strip_suffix('}'))
+      .unwrap_or(rows_text);
+    return split_top_level_commas(rows_inner)
+      .iter()
+      .map(|row| {
+        let row = row.trim();
+        let row_inner = row
+          .strip_prefix('{')
+          .and_then(|r| r.strip_suffix('}'))
+          .unwrap_or(row);
+        split_top_level_commas(row_inner)
+          .iter()
+          .map(|cell| render_boxes_text(cell.trim()))
+          .collect::<Vec<_>>()
+          .join("  ")
+      })
+      .collect::<Vec<_>>()
+      .join("\n");
+  }
+
+  // Anything else falls back to the evaluable-InputForm extractor.
+  extract_cell_content(s)
 }
 
 /// Map Wolfram named operator characters to their InputForm ASCII
@@ -687,6 +864,13 @@ fn unescape_string_inner(s: &str, code: bool) -> String {
           }
           if code && let Some(op) = named_char_to_code_op(&name) {
             result.push_str(op);
+            continue;
+          }
+          // Prose display: `\[Cross]` canonically maps to a private-use
+          // codepoint (U+F3C4) with no glyph in normal fonts; the visible
+          // multiplication sign is what a text cell means (`40 × 40`).
+          if !code && name == "Cross" {
+            result.push('\u{00D7}');
             continue;
           }
           match crate::syntax::named_char_to_unicode(&name) {
@@ -2108,5 +2292,103 @@ Cell[BoxData["2"], "Output", ExpressionUUID -> "bbb"]
       "Text cell should not contain backslashes, got: {:?}",
       text_cell.content
     );
+  }
+  #[test]
+  fn test_inline_math_cells_render_in_text() {
+    // `Cell[BoxData[…], "InlineMath"]` runs inside TextData carry the
+    // prose's symbols (the Wolfram Demonstrations template); they must
+    // render as display text, not vanish.
+    let nb = r#"Notebook[{
+Cell[TextData[{
+ "Here ",
+ Cell[BoxData[
+  FormBox[
+   SubscriptBox["D", "U"], TraditionalForm]], "InlineMath",ExpressionUUID->
+  "332957a9-d341-4570-bd7c-95b02f59c357"],
+ " and ",
+ Cell[BoxData[
+  FormBox[
+   SuperscriptBox["V", "2"], TraditionalForm]], "InlineMath",ExpressionUUID->
+  "f34a7ed8-3e3c-46ff-b104-0705ae5e03bb"],
+ " appear."
+}], "Text"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    match &parsed.cells[0] {
+      CellEntry::Single(cell) => {
+        assert_eq!(cell.style, CellStyle::Text);
+        assert_eq!(cell.content, "Here D_U and V\u{00b2} appear.");
+      }
+      _ => panic!("Expected single cell"),
+    }
+  }
+
+  #[test]
+  fn test_inline_math_grid_of_equations() {
+    // A TextData whose sole element is an inline-math cell holding a
+    // GridBox renders each row on its own line.
+    let nb = r#"Notebook[{
+Cell[TextData[Cell[BoxData[
+ FormBox[
+  RowBox[{"{", GridBox[{
+     {
+      RowBox[{"U", " ", "\[RightArrow]", " ", "P"}]},
+     {
+      RowBox[{"V", " ", "\[RightArrow]", " ", "Q"}]}
+    }]}],
+  TraditionalForm]], \
+"InlineMath",ExpressionUUID->"97d25ac6-5009-432e-bb32-5ac8fe1a68f7"]], "Text"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    match &parsed.cells[0] {
+      CellEntry::Single(cell) => {
+        assert_eq!(cell.content, "{U \u{2192} P\nV \u{2192} Q");
+      }
+      _ => panic!("Expected single cell"),
+    }
+  }
+
+  #[test]
+  fn test_inline_cross_renders_as_multiplication_sign() {
+    // `\[Cross]` canonically maps to a glyphless private-use codepoint;
+    // prose shows the multiplication sign (`40 × 40`).
+    let nb = r#"Notebook[{
+Cell[TextData[{
+ "a field size of ",
+ Cell[BoxData[
+  FormBox[
+   RowBox[{"40", "\[Cross]", "40"}], TraditionalForm]], "InlineMath",
+  ExpressionUUID->"6e1aba5b-f538-4ff2-b2b5-68f7aa88e1fd"]
+}], "Text"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    match &parsed.cells[0] {
+      CellEntry::Single(cell) => {
+        assert_eq!(cell.content, "a field size of 40\u{00d7}40");
+      }
+      _ => panic!("Expected single cell"),
+    }
+  }
+
+  #[test]
+  fn test_non_inline_math_cells_stay_dropped() {
+    // Inline cells that are NOT inline formulas (the Demonstrations
+    // "more info" opener buttons) still carry no textual content.
+    let nb = r#"Notebook[{
+Cell[TextData[{
+ "Caption",
+ Cell[BoxData[
+  PaneSelectorBox[{True->"x"}, Dynamic[y]]],ExpressionUUID->
+  "7d8221a0-ff0d-462f-ac85-47023eae4458"]
+}], "Section"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    match &parsed.cells[0] {
+      CellEntry::Single(cell) => {
+        assert_eq!(cell.style, CellStyle::Section);
+        assert_eq!(cell.content, "Caption");
+      }
+      _ => panic!("Expected single cell"),
+    }
   }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -253,6 +253,7 @@ pub fn named_char_to_unicode(name: &str) -> Option<&'static str> {
     "Product" => Some("\u{220F}"),
     "Integral" => Some("\u{222B}"),
     "PartialD" => Some("\u{2202}"),
+    "Del" => Some("\u{2207}"),
     "DifferentialD" => Some("\u{2146}"),
     "CapitalDifferentialD" => Some("\u{2145}"),
     "Sqrt" => Some("\u{221A}"),
@@ -9617,6 +9618,10 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
             right.as_ref(),
             Expr::FunctionCall { name, args } if name == "Plus" && args.len() >= 2
           )))
+        // Minus with an additive right operand: subtraction is left-
+        // associative, so a held `a - (b + c)` / `a - (b - c)` must keep
+        // its parentheses — printing `a - b + c` changes the value.
+        || (matches!(op, BinaryOperator::Minus) && is_additive(right))
         // Times * Times (right-nested) where the inner left factor is a
         // bare Integer: this is the literal chain produced for
         // `Derivative[n][# ^ k &]` (e.g. `3*(2*#1)`). Times normally

--- a/tests/cli/images/ColorData.md
+++ b/tests/cli/images/ColorData.md
@@ -39,3 +39,16 @@ $ wo 'List @@ ColorData[2, 10]'
 $ wo 'Length[ColorData[3, "ColorList"]]'
 10
 ```
+
+`ColorData["scheme"]` gives a named gradient's color function; applying it
+(or calling `Blend` with the scheme name) interpolates the gradient:
+
+```scrut
+$ wo 'Head[ColorData["TemperatureMap"]]'
+ColorDataFunction
+```
+
+```scrut
+$ wo 'Blend["TemperatureMap", 0]'
+RGBColor[0.178927, 0.305394, 0.933501]
+```

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -11183,6 +11183,162 @@ mod manipulate {
     );
   }
 
+  /// The Wolfram Demonstrations layout pattern: controls grouped inside
+  /// `Row[{Control[…], Spacer[…], Button[…], …}]` arguments flatten into
+  /// individual control rows — SetterBars, a reset Button, and a Trigger
+  /// (the Gray-Scott reaction-diffusion notebook's control panel).
+  #[test]
+  fn spec_row_grouped_controls_flatten() {
+    let expr = interpret_to_expr(
+      "Manipulate[x, \
+       Row[{Control[{{ss, 1, \"field size\"}, {1 -> \"20\", 2 -> \"30\"}, SetterBar, Enabled -> (time === 0)}], Spacer[20], \
+            Control[{{pp, 1, \"pattern\"}, {1 -> \"spot I\", 2 -> \"spot II\"}, SetterBar}]}], \
+       Row[{Button[Style[\"reset\", 11], time = 0; x = 1, ImageSize -> Medium], Spacer[20], \
+            Control[{{time, 0, \"run/stop simulation\"}, 0, Infinity, 1, ControlType -> Trigger, AnimationRunning -> False}]}]]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert_eq!(spec.controls.len(), 4);
+    match &spec.controls[0] {
+      ManipulateControl::Discrete {
+        name,
+        values,
+        value_labels,
+        label,
+        ..
+      } => {
+        assert_eq!(name, "ss");
+        assert_eq!(label, "field size");
+        assert_eq!(values, &["1".to_string(), "2".to_string()]);
+        assert_eq!(value_labels, &["20".to_string(), "30".to_string()]);
+      }
+      other => panic!("expected discrete control for ss, got {other:?}"),
+    }
+    assert!(matches!(
+      &spec.controls[1],
+      ManipulateControl::Discrete { name, .. } if name == "pp"
+    ));
+    match &spec.controls[2] {
+      ManipulateControl::Button { label, action, .. } => {
+        assert_eq!(label, "reset");
+        assert_eq!(action, "time = 0; x = 1");
+      }
+      other => panic!("expected button control, got {other:?}"),
+    }
+    match &spec.controls[3] {
+      ManipulateControl::Trigger {
+        name,
+        min,
+        max,
+        step,
+        initial,
+        running,
+        label,
+        ..
+      } => {
+        assert_eq!(name, "time");
+        assert_eq!(label, "run/stop simulation");
+        assert_eq!(*min, 0.0);
+        assert!(max.is_infinite(), "Infinity end must stay infinite");
+        assert_eq!(*step, 1.0);
+        assert_eq!(*initial, 0.0);
+        assert!(!running, "AnimationRunning -> False starts paused");
+      }
+      other => panic!("expected trigger control, got {other:?}"),
+    }
+    // The Trigger makes the widget animated but paused.
+    assert!(spec.animated);
+    assert!(!spec.animation_running);
+    // The Enabled condition of the first SetterBar is captured.
+    assert!(
+      spec
+        .control_enabled
+        .iter()
+        .any(|(n, cond)| n == "ss" && cond.contains("time === 0")),
+      "missing Enabled condition: {:?}",
+      spec.control_enabled
+    );
+  }
+
+  /// A body wrapped in `Dynamic[…]` evaluates as its first argument — the
+  /// wrapper only adds FrontEnd tracking hints.
+  #[test]
+  fn spec_dynamic_body_unwraps() {
+    let expr = interpret_to_expr(
+      "Manipulate[Dynamic[x^2, time, TrackedSymbols :> {x}], {x, 0, 5}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert_eq!(spec.body_code, "x^2");
+  }
+
+  /// Regression: a bare control-type marker in the spec (`{u, {…}, SetterBar}`)
+  /// previously landed among the bounds and made the whole extraction fail.
+  #[test]
+  fn spec_bare_setter_bar_marker() {
+    let expr =
+      interpret_to_expr("Manipulate[u, {u, {1, 2, 3}, SetterBar}]").unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete { name, values, .. } => {
+        assert_eq!(name, "u");
+        assert_eq!(
+          values,
+          &["1".to_string(), "2".to_string(), "3".to_string()]
+        );
+      }
+      other => panic!("expected discrete control, got {other:?}"),
+    }
+    // A bare PopupMenu marker still selects the dropdown rendering.
+    let expr =
+      interpret_to_expr("Manipulate[u, {u, {1, 2}, PopupMenu}]").unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert!(matches!(
+      &spec.controls[0],
+      ManipulateControl::Discrete { popup: true, .. }
+    ));
+  }
+
+  /// `Row[…]`-grouped controls are valid Manipulate arguments and must not
+  /// emit `Manipulate::vsform`.
+  #[test]
+  fn row_grouped_controls_are_not_vsform() {
+    let res = woxi::interpret_with_stdout(
+      "Manipulate[x, Row[{Control[{x, 0, 1}], Spacer[20]}]]",
+    )
+    .unwrap();
+    assert!(
+      !res.warnings.iter().any(|w| w.contains("vsform")),
+      "unexpected vsform message: {:?}",
+      res.warnings
+    );
+  }
+
+  /// A button's action runs against the live bindings: writes to bound
+  /// control variables come back in the returned list, while writes to
+  /// unbound globals persist as side effects.
+  #[test]
+  fn button_action_writes_back_bindings() {
+    use woxi::functions::graphics::apply_manipulate_button_action;
+    let _ = woxi::interpret("grayScottButtonGlobal = 7");
+    let bindings = vec![
+      ("time".to_string(), "5".to_string()),
+      ("ii".to_string(), "2".to_string()),
+    ];
+    let updated = apply_manipulate_button_action(
+      &bindings,
+      "time = 0; grayScottButtonGlobal = 42",
+    );
+    assert_eq!(
+      updated,
+      vec![
+        ("time".to_string(), "0".to_string()),
+        ("ii".to_string(), "2".to_string()),
+      ]
+    );
+    assert_eq!(woxi::interpret("grayScottButtonGlobal").unwrap(), "42");
+  }
+
   #[test]
   fn spec_discrete_values() {
     let expr =

--- a/tests/interpreter_tests/image.rs
+++ b/tests/interpreter_tests/image.rs
@@ -6785,3 +6785,57 @@ mod image_filter_and_color_space {
     }
   }
 }
+
+mod color_data_gradients {
+  use super::*;
+
+  #[test]
+  fn color_data_named_gradient_is_a_color_function() {
+    clear_state();
+    // The structured form wolframscript echoes for a named gradient.
+    assert_eq!(
+      interpret("Head[ColorData[\"TemperatureMap\"]]").unwrap(),
+      "ColorDataFunction"
+    );
+    // Applying it samples the gradient's stored control points.
+    assert_eq!(
+      interpret("ColorData[\"TemperatureMap\"][0.5]").unwrap(),
+      "RGBColor[0.984192, 0.987731, 0.911643]"
+    );
+    assert_eq!(
+      interpret("ColorData[\"Rainbow\"][0]").unwrap(),
+      "RGBColor[0.471412, 0.108766, 0.527016]"
+    );
+  }
+
+  #[test]
+  fn blend_named_scheme_interpolates_control_points() {
+    clear_state();
+    // The endpoints are the first/last stored control points.
+    assert_eq!(
+      interpret("Blend[\"TemperatureMap\", 0]").unwrap(),
+      "RGBColor[0.178927, 0.305394, 0.933501]"
+    );
+    assert_eq!(
+      interpret("Blend[\"TemperatureMap\", 1]").unwrap(),
+      "RGBColor[0.817319, 0.134127, 0.164218]"
+    );
+    // Out-of-range parameters clamp to the ends.
+    assert_eq!(
+      interpret("Blend[\"TemperatureMap\", 2]").unwrap(),
+      "RGBColor[0.817319, 0.134127, 0.164218]"
+    );
+  }
+
+  #[test]
+  fn refresh_returns_its_first_argument() {
+    clear_state();
+    // Refresh only matters in a Dynamic FrontEnd context; its value is the
+    // (evaluated) first argument.
+    assert_eq!(interpret("Refresh[3, None]").unwrap(), "3");
+    assert_eq!(
+      interpret("time = 7; Refresh[time, UpdateInterval -> 1]").unwrap(),
+      "7"
+    );
+  }
+}

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__field_plots__array_plot_color_function_rainbow.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__field_plots__array_plot_color_function_rainbow.snap
@@ -1,19 +1,20 @@
 ---
 source: tests/interpreter_tests/graphics.rs
+assertion_line: 5844
 expression: "export_svg(\"ArrayPlot[{{0, 0.25, 0.5, 0.75, 1}, {1, 0.75, 0.5, 0.25, 0}}, ColorFunction -> \\\"Rainbow\\\"]\")"
 ---
 <svg width="360" height="144" viewBox="0 0 3600 1440" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
 <rect x="0" y="0" width="3600" height="1440" opacity="1" fill="#FFFFFF" stroke="none"/>
-<rect x="0" y="0" width="720" height="720" opacity="1" fill="#FF0000" stroke="none"/>
-<rect x="720" y="0" width="720" height="720" opacity="1" fill="#C1FF00" stroke="none"/>
-<rect x="1440" y="0" width="720" height="720" opacity="1" fill="#00FF7D" stroke="none"/>
-<rect x="2160" y="0" width="720" height="720" opacity="1" fill="#0044FF" stroke="none"/>
-<rect x="2880" y="0" width="720" height="720" opacity="1" fill="#FA00FF" stroke="none"/>
-<rect x="0" y="720" width="720" height="720" opacity="1" fill="#FA00FF" stroke="none"/>
-<rect x="720" y="720" width="720" height="720" opacity="1" fill="#0044FF" stroke="none"/>
-<rect x="1440" y="720" width="720" height="720" opacity="1" fill="#00FF7D" stroke="none"/>
-<rect x="2160" y="720" width="720" height="720" opacity="1" fill="#C1FF00" stroke="none"/>
-<rect x="2880" y="720" width="720" height="720" opacity="1" fill="#FF0000" stroke="none"/>
+<rect x="0" y="0" width="720" height="720" opacity="1" fill="#781C86" stroke="none"/>
+<rect x="720" y="0" width="720" height="720" opacity="1" fill="#447CCD" stroke="none"/>
+<rect x="1440" y="0" width="720" height="720" opacity="1" fill="#83BA70" stroke="none"/>
+<rect x="2160" y="0" width="720" height="720" opacity="1" fill="#DCAB3C" stroke="none"/>
+<rect x="2880" y="0" width="720" height="720" opacity="1" fill="#DB2122" stroke="none"/>
+<rect x="0" y="720" width="720" height="720" opacity="1" fill="#DB2122" stroke="none"/>
+<rect x="720" y="720" width="720" height="720" opacity="1" fill="#DCAB3C" stroke="none"/>
+<rect x="1440" y="720" width="720" height="720" opacity="1" fill="#83BA70" stroke="none"/>
+<rect x="2160" y="720" width="720" height="720" opacity="1" fill="#447CCD" stroke="none"/>
+<rect x="2880" y="720" width="720" height="720" opacity="1" fill="#781C86" stroke="none"/>
 <rect x="0" y="0" width="3600" height="10" opacity="1" fill="#666666" stroke="none"/>
 <rect x="0" y="1430" width="3600" height="10" opacity="1" fill="#666666" stroke="none"/>
 <rect x="0" y="0" width="10" height="1440" opacity="1" fill="#666666" stroke="none"/>

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -477,6 +477,17 @@ mod operator_shorthand_parens {
     assert_eq!(interpret("Hold[f @@ a^2]").unwrap(), "Hold[f @@ a^2]");
   }
 
+  #[test]
+  fn held_subtraction_keeps_additive_operand_parens() {
+    // Subtraction is left-associative, so a parenthesized additive right
+    // operand must keep its parens: `a - b + c` is a different value.
+    assert_eq!(interpret("Hold[a - (b + c)]").unwrap(), "Hold[a - (b + c)]");
+    assert_eq!(interpret("Hold[a - (b - c)]").unwrap(), "Hold[a - (b - c)]");
+    // Left-nested chains stay flat.
+    assert_eq!(interpret("Hold[a - b + c]").unwrap(), "Hold[a - b + c]");
+    assert_eq!(interpret("Hold[a - b - c]").unwrap(), "Hold[a - b - c]");
+  }
+
   // The InputForm of a held expression must re-parse to the very same
   // expression (checked via FullForm equality).
   #[test]
@@ -488,6 +499,13 @@ mod operator_shorthand_parens {
       "x /. p:{_?NumericQ, _?NumericQ} :> c + RotationMatrix[Pi/4] . (p - c)",
       "(f & ) @@ (a + b)",
       "f /@ a + b",
+      // Subtraction is left-associative: a held additive right operand
+      // must keep its parentheses (regression: the Gray-Scott notebook's
+      // `(# - (2*(#/10) + 2))/2 &` pad width printed as `#1 - 2*#1/10 + 2`,
+      // silently changing 7 into 9).
+      "a - (b + c)",
+      "a - (b - c)",
+      "(#1 - (2*#1/10 + 2))/2 & ",
     ] {
       let full = interpret(&format!("FullForm[Hold[{src}]]")).unwrap();
       let printed =

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -328,6 +328,9 @@ enum Message {
   ManipulateAnimationTick(std::time::Instant),
   /// Toggle play/pause of an animated (Animate/ListAnimate) widget.
   ManipulateTogglePlay(usize),
+  /// A `Button[…]` control row was pressed; run its action code.
+  /// (cell_idx, ctrl_idx)
+  ManipulateButtonPressed(usize, usize),
   /// Swallow an interaction with a disabled control (its `Enabled` condition
   /// is currently `False`) without changing any state.
   Noop,
@@ -1778,6 +1781,18 @@ impl WoxiStudio {
           && let Some(state) = editor.manipulate_state.as_mut()
         {
           state.playing = !state.playing;
+        }
+        Task::none()
+      }
+
+      Message::ManipulateButtonPressed(cell_idx, ctrl_idx) => {
+        if let Some(editor) = self.cell_editors.get_mut(cell_idx)
+          && let Some(state) = editor.manipulate_state.as_mut()
+          && let Some(manipulate::ControlState::Button { action, .. }) =
+            state.controls.get(ctrl_idx)
+        {
+          let action = action.clone();
+          state.apply_button_action(&action);
         }
         Task::none()
       }
@@ -3578,10 +3593,13 @@ fn manipulate_label_char_count(ctrl: &manipulate::ControlState) -> usize {
     | manipulate::ControlState::Discrete { label, name, .. }
     | manipulate::ControlState::Slider2D { label, name, .. }
     | manipulate::ControlState::IntervalSlider { label, name, .. }
+    | manipulate::ControlState::Trigger { label, name, .. }
     | manipulate::ControlState::Locator { label, name, .. } => (label, name),
     // Heading/divider rows span the full row instead of sitting in the
-    // label column, so they don't widen it.
-    manipulate::ControlState::Heading { .. }
+    // label column, so they don't widen it; a button carries its label
+    // inside the button itself.
+    manipulate::ControlState::Button { .. }
+    | manipulate::ControlState::Heading { .. }
     | manipulate::ControlState::Divider => return 0,
   };
   let text = if label.is_empty() { name } else { label };
@@ -3979,6 +3997,66 @@ fn render_manipulate_widget<'a>(
           row![label_widget, points_col].align_y(Center).spacing(8);
         controls_col = controls_col.push(control_row);
       }
+      manipulate::ControlState::Trigger {
+        name,
+        label,
+        label_runs,
+        current,
+        ..
+      } => {
+        // A Trigger control: its own play/pause toggle plus a live readout
+        // of the swept variable (Wolfram's TriggerButton/PauseButton pair).
+        let label_widget = manipulate_label_widget(
+          label_runs,
+          label,
+          name,
+          label_col_width,
+          enabled,
+        );
+        let symbol = if state.playing { "❚❚" } else { "▶" };
+        let play_btn =
+          button(text(symbol).size(11))
+            .padding([3, 10])
+            .on_press(if enabled {
+              Message::ManipulateTogglePlay(cell_idx)
+            } else {
+              Message::Noop
+            });
+        let value_widget = text(format_manipulate_number(*current))
+          .size(11)
+          .font(Font::MONOSPACE)
+          .width(iced::Length::Fixed(64.0));
+        let control_row = row![label_widget, play_btn, value_widget]
+          .align_y(Center)
+          .spacing(8);
+        controls_col = controls_col.push(control_row);
+      }
+      manipulate::ControlState::Button {
+        label, label_runs, ..
+      } => {
+        // A pressable action row (`Button["reset", …]`).
+        let spans: Vec<iced::widget::text::Span<Message>> = label_runs
+          .iter()
+          .map(|run| {
+            let mut font = Font::MONOSPACE;
+            if run.italic {
+              font.style = iced::font::Style::Italic;
+            }
+            iced::widget::span(run.text.clone()).font(font)
+          })
+          .collect();
+        let btn_label: Element<Message> = if spans.is_empty() {
+          text(label.clone()).size(11).font(Font::MONOSPACE).into()
+        } else {
+          rich_text(spans).size(11).into()
+        };
+        let btn = button(btn_label).padding([3, 10]).on_press(if enabled {
+          Message::ManipulateButtonPressed(cell_idx, ctrl_idx)
+        } else {
+          Message::Noop
+        });
+        controls_col = controls_col.push(row![btn].align_y(Center));
+      }
       manipulate::ControlState::Heading { label, label_runs } => {
         // A static heading row (a string or `Style[…]` Manipulate argument,
         // e.g. "signal 1"). Rendered bold across the full row.
@@ -4013,8 +4091,9 @@ fn render_manipulate_widget<'a>(
   // An animated widget (Animate / ListAnimate / Animator) gets a play/pause
   // toggle that starts in the playing state (Wolfram's default
   // AnimationRunning -> True). It stays visible under Appearance -> None so
-  // the animation can still be paused.
-  if state.animated {
+  // the animation can still be paused. A Trigger control renders its own
+  // toggle in its row, so the widget-level one would be redundant.
+  if state.animated && !(show_controls && state.has_trigger()) {
     let symbol = if state.playing { "❚❚" } else { "▶" };
     let play_btn = button(text(symbol).size(11))
       .padding([3, 10])
@@ -6459,6 +6538,87 @@ mod tests {
     }
     state.reevaluate();
     assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+  }
+
+  #[test]
+  fn gray_scott_manipulate_steps_and_resets() {
+    // End-to-end regression for the "Gray-Scott Reaction-Diffusion"
+    // Demonstration: Row-grouped SetterBars, a reset Button, a Trigger
+    // sweeping `time`, a Dynamic body that mutates the simulation state,
+    // and a run-ONCE Initialization (re-running it per frame would freeze
+    // the simulation on its first step).
+    let code = "Manipulate[\n\
+      (Dynamic[U[[ss]]=U[[ss]]+0.125;\n\
+      ArrayPlot[U[[ss]],PlotLabel->Row[{\"time steps \",time}],\
+      ColorFunction->ColorData[\"TemperatureMap\"],ImageSize->100],\
+      time,TrackedSymbols:>{time,ss}]),\n\
+      Row[{Control[{{ss,1,\"field size\"},{1->\"4\",2->\"6\"},SetterBar,\
+      Enabled->(time===0)}],Spacer[20]}],\n\
+      Row[{Button[Style[\"reset\",11],Refresh[time,None];time=0;U=Uinit;,\
+      ImageSize->Medium],Spacer[20],\
+      Control[{{time,0,\"run/stop simulation\"},0,Infinity,1,\
+      ControlType->Trigger,AnimationRunning->False}]}],\n\
+      Initialization:>(\
+      Uinit={Partition[Range[16],4]/16.,Partition[Range[36],6]/36.};\
+      U=Uinit;)]";
+    let mut state = instantiate_stored_manipulate(code)
+      .expect("Gray-Scott Manipulate must build a widget");
+    let kinds: Vec<&str> = state
+      .controls
+      .iter()
+      .map(|c| match c {
+        manipulate::ControlState::Discrete { .. } => "discrete",
+        manipulate::ControlState::Button { .. } => "button",
+        manipulate::ControlState::Trigger { .. } => "trigger",
+        _ => "other",
+      })
+      .collect();
+    assert_eq!(kinds, vec!["discrete", "button", "trigger"]);
+    assert!(state.has_trigger());
+    assert!(state.animated, "a Trigger control animates the widget");
+    assert!(!state.playing, "AnimationRunning -> False starts paused");
+    assert!(state.error.is_none(), "body error: {:?}", state.error);
+    assert!(state.graphics_handle.is_some(), "must render the ArrayPlot");
+    // Initialization ran once; the initial render stepped the field once:
+    // 1/16 + 0.125 = 0.1875.
+    assert_eq!(woxi::interpret("U[[1, 1, 1]]").unwrap(), "0.1875");
+    // With time = 0 the SetterBar is enabled.
+    assert!(state.control_is_enabled[0]);
+
+    // One animation tick: the trigger advances to 1 and the body steps
+    // the simulation again (NOT back to the first step — Initialization
+    // must not re-run).
+    state.advance_animation();
+    match &state.controls[2] {
+      manipulate::ControlState::Trigger { current, .. } => {
+        assert_eq!(*current, 1.0);
+      }
+      other => panic!("expected trigger, got {other:?}"),
+    }
+    assert_eq!(woxi::interpret("U[[1, 1, 1]]").unwrap(), "0.3125");
+    // Once running (time != 0), the Enabled condition greys the SetterBar.
+    assert!(!state.control_is_enabled[0]);
+
+    // Pressing the reset button rewinds the trigger and restores the
+    // fields; the re-render steps once from the restored state.
+    let action = match &state.controls[1] {
+      manipulate::ControlState::Button { action, .. } => action.clone(),
+      other => panic!("expected button, got {other:?}"),
+    };
+    state.apply_button_action(&action);
+    match &state.controls[2] {
+      manipulate::ControlState::Trigger { current, .. } => {
+        assert_eq!(*current, 0.0, "reset must rewind the trigger");
+      }
+      other => panic!("expected trigger, got {other:?}"),
+    }
+    assert_eq!(woxi::interpret("U[[1, 1, 1]]").unwrap(), "0.1875");
+    assert!(
+      state.control_is_enabled[0],
+      "reset re-enables the SetterBar"
+    );
+    assert!(state.error.is_none());
     assert!(state.graphics_handle.is_some());
   }
 

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -84,6 +84,27 @@ pub enum ControlState {
     points: Vec<(f64, f64)>,
     auto_create: bool,
   },
+  /// A `ControlType -> Trigger` control: a play/pause pair sweeping its
+  /// variable from `min` towards `max` in `step` increments while the
+  /// widget is playing. `max` may be infinite (`{time, 0, Infinity, 1}`),
+  /// in which case the sweep never wraps.
+  Trigger {
+    name: String,
+    label: String,
+    label_runs: Vec<LabelRun>,
+    min: f64,
+    max: f64,
+    step: f64,
+    current: f64,
+  },
+  /// A `Button[label, action]` row. Pressing it runs `action` (InputForm)
+  /// against the live bindings — e.g. `time = 0; {U, V} = {Uinit, Vinit}`
+  /// resets a simulation. Binds no variable.
+  Button {
+    label: String,
+    label_runs: Vec<LabelRun>,
+    action: String,
+  },
   /// A static heading row between controls (a string or `Style[…]`
   /// Manipulate argument). Binds no variable.
   Heading {
@@ -101,21 +122,30 @@ impl ControlState {
       ControlState::Discrete { name, .. } => name,
       ControlState::Slider2D { name, .. } => name,
       ControlState::IntervalSlider { name, .. } => name,
+      ControlState::Trigger { name, .. } => name,
       ControlState::Locator { name, .. } => name,
-      ControlState::Heading { .. } | ControlState::Divider => "",
+      ControlState::Button { .. }
+      | ControlState::Heading { .. }
+      | ControlState::Divider => "",
     }
   }
 
-  /// Whether this row binds a variable (annotation rows don't).
+  /// Whether this row binds a variable (annotation/button rows don't).
   pub fn binds_variable(&self) -> bool {
-    !matches!(self, ControlState::Heading { .. } | ControlState::Divider)
+    !matches!(
+      self,
+      ControlState::Button { .. }
+        | ControlState::Heading { .. }
+        | ControlState::Divider
+    )
   }
 
   /// InputForm fragment for the *current* value, for use inside a
   /// `Block[{name = <value>}, …]` binding.
   pub fn current_code(&self) -> String {
     match self {
-      ControlState::Continuous { current, .. } => format_f64(*current),
+      ControlState::Continuous { current, .. }
+      | ControlState::Trigger { current, .. } => format_f64(*current),
       ControlState::Discrete {
         values,
         current_index,
@@ -135,10 +165,76 @@ impl ControlState {
       ControlState::Locator { points, .. } => {
         woxi::functions::graphics::format_point_list_input(points)
       }
-      // Annotation rows bind no variable; never substituted.
-      ControlState::Heading { .. } | ControlState::Divider => {
-        "Null".to_string()
+      // Annotation and button rows bind no variable; never substituted.
+      ControlState::Button { .. }
+      | ControlState::Heading { .. }
+      | ControlState::Divider => "Null".to_string(),
+    }
+  }
+
+  /// Update this control's current value from an InputForm fragment — the
+  /// read-back of a button action's write to the bound variable (e.g.
+  /// `time = 0` rewinds the trigger it drives).
+  fn set_current_from_code(&mut self, code: &str) {
+    use woxi::syntax::Expr;
+    fn as_f64(e: &Expr) -> Option<f64> {
+      match e {
+        Expr::Integer(n) => Some(*n as f64),
+        Expr::Real(r) => Some(*r),
+        _ => None,
       }
+    }
+    fn as_pair(e: &Expr) -> Option<(f64, f64)> {
+      match e {
+        Expr::List(items) if items.len() == 2 => {
+          Some((as_f64(&items[0])?, as_f64(&items[1])?))
+        }
+        _ => None,
+      }
+    }
+    let Ok(expr) = woxi::interpret_to_expr(code) else {
+      return;
+    };
+    match self {
+      ControlState::Continuous { current, .. }
+      | ControlState::Trigger { current, .. } => {
+        if let Some(v) = as_f64(&expr) {
+          *current = v;
+        }
+      }
+      ControlState::Discrete {
+        values,
+        current_index,
+        ..
+      } => {
+        let form = woxi::syntax::expr_to_input_form(&expr);
+        if let Some(i) = values.iter().position(|v| *v == form) {
+          *current_index = i;
+        }
+      }
+      ControlState::Slider2D { x, y, .. } => {
+        if let Some((a, b)) = as_pair(&expr) {
+          *x = a;
+          *y = b;
+        }
+      }
+      ControlState::IntervalSlider { low, high, .. } => {
+        if let Some((a, b)) = as_pair(&expr) {
+          *low = a;
+          *high = b;
+        }
+      }
+      ControlState::Locator { points, .. } => {
+        if let Expr::List(items) = &expr
+          && let Some(new_points) =
+            items.iter().map(as_pair).collect::<Option<Vec<_>>>()
+        {
+          *points = new_points;
+        }
+      }
+      ControlState::Button { .. }
+      | ControlState::Heading { .. }
+      | ControlState::Divider => {}
     }
   }
 }
@@ -148,9 +244,11 @@ impl ControlState {
 #[derive(Debug, Clone)]
 pub struct ManipulateState {
   pub body: String,
-  /// Initialization code from `Initialization :> …`. Prepended to every
-  /// re-evaluation so that helper definitions introduced here remain in
-  /// scope regardless of the slider state.
+  /// Initialization code from `Initialization :> …`. Run once (in
+  /// [`from_expr`]) before the first render; its definitions persist in
+  /// the interpreter's global environment across re-evaluations.
+  ///
+  /// [`from_expr`]: Self::from_expr
   pub initialization: Option<String>,
   pub controls: Vec<ControlState>,
   /// Mutable `ControlType -> None` state variables, `(name, current value as
@@ -245,8 +343,48 @@ impl ManipulateState {
       reeval_applied: 0,
       reeval_scheduled: false,
     };
+    // Run the `Initialization :> …` code ONCE, before the first render.
+    // Re-running it on every re-evaluation would reset any state the body
+    // mutates (e.g. the U/V concentration fields of a simulation stepping
+    // itself forward), freezing the simulation at its first step. Helper
+    // definitions persist in the interpreter's global environment, so a
+    // single run keeps them in scope for every later re-evaluation.
+    if let Some(init) = state.initialization.as_deref() {
+      let _ = woxi::interpret_with_stdout(init);
+    }
     state.reevaluate();
     Some(state)
+  }
+
+  /// Whether any control row is a `Trigger` (which carries its own
+  /// play/pause toggle, replacing the widget-level one).
+  pub fn has_trigger(&self) -> bool {
+    self
+      .controls
+      .iter()
+      .any(|c| matches!(c, ControlState::Trigger { .. }))
+  }
+
+  /// Run a `Button[…]` control's action: global side effects persist, and
+  /// writes to bound control variables (e.g. `time = 0`) move the
+  /// corresponding widgets. Re-renders afterwards.
+  pub fn apply_button_action(&mut self, action: &str) {
+    let updated = woxi::functions::graphics::apply_manipulate_button_action(
+      &self.bindings(),
+      action,
+    );
+    for (name, value) in updated {
+      if let Some(slot) = self.state.iter_mut().find(|(n, _)| *n == name) {
+        slot.1 = value;
+        continue;
+      }
+      for ctrl in &mut self.controls {
+        if ctrl.name() == name {
+          ctrl.set_current_from_code(&value);
+        }
+      }
+    }
+    self.reevaluate();
   }
 
   /// The full binding set (visible controls + mutable state) used to
@@ -307,44 +445,62 @@ impl ManipulateState {
     }
   }
 
-  /// Advance the animated (first continuous) control by one step, wrapping
-  /// back to the start once it passes the end, then re-render. Called from
-  /// the app's animation-tick subscription while `playing` is set.
+  /// Advance the animated control by one step, wrapping back to the start
+  /// once it passes the end, then re-render. A `Trigger` control is the
+  /// sweep target when present (and never wraps past an infinite end);
+  /// otherwise the first continuous control animates. Called from the
+  /// app's animation-tick subscription while `playing` is set.
   pub fn advance_animation(&mut self) {
-    let Some(ControlState::Continuous {
-      min,
-      max,
-      step,
-      current,
-      ..
-    }) = self
-      .controls
-      .iter_mut()
-      .find(|c| matches!(c, ControlState::Continuous { .. }))
-    else {
-      return;
-    };
-    let mut v = *current + *step;
-    // Loop back to the start once we step past the end (small epsilon so
-    // floating-point drift doesn't skip the final frame).
-    if v > *max + *step * 1e-6 {
-      v = *min;
+    let want_trigger = self.has_trigger();
+    let ctrl = self.controls.iter_mut().find(|c| {
+      if want_trigger {
+        matches!(c, ControlState::Trigger { .. })
+      } else {
+        matches!(c, ControlState::Continuous { .. })
+      }
+    });
+    match ctrl {
+      Some(ControlState::Trigger {
+        min,
+        max,
+        step,
+        current,
+        ..
+      })
+      | Some(ControlState::Continuous {
+        min,
+        max,
+        step,
+        current,
+        ..
+      }) => {
+        let mut v = *current + *step;
+        // Loop back to the start once we step past the end (small epsilon
+        // so floating-point drift doesn't skip the final frame). An
+        // infinite end (`{time, 0, Infinity, 1}`) never wraps.
+        if max.is_finite() && v > *max + *step * 1e-6 {
+          v = *min;
+        }
+        *current = v;
+      }
+      _ => return,
     }
-    *current = v;
     self.reevaluate();
   }
 
   /// Re-run the body with the current control bindings and update the
   /// cached SVG / text output. Called on every slider change.
+  ///
+  /// The `Initialization :> …` code deliberately does NOT re-run here: it
+  /// ran once in [`from_expr`], and its helper definitions persist in the
+  /// interpreter's global environment. Re-running it per frame would reset
+  /// any state the body itself mutates (a simulation stepping its fields
+  /// forward would stay frozen on its first step).
+  ///
+  /// [`from_expr`]: Self::from_expr
   pub fn reevaluate(&mut self) {
     let bindings = self.bindings();
-    // Prepend `Initialization :> …` code so helper definitions made there
-    // (e.g. `d[t_] := …`) are in scope while the body evaluates. The init
-    // is a CompoundExpression — join with `;` so both run in one call.
-    let code = match self.initialization.as_deref() {
-      Some(init) => format!("{init}; {}", self.body),
-      None => self.body.clone(),
-    };
+    let code = self.body.clone();
 
     // Install the bindings as globals once so a large `data` matrix is parsed
     // a single time, then evaluate the body, rebuild the display elements, and
@@ -541,6 +697,33 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         y_max: *y_max,
         points: points.clone(),
         auto_create: *auto_create,
+      },
+      ManipulateControl::Trigger {
+        name,
+        min,
+        max,
+        step,
+        initial,
+        label,
+        label_runs,
+        ..
+      } => ControlState::Trigger {
+        name: name.clone(),
+        label: label.clone(),
+        label_runs: label_runs.clone(),
+        min: *min,
+        max: *max,
+        step: *step,
+        current: *initial,
+      },
+      ManipulateControl::Button {
+        label,
+        label_runs,
+        action,
+      } => ControlState::Button {
+        label: label.clone(),
+        label_runs: label_runs.clone(),
+        action: action.clone(),
       },
       ManipulateControl::Heading { label, label_runs } => {
         ControlState::Heading {


### PR DESCRIPTION
## Summary

This PR adds support for Wolfram Demonstrations-style interactive controls and layout patterns to Manipulate widgets, along with ColorData gradient support for color functions.

## Key Changes

### Manipulate Control Enhancements
- **Trigger control**: A play/pause button pair that sweeps a variable from min to max in step increments. Supports infinite endpoints and `AnimationRunning` option to start playing immediately.
- **Button control**: Pressable action rows that execute code against live bindings (e.g., reset buttons). Pressing updates bound control variables and re-renders.
- **Row/Column/Grid layout grouping**: Controls can now be grouped in `Row[{Control[…], Spacer[…], Button[…]}]` arguments (Demonstrations pattern), which flatten into individual control rows.
- **Control wrapper unwrapping**: `Control[spec, opts…]` wraps ordinary variable specs and is now properly unwrapped during parsing.
- **Dynamic body unwrapping**: Manipulate bodies wrapped in `Dynamic[…]` now correctly evaluate their first argument.
- **Bare control-type markers**: Specs like `{u, {1, 2, 3}, SetterBar}` with bare control-type identifiers now parse correctly.

### UI Rendering (woxi-studio)
- Trigger controls render with their own play/pause toggle and live value readout in the control row.
- Button controls render as pressable buttons with styled labels.
- Widget-level play/pause toggle is hidden when a Trigger control is present (to avoid redundancy).
- Button actions run against live bindings; writes to control variables update the corresponding widgets.

### ColorData Gradient Support
- `ColorData["scheme"]` now returns a color function in the structured `ColorDataFunction` form.
- `Blend[scheme, t]` interpolates named gradient control points at parameter t ∈ [0,1].
- `ColorFunction` options in plotting functions accept named schemes, `ColorData[…]` calls, or the structured form.
- Gradient control points are stored for standard schemes (TemperatureMap, Rainbow, etc.).

### Text Cell Rendering
- Inline formula cells (`Cell[BoxData[…], "InlineMath"]` or `"InlineFormula"`) now render as display text within prose, preserving mathematical notation.
- Box expressions render with readable notation: `SubscriptBox` → `_`, `SuperscriptBox` → Unicode superscripts, `FractionBox` → `/`, `GridBox` → multi-line.
- `\[Cross]` in prose displays as multiplication sign (×) instead of glyphless private-use codepoint.

### Initialization Semantics
- `Initialization :> …` code now runs once before the first render, with definitions persisting in the global environment across re-evaluations (not re-run per frame).

### Additional Improvements
- `Refresh[expr, opts…]` evaluates and returns its first argument (FrontEnd wrapper).
- `\[Del]` named character maps to ∇ (nabla).
- Held subtraction with parenthesized additive operands preserves parens: `Hold[a - (b + c)]`.

## Implementation Details

- Control grouping detection recursively flattens nested `Row`/`Column`/`Grid` containers while preserving `Spacer` layout hints.
- Button actions are evaluated in a special context that captures writes to bound variables for widget synchronization.
- Trigger animation uses the same play/pause mechanism as Animator but with infinite-endpoint support.
- Gradient interpolation uses linear blending of stored control points, matching wolframscript behavior.
- Box rendering for inline formulas prioritizes display readability over evaluable InputForm.

https://claude.ai/code/session_019UVkurUWVX8MZGQkZsLiyn