### PR TITLE
Simplify syntax:: imports in src/functions/math_ast

### DIFF
--- a/src/functions/math_ast/airy.rs
+++ b/src/functions/math_ast/airy.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// AiryAi[x] - Airy function of the first kind
 pub fn airy_ai_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1,9 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{
-  BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
-};
 use num_bigint::BigInt;
 use num_bigint::Sign;
 

--- a/src/functions/math_ast/bessel.rs
+++ b/src/functions/math_ast/bessel.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// True if `z_expr` is `<zero_name>[order, k, ...]` whose first argument equals
 /// `n_expr` AND both `order` and `k` are concrete positive integers — the only

--- a/src/functions/math_ast/carlson.rs
+++ b/src/functions/math_ast/carlson.rs
@@ -7,11 +7,10 @@
 
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{Expr, binop, unevaluated};
-
-/// True if `e` contains an inexact (machine) number anywhere.
+use crate::evaluator::evaluate_expr_to_expr as eval_expr;
+use crate::evaluator::pattern_matching::expr_equal;
 use crate::functions::math_ast::contains_inexact_real as is_inexact;
+use crate::functions::math_ast::make_sqrt;
 
 /// R_C(x, y) — degenerate Carlson integral.
 fn carlson_rc(x: f64, y: f64) -> f64 {
@@ -283,11 +282,6 @@ fn carlson_rg(x: f64, y: f64, z: f64) -> f64 {
 // argument patterns (equal arguments, a vanishing argument, …). These fire only
 // for exact input; inexact arguments go through the numeric kernels above.
 // ---------------------------------------------------------------------------
-
-use crate::evaluator::evaluate_expr_to_expr as eval_expr;
-use crate::evaluator::pattern_matching::expr_equal;
-use crate::functions::math_ast::make_sqrt;
-use crate::syntax::BinaryOperator;
 
 fn is_zero(e: &Expr) -> bool {
   matches!(e, Expr::Integer(0))

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// True if `t` carries the imaginary unit `I` as a direct factor (possibly
 /// nested inside Times/negation): `I`, `b I`, `-2 b I`, etc.

--- a/src/functions/math_ast/coordinate_arrays.rs
+++ b/src/functions/math_ast/coordinate_arrays.rs
@@ -5,8 +5,6 @@
 
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{Expr, UnaryOperator, expr_to_output, unevaluated};
 
 /// One coordinate value: an exact rational (p/q, q > 0) or a machine real.
 /// Grids over exact bounds with exact steps stay exact (`Into[2]` of a unit

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -1,9 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{
-  BinaryOperator, Expr, UnaryOperator, expr_to_string, unevaluated,
-};
 use num_bigint::BigInt;
 use num_traits::{Signed, Zero};
 

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -1,11 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::evaluator::evaluate_expr_to_expr;
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, binop, bool_expr,
-  expr_to_string, unevaluated,
-};
 
 fn plus(a: Expr, b: Expr) -> Expr {
   binop(BinaryOperator::Plus, a, b)
@@ -17341,15 +17336,15 @@ pub fn censored_distribution_value(
 
   match head {
     "CDF" => {
-      use crate::syntax::ComparisonOp::{GreaterEqual, Less};
-      if decides(x, Less, &lo) == Some(true) {
+      use ComparisonOp as C;
+      if decides(x, C::Less, &lo) == Some(true) {
         return Ok(Some(Expr::Integer(0)));
       }
-      if decides(x, GreaterEqual, &hi) == Some(true) {
+      if decides(x, C::GreaterEqual, &hi) == Some(true) {
         return Ok(Some(Expr::Integer(1)));
       }
       // Inside the range the base CDF is unchanged.
-      match decides(x, Less, &hi) {
+      match decides(x, C::Less, &hi) {
         Some(true) => Ok(Some(cdf_ast(&[base, x.clone()])?)),
         _ => Ok(None),
       }

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -1,9 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{
-  BinaryOperator, Expr, ExprForm, UnaryOperator, expr_to_string, unevaluated,
-};
+use crate::syntax::ExprForm;
 use num_bigint::BigInt;
 use num_bigint::Sign;
 

--- a/src/functions/math_ast/elliptic.rs
+++ b/src/functions/math_ast/elliptic.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// True if `e` contains an inexact (machine) number. Elliptic functions
 /// numericize only when an argument is inexact; exact (integer/rational)

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 use num_bigint::BigInt;
 
 /// Pochhammer[a, n] - Rising factorial (Pochhammer symbol): a * (a+1) * ... * (a+n-1)

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, binop, expr_to_string, unevaluated};
 
 /// Collect the factors of a product into `out`, descending through nested
 /// `Times` (both spellings) so that factors from separately evaluated parts

--- a/src/functions/math_ast/integrals.rs
+++ b/src/functions/math_ast/integrals.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// ExpIntegralEi[x] - Exponential integral Ei(x)
 pub fn exp_integral_ei_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/jacobi.rs
+++ b/src/functions/math_ast/jacobi.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 /// Compute Jacobi elliptic functions sn(u, m), cn(u, m), dn(u, m) numerically
 /// using the descending Landen (AGM) transformation.

--- a/src/functions/math_ast/mathieu.rs
+++ b/src/functions/math_ast/mathieu.rs
@@ -14,8 +14,9 @@
 //! a smooth (a, q)-dependent factor. Users who need exact wolframscript
 //! agreement should compare ratios `MathieuSPrime(a, q, z) /
 //! MathieuSPrime(a, q, 0)` (these match to numerical precision).
-use crate::InterpreterError;
-use crate::syntax::{Expr, unevaluated};
+
+#[allow(unused_imports)]
+use super::*;
 
 fn try_real_f64(e: &Expr) -> Option<f64> {
   match e {

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -1,9 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{
-  BinaryOperator, Expr, UnaryOperator, binop, expr_to_string, unevaluated,
-};
 use num_bigint::BigInt;
 
 /// QPochhammer[a, q, n] — q-Pochhammer symbol.

--- a/src/functions/math_ast/mod.rs
+++ b/src/functions/math_ast/mod.rs
@@ -2,6 +2,12 @@
 //!
 //! These functions work directly with `Expr` AST nodes.
 
+use crate::InterpreterError;
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, binop, bool_expr,
+  expr_to_output, expr_to_string, unevaluated,
+};
+
 mod airy;
 mod arithmetic;
 mod bessel;

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -1,10 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
-  unevaluated,
-};
 use num_bigint::BigInt;
 use num_traits::{Signed, Zero};
 

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator};
 use num_bigint::BigInt;
 use num_traits::{Signed, Zero};
 

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -1,10 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{
-  BinaryOperator, Expr, UnaryOperator, expr_to_string, substitute_variable,
-  unevaluated,
-};
+use crate::syntax::substitute_variable;
 
 pub fn n_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.is_empty() || args.len() > 2 {

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 use num_bigint::BigInt;
 
 /// Visit every additive term of a polynomial expression, flattening nested and

--- a/src/functions/math_ast/polylog.rs
+++ b/src/functions/math_ast/polylog.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// PolyLog[s, z] - Polylogarithm function Li_s(z)
 pub fn polylog_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// Emit the `<Name>::array` message and return the call unevaluated for an
 /// invalid dimension specification (a negative integer, a non-integer, or a

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -1,10 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, ExprForm, UnaryOperator, binop,
-  bool_expr, expr_to_output, expr_to_string, format_expr, unevaluated,
-};
+use crate::syntax::{ExprForm, format_expr};
 
 /// If the first argument is a numeric scalar, emit
 /// `<F>::rectt: Rectangular array expected at position 1 in <call>.`,

--- a/src/functions/math_ast/triangles.rs
+++ b/src/functions/math_ast/triangles.rs
@@ -8,8 +8,8 @@
 //! `Cos[a - Pi/6] Csc[a]` forms) and are left unevaluated. Symbolic side
 //! lengths pass through fine.
 
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, expr_to_output, unevaluated};
+#[allow(unused_imports)]
+use super::*;
 
 fn fc(name: &str, args: Vec<Expr>) -> Expr {
   Expr::FunctionCall {

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, binop, unevaluated};
 
 /// Try to express a symbolic expression as a rational multiple of Pi: k*Pi/n.
 /// Returns Some((k, n)) in lowest terms, None if not recognized.

--- a/src/functions/math_ast/weierstrass.rs
+++ b/src/functions/math_ast/weierstrass.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{Expr, unevaluated};
 
 // Format a `Power::infy` warning in wolframscript's 2D layout, e.g.
 // `0^-3` renders as:

--- a/src/functions/math_ast/zeta_functions.rs
+++ b/src/functions/math_ast/zeta_functions.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// Check if an expression contains any float-valued components (Real or BigFloat).
 fn contains_float(expr: &Expr) -> bool {


### PR DESCRIPTION
Move most syntax:: imports to src/functions/math_ast/mod.rs to reduce redundant imports in that directory.