### PR TITLE
Improve egf_stirling_numbers

### DIFF
--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -6122,8 +6122,6 @@ fn egf_expr_to_nonneg_int(expr: &Expr) -> Option<usize> {
 /// For k >= 1, factors out x: x * (S(k,1) + S(k,2)*x + ... + S(k,k)*x^(k-1))
 /// to match Wolfram's canonical form (e.g. E^x*x*(1+x) instead of E^x*(x+x^2)).
 fn egf_stirling_polynomial(k: usize, x: &Expr) -> Expr {
-  let stirling = egf_stirling_numbers(k);
-
   // k=0: S(0,0)=1, polynomial is just 1
   if k == 0 {
     return Expr::Integer(1);
@@ -6131,6 +6129,7 @@ fn egf_stirling_polynomial(k: usize, x: &Expr) -> Expr {
 
   // For k >= 1, S(k,0) = 0, so all terms have j >= 1.
   // Factor out x: build inner = S(k,1) + S(k,2)*x + ... + S(k,k)*x^(k-1)
+  let stirling = egf_stirling_numbers(k);
   let mut inner_terms: Vec<Expr> = Vec::new();
   for j in 1..=k {
     let s = stirling[j];
@@ -6197,23 +6196,18 @@ fn egf_stirling_polynomial(k: usize, x: &Expr) -> Expr {
 
 /// Compute Stirling numbers of the second kind S(k, j) for j = 0..k.
 fn egf_stirling_numbers(k: usize) -> Vec<u64> {
-  if k == 0 {
-    return vec![1];
-  }
-  let mut prev = vec![1u64];
+  let mut row = vec![0u64; k + 1];
+  row[0] = 1; // S(0,0) = 1
+  let mut next = vec![0u64; k + 1];
   for i in 1..=k {
-    let mut cur = vec![0u64; i + 1];
-    for j in 0..=i {
-      if j < prev.len() {
-        cur[j] += (j as u64) * prev[j];
-      }
-      if j > 0 && j - 1 < prev.len() {
-        cur[j] += prev[j - 1];
-      }
+    next[0] = 0; // S(i,0) = 0
+    for j in 1..=i {
+      // S(i,j) = S(i-1,j-1) + j*S(i-1,j) (Stirling S2)
+      next[j] = row[j - 1] + (j as u64) * row[j];
     }
-    prev = cur;
+    (row, next) = (next, row);
   }
-  prev
+  row
 }
 
 // ── FourierSinTransform / FourierCosTransform ───────────────────────

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -21183,7 +21183,7 @@ fn factorial_power_series_at_zero(
   order: i128,
 ) -> Expr {
   let n_usize = n as usize;
-  let stirling = signed_stirling_first_row(n_usize);
+  let stirling = signed_stirling_numbers(n_usize);
   let (min_idx, max_idx) = if n == 0 {
     (0usize, 0usize)
   } else {
@@ -21321,17 +21321,15 @@ fn hyperfactorial_series_at_zero(var_name: &str, order: i128) -> Expr {
 
 /// Row `n` of the signed Stirling numbers of the first kind.
 /// `out[k] = s(n, k)`, satisfying x(x-1)...(x-n+1) = sum_k s(n, k) x^k.
-fn signed_stirling_first_row(n: usize) -> Vec<i128> {
-  // Start at row 0: s(0, 0) = 1, all other s(0, k) = 0.
+fn signed_stirling_numbers(n: usize) -> Vec<i128> {
   let mut row = vec![0i128; n + 1];
-  row[0] = 1;
+  row[0] = 1; // s(0,0) = 1
   let mut next = vec![0i128; n + 1];
-  // Build up row by row using s(m+1, k) = s(m, k-1) - m * s(m, k).
-  for m in 0..n {
-    for k in 0..=(m + 1) {
-      let from_left = if k > 0 { row[k - 1] } else { 0 };
-      let from_above = row[k];
-      next[k] = from_left - (m as i128) * from_above;
+  for i in 1..=n {
+    next[0] = 0; // s(i,0) = 0
+    for j in 1..=i {
+      // s(i,j) = s(i-1,j-1) - (i-1)*s(i-1,j) (signed Stirling S1).
+      next[j] = row[j - 1] - ((i - 1) as i128) * row[j];
     }
     (row, next) = (next, row);
   }

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -1369,11 +1369,12 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let zero = BigInt::from(0);
     let one = BigInt::from(1);
     let mut row = vec![zero.clone(); n + 1];
-    row[0] = one.clone();
+    row[0] = one.clone(); // S(0,0) = 1
     let mut next = vec![zero.clone(); n + 1];
     for i in 1..=n {
-      next[0] = zero.clone();
+      next[0] = zero.clone(); // S(i,0) = 0
       for j in 1..=i {
+        // S(i,j) = S(i-1,j-1) + j*S(i-1,j) (Stirling S2)
         next[j] = &row[j - 1] + BigInt::from(j as i128) * &row[j];
       }
       (row, next) = (next, row);
@@ -1584,16 +1585,15 @@ pub fn stirling_s1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Integer(0));
   }
 
-  // s(n,k) = s(n-1,k-1) - (n-1)*s(n-1,k) (signed Stirling S1)
-  // Use DP table with BigInt to avoid overflow
   let zero = BigInt::from(0);
   let one = BigInt::from(1);
   let mut row = vec![zero.clone(); k + 1];
-  row[0] = one.clone();
+  row[0] = one.clone(); // s(0,0) = 1
   let mut next = vec![zero.clone(); k + 1];
   for i in 1..=n {
-    next[0] = zero.clone();
+    next[0] = zero.clone(); // s(i,0) = 0
     for j in 1..=k.min(i) {
+      // s(i,j) = s(i-1,j-1) - (i-1)*s(i-1,j) (signed Stirling S1)
       next[j] = &row[j - 1] - BigInt::from(i - 1) * &row[j];
     }
     (row, next) = (next, row);
@@ -1627,16 +1627,16 @@ pub fn stirling_s2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Integer(0));
   }
 
-  // S(n,k) = k*S(n-1,k) + S(n-1,k-1)
   let zero = BigInt::from(0);
   let one = BigInt::from(1);
   let mut row = vec![zero.clone(); k + 1];
-  row[0] = one.clone();
+  row[0] = one.clone(); // S(0,0) = 1.
   let mut next = vec![zero.clone(); k + 1];
   for i in 1..=n {
-    next[0] = zero.clone();
+    next[0] = zero.clone(); // S(i,0) = 0
     for j in 1..=k.min(i) {
-      next[j] = BigInt::from(j) * &row[j] + &row[j - 1];
+      // S(i,j) = S(i-1,j-1) + j*S(i-1,j) (Stirling S2)
+      next[j] = &row[j - 1] + BigInt::from(j) * &row[j];
     }
     (row, next) = (next, row);
   }


### PR DESCRIPTION
egf_stirling_numbers allocates O(n^2) memory to compute the Stirling numbers.  It can be refactored to allocate O(n) memory by reusing the rows as is done elsewhere in Woxi.
Also update all the Stirling number algorithms to
be more consistent in iterator names (i, j) and comments.