### PR TITLE
Combine public expr_to_i128 implementations

### DIFF
--- a/src/functions/list_helpers_ast/element_access.rs
+++ b/src/functions/list_helpers_ast/element_access.rs
@@ -616,8 +616,7 @@ fn spec_range(n: &Expr) -> Option<(i128, i128)> {
     Expr::Integer(v) if *v >= 0 => Some((1, *v)),
     Expr::Integer(v) => Some((*v, -1)),
     Expr::List(spec) => {
-      let nums: Option<Vec<i128>> =
-        spec.iter().map(super::utilities::expr_to_i128).collect();
+      let nums: Option<Vec<i128>> = spec.iter().map(expr_to_i128).collect();
       match nums.as_deref() {
         Some([i]) => Some((*i, *i)),
         Some([i, j]) | Some([i, j, _]) => Some((*i, *j)),

--- a/src/functions/list_helpers_ast/mod.rs
+++ b/src/functions/list_helpers_ast/mod.rs
@@ -4,6 +4,7 @@
 //! round-trips and re-parsing that the original `list_helpers.rs` functions use.
 
 use crate::InterpreterError;
+use crate::functions::math_ast::expr_to_i128;
 use crate::syntax::Expr;
 
 mod aggregation;

--- a/src/functions/list_helpers_ast/restructuring.rs
+++ b/src/functions/list_helpers_ast/restructuring.rs
@@ -85,15 +85,12 @@ pub fn partition_ast(
   // {k, k} (Partition[list, n, d, k] == Partition[list, n, d, {k, k}]).
   let (k_l, k_r) = match align {
     Some(Expr::List(elems)) if elems.len() == 2 => {
-      match (
-        super::utilities::expr_to_i128(&elems[0]),
-        super::utilities::expr_to_i128(&elems[1]),
-      ) {
+      match (expr_to_i128(&elems[0]), expr_to_i128(&elems[1])) {
         (Some(kl), Some(kr)) => (kl, kr),
         _ => (1, -1), // default: no overhang
       }
     }
-    Some(other) => match super::utilities::expr_to_i128(other) {
+    Some(other) => match expr_to_i128(other) {
       Some(k) => (k, k),
       None => (1, -1),
     },

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -2,7 +2,7 @@
 use super::utilities::*;
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::{gcd_i128, rat_reduce};
+use crate::functions::math_ast::{expr_to_i128, gcd_i128, rat_reduce};
 use crate::syntax::{BinaryOperator, UnaryOperator, unevaluated};
 
 /// AnglePath[{θ1, θ2, ...}] - path with unit steps and cumulative turning angles.

--- a/src/functions/list_helpers_ast/utilities.rs
+++ b/src/functions/list_helpers_ast/utilities.rs
@@ -177,24 +177,11 @@ pub fn get_expr_head_str(expr: &Expr) -> &str {
   }
 }
 
-/// Helper to extract i128 from Expr
-pub(crate) fn expr_to_i128(expr: &Expr) -> Option<i128> {
-  match expr {
-    Expr::Integer(n) => Some(*n),
-    Expr::BigInteger(n) => {
-      use num_traits::ToPrimitive;
-      n.to_i128()
-    }
-    Expr::Real(f) if f.fract() == 0.0 => Some(*f as i128),
-    _ => None,
-  }
-}
-
 /// Like `expr_to_i128`, but also floors fractional Reals and Rationals so
 /// iterator bounds like `Do[..., {i, 1, 7/2}]` or `Do[..., {i, 1, 3.5}]`
 /// behave the same as wolframscript (which iterates up to `Floor[bound]`).
 pub(crate) fn expr_to_i128_floor(expr: &Expr) -> Option<i128> {
-  if let Some(n) = expr_to_i128(expr) {
+  if let Some(n) = crate::functions::math_ast::expr_to_i128(expr) {
     return Some(n);
   }
   let f = crate::functions::math_ast::try_eval_to_f64_with_infinity(expr)?;

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -676,6 +676,7 @@ pub fn expr_to_i128(e: &Expr) -> Option<i128> {
   match e {
     Expr::Integer(n) => Some(*n),
     Expr::BigInteger(n) => n.to_i128(),
+    Expr::Real(f) if f.fract() == 0.0 => Some(*f as i128),
     _ => None,
   }
 }

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -3,6 +3,7 @@
 //! These functions work directly with `Expr` AST nodes, avoiding string round-trips.
 
 use crate::InterpreterError;
+use crate::functions::math_ast::expr_to_i128;
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
 };
@@ -151,7 +152,7 @@ fn is_ambiguous_int_list(spec: &Expr) -> bool {
   matches!(spec, Expr::List(elems)
   if elems.len() >= 4
     && elems.iter().all(|e| {
-      crate::functions::list_helpers_ast::expr_to_i128(e).is_some()
+      expr_to_i128(e).is_some()
     }))
 }
 
@@ -387,8 +388,7 @@ fn string_take_drop(
     // `{}` is an empty sequence specification: take nothing / drop nothing.
     Expr::List(elems) if elems.is_empty() => Ok(empty_or_all(true)),
     Expr::List(elems) if elems.len() == 1 => {
-      let Some(i) = crate::functions::list_helpers_ast::expr_to_i128(&elems[0])
-      else {
+      let Some(i) = expr_to_i128(&elems[0]) else {
         return Ok(unevaluated());
       };
       let real = if i > 0 { i } else { len + i + 1 };
@@ -400,10 +400,7 @@ fn string_take_drop(
       }
     }
     Expr::List(elems) if elems.len() == 2 || elems.len() == 3 => {
-      let nums: Option<Vec<i128>> = elems
-        .iter()
-        .map(crate::functions::list_helpers_ast::expr_to_i128)
-        .collect();
+      let nums: Option<Vec<i128>> = elems.iter().map(expr_to_i128).collect();
       let Some(nums) = nums else {
         return Ok(unevaluated());
       };
@@ -440,7 +437,7 @@ fn string_take_drop(
       name: up_name,
       args: up_args,
     } if up_name == "UpTo" && up_args.len() == 1 => {
-      match crate::functions::list_helpers_ast::expr_to_i128(&up_args[0]) {
+      match expr_to_i128(&up_args[0]) {
         Some(k) if k >= 0 => {
           let count = k.min(len);
           if count == 0 {
@@ -457,9 +454,7 @@ fn string_take_drop(
     // refuses.
     Expr::List(elems)
       if elems.len() >= 4
-        && elems.iter().all(|e| {
-          crate::functions::list_helpers_ast::expr_to_i128(e).is_some()
-        }) =>
+        && elems.iter().all(|e| expr_to_i128(e).is_some()) =>
     {
       if is_take {
         return list_of_specs(fname, &args[0], elems, true);
@@ -468,8 +463,7 @@ fn string_take_drop(
       Ok(unevaluated())
     }
     other => {
-      let Some(count) = crate::functions::list_helpers_ast::expr_to_i128(other)
-      else {
+      let Some(count) = expr_to_i128(other) else {
         return Ok(unevaluated());
       };
       if count.unsigned_abs() > len.unsigned_abs() {
@@ -3541,12 +3535,12 @@ fn string_pattern_to_regex_inner(
         let quantifier = match &args[1] {
           Expr::Integer(n) => format!("{{1,{}}}", n),
           Expr::List(items) if items.len() == 1 => {
-            let n = crate::functions::math_ast::expr_to_i128(&items[0])?;
+            let n = expr_to_i128(&items[0])?;
             format!("{{{}}}", n)
           }
           Expr::List(items) if items.len() == 2 => {
-            let min = crate::functions::math_ast::expr_to_i128(&items[0])?;
-            let max = crate::functions::math_ast::expr_to_i128(&items[1])?;
+            let min = expr_to_i128(&items[0])?;
+            let max = expr_to_i128(&items[1])?;
             format!("{{{},{}}}", min, max)
           }
           _ => return None,


### PR DESCRIPTION
Both list_helpers/utilites.rs and math_ast/numeric_utils.rs have public implementations of expr_to_i128.  They only differ in handling floating point integers, so try to combine them into a single implementation.