### PR TITLE
Unify NDSolve to handle all ODE shapes through single integrator

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -2209,11 +2209,7 @@ fn inset_primitives(
   let pos = args.get(1).and_then(expr_to_point).unwrap_or((0.0, 0.0));
   // `opos` names the point of the object that lands on `pos`, in the
   // object's own coordinates (Automatic = its centre).
-  let (ox, oy) = args
-    .get(2)
-    .and_then(expr_to_point)
-    .map(|(x, y)| (x, y))
-    .unwrap_or((cx, cy));
+  let (ox, oy) = args.get(2).and_then(expr_to_point).unwrap_or((cx, cy));
 
   let placed = inner
     .iter()
@@ -15298,8 +15294,22 @@ fn manipulate_label_runs(expr: &Expr, italic: bool) -> Vec<LabelRun> {
       },
       "Subscript" => script_runs(args, italic, false),
       "Superscript" => script_runs(args, italic, true),
+      // `Power[b, e]`, which is what a label's typeset `SuperscriptBox`
+      // reads as: a Demonstration writes its gravity slider's unit as
+      // `m/\!\(\*SuperscriptBox[\(s\), \(2\)]\)`, and it must show as
+      // `m/s²`, not `m/s^2`.
+      "Power" if args.len() == 2 => script_runs(args, italic, true),
       _ => output_run(italic),
     },
+    Expr::BinaryOp {
+      op: crate::syntax::BinaryOperator::Power,
+      left,
+      right,
+    } => script_runs(
+      &[left.as_ref().clone(), right.as_ref().clone()],
+      italic,
+      true,
+    ),
     // A label written in the notebook FrontEnd carries its typeset bits as
     // inline linear syntax inside the string: `"value to test against
     // \!\(\*SubscriptBox[\(p\), \(0\)]\)"`. Render each box segment as the

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -249,21 +249,12 @@ pub fn ndsolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let opts = &args[n_pos..];
   let event = parse_event_locator_option(opts);
 
-  // A list of dependent functions (`{θ, ϕ, ψ}`), an event-driven solve, or
-  // any spec the scalar path can't handle goes through the system solver.
-  let scalar_capable =
-    matches!(&args[1], Expr::FunctionCall { .. } | Expr::Identifier(_))
-      && event.is_none();
-  if scalar_capable {
-    let result = ndsolve_scalar(&args[..3])?;
-    // The scalar path returns the input unevaluated for shapes it doesn't
-    // support (e.g. initial conditions at an interior point of the
-    // domain); give the system solver a chance before giving up.
-    if !matches!(&result, Expr::FunctionCall { name, .. } if name == "NDSolve")
-    {
-      return Ok(result);
-    }
-  }
+  // Every shape — one equation or a coupled system, linear or not — goes
+  // through the same integrator. A single scalar equation used to take a
+  // separate path built on DSolve's *linear* term classifier, which
+  // refused anything nonlinear in the dependent variable (the pendulum's
+  // `Sin[θ[t]]`) even though nothing about integrating it numerically
+  // needs the equation to be linear.
   match ndsolve_system(&args[..3], event.as_ref()) {
     Ok(Some(result)) => Ok(result),
     Ok(None) => Ok(unevaluated("NDSolve", args)),
@@ -271,197 +262,15 @@ pub fn ndsolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 }
 
-fn ndsolve_scalar(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let eqns_arg = &args[0];
-  let dep_arg = &args[1];
-  let domain_arg = &args[2];
-
-  // Extract domain {x, xmin, xmax}
-  let (x_name, x_min, x_max) = match domain_arg {
-    Expr::List(items) if items.len() == 3 => {
-      let xn = match &items[0] {
-        Expr::Identifier(name) => name.clone(),
-        _ => {
-          return Ok(unevaluated("NDSolve", args));
-        }
-      };
-      let xmin =
-        expr_to_f64(&crate::evaluator::evaluate_expr_to_expr(&items[1])?)?;
-      let xmax =
-        expr_to_f64(&crate::evaluator::evaluate_expr_to_expr(&items[2])?)?;
-      (xn, xmin, xmax)
-    }
-    _ => {
-      return Ok(unevaluated("NDSolve", args));
-    }
-  };
-
-  // Extract dependent variable name
-  let (y_name, function_form) = match dep_arg {
-    Expr::FunctionCall { name, args: fargs } if fargs.len() == 1 => {
-      if let Expr::Identifier(xn) = &fargs[0] {
-        if xn == &x_name {
-          (name.clone(), false)
-        } else {
-          return Ok(unevaluated("NDSolve", args));
-        }
-      } else {
-        return Ok(unevaluated("NDSolve", args));
-      }
-    }
-    Expr::Identifier(name) => (name.clone(), true),
-    _ => {
-      return Ok(unevaluated("NDSolve", args));
-    }
-  };
-
-  // Extract equations and initial conditions from list
-  let items = match eqns_arg {
-    Expr::List(items) => items.clone(),
-    _ => vec![eqns_arg.clone()].into(),
-  };
-
-  // Separate ODE from initial conditions
-  let mut ode_expr = None;
-  let mut initial_conditions: Vec<(usize, f64, f64)> = Vec::new(); // (deriv_order, x_val, y_val)
-
-  for item in &items {
-    if let Some((order, x_val, y_val)) =
-      parse_numeric_initial_condition(item, &y_name)?
-    {
-      initial_conditions.push((order, x_val, y_val));
-    } else {
-      if ode_expr.is_some() {
-        return Ok(unevaluated("NDSolve", args));
-      }
-      ode_expr = Some(item.clone());
-    }
-  }
-
-  let ode = match ode_expr {
-    Some(e) => e,
-    None => {
-      return Ok(unevaluated("NDSolve", args));
-    }
-  };
-
-  // Parse the ODE and determine order
-  let ode_normalized = normalize_equation(&ode)?;
-  let terms = collect_ode_terms(&ode_normalized, &y_name, &x_name)?;
-  let max_order = terms.iter().map(|t| t.order).max().unwrap_or(0) as usize;
-
-  if max_order == 0 || initial_conditions.len() != max_order {
-    return Ok(unevaluated("NDSolve", args));
-  }
-
-  // Build the RHS function: solve for highest derivative
-  // Sum of terms = 0, so y^(n) = -(sum of other terms) / coeff_of_y^(n)
-  let rhs_expr =
-    build_rhs_for_highest_derivative(&terms, max_order, &y_name, &x_name)?;
-
-  // Sort ICs by order
-  let mut ics_by_order: Vec<Option<(f64, f64)>> = vec![None; max_order];
-  for (order, xv, yv) in &initial_conditions {
-    if *order < max_order {
-      ics_by_order[*order] = Some((*xv, *yv));
-    }
-  }
-
-  // Verify all ICs present and at same x
-  let x0 = match ics_by_order[0] {
-    Some((xv, _)) => xv,
-    None => {
-      return Ok(unevaluated("NDSolve", args));
-    }
-  };
-
-  let mut y0: Vec<f64> = Vec::new();
-  for ic in &ics_by_order {
-    match ic {
-      Some((_, yv)) => y0.push(*yv),
-      None => {
-        return Ok(unevaluated("NDSolve", args));
-      }
-    }
-  }
-
-  // Perform RK4 integration
-  let n_steps = 1000;
-  let h = (x_max - x_min) / n_steps as f64;
-  let mut data_points: Vec<(f64, f64)> = Vec::with_capacity(n_steps + 1);
-
-  // state = [y, y', y'', ...] (values of y and its derivatives)
-  let mut state = y0;
-  let mut x = x_min;
-
-  // We need to handle the case where x0 != x_min
-  // For simplicity, we require x0 == x_min (or very close)
-  if (x0 - x_min).abs() > 1e-10 {
-    return Ok(unevaluated("NDSolve", args));
-  }
-
-  data_points.push((x, state[0]));
-
-  for _ in 0..n_steps {
-    let new_state =
-      rk4_step(&rhs_expr, &state, x, h, max_order, &y_name, &x_name)?;
-    state = new_state;
-    x += h;
-    data_points.push((x, state[0]));
-  }
-
-  // Build InterpolatingFunction
-  let domain = Expr::List(
-    vec![Expr::List(
-      vec![Expr::Real(x_min), Expr::Real(x_max)].into(),
-    )]
-    .into(),
-  );
-
-  // Store data as a list of {x, y} pairs
-  let data_expr = Expr::List(
-    data_points
-      .iter()
-      .map(|(xv, yv)| Expr::List(vec![Expr::Real(*xv), Expr::Real(*yv)].into()))
-      .collect(),
-  );
-
-  let interp_func = Expr::FunctionCall {
-    name: "InterpolatingFunction".to_string(),
-    args: vec![domain, data_expr].into(),
-  };
-
-  // Build result: {{y -> InterpolatingFunction[...]}} for the `y` form, or
-  // {{y[x] -> InterpolatingFunction[...][x]}} for the `y[x]` form.
-  let rule = if function_form {
-    Expr::Rule {
-      pattern: Box::new(Expr::Identifier(y_name)),
-      replacement: Box::new(interp_func),
-    }
-  } else {
-    Expr::Rule {
-      pattern: Box::new(Expr::FunctionCall {
-        name: y_name,
-        args: vec![Expr::Identifier(x_name.clone())].into(),
-      }),
-      replacement: Box::new(Expr::CurriedCall {
-        func: Box::new(interp_func),
-        args: vec![Expr::Identifier(x_name)],
-      }),
-    }
-  };
-
-  Ok(Expr::List(vec![Expr::List(vec![rule].into())].into()))
-}
-
-// ─── NDSolve for systems of ODEs ───────────────────────────────────────
+// ─── The NDSolve integrator ────────────────────────────────────────────
 //
-// Handles what the scalar path above cannot: several coupled dependent
-// functions (`NDSolve[eqns, {θ, ϕ, ψ}, {t, t0, t1}]`), equations that are
-// implicit in the highest derivatives (each equation may mix θ'', ϕ'',
-// ψ''), initial conditions given at an interior point of the domain
-// (integrating both directions), and the `Method -> {"EventLocator", …}`
-// option that stops integration when an event function crosses zero.
+// Handles every shape NDSolve takes: one equation or several coupled
+// dependent functions (`NDSolve[eqns, {θ, ϕ, ψ}, {t, t0, t1}]`), any
+// order, linear or not, equations that are implicit in the highest
+// derivatives (each equation may mix θ'', ϕ'', ψ''), initial conditions
+// given at an interior point of the domain (integrating both
+// directions), and the `Method -> {"EventLocator", …}` option that stops
+// integration when an event function crosses zero.
 //
 // Each step evaluates the residuals numerically: with the state fixed,
 // every residual is affine in the vector of highest derivatives, so one
@@ -642,6 +451,13 @@ fn find_function_call(expr: &Expr, fname: &str) -> Option<Expr> {
     .into_iter()
     .find_map(|c| find_function_call(c, fname))
 }
+
+/// The interpolation order NDSolve's InterpolatingFunctions carry, matching
+/// the Wolfram Language's default. Reading the solution back between grid
+/// points then has the accuracy of the integration itself; a linear
+/// interpolation would throw most of it away — visibly so through `θ'`,
+/// which differentiates the interpolating piece.
+const NDSOLVE_INTERPOLATION_ORDER: i128 = 3;
 
 fn ndsolve_system(
   args: &[Expr],
@@ -921,7 +737,8 @@ fn ndsolve_system(
     );
     let interp = Expr::FunctionCall {
       name: "InterpolatingFunction".to_string(),
-      args: vec![domain, data].into(),
+      args: vec![domain, data, Expr::Integer(NDSOLVE_INTERPOLATION_ORDER)]
+        .into(),
     };
     rules.push(if f.function_form {
       Expr::Rule {
@@ -969,7 +786,8 @@ fn ndsolve_system(
     );
     let interp = Expr::FunctionCall {
       name: "InterpolatingFunction".to_string(),
-      args: vec![domain, data].into(),
+      args: vec![domain, data, Expr::Integer(NDSOLVE_INTERPOLATION_ORDER)]
+        .into(),
     };
     rules.push(if f.function_form {
       Expr::Rule {
@@ -1028,6 +846,22 @@ fn integrate_leg(
   x_name: &str,
 ) -> Result<Option<Vec<(f64, Vec<f64>)>>, InterpreterError> {
   let n_steps = ((x_to - x_from) / h).round() as usize;
+  // Each grid point is computed from the leg's ends rather than by adding
+  // `h` to the previous one, and the last one *is* `x_to`: accumulating
+  // the step leaves the domain a few ulps short of where it was asked to
+  // end (`{{0., 4.999999999999916}}` instead of `{{0., 5.}}`).
+  let step = if n_steps > 0 {
+    (x_to - x_from) / n_steps as f64
+  } else {
+    h
+  };
+  let grid = |i: usize| {
+    if i >= n_steps {
+      x_to
+    } else {
+      x_from + i as f64 * step
+    }
+  };
   let mut points: Vec<(f64, Vec<f64>)> = Vec::with_capacity(n_steps + 1);
   let mut state = init_state;
   let mut x = x_from;
@@ -1038,13 +872,14 @@ fn integrate_leg(
   };
   let mut prev_event = eval_event(x, &state);
 
-  for _ in 0..n_steps {
+  for i in 0..n_steps {
+    let new_x = grid(i + 1);
+    let h = new_x - x;
     let Some(new_state) =
       rk4_system_step(residuals, funcs, state_offset, &state, x, h)?
     else {
       return Ok(None);
     };
-    let new_x = x + h;
 
     if let Some(prev_g) = prev_event
       && let Some(new_g) = eval_event(new_x, &new_state)
@@ -3134,171 +2969,6 @@ fn exprs_match(a: &Expr, b: &Expr) -> bool {
 }
 
 // ─── NDSolve RK4 Helpers ──────────────────────────────────────────────
-
-/// Build the RHS expression for the highest derivative:
-/// y^(n) = -(sum of lower-order terms + forcing) / leading_coeff
-fn build_rhs_for_highest_derivative(
-  terms: &[OdeTerm],
-  max_order: usize,
-  _y_name: &str,
-  _x_name: &str,
-) -> Result<Expr, InterpreterError> {
-  let mut leading_coeff = None;
-  let mut other_terms: Vec<OdeTerm> = Vec::new();
-
-  for term in terms {
-    if term.order == max_order as i32 {
-      leading_coeff = Some(term.coefficient.clone());
-    } else {
-      other_terms.push(term.clone());
-    }
-  }
-
-  let leading = match leading_coeff {
-    Some(c) => c,
-    None => {
-      return Err(InterpreterError::EvaluationError(
-        "NDSolve: no highest-order term found".into(),
-      ));
-    }
-  };
-
-  // Store coefficients for each order and forcing
-  // We'll evaluate numerically during RK4 steps
-  // Store as metadata in a special expression
-  // Instead of building a symbolic expression, we'll store the term data
-  // For NDSolve we need a representation we can evaluate numerically
-  // Use a FunctionCall to wrap the data
-
-  // Actually, let's build the symbolic RHS and evaluate it numerically in RK4
-  // rhs = -(other terms evaluated with y and derivatives substituted) / leading
-
-  // Build: -(a_{n-1}*y^(n-1) + ... + a_0*y + forcing) / a_n
-  let mut numerator_terms: Vec<Expr> = Vec::new();
-  for term in terms {
-    if term.order == max_order as i32 {
-      continue;
-    }
-    let coeff = term.coefficient.clone();
-    if term.order >= 0 {
-      // This will have y^(order) replaced by state variables during RK4
-      let var_name = if term.order == 0 {
-        "__y_0".to_string()
-      } else {
-        format!("__y_{}", term.order)
-      };
-      numerator_terms.push(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(coeff),
-        right: Box::new(Expr::Identifier(var_name)),
-      });
-    } else {
-      numerator_terms.push(coeff);
-    }
-  }
-
-  if numerator_terms.is_empty() {
-    return Ok(Expr::Integer(0));
-  }
-
-  let mut sum = numerator_terms.remove(0);
-  for t in numerator_terms {
-    sum = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(sum),
-      right: Box::new(t),
-    };
-  }
-
-  // RHS = -sum / leading
-  Ok(Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(negate_expr(&sum)),
-    right: Box::new(leading),
-  })
-}
-
-/// Perform one step of RK4 for an ODE system
-fn rk4_step(
-  rhs_expr: &Expr,
-  state: &[f64],
-  x: f64,
-  h: f64,
-  max_order: usize,
-  _y_name: &str,
-  x_name: &str,
-) -> Result<Vec<f64>, InterpreterError> {
-  let n = max_order;
-
-  // Evaluate the derivative of the system at a given state
-  let eval_system = |s: &[f64],
-                     xv: f64|
-   -> Result<Vec<f64>, InterpreterError> {
-    let mut derivs = vec![0.0; n];
-    // d/dx y_0 = y_1, d/dx y_1 = y_2, ..., d/dx y_{n-2} = y_{n-1}
-    derivs[..(n - 1)].copy_from_slice(&s[1..((n - 1) + 1)]);
-    // d/dx y_{n-1} = rhs_expr evaluated with substitutions
-    let mut expr = rhs_expr.clone();
-    // Substitute x
-    expr = crate::syntax::substitute_variable(&expr, x_name, &Expr::Real(xv));
-    // Substitute __y_i
-    for i in 0..n {
-      let var_name = format!("__y_{}", i);
-      expr =
-        crate::syntax::substitute_variable(&expr, &var_name, &Expr::Real(s[i]));
-    }
-    let result =
-      crate::evaluator::evaluate_expr_to_expr(&expr).map_err(|e| {
-        InterpreterError::EvaluationError(format!(
-          "NDSolve RK4: evaluation failed for expr '{}': {}",
-          crate::syntax::expr_to_string(&expr),
-          e
-        ))
-      })?;
-    derivs[n - 1] = expr_to_f64(&result).map_err(|e| {
-      InterpreterError::EvaluationError(format!(
-        "NDSolve RK4: cannot convert result '{}' to f64: {}",
-        crate::syntax::expr_to_string(&result),
-        e
-      ))
-    })?;
-    Ok(derivs)
-  };
-
-  // k1
-  let k1 = eval_system(state, x)?;
-
-  // k2
-  let s2: Vec<f64> = state
-    .iter()
-    .zip(k1.iter())
-    .map(|(s, k)| s + h / 2.0 * k)
-    .collect();
-  let k2 = eval_system(&s2, x + h / 2.0)?;
-
-  // k3
-  let s3: Vec<f64> = state
-    .iter()
-    .zip(k2.iter())
-    .map(|(s, k)| s + h / 2.0 * k)
-    .collect();
-  let k3 = eval_system(&s3, x + h / 2.0)?;
-
-  // k4
-  let s4: Vec<f64> = state
-    .iter()
-    .zip(k3.iter())
-    .map(|(s, k)| s + h * k)
-    .collect();
-  let k4 = eval_system(&s4, x + h)?;
-
-  // Update state
-  let new_state: Vec<f64> = (0..n)
-    .map(|i| state[i] + h / 6.0 * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]))
-    .collect();
-
-  Ok(new_state)
-}
 
 /// Convert Expr to f64
 fn expr_to_f64(expr: &Expr) -> Result<f64, InterpreterError> {

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -841,7 +841,9 @@ fn bounding_box_corners() -> [Point3D; 8] {
   ]
 }
 
-/// Draw 3D axis lines with ticks and labels
+/// Draw 3D axis lines with ticks and labels over the normalized cube the
+/// surface plots draw in. `AxesLabel` strings, when given, name the x, y
+/// and z axis in that order.
 fn draw_axes(
   svg: &mut String,
   camera: &Camera,
@@ -850,16 +852,51 @@ fn draw_axes(
   y_range: (f64, f64),
   z_range: (f64, f64),
 ) {
+  draw_axes_on_box(
+    svg,
+    camera,
+    to_svg,
+    &bounding_box_corners(),
+    x_range,
+    y_range,
+    z_range,
+    &[None, None, None],
+  );
+}
+
+/// Draw 3D axis lines with ticks and labels along the edges of `corners`,
+/// the box the scene is framed by. `corners` is ordered as
+/// `bounding_box_corners()` builds it: the four `z_min` corners first,
+/// each pair varying x fastest.
+#[allow(clippy::too_many_arguments)]
+fn draw_axes_on_box(
+  svg: &mut String,
+  camera: &Camera,
+  to_svg: &dyn Fn(f64, f64) -> (f64, f64),
+  corners: &[Point3D; 8],
+  x_range: (f64, f64),
+  y_range: (f64, f64),
+  z_range: (f64, f64),
+  axes_labels: &[Option<String>; 3],
+) {
   let (_, axis_rgb, _, _, _) = crate::functions::plot::plot_theme();
   let axis_color = format!("rgb({},{},{})", axis_rgb.0, axis_rgb.1, axis_rgb.2);
   let font_size = 13;
 
-  // Find the bottom corner (z=-1) closest to the viewer (smallest depth)
-  let corners = bounding_box_corners();
+  // The box in scene coordinates. `mirror_*` flips a coordinate to the
+  // opposite face, which is how each axis edge finds its far end.
+  let (box_x_lo, box_x_hi) = (corners[0].x, corners[7].x);
+  let (box_y_lo, box_y_hi) = (corners[0].y, corners[7].y);
+  let (box_z_lo, box_z_hi) = (corners[0].z, corners[7].z);
+  let mirror_x = |x: f64| box_x_lo + box_x_hi - x;
+  let mirror_y = |y: f64| box_y_lo + box_y_hi - y;
+
+  // Find the bottom corner (z at the box floor) closest to the viewer
+  // (smallest depth)
   let mut min_depth_idx = 0;
   let mut min_depth = f64::INFINITY;
   for (idx, &corner) in corners.iter().enumerate() {
-    if corner.z > -Z_SCALE + 0.01 {
+    if corner.z > box_z_lo + (box_z_hi - box_z_lo) * 0.01 {
       continue;
     }
     let d = depth(corner, camera);
@@ -873,16 +910,16 @@ fn draw_axes(
 
   // The three axis edges from the closest corner.
   // Each entry: (endpoint, value_range, axis_goes_negative).
-  // When the axis direction goes from +1 to -1 in normalized space, the
-  // normalized origin represents val_max and we must flip the mapping.
+  // When the edge runs from the box's high face to its low one, the
+  // origin corner stands for val_max and the mapping has to be flipped.
   let x_end = Point3D {
-    x: -origin.x,
+    x: mirror_x(origin.x),
     y: origin.y,
     z: origin.z,
   };
   let y_end = Point3D {
     x: origin.x,
-    y: -origin.y,
+    y: mirror_y(origin.y),
     z: origin.z,
   };
   // Place the z-axis on the vertical edge that is most to the left or right
@@ -918,25 +955,27 @@ fn draw_axes(
   let z_end = Point3D {
     x: z_origin.x,
     y: z_origin.y,
-    z: Z_SCALE,
+    z: box_z_hi,
   };
 
   let axes: [(Point3D, Point3D, (f64, f64), bool); 3] = [
     (origin, x_end, x_range, origin.x > x_end.x),
     (origin, y_end, y_range, origin.y > y_end.y),
-    (z_origin, z_end, z_range, false), // z always goes from -Z_SCALE to +Z_SCALE
+    (z_origin, z_end, z_range, false), // z always runs from floor to ceiling
   ];
 
   // Project the box center so we can orient tick labels outward
   let box_center = Point3D {
-    x: 0.0,
-    y: 0.0,
-    z: 0.0,
+    x: (box_x_lo + box_x_hi) / 2.0,
+    y: (box_y_lo + box_y_hi) / 2.0,
+    z: (box_z_lo + box_z_hi) / 2.0,
   };
   let (cx, cy) =
     to_svg(project(box_center, camera).0, project(box_center, camera).1);
 
-  for &(axis_origin, end, (val_min, val_max), flipped) in &axes {
+  for (ai, &(axis_origin, end, (val_min, val_max), flipped)) in
+    axes.iter().enumerate()
+  {
     let (sx0, sy0) = to_svg(
       project(axis_origin, camera).0,
       project(axis_origin, camera).1,
@@ -949,14 +988,50 @@ fn draw_axes(
             sx0, sy0, sx1, sy1, axis_color
         ));
 
-    // Ticks
-    let step = nice_step(val_max - val_min, 4);
-    if step <= 0.0 {
-      continue;
+    // The axis label sits centred on the axis, clear of the tick labels
+    // already sitting there — where Wolfram puts it.
+    if let Some(label) = axes_labels[ai].as_deref().filter(|l| !l.is_empty()) {
+      let (dx, dy) = (sx1 - sx0, sy1 - sy0);
+      let len = (dx * dx + dy * dy).sqrt();
+      if len > 1.0 {
+        let (mid_x, mid_y) = ((sx0 + sx1) * 0.5, (sy0 + sy1) * 0.5);
+        let (perpx, perpy) = (-dy / len, dx / len);
+        let sign = if perpx * (cx - mid_x) + perpy * (cy - mid_y) > 0.0 {
+          -1.0
+        } else {
+          1.0
+        };
+        // How far the tick labels already reach, in the direction the
+        // axis label is being pushed: their own offset plus half of the
+        // widest one's box. Sideways of a vertical axis that is the text
+        // width, below a horizontal one it is the line height.
+        let tick_chars = tick_values(val_min, val_max)
+          .iter()
+          .map(|v| format_tick(*v).chars().count())
+          .max()
+          .unwrap_or(1) as f64;
+        let half_w = tick_chars * font_size as f64 * 0.3;
+        let half_h = font_size as f64 * 0.5;
+        // …plus half of the label's own box, so `offset` can centre it
+        // just past them.
+        let own_w = label_half_width(label, font_size);
+        let reach = TICK_LABEL_OFFSET
+          + (perpx * sign).abs() * (half_w + own_w)
+          + (perpy * sign).abs() * (half_h + half_h);
+        let offset = reach + font_size as f64 * 0.5;
+        svg.push_str(&format!(
+          "<text x=\"{:.1}\" y=\"{:.1}\" font-size=\"{}\" fill=\"{}\" text-anchor=\"middle\" dominant-baseline=\"middle\">{}</text>\n",
+          mid_x + perpx * offset * sign,
+          mid_y + perpy * offset * sign,
+          font_size,
+          axis_color,
+          label
+        ));
+      }
     }
-    let first_tick = (val_min / step).ceil() * step;
-    let mut tick_val = first_tick;
-    while tick_val <= val_max + step * 0.01 {
+
+    // Ticks
+    for tick_val in tick_values(val_min, val_max) {
       // Map tick_val to parameter t along the axis [origin → end]
       let t_raw = if (val_max - val_min).abs() < 1e-15 {
         0.5
@@ -1000,13 +1075,49 @@ fn draw_axes(
         let label = format_tick(tick_val);
         svg.push_str(&format!(
                     "<text x=\"{:.1}\" y=\"{:.1}\" font-size=\"{}\" fill=\"{}\" text-anchor=\"middle\" dominant-baseline=\"middle\">{}</text>\n",
-                    tx + perpx * 3.0 * sign, ty + perpy * 3.0 * sign, font_size, axis_color, label
+                    tx + perpx / 4.0 * TICK_LABEL_OFFSET * sign, ty + perpy / 4.0 * TICK_LABEL_OFFSET * sign, font_size, axis_color, label
                 ));
       }
-
-      tick_val += step;
     }
   }
+}
+
+/// How far from the axis line the tick labels are centred.
+const TICK_LABEL_OFFSET: f64 = 12.0;
+
+/// Half the width a text label takes at `font_size`, estimated from its
+/// character count — enough to keep labels from landing on each other.
+fn label_half_width(label: &str, font_size: i32) -> f64 {
+  markup_char_count(label) as f64 * font_size as f64 * 0.3
+}
+
+/// The margin a frame needs outside its box for `AxesLabel` text: the tick
+/// labels' own room plus the widest axis label. Capped at a fifth of the
+/// frame so a long label shrinks the plot rather than squeezing it away.
+fn axes_label_margin(axes_labels: &[Option<String>; 3], size: u32) -> f64 {
+  let font_size = 13;
+  let widest = axes_labels
+    .iter()
+    .flatten()
+    .map(|l| label_half_width(l, font_size) * 2.0)
+    .fold(0.0_f64, f64::max);
+  (25.0 + widest * 0.5).min(size as f64 / 5.0)
+}
+
+/// The tick positions along an axis spanning `val_min` to `val_max`, the
+/// same ones the tick marks are drawn at.
+fn tick_values(val_min: f64, val_max: f64) -> Vec<f64> {
+  let step = nice_step(val_max - val_min, 4);
+  if step <= 0.0 {
+    return Vec::new();
+  }
+  let mut ticks = Vec::new();
+  let mut tick_val = (val_min / step).ceil() * step;
+  while tick_val <= val_max + step * 0.01 {
+    ticks.push(tick_val);
+    tick_val += step;
+  }
+  ticks
 }
 
 // ── VectorPlot3D implementation ─────────────────────────────────────
@@ -2818,8 +2929,11 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut camera = Camera::default();
   // `PlotRange -> r` (a single number): the displayed region is the fixed
   // cube [-r, r]³, so the framing stays put while contents move (as in a
-  // Manipulate re-render).
-  let mut plot_range: Option<f64> = None;
+  // Manipulate re-render). `PlotRange -> {{x0, x1}, {y0, y1}, {z0, z1}}`
+  // pins each axis separately.
+  let mut plot_range: Option<[(f64, f64); 3]> = None;
+  let mut show_axes = false;
+  let mut axes_labels: [Option<String>; 3] = [None, None, None];
   for opt in &args[1..] {
     let opt_eval = evaluate_expr_to_expr(opt).unwrap_or(opt.clone());
     if let Expr::Rule {
@@ -2876,12 +2990,36 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }
         }
         "PlotRange" => {
-          if let Some(r) = try_eval_to_f64(
-            &evaluate_expr_to_expr(replacement)
-              .unwrap_or_else(|_| replacement.as_ref().clone()),
-          ) && r > 0.0
-          {
-            plot_range = Some(r);
+          let value = evaluate_expr_to_expr(replacement)
+            .unwrap_or_else(|_| replacement.as_ref().clone());
+          if let Some(r) = try_eval_to_f64(&value) {
+            if r > 0.0 {
+              plot_range = Some([(-r, r); 3]);
+            }
+          } else if let Some(ranges) = parse_axis_ranges(&value) {
+            plot_range = Some(ranges);
+          }
+        }
+        "Axes" => match replacement.as_ref() {
+          Expr::Identifier(s) if s == "False" => show_axes = false,
+          Expr::Identifier(s) if s == "True" => show_axes = true,
+          // `Axes -> {True, True, False}`: drawn as long as any is on.
+          Expr::List(items) => {
+            show_axes = items
+              .iter()
+              .any(|i| matches!(i, Expr::Identifier(s) if s == "True"));
+          }
+          _ => {}
+        },
+        "AxesLabel" => {
+          let value = evaluate_expr_to_expr(replacement)
+            .unwrap_or_else(|_| replacement.as_ref().clone());
+          let items: Vec<Expr> = match &value {
+            Expr::List(items) => items.to_vec(),
+            other => vec![other.clone()],
+          };
+          for (i, item) in items.iter().take(3).enumerate() {
+            axes_labels[i] = axis_label_markup(item);
           }
         }
         _ => {}
@@ -3214,15 +3352,15 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   z3_min -= pad_z;
   z3_max += pad_z;
 
-  // An explicit PlotRange pins the displayed region to [-r, r]³ regardless
-  // of the content's extent, keeping the framing stable across re-renders.
-  if let Some(r) = plot_range {
-    x3_min = -r;
-    x3_max = r;
-    y3_min = -r;
-    y3_max = r;
-    z3_min = -r;
-    z3_max = r;
+  // An explicit PlotRange pins the displayed region regardless of the
+  // content's extent, keeping the framing stable across re-renders.
+  if let Some([(xl, xh), (yl, yh), (zl, zh)]) = plot_range {
+    x3_min = xl;
+    x3_max = xh;
+    y3_min = yl;
+    y3_max = yh;
+    z3_min = zl;
+    z3_max = zh;
   }
 
   // Build box corners
@@ -3337,7 +3475,13 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let p_width = if p_width < 1e-15 { 1.0 } else { p_width };
   let p_height = if p_height < 1e-15 { 1.0 } else { p_height };
 
-  let margin = 10.0;
+  // Axes need room outside the box for their ticks, and more again for
+  // the axis labels sitting beyond those.
+  let margin = match (show_axes, axes_labels.iter().any(Option::is_some)) {
+    (true, true) => axes_label_margin(&axes_labels, svg_width.min(svg_height)),
+    (true, false) => 25.0,
+    (false, _) => 10.0,
+  };
   let draw_w = svg_width as f64 - 2.0 * margin;
   let draw_h = svg_height as f64 - 2.0 * margin;
   let scale = (draw_w / p_width).min(draw_h / p_height);
@@ -3628,8 +3772,81 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
+  // Axes (with their ticks and labels) go on top of the scene.
+  if show_axes {
+    draw_axes_on_box(
+      &mut svg,
+      &camera,
+      &to_svg,
+      &box_corners,
+      (x3_min, x3_max),
+      (y3_min, y3_max),
+      (z3_min, z3_max),
+      &axes_labels,
+    );
+  }
+
   svg.push_str("</svg>");
   Ok(crate::graphics3d_result_with_structure(svg, structure))
+}
+
+/// `PlotRange -> {{x0, x1}, {y0, y1}, {z0, z1}}`: one explicit interval per
+/// axis. Anything else (a single interval, `Automatic`, …) is not this form.
+fn parse_axis_ranges(expr: &Expr) -> Option<[(f64, f64); 3]> {
+  let Expr::List(items) = expr else {
+    return None;
+  };
+  if items.len() != 3 {
+    return None;
+  }
+  let mut ranges = [(0.0, 0.0); 3];
+  for (i, item) in items.iter().enumerate() {
+    let Expr::List(pair) = item else {
+      return None;
+    };
+    if pair.len() != 2 {
+      return None;
+    }
+    let lo = try_eval_to_f64(&evaluate_expr_to_expr(&pair[0]).ok()?)?;
+    let hi = try_eval_to_f64(&evaluate_expr_to_expr(&pair[1]).ok()?)?;
+    // A reversed or degenerate interval (or a NaN bound) is not a frame.
+    if hi.partial_cmp(&lo) != Some(std::cmp::Ordering::Greater) {
+      return None;
+    }
+    ranges[i] = (lo, hi);
+  }
+  Some(ranges)
+}
+
+/// The SVG markup of one `AxesLabel` entry. `None` for `None` — the way an
+/// axis asks to stay unlabelled. Everything else is typeset by the shared
+/// label renderer, so a label written in the FrontEnd as linear syntax
+/// (`"\!\(\*FractionBox[\(d\[Theta]\), \(dt\)]\) (rad/s)"`) draws as the
+/// fraction it stands for.
+fn axis_label_markup(expr: &Expr) -> Option<String> {
+  match expr {
+    Expr::Identifier(s) if s == "None" => None,
+    _ => {
+      let markup = crate::functions::graphics::expr_to_svg_markup(expr);
+      (!markup.is_empty()).then_some(markup)
+    }
+  }
+}
+
+/// The characters an SVG markup fragment actually shows, for width
+/// estimation: everything outside its tags.
+fn markup_char_count(markup: &str) -> usize {
+  let mut count = 0;
+  let mut in_tag = false;
+  for c in markup.chars() {
+    match c {
+      '<' => in_tag = true,
+      '>' => in_tag = false,
+      _ if !in_tag => count += 1,
+      _ => {}
+    }
+  }
+  count.max(1)
 }
 
 /// Implementation of ListPlot3D[data, opts...].

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3015,7 +3015,18 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
       // A trailing call suffix applies the Part result: a[[i]][x] -> (a[[i]])[x].
       let mut result = base_expr;
       for p in inner {
-        if matches!(p.as_rule(), Rule::BracketArgs) {
+        if matches!(p.as_rule(), Rule::DerivativePrime) {
+          // `a[[i]]'` differentiates what the part extracted, and any
+          // bracket call after it applies the derivative: `a[[i]]'[t]`.
+          let order = p.as_str().chars().filter(|c| *c == '\'').count();
+          result = Expr::CurriedCall {
+            func: Box::new(Expr::FunctionCall {
+              name: "Derivative".to_string(),
+              args: vec![Expr::Integer(order as i128)].into(),
+            }),
+            args: vec![result],
+          };
+        } else if matches!(p.as_rule(), Rule::BracketArgs) {
           let args: Vec<Expr> = p
             .into_inner()
             .filter(|c| {

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -34,8 +34,11 @@ PartIndexSuffix = { (PartOpen ~ PartIndex ~ ("," ~ PartIndex)* ~ PartClose)+ }
 // FunctionCall-based Part extraction is handled by FunctionCallExtended
 // List-based Part extraction is handled by ListExtended
 // A trailing `BracketArgs*` lets a Part result be applied as a function:
-// `a[[i]][x]` (e.g. extract a function from a list and call it).
-PartExtract = { (Slot | Identifier | UnsignedNumericValue | String) ~ (PartOpen ~ PartIndex ~ ("," ~ PartIndex)* ~ PartClose)+ ~ BracketArgs* }
+// `a[[i]][x]` (e.g. extract a function from a list and call it). A prime
+// between the two differentiates the extracted function first, the way it
+// does after a parenthesis: `solutions[[i]][[2]]'[t]` differentiates the
+// InterpolatingFunction an NDSolve rule was carrying.
+PartExtract = { (Slot | Identifier | UnsignedNumericValue | String) ~ (PartOpen ~ PartIndex ~ ("," ~ PartIndex)* ~ PartClose)+ ~ DerivativePrime? ~ BracketArgs* }
 
 // Optional inline whitespace, spelled out so the atomic numeric-literal
 // lookaheads below can see a `^` that is separated from its base by spaces

--- a/tests/cli/symbolic/NDSolve.md
+++ b/tests/cli/symbolic/NDSolve.md
@@ -1,3 +1,24 @@
 # `NDSolve`
 
 Solves ordinary differential equations numerically.
+
+```scrut
+$ wo "NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]"
+{{y -> InterpolatingFunction[{{0., 5.}}, <>]}}
+```
+
+The equation does not have to be linear in the function being solved for —
+here the pendulum equation, whose `Sin[y[t]]` has no closed-form solution:
+
+```scrut
+$ wo "s = NDSolve[{y''[t] == -Sin[y[t]], y[0] == 1, y'[0] == 0}, y, {t, 0, 5}]; (y /. s[[1]])[3.0]"
+-0.94875159694288
+```
+
+A solution rule carries an `InterpolatingFunction`, which can be
+differentiated:
+
+```scrut
+$ wo "s = Flatten[NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]]; s[[1]][[2]]'[2.0]"
+-0.1353352846442526
+```

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7377,6 +7377,105 @@ mod ndsolve {
       val
     );
   }
+
+  #[test]
+  fn nonlinear_pendulum_equation() {
+    // Nothing about integrating an ODE numerically needs it to be linear
+    // in the dependent variable. The damped driven pendulum,
+    // `θ'' == -(g/l) Sin[θ] - γ θ' + a Cos[ω t]`, is the classic
+    // counter-example — `Sin[θ[t]]` used to make NDSolve give up with
+    // "DSolve: cannot classify term involving θ".
+    let result = interpret(
+      "s = NDSolve[{th''[t] == -4.905 Sin[th[t]] - 1.11 th'[t] \
+         + 5.73 Cos[1.48 t], th[0] == -0.075, th'[0] == -0.075}, \
+       th, {t, 0, 25}]; (th /. s[[1]])[10.0]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    // Reference: the same initial-value problem integrated with RK4 at
+    // 200x this step size.
+    assert!(
+      (val - -0.6704006).abs() < 1e-4,
+      "Expected -0.6704006, got {val}"
+    );
+  }
+
+  #[test]
+  fn nonlinear_first_order_equation() {
+    // y' = y², y(0) = 1 has the closed form 1/(1 - t).
+    let result = interpret(
+      "s = NDSolve[{y'[t] == y[t]^2, y[0] == 1}, y, {t, 0, 0.5}]; \
+       (y /. s[[1]])[0.4]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    assert!((val - 1.0 / 0.6).abs() < 1e-6, "Expected 1.6667, got {val}");
+  }
+
+  #[test]
+  fn domain_ends_exactly_where_asked() {
+    // Stepping by adding `h` a thousand times drifts off the end of the
+    // domain; the reported domain must still be the one asked for.
+    assert_eq!(
+      interpret("NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]").unwrap(),
+      "{{y -> InterpolatingFunction[{{0., 5.}}, <>]}}"
+    );
+    assert_eq!(
+      interpret("NDSolve[{y'[t] == -y[t], y[1] == 1}, y, {t, 1, 3.5}]")
+        .unwrap(),
+      "{{y -> InterpolatingFunction[{{1., 3.5}}, <>]}}"
+    );
+  }
+
+  #[test]
+  fn solution_interpolates_between_grid_points() {
+    // NDSolve's InterpolatingFunction interpolates to third order, as the
+    // Wolfram Language's does, so reading the solution back off the grid
+    // keeps the accuracy the integration had. Linear interpolation would
+    // be out by ~1e-5 here, and its derivative by ~1e-3.
+    let value = interpret(
+      "s = NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]; \
+       (y /. s[[1]])[2.0023]",
+    )
+    .unwrap()
+    .parse::<f64>()
+    .expect("should be a number");
+    assert!(
+      (value - (-2.0023_f64).exp()).abs() < 1e-9,
+      "Expected {}, got {value}",
+      (-2.0023_f64).exp()
+    );
+    let slope = interpret(
+      "s = NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]; \
+       (y /. s[[1]])'[2.0023]",
+    )
+    .unwrap()
+    .parse::<f64>()
+    .expect("should be a number");
+    assert!(
+      (slope - -(-2.0023_f64).exp()).abs() < 1e-7,
+      "Expected {}, got {slope}",
+      -(-2.0023_f64).exp()
+    );
+  }
+
+  #[test]
+  fn derivative_of_a_part_extracted_solution() {
+    // `solutions[[i]][[2]]'[t]` — the prime differentiates the
+    // InterpolatingFunction the rule was carrying. It used to be a parse
+    // error ("expected SpanSep").
+    let result = interpret(
+      "s = Flatten[NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]]; \
+       s[[1]][[2]]'[2.0]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    assert!(
+      (val - -(-2.0_f64).exp()).abs() < 1e-6,
+      "Expected {}, got {val}",
+      -(-2.0_f64).exp()
+    );
+  }
 }
 
 mod sinh_cosh {

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -2592,6 +2592,66 @@ mod tests {
     }
 
     #[test]
+    fn graphics3d_axes_carry_ticks_and_labels() {
+      // `Show[Graphics3D[…], Axes -> True, AxesLabel -> {…}]`: a
+      // Demonstration frames a 3D scene this way, and the axes, their tick
+      // labels and the axis labels all have to be drawn.
+      let svg = svg_of(
+        "Graphics3D[{Line[{{0, 0, 0}, {1, 10, 5}}]}, Axes -> True, \
+         AxesLabel -> {\"across\", \"t (s)\", \"up\"}]",
+      );
+      for label in ["across", "t (s)", "up"] {
+        assert!(svg.contains(label), "expected the {label} label: {svg}");
+      }
+      // Without `Axes -> True` there is only the wireframe box.
+      let plain = svg_of("Graphics3D[{Line[{{0, 0, 0}, {1, 10, 5}}]}]");
+      assert!(!plain.contains("<text"), "expected no axes: {plain}");
+    }
+
+    #[test]
+    fn graphics3d_axes_label_typesets_inline_boxes() {
+      // An axis label written in the FrontEnd carries its typesetting as
+      // linear syntax inside the string; it must draw as the superscript
+      // it stands for, not as the box source.
+      let svg = svg_of(
+        "Graphics3D[{Line[{{0, 0, 0}, {1, 1, 1}}]}, Axes -> True, \
+         AxesLabel -> {\"m/\\!\\(\\*SuperscriptBox[\\(s\\), \\(2\\)]\\)\", \
+         None, None}]",
+      );
+      assert!(
+        svg.contains("m/s<tspan baseline-shift=\"super\""),
+        "expected a typeset exponent: {svg}"
+      );
+      assert!(
+        !svg.contains("SuperscriptBox"),
+        "the box source must not be drawn: {svg}"
+      );
+    }
+
+    #[test]
+    fn graphics3d_plot_range_frames_each_axis() {
+      // `PlotRange -> {{x0, x1}, {y0, y1}, {z0, z1}}` pins the displayed
+      // region, so the ticks span the range asked for rather than the
+      // extent of the contents.
+      let svg = svg_of(
+        "Graphics3D[{Line[{{0, 0, 0}, {1, 1, 1}}]}, Axes -> True, \
+         PlotRange -> {{-7, 7}, {0, 25}, {-20, 20}}]",
+      );
+      for tick in [">-5<", ">20<", ">-20<"] {
+        assert!(svg.contains(tick), "expected a {tick} tick: {svg}");
+      }
+      // The contents alone would never reach those values.
+      let fitted = svg_of(
+        "Graphics3D[{Line[{{0, 0, 0}, {1, 1, 1}}]}, \
+         Axes -> True]",
+      );
+      assert!(
+        !fitted.contains(">20<"),
+        "expected a fitted frame: {fitted}"
+      );
+    }
+
+    #[test]
     fn raster3d_renders_voxels() {
       let svg =
         svg_of("Graphics3D[Raster3D[{{{0, 1}, {1, 0}}, {{1, 0}, {0, 1}}}]]");

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -10550,4 +10550,362 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`fam$$ = 1}, \"\\[Ellipsis]\"]"], "O
     assert_ne!(net, render(3, 2), "the family control must matter");
     assert_ne!(net, render(1, 1), "the view control must matter");
   }
+
+  /// End-to-end regression for the "Chaos and Order in the Damped Forced
+  /// Pendulum in a Plane" Demonstration: it integrates the damped driven
+  /// pendulum `θ'' == -(g/l) Sin[θ] - γ θ' + a Cos[ω t]` from a grid of
+  /// initial conditions and draws every trajectory in (θ', t, θ) space.
+  ///
+  /// The notebook is trimmed the way `tests/notebooks` trims the others —
+  /// the author's comments are dropped and the published default of the
+  /// "number of trajectories" picklist is its first choice (1) instead of
+  /// 16, so the test integrates one trajectory rather than sixteen. Every
+  /// structure the Demonstration relies on is kept: the typeset second
+  /// derivative in the differential equation, the derivative of the
+  /// InterpolatingFunction a part-extracted solution rule carries, and the
+  /// `Show[Graphics3D[…], Axes -> True, PlotRange -> {…}, AxesLabel -> {…}]`
+  /// frame.
+  #[test]
+  fn damped_forced_pendulum_notebook_draws_its_trajectories() {
+    let nb_src = r##"Notebook[{
+Cell[CellGroupData[{
+Cell["Initialization Code", "Section"],
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"DFPPlot", "[", 
+   RowBox[{
+   "tmax_", ",", "ntray_", ",", "long_", ",", "mass_", ",", "grav_", ",", 
+    "resis_", ",", "f0ext_", ",", "wext_"}], "]"}], ":=", 
+  RowBox[{"Module", "[", 
+   RowBox[{
+    RowBox[{"{", 
+     RowBox[{
+      RowBox[{"tmaximun", "=", "tmax"}], ",", 
+      RowBox[{"ntrayec", "=", "ntray"}], ",", "n", ",", 
+      RowBox[{"g", "=", "grav"}], ",", 
+      RowBox[{"l", "=", "long"}], ",", 
+      RowBox[{"m", "=", "mass"}], ",", 
+      RowBox[{"b", "=", "resis"}], ",", 
+      RowBox[{"w", "=", "wext"}], ",", "w0", ",", "gamma", ",", "amp", ",", 
+      "\[Theta]", ",", "\[Theta]0min", ",", "\[Theta]0max", ",", "v0min", ",",
+       "v0max", ",", "\[Theta]aux", ",", "vaux", ",", "f", ",", "t", ",", "x",
+       ",", "i", ",", "j", ",", "solutions", ",", "trayec"}], "}"}], ",", 
+    RowBox[{
+     RowBox[{"n", "=", 
+      RowBox[{"Round", "[", 
+       RowBox[{"Sqrt", "[", "ntrayec", "]"}], "]"}]}], ";", 
+     RowBox[{"ntrayec", "=", 
+      RowBox[{"n", "^", "2"}]}], ";", RowBox[{"gamma", "=", 
+      RowBox[{"b", "/", "m"}]}], ";", RowBox[{"amp", " ", "=", 
+      RowBox[{"f0ext", "/", 
+       RowBox[{"(", 
+        RowBox[{"m", "*", "l"}], ")"}]}]}], ";", RowBox[{"\[Theta]0min", "=", 
+      RowBox[{"-", "0.15"}]}], ";", RowBox[{"\[Theta]0max", "=", "0.15"}], ";", RowBox[{"v0min", "=", 
+      RowBox[{"-", "0.15"}]}], ";", RowBox[{"v0max", "=", "0.15"}], ";", RowBox[{"\[Theta]aux", "=", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{"\[Theta]0max", "-", "\[Theta]0min"}], ")"}], "/", "n"}]}], 
+     ";", " ", 
+      RowBox[{"vaux", "=", 
+      RowBox[{
+       RowBox[{"(", 
+        RowBox[{"v0max", "-", "v0min"}], ")"}], "/", "n"}]}], ";", "   ", 
+      RowBox[{"solutions", "=", 
+      RowBox[{"{", "}"}]}], ";", RowBox[{"Do", "[", RowBox[{
+       RowBox[{"Do", "[", 
+        RowBox[{
+         RowBox[{"AppendTo", "[", 
+          RowBox[{"solutions", ",", 
+           RowBox[{"NDSolve", "[", 
+            RowBox[{
+             RowBox[{"{", 
+              RowBox[{
+               RowBox[{
+                RowBox[{
+                 SuperscriptBox[
+                  SuperscriptBox["\[Theta]", "\[Prime]",
+                   MultilineFunction->None], "\[Prime]",
+                  MultilineFunction->None], "[", "t", "]"}], "\[Equal]", 
+                RowBox[{
+                 RowBox[{
+                  RowBox[{"-", 
+                   RowBox[{"(", 
+                    RowBox[{"g", "/", "l"}], ")"}]}], " ", 
+                  RowBox[{"Sin", "[", 
+                   RowBox[{"\[Theta]", "[", "t", "]"}], "]"}]}], "-", 
+                 RowBox[{"gamma", "*", 
+                  RowBox[{
+                   SuperscriptBox["\[Theta]", "\[Prime]",
+                    MultilineFunction->None], "[", "t", "]"}]}], "+", 
+                 RowBox[{"amp", "*", 
+                  RowBox[{"Cos", "[", 
+                   RowBox[{"w", "*", "t"}], "]"}]}]}]}], ",", 
+               RowBox[{
+                RowBox[{"\[Theta]", "[", "0", "]"}], "\[Equal]", 
+                RowBox[{"\[Theta]0min", "+", 
+                 RowBox[{"\[Theta]aux", "*", "i"}]}]}], ",", 
+               RowBox[{
+                RowBox[{
+                 SuperscriptBox["\[Theta]", "\[Prime]",
+                  MultilineFunction->None], "[", "0", "]"}], "\[Equal]", 
+                RowBox[{"v0min", "+", 
+                 RowBox[{"vaux", "*", "j"}]}]}]}], "}"}], ",", "\[Theta]", 
+             ",", 
+             RowBox[{"{", 
+              RowBox[{"t", ",", "0", ",", "tmaximun"}], "}"}], ",", 
+             RowBox[{"MaxSteps", "\[Rule]", "20000"}]}], "]"}]}], "]"}], ",", 
+         RowBox[{"{", 
+          RowBox[{"i", ",", "1", ",", "n"}], "}"}]}], "]"}], ",", 
+       RowBox[{"{", 
+        RowBox[{"j", ",", "1", ",", "n"}], "}"}]}], "]"}], ";", RowBox[{"solutions", "=", 
+      RowBox[{"Flatten", "[", "solutions", "]"}]}], ";", 
+     RowBox[{"trayec", "=", 
+      RowBox[{"{", "}"}]}], ";", RowBox[{"Do", "[", RowBox[{
+       RowBox[{"AppendTo", "[", 
+        RowBox[{"trayec", ",", 
+         RowBox[{
+          RowBox[{"ParametricPlot3D", "[", 
+           RowBox[{
+            RowBox[{"Evaluate", "[", 
+             RowBox[{"{", 
+              RowBox[{
+               RowBox[{
+                RowBox[{
+                 RowBox[{
+                  RowBox[{"solutions", "[", 
+                   RowBox[{"[", "i", "]"}], "]"}], "[", 
+                  RowBox[{"[", "2", "]"}], "]"}], "'"}], "[", "t", "]"}], ",",
+                "t", ",", 
+               RowBox[{
+                RowBox[{
+                 RowBox[{"solutions", "[", 
+                  RowBox[{"[", "i", "]"}], "]"}], "[", 
+                 RowBox[{"[", "2", "]"}], "]"}], "[", "t", "]"}]}], "}"}], 
+             "]"}], ",", 
+            RowBox[{"{", 
+             RowBox[{"t", ",", "0", ",", "tmaximun"}], "}"}], ",", 
+            RowBox[{"PerformanceGoal", "\[Rule]", "\"\<Speed\>\""}], ",", 
+            RowBox[{"Axes", "\[Rule]", "False"}], ",", 
+            RowBox[{"PlotStyle", "\[Rule]", 
+             RowBox[{"Hue", "[", 
+              RowBox[{
+               RowBox[{"1", "-", 
+                RowBox[{"i", "/", "ntrayec"}]}], ",", "1", ",", "0.75"}], 
+              "]"}]}]}], "]"}], "\[LeftDoubleBracket]", "1", 
+          "\[RightDoubleBracket]"}]}], "]"}], ",", RowBox[{"{", 
+        RowBox[{"i", ",", "1", ",", "ntrayec"}], "}"}]}], "]"}], ";", 
+     RowBox[{"Show", "[", 
+      RowBox[{
+       RowBox[{"Graphics3D", "[", "trayec", "]"}], ",", 
+       RowBox[{"ViewPoint", "\[Rule]", 
+        RowBox[{"{", 
+         RowBox[{"2.714", ",", " ", "1.876", ",", " ", "0.751"}], "}"}]}], 
+       ",", 
+       RowBox[{"Axes", "\[Rule]", "True"}], ",", 
+       RowBox[{"PlotRange", "\[Rule]", 
+        RowBox[{"{", 
+         RowBox[{
+          RowBox[{"{", 
+           RowBox[{
+            RowBox[{"-", "7"}], ",", "7"}], "}"}], ",", 
+          RowBox[{"{", 
+           RowBox[{"0", ",", "25"}], "}"}], ",", 
+          RowBox[{"{", 
+           RowBox[{
+            RowBox[{"-", "20"}], ",", "20"}], "}"}]}], "}"}]}], ",", 
+       RowBox[{"Background", "\[Rule]", 
+        RowBox[{"GrayLevel", "[", "1", "]"}]}], ",", 
+       RowBox[{"AxesLabel", "\[Rule]", 
+        RowBox[{"{", 
+         RowBox[{
+         "\"\<\!\(\*FractionBox[\(d\[InvisibleSpace]\[Theta]\), \(d\
+\[InvisibleSpace]t\)]\) (rad/s)\>\"", ",", " ", "\"\<t (s)\>\"", ",", " ", 
+          "\"\<\[Theta] (rad)\>\""}], "}"}]}], ",", 
+       RowBox[{"AspectRatio", "\[Rule]", "1"}], ",", 
+       RowBox[{"ImageSize", "\[Rule]", 
+        RowBox[{"{", 
+         RowBox[{"300", ",", "300"}], "}"}]}]}], "]"}]}]}], "]"}]}]], "Input"]
+}, Closed]],
+Cell[CellGroupData[{
+Cell["Manipulate", "Section"],
+Cell[CellGroupData[{
+Cell[BoxData[
+ RowBox[{"Manipulate", "[", "\[IndentingNewLine]", 
+  RowBox[{
+   RowBox[{"DFPPlot", "[", 
+    RowBox[{
+    "time", ",", "ntrayec", ",", "length", ",", "mass", ",", "gravity", ",", 
+     "resis", ",", "fext", ",", "wext"}], "]"}], ",", "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"Style", "[", 
+    RowBox[{"\"\<parameters of the trajectories\>\"", ",", "Bold"}], "]"}], 
+   ",", "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"time", ",", "25", ",", "\"\<time (s)\>\""}], "}"}], ",", "1", 
+     ",", "25", ",", ".01", ",", 
+     RowBox[{"Appearance", "\[Rule]", "\"\<Labeled\>\""}], ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Small"}]}], "}"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"ntrayec", ",", "1", ",", "\"\<number of trajectories\>\""}], 
+      "}"}], ",", 
+     RowBox[{"{", 
+      RowBox[{
+      "1", ",", "4", ",", "9", ",", "16", ",", "25", ",", "36", ",", "49", 
+       ",", "64"}], "}"}]}], "}"}], ",", "\[IndentingNewLine]", "Delimiter", 
+   ",", "\[IndentingNewLine]", 
+   RowBox[{"Style", "[", 
+    RowBox[{"\"\<parameters of the pendulum\>\"", ",", "Bold"}], "]"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"length", ",", "2", ",", "\"\<length ( m )\>\""}], "}"}], ",", 
+     "1", ",", "10", ",", ".01", ",", 
+     RowBox[{"Appearance", "\[Rule]", "\"\<Labeled\>\""}], ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Small"}]}], "}"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"mass", ",", "1", ",", "\"\<mass ( kg )\>\""}], "}"}], ",", "1",
+      ",", "10", ",", ".01", ",", 
+     RowBox[{"Appearance", "\[Rule]", "\"\<Labeled\>\""}], ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Small"}]}], "}"}], ",", 
+   "\[IndentingNewLine]", "Delimiter", ",", "\[IndentingNewLine]", 
+   RowBox[{"Style", "[", 
+    RowBox[{"\"\<acceleration due to gravity\>\"", ",", "Bold"}], "]"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{
+      "gravity", ",", "9.81", ",", 
+       "\"\<gravity ( m/\!\(\*SuperscriptBox[\(s\), \(2\)]\) )\>\""}], "}"}], 
+     ",", "0", ",", "12", ",", ".01", ",", 
+     RowBox[{"Appearance", "\[Rule]", "\"\<Labeled\>\""}], ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Small"}]}], "}"}], ",", 
+   "\[IndentingNewLine]", "Delimiter", ",", "\[IndentingNewLine]", 
+   RowBox[{"Style", "[", 
+    RowBox[{"\"\<resistance of the fluid\>\"", ",", "Bold"}], "]"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"resis", ",", "1.11", ",", "\"\<resistance ( kg/s ) \>\""}], 
+      "}"}], ",", "0", ",", "10", ",", ".01", ",", 
+     RowBox[{"Appearance", "\[Rule]", "\"\<Labeled\>\""}], ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Small"}]}], "}"}], ",", 
+   "\[IndentingNewLine]", "Delimiter", ",", "\[IndentingNewLine]", 
+   RowBox[{"Style", "[", 
+    RowBox[{"\"\<external force applied to pendulum\>\"", ",", "Bold"}], 
+    "]"}], ",", "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"fext", ",", "11.46", ",", "\"\<amplitude ( N ) \>\""}], "}"}], 
+     ",", "0", ",", "15", ",", ".01", ",", 
+     RowBox[{"Appearance", "\[Rule]", "\"\<Labeled\>\""}], ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Small"}]}], "}"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"wext", ",", "1.48", ",", "\"\<frequency ( rad/s ) \>\""}], 
+      "}"}], ",", "0", ",", "4", ",", ".01", ",", 
+     RowBox[{"Appearance", "\[Rule]", "\"\<Labeled\>\""}], ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Small"}]}], "}"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"ControlPlacement", "\[Rule]", "Left"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"SaveDefinitions", "\[Rule]", "True"}]}], "\[IndentingNewLine]", 
+  "]"}]], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`time$$ = 25}, \"\\[Ellipsis]\"]"], "Output"]
+}, Open]]
+}, Closed]]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .iter()
+      .find_map(|e| e.manipulate_state.as_ref())
+      .expect("the Manipulate cell must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "the pendulum must integrate: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "the trajectories must draw"
+    );
+
+    // Every control the Demonstration publishes, in order: five headings
+    // separated by delimiters, seven sliders and one picklist.
+    let labels: Vec<String> = widget
+      .controls
+      .iter()
+      .map(|c| match c {
+        manipulate::ControlState::Continuous { name, label, .. }
+        | manipulate::ControlState::Discrete { name, label, .. } => {
+          format!("{name}: {label}")
+        }
+        manipulate::ControlState::Heading { label, .. } => label.clone(),
+        manipulate::ControlState::Divider => "-".to_string(),
+        other => panic!("unexpected control: {other:?}"),
+      })
+      .collect();
+    assert_eq!(
+      labels,
+      vec![
+        "parameters of the trajectories",
+        "time: time (s)",
+        "ntrayec: number of trajectories",
+        "-",
+        "parameters of the pendulum",
+        "length: length ( m )",
+        "mass: mass ( kg )",
+        "-",
+        "acceleration due to gravity",
+        // The unit's typeset exponent, not its box source.
+        "gravity: gravity ( m/s\u{b2} )",
+        "-",
+        "resistance of the fluid",
+        "resis: resistance ( kg/s ) ",
+        "-",
+        "external force applied to pendulum",
+        "fext: amplitude ( N ) ",
+        "wext: frequency ( rad/s ) ",
+      ]
+    );
+
+    let render = |time: f64| {
+      woxi::interpret_with_stdout(&format!(
+        "time = {time}; ntrayec = 1; length = 2; mass = 1; gravity = 9.81; \
+         resis = 1.11; fext = 11.46; wext = 1.48;\n{}",
+        widget.body
+      ))
+      .expect("the body must render")
+      .graphics
+      .expect("the body must produce a graphic")
+    };
+    let published = render(25.0);
+    // The frame the notebook asks for: `PlotRange -> {{-7, 7}, {0, 25},
+    // {-20, 20}}` with all three axes labelled.
+    for text in [">-5<", ">20<", ">-20<", "t (s)", "(rad/s)"] {
+      assert!(published.contains(text), "expected {text} in the frame");
+    }
+    // A trajectory is a long polyline of coloured segments, not a handful.
+    assert!(
+      published.matches("<line").count() > 500,
+      "expected a resolved trajectory, got {} segments",
+      published.matches("<line").count()
+    );
+    // Integrating over a shorter interval draws a different trajectory.
+    assert_ne!(render(5.0), published, "the time control must matter");
+  }
 }


### PR DESCRIPTION
## Summary

This PR removes the scalar-only ODE solver path from NDSolve and unifies all differential equation solving through a single system integrator. The scalar path was built on DSolve's linear term classifier, which rejected nonlinear equations like the pendulum's `Sin[θ[t]]` despite numerical integration having no such requirement.

## Key Changes

- **Removed scalar-only solver**: Deleted `ndsolve_scalar()` and its supporting functions (`build_rhs_for_highest_derivative()`, `rk4_step()`) that only handled linear equations in the dependent variable
- **Unified integrator**: All ODE shapes—single equations or coupled systems, linear or nonlinear—now route through `ndsolve_system()`
- **Fixed domain precision**: Grid points are now computed from the domain endpoints rather than accumulated stepping, ensuring the reported domain exactly matches what was requested (e.g., `{{0., 5.}}` instead of `{{0., 4.999999999999916}}`)
- **Added cubic interpolation**: InterpolatingFunction results now carry interpolation order 3 (matching Wolfram Language defaults), preserving integration accuracy when reading solutions between grid points
- **Enhanced Graphics3D axes**: 
  - Added support for `Axes -> True` to draw axis lines with ticks
  - Added `AxesLabel` support with proper positioning and typeset markup rendering
  - Extended `PlotRange` to accept per-axis ranges: `{{x0, x1}, {y0, y1}, {z0, z1}}`
  - Refactored axis drawing to work with arbitrary box corners for flexible framing
- **Parser enhancement**: Added support for differentiating part-extracted solutions (e.g., `a[[i]]'[t]`)

## Notable Implementation Details

- The grid computation now uses `grid(i) = x_from + i * step` where `step = (x_to - x_from) / n_steps`, with special handling for the final point to ensure it lands exactly at `x_to`
- Axis labels are positioned perpendicular to their axes, accounting for tick label reach to avoid overlap
- The `NDSOLVE_INTERPOLATION_ORDER` constant documents why cubic interpolation is used
- Added comprehensive regression tests including the damped forced pendulum demonstration and nonlinear first-order equations

## Tests Added

- `nonlinear_pendulum_equation`: Validates the damped driven pendulum with `Sin[θ[t]]`
- `nonlinear_first_order_equation`: Tests `y' = y²` with known closed form
- `domain_ends_exactly_where_asked`: Ensures reported domain matches requested range
- `solution_interpolates_between_grid_points`: Verifies cubic interpolation accuracy
- `derivative_of_a_part_extracted_solution`: Tests the new `a[[i]]'[t]` syntax
- `damped_forced_pendulum_notebook_draws_its_trajectories`: End-to-end regression for a Wolfram Demonstration
- Graphics3D axis rendering tests for ticks, labels, and typeset markup

https://claude.ai/code/session_01LqL5S2VCUP2JdGYfro4k5h