### PR TITLE
Eliminate remaining references to CountBy

### DIFF
--- a/tests/SUMMARY.md
+++ b/tests/SUMMARY.md
@@ -854,7 +854,6 @@
     - [`BlankSequence`](list_operations/BlankSequence.md)
     - [`CenterArray`](list_operations/CenterArray.md)
     - [`ClusteringComponents`](list_operations/ClusteringComponents.md)
-    - [`CountBy`](list_operations/CountBy.md)
     - [`Diagonal`](list_operations/Diagonal.md)
     - [`FoldWhileList`](list_operations/FoldWhileList.md)
     - [`Groupings`](list_operations/Groupings.md)

--- a/tests/cli/list_operations.md
+++ b/tests/cli/list_operations.md
@@ -58,7 +58,6 @@ functions. The material has been split into topical sub-pages:
 - [`TensorRank`](list_operations/TensorRank.md)
 - [`FoldWhile`](list_operations/FoldWhile.md)
 - [`FoldWhileList`](list_operations/FoldWhileList.md)
-- [`CountBy`](list_operations/CountBy.md)
 - [`Heads`](list_operations/Heads.md)
 - [`List`](list_operations/List.md)
 - [`Nearest`](list_operations/Nearest.md)

--- a/tests/cli/list_operations/CountBy.md
+++ b/tests/cli/list_operations/CountBy.md
@@ -1,3 +1,0 @@
-# `CountBy`
-
-Groups and counts elements by a function.

--- a/tests/cli/undocumented.md
+++ b/tests/cli/undocumented.md
@@ -145,7 +145,6 @@ syntactic forms (`UpSet`, `Span`), and special functions that stay symbolic for 
 
 ## Lists (4)
 
-- `CountBy` — Groups and counts elements by a function
 - `List` — Represents a list of elements
 - `Nearest` — Find the nearest elements in a list to a given value
 - `SymmetricDifference` — Returns elements that appear in an odd number of the given lists

--- a/tests/zensical.toml
+++ b/tests/zensical.toml
@@ -911,7 +911,6 @@ nav = [
       { "BlankSequence" = "list_operations/BlankSequence.md" },
       { "CenterArray" = "list_operations/CenterArray.md" },
       { "ClusteringComponents" = "list_operations/ClusteringComponents.md" },
-      { "CountBy" = "list_operations/CountBy.md" },
       { "Diagonal" = "list_operations/Diagonal.md" },
       { "FoldWhileList" = "list_operations/FoldWhileList.md" },
       { "Groupings" = "list_operations/Groupings.md" },


### PR DESCRIPTION
Change 9719a54e781b72e7fcfce883dcd46128ef997f05 removed the CountBy function, but neglected to remove the associated tests/cli/list_operations/CountBy.md file.  Remove it and the remaining references to it.