### PR TITLE
Fix Demonstration plots: nested plots, framed axes, and labels

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,22 @@
 
 # Unreleased
 
+- Fixes driven by the "Mass with a Spring and a Rubber Band" Wolfram
+    Demonstration:
+    - Substituting an `NDSolve` solution into a derivative
+        (`y'[t] /. sol`) evaluates numerically instead of echoing a
+        `Derivative[…]` expression, so a phase portrait of a numeric
+        solution can be plotted.
+    - A plot nested in a `Row` inside a `Column` keeps its own coordinate
+        space and is drawn (it used to render blank).
+    - `Frame -> True` labels its frame ticks even with `Axes -> False`.
+    - `AspectRatio` together with `ImagePadding` sizes the image so the
+        plot area spans the full width, instead of shrinking it into a
+        canvas sized by the default ratio.
+    - Labels written as a function of the plot variable typeset the way
+        Wolfram draws them — `AxesLabel -> {t, y[t]}` reads `y(t)` and a
+        derivative reads `y′(t)`, where both used to be dropped — and a
+        `Manipulate` control labelled `Style["y", Italic]'` shows `y′`.
 - Symbol names may contain `$` anywhere (`a$b`, `signal$1`), matching Wolfram.
 - `PlotRange` bounds given in reversed order (e.g. `{3, -3}`) normalize to
     the same plot as the sorted form, matching Wolfram.

--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -221,12 +221,69 @@ pub fn extract_var_power_factor(
   None
 }
 
+/// Apply `Derivative[order][value][point]` for a `value` that is not a
+/// symbol: the `InterpolatingFunction` that `y'[t] /. NDSolve[…]` splices in,
+/// a pure function, or anything else whose derivative is itself applicable.
+/// Returns `None` when no applicable derivative can be formed, so the caller
+/// falls back to the symbolic paths.
+fn apply_derivative_of_value(
+  order: &Expr,
+  value: &Expr,
+  point: &Expr,
+) -> Option<Result<Expr, InterpreterError>> {
+  let derivative = match evaluate_expr_to_expr(&Expr::CurriedCall {
+    func: Box::new(Expr::FunctionCall {
+      name: "Derivative".to_string(),
+      args: vec![order.clone()].into(),
+    }),
+    args: vec![value.clone()],
+  }) {
+    Ok(d) => d,
+    Err(e) => return Some(Err(e)),
+  };
+  // Only an applicable derivative is worth applying; anything else — above
+  // all the unevaluated `Derivative[order][value]` itself — would flatten
+  // straight back into this branch.
+  let applicable = matches!(
+    &derivative,
+    Expr::Function { .. } | Expr::NamedFunction { .. }
+  ) || matches!(
+    &derivative,
+    Expr::FunctionCall { name, .. } if name == "InterpolatingFunction"
+  );
+  if !applicable {
+    return None;
+  }
+  Some(evaluate_expr_to_expr(&Expr::CurriedCall {
+    func: Box::new(derivative),
+    args: vec![point.clone()],
+  }))
+}
+
 pub fn dispatch_calculus_functions(
   name: &str,
   args: &[Expr],
 ) -> Option<Result<Expr, InterpreterError>> {
   match name {
     "Derivative" if args.len() == 3 => {
+      // `Derivative[n][f][x]` reaches us flattened to `Derivative[n, f, x]`.
+      // When `f` is an applicable value rather than a symbol — most commonly
+      // an `InterpolatingFunction` substituted in by `y'[t] /. NDSolve[…]` —
+      // build `Derivative[n][f]` and apply the result to the point. A middle
+      // argument that is a number belongs to the multi-index form
+      // `Derivative[n1, n2][f]`, which flattens the same way and must not be
+      // read as a function to differentiate.
+      if matches!(
+        &args[1],
+        Expr::FunctionCall { .. }
+          | Expr::CurriedCall { .. }
+          | Expr::Function { .. }
+          | Expr::NamedFunction { .. }
+      ) && let Some(value) =
+        apply_derivative_of_value(&args[0], &args[1], &args[2])
+      {
+        return Some(value);
+      }
       if let (Expr::Integer(n), Expr::Identifier(func_name)) =
         (&args[0], &args[1])
       {

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -286,8 +286,66 @@ pub(crate) fn expr_to_label(e: &Expr) -> Option<String> {
       let sep = args.get(1).and_then(expr_to_label).unwrap_or_default();
       Some(parts.join(&sep))
     }
-    _ => None,
+    // A label written as a function of the plot's variable — a Demonstration
+    // writes `AxesLabel -> {t, y[t]}` and `FrameLabel -> {y[t], y'[t]}` —
+    // typesets the way a graphic's labels do, with the argument in
+    // parentheses and a derivative marked by primes: `y(t)`, `y′(t)`. Only an
+    // unknown head reads as an application; a built-in keeps whatever the
+    // branches above (or the caller) make of it.
+    _ => applied_label(e),
   }
+}
+
+/// A label for a function application of an unknown head: `y[t]` → `y(t)`,
+/// `y'[t]` → `y′(t)`, `y''` → `y″`. `None` for anything else, including
+/// applications of built-in functions, whose own formatting rules apply.
+fn applied_label(e: &Expr) -> Option<String> {
+  use crate::functions::graphics::{as_derivative_of, derivative_prime_marks};
+  // `Derivative[n][f]`, with or without an argument applied to it.
+  if let Some((func, order)) = as_derivative_of(e) {
+    return Some(format!(
+      "{}{}",
+      expr_to_label(func)?,
+      derivative_prime_marks(order)
+    ));
+  }
+  let (head_label, args): (String, &[Expr]) = match e {
+    // `Derivative[n][f][x]` reaches the evaluator flattened to
+    // `Derivative[n, f, x]`; its head is the curried derivative.
+    Expr::FunctionCall { name, args } if name == "Derivative" => {
+      let (order, rest) = args.split_first()?;
+      let (func, arg) = (rest.first()?, rest.get(1)?);
+      let derivative = Expr::CurriedCall {
+        func: Box::new(Expr::FunctionCall {
+          name: "Derivative".to_string(),
+          args: vec![order.clone()].into(),
+        }),
+        args: vec![func.clone()],
+      };
+      return Some(format!(
+        "{}({})",
+        applied_label(&derivative)?,
+        expr_to_label(arg)?
+      ));
+    }
+    Expr::CurriedCall { func, args } => (
+      applied_label(func).or_else(|| expr_to_label(func))?,
+      &args[..],
+    ),
+    Expr::FunctionCall { name, args }
+      if crate::evaluator::functions::get_builtin_function_info(name)
+        .is_none() =>
+    {
+      (name.clone(), &args[..])
+    }
+    _ => return None,
+  };
+  if args.is_empty() {
+    return None;
+  }
+  let parts: Vec<String> =
+    args.iter().map(expr_to_label).collect::<Option<Vec<_>>>()?;
+  Some(format!("{head_label}({})", parts.join(", ")))
 }
 
 /// Extract a chart label from an Expr, supporting Rotate[label, angle].

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -13705,8 +13705,14 @@ pub fn row_to_svg(args: &[Expr]) -> Option<String> {
         height,
       } => {
         let y_off = cell_top(*height);
+        // The child keeps its own coordinate space: a plot draws at a
+        // multiple of its display size, so the nested `<svg>` needs the
+        // child's viewBox or none of it lands inside the cell.
+        let view_box = parse_svg_dimensions(child)
+          .map(|p| p.view_box)
+          .unwrap_or_else(|| format!("0 0 {width} {height}"));
         svg.push_str(&format!(
-          "<svg x=\"{x:.1}\" y=\"{y_off:.1}\" width=\"{width:.1}\" height=\"{height:.1}\">\n"
+          "<svg x=\"{x:.1}\" y=\"{y_off:.1}\" width=\"{width:.1}\" height=\"{height:.1}\" viewBox=\"{view_box}\" preserveAspectRatio=\"xMidYMid meet\">\n"
         ));
         svg.push_str(strip_svg_wrapper(child));
         svg.push_str("</svg>\n");
@@ -16089,6 +16095,16 @@ fn manipulate_label_runs(expr: &Expr, italic: bool) -> Vec<LabelRun> {
       vec![LabelRun { text, italic }]
     }
   };
+  // `Derivative[n][f]` — a slider labelled `y'(0)` writes its `y'` this way.
+  // The primes are upright even when the function they mark is italic.
+  if let Some((func, order)) = as_derivative_of(expr) {
+    let mut runs = manipulate_label_runs(func, italic);
+    runs.push(LabelRun {
+      text: derivative_prime_marks(order),
+      italic: false,
+    });
+    return runs;
+  }
   match expr {
     Expr::FunctionCall { name, args } => match name.as_str() {
       // Style[expr, dir…] — render `expr`, turning italic on if any directive
@@ -16263,6 +16279,55 @@ fn is_italic_directive(dir: &Expr) -> bool {
 /// plain string is needed (JSON export, Unicode-script folding).
 fn flatten_label_runs(runs: &[LabelRun]) -> String {
   runs.iter().map(|r| r.text.as_str()).collect()
+}
+
+/// The mark the Wolfram Language typesets `Derivative[n][f]` with: a prime
+/// per order up to three (`y′`, `y″`, `y‴`) and a parenthesised superscript
+/// order beyond that (`y⁽⁴⁾`).
+pub(crate) fn derivative_prime_marks(order: u32) -> String {
+  match order {
+    0 => String::new(),
+    1 => "\u{2032}".to_string(),
+    2 => "\u{2033}".to_string(),
+    3 => "\u{2034}".to_string(),
+    n => to_unicode_script(&format!("({n})"), true),
+  }
+}
+
+/// Split a derivative application into the function it differentiates and
+/// the order. Covers both shapes the parser leaves behind: the curried
+/// `Derivative[n][f]` and the flattened `Derivative[n, f]` that
+/// `expr_to_output` prints back as `Derivative[n][f]`.
+pub(crate) fn as_derivative_of(expr: &Expr) -> Option<(&Expr, u32)> {
+  let (head, args): (&Expr, &[Expr]) = match expr {
+    Expr::CurriedCall { func, args } => (func.as_ref(), args),
+    Expr::FunctionCall { name, args } if name == "Derivative" => {
+      return match args.len() {
+        2 => order_of(&args[0]).map(|n| (&args[1], n)),
+        _ => None,
+      };
+    }
+    _ => return None,
+  };
+  if args.len() != 1 {
+    return None;
+  }
+  match head {
+    Expr::FunctionCall { name, args: hargs }
+      if name == "Derivative" && hargs.len() == 1 =>
+    {
+      order_of(&hargs[0]).map(|n| (&args[0], n))
+    }
+    _ => None,
+  }
+}
+
+/// The integer order of a `Derivative[n]` index.
+fn order_of(expr: &Expr) -> Option<u32> {
+  match expr {
+    Expr::Integer(n) if *n >= 0 => u32::try_from(*n).ok(),
+    _ => None,
+  }
 }
 
 /// Map the characters of `s` to their Unicode sub-/superscript form when a
@@ -18706,5 +18771,56 @@ mod manipulate_label_tests {
     );
     assert_eq!(runs(&row), vec![run("a", true), run("b", false)]);
     assert_eq!(flatten_label_runs(&runs(&row)), "ab");
+  }
+
+  /// `Derivative[n][f]` — a slider labelled `y'(0)` in a Demonstration.
+  fn derivative(order: i128, func: Expr) -> Expr {
+    Expr::CurriedCall {
+      func: Box::new(call("Derivative", vec![Expr::Integer(order)])),
+      args: vec![func],
+    }
+  }
+
+  #[test]
+  fn derivative_of_an_italic_style_primes_an_italic_base() {
+    let italic_y = call(
+      "Style",
+      vec![Expr::String("y".into()), Expr::Identifier("Italic".into())],
+    );
+    let label = call(
+      "Text",
+      vec![call(
+        "Row",
+        vec![Expr::List(
+          vec![derivative(1, italic_y), Expr::String("(0)".into())].into(),
+        )],
+      )],
+    );
+    assert_eq!(
+      runs(&label),
+      vec![run("y", true), run("\u{2032}", false), run("(0)", false),]
+    );
+    assert_eq!(flatten_label_runs(&runs(&label)), "y\u{2032}(0)");
+  }
+
+  #[test]
+  fn higher_derivative_orders_get_their_own_marks() {
+    let y = || Expr::Identifier("y".into());
+    let marks = |order| flatten_label_runs(&runs(&derivative(order, y())));
+    assert_eq!(marks(2), "y\u{2033}");
+    assert_eq!(marks(3), "y\u{2034}");
+    // Past three primes the order is written as a superscript in parens.
+    assert_eq!(marks(4), "y\u{207D}\u{2074}\u{207E}");
+  }
+
+  /// The evaluator hands back `Derivative[n][f]` flattened to
+  /// `Derivative[n, f]`; both shapes must label the same.
+  #[test]
+  fn flattened_derivative_labels_like_the_curried_one() {
+    let flat = call(
+      "Derivative",
+      vec![Expr::Integer(1), Expr::Identifier("y".into())],
+    );
+    assert_eq!(flatten_label_runs(&runs(&flat)), "y\u{2032}");
   }
 }

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -2252,6 +2252,14 @@ fn generate_svg_with_options(
   let mut svg_height = opts.svg_height;
   let full_width = opts.full_width;
   let (show_x_axis, show_y_axis) = opts.axes;
+  // A framed plot carries its ticks on the frame edges, so they are labelled
+  // whether or not the axes themselves are drawn — `Frame -> True, Axes ->
+  // False` is the standard framed look, and it used to come out bare.
+  let (tick_axis_x, tick_axis_y) = if opts.frame {
+    (true, true)
+  } else {
+    (show_x_axis, show_y_axis)
+  };
   let show_ticks = opts.ticks;
   let render_width = svg_width * RESOLUTION_SCALE;
   let mut render_height = svg_height * RESOLUTION_SCALE;
@@ -2301,26 +2309,26 @@ fn generate_svg_with_options(
 
   // Label areas and margins computed per-axis.
   // Setting a label area to 0 suppresses that axis line in plotters.
-  let bottom_extra = if show_x_axis && show_ticks && has_x_axis_label {
+  let bottom_extra = if tick_axis_x && show_ticks && has_x_axis_label {
     24.0 * sf
   } else {
     0.0
   };
-  let x_label_area: u32 = if !show_x_axis {
+  let x_label_area: u32 = if !tick_axis_x {
     0
   } else if !show_ticks {
     5 * RESOLUTION_SCALE
   } else {
     40 * RESOLUTION_SCALE + bottom_extra as u32
   };
-  let y_label_area: u32 = if !show_y_axis {
+  let y_label_area: u32 = if !tick_axis_y {
     0
   } else if !show_ticks {
     5 * RESOLUTION_SCALE
   } else {
     65 * RESOLUTION_SCALE
   };
-  let margin_left: u32 = if show_y_axis {
+  let margin_left: u32 = if tick_axis_y {
     10 * s as u32
   } else {
     5 * s as u32
@@ -2340,11 +2348,27 @@ fn generate_svg_with_options(
   } else {
     10 * s as u32
   };
-  let margin_bottom: u32 = if show_x_axis {
+  let margin_bottom: u32 = if tick_axis_x {
     10 * s as u32
   } else {
     5 * s as u32
   };
+
+  // With `ImagePadding` the padding *is* the margin, so an `AspectRatio`
+  // fixes the canvas height directly: the plot area spans the width the
+  // padding leaves, and the height follows from the ratio. Deriving it here,
+  // before the margins are computed, keeps the frame as wide as the image
+  // instead of shrinking it to fit a canvas sized by the default ratio.
+  if let Some(ar) = opts.aspect_ratio
+    && let Some([pad_left, pad_right, pad_bottom, pad_top]) = opts.image_padding
+  {
+    let plot_w = render_width as f64 - (pad_left + pad_right) * sf;
+    if plot_w > 0.0 && ar > 0.0 {
+      let target_render_h = plot_w * ar + (pad_bottom + pad_top) * sf;
+      svg_height = ((target_render_h / sf).round() as u32).max(1);
+      render_height = svg_height * RESOLUTION_SCALE;
+    }
+  }
 
   // `ImagePadding` replaces the automatic margins: the left/bottom padding
   // becomes the tick label areas (the axis labels are drawn inside them) and
@@ -2440,7 +2464,7 @@ fn generate_svg_with_options(
         // An axis given explicit ticks draws them itself, below.
         let has_explicit_x_ticks = opts.ticks_x.is_some();
         let has_explicit_y_ticks = opts.ticks_y.is_some();
-        if show_ticks && (show_x_axis || show_y_axis) {
+        if show_ticks && (tick_axis_x || tick_axis_y) {
           let xmaj = if date_axis {
             nice_date_step(x_max - x_min)
           } else {
@@ -2451,7 +2475,7 @@ fn generate_svg_with_options(
           y_major = ymaj;
           let x_minor = if date_axis { xmaj } else { xmaj / 5.0 };
           let y_minor = ymaj / 5.0;
-          x_labels_count = if !show_x_axis || date_axis || has_explicit_x_ticks
+          x_labels_count = if !tick_axis_x || date_axis || has_explicit_x_ticks
           {
             0
           } else if log_x {
@@ -2460,15 +2484,15 @@ fn generate_svg_with_options(
           } else {
             ((x_max - x_min) / x_minor).round() as usize + 1
           };
-          y_labels_count = if !show_y_axis || has_explicit_y_ticks {
+          y_labels_count = if !tick_axis_y || has_explicit_y_ticks {
             0
           } else if log_y {
             10
           } else {
             ((y_max - y_min) / y_minor).round() as usize + 1
           };
-          x_tick_size = if show_x_axis { tick } else { 0 };
-          y_tick_size = if show_y_axis { tick } else { 0 };
+          x_tick_size = if tick_axis_x { tick } else { 0 };
+          y_tick_size = if tick_axis_y { tick } else { 0 };
         } else {
           x_major = 1.0;
           y_major = 1.0;
@@ -3561,16 +3585,21 @@ pub(crate) fn generate_scatter_svg_with_options(
 
   // AspectRatio sizes the plotting area (the data frame), not the whole image.
   // Derive the total height so the frame has the requested height/width ratio.
-  // With `ImagePadding` the image size is fixed instead and the area is fitted
-  // inside the padding, below.
-  if let Some(ar) = opts.aspect_ratio
-    && opts.image_padding.is_none()
-  {
-    let plot_w =
-      render_width as f64 - margin_left - margin_right - y_label_area;
-    if plot_w > 0.0 {
-      let plot_h = plot_w * ar;
-      let target_render_h = plot_h + margin_top + margin_bottom + x_label_area;
+  // With `ImagePadding` the padding replaces the margins, so the area spans
+  // the width the padding leaves and the height follows from the ratio.
+  if let Some(ar) = opts.aspect_ratio {
+    let (plot_w, extra_h) = match opts.image_padding {
+      Some([pad_left, pad_right, pad_bottom, pad_top]) => (
+        render_width as f64 - (pad_left + pad_right) * sf,
+        (pad_bottom + pad_top) * sf,
+      ),
+      None => (
+        render_width as f64 - margin_left - margin_right - y_label_area,
+        margin_top + margin_bottom + x_label_area,
+      ),
+    };
+    if plot_w > 0.0 && ar > 0.0 {
+      let target_render_h = plot_w * ar + extra_h;
       svg_height = ((target_render_h / sf).round() as u32).max(1);
       render_height = svg_height * RESOLUTION_SCALE;
     }

--- a/tests/cli/studio.md
+++ b/tests/cli/studio.md
@@ -102,6 +102,9 @@ state: extra display arguments such as a trailing
 `Dynamic[Panel[Grid[… Checkbox …]]]` are rendered as interactive
 widgets, and toggling a checkbox writes back into that state and
 re-renders both the display and the body.
+A control keeps the typesetting its label was written with:
+`Style["t", Italic]` stays italic, `Subscript[Style["k", Italic], 1]`
+reads `k₁`, and a derivative such as `Style["y", Italic]'` reads `y′`.
 
 Output text is rendered in a read-only text editor, so it can be
 selected and copied with the mouse.

--- a/tests/cli/symbolic/NDSolve.md
+++ b/tests/cli/symbolic/NDSolve.md
@@ -22,3 +22,11 @@ differentiated:
 $ wo "s = Flatten[NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]]; s[[1]][[2]]'[2.0]"
 -0.1353352846442526
 ```
+
+Substituting the solution into a derivative works the same way, which is how
+a function and its slope are sampled together (for a phase portrait, say):
+
+```scrut
+$ wo "s = NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]; {y[2.0], y'[2.0]} /. First[s]"
+{0.1353352832380283, -0.1353352846442526}
+```

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7267,6 +7267,53 @@ mod ndsolve {
     assert_eq!(result, "{w, x}");
   }
 
+  /// Substituting the solution rules into a derivative — `y'[t] /. sol`, how
+  /// a Demonstration plots a phase portrait — leaves
+  /// `Derivative[1][InterpolatingFunction[…]][t]`, which has to evaluate to
+  /// the slope, not stay a symbolic `Derivative[…]` echo.
+  #[test]
+  fn a_substituted_derivative_evaluates_numerically() {
+    // y' = y, y(0) = 1 → y(t) = y'(t) = E^t.
+    let result = interpret(
+      "sol = NDSolve[{y'[t] == y[t], y[0] == 1}, y, {t, 0, 1}]; \
+       {y[0.5], y'[0.5]} /. sol[[1]]",
+    )
+    .unwrap();
+    let nums: Vec<f64> = result
+      .trim_matches(['{', '}'])
+      .split(", ")
+      .map(|s| s.parse().expect("both entries are numbers"))
+      .collect();
+    let expected = std::f64::consts::E.powf(0.5);
+    for value in &nums {
+      assert!(
+        (value - expected).abs() < 1e-3,
+        "expected about {expected}, got {result}"
+      );
+    }
+  }
+
+  /// The same for a second derivative, and for the whole solution list
+  /// (`/. sol` rather than `/. sol[[1]]`).
+  #[test]
+  fn a_substituted_second_derivative_evaluates_numerically() {
+    // y'' = -y with y(0) = 0, y'(0) = 1 → y = Sin[t], y'' = -Sin[t].
+    let result = interpret(
+      "sol = NDSolve[{y''[t] == -y[t], y[0] == 0, y'[0] == 1}, y, \
+       {t, 0, 3}]; y''[1.0] /. sol",
+    )
+    .unwrap();
+    let value: f64 = result
+      .trim_matches(['{', '}'])
+      .parse()
+      .expect("a single numeric solution");
+    let expected = -1.0f64.sin();
+    assert!(
+      (value - expected).abs() < 1e-3,
+      "expected about {expected}, got {result}"
+    );
+  }
+
   #[test]
   fn exponential_growth() {
     // NDSolve y'=y, y(0)=1, check y(0.5) ≈ E^0.5

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -18873,3 +18873,124 @@ mod list_plot_markers_and_epilog {
     assert!(text.contains("font-size=\"200\""), "{text}");
   }
 }
+
+/// The layout a Demonstration builds its output with: a `Column` whose rows
+/// hold several plots side by side, each framed, squared and labelled as a
+/// function of the plot variable.
+mod demonstration_plot_layout {
+  use super::*;
+
+  /// A plot nested in a `Row` inside a `Column` draws in its own coordinate
+  /// space (a plot's internal units are a multiple of its display size), so
+  /// the cell it is embedded in has to carry the child's `viewBox` — without
+  /// it the whole curve lands outside the cell and the plot shows up blank.
+  #[test]
+  fn a_plot_nested_in_a_row_keeps_its_coordinate_space() {
+    clear_state();
+    let result = interpret_with_stdout(
+      "Column[{Row[{Graphics[{Blue, Rectangle[]}, ImageSize -> {80, 100}], \
+       Plot[Sin[x], {x, 0, 6}, ImageSize -> 120]}]}]",
+    )
+    .unwrap();
+    let svg = result.graphics.expect("a rendered column");
+    let nested: Vec<&str> = svg
+      .split("<svg ")
+      .skip(1)
+      .filter_map(|tag| tag.split_once('>').map(|(open, _)| open))
+      .collect();
+    assert!(
+      nested.len() >= 3,
+      "outer + row + two cells expected, got {}: {svg}",
+      nested.len()
+    );
+    assert!(
+      nested.iter().all(|open| open.contains("viewBox=")),
+      "every nested cell needs its own viewBox: {nested:?}"
+    );
+    // The curve itself has to be inside the plot's cell, i.e. the sampled
+    // polyline survives the nesting.
+    let longest = svg
+      .split("points=\"")
+      .skip(1)
+      .map(|s| s.split('"').next().unwrap_or("").len())
+      .max()
+      .unwrap_or(0);
+    assert!(longest > 200, "the nested curve must be drawn: {svg}");
+  }
+
+  /// `Frame -> True, Axes -> False` is the standard framed look: the ticks
+  /// move to the frame edges and keep their labels.
+  #[test]
+  fn a_framed_plot_labels_its_ticks_without_axes() {
+    clear_state();
+    let svg = export_svg(
+      "ParametricPlot[{Cos[t], Sin[t]}, {t, 0, 2 Pi}, Frame -> True, \
+       Axes -> False, ImageSize -> 250]",
+    );
+    let labels: Vec<String> = svg
+      .split("<text ")
+      .skip(1)
+      .filter_map(|tag| tag.split_once('>'))
+      .filter_map(|(_, rest)| rest.split('<').next())
+      .map(|t| t.trim().to_string())
+      .filter(|t| !t.is_empty())
+      .collect();
+    for expected in ["-1.0", "-0.5", "0.0", "0.5"] {
+      // Both frame edges carry the set, so each label appears twice.
+      assert_eq!(
+        labels.iter().filter(|l| *l == expected).count(),
+        2,
+        "both framed axes must label their ticks, got {labels:?}"
+      );
+    }
+  }
+
+  /// With `ImagePadding` the padding is the whole margin, so an
+  /// `AspectRatio` fixes the image height directly: a square frame in a
+  /// 250-wide image makes a 250-tall image, not one sized by the default
+  /// ratio with the frame shrunk to fit.
+  #[test]
+  fn an_aspect_ratio_sizes_a_padded_image() {
+    clear_state();
+    let svg = export_svg(
+      "ParametricPlot[{Cos[t], Sin[t]}, {t, 0, 2 Pi}, ImageSize -> 250, \
+       AspectRatio -> 1, ImagePadding -> 35]",
+    );
+    let header = svg.split_once('>').expect("an svg tag").0;
+    assert!(
+      header.contains("width=\"250\"") && header.contains("height=\"250\""),
+      "a square padded plot keeps its width: {header}"
+    );
+    // Half the ratio halves the height: 180 wide plot area + 70 padding.
+    let svg = export_svg(
+      "ParametricPlot[{Cos[t], Sin[t]}, {t, 0, 2 Pi}, ImageSize -> 250, \
+       AspectRatio -> 1/2, ImagePadding -> 35]",
+    );
+    let header = svg.split_once('>').expect("an svg tag").0;
+    assert!(
+      header.contains("height=\"160\""),
+      "the plot area follows the ratio: {header}"
+    );
+  }
+
+  /// A label written as a function of the plot variable typesets the way a
+  /// graphic's labels do: `y[t]` reads `y(t)` and `y'[t]` reads `y′(t)`.
+  /// They used to be dropped entirely.
+  #[test]
+  fn function_labels_typeset_with_parentheses_and_primes() {
+    clear_state();
+    let svg = export_svg(
+      "Plot[Sin[x], {x, 0, 10}, AxesLabel -> {t, y[t]}, ImageSize -> 300]",
+    );
+    assert!(svg.contains(">y(t)<"), "the y axis label is missing: {svg}");
+    let svg = export_svg(
+      "ParametricPlot[{Cos[t], Sin[t]}, {t, 0, 2 Pi}, Frame -> True, \
+       FrameLabel -> {y[t], y'[t]}, ImageSize -> 250]",
+    );
+    assert!(svg.contains(">y(t)<"), "the bottom frame label: {svg}");
+    assert!(
+      svg.contains(">y\u{2032}(t)<"),
+      "the left frame label needs its prime: {svg}"
+    );
+  }
+}


### PR DESCRIPTION
Fixes several issues that prevented proper rendering of Wolfram Demonstrations, particularly those with phase portraits and parametric plots.

## Summary
This PR addresses five related issues discovered while implementing the "Mass with a Spring and a Rubber Band" Demonstration:

1. **Nested plots render blank** - Plots inside `Row` within `Column` lost their coordinate space
2. **Framed plots lack tick labels** - `Frame -> True` with `Axes -> False` didn't show tick labels
3. **AspectRatio with ImagePadding miscalculates** - Plot area shrunk instead of spanning full width
4. **Function labels dropped** - `AxesLabel -> {t, y[t]}` and `FrameLabel -> {y[t], y'[t]}` were ignored
5. **Substituted derivatives don't evaluate** - `y'[t] /. NDSolve[…]` stayed symbolic instead of computing numerically

## Key Changes

### Graphics & Layout (`src/functions/graphics.rs`)
- Added `viewBox` and `preserveAspectRatio` attributes to nested SVG elements in `row_to_svg()` so plots maintain their coordinate space when embedded in rows/columns
- Implemented `derivative_prime_marks()` to render derivative orders as Unicode primes (′, ″, ‴) or superscript notation
- Added `as_derivative_of()` to recognize both curried `Derivative[n][f]` and flattened `Derivative[n, f]` forms
- Extended `manipulate_label_runs()` to handle derivative expressions with proper prime formatting

### Plot Rendering (`src/functions/plot.rs`)
- Modified tick/label logic to use `tick_axis_x/y` variables that remain true when `Frame -> True` even if `Axes -> False`
- Moved `AspectRatio` calculation before margin computation when `ImagePadding` is set, so the plot area spans the full padded width
- Applied same `AspectRatio` fix to scatter plots

### Chart Labels (`src/functions/chart.rs`)
- Added `applied_label()` function to format function applications as labels: `y[t]` → `y(t)`, `y'[t]` → `y′(t)`
- Extended `expr_to_label()` to handle unknown function heads and derivatives
- Handles both curried and flattened `Derivative` forms

### Calculus (`src/evaluator/dispatch/calculus_functions.rs`)
- Added `apply_derivative_of_value()` to evaluate `Derivative[n][f][x]` when `f` is an applicable value (like `InterpolatingFunction`)
- Modified `dispatch_calculus_functions()` to detect and evaluate substituted derivatives from `NDSolve` solutions

## Tests
- Added comprehensive test module `demonstration_plot_layout` covering nested plots, framed axes, aspect ratio with padding, and function label typesetting
- Added derivative label tests in `manipulate_label_tests`
- Added `NDSolve` substitution tests for first and second derivatives
- Updated CLI documentation tests for `NDSolve` derivative substitution

https://claude.ai/code/session_01QVXZzPHsUHRa4NAy4jbLRL