### PR TITLE
Add support for polygons with holes

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -517,6 +517,9 @@ enum Primitive {
   },
   PolygonPrim {
     points: Vec<(f64, f64)>,
+    /// Boundaries cut out of the polygon (`Polygon[outer -> holes]`).
+    /// Empty for an ordinary polygon.
+    holes: Vec<Vec<(f64, f64)>>,
     style: StyleState,
   },
   ArrowPrim {
@@ -1842,6 +1845,17 @@ fn parse_polygon(
   if let Some(pts) = expr_to_point_list(&args[0]) {
     prims.push(Primitive::PolygonPrim {
       points: pts,
+      holes: Vec::new(),
+      style: style.clone(),
+    });
+  } else if let Some((outer, holes)) =
+    crate::functions::polygon_holes::split_holes(&args[0], &expr_to_point_list)
+  {
+    // Polygon[outer -> holes] — a polygon with the hole boundaries cut
+    // out of it.
+    prims.push(Primitive::PolygonPrim {
+      points: outer,
+      holes,
       style: style.clone(),
     });
   } else if let Expr::List(items) = &args[0] {
@@ -1849,6 +1863,15 @@ fn parse_polygon(
       if let Some(pts) = expr_to_point_list(item) {
         prims.push(Primitive::PolygonPrim {
           points: pts,
+          holes: Vec::new(),
+          style: style.clone(),
+        });
+      } else if let Some((outer, holes)) =
+        crate::functions::polygon_holes::split_holes(item, &expr_to_point_list)
+      {
+        prims.push(Primitive::PolygonPrim {
+          points: outer,
+          holes,
           style: style.clone(),
         });
       }
@@ -1892,6 +1915,7 @@ fn parse_parallelogram(
   ];
   prims.push(Primitive::PolygonPrim {
     points,
+    holes: Vec::new(),
     style: style.clone(),
   });
 }
@@ -2019,6 +2043,7 @@ fn parse_regular_polygon(
     .collect();
   prims.push(Primitive::PolygonPrim {
     points: pts,
+    holes: Vec::new(),
     style: style.clone(),
   });
 }
@@ -2325,6 +2350,7 @@ fn parse_polar_curve(
   if filled {
     prims.push(Primitive::PolygonPrim {
       points,
+      holes: Vec::new(),
       style: style.clone(),
     });
   } else {
@@ -2857,8 +2883,16 @@ fn rotate_primitive(
         .collect(),
       style: style.clone(),
     },
-    Primitive::PolygonPrim { points, style } => Primitive::PolygonPrim {
+    Primitive::PolygonPrim {
+      points,
+      holes,
+      style,
+    } => Primitive::PolygonPrim {
       points: points.iter().map(|&(x, y)| rp(x, y)).collect(),
+      holes: holes
+        .iter()
+        .map(|h| h.iter().map(|&(x, y)| rp(x, y)).collect())
+        .collect(),
       style: style.clone(),
     },
     Primitive::ArrowPrim {
@@ -2894,6 +2928,7 @@ fn rotate_primitive(
       .iter()
       .map(|&(x, y)| rp(x, y))
       .collect(),
+      holes: Vec::new(),
       style: style.clone(),
     },
     Primitive::Disk {
@@ -3022,8 +3057,16 @@ fn translate_primitive(prim: &Primitive, dx: f64, dy: f64) -> Primitive {
         .collect(),
       style: style.clone(),
     },
-    Primitive::PolygonPrim { points, style } => Primitive::PolygonPrim {
+    Primitive::PolygonPrim {
+      points,
+      holes,
+      style,
+    } => Primitive::PolygonPrim {
       points: points.iter().map(|&(x, y)| tp(x, y)).collect(),
+      holes: holes
+        .iter()
+        .map(|h| h.iter().map(|&(x, y)| tp(x, y)).collect())
+        .collect(),
       style: style.clone(),
     },
     Primitive::ArrowPrim {
@@ -3195,8 +3238,16 @@ fn scale_primitive(
         .collect(),
       style: style.clone(),
     },
-    Primitive::PolygonPrim { points, style } => Primitive::PolygonPrim {
+    Primitive::PolygonPrim {
+      points,
+      holes,
+      style,
+    } => Primitive::PolygonPrim {
       points: points.iter().map(|&(x, y)| sp(x, y)).collect(),
+      holes: holes
+        .iter()
+        .map(|h| h.iter().map(|&(x, y)| sp(x, y)).collect())
+        .collect(),
       style: style.clone(),
     },
     Primitive::ArrowPrim {
@@ -4427,7 +4478,11 @@ fn render_primitive(
         stroke_attr,
       ));
     }
-    Primitive::PolygonPrim { points, style } => {
+    Primitive::PolygonPrim {
+      points,
+      holes,
+      style,
+    } => {
       let color = style.effective_color();
       let pts: Vec<String> = points
         .iter()
@@ -4459,13 +4514,43 @@ fn render_primitive(
       } else {
         String::new()
       };
-      out.push_str(&format!(
-        "<polygon points=\"{}\" fill=\"{}\"{}{}/>\n",
-        pts.join(" "),
-        color.to_svg_rgb(),
-        fill_opacity,
-        stroke_attr,
-      ));
+      if holes.is_empty() {
+        out.push_str(&format!(
+          "<polygon points=\"{}\" fill=\"{}\"{}{}/>\n",
+          pts.join(" "),
+          color.to_svg_rgb(),
+          fill_opacity,
+          stroke_attr,
+        ));
+      } else {
+        // A polygon with holes becomes one path per boundary, filled with
+        // the even-odd rule so the hole subpaths are cut out.
+        let subpath = |ring: &[(f64, f64)]| {
+          let mut d = String::new();
+          for (i, &(x, y)) in ring.iter().enumerate() {
+            d.push_str(&format!(
+              "{}{:.2},{:.2}",
+              if i == 0 { "M" } else { "L" },
+              coord_x(x, bb, svg_w),
+              coord_y(y, bb, svg_h)
+            ));
+            d.push(' ');
+          }
+          d.push_str("Z ");
+          d
+        };
+        let mut d = subpath(points);
+        for hole in holes {
+          d.push_str(&subpath(hole));
+        }
+        out.push_str(&format!(
+          "<path d=\"{}\" fill=\"{}\" fill-rule=\"evenodd\"{}{}/>\n",
+          d.trim_end(),
+          color.to_svg_rgb(),
+          fill_opacity,
+          stroke_attr,
+        ));
+      }
     }
     Primitive::HalfPlanePrim {
       p,
@@ -5039,9 +5124,17 @@ fn primitives_to_box_elements(primitives: &[Primitive]) -> Vec<String> {
         elements.extend(tracker.emit_style_changes(style));
         elements.push(gbox::rectangle_box(*x_min, *y_min, *x_max, *y_max));
       }
-      Primitive::PolygonPrim { points, style } => {
+      Primitive::PolygonPrim {
+        points,
+        holes,
+        style,
+      } => {
         elements.extend(tracker.emit_style_changes(style));
-        elements.push(gbox::polygon_box(points));
+        elements.push(if holes.is_empty() {
+          gbox::polygon_box(points)
+        } else {
+          gbox::polygon_with_holes_box(points, holes)
+        });
       }
       Primitive::ArrowPrim {
         points,

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -2234,11 +2234,7 @@ fn inset_primitives(
   let pos = args.get(1).and_then(expr_to_point).unwrap_or((0.0, 0.0));
   // `opos` names the point of the object that lands on `pos`, in the
   // object's own coordinates (Automatic = its centre).
-  let (ox, oy) = args
-    .get(2)
-    .and_then(expr_to_point)
-    .map(|(x, y)| (x, y))
-    .unwrap_or((cx, cy));
+  let (ox, oy) = args.get(2).and_then(expr_to_point).unwrap_or((cx, cy));
 
   let placed = inner
     .iter()

--- a/src/functions/graphicsbox.rs
+++ b/src/functions/graphicsbox.rs
@@ -207,6 +207,23 @@ pub fn polygon_box(points: &[(f64, f64)]) -> String {
   }
 }
 
+/// PolygonBox[{{x1,y1}, ...} -> {{{u1,v1}, ...}, ...}] — a polygon with
+/// holes, the box form of `Polygon[outer -> holes]`.
+pub fn polygon_with_holes_box(
+  points: &[(f64, f64)],
+  holes: &[Vec<(f64, f64)>],
+) -> String {
+  let ring = |pts: &[(f64, f64)]| {
+    let items: Vec<String> = pts
+      .iter()
+      .map(|(x, y)| format!("{{{}, {}}}", fmt_real(*x), fmt_real(*y)))
+      .collect();
+    format!("{{{}}}", items.join(", "))
+  };
+  let holes: Vec<String> = holes.iter().map(|h| ring(h)).collect();
+  format!("PolygonBox[{} -> {{{}}}]", ring(points), holes.join(", "))
+}
+
 /// ArrowBox[{{x1,y1}, ...}] or ArrowBox[{{x1,y1}, ...}, {s1, s2}]
 pub fn arrow_box(points: &[(f64, f64)], setback: (f64, f64)) -> String {
   let pts: Vec<String> = points

--- a/src/functions/list_helpers_ast/restructuring.rs
+++ b/src/functions/list_helpers_ast/restructuring.rs
@@ -1978,6 +1978,37 @@ pub fn join_ast(lists: &[Expr]) -> Result<Expr, InterpreterError> {
     return join_ast(&lists[..lists.len() - 1]);
   }
 
+  // `Rule`/`RuleDelayed` are ordinary (nonatomic) expressions as far as Join
+  // is concerned — `Join[a -> b]` gives `a -> b` and `Join[a -> b, c -> d]`
+  // gives `Rule[a, b, c, d]`. Normalize them to the generic function-call
+  // shape so the common head logic below applies unchanged.
+  if lists
+    .iter()
+    .any(|e| matches!(e, Expr::Rule { .. } | Expr::RuleDelayed { .. }))
+  {
+    let normalized: Vec<Expr> = lists
+      .iter()
+      .map(|e| match e {
+        Expr::Rule {
+          pattern,
+          replacement,
+        } => Expr::FunctionCall {
+          name: "Rule".to_string(),
+          args: vec![(**pattern).clone(), (**replacement).clone()].into(),
+        },
+        Expr::RuleDelayed {
+          pattern,
+          replacement,
+        } => Expr::FunctionCall {
+          name: "RuleDelayed".to_string(),
+          args: vec![(**pattern).clone(), (**replacement).clone()].into(),
+        },
+        other => other.clone(),
+      })
+      .collect();
+    return join_ast(&normalized);
+  }
+
   // Check if all arguments are associations
   if lists.iter().all(|l| matches!(l, Expr::Association(_))) {
     let mut result: Vec<(Expr, Expr)> = Vec::new();

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -56,6 +56,7 @@ pub mod periodic_table_plot;
 pub mod plot;
 pub mod plot3d;
 pub mod plot_epilog;
+pub mod polygon_holes;
 pub mod polyhedron_data;
 pub mod polynomial_ast;
 pub mod predicate_ast;

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -1504,6 +1504,9 @@ fn parse_point3d_list(expr: &Expr) -> Option<Vec<Point3D>> {
 #[derive(Clone)]
 struct StyleState3D {
   color: Option<(u8, u8, u8)>,
+  /// `FaceForm[front, back]`: the colour of faces turned away from the
+  /// viewer. None means both sides use `color`.
+  back_color: Option<(u8, u8, u8)>,
   opacity: f64,
   /// Stroke width in pixels for Line3D primitives. None means default 1.5.
   thickness: Option<f64>,
@@ -1513,6 +1516,7 @@ impl Default for StyleState3D {
   fn default() -> Self {
     Self {
       color: None, // None means use default blue
+      back_color: None,
       opacity: 1.0,
       thickness: None,
     }
@@ -1533,6 +1537,9 @@ enum Primitive3D {
   },
   Polygon3D {
     points: Vec<Point3D>,
+    /// Boundaries cut out of the face (`Polygon[outer -> holes]`). Empty
+    /// for an ordinary polygon.
+    holes: Vec<Vec<Point3D>>,
     style: StyleState3D,
   },
   Line3D {
@@ -1577,9 +1584,34 @@ fn apply_3d_directive(expr: &Expr, style: &mut StyleState3D) -> bool {
     let g = (color.g.clamp(0.0, 1.0) * 255.0).round() as u8;
     let b = (color.b.clamp(0.0, 1.0) * 255.0).round() as u8;
     style.color = Some((r, g, b));
+    style.back_color = None;
     if color.a < 1.0 {
       style.opacity = color.a;
     }
+    return true;
+  }
+
+  // FaceForm[front] colours both sides; FaceForm[front, back] gives the
+  // side turned away from the viewer its own colour.
+  if let Expr::FunctionCall { name, args } = expr
+    && name == "FaceForm"
+    && !args.is_empty()
+  {
+    let mut front = StyleState3D::default();
+    if !apply_3d_directive(&args[0], &mut front) {
+      return true;
+    }
+    style.color = front.color;
+    style.opacity = front.opacity;
+    style.back_color = match args.get(1) {
+      Some(back) => {
+        let mut b = StyleState3D::default();
+        apply_3d_directive(back, &mut b)
+          .then_some(b.color)
+          .flatten()
+      }
+      None => None,
+    };
     return true;
   }
 
@@ -1852,8 +1884,12 @@ fn transform_primitive3d(prim: &mut Primitive3D, xf: &Affine3) {
         z: a.z.max(b.z),
       };
     }
-    Primitive3D::Polygon3D { points, .. }
-    | Primitive3D::Point3DPrim { points, .. }
+    Primitive3D::Polygon3D { points, holes, .. } => {
+      for p in points.iter_mut().chain(holes.iter_mut().flatten()) {
+        *p = xf.apply(*p);
+      }
+    }
+    Primitive3D::Point3DPrim { points, .. }
     | Primitive3D::Arrow3D { points, .. } => {
       for p in points {
         *p = xf.apply(*p);
@@ -2015,6 +2051,20 @@ fn collect_3d_primitives(
           if let Some(pts) = parse_point3d_list(&args[0]) {
             prims.push(Primitive3D::Polygon3D {
               points: pts,
+              holes: Vec::new(),
+              style: style.clone(),
+            });
+          } else if let Some((outer, holes)) =
+            crate::functions::polygon_holes::split_holes(
+              &args[0],
+              &parse_point3d_list,
+            )
+          {
+            // Polygon[outer -> holes]: a face with the hole boundaries
+            // cut out of it.
+            prims.push(Primitive3D::Polygon3D {
+              points: outer,
+              holes,
               style: style.clone(),
             });
           } else if let Expr::List(poly_exprs) = &args[0] {
@@ -2024,6 +2074,18 @@ fn collect_3d_primitives(
               if let Some(pts) = parse_point3d_list(poly) {
                 prims.push(Primitive3D::Polygon3D {
                   points: pts,
+                  holes: Vec::new(),
+                  style: style.clone(),
+                });
+              } else if let Some((outer, holes)) =
+                crate::functions::polygon_holes::split_holes(
+                  poly,
+                  &parse_point3d_list,
+                )
+              {
+                prims.push(Primitive3D::Polygon3D {
+                  points: outer,
+                  holes,
                   style: style.clone(),
                 });
               }
@@ -2571,6 +2633,113 @@ fn collect_raster3d(
   }
 }
 
+/// Tessellate a planar polygon with holes (`Polygon[outer -> holes]`).
+///
+/// The face is flattened onto its own plane, triangulated there, and the
+/// triangles are lifted back to 3D. The second result marks, per triangle,
+/// which of its three edges lie on the outer boundary or on a hole
+/// boundary — the rest are internal cuts that must not be stroked.
+fn tessellate_polygon_with_holes(
+  outer: &[Point3D],
+  holes: &[Vec<Point3D>],
+) -> (Vec<(Point3D, Point3D, Point3D)>, Vec<[bool; 3]>) {
+  use crate::functions::polygon_holes::triangulate_with_holes;
+
+  if outer.len() < 3 {
+    return (Vec::new(), Vec::new());
+  }
+  // Newell's method: a plane normal that is robust for non-planar input.
+  let mut n = Point3D {
+    x: 0.0,
+    y: 0.0,
+    z: 0.0,
+  };
+  for i in 0..outer.len() {
+    let a = outer[i];
+    let b = outer[(i + 1) % outer.len()];
+    n.x += (a.y - b.y) * (a.z + b.z);
+    n.y += (a.z - b.z) * (a.x + b.x);
+    n.z += (a.x - b.x) * (a.y + b.y);
+  }
+  let len = (n.x * n.x + n.y * n.y + n.z * n.z).sqrt();
+  if !len.is_finite() || len == 0.0 {
+    return (Vec::new(), Vec::new());
+  }
+  let n = Point3D {
+    x: n.x / len,
+    y: n.y / len,
+    z: n.z / len,
+  };
+  // Any vector not parallel to the normal yields an in-plane basis.
+  let helper = if n.x.abs() < 0.9 {
+    Point3D {
+      x: 1.0,
+      y: 0.0,
+      z: 0.0,
+    }
+  } else {
+    Point3D {
+      x: 0.0,
+      y: 1.0,
+      z: 0.0,
+    }
+  };
+  let cross = |a: Point3D, b: Point3D| Point3D {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+  let u = cross(n, helper);
+  let ulen = (u.x * u.x + u.y * u.y + u.z * u.z).sqrt();
+  let u = Point3D {
+    x: u.x / ulen,
+    y: u.y / ulen,
+    z: u.z / ulen,
+  };
+  let v = cross(n, u);
+  let origin = outer[0];
+  let flatten = |p: &Point3D| {
+    let d = Point3D {
+      x: p.x - origin.x,
+      y: p.y - origin.y,
+      z: p.z - origin.z,
+    };
+    (
+      d.x * u.x + d.y * u.y + d.z * u.z,
+      d.x * v.x + d.y * v.y + d.z * v.z,
+    )
+  };
+
+  let mut verts3: Vec<Point3D> = outer.to_vec();
+  let outer_idx: Vec<usize> = (0..outer.len()).collect();
+  let mut hole_idx: Vec<Vec<usize>> = Vec::with_capacity(holes.len());
+  for hole in holes {
+    let start = verts3.len();
+    verts3.extend(hole.iter().copied());
+    hole_idx.push((start..verts3.len()).collect());
+  }
+  let verts2: Vec<(f64, f64)> = verts3.iter().map(flatten).collect();
+
+  let result = triangulate_with_holes(&verts2, &outer_idx, &hole_idx);
+  let tris = result
+    .triangles
+    .iter()
+    .map(|t| (verts3[t[0]], verts3[t[1]], verts3[t[2]]))
+    .collect();
+  let flags = result
+    .triangles
+    .iter()
+    .map(|t| {
+      [
+        result.is_boundary(t[0], t[1]),
+        result.is_boundary(t[1], t[2]),
+        result.is_boundary(t[2], t[0]),
+      ]
+    })
+    .collect();
+  (tris, flags)
+}
+
 /// Tessellate a cuboid into 12 triangles (2 per face).
 pub(crate) fn tessellate_cuboid(
   p_min: &Point3D,
@@ -2940,6 +3109,9 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   for prim in &prims {
+    // Per-triangle edge flags for a polygon with holes; the ordinary
+    // hole-free cases derive theirs from the fan below.
+    let mut holed_boundaries: Vec<[bool; 3]> = Vec::new();
     let (tris, prim_style): (Vec<(Point3D, Point3D, Point3D)>, &StyleState3D) =
       match prim {
         Primitive3D::Sphere {
@@ -2971,7 +3143,11 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           radius,
           style,
         } => (tessellate_cone(p1, p2, *radius), style),
-        Primitive3D::Polygon3D { points, style } => {
+        Primitive3D::Polygon3D {
+          points,
+          holes,
+          style,
+        } if holes.is_empty() => {
           // Simple fan triangulation
           let t = if points.len() >= 3 {
             (1..points.len() - 1)
@@ -2982,36 +3158,65 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           };
           (t, style)
         }
+        Primitive3D::Polygon3D {
+          points,
+          holes,
+          style,
+        } => {
+          let (t, flags) = tessellate_polygon_with_holes(points, holes);
+          holed_boundaries = flags;
+          (t, style)
+        }
         Primitive3D::Surface3D { tris, style } => (tris.clone(), style),
         // Line and Point are handled separately below
         _ => (
           vec![],
           &StyleState3D {
             color: None,
+            back_color: None,
             opacity: 1.0,
             thickness: None,
           },
         ),
       };
     let prim_color = prim_style.color.unwrap_or(base_color);
+    let prim_back_color = prim_style.back_color;
     let prim_opacity = prim_style.opacity;
+    // Direction from the scene towards the viewer; a face whose normal
+    // points along it shows its front side.
+    let view_dir = {
+      let (sa, ca) = camera.azimuth.sin_cos();
+      let (se, ce) = camera.elevation.sin_cos();
+      [ce * ca, ce * sa, se]
+    };
 
     // A polygon with more than three corners was fan-triangulated above:
     // every triangle keeps the polygon edge it sits on, but the cuts back
     // to the fan's first corner are internal and must not be stroked.
     let fan_corners = match prim {
-      Primitive3D::Polygon3D { points, .. } => points.len(),
+      Primitive3D::Polygon3D { points, holes, .. } if holes.is_empty() => {
+        points.len()
+      }
       _ => 0,
     };
     let tri_count = tris.len();
     for (i, (v0, v1, v2)) in tris.into_iter().enumerate() {
-      let boundary = if fan_corners > 3 {
+      let boundary = if let Some(flags) = holed_boundaries.get(i) {
+        *flags
+      } else if fan_corners > 3 {
         [i == 0, true, i + 1 == tri_count]
       } else {
         [true; 3]
       };
       let normal = triangle_normal(v0, v1, v2);
-      let color = apply_lighting(prim_color, normal);
+      let facing = normal[0] * view_dir[0]
+        + normal[1] * view_dir[1]
+        + normal[2] * view_dir[2];
+      let side_color = match prim_back_color {
+        Some(back) if facing < 0.0 => back,
+        _ => prim_color,
+      };
+      let color = apply_lighting(side_color, normal);
       let p0 = project(v0, &camera);
       let p1 = project(v1, &camera);
       let p2 = project(v2, &camera);

--- a/src/functions/polygon_holes.rs
+++ b/src/functions/polygon_holes.rs
@@ -1,0 +1,406 @@
+//! Support for `Polygon[outer -> holes]` — a filled polygon with one or
+//! more holes cut out of it.
+//!
+//! Wolfram writes such a polygon as a rule whose left side is the outer
+//! boundary and whose right side lists the hole boundaries:
+//! `Polygon[{p1, …, pn} -> {{q1, …, qm}, …}]`. A single hole may also be
+//! given unwrapped (`{p1, …, pn} -> {q1, …, qm}`), which is the shape most
+//! Demonstrations use.
+//!
+//! Two-dimensional output renders holes directly (an SVG path with the
+//! even-odd fill rule), but three-dimensional output has to tessellate the
+//! face into triangles, so this module also provides a general
+//! triangulation for polygons with holes: each hole is spliced into the
+//! outer boundary through a bridge edge, and the resulting simple polygon
+//! is ear-clipped.
+
+use crate::syntax::Expr;
+
+/// Split a `Polygon`/`Triangle` first argument into its outer boundary and
+/// hole boundaries. Returns `None` when the argument is not a rule, i.e.
+/// for an ordinary hole-free polygon.
+///
+/// `points_of` extracts a coordinate list of the caller's dimensionality
+/// (2D for `Graphics`, 3D for `Graphics3D`), so the same shape analysis
+/// serves both renderers.
+pub fn split_holes<P, T>(
+  arg: &Expr,
+  points_of: &P,
+) -> Option<(Vec<T>, Vec<Vec<T>>)>
+where
+  P: Fn(&Expr) -> Option<Vec<T>>,
+{
+  let Expr::Rule {
+    pattern,
+    replacement,
+  } = arg
+  else {
+    return None;
+  };
+  let outer = points_of(pattern)?;
+  // `outer -> {{q…}, …}`: every element of the right side is a hole.
+  // `outer -> {q…}`: the right side is one hole. The two are told apart by
+  // whether the right side parses as a coordinate list itself.
+  let holes = match points_of(replacement) {
+    Some(single) => vec![single],
+    None => {
+      let Expr::List(items) = replacement.as_ref() else {
+        return None;
+      };
+      items.iter().filter_map(points_of).collect()
+    }
+  };
+  Some((outer, holes))
+}
+
+/// Signed area of a closed 2D ring (positive when counterclockwise).
+fn signed_area(pts: &[(f64, f64)], ring: &[usize]) -> f64 {
+  let mut acc = 0.0;
+  for i in 0..ring.len() {
+    let (x1, y1) = pts[ring[i]];
+    let (x2, y2) = pts[ring[(i + 1) % ring.len()]];
+    acc += x1 * y2 - x2 * y1;
+  }
+  acc / 2.0
+}
+
+fn cross(o: (f64, f64), a: (f64, f64), b: (f64, f64)) -> f64 {
+  (a.0 - o.0) * (b.1 - o.1) - (a.1 - o.1) * (b.0 - o.0)
+}
+
+/// Is `p` inside (or on the edge of) triangle `a b c`?
+fn point_in_triangle(
+  p: (f64, f64),
+  a: (f64, f64),
+  b: (f64, f64),
+  c: (f64, f64),
+) -> bool {
+  let d1 = cross(a, b, p);
+  let d2 = cross(b, c, p);
+  let d3 = cross(c, a, p);
+  let has_neg = d1 < 0.0 || d2 < 0.0 || d3 < 0.0;
+  let has_pos = d1 > 0.0 || d2 > 0.0 || d3 > 0.0;
+  !(has_neg && has_pos)
+}
+
+/// Splice `hole` (a clockwise ring) into `outer` (a counterclockwise ring)
+/// through a bridge edge, yielding a single ring that traces both.
+///
+/// The bridge starts at the hole's rightmost vertex `m` and runs to a
+/// vertex of `outer` that `m` can see: cast a ray from `m` towards +x, take
+/// the first outer edge it meets and that edge's right-hand endpoint `p`,
+/// then — if any reflex outer vertex blocks the segment `m…p` — replace `p`
+/// by the blocking vertex closest in angle to the ray.
+fn bridge_hole(
+  pts: &[(f64, f64)],
+  outer: &[usize],
+  hole: &[usize],
+) -> Vec<usize> {
+  let Some(m) = (0..hole.len()).max_by(|&i, &j| {
+    pts[hole[i]]
+      .partial_cmp(&pts[hole[j]])
+      .unwrap_or(std::cmp::Ordering::Equal)
+  }) else {
+    return outer.to_vec();
+  };
+  let mp = pts[hole[m]];
+
+  // Nearest intersection of the +x ray from `mp` with an outer edge.
+  let mut best: Option<(f64, usize)> = None;
+  for i in 0..outer.len() {
+    let a = pts[outer[i]];
+    let b = pts[outer[(i + 1) % outer.len()]];
+    if (a.1 > mp.1) == (b.1 > mp.1) {
+      continue;
+    }
+    let t = (mp.1 - a.1) / (b.1 - a.1);
+    let x = a.0 + t * (b.0 - a.0);
+    if x < mp.0 {
+      continue;
+    }
+    if best.is_none_or(|(bx, _)| x < bx) {
+      best = Some((x, i));
+    }
+  }
+  // A hole that is not enclosed by the outer ring cannot be bridged;
+  // leave the outer ring alone.
+  let Some((ix, edge)) = best else {
+    return outer.to_vec();
+  };
+  let intersection = (ix, mp.1);
+
+  // The candidate bridge endpoint is the edge endpoint with the larger x.
+  let e0 = outer[edge];
+  let e1 = outer[(edge + 1) % outer.len()];
+  let mut p_at = if pts[e0].0 >= pts[e1].0 {
+    edge
+  } else {
+    (edge + 1) % outer.len()
+  };
+
+  // Any reflex outer vertex inside the triangle (mp, intersection, p)
+  // blocks the direct bridge; the visible one is the one whose direction
+  // from `mp` makes the smallest angle with the +x ray.
+  let mut best_angle = f64::INFINITY;
+  let mut best_dist = f64::INFINITY;
+  for i in 0..outer.len() {
+    let v = pts[outer[i]];
+    let prev = pts[outer[(i + outer.len() - 1) % outer.len()]];
+    let next = pts[outer[(i + 1) % outer.len()]];
+    // Reflex in a counterclockwise ring means a clockwise turn.
+    if cross(prev, v, next) > 0.0 {
+      continue;
+    }
+    if !point_in_triangle(v, mp, intersection, pts[outer[p_at]]) {
+      continue;
+    }
+    let dx = v.0 - mp.0;
+    let dy = v.1 - mp.1;
+    let dist = (dx * dx + dy * dy).sqrt();
+    if dist == 0.0 {
+      continue;
+    }
+    let angle = (dy / dist).abs();
+    if angle < best_angle || (angle == best_angle && dist < best_dist) {
+      best_angle = angle;
+      best_dist = dist;
+      p_at = i;
+    }
+  }
+
+  // outer[..=p] + hole[m..] + hole[..=m] + outer[p..]
+  let mut out = Vec::with_capacity(outer.len() + hole.len() + 2);
+  out.extend_from_slice(&outer[..=p_at]);
+  out.extend(hole[m..].iter().copied());
+  out.extend(hole[..=m].iter().copied());
+  out.extend_from_slice(&outer[p_at..]);
+  out
+}
+
+/// Drop repeated vertices from a ring, including a final vertex that
+/// repeats the first. Wolfram code routinely writes rings closed
+/// (`{a, b, c, a}`); a duplicated corner has no ear and would stall the
+/// clipper.
+fn close_ring(pts: &[(f64, f64)], ring: &[usize]) -> Vec<usize> {
+  let mut out: Vec<usize> = Vec::with_capacity(ring.len());
+  for &i in ring {
+    if out.last().is_some_and(|&j| pts[j] == pts[i]) {
+      continue;
+    }
+    out.push(i);
+  }
+  while out.len() > 1 && pts[out[0]] == pts[out[out.len() - 1]] {
+    out.pop();
+  }
+  out
+}
+
+/// Ear-clip a simple counterclockwise ring into triangles.
+fn ear_clip(pts: &[(f64, f64)], ring: &[usize]) -> Vec<[usize; 3]> {
+  let mut idx: Vec<usize> = ring.to_vec();
+  let mut tris = Vec::new();
+  let mut guard = 0;
+  while idx.len() > 3 {
+    let n = idx.len();
+    guard += 1;
+    // Give up on a self-intersecting ring rather than spin forever; the
+    // fallback below still emits a fan so the face is not lost.
+    if guard > 4 * ring.len() + 8 {
+      break;
+    }
+    let mut clipped = false;
+    for i in 0..n {
+      let a = idx[(i + n - 1) % n];
+      let b = idx[i];
+      let c = idx[(i + 1) % n];
+      if cross(pts[a], pts[b], pts[c]) <= 0.0 {
+        continue;
+      }
+      let contains = idx.iter().any(|&v| {
+        v != a
+          && v != b
+          && v != c
+          && point_in_triangle(pts[v], pts[a], pts[b], pts[c])
+      });
+      if contains {
+        continue;
+      }
+      tris.push([a, b, c]);
+      idx.remove(i);
+      clipped = true;
+      break;
+    }
+    if !clipped {
+      break;
+    }
+  }
+  if idx.len() == 3 {
+    tris.push([idx[0], idx[1], idx[2]]);
+  } else if idx.len() > 3 {
+    for i in 1..idx.len() - 1 {
+      tris.push([idx[0], idx[i], idx[i + 1]]);
+    }
+  }
+  tris
+}
+
+/// The result of triangulating a polygon with holes.
+pub struct HoledTriangulation {
+  /// Triangles, as indices into the caller's vertex list.
+  pub triangles: Vec<[usize; 3]>,
+  /// Unordered index pairs that lie on the outer boundary or on a hole
+  /// boundary — the edges a renderer should stroke. Everything else is an
+  /// internal cut introduced by the triangulation.
+  pub boundary_edges: std::collections::HashSet<(usize, usize)>,
+}
+
+/// Is the edge between `a` and `b` part of an original contour?
+impl HoledTriangulation {
+  pub fn is_boundary(&self, a: usize, b: usize) -> bool {
+    self.boundary_edges.contains(&(a.min(b), a.max(b)))
+  }
+}
+
+/// Triangulate a planar polygon with holes.
+///
+/// `outer` and each hole are given in a shared index space: the caller
+/// supplies `pts` (all vertices, 2D), `outer` (indices of the outer ring)
+/// and `holes` (indices of each hole ring). The returned triangles index
+/// into `pts`.
+pub fn triangulate_with_holes(
+  pts: &[(f64, f64)],
+  outer: &[usize],
+  holes: &[Vec<usize>],
+) -> HoledTriangulation {
+  let mut boundary_edges = std::collections::HashSet::new();
+  let mut record = |ring: &[usize]| {
+    for i in 0..ring.len() {
+      let a = ring[i];
+      let b = ring[(i + 1) % ring.len()];
+      boundary_edges.insert((a.min(b), a.max(b)));
+    }
+  };
+  let mut ring = close_ring(pts, outer);
+  if ring.len() < 3 {
+    return HoledTriangulation {
+      triangles: Vec::new(),
+      boundary_edges,
+    };
+  }
+  record(&ring);
+  if signed_area(pts, &ring) < 0.0 {
+    ring.reverse();
+  }
+  // Bridge the rightmost hole first: a hole spliced earlier can sit
+  // between a later hole and the original boundary, and the bridge search
+  // walks the ring as it stands.
+  let mut ordered: Vec<Vec<usize>> = holes
+    .iter()
+    .map(|h| close_ring(pts, h))
+    .filter(|h| h.len() >= 3)
+    .map(|mut h| {
+      if signed_area(pts, &h) > 0.0 {
+        h.reverse();
+      }
+      h
+    })
+    .collect();
+  ordered.sort_by(|a, b| {
+    let max_x = |h: &Vec<usize>| {
+      h.iter()
+        .fold(f64::NEG_INFINITY, |acc, &i| acc.max(pts[i].0))
+    };
+    max_x(b)
+      .partial_cmp(&max_x(a))
+      .unwrap_or(std::cmp::Ordering::Equal)
+  });
+  for hole in &ordered {
+    record(hole);
+    ring = bridge_hole(pts, &ring, hole);
+  }
+  HoledTriangulation {
+    triangles: ear_clip(pts, &ring),
+    boundary_edges,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn area(pts: &[(f64, f64)], tris: &HoledTriangulation) -> f64 {
+    tris
+      .triangles
+      .iter()
+      .map(|t| cross(pts[t[0]], pts[t[1]], pts[t[2]]).abs() / 2.0)
+      .sum()
+  }
+
+  #[test]
+  fn triangulates_square_with_square_hole() {
+    let pts = vec![
+      (0.0, 0.0),
+      (4.0, 0.0),
+      (4.0, 4.0),
+      (0.0, 4.0),
+      (1.0, 1.0),
+      (3.0, 1.0),
+      (3.0, 3.0),
+      (1.0, 3.0),
+    ];
+    let tris = triangulate_with_holes(&pts, &[0, 1, 2, 3], &[vec![4, 5, 6, 7]]);
+    // 16 (outer) - 4 (hole) = 12
+    assert!((area(&pts, &tris) - 12.0).abs() < 1e-9);
+  }
+
+  #[test]
+  fn triangulates_polygon_without_holes() {
+    let pts = vec![(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)];
+    let tris = triangulate_with_holes(&pts, &[0, 1, 2, 3], &[]);
+    assert_eq!(tris.triangles.len(), 2);
+    assert!((area(&pts, &tris) - 4.0).abs() < 1e-9);
+    assert!(tris.is_boundary(0, 1));
+    // The fan cut from corner 0 to corner 2 is internal.
+    assert!(!tris.is_boundary(0, 2));
+  }
+
+  #[test]
+  fn triangulates_two_holes() {
+    let pts = vec![
+      (0.0, 0.0),
+      (10.0, 0.0),
+      (10.0, 10.0),
+      (0.0, 10.0),
+      (1.0, 1.0),
+      (3.0, 1.0),
+      (3.0, 3.0),
+      (1.0, 3.0),
+      (6.0, 6.0),
+      (8.0, 6.0),
+      (8.0, 8.0),
+      (6.0, 8.0),
+    ];
+    let tris = triangulate_with_holes(
+      &pts,
+      &[0, 1, 2, 3],
+      &[vec![4, 5, 6, 7], vec![8, 9, 10, 11]],
+    );
+    assert!((area(&pts, &tris) - (100.0 - 4.0 - 4.0)).abs() < 1e-9);
+  }
+
+  #[test]
+  fn accepts_clockwise_input() {
+    let pts = vec![
+      (0.0, 0.0),
+      (0.0, 4.0),
+      (4.0, 4.0),
+      (4.0, 0.0),
+      (1.0, 1.0),
+      (1.0, 3.0),
+      (3.0, 3.0),
+      (3.0, 1.0),
+    ];
+    let tris = triangulate_with_holes(&pts, &[0, 1, 2, 3], &[vec![4, 5, 6, 7]]);
+    assert!((area(&pts, &tris) - 12.0).abs() < 1e-9);
+  }
+}

--- a/tests/cli/math/utility/Polygon.md
+++ b/tests/cli/math/utility/Polygon.md
@@ -19,3 +19,20 @@ $ wo 'StringCount[ExportString[Graphics[{Red, Polygon[{{{0, 0}, {1, 0}, {0, 1}},
 $ wo 'StringCount[ExportString[Graphics[{Red, Polygon[{{0, 0}, {1, 0}, {0, 1}}]}], "SVG"], "<polygon"]'
 1
 ```
+
+`Polygon[outer -> holes]` cuts the hole boundaries out of the face. In SVG
+that becomes one path per boundary, filled with the even-odd rule:
+
+```scrut
+$ wo 'StringCount[ExportString[Graphics[Polygon[{{0, 0}, {4, 0}, {4, 4}, {0, 4}} -> {{{1, 1}, {3, 1}, {3, 3}, {1, 3}}}]], "SVG"], "evenodd"]'
+1
+```
+
+A single hole may be given without the enclosing list. In 3D the face is
+tessellated around the hole — a square ring becomes eight triangles instead
+of the two a solid square gives:
+
+```scrut
+$ wo 'StringCount[ExportString[Graphics3D[Polygon[{{0, 0, 0}, {4, 0, 0}, {4, 4, 0}, {0, 4, 0}} -> {{1, 1, 0}, {3, 1, 0}, {3, 3, 0}, {1, 3, 0}}], Boxed -> False], "SVG"], "<polygon"]'
+8
+```

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -276,6 +276,33 @@ mod graphics {
       ));
     }
 
+    /// `Polygon[outer -> holes]` draws the outer boundary with the hole
+    /// boundaries cut out, which SVG expresses as one path per boundary
+    /// filled with the even-odd rule.
+    #[test]
+    fn polygon_with_holes() {
+      let svg = export_svg(
+        "Graphics[Polygon[{{0, 0}, {4, 0}, {4, 4}, {0, 4}} -> \
+         {{{1, 1}, {3, 1}, {3, 3}, {1, 3}}}]]",
+      );
+      assert!(svg.contains("fill-rule=\"evenodd\""), "{svg}");
+      // Two subpaths: the outer square and the hole.
+      assert_eq!(svg.matches(" Z").count(), 2, "{svg}");
+      // A single hole may also be given unwrapped.
+      assert_eq!(
+        export_svg(
+          "Graphics[Polygon[{{0, 0}, {4, 0}, {4, 4}, {0, 4}} -> \
+           {{1, 1}, {3, 1}, {3, 3}, {1, 3}}]]"
+        ),
+        svg
+      );
+      // Without holes the plain <polygon> form is kept.
+      let solid =
+        export_svg("Graphics[Polygon[{{0, 0}, {4, 0}, {4, 4}, {0, 4}}]]");
+      assert!(solid.contains("<polygon"), "{solid}");
+      assert!(!solid.contains("evenodd"), "{solid}");
+    }
+
     #[test]
     fn arrow() {
       insta::assert_snapshot!(export_svg(
@@ -2122,6 +2149,91 @@ mod plot3d {
         scene(&format!("Rotate[{square}, 0., {{0,1,0}}, {{1,0,0}}]")),
         scene(square)
       );
+    }
+
+    /// `Polygon[outer -> holes]` cuts the hole boundaries out of the face.
+    /// The square annulus below tessellates into eight triangles (two per
+    /// side of the ring) instead of the two a solid square would give, and
+    /// only the ring's own eight edges are stroked.
+    #[test]
+    fn graphics3d_polygon_with_hole() {
+      let svg = export_svg(
+        "Graphics3D[Polygon[{{0,0,0},{4,0,0},{4,4,0},{0,4,0}} -> \
+         {{1,1,0},{3,1,0},{3,3,0},{1,3,0}}], Boxed -> False]",
+      );
+      assert_eq!(svg.matches("<polygon").count(), 8, "{svg}");
+      assert_eq!(svg.matches("<line").count(), 8, "{svg}");
+      // The documented nesting — a list of hole boundaries — describes the
+      // same face.
+      let nested = export_svg(
+        "Graphics3D[Polygon[{{0,0,0},{4,0,0},{4,4,0},{0,4,0}} -> \
+         {{{1,1,0},{3,1,0},{3,3,0},{1,3,0}}}], Boxed -> False]",
+      );
+      assert_eq!(nested, svg);
+      // Two holes leave twelve triangles and twelve stroked edges.
+      let two = export_svg(
+        "Graphics3D[Polygon[{{0,0,0},{10,0,0},{10,10,0},{0,10,0}} -> \
+         {{{1,1,0},{3,1,0},{3,3,0},{1,3,0}}, \
+          {{6,6,0},{8,6,0},{8,8,0},{6,8,0}}}], Boxed -> False]",
+      );
+      assert_eq!(two.matches("<line").count(), 12, "{two}");
+      // Without a hole the same outline is a plain quad again.
+      let solid = export_svg(
+        "Graphics3D[Polygon[{{0,0,0},{4,0,0},{4,4,0},{0,4,0}}], \
+         Boxed -> False]",
+      );
+      assert_eq!(solid.matches("<polygon").count(), 2, "{solid}");
+    }
+
+    /// A hole boundary rides along with the transforms wrapping its
+    /// polygon; if it did not, the face would come back solid.
+    #[test]
+    fn graphics3d_polygon_with_hole_transforms() {
+      let ring = "Polygon[{{0,0,0},{4,0,0},{4,4,0},{0,4,0}} -> \
+                  {{1,1,0},{3,1,0},{3,3,0},{1,3,0}}]";
+      let moved = export_svg(&format!(
+        "Graphics3D[Translate[Rotate[{ring}, Pi/5, {{0,0,1}}], {{1,2,3}}], \
+         Boxed -> False]"
+      ));
+      assert_eq!(moved.matches("<polygon").count(), 8, "{moved}");
+      assert_ne!(
+        moved,
+        export_svg(&format!("Graphics3D[{ring}, Boxed -> False]"))
+      );
+    }
+
+    /// A face built as `Polygon[outer -> holes]` in a Demonstration is
+    /// written `Polygon[Join[outer -> holes]]`; `Join` of a single
+    /// expression returns it unchanged, so the two must render alike.
+    #[test]
+    fn graphics3d_polygon_with_hole_through_join() {
+      let ring = "{{0,0,0},{4,0,0},{4,4,0},{0,4,0}} -> \
+                  {{1,1,0},{3,1,0},{3,3,0},{1,3,0}}";
+      assert_eq!(
+        export_svg(&format!("Graphics3D[Polygon[Join[{ring}]], Boxed->False]")),
+        export_svg(&format!("Graphics3D[Polygon[{ring}], Boxed->False]"))
+      );
+    }
+
+    /// `FaceForm[front, back]` colours the two sides of a face
+    /// differently: the upward-facing square below shows `front`, the
+    /// downward-facing one `back`.
+    #[test]
+    fn graphics3d_face_form_two_sided() {
+      let svg = export_svg(
+        "Graphics3D[{FaceForm[Blue, Yellow], \
+         Polygon[{{0,0,0},{1,0,0},{1,1,0},{0,1,0}}], \
+         Polygon[{{0,1,1},{1,1,1},{1,0,1},{0,0,1}}]}, Boxed -> False]",
+      );
+      assert!(svg.contains("fill=\"rgb(0,0,216)\""), "{svg}");
+      assert!(svg.contains("fill=\"rgb(216,216,0)\""), "{svg}");
+      // A one-argument FaceForm colours both sides the same.
+      let one = export_svg(
+        "Graphics3D[{FaceForm[Blue], \
+         Polygon[{{0,0,0},{1,0,0},{1,1,0},{0,1,0}}], \
+         Polygon[{{0,1,1},{1,1,1},{1,0,1},{0,0,1}}]}, Boxed -> False]",
+      );
+      assert!(!one.contains("fill=\"rgb(216,216,0)\""), "{one}");
     }
 
     // A scene with many spheres scales each sphere's tessellation with

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -9023,6 +9023,19 @@ mod join_non_list {
     );
   }
 
+  /// A rule is an ordinary expression as far as Join is concerned, so
+  /// joining one returns it unchanged. Demonstrations wrap a polygon's
+  /// hole specification this way: `Polygon[Join[outer -> hole]]`.
+  #[test]
+  fn join_single_rule_is_the_rule() {
+    assert_eq!(interpret("Join[a -> b]").unwrap(), "a -> b");
+    assert_eq!(
+      interpret("Join[{{0, 0}, {1, 0}} -> {{2, 2}}]").unwrap(),
+      "{{0, 0}, {1, 0}} -> {{2, 2}}"
+    );
+    assert_eq!(interpret("Join[a :> b]").unwrap(), "a :> b");
+  }
+
   #[test]
   fn join_mismatched_heads_stays_unevaluated() {
     // Different heads (Plus vs Times) can't be joined — wolframscript emits


### PR DESCRIPTION
## Summary

Implement support for `Polygon[outer -> holes]` syntax to render filled polygons with one or more holes cut out. This includes 2D SVG rendering with the even-odd fill rule and 3D tessellation via ear-clipping triangulation.

## Key Changes

- **New module `polygon_holes.rs`**: Provides general-purpose polygon triangulation with holes
  - `split_holes()`: Parses `Polygon[outer -> holes]` syntax, supporting both wrapped and unwrapped hole specifications
  - `triangulate_with_holes()`: Tessellates polygons with holes by bridging each hole into the outer boundary and ear-clipping the result
  - `bridge_hole()`: Splices holes into the outer ring through a bridge edge, using ray-casting to find visible vertices
  - `ear_clip()`: Triangulates simple polygons via ear-clipping algorithm
  - Comprehensive test coverage for various polygon configurations

- **2D Graphics (`graphics.rs`)**:
  - Extended `PolygonPrim` to store hole boundaries
  - Updated polygon parsing to recognize and extract hole specifications
  - SVG rendering uses `<path>` with `fill-rule="evenodd"` for polygons with holes
  - Updated all polygon-related transformations (rotate, translate, scale) to handle holes
  - Added `polygon_with_holes_box()` helper for box form output

- **3D Graphics (`plot3d.rs`)**:
  - Extended `Polygon3D` primitive to store hole boundaries
  - Added `tessellate_polygon_with_holes()` function that:
    - Flattens 3D polygons onto their plane using Newell's method
    - Triangulates in 2D using the new `triangulate_with_holes()` function
    - Lifts triangles back to 3D
    - Tracks which edges are boundary vs. internal cuts
  - Implemented `FaceForm[front, back]` directive for two-sided face coloring
  - Updated triangle rendering to use back-face color when appropriate
  - Updated all 3D transformations to handle hole boundaries

- **List operations (`restructuring.rs`)**:
  - Enhanced `Join` to properly handle `Rule` and `RuleDelayed` expressions
  - Allows `Polygon[Join[outer -> holes]]` pattern used in Demonstrations

- **Tests and Documentation**:
  - Added unit tests for polygon triangulation (square with hole, multiple holes, clockwise input)
  - Added integration tests for 2D and 3D polygon rendering with holes
  - Added tests for `FaceForm` two-sided coloring
  - Added tests for polygon transformations with holes
  - Updated CLI documentation with examples

## Implementation Details

The triangulation algorithm handles non-convex polygons and multiple holes by:
1. Ensuring consistent winding (counterclockwise for outer, clockwise for holes)
2. Bridging each hole into the outer boundary via a visible vertex found by ray-casting
3. Processing holes in right-to-left order to handle nested configurations
4. Ear-clipping the resulting simple polygon with guards against self-intersecting input

The 3D implementation projects polygons onto their own plane, triangulates there, and lifts results back, preserving the original 3D coordinates for accurate rendering.

https://claude.ai/code/session_01SyQ88T3X4Tmi4PGyrXR5K3