### PR TITLE
Simplify "Det" expression.

### DIFF
--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -1271,7 +1271,8 @@ pub fn det_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => return Ok(matsq_unevaluated("Det", args)),
   };
   let det = determinant(&matrix);
-  Ok(crate::functions::expand_and_combine(&det))
+  let r = crate::functions::expand_and_combine(&det);
+  Ok(simplify_expr(&r))
 }
 
 /// True for an exact rational scalar (Integer, BigInteger, or literal

--- a/tests/interpreter_tests/linear_algebra.rs
+++ b/tests/interpreter_tests/linear_algebra.rs
@@ -254,6 +254,7 @@ mod array_dot {
 }
 
 mod det {
+  use super::super::case_helpers::assert_case;
   use super::*;
 
   #[test]
@@ -329,6 +330,14 @@ mod det {
     assert_eq!(
       interpret("Det[HilbertMatrix[5]]").unwrap(),
       "1/266716800000"
+    );
+  }
+
+  #[test]
+  fn det_polynomial() {
+    assert_case(
+      r#"m = Table[1 / (i + j + 1), {i, 3}, {j, 3}]; Det[m - x IdentityMatrix[3]]"#,
+      r#"-((-1 + 4755*x - 255600*x^2 + 378000*x^3)/378000)"#,
     );
   }
 }


### PR DESCRIPTION
Table[1 / (i + j + 1), {i, 3}, {j, 3}]; Det[m - x IdentityMatrix[3]] resulted in a complicated mess of polynomial terms.  Call simplify_expr on it to make the result more sensible.