### PR TITLE
Simplify syntax:: imports in src\evaluator

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, ComparisonOp, UnaryOperator};
 use std::cell::Cell;
 
 thread_local! {

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, ComparisonOp, bool_expr, unevaluated};
 
 /// Report that an in-place modification has nothing to modify:
 /// `<Fn>::rvalue: <target> is not a variable with a value, so its value

--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -1,5 +1,5 @@
+#[allow(unused_imports)]
 use super::*;
-use crate::syntax::unevaluated;
 
 /// Returns the valid argument count range (min, max) for a known built-in function.
 /// Returns None if the function is not in the table.

--- a/src/evaluator/dispatch/association_functions.rs
+++ b/src/evaluator/dispatch/association_functions.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::unevaluated;
 
 pub fn dispatch_association_functions(
   name: &str,

--- a/src/evaluator/dispatch/audio_functions.rs
+++ b/src/evaluator/dispatch/audio_functions.rs
@@ -6,9 +6,9 @@
 //! TotalVariationFilter), and the Audio paths of shared functions
 //! (Mean/Median/Variance/Quantile, MeanFilter, LowpassFilter).
 
-use crate::InterpreterError;
+#[allow(unused_imports)]
+use super::*;
 use crate::functions::audio_ast as audio;
-use crate::syntax::Expr;
 
 pub(super) fn dispatch_audio_functions(
   name: &str,

--- a/src/evaluator/dispatch/boolean_functions.rs
+++ b/src/evaluator/dispatch/boolean_functions.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{ComparisonOp, bool_expr};
 
 pub fn dispatch_boolean_functions(
   name: &str,

--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -1,9 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::is_sqrt;
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, UnaryOperator, bool_expr, unevaluated,
-};
 
 /// Check if the result of differentiation contains a
 /// `Derivative[...][func_name][...]` pattern (as CurriedCall),

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -3,10 +3,6 @@ use super::*;
 use crate::functions::math_ast::{
   expr_to_rational, is_sqrt, make_sqrt, rat_reduce,
 };
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, binop, bool_expr,
-  unevaluated,
-};
 
 pub fn dispatch_complex_and_special(
   name: &str,

--- a/src/evaluator/dispatch/datetime_functions.rs
+++ b/src/evaluator/dispatch/datetime_functions.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 
 /// How many date components a granularity keeps: `"Month"` names a year and a
 /// month, `"Hour"` everything down to the hour, and so on. `None` for a

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -1,8 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-
 use crate::functions::math_ast::rat_reduce;
-use crate::syntax::bool_expr;
 
 /// Transform a Dataset type expression for DeleteMissing:
 /// Replace the fixed-length count in Vector[elem_type, N] with TypeSystem`AnyLength.

--- a/src/evaluator/dispatch/evaluation_control.rs
+++ b/src/evaluator/dispatch/evaluation_control.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, bool_expr, unevaluated};
 
 pub fn dispatch_evaluation_control(
   name: &str,

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{bool_expr, unevaluated};
 
 /// Colors of a Wolfram `ColorData` indexed scheme (`ColorData[n, "ColorList"]`).
 ///

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::unevaluated;
 use std::cell::RefCell;
 use std::collections::HashMap;
 

--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -1,7 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::{make_sqrt, rat_reduce};
-use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 
 /// `BoxMatrix[r, w]` / `DiamondMatrix[r, w]`: the structuring element of
 /// radius `r` centred in a grid `w` wide along each dimension, zero

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -2,7 +2,6 @@
 use super::*;
 use crate::functions::list_helpers_ast;
 use crate::functions::string_ast::{Overlaps, parse_overlaps_option};
-use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 
 /// Parse the `m` argument of NestWhile[f, x, test, m, ...]. Returns `All` for
 /// the symbol `All`, `Last(n)` for a positive integer, and `None` otherwise.

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -3,9 +3,6 @@ use super::*;
 use crate::functions::math_ast::{
   expr_to_rational, gcd_i128, gcd_u64, make_rational, make_sqrt, rat_reduce,
 };
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, UnaryOperator, binop, unevaluated,
-};
 
 /// Columnwise quartile-family statistic for a matrix argument.
 ///

--- a/src/evaluator/dispatch/mod.rs
+++ b/src/evaluator/dispatch/mod.rs
@@ -1,17 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
 
-// Re-export crate types/functions for submodules (used by submodules via `use super::*`)
-#[allow(unused_imports)]
-pub(crate) use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
-  unevaluated,
-};
-#[allow(unused_imports)]
-pub(crate) use crate::{
-  ENV, InterpreterError, PART_DEPTH, StoredValue, interpret,
-};
-
 pub mod arg_count;
 mod association_functions;
 mod audio_functions;

--- a/src/evaluator/dispatch/music_functions.rs
+++ b/src/evaluator/dispatch/music_functions.rs
@@ -7,7 +7,6 @@
 
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::unevaluated;
 
 pub(super) fn dispatch_music_functions(
   name: &str,

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, unevaluated};
 
 /// Wrap a plot function call in Quiet mode so that messages emitted during
 /// function sampling (e.g. Power::indet for 0^0) are suppressed and discarded.

--- a/src/evaluator/dispatch/polynomial_functions.rs
+++ b/src/evaluator/dispatch/polynomial_functions.rs
@@ -1,7 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::rat_reduce;
-use crate::syntax::{BinaryOperator, ComparisonOp, bool_expr, unevaluated};
 
 /// The optimization family takes an optional domain as its third argument.
 /// `Reals` is the default, so it is dropped here — which also lets the

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{ComparisonOp, bool_expr, unevaluated};
 
 /// True if `expr` contains any Real or BigFloat node — used to decide
 /// between exact and inexact number predicates.

--- a/src/evaluator/dispatch/string_functions.rs
+++ b/src/evaluator/dispatch/string_functions.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{bool_expr, unevaluated};
 
 pub fn dispatch_string_functions(
   name: &str,

--- a/src/evaluator/dispatch/structural.rs
+++ b/src/evaluator/dispatch/structural.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::unevaluated;
 
 pub fn dispatch_structural(
   name: &str,

--- a/src/evaluator/dispatch/timeseries_functions.rs
+++ b/src/evaluator/dispatch/timeseries_functions.rs
@@ -4,9 +4,9 @@
 //! runs before `list_operations` so the statistics heads can pull the value
 //! path out of a `TimeSeries` before the generic list handlers see it.
 
-use crate::InterpreterError;
+#[allow(unused_imports)]
+use super::*;
 use crate::functions::timeseries_ast;
-use crate::syntax::Expr;
 
 pub(super) fn dispatch_timeseries_functions(
   name: &str,

--- a/src/evaluator/dispatch/wavelet_functions.rs
+++ b/src/evaluator/dispatch/wavelet_functions.rs
@@ -5,9 +5,9 @@
 //! and the wavelet plot functions. Also intercepts `Normal` applied to a
 //! DiscreteWaveletData or ContinuousWaveletData object.
 
-use crate::InterpreterError;
+#[allow(unused_imports)]
+use super::*;
 use crate::functions::wavelet_ast as wa;
-use crate::syntax::Expr;
 use wa::transforms::TransformKind;
 
 pub(super) fn dispatch_wavelet_functions(

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, bool_expr, unevaluated};
 
 /// MapAll[f, expr] - apply f to every subexpression in expr (bottom-up)
 pub fn map_all_ast(f: &Expr, expr: &Expr) -> Result<Expr, InterpreterError> {
@@ -275,7 +274,6 @@ fn differentiate_function_body(body: &Expr, orders: &[i128]) -> Option<Expr> {
 
 /// Split an expression by its head. E.g., split_by_head(a + b, "Plus") = [a, b]
 fn split_by_head(expr: &Expr, head: &str) -> Vec<Expr> {
-  use crate::syntax::BinaryOperator;
   // Operators like `|` (Alternatives) or `+` (Plus) are stored as (possibly
   // nested) BinaryOp nodes rather than FunctionCall nodes. Map the operator to
   // its head name so Distribute can split e.g. `a | b | c` into {a, b, c}.
@@ -346,7 +344,6 @@ pub fn apply_apply_ast(
     // FunctionCall nodes — notably Alternatives (`a | b | c`). Flatten
     // same-operator chains so `List @@ (a | b | c)` → {a, b, c}, matching WS.
     Expr::BinaryOp { op, left, right } => {
-      use crate::syntax::BinaryOperator;
       fn flatten(op: &BinaryOperator, e: &Expr, out: &mut Vec<Expr>) {
         if let Expr::BinaryOp {
           op: inner,

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::bool_expr;
 
 /// Dispatch function call to built-in implementations (AST version).
 /// This is the AST equivalent of the string-based function dispatch.

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -1,4 +1,7 @@
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, binop, bool_expr,
+  expr_to_string, unevaluated,
+};
 use crate::{ENV, InterpreterError, PART_DEPTH, StoredValue, interpret};
 
 pub(crate) mod assignment;

--- a/src/evaluator/part_extraction.rs
+++ b/src/evaluator/part_extraction.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, UnaryOperator};
 
 fn expr_to_i64(expr: &Expr) -> Option<i64> {
   match expr {

--- a/src/evaluator/pattern_functions.rs
+++ b/src/evaluator/pattern_functions.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::unevaluated;
 
 /// Pattern[name, Blank[]] → name_ or Pattern[name, Blank[h]] → name_h
 #[inline(never)]

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, UnaryOperator, bool_expr, unevaluated};
 use std::cell::RefCell;
 
 // Thread-local stack of accumulated bindings from outer FunctionCall arg loops.

--- a/src/evaluator/scoping.rs
+++ b/src/evaluator/scoping.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{BinaryOperator, ComparisonOp, bool_expr};
 
 /// AST-based Module implementation to avoid interpret() recursion
 pub fn module_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {


### PR DESCRIPTION
Woxi often imports functions via the use super::* syntax, but rarely puts those imports in mod.rs files to make them available. One place it does so is src\evaluator\mod.rs, but most files still explicitly import the fns and enums. This PR removes the redundant imports.