### PR TITLE
Add Locator, Dynamic, Tooltip support and stored output rendering

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -140,7 +140,7 @@ Mod,Returns the remainder on division (m - n Floor[m/n]; Gaussian integers use m
 Arg,Returns the argument (phase angle) of a complex number,✅,pure,1.0,135
 Or,Checks if at least one condition is true,✅,pure,1.0,136
 BaseStyle,Option specifying the base style for elements in a graphic or other output,✅,none,6.0,137
-Dynamic,Dynamic display wrapper (stays symbolic in script mode),✅,unevaluated,6.0,138
+Dynamic,Dynamic display wrapper; rendered output shows its current value,✅,unevaluated,6.0,138
 Not,Logical negation of an expression — written with the ! operator and bracketed inside anything that binds tighter than it,✅,pure,1.0,139
 Last,Returns the last element of a list or the given default which is only evaluated when used,✅,pure,1.0,140
 AdministrativeDivisionData,,🚫,,10.0,141
@@ -557,7 +557,7 @@ Ordering,Returns the positions that would sort a list optionally by an ordering 
 ElementData,Returns properties of chemical elements,✅,pure,6.0,546
 Dividers,Option for dividing lines in Grid,✅,none,6.0,547
 SetPrecision,Sets the precision of a number to a specified number of digits,✅,pure,2.0,548
-Locator,Interactive locator object,✅,none,6.0,549
+Locator,Draggable locator; renders as a marker at its point (custom appearance graphics keep their ImageSize),✅,none,6.0,549
 AddTo,Adds a value to a variable; a literal target parses and reports ::rvalue,✅,stateful,1.0,550
 EllipticTheta,Jacobi theta function,✅,pure,1.0,551
 MatrixPlot,Plots a matrix as a colored grid,✅,pure,6.0,552
@@ -1693,7 +1693,7 @@ SoftmaxLayer,Softmax neural layer,,unevaluated,11.0,1712
 ProductDistribution,Independent product of distributions (merged PDF plus component stats),✅,pure,8.0,1713
 Save,Saves definitions associated with symbols to a file,✅,effectful,1.0,1714
 RegionDimension,Intrinsic (manifold) dimension of a region,✅,pure,10.0,1716
-TogglerBar,Toggler bar control (stays symbolic in script mode),✅,unevaluated,6.0,1716
+TogglerBar,Toggle-button bar bound to a list variable; interactive in visual front-ends,✅,unevaluated,6.0,1716
 GeoElevationData,,🚫,,10.0,1717
 WeierstrassPPrime,Derivative of the Weierstrass elliptic function,✅,pure,1.0,1718
 FeatureExtractor,Feature extractor,,unevaluated,11.0,1719

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -2207,6 +2207,33 @@ pub fn apply_replace_all_ast(
     rules
   };
 
+  // A rendered graphic is opaque to pattern replacement except for its
+  // remembered symbolic `structure`: Wolfram's `plot /. Tooltip[x_, ___] :> x`
+  // rewrites the graphic's content in place. The rendering (SVG) is kept;
+  // only the structure is transformed so later structural access (`[[1]]`)
+  // sees the replaced form. Without this, the graphic would be serialized to
+  // its `-Graphics-` placeholder and fail to re-parse.
+  if let Expr::Graphics {
+    svg,
+    is_3d,
+    source,
+    head,
+    structure,
+  } = expr
+  {
+    let new_structure = match structure {
+      Some(s) => Some(Box::new(apply_replace_all_ast(s, rules)?)),
+      None => None,
+    };
+    return Ok(Expr::Graphics {
+      svg: svg.clone(),
+      is_3d: *is_3d,
+      source: source.clone(),
+      head: head.clone(),
+      structure: new_structure,
+    });
+  }
+
   // Try AST-based structural pattern matching first for single rules
   match rules {
     Expr::Rule {

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -629,9 +629,20 @@ fn marching_squares_segments(
 fn chain_segments(
   segments: &[((f64, f64), (f64, f64))],
 ) -> Vec<Vec<(f64, f64)>> {
+  chain_segments_scaled(segments, 16.0)
+}
+
+/// Like `chain_segments`, but with an explicit endpoint-matching resolution:
+/// two endpoints snap together when equal at `1 / key_scale` granularity.
+/// Screen-pixel callers use 16.0; data-coordinate callers must scale by the
+/// plot range so the tolerance stays proportionally as fine.
+fn chain_segments_scaled(
+  segments: &[((f64, f64), (f64, f64))],
+  key_scale: f64,
+) -> Vec<Vec<(f64, f64)>> {
   use std::collections::HashMap;
   let key = |p: (f64, f64)| -> (i64, i64) {
-    ((p.0 * 16.0).round() as i64, (p.1 * 16.0).round() as i64)
+    ((p.0 * key_scale).round() as i64, (p.1 * key_scale).round() as i64)
   };
   // Zero-length segments occur when the contour passes exactly through a
   // grid node; neighboring cells provide the connecting geometry, so they
@@ -781,7 +792,35 @@ pub fn density_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// ContourPlot[f, {x, xmin, xmax}, {y, ymin, ymax}]
 /// Uses marching squares to draw contour lines.
 pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let body = &args[0];
+  // `ContourPlot[lhs == rhs, …]` draws the single implicit curve
+  // `lhs - rhs = 0` (no band shading), matching Wolfram's equation form.
+  let equation_body;
+  let (body, is_equation) = match &args[0] {
+    Expr::Comparison {
+      operands,
+      operators,
+    } if operators.len() == 1
+      && operators[0] == crate::syntax::ComparisonOp::Equal =>
+    {
+      equation_body = Expr::BinaryOp {
+        op: crate::syntax::BinaryOperator::Minus,
+        left: Box::new(operands[0].clone()),
+        right: Box::new(operands[1].clone()),
+      };
+      (&equation_body, true)
+    }
+    Expr::FunctionCall { name, args: eargs }
+      if name == "Equal" && eargs.len() == 2 =>
+    {
+      equation_body = Expr::BinaryOp {
+        op: crate::syntax::BinaryOperator::Minus,
+        left: Box::new(eargs[0].clone()),
+        right: Box::new(eargs[1].clone()),
+      };
+      (&equation_body, true)
+    }
+    other => (other, false),
+  };
   let (xvar, x_min, x_max) = parse_iterator(&args[1], "ContourPlot")?;
   let (yvar, y_min, y_max) = parse_iterator(&args[2], "ContourPlot")?;
   let opts = parse_density_contour_options(args, 3);
@@ -813,7 +852,48 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  let levels = resolve_contour_levels(&opts.contours, v_min, v_max);
+  let levels = if is_equation {
+    vec![0.0]
+  } else {
+    resolve_contour_levels(&opts.contours, v_min, v_max)
+  };
+
+  // Data-space contour polylines for the symbolic `structure`, so
+  // `ContourPlot[…][[1]]` yields primitives (with the ContourStyle
+  // directives) that can be re-embedded in an outer `Graphics[…]` the way
+  // Wolfram's GraphicsComplex form allows.
+  let mut structure_items: Vec<Expr> = contour_style_directives(args, 3);
+  {
+    let step_x = (x_max - x_min) / FIELD_GRID as f64;
+    let step_y = (y_max - y_min) / FIELD_GRID as f64;
+    // Endpoint snapping must stay proportional to the range (the pixel
+    // callers use 16.0 on a ~400px canvas).
+    let span = (x_max - x_min).abs().max((y_max - y_min).abs());
+    let key_scale = if span > 0.0 { 4096.0 / span } else { 16.0 };
+    for &level in &levels {
+      // `plot_y0 = y_max` with a negated cell height turns the screen-space
+      // (top-down) y mapping into the plain data-space one.
+      let segments = marching_squares_segments(
+        &grid, level, x_min, y_max, step_x, -step_y,
+      );
+      for chain in chain_segments_scaled(&segments, key_scale) {
+        let points: Vec<Expr> = chain
+          .iter()
+          .map(|(x, y)| {
+            Expr::List(vec![Expr::Real(*x), Expr::Real(*y)].into())
+          })
+          .collect();
+        structure_items.push(Expr::FunctionCall {
+          name: "Line".to_string(),
+          args: vec![Expr::List(points.into())].into(),
+        });
+      }
+    }
+  }
+  let structure = Expr::FunctionCall {
+    name: "Graphics".to_string(),
+    args: vec![Expr::List(structure_items.into())].into(),
+  };
 
   // Use plotters for axes
   let area = generate_axes_only(
@@ -832,7 +912,7 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let cell_w = area.plot_w / FIELD_GRID as f64;
   let cell_h = area.plot_h / FIELD_GRID as f64;
 
-  if opts.contour_shading {
+  if opts.contour_shading && !is_equation {
     render_contour_bands(
       &mut svg,
       &grid,
@@ -865,7 +945,31 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   );
 
   svg.push_str("</svg>");
-  Ok(crate::graphics_result(svg))
+  Ok(crate::graphics_result_with_structure(svg, structure))
+}
+
+/// The `ContourStyle -> …` option items of a ContourPlot call (a single
+/// directive or a directive list), for embedding into the plot's symbolic
+/// `structure`. Empty when the option is absent.
+fn contour_style_directives(args: &[Expr], opts_from: usize) -> Vec<Expr> {
+  for arg in args.iter().skip(opts_from) {
+    if let Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    } = arg
+      && matches!(pattern.as_ref(), Expr::Identifier(s) if s == "ContourStyle")
+    {
+      return match replacement.as_ref() {
+        Expr::List(items) => items.iter().cloned().collect(),
+        other => vec![other.clone()],
+      };
+    }
+  }
+  Vec::new()
 }
 
 /// RegionPlot[cond, {x, xmin, xmax}, {y, ymin, ymax}]

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -642,7 +642,10 @@ fn chain_segments_scaled(
 ) -> Vec<Vec<(f64, f64)>> {
   use std::collections::HashMap;
   let key = |p: (f64, f64)| -> (i64, i64) {
-    ((p.0 * key_scale).round() as i64, (p.1 * key_scale).round() as i64)
+    (
+      (p.0 * key_scale).round() as i64,
+      (p.1 * key_scale).round() as i64,
+    )
   };
   // Zero-length segments occur when the contour passes exactly through a
   // grid node; neighboring cells provide the connecting geometry, so they
@@ -873,15 +876,12 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     for &level in &levels {
       // `plot_y0 = y_max` with a negated cell height turns the screen-space
       // (top-down) y mapping into the plain data-space one.
-      let segments = marching_squares_segments(
-        &grid, level, x_min, y_max, step_x, -step_y,
-      );
+      let segments =
+        marching_squares_segments(&grid, level, x_min, y_max, step_x, -step_y);
       for chain in chain_segments_scaled(&segments, key_scale) {
         let points: Vec<Expr> = chain
           .iter()
-          .map(|(x, y)| {
-            Expr::List(vec![Expr::Real(*x), Expr::Real(*y)].into())
-          })
+          .map(|(x, y)| Expr::List(vec![Expr::Real(*x), Expr::Real(*y)].into()))
           .collect();
         structure_items.push(Expr::FunctionCall {
           name: "Line".to_string(),

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -553,6 +553,16 @@ enum Primitive {
     full: bool,
     style: StyleState,
   },
+  /// A fixed-pixel-size marker (e.g. a `Locator`'s appearance graphic)
+  /// centered on a data-space point. The pre-rendered SVG is embedded at
+  /// `w`×`h` screen pixels regardless of the plot's coordinate scale.
+  MarkerPrim {
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    svg: String,
+  },
 }
 
 impl Primitive {
@@ -572,7 +582,7 @@ impl Primitive {
       | Primitive::TextPrim { style, .. }
       | Primitive::BezierCurvePrim { style, .. }
       | Primitive::HalfPlanePrim { style, .. } => Some(style),
-      Primitive::RasterPrim { .. } => None,
+      Primitive::RasterPrim { .. } | Primitive::MarkerPrim { .. } => None,
     }
   }
 }
@@ -1455,6 +1465,35 @@ fn collect_primitives(
           }
         }
 
+        // `Dynamic[expr]` displays as the current value of `expr`: release
+        // the hold and render the result. Evaluation also runs any
+        // assignments the Dynamic performs (the Demonstrations pattern
+        // computes shared values inside a graphic's Dynamic), which later
+        // display items read. Any graphics the evaluation captures are
+        // embedded here, not standalone outputs — drop them from the
+        // capture buffer.
+        "Dynamic" if !args.is_empty() => {
+          let captured = crate::captured_graphics_count();
+          if let Ok(inner) = crate::evaluator::evaluate_expr_to_expr(&args[0])
+          {
+            crate::truncate_captured_graphics(captured);
+            collect_primitives(&inner, style, prims, errors);
+          } else {
+            crate::truncate_captured_graphics(captured);
+          }
+        }
+        // `Tooltip[g, label]` draws `g`; the hover label has no static SVG
+        // form. Only the first argument is rendered — the label must not
+        // leak into the graphic.
+        "Tooltip" if !args.is_empty() => {
+          collect_primitives(&args[0], style, prims, errors);
+        }
+        // `Locator[pt]` / `Locator[Dynamic[pt, …], appearance]`: a marker
+        // drawn at the point's current position. A custom appearance
+        // graphic keeps its own ImageSize in screen pixels.
+        "Locator" if !args.is_empty() => {
+          parse_locator(args, prims);
+        }
         _ => {
           // Try as directive first
           if !apply_directive(expr, style) {
@@ -2329,6 +2368,108 @@ fn parse_raster(args: &[Expr], prims: &mut Vec<Primitive>) {
   });
 }
 
+/// `Locator[pt]` / `Locator[Dynamic[pt, …], appearance]`: a marker drawn at
+/// the point's current position. The position may be held inside `Dynamic`
+/// (whose second argument, the write-back callback, only matters to
+/// interactive front-ends). A custom appearance graphic is embedded at its
+/// own ImageSize in screen pixels, centered on the position — Wolfram
+/// treats the appearance as a screen-space icon, not data-space geometry.
+fn parse_locator(args: &[Expr], prims: &mut Vec<Primitive>) {
+  let pos_expr = match &args[0] {
+    Expr::FunctionCall { name, args: dargs }
+      if name == "Dynamic" && !dargs.is_empty() =>
+    {
+      &dargs[0]
+    }
+    other => other,
+  };
+  let captured = crate::captured_graphics_count();
+  let evaluated = crate::evaluator::evaluate_expr_to_expr(pos_expr)
+    .unwrap_or_else(|_| pos_expr.clone());
+  let points: Vec<(f64, f64)> = if let Some(p) = expr_to_point(&evaluated) {
+    vec![p]
+  } else {
+    expr_to_point_list(&evaluated).unwrap_or_default()
+  };
+  if points.is_empty() {
+    crate::truncate_captured_graphics(captured);
+    return;
+  }
+
+  // The appearance graphic, pre-rendered at its own ImageSize. `Automatic`
+  // (or no appearance) uses the default crosshair marker; `None` hides the
+  // marker entirely.
+  let appearance = args.get(1).filter(|a| {
+    !matches!(a, Expr::Identifier(s) if s == "Automatic")
+  });
+  if appearance
+    .is_some_and(|a| matches!(a, Expr::Identifier(s) if s == "None"))
+  {
+    crate::truncate_captured_graphics(captured);
+    return;
+  }
+  let marker: Option<(String, f64, f64)> = appearance.and_then(|a| {
+    // Render the appearance to a graphic. A held `Graphics[…]` call is
+    // rendered directly (Graphics evaluates lazily at display time);
+    // anything else is evaluated first.
+    let rendered = match a {
+      Expr::Graphics { .. } => Some(a.clone()),
+      Expr::FunctionCall { name, args: gargs } if name == "Graphics" => {
+        graphics_ast(gargs).ok()
+      }
+      other => match crate::evaluator::evaluate_expr_to_expr(other) {
+        Ok(ev) => match &ev {
+          Expr::Graphics { .. } => Some(ev.clone()),
+          Expr::FunctionCall { name, args: gargs }
+            if name == "Graphics" =>
+          {
+            graphics_ast(&gargs.iter().cloned().collect::<Vec<_>>()).ok()
+          }
+          _ => None,
+        },
+        Err(_) => None,
+      },
+    };
+    if let Some(Expr::Graphics { svg, .. }) = &rendered {
+      let (w, h) = parse_svg_wh(svg);
+      if w > 0.0 && h > 0.0 {
+        return Some((svg.clone(), w, h));
+      }
+    }
+    None
+  });
+  // Sub-evaluations may have rendered graphics (the appearance itself, or
+  // anything a Dynamic position computed); those are embedded here, not
+  // standalone outputs.
+  crate::truncate_captured_graphics(captured);
+
+  for (x, y) in points {
+    let (svg, w, h) = match &marker {
+      Some((svg, w, h)) => (svg.clone(), *w, *h),
+      None => {
+        let (svg, size) = default_locator_marker_svg();
+        (svg, size, size)
+      }
+    };
+    prims.push(Primitive::MarkerPrim { x, y, w, h, svg });
+  }
+}
+
+/// Wolfram's default Locator appearance: a small circled crosshair.
+fn default_locator_marker_svg() -> (String, f64) {
+  let size = 16.0;
+  let c = size / 2.0;
+  let svg = format!(
+    "<svg width=\"{size}\" height=\"{size}\" viewBox=\"0 0 {size} {size}\" xmlns=\"http://www.w3.org/2000/svg\">\
+     <circle cx=\"{c}\" cy=\"{c}\" r=\"{r:.1}\" fill=\"rgba(180,180,180,0.35)\" stroke=\"#606060\" stroke-width=\"1\"/>\
+     <line x1=\"{c}\" y1=\"1\" x2=\"{c}\" y2=\"{size}\" stroke=\"#606060\" stroke-width=\"1\"/>\
+     <line x1=\"1\" y1=\"{c}\" x2=\"{size}\" y2=\"{c}\" stroke=\"#606060\" stroke-width=\"1\"/>\
+     </svg>",
+    r = c - 1.0,
+  );
+  (svg, size)
+}
+
 // ── Bounding box computation ─────────────────────────────────────────────
 
 fn primitive_bbox(prim: &Primitive) -> BBox {
@@ -2354,6 +2495,11 @@ fn primitive_bbox(prim: &Primitive) -> BBox {
     | Primitive::Disk { cx, cy, rx, ry, .. } => {
       bb.include_point(cx - rx, cy - ry);
       bb.include_point(cx + rx, cy + ry);
+    }
+    // A marker is a screen-space icon: only its anchor point occupies data
+    // space.
+    Primitive::MarkerPrim { x, y, .. } => {
+      bb.include_point(*x, *y);
     }
     Primitive::DiskSector {
       cx,
@@ -2612,6 +2758,18 @@ fn rotate_primitive(
       full: *full,
       style: style.clone(),
     },
+    // A marker is a screen-space icon anchored on a data point: transforms
+    // move the anchor and leave the icon itself untouched.
+    Primitive::MarkerPrim { x, y, w, h, svg } => {
+      let (x, y) = rp(*x, *y);
+      Primitive::MarkerPrim {
+        x,
+        y,
+        w: *w,
+        h: *h,
+        svg: svg.clone(),
+      }
+    }
   }
 }
 
@@ -2743,6 +2901,13 @@ fn translate_primitive(prim: &Primitive, dx: f64, dy: f64) -> Primitive {
       w: *w,
       full: *full,
       style: style.clone(),
+    },
+    Primitive::MarkerPrim { x, y, w, h, svg } => Primitive::MarkerPrim {
+      x: x + dx,
+      y: y + dy,
+      w: *w,
+      h: *h,
+      svg: svg.clone(),
     },
   }
 }
@@ -2932,6 +3097,16 @@ fn scale_primitive(
       full: *full,
       style: style.clone(),
     },
+    Primitive::MarkerPrim { x, y, w, h, svg } => {
+      let (nx, ny) = sp(*x, *y);
+      Primitive::MarkerPrim {
+        x: nx,
+        y: ny,
+        w: *w,
+        h: *h,
+        svg: svg.clone(),
+      }
+    }
   }
 }
 
@@ -4306,6 +4481,19 @@ fn render_primitive(
         }
       }
     }
+    // A screen-space icon (e.g. a Locator's appearance) centered on its
+    // data-space anchor: embed the pre-rendered SVG at its pixel size.
+    Primitive::MarkerPrim { x, y, w, h, svg } => {
+      let scx = coord_x(*x, bb, svg_w);
+      let scy = coord_y(*y, bb, svg_h);
+      out.push_str(&format!(
+        "<svg x=\"{:.2}\" y=\"{:.2}\" width=\"{w:.2}\" height=\"{h:.2}\" viewBox=\"0 0 {w:.2} {h:.2}\">\n",
+        scx - w / 2.0,
+        scy - h / 2.0,
+      ));
+      out.push_str(strip_svg_wrapper(svg));
+      out.push_str("</svg>\n");
+    }
   }
 }
 
@@ -4496,6 +4684,9 @@ fn primitives_to_box_elements(primitives: &[Primitive]) -> Vec<String> {
       }
       Primitive::HalfPlanePrim { .. } => {
         // Unbounded fills have no fixed-coordinate box form; skip
+      }
+      Primitive::MarkerPrim { .. } => {
+        // Screen-space marker icons have no box form; skip
       }
     }
   }
@@ -11041,6 +11232,34 @@ fn render_tabular_svg_grid(
   Some(svg)
 }
 
+/// Resolve a `Column`/`Row` display item for rendering: release a held
+/// `Dynamic[…]` (a static rendering shows its current value; front-ends
+/// re-evaluate the whole display on interaction) and unwrap a top-level
+/// `Text[…]` wrapper, which displays as its content. Any graphics that the
+/// `Dynamic` evaluation captures are embedded in the surrounding layout, not
+/// standalone outputs, so they are dropped from the capture buffer.
+fn resolve_display_item(expr: &Expr) -> Expr {
+  let mut current = expr.clone();
+  if let Expr::FunctionCall { name, args } = &current
+    && name == "Dynamic"
+    && !args.is_empty()
+  {
+    let captured = crate::captured_graphics_count();
+    let evaluated = crate::evaluator::evaluate_expr_to_expr(&args[0]);
+    crate::truncate_captured_graphics(captured);
+    if let Ok(inner) = evaluated {
+      current = inner;
+    }
+  }
+  if let Expr::FunctionCall { name, args } = &current
+    && name == "Text"
+    && args.len() == 1
+  {
+    current = args[0].clone();
+  }
+  current
+}
+
 /// Render `Column[{expr1, expr2, ...}]` as an SVG with items stacked vertically.
 /// Optionally accepts an alignment argument (Left, Center, Right); defaults to Left.
 pub fn column_to_svg(args: &[Expr]) -> Option<String> {
@@ -11058,15 +11277,26 @@ pub fn column_to_svg(args: &[Expr]) -> Option<String> {
     return None;
   }
 
-  // Parse optional alignment from second arg (default: Left)
-  let alignment = if args.len() >= 2 {
-    match &args[1] {
-      Expr::Identifier(s) if s == "Center" => "middle",
-      Expr::Identifier(s) if s == "Right" => "end",
-      _ => "start", // Left or anything else
+  // Parse optional alignment from the second arg — either positional
+  // (`Column[list, Center]`) or the option form (`Column[list,
+  // Alignment -> Center]`). Default: Left.
+  let alignment_spec = args.get(1).map(|a| match a {
+    Expr::Rule {
+      pattern,
+      replacement,
     }
-  } else {
-    "start"
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    } if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "Alignment") => {
+      replacement.as_ref()
+    }
+    other => other,
+  });
+  let alignment = match alignment_spec {
+    Some(Expr::Identifier(s)) if s == "Center" => "middle",
+    Some(Expr::Identifier(s)) if s == "Right" => "end",
+    _ => "start", // Left or anything else
   };
 
   // Parse optional spacing from third arg in ems (default: 0)
@@ -11100,16 +11330,19 @@ pub fn column_to_svg(args: &[Expr]) -> Option<String> {
 
   let cells: Vec<Cell> = items
     .iter()
-    .map(|item| match item {
-      Expr::Graphics { svg, .. } => {
-        let (w, h) = parse_svg_wh(svg);
-        Cell::Svg {
-          svg: svg.clone(),
-          width: w,
-          height: h,
+    .map(|item| {
+      let resolved = resolve_display_item(item);
+      match &resolved {
+        Expr::Graphics { svg, .. } => {
+          let (w, h) = parse_svg_wh(svg);
+          Cell::Svg {
+            svg: svg.clone(),
+            width: w,
+            height: h,
+          }
         }
+        _ => Cell::Text(resolved),
       }
-      _ => Cell::Text(item.clone()),
     })
     .collect();
 
@@ -11331,16 +11564,19 @@ pub fn row_to_svg(args: &[Expr]) -> Option<String> {
 
   let cells: Vec<Cell> = items
     .iter()
-    .map(|item| match item {
-      Expr::Graphics { svg, .. } => {
-        let (w, h) = parse_svg_wh(svg);
-        Cell::Svg {
-          svg: svg.clone(),
-          width: w,
-          height: h,
+    .map(|item| {
+      let resolved = resolve_display_item(item);
+      match &resolved {
+        Expr::Graphics { svg, .. } => {
+          let (w, h) = parse_svg_wh(svg);
+          Cell::Svg {
+            svg: svg.clone(),
+            width: w,
+            height: h,
+          }
         }
+        _ => make_text_cell(&resolved),
       }
-      _ => make_text_cell(item),
     })
     .collect();
 

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1474,8 +1474,7 @@ fn collect_primitives(
         // capture buffer.
         "Dynamic" if !args.is_empty() => {
           let captured = crate::captured_graphics_count();
-          if let Ok(inner) = crate::evaluator::evaluate_expr_to_expr(&args[0])
-          {
+          if let Ok(inner) = crate::evaluator::evaluate_expr_to_expr(&args[0]) {
             crate::truncate_captured_graphics(captured);
             collect_primitives(&inner, style, prims, errors);
           } else {
@@ -2399,11 +2398,10 @@ fn parse_locator(args: &[Expr], prims: &mut Vec<Primitive>) {
   // The appearance graphic, pre-rendered at its own ImageSize. `Automatic`
   // (or no appearance) uses the default crosshair marker; `None` hides the
   // marker entirely.
-  let appearance = args.get(1).filter(|a| {
-    !matches!(a, Expr::Identifier(s) if s == "Automatic")
-  });
-  if appearance
-    .is_some_and(|a| matches!(a, Expr::Identifier(s) if s == "None"))
+  let appearance = args
+    .get(1)
+    .filter(|a| !matches!(a, Expr::Identifier(s) if s == "Automatic"));
+  if appearance.is_some_and(|a| matches!(a, Expr::Identifier(s) if s == "None"))
   {
     crate::truncate_captured_graphics(captured);
     return;
@@ -2420,9 +2418,7 @@ fn parse_locator(args: &[Expr], prims: &mut Vec<Primitive>) {
       other => match crate::evaluator::evaluate_expr_to_expr(other) {
         Ok(ev) => match &ev {
           Expr::Graphics { .. } => Some(ev.clone()),
-          Expr::FunctionCall { name, args: gargs }
-            if name == "Graphics" =>
-          {
+          Expr::FunctionCall { name, args: gargs } if name == "Graphics" => {
             graphics_ast(&gargs.iter().cloned().collect::<Vec<_>>()).ok()
           }
           _ => None,
@@ -12993,16 +12989,12 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
             .iter()
             .filter(|it| !is_control_type_rule(it))
             .cloned()
-            .chain(std::iter::once(Expr::Identifier(
-              "Locator".to_string(),
-            )))
+            .chain(std::iter::once(Expr::Identifier("Locator".to_string())))
             .collect();
           if let Some(ParsedControl::Visible(mut c, enabled2)) =
             parse_manipulate_control(&Expr::List(promoted.into()))
           {
-            if let ManipulateControl::Slider2D { write_callback, .. } =
-              &mut c
-            {
+            if let ManipulateControl::Slider2D { write_callback, .. } = &mut c {
               *write_callback = callback.clone();
             }
             if let Some(cond) = enabled2 {
@@ -13105,8 +13097,7 @@ fn collect_body_locator_callbacks(
           && let Some(Expr::Identifier(var)) = dargs.first()
           && !found.iter().any(|(n, _)| n == var)
         {
-          let callback =
-            dargs.get(1).map(crate::syntax::expr_to_input_form);
+          let callback = dargs.get(1).map(crate::syntax::expr_to_input_form);
           found.push((var.clone(), callback));
         }
         for a in args {
@@ -13134,10 +13125,7 @@ fn collect_body_locator_callbacks(
 /// Replace every `TogglerBar[Dynamic[var], …]` in a Manipulate body with
 /// `Nothing`, pushing each one's InputForm onto `displays` so the front-end
 /// renders it as a live widget instead of a static picture.
-fn extract_body_togglerbars(
-  expr: &Expr,
-  displays: &mut Vec<String>,
-) -> Expr {
+fn extract_body_togglerbars(expr: &Expr, displays: &mut Vec<String>) -> Expr {
   match expr {
     Expr::FunctionCall { name, args }
       if name == "TogglerBar"
@@ -15198,10 +15186,9 @@ fn togglerbar_node(
     return None;
   };
   // The current selection, for the per-choice `selected` state.
-  let current = crate::evaluator::evaluate_expr_to_expr(&Expr::Identifier(
-    var.clone(),
-  ))
-  .ok();
+  let current =
+    crate::evaluator::evaluate_expr_to_expr(&Expr::Identifier(var.clone()))
+      .ok();
   let mut buttons = Vec::with_capacity(choices.len());
   for choice in choices {
     let (value, label) = match choice {
@@ -15220,9 +15207,7 @@ fn togglerbar_node(
       Some(Expr::List(items)) => items
         .iter()
         .any(|it| crate::syntax::expr_to_input_form(it) == value_code),
-      Some(single) => {
-        crate::syntax::expr_to_input_form(single) == value_code
-      }
+      Some(single) => crate::syntax::expr_to_input_form(single) == value_code,
       None => false,
     };
     let mutation = format!(

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -11257,7 +11257,31 @@ fn resolve_display_item(expr: &Expr) -> Expr {
   {
     current = args[0].clone();
   }
+  // `InputForm[expr]` displays as the InputForm text of `expr`.
+  if let Expr::FunctionCall { name, args } = &current
+    && name == "InputForm"
+    && args.len() == 1
+  {
+    current = Expr::Raw(crate::syntax::expr_to_input_form(&args[0]));
+  }
   current
+}
+
+/// Render a resolved `Column`/`Row` item that is itself a layout construct
+/// (`Row[…]` / `Column[…]`) to a nested SVG, so mixed text/graphics rows
+/// compose instead of printing as raw InputForm text. `None` for other
+/// expressions (rendered as a plain text line by the caller).
+fn nested_layout_svg(expr: &Expr) -> Option<String> {
+  if let Expr::FunctionCall { name, args } = expr {
+    let args: Vec<Expr> = args.iter().cloned().collect();
+    if name == "Row" {
+      return row_to_svg(&args);
+    }
+    if name == "Column" {
+      return column_to_svg(&args);
+    }
+  }
+  None
 }
 
 /// Render `Column[{expr1, expr2, ...}]` as an SVG with items stacked vertically.
@@ -11341,7 +11365,17 @@ pub fn column_to_svg(args: &[Expr]) -> Option<String> {
             height: h,
           }
         }
-        _ => Cell::Text(resolved),
+        _ => match nested_layout_svg(&resolved) {
+          Some(svg) => {
+            let (w, h) = parse_svg_wh(&svg);
+            Cell::Svg {
+              svg,
+              width: w,
+              height: h,
+            }
+          }
+          None => Cell::Text(resolved),
+        },
       }
     })
     .collect();
@@ -11575,7 +11609,17 @@ pub fn row_to_svg(args: &[Expr]) -> Option<String> {
             height: h,
           }
         }
-        _ => make_text_cell(&resolved),
+        _ => match nested_layout_svg(&resolved) {
+          Some(svg) => {
+            let (w, h) = parse_svg_wh(&svg);
+            Cell::Svg {
+              svg,
+              width: w,
+              height: h,
+            }
+          }
+          None => make_text_cell(&resolved),
+        },
       }
     })
     .collect();
@@ -12639,6 +12683,12 @@ pub enum ManipulateControl {
     x_initial: f64,
     y_initial: f64,
     label: String,
+    /// InputForm of a write-back function (the second argument of a
+    /// `Locator[Dynamic[var, cb], …]` this control was promoted from).
+    /// Candidate values pass through it — `(cb)[{x, y}]` — before the
+    /// variable is read back, so e.g. `Clip[Round[#], …]` validation runs
+    /// exactly as Wolfram would.
+    write_callback: Option<String>,
   },
   /// An interval control (`ControlType -> IntervalSlider`). Binds its
   /// variable to a 2-vector `{low, high}` describing the selected range.
@@ -12812,15 +12862,28 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         inner.control_enabled,
       )
     }
-    None => (
-      crate::syntax::expr_to_input_form(&args[0]),
-      Vec::with_capacity(args.len() - 1),
-      Vec::new(),
-      Vec::new(),
-      None,
-      Vec::new(),
-    ),
+    None => {
+      // `TogglerBar[Dynamic[var], …]` inside the body moves into the
+      // display list (replaced by `Nothing` in the body): a front-end
+      // renders displays as live widgets, whereas inside the rendered
+      // output it would only be a static picture.
+      let mut body_displays = Vec::new();
+      let body_expr = extract_body_togglerbars(&args[0], &mut body_displays);
+      (
+        crate::syntax::expr_to_input_form(&body_expr),
+        Vec::with_capacity(args.len() - 1),
+        Vec::new(),
+        body_displays,
+        None,
+        Vec::new(),
+      )
+    }
   };
+  // `Locator[Dynamic[var, cb], …]` markers inside the body drive their
+  // variable interactively: a hidden `ControlType -> None` spec for such a
+  // variable is promoted to a visible Locator-style control below (with
+  // `cb` as its write-back callback).
+  let body_locators = collect_body_locator_callbacks(&args[0]);
   // `Locator` bindings are baked into the body (never rewritten by a
   // display); `ControlType -> None` bindings become live mutable state.
   let mut fixed: Vec<(String, String)> = Vec::new();
@@ -12917,6 +12980,38 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         if let Some((_, orig_form, synth)) = &rename {
           renames.push((orig_form.clone(), synth.clone()));
         }
+        // A hidden variable driven by an in-body `Locator[Dynamic[…]]`
+        // becomes a visible Locator-style control: re-parse its spec with
+        // the `ControlType -> None` option swapped for a `Locator` marker,
+        // and carry the Dynamic's write-back callback so candidate values
+        // are validated the way Wolfram would.
+        if let Some((_, callback)) =
+          body_locators.iter().find(|(n, _)| *n == name)
+          && let Expr::List(items) = &spec
+        {
+          let promoted: Vec<Expr> = items
+            .iter()
+            .filter(|it| !is_control_type_rule(it))
+            .cloned()
+            .chain(std::iter::once(Expr::Identifier(
+              "Locator".to_string(),
+            )))
+            .collect();
+          if let Some(ParsedControl::Visible(mut c, enabled2)) =
+            parse_manipulate_control(&Expr::List(promoted.into()))
+          {
+            if let ManipulateControl::Slider2D { write_callback, .. } =
+              &mut c
+            {
+              *write_callback = callback.clone();
+            }
+            if let Some(cond) = enabled2 {
+              control_enabled.push((c.name().to_string(), cond));
+            }
+            controls.push(c);
+            continue;
+          }
+        }
         state.push((name, value));
       }
     }
@@ -12981,6 +13076,129 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animation_running,
     appearance_none,
   })
+}
+
+/// Whether a control-spec item is a `ControlType -> …` option rule.
+fn is_control_type_rule(item: &Expr) -> bool {
+  matches!(
+    item,
+    Expr::Rule { pattern, .. } | Expr::RuleDelayed { pattern, .. }
+      if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "ControlType")
+  )
+}
+
+/// The variables driven by `Locator[Dynamic[var, cb], …]` markers inside a
+/// Manipulate body, each with the InputForm of its write-back callback (the
+/// Dynamic's second argument), in first-seen order.
+fn collect_body_locator_callbacks(
+  expr: &Expr,
+) -> Vec<(String, Option<String>)> {
+  fn walk(expr: &Expr, found: &mut Vec<(String, Option<String>)>) {
+    match expr {
+      Expr::FunctionCall { name, args } => {
+        if name == "Locator"
+          && let Some(Expr::FunctionCall {
+            name: dname,
+            args: dargs,
+          }) = args.first()
+          && dname == "Dynamic"
+          && let Some(Expr::Identifier(var)) = dargs.first()
+          && !found.iter().any(|(n, _)| n == var)
+        {
+          let callback =
+            dargs.get(1).map(crate::syntax::expr_to_input_form);
+          found.push((var.clone(), callback));
+        }
+        for a in args {
+          walk(a, found);
+        }
+      }
+      Expr::List(items) => {
+        for it in items {
+          walk(it, found);
+        }
+      }
+      Expr::CompoundExpr(items) => {
+        for it in items {
+          walk(it, found);
+        }
+      }
+      _ => {}
+    }
+  }
+  let mut found = Vec::new();
+  walk(expr, &mut found);
+  found
+}
+
+/// Replace every `TogglerBar[Dynamic[var], …]` in a Manipulate body with
+/// `Nothing`, pushing each one's InputForm onto `displays` so the front-end
+/// renders it as a live widget instead of a static picture.
+fn extract_body_togglerbars(
+  expr: &Expr,
+  displays: &mut Vec<String>,
+) -> Expr {
+  match expr {
+    Expr::FunctionCall { name, args }
+      if name == "TogglerBar"
+        && matches!(
+          args.first(),
+          Some(Expr::FunctionCall { name: dname, args: dargs })
+            if dname == "Dynamic"
+              && matches!(dargs.first(), Some(Expr::Identifier(_)))
+        ) =>
+    {
+      displays.push(crate::syntax::expr_to_input_form(expr));
+      Expr::Identifier("Nothing".to_string())
+    }
+    Expr::FunctionCall { name, args } => Expr::FunctionCall {
+      name: name.clone(),
+      args: args
+        .iter()
+        .map(|a| extract_body_togglerbars(a, displays))
+        .collect::<Vec<_>>()
+        .into(),
+    },
+    Expr::List(items) => Expr::List(
+      items
+        .iter()
+        .map(|it| extract_body_togglerbars(it, displays))
+        .collect::<Vec<_>>()
+        .into(),
+    ),
+    Expr::CompoundExpr(items) => Expr::CompoundExpr(
+      items
+        .iter()
+        .map(|it| extract_body_togglerbars(it, displays))
+        .collect(),
+    ),
+    other => other.clone(),
+  }
+}
+
+/// Apply a control's write-back callback to a candidate value: evaluates
+/// `(cb)[value]` under the current bindings (the callback usually assigns
+/// the control variable itself, possibly transformed or rejected), then
+/// reads the variable back. Returns its new InputForm value, or `None` when
+/// evaluation fails.
+pub fn apply_manipulate_callback(
+  bindings: &[(String, String)],
+  callback: &str,
+  value: &str,
+  var: &str,
+) -> Option<String> {
+  let body = format!("({callback})[{value}]; {var}");
+  let code = manipulate_block_code(&body, bindings);
+  crate::interpret_to_expr(&code)
+    .ok()
+    .map(|e| crate::syntax::expr_to_input_form(&e))
+}
+
+/// Parse an InputForm `{x, y}` point (as stored in a Manipulate binding)
+/// back into coordinates.
+pub fn parse_manipulate_point(code: &str) -> Option<(f64, f64)> {
+  let expr = crate::interpret_to_expr(code).ok()?;
+  list2_f64(&expr)
 }
 
 /// Synthesize a plain symbol name for a compound (non-Identifier) control
@@ -13276,6 +13494,7 @@ pub fn extract_locator_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     x_initial,
     y_initial,
     label: var,
+    write_callback: None,
   };
   Some(ManipulateSpec {
     body_code,
@@ -13322,6 +13541,7 @@ pub fn extract_click_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     x_initial: (x_min + x_max) / 2.0,
     y_initial: (y_min + y_max) / 2.0,
     label: "pos".to_string(),
+    write_callback: None,
   };
   Some(ManipulateSpec {
     body_code,
@@ -13762,6 +13982,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
           x_initial: x,
           y_initial: y,
           label,
+          write_callback: None,
         },
         enabled,
       ));
@@ -13846,6 +14067,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
         x_initial,
         y_initial,
         label,
+        write_callback: None,
       },
       enabled,
     ));
@@ -14561,6 +14783,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
         x_initial,
         y_initial,
         label,
+        ..
       } => {
         ctrl_parts.push(format!(
           r#"{{"kind":"slider2d","name":"{}","label":"{}","xMin":{},"xMax":{},"yMin":{},"yMax":{},"xInit":{},"yInit":{}}}"#,
@@ -14718,6 +14941,15 @@ pub enum DisplayNode {
     on: String,
     off: String,
   },
+  /// One choice of a `TogglerBar[Dynamic[var], …]`: a toggle button that
+  /// adds `value` to (or removes it from) the list variable. `mutation` is
+  /// the ready-to-evaluate write-back assignment; `selected` is whether the
+  /// value is currently a member of the list.
+  Toggler {
+    label: Box<DisplayNode>,
+    mutation: String,
+    selected: bool,
+  },
   /// Any unrecognized leaf, rendered to SVG (graphics) or text.
   Static { svg: Option<String>, text: String },
 }
@@ -14849,6 +15081,14 @@ fn display_expr_to_node(
         DisplayNode::Row(list_children(&args[0], bindings, probes, ons))
       }
       "Checkbox" => checkbox_node(args, probes, ons),
+      // `TogglerBar[Dynamic[var], {v1 -> label1, …}]`: a row of toggle
+      // buttons; clicking one adds/removes its value from the list `var`.
+      "TogglerBar" if args.len() >= 2 => {
+        match togglerbar_node(args, bindings, probes, ons) {
+          Some(node) => node,
+          None => static_leaf_node(expr, bindings),
+        }
+      }
       _ => static_leaf_node(expr, bindings),
     },
     // A bare list of display elements stacks vertically, like `Column`.
@@ -14927,6 +15167,77 @@ fn checkbox_node(
   }
 }
 
+/// Build a `TogglerBar[Dynamic[var], choices]` display: a Row of Toggler
+/// buttons. Each choice is `value -> label` (or a plain value, labelled by
+/// itself); clicking a button toggles the value's membership in the list
+/// `var`. Returns `None` when the arguments don't have that shape (the
+/// caller falls back to a static rendering).
+fn togglerbar_node(
+  args: &[Expr],
+  bindings: &[(String, String)],
+  probes: &mut Vec<String>,
+  ons: &mut Vec<String>,
+) -> Option<DisplayNode> {
+  let var = match args.first() {
+    Some(Expr::FunctionCall { name, args: dargs })
+      if name == "Dynamic" && !dargs.is_empty() =>
+    {
+      match &dargs[0] {
+        Expr::Identifier(v) => v.clone(),
+        _ => return None,
+      }
+    }
+    _ => return None,
+  };
+  // The choice list may be held (e.g. `Thread[Range[1, 4] -> {…}]`).
+  let choices_expr = match &args[1] {
+    l @ Expr::List(_) => l.clone(),
+    other => crate::evaluator::evaluate_expr_to_expr(other).ok()?,
+  };
+  let Expr::List(choices) = &choices_expr else {
+    return None;
+  };
+  // The current selection, for the per-choice `selected` state.
+  let current = crate::evaluator::evaluate_expr_to_expr(&Expr::Identifier(
+    var.clone(),
+  ))
+  .ok();
+  let mut buttons = Vec::with_capacity(choices.len());
+  for choice in choices {
+    let (value, label) = match choice {
+      Expr::Rule {
+        pattern,
+        replacement,
+      }
+      | Expr::RuleDelayed {
+        pattern,
+        replacement,
+      } => (pattern.as_ref(), replacement.as_ref()),
+      other => (other, other),
+    };
+    let value_code = crate::syntax::expr_to_input_form(value);
+    let selected = match &current {
+      Some(Expr::List(items)) => items
+        .iter()
+        .any(|it| crate::syntax::expr_to_input_form(it) == value_code),
+      Some(single) => {
+        crate::syntax::expr_to_input_form(single) == value_code
+      }
+      None => false,
+    };
+    let mutation = format!(
+      "{var} = If[MemberQ[{var}, {value_code}], DeleteCases[{var}, \
+       {value_code}], Append[{var}, {value_code}]]"
+    );
+    buttons.push(DisplayNode::Toggler {
+      label: Box::new(display_expr_to_node(label, bindings, probes, ons)),
+      mutation,
+      selected,
+    });
+  }
+  Some(DisplayNode::Row(buttons))
+}
+
 /// Fill in each checkbox's `checked` flag from the batched probe results, in
 /// the same pre-order the probes were collected.
 fn assign_checkbox_state(
@@ -14947,6 +15258,9 @@ fn assign_checkbox_state(
       for c in children {
         assign_checkbox_state(c, flags, idx);
       }
+    }
+    DisplayNode::Toggler { label, .. } => {
+      assign_checkbox_state(label, flags, idx)
     }
     DisplayNode::Checkbox { checked, .. } => {
       if let Some(f) = flags.get(*idx) {
@@ -15037,6 +15351,16 @@ fn display_node_to_json(node: &DisplayNode) -> String {
         json_escape_manipulate(off),
       ),
     },
+    DisplayNode::Toggler {
+      label,
+      mutation,
+      selected,
+    } => format!(
+      r#"{{"kind":"toggler","label":{},"mutation":"{}","selected":{}}}"#,
+      display_node_to_json(label),
+      json_escape_manipulate(mutation),
+      selected,
+    ),
     DisplayNode::Static { svg, text } => match svg {
       Some(svg) => format!(
         r#"{{"kind":"static","svg":"{}"}}"#,

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -185,6 +185,16 @@ pub(crate) fn evaluate_at_xy(
   let sub1 = substitute_var(body, xvar, &Expr::Real(xval));
   let sub2 = substitute_var(&sub1, yvar, &Expr::Real(yval));
   let result = evaluate_expr_to_expr(&sub2).ok()?;
+  if let Some(v) = try_eval_to_f64(&result) {
+    return Some(v);
+  }
+  // The body may reference a variable (e.g. `lineA` holding `-5 - 3 x + 2 y`)
+  // that only resolved to an x/y expression during evaluation — after the
+  // substitution above already ran. Substitute into the evaluated form and
+  // evaluate once more.
+  let sub1 = substitute_var(&result, xvar, &Expr::Real(xval));
+  let sub2 = substitute_var(&sub1, yvar, &Expr::Real(yval));
+  let result = evaluate_expr_to_expr(&sub2).ok()?;
   try_eval_to_f64(&result)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -867,6 +867,23 @@ pub fn graphics3d_result(svg: String) -> syntax::Expr {
 
 /// Like `graphics3d_result` but remembers the symbolic expression the
 /// rendering came from, so `Part` can index into it (Wolfram's
+/// Like `graphics_result` but also remembers the symbolic expression the
+/// rendering came from, so structural operations can look inside it (Wolfram's
+/// `ContourPlot[…][[1]]` returns the graphic's content).
+pub fn graphics_result_with_structure(
+  svg: String,
+  structure: syntax::Expr,
+) -> syntax::Expr {
+  capture_graphics(&svg);
+  syntax::Expr::Graphics {
+    svg,
+    is_3d: false,
+    source: None,
+    head: None,
+    structure: Some(Box::new(structure)),
+  }
+}
+
 /// `Graphics3D[…][[1]]` returns the graphic's content).
 pub fn graphics3d_result_with_structure(
   svg: String,
@@ -885,6 +902,25 @@ pub fn graphics3d_result_with_structure(
 /// Gets the last captured graphics content (backward compatible)
 pub fn get_captured_graphics() -> Option<String> {
   CAPTURED_GRAPHICS.with(|buffer| buffer.borrow().last().cloned())
+}
+
+/// Number of entries currently in the captured-graphics buffer. Paired with
+/// `truncate_captured_graphics` so a renderer that evaluates sub-expressions
+/// (e.g. the content of a `Dynamic[…]` inside `Graphics[…]`) can drop any
+/// graphics those evaluations captured — they are embedded in the outer
+/// rendering, not standalone outputs.
+pub fn captured_graphics_count() -> usize {
+  CAPTURED_GRAPHICS.with(|buffer| buffer.borrow().len())
+}
+
+/// Truncates the captured-graphics buffer back to `len` entries.
+pub fn truncate_captured_graphics(len: usize) {
+  CAPTURED_GRAPHICS.with(|buffer| {
+    let mut buf = buffer.borrow_mut();
+    if buf.len() > len {
+      buf.truncate(len);
+    }
+  });
 }
 
 /// Removes the most recent captured-graphics entry equal to `svg`.

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -569,9 +569,24 @@ fn render_text_element(s: &str) -> String {
     }
   }
 
-  // Inline `Cell[...]` elements are the attached "more info" opener buttons in
-  // Demonstrations templates — they carry no textual content, so drop them.
-  if s.starts_with("Cell[") {
+  // Inline `Cell[...]` elements: an inline math cell (`Cell[BoxData[
+  // FormBox[…, TraditionalForm]], "InlineMath"]`) contributes its typeset
+  // content as text. The attached "more info" opener buttons in
+  // Demonstrations templates (PaneSelectorBox around a TemplateBox) carry
+  // no textual content and are dropped.
+  if let Some(rest) = s.strip_prefix("Cell[")
+    && let Ok((inner, _)) = find_matching_bracket(rest)
+  {
+    if let Some(first) = split_top_level_commas(inner).first() {
+      let first = first.trim();
+      if let Some(box_rest) = first.strip_prefix("BoxData[")
+        && !box_rest.contains("MoreInfoOpenerButtonTemplate")
+        && !box_rest.contains("PaneSelectorBox")
+        && let Ok((content, _)) = find_matching_bracket(box_rest)
+      {
+        return extract_cell_content(content.trim());
+      }
+    }
     return String::new();
   }
 
@@ -1407,6 +1422,175 @@ impl Notebook {
   }
 }
 
+// ── Stored-output rendering ─────────────────────────────────────────────
+//
+// Notebooks saved by Mathematica can carry pre-rendered results that Woxi
+// cannot regenerate: `RasterBox[CompressedData["…"]]` snapshot images and
+// `CheckboxBox[…]` grids (the Demonstrations submission templates). These
+// helpers decode such stored Output cells into something displayable.
+
+/// Decode the `RasterBox[CompressedData["…"]]` image embedded in a stored
+/// Output cell into an SVG that embeds the pixels as a PNG data URI.
+/// Returns `None` when the content holds no decodable raster.
+///
+/// The compressed payload is Mathematica's binary serialization of
+/// `RawArray["UnsignedInteger8", pixels]`: `!boR` magic, an `f`unction
+/// header naming `RawArray`, a `S`tring type tag, and a `b`yte-array tag
+/// with rank, dimensions (`{height, width, channels}` or
+/// `{height, width}`), and the raw samples.
+pub fn stored_output_image_svg(content: &str) -> Option<String> {
+  let start = content.find("RasterBox[CompressedData[\"")?;
+  let rest = &content[start + "RasterBox[CompressedData[\"".len()..];
+  let end = rest.find('"')?;
+  let b64: String = rest[..end]
+    .chars()
+    .filter(|c| !c.is_whitespace() && *c != '\\')
+    .collect();
+  let b64 = b64.strip_prefix("1:")?;
+
+  use base64::Engine;
+  let compressed =
+    base64::engine::general_purpose::STANDARD.decode(b64).ok()?;
+  let mut raw = Vec::new();
+  std::io::Read::read_to_end(
+    &mut flate2::read::ZlibDecoder::new(&compressed[..]),
+    &mut raw,
+  )
+  .ok()?;
+
+  let (height, width, channels, pixels) = parse_raw_array_u8(&raw)?;
+
+  // Encode as PNG (top row first, matching Image/Rasterize order).
+  let mut png = Vec::new();
+  let color = match channels {
+    1 => image::ExtendedColorType::L8,
+    3 => image::ExtendedColorType::Rgb8,
+    4 => image::ExtendedColorType::Rgba8,
+    _ => return None,
+  };
+  use image::ImageEncoder;
+  image::codecs::png::PngEncoder::new(&mut png)
+    .write_image(pixels, width, height, color)
+    .ok()?;
+  let png_b64 = base64::engine::general_purpose::STANDARD.encode(&png);
+
+  // Display at the notebook's typical pane width; the viewBox keeps the
+  // native resolution so zooming stays sharp.
+  let max_display = 450.0_f64;
+  let scale = (max_display / width as f64).min(1.0);
+  let dw = (width as f64 * scale).round() as u32;
+  let dh = (height as f64 * scale).round() as u32;
+  Some(format!(
+    "<svg width=\"{dw}\" height=\"{dh}\" viewBox=\"0 0 {width} {height}\" \
+     xmlns=\"http://www.w3.org/2000/svg\" \
+     xmlns:xlink=\"http://www.w3.org/1999/xlink\">\
+     <image width=\"{width}\" height=\"{height}\" \
+     xlink:href=\"data:image/png;base64,{png_b64}\"/></svg>"
+  ))
+}
+
+/// Parse Mathematica's serialized `RawArray["UnsignedInteger8", …]`:
+/// returns `(height, width, channels, samples)`. Rank-2 arrays are
+/// grayscale (`channels = 1`).
+fn parse_raw_array_u8(raw: &[u8]) -> Option<(u32, u32, u8, &[u8])> {
+  let mut pos = 0usize;
+  let take = |pos: &mut usize, n: usize| -> Option<&[u8]> {
+    let s = raw.get(*pos..*pos + n)?;
+    *pos += n;
+    Some(s)
+  };
+  let read_u32 = |pos: &mut usize| -> Option<u32> {
+    take(pos, 4).map(|b| u32::from_le_bytes(b.try_into().unwrap()))
+  };
+
+  if take(&mut pos, 4)? != b"!boR" {
+    return None;
+  }
+  // f <argc> s <len> "RawArray"
+  if take(&mut pos, 1)? != b"f" {
+    return None;
+  }
+  let _argc = read_u32(&mut pos)?;
+  if take(&mut pos, 1)? != b"s" {
+    return None;
+  }
+  let name_len = read_u32(&mut pos)? as usize;
+  if take(&mut pos, name_len)? != b"RawArray" {
+    return None;
+  }
+  // S <len> "UnsignedInteger8"
+  if take(&mut pos, 1)? != b"S" {
+    return None;
+  }
+  let ty_len = read_u32(&mut pos)? as usize;
+  if take(&mut pos, ty_len)? != b"UnsignedInteger8" {
+    return None;
+  }
+  // b <rank> <dim…> <samples>
+  if take(&mut pos, 1)? != b"b" {
+    return None;
+  }
+  let rank = read_u32(&mut pos)? as usize;
+  if !(2..=3).contains(&rank) {
+    return None;
+  }
+  let mut dims = [0u32; 3];
+  for d in dims.iter_mut().take(rank) {
+    *d = read_u32(&mut pos)?;
+  }
+  let (height, width, channels) = if rank == 2 {
+    (dims[0], dims[1], 1u8)
+  } else {
+    (dims[0], dims[1], u8::try_from(dims[2]).ok()?)
+  };
+  let expected = height as usize * width as usize * channels as usize;
+  let pixels = raw.get(pos..pos + expected)?;
+  Some((height, width, channels, pixels))
+}
+
+/// Render a stored `CheckboxBox[…]` output (the Demonstrations category /
+/// compatibility pickers) as plain text: one `[x] label` / `[ ] label`
+/// entry per checkbox, in source order. Returns `None` when the content
+/// holds no CheckboxBox.
+pub fn stored_output_checkbox_text(content: &str) -> Option<String> {
+  let mut lines = Vec::new();
+  let mut rest = content;
+  while let Some(idx) = rest.find("CheckboxBox[") {
+    rest = &rest[idx + "CheckboxBox[".len()..];
+    let (inner, tail) = find_matching_bracket(rest).ok()?;
+    let args = split_top_level_commas(inner);
+    let checked = args.first().map(|a| a.trim()) == Some("True");
+    // The label is the "on" value when it is a string (`{False, "Math"}`);
+    // a plain `{False, True}` checkbox has no label.
+    let label = args
+      .get(1)
+      .map(|a| a.trim())
+      .and_then(|vals| {
+        let vals = vals.strip_prefix('{')?.strip_suffix('}')?;
+        let parts = split_top_level_commas(vals);
+        let on = parts.get(1)?.trim();
+        if on.starts_with('"') && on.ends_with('"') && on.len() >= 2 {
+          Some(extract_string_content(on))
+        } else {
+          None
+        }
+      })
+      .unwrap_or_default();
+    let mark = if checked { "[x]" } else { "[ ]" };
+    if label.is_empty() {
+      lines.push(mark.to_string());
+    } else {
+      lines.push(format!("{mark} {label}"));
+    }
+    rest = tail;
+  }
+  if lines.is_empty() {
+    None
+  } else {
+    Some(lines.join("\n"))
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -1990,6 +2174,92 @@ Cell["Chapter 2", "Chapter"]
     "MoreInfoOpenerButtonTemplate"]}, Dynamic[x]]]]
 }]"#;
     assert_eq!(extract_cell_content(s), "Manipulate");
+  }
+
+  #[test]
+  fn test_extract_textdata_inline_math() {
+    // Inline math cells (`Cell[BoxData[FormBox[…, TraditionalForm]],
+    // "InlineMath"]`) contribute their typeset content to the prose —
+    // dropping them loses words ("The triangle ABC" became "The triangle").
+    let s = r#"TextData[{
+ "The triangle ",
+ Cell[BoxData[
+  FormBox["ABC", TraditionalForm]], "InlineMath",ExpressionUUID->
+  "4b134b90-4d52-4df9-bcc7-264d63b666b9"],
+ " is limited to the range ",
+ Cell[BoxData[
+  FormBox[
+   RowBox[{"[",
+    RowBox[{
+     RowBox[{"-", "9"}], ",", "9"}], "]"}], TraditionalForm]], "InlineMath",
+  ExpressionUUID->"4a1e2e70-0973-4b3c-994b-25f0dad1ea7d"],
+ ". Drag the point ",
+ Cell[BoxData[
+  FormBox[
+   StyleBox["A",
+    FontSlant->"Plain"], TraditionalForm]], "InlineMath",ExpressionUUID->
+  "d0cf31da-6a61-4979-98a7-c37abad7eb18"],
+ "."
+}]"#;
+    assert_eq!(
+      extract_cell_content(s),
+      "The triangle ABC is limited to the range [-9,9]. Drag the point A."
+    );
+  }
+
+  #[test]
+  fn test_stored_output_raster_snapshot_decodes_to_svg() {
+    // Build the exact serialization Mathematica writes for a stored
+    // Rasterize result: `RawArray["UnsignedInteger8", pixels]` with a
+    // rank-3 {height, width, 3} byte array, zlib-compressed and
+    // base64-encoded behind a "1:" prefix.
+    let (h, w) = (2u32, 3u32);
+    let mut raw: Vec<u8> = Vec::new();
+    raw.extend_from_slice(b"!boR");
+    raw.push(b'f');
+    raw.extend_from_slice(&2u32.to_le_bytes());
+    raw.push(b's');
+    raw.extend_from_slice(&8u32.to_le_bytes());
+    raw.extend_from_slice(b"RawArray");
+    raw.push(b'S');
+    raw.extend_from_slice(&16u32.to_le_bytes());
+    raw.extend_from_slice(b"UnsignedInteger8");
+    raw.push(b'b');
+    raw.extend_from_slice(&3u32.to_le_bytes());
+    raw.extend_from_slice(&h.to_le_bytes());
+    raw.extend_from_slice(&w.to_le_bytes());
+    raw.extend_from_slice(&3u32.to_le_bytes());
+    raw.extend_from_slice(&[128u8; 2 * 3 * 3]);
+
+    use base64::Engine;
+    use std::io::Write;
+    let mut enc = flate2::write::ZlibEncoder::new(
+      Vec::new(),
+      flate2::Compression::default(),
+    );
+    enc.write_all(&raw).unwrap();
+    let b64 =
+      base64::engine::general_purpose::STANDARD.encode(enc.finish().unwrap());
+    let content = format!(
+      "PaneBox[\n  GraphicsBox[\n   TagBox[RasterBox[CompressedData[\"\n\
+       1:{b64}\n    \"], {{{{0, 0}}, {{1, 1}}}}]]]]"
+    );
+
+    let svg = stored_output_image_svg(&content).expect("decodes");
+    assert!(svg.contains("viewBox=\"0 0 3 2\""), "{svg}");
+    assert!(svg.contains("data:image/png;base64,"), "{svg}");
+    // Non-raster outputs decode to nothing.
+    assert!(stored_output_image_svg("{1, 2, 3}").is_none());
+  }
+
+  #[test]
+  fn test_stored_output_checkbox_grid_renders_as_text() {
+    let content = r#"{{{{CheckboxBox[False, {False, "Mathematics"}]}, {CheckboxBox[True, {False, "Life Sciences"}]}}, {{CheckboxBox[False, {False, True}]}}}}"#;
+    assert_eq!(
+      stored_output_checkbox_text(content).unwrap(),
+      "[ ] Mathematics\n[x] Life Sciences\n[ ]"
+    );
+    assert!(stored_output_checkbox_text("{1, 2}").is_none());
   }
 
   #[test]

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -6776,6 +6776,17 @@ fn printed_infix_precedence(e: &Expr) -> Option<u8> {
   }
 }
 
+/// Whether a `Part` base must be parenthesized so `base[[i]]` re-parses to
+/// the same tree. `[[…]]` binds tighter than every infix operator, so any
+/// base that prints with a top-level operator (`a /. b`, `a + b`, `x &`, …)
+/// or as a negative literal needs parens: `(a /. b :> c)[[1]]` must not
+/// print as `a /. b :> c[[1]]`.
+fn part_base_needs_parens(base: &Expr) -> bool {
+  printed_infix_precedence(base).is_some()
+    || matches!(base, Expr::Integer(n) if *n < 0)
+    || matches!(base, Expr::Real(f) if *f < 0.0)
+}
+
 /// Render an application shorthand (`f /@ list`, `f @@ list`, `f @@@ list`)
 /// in InputForm, parenthesizing either operand when it would otherwise bind
 /// differently on re-parse. `prec` is the shorthand's own parse precedence
@@ -9974,7 +9985,12 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
         base = inner_expr.as_ref();
       }
       indices.reverse();
-      format!("{}[[{}]]", format_expr(base, form), indices.join(","))
+      let base_str = format_expr(base, form);
+      if part_base_needs_parens(base) {
+        format!("({})[[{}]]", base_str, indices.join(","))
+      } else {
+        format!("{}[[{}]]", base_str, indices.join(","))
+      }
     }
     Expr::Function { body } => {
       // Wolfram shows anonymous functions with trailing space: "f & " (not "f &")
@@ -11723,7 +11739,12 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
         base = inner_expr.as_ref();
       }
       indices.reverse();
-      format!("{}[[{}]]", expr_to_input_form(base), indices.join(","))
+      let base_str = expr_to_input_form(base);
+      if part_base_needs_parens(base) {
+        format!("({})[[{}]]", base_str, indices.join(","))
+      } else {
+        format!("{}[[{}]]", base_str, indices.join(","))
+      }
     }
     // For all other cases (infix operators, simple literals), delegate to expr_to_output
     _ => expr_to_output(expr),

--- a/tests/cli/syntax.md
+++ b/tests/cli/syntax.md
@@ -123,6 +123,23 @@ FullForm[a[[1,2,3]]]
 ```
 
 
+## Part of an operator expression (`(a /. b)[[i]]`)
+
+`[[…]]` binds tighter than every infix operator, so a parenthesized
+operator expression keeps its parentheses when echoed — dropping them
+would change what re-parsing produces.
+
+```scrut
+$ wo '({9, 8} /. 8 -> 5)[[1]]'
+9
+```
+
+```scrut
+$ wo 'ToString[Hold[(a /. b :> c)[[1]]], InputForm]'
+Hold[(a /. b :> c)[[1]]]
+```
+
+
 ## Increment (`++`) and Decrement (`--`)
 
 `x++` increments `x` by 1 and returns the old value.

--- a/tests/interpreter_tests/column.rs
+++ b/tests/interpreter_tests/column.rs
@@ -148,6 +148,31 @@ mod column_visual_mode {
   }
 
   #[test]
+  fn column_alignment_option_rule_svg() {
+    // The option form `Alignment -> Center` aligns like the positional
+    // `Center` argument.
+    clear_state();
+    let result =
+      interpret_with_stdout("Column[{1, 2, 3}, Alignment -> Center]").unwrap();
+    assert!(result.graphics.is_some());
+    let svg = result.graphics.unwrap();
+    assert!(svg.contains("text-anchor=\"middle\""));
+  }
+
+  #[test]
+  fn column_dynamic_item_shows_current_value() {
+    // A held `Dynamic[expr]` item displays as the current value of `expr`,
+    // and a `Text[…]` wrapper displays as its content.
+    clear_state();
+    let result =
+      interpret_with_stdout("Column[{Dynamic[Text[1 + 1]], 3}]").unwrap();
+    assert!(result.graphics.is_some());
+    let svg = result.graphics.unwrap();
+    assert!(svg.contains(">2</text>"), "{svg}");
+    assert!(!svg.contains("Dynamic"), "{svg}");
+  }
+
+  #[test]
   fn column_right_alignment_svg() {
     clear_state();
     let result = interpret_with_stdout("Column[{1, 2, 3}, Right]").unwrap();

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -14964,7 +14964,10 @@ mod color_data_indexed {
       "Graphics[{Dynamic[{p = {1, 1}; Disk[p, 1], Line[{{0, 0}, p}]}]}]",
     );
     assert!(svg.contains("<ellipse"), "Disk from Dynamic content: {svg}");
-    assert!(svg.contains("<polyline"), "Line from Dynamic content: {svg}");
+    assert!(
+      svg.contains("<polyline"),
+      "Line from Dynamic content: {svg}"
+    );
   }
 
   // `Tooltip[g, label]` inside Graphics draws only `g`; the label must not

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -14953,4 +14953,88 @@ mod color_data_indexed {
     assert_eq!(interpret("Head[ColorData[1, 1]]").unwrap(), "RGBColor");
     assert_eq!(interpret("Head[ColorData[2, 1]]").unwrap(), "RGBColor");
   }
+
+  // `Dynamic[…]` inside a Graphics primitive list displays as its current
+  // value; assignments made inside the Dynamic run (the Demonstrations
+  // pattern computes shared values there).
+  #[test]
+  fn dynamic_inside_graphics_renders_its_content() {
+    clear_state();
+    let svg = export_svg(
+      "Graphics[{Dynamic[{p = {1, 1}; Disk[p, 1], Line[{{0, 0}, p}]}]}]",
+    );
+    assert!(svg.contains("<ellipse"), "Disk from Dynamic content: {svg}");
+    assert!(svg.contains("<polyline"), "Line from Dynamic content: {svg}");
+  }
+
+  // `Tooltip[g, label]` inside Graphics draws only `g`; the label must not
+  // leak into the rendering as stray primitives or text.
+  #[test]
+  fn tooltip_inside_graphics_renders_only_content() {
+    clear_state();
+    let svg =
+      export_svg("Graphics[{Tooltip[Disk[{0, 0}, 1], Disk[{5, 5}, 1]]}]");
+    assert_eq!(svg.matches("<ellipse").count(), 1, "{svg}");
+  }
+
+  // A `Locator` is a screen-space marker icon centered on its point: the
+  // default appearance is the crosshair, a custom appearance graphic keeps
+  // its own ImageSize in pixels.
+  #[test]
+  fn locator_renders_as_marker_icon() {
+    clear_state();
+    let svg = export_svg("Graphics[{Locator[{1, 2}]}]");
+    assert!(
+      svg.contains("width=\"16.00\" height=\"16.00\""),
+      "default crosshair marker: {svg}"
+    );
+    let svg = export_svg(
+      "Graphics[{Locator[Dynamic[{1, 2}], \
+       Graphics[{Yellow, Disk[{0, 0}, 1]}, ImageSize -> 20]]}]",
+    );
+    assert!(
+      svg.contains("width=\"20.00\" height=\"20.00\""),
+      "appearance keeps its ImageSize: {svg}"
+    );
+    assert!(svg.contains("255,255,0"), "appearance fill: {svg}");
+  }
+
+  // `ContourPlot[lhs == rhs, …]` draws the implicit curve `lhs - rhs = 0`,
+  // and `plot[[1]]` yields the contour primitives (with the ContourStyle
+  // directives) for re-embedding in an outer Graphics — including after
+  // rewriting the plot with `/.` (the Demonstrations Tooltip-stripping
+  // idiom).
+  #[test]
+  fn equation_contour_plot_part_yields_primitives() {
+    clear_state();
+    assert_eq!(
+      interpret("Head[ContourPlot[x == y, {x, -3, 3}, {y, -3, 3}][[1]]]")
+        .unwrap(),
+      "List"
+    );
+    assert_eq!(
+      interpret(
+        "With[{prims = (ContourPlot[x == y, {x, -3, 3}, {y, -3, 3}, \
+         ContourStyle -> {Pink}] /. Tooltip[q_, ___] :> q)[[1]]}, \
+         {prims[[1]], Head[prims[[2]]]}]"
+      )
+      .unwrap(),
+      "{RGBColor[1, 0.5, 0.5], Line}"
+    );
+    // The extracted primitives embed into an outer Graphics.
+    let svg = export_svg(
+      "Graphics[{ContourPlot[x == y, {x, -3, 3}, {y, -3, 3}, \
+       ContourStyle -> {Pink}][[1]]}]",
+    );
+    assert!(svg.contains("<polyline"), "{svg}");
+    // A plot body held in a variable resolves during sampling.
+    assert_eq!(
+      interpret(
+        "lineA = -5 - 3*x + 2*y; \
+         Head[ContourPlot[lineA == 0, {x, -9, 9}, {y, -9, 9}][[1]]]"
+      )
+      .unwrap(),
+      "List"
+    );
+  }
 }

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -8791,6 +8791,32 @@ mod part_span {
     );
   }
 
+  // A Part base that prints with a top-level operator keeps its parens so
+  // the printed form re-parses to the same tree: `(a /. b :> c)[[1]]` must
+  // not print as `a /. b :> c[[1]]` (which re-parses as Part of `c`).
+  #[test]
+  fn part_base_operator_expression_keeps_parens() {
+    assert_eq!(
+      interpret("ToString[Hold[(a /. b :> c)[[1]]], InputForm]").unwrap(),
+      "Hold[(a /. b :> c)[[1]]]"
+    );
+    assert_eq!(
+      interpret("ToString[Hold[(a + b)[[1]]], InputForm]").unwrap(),
+      "Hold[(a + b)[[1]]]"
+    );
+    assert_eq!(
+      interpret("ToString[Hold[(f /@ l)[[1]]], InputForm]").unwrap(),
+      "Hold[(f /@ l)[[1]]]"
+    );
+    // The evaluation itself picks the replaced expression's part.
+    assert_eq!(interpret("({9, 8} /. 8 -> 5)[[1]]").unwrap(), "9");
+    // Self-delimiting bases stay unparenthesized.
+    assert_eq!(
+      interpret("ToString[Hold[f[x][[1]]], InputForm]").unwrap(),
+      "Hold[f[x][[1]]]"
+    );
+  }
+
   // The unevaluated echo shows the Span in head form — wolframscript 15
   // prints {a, b, c, d, e}[[Span[5, 2]]] and never uses the ;; operator
   // in output (verified directly; the previous ;; expectation encoded a

--- a/tests/playground/script.js
+++ b/tests/playground/script.js
@@ -576,6 +576,22 @@ function renderManipulate(item) {
         }
         return input
       }
+      case "toggler": {
+        // One choice of a TogglerBar[Dynamic[var], …]: clicking adds or
+        // removes its value from the bound list variable.
+        const btn = document.createElement("button")
+        btn.type = "button"
+        btn.className = node.selected
+          ? "manipulate-display-toggler selected"
+          : "manipulate-display-toggler"
+        if (node.label) btn.appendChild(renderDisplayTree(node.label))
+        if (node.mutation) {
+          btn.addEventListener("click", () => {
+            requestUpdate([node.mutation])
+          })
+        }
+        return btn
+      }
       case "static": {
         const div = document.createElement("div")
         if (node.svg) {

--- a/tests/playground/style.css
+++ b/tests/playground/style.css
@@ -722,6 +722,26 @@ pre.output-box {
   cursor: default;
 }
 
+/* One choice of a TogglerBar[Dynamic[var], …]: a toggle button whose
+   pressed state mirrors the value's membership in the list variable. */
+.manipulate-display-toggler {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--border-color, #bbb);
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+}
+
+.manipulate-display-toggler.selected {
+  background: var(--accent-color, #4a90d9);
+  border-color: var(--accent-color, #4a90d9);
+  color: #fff;
+}
+
 .status {
   position: fixed;
   top: 1rem;

--- a/woxi-studio/examples/dump_manipulate.rs
+++ b/woxi-studio/examples/dump_manipulate.rs
@@ -4,7 +4,10 @@
 //! resulting widget structure. This makes "does this notebook's
 //! Manipulate work in the Studio?" checkable without launching the GUI.
 //!
-//! Usage: cargo run --example dump_manipulate -- path/to/notebook.nb
+//! Usage: cargo run --example dump_manipulate -- path/to/notebook.nb [svg-out-dir]
+//!
+//! When `svg-out-dir` is given, each widget's rendered SVG is written to
+//! `<svg-out-dir>/widget-<n>.svg` so the visual output can be inspected.
 
 use std::path::PathBuf;
 
@@ -21,6 +24,7 @@ fn main() {
     .nth(1)
     .expect("notebook path required")
     .into();
+  let svg_out_dir: Option<PathBuf> = std::env::args().nth(2).map(Into::into);
   let src = std::fs::read_to_string(&path).expect("read file");
   let nb = parse_notebook(&src).expect("parse notebook");
 
@@ -82,6 +86,34 @@ fn main() {
         state.text_output,
         state.error
       );
+      if let Some(dir) = &svg_out_dir
+        && state.graphics_handle.is_some()
+      {
+        // Re-render through the same bindings the widget uses so the SVG
+        // bytes can be captured (the iced handle doesn't expose them).
+        let mut bindings: Vec<(String, String)> = state
+          .controls
+          .iter()
+          .filter(|c| c.binds_variable())
+          .map(|c| (c.name().to_string(), c.current_code()))
+          .collect();
+        bindings.extend(state.state.iter().cloned());
+        let code = match state.initialization.as_deref() {
+          Some(init) => format!("{init}; {}", state.body),
+          None => state.body.clone(),
+        };
+        let render = woxi::with_scoped_globals(&bindings, || {
+          woxi::interpret_with_stdout(&code)
+        });
+        if let Ok(res) = render
+          && let Some(svg) = res.graphics
+        {
+          std::fs::create_dir_all(dir).expect("create svg out dir");
+          let out = dir.join(format!("widget-{widget_count}.svg"));
+          std::fs::write(&out, svg).expect("write svg");
+          println!("wrote {}", out.display());
+        }
+      }
       println!();
     }
   }

--- a/woxi-studio/examples/dump_manipulate.rs
+++ b/woxi-studio/examples/dump_manipulate.rs
@@ -76,6 +76,19 @@ fn main() {
           println!("  {n} = {snippet}");
         }
       }
+      if !state.displays.is_empty() {
+        println!("displays:");
+        for d in &state.displays {
+          let snippet: String = d.chars().take(120).collect();
+          println!("  {snippet}");
+        }
+        println!("display trees:");
+        for t in &state.display_trees {
+          let dbg = format!("{t:?}");
+          let snippet: String = dbg.chars().take(300).collect();
+          println!("  {snippet}");
+        }
+      }
       println!("body:");
       for line in state.body.lines() {
         println!("  {line}");

--- a/woxi-studio/examples/dump_stored_outputs.rs
+++ b/woxi-studio/examples/dump_stored_outputs.rs
@@ -1,0 +1,47 @@
+//! Decode the stored Output cells of a notebook (RasterBox snapshots and
+//! CheckboxBox grids) so their display support can be checked headlessly.
+//!
+//! Usage: cargo run --example dump_stored_outputs -- notebook.nb [out-dir]
+
+use std::path::PathBuf;
+
+use woxi::notebook::{
+  CellEntry, CellStyle, parse_notebook, stored_output_checkbox_text,
+  stored_output_image_svg,
+};
+
+fn main() {
+  let path: PathBuf = std::env::args()
+    .nth(1)
+    .expect("notebook path required")
+    .into();
+  let out_dir: Option<PathBuf> = std::env::args().nth(2).map(Into::into);
+  let src = std::fs::read_to_string(&path).expect("read file");
+  let nb = parse_notebook(&src).expect("parse notebook");
+
+  let mut idx = 0;
+  for entry in &nb.cells {
+    let cells: Vec<_> = match entry {
+      CellEntry::Single(c) => vec![c],
+      CellEntry::Group(g) => g.cells.iter().collect(),
+    };
+    for cell in cells {
+      idx += 1;
+      if cell.style != CellStyle::Output {
+        continue;
+      }
+      if let Some(svg) = stored_output_image_svg(&cell.content) {
+        let head: String = svg.chars().take(100).collect();
+        println!("#{idx}: raster snapshot -> {head}");
+        if let Some(dir) = &out_dir {
+          std::fs::create_dir_all(dir).unwrap();
+          let f = dir.join(format!("snapshot-{idx}.svg"));
+          std::fs::write(&f, &svg).unwrap();
+          println!("  wrote {}", f.display());
+        }
+      } else if let Some(text) = stored_output_checkbox_text(&cell.content) {
+        println!("#{idx}: checkboxes:\n{text}");
+      }
+    }
+  }
+}

--- a/woxi-studio/examples/extract_cells.rs
+++ b/woxi-studio/examples/extract_cells.rs
@@ -1,0 +1,22 @@
+//! Extract full content of each cell to numbered files.
+use std::path::PathBuf;
+use woxi::notebook::{CellEntry, parse_notebook};
+
+fn main() {
+  let path: PathBuf = std::env::args().nth(1).expect("notebook path").into();
+  let outdir: PathBuf = std::env::args().nth(2).expect("out dir").into();
+  let src = std::fs::read_to_string(&path).expect("read file");
+  let nb = parse_notebook(&src).expect("parse notebook");
+  let mut idx = 0;
+  for entry in &nb.cells {
+    let cells: Vec<_> = match entry {
+      CellEntry::Single(c) => vec![c],
+      CellEntry::Group(g) => g.cells.iter().collect(),
+    };
+    for cell in cells {
+      idx += 1;
+      let f = outdir.join(format!("{:03}_{}.txt", idx, cell.style));
+      std::fs::write(f, &cell.content).unwrap();
+    }
+  }
+}

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -1630,14 +1630,10 @@ impl WoxiStudio {
       Message::ManipulateSlider2DChanged(cell_idx, ctrl_idx, axis, value) => {
         if let Some(editor) = self.cell_editors.get_mut(cell_idx)
           && let Some(state) = editor.manipulate_state.as_mut()
-          && let Some(control) = state.controls.get_mut(ctrl_idx)
-          && let manipulate::ControlState::Slider2D { x, y, .. } = control
         {
-          if axis == 0 {
-            *x = value;
-          } else {
-            *y = value;
-          }
+          // Routes through the control's write-back callback (if any), so
+          // e.g. Locator-promoted controls round/validate the candidate.
+          state.slider2d_change(ctrl_idx, axis, value);
           if state.request_reeval() {
             return manipulate_reeval_task(cell_idx);
           }
@@ -3789,6 +3785,7 @@ fn render_manipulate_widget<'a>(
         y_max,
         x,
         y,
+        ..
       } => {
         // Rendered as two linked sliders (X and Y) driving the 2-vector.
         let x_span = (*x_max - *x_min).abs();
@@ -4125,6 +4122,29 @@ fn render_display_node<'a>(
         // Non-interactive checkbox: rendered but not clickable.
         None => cb.into(),
       }
+    }
+    DisplayNode::Toggler {
+      label,
+      mutation,
+      selected,
+    } => {
+      // One choice of a TogglerBar: a toggle button whose press adds or
+      // removes its value from the bound list variable.
+      let selected = *selected;
+      let mutation = mutation.clone();
+      button(render_display_node(cell_idx, label))
+        .padding([2, 6])
+        .style(move |theme: &iced::Theme, status| {
+          let mut style = if selected {
+            button::primary(theme, status)
+          } else {
+            button::secondary(theme, status)
+          };
+          style.border.radius = 4.0.into();
+          style
+        })
+        .on_press(Message::ManipulateDisplayToggled(cell_idx, mutation))
+        .into()
     }
     DisplayNode::Static {
       svg: svg_src,
@@ -6460,6 +6480,117 @@ mod tests {
     state.reevaluate();
     assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
     assert!(state.graphics_handle.is_some());
+  }
+
+  #[test]
+  fn in_body_locator_and_togglerbar_build_interactive_widget() {
+    // The "Triangle Calculator" Demonstration pattern: every variable is
+    // `ControlType -> None`, the points are driven by `Locator[Dynamic[…]]`
+    // markers inside the body's Graphics, and a `TogglerBar[Dynamic[…]]`
+    // in the output column switches display layers. The widget must expose
+    // the points as controls (with the Dynamic's write-back callback) and
+    // the TogglerBar as an interactive display row.
+    let code = "Manipulate[\
+      Column[{\
+        Graphics[{Dynamic[{Line[{ptA, ptB}]}], \
+          Locator[Dynamic[ptA, (If[valuesOK[{#, ptB}], ptA = #] &)[\
+            Clip[Round[#], {-8, 8}]] &], \
+            Graphics[{Disk[{0, 0}, 1]}, ImageSize -> 20]], \
+          Locator[Dynamic[ptB, (If[valuesOK[{ptA, #}], ptB = #] &)[\
+            Clip[Round[#], {-8, 8}]] &]]}, \
+          PlotRange -> {{-9, 9}, {-9, 9}}], \
+        TogglerBar[Dynamic[switches], {1 -> \"one\", 2 -> \"two\"}]}], \
+      {{ptA, {7, -1}}, {-9, -9}, {9, 9}, ControlType -> None}, \
+      {{ptB, {-5, -5}}, {-9, -9}, {9, 9}, ControlType -> None}, \
+      {{switches, {1, 2}}, ControlType -> None}, \
+      Initialization :> (valuesOK[pts_] := pts[[1]] =!= pts[[2]])]";
+    let mut state = instantiate_stored_manipulate(code)
+      .expect("in-body locator Manipulate must build a widget");
+    assert!(state.error.is_none(), "body must render: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+
+    // The two locator-driven points are visible 2D-slider controls with
+    // their write-back callbacks; `switches` stays hidden mutable state.
+    let sliders: Vec<&manipulate::ControlState> = state
+      .controls
+      .iter()
+      .filter(|c| matches!(c, manipulate::ControlState::Slider2D { .. }))
+      .collect();
+    assert_eq!(sliders.len(), 2, "ptA and ptB must be promoted");
+    assert_eq!(state.state.len(), 1);
+    assert_eq!(state.state[0].0, "switches");
+
+    // The TogglerBar is an interactive display row with both choices
+    // selected initially.
+    let togglers = collect_togglers(&state.display_trees);
+    assert_eq!(togglers.len(), 2);
+    assert!(togglers.iter().all(|(_, selected)| *selected));
+
+    // A slider move routes through the callback: the candidate is rounded
+    // to the lattice…
+    state.slider2d_change(0, 0, 3.4);
+    match &state.controls[0] {
+      manipulate::ControlState::Slider2D { x, y, .. } => {
+        assert_eq!((*x, *y), (3.0, -1.0));
+      }
+      other => panic!("expected Slider2D, got {other:?}"),
+    }
+    // …and a move that lands both points on the same spot is rejected by
+    // the notebook's valuesOK check (ptB stays put).
+    state.slider2d_change(1, 0, 3.0);
+    state.slider2d_change(1, 1, -1.0);
+    match &state.controls[1] {
+      manipulate::ControlState::Slider2D { x, y, .. } => {
+        assert_eq!((*x, *y), (3.0, -5.0), "degenerate move must be rejected");
+      }
+      other => panic!("expected Slider2D, got {other:?}"),
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+
+    // Clicking a toggler removes its value from the list; the rebuilt
+    // display shows it unselected.
+    let mutation = collect_togglers(&state.display_trees)[0].0.clone();
+    state.apply_display_mutation(&mutation);
+    assert_eq!(state.state[0].1, "{2}");
+    let togglers = collect_togglers(&state.display_trees);
+    assert_eq!(
+      togglers.iter().map(|(_, s)| *s).collect::<Vec<_>>(),
+      vec![false, true]
+    );
+  }
+
+  /// Collect `(mutation, selected)` of every Toggler in a display tree.
+  fn collect_togglers(
+    trees: &[woxi::functions::graphics::DisplayNode],
+  ) -> Vec<(String, bool)> {
+    use woxi::functions::graphics::DisplayNode;
+    fn walk(node: &DisplayNode, out: &mut Vec<(String, bool)>) {
+      match node {
+        DisplayNode::Toggler {
+          mutation, selected, ..
+        } => out.push((mutation.clone(), *selected)),
+        DisplayNode::Panel(child) => walk(child, out),
+        DisplayNode::Grid(rows) => {
+          for row in rows {
+            for cell in row {
+              walk(cell, out);
+            }
+          }
+        }
+        DisplayNode::Column(children) | DisplayNode::Row(children) => {
+          for c in children {
+            walk(c, out);
+          }
+        }
+        DisplayNode::Checkbox { .. } | DisplayNode::Static { .. } => {}
+      }
+    }
+    let mut out = Vec::new();
+    for t in trees {
+      walk(t, &mut out);
+    }
+    out
   }
 
   #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -143,6 +143,11 @@ struct CellEditor {
   graphics_handle: Option<svg::Handle>,
   /// Pre-rasterized image of the SVG (avoids resvg parse on scroll).
   graphics_image: Option<(iced::widget::image::Handle, u32, u32)>,
+  /// A display-only stored rendering from the .nb file (e.g. a
+  /// Demonstrations snapshot decoded from `RasterBox[CompressedData[…]]`).
+  /// The cell shows only the graphic; its box text stays in `content` so
+  /// saving round-trips it.
+  stored_graphic: bool,
   /// Typeset SVG renderings of the result outputs — the same SVGs the
   /// Playground shows — one per result statement that produced one. This is how
   /// number/superscript/fraction formatting is reused instead of being
@@ -505,6 +510,9 @@ impl WoxiStudio {
       match entry {
         CellEntry::Single(cell) => {
           if matches!(cell.style, CellStyle::Output | CellStyle::Print) {
+            if let Some(editor) = stored_output_editor(cell) {
+              editors.push(editor);
+            }
             continue;
           }
           editors.push(CellEditor {
@@ -527,6 +535,7 @@ impl WoxiStudio {
             is_collapsed: cell.collapsed,
             manipulate_state: None,
             hyperlinks: Vec::new(),
+            stored_graphic: false,
             output_content: text_editor::Content::new(),
             stdout_content: text_editor::Content::new(),
           });
@@ -610,13 +619,19 @@ impl WoxiStudio {
                 is_collapsed: false,
                 manipulate_state,
                 hyperlinks: Vec::new(),
+                stored_graphic: false,
                 output_content,
                 stdout_content,
               });
               i = j;
             } else if matches!(cell.style, CellStyle::Output | CellStyle::Print)
             {
-              // Skip standalone output/print in groups
+              // A standalone stored output (no preceding Input) is shown
+              // when it decodes to something displayable — e.g. the
+              // Demonstrations "Snapshots" rasters — and skipped otherwise.
+              if let Some(editor) = stored_output_editor(cell) {
+                editors.push(editor);
+              }
               i += 1;
             } else {
               editors.push(CellEditor {
@@ -639,6 +654,7 @@ impl WoxiStudio {
                 is_collapsed: false,
                 manipulate_state: None,
                 hyperlinks: Vec::new(),
+                stored_graphic: false,
                 output_content: text_editor::Content::new(),
                 stdout_content: text_editor::Content::new(),
               });
@@ -800,6 +816,17 @@ impl WoxiStudio {
               );
               woxi::set_dark_mode(!matches!(self.theme, Theme::Light));
               self.cell_editors = Self::editors_from_notebook(&nb);
+              // Stored graphics (snapshots decoded from the .nb) rasterize
+              // at load; the scale-change handler re-rasterizes them like
+              // any evaluated graphic.
+              for editor in &mut self.cell_editors {
+                if editor.stored_graphic
+                  && let Some(ref svg) = editor.graphics_svg
+                {
+                  editor.graphics_image =
+                    rasterize_svg(svg, self.scale_factor, &self.fontdb);
+                }
+              }
               self.notebook = nb;
               self.file_path = Some(path);
               self.is_dirty = false;
@@ -1841,6 +1868,7 @@ impl WoxiStudio {
             is_collapsed: false,
             manipulate_state: None,
             hyperlinks: Vec::new(),
+            stored_graphic: false,
             output_content: text_editor::Content::new(),
             stdout_content: text_editor::Content::new(),
           },
@@ -1880,6 +1908,7 @@ impl WoxiStudio {
             is_collapsed: false,
             manipulate_state: None,
             hyperlinks: Vec::new(),
+            stored_graphic: false,
             output_content: text_editor::Content::new(),
             stdout_content: text_editor::Content::new(),
           },
@@ -2778,7 +2807,10 @@ impl WoxiStudio {
           .replace("-Image-", "");
         !d.trim().is_empty()
       });
-    let is_grouped = is_input && has_output && !in_preview;
+    // Display-only stored graphics (Demonstrations snapshots) show their
+    // output section without an editor row.
+    let is_grouped =
+      (is_input && has_output || editor.stored_graphic) && !in_preview;
     let cursor_pos = editor.content.cursor().position;
     let cursor_line = cursor_pos.line;
     let cursor_column = cursor_pos.column;
@@ -2954,7 +2986,9 @@ impl WoxiStudio {
     // ── Content column: editor + outputs ──
 
     let mut content_col = Column::new().spacing(0).width(Fill);
-    content_col = content_col.push(cell_editor);
+    if !editor.stored_graphic {
+      content_col = content_col.push(cell_editor);
+    }
 
     let stale = editor.output_stale;
     let stale_opacity = if stale { 0.35 } else { 1.0 };
@@ -4280,6 +4314,77 @@ fn format_manipulate_number(v: f64) -> String {
   } else {
     trimmed.to_string()
   }
+}
+
+/// Build a display-only editor for a stored Output cell the interpreter
+/// cannot regenerate: a Demonstrations snapshot (`RasterBox[
+/// CompressedData["…"]]`) shows as a graphic, a `CheckboxBox[…]` grid as
+/// read-only text lines. The original box text stays in `content` so
+/// saving round-trips it. `None` for outputs with no displayable form.
+fn stored_output_editor(cell: &Cell) -> Option<CellEditor> {
+  let svg =
+    woxi::notebook::stored_output_image_svg(&cell.content).or_else(|| {
+      woxi::notebook::stored_output_checkbox_text(&cell.content)
+        .map(|text| plain_text_svg(&text))
+    })?;
+  // The svg handle is a fallback for when rasterization fails; the normal
+  // path shows the pre-rasterized image.
+  let handle = svg::Handle::from_memory(svg.clone().into_bytes());
+  Some(CellEditor {
+    content: text_editor::Content::with_text(&cell.content),
+    style: cell.style,
+    output: None,
+    stdout: None,
+    graphics_svg: Some(svg),
+    graphics_handle: Some(handle),
+    graphics_image: None,
+    output_svgs: Vec::new(),
+    output_images: Vec::new(),
+    output_dark: false,
+    output_all_svg: false,
+    sound: None,
+    warnings: Vec::new(),
+    undo_stack: Vec::new(),
+    redo_stack: Vec::new(),
+    output_stale: false,
+    is_collapsed: cell.collapsed,
+    manipulate_state: None,
+    hyperlinks: Vec::new(),
+    stored_graphic: true,
+    output_content: text_editor::Content::new(),
+    stdout_content: text_editor::Content::new(),
+  })
+}
+
+/// A minimal SVG rendering of plain text lines (used for stored outputs
+/// like checkbox grids), on a white card so it reads the same in both
+/// themes.
+fn plain_text_svg(text: &str) -> String {
+  let lines: Vec<&str> = text.lines().collect();
+  let char_w = 8.4_f64;
+  let line_h = 20.0_f64;
+  let width = lines.iter().map(|l| l.chars().count()).max().unwrap_or(0) as f64
+    * char_w
+    + 16.0;
+  let height = lines.len() as f64 * line_h + 12.0;
+  let mut svg = format!(
+    "<svg width=\"{width:.0}\" height=\"{height:.0}\" viewBox=\"0 0 \
+     {width:.0} {height:.0}\" xmlns=\"http://www.w3.org/2000/svg\">\n\
+     <rect width=\"{width:.0}\" height=\"{height:.0}\" fill=\"white\"/>\n"
+  );
+  for (i, line) in lines.iter().enumerate() {
+    let escaped = line
+      .replace('&', "&amp;")
+      .replace('<', "&lt;")
+      .replace('>', "&gt;");
+    let y = 6.0 + i as f64 * line_h + 14.0;
+    svg.push_str(&format!(
+      "<text x=\"8\" y=\"{y:.0}\" font-family=\"monospace\" \
+       font-size=\"14\" fill=\"#333\">{escaped}</text>\n"
+    ));
+  }
+  svg.push_str("</svg>");
+  svg
 }
 
 fn rasterize_svg(
@@ -6754,6 +6859,7 @@ mod tests {
       is_collapsed: false,
       manipulate_state: None,
       hyperlinks: Vec::new(),
+      stored_graphic: false,
       output_content: text_editor::Content::new(),
       stdout_content: text_editor::Content::new(),
     }

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -60,6 +60,10 @@ pub enum ControlState {
     y_max: f64,
     x: f64,
     y: f64,
+    /// Write-back function (from `Locator[Dynamic[var, cb], …]` promotion):
+    /// candidate values pass through `(cb)[{x, y}]` — which typically
+    /// rounds, clips, or rejects them — before the variable is read back.
+    write_callback: Option<String>,
   },
   /// An interval slider binding its variable to a `{low, high}` pair.
   IntervalSlider {
@@ -276,6 +280,58 @@ impl ManipulateState {
     self.reevaluate();
   }
 
+  /// Apply a 2D-slider change to axis 0 (x) or 1 (y). A control promoted
+  /// from an in-body `Locator[Dynamic[var, cb], …]` routes the candidate
+  /// point through `cb` first — evaluated against the *previous* bindings —
+  /// and takes whatever value the callback actually stored (rounded,
+  /// clamped, or unchanged when the callback rejects the move), exactly as
+  /// Wolfram would.
+  pub fn slider2d_change(&mut self, ctrl_idx: usize, axis: u8, value: f64) {
+    let (candidate, callback, name) = {
+      let Some(ControlState::Slider2D {
+        name,
+        x,
+        y,
+        write_callback,
+        ..
+      }) = self.controls.get(ctrl_idx)
+      else {
+        return;
+      };
+      let candidate = if axis == 0 { (value, *y) } else { (*x, value) };
+      (candidate, write_callback.clone(), name.clone())
+    };
+    let accepted = match callback {
+      Some(cb) => {
+        // Bindings still hold the previous point, so the callback's
+        // validation (e.g. a degenerate-triangle check) sees the old state.
+        let bindings = self.bindings();
+        let value_code = format!(
+          "{{{}, {}}}",
+          format_f64(candidate.0),
+          format_f64(candidate.1)
+        );
+        woxi::functions::graphics::apply_manipulate_callback(
+          &bindings,
+          &cb,
+          &value_code,
+          &name,
+        )
+        .and_then(|v| {
+          woxi::functions::graphics::parse_manipulate_point(&v)
+        })
+        .unwrap_or(candidate)
+      }
+      None => candidate,
+    };
+    if let Some(ControlState::Slider2D { x, y, .. }) =
+      self.controls.get_mut(ctrl_idx)
+    {
+      *x = accepted.0;
+      *y = accepted.1;
+    }
+  }
+
   /// Register a control change and report whether the caller must arm a
   /// throttle timer. Re-evaluating the body on *every* slider mouse-move tick
   /// blocks the UI thread and makes the graphic stutter/flicker while
@@ -490,6 +546,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         y_max,
         x_initial,
         y_initial,
+        write_callback,
       } => ControlState::Slider2D {
         name: name.clone(),
         label: label.clone(),
@@ -499,6 +556,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         y_max: *y_max,
         x: *x_initial,
         y: *y_initial,
+        write_callback: write_callback.clone(),
       },
       ManipulateControl::IntervalSlider {
         name,

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -317,9 +317,7 @@ impl ManipulateState {
           &value_code,
           &name,
         )
-        .and_then(|v| {
-          woxi::functions::graphics::parse_manipulate_point(&v)
-        })
+        .and_then(|v| woxi::functions::graphics::parse_manipulate_point(&v))
         .unwrap_or(candidate)
       }
       None => candidate,


### PR DESCRIPTION
## Summary

This PR adds support for interactive `Locator` markers in graphics, proper handling of `Dynamic` and `Tooltip` constructs within graphics, and decoding of stored output cells (raster snapshots and checkbox grids) from Mathematica notebooks. It also improves `ContourPlot` to support equation form and enables structural access to plot contents.

## Key Changes

### Graphics Primitives and Rendering
- **New `MarkerPrim` primitive**: Screen-space icon markers (fixed pixel size) anchored on data-space points, used for `Locator` appearance graphics
- **`Locator` support**: Renders interactive point markers with customizable appearance graphics; default is a small circled crosshair
- **`Dynamic` in graphics**: Evaluates held `Dynamic[expr]` expressions to their current values within graphics primitives
- **`Tooltip` in graphics**: Renders only the graphic content, dropping the label (which has no static SVG form)
- **Marker transformation handling**: Properly scales, translates, and rotates marker anchors while keeping icon size fixed

### Plot Enhancements
- **Equation-form `ContourPlot`**: `ContourPlot[lhs == rhs, ...]` now draws the implicit curve `lhs - rhs = 0` without band shading
- **Structural access to plots**: `ContourPlot[...][[1]]` returns the graphic's content (contour primitives with styling) for re-embedding in outer graphics or rewriting with `/.`
- **Segment chaining with configurable tolerance**: Refactored to support both screen-pixel and data-coordinate granularity

### Stored Output Decoding
- **Raster snapshot support**: Decodes `RasterBox[CompressedData["..."]]` from Mathematica notebooks into PNG-embedded SVG
- **Checkbox grid support**: Parses `CheckboxBox[...]` grids as readable text (`[x] label` / `[ ] label` format)
- **Studio integration**: Display-only editors for stored outputs; snapshots rasterize at load and on scale changes

### Layout and Display Improvements
- **`Dynamic` in `Column`/`Row`**: Resolves held `Dynamic[expr]` to current values; embedded graphics are captured and composed
- **Nested layout support**: `Column`/`Row` items that are themselves layout constructs render as nested SVGs instead of raw text
- **Alignment option form**: `Column[list, Alignment -> Center]` now works alongside positional form
- **Inline math cells**: `Cell[BoxData[FormBox[...]], "InlineMath"]` contributes typeset content to prose

### Manipulate Enhancements
- **Locator-promoted controls**: `Locator[Dynamic[var, cb], ...]` in the body becomes a visible 2D slider control with write-back callback validation
- **TogglerBar display support**: `TogglerBar[Dynamic[var], ...]` items appear in the display list as toggle buttons
- **Callback routing**: 2D slider changes pass through write-back callbacks (e.g., `Clip[Round[#], ...]`) before variable update, matching Wolfram behavior

### Pattern Matching and Serialization
- **Graphic structure preservation**: `plot /. Tooltip[x_, ___] :> x` rewrites a graphic's symbolic structure in place while keeping the SVG rendering
- **Part base parenthesization**: Operator expressions used as `Part` bases are parenthesized so `(a /. b)[[i]]` re-parses correctly

## Implementation Details

- Marker icons are embedded as pre-rendered SVG at their specified pixel dimensions, centered on data-space anchor points
- `Dynamic` evaluation within graphics captures any sub-graphics and drops them from the output buffer (they're embedded, not standalone)
- Stored output decoding handles Mathematica's binary serialization format (`!boR` magic, `RawArray` structure) and zlib compression
- Locator write-back callbacks are evaluated against previous bindings, allowing validation logic to see the state before the move
- Contour plot structure is built as a list of styled primitives, enabling both `[[1]]` access and `/.` rewriting

## Testing

https://claude.ai/code/session_01VgAytcPwvyefWDVBx8iADo