### PR TITLE
Reduce crate::function::math_ast:: usage

### DIFF
--- a/src/functions/math_ast/airy.rs
+++ b/src/functions/math_ast/airy.rs
@@ -29,13 +29,12 @@ pub fn airy_ai_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Complex floating-point argument: power series via complex arithmetic.
-  if let Some((re, im)) =
-    crate::functions::math_ast::try_extract_complex_float(&args[0])
+  if let Some((re, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
     && contains_inexact_real(&args[0])
   {
     let (ar, ai) = airy_ai_complex(re, im);
-    return Ok(crate::functions::math_ast::build_complex_float_expr(ar, ai));
+    return Ok(build_complex_float_expr(ar, ai));
   }
 
   Ok(unevaluated("AiryAi", args))
@@ -72,8 +71,6 @@ fn airy_ai_complex(re: f64, im: f64) -> (f64, f64) {
   }
   (c1 * f.0 - c2 * g.0, c1 * f.1 - c2 * g.1)
 }
-
-use super::zeta_functions::cmul;
 
 /// Compute Ai(x) using the two power series
 /// Ai(x) = c1 * f(x) - c2 * g(x)
@@ -159,13 +156,12 @@ pub fn airy_bi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Complex floating-point argument: same power series, complex arithmetic.
-  if let Some((re, im)) =
-    crate::functions::math_ast::try_extract_complex_float(&args[0])
+  if let Some((re, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
     && contains_inexact_real(&args[0])
   {
     let (br, bi) = airy_bi_complex(re, im);
-    return Ok(crate::functions::math_ast::build_complex_float_expr(br, bi));
+    return Ok(build_complex_float_expr(br, bi));
   }
 
   Ok(unevaluated("AiryBi", args))

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
+use contains_inexact_real as contains_real;
 use num_bigint::BigInt;
 use num_bigint::Sign;
 
@@ -1264,7 +1265,7 @@ pub fn plus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           // Whole term reduces to a Real (e.g. Pi, E, Sqrt[2]).
           numerified_tail.push(f);
         } else if contains_named_numeric_constant(&arg)
-          && let Ok(n_val) = crate::functions::math_ast::n_eval(&arg)
+          && let Ok(n_val) = n_eval(&arg)
         {
           remaining_symbolic.push(n_val);
         } else {
@@ -1755,8 +1756,8 @@ fn expr_to_coeff(arg: &Expr) -> Option<Coeff> {
       if let (Expr::Integer(n), Expr::Integer(d)) = (&args[0], &args[1]) {
         Some(Coeff::Exact(*n, *d))
       } else {
-        let n = crate::functions::math_ast::expr_to_bigint(&args[0])?;
-        let d = crate::functions::math_ast::expr_to_bigint(&args[1])?;
+        let n = expr_to_bigint(&args[0])?;
+        let d = expr_to_bigint(&args[1])?;
         Some(Coeff::BigExact(n, d))
       }
     }
@@ -6776,7 +6777,6 @@ fn try_series_data_times_var_power(
 /// expressions, and at least one real-free nested product carrying both an
 /// exact coefficient and a constant part.
 pub fn nested_exact_const_machine_times(args: &[Expr]) -> Option<Expr> {
-  use crate::functions::math_ast::try_eval_to_f64;
   fn exact_val(e: &Expr) -> Option<(i128, i128)> {
     match e {
       Expr::Integer(n) => Some((*n, 1)),
@@ -6903,7 +6903,7 @@ pub fn nested_exact_const_machine_times(args: &[Expr]) -> Option<Expr> {
               _ => None,
             };
             exp
-              .and_then(crate::functions::math_ast::try_eval_to_f64)
+              .and_then(try_eval_to_f64)
               .map(|v| v < 0.0)
               .unwrap_or(false)
           };
@@ -7281,8 +7281,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   let complex_idx = flat_args.iter().position(|a| {
-    if let Some(((_re_n, _re_d), (im_n, _im_d))) =
-      crate::functions::math_ast::try_extract_complex_exact(a)
+    if let Some(((_re_n, _re_d), (im_n, _im_d))) = try_extract_complex_exact(a)
     {
       return im_n != 0;
     }
@@ -7341,7 +7340,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Known real sign of a factor: Some(1) positive, Some(-1) negative,
     // None when the sign can't be determined (symbolic).
     fn real_factor_sign(e: &Expr) -> Option<i8> {
-      if crate::functions::math_ast::complex::is_strictly_positive_real(e) {
+      if is_strictly_positive_real(e) {
         return Some(1);
       }
       match e {
@@ -7617,10 +7616,8 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // `x*(2. + I)` is left untouched; an all-exact product like `Pi*(2 + I)`
   // lacks an inexact factor and stays symbolic.
   if args.len() >= 2 {
-    let float_parts: Vec<Option<(f64, f64)>> = args
-      .iter()
-      .map(crate::functions::math_ast::try_extract_complex_float)
-      .collect();
+    let float_parts: Vec<Option<(f64, f64)>> =
+      args.iter().map(try_extract_complex_float).collect();
     if float_parts.iter().all(|c| c.is_some()) {
       let any_imag = float_parts.iter().any(|c| c.unwrap().1 != 0.0);
       // Trigger on a machine Real (so the product is genuinely machine
@@ -7666,11 +7663,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // parts as machine reals, matching wolframscript's `6. + 8.*I` and
         // `-2. + 0.*I`.
         if re != 0.0 {
-          return Ok(
-            crate::functions::math_ast::build_complex_float_expr_keep_real(
-              re, im,
-            ),
-          );
+          return Ok(build_complex_float_expr_keep_real(re, im));
         }
       }
     }
@@ -8348,7 +8341,7 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               symbolic_args.remove(i);
             } else if matches!(&new_exp, Expr::FunctionCall { name, args } if name == "Rational" && args.len() == 2 && matches!((&args[0], &args[1]), (Expr::Integer(1), Expr::Integer(2))))
             {
-              symbolic_args[i] = crate::functions::math_ast::sqrt_ast(&[base])?;
+              symbolic_args[i] = sqrt_ast(&[base])?;
             } else if matches!(&new_exp, Expr::Integer(1)) {
               symbolic_args[i] = base;
             } else {
@@ -8695,16 +8688,14 @@ fn direct_real_divide(a: &Expr, b: &Expr) -> Option<Expr> {
       if contains_real(a) {
         return None;
       }
-      let hi = super::numerical::n_eval_arbitrary(a, 25.0)
-        .ok()
-        .and_then(|e| match &e {
-          Expr::BigFloat(digits, _) => digits.parse::<f64>().ok(),
-          Expr::Real(x) => Some(*x),
-          _ => None,
-        });
+      let hi = n_eval_arbitrary(a, 25.0).ok().and_then(|e| match &e {
+        Expr::BigFloat(digits, _) => digits.parse::<f64>().ok(),
+        Expr::Real(x) => Some(*x),
+        _ => None,
+      });
       match hi {
         Some(x) if x.is_finite() => x,
-        _ => match super::numerical::n_eval(a) {
+        _ => match n_eval(a) {
           Ok(Expr::Real(x)) => x,
           _ => return None,
         },
@@ -9678,7 +9669,7 @@ fn infinity_direction(expr: &Expr) -> Option<Option<Expr>> {
   {
     return Some(Some(Expr::Integer(1)));
   }
-  if crate::functions::math_ast::is_neg_infinity(expr) {
+  if is_neg_infinity(expr) {
     return Some(Some(Expr::Integer(-1)));
   }
   if matches!(expr, Expr::Identifier(n) if n == "ComplexInfinity") {
@@ -9880,9 +9871,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
   if matches!(base, Expr::Constant(c) if c == "E")
     && matches!(exp, Expr::BigFloat(_, _))
   {
-    return crate::functions::math_ast::trigonometric::exp_ast(
-      std::slice::from_ref(exp),
-    );
+    return exp_ast(std::slice::from_ref(exp));
   }
 
   // An inexact complex base (a machine float with a nonzero imaginary part)
@@ -9959,18 +9948,16 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     && name == "Rational"
     && rargs.len() == 2
     && let Expr::Integer(k) = exp
-    && let (Some(n), Some(d)) = (
-      crate::functions::math_ast::expr_to_bigint(&rargs[0]),
-      crate::functions::math_ast::expr_to_bigint(&rargs[1]),
-    )
+    && let (Some(n), Some(d)) =
+      (expr_to_bigint(&rargs[0]), expr_to_bigint(&rargs[1]))
   {
     let absk = k.unsigned_abs() as u32;
     let np = n.pow(absk);
     let dp = d.pow(absk);
     return Ok(if *k >= 0 {
-      crate::functions::math_ast::number_theory::make_rational_expr(np, dp)
+      make_rational_expr(np, dp)
     } else {
-      crate::functions::math_ast::number_theory::make_rational_expr(dp, np)
+      make_rational_expr(dp, np)
     });
   }
 
@@ -10022,7 +10009,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     let y_expr = if yd == 1 {
       Expr::Integer(yn)
     } else {
-      crate::functions::math_ast::make_rational(yn, yd)
+      make_rational(yn, yd)
     };
     let neg_one_pow = Expr::FunctionCall {
       name: "Power".to_string(),
@@ -10065,7 +10052,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     let y_expr = if yd == 1 {
       Expr::Integer(yn)
     } else {
-      crate::functions::math_ast::make_rational(yn, yd)
+      make_rational(yn, yd)
     };
     let neg_one_pow = Expr::FunctionCall {
       name: "Power".to_string(),
@@ -10242,7 +10229,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     && !matches!(exp, Expr::Identifier(s) if s == "Infinity"
       || s == "ComplexInfinity"
       || s == "Indeterminate")
-    && !crate::functions::math_ast::is_neg_infinity(exp)
+    && !is_neg_infinity(exp)
   {
     return Ok(Expr::Integer(1));
   }
@@ -10255,7 +10242,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     && !matches!(base, Expr::Identifier(s) if s == "Infinity"
       || s == "ComplexInfinity"
       || s == "Indeterminate")
-    && !crate::functions::math_ast::is_neg_infinity(base)
+    && !is_neg_infinity(base)
   {
     // A raw inexact numeric base gives an inexact 1: 2.0^0 -> 1. and an
     // inexact complex -> 1. + 0.*I. Symbolic expressions merely
@@ -10266,7 +10253,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     }
     if contains_real(base)
       && matches!(
-        crate::functions::math_ast::try_extract_complex_float(base),
+        try_extract_complex_float(base),
         Some((_, im)) if im != 0.0
       )
     {
@@ -10280,9 +10267,9 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
 
   // Handle Power with Infinity in base or exponent
   let base_is_pos_inf = matches!(base, Expr::Identifier(s) if s == "Infinity");
-  let base_is_neg_inf = crate::functions::math_ast::is_neg_infinity(base);
+  let base_is_neg_inf = is_neg_infinity(base);
   let exp_is_pos_inf = matches!(exp, Expr::Identifier(s) if s == "Infinity");
-  let exp_is_neg_inf = crate::functions::math_ast::is_neg_infinity(exp);
+  let exp_is_neg_inf = is_neg_infinity(exp);
   let base_is_complex_inf =
     matches!(base, Expr::Identifier(s) if s == "ComplexInfinity");
   let exp_is_complex_inf =
@@ -10902,12 +10889,10 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     && (denom == 1 || denom == 2)
   {
     // Build the symbolic argument k*Pi
-    let k_pi =
-      crate::functions::math_ast::complex::make_rational_times_pi(numer, denom);
+    let k_pi = make_rational_times_pi(numer, denom);
     // Evaluate Cos[k*Pi] and Sin[k*Pi] symbolically
-    let cos_val =
-      crate::functions::math_ast::cos_ast(std::slice::from_ref(&k_pi))?;
-    let sin_val = crate::functions::math_ast::sin_ast(&[k_pi])?;
+    let cos_val = cos_ast(std::slice::from_ref(&k_pi))?;
+    let sin_val = sin_ast(&[k_pi])?;
     // Build result: cos_val + I*sin_val
     let sin_is_zero = matches!(&sin_val, Expr::Integer(0));
     let cos_is_zero = matches!(&cos_val, Expr::Integer(0));
@@ -11056,7 +11041,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
       ));
     } else {
       let exp_str = expr_to_string(exp);
-      crate::emit_message(&super::format_power_infy_2d(&base_str, &exp_str));
+      crate::emit_message(&format_power_infy_2d(&base_str, &exp_str));
     }
     return Ok(Expr::Identifier("ComplexInfinity".to_string()));
   }
@@ -11242,9 +11227,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     if let Some(bb) = bb_opt {
       let r = bb.nth_root(*denom as u32);
       if r.pow(*denom as u32) == bb {
-        return Ok(crate::functions::math_ast::bigint_to_expr(
-          r.pow(*numer as u32),
-        ));
+        return Ok(bigint_to_expr(r.pow(*numer as u32)));
       }
     }
   }
@@ -11259,7 +11242,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
     && let (Expr::Integer(numer), Expr::Integer(denom)) = (&rargs[0], &rargs[1])
     && *denom > 0
   {
-    let magnitude = crate::functions::math_ast::bigint_to_expr(-b.clone());
+    let magnitude = bigint_to_expr(-b.clone());
     return negative_base_rational_power(&magnitude, *numer, *denom);
   }
 
@@ -11469,12 +11452,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
       && !num_traits::Zero::is_zero(&b)
     {
       let den = num_traits::pow::pow(b, e.unsigned_abs() as usize);
-      return Ok(
-        crate::functions::math_ast::number_theory::make_rational_expr(
-          BigInt::from(1),
-          den,
-        ),
-      );
+      return Ok(make_rational_expr(BigInt::from(1), den));
     }
   }
 
@@ -11506,7 +11484,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
       // wolframscript's multiplication chains rather than libm pow — the
       // two round differently in the last ULP.
       let result = if let (true, Expr::Integer(e)) = (has_real, exp) {
-        crate::functions::math_ast::numeric_utils::wolfram_powi(a, *e)
+        wolfram_powi(a, *e)
       } else {
         a.powf(b)
       };
@@ -11568,10 +11546,7 @@ pub fn power_two(base: &Expr, exp: &Expr) -> Result<Expr, InterpreterError> {
         && b != 0.0
         && contains_real(base)
       {
-        let (re, im) =
-          crate::functions::math_ast::numeric_utils::wolfram_powi_complex(
-            a, b, *n,
-          );
+        let (re, im) = wolfram_powi_complex(a, b, *n);
         return Ok(build_complex_float_expr(re, im));
       }
       // Try complex float evaluation: z^w = exp(w * log(z))
@@ -11857,8 +11832,6 @@ pub fn try_around_unary(
   Some(Ok(make_around_general(fa, m, p, ar.asym)))
 }
 
-use crate::functions::math_ast::contains_inexact_real as contains_real;
-
 /// Structurally complex: the expression mentions the imaginary unit, even
 /// when its numeric imaginary part works out to `0.` (as in `0.5 + 0.*I`).
 /// Such operands must still numericize in the complex power path of
@@ -12071,7 +12044,7 @@ fn negative_number_magnitude(expr: &Expr) -> Option<Expr> {
   match expr {
     Expr::Integer(n) if *n < 0 => Some(Expr::Integer(-*n)),
     Expr::BigInteger(n) if *n < BigInt::from(0) => {
-      Some(crate::functions::math_ast::bigint_to_expr(-n.clone()))
+      Some(bigint_to_expr(-n.clone()))
     }
     Expr::FunctionCall { name, args }
       if name == "Rational"
@@ -12546,16 +12519,12 @@ fn bigfloat_plus(args: &[Expr]) -> Result<Expr, InterpreterError> {
       })
       .fold(0.0f64, f64::max)
       .max(result_prec);
-    let bits = crate::functions::math_ast::numerical::nominal_bits(
-      max_prec.ceil() as usize,
-    );
+    let bits = nominal_bits(max_prec.ceil() as usize);
     if let Ok(mut cc) = Consts::new() {
       let mut sum = BigFloat::from_i32(0, bits);
       let mut ok = true;
       for arg in args {
-        match crate::functions::math_ast::numerical::expr_to_bigfloat(
-          arg, bits, rm, &mut cc,
-        ) {
+        match expr_to_bigfloat(arg, bits, rm, &mut cc) {
           Ok(v) => sum = sum.add(&v, bits, rm),
           Err(_) => {
             ok = false;
@@ -12566,12 +12535,9 @@ fn bigfloat_plus(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if ok {
         let max_fraction_digits =
           ((bits as f64 + 1.0) * std::f64::consts::LOG10_2).floor() as usize;
-        if let Ok(s) = crate::functions::math_ast::numerical::bigfloat_to_string(
-          &sum,
-          Some(max_fraction_digits),
-          rm,
-          &mut cc,
-        ) {
+        if let Ok(s) =
+          bigfloat_to_string(&sum, Some(max_fraction_digits), rm, &mut cc)
+        {
           return Ok(Expr::BigFloat(s, result_prec));
         }
       }
@@ -12731,32 +12697,26 @@ fn try_bigfloat_power(
   };
 
   let rm = RoundingMode::ToEven;
-  let bits = crate::functions::math_ast::numerical::nominal_bits(
-    base_prec.ceil() as usize,
-  );
+  let bits = nominal_bits(base_prec.ceil() as usize);
   let mut cc = match Consts::new() {
     Ok(c) => c,
     Err(e) => {
       return Some(Err(InterpreterError::EvaluationError(format!("{}", e))));
     }
   };
-  let base_bf = match crate::functions::math_ast::numerical::expr_to_bigfloat(
-    base, bits, rm, &mut cc,
-  ) {
+  let base_bf = match expr_to_bigfloat(base, bits, rm, &mut cc) {
     Ok(b) => b,
     Err(e) => return Some(Err(e)),
   };
 
   let result = if let Some(n) = int_exp {
-    crate::functions::math_ast::numerical::bigfloat_powi(&base_bf, n, bits, rm)
+    bigfloat_powi(&base_bf, n, bits, rm)
   } else {
     // Non-integer exponent on a negative base is complex — defer.
     if base_bf.is_negative() {
       return None;
     }
-    let exp_bf = match crate::functions::math_ast::numerical::expr_to_bigfloat(
-      exp, bits, rm, &mut cc,
-    ) {
+    let exp_bf = match expr_to_bigfloat(exp, bits, rm, &mut cc) {
       Ok(e) => e,
       Err(e) => return Some(Err(e)),
     };
@@ -12767,12 +12727,7 @@ fn try_bigfloat_power(
   let max_fraction_digits =
     ((bits as f64 + 1.0) * std::f64::consts::LOG10_2).floor() as usize;
   let result_str =
-    match crate::functions::math_ast::numerical::bigfloat_to_string(
-      &result,
-      Some(max_fraction_digits),
-      rm,
-      &mut cc,
-    ) {
+    match bigfloat_to_string(&result, Some(max_fraction_digits), rm, &mut cc) {
       Ok(s) => s,
       Err(e) => return Some(Err(e)),
     };
@@ -12810,29 +12765,21 @@ fn bigfloat_times(args: &[Expr]) -> Result<Expr, InterpreterError> {
     min_contrib
   };
 
-  let bits = crate::functions::math_ast::numerical::nominal_bits(
-    min_contrib.ceil() as usize,
-  );
+  let bits = nominal_bits(min_contrib.ceil() as usize);
   let rm = RoundingMode::ToEven;
   let mut cc = Consts::new()
     .map_err(|e| InterpreterError::EvaluationError(format!("{}", e)))?;
 
   let mut product = BigFloat::from_i32(1, bits);
   for arg in args {
-    let factor = crate::functions::math_ast::numerical::expr_to_bigfloat(
-      arg, bits, rm, &mut cc,
-    )?;
+    let factor = expr_to_bigfloat(arg, bits, rm, &mut cc)?;
     product = product.mul(&factor, bits, rm);
   }
 
   let max_fraction_digits =
     ((bits as f64 + 1.0) * std::f64::consts::LOG10_2).floor() as usize;
-  let result_str = crate::functions::math_ast::numerical::bigfloat_to_string(
-    &product,
-    Some(max_fraction_digits),
-    rm,
-    &mut cc,
-  )?;
+  let result_str =
+    bigfloat_to_string(&product, Some(max_fraction_digits), rm, &mut cc)?;
   Ok(Expr::BigFloat(result_str, result_prec))
 }
 

--- a/src/functions/math_ast/bessel.rs
+++ b/src/functions/math_ast/bessel.rs
@@ -89,11 +89,10 @@ pub fn bessel_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // anchored at J_{±1/2}. Walks numerically through the integer m in n = m/2.
   // wolframscript only expands when the argument contains free symbols;
   // exact numeric arguments (6, 2/3, Pi) stay unevaluated.
-  if let Some((n_num, n_den)) =
-    crate::functions::math_ast::expr_to_rational(n_expr)
+  if let Some((n_num, n_den)) = expr_to_rational(n_expr)
     && n_den == 2
     && (n_num.unsigned_abs() <= 51)
-    && crate::functions::math_ast::try_eval_to_f64(z_expr).is_none()
+    && try_eval_to_f64(z_expr).is_none()
     && let Some(result) = half_int_bessel_j(n_num, z_expr)?
   {
     return Ok(result);
@@ -660,11 +659,10 @@ pub fn bessel_i_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Closed-form rules at half-integer orders. Anchored at I_{±1/2}; the
   // recurrence I_{n+1}(z) = I_{n-1}(z) - (2n/z) I_n(z) (sign-flipped vs J).
   // Exact numeric arguments stay unevaluated (wolframscript).
-  if let Some((n_num, n_den)) =
-    crate::functions::math_ast::expr_to_rational(n_expr)
+  if let Some((n_num, n_den)) = expr_to_rational(n_expr)
     && n_den == 2
     && (n_num.unsigned_abs() <= 51)
-    && crate::functions::math_ast::try_eval_to_f64(z_expr).is_none()
+    && try_eval_to_f64(z_expr).is_none()
     && let Some(result) = half_int_bessel_i(n_num, z_expr)?
   {
     return Ok(result);
@@ -744,11 +742,10 @@ pub fn bessel_k_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Sqrt[Pi/(2z)] * E^(-z); K_{n+1}(z) = (2n/z) K_n(z) + K_{n-1}(z).
   // K is symmetric: K_{-n}(z) = K_n(z).
   // Exact numeric arguments stay unevaluated (wolframscript).
-  if let Some((n_num, n_den)) =
-    crate::functions::math_ast::expr_to_rational(n_expr)
+  if let Some((n_num, n_den)) = expr_to_rational(n_expr)
     && n_den == 2
     && (n_num.unsigned_abs() <= 51)
-    && crate::functions::math_ast::try_eval_to_f64(z_expr).is_none()
+    && try_eval_to_f64(z_expr).is_none()
     && let Some(result) = half_int_bessel_k(n_num, z_expr)?
   {
     return Ok(result);
@@ -1049,12 +1046,11 @@ pub fn bessel_y_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // We bake the sign into J_{-m/2}'s inner polynomial so the result
   // displays as Sqrt[2/Pi] * P / Sqrt[z] without an outer negation
   // wrapper (matching wolframscript).
-  if let Some((n_num, n_den)) =
-    crate::functions::math_ast::expr_to_rational(n_expr)
+  if let Some((n_num, n_den)) = expr_to_rational(n_expr)
     && n_den == 2
     && (n_num.unsigned_abs() <= 51)
     && (-n_num) % 2 != 0
-    && crate::functions::math_ast::try_eval_to_f64(z_expr).is_none()
+    && try_eval_to_f64(z_expr).is_none()
   {
     let k = (n_num - 1).div_euclid(2);
     let sign: i128 = if k.rem_euclid(2) == 0 { -1 } else { 1 };
@@ -1253,10 +1249,9 @@ fn coulomb_wave_reduce(
     // H2 = Conjugate(H+).
     if let Some(l_int) = expr_to_i128(l)
       && l_int >= 0
-      && (crate::functions::math_ast::contains_inexact_real(eta)
-        || crate::functions::math_ast::contains_inexact_real(z))
-      && crate::functions::math_ast::try_eval_to_f64(eta).is_some()
-      && crate::functions::math_ast::try_eval_to_f64(z).is_some()
+      && (contains_inexact_real(eta) || contains_inexact_real(z))
+      && try_eval_to_f64(eta).is_some()
+      && try_eval_to_f64(z).is_some()
     {
       let fc = |name: &str, a: Vec<Expr>| Expr::FunctionCall {
         name: name.to_string(),

--- a/src/functions/math_ast/carlson.rs
+++ b/src/functions/math_ast/carlson.rs
@@ -9,8 +9,6 @@
 use super::*;
 use crate::evaluator::evaluate_expr_to_expr as eval_expr;
 use crate::evaluator::pattern_matching::expr_equal;
-use crate::functions::math_ast::contains_inexact_real as is_inexact;
-use crate::functions::math_ast::make_sqrt;
 
 /// R_C(x, y) — degenerate Carlson integral.
 fn carlson_rc(x: f64, y: f64) -> f64 {
@@ -472,12 +470,12 @@ fn carlson_ast(
   if args.len() != arity {
     return symbolic();
   }
-  if !args.iter().any(is_inexact) {
+  if !args.iter().any(contains_inexact_real) {
     return symbolic();
   }
   let mut vals = Vec::with_capacity(arity);
   for a in args {
-    match crate::functions::math_ast::expr_to_f64(a) {
+    match expr_to_f64(a) {
       Some(v) => vals.push(v),
       None => return symbolic(),
     }
@@ -490,7 +488,7 @@ fn carlson_ast(
 
 /// True when no argument is inexact, so exact reductions may apply.
 fn all_exact(args: &[Expr]) -> bool {
-  !args.iter().any(is_inexact)
+  !args.iter().any(contains_inexact_real)
 }
 
 pub fn carlson_rc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -514,16 +512,16 @@ pub fn carlson_rf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // nonzero imaginary part, use the complex duplication kernel (the real
   // kernel and `expr_to_f64` cannot handle complex arguments).
   if args.len() == 3
-    && args.iter().any(is_inexact)
+    && args.iter().any(contains_inexact_real)
     && let (Some(x), Some(y), Some(z)) = (
-      crate::functions::math_ast::try_extract_complex_f64(&args[0]),
-      crate::functions::math_ast::try_extract_complex_f64(&args[1]),
-      crate::functions::math_ast::try_extract_complex_f64(&args[2]),
+      try_extract_complex_f64(&args[0]),
+      try_extract_complex_f64(&args[1]),
+      try_extract_complex_f64(&args[2]),
     )
     && (x.1 != 0.0 || y.1 != 0.0 || z.1 != 0.0)
   {
     let (rr, ri) = carlson_rf_complex(x, y, z);
-    return Ok(crate::functions::math_ast::build_complex_float_expr(rr, ri));
+    return Ok(build_complex_float_expr(rr, ri));
   }
   carlson_ast("CarlsonRF", args, 3, |v| Some(carlson_rf(v[0], v[1], v[2])))
 }

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -502,7 +502,7 @@ pub fn is_real_valued(expr: &Expr) -> bool {
   // NumericQ expressions: check if they evaluate to a real number
   if crate::functions::predicate_ast::is_numeric_q(expr) {
     // Try to evaluate numerically - if it gives a real, it's real-valued
-    if let Some(val) = crate::functions::math_ast::try_eval_to_f64(expr) {
+    if let Some(val) = try_eval_to_f64(expr) {
       return val.is_finite() || val.is_nan();
     }
   }
@@ -1070,10 +1070,9 @@ pub fn arg_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "Re",
         std::slice::from_ref(z),
       )?;
-      if let (Some(im_f), Some(_re_f)) = (
-        crate::functions::math_ast::try_eval_to_f64(&imz),
-        crate::functions::math_ast::try_eval_to_f64(&rez),
-      ) {
+      if let (Some(im_f), Some(_re_f)) =
+        (try_eval_to_f64(&imz), try_eval_to_f64(&rez))
+      {
         use std::f64::consts::PI;
         let two_pi = 2.0 * PI;
         // k brings im into (-Pi, Pi]: im - 2*k*Pi ∈ (-Pi, Pi].
@@ -1188,7 +1187,7 @@ pub fn arg_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Real-valued composite (Sqrt[2], Log[2], Pi^2, Pi - 4, …): Arg is 0 for a
   // positive (or zero) value and Pi for a negative one.
   if is_real_valued(&args[0])
-    && let Some(v) = crate::functions::math_ast::try_eval_to_f64(&args[0])
+    && let Some(v) = try_eval_to_f64(&args[0])
   {
     return if v < 0.0 {
       Ok(Expr::Identifier("Pi".to_string()))
@@ -1303,8 +1302,7 @@ pub fn arg_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     crate::evaluator::evaluate_function_call_ast("Im", &[args[0].clone()]),
   ) && is_real_valued(&re)
     && is_real_valued(&im)
-    && crate::functions::math_ast::try_eval_to_f64(&im)
-      .is_some_and(|v| v != 0.0)
+    && try_eval_to_f64(&im).is_some_and(|v| v != 0.0)
   {
     return crate::evaluator::evaluate_function_call_ast("ArcTan", &[re, im]);
   }
@@ -1408,8 +1406,7 @@ pub fn rationalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Complex argument: rationalize the real and imaginary parts. Following
   // wolframscript, if either part has no exact rational (within the tolerance)
   // both parts stay as machine reals (all-or-nothing).
-  if let Some((re, im)) =
-    crate::functions::math_ast::try_extract_complex_float(&args[0])
+  if let Some((re, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
   {
     let rat = |v: f64| -> Result<Expr, InterpreterError> {
@@ -1504,8 +1501,7 @@ pub fn rationalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(x) => x,
     None => {
       // Fall back to numeric evaluation (e.g. for Pi, E) when available.
-      match crate::functions::math_ast::numeric_utils::try_eval_to_f64(&args[0])
-      {
+      match try_eval_to_f64(&args[0]) {
         Some(x) => x,
         None => {
           return Ok(unevaluated("Rationalize", args));
@@ -1552,16 +1548,10 @@ pub fn rationalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // N[999999/1000003], N[1/2^40], and N[1000001/2^30] do not
     // (differential fuzzer, seed 15336548261066338105).
     match rationalize_machine_default(x) {
-      Some((n, d)) if d == num_bigint::BigInt::from(1) => {
-        Ok(crate::functions::math_ast::bigint_to_expr(n))
-      }
+      Some((n, d)) if d == num_bigint::BigInt::from(1) => Ok(bigint_to_expr(n)),
       Some((n, d)) => Ok(Expr::FunctionCall {
         name: "Rational".to_string(),
-        args: vec![
-          crate::functions::math_ast::bigint_to_expr(n),
-          crate::functions::math_ast::bigint_to_expr(d),
-        ]
-        .into(),
+        args: vec![bigint_to_expr(n), bigint_to_expr(d)].into(),
       }),
       None => Ok(num_to_expr(x)),
     }

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -3597,9 +3597,7 @@ pub fn number_digit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let mut cc = astro_float::Consts::new()
         .map_err(|e| InterpreterError::EvaluationError(format!("N: {e}")))?;
       let rm = astro_float::RoundingMode::ToEven;
-      match crate::functions::math_ast::numerical::expr_to_bigfloat(
-        other, bits, rm, &mut cc,
-      ) {
+      match expr_to_bigfloat(other, bits, rm, &mut cc) {
         Ok(bf) => {
           let Some(radix) = radix else {
             return Ok(unevaluated());

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -183,7 +183,7 @@ pub fn pdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if dist_name == "MixtureDistribution" && dargs.len() == 2 {
     let x = args[1].clone();
     return Ok(
-      super::statistics::mixture_weighted_component_quantity(dargs, |d| {
+      mixture_weighted_component_quantity(dargs, |d| {
         pdf_ast(&[d.clone(), x.clone()])
       })?
       .unwrap_or_else(|| unevaluated("PDF", args)),
@@ -522,7 +522,7 @@ pub fn quantile_distribution_closed_form(
 ) -> Option<Expr> {
   // Numeric q in [0, 1] only; the symbolic-q forms wolframscript returns
   // are ConditionalExpression/Piecewise wrappers that are out of scope.
-  let q_num = crate::functions::math_ast::expr_to_num(q)?;
+  let q_num = expr_to_num(q)?;
   if !(0.0..=1.0).contains(&q_num) {
     return None;
   }
@@ -548,7 +548,7 @@ pub fn quantile_distribution_closed_form(
           return Some(if v.1 == 1 {
             Expr::Integer(v.0)
           } else {
-            crate::functions::math_ast::make_rational(v.0, v.1)
+            make_rational(v.0, v.1)
           });
         }
       }
@@ -556,7 +556,7 @@ pub fn quantile_distribution_closed_form(
         if v.1 == 1 {
           Expr::Integer(v.0)
         } else {
-          crate::functions::math_ast::make_rational(v.0, v.1)
+          make_rational(v.0, v.1)
         }
       })
     }
@@ -588,8 +588,7 @@ pub fn quantile_distribution_closed_form(
       }
       let (a, b) = (dargs[0].clone(), dargs[1].clone());
       let pi = pi();
-      let q_minus_half =
-        minus(q.clone(), crate::functions::math_ast::make_rational(1, 2));
+      let q_minus_half = minus(q.clone(), make_rational(1, 2));
       let tan = call("Tan", vec![times(pi, q_minus_half)]);
       eval(plus(a, times(b, tan))).ok()
     }
@@ -704,7 +703,7 @@ pub fn quantile_distribution_closed_form(
           return Some(infinity());
         }
         // InverseErfc[1] = 0: the median is exactly m
-        if let Some((1, 2)) = crate::functions::math_ast::expr_to_rational(q) {
+        if let Some((1, 2)) = expr_to_rational(q) {
           return eval(m).ok();
         }
         // m - Sqrt[2]*s*InverseErfc[2q]. Evaluating the result reflects
@@ -725,9 +724,9 @@ pub fn quantile_distribution_closed_form(
         return eval(result).ok();
       }
       // Machine-precision q: numeric inverse CDF (requires numeric m, s)
-      let m_num = crate::functions::math_ast::expr_to_num(&m)?;
-      let s_num = crate::functions::math_ast::expr_to_num(&s)?;
-      let z = crate::functions::math_ast::inverse_erf_f64(2.0 * q_num - 1.0);
+      let m_num = expr_to_num(&m)?;
+      let s_num = expr_to_num(&s)?;
+      let z = inverse_erf_f64(2.0 * q_num - 1.0);
       Some(Expr::Real(m_num + s_num * std::f64::consts::SQRT_2 * z))
     }
     // Quantile[GammaDistribution[a, b], q] = b InverseGammaRegularized[a, 0, q]
@@ -786,7 +785,7 @@ pub fn quantile_distribution_closed_form(
     // in Woxi, so it is intentionally not handled here.)
     "StudentTDistribution" if dargs.len() == 1 => {
       let nu = dargs[0].clone();
-      crate::functions::math_ast::expr_to_num(&nu)?;
+      expr_to_num(&nu)?;
 
       if is_exact_q && q_num == 0.0 {
         return Some(neg_infinity());
@@ -804,11 +803,7 @@ pub fn quantile_distribution_closed_form(
       };
       let ibr = call(
         "InverseBetaRegularized",
-        vec![
-          s,
-          divide(nu.clone(), int(2)),
-          crate::functions::math_ast::make_rational(1, 2),
-        ],
+        vec![s, divide(nu.clone(), int(2)), make_rational(1, 2)],
       );
       let radical = sqrt(times(nu, plus(int(-1), power(ibr, int(-1)))));
       eval(if q_num < 0.5 { neg(radical) } else { radical }).ok()
@@ -829,8 +824,8 @@ pub fn quantile_distribution_closed_form(
         }
       }
       let (n, m) = (dargs[0].clone(), dargs[1].clone());
-      crate::functions::math_ast::expr_to_num(&n)?;
-      crate::functions::math_ast::expr_to_num(&m)?;
+      expr_to_num(&n)?;
+      expr_to_num(&m)?;
       let ibr = call(
         "InverseBetaRegularized",
         vec![
@@ -868,7 +863,7 @@ pub fn inverse_survival_closed_form(
   dargs: &[Expr],
   q: &Expr,
 ) -> Option<Expr> {
-  let q_num = crate::functions::math_ast::expr_to_num(q)?;
+  let q_num = expr_to_num(q)?;
   if !(0.0..=1.0).contains(&q_num) {
     return None;
   }
@@ -891,7 +886,7 @@ pub fn inverse_survival_closed_form(
           return Some(neg_infinity());
         }
         // InverseErfc[1] = 0, so the median survival point is exactly m.
-        if let Some((1, 2)) = crate::functions::math_ast::expr_to_rational(q) {
+        if let Some((1, 2)) = expr_to_rational(q) {
           return eval(m).ok();
         }
       }
@@ -967,7 +962,7 @@ fn discrete_support(
   dargs: &[Expr],
 ) -> Option<(i128, Option<i128>)> {
   let as_int = |e: &Expr| {
-    crate::functions::math_ast::expr_to_num(e)
+    expr_to_num(e)
       .filter(|v| v.fract() == 0.0)
       .map(|v| v as i128)
   };
@@ -1703,7 +1698,7 @@ fn pdf_log_logistic(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // Concrete x <= 0 is outside the support. Evaluating the density there would
   // raise x^(-1 + g) (or (x/s)^g) at x = 0 for g < 1 and emit a spurious
   // Power::infy message even though the piecewise selects the 0 branch.
-  if let Some(xv) = crate::functions::math_ast::expr_to_num(&x)
+  if let Some(xv) = expr_to_num(&x)
     && xv <= 0.0
   {
     return Ok(int(0));
@@ -1729,7 +1724,7 @@ fn cdf_log_logistic(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // Concrete x <= 0 is outside the support; return 0 directly. At x = 0 the
   // value has (x/s)^(-g) = 0^(-g), which would emit a spurious Power::infy
   // message even though the piecewise selects the 0 branch.
-  if let Some(xv) = crate::functions::math_ast::expr_to_num(&x)
+  if let Some(xv) = expr_to_num(&x)
     && xv <= 0.0
   {
     return Ok(int(0));
@@ -1808,7 +1803,7 @@ pub fn cdf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if dist_name == "MixtureDistribution" && dargs.len() == 2 {
     let x = args[1].clone();
     return Ok(
-      super::statistics::mixture_weighted_component_quantity(dargs, |d| {
+      mixture_weighted_component_quantity(dargs, |d| {
         cdf_ast(&[d.clone(), x.clone()])
       })?
       .unwrap_or_else(|| unevaluated("CDF", args)),
@@ -4025,7 +4020,7 @@ pub fn distribution_mean_variance(
         ))?;
         let numeric = [&a, &b, &m, &g]
           .iter()
-          .all(|e| crate::functions::math_ast::try_eval_to_f64(e).is_some());
+          .all(|e| try_eval_to_f64(e).is_some());
         let f1 = call(
           "Plus",
           vec![
@@ -6517,7 +6512,7 @@ fn pdf_multinomial(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn any_concrete_non_integer(xs: &[Expr]) -> bool {
   xs.iter().any(|xi| {
     !matches!(xi, Expr::Integer(_) | Expr::BigInteger(_))
-      && crate::functions::math_ast::expr_to_num(xi).is_some()
+      && expr_to_num(xi).is_some()
   })
 }
 
@@ -7251,7 +7246,7 @@ fn pdf_first_passage(
   let Some(f) = fptd_parts(dargs) else {
     return unevaluated(x);
   };
-  match crate::functions::math_ast::try_eval_to_f64(&x) {
+  match try_eval_to_f64(&x) {
     Some(v) => {
       if v < 1.0 || v.fract() != 0.0 || v > 100_000.0 {
         return Ok(int(0));
@@ -7279,7 +7274,7 @@ fn cdf_first_passage(
   let Some(f) = fptd_parts(dargs) else {
     return unevaluated(x);
   };
-  match crate::functions::math_ast::try_eval_to_f64(&x) {
+  match try_eval_to_f64(&x) {
     Some(v) => {
       if v < 1.0 {
         return Ok(int(0));
@@ -7490,7 +7485,7 @@ fn wakeby_checked(dargs: &[Expr]) -> Option<()> {
     ));
     return None;
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let dist =
     || crate::syntax::expr_to_string(&unevaluated("WakebyDistribution", dargs));
   for pos in [0usize, 2] {
@@ -7546,7 +7541,7 @@ pub fn wakeby_quantile(
     return unevaluated();
   };
   let inf = infinity();
-  match crate::functions::math_ast::try_eval_to_f64(q) {
+  match try_eval_to_f64(q) {
     Some(qv) if qv > 0.0 && qv < 1.0 => eval(wakeby_quantile_body(dargs, q)),
     Some(0.0) => eval(dargs[4].clone()),
     Some(1.0) => Ok(inf),
@@ -7648,7 +7643,7 @@ fn wakeby_mean_variance(
       ),
     ),
   );
-  match crate::functions::math_ast::try_eval_to_f64(&d) {
+  match try_eval_to_f64(&d) {
     Some(dv) => {
       let mean = if dv < 1.0 {
         eval(mean_body)?
@@ -7700,7 +7695,7 @@ fn compound_poisson_mean_variance(
     ));
     return bail();
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let dist_str = || {
     crate::syntax::expr_to_string(&unevaluated(
       "CompoundPoissonDistribution",
@@ -7763,7 +7758,7 @@ fn hoyt_checked(dargs: &[Expr]) -> Option<()> {
     ));
     return None;
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let dist =
     || crate::syntax::expr_to_string(&unevaluated("HoytDistribution", dargs));
   if num(&dargs[0]).is_some_and(|v| !(v > 0.0 && v <= 1.0)) {
@@ -7884,7 +7879,7 @@ fn variance_gamma_checked(dargs: &[Expr]) -> Option<()> {
     ));
     return None;
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let dist = || {
     crate::syntax::expr_to_string(&unevaluated(
       "VarianceGammaDistribution",
@@ -7985,7 +7980,7 @@ fn variance_gamma_pdf(
   let inf = infinity();
   let cond_above = comparison(x.clone(), ComparisonOp::Greater, m.clone());
   let cond_below = comparison(x.clone(), ComparisonOp::Less, m.clone());
-  match crate::functions::math_ast::try_eval_to_f64(&l) {
+  match try_eval_to_f64(&l) {
     Some(lv) => {
       // The point branch folds into the default when λ is numeric.
       let default = if lv > 0.5 { eval(point)? } else { inf };
@@ -8067,7 +8062,7 @@ fn tsallis_checked(dargs: &[Expr]) -> Option<()> {
     ));
     return None;
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let dist = || {
     crate::syntax::expr_to_string(&unevaluated(
       "TsallisQGaussianDistribution",
@@ -8212,13 +8207,14 @@ fn tsallis_qgaussian_pdf(
     return unevaluated(x);
   };
   let (m, b, q) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
-  if dargs.iter().any(|e| {
-    !coxian_exact(e) && crate::functions::math_ast::try_eval_to_f64(e).is_some()
-  }) {
+  if dargs
+    .iter()
+    .any(|e| !coxian_exact(e) && try_eval_to_f64(e).is_some())
+  {
     return unevaluated(x);
   }
   let parts = tsallis_parts(&m, &b, &q, &x);
-  match crate::functions::math_ast::try_eval_to_f64(&q) {
+  match try_eval_to_f64(&q) {
     Some(1.0) => eval(parts.gaussian),
     Some(qv) if qv > 1.0 => eval(parts.branch_wide),
     Some(_) => {
@@ -8294,7 +8290,7 @@ fn tsallis_qgaussian_cdf(
     ),
     int(2),
   );
-  match crate::functions::math_ast::try_eval_to_f64(&q) {
+  match try_eval_to_f64(&q) {
     Some(1.0) => eval(erf_form),
     Some(_) => unevaluated(x),
     None => unevaluated(x),
@@ -8319,7 +8315,7 @@ fn tsallis_qgaussian_mean_variance(
     times(int(2), power(b.clone(), int(2))),
     plus(int(5), times(int(-3), q.clone())),
   );
-  match crate::functions::math_ast::try_eval_to_f64(&q) {
+  match try_eval_to_f64(&q) {
     Some(qv) => {
       let mean = if qv < 2.0 { eval(m)? } else { indet.clone() };
       let variance = if qv < 5.0 / 3.0 {
@@ -8399,7 +8395,7 @@ fn tukey_lambda_pdf_cdf(
     return unevaluated(x);
   };
   let lam = dargs[0].clone();
-  let Some(lv) = crate::functions::math_ast::try_eval_to_f64(&lam) else {
+  let Some(lv) = try_eval_to_f64(&lam) else {
     return unevaluated(x);
   };
   let scaled = dargs.len() == 3;
@@ -8558,7 +8554,7 @@ fn tukey_lambda_mean_variance(
   };
   let lam = dargs[0].clone();
   let indet = indeterminate();
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let mu = if dargs.len() == 3 {
     dargs[1].clone()
   } else {
@@ -8632,7 +8628,7 @@ fn hotelling_checked(dargs: &[Expr]) -> Option<()> {
     ));
     return None;
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   for pos in 0..2 {
     if num(&dargs[pos]).is_some_and(|v| v <= 0.0) {
       crate::emit_message(&format!(
@@ -8664,7 +8660,7 @@ fn pdf_hotelling(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     return unevaluated(x);
   };
   let (pp, m) = (dargs[0].clone(), dargs[1].clone());
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let half = |e: Expr| divide(e, int(2));
   let beta = call(
     "Beta",
@@ -8780,7 +8776,7 @@ fn hotelling_mean_variance(
   };
   let (pp, m) = (dargs[0].clone(), dargs[1].clone());
   let indet = indeterminate();
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let numeric = num(&pp).zip(num(&m));
   // Mean: (m p)/(-1 + m - p) when -1 + m - p > 0. For numeric
   // parameters the condition is decided up front so a dead branch never
@@ -8863,7 +8859,7 @@ fn benini_checked(dargs: &[Expr]) -> Option<()> {
     ));
     return None;
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let dist =
     || crate::syntax::expr_to_string(&unevaluated("BeniniDistribution", dargs));
   for pos in 0..2 {
@@ -8919,7 +8915,7 @@ fn pdf_benini(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     e(),
     times(times(int(-1), b.clone()), power(lg.clone(), int(2))),
   );
-  let value = if crate::functions::math_ast::try_eval_to_f64(&a).is_some() {
+  let value = if try_eval_to_f64(&a).is_some() {
     call(
       "Times",
       vec![
@@ -8959,7 +8955,7 @@ fn cdf_benini(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   };
   let (a, b, sg) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
   let lg = benini_log(&x, &sg);
-  let survival = if crate::functions::math_ast::try_eval_to_f64(&a).is_some() {
+  let survival = if try_eval_to_f64(&a).is_some() {
     call(
       "Times",
       vec![
@@ -9057,7 +9053,7 @@ fn vonmises_checked(dargs: &[Expr]) -> Option<()> {
     ));
     return None;
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   if num(&dargs[1]).is_some_and(|v| v < 0.0) {
     crate::emit_message(&format!(
       "VonMisesDistribution::nnegprm: Parameter {} at position 2 in {} is expected to be non-negative.",
@@ -9127,7 +9123,7 @@ fn hyperexponential_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
     ));
     return None;
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let vals: Vec<Option<f64>> = probs.iter().map(&num).collect();
   let negative = vals.iter().any(|v| v.is_some_and(|v| v < 0.0));
   let bad_sum = vals.iter().all(|v| v.is_some())
@@ -9160,7 +9156,7 @@ fn hyperexponential_numeric_terms(
   rates: &[Expr],
   scale_by_rate: bool,
 ) -> Option<Vec<(Expr, Expr)>> {
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   let vals: Vec<f64> = rates.iter().map(num).collect::<Option<_>>()?;
   let mut groups: Vec<(f64, Expr, Vec<Expr>)> = Vec::new();
   for (i, v) in vals.iter().enumerate() {
@@ -9306,7 +9302,7 @@ fn coxian_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
     ));
     return None;
   }
-  let num = crate::functions::math_ast::try_eval_to_f64;
+  let num = try_eval_to_f64;
   if alphas
     .iter()
     .any(|a| num(a).is_some_and(|v| !(0.0..=1.0).contains(&v)))
@@ -9419,7 +9415,7 @@ fn coxian_exact(e: &Expr) -> bool {
       _ => true,
     }
   }
-  no_real(e) && crate::functions::math_ast::try_eval_to_f64(e).is_some()
+  no_real(e) && try_eval_to_f64(e).is_some()
 }
 
 /// Coxian rate layout for the closed forms: Some(true) if all rates are
@@ -9430,10 +9426,8 @@ fn coxian_rate_layout(alphas: &[Expr], rates: &[Expr]) -> Option<bool> {
   if !alphas.iter().all(coxian_exact) || !rates.iter().all(coxian_exact) {
     return None;
   }
-  let vals: Vec<f64> = rates
-    .iter()
-    .map(|r| crate::functions::math_ast::try_eval_to_f64(r).unwrap())
-    .collect();
+  let vals: Vec<f64> =
+    rates.iter().map(|r| try_eval_to_f64(r).unwrap()).collect();
   let distinct = vals
     .iter()
     .enumerate()
@@ -9510,9 +9504,7 @@ fn pdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let terms: Vec<Expr> = if distinct {
     let coeffs = coxian_distinct_coefficients(&alphas, &rates)?;
     let mut order: Vec<usize> = (0..rates.len()).collect();
-    let val = |i: usize| {
-      crate::functions::math_ast::try_eval_to_f64(&rates[i]).unwrap()
-    };
+    let val = |i: usize| try_eval_to_f64(&rates[i]).unwrap();
     order.sort_by(|&a, &b| val(b).partial_cmp(&val(a)).unwrap());
     order
       .iter()
@@ -9572,9 +9564,7 @@ fn cdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   if distinct {
     let coeffs = coxian_distinct_coefficients(&alphas, &rates)?;
     let mut order: Vec<usize> = (0..rates.len()).collect();
-    let val = |i: usize| {
-      crate::functions::math_ast::try_eval_to_f64(&rates[i]).unwrap()
-    };
+    let val = |i: usize| try_eval_to_f64(&rates[i]).unwrap();
     order.sort_by(|&a, &b| val(b).partial_cmp(&val(a)).unwrap());
     for &i in &order {
       let c = eval(times(int(-1), coeffs[i].clone()))?;
@@ -9623,9 +9613,7 @@ fn hypoexponential_distinct_rates(dargs: &[Expr]) -> Option<Vec<(Expr, f64)>> {
     [Expr::List(rates)] if !rates.is_empty() => {
       let keyed: Option<Vec<(Expr, f64)>> = rates
         .iter()
-        .map(|r| {
-          crate::functions::math_ast::try_eval_to_f64(r).map(|f| (r.clone(), f))
-        })
+        .map(|r| try_eval_to_f64(r).map(|f| (r.clone(), f)))
         .collect();
       let keyed = keyed?;
       for i in 0..keyed.len() {
@@ -9831,10 +9819,7 @@ fn cdf_negative_multinomial(
   let Ok((n, probs)) = negative_multinomial_params(dargs) else {
     return unevaluated(x);
   };
-  if crate::functions::math_ast::expr_to_num(&n).is_none()
-    || probs
-      .iter()
-      .any(|p| crate::functions::math_ast::expr_to_num(p).is_none())
+  if expr_to_num(&n).is_none() || probs.iter().any(|p| expr_to_num(p).is_none())
   {
     return unevaluated(x);
   }
@@ -9846,7 +9831,7 @@ fn cdf_negative_multinomial(
   }
   let mut bounds: Vec<i64> = Vec::with_capacity(xs.len());
   for xi in xs.iter() {
-    let Some(v) = crate::functions::math_ast::expr_to_num(xi) else {
+    let Some(v) = expr_to_num(xi) else {
       return unevaluated(x.clone());
     };
     let f = v.floor();
@@ -10122,7 +10107,7 @@ pub fn wishart_mean_variance(
     }
     let mut row_exprs = Vec::with_capacity(p);
     for (j, cell) in cells.iter().enumerate() {
-      let Some(v) = crate::functions::math_ast::try_eval_to_f64(cell) else {
+      let Some(v) = try_eval_to_f64(cell) else {
         return fail(posdefprm(sigma));
       };
       sig[i][j] = v;
@@ -10181,7 +10166,7 @@ pub fn wishart_mean_variance(
       dist_str()
     )
   };
-  let Some(nu_f) = crate::functions::math_ast::try_eval_to_f64(nu) else {
+  let Some(nu_f) = try_eval_to_f64(nu) else {
     return fail(bprm());
   };
   if nu_f <= (p as f64) - 1.0 {
@@ -11255,7 +11240,7 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let half_log_2pi = divide(plus(log_of(int(2)), log_of(pi())), int(2));
       let result = plus(
         times(
-          crate::functions::math_ast::make_rational(-1, 2),
+          make_rational(-1, 2),
           divide(poly, times(s.clone(), s.clone())),
         ),
         times(int(-n), plus(half_log_2pi, log_of(s.clone()))),
@@ -11719,7 +11704,7 @@ fn frac_to_rational_expr(f: (i128, i128)) -> Expr {
   if f.1 == 1 {
     Expr::Integer(f.0)
   } else {
-    crate::functions::math_ast::make_rational(f.0, f.1)
+    make_rational(f.0, f.1)
   }
 }
 
@@ -11786,10 +11771,7 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       neg(sq)
     } else if !first_scaled_seen {
       first_scaled_seen = true;
-      times(
-        crate::functions::math_ast::make_rational(-1, variances[i]),
-        sq,
-      )
+      times(make_rational(-1, variances[i]), sq)
     } else {
       neg(div2(sq, int(variances[i])))
     };
@@ -11810,7 +11792,7 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   } else {
     // k == 3: 2*Sqrt[2*det]*Pi^(3/2)
     let sqrt_part = eval(call("Sqrt", vec![int(2 * det)]))?;
-    let pi_pow = power(pi(), crate::functions::math_ast::make_rational(3, 2));
+    let pi_pow = power(pi(), make_rational(3, 2));
     match &sqrt_part {
       Expr::Integer(s) => call("Times", vec![int(2 * s), pi_pow]),
       _ => call("Times", vec![int(2), sqrt_part, pi_pow]),
@@ -11895,7 +11877,7 @@ pub fn empirical_distribution_ast(
     uniques.push(if v.1 == 1 {
       Expr::Integer(v.0)
     } else {
-      crate::functions::math_ast::make_rational(v.0, v.1)
+      make_rational(v.0, v.1)
     });
   }
   Ok(call(
@@ -11938,7 +11920,7 @@ fn frac_expr((n, d): (i128, i128)) -> Expr {
   if d == 1 {
     Expr::Integer(n)
   } else {
-    crate::functions::math_ast::make_rational(n, d)
+    make_rational(n, d)
   }
 }
 
@@ -11961,10 +11943,7 @@ pub fn histogram_distribution_ast(
     }
     _ => return unevaluated(),
   };
-  let Some(values) = data
-    .iter()
-    .map(crate::functions::math_ast::expr_to_f64)
-    .collect::<Option<Vec<f64>>>()
+  let Some(values) = data.iter().map(expr_to_f64).collect::<Option<Vec<f64>>>()
   else {
     // Multivariate (matrix) data is not implemented yet: stay silently
     // symbolic. Anything else — symbolic entries, non-numbers — is invalid
@@ -12055,9 +12034,7 @@ pub fn histogram_distribution_ast(
 
   // Machine-real path: automatic binning, a non-exact width, or the
   // value-centered layout.
-  let dx_opt = match width_spec
-    .map(|e| crate::functions::math_ast::expr_to_f64(e).filter(|v| *v > 0.0))
-  {
+  let dx_opt = match width_spec.map(|e| expr_to_f64(e).filter(|v| *v > 0.0)) {
     None => None,
     Some(Some(dx)) => Some(dx),
     Some(None) => return unevaluated(),
@@ -12131,14 +12108,14 @@ fn histogram_pdf_cdf(
   // point the built form is returned as-is, preserving wolframscript's term
   // order (CDF leads with Boole[x >= last] and the bins follow ascending),
   // which ordinary Plus canonicalization would reshuffle.
-  let numeric_point = crate::functions::math_ast::expr_to_f64(x);
+  let numeric_point = expr_to_f64(x);
   // PDF at a numeric point is a direct bin lookup: the stored density inside
   // a bin, and the *exact* integer 0 outside the support (wolframscript
   // returns 0, not 0., even for a real point).
   if let Some(xf) = numeric_point
     && !cumulative
   {
-    let ef = |e: &Expr| crate::functions::math_ast::expr_to_f64(e);
+    let ef = |e: &Expr| expr_to_f64(e);
     for (i, w) in weights.iter().enumerate() {
       let (Some(lo), Some(hi)) = (ef(&edges[i]), ef(&edges[i + 1])) else {
         return Some(Ok(Expr::Integer(0)));
@@ -12250,7 +12227,7 @@ fn histogram_moment(dargs: &[Expr], k: u32) -> Option<Expr> {
     return Some(frac_expr(m));
   }
   // Machine-real path, accumulated left-to-right.
-  let to_f64 = crate::functions::math_ast::expr_to_f64;
+  let to_f64 = expr_to_f64;
   let ws: Option<Vec<f64>> = weights.iter().map(to_f64).collect();
   let es: Option<Vec<f64>> = edges.iter().map(to_f64).collect();
   let (ws, es) = (ws?, es?);
@@ -12327,7 +12304,7 @@ pub fn data_distribution_moment(dargs: &[Expr], k: u32) -> Option<Expr> {
   Some(if den == 1 {
     Expr::Integer(num)
   } else {
-    crate::functions::math_ast::make_rational(num, den)
+    make_rational(num, den)
   })
 }
 
@@ -12365,7 +12342,7 @@ fn data_distribution_pdf_cdf(
   Some(if den == 1 {
     Expr::Integer(num)
   } else {
-    crate::functions::math_ast::make_rational(num, den)
+    make_rational(num, den)
   })
 }
 
@@ -12442,7 +12419,7 @@ fn pdf_product_distribution(
         let sq = pow2(v);
         terms.push(if !first_scaled_seen {
           first_scaled_seen = true;
-          times(crate::functions::math_ast::make_rational(-1, 2), sq)
+          times(make_rational(-1, 2), sq)
         } else {
           neg(div2(sq, int(2)))
         });
@@ -17273,7 +17250,7 @@ pub fn truncated_distribution_value(
           eval("Times", vec![x.clone(), z])?,
         ],
       )?;
-      Ok(Some(super::statistics::quantile_ast(&[base, base_q])?))
+      Ok(Some(quantile_ast(&[base, base_q])?))
     }
     _ => Ok(None),
   }
@@ -17350,7 +17327,7 @@ pub fn censored_distribution_value(
       }
     }
     "Quantile" => {
-      let q = super::statistics::quantile_ast(&[base, x.clone()])?;
+      let q = quantile_ast(&[base, x.clone()])?;
       let clamped = eval("Max", vec![lo, eval("Min", vec![q, hi])?])?;
       Ok(Some(clamped))
     }

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -69,7 +69,7 @@ pub fn abs_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Abs[known positive real] = x (symbolic, no numeric conversion):
   // Pi, E, GoldenRatio, Sqrt[n>0], positive^anything, etc.
-  if crate::functions::math_ast::complex::is_strictly_positive_real(&args[0]) {
+  if is_strictly_positive_real(&args[0]) {
     return Ok(args[0].clone());
   }
   // Abs[Conjugate[x]] = Abs[x]
@@ -98,7 +98,7 @@ pub fn abs_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let mut kept: Vec<Expr> = Vec::new();
       let mut simplified = false;
       for f in &factors {
-        if crate::functions::math_ast::complex::is_strictly_positive_real(f) {
+        if is_strictly_positive_real(f) {
           pulled.push((*f).clone());
           simplified = true;
         } else if let Some(absval) = negative_literal_abs(f) {
@@ -143,7 +143,7 @@ pub fn abs_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // complex/symbolic exponents the real-exponent rule below can't reach,
   // e.g. Abs[E^(2 I)] = 1, Abs[E^(2 + 3 I)] = E^2, Abs[2^(I x)] = 2^(-Im[x]).
   if let Some((base, exp)) = as_power(&args[0])
-    && crate::functions::math_ast::complex::is_strictly_positive_real(base)
+    && is_strictly_positive_real(base)
   {
     let re_exp = Expr::FunctionCall {
       name: "Re".to_string(),
@@ -458,7 +458,7 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Sign[2^x] = 2^(I Im[x])). The purely-imaginary-exponent case above already
   // returned the expression unchanged.
   if let Some((base, exp)) = power_parts
-    && crate::functions::math_ast::complex::is_strictly_positive_real(base)
+    && is_strictly_positive_real(base)
   {
     let im_exp = Expr::FunctionCall {
       name: "Im".to_string(),
@@ -713,7 +713,7 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let mut kept: Vec<Expr> = Vec::new();
       let mut simplified = false;
       for f in &factors {
-        if crate::functions::math_ast::complex::is_strictly_positive_real(f) {
+        if is_strictly_positive_real(f) {
           simplified = true; // Sign = 1, drop it
         } else if negative_literal_abs(f).is_some() {
           pulled.push(Expr::Integer(-1));
@@ -849,10 +849,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // the precision-tracked bigfloat path computes it (rather than leaving
   // `Sqrt[2.`30.]` unevaluated).
   if matches!(&args[0], Expr::BigFloat(_, _)) {
-    return crate::functions::math_ast::power_two(
-      &args[0],
-      &make_rational(1, 2),
-    );
+    return power_two(&args[0], &make_rational(1, 2));
   }
   // Sqrt of a power whose exponents combine — either the inner exponent is
   // numeric with magnitude below 1 (`Sqrt[Sqrt[z]]` = z^(1/4)) or the inner
@@ -878,13 +875,9 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       _ => None,
     };
     if let Some((base, e)) = nested
-      && (crate::functions::math_ast::inner_exp_abs_lt_one(&e)
-        || crate::functions::math_ast::is_pos_numeric(&base))
+      && (inner_exp_abs_lt_one(&e) || is_pos_numeric(&base))
     {
-      return crate::functions::math_ast::power_two(
-        &args[0],
-        &make_rational(1, 2),
-      );
+      return power_two(&args[0], &make_rational(1, 2));
     }
   }
   // Sqrt[I] / Sqrt[-I]: delegate to Power[base, 1/2] so the imaginary-unit
@@ -894,25 +887,18 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::UnaryOp { op: UnaryOperator::Minus, operand }
         if matches!(operand.as_ref(), Expr::Identifier(s) if s == "I"))
   {
-    return crate::functions::math_ast::power_two(
-      &args[0],
-      &make_rational(1, 2),
-    );
+    return power_two(&args[0], &make_rational(1, 2));
   }
   // Sqrt of an inexact complex number (a machine float with a nonzero
   // imaginary part, e.g. `2.0 + 3.0 I`) numericizes via Power[base, 1/2] to
   // match wolframscript, rather than staying wrapped as a symbolic Sqrt[…].
   // Exact complex arguments like `2 + 3 I` have no Real component and are left
   // symbolic.
-  if let Some((_, im)) =
-    crate::functions::math_ast::try_extract_complex_float(&args[0])
+  if let Some((_, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
-    && crate::functions::math_ast::contains_inexact_real(&args[0])
+    && contains_inexact_real(&args[0])
   {
-    return crate::functions::math_ast::power_two(
-      &args[0],
-      &make_rational(1, 2),
-    );
+    return power_two(&args[0], &make_rational(1, 2));
   }
   // Handle Sqrt[Quantity[mag, unit]] by delegating to Power[quantity, 1/2]
   if crate::functions::quantity_ast::is_quantity(&args[0]).is_some() {
@@ -930,7 +916,7 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let bn = BigInt::from(*n);
       let r = bn.sqrt();
       if &r * &r == bn {
-        return Ok(crate::functions::math_ast::bigint_to_expr(r));
+        return Ok(bigint_to_expr(r));
       }
       // Partial extraction (e.g. Sqrt[12] = 2*Sqrt[3]) runs in u64, so only
       // when n fits u64 — casting a larger i128 to u64 would truncate.
@@ -959,12 +945,8 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Larger than u64: extract square factors in BigInt.
         let (outside, inside) = extract_square_factor_big(&bn);
         if outside > BigInt::from(1) {
-          let sqrt_part =
-            make_sqrt(crate::functions::math_ast::bigint_to_expr(inside));
-          return times_ast(&[
-            crate::functions::math_ast::bigint_to_expr(outside),
-            sqrt_part,
-          ]);
+          let sqrt_part = make_sqrt(bigint_to_expr(inside));
+          return times_ast(&[bigint_to_expr(outside), sqrt_part]);
         }
       }
       // Not a perfect square, return symbolic
@@ -975,16 +957,12 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::BigInteger(n) if *n >= BigInt::from(0) => {
       let r = n.sqrt();
       if &r * &r == *n {
-        return Ok(crate::functions::math_ast::bigint_to_expr(r));
+        return Ok(bigint_to_expr(r));
       }
       let (outside, inside) = extract_square_factor_big(n);
       if outside > BigInt::from(1) {
-        let sqrt_part =
-          make_sqrt(crate::functions::math_ast::bigint_to_expr(inside));
-        return times_ast(&[
-          crate::functions::math_ast::bigint_to_expr(outside),
-          sqrt_part,
-        ]);
+        let sqrt_part = make_sqrt(bigint_to_expr(inside));
+        return times_ast(&[bigint_to_expr(outside), sqrt_part]);
       }
       Ok(make_sqrt(args[0].clone()))
     }
@@ -1065,7 +1043,6 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let (Some(nb), Some(db)) = (to_big(&rargs[0]), to_big(&rargs[1]))
         && db > BigInt::from(0)
       {
-        use crate::functions::math_ast::{bigint_to_expr, make_rational_expr};
         let one = BigInt::from(1);
         let (n_out, n_in) = extract_square_factor_big(&nb);
         let (d_out, d_in) = extract_square_factor_big(&db);
@@ -1329,9 +1306,7 @@ fn has_only_numeric_leaves(e: &Expr) -> bool {
     | Expr::Real(_)
     | Expr::BigFloat(_, _)
     | Expr::Constant(_) => true,
-    Expr::Identifier(name) => {
-      name == "I" || crate::functions::math_ast::is_pos_real_const(name)
-    }
+    Expr::Identifier(name) => name == "I" || is_pos_real_const(name),
     Expr::FunctionCall { args, .. } => args.iter().all(has_only_numeric_leaves),
     Expr::BinaryOp { left, right, .. } => {
       has_only_numeric_leaves(left) && has_only_numeric_leaves(right)
@@ -1367,7 +1342,7 @@ fn numeric_real_value(e: &Expr) -> Option<f64> {
 /// special-function value — and products/powers of those.
 fn is_pos_numeric_factor(e: &Expr) -> bool {
   matches!(e, Expr::Real(r) if *r > 0.0)
-    || crate::functions::math_ast::is_pos_numeric(e)
+    || is_pos_numeric(e)
     || numeric_real_value(e).is_some_and(|v| v > 0.0)
 }
 
@@ -1570,7 +1545,7 @@ fn try_sqrt_plus_gcd(expr: &Expr) -> Option<Expr> {
     } else if new_coeff == 1 {
       new_terms.push(base.clone());
     } else if new_coeff == -1 {
-      new_terms.push(super::trigonometric::negate_expr(base.clone()));
+      new_terms.push(negate_expr(base.clone()));
     } else {
       new_terms.push(Expr::FunctionCall {
         name: "Times".to_string(),
@@ -1603,7 +1578,6 @@ fn try_sqrt_plus_gcd(expr: &Expr) -> Option<Expr> {
 /// choosing the principal root with `p >= 0` (or `p == 0, q > 0`).
 /// Returns `None` if no such integer solution exists.
 fn try_sqrt_gaussian(expr: &Expr) -> Option<Expr> {
-  use crate::functions::math_ast::numeric_utils::try_extract_complex_exact;
   let ((rn, rd), (in_, id)) = try_extract_complex_exact(expr)?;
   // Normalize to integers a and b where z = a + b*I
   // Require both parts to be integers (denominator 1 after reducing)
@@ -1754,17 +1728,11 @@ fn floor_via_bigfloat(
   // plus a safety margin.
   let mag_digits = approx.abs().log10().ceil() as i64;
   let precision = (mag_digits.max(20) as usize) + 10;
-  let bits = crate::functions::math_ast::numerical::nominal_bits(precision);
+  let bits = nominal_bits(precision);
   let mut cc = Consts::new().ok()?;
   let rm = RoundingMode::ToEven;
-  let bf = crate::functions::math_ast::numerical::expr_to_bigfloat(
-    expr, bits, rm, &mut cc,
-  )
-  .ok()?;
-  let decimal = crate::functions::math_ast::numerical::bigfloat_to_string(
-    &bf, None, rm, &mut cc,
-  )
-  .ok()?;
+  let bf = expr_to_bigfloat(expr, bits, rm, &mut cc).ok()?;
+  let decimal = bigfloat_to_string(&bf, None, rm, &mut cc).ok()?;
   // decimal looks like "[-]DIGITS.FRAC" (or just "[-]DIGITS.").
   let (sign, rest) = if let Some(s) = decimal.strip_prefix('-') {
     ("-", s)
@@ -1807,7 +1775,6 @@ fn floor_via_bigfloat(
 /// i128::MAX (e.g. Egyptian-fraction denominators around 1e300). Returns None
 /// for non-exact arguments (Real, symbolic, complex), which fall through.
 fn exact_floor_ceil(arg: &Expr, is_floor: bool) -> Option<Expr> {
-  use crate::functions::math_ast::{bigint_to_expr, expr_to_bigint};
   use num_traits::Zero;
   // Plain integers are already integral.
   if let Some(n) = expr_to_bigint(arg) {
@@ -1858,7 +1825,7 @@ fn infinity_passthrough(arg: &Expr) -> Option<Expr> {
   {
     return Some(arg.clone());
   }
-  if crate::functions::math_ast::is_neg_infinity(arg) {
+  if is_neg_infinity(arg) {
     return Some(arg.clone());
   }
   None
@@ -2369,8 +2336,7 @@ pub fn round_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     );
   }
   // Exact complex in Plus/Times form: extract and round parts separately
-  if let Some(((rn, rd), (in_, id))) =
-    crate::functions::math_ast::try_extract_complex_exact(&args[0])
+  if let Some(((rn, rd), (in_, id))) = try_extract_complex_exact(&args[0])
     && in_ != 0
   {
     let re_rat = make_rational(rn, rd);
@@ -2406,9 +2372,7 @@ fn is_complex_number(expr: &Expr) -> bool {
   {
     return !matches!(&args[1], Expr::Integer(0));
   }
-  if let Some(((_, _), (in_, _))) =
-    crate::functions::math_ast::try_extract_complex_exact(expr)
-  {
+  if let Some(((_, _), (in_, _))) = try_extract_complex_exact(expr) {
     return in_ != 0;
   }
   false
@@ -2420,7 +2384,7 @@ fn is_complex_number(expr: &Expr) -> bool {
 fn is_infinite_expr(expr: &Expr) -> bool {
   matches!(expr, Expr::Identifier(n) | Expr::Constant(n)
     if n == "Infinity" || n == "ComplexInfinity")
-    || crate::functions::math_ast::is_neg_infinity(expr)
+    || is_neg_infinity(expr)
     || matches!(expr, Expr::FunctionCall { name, .. } if name == "DirectedInfinity")
 }
 
@@ -2454,7 +2418,7 @@ fn infinite_mod_quotient(
     // Quotient[±Infinity, y] diverges in the direction of the dividend,
     // flipped by the sign of the divisor.
     let flip = matches!(
-      crate::functions::math_ast::try_eval_to_f64(n),
+      try_eval_to_f64(n),
       Some(v) if v < 0.0
     );
     let divided =
@@ -2940,7 +2904,7 @@ pub fn quotient_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         {
           q -= 1;
         }
-        return Ok(crate::functions::math_ast::bigint_to_expr(q));
+        return Ok(bigint_to_expr(q));
       }
       if let (Some(a), Some(b)) =
         (try_eval_to_f64(&args[0]), try_eval_to_f64(&args[1]))
@@ -2953,8 +2917,8 @@ pub fn quotient_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Ok(Expr::Integer((a / b).floor() as i128))
         }
       } else if let (Some((_, a_im)), Some((c_re, c_im))) = (
-        crate::functions::math_ast::try_extract_complex_float(&args[0]),
-        crate::functions::math_ast::try_extract_complex_float(&args[1]),
+        try_extract_complex_float(&args[0]),
+        try_extract_complex_float(&args[1]),
       ) && (a_im != 0.0 || c_im != 0.0)
       {
         if c_re == 0.0 && c_im == 0.0 {
@@ -3033,24 +2997,21 @@ pub fn clip_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // preserved in the result, so Clip[1/2] stays 1/2 and Clip[Pi, {0, 10}] stays
   // Pi rather than being floatified. Infinity / -Infinity resolve to ±inf so
   // they clamp to the upper / lower bound respectively.
-  let x =
-    match crate::functions::math_ast::try_eval_to_f64_with_infinity(&args[0]) {
-      Some(v) => v,
-      None => return unevaluated(),
-    };
+  let x = match try_eval_to_f64_with_infinity(&args[0]) {
+    Some(v) => v,
+    None => return unevaluated(),
+  };
 
   // Bounds: exact expressions plus their numeric values. The default range is
   // {-1, 1}.
   let (min_expr, max_expr, min_val, max_val) = if args.len() >= 2 {
     match &args[1] {
       Expr::List(bounds) if bounds.len() == 2 => {
-        let min = match crate::functions::math_ast::try_eval_to_f64(&bounds[0])
-        {
+        let min = match try_eval_to_f64(&bounds[0]) {
           Some(v) => v,
           None => return unevaluated(),
         };
-        let max = match crate::functions::math_ast::try_eval_to_f64(&bounds[1])
-        {
+        let max = match try_eval_to_f64(&bounds[1]) {
           Some(v) => v,
           None => return unevaluated(),
         };
@@ -3151,8 +3112,6 @@ pub fn integer_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 // ─── IntegerPart / FractionalPart ──────────────────────────────────
 
-use crate::functions::math_ast::contains_inexact_real as contains_inexact_literal;
-
 /// Build `re + im*I`, dropping a zero imaginary part. Used by the complex
 /// branches of IntegerPart/FractionalPart.
 fn build_complex_result(re: Expr, im: Expr) -> Result<Expr, InterpreterError> {
@@ -3181,8 +3140,7 @@ fn complex_parts_for_rounding(expr: &Expr) -> Option<(Expr, Expr)> {
   {
     return Some((re, im));
   }
-  if let Some((re, im)) =
-    crate::functions::math_ast::try_extract_complex_float(expr)
+  if let Some((re, im)) = try_extract_complex_float(expr)
     && im != 0.0
   {
     return Some((Expr::Real(re), Expr::Real(im)));
@@ -3234,8 +3192,7 @@ pub fn integer_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Complex number: IntegerPart[a + b I] = IntegerPart[a] + IntegerPart[b] I,
   // truncating each component toward zero. Covers numeric/Real components;
   // symbolic-constant components (Pi + E I) extract no float and fall through.
-  if let Some((re, im)) =
-    crate::functions::math_ast::try_extract_complex_float(&args[0])
+  if let Some((re, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
   {
     return build_complex_result(
@@ -3313,7 +3270,7 @@ pub fn fractional_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       return Ok(unit_interval(0, 1));
     }
-    if crate::functions::math_ast::is_neg_infinity(&args[0]) {
+    if is_neg_infinity(&args[0]) {
       return Ok(unit_interval(-1, 0));
     }
   }
@@ -3323,8 +3280,7 @@ pub fn fractional_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Exact complex rational: apply FractionalPart to real and imag parts
   // separately (FractionalPart truncates toward zero).
-  if let Some(((rn, rd), (in_, id))) =
-    crate::functions::math_ast::try_extract_complex_exact(&args[0])
+  if let Some(((rn, rd), (in_, id))) = try_extract_complex_exact(&args[0])
     && in_ != 0
   {
     let re_frac = rational_fractional_part(rn, rd);
@@ -3345,9 +3301,8 @@ pub fn fractional_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // FractionalPart[b] I with Real components. Forming a complex from a Real
   // promotes both parts to Real (Complex[2., 2.5]), so even an integer-valued
   // component yields `0.` here — matching wolframscript.
-  if contains_inexact_literal(&args[0])
-    && let Some((re, im)) =
-      crate::functions::math_ast::try_extract_complex_float(&args[0])
+  if contains_inexact_real(&args[0])
+    && let Some((re, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
   {
     return build_complex_result(
@@ -3393,8 +3348,7 @@ pub fn fractional_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       if !has_inexact(&args[0])
-        && let Ok(floor_val) =
-          crate::functions::math_ast::floor_ast(&[args[0].clone()])
+        && let Ok(floor_val) = floor_ast(&[args[0].clone()])
       {
         // IntegerPart truncates toward zero: Floor for x >= 0, Ceiling
         // for x < 0 (FractionalPart[81*(Pi - 29/2)] = 920 + 81*(-29/2 + Pi),
@@ -3405,8 +3359,7 @@ pub fn fractional_part_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           _ => false,
         };
         let int_val = if x_negative {
-          crate::functions::math_ast::ceiling_ast(&[args[0].clone()])
-            .unwrap_or(floor_val)
+          ceiling_ast(&[args[0].clone()]).unwrap_or(floor_val)
         } else {
           floor_val
         };
@@ -4001,7 +3954,7 @@ pub fn ramp_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Exact rationals and real-valued symbolic numerics (Pi, Sqrt[2], E - 3,
     // …): Ramp[x] = x for x >= 0, else 0. The exact input is preserved; a
     // negative value yields the integer 0 (the Real case is handled above).
-    other => match crate::functions::math_ast::try_eval_to_f64(other) {
+    other => match try_eval_to_f64(other) {
       Some(v) if v >= 0.0 => Ok(other.clone()),
       Some(_) => Ok(Expr::Integer(0)),
       None => Ok(unevaluated("Ramp", args)),
@@ -4106,7 +4059,7 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() > 1 {
     let mut remaining: Vec<Expr> = Vec::new();
     for arg in args {
-      match crate::functions::math_ast::try_eval_to_f64(arg) {
+      match try_eval_to_f64(arg) {
         Some(v) if v < 0.0 => return Ok(Expr::Integer(0)),
         Some(_) => {} // >= 0: contributes 1, drop it
         None => {
@@ -4180,7 +4133,7 @@ pub fn unit_step_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     // Exact rationals and real-valued symbolic numerics (Sqrt[2] - 2, …):
     // UnitStep[x] = 1 for x >= 0, else 0.
-    other => match crate::functions::math_ast::try_eval_to_f64(other) {
+    other => match try_eval_to_f64(other) {
       Some(v) if v >= 0.0 => Ok(Expr::Integer(1)),
       Some(_) => Ok(Expr::Integer(0)),
       None => Ok(unevaluated("UnitStep", args)),
@@ -4280,7 +4233,7 @@ pub fn heaviside_theta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Identifier(name) if name == "Infinity" => Ok(Expr::Integer(1)),
     // Exact rationals and real-valued symbolic numerics (Sqrt[2] - 2, …):
     // HeavisideTheta[x] = 1 for x > 0, 0 for x < 0, and stays unevaluated at 0.
-    other => match crate::functions::math_ast::try_eval_to_f64(other) {
+    other => match try_eval_to_f64(other) {
       Some(v) if v > 0.0 => Ok(Expr::Integer(1)),
       Some(v) if v < 0.0 => Ok(Expr::Integer(0)),
       _ => Ok(unevaluated("HeavisideTheta", args)),
@@ -4593,7 +4546,7 @@ pub fn heaviside_lambda_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         // 1 - |n/d| = (|d| - |n|) / |d|
         let num = abs_d - abs_n;
-        return Ok(crate::functions::math_ast::make_rational(num, abs_d));
+        return Ok(make_rational(num, abs_d));
       }
       Ok(unevaluated("HeavisideLambda", args))
     }

--- a/src/functions/math_ast/elliptic.rs
+++ b/src/functions/math_ast/elliptic.rs
@@ -190,7 +190,7 @@ pub fn inverse_elliptic_nome_q_ast(
     Expr::Real(f) => Ok(Expr::Real(inverse_elliptic_nome_q_numeric(*f))),
     other => {
       if expr_is_inexact(other)
-        && let Some(q) = crate::functions::math_ast::expr_to_f64(other)
+        && let Some(q) = expr_to_f64(other)
       {
         return Ok(Expr::Real(inverse_elliptic_nome_q_numeric(q)));
       }
@@ -812,14 +812,11 @@ pub fn dedekind_eta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // — e.g. `2*I` should not auto-evaluate numerically).
   let has_real_part = expr_contains_real(&args[0]);
   if has_real_part
-    && let Some((re, im)) =
-      crate::functions::math_ast::try_extract_complex_float(&args[0])
+    && let Some((re, im)) = try_extract_complex_float(&args[0])
     && im > 0.0
   {
     let (eta_re, eta_im) = dedekind_eta_numeric(re, im);
-    return Ok(crate::functions::math_ast::build_complex_float_expr(
-      eta_re, eta_im,
-    ));
+    return Ok(build_complex_float_expr(eta_re, eta_im));
   }
 
   Ok(unevaluated("DedekindEta", args))
@@ -1025,7 +1022,7 @@ fn weierstrass_cm_invariants(
       args: vec![e.clone()].into(),
     };
     let r = crate::evaluator::evaluate_expr_to_expr(&n).ok()?;
-    crate::functions::math_ast::try_extract_complex_float(&r)
+    try_extract_complex_float(&r)
   };
   let (w1, w2) = match (to_complex(w1e), to_complex(w2e)) {
     (Some(a), Some(b)) => (a, b),
@@ -1116,8 +1113,8 @@ pub fn weierstrass_invariants_ast(
     return unevaluated();
   }
   let (w1, w2) = match (
-    crate::functions::math_ast::try_extract_complex_float(&periods[0]),
-    crate::functions::math_ast::try_extract_complex_float(&periods[1]),
+    try_extract_complex_float(&periods[0]),
+    try_extract_complex_float(&periods[1]),
   ) {
     (Some(a), Some(b)) => (a, b),
     _ => return unevaluated(),
@@ -1125,12 +1122,8 @@ pub fn weierstrass_invariants_ast(
   match weierstrass_invariants_numeric(w1, w2) {
     Some((g2, g3)) => Ok(Expr::List(
       vec![
-        crate::functions::math_ast::build_complex_float_expr_keep_real(
-          g2.0, g2.1,
-        ),
-        crate::functions::math_ast::build_complex_float_expr_keep_real(
-          g3.0, g3.1,
-        ),
+        build_complex_float_expr_keep_real(g2.0, g2.1),
+        build_complex_float_expr_keep_real(g3.0, g3.1),
       ]
       .into(),
     )),
@@ -1163,8 +1156,8 @@ pub fn weierstrass_half_periods_ast(
   }
   // Real invariants only; a complex g₂/g₃ falls back to symbolic.
   let (g2, g3) = match (
-    crate::functions::math_ast::try_extract_complex_float(&items[0]),
-    crate::functions::math_ast::try_extract_complex_float(&items[1]),
+    try_extract_complex_float(&items[0]),
+    try_extract_complex_float(&items[1]),
   ) {
     (Some((a, ai)), Some((b, bi))) if ai == 0.0 && bi == 0.0 => (a, b),
     _ => return unevaluated(),
@@ -1196,9 +1189,7 @@ pub fn weierstrass_half_periods_ast(
   Ok(Expr::List(
     vec![
       Expr::Real(omega1),
-      crate::functions::math_ast::build_complex_float_expr_keep_real(
-        0.0, omega2_im,
-      ),
+      build_complex_float_expr_keep_real(0.0, omega2_im),
     ]
     .into(),
   ))
@@ -1221,12 +1212,11 @@ pub fn modular_lambda_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Numeric (machine-precision) argument in the upper half-plane.
   if expr_contains_real(&args[0])
-    && let Some((re, im)) =
-      crate::functions::math_ast::try_extract_complex_float(&args[0])
+    && let Some((re, im)) = try_extract_complex_float(&args[0])
     && im > 0.0
   {
     let (lr, li) = modular_lambda_numeric(re, im);
-    return Ok(crate::functions::math_ast::build_complex_float_expr(lr, li));
+    return Ok(build_complex_float_expr(lr, li));
   }
   unevaluated()
 }
@@ -1246,8 +1236,7 @@ pub fn klein_invariant_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Integer(1));
   }
   if expr_contains_real(&args[0])
-    && let Some((re, im)) =
-      crate::functions::math_ast::try_extract_complex_float(&args[0])
+    && let Some((re, im)) = try_extract_complex_float(&args[0])
     && im > 0.0
   {
     let lam = modular_lambda_numeric(re, im);
@@ -1260,9 +1249,7 @@ pub fn klein_invariant_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let (jr, ji) = cdiv(num, den);
     // wolframscript reports the j-invariant as a complex machine number even on
     // the imaginary axis (e.g. `166.375 + 0.*I`), so keep the imaginary part.
-    return Ok(
-      crate::functions::math_ast::build_complex_float_expr_keep_real(jr, ji),
-    );
+    return Ok(build_complex_float_expr_keep_real(jr, ji));
   }
   unevaluated()
 }
@@ -1619,10 +1606,7 @@ pub fn neville_theta_ast(
   // arguments stay symbolic in wolframscript).
   let has_real = matches!(z, Expr::Real(_)) || matches!(m, Expr::Real(_));
   if has_real
-    && let (Some(zv), Some(mv)) = (
-      crate::functions::math_ast::try_eval_to_f64(z),
-      crate::functions::math_ast::try_eval_to_f64(m),
-    )
+    && let (Some(zv), Some(mv)) = (try_eval_to_f64(z), try_eval_to_f64(m))
     && let Some(v) = neville_theta_numeric(kind, zv, mv)
   {
     return Ok(Expr::Real(v));

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -157,8 +157,8 @@ pub fn pochhammer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let has_real =
         matches!(&args[0], Expr::Real(_)) || matches!(&args[1], Expr::Real(_));
       if has_real {
-        let gamma_a = super::gamma_fn(a_f);
-        let gamma_a_n = super::gamma_fn(a_f + n_f);
+        let gamma_a = gamma_fn(a_f);
+        let gamma_a_n = gamma_fn(a_f + n_f);
         if gamma_a.is_finite()
           && gamma_a_n.is_finite()
           && gamma_a.abs() > 1e-300
@@ -432,16 +432,12 @@ pub fn gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Only triggers when the argument has a non-zero imaginary part AND
       // some component is a Real (not exact rationals/integers — those are
       // handled symbolically above).
-      if let Some((re, im)) =
-        crate::functions::math_ast::try_extract_complex_float(&args[0])
+      if let Some((re, im)) = try_extract_complex_float(&args[0])
         && im != 0.0
         && contains_inexact_real(&args[0])
       {
-        let (gr, gi) =
-          crate::functions::math_ast::zeta_functions::gamma_complex(re, im);
-        return Ok(crate::functions::math_ast::build_complex_float_expr(
-          gr, gi,
-        ));
+        let (gr, gi) = gamma_complex(re, im);
+        return Ok(build_complex_float_expr(gr, gi));
       }
       Ok(unevaluated("Gamma", args))
     }
@@ -1308,14 +1304,12 @@ pub fn log_gamma_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // forward-shift + Stirling series. Wolfram's LogGamma is the analytic
   // continuation, which can differ from Log[Gamma[z]] by a 2πi multiple
   // for z to the left of the imaginary axis.
-  if let Some((re, im)) =
-    crate::functions::math_ast::try_extract_complex_float(z)
+  if let Some((re, im)) = try_extract_complex_float(z)
     && im != 0.0
     && contains_inexact_real(z)
   {
-    let (lr, li) =
-      crate::functions::math_ast::zeta_functions::log_gamma_complex(re, im);
-    return Ok(crate::functions::math_ast::build_complex_float_expr(lr, li));
+    let (lr, li) = log_gamma_complex(re, im);
+    return Ok(build_complex_float_expr(lr, li));
   }
 
   // Return unevaluated for symbolic case
@@ -1850,7 +1844,7 @@ pub fn marcum_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           _ => None,
         }
       }
-      _ => crate::functions::math_ast::numeric_utils::try_eval_to_f64(e),
+      _ => try_eval_to_f64(e),
     }
   };
   let has_real = args.iter().any(|e| matches!(e, Expr::Real(_)));
@@ -2035,10 +2029,7 @@ pub fn owen_t_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Numeric evaluation requires an inexact argument.
   if has_real
-    && let (Some(hv), Some(av)) = (
-      crate::functions::math_ast::numeric_utils::try_eval_to_f64(h),
-      crate::functions::math_ast::numeric_utils::try_eval_to_f64(a),
-    )
+    && let (Some(hv), Some(av)) = (try_eval_to_f64(h), try_eval_to_f64(a))
   {
     return Ok(Expr::Real(owen_t_numeric(hv, av)));
   }

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -318,9 +318,8 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       //   0F1[; b; -w] = Gamma[b] w^((1-b)/2) BesselJ[b-1, 2 Sqrt[w]],
       // which is what wolframscript prints. Keeping the I-form would make
       // `Sqrt[z]` imaginary and expand into a complex Sinh/Cosh product.
-      let is_negative_real = is_number(z)
-        && crate::functions::math_ast::try_eval_to_f64(z)
-          .is_some_and(|v| v < 0.0);
+      let is_negative_real =
+        is_number(z) && try_eval_to_f64(z).is_some_and(|v| v < 0.0);
       let (radicand, bessel_name) = if is_negative_real {
         (
           crate::evaluator::evaluate_expr_to_expr(&call(
@@ -363,7 +362,7 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let v = crate::evaluator::evaluate_expr_to_expr(&part)?;
         flatten_times(&v, &mut factors);
       }
-      return crate::functions::math_ast::times_ast(&factors);
+      return times_ast(&factors);
     }
   }
 
@@ -489,9 +488,11 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // simplifications. Delegate so e.g. `HypergeometricPFQ[{6},{1},2]` →
   // `(719*E^2)/15` rather than the unsimplified series.
   if a_list.len() == 1 && b_list.len() == 1 {
-    return crate::functions::math_ast::hypergeometric::hypergeometric1f1_ast(
-      &[a_list[0].clone(), b_list[0].clone(), z.clone()],
-    );
+    return hypergeometric1f1_ast(&[
+      a_list[0].clone(),
+      b_list[0].clone(),
+      z.clone(),
+    ]);
   }
 
   // p=2, q=1 form is exactly Hypergeometric2F1, which carries its own
@@ -501,13 +502,12 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Hypergeometric2F1, so in that case we fall through and keep the input as
   // HypergeometricPFQ.
   if a_list.len() == 2 && b_list.len() == 1 {
-    let reduced =
-      crate::functions::math_ast::hypergeometric::hypergeometric2f1_ast(&[
-        a_list[0].clone(),
-        a_list[1].clone(),
-        b_list[0].clone(),
-        z.clone(),
-      ])?;
+    let reduced = hypergeometric2f1_ast(&[
+      a_list[0].clone(),
+      a_list[1].clone(),
+      b_list[0].clone(),
+      z.clone(),
+    ])?;
     let is_bare_2f1 = matches!(
       &reduced,
       Expr::FunctionCall { name, .. } if name == "Hypergeometric2F1"
@@ -573,7 +573,7 @@ pub fn hypergeometric_pfq_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       ]
       .into(),
     };
-    return crate::functions::math_ast::times_ast(&[
+    return times_ast(&[
       Expr::Integer(-4),
       inner_neg,
       Expr::FunctionCall {
@@ -1578,7 +1578,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           &[Expr::Integer(num), z_pow],
         )?,
         (num, den) => {
-          let rat = crate::functions::math_ast::make_rational(num, den);
+          let rat = make_rational(num, den);
           crate::evaluator::evaluate_function_call_ast("Times", &[rat, z_pow])?
         }
       };
@@ -1616,14 +1616,13 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // real path.
   let any_inexact = args.iter().any(|a| {
     matches!(a, Expr::Real(_) | Expr::BigFloat(_, _))
-      || crate::functions::math_ast::try_extract_complex_float(a)
-        .is_some_and(|(_, im)| im != 0.0)
+      || try_extract_complex_float(a).is_some_and(|(_, im)| im != 0.0)
   });
   if any_inexact
     && let (Some(a), Some(b), Some(z)) = (
-      crate::functions::math_ast::try_extract_complex_float(&args[0]),
-      crate::functions::math_ast::try_extract_complex_float(&args[1]),
-      crate::functions::math_ast::try_extract_complex_float(&args[2]),
+      try_extract_complex_float(&args[0]),
+      try_extract_complex_float(&args[1]),
+      try_extract_complex_float(&args[2]),
     )
   {
     let inexact_marker = matches!(&args[0], Expr::Real(_))
@@ -1634,7 +1633,7 @@ pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       || z.1 != 0.0;
     if inexact_marker {
       let (re, im) = hypergeometric_1f1_complex(a, b, z);
-      return Ok(crate::functions::math_ast::build_complex_float_expr(re, im));
+      return Ok(build_complex_float_expr(re, im));
     }
   }
 
@@ -2378,19 +2377,18 @@ pub fn hypergeometric2f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // arithmetic.
   let any_inexact = args.iter().any(|a| {
     matches!(a, Expr::Real(_) | Expr::BigFloat(_, _))
-      || crate::functions::math_ast::try_extract_complex_float(a)
-        .is_some_and(|(_, im)| im != 0.0)
+      || try_extract_complex_float(a).is_some_and(|(_, im)| im != 0.0)
   });
   if any_inexact
     && let (Some(av), Some(bv), Some(cv), Some(zv)) = (
-      crate::functions::math_ast::try_extract_complex_float(&args[0]),
-      crate::functions::math_ast::try_extract_complex_float(&args[1]),
-      crate::functions::math_ast::try_extract_complex_float(&args[2]),
-      crate::functions::math_ast::try_extract_complex_float(&args[3]),
+      try_extract_complex_float(&args[0]),
+      try_extract_complex_float(&args[1]),
+      try_extract_complex_float(&args[2]),
+      try_extract_complex_float(&args[3]),
     )
   {
     let (re, im) = hypergeometric_2f1_complex(av, bv, cv, zv);
-    return Ok(crate::functions::math_ast::build_complex_float_expr(re, im));
+    return Ok(build_complex_float_expr(re, im));
   }
 
   // Return unevaluated
@@ -3010,13 +3008,9 @@ pub fn whittaker_m_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       im = 0.0;
     }
     if im == 0.0 {
-      return Ok(crate::functions::math_ast::build_complex_float_expr(
-        re, 0.0,
-      ));
+      return Ok(build_complex_float_expr(re, 0.0));
     }
-    return Ok(
-      crate::functions::math_ast::build_complex_float_expr_keep_real(re, im),
-    );
+    return Ok(build_complex_float_expr_keep_real(re, im));
   }
 
   // Unevaluated symbolic form.
@@ -3094,7 +3088,7 @@ pub fn whittaker_w_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               for n in 1..=(-ki) {
                 fact *= n;
               }
-              return Ok(crate::functions::math_ast::make_rational(1, fact));
+              return Ok(make_rational(1, fact));
             }
             let rounded = value.round();
             if (value - rounded).abs() < 1e-12 {
@@ -3143,13 +3137,9 @@ pub fn whittaker_w_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       im = 0.0;
     }
     if im == 0.0 {
-      return Ok(crate::functions::math_ast::build_complex_float_expr(
-        re, 0.0,
-      ));
+      return Ok(build_complex_float_expr(re, 0.0));
     }
-    return Ok(
-      crate::functions::math_ast::build_complex_float_expr_keep_real(re, im),
-    );
+    return Ok(build_complex_float_expr_keep_real(re, im));
   }
 
   // Unevaluated symbolic form.

--- a/src/functions/math_ast/integrals.rs
+++ b/src/functions/math_ast/integrals.rs
@@ -181,7 +181,7 @@ pub fn fresnel_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // form (including negative rational coefficients, e.g. FresnelS[-x/2]) via the
   // shared helper; recursion evaluates special values such as
   // FresnelS[-Infinity] = -1/2.
-  if let Some(pos) = crate::functions::math_ast::strip_negation(&args[0]) {
+  if let Some(pos) = strip_negation(&args[0]) {
     let inner = fresnel_s_ast(&[pos])?;
     return crate::evaluator::evaluate_function_call_ast(
       "Times",
@@ -204,9 +204,7 @@ pub fn fresnel_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // FresnelS[0] = 0
     Expr::Integer(0) => Ok(Expr::Integer(0)),
     // FresnelS[Infinity] = 1/2
-    Expr::Identifier(s) if s == "Infinity" => {
-      Ok(crate::functions::math_ast::make_rational(1, 2))
-    }
+    Expr::Identifier(s) if s == "Infinity" => Ok(make_rational(1, 2)),
     // FresnelS[ComplexInfinity] = Indeterminate
     Expr::Identifier(s) if s == "ComplexInfinity" => {
       Ok(Expr::Identifier("Indeterminate".to_string()))
@@ -232,7 +230,7 @@ pub fn fresnel_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } => {
       // Check for -Infinity first
       if matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity") {
-        return Ok(crate::functions::math_ast::make_rational(-1, 2));
+        return Ok(make_rational(-1, 2));
       }
       Ok(negate_fresnel_s(*operand.clone()))
     }
@@ -279,7 +277,7 @@ pub fn fresnel_s_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Check for -Infinity (Times[-1, Infinity] form)
     other => {
       if is_neg_infinity(other) {
-        return Ok(crate::functions::math_ast::make_rational(-1, 2));
+        return Ok(make_rational(-1, 2));
       }
       // Unevaluated
       Ok(unevaluated("FresnelS", args))
@@ -306,7 +304,7 @@ pub fn fresnel_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // FresnelC is odd: FresnelC[-x] = -FresnelC[x] (see fresnel_s_ast).
-  if let Some(pos) = crate::functions::math_ast::strip_negation(&args[0]) {
+  if let Some(pos) = strip_negation(&args[0]) {
     let inner = fresnel_c_ast(&[pos])?;
     return crate::evaluator::evaluate_function_call_ast(
       "Times",
@@ -329,9 +327,7 @@ pub fn fresnel_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // FresnelC[0] = 0
     Expr::Integer(0) => Ok(Expr::Integer(0)),
     // FresnelC[Infinity] = 1/2
-    Expr::Identifier(s) if s == "Infinity" => {
-      Ok(crate::functions::math_ast::make_rational(1, 2))
-    }
+    Expr::Identifier(s) if s == "Infinity" => Ok(make_rational(1, 2)),
     // FresnelC[ComplexInfinity] = Indeterminate
     Expr::Identifier(s) if s == "ComplexInfinity" => {
       Ok(Expr::Identifier("Indeterminate".to_string()))
@@ -356,7 +352,7 @@ pub fn fresnel_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } => {
       // Check for -Infinity first
       if matches!(operand.as_ref(), Expr::Identifier(s) if s == "Infinity") {
-        return Ok(crate::functions::math_ast::make_rational(-1, 2));
+        return Ok(make_rational(-1, 2));
       }
       Ok(negate_fresnel_c(*operand.clone()))
     }
@@ -402,7 +398,7 @@ pub fn fresnel_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Check for -Infinity (Times[-1, Infinity] form)
     other => {
       if is_neg_infinity(other) {
-        return Ok(crate::functions::math_ast::make_rational(-1, 2));
+        return Ok(make_rational(-1, 2));
       }
       // Unevaluated
       Ok(unevaluated("FresnelC", args))
@@ -615,11 +611,7 @@ pub fn sin_integral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // SinIntegral[Infinity] = Pi/2
     Expr::Identifier(s) if s == "Infinity" => Ok(Expr::FunctionCall {
       name: "Times".to_string(),
-      args: vec![
-        crate::functions::math_ast::make_rational(1, 2),
-        Expr::Constant("Pi".to_string()),
-      ]
-      .into(),
+      args: vec![make_rational(1, 2), Expr::Constant("Pi".to_string())].into(),
     }),
     // Numeric evaluation
     Expr::Real(x) => Ok(Expr::Real(sin_integral_numeric(*x))),
@@ -629,11 +621,8 @@ pub fn sin_integral_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // SinIntegral[-Infinity] = -Pi/2
         return Ok(Expr::FunctionCall {
           name: "Times".to_string(),
-          args: vec![
-            crate::functions::math_ast::make_rational(-1, 2),
-            Expr::Constant("Pi".to_string()),
-          ]
-          .into(),
+          args: vec![make_rational(-1, 2), Expr::Constant("Pi".to_string())]
+            .into(),
         });
       }
       // Unevaluated
@@ -1122,7 +1111,7 @@ pub fn fresnel_fg_ast(
   if !matches!(&args[0], Expr::Real(_) | Expr::BigFloat(..)) {
     return unevaluated();
   }
-  let Some(x) = crate::functions::math_ast::try_eval_to_f64(&args[0]) else {
+  let Some(x) = try_eval_to_f64(&args[0]) else {
     return unevaluated();
   };
   Ok(Expr::Real(fresnel_fg_numeric(name == "FresnelF", x)))

--- a/src/functions/math_ast/jacobi.rs
+++ b/src/functions/math_ast/jacobi.rs
@@ -72,11 +72,7 @@ pub fn jacobi_amplitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // JacobiAmplitude[u, 0] = u (the modulus vanishes, so am collapses to u).
-  if let Some(result) =
-    crate::functions::math_ast::elliptic::elliptic_param_zero_reduces_to_first(
-      u, m,
-    )
-  {
+  if let Some(result) = elliptic_param_zero_reduces_to_first(u, m) {
     return Ok(result);
   }
 
@@ -123,11 +119,7 @@ pub fn jacobi_epsilon_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // JacobiEpsilon[u, 0] = u (the integrand dn^2 collapses to 1).
-  if let Some(result) =
-    crate::functions::math_ast::elliptic::elliptic_param_zero_reduces_to_first(
-      u, m,
-    )
-  {
+  if let Some(result) = elliptic_param_zero_reduces_to_first(u, m) {
     return Ok(result);
   }
 
@@ -145,9 +137,7 @@ pub fn jacobi_epsilon_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     let (sn, cn, _) = jacobi_elliptic(u_f, m_f);
     let am = sn.atan2(cn);
-    return Ok(Expr::Real(
-      crate::functions::math_ast::elliptic::elliptic_e_incomplete(am, m_f),
-    ));
+    return Ok(Expr::Real(elliptic_e_incomplete(am, m_f)));
   }
 
   Ok(unevaluated("JacobiEpsilon", args))

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -539,7 +539,7 @@ pub fn product_log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         wr -= step_re;
         wi -= step_im;
       }
-      return Ok(crate::functions::math_ast::build_complex_float_expr(wr, wi));
+      return Ok(build_complex_float_expr(wr, wi));
     }
     _ => {}
   }
@@ -1764,13 +1764,10 @@ fn weber_e_integer_closed_form(
       if p > 0 {
         // power_ast so an exact argument simplifies (e.g. 3^1 -> 3), letting
         // times_ast fold it into the coefficient (WeberE[2, 3] -> 2/Pi - ...).
-        factors.push(crate::functions::math_ast::power_ast(&[
-          z.clone(),
-          Expr::Integer(p),
-        ])?);
+        factors.push(power_ast(&[z.clone(), Expr::Integer(p)])?);
       }
       factors.push(pi_inv.clone());
-      terms.push(crate::functions::math_ast::times_ast(&factors)?);
+      terms.push(times_ast(&factors)?);
     }
   }
 
@@ -1779,16 +1776,12 @@ fn weber_e_integer_closed_form(
     name: "StruveH".to_string(),
     args: vec![Expr::Integer(m), z.clone()].into(),
   };
-  terms.push(crate::functions::math_ast::times_ast(&[
-    Expr::Integer(-1),
-    struve,
-  ])?);
+  terms.push(times_ast(&[Expr::Integer(-1), struve])?);
 
-  let mut result = crate::functions::math_ast::plus_ast(&terms)?;
+  let mut result = plus_ast(&terms)?;
   // Reflection: WeberE[-n, z] = (-1)^n WeberE[n, z]; only an odd |n| flips sign.
   if n < 0 && m % 2 == 1 {
-    result =
-      crate::functions::math_ast::times_ast(&[Expr::Integer(-1), result])?;
+    result = times_ast(&[Expr::Integer(-1), result])?;
   }
   Ok(result)
 }
@@ -2325,9 +2318,7 @@ pub fn norlund_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           None => return evaluate_norlund_symbolic(&poly, a_expr),
         };
       }
-      return Ok(crate::functions::math_ast::make_rational(
-        result_n, result_d,
-      ));
+      return Ok(make_rational(result_n, result_d));
     }
   }
 
@@ -2384,7 +2375,7 @@ fn evaluate_norlund_symbolic(
     if cn == 0 {
       continue;
     }
-    let coeff = crate::functions::math_ast::make_rational(cn, cd);
+    let coeff = make_rational(cn, cd);
     let term = if k == 0 {
       coeff
     } else {
@@ -3400,7 +3391,7 @@ pub fn real_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Determine the base. Default is 10. The base must be a real number > 1.
   let base: f64 = if args.len() == 2 {
-    match crate::functions::math_ast::try_eval_to_f64(&args[1]) {
+    match try_eval_to_f64(&args[1]) {
       Some(b) if b.is_finite() && b > 1.0 => b,
       _ => return Ok(unevaluated()),
     }
@@ -3422,7 +3413,7 @@ pub fn real_exponent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
 
-  let magnitude = match crate::functions::math_ast::try_eval_to_f64(&abs_expr) {
+  let magnitude = match try_eval_to_f64(&abs_expr) {
     Some(m) if m.is_finite() && m > 0.0 => m,
     _ => return Ok(unevaluated()),
   };

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -158,8 +158,7 @@ fn gaussian_lcm(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
 /// Extract a Gaussian integer (re, im) from an expression, or None if it is not
 /// an exact complex number with integer real and imaginary parts.
 fn expr_to_gaussian_int(expr: &Expr) -> Option<(i128, i128)> {
-  let ((rn, rd), (in_, id)) =
-    crate::functions::math_ast::try_extract_complex_exact(expr)?;
+  let ((rn, rd), (in_, id)) = try_extract_complex_exact(expr)?;
   if rd == 1 && id == 1 {
     Some((rn, in_))
   } else {
@@ -503,20 +502,19 @@ pub fn factorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::Real(exact.to_f64().unwrap_or(f64::INFINITY)));
     }
     // Factorial[x] = Gamma[x+1] for real numbers
-    let result = super::gamma_fn(*f + 1.0);
+    let result = gamma_fn(*f + 1.0);
     if result.is_infinite() {
       Ok(Expr::Identifier("ComplexInfinity".to_string()))
     } else {
       Ok(Expr::Real(result))
     }
-  } else if let Some((re, im)) = super::try_extract_complex_float(&args[0])
+  } else if let Some((re, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
     && contains_inexact_real(&args[0])
   {
     // Complex floating-point argument: Factorial[z] = Gamma[z+1].
-    let (gr, gi) =
-      crate::functions::math_ast::zeta_functions::gamma_complex(re + 1.0, im);
-    Ok(super::build_complex_float_expr(gr, gi))
+    let (gr, gi) = gamma_complex(re + 1.0, im);
+    Ok(build_complex_float_expr(gr, gi))
   } else {
     // For rationals and other symbolic expressions, delegate to Gamma[n+1]
     // Build the expression Gamma[n + 1] and evaluate via gamma_ast
@@ -540,7 +538,7 @@ pub fn factorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         return Ok(unevaluated("Factorial", args));
       }
     };
-    super::gamma_ast(&[n_plus_1])
+    gamma_ast(&[n_plus_1])
   }
 }
 
@@ -588,7 +586,7 @@ pub fn factorial2_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // integer and coincides with wolframscript on non-integer reals.
     let shift = (1.0 - (std::f64::consts::PI * x).cos()) / 4.0;
     let pow2 = 2.0f64.powf(x / 2.0 + shift);
-    let gamma = super::gamma_fn(x / 2.0 + 1.0);
+    let gamma = gamma_fn(x / 2.0 + 1.0);
     let pi_pow = std::f64::consts::PI.powf(shift);
     let result = pow2 * gamma / pi_pow;
     if result.is_nan() || result.is_infinite() {
@@ -927,7 +925,7 @@ pub fn divisor_sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
     }
     let val = crate::evaluator::apply_function_to_arg(func, &Expr::Integer(d))?;
-    sum = super::plus_ast(&[sum, val])?;
+    sum = plus_ast(&[sum, val])?;
   }
   Ok(sum)
 }
@@ -1357,7 +1355,7 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       (row, next) = (next, row);
     }
 
-    Ok(crate::functions::math_ast::bigint_to_expr(row[n].clone()))
+    Ok(bigint_to_expr(row[n].clone()))
   } else {
     // Bell polynomial B_n(x) = sum_{k=0}^{n} S(n,k) * x^k
     // where S(n,k) is the Stirling number of the second kind
@@ -1388,7 +1386,7 @@ pub fn bell_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         continue;
       }
       let is_one = s == one;
-      let coeff = crate::functions::math_ast::bigint_to_expr(s);
+      let coeff = bigint_to_expr(s);
       let term = if k == 0 {
         coeff
       } else if k == 1 {
@@ -1521,8 +1519,8 @@ pub fn catalan_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::Real(exact.to_f64().unwrap_or(f64::INFINITY)));
     }
     let z = *f;
-    let val = 4.0_f64.powf(z) * super::gamma_fn(z + 0.5)
-      / (std::f64::consts::PI.sqrt() * super::gamma_fn(z + 2.0));
+    let val = 4.0_f64.powf(z) * gamma_fn(z + 0.5)
+      / (std::f64::consts::PI.sqrt() * gamma_fn(z + 2.0));
     return Ok(Expr::Real(val));
   }
 
@@ -1542,7 +1540,7 @@ pub fn catalan_number_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // CatalanNumber[n] = Binomial[2n, n] / (n + 1), in BigInt so large results
   // (e.g. CatalanNumber[100], 57 digits) don't overflow i128.
   let result = binomial_coeff_big(2 * n, n) / BigInt::from(n + 1);
-  Ok(crate::functions::math_ast::bigint_to_expr(result))
+  Ok(bigint_to_expr(result))
 }
 
 /// StirlingS1[n, k] - Stirling number of the first kind (signed)
@@ -2550,8 +2548,7 @@ fn extract_gaussian_integer(expr: &Expr) -> Option<(i128, i128)> {
   if let Expr::Integer(n) = expr {
     return Some((*n, 0));
   }
-  let ((rn, rd), (in_, id)) =
-    crate::functions::math_ast::try_extract_complex_exact(expr)?;
+  let ((rn, rd), (in_, id)) = try_extract_complex_exact(expr)?;
   if rd == 1 && id == 1 {
     Some((rn, in_))
   } else {
@@ -4469,9 +4466,7 @@ pub fn binomial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     });
   }
   match (expr_to_i128(&args[0]), expr_to_i128(&args[1])) {
-    (Some(n), Some(k)) => Ok(crate::functions::math_ast::bigint_to_expr(
-      binomial_coeff_big(n, k),
-    )),
+    (Some(n), Some(k)) => Ok(bigint_to_expr(binomial_coeff_big(n, k))),
     (None, Some(k)) if k >= 0 => {
       // Generalized binomial for non-integer n with non-negative integer k:
       // Binomial[n, k] = n*(n-1)*...*(n-k+1) / k!
@@ -4483,29 +4478,28 @@ pub fn binomial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Compute falling factorial: n * (n-1) * ... * (n-k+1)
       let mut numer_factors: Vec<Expr> = Vec::with_capacity(k);
       for i in 0..k {
-        let factor =
-          super::plus_ast(&[args[0].clone(), Expr::Integer(-(i as i128))])?;
+        let factor = plus_ast(&[args[0].clone(), Expr::Integer(-(i as i128))])?;
         numer_factors.push(factor);
       }
-      let numer = super::times_ast(&numer_factors)?;
+      let numer = times_ast(&numer_factors)?;
       let mut denom_val: i128 = 1;
       for i in 1..=(k as i128) {
         denom_val *= i;
       }
       let denom = Expr::Integer(denom_val);
-      super::divide_ast(&[numer, denom])
+      divide_ast(&[numer, denom])
     }
     _ => {
       // Try Real evaluation using Gamma function
       let n_f64 = match &args[0] {
         Expr::Real(f) => Some(*f),
         Expr::Integer(n) => Some(*n as f64),
-        _ => crate::functions::math_ast::try_eval_to_f64(&args[0]),
+        _ => try_eval_to_f64(&args[0]),
       };
       let k_f64 = match &args[1] {
         Expr::Real(f) => Some(*f),
         Expr::Integer(n) => Some(*n as f64),
-        _ => crate::functions::math_ast::try_eval_to_f64(&args[1]),
+        _ => try_eval_to_f64(&args[1]),
       };
       if let (Some(n), Some(k)) = (n_f64, k_f64) {
         // A negative integer n (as a machine real) with a non-negative integer
@@ -4731,10 +4725,10 @@ pub fn multinomial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       total += n;
       result *= binomial_coeff_big(total, n);
     }
-    return Ok(crate::functions::math_ast::bigint_to_expr(result));
+    return Ok(bigint_to_expr(result));
   }
 
-  use crate::functions::math_ast::expr_to_rational;
+  use expr_to_rational;
   let symbolic_indices: Vec<usize> = (0..args.len())
     .filter(|&i| expr_to_rational(&args[i]).is_none())
     .collect();
@@ -5128,7 +5122,7 @@ pub fn prime_pi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     _ => {
       // Try to evaluate symbolic constants (Pi, E, etc.) to f64
-      if let Some(f) = crate::functions::math_ast::try_eval_to_f64(&args[0]) {
+      if let Some(f) = try_eval_to_f64(&args[0]) {
         if f < 2.0 {
           return Ok(Expr::Integer(0));
         }
@@ -9033,7 +9027,7 @@ fn six_j_symbol_symbolic(
       let forced = if v_2j.rem_euclid(2) == 0 {
         Expr::Integer(v_j)
       } else {
-        crate::functions::math_ast::make_rational(v_2j, 2)
+        make_rational(v_2j, 2)
       };
       new_items[k] = forced.clone();
       new_args[group] = Expr::List(new_items.into());
@@ -9185,7 +9179,7 @@ pub fn clebsch_gordan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let forced_m_expr = if two_m[idx].rem_euclid(2) == 0 {
       Expr::Integer(two_m[idx] / 2)
     } else {
-      crate::functions::math_ast::make_rational(two_m[idx], 2)
+      make_rational(two_m[idx], 2)
     };
     // Build the concrete-m args and recurse so all the existing
     // selection-rule machinery runs.
@@ -9313,7 +9307,7 @@ impl PipeThroughRational for Expr {
       if n.rem_euclid(denom) == 0 {
         return Expr::Integer(n / denom);
       }
-      return crate::functions::math_ast::make_rational(n, denom);
+      return make_rational(n, denom);
     }
     self
   }
@@ -9402,9 +9396,7 @@ pub fn fibonorial_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         a = b;
         b = next;
       }
-      Ok(crate::functions::math_ast::numeric_utils::bigint_to_expr(
-        product,
-      ))
+      Ok(bigint_to_expr(product))
     }
     Expr::Integer(_) => Ok(Expr::Identifier("ComplexInfinity".to_string())),
     _ if is_non_integer_number => {

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -446,18 +446,13 @@ pub fn try_eval_to_f64(expr: &Expr) -> Option<f64> {
       // numericizable (so N[FresnelF[1]] works).
       "FresnelF" | "FresnelG" if args.len() == 1 => {
         let x = try_eval_to_f64(&args[0])?;
-        Some(crate::functions::math_ast::integrals::fresnel_fg_numeric(
-          name == "FresnelF",
-          x,
-        ))
+        Some(fresnel_fg_numeric(name == "FresnelF", x))
       }
       // Champernowne constants: numeric (NumericQ True) but symbolic until
       // numericized.
       "ChampernowneNumber" if args.len() <= 1 => match args.first() {
-        None => Some(crate::functions::math_ast::champernowne_f64(10)),
-        Some(Expr::Integer(b)) if *b >= 2 => {
-          Some(crate::functions::math_ast::champernowne_f64(*b))
-        }
+        None => Some(champernowne_f64(10)),
+        Some(Expr::Integer(b)) if *b >= 2 => Some(champernowne_f64(*b)),
         _ => None,
       },
       // Stieltjes constants (machine-precision values from wolframscript)
@@ -524,25 +519,25 @@ pub fn try_eval_to_f64(expr: &Expr) -> Option<f64> {
       "BesselI" if args.len() == 2 => {
         let n = try_eval_to_f64(&args[0])?;
         let z = try_eval_to_f64(&args[1])?;
-        let v = crate::functions::math_ast::bessel::bessel_i(n, z);
+        let v = bessel_i(n, z);
         v.is_finite().then_some(v)
       }
       "BesselJ" if args.len() == 2 => {
         let n = try_eval_to_f64(&args[0])?;
         let z = try_eval_to_f64(&args[1])?;
-        let v = crate::functions::math_ast::bessel::bessel_j(n, z);
+        let v = bessel_j(n, z);
         v.is_finite().then_some(v)
       }
       "BesselK" if args.len() == 2 => {
         let n = try_eval_to_f64(&args[0])?;
         let z = try_eval_to_f64(&args[1])?;
-        let v = crate::functions::math_ast::bessel::bessel_k(n, z);
+        let v = bessel_k(n, z);
         v.is_finite().then_some(v)
       }
       "BesselY" if args.len() == 2 => {
         let n = try_eval_to_f64(&args[0])?;
         let z = try_eval_to_f64(&args[1])?;
-        let v = crate::functions::math_ast::bessel::bessel_y(n, z);
+        let v = bessel_y(n, z);
         v.is_finite().then_some(v)
       }
       "Sqrt" if args.len() == 1 => try_eval_to_f64(&args[0]).map(|v| v.sqrt()),
@@ -555,10 +550,10 @@ pub fn try_eval_to_f64(expr: &Expr) -> Option<f64> {
       "Erfi" if args.len() == 1 => try_eval_to_f64(&args[0]).map(erfi_f64),
       "DawsonF" if args.len() == 1 => try_eval_to_f64(&args[0]).map(dawson_f64),
       "FresnelS" if args.len() == 1 => {
-        try_eval_to_f64(&args[0]).map(super::fresnel_s_numeric)
+        try_eval_to_f64(&args[0]).map(fresnel_s_numeric)
       }
       "FresnelC" if args.len() == 1 => {
-        try_eval_to_f64(&args[0]).map(super::fresnel_c_numeric)
+        try_eval_to_f64(&args[0]).map(fresnel_c_numeric)
       }
       "InverseErf" if args.len() == 1 => {
         try_eval_to_f64(&args[0]).and_then(|v| {

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -135,12 +135,12 @@ pub fn n_eval(expr: &Expr) -> Result<Expr, InterpreterError> {
         && let Some(n) = expr_to_i128(&args[0])
       {
         if name == "AiryAiZero"
-          && let Some(r) = crate::functions::math_ast::airy_ai_zero_n_eval(n)
+          && let Some(r) = airy_ai_zero_n_eval(n)
         {
           return Ok(r);
         }
         if name == "AiryBiZero"
-          && let Some(r) = crate::functions::math_ast::airy_bi_zero_n_eval(n)
+          && let Some(r) = airy_bi_zero_n_eval(n)
         {
           return Ok(r);
         }
@@ -2830,10 +2830,8 @@ pub fn unitize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(Expr::List(results?.into()));
     }
 
-    let x_val =
-      crate::functions::math_ast::numeric_utils::try_eval_to_f64(&args[0]);
-    let tol_val =
-      crate::functions::math_ast::numeric_utils::try_eval_to_f64(&args[1]);
+    let x_val = try_eval_to_f64(&args[0]);
+    let tol_val = try_eval_to_f64(&args[1]);
     if let (Some(x), Some(tol)) = (x_val, tol_val) {
       if x.abs() < tol {
         return Ok(Expr::Integer(0));
@@ -2863,8 +2861,7 @@ pub fn unitize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Sqrt[2], 2*Pi, 3/4, Log[2], ...). Zero numeric results are
       // already handled because Pi - Pi etc. simplify symbolically
       // before reaching Unitize.
-      if let Some(v) =
-        crate::functions::math_ast::numeric_utils::try_eval_to_f64(&args[0])
+      if let Some(v) = try_eval_to_f64(&args[0])
         && v.is_finite()
         && v != 0.0
       {
@@ -3734,10 +3731,7 @@ pub fn linear_recurrence_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 fn warping_distance_value(a: &Expr, b: &Expr) -> Option<f64> {
   let to_vec = |e: &Expr| -> Option<Vec<f64>> {
     match e {
-      Expr::List(items) => items
-        .iter()
-        .map(crate::functions::math_ast::try_eval_to_f64)
-        .collect(),
+      Expr::List(items) => items.iter().map(try_eval_to_f64).collect(),
       _ => None,
     }
   };
@@ -3769,10 +3763,7 @@ fn warping_correspondence_path(
 ) -> Option<(Vec<i128>, Vec<i128>)> {
   let to_vec = |e: &Expr| -> Option<Vec<f64>> {
     match e {
-      Expr::List(items) => items
-        .iter()
-        .map(crate::functions::math_ast::try_eval_to_f64)
-        .collect(),
+      Expr::List(items) => items.iter().map(try_eval_to_f64).collect(),
       _ => None,
     }
   };
@@ -3846,7 +3837,7 @@ pub fn warping_correspondence_ast(
     None => {
       let is_numeric_vec = |e: &Expr| {
         matches!(e, Expr::List(items) if !items.is_empty()
-          && items.iter().all(|x| crate::functions::math_ast::try_eval_to_f64(x).is_some()))
+          && items.iter().all(|x| try_eval_to_f64(x).is_some()))
       };
       if let Some(bad) = args.iter().find(|a| !is_numeric_vec(a)) {
         crate::emit_message(&format!(
@@ -3869,7 +3860,7 @@ pub fn warping_distance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // wolframscript WarpingDistance::invarg message.
     let is_numeric_vec = |e: &Expr| {
       matches!(e, Expr::List(items) if !items.is_empty()
-        && items.iter().all(|x| crate::functions::math_ast::try_eval_to_f64(x).is_some()))
+        && items.iter().all(|x| try_eval_to_f64(x).is_some()))
     };
     if let Some(bad) = args.iter().find(|a| !is_numeric_vec(a)) {
       crate::emit_message(&format!(

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -252,21 +252,15 @@ fn jacobi_p_integer_ab(
   if n == 1 {
     let a_e = Expr::Integer(a);
     let b_e = Expr::Integer(b);
-    let two_plus_ab = crate::functions::math_ast::plus_ast(&[
-      Expr::Integer(2),
-      a_e.clone(),
-      b_e.clone(),
-    ])?;
-    let coeff_x =
-      crate::functions::math_ast::times_ast(&[two_plus_ab, x.clone()])?;
-    let neg_b =
-      crate::functions::math_ast::times_ast(&[Expr::Integer(-1), b_e])?;
-    let numer = crate::functions::math_ast::plus_ast(&[a_e, neg_b, coeff_x])?;
+    let two_plus_ab = plus_ast(&[Expr::Integer(2), a_e.clone(), b_e.clone()])?;
+    let coeff_x = times_ast(&[two_plus_ab, x.clone()])?;
+    let neg_b = times_ast(&[Expr::Integer(-1), b_e])?;
+    let numer = plus_ast(&[a_e, neg_b, coeff_x])?;
     let half = Expr::FunctionCall {
       name: "Rational".to_string(),
       args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
     };
-    return crate::functions::math_ast::times_ast(&[half, numer]);
+    return times_ast(&[half, numer]);
   }
 
   let ni = n as i128;
@@ -360,20 +354,19 @@ pub fn jacobi_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n_is_nonneg_integer = matches!(&args[0], Expr::Integer(n) if *n >= 0);
   let any_inexact = args.iter().any(|a| {
     matches!(a, Expr::Real(_) | Expr::BigFloat(_, _))
-      || crate::functions::math_ast::try_extract_complex_float(a)
-        .is_some_and(|(_, im)| im != 0.0)
+      || try_extract_complex_float(a).is_some_and(|(_, im)| im != 0.0)
   });
   if !n_is_nonneg_integer
     && any_inexact
     && let (Some(n_c), Some(a_c), Some(b_c), Some(z_c)) = (
-      crate::functions::math_ast::try_extract_complex_float(&args[0]),
-      crate::functions::math_ast::try_extract_complex_float(&args[1]),
-      crate::functions::math_ast::try_extract_complex_float(&args[2]),
-      crate::functions::math_ast::try_extract_complex_float(&args[3]),
+      try_extract_complex_float(&args[0]),
+      try_extract_complex_float(&args[1]),
+      try_extract_complex_float(&args[2]),
+      try_extract_complex_float(&args[3]),
     )
   {
     let (re, im) = jacobi_p_complex(n_c, a_c, b_c, z_c);
-    return Ok(crate::functions::math_ast::build_complex_float_expr(re, im));
+    return Ok(build_complex_float_expr(re, im));
   }
 
   let n = match &args[0] {
@@ -400,8 +393,7 @@ pub fn jacobi_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // (JacobiP[3, 1/2, 1/2, 1/3] = -245/432, not the float -0.5671…).
   let is_inexact = |e: &Expr| {
     matches!(e, Expr::Real(_) | Expr::BigFloat(_, _))
-      || crate::functions::math_ast::try_extract_complex_float(e)
-        .is_some_and(|(_, im)| im != 0.0)
+      || try_extract_complex_float(e).is_some_and(|(_, im)| im != 0.0)
   };
   let args_inexact =
     is_inexact(&args[1]) || is_inexact(&args[2]) || is_inexact(&args[3]);
@@ -425,19 +417,15 @@ pub fn jacobi_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let a = args[1].clone();
     let b = args[2].clone();
     let x = args[3].clone();
-    let two_plus_ab = crate::functions::math_ast::plus_ast(&[
-      Expr::Integer(2),
-      a.clone(),
-      b.clone(),
-    ])?;
-    let coeff_x = crate::functions::math_ast::times_ast(&[two_plus_ab, x])?;
-    let neg_b = crate::functions::math_ast::times_ast(&[Expr::Integer(-1), b])?;
-    let numer = crate::functions::math_ast::plus_ast(&[a, neg_b, coeff_x])?;
+    let two_plus_ab = plus_ast(&[Expr::Integer(2), a.clone(), b.clone()])?;
+    let coeff_x = times_ast(&[two_plus_ab, x])?;
+    let neg_b = times_ast(&[Expr::Integer(-1), b])?;
+    let numer = plus_ast(&[a, neg_b, coeff_x])?;
     let half = Expr::FunctionCall {
       name: "Rational".to_string(),
       args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
     };
-    return crate::functions::math_ast::times_ast(&[half, numer]);
+    return times_ast(&[half, numer]);
   }
 
   // n >= 2 with rational (non-integer) a, b and a non-numeric x: build the
@@ -574,12 +562,7 @@ pub fn legendre_p_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           || matches!(&args[1], Expr::Real(_));
         if any_real {
           let z = (1.0 - xf) / 2.0;
-          let value = crate::functions::math_ast::hypergeometric2f1(
-            -nu,
-            nu + 1.0,
-            1.0,
-            z,
-          );
+          let value = hypergeometric2f1(-nu, nu + 1.0, 1.0, z);
           return Ok(Expr::Real(value));
         }
       }
@@ -647,18 +630,17 @@ fn associated_legendre_p_ast(
     // real arithmetic (negative base, non-integer exponent).
     let any_inexact = [n_expr, m_expr, x_expr].iter().any(|a| {
       matches!(a, Expr::Real(_) | Expr::BigFloat(_, _))
-        || crate::functions::math_ast::try_extract_complex_float(a)
-          .is_some_and(|(_, im)| im != 0.0)
+        || try_extract_complex_float(a).is_some_and(|(_, im)| im != 0.0)
     });
     if any_inexact
       && let (Some(nc), Some(mc), Some(zc)) = (
-        crate::functions::math_ast::try_extract_complex_float(n_expr),
-        crate::functions::math_ast::try_extract_complex_float(m_expr),
-        crate::functions::math_ast::try_extract_complex_float(x_expr),
+        try_extract_complex_float(n_expr),
+        try_extract_complex_float(m_expr),
+        try_extract_complex_float(x_expr),
       )
     {
       let (re, im) = legendre_p_associated_complex(nc, mc, zc);
-      return Ok(crate::functions::math_ast::build_complex_float_expr(re, im));
+      return Ok(build_complex_float_expr(re, im));
     }
     return Ok(Expr::FunctionCall {
       name: "LegendreP".to_string(),
@@ -1654,48 +1636,33 @@ pub fn legendre_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // of ν / z is inexact and |z| > 1 (so the 2F1 series converges).
       let any_inexact = args.iter().any(|a| {
         matches!(a, Expr::Real(_) | Expr::BigFloat(_, _))
-          || crate::functions::math_ast::try_extract_complex_float(a)
-            .is_some_and(|(_, im)| im != 0.0)
+          || try_extract_complex_float(a).is_some_and(|(_, im)| im != 0.0)
       });
       if any_inexact
         && let (Some(nc), Some(zc)) = (
-          crate::functions::math_ast::try_extract_complex_float(&args[0]),
-          crate::functions::math_ast::try_extract_complex_float(&args[1]),
+          try_extract_complex_float(&args[0]),
+          try_extract_complex_float(&args[1]),
         )
         && (zc.0 * zc.0 + zc.1 * zc.1) > 1.0
       {
         let (re, im) = legendre_q_complex(nc, zc);
-        return Ok(crate::functions::math_ast::build_complex_float_expr(
-          re, im,
-        ));
+        return Ok(build_complex_float_expr(re, im));
       }
       // Real z with |z| < 1 and non-integer ν: type-2 LegendreQ on the cut.
       //   Q_ν(z) = (π / (2 sin(νπ))) · [P_ν(z) cos(νπ) − P_ν(−z)]
       // with P_ν(z) = 2F1(-ν, ν+1; 1; (1-z)/2). The formula is singular at
       // integer ν, but the integer-ν path is already handled above.
       if any_inexact
-        && let (Some(nu), Some(xf)) = (
-          crate::functions::math_ast::try_eval_to_f64(&args[0]),
-          crate::functions::math_ast::try_eval_to_f64(&args[1]),
-        )
+        && let (Some(nu), Some(xf)) =
+          (try_eval_to_f64(&args[0]), try_eval_to_f64(&args[1]))
         && xf.abs() < 1.0
       {
         let pi = std::f64::consts::PI;
         let sin_nu_pi = (nu * pi).sin();
         if sin_nu_pi.abs() > 1e-12 {
           let cos_nu_pi = (nu * pi).cos();
-          let p_z = crate::functions::math_ast::hypergeometric2f1(
-            -nu,
-            nu + 1.0,
-            1.0,
-            (1.0 - xf) / 2.0,
-          );
-          let p_negz = crate::functions::math_ast::hypergeometric2f1(
-            -nu,
-            nu + 1.0,
-            1.0,
-            (1.0 + xf) / 2.0,
-          );
+          let p_z = hypergeometric2f1(-nu, nu + 1.0, 1.0, (1.0 - xf) / 2.0);
+          let p_negz = hypergeometric2f1(-nu, nu + 1.0, 1.0, (1.0 + xf) / 2.0);
           let q = pi / (2.0 * sin_nu_pi) * (p_z * cos_nu_pi - p_negz);
           return Ok(Expr::Real(q));
         }
@@ -1828,7 +1795,6 @@ fn legendre_q_symbolic_ast(
 /// `Q_ν(z) = Q_real(z) − (i π/2) · P_ν(z)` where
 /// `Q_real(z) = √π/2 · Γ(ν+1) / (2^ν · Γ(ν+3/2) · z^(ν+1)) · 2F1(…)`.
 fn legendre_q_complex(n: (f64, f64), z: (f64, f64)) -> (f64, f64) {
-  use crate::functions::math_ast::zeta_functions::gamma_complex;
   let cmul = |(ar, ai): (f64, f64), (br, bi): (f64, f64)| {
     (ar * br - ai * bi, ar * bi + ai * br)
   };
@@ -1864,13 +1830,12 @@ fn legendre_q_complex(n: (f64, f64), z: (f64, f64)) -> (f64, f64) {
   let prefactor = cmul(sqrt_pi_half, prefactor);
 
   let inv_z_sq = cdiv((1.0, 0.0), cmul(z, z));
-  let f =
-    crate::functions::math_ast::hypergeometric::hypergeometric_2f1_complex(
-      ((n.0 + 1.0) / 2.0, n.1 / 2.0),
-      ((n.0 + 2.0) / 2.0, n.1 / 2.0),
-      n_plus_three_half,
-      inv_z_sq,
-    );
+  let f = hypergeometric_2f1_complex(
+    ((n.0 + 1.0) / 2.0, n.1 / 2.0),
+    ((n.0 + 2.0) / 2.0, n.1 / 2.0),
+    n_plus_three_half,
+    inv_z_sq,
+  );
   let q_real = cmul(prefactor, f);
 
   // Subtract (iπ/2) · P_ν(z). Reuse the existing Legendre P numeric path
@@ -1898,22 +1863,21 @@ fn legendre_q_associated_ast(
   };
   let any_inexact = [n_expr, m_expr, z_expr].iter().any(|a| {
     matches!(a, Expr::Real(_) | Expr::BigFloat(_, _))
-      || crate::functions::math_ast::try_extract_complex_float(a)
-        .is_some_and(|(_, im)| im != 0.0)
+      || try_extract_complex_float(a).is_some_and(|(_, im)| im != 0.0)
   });
   if !any_inexact {
     return Ok(unevaluated());
   }
   let (n, m, z) = match (
-    crate::functions::math_ast::try_extract_complex_float(n_expr),
-    crate::functions::math_ast::try_extract_complex_float(m_expr),
-    crate::functions::math_ast::try_extract_complex_float(z_expr),
+    try_extract_complex_float(n_expr),
+    try_extract_complex_float(m_expr),
+    try_extract_complex_float(z_expr),
   ) {
     (Some(n), Some(m), Some(z)) => (n, m, z),
     _ => return Ok(unevaluated()),
   };
   let (re, im) = legendre_q_associated_complex(n, m, z);
-  Ok(crate::functions::math_ast::build_complex_float_expr(re, im))
+  Ok(build_complex_float_expr(re, im))
 }
 
 /// Compute LegendreP[ν, μ, z] (Ferrers form) for complex/inexact args
@@ -1924,7 +1888,6 @@ fn legendre_p_associated_value_complex(
   m: (f64, f64),
   z: (f64, f64),
 ) -> (f64, f64) {
-  use crate::functions::math_ast::zeta_functions::gamma_complex;
   let cmul = |(ar, ai): (f64, f64), (br, bi): (f64, f64)| {
     (ar * br - ai * bi, ar * bi + ai * br)
   };
@@ -1952,13 +1915,12 @@ fn legendre_p_associated_value_complex(
   let neg_n = (-n.0, -n.1);
   let n_plus_one = (n.0 + 1.0, n.1);
   let half_one_minus_z = (0.5 - 0.5 * z.0, -0.5 * z.1);
-  let f =
-    crate::functions::math_ast::hypergeometric::hypergeometric_2f1_complex(
-      neg_n,
-      n_plus_one,
-      one_minus_m,
-      half_one_minus_z,
-    );
+  let f = hypergeometric_2f1_complex(
+    neg_n,
+    n_plus_one,
+    one_minus_m,
+    half_one_minus_z,
+  );
   cmul(cmul(g_inv, pow_term), f)
 }
 
@@ -1973,7 +1935,6 @@ fn legendre_q_associated_complex(
   m: (f64, f64),
   z: (f64, f64),
 ) -> (f64, f64) {
-  use crate::functions::math_ast::zeta_functions::gamma_complex;
   let cmul = |(ar, ai): (f64, f64), (br, bi): (f64, f64)| {
     (ar * br - ai * bi, ar * bi + ai * br)
   };
@@ -2011,12 +1972,7 @@ fn legendre_p_value_complex(n: (f64, f64), z: (f64, f64)) -> (f64, f64) {
   let neg_n = (-n.0, -n.1);
   let n_plus_one = (n.0 + 1.0, n.1);
   let half_one_minus_z = (0.5 - 0.5 * z.0, -0.5 * z.1);
-  crate::functions::math_ast::hypergeometric::hypergeometric_2f1_complex(
-    neg_n,
-    n_plus_one,
-    (1.0, 0.0),
-    half_one_minus_z,
-  )
+  hypergeometric_2f1_complex(neg_n, n_plus_one, (1.0, 0.0), half_one_minus_z)
 }
 
 /// Evaluate Q_n(x) numerically using recurrence
@@ -2688,19 +2644,18 @@ pub fn gegenbauer_c_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let n_is_nonneg_integer = matches!(&args[0], Expr::Integer(n) if *n >= 0);
   let any_inexact = args.iter().any(|a| {
     matches!(a, Expr::Real(_) | Expr::BigFloat(_, _))
-      || crate::functions::math_ast::try_extract_complex_float(a)
-        .is_some_and(|(_, im)| im != 0.0)
+      || try_extract_complex_float(a).is_some_and(|(_, im)| im != 0.0)
   });
   if !n_is_nonneg_integer
     && any_inexact
     && let (Some(n_c), Some(lam_c), Some(z_c)) = (
-      crate::functions::math_ast::try_extract_complex_float(&args[0]),
-      crate::functions::math_ast::try_extract_complex_float(&args[1]),
-      crate::functions::math_ast::try_extract_complex_float(&args[2]),
+      try_extract_complex_float(&args[0]),
+      try_extract_complex_float(&args[1]),
+      try_extract_complex_float(&args[2]),
     )
   {
     let (re, im) = gegenbauer_c_complex(n_c, lam_c, z_c);
-    return Ok(crate::functions::math_ast::build_complex_float_expr(re, im));
+    return Ok(build_complex_float_expr(re, im));
   }
 
   let n = match &args[0] {
@@ -2940,7 +2895,6 @@ fn legendre_p_associated_complex(
   m: (f64, f64),
   z: (f64, f64),
 ) -> (f64, f64) {
-  use crate::functions::math_ast::zeta_functions::gamma_complex;
   let cmul = |(ar, ai): (f64, f64), (br, bi): (f64, f64)| {
     (ar * br - ai * bi, ar * bi + ai * br)
   };
@@ -2977,13 +2931,12 @@ fn legendre_p_associated_complex(
   let neg_n = (-n.0, -n.1);
   let n_plus_one = (n.0 + 1.0, n.1);
   let half_one_minus_z = (0.5 - 0.5 * z.0, -0.5 * z.1);
-  let f =
-    crate::functions::math_ast::hypergeometric::hypergeometric_2f1_complex(
-      neg_n,
-      n_plus_one,
-      one_minus_m,
-      half_one_minus_z,
-    );
+  let f = hypergeometric_2f1_complex(
+    neg_n,
+    n_plus_one,
+    one_minus_m,
+    half_one_minus_z,
+  );
   cmul(cmul(g_inv, pow_term), f)
 }
 
@@ -2995,7 +2948,6 @@ fn jacobi_p_complex(
   b: (f64, f64),
   z: (f64, f64),
 ) -> (f64, f64) {
-  use crate::functions::math_ast::zeta_functions::gamma_complex;
   let cmul = |(ar, ai): (f64, f64), (br, bi): (f64, f64)| {
     (ar * br - ai * bi, ar * bi + ai * br)
   };
@@ -3014,13 +2966,12 @@ fn jacobi_p_complex(
   let neg_n = (-n.0, -n.1);
   let n_plus_ab_plus_1 = (n.0 + a.0 + b.0 + 1.0, n.1 + a.1 + b.1);
   let half_one_minus_z = (0.5 - 0.5 * z.0, -0.5 * z.1);
-  let f =
-    crate::functions::math_ast::hypergeometric::hypergeometric_2f1_complex(
-      neg_n,
-      n_plus_ab_plus_1,
-      a_plus_one,
-      half_one_minus_z,
-    );
+  let f = hypergeometric_2f1_complex(
+    neg_n,
+    n_plus_ab_plus_1,
+    a_plus_one,
+    half_one_minus_z,
+  );
   cmul(prefactor, f)
 }
 
@@ -3032,7 +2983,6 @@ fn gegenbauer_c_complex(
   lam: (f64, f64),
   z: (f64, f64),
 ) -> (f64, f64) {
-  use crate::functions::math_ast::zeta_functions::gamma_complex;
   let cmul = |(ar, ai): (f64, f64), (br, bi): (f64, f64)| {
     (ar * br - ai * bi, ar * bi + ai * br)
   };
@@ -3052,13 +3002,12 @@ fn gegenbauer_c_complex(
   let n_plus_two_lam = (n.0 + two_lam.0, n.1 + two_lam.1);
   let lam_plus_half = (lam.0 + 0.5, lam.1);
   let half_one_minus_z = (0.5 - 0.5 * z.0, -0.5 * z.1);
-  let f =
-    crate::functions::math_ast::hypergeometric::hypergeometric_2f1_complex(
-      neg_n,
-      n_plus_two_lam,
-      lam_plus_half,
-      half_one_minus_z,
-    );
+  let f = hypergeometric_2f1_complex(
+    neg_n,
+    n_plus_two_lam,
+    lam_plus_half,
+    half_one_minus_z,
+  );
   cmul(prefactor, f)
 }
 
@@ -3441,8 +3390,7 @@ fn generalized_laguerre_l_ast(
   // below (LaguerreL[3, 1/2, 1/3] = 1189/1296, not the float 0.9174…).
   let is_inexact = |e: &Expr| {
     matches!(e, Expr::Real(_) | Expr::BigFloat(_, _))
-      || crate::functions::math_ast::try_extract_complex_float(e)
-        .is_some_and(|(_, im)| im != 0.0)
+      || try_extract_complex_float(e).is_some_and(|(_, im)| im != 0.0)
   };
   if (is_inexact(a_expr) || is_inexact(x_expr))
     && let (Some(af), Some(xf)) =

--- a/src/functions/math_ast/polylog.rs
+++ b/src/functions/math_ast/polylog.rs
@@ -35,7 +35,7 @@ pub fn polylog_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // any exact numeric (an integer, a Rational such as 1/2, or a constant
       // expression like Pi/4) — not only Integer/Real. `PolyLog[2., 1/2]` must
       // evaluate, matching wolframscript.
-      if let Some(zf) = crate::functions::math_ast::try_eval_to_f64(z_expr) {
+      if let Some(zf) = try_eval_to_f64(z_expr) {
         return Ok(Expr::Real(polylog_numeric(*sf, zf)));
       }
     }

--- a/src/functions/math_ast/random.rs
+++ b/src/functions/math_ast/random.rs
@@ -606,7 +606,7 @@ fn quantity_span_seconds(expr: &Expr) -> Option<f64> {
   if name != "Quantity" || args.len() != 2 {
     return None;
   }
-  let value = crate::functions::math_ast::try_eval_to_f64(&args[0])?;
+  let value = try_eval_to_f64(&args[0])?;
   let unit = match &args[1] {
     Expr::String(s) => s.as_str(),
     Expr::Identifier(s) => s.as_str(),
@@ -642,7 +642,7 @@ fn time_object_span(expr: &Expr) -> Option<(f64, f64)> {
   }
   let mut secs = [0.0f64; 3];
   for (i, c) in comps.iter().enumerate() {
-    secs[i] = crate::functions::math_ast::try_eval_to_f64(c)?;
+    secs[i] = try_eval_to_f64(c)?;
   }
   let start = (secs[0] * 3600.0 + secs[1] * 60.0 + secs[2]).rem_euclid(86400.0);
   let granularity = match args.get(1) {
@@ -1752,11 +1752,11 @@ pub fn random_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && name == "BernoulliGraphDistribution"
     && bargs.len() == 2
   {
-    let n = match crate::functions::math_ast::expr_to_i128(&bargs[0]) {
+    let n = match expr_to_i128(&bargs[0]) {
       Some(n) if n >= 0 => n as usize,
       _ => return Ok(unevaluated()),
     };
-    let p = match crate::functions::math_ast::try_eval_to_f64(&bargs[1]) {
+    let p = match try_eval_to_f64(&bargs[1]) {
       Some(p) if (0.0..=1.0).contains(&p) => p,
       _ => return Ok(unevaluated()),
     };
@@ -1792,10 +1792,7 @@ pub fn random_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let (n, m) = match positional[0] {
     Expr::List(items) if items.len() == 2 => {
-      match (
-        crate::functions::math_ast::expr_to_i128(&items[0]),
-        crate::functions::math_ast::expr_to_i128(&items[1]),
-      ) {
+      match (expr_to_i128(&items[0]), expr_to_i128(&items[1])) {
         (Some(n), Some(m)) if n >= 0 && m >= 0 => (n as usize, m as usize),
         _ => return Ok(unevaluated()),
       }
@@ -1811,7 +1808,7 @@ pub fn random_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let k = match positional.len() {
     1 => None,
-    2 => match crate::functions::math_ast::expr_to_i128(positional[1]) {
+    2 => match expr_to_i128(positional[1]) {
       Some(k) if k >= 0 => Some(k as usize),
       _ => return Ok(unevaluated()),
     },

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -843,7 +843,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Invalid parameters (e.g. BenktanderGibratDistribution[1, 2]) emit a
       // message and leave the call unevaluated, matching wolframscript;
       // they must not surface as an evaluation error.
-      match super::distributions::distribution_mean_variance(dist_name, dargs) {
+      match distribution_mean_variance(dist_name, dargs) {
         Ok((mean, _)) => crate::evaluator::evaluate_expr_to_expr(&mean),
         Err(_) => Ok(unevaluated("Mean", args)),
       }
@@ -852,7 +852,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "JohnsonDistribution" => {
-      match super::distributions::distribution_mean_variance(dist_name, dargs) {
+      match distribution_mean_variance(dist_name, dargs) {
         Ok((mean, _)) => crate::evaluator::evaluate_expr_to_expr(&mean),
         Err(_) => Ok(Expr::FunctionCall {
           name: "Mean".to_string(),
@@ -867,10 +867,10 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::FunctionCall {
       name: dist_name, ..
     } if dist_name == "CensoredDistribution"
-      && super::distributions::censored_mean_variance(&args[0])?.is_some() =>
+      && censored_mean_variance(&args[0])?.is_some() =>
     {
       Ok(
-        super::distributions::censored_mean_variance(&args[0])?
+        censored_mean_variance(&args[0])?
           .expect("checked in the guard")
           .0,
       )
@@ -878,10 +878,10 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::FunctionCall {
       name: dist_name, ..
     } if dist_name == "TruncatedDistribution"
-      && super::distributions::truncated_mean_variance(&args[0])?.is_some() =>
+      && truncated_mean_variance(&args[0])?.is_some() =>
     {
       Ok(
-        super::distributions::truncated_mean_variance(&args[0])?
+        truncated_mean_variance(&args[0])?
           .expect("checked in the guard")
           .0,
       )
@@ -903,15 +903,14 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "MultinomialDistribution" => {
-      let (mean, _) = super::distributions::multinomial_mean_variance(dargs)?;
+      let (mean, _) = multinomial_mean_variance(dargs)?;
       Ok(mean)
     }
     Expr::FunctionCall {
       name: dist_name,
       args: dargs,
     } if dist_name == "NegativeMultinomialDistribution" => {
-      let (mean, _) =
-        super::distributions::negative_multinomial_mean_variance(dargs)?;
+      let (mean, _) = negative_multinomial_mean_variance(dargs)?;
       Ok(mean)
     }
     Expr::FunctionCall {
@@ -920,7 +919,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } if dist_name == "WishartMatrixDistribution" && dargs.len() == 2 => {
       // Invalid parameters have already emitted their message; the call
       // stays unevaluated.
-      match super::distributions::wishart_mean_variance(dargs) {
+      match wishart_mean_variance(dargs) {
         Ok((mean, _)) => Ok(mean),
         Err(_) => Ok(unevaluated("Mean", args)),
       }
@@ -929,7 +928,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "FirstPassageTimeDistribution" && dargs.len() == 2 => {
-      match super::distributions::fptd_mean(dargs)? {
+      match fptd_mean(dargs)? {
         Some(mean) => Ok(mean),
         None => Ok(unevaluated("Mean", args)),
       }
@@ -941,7 +940,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Mean of a Markov chain's stationary distribution: Σ k π_k.
       if let Expr::FunctionCall { name, args: mp } = &dargs[0]
         && name == "DiscreteMarkovProcess"
-        && let Some(mean) = super::distributions::dmp_stationary_mean(mp)?
+        && let Some(mean) = dmp_stationary_mean(mp)?
       {
         return Ok(mean);
       }
@@ -963,15 +962,14 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "DirichletDistribution" => {
-      let (mean, _) = super::distributions::dirichlet_mean_variance(dargs)?;
+      let (mean, _) = dirichlet_mean_variance(dargs)?;
       Ok(mean)
     }
     Expr::FunctionCall {
       name: dist_name,
       args: dargs,
     } if dist_name == "MultivariatePoissonDistribution" => {
-      let (mean, _) =
-        super::distributions::multivariate_poisson_mean_variance(dargs)?;
+      let (mean, _) = multivariate_poisson_mean_variance(dargs)?;
       Ok(mean)
     }
     Expr::FunctionCall {
@@ -979,7 +977,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: dargs,
     } if dist_name == "BinormalDistribution" => {
       // Mean[BinormalDistribution[{m1, m2}, …]] = {m1, m2}.
-      match super::distributions::binormal_params(dargs) {
+      match binormal_params(dargs) {
         Some((m1, m2, ..)) => Ok(Expr::List(vec![m1, m2].into())),
         None => Ok(unevaluated("Mean", args)),
       }
@@ -1002,9 +1000,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Random-process time slices delegate to their slice distribution.
     Expr::CurriedCall { func, args: targs } if targs.len() == 1 => {
       if let Expr::FunctionCall { name, args: dargs } = func.as_ref()
-        && let Some(slice) = super::distributions::process_slice_distribution(
-          name, dargs, &targs[0],
-        )
+        && let Some(slice) = process_slice_distribution(name, dargs, &targs[0])
       {
         return mean_ast(&[slice]);
       }
@@ -1115,14 +1111,10 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some(uneval) = rectt_if_ragged("Variance", args) {
     return Ok(uneval);
   }
-  if let Some((_, variance)) =
-    super::distributions::truncated_mean_variance(&args[0])?
-  {
+  if let Some((_, variance)) = truncated_mean_variance(&args[0])? {
     return Ok(variance);
   }
-  if let Some((_, variance)) =
-    super::distributions::censored_mean_variance(&args[0])?
-  {
+  if let Some((_, variance)) = censored_mean_variance(&args[0])? {
     return Ok(variance);
   }
   match &args[0] {
@@ -1170,9 +1162,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let sum_sq: BigInt = int_vals.iter().map(|x| x * x).sum();
         let numer = &n * &sum_sq - &sum * &sum;
         let denom = &n * (&n - BigInt::from(1));
-        return Ok(crate::functions::math_ast::make_rational_expr(
-          numer, denom,
-        ));
+        return Ok(make_rational_expr(numer, denom));
       }
       let _ = has_real;
       if !all_int {
@@ -1299,7 +1289,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       // Invalid parameters emit a message and leave the call unevaluated
       // (matching wolframscript), never an evaluation error.
-      match super::distributions::distribution_mean_variance(dist_name, dargs) {
+      match distribution_mean_variance(dist_name, dargs) {
         Ok((_, variance)) => crate::evaluator::evaluate_expr_to_expr(&variance),
         Err(_) => Ok(unevaluated("Variance", args)),
       }
@@ -1308,7 +1298,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "JohnsonDistribution" => {
-      match super::distributions::distribution_mean_variance(dist_name, dargs) {
+      match distribution_mean_variance(dist_name, dargs) {
         Ok((_, variance)) => crate::evaluator::evaluate_expr_to_expr(&variance),
         Err(_) => Ok(Expr::FunctionCall {
           name: "Variance".to_string(),
@@ -1335,16 +1325,14 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "MultinomialDistribution" => {
-      let (_, variance) =
-        super::distributions::multinomial_mean_variance(dargs)?;
+      let (_, variance) = multinomial_mean_variance(dargs)?;
       Ok(variance)
     }
     Expr::FunctionCall {
       name: dist_name,
       args: dargs,
     } if dist_name == "NegativeMultinomialDistribution" => {
-      let (_, variance) =
-        super::distributions::negative_multinomial_mean_variance(dargs)?;
+      let (_, variance) = negative_multinomial_mean_variance(dargs)?;
       Ok(variance)
     }
     Expr::FunctionCall {
@@ -1353,7 +1341,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } if dist_name == "WishartMatrixDistribution" && dargs.len() == 2 => {
       // Invalid parameters have already emitted their message; the call
       // stays unevaluated.
-      match super::distributions::wishart_mean_variance(dargs) {
+      match wishart_mean_variance(dargs) {
         Ok((_, variance)) => Ok(variance),
         Err(_) => Ok(unevaluated("Variance", args)),
       }
@@ -1362,7 +1350,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "FirstPassageTimeDistribution" && dargs.len() == 2 => {
-      match super::distributions::fptd_variance(dargs)? {
+      match fptd_variance(dargs)? {
         Some(variance) => Ok(variance),
         None => Ok(unevaluated("Variance", args)),
       }
@@ -1381,15 +1369,14 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: dist_name,
       args: dargs,
     } if dist_name == "DirichletDistribution" => {
-      let (_, variance) = super::distributions::dirichlet_mean_variance(dargs)?;
+      let (_, variance) = dirichlet_mean_variance(dargs)?;
       Ok(variance)
     }
     Expr::FunctionCall {
       name: dist_name,
       args: dargs,
     } if dist_name == "MultivariatePoissonDistribution" => {
-      let (_, variance) =
-        super::distributions::multivariate_poisson_mean_variance(dargs)?;
+      let (_, variance) = multivariate_poisson_mean_variance(dargs)?;
       Ok(variance)
     }
     Expr::FunctionCall {
@@ -1397,7 +1384,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       args: dargs,
     } if dist_name == "BinormalDistribution" => {
       // Variance[BinormalDistribution[…, {s1, s2}, …]] = {s1^2, s2^2}.
-      match super::distributions::binormal_params(dargs) {
+      match binormal_params(dargs) {
         Some((_, _, s1, s2, _)) => {
           let sq = |s: Expr| binop(BinaryOperator::Power, s, Expr::Integer(2));
           crate::evaluator::evaluate_expr_to_expr(&Expr::List(
@@ -1423,9 +1410,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Random-process time slices delegate to their slice distribution.
     Expr::CurriedCall { func, args: targs } if targs.len() == 1 => {
       if let Expr::FunctionCall { name, args: dargs } = func.as_ref()
-        && let Some(slice) = super::distributions::process_slice_distribution(
-          name, dargs, &targs[0],
-        )
+        && let Some(slice) = process_slice_distribution(name, dargs, &targs[0])
       {
         return variance_ast(&[slice]);
       }
@@ -1538,8 +1523,7 @@ pub fn standard_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // symbolic sigma of unknown sign.
   if let Expr::FunctionCall { name, args: dargs } = &args[0]
     && name == "BinormalDistribution"
-    && let Some((_, _, s1, s2, _)) =
-      super::distributions::binormal_params(dargs)
+    && let Some((_, _, s1, s2, _)) = binormal_params(dargs)
   {
     return Ok(Expr::List(vec![s1, s2].into()));
   }
@@ -1845,12 +1829,12 @@ pub fn geometric_mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         .any(|i| matches!(i, Expr::Real(_) | Expr::BigFloat(_, _)));
       // Exact path: if all elements are exact (integers or rationals),
       // compute product symbolically and return Power[product, 1/n]
-      let product = super::times_ast(items);
+      let product = times_ast(items);
       if let Ok(ref prod) = product
         && !has_real
       {
-        let exponent = super::make_rational(1, n);
-        return super::power_two(prod, &exponent);
+        let exponent = make_rational(1, n);
+        return power_two(prod, &exponent);
       }
       // Float path
       let mut vals = Vec::new();
@@ -2319,7 +2303,7 @@ pub fn covariance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && let Expr::FunctionCall { name, args: dargs } = &args[0]
     && name == "DirichletDistribution"
   {
-    return super::distributions::dirichlet_covariance(dargs);
+    return dirichlet_covariance(dargs);
   }
 
   // Covariance[NegativeMultinomialDistribution[n, {p1, …}]] is the k×k
@@ -2328,7 +2312,7 @@ pub fn covariance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && let Expr::FunctionCall { name, args: dargs } = &args[0]
     && name == "NegativeMultinomialDistribution"
   {
-    return super::distributions::negative_multinomial_covariance(dargs);
+    return negative_multinomial_covariance(dargs);
   }
 
   // Covariance[BinormalDistribution[…, {s1, s2}, rho]] is the 2×2 covariance
@@ -2336,8 +2320,7 @@ pub fn covariance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() == 1
     && let Expr::FunctionCall { name, args: dargs } = &args[0]
     && name == "BinormalDistribution"
-    && let Some((_, _, s1, s2, rho)) =
-      super::distributions::binormal_params(dargs)
+    && let Some((_, _, s1, s2, rho)) = binormal_params(dargs)
   {
     use BinaryOperator as B;
     let sq = |s: Expr| binop(B::Power, s, Expr::Integer(2));
@@ -2472,10 +2455,8 @@ fn transpose_rows(rows: &[Expr]) -> Option<Vec<Vec<Expr>>> {
 /// Returns `None` if any element is non-numeric.
 fn average_ranks(items: &[Expr]) -> Option<Vec<Expr>> {
   let n = items.len();
-  let vals: Vec<f64> = items
-    .iter()
-    .map(crate::functions::math_ast::try_eval_to_f64)
-    .collect::<Option<_>>()?;
+  let vals: Vec<f64> =
+    items.iter().map(try_eval_to_f64).collect::<Option<_>>()?;
   let mut order: Vec<usize> = (0..n).collect();
   order.sort_by(|&a, &b| {
     vals[a]
@@ -2492,7 +2473,7 @@ fn average_ranks(items: &[Expr]) -> Option<Vec<Expr>> {
     // Positions i+1 ..= j+1 (1-based); shared rank = mean of positions.
     let count = (j - i + 1) as i128;
     let sum_pos: i128 = ((i as i128 + 1)..=(j as i128 + 1)).sum();
-    let rank = crate::functions::math_ast::make_rational(sum_pos, count);
+    let rank = make_rational(sum_pos, count);
     for &idx in &order[i..=j] {
       ranks[idx] = rank.clone();
     }
@@ -2558,12 +2539,8 @@ pub fn kendall_tau_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => return rctneqln(),
   };
   let (Some(xf), Some(yf)) = (
-    x.iter()
-      .map(crate::functions::math_ast::try_eval_to_f64)
-      .collect::<Option<Vec<f64>>>(),
-    y.iter()
-      .map(crate::functions::math_ast::try_eval_to_f64)
-      .collect::<Option<Vec<f64>>>(),
+    x.iter().map(try_eval_to_f64).collect::<Option<Vec<f64>>>(),
+    y.iter().map(try_eval_to_f64).collect::<Option<Vec<f64>>>(),
   ) else {
     return rctneqln();
   };
@@ -2722,9 +2699,7 @@ pub fn hoeffding_d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
   let to_f64s = |v: &[Expr]| -> Option<Vec<f64>> {
-    v.iter()
-      .map(crate::functions::math_ast::try_eval_to_f64)
-      .collect()
+    v.iter().map(try_eval_to_f64).collect()
   };
   let has_real = |v: &[Expr]| {
     v.iter()
@@ -2844,9 +2819,7 @@ fn rank_statistic_forms(
     unevaluated()
   };
   let to_f64s = |v: &[Expr]| -> Option<Vec<f64>> {
-    v.iter()
-      .map(crate::functions::math_ast::try_eval_to_f64)
-      .collect()
+    v.iter().map(try_eval_to_f64).collect()
   };
   let has_real = |v: &[Expr]| {
     v.iter()
@@ -4232,17 +4205,15 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // A truncated distribution maps the requested quantile onto the base
   // distribution's scale.
   if args.len() == 2
-    && let Some(value) = super::distributions::truncated_distribution_value(
-      "Quantile", &args[0], &args[1],
-    )?
+    && let Some(value) =
+      truncated_distribution_value("Quantile", &args[0], &args[1])?
   {
     return Ok(value);
   }
   // A censored distribution clamps the base quantile to the range.
   if args.len() == 2
-    && let Some(value) = super::distributions::censored_distribution_value(
-      "Quantile", &args[0], &args[1],
-    )?
+    && let Some(value) =
+      censored_distribution_value("Quantile", &args[0], &args[1])?
   {
     return Ok(value);
   }
@@ -4251,7 +4222,7 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // result). For plain data a symbolic q is also rejected, whereas a
   // distribution accepts a symbolic q (yielding a ConditionalExpression).
   let q_invalid = |e: &Expr, data_is_list: bool| -> bool {
-    match crate::functions::math_ast::try_eval_to_f64(e) {
+    match try_eval_to_f64(e) {
       Some(v) => !(0.0..=1.0).contains(&v),
       None => data_is_list,
     }
@@ -4275,7 +4246,7 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     let gamma = Expr::FunctionCall {
       name: "GammaDistribution".to_string(),
-      args: super::distributions::erlang_gamma_dargs(dargs)?.into(),
+      args: erlang_gamma_dargs(dargs)?.into(),
     };
     let mut new_args = args.to_vec();
     new_args[0] = gamma;
@@ -4287,7 +4258,7 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && args.len() == 2
     && !matches!(&args[1], Expr::List(_))
   {
-    return super::distributions::wakeby_quantile(dargs, &args[1]);
+    return wakeby_quantile(dargs, &args[1]);
   }
   // Quantile[dist, {p1, p2, ...}] for a distribution head threads over the
   // probability list (the second argument of Quantile is always a scalar
@@ -4360,16 +4331,11 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // then fall back to the numerical CDF-inversion for ProbabilityDistribution.
   if let Expr::FunctionCall { name, args: dargs } = &args[0] {
     if let Some(result) =
-      crate::functions::math_ast::distributions::quantile_distribution_closed_form(
-        name, dargs, &args[1],
-      )
+      quantile_distribution_closed_form(name, dargs, &args[1])
     {
       return Ok(result);
     }
-    if let Some(result) =
-      crate::functions::math_ast::quantile_distribution_numeric(
-        name, dargs, &args[1],
-      )?
+    if let Some(result) = quantile_distribution_numeric(name, dargs, &args[1])?
     {
       return Ok(result);
     }
@@ -7178,9 +7144,7 @@ pub fn biweight_midvariance_ast(
   }
   let c = match args.get(1) {
     None => Expr::Integer(9),
-    Some(e) if crate::functions::math_ast::try_eval_to_f64(e).is_some() => {
-      e.clone()
-    }
+    Some(e) if try_eval_to_f64(e).is_some() => e.clone(),
     _ => return unevaluated(),
   };
   let ev = crate::evaluator::evaluate_expr_to_expr;
@@ -7199,7 +7163,7 @@ pub fn biweight_midvariance_ast(
     })
     .collect();
   let mad = ev(&call("Median", vec![Expr::List(deviations.into())]))?;
-  match crate::functions::math_ast::try_eval_to_f64(&mad) {
+  match try_eval_to_f64(&mad) {
     Some(v) if v != 0.0 => {}
     Some(_) => return Ok(Expr::Identifier("Indeterminate".to_string())),
     None => return unevaluated(),
@@ -7210,7 +7174,7 @@ pub fn biweight_midvariance_ast(
   for x in items.iter() {
     let dev = binop(BinaryOperator::Minus, x.clone(), median.clone());
     let u = ev(&binop(BinaryOperator::Divide, dev.clone(), scale.clone()))?;
-    let Some(u_f) = crate::functions::math_ast::try_eval_to_f64(&u) else {
+    let Some(u_f) = try_eval_to_f64(&u) else {
       return unevaluated();
     };
     if u_f.abs() >= 1.0 {
@@ -7746,10 +7710,7 @@ pub fn characteristic_function_ast(
         e_sym(),
         call(
           "Times",
-          vec![
-            crate::functions::math_ast::make_rational(-1, 2),
-            pow(t.clone(), Expr::Integer(2)),
-          ],
+          vec![make_rational(-1, 2), pow(t.clone(), Expr::Integer(2))],
         ),
       ),
       false,
@@ -9007,7 +8968,7 @@ pub fn ztest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::List(items) if items.len() >= 2 => {
       match items
         .iter()
-        .map(crate::functions::math_ast::numeric_utils::try_eval_to_f64)
+        .map(try_eval_to_f64)
         .collect::<Option<Vec<f64>>>()
       {
         Some(v) => v,
@@ -9021,37 +8982,27 @@ pub fn ztest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let variance = match args.get(1) {
     None => None,
     Some(Expr::Identifier(s)) if s == "Automatic" => None,
-    Some(e) => {
-      match crate::functions::math_ast::numeric_utils::try_eval_to_f64(e) {
-        Some(v) if v > 0.0 => Some(v),
-        _ => return Ok(uneval()),
-      }
-    }
+    Some(e) => match try_eval_to_f64(e) {
+      Some(v) if v > 0.0 => Some(v),
+      _ => return Ok(uneval()),
+    },
   }
   .unwrap_or_else(|| {
     data.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / (n - 1.0)
   });
   let mu0 = match args.get(2) {
     None => 0.0,
-    Some(e) => {
-      match crate::functions::math_ast::numeric_utils::try_eval_to_f64(e) {
-        Some(v) => v,
-        None => return Ok(uneval()),
-      }
-    }
+    Some(e) => match try_eval_to_f64(e) {
+      Some(v) => v,
+      None => return Ok(uneval()),
+    },
   };
   let z = (mean - mu0) / (variance / n).sqrt();
   match args.get(3) {
-    None => Ok(Expr::Real(
-      crate::functions::math_ast::numeric_utils::erfc_cf(
-        z.abs() / std::f64::consts::SQRT_2,
-      ),
-    )),
-    Some(Expr::String(p)) if p == "PValue" => Ok(Expr::Real(
-      crate::functions::math_ast::numeric_utils::erfc_cf(
-        z.abs() / std::f64::consts::SQRT_2,
-      ),
-    )),
+    None => Ok(Expr::Real(erfc_cf(z.abs() / std::f64::consts::SQRT_2))),
+    Some(Expr::String(p)) if p == "PValue" => {
+      Ok(Expr::Real(erfc_cf(z.abs() / std::f64::consts::SQRT_2)))
+    }
     Some(Expr::String(p)) if p == "TestStatistic" => Ok(Expr::Real(z)),
     _ => Ok(uneval()),
   }
@@ -9079,7 +9030,7 @@ pub fn fisher_ratio_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::List(items) if items.len() >= 2 => {
       match items
         .iter()
-        .map(crate::functions::math_ast::numeric_utils::try_eval_to_f64)
+        .map(try_eval_to_f64)
         .collect::<Option<Vec<f64>>>()
       {
         Some(v) => v,
@@ -9090,18 +9041,16 @@ pub fn fisher_ratio_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
   let sigma2 = match args.get(1) {
     None => 1.0,
-    Some(e) => {
-      match crate::functions::math_ast::numeric_utils::try_eval_to_f64(e) {
-        Some(v) if v > 0.0 => v,
-        _ => {
-          crate::emit_message(&format!(
-            "FisherRatioTest::sigmnt: The argument {} should be a positive number.",
-            expr_to_string(&args[1])
-          ));
-          return Ok(uneval());
-        }
+    Some(e) => match try_eval_to_f64(e) {
+      Some(v) if v > 0.0 => v,
+      _ => {
+        crate::emit_message(&format!(
+          "FisherRatioTest::sigmnt: The argument {} should be a positive number.",
+          expr_to_string(&args[1])
+        ));
+        return Ok(uneval());
       }
-    }
+    },
   };
   let n = data.len() as f64;
   let mean = data.iter().sum::<f64>() / n;
@@ -9115,10 +9064,7 @@ pub fn fisher_ratio_test_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => return Ok(uneval()),
   }
   // Two-sided p-value from the chi-square(n-1) CDF
-  let upper = crate::functions::math_ast::gamma::gamma_regularized_numeric(
-    (n - 1.0) / 2.0,
-    t / 2.0,
-  );
+  let upper = gamma_regularized_numeric((n - 1.0) / 2.0, t / 2.0);
   let lower = 1.0 - upper;
   Ok(Expr::Real(2.0 * lower.min(upper)))
 }
@@ -9637,10 +9583,10 @@ fn erlang_b_symbolic(
   };
   let plausible_symbol = |e: &Expr| {
     !matches!(e, Expr::String(_) | Expr::List(_))
-      && crate::functions::math_ast::try_eval_to_f64(e).is_none()
+      && try_eval_to_f64(e).is_none()
   };
-  let c_num = crate::functions::math_ast::try_eval_to_f64(&args[0]);
-  let a_num = crate::functions::math_ast::try_eval_to_f64(&args[1]);
+  let c_num = try_eval_to_f64(&args[0]);
+  let a_num = try_eval_to_f64(&args[1]);
   // Both numeric → exact numeric path; non-scalar symbolic shapes echo.
   if c_num.is_some() && a_num.is_some() {
     return None;
@@ -9797,7 +9743,7 @@ fn erlang_common(
   // stay unevaluated.
   let c = match &args[0] {
     Expr::Integer(n) if *n >= 1 && *n <= 1_000 => *n as u32,
-    other if crate::functions::math_ast::try_eval_to_f64(other).is_some() => {
+    other if try_eval_to_f64(other).is_some() => {
       crate::emit_message(&format!(
         "{}::intp: Positive integer expected at position 1 in {}[{}, {}].",
         name,
@@ -10192,8 +10138,8 @@ pub fn trimmed_statistic_ast(
     None => (count(0.05, n), count(0.05, n)),
     Some(Expr::List(fractions)) if fractions.len() == 2 => {
       let (Some(first), Some(second)) = (
-        super::try_eval_to_f64(&fractions[0]),
-        super::try_eval_to_f64(&fractions[1]),
+        try_eval_to_f64(&fractions[0]),
+        try_eval_to_f64(&fractions[1]),
       ) else {
         arg2();
         return uneval();
@@ -10205,7 +10151,7 @@ pub fn trimmed_statistic_ast(
       (count(first, n), count(second, n))
     }
     Some(spec) => {
-      let Some(fraction) = super::try_eval_to_f64(spec) else {
+      let Some(fraction) = try_eval_to_f64(spec) else {
         arg2();
         return uneval();
       };
@@ -10243,8 +10189,8 @@ pub fn trimmed_statistic_ast(
   let mut sorted: Vec<Expr> = elems.to_vec();
   sorted.sort_by(|a, b| {
     let (a, b) = (
-      super::try_eval_to_f64(a).unwrap_or(0.0),
-      super::try_eval_to_f64(b).unwrap_or(0.0),
+      try_eval_to_f64(a).unwrap_or(0.0),
+      try_eval_to_f64(b).unwrap_or(0.0),
     );
     a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal)
   });

--- a/src/functions/math_ast/triangles.rs
+++ b/src/functions/math_ast/triangles.rs
@@ -24,14 +24,14 @@ fn eval(e: Expr) -> Result<Expr, InterpreterError> {
 
 /// The numeric value of an angle argument, when it has one.
 fn angle_value(e: &Expr) -> Option<f64> {
-  let v = crate::functions::math_ast::try_eval_to_f64(e)?;
+  let v = try_eval_to_f64(e)?;
   v.is_finite().then_some(v)
 }
 
 /// A numeric side must be positive; a non-numeric side passes through
 /// (wolframscript computes `SASTriangle[x, Pi/2, 4]` symbolically).
 fn side_ok(e: &Expr) -> bool {
-  match crate::functions::math_ast::try_eval_to_f64(e) {
+  match try_eval_to_f64(e) {
     Some(v) => v.is_finite() && v > 0.0,
     None => true,
   }
@@ -423,7 +423,7 @@ pub fn triangle_measurement_ast(
     ],
   );
   let signed = eval(twice_signed_area.clone())?;
-  if crate::functions::math_ast::try_eval_to_f64(&signed) == Some(0.0) {
+  if try_eval_to_f64(&signed) == Some(0.0) {
     crate::emit_message(&format!(
       "TriangleMeasurement::invtri: {} expected to specify a nondegenerate triangle in the plane.",
       expr_to_output(&args[0])

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -1076,10 +1076,7 @@ pub fn negate_expr(mut expr: Expr) -> Expr {
       // coefficient, matching Wolfram: -(Sqrt[3]/2) => -1/2*Sqrt[3] and
       // -((-1 + Sqrt[3])/(2 Sqrt[2])) => -1/2*(-1 + Sqrt[3])/Sqrt[2].
       if let Some((k, rest)) = denom_integer_factor(right) {
-        let mut factors = vec![
-          crate::functions::math_ast::make_rational(-1, k),
-          (**left).clone(),
-        ];
+        let mut factors = vec![make_rational(-1, k), (**left).clone()];
         if let Some(rest) = rest {
           factors.push(binop(BinaryOperator::Power, rest, Expr::Integer(-1)));
         }
@@ -1724,10 +1721,7 @@ pub fn sin_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // so output precision = `prec_in - log10(|x/tan(x)|)`.
   if let Expr::BigFloat(digits, prec) = &args[0] {
     let p_in = (*prec).max(1.0);
-    let result = crate::functions::math_ast::n_eval_arbitrary(
-      &unevaluated("Sin", args),
-      p_in,
-    )?;
+    let result = n_eval_arbitrary(&unevaluated("Sin", args), p_in)?;
     if let Expr::BigFloat(ref out_digits, _) = result {
       let x_f64 = digits.parse::<f64>().unwrap_or(0.0);
       let t = x_f64.tan();
@@ -1927,10 +1921,7 @@ pub fn cos_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // relative precision is `prec_in - log10(|x*tan(x)|)`.
   if let Expr::BigFloat(digits, prec) = &args[0] {
     let p_in = (*prec).max(1.0);
-    let result = crate::functions::math_ast::n_eval_arbitrary(
-      &unevaluated("Cos", args),
-      p_in,
-    )?;
+    let result = n_eval_arbitrary(&unevaluated("Cos", args), p_in)?;
     if let Expr::BigFloat(ref out_digits, _) = result {
       let x_f64 = digits.parse::<f64>().unwrap_or(0.0);
       let cond = (x_f64 * x_f64.tan()).abs();
@@ -2374,9 +2365,7 @@ pub fn exp_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Arbitrary-precision argument: compute e^x at the tracked precision
     // instead of leaving `E^1.`30.` unevaluated.
     Expr::BigFloat(digits, prec) => {
-      if let Some(result) =
-        crate::functions::math_ast::numerical::bigfloat_exp(digits, *prec)
-      {
+      if let Some(result) = bigfloat_exp(digits, *prec) {
         return result;
       }
       power_two(&Expr::Constant("E".to_string()), &args[0])
@@ -2421,13 +2410,10 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // the direct difference loses precision to cancellation — the complementary
     // form avoids it.
     let any_inexact =
-      crate::functions::math_ast::contains_inexact_real(&args[0])
-        || crate::functions::math_ast::contains_inexact_real(&args[1]);
+      contains_inexact_real(&args[0]) || contains_inexact_real(&args[1]);
     if any_inexact
-      && let (Some(a), Some(b)) = (
-        crate::functions::math_ast::try_eval_to_f64(&args[0]),
-        crate::functions::math_ast::try_eval_to_f64(&args[1]),
-      )
+      && let (Some(a), Some(b)) =
+        (try_eval_to_f64(&args[0]), try_eval_to_f64(&args[1]))
     {
       let result = if a >= 0.0 && b >= 0.0 {
         erfc_f64(a) - erfc_f64(b)
@@ -2445,7 +2431,7 @@ pub fn erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Erf is odd: Erf[-x] = -Erf[x]. Fold every negated argument form (including
   // negative rational coefficients, e.g. Erf[-x/2]) via the shared helper;
   // recursion evaluates special values such as Erf[-Infinity] = -1.
-  if let Some(pos) = crate::functions::math_ast::strip_negation(&args[0]) {
+  if let Some(pos) = strip_negation(&args[0]) {
     let inner = erf_ast(&[pos])?;
     return crate::evaluator::evaluate_function_call_ast(
       "Times",
@@ -2587,7 +2573,7 @@ pub fn erfi_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Erfi is odd: Erfi[-x] = -Erfi[x]. Fold every negated argument form
   // (including negative rational coefficients, e.g. Erfi[-x/2]) via the shared
   // helper; recursion evaluates special values such as Erfi[-Infinity].
-  if let Some(pos) = crate::functions::math_ast::strip_negation(&args[0]) {
+  if let Some(pos) = strip_negation(&args[0]) {
     let inner = erfi_ast(&[pos])?;
     return crate::evaluator::evaluate_function_call_ast(
       "Times",
@@ -2769,9 +2755,7 @@ pub fn inverse_erf_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // Numeric evaluation for Real arguments
     Expr::Real(f) => {
       if *f > -1.0 && *f < 1.0 {
-        Ok(Expr::Real(
-          crate::functions::math_ast::numeric_utils::inverse_erf_f64(*f),
-        ))
+        Ok(Expr::Real(inverse_erf_f64(*f)))
       } else if *f == 1.0 {
         Ok(Expr::Identifier("Infinity".to_string()))
       } else if *f == -1.0 {
@@ -2828,9 +2812,7 @@ pub fn inverse_erfc_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Real(f) => {
       if *f > 0.0 && *f < 2.0 {
         // InverseErfc[x] = InverseErf[1 - x]
-        Ok(Expr::Real(
-          crate::functions::math_ast::numeric_utils::inverse_erf_f64(1.0 - *f),
-        ))
+        Ok(Expr::Real(inverse_erf_f64(1.0 - *f)))
       } else if *f == 0.0 {
         Ok(Expr::Identifier("Infinity".to_string()))
       } else if *f == 2.0 {
@@ -2999,10 +2981,9 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             "Re",
             std::slice::from_ref(z),
           )?;
-          if let (Some(im_f), Some(_re_f)) = (
-            crate::functions::math_ast::try_eval_to_f64(&imz),
-            crate::functions::math_ast::try_eval_to_f64(&rez),
-          ) {
+          if let (Some(im_f), Some(_re_f)) =
+            (try_eval_to_f64(&imz), try_eval_to_f64(&rez))
+          {
             use std::f64::consts::PI;
             let two_pi = 2.0 * PI;
             // k brings im into (-Pi, Pi]: im - 2*k*Pi ∈ (-Pi, Pi].
@@ -3079,7 +3060,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           "Times",
           &[
             Expr::Identifier("I".to_string()),
-            crate::functions::math_ast::make_rational(1, 2),
+            make_rational(1, 2),
             Expr::Constant("Pi".to_string()),
           ],
         );
@@ -3118,7 +3099,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             &[
               Expr::Integer(-1),
               Expr::Identifier("I".to_string()),
-              crate::functions::math_ast::make_rational(1, 2),
+              make_rational(1, 2),
               Expr::Constant("Pi".to_string()),
             ],
           );
@@ -3129,9 +3110,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Real coefficients (e.g. 2.5 I) are handled by the numeric complex
       // path below; symbolic-real ones (Pi I, Sqrt[2] I) stay unevaluated,
       // matching wolframscript.
-      if let Some(coeff) =
-        crate::functions::math_ast::complex::extract_i_times_real(&args[0])
-      {
+      if let Some(coeff) = extract_i_times_real(&args[0]) {
         let is_exact_real = matches!(&coeff, Expr::Integer(_))
           || matches!(&coeff, Expr::FunctionCall { name, .. } if name == "Rational");
         if is_exact_real {
@@ -3155,7 +3134,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                     name: "Sign".to_string(),
                     args: vec![coeff.clone()].into(),
                   },
-                  crate::functions::math_ast::make_rational(1, 2),
+                  make_rational(1, 2),
                   Expr::Identifier("I".to_string()),
                   Expr::Constant("Pi".to_string()),
                 ]
@@ -3257,7 +3236,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         return Ok(Expr::Identifier("Infinity".to_string()));
       }
       // Log[-Infinity] = Infinity (principal value)
-      if crate::functions::math_ast::is_neg_infinity(&args[0]) {
+      if is_neg_infinity(&args[0]) {
         return Ok(Expr::Identifier("Infinity".to_string()));
       }
       // Log[p/q] where 0 < p < q: return -Log[q/p]
@@ -3281,8 +3260,7 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Arbitrary-precision argument: compute ln(x) at the tracked precision
       // instead of leaving `Log[2.`30.]` unevaluated.
       if let Expr::BigFloat(digits, prec) = &args[0]
-        && let Some(result) =
-          crate::functions::math_ast::numerical::bigfloat_log(digits, *prec)
+        && let Some(result) = bigfloat_log(digits, *prec)
       {
         return result;
       }
@@ -3303,16 +3281,13 @@ pub fn log_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       // Log of a complex floating-point number: principal value
       // = 0.5*Log[a^2 + b^2] + I*atan2(b, a)
-      if let Some((a, b)) =
-        crate::functions::math_ast::try_extract_complex_float(&args[0])
+      if let Some((a, b)) = try_extract_complex_float(&args[0])
         && b != 0.0
         && contains_inexact_real_log(&args[0])
       {
         let re = 0.5 * (a * a + b * b).ln();
         let im = b.atan2(a);
-        return Ok(crate::functions::math_ast::build_complex_float_expr(
-          re, im,
-        ));
+        return Ok(build_complex_float_expr(re, im));
       }
       Ok(unevaluated("Log", args))
     }
@@ -3487,7 +3462,7 @@ fn try_complex_inverse_trig(
   if !contains_inexact_real(arg) {
     return None;
   }
-  let (x, y) = crate::functions::math_ast::try_extract_complex_float(arg)?;
+  let (x, y) = try_extract_complex_float(arg)?;
   if y == 0.0 {
     return None;
   }
@@ -3926,7 +3901,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => {}
   }
   // ArcTan[-Infinity] = -Pi/2
-  if crate::functions::math_ast::is_neg_infinity(&args[0]) {
+  if is_neg_infinity(&args[0]) {
     return Ok(Expr::FunctionCall {
       name: "Times".to_string(),
       args: vec![
@@ -3942,7 +3917,7 @@ pub fn arctan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Additional exact values: ArcTan[Sqrt[3]] = Pi/3, ArcTan[1/Sqrt[3]] = Pi/6
   // Use numerical comparison to detect these values robustly regardless of internal form.
-  if let Some(val) = crate::functions::math_ast::try_eval_to_f64(&args[0]) {
+  if let Some(val) = try_eval_to_f64(&args[0]) {
     let sqrt3 = 3.0_f64.sqrt();
     let eps = 1e-12;
     if (val - sqrt3).abs() < eps {
@@ -4982,8 +4957,7 @@ pub fn arctanh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Only fire for inexact inputs — wolframscript keeps purely exact
   // arguments like ArcTanh[2 + I] symbolic.
   if contains_inexact_real(&args[0])
-    && let Some((re, im)) =
-      crate::functions::math_ast::try_extract_complex_float(&args[0])
+    && let Some((re, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
   {
     let one_minus_re_sq = (1.0 - re) * (1.0 - re);
@@ -5024,7 +4998,7 @@ pub fn arccoth_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // ArcCoth[±Infinity] = 0.
   if matches!(&args[0], Expr::Identifier(s) if s == "Infinity")
-    || crate::functions::math_ast::is_neg_infinity(&args[0])
+    || is_neg_infinity(&args[0])
   {
     return Ok(Expr::Integer(0));
   }
@@ -5164,9 +5138,7 @@ pub fn arccot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let unevaluated = || Ok(unevaluated("ArcCot", args));
 
   // ArcCot[±Infinity] = 0; ArcCot[0] = Pi/2.
-  if matches!(x, Expr::Identifier(s) if s == "Infinity")
-    || crate::functions::math_ast::is_neg_infinity(x)
-  {
+  if matches!(x, Expr::Identifier(s) if s == "Infinity") || is_neg_infinity(x) {
     return Ok(Expr::Integer(0));
   }
   if matches!(x, Expr::Integer(0)) {
@@ -5300,9 +5272,7 @@ pub fn arccsch_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Identifier("ComplexInfinity".to_string()));
   }
   // ArcCsch[±Infinity] = 0.
-  if matches!(x, Expr::Identifier(s) if s == "Infinity")
-    || crate::functions::math_ast::is_neg_infinity(x)
-  {
+  if matches!(x, Expr::Identifier(s) if s == "Infinity") || is_neg_infinity(x) {
     return Ok(Expr::Integer(0));
   }
   // Only inexact arguments evaluate numerically; exact ones (e.g. ArcCsch[2])
@@ -5649,8 +5619,7 @@ pub fn logistic_sigmoid_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Complex float input: 1 / (1 + exp(-z)) using complex arithmetic. Only
   // fires for an inexact argument so an exact complex like I stays symbolic.
   if contains_inexact_real(&args[0])
-    && let Some((re, im)) =
-      crate::functions::math_ast::try_extract_complex_float(&args[0])
+    && let Some((re, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
   {
     // exp(-z) = exp(-re) * (cos(-im) + I*sin(-im))

--- a/src/functions/math_ast/zeta_functions.rs
+++ b/src/functions/math_ast/zeta_functions.rs
@@ -95,14 +95,11 @@ pub fn zeta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Only evaluate numerically if the argument contains float components
       // (e.g., Zeta[0.5 + 3.0*I] evaluates, but Zeta[1/2 + 3*I] stays symbolic)
       if contains_float(&args[0])
-        && let Some((re, im)) =
-          crate::functions::math_ast::try_extract_complex_float(&args[0])
+        && let Some((re, im)) = try_extract_complex_float(&args[0])
       {
         if im != 0.0 {
           let (res_re, res_im) = zeta_numeric_complex(re, im);
-          return Ok(crate::functions::math_ast::build_complex_float_expr(
-            res_re, res_im,
-          ));
+          return Ok(build_complex_float_expr(res_re, res_im));
         } else {
           return Ok(Expr::Real(zeta_numeric(re)));
         }
@@ -372,8 +369,7 @@ fn hurwitz_zeta_ast_inner(
         }
         _ => {
           if contains_float(a_expr)
-            && let Some((re, _im)) =
-              crate::functions::math_ast::try_extract_complex_float(a_expr)
+            && let Some((re, _im)) = try_extract_complex_float(a_expr)
           {
             let result = hurwitz_zeta_numeric(s, re);
             return Ok(Expr::Real(result));
@@ -512,9 +508,7 @@ fn expr_to_f64(expr: &Expr) -> Option<f64> {
     }
     _ => {
       if contains_float(expr) {
-        if let Some((re, _im)) =
-          crate::functions::math_ast::try_extract_complex_float(expr)
-        {
+        if let Some((re, _im)) = try_extract_complex_float(expr) {
           Some(re)
         } else {
           None
@@ -1880,7 +1874,7 @@ fn ramanujan_tau_l_numeric(s: (f64, f64)) -> (f64, f64) {
   let twopi_pow = cpow((twopi, 0.0), (2.0 * s.0 - 12.0, 2.0 * s.1));
   let mut sum = (0.0_f64, 0.0_f64);
   for n in 1..500 {
-    let tau = crate::functions::math_ast::ramanujan_tau_compute(n) as f64;
+    let tau = ramanujan_tau_compute(n) as f64;
     let x = twopi * n as f64;
     // tau * n^{-s} * Gamma(s, x)
     let n_neg_s = cpow((n as f64, 0.0), (-s.0, -s.1));
@@ -1939,14 +1933,11 @@ pub fn ramanujan_tau_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(Expr::Real(v.0));
   }
   // Complex machine argument (re + im I with at least one inexact part).
-  if let Some((re, im)) =
-    crate::functions::math_ast::try_extract_complex_float(&args[0])
+  if let Some((re, im)) = try_extract_complex_float(&args[0])
     && im != 0.0
   {
     let v = ramanujan_tau_l_numeric((re, im));
-    return Ok(crate::functions::math_ast::build_complex_float_expr(
-      v.0, v.1,
-    ));
+    return Ok(build_complex_float_expr(v.0, v.1));
   }
   Ok(unevaluated("RamanujanTauL", args))
 }
@@ -2080,7 +2071,7 @@ pub fn dirichlet_beta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Exact integer argument.
-  if let Some(n) = crate::functions::math_ast::expr_to_i128(s) {
+  if let Some(n) = expr_to_i128(s) {
     // β(n) = EulerE[-n]/2 for n <= 0.
     if n <= 0 {
       let euler = crate::evaluator::evaluate_function_call_ast(

--- a/src/functions/polynomial_ast/apart.rs
+++ b/src/functions/polynomial_ast/apart.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::{gcd_i128, lcm_i128, rat_reduce};
+use crate::functions::math_ast::times_ast;
 
 // ─── Apart ──────────────────────────────────────────────────────────
 
@@ -1237,8 +1237,7 @@ fn extract_leading_sign(expr: &Expr) -> (i128, Expr) {
       let (lsign, labs) = extract_leading_sign(left);
       if lsign < 0 {
         let rebuilt =
-          crate::functions::math_ast::times_ast(&[labs, *right.clone()])
-            .unwrap_or(*right.clone());
+          times_ast(&[labs, *right.clone()]).unwrap_or(*right.clone());
         (-1, rebuilt)
       } else {
         (1, expr.clone())
@@ -1251,8 +1250,7 @@ fn extract_leading_sign(expr: &Expr) -> (i128, Expr) {
       if lsign < 0 {
         let mut new_args = vec![labs];
         new_args.extend_from_slice(&args[1..]);
-        let rebuilt = crate::functions::math_ast::times_ast(&new_args)
-          .unwrap_or(expr.clone());
+        let rebuilt = times_ast(&new_args).unwrap_or(expr.clone());
         (-1, rebuilt)
       } else {
         (1, expr.clone())
@@ -1284,11 +1282,8 @@ fn apart_symbolic(
   for f in &factors {
     if !crate::functions::polynomial_ast::contains_var(f, var) {
       // Constant factor (doesn't contain var)
-      other_factor = crate::functions::math_ast::times_ast(&[
-        other_factor.clone(),
-        f.clone(),
-      ])
-      .unwrap_or(other_factor);
+      other_factor =
+        times_ast(&[other_factor.clone(), f.clone()]).unwrap_or(other_factor);
       continue;
     }
     if let Some((coeff, constant)) = extract_linear_coeffs(f, var) {
@@ -1341,8 +1336,7 @@ fn apart_symbolic(
         scalar_parts.push(fj_at_ri);
       }
     }
-    let scalar = crate::functions::math_ast::times_ast(&scalar_parts)
-      .unwrap_or(Expr::Integer(1));
+    let scalar = times_ast(&scalar_parts).unwrap_or(Expr::Integer(1));
 
     // Extract sign from scalar: if leading coefficient is negative, flip sign
     let (sign, abs_scalar) = extract_leading_sign(&scalar);
@@ -1363,8 +1357,7 @@ fn apart_symbolic(
     let mut denom_factors = Vec::new();
     flatten_product_factors(&abs_scalar, &mut denom_factors);
     denom_factors.push(factor_for_display);
-    let full_denom = crate::functions::math_ast::times_ast(&denom_factors)
-      .unwrap_or(Expr::Integer(1));
+    let full_denom = times_ast(&denom_factors).unwrap_or(Expr::Integer(1));
 
     // Build fraction. When the term is negative, fold the sign into the
     // numerator so the result evaluates as `-num_val / full_denom` and

--- a/src/functions/polynomial_ast/cancel.rs
+++ b/src/functions/polynomial_ast/cancel.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::{gcd_i128, is_sqrt, make_sqrt, rat_reduce};
+use crate::functions::math_ast::make_divide;
 
 // ─── Cancel ─────────────────────────────────────────────────────────
 
@@ -199,7 +199,7 @@ fn cancel_expr_impl(expr: &Expr, canonicalize_sign: bool) -> Expr {
             if new_den == [1] {
               return num_expr;
             }
-            return crate::functions::math_ast::make_divide(num_expr, den_expr);
+            return make_divide(num_expr, den_expr);
           }
         }
 
@@ -237,10 +237,7 @@ fn cancel_expr_impl(expr: &Expr, canonicalize_sign: bool) -> Expr {
           if new_den == [1] {
             return num_expr;
           }
-          return crate::functions::math_ast::make_divide(
-            num_expr,
-            coeffs_to_expr(&new_den, &var),
-          );
+          return make_divide(num_expr, coeffs_to_expr(&new_den, &var));
         }
 
         // A bare negative-constant denominator absorbs its sign into the
@@ -252,7 +249,7 @@ fn cancel_expr_impl(expr: &Expr, canonicalize_sign: bool) -> Expr {
           && num_coeffs.len() > 1
         {
           let neg_num: Vec<i128> = num_coeffs.iter().map(|c| -c).collect();
-          return crate::functions::math_ast::make_divide(
+          return make_divide(
             coeffs_to_expr(&neg_num, &var),
             Expr::Integer(-den_coeffs[0]),
           );
@@ -507,10 +504,7 @@ fn cancel_expr_impl(expr: &Expr, canonicalize_sign: bool) -> Expr {
               }
               // Recursively cancel in case more simplification is possible
               return cancel_expr_impl(
-                &crate::functions::math_ast::make_divide(
-                  new_num_expr,
-                  new_den_expr,
-                ),
+                &make_divide(new_num_expr, new_den_expr),
                 canonicalize_sign,
               );
             }
@@ -840,7 +834,7 @@ pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
 
   if !changed && !numeric_changed {
     // Nothing was cancelled, return original
-    return crate::functions::math_ast::make_divide(num.clone(), den.clone());
+    return make_divide(num.clone(), den.clone());
   }
 
   // Rebuild numerator and denominator
@@ -870,7 +864,7 @@ pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
   if let Expr::Integer(1) = &new_den {
     new_num
   } else {
-    crate::functions::math_ast::make_divide(new_num, new_den)
+    make_divide(new_num, new_den)
   }
 }
 

--- a/src/functions/polynomial_ast/decompose.rs
+++ b/src/functions/polynomial_ast/decompose.rs
@@ -3,7 +3,6 @@ use super::coefficient::term_var_power_and_coeff;
 use super::expand::expand_and_combine;
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::gcd_i128;
 
 /// Decompose[poly, x] - decompose a polynomial into a composition of simpler polynomials.
 /// Returns a list {g1, g2, ..., gn} such that poly(x) = g1(g2(...gn(x)...)).

--- a/src/functions/polynomial_ast/eliminate.rs
+++ b/src/functions/polynomial_ast/eliminate.rs
@@ -2,7 +2,6 @@ use super::together::negate_expr;
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
-use crate::functions::math_ast::rat_reduce;
 
 /// Eliminate[{eq1, eq2, ...}, var]  or  Eliminate[{eq1, eq2, ...}, {v1, v2, ...}]
 /// Eliminates variables from a system of equations.

--- a/src/functions/polynomial_ast/exponent.rs
+++ b/src/functions/polynomial_ast/exponent.rs
@@ -1,7 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::calculus_ast::is_constant_wrt;
-use crate::functions::math_ast::rat_reduce;
 
 // ─── Rational exponent helpers ─────────────────────────────────────
 

--- a/src/functions/polynomial_ast/factor.rs
+++ b/src/functions/polynomial_ast/factor.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::calculus_ast::simplify;
-use crate::functions::math_ast::{gcd_i128, lcm_i128, rat_reduce};
+use crate::functions::math_ast::{divide_ast, times_ast};
 
 // ─── Factor ─────────────────────────────────────────────────────────
 
@@ -1460,7 +1460,7 @@ fn decompose_product(
       // base^exp
       if is_numeric_expr(left) {
         // numeric^exp: handle as coefficient
-        *numeric_coeff = crate::functions::math_ast::times_ast(&[
+        *numeric_coeff = times_ast(&[
           numeric_coeff.clone(),
           Expr::BinaryOp {
             op: BinaryOperator::Power,
@@ -1475,41 +1475,29 @@ fn decompose_product(
     }
     Expr::FunctionCall { name, args } if name == "Power" && args.len() == 2 => {
       if is_numeric_expr(&args[0]) {
-        *numeric_coeff = crate::functions::math_ast::times_ast(&[
-          numeric_coeff.clone(),
-          expr.clone(),
-        ])
-        .unwrap_or(expr.clone());
+        *numeric_coeff = times_ast(&[numeric_coeff.clone(), expr.clone()])
+          .unwrap_or(expr.clone());
       } else {
         pairs.push(Expr::List(vec![args[0].clone(), args[1].clone()].into()));
       }
     }
     Expr::Integer(_) | Expr::Real(_) | Expr::BigInteger(_) => {
-      *numeric_coeff = crate::functions::math_ast::times_ast(&[
-        numeric_coeff.clone(),
-        expr.clone(),
-      ])
-      .unwrap_or(expr.clone());
+      *numeric_coeff = times_ast(&[numeric_coeff.clone(), expr.clone()])
+        .unwrap_or(expr.clone());
     }
     Expr::FunctionCall { name, args }
       if name == "Rational" && args.len() == 2 =>
     {
-      *numeric_coeff = crate::functions::math_ast::times_ast(&[
-        numeric_coeff.clone(),
-        expr.clone(),
-      ])
-      .unwrap_or(expr.clone());
+      *numeric_coeff = times_ast(&[numeric_coeff.clone(), expr.clone()])
+        .unwrap_or(expr.clone());
     }
     Expr::UnaryOp {
       op: UnaryOperator::Minus,
       operand,
     } => {
       // -expr: multiply coeff by -1 and decompose inner
-      *numeric_coeff = crate::functions::math_ast::times_ast(&[
-        numeric_coeff.clone(),
-        Expr::Integer(-1),
-      ])
-      .unwrap_or(Expr::Integer(-1));
+      *numeric_coeff = times_ast(&[numeric_coeff.clone(), Expr::Integer(-1)])
+        .unwrap_or(Expr::Integer(-1));
       decompose_product(operand, pairs, numeric_coeff);
     }
     _ => {
@@ -3080,11 +3068,8 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
         if n % div == 0 {
           Expr::Integer(n / div)
         } else {
-          crate::functions::math_ast::divide_ast(&[
-            term.clone(),
-            Expr::Integer(div),
-          ])
-          .unwrap_or_else(|_| term.clone())
+          divide_ast(&[term.clone(), Expr::Integer(div)])
+            .unwrap_or_else(|_| term.clone())
         }
       }
       Expr::UnaryOp {
@@ -3092,11 +3077,12 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
         operand,
       } => {
         let inner = divide_term(operand, div);
-        crate::functions::math_ast::times_ast(&[Expr::Integer(-1), inner])
-          .unwrap_or_else(|_| Expr::UnaryOp {
+        times_ast(&[Expr::Integer(-1), inner]).unwrap_or_else(|_| {
+          Expr::UnaryOp {
             op: UnaryOperator::Minus,
             operand: Box::new(divide_term(operand, div)),
-          })
+          }
+        })
       }
       Expr::FunctionCall { name, args } if name == "Times" => {
         let mut new_args = Vec::with_capacity(args.len());
@@ -3119,14 +3105,10 @@ fn extract_multi_var_content(expanded: &Expr) -> Expr {
           // No integer factor matched — prepend 1/div as a Rational.
           new_args.insert(0, crate::functions::math_ast::make_rational(1, div));
         }
-        crate::functions::math_ast::times_ast(&new_args)
-          .unwrap_or_else(|_| term.clone())
+        times_ast(&new_args).unwrap_or_else(|_| term.clone())
       }
-      _ => crate::functions::math_ast::divide_ast(&[
-        term.clone(),
-        Expr::Integer(div),
-      ])
-      .unwrap_or_else(|_| term.clone()),
+      _ => divide_ast(&[term.clone(), Expr::Integer(div)])
+        .unwrap_or_else(|_| term.clone()),
     }
   }
   let new_summands: Vec<Expr> = summands
@@ -3271,8 +3253,7 @@ pub fn factor_terms_list_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           } else if fs.len() == 1 {
             fs.into_iter().next().unwrap()
           } else {
-            crate::functions::math_ast::times_ast(&fs)
-              .unwrap_or(Expr::Integer(1))
+            times_ast(&fs).unwrap_or(Expr::Integer(1))
           }
         };
         let non_var_part = combine(non_var_factors);
@@ -4610,7 +4591,6 @@ fn build_multivariate_result(
     // grouping and sign placement but doesn't match Wolfram's display
     // order; running through `times_ast` applies the canonical Times
     // sort that Times itself uses.
-    crate::functions::math_ast::times_ast(&result_factors)
-      .unwrap_or_else(|_| build_product(result_factors))
+    times_ast(&result_factors).unwrap_or_else(|_| build_product(result_factors))
   }
 }

--- a/src/functions/polynomial_ast/linear_programming.rs
+++ b/src/functions/polynomial_ast/linear_programming.rs
@@ -21,7 +21,6 @@
 
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::rat_reduce_bigint;
 use num_bigint::BigInt;
 use num_traits::{One, Signed, Zero};
 

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::{
-  expr_to_f64, expr_to_i128, expr_to_rational, gcd_bigint, gcd_i128, is_sqrt,
+  expr_to_f64, expr_to_i128, expr_to_rational, gcd_bigint,
 };
 
 /// MinimalPolynomial[α, x] - Computes the minimal polynomial of an algebraic number α

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -3,6 +3,9 @@
 //! Expand, Factor, Simplify, Coefficient, Exponent, PolynomialQ.
 
 use crate::InterpreterError;
+use crate::functions::math_ast::{
+  gcd_i128, is_sqrt, lcm_i128, make_sqrt, rat_reduce, rat_reduce_bigint,
+};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
   unevaluated,

--- a/src/functions/polynomial_ast/polynomial_mod.rs
+++ b/src/functions/polynomial_ast/polynomial_mod.rs
@@ -1,7 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::evaluator::evaluate_expr_to_expr;
-use crate::functions::math_ast::gcd_i128;
 
 /// PolynomialMod[poly, m] — reduce poly modulo m.
 ///

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -3,7 +3,7 @@ use super::together::negate_expr;
 use super::*;
 
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
-use crate::functions::math_ast::{gcd_i128, make_sqrt};
+use crate::functions::math_ast::try_eval_to_f64;
 
 // ─── Reduce ──────────────────────────────────────────────────────────
 
@@ -124,7 +124,7 @@ fn tighten_integer_one_sided(result: &Expr, var: &str) -> Option<Expr> {
   if contains_inexact_literal(&operands[1]) {
     return None;
   }
-  let c = crate::functions::math_ast::try_eval_to_f64(&operands[1])?;
+  let c = try_eval_to_f64(&operands[1])?;
   let (bound, out_op) = match operators[0] {
     ComparisonOp::Greater => {
       ((c.floor() as i64) + 1, ComparisonOp::GreaterEqual)
@@ -171,8 +171,8 @@ fn enumerate_integer_interval(result: &Expr, var: &str) -> Option<Expr> {
   if !matches!(&args[2], Expr::Identifier(s) if s == var) {
     return None;
   }
-  let lo = crate::functions::math_ast::try_eval_to_f64(&args[0])?;
-  let hi = crate::functions::math_ast::try_eval_to_f64(&args[4])?;
+  let lo = try_eval_to_f64(&args[0])?;
+  let hi = try_eval_to_f64(&args[4])?;
   let op1 = match &args[1] {
     Expr::Identifier(s) => s.as_str(),
     _ => return None,
@@ -243,8 +243,8 @@ fn numeric_var_bounds(
     && args.len() == 5
     && is_var(&args[2])
   {
-    let lo = crate::functions::math_ast::try_eval_to_f64(&args[0])?;
-    let hi = crate::functions::math_ast::try_eval_to_f64(&args[4])?;
+    let lo = try_eval_to_f64(&args[0])?;
+    let hi = try_eval_to_f64(&args[4])?;
     let op1 = comparison_op_of(&args[1])?;
     let op2 = comparison_op_of(&args[3])?;
     return Some((lower_from(op1, lo), upper_from(op2, hi)));
@@ -279,7 +279,7 @@ fn numeric_var_bounds(
     let mut upper: Option<i64> = None;
     // Left neighbor: `o[k-1] op var`.
     if k > 0 {
-      let v = crate::functions::math_ast::try_eval_to_f64(&operands[k - 1])?;
+      let v = try_eval_to_f64(&operands[k - 1])?;
       match operators[k - 1] {
         ComparisonOp::Less | ComparisonOp::LessEqual => {
           lower = lower_from(operators[k - 1], v);
@@ -291,7 +291,7 @@ fn numeric_var_bounds(
     }
     // Right neighbor: `var op o[k+1]`.
     if k + 1 < operands.len() {
-      let v = crate::functions::math_ast::try_eval_to_f64(&operands[k + 1])?;
+      let v = try_eval_to_f64(&operands[k + 1])?;
       match operators[k] {
         ComparisonOp::Less | ComparisonOp::LessEqual => {
           upper = upper_from(operators[k], v);

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::calculus_ast::simplify;
-use crate::functions::math_ast::{gcd_i128, rat_reduce, rat_reduce_bigint};
+use crate::functions::math_ast::{
+  bigint_to_expr, make_rational, plus_ast, try_eval_to_f64,
+};
 
 // ─── Refine ─────────────────────────────────────────────────────────
 
@@ -2913,7 +2915,7 @@ fn variable_numeric_bounds(
   var_name: &str,
   info: &AssumptionInfo,
 ) -> Option<(f64, bool, f64, bool)> {
-  let value = |e: &Expr| crate::functions::math_ast::try_eval_to_f64(e);
+  let value = |e: &Expr| try_eval_to_f64(e);
   let mut lo: Option<(f64, bool)> = None;
   let mut hi: Option<(f64, bool)> = None;
   let mut tighten_lo = |v: f64, strict: bool| {
@@ -5307,7 +5309,7 @@ fn simplify_expr_with_together(expr: &Expr) -> Expr {
                 Expr::FunctionCall {
                   name: "Times".to_string(),
                   args: vec![
-                    crate::functions::math_ast::make_rational(-1, g_den),
+                    make_rational(-1, g_den),
                     inner,
                     Expr::BinaryOp {
                       op: BinaryOperator::Power,
@@ -6649,8 +6651,8 @@ fn try_partial_factor_components(expr: &Expr) -> Option<Expr> {
     }
   }
 
-  let result = crate::functions::math_ast::plus_ast(&result_parts)
-    .unwrap_or_else(|_| build_sum(result_parts));
+  let result =
+    plus_ast(&result_parts).unwrap_or_else(|_| build_sum(result_parts));
   if leaf_count(&result) < original_complexity {
     Some(result)
   } else {
@@ -6806,8 +6808,8 @@ fn pull_common_factor(expr: &Expr) -> Expr {
     stripped.push(new_term);
   }
 
-  let stripped_sum = crate::functions::math_ast::plus_ast(&stripped)
-    .unwrap_or_else(|_| build_sum(stripped));
+  let stripped_sum =
+    plus_ast(&stripped).unwrap_or_else(|_| build_sum(stripped));
   let common_expr = if common.len() == 1 {
     common.into_iter().next().unwrap().1
   } else {
@@ -6878,10 +6880,7 @@ fn simplify_collected_coefficients(
     new_terms.push(new_term);
   }
 
-  Some(
-    crate::functions::math_ast::plus_ast(&new_terms)
-      .unwrap_or_else(|_| build_sum(new_terms)),
-  )
+  Some(plus_ast(&new_terms).unwrap_or_else(|_| build_sum(new_terms)))
 }
 
 /// If `expr` is `factor * Plus[...]` (or `Times[..., Plus[...]]`),
@@ -7282,16 +7281,14 @@ fn extract_var_bound(expr: &Expr) -> Option<(String, &'static str, f64)> {
     && operands.len() == 2
     && operators.len() == 1
   {
-    if let (Expr::Identifier(name), Some(v)) = (
-      &operands[0],
-      crate::functions::math_ast::try_eval_to_f64(&operands[1]),
-    ) {
+    if let (Expr::Identifier(name), Some(v)) =
+      (&operands[0], try_eval_to_f64(&operands[1]))
+    {
       return Some((name.clone(), to_op(&operators[0]), v));
     }
-    if let (Some(v), Expr::Identifier(name)) = (
-      crate::functions::math_ast::try_eval_to_f64(&operands[0]),
-      &operands[1],
-    ) {
+    if let (Some(v), Expr::Identifier(name)) =
+      (try_eval_to_f64(&operands[0]), &operands[1])
+    {
       // Flip: `c < a` ≡ `a > c`.
       let flipped = match operators[0] {
         ComparisonOp::Less => ">",
@@ -7318,16 +7315,14 @@ fn extract_var_bound(expr: &Expr) -> Option<(String, &'static str, f64)> {
       "Unequal" => "!=",
       _ => return None,
     };
-    if let (Expr::Identifier(n), Some(v)) = (
-      &args[0],
-      crate::functions::math_ast::try_eval_to_f64(&args[1]),
-    ) {
+    if let (Expr::Identifier(n), Some(v)) =
+      (&args[0], try_eval_to_f64(&args[1]))
+    {
       return Some((n.clone(), op, v));
     }
-    if let (Some(v), Expr::Identifier(n)) = (
-      crate::functions::math_ast::try_eval_to_f64(&args[0]),
-      &args[1],
-    ) {
+    if let (Some(v), Expr::Identifier(n)) =
+      (try_eval_to_f64(&args[0]), &args[1])
+    {
       let flipped = match op {
         "<" => ">",
         "<=" => ">=",
@@ -7426,10 +7421,7 @@ pub fn apply_trig_identities(expr: &Expr) -> Expr {
           // result is the Cosh coefficient (so Sinh^2 - Cosh^2 → -1).
           if is_coshsinh
             && matches!(
-              crate::functions::math_ast::plus_ast(&[
-                coeff_i.clone(),
-                coeff_j.clone()
-              ]),
+              plus_ast(&[coeff_i.clone(), coeff_j.clone()]),
               Ok(Expr::Integer(0))
             )
           {
@@ -7453,7 +7445,7 @@ pub fn apply_trig_identities(expr: &Expr) -> Expr {
   }
 
   // Re-combine to simplify (e.g. 1 + 1 → 2)
-  if let Ok(result) = crate::functions::math_ast::plus_ast(&result_terms) {
+  if let Ok(result) = plus_ast(&result_terms) {
     result
   } else {
     build_sum(result_terms)
@@ -8777,7 +8769,7 @@ fn simplify_quotient_select(
         Expr::FunctionCall {
           name: "Times".to_string(),
           args: vec![
-            crate::functions::math_ast::make_rational(-1, den_mono_coeff),
+            make_rational(-1, den_mono_coeff),
             num_expr,
             Expr::BinaryOp {
               op: BinaryOperator::Power,
@@ -10006,15 +9998,11 @@ fn try_merge_logs(expr: &Expr) -> Option<Expr> {
     }
     let (num, den) = rat_reduce_bigint(&num, &den);
     let q = if den.is_one() {
-      crate::functions::math_ast::bigint_to_expr(num)
+      bigint_to_expr(num)
     } else {
       Expr::FunctionCall {
         name: "Rational".to_string(),
-        args: vec![
-          crate::functions::math_ast::bigint_to_expr(num),
-          crate::functions::math_ast::bigint_to_expr(den),
-        ]
-        .into(),
+        args: vec![bigint_to_expr(num), bigint_to_expr(den)].into(),
       }
     };
     Expr::FunctionCall {
@@ -10418,9 +10406,7 @@ fn factor_common_power_base(terms: &[Expr]) -> Option<Expr> {
             new_factors.push(Expr::BinaryOp {
               op: BinaryOperator::Power,
               left: Box::new(candidate.base.clone()),
-              right: Box::new(crate::functions::math_ast::make_rational(
-                sn, sd,
-              )),
+              right: Box::new(make_rational(sn, sd)),
             });
           }
         } else {
@@ -10449,9 +10435,7 @@ fn factor_common_power_base(terms: &[Expr]) -> Option<Expr> {
       Expr::BinaryOp {
         op: BinaryOperator::Power,
         left: Box::new(candidate.base.clone()),
-        right: Box::new(crate::functions::math_ast::make_rational(
-          min_n, min_d,
-        )),
+        right: Box::new(make_rational(min_n, min_d)),
       }
     };
     let inner_sum = build_sum(new_terms);

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2,7 +2,9 @@ use super::together::negate_expr;
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::calculus_ast::{is_constant_wrt, simplify};
-use crate::functions::math_ast::{gcd_i128, is_sqrt, make_sqrt, rat_reduce};
+use crate::functions::math_ast::{
+  make_rational, n_ast, try_eval_to_f64, try_extract_complex_float,
+};
 
 /// In Solve context, simplify Sqrt[expr^(2n)] → expr^n since ± handles the sign.
 /// Also simplifies products containing such terms.
@@ -113,10 +115,10 @@ fn filter_real_nsolve_solutions(expr: Expr) -> Expr {
       let Expr::Rule { replacement, .. } = r else {
         return true;
       };
-      if crate::functions::math_ast::try_eval_to_f64(replacement).is_some() {
+      if try_eval_to_f64(replacement).is_some() {
         return true;
       }
-      match crate::functions::math_ast::try_extract_complex_float(replacement) {
+      match try_extract_complex_float(replacement) {
         Some((_re, im)) => im.abs() < 1e-8,
         // A non-numeric (still symbolic) replacement is left in place.
         None => true,
@@ -143,10 +145,10 @@ fn sort_nsolve_solutions(expr: Expr) -> Expr {
     return expr;
   };
   let value_of = |replacement: &Expr| -> Option<(f64, f64)> {
-    if let Some(v) = crate::functions::math_ast::try_eval_to_f64(replacement) {
+    if let Some(v) = try_eval_to_f64(replacement) {
       return Some((v, 0.0));
     }
-    crate::functions::math_ast::try_extract_complex_float(replacement)
+    try_extract_complex_float(replacement)
   };
   let key = |item: &Expr| -> Option<(f64, f64)> {
     if let Expr::List(rules) = item
@@ -259,7 +261,7 @@ fn try_nsolve_quadratic(
   for d in 0..=2 {
     for term in &terms {
       if let Some(c) = extract_coefficient_of_power(term, &var, d as i128) {
-        let val = crate::functions::math_ast::try_eval_to_f64(&simplify(c))?;
+        let val = try_eval_to_f64(&simplify(c))?;
         coeffs_f64[d] += val;
       }
     }
@@ -370,7 +372,7 @@ fn try_nsolve_pure_power(
   for (d, slot) in coeffs_f64.iter_mut().enumerate() {
     for term in &terms {
       if let Some(c) = extract_coefficient_of_power(term, &var, d as i128) {
-        *slot += crate::functions::math_ast::try_eval_to_f64(&simplify(c))?;
+        *slot += try_eval_to_f64(&simplify(c))?;
       }
     }
   }
@@ -428,7 +430,7 @@ fn complex_pow(a: f64, b: f64, c: f64, d: f64) -> (f64, f64) {
 /// symbolic `Power` into NSolve's output.
 fn eval_complex_full(expr: &Expr) -> Option<(f64, f64)> {
   // Reuse the existing extractor for everything but Power.
-  if let Some(v) = crate::functions::math_ast::try_extract_complex_float(expr) {
+  if let Some(v) = try_extract_complex_float(expr) {
     return Some(v);
   }
   let pow_parts = |base: &Expr, exp: &Expr| -> Option<(f64, f64)> {
@@ -521,7 +523,7 @@ fn nsolve_numerize(expr: &Expr) -> Result<Expr, InterpreterError> {
     }),
     _ => {
       // Try pure real first
-      if let Some(v) = crate::functions::math_ast::try_eval_to_f64(expr) {
+      if let Some(v) = try_eval_to_f64(expr) {
         return Ok(Expr::Real(v));
       }
       // Try complex (handles I, -I, a + b*I, and radical Power roots like
@@ -697,7 +699,7 @@ pub fn nroots_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for d in 0..=degree {
     for term in &terms {
       if let Some(c) = extract_coefficient_of_power(term, &var, d as i128) {
-        let val = crate::functions::math_ast::try_eval_to_f64(&simplify(c));
+        let val = try_eval_to_f64(&simplify(c));
         match val {
           Some(v) => coeffs[d] += v,
           None => return Ok(unevaluated()),
@@ -2267,7 +2269,7 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
                   | ComparisonOp::Greater
                   | ComparisonOp::GreaterEqual)));
             is_ordering
-              && crate::functions::math_ast::try_extract_complex_float(&numeric)
+              && try_extract_complex_float(&numeric)
                 .is_some_and(|(_re, im)| im.abs() > 1e-10)
           };
           let violated = matches!(sol, Expr::List(rules) if rules.iter().any(|rule| {
@@ -2288,8 +2290,7 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
             if let Expr::List(rules) = sol
               && let Some(Expr::Rule { replacement, .. }) = rules.first()
             {
-              crate::functions::math_ast::try_eval_to_f64(replacement)
-                .unwrap_or(f64::INFINITY)
+              try_eval_to_f64(replacement).unwrap_or(f64::INFINITY)
             } else {
               f64::INFINITY
             }
@@ -2671,8 +2672,7 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
               // Special case: when nb == 0 and so == 1, absorb denominator into Sqrt
               // E.g. Sqrt[6]/2 → Sqrt[3/2] to match Wolfram's canonical form
               if nb == 0 && den != 1 && so == 1 {
-                let rational_arg =
-                  crate::functions::math_ast::make_rational(sqrt_in, den * den);
+                let rational_arg = make_rational(sqrt_in, den * den);
                 if let Ok(simplified) =
                   crate::functions::math_ast::sqrt_ast(&[rational_arg])
                 {
@@ -2729,11 +2729,7 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
             let make_neg1_pow = |p: i128, q: i128| -> Expr {
               Expr::FunctionCall {
                 name: "Power".to_string(),
-                args: vec![
-                  Expr::Integer(-1),
-                  crate::functions::math_ast::make_rational(p, q),
-                ]
-                .into(),
+                args: vec![Expr::Integer(-1), make_rational(p, q)].into(),
               }
             };
             // After multiplying by -1, the b/a sign flips along with a's
@@ -2986,7 +2982,7 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
           // Solve[x^3 == -2, x] gives -2^(1/3), not (-2)^(1/3), as its
           // second solution.
           let negative_val = matches!(
-            crate::functions::math_ast::try_eval_to_f64(&val),
+            try_eval_to_f64(&val),
             Some(v) if v < 0.0
           );
           let root_of = |value: &Expr| -> Expr {
@@ -3221,7 +3217,7 @@ fn max_degree_of_var(eq: &Expr, var: &str) -> Option<i128> {
 fn numeric_polynomial_solutions(coeffs: &[Expr], var: &str) -> Option<Expr> {
   let mut numeric = Vec::with_capacity(coeffs.len());
   for c in coeffs {
-    numeric.push(crate::functions::math_ast::try_eval_to_f64(c)?);
+    numeric.push(try_eval_to_f64(c)?);
   }
   let degree = numeric.len().checked_sub(1)?;
   if degree < 1 || numeric[degree].abs() < 1e-300 {
@@ -3674,7 +3670,7 @@ fn try_solve_abs_eq(
   };
 
   let mut solutions: Vec<Expr> = Vec::new();
-  match crate::functions::math_ast::try_eval_to_f64(&eff) {
+  match try_eval_to_f64(&eff) {
     Some(v) if v < 0.0 => {} // no real solution → {}
     Some(0.0) => {
       solutions.extend(solve_branch(Expr::Integer(0))?);
@@ -3708,9 +3704,7 @@ fn try_solve_abs_eq(
 /// back unchanged.
 fn strip_constant_factor(expr: &Expr, var: &str) -> Expr {
   let is_nonzero_const = |e: &Expr| -> bool {
-    !contains_var(e, var)
-      && crate::functions::math_ast::try_eval_to_f64(e)
-        .is_some_and(|v| v != 0.0)
+    !contains_var(e, var) && try_eval_to_f64(e).is_some_and(|v| v != 0.0)
   };
   match expr {
     Expr::UnaryOp {
@@ -3791,7 +3785,7 @@ fn try_solve_trig_eq(eq: &Expr, var: &str) -> Option<Expr> {
     // Sin/Cos is still solved symbolically via ArcSin/ArcCos (the inverse is
     // complex-valued), matching wolframscript's ConditionalExpression form —
     // e.g. Solve[Cos[x] == 2, x] -> ±ArcCos[2] + 2*Pi*C[1].
-    let _c = crate::functions::math_ast::try_eval_to_f64(rhs)?;
+    let _c = try_eval_to_f64(rhs)?;
   }
 
   let var_expr = Expr::Identifier(var.to_string());
@@ -3820,7 +3814,7 @@ fn try_solve_trig_eq(eq: &Expr, var: &str) -> Option<Expr> {
   };
   let neg_half_pi = Expr::BinaryOp {
     op: BinaryOperator::Times,
-    left: Box::new(crate::functions::math_ast::make_rational(-1, 2)),
+    left: Box::new(make_rational(-1, 2)),
     right: Box::new(pi.clone()),
   };
   let half_pi = Expr::BinaryOp {
@@ -4482,9 +4476,7 @@ pub fn solve_divide(num: &Expr, den: &Expr) -> Expr {
   match (num, den) {
     (Expr::Integer(0), _) => Expr::Integer(0),
     (_, Expr::Integer(1)) => num.clone(),
-    (Expr::Integer(n), Expr::Integer(d)) if *d != 0 => {
-      crate::functions::math_ast::make_rational(*n, *d)
-    }
+    (Expr::Integer(n), Expr::Integer(d)) if *d != 0 => make_rational(*n, *d),
     // Non-integer denominator (a rational such as -1/2, or a symbolic
     // expression): evaluate the quotient so it is fully simplified
     // (e.g. -x / (-1/2) -> 2*x) rather than left as a nested fraction.
@@ -5351,8 +5343,7 @@ fn build_find_root_func(arg: &Expr) -> Expr {
 /// Try to evaluate `expr` to a complex `(re, im)` pair using f64
 /// arithmetic. Returns None when the expression isn't fully numeric.
 fn try_extract_complex_f64(expr: &Expr) -> Option<(f64, f64)> {
-  let n_result =
-    crate::functions::math_ast::n_ast(std::slice::from_ref(expr)).ok()?;
+  let n_result = n_ast(std::slice::from_ref(expr)).ok()?;
   expr_to_complex_f64(&n_result)
 }
 
@@ -5498,7 +5489,7 @@ fn find_root_eval_complex_at(
   if let Some(c) = expr_to_complex_f64(&evaled) {
     return Some(c);
   }
-  let n_result = crate::functions::math_ast::n_ast(&[evaled]).ok()?;
+  let n_result = n_ast(&[evaled]).ok()?;
   expr_to_complex_f64(&n_result)
 }
 
@@ -5631,7 +5622,7 @@ fn find_root_eval_at(
     }
     _ => {
       // Try N[] evaluation
-      let n_result = crate::functions::math_ast::n_ast(&[evaled])?;
+      let n_result = n_ast(&[evaled])?;
       match &n_result {
         Expr::Real(r) => Ok(*r),
         Expr::Integer(n) => Ok(*n as f64),
@@ -5705,7 +5696,7 @@ fn find_root_eval_multivar(
       }
     }
     _ => {
-      let n_result = crate::functions::math_ast::n_ast(&[evaled])?;
+      let n_result = n_ast(&[evaled])?;
       match &n_result {
         Expr::Real(r) => Ok(*r),
         Expr::Integer(k) => Ok(*k as f64),
@@ -6347,9 +6338,7 @@ fn minimize_try_f64(expr: &Expr) -> Option<f64> {
       }
     }
     _ => {
-      if let Ok(n_result) =
-        crate::functions::math_ast::n_ast(std::slice::from_ref(expr))
-      {
+      if let Ok(n_result) = n_ast(std::slice::from_ref(expr)) {
         match n_result {
           Expr::Real(r) => Some(r),
           Expr::Integer(n) => Some(n as f64),
@@ -6445,8 +6434,7 @@ fn minimize_poly_roots_int(coeffs: &[i128], var: &str) -> Vec<Expr> {
               // When nb == 0 and den != 1 and so == 1, use Sqrt[sqrt_in/den^2]
               // to produce canonical form like Sqrt[3/2] instead of Sqrt[6]/2
               if nb == 0 && den != 1 && so == 1 {
-                let rational_arg =
-                  crate::functions::math_ast::make_rational(sqrt_in, den * den);
+                let rational_arg = make_rational(sqrt_in, den * den);
                 if let Ok(simplified) =
                   crate::functions::math_ast::sqrt_ast(&[rational_arg])
                 {
@@ -9331,14 +9319,12 @@ fn specialize_periodic_solution(
     })
   };
   // Linear coefficients: a = body | C=0, b = Coefficient[body, C, 1].
-  let a = crate::functions::math_ast::try_eval_to_f64(&subst_param(
-    Expr::Integer(0),
-  )?)?;
+  let a = try_eval_to_f64(&subst_param(Expr::Integer(0))?)?;
   let b_expr = eval(Expr::FunctionCall {
     name: "Coefficient".to_string(),
     args: vec![body.clone(), param.clone(), Expr::Integer(1)].into(),
   })?;
-  let b = crate::functions::math_ast::try_eval_to_f64(&b_expr)?;
+  let b = try_eval_to_f64(&b_expr)?;
   if b.abs() < 1e-12 {
     return None;
   }
@@ -9351,7 +9337,7 @@ fn specialize_periodic_solution(
         if crate::syntax::expr_to_string(op) == var_name {
           continue;
         }
-        if let Some(v) = crate::functions::math_ast::try_eval_to_f64(op) {
+        if let Some(v) = try_eval_to_f64(op) {
           x_bounds.push(v);
         }
       }
@@ -9735,8 +9721,7 @@ fn expr_to_f64(expr: &Expr) -> Result<f64, InterpreterError> {
       }
     }
     _ => {
-      let n_result =
-        crate::functions::math_ast::n_ast(std::slice::from_ref(expr))?;
+      let n_result = n_ast(std::slice::from_ref(expr))?;
       match &n_result {
         Expr::Real(r) => Ok(*r),
         Expr::Integer(n) => Ok(*n as f64),

--- a/src/functions/polynomial_ast/to_radicals.rs
+++ b/src/functions/polynomial_ast/to_radicals.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::gcd_i128;
 
 /// ToRadicals[expr] — convert Root objects to explicit radical expressions.
 pub fn to_radicals_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use crate::functions::math_ast::{gcd_i128, rat_reduce};
 
 // ─── Together ───────────────────────────────────────────────────────
 

--- a/src/functions/polynomial_ast/zassenhaus.rs
+++ b/src/functions/polynomial_ast/zassenhaus.rs
@@ -7,9 +7,8 @@
 //! cap breach returns None so the caller can fall back to other methods.
 
 use super::gf_factor::gf_factor_coeffs;
-use super::poly_div;
-use super::{deg, is_zero, trim};
-use crate::functions::math_ast::gcd_i128;
+#[allow(unused_imports)]
+use super::*;
 
 const PRIMES: [i128; 15] =
   [3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53];


### PR DESCRIPTION
math_ast/*.rs files generally don't need to refer to crate::function::math_ast::. Additionally, this PR moves some math_ast imports in polynomial_ast/*.rs to polynomial_ast/mod.rs.