### PR TITLE
Simplify syntax:: imports in src/functions/polynomial_ast

### DIFF
--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -1,8 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::functions::math_ast::{gcd_i128, lcm_i128, rat_reduce};
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
 
 // ─── Apart ──────────────────────────────────────────────────────────
 

--- a/src/functions/polynomial_ast/cancel.rs
+++ b/src/functions/polynomial_ast/cancel.rs
@@ -1,8 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::functions::math_ast::{gcd_i128, is_sqrt, make_sqrt, rat_reduce};
-use crate::syntax::{BinaryOperator, Expr, expr_to_string};
 
 // ─── Cancel ─────────────────────────────────────────────────────────
 
@@ -267,7 +265,6 @@ fn cancel_expr_impl(expr: &Expr, canonicalize_sign: bool) -> Expr {
       {
         use super::coefficient::collect_additive_terms;
         use super::expand::{build_product, collect_multiplicative_factors};
-        use crate::syntax::expr_to_string;
 
         let terms = collect_additive_terms(&num);
         if terms.len() >= 2 {

--- a/src/functions/polynomial_ast/coefficient.rs
+++ b/src/functions/polynomial_ast/coefficient.rs
@@ -1,10 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::evaluator::pattern_matching::expr_equal;
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
-};
 
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 

--- a/src/functions/polynomial_ast/collect.rs
+++ b/src/functions/polynomial_ast/collect.rs
@@ -1,8 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
-
 use crate::functions::calculus_ast::simplify;
 use crate::functions::math_ast::times_ast;
 use crate::functions::polynomial_ast::expand::is_sum;

--- a/src/functions/polynomial_ast/cyclotomic.rs
+++ b/src/functions/polynomial_ast/cyclotomic.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// Cyclotomic[n, x] - The n-th cyclotomic polynomial evaluated at x
 pub fn cyclotomic_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/polynomial_ast/decompose.rs
+++ b/src/functions/polynomial_ast/decompose.rs
@@ -1,10 +1,9 @@
-use crate::InterpreterError;
-use crate::functions::math_ast::gcd_i128;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
-
 use super::coefficient::collect_additive_terms;
 use super::coefficient::term_var_power_and_coeff;
 use super::expand::expand_and_combine;
+#[allow(unused_imports)]
+use super::*;
+use crate::functions::math_ast::gcd_i128;
 
 /// Decompose[poly, x] - decompose a polynomial into a composition of simpler polynomials.
 /// Returns a list {g1, g2, ..., gn} such that poly(x) = g1(g2(...gn(x)...)).

--- a/src/functions/polynomial_ast/discriminant.rs
+++ b/src/functions/polynomial_ast/discriminant.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{Expr, unevaluated};
 
 /// True when `e` is a numeric literal equal to zero (integer or real).
 fn is_zero_const(e: &Expr) -> bool {

--- a/src/functions/polynomial_ast/eliminate.rs
+++ b/src/functions/polynomial_ast/eliminate.rs
@@ -1,12 +1,8 @@
 use super::together::negate_expr;
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 use crate::functions::math_ast::rat_reduce;
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, bool_expr, expr_to_string, unevaluated,
-};
 
 /// Eliminate[{eq1, eq2, ...}, var]  or  Eliminate[{eq1, eq2, ...}, {v1, v2, ...}]
 /// Eliminates variables from a system of equations.

--- a/src/functions/polynomial_ast/expand.rs
+++ b/src/functions/polynomial_ast/expand.rs
@@ -1,8 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
-
 use crate::functions::calculus_ast::simplify;
 
 // ─── Expand ─────────────────────────────────────────────────────────

--- a/src/functions/polynomial_ast/exponent.rs
+++ b/src/functions/polynomial_ast/exponent.rs
@@ -1,8 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
-
 use crate::functions::calculus_ast::is_constant_wrt;
 use crate::functions::math_ast::rat_reduce;
 

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -1,11 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::functions::calculus_ast::simplify;
 use crate::functions::math_ast::{gcd_i128, lcm_i128, rat_reduce};
-use crate::syntax::{
-  BinaryOperator, Expr, UnaryOperator, bool_expr, expr_to_string, unevaluated,
-};
 
 // ─── Factor ─────────────────────────────────────────────────────────
 

--- a/src/functions/polynomial_ast/function_expand.rs
+++ b/src/functions/polynomial_ast/function_expand.rs
@@ -1,6 +1,5 @@
-use super::{mk_call, mk_int, mk_power, mk_ratio, mk_times};
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr};
+#[allow(unused_imports)]
+use super::*;
 
 /// FunctionExpand[expr] — expand special mathematical functions into simpler forms.
 pub fn function_expand_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/polynomial_ast/gf_factor.rs
+++ b/src/functions/polynomial_ast/gf_factor.rs
@@ -9,8 +9,6 @@
 
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, bool_expr, unevaluated};
 
 /// Keep the c-sweep in Berlekamp splitting bounded.
 const MAX_MODULUS: i128 = 65_536;

--- a/src/functions/polynomial_ast/helpers.rs
+++ b/src/functions/polynomial_ast/helpers.rs
@@ -1,8 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, bool_expr, expr_to_string,
-};
 
 // ─── helpers ────────────────────────────────────────────────────────
 

--- a/src/functions/polynomial_ast/horner.rs
+++ b/src/functions/polynomial_ast/horner.rs
@@ -1,8 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
-
 use crate::functions::polynomial_ast::coefficient::coefficient_ast;
 use crate::functions::polynomial_ast::exponent::max_power_int;
 use crate::functions::polynomial_ast::simplify::collect_variables;

--- a/src/functions/polynomial_ast/interpolating_polynomial.rs
+++ b/src/functions/polynomial_ast/interpolating_polynomial.rs
@@ -1,6 +1,6 @@
-use crate::InterpreterError;
+#[allow(unused_imports)]
+use super::*;
 use crate::evaluator::evaluate_expr_to_expr;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// InterpolatingPolynomial[data, x] — find the polynomial that interpolates the data.
 ///

--- a/src/functions/polynomial_ast/linear_programming.rs
+++ b/src/functions/polynomial_ast/linear_programming.rs
@@ -19,9 +19,9 @@
 //! when a problem has multiple optima — and falls back to Bland's rule after a
 //! generous iteration budget so it can never cycle on degenerate problems.
 
-use crate::InterpreterError;
+#[allow(unused_imports)]
+use super::*;
 use crate::functions::math_ast::rat_reduce_bigint;
-use crate::syntax::{Expr, unevaluated};
 use num_bigint::BigInt;
 use num_traits::{One, Signed, Zero};
 

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -1,12 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::functions::math_ast::{
   expr_to_f64, expr_to_i128, expr_to_rational, gcd_bigint, gcd_i128, is_sqrt,
-};
-
-use crate::syntax::{
-  BinaryOperator, Expr, UnaryOperator, bool_expr, unevaluated,
 };
 
 /// MinimalPolynomial[α, x] - Computes the minimal polynomial of an algebraic number α

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -2,6 +2,12 @@
 //!
 //! Expand, Factor, Simplify, Coefficient, Exponent, PolynomialQ.
 
+use crate::InterpreterError;
+use crate::syntax::{
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
+  unevaluated,
+};
+
 mod apart;
 mod cancel;
 mod coefficient;

--- a/src/functions/polynomial_ast/polynomial_division.rs
+++ b/src/functions/polynomial_ast/polynomial_division.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, expr_to_string, unevaluated};
 
 /// Split `[p, q, x]` or `[p, q, x, Modulus -> n]` into the three positional
 /// arguments and an optional modulus.

--- a/src/functions/polynomial_ast/polynomial_extended_gcd.rs
+++ b/src/functions/polynomial_ast/polynomial_extended_gcd.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{Expr, expr_to_string, unevaluated};
 
 /// PolynomialExtendedGCD[p, q, x] - extended GCD of two polynomials.
 ///

--- a/src/functions/polynomial_ast/polynomial_gcd.rs
+++ b/src/functions/polynomial_ast/polynomial_gcd.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
 
 /// PolynomialGCD[p1, p2, ...] - greatest common divisor of polynomials
 pub fn polynomial_gcd_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/polynomial_ast/polynomial_mod.rs
+++ b/src/functions/polynomial_ast/polynomial_mod.rs
@@ -1,7 +1,7 @@
-use crate::InterpreterError;
+#[allow(unused_imports)]
+use super::*;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::gcd_i128;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// PolynomialMod[poly, m] — reduce poly modulo m.
 ///

--- a/src/functions/polynomial_ast/polynomial_q.rs
+++ b/src/functions/polynomial_ast/polynomial_q.rs
@@ -1,9 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::evaluator::pattern_matching::expr_equal;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, bool_expr};
-
 use crate::functions::calculus_ast::is_constant_wrt;
 
 // ─── PolynomialQ ────────────────────────────────────────────────────

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -1,11 +1,6 @@
 use super::together::negate_expr;
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
-  unevaluated,
-};
 
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 use crate::functions::math_ast::{gcd_i128, make_sqrt};

--- a/src/functions/polynomial_ast/resultant.rs
+++ b/src/functions/polynomial_ast/resultant.rs
@@ -1,8 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::functions::math_ast::expr_to_i128;
-use crate::syntax::{BinaryOperator, Expr, unevaluated};
 
 /// Resultant[poly1, poly2, var] - Computes the resultant of two polynomials
 /// with respect to the given variable.

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -1,11 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::functions::calculus_ast::simplify;
 use crate::functions::math_ast::{gcd_i128, rat_reduce, rat_reduce_bigint};
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
-};
 
 // ─── Refine ─────────────────────────────────────────────────────────
 
@@ -5001,7 +4997,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
       ))
       .is_some();
     let factored = if neg_power_sum {
-      Err(crate::InterpreterError::EvaluationError(String::new()))
+      Err(InterpreterError::EvaluationError(String::new()))
     } else if is_sum && polynomial_like(&best) {
       super::factor::factor_square_free_ast(&[best.clone()])
     } else {

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -1,12 +1,6 @@
 use super::together::negate_expr;
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
-use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
-  unevaluated,
-};
-
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 use crate::functions::math_ast::{gcd_i128, is_sqrt, make_sqrt, rat_reduce};
 

--- a/src/functions/polynomial_ast/symmetric_reduction.rs
+++ b/src/functions/polynomial_ast/symmetric_reduction.rs
@@ -9,8 +9,8 @@
 //! `s_k`. Uses the classical reduction by elementary symmetric polynomials in
 //! lexicographic monomial order.
 
-use crate::InterpreterError;
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, unevaluated};
+#[allow(unused_imports)]
+use super::*;
 
 fn eval(e: Expr) -> Result<Expr, InterpreterError> {
   crate::evaluator::evaluate_expr_to_expr(&e)

--- a/src/functions/polynomial_ast/to_radicals.rs
+++ b/src/functions/polynomial_ast/to_radicals.rs
@@ -1,7 +1,6 @@
-use super::{mk_call, mk_int, mk_power, mk_ratio, mk_times};
-use crate::InterpreterError;
+#[allow(unused_imports)]
+use super::*;
 use crate::functions::math_ast::gcd_i128;
-use crate::syntax::{BinaryOperator, Expr};
 
 /// ToRadicals[expr] — convert Root objects to explicit radical expressions.
 pub fn to_radicals_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -1,8 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::InterpreterError;
 use crate::functions::math_ast::{gcd_i128, rat_reduce};
-use crate::syntax::{BinaryOperator, Expr, UnaryOperator, expr_to_string};
 
 // ─── Together ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Move syntax:: imports to src/functions/polynomial_ast/mod.rs to reduce redundant imports in that directory.