### PR TITLE
Add PlotRange full form and BoxRatios support to 3D graphics

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1671,7 +1671,7 @@ Mouseover,Mouseover display wrapper (stays symbolic),✅,unevaluated,6.0,1683
 AffineStateSpaceModel,Affine state-space model,,unevaluated,10.0,1687
 LogLikelihood,Log-likelihood of numeric observations under a distribution,✅,pure,8.0,1687
 RectangleChart,Rectangle chart,,unevaluated,7.0,1687
-SpanFromAbove,Span from above,,unevaluated,6.0,1687
+SpanFromAbove,Grid element that merges into the cell above it,✅,none,6.0,1687
 Cubics,Option for solving cubic equations using radical formulas,✅,pure,1.0,1688
 MinValue,Global symbolic minimum value of a function over variables with optional constraints and an optional Reals or Integers domain,✅,pure,7.0,1690
 Exit,Terminates the kernel session with optional exit code,✅,effectful,1.0,1692
@@ -2462,7 +2462,7 @@ SystemsModelStateFeedbackConnect,,🚫,,8.0,2491
 TraceScan,Apply a function as a side effect to each sub-expression during evaluation,✅,effectful,2.0,2491
 ImageType,Returns the data type of an image,✅,pure,7.0,2495
 ResetDirectory,resets the current directory to the previous one set by SetDirectory,✅,io,2.0,2495
-SpanFromBoth,,🚫,,6.0,2495
+SpanFromBoth,Grid element that merges into a block spanning both left and above,✅,none,6.0,2495
 AudioData,Samples of an audio object one list per channel optionally scaled onto an integer sample type,✅,pure,11.0,2503
 BinomialProcess,Binomial counting process with Binomial time slices,✅,unevaluated,9.0,2503
 ExponentialGeneratingFunction,Compute the exponential generating function of a sequence,✅,pure,7.0,2503

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -9138,22 +9138,39 @@ fn evaluate_function_call_ast_inner(
   // CreateDirectory[] — create a temporary directory
   if name == "CreateDirectory" {
     if args.is_empty() {
-      // Create a temporary directory
-      match std::env::temp_dir()
-        .to_str()
-        .map(|t| format!("{}/woxi_{}", t, std::process::id()))
-      {
-        Some(tmp_path) => match std::fs::create_dir_all(&tmp_path) {
-          Ok(()) => return Ok(Expr::String(tmp_path)),
-          Err(e) => {
-            crate::emit_message(&format!("CreateDirectory::failed: {}", e));
-            return Ok(Expr::Identifier("$Failed".to_string()));
+      // Create a temporary directory. Every call makes a *new* one, as
+      // Wolfram does: handing the same path back twice lets one caller
+      // delete the directory another is still using — the failure that
+      // showed up as `DirectoryQ[CreateDirectory[]]` reporting False.
+      static NEXT_TEMP_DIR: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+      let mut last_err = None;
+      for _ in 0..1000 {
+        let n =
+          NEXT_TEMP_DIR.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+          "woxi_{}_{}",
+          std::process::id(),
+          n
+        ));
+        // `create_dir` fails rather than reusing an existing directory, so
+        // a name left behind by an earlier run is skipped instead of shared.
+        match std::fs::create_dir(&path) {
+          Ok(()) => {
+            return Ok(Expr::String(path.to_string_lossy().into_owned()));
           }
-        },
-        None => {
-          return Ok(Expr::Identifier("$Failed".to_string()));
+          Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+          Err(e) => {
+            last_err = Some(e);
+            break;
+          }
         }
       }
+      let message = last_err
+        .map(|e| e.to_string())
+        .unwrap_or_else(|| "no free directory name".to_string());
+      crate::emit_message(&format!("CreateDirectory::failed: {message}"));
+      return Ok(Expr::Identifier("$Failed".to_string()));
     }
     if args.len() == 1 {
       if let Expr::String(path) = &args[0] {

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -4202,7 +4202,38 @@ pub(crate) fn labeled_display_svg(expr: &Expr) -> Option<String> {
   is_labeled.then(|| expr_to_svg(expr))
 }
 
+/// The picture behind a wrapper that only shows one once its content
+/// evaluates. `None` when it does not, which leaves the call to the arms
+/// below — a `Dynamic` whose body errors still prints as itself.
+fn evaluated_wrapper_svg(expr: &Expr) -> Option<String> {
+  let Expr::FunctionCall { name, args } = expr else {
+    return None;
+  };
+  match name.as_str() {
+    // `Dynamic[expr]` displays the value `expr` has now — a front end
+    // shows the content, never the wrapper. (Script-mode *text* output
+    // keeps the wrapper, matching wolframscript; this is the picture path,
+    // which is what a notebook shows.)
+    "Dynamic" if args.len() == 1 => {
+      let value = crate::evaluator::evaluate_expr_to_expr(&args[0]).ok()?;
+      Some(expr_to_svg(&unquoted_display_string(&value)))
+    }
+    // `LocatorPane[locators, body, …]` displays `body` with a marker on
+    // every locator.
+    "LocatorPane" if args.len() >= 2 => {
+      let drawn = locator_pane_graphic(args)?;
+      Some(expr_to_svg(
+        &crate::evaluator::evaluate_expr_to_expr(&drawn).unwrap_or(drawn),
+      ))
+    }
+    _ => None,
+  }
+}
+
 pub(crate) fn expr_to_svg(expr: &Expr) -> String {
+  if let Some(svg) = evaluated_wrapper_svg(expr) {
+    return svg;
+  }
   match expr {
     Expr::Graphics { svg: svg_data, .. } => svg_data.clone(),
     // `Pane[content, opts…]` only constrains its content's size; the
@@ -4211,29 +4242,6 @@ pub(crate) fn expr_to_svg(expr: &Expr) -> String {
     // this, `Export[…, Pane[graphic]]` wrote the expression as text.)
     Expr::FunctionCall { name, args } if name == "Pane" && !args.is_empty() => {
       expr_to_svg(&args[0])
-    }
-    // `Dynamic[expr]` displays the value `expr` has now — a front end shows
-    // the content, never the wrapper. (Script-mode *text* output keeps the
-    // wrapper, matching wolframscript; this is the picture path, which is
-    // what a notebook shows.)
-    Expr::FunctionCall { name, args }
-      if name == "Dynamic"
-        && args.len() == 1
-        && let Ok(value) =
-          crate::evaluator::evaluate_expr_to_expr(&args[0]) =>
-    {
-      expr_to_svg(&unquoted_display_string(&value))
-    }
-    // `LocatorPane[locators, body, …]` displays `body` with a marker on
-    // every locator.
-    Expr::FunctionCall { name, args }
-      if name == "LocatorPane"
-        && args.len() >= 2
-        && let Some(drawn) = locator_pane_graphic(args) =>
-    {
-      expr_to_svg(
-        &crate::evaluator::evaluate_expr_to_expr(&drawn).unwrap_or(drawn),
-      )
     }
     // `Item[expr, opts…]` is a layout cell; the options place it and what
     // it displays is `expr`.

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -9733,9 +9733,23 @@ pub struct GridStyle {
 
 /// `SpanFromLeft` in a `Grid` cell means "the cell to my left continues into
 /// this column": it draws nothing itself, and its neighbour is laid out
-/// across the merged span.
+/// across the merged span. `SpanFromBoth` continues a cell that spans both
+/// ways, so it is a left continuation too.
 fn is_span_from_left(cell: &Expr) -> bool {
-  matches!(cell, Expr::Identifier(s) if s == "SpanFromLeft")
+  matches!(cell, Expr::Identifier(s) if s == "SpanFromLeft" || s == "SpanFromBoth")
+}
+
+/// `SpanFromAbove` means "the cell above me continues into this row" — the
+/// vertical counterpart of `SpanFromLeft`, with `SpanFromBoth` marking the
+/// inside of a block that is merged in both directions.
+fn is_span_from_above(cell: &Expr) -> bool {
+  matches!(cell, Expr::Identifier(s) if s == "SpanFromAbove" || s == "SpanFromBoth")
+}
+
+/// A cell that only continues a merged one, in either direction: it holds no
+/// content of its own and so is skipped by every sizing and drawing pass.
+fn is_span_placeholder(cell: &Expr) -> bool {
+  is_span_from_left(cell) || is_span_from_above(cell)
 }
 
 /// How many columns the cell at `j` covers — itself plus every
@@ -9744,6 +9758,15 @@ fn span_width(row: &[Expr], j: usize) -> usize {
   1 + row[j + 1..]
     .iter()
     .take_while(|c| is_span_from_left(c))
+    .count()
+}
+
+/// How many rows the cell at `(i, j)` covers — itself plus every row below
+/// whose cell in that column continues it.
+fn span_height(rows: &[Vec<Expr>], i: usize, j: usize) -> usize {
+  1 + rows[i + 1..]
+    .iter()
+    .take_while(|row| row.get(j).is_some_and(is_span_from_above))
     .count()
 }
 
@@ -10416,7 +10439,7 @@ fn grid_svg_styled_internal(
   let mut spans: Vec<(usize, usize, f64)> = Vec::new();
   for row in &rows {
     for (j, cell) in row.iter().enumerate() {
-      if is_span_from_left(cell) {
+      if is_span_placeholder(cell) {
         continue;
       }
       let w = match grid_cell_graphic(cell) {
@@ -10470,45 +10493,59 @@ fn grid_svg_styled_internal(
     }
   }
 
-  // Compute per-row heights (taller for fractions or images)
-  let row_heights: Vec<f64> = rows
-    .iter()
-    .map(|row| {
-      let mut max_h = if row.iter().any(has_fraction) {
+  // Compute per-row heights (taller for fractions or images). Cells that
+  // span several rows are held back the way column spans are: the rows are
+  // sized by the ordinary cells first, and only what a span still needs is
+  // added afterwards, so one tall picture does not stretch a single row.
+  let mut row_spans: Vec<(usize, usize, f64)> = Vec::new();
+  let mut row_heights: Vec<f64> = Vec::with_capacity(num_rows);
+  for (i, row) in rows.iter().enumerate() {
+    let mut max_h = base_row_height;
+    for (j, cell) in row.iter().enumerate() {
+      if is_span_placeholder(cell) {
+        continue;
+      }
+      let mut cell_h = if has_fraction(cell) {
         frac_row_height
       } else {
         base_row_height
       };
       // A graphic cell keeps its own height.
-      for cell in row.iter() {
-        if let Some((_, _, nat_h)) = grid_cell_graphic(cell) {
-          max_h = max_h.max(nat_h + pad_y);
-        }
+      if let Some((_, _, nat_h)) = grid_cell_graphic(cell) {
+        cell_h = cell_h.max(nat_h + pad_y);
       }
-      // Check for Image cells — scale to fit column width, compute height
-      for (j, cell) in row.iter().enumerate() {
-        if let Some(img) = unwrap_to_image(cell)
-          && let Expr::Image {
-            width: iw,
-            height: ih,
-            ..
-          } = img
-        {
-          let col_w = if j < col_widths.len() {
-            col_widths[j] - pad_x
-          } else {
-            200.0
-          };
-          let scale = col_w / (*iw as f64);
-          let img_h = (*ih as f64) * scale + pad_y;
-          if img_h > max_h {
-            max_h = img_h;
-          }
-        }
+      // An Image cell is scaled to fit the column width, which fixes its height.
+      if let Some(img) = unwrap_to_image(cell)
+        && let Expr::Image {
+          width: iw,
+          height: ih,
+          ..
+        } = img
+      {
+        let col_w = if j < col_widths.len() {
+          col_widths[j] - pad_x
+        } else {
+          200.0
+        };
+        let scale = col_w / (*iw as f64);
+        cell_h = cell_h.max((*ih as f64) * scale + pad_y);
       }
-      max_h
-    })
-    .collect();
+      let span = span_height(&rows, i, j);
+      if span > 1 {
+        row_spans.push((i, span, cell_h));
+      } else {
+        max_h = max_h.max(cell_h);
+      }
+    }
+    row_heights.push(max_h);
+  }
+  for (i, span, h) in row_spans {
+    let end = (i + span).min(num_rows);
+    let have: f64 = row_heights[i..end].iter().sum();
+    if h > have && end > i {
+      row_heights[end - 1] += h - have;
+    }
+  }
 
   let grid_width: f64 = col_widths.iter().sum();
   let total_gap: f64 = group_gaps.len() as f64 * group_gap;
@@ -10748,9 +10785,9 @@ fn grid_svg_styled_internal(
   for (i, row) in rows.iter().enumerate() {
     let mut x_offset: f64 = paren_margin;
     for (j, cell) in row.iter().enumerate() {
-      // A `SpanFromLeft` placeholder draws nothing; the cell it continues
-      // was already laid out across this column.
-      if is_span_from_left(cell) {
+      // A span placeholder draws nothing; the cell it continues was already
+      // laid out across this column or row.
+      if is_span_placeholder(cell) {
         x_offset += col_widths[j];
         continue;
       }
@@ -10758,6 +10795,9 @@ fn grid_svg_styled_internal(
         let end = (j + span_width(row, j)).min(num_cols);
         col_widths[j..end].iter().sum()
       };
+      // A row-spanning cell is centred over all the rows it covers.
+      let last_row = (i + span_height(&rows, i, j)).min(num_rows) - 1;
+      let (cell_top, cell_bottom) = (visual_tops[i], visual_bottoms[last_row]);
       let col_align = col_alignments.get(j).copied().unwrap_or(alignment_h);
       // Decimal columns anchor each cell so its decimal point lands at a shared
       // `dot_x`; the whole number is start-anchored at `dot_x - int_width`.
@@ -10783,7 +10823,7 @@ fn grid_svg_styled_internal(
       };
       // Shift text down slightly to compensate for ascenders being taller
       // than descenders, which makes mathematical centering look top-heavy.
-      let cy = (visual_tops[i] + visual_bottoms[i]) / 2.0 - 1.0;
+      let cy = (cell_top + cell_bottom) / 2.0 - 1.0;
 
       // A graphic cell is drawn as a nested <svg> at its own size,
       // centred in the cell.
@@ -10791,8 +10831,8 @@ fn grid_svg_styled_internal(
         && let Some(parsed) = parse_svg_dimensions(&cell_svg)
       {
         let gx = x_offset + (col_w - nat_w) / 2.0;
-        let vis_h = visual_bottoms[i] - visual_tops[i];
-        let gy = visual_tops[i] + (vis_h - nat_h) / 2.0;
+        let vis_h = cell_bottom - cell_top;
+        let gy = cell_top + (vis_h - nat_h) / 2.0;
         svg.push_str(&format!(
           "<svg x=\"{gx:.1}\" y=\"{gy:.1}\" width=\"{nat_w:.1}\" height=\"{nat_h:.1}\" viewBox=\"{}\" preserveAspectRatio=\"xMidYMid meet\">\n{}</svg>\n",
           parsed.view_box, parsed.inner_content
@@ -10816,8 +10856,8 @@ fn grid_svg_styled_internal(
           let draw_w = avail_w;
           let draw_h = (*ih as f64) * scale;
           let ix = x_offset + pad_x / 2.0;
-          let vis_h = visual_bottoms[i] - visual_tops[i];
-          let iy = visual_tops[i] + (vis_h - draw_h) / 2.0;
+          let vis_h = cell_bottom - cell_top;
+          let iy = cell_top + (vis_h - draw_h) / 2.0;
 
           // Encode image as base64 PNG
           let dyn_img = crate::functions::image_ast::expr_to_dynamic_image(
@@ -10949,10 +10989,34 @@ fn grid_svg_styled_internal(
         } else {
           visual_tops[i]
         };
-        svg.push_str(&format!(
-          "<line x1=\"{paren_margin:.1}\" y1=\"{draw_y:.1}\" x2=\"{:.1}\" y2=\"{draw_y:.1}\" stroke=\"{stroke}\" stroke-width=\"1\"/>\n",
-          paren_margin + grid_width
-        ));
+        // A divider is interrupted wherever it would cut through a cell
+        // that spans across it (`SpanFromAbove`), so it is drawn per column
+        // and contiguous runs are merged back into one line.
+        let mut x_offset: f64 = paren_margin;
+        let mut run_start: Option<f64> = None;
+        for j in 0..num_cols {
+          let spanned = !is_border
+            && rows
+              .get(i)
+              .and_then(|row| row.get(j))
+              .is_some_and(is_span_from_above);
+          if spanned {
+            if let Some(x0) = run_start.take() {
+              svg.push_str(&format!(
+                "<line x1=\"{x0:.1}\" y1=\"{draw_y:.1}\" x2=\"{x_offset:.1}\" y2=\"{draw_y:.1}\" stroke=\"{stroke}\" stroke-width=\"1\"/>\n"
+              ));
+            }
+          } else if run_start.is_none() {
+            run_start = Some(x_offset);
+          }
+          x_offset += col_widths[j];
+        }
+        if let Some(x0) = run_start {
+          svg.push_str(&format!(
+            "<line x1=\"{x0:.1}\" y1=\"{draw_y:.1}\" x2=\"{:.1}\" y2=\"{draw_y:.1}\" stroke=\"{stroke}\" stroke-width=\"1\"/>\n",
+            paren_margin + grid_width
+          ));
+        }
       }
     }
   }

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -313,8 +313,8 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let body = &args[0];
 
   // Parse iterators
-  let (xvar, x_min, x_max) = parse_iterator(&args[1], "first")?;
-  let (yvar, y_min, y_max) = parse_iterator(&args[2], "second")?;
+  let (xvar, mut x_min, mut x_max) = parse_iterator(&args[1], "first")?;
+  let (yvar, mut y_min, mut y_max) = parse_iterator(&args[2], "second")?;
 
   // Parse options
   let mut svg_width = DEFAULT_SIZE;
@@ -348,7 +348,24 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }
         }
         Expr::Identifier(name) if name == "PlotRange" => {
-          if let Expr::List(items) = replacement.as_ref()
+          // `PlotRange -> {zmin, zmax}` bounds the vertical axis only. The
+          // full form `{{xmin, xmax}, {ymin, ymax}, {zmin, zmax}}` bounds
+          // all three; the horizontal bounds narrow the plotted domain, so
+          // a surface asked for over a wider iterator range is cropped to
+          // the box rather than drawn past it.
+          if let Some([xr, yr, zr]) = parse_axis_ranges(replacement) {
+            // An empty intersection would leave nothing to sample, so a
+            // box that misses the iterator range leaves the domain alone.
+            if x_min.max(xr.0) < x_max.min(xr.1)
+              && y_min.max(yr.0) < y_max.min(yr.1)
+            {
+              x_min = x_min.max(xr.0);
+              x_max = x_max.min(xr.1);
+              y_min = y_min.max(yr.0);
+              y_max = y_max.min(yr.1);
+            }
+            z_clip = Some(zr);
+          } else if let Expr::List(items) = replacement.as_ref()
             && items.len() == 2
           {
             let lo = try_eval_to_f64(&evaluate_expr_to_expr(&items[0])?);
@@ -420,6 +437,193 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Phase 2: Build triangles using the shared z range
   let mut all_triangles: Vec<Triangle> = Vec::new();
   let num_surfaces = grids.len();
+
+  // ── Symbolic structure: Graphics3D[GraphicsComplex[points, {…}]] ──
+  // `Show` merges the *primitives* of the graphics it is given, so a
+  // surface that exists only as a rendering is dropped when it is shown
+  // together with a `Graphics3D`. Emitting the sampled surface in world
+  // coordinates — coloured by height, the way the standalone render
+  // colours it — lets `Show[Plot3D[…], Graphics3D[…]]` draw both.
+  let structure = {
+    let complexes: Vec<Expr> = grids
+      .iter()
+      .enumerate()
+      .map(|(surface_idx, grid)| {
+        let mut index_of: Vec<Vec<Option<usize>>> =
+          vec![vec![None; GRID_N + 1]; GRID_N + 1];
+        let mut point_exprs: Vec<Expr> = Vec::new();
+        for (i, row) in grid.iter().enumerate() {
+          for (j, &z) in row.iter().enumerate() {
+            if !z.is_finite() {
+              continue;
+            }
+            index_of[i][j] = Some(point_exprs.len());
+            point_exprs.push(Expr::List(
+              vec![
+                Expr::Real(x_min + i as f64 * x_step),
+                Expr::Real(y_min + j as f64 * y_step),
+                Expr::Real(z.clamp(z_lo, z_hi)),
+              ]
+              .into(),
+            ));
+          }
+        }
+        let mut content: Vec<Expr> = Vec::new();
+        // The sampling quads are far finer than the mesh a surface shows,
+        // so their own outlines are suppressed and the mesh is drawn as
+        // lines below — otherwise a shown surface turns into a wireframe.
+        if !matches!(mesh_mode, MeshMode::All) {
+          content.push(Expr::FunctionCall {
+            name: "EdgeForm".to_string(),
+            args: Vec::new().into(),
+          });
+        }
+        for i in 0..GRID_N {
+          for j in 0..GRID_N {
+            let (Some(a), Some(b), Some(c), Some(d)) = (
+              index_of[i][j],
+              index_of[i + 1][j],
+              index_of[i + 1][j + 1],
+              index_of[i][j + 1],
+            ) else {
+              continue;
+            };
+            let avg_z_norm = [
+              grid[i][j],
+              grid[i + 1][j],
+              grid[i + 1][j + 1],
+              grid[i][j + 1],
+            ]
+            .iter()
+            .map(|z| (z.clamp(z_lo, z_hi) - z_lo) / z_range)
+            .sum::<f64>()
+              / 4.0;
+            let (cr, cg, cb) =
+              surface_height_color(avg_z_norm, surface_idx, num_surfaces);
+            // Colour and polygon travel in a sublist so the directive does
+            // not leak onto the quads drawn after it.
+            content.push(Expr::List(
+              vec![
+                Expr::FunctionCall {
+                  name: "RGBColor".to_string(),
+                  args: vec![
+                    Expr::Real(cr as f64 / 255.0),
+                    Expr::Real(cg as f64 / 255.0),
+                    Expr::Real(cb as f64 / 255.0),
+                  ]
+                  .into(),
+                },
+                Expr::FunctionCall {
+                  name: "Polygon".to_string(),
+                  args: vec![Expr::List(
+                    [a, b, c, d]
+                      .iter()
+                      .map(|&k| Expr::Integer(k as i128 + 1))
+                      .collect::<Vec<_>>()
+                      .into(),
+                  )]
+                  .into(),
+                },
+              ]
+              .into(),
+            ));
+          }
+        }
+        // The mesh, at the spacing the standalone render rules it with.
+        if matches!(mesh_mode, MeshMode::Default) {
+          let mut segments: Vec<Expr> = Vec::new();
+          let mut push_segment = |a: Option<usize>, b: Option<usize>| {
+            if let (Some(a), Some(b)) = (a, b) {
+              segments.push(Expr::List(
+                vec![
+                  Expr::Integer(a as i128 + 1),
+                  Expr::Integer(b as i128 + 1),
+                ]
+                .into(),
+              ));
+            }
+          };
+          for j in (0..=GRID_N).step_by(MESH_STEP) {
+            for i in 0..GRID_N {
+              push_segment(index_of[i][j], index_of[i + 1][j]);
+            }
+          }
+          for i in (0..=GRID_N).step_by(MESH_STEP) {
+            for j in 0..GRID_N {
+              push_segment(index_of[i][j], index_of[i][j + 1]);
+            }
+          }
+          if !segments.is_empty() {
+            content.push(Expr::List(
+              vec![
+                Expr::FunctionCall {
+                  name: "Opacity".to_string(),
+                  args: vec![Expr::Real(0.63)].into(),
+                },
+                Expr::FunctionCall {
+                  name: "RGBColor".to_string(),
+                  args: vec![Expr::Real(0.0), Expr::Real(0.0), Expr::Real(0.0)]
+                    .into(),
+                },
+                Expr::FunctionCall {
+                  name: "AbsoluteThickness".to_string(),
+                  args: vec![Expr::Real(0.5)].into(),
+                },
+                Expr::FunctionCall {
+                  name: "Line".to_string(),
+                  args: vec![Expr::List(segments.into())].into(),
+                },
+              ]
+              .into(),
+            ));
+          }
+        }
+        Expr::FunctionCall {
+          name: "GraphicsComplex".to_string(),
+          args: vec![
+            Expr::List(point_exprs.into()),
+            Expr::List(content.into()),
+          ]
+          .into(),
+        }
+      })
+      .collect();
+    let content = if complexes.len() == 1 {
+      complexes.into_iter().next().expect("one complex")
+    } else {
+      Expr::List(complexes.into())
+    };
+    // `Plot3D` draws axes and squats its box where a bare `Graphics3D`
+    // does neither, so both defaults are spelled out: a surface shown
+    // inside another graphic keeps the shape it was drawn with.
+    let mut structure_args = vec![content];
+    structure_args.extend(args[3..].iter().cloned());
+    let names = |opt: &str| {
+      structure_args.iter().any(|o| {
+        matches!(o, Expr::Rule { pattern, .. } | Expr::RuleDelayed { pattern, .. }
+          if matches!(pattern.as_ref(), Expr::Identifier(n) if n == opt))
+      })
+    };
+    let (names_axes, names_ratios) = (names("Axes"), names("BoxRatios"));
+    if !names_axes {
+      structure_args.push(Expr::Rule {
+        pattern: Box::new(Expr::Identifier("Axes".to_string())),
+        replacement: Box::new(Expr::Identifier("True".to_string())),
+      });
+    }
+    if !names_ratios {
+      structure_args.push(Expr::Rule {
+        pattern: Box::new(Expr::Identifier("BoxRatios".to_string())),
+        replacement: Box::new(Expr::List(
+          vec![Expr::Integer(1), Expr::Integer(1), Expr::Real(Z_SCALE)].into(),
+        )),
+      });
+    }
+    Expr::FunctionCall {
+      name: "Graphics3D".to_string(),
+      args: structure_args.into(),
+    }
+  };
 
   for (surface_idx, grid) in grids.iter().enumerate() {
     for i in 0..GRID_N {
@@ -578,7 +782,7 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     show_axes,
   )?;
 
-  Ok(crate::graphics3d_result(svg))
+  Ok(crate::graphics3d_result_with_structure(svg, structure))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3387,6 +3591,177 @@ fn tessellate_cone(
   tris
 }
 
+/// The world-coordinate bounding box of a set of 3D primitives, as
+/// `[(xlo, xhi), (ylo, yhi), (zlo, zhi)]`. Infinite when there is nothing
+/// to bound.
+fn primitives_bounds(prims: &[Primitive3D]) -> [(f64, f64); 3] {
+  let mut x3_min = f64::INFINITY;
+  let mut x3_max = f64::NEG_INFINITY;
+  let mut y3_min = f64::INFINITY;
+  let mut y3_max = f64::NEG_INFINITY;
+  let mut z3_min = f64::INFINITY;
+  let mut z3_max = f64::NEG_INFINITY;
+
+  let extend_3d = |pt: &Point3D,
+                   x3_min: &mut f64,
+                   x3_max: &mut f64,
+                   y3_min: &mut f64,
+                   y3_max: &mut f64,
+                   z3_min: &mut f64,
+                   z3_max: &mut f64| {
+    *x3_min = x3_min.min(pt.x);
+    *x3_max = x3_max.max(pt.x);
+    *y3_min = y3_min.min(pt.y);
+    *y3_max = y3_max.max(pt.y);
+    *z3_min = z3_min.min(pt.z);
+    *z3_max = z3_max.max(pt.z);
+  };
+
+  for prim in prims {
+    match prim {
+      Primitive3D::Sphere { center, radius, .. } => {
+        let r = *radius;
+        extend_3d(
+          &Point3D {
+            x: center.x - r,
+            y: center.y - r,
+            z: center.z - r,
+          },
+          &mut x3_min,
+          &mut x3_max,
+          &mut y3_min,
+          &mut y3_max,
+          &mut z3_min,
+          &mut z3_max,
+        );
+        extend_3d(
+          &Point3D {
+            x: center.x + r,
+            y: center.y + r,
+            z: center.z + r,
+          },
+          &mut x3_min,
+          &mut x3_max,
+          &mut y3_min,
+          &mut y3_max,
+          &mut z3_min,
+          &mut z3_max,
+        );
+      }
+      Primitive3D::Cuboid { p_min, p_max, .. } => {
+        extend_3d(
+          p_min,
+          &mut x3_min,
+          &mut x3_max,
+          &mut y3_min,
+          &mut y3_max,
+          &mut z3_min,
+          &mut z3_max,
+        );
+        extend_3d(
+          p_max,
+          &mut x3_min,
+          &mut x3_max,
+          &mut y3_min,
+          &mut y3_max,
+          &mut z3_min,
+          &mut z3_max,
+        );
+      }
+      Primitive3D::Cylinder { p1, p2, radius, .. }
+      | Primitive3D::Cone { p1, p2, radius, .. } => {
+        let r = *radius;
+        for p in [p1, p2] {
+          extend_3d(
+            &Point3D {
+              x: p.x - r,
+              y: p.y - r,
+              z: p.z - r,
+            },
+            &mut x3_min,
+            &mut x3_max,
+            &mut y3_min,
+            &mut y3_max,
+            &mut z3_min,
+            &mut z3_max,
+          );
+          extend_3d(
+            &Point3D {
+              x: p.x + r,
+              y: p.y + r,
+              z: p.z + r,
+            },
+            &mut x3_min,
+            &mut x3_max,
+            &mut y3_min,
+            &mut y3_max,
+            &mut z3_min,
+            &mut z3_max,
+          );
+        }
+      }
+      Primitive3D::Polygon3D { points, .. } => {
+        for pt in points {
+          extend_3d(
+            pt,
+            &mut x3_min,
+            &mut x3_max,
+            &mut y3_min,
+            &mut y3_max,
+            &mut z3_min,
+            &mut z3_max,
+          );
+        }
+      }
+      Primitive3D::Point3DPrim { points, .. }
+      | Primitive3D::Arrow3D { points, .. } => {
+        for pt in points {
+          extend_3d(
+            pt,
+            &mut x3_min,
+            &mut x3_max,
+            &mut y3_min,
+            &mut y3_max,
+            &mut z3_min,
+            &mut z3_max,
+          );
+        }
+      }
+      Primitive3D::Line3D { segments, .. } => {
+        for seg in segments {
+          for pt in seg {
+            extend_3d(
+              pt,
+              &mut x3_min,
+              &mut x3_max,
+              &mut y3_min,
+              &mut y3_max,
+              &mut z3_min,
+              &mut z3_max,
+            );
+          }
+        }
+      }
+      Primitive3D::Surface3D { tris, .. } => {
+        for (a, b, c) in tris {
+          for pt in [a, b, c] {
+            extend_3d(
+              pt,
+              &mut x3_min,
+              &mut x3_max,
+              &mut y3_min,
+              &mut y3_max,
+              &mut z3_min,
+              &mut z3_max,
+            );
+          }
+        }
+      }
+    }
+  }
+  [(x3_min, x3_max), (y3_min, y3_max), (z3_min, z3_max)]
+}
+
 /// Graphics3D[primitives, options...]
 pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let content = evaluate_expr_to_expr(&args[0])?;
@@ -3403,6 +3778,9 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Manipulate re-render). `PlotRange -> {{x0, x1}, {y0, y1}, {z0, z1}}`
   // pins each axis separately.
   let mut plot_range: Option<[(f64, f64); 3]> = None;
+  // `BoxRatios -> {rx, ry, rz}`; `None` is Wolfram's `Automatic`, where the
+  // box simply has the proportions of the data.
+  let mut box_ratios: Option<[f64; 3]> = None;
   let mut show_axes = false;
   let mut axes_labels: [Option<String>; 3] = [None, None, None];
   for opt in &args[1..] {
@@ -3471,6 +3849,19 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             plot_range = Some(ranges);
           }
         }
+        // `BoxRatios -> {rx, ry, rz}` fixes the *shape* of the bounding
+        // box regardless of how large the data is along each axis, which
+        // is what keeps a plot whose values run far wider than its domain
+        // (or the other way round) from drawing as a sliver.
+        "BoxRatios" => {
+          let value = evaluate_expr_to_expr(replacement)
+            .unwrap_or_else(|_| replacement.as_ref().clone());
+          if let Some(r) = eval_vec3(&value)
+            && r.iter().all(|v| *v > 0.0)
+          {
+            box_ratios = Some(r);
+          }
+        }
         "Axes" => match replacement.as_ref() {
           Expr::Identifier(s) if s == "False" => show_axes = false,
           Expr::Identifier(s) if s == "True" => show_axes = true,
@@ -3521,6 +3912,49 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(crate::graphics3d_result_with_structure(
       empty_svg, structure,
     ));
+  }
+
+  // `BoxRatios` asks for a box of a given shape, so each axis is scaled to
+  // bring the world coordinates into those proportions before anything is
+  // tessellated. The axes keep reporting the values before scaling —
+  // `axis_scale` divides them back out where they are drawn.
+  let mut axis_scale = [1.0_f64; 3];
+  if let Some(ratios) = box_ratios {
+    let bounds = plot_range.unwrap_or_else(|| primitives_bounds(&prims));
+    let extents = [
+      bounds[0].1 - bounds[0].0,
+      bounds[1].1 - bounds[1].0,
+      bounds[2].1 - bounds[2].0,
+    ];
+    // Every axis is brought down to the tightest of the requested
+    // proportions, so honouring them never inflates the picture.
+    let unit = (0..3)
+      .filter(|&i| extents[i].is_finite() && extents[i] > 0.0)
+      .map(|i| extents[i] / ratios[i])
+      .fold(f64::INFINITY, f64::min);
+    if unit.is_finite() && unit > 0.0 {
+      for i in 0..3 {
+        if extents[i].is_finite() && extents[i] > 0.0 {
+          axis_scale[i] = ratios[i] * unit / extents[i];
+        }
+      }
+      let xf = Affine3 {
+        m: [
+          [axis_scale[0], 0.0, 0.0],
+          [0.0, axis_scale[1], 0.0],
+          [0.0, 0.0, axis_scale[2]],
+        ],
+        t: [0.0; 3],
+      };
+      for prim in &mut prims {
+        transform_primitive3d(prim, &xf);
+      }
+      if let Some(range) = plot_range.as_mut() {
+        for i in 0..3 {
+          range[i] = (range[i].0 * axis_scale[i], range[i].1 * axis_scale[i]);
+        }
+      }
+    }
   }
 
   // Tessellate all primitives into triangles
@@ -3723,170 +4157,11 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   });
 
   // Compute 3D bounding box of all primitives for the wireframe box
-  let mut x3_min = f64::INFINITY;
-  let mut x3_max = f64::NEG_INFINITY;
-  let mut y3_min = f64::INFINITY;
-  let mut y3_max = f64::NEG_INFINITY;
-  let mut z3_min = f64::INFINITY;
-  let mut z3_max = f64::NEG_INFINITY;
-
-  let extend_3d = |pt: &Point3D,
-                   x3_min: &mut f64,
-                   x3_max: &mut f64,
-                   y3_min: &mut f64,
-                   y3_max: &mut f64,
-                   z3_min: &mut f64,
-                   z3_max: &mut f64| {
-    *x3_min = x3_min.min(pt.x);
-    *x3_max = x3_max.max(pt.x);
-    *y3_min = y3_min.min(pt.y);
-    *y3_max = y3_max.max(pt.y);
-    *z3_min = z3_min.min(pt.z);
-    *z3_max = z3_max.max(pt.z);
-  };
-
-  for prim in &prims {
-    match prim {
-      Primitive3D::Sphere { center, radius, .. } => {
-        let r = *radius;
-        extend_3d(
-          &Point3D {
-            x: center.x - r,
-            y: center.y - r,
-            z: center.z - r,
-          },
-          &mut x3_min,
-          &mut x3_max,
-          &mut y3_min,
-          &mut y3_max,
-          &mut z3_min,
-          &mut z3_max,
-        );
-        extend_3d(
-          &Point3D {
-            x: center.x + r,
-            y: center.y + r,
-            z: center.z + r,
-          },
-          &mut x3_min,
-          &mut x3_max,
-          &mut y3_min,
-          &mut y3_max,
-          &mut z3_min,
-          &mut z3_max,
-        );
-      }
-      Primitive3D::Cuboid { p_min, p_max, .. } => {
-        extend_3d(
-          p_min,
-          &mut x3_min,
-          &mut x3_max,
-          &mut y3_min,
-          &mut y3_max,
-          &mut z3_min,
-          &mut z3_max,
-        );
-        extend_3d(
-          p_max,
-          &mut x3_min,
-          &mut x3_max,
-          &mut y3_min,
-          &mut y3_max,
-          &mut z3_min,
-          &mut z3_max,
-        );
-      }
-      Primitive3D::Cylinder { p1, p2, radius, .. }
-      | Primitive3D::Cone { p1, p2, radius, .. } => {
-        let r = *radius;
-        for p in [p1, p2] {
-          extend_3d(
-            &Point3D {
-              x: p.x - r,
-              y: p.y - r,
-              z: p.z - r,
-            },
-            &mut x3_min,
-            &mut x3_max,
-            &mut y3_min,
-            &mut y3_max,
-            &mut z3_min,
-            &mut z3_max,
-          );
-          extend_3d(
-            &Point3D {
-              x: p.x + r,
-              y: p.y + r,
-              z: p.z + r,
-            },
-            &mut x3_min,
-            &mut x3_max,
-            &mut y3_min,
-            &mut y3_max,
-            &mut z3_min,
-            &mut z3_max,
-          );
-        }
-      }
-      Primitive3D::Polygon3D { points, .. } => {
-        for pt in points {
-          extend_3d(
-            pt,
-            &mut x3_min,
-            &mut x3_max,
-            &mut y3_min,
-            &mut y3_max,
-            &mut z3_min,
-            &mut z3_max,
-          );
-        }
-      }
-      Primitive3D::Point3DPrim { points, .. }
-      | Primitive3D::Arrow3D { points, .. } => {
-        for pt in points {
-          extend_3d(
-            pt,
-            &mut x3_min,
-            &mut x3_max,
-            &mut y3_min,
-            &mut y3_max,
-            &mut z3_min,
-            &mut z3_max,
-          );
-        }
-      }
-      Primitive3D::Line3D { segments, .. } => {
-        for seg in segments {
-          for pt in seg {
-            extend_3d(
-              pt,
-              &mut x3_min,
-              &mut x3_max,
-              &mut y3_min,
-              &mut y3_max,
-              &mut z3_min,
-              &mut z3_max,
-            );
-          }
-        }
-      }
-      Primitive3D::Surface3D { tris, .. } => {
-        for (a, b, c) in tris {
-          for pt in [a, b, c] {
-            extend_3d(
-              pt,
-              &mut x3_min,
-              &mut x3_max,
-              &mut y3_min,
-              &mut y3_max,
-              &mut z3_min,
-              &mut z3_max,
-            );
-          }
-        }
-      }
-    }
-  }
+  let [
+    (mut x3_min, mut x3_max),
+    (mut y3_min, mut y3_max),
+    (mut z3_min, mut z3_max),
+  ] = primitives_bounds(&prims);
 
   // Add some padding to the 3D bounding box
   let pad_x = (x3_max - x3_min) * 0.05;
@@ -4321,14 +4596,16 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Axes (with their ticks and labels) go on top of the scene.
   if show_axes {
+    // The ticks report coordinates as they were given, so a box reshaped
+    // by `BoxRatios` still reads off the data's own values.
     draw_axes_on_box(
       &mut svg,
       &camera,
       &to_svg,
       &box_corners,
-      (x3_min, x3_max),
-      (y3_min, y3_max),
-      (z3_min, z3_max),
+      (x3_min / axis_scale[0], x3_max / axis_scale[0]),
+      (y3_min / axis_scale[1], y3_max / axis_scale[1]),
+      (z3_min / axis_scale[2], z3_max / axis_scale[2]),
       &axes_labels,
     );
   }

--- a/tests/interpreter_tests/batch_wrappers.rs
+++ b/tests/interpreter_tests/batch_wrappers.rs
@@ -11175,6 +11175,29 @@ mod batch_unevaluated_wrappers_2 {
     );
   }
 
+  /// Every call creates a *new* directory. Regression: the name was fixed
+  /// per process, so a second call handed back the first one's directory —
+  /// deleting one then made the other's disappear underneath it.
+  #[test]
+  fn create_directory_no_args_is_a_fresh_directory_each_time() {
+    let first = interpret("CreateDirectory[]").unwrap();
+    let second = interpret("CreateDirectory[]").unwrap();
+    assert_ne!(first, second, "the same directory was handed out twice");
+    for dir in [&first, &second] {
+      assert!(std::path::Path::new(dir).is_dir(), "{dir} was not created");
+      std::fs::remove_dir_all(dir).ok();
+    }
+    // Deleting one leaves the other alone.
+    assert_eq!(
+      interpret(
+        "a = CreateDirectory[]; b = CreateDirectory[]; DeleteDirectory[a]; \
+         out = {DirectoryQ[a], DirectoryQ[b]}; DeleteDirectory[b]; out"
+      )
+      .unwrap(),
+      "{False, True}"
+    );
+  }
+
   #[test]
   fn create_directory_non_string() {
     assert_eq!(interpret("CreateDirectory[123]").unwrap(), "$Failed");

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1321,6 +1321,53 @@ mod plot3d {
         "Plot3D[x^2 + y^2, {x, -2, 2}, {y, -2, 2}, PlotRange -> {0, 4}]"
       ));
     }
+
+    /// The largest magnitude among the axis tick labels — how far the box
+    /// reaches along its widest axis.
+    fn largest_tick(svg: &str) -> f64 {
+      svg
+        .split("</text>")
+        .filter_map(|t| t.rsplit('>').next())
+        .filter_map(|t| t.parse::<f64>().ok())
+        .fold(0.0_f64, |acc, v| acc.max(v.abs()))
+    }
+
+    /// `PlotRange -> {{xmin, xmax}, {ymin, ymax}, {zmin, zmax}}` bounds all
+    /// three axes. Only the two-element (z-only) form used to be read, so
+    /// this full form was ignored: a surface that shoots off past the box
+    /// was drawn whole, and the vertical axis was labelled with the data's
+    /// own extent instead of the range asked for.
+    #[test]
+    fn plot_range_bounds_all_three_axes() {
+      let unbounded =
+        export_svg("Plot3D[1/(x y), {x, -3, 3}, {y, -3, 3}, Mesh -> None]");
+      assert!(
+        largest_tick(&unbounded) > 10.0,
+        "the unbounded surface reaches far past the domain: {unbounded}"
+      );
+      let bounded = export_svg(
+        "Plot3D[1/(x y), {x, -3, 3}, {y, -3, 3}, Mesh -> None, \
+         PlotRange -> {{-3, 3}, {-3, 3}, {-2, 2}}]",
+      );
+      assert!(
+        largest_tick(&bounded) <= 3.0,
+        "a tick runs past the range asked for: {bounded}"
+      );
+    }
+
+    /// The horizontal bounds of the full form narrow the plotted domain,
+    /// so a surface asked for over a wider iterator range is cropped.
+    #[test]
+    fn plot_range_crops_the_domain() {
+      let svg = export_svg(
+        "Plot3D[x + y, {x, -10, 10}, {y, -10, 10}, Mesh -> None, \
+         PlotRange -> {{-1, 1}, {-1, 1}, {-2, 2}}]",
+      );
+      assert!(
+        largest_tick(&svg) <= 2.0,
+        "the box must stop at the range asked for, not at the domain: {svg}"
+      );
+    }
   }
 
   mod errors {
@@ -2041,6 +2088,59 @@ mod plot3d {
       insta::assert_snapshot!(export_svg(
         "Graphics3D[Polygon[{{0,0,0}, {0,1,1}, {1,0,0}}]]"
       ));
+    }
+
+    /// `BoxRatios -> {rx, ry, rz}` sets the shape of the bounding box
+    /// independently of how far the data runs along each axis, so a scene
+    /// a hundred units tall over a ten-unit base draws as a cube rather
+    /// than a sliver. The ticks keep reporting the original coordinates.
+    #[test]
+    fn box_ratios_reshape_the_box_without_moving_the_ticks() {
+      let shape = "Polygon[{{0, 0, 0}, {10, 0, 0}, {10, 10, 100}, \
+         {0, 0, 100}}]";
+      let tall = export_svg(&format!("Graphics3D[{shape}, Axes -> True]"));
+      let cube = export_svg(&format!(
+        "Graphics3D[{shape}, Axes -> True, BoxRatios -> {{1, 1, 1}}]"
+      ));
+      // Both label the axes with the data's own values …
+      for svg in [&tall, &cube] {
+        assert!(svg.contains(">100</text>"), "{svg}");
+        assert!(svg.contains(">10</text>"), "{svg}");
+      }
+      // … but the drawn box is far less lopsided once the ratios apply.
+      let aspect = |svg: &str| -> f64 {
+        let ys: Vec<f64> = svg
+          .split("<polygon points=\"")
+          .skip(1)
+          .filter_map(|p| p.split('"').next())
+          .flat_map(|p| {
+            p.split_whitespace()
+              .filter_map(|c| c.split(',').nth(1)?.parse::<f64>().ok())
+              .collect::<Vec<_>>()
+          })
+          .collect();
+        let xs: Vec<f64> = svg
+          .split("<polygon points=\"")
+          .skip(1)
+          .filter_map(|p| p.split('"').next())
+          .flat_map(|p| {
+            p.split_whitespace()
+              .filter_map(|c| c.split(',').next()?.parse::<f64>().ok())
+              .collect::<Vec<_>>()
+          })
+          .collect();
+        let span = |v: &[f64]| {
+          v.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b))
+            - v.iter().fold(f64::INFINITY, |a, &b| a.min(b))
+        };
+        span(&ys) / span(&xs)
+      };
+      assert!(
+        aspect(&cube) < aspect(&tall),
+        "the box was not squatted: {} vs {}",
+        aspect(&cube),
+        aspect(&tall)
+      );
     }
 
     /// A face with more than three corners is fan-triangulated to render,
@@ -8898,6 +8998,58 @@ mod show {
     assert!(svg.contains("<path") || svg.contains("<polyline"), "{svg}");
   }
 
+  /// `Show` merges the primitives of the graphics it is given, so a
+  /// `Plot3D` surface has to be available as primitives too. Regression:
+  /// the surface existed only as a rendering, so showing one together with
+  /// a `Graphics3D` dropped it and left only the other graphic — the way a
+  /// Demonstration draws cutting planes through a plotted surface.
+  #[test]
+  fn show_keeps_a_plot3d_surface_beside_a_graphics3d() {
+    clear_state();
+    let plane = "Graphics3D[{Orange, \
+       Polygon[{{1, -3, -2}, {1, 3, -2}, {1, 3, 2}, {1, -3, 2}}]}]";
+    let surface = "Plot3D[Sin[x y], {x, -3, 3}, {y, -3, 3}]";
+    let merged = export_svg(&format!("Show[{{{surface}, {plane}}}]"));
+    let alone = export_svg(&format!("Show[{{{plane}}}, Axes -> True]"));
+    // The plane alone is a handful of polygons; with the surface merged in
+    // there are thousands.
+    let faces = |svg: &str| svg.matches("<polygon").count();
+    assert!(
+      faces(&merged) > faces(&alone) + 100,
+      "the surface is missing: {} vs {} faces",
+      faces(&merged),
+      faces(&alone)
+    );
+    // And the plane is still there — the surface did not replace it.
+    assert!(
+      merged.contains(&format!("fill=\"{}\"", orange_fill(&alone))),
+      "the plane is missing: {merged}"
+    );
+  }
+
+  /// The fill colour of the largest polygon in an SVG.
+  fn orange_fill(svg: &str) -> String {
+    svg
+      .split("<polygon ")
+      .skip(1)
+      .filter_map(|p| p.split("fill=\"").nth(1))
+      .filter_map(|p| p.split('"').next())
+      .find(|c| c.starts_with("rgb"))
+      .unwrap_or_default()
+      .to_string()
+  }
+
+  /// `First[Plot3D[…]]` is the surface itself, so a plotted surface can be
+  /// redrawn inside another graphic.
+  #[test]
+  fn first_of_a_plot3d_is_its_surface() {
+    clear_state();
+    assert_eq!(
+      interpret("Head[First[Plot3D[x y, {x, 0, 1}, {y, 0, 1}]]]").unwrap(),
+      "GraphicsComplex"
+    );
+  }
+
   #[test]
   fn show_two_graphics() {
     clear_state();
@@ -9979,6 +10131,108 @@ mod grid_frame_and_background {
       !svg.contains("y1=\"0\" x2=\"") || svg.matches("<line").count() > 4,
       "{svg}"
     );
+  }
+
+  /// `SpanFromAbove` is the vertical counterpart: the cell above continues
+  /// down into the row, so it draws nothing, its neighbour is centred over
+  /// both rows, and the divider between them is interrupted across that
+  /// column. Regression: the symbol's name was printed as the cell's text.
+  #[test]
+  fn span_from_above_merges_into_the_cell_above_it() {
+    let svg =
+      export_svg(r#"Grid[{{"a", "b"}, {SpanFromAbove, "c"}}, Frame -> All]"#);
+    assert!(
+      !svg.contains("SpanFromAbove"),
+      "the symbol must not print: {svg}"
+    );
+    let y_of = |label: &str| -> f64 {
+      svg
+        .split("<text ")
+        .find(|t| t.split_once('>').is_some_and(|(_, r)| r.starts_with(label)))
+        .and_then(|t| t.split("y=\"").nth(1))
+        .and_then(|v| v.split('"').next())
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| panic!("{label} missing: {svg}"))
+    };
+    // "a" is centred across both rows, so it sits below "b" (which is
+    // centred in the first row alone) and above "c" (the second row).
+    assert!(
+      y_of("b") < y_of("a") && y_of("a") < y_of("c"),
+      "the spanning cell centres across both rows: {svg}"
+    );
+    // The inner divider only covers the second column: the first column's
+    // stretch of it would cut through the merged cell.
+    let inner: Vec<&str> = svg
+      .split("<line ")
+      .skip(1)
+      .filter(|l| {
+        let get = |k: &str| -> f64 {
+          l.split(k)
+            .nth(1)
+            .unwrap()
+            .split('"')
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap()
+        };
+        (get("y1=\"") - get("y2=\"")).abs() < 0.05 && get("y1=\"") > 0.5
+      })
+      .collect();
+    assert!(
+      inner.iter().any(|l| l.starts_with("x1=\"0.0\"")),
+      "the bottom border spans the whole grid: {svg}"
+    );
+    assert!(
+      inner.iter().any(|l| !l.starts_with("x1=\"0.0\"")),
+      "the divider between the rows starts past the merged cell: {svg}"
+    );
+  }
+
+  /// `SpanFromBoth` marks the inside of a block merged in both directions,
+  /// so a 2×2 block collapses to a single cell with no divider through it.
+  #[test]
+  fn span_from_both_merges_a_block_in_both_directions() {
+    let svg = export_svg(concat!(
+      r#"Grid[{{"x", SpanFromLeft}, {SpanFromAbove, SpanFromBoth}, "#,
+      r#"{"p", "q"}}, Frame -> All]"#
+    ));
+    for symbol in ["SpanFromLeft", "SpanFromAbove", "SpanFromBoth"] {
+      assert!(!svg.contains(symbol), "{symbol} must not print: {svg}");
+    }
+    // Only the outer frame plus the divider above the last row survive: the
+    // 2×2 block has no lines running through it, so the vertical divider
+    // starts where the block ends and the row divider inside it is gone.
+    assert_eq!(svg.matches("<text ").count(), 3, "one cell each: {svg}");
+    let lines: Vec<&str> = svg.split("<line ").skip(1).collect();
+    let attr = |l: &str, k: &str| -> f64 {
+      l.split(k)
+        .nth(1)
+        .unwrap()
+        .split('"')
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap()
+    };
+    // Three equal rows, so the merged block ends two thirds of the way down.
+    let height = lines.iter().map(|l| attr(l, "y2=\"")).fold(0.0, f64::max);
+    let width = lines.iter().map(|l| attr(l, "x2=\"")).fold(0.0, f64::max);
+    let block_bottom = height / 3.0 * 2.0;
+    for l in &lines {
+      let (x1, y1, y2) = (attr(l, "x1=\""), attr(l, "y1=\""), attr(l, "y2=\""));
+      if (y1 - y2).abs() < 0.05 {
+        assert!(
+          y1 < 0.05 || y1 > block_bottom - 0.05,
+          "a row divider cuts through the block: {l}"
+        );
+      } else if x1 > 0.05 && x1 < width - 0.05 {
+        assert!(
+          y1 > block_bottom - 0.05,
+          "a column divider cuts through the block: {l}"
+        );
+      }
+    }
   }
 
   /// A ragged row still sits on the grid's background for its full width,


### PR DESCRIPTION
## Summary

This PR extends 3D graphics support with two major features: the full form of `PlotRange` for bounding all three axes in `Plot3D`, and `BoxRatios` for controlling the aspect ratio of the bounding box in `Graphics3D`. Additionally, `Plot3D` surfaces are now emitted as symbolic `GraphicsComplex` structures so they can be properly merged with other graphics via `Show`.

## Key Changes

### Plot3D Enhancements
- **PlotRange full form**: `PlotRange -> {{xmin, xmax}, {ymin, ymax}, {zmin, zmax}}` now properly bounds all three axes. The horizontal bounds narrow the plotted domain (cropping the surface), while the vertical bounds clip the rendered output.
- **Domain cropping**: When horizontal bounds are specified, the sampling domain is intersected with the requested range, preventing surfaces from being drawn outside the box.
- **Symbolic structure**: `Plot3D` now returns a `Graphics3D[GraphicsComplex[...]]` structure containing the sampled surface as world-coordinate primitives, enabling proper composition with `Show` and other graphics operations.

### Graphics3D Enhancements
- **BoxRatios support**: `BoxRatios -> {rx, ry, rz}` controls the shape of the bounding box independently of data extent. This prevents tall/narrow data from rendering as slivers.
- **Axis scaling**: Primitives are transformed to achieve the requested aspect ratio while axis labels continue to report original coordinates.
- **Bounds calculation**: Extracted `primitives_bounds()` helper function to compute 3D bounding boxes for all primitive types.

### Grid Improvements
- **Vertical spanning**: Added support for `SpanFromAbove` and `SpanFromBoth` in `Grid` for merging cells vertically, complementing the existing horizontal `SpanFromLeft`.
- **Row height calculation**: Cells spanning multiple rows are now handled similarly to column spans—rows are sized by ordinary cells first, then spanning cells add what they still need.

### Other Fixes
- **CreateDirectory**: Fixed to create a fresh directory on each call (was reusing the same path per process).
- **Dynamic and LocatorPane**: Moved SVG extraction logic into a dedicated `evaluated_wrapper_svg()` function for cleaner handling of display wrappers.

## Implementation Details

- The `parse_axis_ranges()` helper parses both the two-element (z-only) and full three-element forms of `PlotRange`.
- Horizontal bounds are validated to ensure they intersect the iterator range before applying; empty intersections leave the domain unchanged.
- `BoxRatios` scaling is applied via affine transformation before tessellation, with axis labels unscaled for correct value reporting.
- Row spanning uses `span_height()` to determine how many rows a cell covers, mirroring the existing `span_width()` logic.
- All changes include regression tests to prevent future regressions.

https://claude.ai/code/session_017fu5KTTFFBHQQo9H2LntZr