### PR TITLE
Support TraditionalForm display and Manipulate improvements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,28 @@
 - `PlotLabel` works on plain `Graphics[…]` (rendered as a centered title),
     and labels may be arbitrary expressions such as
     `Row[{"center of mass: ", CM}]` on all plot types.
+- An operator that binds tighter than `Times` now reaches into an adjacent
+    implicit product: `2 Times @@ {3, 4}` is `2 (Times @@ {3, 4})` and
+    `a b . c` is `a (b . c)`, matching Wolfram. Previously the whole product
+    became one operand, so `lcm^n Times @@ Table[…]` applied the wrong head.
+- Manipulate improvements (driven by the "Descartes's Rule of Signs"
+    Wolfram Demonstration):
+    - `Setter`, `Toggler`, `CheckboxBar`, `Opener` and `OpenerBar` are
+        recognised as control types. A `Setter` spec used to be read as a
+        slider bound, and since one unparsable spec aborts the whole
+        extraction, the entire Manipulate fell back to a text echo.
+    - `{v, domain, ControlType -> None}` starts `v` at the first choice of
+        its domain rather than binding the choice list itself.
+    - `TrackedSymbols :> {…}` limits which controls re-run the body; the
+        others move without re-rendering, as in Wolfram.
+- Display of `Text[content]` in the visual hosts (Woxi Studio, the
+    Playground) shows the content, so a `Text@Pane[Column[{…}]]` body
+    renders the whole column instead of only the picture inside it.
+- `TraditionalForm` inside a layout is typeset in conventional notation
+    rather than being stripped to StandardForm markup: `Equal` reads `=`
+    (`≤`, `≥`, `≠` likewise), a `Row` of strings and `Style[…]`s is set as
+    the text it displays, and a term with a negative coefficient carries
+    its sign on the operator (`a - 130 x³`, not `a + -130 x³`).
 
 # 2026-07-16 - 0.2.0
 

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -4461,6 +4461,15 @@ fn tf_parens(inner: Expr) -> Expr {
   tf_row(vec![tf_string("("), inner, tf_string(")")])
 }
 
+/// The boxes of an item that is *displayed* rather than printed: a string
+/// contributes its own text, without the quotes a literal would carry.
+fn tf_display(expr: &Expr) -> Expr {
+  match expr {
+    Expr::String(s) => tf_string(s),
+    other => tf(other),
+  }
+}
+
 /// Map a symbol/constant name to its TraditionalForm glyph. Greek letters
 /// entered as `\[Mu]` etc. already arrive as their Unicode character, so
 /// only the named mathematical constants need translating here.
@@ -4711,6 +4720,45 @@ fn tf_times(expr: &Expr) -> Expr {
   }
 }
 
+/// The positive counterpart of an additive term that carries its sign in a
+/// leading negative number — `-9`, `Times[-130, x^3]` — or `None` when the
+/// term is not negative. TraditionalForm puts such a sign on the `+`/`-`
+/// operator instead of on the number, so `a + Times[-130, x^3]` is set as
+/// `a - 130 x³`, never `a + -130 x³`.
+fn tf_negated_term(term: &Expr) -> Option<Expr> {
+  fn positive(e: &Expr) -> Option<Expr> {
+    match e {
+      Expr::Integer(n) if *n < 0 => Some(Expr::Integer(-n)),
+      Expr::Real(f) if *f < 0.0 => Some(Expr::Real(-f)),
+      Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
+        Some(Expr::BigInteger(-n.clone()))
+      }
+      _ => None,
+    }
+  }
+  if let Some(pos) = positive(term) {
+    return Some(pos);
+  }
+  let mut factors = Vec::new();
+  tf_flatten_times(term, &mut factors);
+  if factors.len() < 2 {
+    return None;
+  }
+  let pos_first = positive(&factors[0])?;
+  // A coefficient of 1 left behind is implicit: `Times[-1, x]` is `-x`.
+  let rest = if matches!(pos_first, Expr::Integer(1)) {
+    factors[1..].to_vec()
+  } else {
+    std::iter::once(pos_first)
+      .chain(factors[1..].iter().cloned())
+      .collect()
+  };
+  Some(match rest.len() {
+    1 => rest.into_iter().next().unwrap(),
+    _ => unevaluated("Times", &rest),
+  })
+}
+
 /// TraditionalForm box of an additive expression.
 fn tf_plus(expr: &Expr) -> Expr {
   let mut terms = Vec::new();
@@ -4720,14 +4768,19 @@ fn tf_plus(expr: &Expr) -> Expr {
   }
   let mut items: Vec<Expr> = Vec::new();
   for (i, (neg, term)) in terms.iter().enumerate() {
+    // A term whose own leading number is negative contributes the sign.
+    let (neg, term) = match tf_negated_term(term) {
+      Some(positive) => (!*neg, positive),
+      None => (*neg, term.clone()),
+    };
     if i == 0 {
-      if *neg {
+      if neg {
         items.push(tf_string("-"));
       }
     } else {
-      items.push(tf_string(if *neg { "-" } else { "+" }));
+      items.push(tf_string(if neg { "-" } else { "+" }));
     }
-    items.push(tf(term));
+    items.push(tf(&term));
   }
   tf_row(items)
 }
@@ -4914,6 +4967,36 @@ fn tf_call(name: &str, args: &[Expr]) -> Expr {
   match name {
     "HoldForm" | "HoldComplete" | "Defer" | "Identity" if args.len() == 1 => {
       tf(&args[0])
+    }
+    // `Style[content, directives…]` selects an appearance, not a notation:
+    // the content is what is set. (`expr_to_box_form` does the same.)
+    "Style" | "StyleForm" if !args.is_empty() => tf_display(&args[0]),
+    // `Row[{a, b, …}]` / `Row[{…}, sep]` sets its items side by side. A row
+    // *displays* its parts, so a string item contributes its text — that is
+    // what makes `Row[{Style["p", Italic], "(", x, ")"}]` read as `p(x)`.
+    "Row" if !args.is_empty() && matches!(&args[0], Expr::List(_)) => {
+      let Expr::List(items) = &args[0] else {
+        unreachable!()
+      };
+      // A rule in separator position is an option, not a separator.
+      let separator = args
+        .get(1)
+        .filter(|a| !crate::syntax::is_rule_expr(a))
+        .map(tf_display);
+      let mut parts: Vec<Expr> = Vec::with_capacity(items.len());
+      for (i, item) in items.iter().enumerate() {
+        if i > 0
+          && let Some(sep) = &separator
+        {
+          parts.push(sep.clone());
+        }
+        parts.push(tf_display(item));
+      }
+      if parts.is_empty() {
+        tf_string("")
+      } else {
+        tf_row(parts)
+      }
     }
     "Sqrt" if args.len() == 1 => tf_box("SqrtBox", vec![tf(&args[0])]),
     "Power" if args.len() == 2 => tf_power(&args[0], &args[1]),

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -13081,6 +13081,47 @@ fn render_tabular_svg_grid(
 /// `Text[…]` wrapper, which displays as its content. Any graphics that the
 /// `Dynamic` evaluation captures are embedded in the surrounding layout, not
 /// standalone outputs, so they are dropped from the capture buffer.
+/// Peel the wrappers that say how to *set* what they hold rather than what
+/// to show: `Text[…]`, an `Item[…]` cell, and the form wrappers. They nest
+/// in any order — `Item[Text@TraditionalForm@Framed[…], …]` — so peel until
+/// what is left is the thing that actually draws.
+///
+/// A `TraditionalForm` around a picture or a layout only asks for its
+/// contents to be set traditionally, and the layout renderer takes it from
+/// there. Around an ordinary expression the form *is* what to show —
+/// `p(x) = 1 + x`, not `p(x) == 1 + x` — so the wrapper is put back, for
+/// the caller to typeset through the traditional box builder.
+pub fn unwrap_display_wrappers(expr: &Expr) -> Expr {
+  let mut current = expr.clone();
+  let mut traditional = false;
+  while let Expr::FunctionCall { name, args } = &current {
+    let pass_through = match name.as_str() {
+      "Text" | "TraditionalForm" | "StandardForm" | "DisplayForm" => {
+        args.len() == 1
+      }
+      "Item" => !args.is_empty(),
+      _ => false,
+    };
+    if !pass_through {
+      break;
+    }
+    traditional |= name == "TraditionalForm";
+    let inner = args[0].clone();
+    current = inner;
+  }
+  if traditional
+    && !crate::evaluator::lays_out_a_graphic(&current)
+    && !matches!(&current, Expr::FunctionCall { name, .. }
+      if matches!(name.as_str(), "Grid" | "Column" | "Row" | "Framed"))
+  {
+    current = Expr::FunctionCall {
+      name: "TraditionalForm".to_string(),
+      args: vec![current].into(),
+    };
+  }
+  current
+}
+
 fn resolve_display_item(expr: &Expr) -> Expr {
   let mut current = expr.clone();
   if let Expr::FunctionCall { name, args } = &current
@@ -13094,26 +13135,7 @@ fn resolve_display_item(expr: &Expr) -> Expr {
       current = inner;
     }
   }
-  // Wrappers that say how to *set* what they hold rather than what to
-  // show: `Text[…]`, an `Item[…]` cell, and the form wrappers. They nest
-  // in any order — `Item[Text@TraditionalForm@Framed[…], …]` — so peel
-  // until what is left is the thing that actually draws.
-  loop {
-    let Expr::FunctionCall { name, args } = &current else {
-      break;
-    };
-    let pass_through = match name.as_str() {
-      "Text" | "TraditionalForm" | "StandardForm" | "DisplayForm" => {
-        args.len() == 1
-      }
-      "Item" => !args.is_empty(),
-      _ => false,
-    };
-    if !pass_through {
-      break;
-    }
-    current = args[0].clone();
-  }
+  current = unwrap_display_wrappers(&current);
   // `InputForm[expr]` displays as the InputForm text of `expr`.
   if let Expr::FunctionCall { name, args } = &current
     && name == "InputForm"
@@ -13167,6 +13189,22 @@ fn style_pushed_into_layout(inner: &Expr, directives: &[Expr]) -> Option<Expr> {
   })
 }
 
+/// Typeset `expr` in TraditionalForm as a standalone SVG, through the same
+/// box builder and box layout the top-level display uses. `None` when the
+/// boxes lay out to nothing.
+pub fn form_box_svg(expr: &Expr) -> Option<String> {
+  let boxes =
+    crate::evaluator::dispatch::complex_and_special::expr_to_box_form_traditional(
+      expr,
+    );
+  let boxes = crate::strip_number_precision_markers(&boxes);
+  let layout = layout_box(&boxes, 14.0);
+  if layout.width <= 0.0 || layout.height <= 0.0 {
+    return None;
+  }
+  Some(layout_to_svg(&layout, theme().text_primary))
+}
+
 /// Render a resolved `Column`/`Row` item that is itself a layout construct
 /// (`Row[…]` / `Column[…]`) to a nested SVG, so mixed text/graphics rows
 /// compose instead of printing as raw InputForm text. `None` for other
@@ -13186,6 +13224,13 @@ fn nested_layout_svg(expr: &Expr) -> Option<String> {
       // A `Framed[…]` box draws its border and its content; a `Column`
       // item that is one used to print as source.
       "Framed" if !args.is_empty() => return framed_to_svg(&args),
+      // `TraditionalForm[expr]` is typeset in conventional notation —
+      // `=` for `Equal`, `≤` for `LessEqual`, `sin(x)` for `Sin[x]`,
+      // stacked fractions — by the same box pipeline the top-level
+      // display uses.
+      "TraditionalForm" if args.len() == 1 => {
+        return form_box_svg(&args[0]);
+      }
       // A styled layout keeps its layout, and its style: `Style[Row[{…}],
       // Bold, 20]` sets every item of the row, since a `Style` is inherited
       // by what it wraps. Pushing the directives inwards is what lets the
@@ -14818,6 +14863,14 @@ pub struct ManipulateSpec {
   /// `Appearance -> None`: the widget shows no visible control rows (the
   /// animation just runs), matching Wolfram's control-free appearance.
   pub appearance_none: bool,
+  /// `TrackedSymbols :> {a, b}`: the only variables whose change re-runs the
+  /// body. A control outside the list still moves — it just does not
+  /// re-render until a tracked variable changes too (Descartes's Rule of
+  /// Signs tracks only the seed and the zoom, so picking a new polynomial
+  /// degree takes effect when the "new polynomial" button reseeds). `None`
+  /// means every variable is tracked, which is Wolfram's default and also
+  /// what `TrackedSymbols -> All` / `-> Manipulate` ask for.
+  pub tracked_symbols: Option<Vec<String>>,
 }
 
 /// Result of parsing a single list-shaped Manipulate argument.
@@ -14944,6 +14997,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   // display); `ControlType -> None` bindings become live mutable state.
   let mut fixed: Vec<(String, String)> = Vec::new();
   let mut appearance_none = false;
+  let mut tracked_symbols: Option<Vec<String>> = None;
   // Compound (non-symbol) control variables such as `Subscript[signal, 1]`
   // cannot be bound by name; each is renamed to a synthesized plain symbol,
   // and every occurrence in the body (and related code fragments) is
@@ -15059,6 +15113,25 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         && matches!(replacement.as_ref(), Expr::Identifier(s) if s == "False")
       {
         animation_running = false;
+      }
+      // `TrackedSymbols :> {a, b}` narrows re-evaluation to those
+      // variables; a single symbol may be given bare. `All` / `Manipulate`
+      // (and anything else) keep the default of tracking everything.
+      if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "TrackedSymbols")
+      {
+        tracked_symbols = match replacement.as_ref() {
+          Expr::List(items) => items
+            .iter()
+            .map(|it| match it {
+              Expr::Identifier(s) => Some(s.clone()),
+              _ => None,
+            })
+            .collect::<Option<Vec<_>>>(),
+          Expr::Identifier(s) if s != "All" && s != "Manipulate" => {
+            Some(vec![s.clone()])
+          }
+          _ => None,
+        };
       }
       continue;
     }
@@ -15314,6 +15387,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animated,
     animation_running,
     appearance_none,
+    tracked_symbols,
   })
 }
 
@@ -15741,6 +15815,7 @@ pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animated: true,
     animation_running: true,
     appearance_none: false,
+    tracked_symbols: None,
   })
 }
 
@@ -15815,6 +15890,7 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animated: true,
     animation_running: true,
     appearance_none: false,
+    tracked_symbols: None,
   })
 }
 
@@ -15888,6 +15964,7 @@ pub fn extract_locator_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animated: false,
     animation_running: true,
     appearance_none: false,
+    tracked_symbols: None,
   })
 }
 
@@ -15937,6 +16014,7 @@ pub fn extract_click_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animated: false,
     animation_running: true,
     appearance_none: false,
+    tracked_symbols: None,
   })
 }
 
@@ -15995,6 +16073,7 @@ pub fn extract_control_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animated: animate.is_some(),
     animation_running: animate.unwrap_or(true),
     appearance_none: false,
+    tracked_symbols: None,
   })
 }
 
@@ -16483,8 +16562,24 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
       .unwrap_or(Expr::Identifier("Null".to_string()));
     if is_hidden {
       // A `ControlType -> None` variable stays a live, mutable binding so
-      // an interactive display can rewrite it.
-      let value = manipulate_value_to_input_form(&value_expr);
+      // an interactive display can rewrite it. Without an explicit initial
+      // (`{v, domain, ControlType -> None}` rather than `{{v, init}, …}`)
+      // the second element is the variable's *domain*, exactly as it is for
+      // a visible control: a list of choices, whose first entry is where the
+      // variable starts. Taking the list itself would bind one level too
+      // deep — `{aa, {{1, 1, 1, 1}}, ControlType -> None}` starts `aa` at
+      // `{1, 1, 1, 1}`, not at `{{1, 1, 1, 1}}`.
+      let value = match (&explicit_initial, &value_expr) {
+        (None, domain) => match crate::evaluator::evaluate_expr_to_expr(domain)
+        {
+          Ok(Expr::List(ref choices)) if !choices.is_empty() => {
+            crate::syntax::expr_to_input_form(&choices[0])
+          }
+          Ok(evaluated) => crate::syntax::expr_to_input_form(&evaluated),
+          Err(_) => crate::syntax::expr_to_input_form(domain),
+        },
+        _ => manipulate_value_to_input_form(&value_expr),
+      };
       return Some(ParsedControl::State { name, value });
     }
     // A Locator drives its variable interactively: a single `{x, y}` point
@@ -16580,11 +16675,16 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
         | "Manipulator"
         | "InputField"
         | "PopupMenu"
+        | "Setter"
         | "SetterBar"
         | "RadioButton"
         | "RadioButtonBar"
+        | "Toggler"
         | "TogglerBar"
         | "Checkbox"
+        | "CheckboxBar"
+        | "Opener"
+        | "OpenerBar"
         | "ColorSlider"
         | "ColorSetter"
         | "IntervalSlider"
@@ -16776,7 +16876,9 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
     Some(
       "RadioButton"
         | "RadioButtonBar"
+        | "Setter"
         | "SetterBar"
+        | "Toggler"
         | "TogglerBar"
         | "PopupMenu"
     )
@@ -17866,9 +17968,21 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
     }
     None => String::new(),
   };
+  // Absent when every variable is tracked (the default), so a frontend that
+  // does not know the option keeps re-rendering on every change.
+  let tracked_json = match &spec.tracked_symbols {
+    Some(names) => {
+      let parts: Vec<String> = names
+        .iter()
+        .map(|n| format!(r#""{}""#, json_escape_manipulate(n)))
+        .collect();
+      format!(r#","trackedSymbols":[{}]"#, parts.join(","))
+    }
+    None => String::new(),
+  };
 
   format!(
-    r#""body":"{}","controls":[{}],"state":{{{}}},"displays":[{}]{}{}{}"#,
+    r#""body":"{}","controls":[{}],"state":{{{}}},"displays":[{}]{}{}{}{}"#,
     json_escape_manipulate(&spec.body_code),
     ctrl_parts.join(","),
     state_parts.join(","),
@@ -17876,6 +17990,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
     animated_json,
     appearance_json,
     animation_var_json,
+    tracked_json,
   )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2022,7 +2022,7 @@ fn format_top_level_result(result_expr: syntax::Expr) -> String {
     // the wrapped content (e.g. Pane[Column[{…, Graphics[…]}]] renders the
     // column with its embedded graphic). CLI mode keeps the symbolic
     // Pane[…] echo to match wolframscript.
-    let result_expr = unwrap_pane_if_needed(result_expr);
+    let result_expr = unwrap_pane_or_text_if_needed(result_expr);
     let result_expr = render_interactive_pane_if_needed(result_expr);
     let result_expr = render_labeled_if_needed(result_expr);
     let result_expr = render_dynamic_if_needed(result_expr);
@@ -2760,12 +2760,18 @@ pub(crate) fn render_traditionalform_list_if_needed(
 /// the content is the right thing to render — otherwise e.g.
 /// `Pane[Column[{…, Graphics[…]}]]` (the shape of many Manipulate bodies)
 /// would stay a textual echo with the graphic never rendered.
-fn unwrap_pane_if_needed(expr: syntax::Expr) -> syntax::Expr {
+/// `Text[content]` is the same kind of wrapper: it selects the font the
+/// content is set in, not what is shown, so `Text@Pane[Column[{…}]]` — the
+/// standard Demonstrations body — has to reach the column underneath.
+/// `Text[expr, pos, …]` is the *graphics primitive* instead and is left
+/// alone.
+fn unwrap_pane_or_text_if_needed(expr: syntax::Expr) -> syntax::Expr {
   match expr {
     syntax::Expr::FunctionCall { ref name, ref args }
-      if name == "Pane" && !args.is_empty() =>
+      if (name == "Pane" && !args.is_empty())
+        || (name == "Text" && args.len() == 1) =>
     {
-      unwrap_pane_if_needed(args[0].clone())
+      unwrap_pane_or_text_if_needed(args[0].clone())
     }
     other => other,
   }
@@ -2776,23 +2782,7 @@ fn unwrap_pane_if_needed(expr: syntax::Expr) -> syntax::Expr {
 /// has to see through them to reach the thing that actually draws — a
 /// `Framed[…]` inside a `Text@TraditionalForm@…` is still a framed box.
 fn unwrap_display_pass_through(expr: syntax::Expr) -> syntax::Expr {
-  match &expr {
-    syntax::Expr::FunctionCall { name, args }
-      if args.len() == 1
-        && matches!(
-          name.as_str(),
-          "Text" | "TraditionalForm" | "StandardForm" | "DisplayForm"
-        ) =>
-    {
-      unwrap_display_pass_through(args[0].clone())
-    }
-    syntax::Expr::FunctionCall { name, args }
-      if name == "Item" && !args.is_empty() =>
-    {
-      unwrap_display_pass_through(args[0].clone())
-    }
-    _ => expr,
-  }
+  functions::graphics::unwrap_display_wrappers(&expr)
 }
 
 /// In visual (notebook) display mode, `ClickPane[expr, …]` and
@@ -2835,7 +2825,7 @@ fn render_inline_display_wrapper(expr: syntax::Expr) -> syntax::Expr {
   // wrapper arguments, so we apply the relevant ones here for a single
   // sub-expression.
   let expr = unwrap_display_pass_through(expr);
-  let expr = unwrap_pane_if_needed(expr);
+  let expr = unwrap_pane_or_text_if_needed(expr);
   let expr = render_interactive_pane_if_needed(expr);
   let expr = render_dynamic_if_needed(expr);
   let expr = render_grid_if_needed(expr);

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3479,6 +3479,63 @@ fn flatten_times_chain(expr: Expr) -> Vec<Expr> {
   out
 }
 
+/// Whether `op` binds tighter than `Times`, so that it has to reach into an
+/// adjacent implicit product rather than take the whole product as one
+/// operand. `NEGATE` (the synthetic unary minus) and the `~f~` tilde infix
+/// are excluded: both already bind around a whole product the way Wolfram
+/// reads them.
+fn splits_implicit_product(op: &str) -> bool {
+  if op == "NEGATE"
+    || (op.starts_with('~') && op.ends_with('~') && op.len() > 2)
+  {
+    return false;
+  }
+  operator_precedence(op) > operator_precedence("*")
+}
+
+/// An implicit product (`2 x`) is `Times` at ordinary multiplicative
+/// precedence, but the grammar hands it to the tree builder as a single
+/// term. When a neighbouring operator binds tighter than `Times` that
+/// operator must reach the adjacent *factor* — Wolfram reads
+/// `2 Times @@ {3, 4}` as `2 (Times @@ {3, 4})` and `a b . c` as
+/// `a (b . c)` — so split such a term into its factors joined by explicit
+/// `*` operators and let the precedence climb do the rest.
+fn split_implicit_products(
+  terms: &mut Vec<Expr>,
+  operators: &mut Vec<String>,
+  was_implicit: &[bool],
+) {
+  if !was_implicit.iter().any(|b| *b) {
+    return;
+  }
+  let mut new_terms: Vec<Expr> = Vec::with_capacity(terms.len());
+  let mut new_ops: Vec<String> = Vec::with_capacity(operators.len());
+  for (i, term) in std::mem::take(terms).into_iter().enumerate() {
+    if i > 0 {
+      new_ops.push(operators[i - 1].clone());
+    }
+    let touches_tighter_op = (i > 0
+      && splits_implicit_product(&operators[i - 1]))
+      || operators
+        .get(i)
+        .is_some_and(|op| splits_implicit_product(op));
+    if was_implicit.get(i).copied().unwrap_or(false) && touches_tighter_op {
+      let mut factors = flatten_times_chain(term).into_iter();
+      if let Some(first) = factors.next() {
+        new_terms.push(first);
+        for factor in factors {
+          new_ops.push("*".to_string());
+          new_terms.push(factor);
+        }
+      }
+    } else {
+      new_terms.push(term);
+    }
+  }
+  *terms = new_terms;
+  *operators = new_ops;
+}
+
 fn parse_list(pair: Pair<Rule>) -> Expr {
   let items: Vec<Expr> = pair
     .into_inner()
@@ -4354,6 +4411,7 @@ fn parse_expression_inner(
     &mut terms,
     &mut term_was_implicit_times,
   );
+  split_implicit_products(&mut terms, &mut operators, &term_was_implicit_times);
 
   let mut result = if terms.len() == 1 {
     terms.remove(0)

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -8240,6 +8240,95 @@ mod pane_wrapper_display {
     assert!(svg.contains("<svg x="), "expected embedded graphic");
   }
 
+  // `Text[content]` is a font wrapper, not a thing to show: the standard
+  // Demonstrations body `Text@Pane[Column[{…}]]` has to reach the column
+  // underneath. Without this the whole body echoed as text and only the
+  // plot inside it (captured on its own while evaluating) was drawn.
+  #[test]
+  fn text_of_pane_of_column_renders_in_visual_mode() {
+    clear_state();
+    let result = interpret_with_stdout(
+      "Text@Pane[Column[{\"caption\", \
+         Graphics[{Disk[]}, ImageSize -> {60, 60}]}, Alignment -> Center], \
+         Alignment -> Center]",
+    )
+    .unwrap();
+    assert_eq!(result.result, "-Graphics-");
+    let svg = result.graphics.expect("text/pane content should render");
+    assert!(
+      svg.contains("caption"),
+      "expected the caption row in: {svg}"
+    );
+    assert!(svg.contains("<svg x="), "expected embedded graphic");
+  }
+
+  // A `TraditionalForm` item inside a layout is typeset in conventional
+  // notation — `=` for `Equal`, and a `Row` of strings/`Style`s set as the
+  // text it displays — instead of being stripped down to the StandardForm
+  // markup (`p(x) == …` with quoted string parts).
+  #[test]
+  fn traditionalform_column_item_uses_traditional_notation() {
+    clear_state();
+    let svg = interpret_with_stdout(
+      "Column[{TraditionalForm[\
+         Row[{Style[\"p\", Italic], \"(\", x, \")\"}] == 1 + x^2], \
+         Graphics[{Disk[]}, ImageSize -> {60, 60}]}]",
+    )
+    .unwrap()
+    .graphics
+    .expect("column should render");
+    for part in ["p", "(", "x", ")", "=", "1"] {
+      assert!(
+        svg.contains(&format!(">{part}<")),
+        "missing `{part}`: {svg}"
+      );
+    }
+    assert!(!svg.contains("=="), "TraditionalForm shows `=`, not `==`");
+    assert!(!svg.contains("&quot;"), "Row items display unquoted: {svg}");
+    assert!(!svg.contains(">Row<"), "Row must be laid out, not printed");
+  }
+
+  // A term whose leading number is negative carries its sign on the
+  // operator: `a - 130 x^3`, never `a + -130 x^3`.
+  #[test]
+  fn traditionalform_negative_terms_use_a_minus_sign() {
+    clear_state();
+    let svg = interpret_with_stdout(
+      "Column[{TraditionalForm[{1, x, x^2, x^3} . {-9, 24, 77, -130}], \
+        TraditionalForm[a - x], TraditionalForm[b - 2.5 y], \
+        Graphics[{Disk[]}, ImageSize -> {60, 60}]}]",
+    )
+    .unwrap()
+    .graphics
+    .expect("column should render");
+    let text: String = svg
+      .split("</text>")
+      .filter_map(|chunk| chunk.rsplit_once('>').map(|(_, t)| t.to_string()))
+      .collect();
+    assert!(!text.contains("+-"), "no `+ -` term should survive: {text}");
+    assert!(text.contains("-130"), "negated coefficient: {text}");
+    // `Times[-1, x]` drops the implicit coefficient: `a - x`.
+    assert!(!text.contains("-1x"), "`-1 x` must print as `- x`: {text}");
+    assert!(text.contains("-2.5"), "negated real coefficient: {text}");
+  }
+
+  // The relational operators all take their traditional glyphs.
+  #[test]
+  fn traditionalform_column_item_relational_glyphs() {
+    clear_state();
+    let svg = interpret_with_stdout(
+      "Column[{TraditionalForm[a <= b], TraditionalForm[c >= d], \
+        TraditionalForm[e != f], \
+        Graphics[{Disk[]}, ImageSize -> {60, 60}]}]",
+    )
+    .unwrap()
+    .graphics
+    .expect("column should render");
+    for glyph in ['\u{2264}', '\u{2265}', '\u{2260}'] {
+      assert!(svg.contains(glyph), "missing `{glyph}` in: {svg}");
+    }
+  }
+
   // The CLI (plain `interpret`, matching wolframscript) keeps the
   // symbolic echo — the unwrap is a visual-host affordance only.
   #[test]
@@ -8248,6 +8337,10 @@ mod pane_wrapper_display {
     assert_eq!(
       interpret("Pane[Column[{1, 2}], ImageSize -> 500]").unwrap(),
       "Pane[Column[{1, 2}], ImageSize -> 500]"
+    );
+    assert_eq!(
+      interpret("Text[Pane[Column[{1, 2}]]]").unwrap(),
+      "Text[Pane[Column[{1, 2}]]]"
     );
   }
 }
@@ -13569,6 +13662,122 @@ mod manipulate {
       }
       other => panic!("expected a discrete control, got {other:?}"),
     }
+  }
+
+  /// A `Setter` / `Toggler` control type offers one widget per value, the
+  /// way `SetterBar` and `RadioButton` already do. Before these were
+  /// recognised as control-type names they were read as a *bound*, the
+  /// spec failed to parse, and — because one unparsable spec aborts the
+  /// whole extraction — the entire Manipulate fell back to a text echo.
+  #[test]
+  fn spec_setter_and_toggler_control_types() {
+    for control_type in ["Setter", "Toggler"] {
+      let expr = interpret_to_expr(&format!(
+        "Manipulate[n, Control@{{{{n, 3, \"degree\"}}, Range[1, 7], \
+         {control_type}}}]"
+      ))
+      .unwrap();
+      let spec =
+        extract_manipulate_spec(&expr).expect("{control_type} control spec");
+      match &spec.controls[0] {
+        ManipulateControl::Discrete {
+          name,
+          values,
+          initial_index,
+          label,
+          popup,
+          ..
+        } => {
+          assert_eq!(name, "n");
+          assert_eq!(label, "degree");
+          assert_eq!(values, &["1", "2", "3", "4", "5", "6", "7"]);
+          assert_eq!(*initial_index, 2); // initial value 3
+          assert!(!*popup, "{control_type} is not a dropdown");
+        }
+        other => panic!("expected a discrete control, got {other:?}"),
+      }
+    }
+  }
+
+  /// `Setter` also enumerates a numeric range into one choice per value,
+  /// like the other per-value control types.
+  #[test]
+  fn spec_setter_enumerates_numeric_range() {
+    let expr =
+      interpret_to_expr("Manipulate[n, {{n, 1}, 1, 4, 1, Setter}]").unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("setter range spec");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete { values, .. } => {
+        assert_eq!(values, &["1", "2", "3", "4"]);
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
+  /// `{v, domain, ControlType -> None}` states the variable's *domain*, not
+  /// its value: a list of choices starts the variable at the first one. It
+  /// used to bind the whole list, so `{aa, {{1, 1, 1, 1}}, ControlType ->
+  /// None}` started `aa` one level too deep.
+  #[test]
+  fn spec_hidden_variable_starts_at_first_choice() {
+    let expr = interpret_to_expr(
+      "Manipulate[aa, {aa, {{1, 1, 1, 1}}, ControlType -> None}, \
+       {bb, {7, 8, 9}, ControlType -> None}, \
+       Control@{cc, RandomInteger[{5, 5}], ControlType -> None}, \
+       {{dd, {2, 3}}, ControlType -> None}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("hidden variables");
+    assert_eq!(
+      spec.state,
+      vec![
+        ("aa".to_string(), "{1, 1, 1, 1}".to_string()),
+        ("bb".to_string(), "7".to_string()),
+        // A non-list domain is the initial value itself, evaluated once.
+        ("cc".to_string(), "5".to_string()),
+        // An explicit initial value is used as given.
+        ("dd".to_string(), "{2, 3}".to_string()),
+      ]
+    );
+  }
+
+  /// `TrackedSymbols :> {…}` narrows which variables re-run the body; the
+  /// other spellings (`All`, `Manipulate`, absent) track everything.
+  #[test]
+  fn spec_tracked_symbols() {
+    let tracked = |code: &str| {
+      let expr = interpret_to_expr(code).unwrap();
+      extract_manipulate_spec(&expr)
+        .expect("well-formed Manipulate")
+        .tracked_symbols
+    };
+    assert_eq!(
+      tracked("Manipulate[a + b, {a, 0, 1}, {b, 0, 1}, TrackedSymbols :> {b}]"),
+      Some(vec!["b".to_string()])
+    );
+    assert_eq!(
+      tracked("Manipulate[a + b, {a, 0, 1}, {b, 0, 1}, TrackedSymbols -> b]"),
+      Some(vec!["b".to_string()])
+    );
+    assert_eq!(
+      tracked("Manipulate[a + b, {a, 0, 1}, {b, 0, 1}, TrackedSymbols :> All]"),
+      None
+    );
+    assert_eq!(
+      tracked(
+        "Manipulate[a + b, {a, 0, 1}, {b, 0, 1}, \
+         TrackedSymbols -> Manipulate]"
+      ),
+      None
+    );
+    assert_eq!(tracked("Manipulate[a, {a, 0, 1}]"), None);
+    let expr = interpret_to_expr(
+      "Manipulate[a + b, {a, 0, 1}, {b, 0, 1}, TrackedSymbols :> {b}]",
+    )
+    .unwrap();
+    let json =
+      manipulate_spec_to_json(&extract_manipulate_spec(&expr).unwrap());
+    assert!(json.contains(r#""trackedSymbols":["b"]"#), "{json}");
   }
 
   /// End-to-end regression for the animated `I^t` ParametricPlot widget:

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -494,6 +494,33 @@ mod operator_shorthand_parens {
     assert_eq!(interpret("Hold[f @@ a^2]").unwrap(), "Hold[f @@ a^2]");
   }
 
+  // An implicit product (`2 f`) is `Times` at multiplicative precedence, so
+  // an operator that binds tighter reaches its adjacent *factor*, not the
+  // whole product. Regression: `lcm^n Times @@ Table[…]` — the
+  // Demonstrations idiom for building a polynomial from its roots — parsed
+  // as `(lcm^n Times) @@ Table[…]`, which applies the wrong head and yields
+  // an unevaluable expression instead of the product.
+  #[test]
+  fn implicit_product_yields_to_tighter_operators() {
+    // Apply / MapApply / Map (precedence 620) over Times (400).
+    assert_eq!(interpret("2 Times @@ {3, 4}").unwrap(), "24");
+    assert_eq!(interpret("2 Plus @@ {3, 4}").unwrap(), "14");
+    // `3 (List @@@ {{1}})` is `3 {{1}}`, and Times threads over the list.
+    assert_eq!(interpret("3 List @@@ {{1}}").unwrap(), "{{3}}");
+    assert_eq!(interpret("2 f /@ {a, b}").unwrap(), "{2*f[a], 2*f[b]}");
+    // The product on the *right* of a tighter operator splits too:
+    // `(List @@ 2) x` is `2 x`, not `List @@ (2 x)`.
+    assert_eq!(interpret("List @@ 2 x").unwrap(), "2*x");
+    // Dot (490) over Times.
+    assert_eq!(interpret("2 {1, 2} . {3, 4}").unwrap(), "22");
+    assert_eq!(interpret("{1, 2} . {3, 4} 2").unwrap(), "22");
+    // Power (590) over Times: `2 x ^ 3` is `2 (x^3)`.
+    assert_eq!(interpret("2 x^3 /. x -> 2").unwrap(), "16");
+    // A product with no tighter neighbour is untouched.
+    assert_eq!(interpret("2 x + 1 /. x -> 3").unwrap(), "7");
+    assert_eq!(interpret("-2 x /. x -> 3").unwrap(), "-6");
+  }
+
   #[test]
   fn held_subtraction_keeps_additive_operand_parens() {
     // Subtraction is left-associative, so a parenthesized additive right

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -1665,7 +1665,7 @@ impl WoxiStudio {
           && let manipulate::ControlState::Continuous { current, .. } = control
         {
           *current = value;
-          if state.request_reeval() {
+          if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
         }
@@ -1684,7 +1684,7 @@ impl WoxiStudio {
           && let Some(idx) = value_labels.iter().position(|v| *v == choice)
         {
           *current_index = idx;
-          if state.request_reeval() {
+          if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
         }
@@ -1698,7 +1698,7 @@ impl WoxiStudio {
           // Routes through the control's write-back callback (if any), so
           // e.g. Locator-promoted controls round/validate the candidate.
           state.slider2d_change(ctrl_idx, axis, value);
-          if state.request_reeval() {
+          if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
         }
@@ -1724,7 +1724,7 @@ impl WoxiStudio {
           } else {
             *high = value.max(*low);
           }
-          if state.request_reeval() {
+          if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
         }
@@ -1749,7 +1749,7 @@ impl WoxiStudio {
           } else {
             point.1 = value;
           }
-          if state.request_reeval() {
+          if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
         }
@@ -1771,7 +1771,7 @@ impl WoxiStudio {
         {
           // New points appear at the range centre, ready to drag.
           points.push(((*x_min + *x_max) / 2.0, (*y_min + *y_max) / 2.0));
-          if state.request_reeval() {
+          if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
         }
@@ -1786,7 +1786,7 @@ impl WoxiStudio {
           && point_idx < points.len()
         {
           points.remove(point_idx);
-          if state.request_reeval() {
+          if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
         }
@@ -6508,15 +6508,15 @@ mod tests {
     let mut state = manipulate::ManipulateState::from_expr(&expr).unwrap();
 
     // First change schedules the timer; the rest only accumulate.
-    assert!(state.request_reeval(), "first change should arm the timer");
-    assert!(!state.request_reeval(), "second change must not re-arm");
-    assert!(!state.request_reeval(), "third change must not re-arm");
+    assert!(state.request_reeval(0), "first change should arm the timer");
+    assert!(!state.request_reeval(0), "second change must not re-arm");
+    assert!(!state.request_reeval(0), "third change must not re-arm");
 
     // Timer fires: the pending changes render and the flag clears, so the
     // next change arms a fresh timer.
     state.run_scheduled_reeval();
     assert!(
-      state.request_reeval(),
+      state.request_reeval(0),
       "a change after the timer fired should arm a new timer"
     );
 
@@ -6524,7 +6524,32 @@ mod tests {
     // clears the flag (so a later change can re-arm).
     state.run_scheduled_reeval();
     state.run_scheduled_reeval();
-    assert!(state.request_reeval(), "flag must clear on an empty fire");
+    assert!(state.request_reeval(0), "flag must clear on an empty fire");
+  }
+
+  #[test]
+  fn manipulate_untracked_control_does_not_reeval() {
+    // `TrackedSymbols :> {b}`: moving `a` changes its value but must not
+    // re-run the body — Wolfram leaves the rendering as it is until a
+    // tracked variable changes. Descartes's Rule of Signs relies on this:
+    // its degree setter would otherwise feed the body a polynomial degree
+    // that the (still stale) coefficient list cannot be dotted with.
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[a + b, {a, 0, 10}, {b, 0, 10}, TrackedSymbols :> {b}]",
+    )
+    .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    assert_eq!(state.controls[0].name(), "a");
+    assert_eq!(state.controls[1].name(), "b");
+    assert!(!state.request_reeval(0), "untracked `a` must not re-render");
+    assert!(state.request_reeval(1), "tracked `b` must re-render");
+
+    // Without the option every control is tracked, as before.
+    let expr =
+      woxi::interpret_to_expr("Manipulate[a + b, {a, 0, 10}, {b, 0, 10}]")
+        .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    assert!(state.request_reeval(0), "default tracks every control");
   }
 
   #[test]
@@ -7265,6 +7290,95 @@ Cell[BoxData["ImageDimensions[tex]"], "Input"]
     }
     state.reevaluate();
     assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+  }
+
+  #[test]
+  fn setter_row_manipulate_renders_its_traditionalform_body() {
+    // End-to-end regression for the Demonstrations layout that pairs a
+    // `Setter` control and a `Button` inside a `Row[…]` with hidden
+    // `ControlType -> None` state, and whose body is
+    // `Text@Pane[Column[{TraditionalForm[…], Grid[…], Plot[…]}]]`.
+    // Every piece used to break the widget: `Setter` was read as a bound
+    // (so the whole Manipulate fell back to a text echo), the hidden
+    // variable bound its choice *list* instead of its first choice, and
+    // the `Text@Pane` body rendered only the plot buried inside it.
+    let code = "Manipulate[\
+        Text@Pane[Column[{\
+          TraditionalForm[Row[{Style[\"q\", Italic], \"(\", x, \")\"}] == \
+            Take[powers, deg + 1] . Reverse[coeffs]], \
+          Grid[{Reverse[Take[powers, deg + 1]], coeffs}, Frame -> All], \
+          Plot[Take[powers, deg + 1] . Reverse[coeffs], {x, -2, 2}, \
+            ImageSize -> {200, Automatic}]}, Alignment -> Center], \
+          ImageSize -> {400, 260}], \
+        {coeffs, {{1, 1, 1}}, ControlType -> None}, \
+        Row[{Control@{{deg, 2, \"degree\"}, Range[1, 4], Setter}, \
+          Spacer[10], \
+          Button[\"reset\", coeffs = {1, 1, 1}], \
+          Spacer[10], \
+          Control@{{scale, 1, \"scale\"}, Range[3]}}], \
+        TrackedSymbols :> {scale}, \
+        Initialization :> (powers = Table[x^i, {i, 0, 6}];)]";
+    let state = instantiate_stored_manipulate(code, "")
+      .expect("the setter-row Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the initial render must produce the column graphic"
+    );
+
+    // A setter, a button and a second setter, in display order.
+    let kinds: Vec<&str> = state
+      .controls
+      .iter()
+      .map(|c| match c {
+        manipulate::ControlState::Discrete { label, .. } => label.as_str(),
+        manipulate::ControlState::Button { label, .. } => label.as_str(),
+        other => panic!("unexpected control {other:?}"),
+      })
+      .collect();
+    assert_eq!(kinds, vec!["degree", "reset", "scale"]);
+    match &state.controls[0] {
+      manipulate::ControlState::Discrete {
+        values,
+        current_index,
+        ..
+      } => {
+        assert_eq!(values, &vec!["1", "2", "3", "4"]);
+        assert_eq!(*current_index, 1, "initial degree 2");
+      }
+      other => panic!("expected the degree setter, got {other:?}"),
+    }
+    // The hidden variable starts at the first choice of its domain.
+    assert_eq!(
+      state.state,
+      vec![("coeffs".to_string(), "{1, 1, 1}".to_string())]
+    );
+
+    // `TrackedSymbols :> {scale}`: the degree setter moves without
+    // re-rendering, the scale setter re-renders.
+    let mut state = state;
+    assert!(!state.request_reeval(0), "degree is not tracked");
+    assert!(state.request_reeval(2), "scale is tracked");
+    state.run_scheduled_reeval();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+
+    // The button writes the coefficient list back and re-renders.
+    let action = state
+      .controls
+      .iter()
+      .find_map(|c| match c {
+        manipulate::ControlState::Button { action, .. } => Some(action.clone()),
+        _ => None,
+      })
+      .expect("a button row");
+    state.apply_button_action(&action);
+    assert!(state.error.is_none(), "button failed: {:?}", state.error);
     assert!(state.graphics_handle.is_some());
   }
 

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -277,6 +277,10 @@ pub struct ManipulateState {
   /// `Appearance -> None`: hide the control rows (the animation just runs);
   /// the play/pause toggle stays visible for animated widgets.
   pub appearance_none: bool,
+  /// `TrackedSymbols :> {…}`: the variables whose change re-runs the body.
+  /// A control bound to any other variable still moves, but the rendering
+  /// waits for a tracked variable to change. `None` tracks everything.
+  tracked_symbols: Option<Vec<String>>,
   /// The variable a `ControlType -> Trigger`/`Animator` spec animates.
   /// `advance_animation` targets this control instead of defaulting to the
   /// first continuous one.
@@ -350,6 +354,7 @@ impl ManipulateState {
       // unless the spec was built paused (`AnimationRunning -> False`).
       playing: spec.animated && spec.animation_running,
       appearance_none: spec.appearance_none,
+      tracked_symbols: spec.tracked_symbols,
       animation_var: spec.animation_var,
       dynamic_bounds: spec.dynamic_bounds,
       control_enabled,
@@ -479,6 +484,25 @@ impl ManipulateState {
     }
   }
 
+  /// Whether moving the control at `ctrl_idx` re-runs the body. With
+  /// `TrackedSymbols :> {…}` only the listed variables do: Wolfram leaves
+  /// the rendering as it is until one of them changes, so a control outside
+  /// the list moves without re-rendering (and cannot show the body a
+  /// half-updated set of values).
+  fn control_is_tracked(&self, ctrl_idx: usize) -> bool {
+    let Some(tracked) = &self.tracked_symbols else {
+      return true;
+    };
+    match self.controls.get(ctrl_idx) {
+      // A row that binds no variable (a button, a heading) is not a
+      // variable change; its own handler decides whether to re-render.
+      Some(control) if control.binds_variable() => {
+        tracked.iter().any(|n| n == control.name())
+      }
+      _ => true,
+    }
+  }
+
   /// Register a control change and report whether the caller must arm a
   /// throttle timer. Re-evaluating the body on *every* slider mouse-move tick
   /// blocks the UI thread and makes the graphic stutter/flicker while
@@ -488,7 +512,10 @@ impl ManipulateState {
   /// caller should spawn one.
   ///
   /// [`run_scheduled_reeval`]: Self::run_scheduled_reeval
-  pub fn request_reeval(&mut self) -> bool {
+  pub fn request_reeval(&mut self, ctrl_idx: usize) -> bool {
+    if !self.control_is_tracked(ctrl_idx) {
+      return false;
+    }
     self.reeval_pending = self.reeval_pending.wrapping_add(1);
     if self.reeval_scheduled {
       false


### PR DESCRIPTION
## Summary

This PR adds support for displaying `TraditionalForm` expressions in layouts, improves `Manipulate` control type recognition and variable tracking, and fixes operator precedence handling for implicit products.

## Key Changes

### Display and Rendering
- **TraditionalForm in layouts**: `TraditionalForm` expressions inside `Column`, `Row`, and other layouts now render with traditional mathematical notation (e.g., `=` instead of `==`, `≤` instead of `LessEqual`) via a new `form_box_svg()` function
- **Text wrapper unwrapping**: `Text[content]` is now properly unwrapped to display the content, fixing cases like `Text@Pane[Column[{…}]]` which is the standard Demonstrations body pattern
- **Negative term handling**: TraditionalForm now correctly displays negative coefficients with minus signs on operators (e.g., `a - 130 x³` instead of `a + -130 x³`)
- **Row display**: `Row[{items}]` inside layouts now displays items without quotes, properly handling `Style` directives

### Manipulate Improvements
- **New control types**: Added recognition for `Setter`, `Toggler`, `CheckboxBar`, `Opener`, and `OpenerBar` as control type names. Previously `Setter` was misread as a slider bound, causing the entire Manipulate to fall back to text echo
- **Hidden variable initialization**: Fixed `{v, domain, ControlType -> None}` to start `v` at the first choice of its domain rather than binding the entire choice list
- **TrackedSymbols support**: Implemented `TrackedSymbols :> {…}` option to limit which controls re-run the body. Controls outside the tracked set move without re-rendering, matching Wolfram behavior
- **Control state tracking**: Updated `ManipulateState::request_reeval()` to accept a control index and check if that control is tracked before scheduling re-evaluation

### Parser Improvements
- **Implicit product operator precedence**: Fixed parsing of implicit products (`2 x`) when adjacent to operators with higher precedence than `Times`. Now `2 Times @@ {3, 4}` correctly parses as `2 (Times @@ {3, 4})` and `a b . c` as `a (b . c)`, matching Wolfram's behavior. This fixes the Demonstrations idiom `lcm^n Times @@ Table[…]` for building polynomials from roots

## Implementation Details

- Added `unwrap_display_wrappers()` function to peel `Text`, `TraditionalForm`, and `Item` wrappers while preserving `TraditionalForm` when needed for non-layout expressions
- Extended `nested_layout_svg()` to handle `TraditionalForm` by calling the traditional box builder
- Added `split_implicit_products()` to the parser to handle operator precedence correctly when implicit products are adjacent to higher-precedence operators
- Updated all `ManipulateSpec` construction sites to include the new `tracked_symbols` field
- Added comprehensive tests for all new functionality including end-to-end regression tests for the "Descartes's Rule of Signs" Demonstration

https://claude.ai/code/session_01DLieDAqbX8wEgSNGCTV5av