### PR TITLE
Fix vector field rendering: ColorData properties, ImagePadding, and arrowheads

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,20 @@
 
 # Unreleased
 
+- Fixes driven by a Wolfram Demonstration that draws a complex function as
+    a colored vector field:
+    - `ColorData[name, "ColorFunction"]` gives the gradient's color
+        function, the same object `ColorData[name]` gives on its own. It
+        used to be reported as unimplemented, so every primitive colored
+        through it fell back to black. `ColorData[name, "Range"]` reads
+        the parameter interval alongside it.
+    - `Graphics[…, ImagePadding -> …]` honours the padding (it was only
+        read by the plot functions), so the drawing area sits where the
+        notebook puts it instead of at the automatic frame margins.
+    - A named `Arrowheads` size is a fraction of the plot width and
+        nothing else. It used to be capped at 45% of the arrow carrying
+        it, which shrank the heads of a dense vector field — where each
+        arrow is barely longer than its head — to unreadable specks.
 - Fixes driven by the "Mass with a Spring and a Rubber Band" Wolfram
     Demonstration:
     - Substituting an `NDSolve` solution into a derivative

--- a/functions.csv
+++ b/functions.csv
@@ -228,7 +228,7 @@ While,Evaluates an expression repeatedly while a condition is true,✅,pure,1.0,
 FrameLabel,Axis labels for framed charts (alias for AxesLabel),✅,pure,2.0,221
 FindRoot,Numerically finds a root of an equation using a damped Newton iteration — honours MaxIterations and reports non-convergence or a singular derivative (WorkingPrecision and the accuracy goals are accepted but ignored),✅,pure,1.0,222
 Image,Constructs an image from pixel data,✅,pure,7.0,223
-ColorData,"Named color data: the categories; the CSS colours of the ""HTML"" scheme; the colors of indexed schemes 1 (generated) 2 3 and 97; named gradients give a ColorDataFunction sampling the scheme (e.g. ColorData[""TemperatureMap""][0.5]), sample directly via ColorData[name, t], and render ""Image"" swatches (Rainbow-family control points sampled from Wolfram; the remaining gradients are approximations)",✅,pure,6.0,224
+ColorData,"Named color data: the categories; the CSS colours of the ""HTML"" scheme; the colors of indexed schemes 1 (generated) 2 3 and 97; named gradients give a ColorDataFunction sampling the scheme (e.g. ColorData[""TemperatureMap""][0.5]), sample directly via ColorData[name, t], read the ""ColorFunction"" and ""Range"" properties, and render ""Image"" swatches (Rainbow-family control points sampled from Wolfram; the remaining gradients are approximations)",✅,pure,6.0,224
 Binomial,Returns the binomial coefficient,✅,pure,1.0,225
 Which,Evaluates conditions and returns the value for the first true one,✅,pure,1.0,226
 Replace,Applies transformation rules to an expression,✅,pure,1.0,227

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -57,6 +57,31 @@ const SCHEME_3: [(f64, f64, f64); 10] = [
   (231.0 / 255.0, 7.0 / 255.0, 33.0 / 255.0),
 ];
 
+/// The color function of a named gradient, echoed in wolframscript's
+/// structured form
+///   `ColorDataFunction[scheme, "Gradients", {0, 1}, Blend[scheme, #1] &]`.
+/// Both `ColorData["scheme"]` and `ColorData["scheme", "ColorFunction"]`
+/// give it; applying it blends the stored control points at the parameter
+/// (see `apply_curried_call`).
+fn gradient_color_function(scheme: &str) -> Expr {
+  let blend = Expr::Function {
+    body: Box::new(Expr::FunctionCall {
+      name: "Blend".to_string(),
+      args: vec![Expr::String(scheme.to_string()), Expr::Slot(1)].into(),
+    }),
+  };
+  Expr::FunctionCall {
+    name: "ColorDataFunction".to_string(),
+    args: vec![
+      Expr::String(scheme.to_string()),
+      Expr::String("Gradients".to_string()),
+      Expr::List(vec![Expr::Integer(0), Expr::Integer(1)].into()),
+      blend,
+    ]
+    .into(),
+  }
+}
+
 /// A horizontal gradient strip rendered as an Image — what
 /// `ColorData[name, "Image"]` returns, shown as the swatch in gradient
 /// pickers (e.g. a Manipulate color-scheme dropdown).
@@ -739,6 +764,20 @@ pub fn dispatch_image_functions(
         if matches!(&args[1], Expr::String(p) if p == "Image") {
           return Some(Ok(gradient_strip_image(controls)));
         }
+        // ColorData[name, "ColorFunction"]: the gradient's color function,
+        // the same object `ColorData[name]` gives on its own. Demonstrations
+        // reach for the property form when the result is applied straight
+        // away, as in `ColorData[name, "ColorFunction"][t]`.
+        if matches!(&args[1], Expr::String(p) if p == "ColorFunction") {
+          return Some(Ok(gradient_color_function(scheme)));
+        }
+        // ColorData[name, "Range"]: the parameter interval the gradient is
+        // defined over — always {0, 1} for the built-in gradients.
+        if matches!(&args[1], Expr::String(p) if p == "Range") {
+          return Some(Ok(Expr::List(
+            vec![Expr::Integer(0), Expr::Integer(1)].into(),
+          )));
+        }
         if !matches!(&args[1], Expr::String(_))
           && let Some(t) = crate::functions::math_ast::try_eval_to_f64(&args[1])
         {
@@ -861,22 +900,7 @@ pub fn dispatch_image_functions(
       if let Expr::String(scheme) = &args[0]
         && crate::functions::chart::named_color_scheme(scheme).is_some()
       {
-        let blend = Expr::Function {
-          body: Box::new(Expr::FunctionCall {
-            name: "Blend".to_string(),
-            args: vec![Expr::String(scheme.clone()), Expr::Slot(1)].into(),
-          }),
-        };
-        return Some(Ok(Expr::FunctionCall {
-          name: "ColorDataFunction".to_string(),
-          args: vec![
-            Expr::String(scheme.clone()),
-            Expr::String("Gradients".to_string()),
-            Expr::List(vec![Expr::Integer(0), Expr::Integer(1)].into()),
-            blend,
-          ]
-          .into(),
-        }));
+        return Some(Ok(gradient_color_function(scheme)));
       }
     }
     "ImageCompose" if args.len() == 2 => {

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -5158,9 +5158,12 @@ fn render_primitive(
             .iter()
             .filter(|h| h.graphic.is_none())
             .map(|h| {
-              // A size is a fraction of the plot width, as Wolfram's is,
-              // capped so a head never swallows the arrow it sits on.
-              let px = (h.size.abs() * svg_w).min(total_len_px * 0.45);
+              // A size is a fraction of the plot width, as Wolfram's is —
+              // uncapped, because the whole point of naming it is to fix
+              // the head's size. A vector field draws hundreds of arrows
+              // barely longer than their heads, and Wolfram lets the head
+              // take up nearly all of each one.
+              let px = h.size.abs() * svg_w;
               (h.position, px.max(1.0), h.size.signum())
             })
             .collect(),
@@ -5732,6 +5735,10 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // When true, skip uniform scaling so x and y axes scale independently
   // (needed for plots where data aspect ≠ image aspect).
   let mut aspect_ratio_full = false;
+  // `ImagePadding -> {{left, right}, {bottom, top}}` (or a single number for
+  // all four sides): the room reserved around the drawing area, replacing the
+  // automatic margins that the frame and its tick labels would ask for.
+  let mut image_padding: Option<[f64; 4]> = None;
 
   for raw_opt in &args[1..] {
     let opt =
@@ -5842,6 +5849,10 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           {
             frame_ticks = false;
           }
+        }
+        "ImagePadding" => {
+          image_padding =
+            crate::functions::plot::parse_image_padding(replacement);
         }
         "GridLines" => match replacement {
           Expr::Identifier(s)
@@ -5998,6 +6009,14 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       20.0
     } else {
       0.0
+    };
+  // `ImagePadding` states the room around the drawing area outright, so it
+  // replaces the margins the frame and its labels would otherwise claim
+  // (Wolfram draws the tick labels inside that padding).
+  let (margin_left, margin_right, margin_bottom, margin_top) =
+    match image_padding {
+      Some([left, right, bottom, top]) => (left, right, bottom, top),
+      None => (margin_left, margin_right, margin_bottom, margin_top),
     };
   // The size asked for is the whole picture, so the drawing area is what
   // is left of it once the axes and their labels have taken their room.

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -19069,6 +19069,48 @@ mod color_data_gradients {
     );
   }
 
+  /// `ColorData[name, "ColorFunction"]` is the same color function
+  /// `ColorData[name]` gives on its own — the property form a
+  /// Demonstration reaches for when it applies the result straight away.
+  #[test]
+  fn gradient_color_function_property() {
+    clear_state();
+    assert_eq!(
+      interpret("ColorData[\"RedBlueTones\", \"ColorFunction\"]").unwrap(),
+      "ColorDataFunction[RedBlueTones, Gradients, {0, 1}, \
+       Blend[\"RedBlueTones\", #1] & ]"
+    );
+    // Applying it samples the gradient, exactly as ColorData[name] does.
+    assert_eq!(
+      interpret(
+        "ColorData[\"Rainbow\", \"ColorFunction\"][0.5] === \
+         ColorData[\"Rainbow\"][0.5]"
+      )
+      .unwrap(),
+      "True"
+    );
+    // Every listed gradient answers the property, not just one.
+    assert_eq!(
+      interpret(
+        "AllTrue[ColorData[\"Gradients\"], \
+         Head[ColorData[#, \"ColorFunction\"]] === ColorDataFunction &]"
+      )
+      .unwrap(),
+      "True"
+    );
+  }
+
+  /// `ColorData[name, "Range"]` is the parameter interval the gradient
+  /// covers: the built-in gradients all run over {0, 1}.
+  #[test]
+  fn gradient_range_property() {
+    clear_state();
+    assert_eq!(
+      interpret("ColorData[\"Rainbow\", \"Range\"]").unwrap(),
+      "{0, 1}"
+    );
+  }
+
   #[test]
   fn show_passes_an_image_through() {
     clear_state();
@@ -19248,6 +19290,54 @@ mod arrowheads_render {
       (x - width / 2.0).abs() < width * 0.15,
       "the label belongs at the midpoint, got {x} of {width}"
     );
+  }
+
+  /// A named head size is a fraction of the plot width and nothing else,
+  /// even when that makes the head as long as the arrow carrying it. A
+  /// vector field (the Pólya-plot idiom: hundreds of short arrows under
+  /// `Arrowheads[1./(2 pp)]`) is drawn almost entirely out of heads, and
+  /// shrinking them to fit their shafts loses the field's direction cues.
+  #[test]
+  fn a_named_size_is_a_fraction_of_the_plot_width() {
+    clear_state();
+    // Two arrows an eighth of the plot wide, with heads asked to be a
+    // tenth of it — longer than 45% of the shaft they sit on.
+    let svg = export_svg(
+      "Graphics[{Arrowheads[0.1], Arrow[{{0, 0}, {1, 0}}], \
+       Arrow[{{0, 8}, {1, 8}}]}, PlotRange -> {{0, 8}, {0, 8}}, \
+       ImageSize -> 400]",
+    );
+    let head_len = |points: &str| -> f64 {
+      let pts: Vec<(f64, f64)> = points
+        .split_whitespace()
+        .filter_map(|p| p.split_once(','))
+        .filter_map(|(x, y)| Some((x.parse().ok()?, y.parse().ok()?)))
+        .collect();
+      // Tip first, then the two base corners: the head's length is the
+      // tip's distance from the midpoint of the base.
+      let (tip, a, b) = (pts[0], pts[1], pts[2]);
+      let mid = ((a.0 + b.0) / 2.0, (a.1 + b.1) / 2.0);
+      ((tip.0 - mid.0).powi(2) + (tip.1 - mid.1).powi(2)).sqrt()
+    };
+    let lengths: Vec<f64> = svg
+      .split("<polygon points=\"")
+      .skip(1)
+      .filter_map(|tag| tag.split('"').next())
+      .map(head_len)
+      .collect();
+    assert_eq!(lengths.len(), 2, "one head per arrow: {svg:.600}");
+    let plot_width: f64 = svg
+      .split("width=\"")
+      .nth(1)
+      .and_then(|t| t.split('"').next())
+      .and_then(|n| n.parse().ok())
+      .expect("the SVG must carry a width");
+    for len in lengths {
+      assert!(
+        (len - plot_width * 0.1).abs() < plot_width * 0.02,
+        "a 0.1 head spans a tenth of the {plot_width}px plot, got {len}"
+      );
+    }
   }
 }
 
@@ -19615,6 +19705,49 @@ mod demonstration_plot_layout {
     assert!(
       header.contains("height=\"160\""),
       "the plot area follows the ratio: {header}"
+    );
+  }
+
+  /// `Graphics` honours `ImagePadding` too, not just the plot functions:
+  /// the padding replaces the gutters the frame and its tick labels would
+  /// otherwise claim, so the drawing area sits exactly where it says.
+  #[test]
+  fn image_padding_places_a_graphics_drawing_area() {
+    clear_state();
+    let svg = export_svg(
+      "Graphics[{Line[{{0, 0}, {1, 1}}]}, Frame -> True, \
+       ImageSize -> {200, 200}, ImagePadding -> {{25, 25}, {25, 25}}]",
+    );
+    assert!(
+      svg.contains("translate(25,25)"),
+      "the drawing area starts at the named padding: {svg:.400}"
+    );
+    // 200 wide less 25 either side, and the same vertically.
+    assert!(
+      svg.contains("width=\"150.00\" height=\"150.00\""),
+      "the padding leaves a 150x150 frame: {svg:.600}"
+    );
+    // An uneven spec puts a different amount on each side.
+    let svg = export_svg(
+      "Graphics[{Line[{{0, 0}, {1, 1}}]}, Frame -> True, \
+       ImageSize -> {200, 200}, ImagePadding -> {{40, 10}, {30, 20}}]",
+    );
+    assert!(
+      svg.contains("translate(40,20)"),
+      "left padding offsets across, top padding down: {svg:.400}"
+    );
+    assert!(
+      svg.contains("width=\"150.00\" height=\"150.00\""),
+      "200 less 40+10 across and 30+20 down: {svg:.600}"
+    );
+    // A bare number pads all four sides alike.
+    let svg = export_svg(
+      "Graphics[{Line[{{0, 0}, {1, 1}}]}, Frame -> True, \
+       ImageSize -> {200, 200}, ImagePadding -> 30]",
+    );
+    assert!(
+      svg.contains("translate(30,30)"),
+      "a single padding applies to every side: {svg:.400}"
     );
   }
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -12034,6 +12034,90 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`time$$ = 25}, \"\\[Ellipsis]\"]"], 
     assert_ne!(render(5.0), published, "the time control must matter");
   }
 
+  /// End-to-end regression for a Demonstration that draws a vector field:
+  /// a grid of short arrows, each coloured by looking its value up in a
+  /// named gradient through `ColorData[scheme, "ColorFunction"]`, inside a
+  /// `Graphics` whose margins come from `ImagePadding`. All three used to
+  /// fail together — the colour lookup was unimplemented so every arrow
+  /// came out black, the padding was ignored, and the arrowheads were
+  /// shrunk to fit shafts barely longer than themselves.
+  #[test]
+  fn vector_field_manipulate_colours_its_arrows() {
+    let nb_src = r##"Notebook[{
+Cell[BoxData["Manipulate[Module[{s = 2. r/n, pts}, pts = Table[{{x, y}, {y, -x}}, {x, -r, r, 2 r/n}, {y, -r, r, 2 r/n}]; Graphics[{Arrowheads[1./(2 n)], Map[{ColorData[scheme, \"ColorFunction\"][Norm[#[[2]]]/(Sqrt[2] r)], Arrow[{#[[1]], #[[1]] + s #[[2]]/Max[Norm[#[[2]]], 0.001]}]} &, pts, {2}]}, PlotRange -> All, Frame -> True, ImageSize -> {320, 300}, ImagePadding -> {{25, 25}, {25, 25}}]], {{scheme, \"RedBlueTones\", \"colors\"}, {\"RedBlueTones\", \"Rainbow\", \"SunsetColors\"}}, {{r, 3, \"domain size\"}, 1, 6}, {{n, 8, \"resolution\"}, 4, 12, 1}]"], "Input"]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let code = editors
+      .iter()
+      .map(|e| e.content.text())
+      .find(|t| t.starts_with("Manipulate["))
+      .expect("the Manipulate cell must load");
+    let widget = instantiate_stored_manipulate(&code, "")
+      .expect("the Manipulate must instantiate");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(widget.graphics_handle.is_some(), "the field must draw");
+    // One discrete gradient chooser and two sliders.
+    assert_eq!(widget.controls.len(), 3, "{:?}", widget.controls);
+
+    let svg = woxi::interpret_with_stdout(&format!(
+      "scheme = \"RedBlueTones\"; r = 3; n = 8;\n{}",
+      widget.body
+    ))
+    .expect("the body must render")
+    .graphics
+    .expect("the body must produce a graphic");
+    // `ImagePadding -> {{25, 25}, {25, 25}}` puts the drawing area 25px in
+    // from the top left, leaving 320-50 by 300-50 for the frame.
+    assert!(
+      svg.contains("translate(25,25)"),
+      "the padding must place the drawing area: {svg:.400}"
+    );
+    // Each arrow is coloured from the gradient, so the fill colours are
+    // many and none of them is the default black.
+    let fills: std::collections::BTreeSet<&str> = svg
+      .split("<polygon")
+      .skip(1)
+      .filter_map(|tag| tag.split_once("fill=\""))
+      .filter_map(|(_, rest)| rest.split('"').next())
+      .collect();
+    assert!(
+      fills.len() > 5,
+      "the gradient must colour the arrows, got {fills:?}"
+    );
+    assert!(
+      !fills.contains("rgb(0,0,0)"),
+      "no arrow falls back to black: {fills:?}"
+    );
+    // `Arrowheads[1./(2 n)]` asks for heads a sixteenth of the plot wide;
+    // they are drawn at that size even though each arrow is barely longer.
+    let head_len = svg
+      .split("<polygon points=\"")
+      .nth(1)
+      .and_then(|tag| tag.split('"').next())
+      .map(|points| {
+        let pts: Vec<(f64, f64)> = points
+          .split_whitespace()
+          .filter_map(|p| p.split_once(','))
+          .filter_map(|(x, y)| Some((x.parse().ok()?, y.parse().ok()?)))
+          .collect();
+        let (tip, a, b) = (pts[0], pts[1], pts[2]);
+        let mid = ((a.0 + b.0) / 2.0, (a.1 + b.1) / 2.0);
+        ((tip.0 - mid.0).powi(2) + (tip.1 - mid.1).powi(2)).sqrt()
+      })
+      .expect("an arrowhead must be drawn");
+    // The drawing area is 320 less the 25px padding either side.
+    let expected = (320.0 - 50.0) / 16.0;
+    assert!(
+      (head_len - expected).abs() < 2.0,
+      "a 1/16 head spans {expected}px, got {head_len}"
+    );
+  }
+
   /// The SetterBar/PopupMenu split Wolfram's `Manipulate` makes on its own,
   /// pinned to the Demonstrations it was read off (see
   /// [`renders_as_setter_bar`]). The interesting pair is four phrases (a bar)


### PR DESCRIPTION
Fixes three related issues that prevented proper rendering of Wolfram Demonstrations with colored vector fields.

## Summary
This PR implements missing `ColorData` properties, adds support for `ImagePadding` in `Graphics`, and corrects arrowhead sizing to match Wolfram's behavior. These fixes enable proper rendering of complex demonstrations like colored vector fields.

## Key Changes

- **ColorData properties**: Implemented `ColorData[name, "ColorFunction"]` and `ColorData[name, "Range"]` properties. Both properties now return the expected values, with `"ColorFunction"` returning a `ColorDataFunction` object that can be applied to sample the gradient.

- **ImagePadding support**: Added `ImagePadding` option handling to `Graphics` (previously only supported by plot functions). The padding now correctly replaces automatic frame margins, positioning the drawing area exactly as specified.

- **Arrowhead sizing**: Removed the 45% cap on named arrowhead sizes. Named sizes are now strictly a fraction of the plot width, allowing vector fields with dense arrows (where each arrow is barely longer than its head) to remain readable instead of being shrunk to unreadable specks.

- **Code refactoring**: Extracted `gradient_color_function()` helper to eliminate duplication between `ColorData[name]` and `ColorData[name, "ColorFunction"]` implementations.

## Testing
Added comprehensive test coverage:
- Unit tests for `ColorData` properties (`gradient_color_function_property`, `gradient_range_property`)
- Unit test for arrowhead sizing behavior (`a_named_size_is_a_fraction_of_the_plot_width`)
- Unit test for `ImagePadding` in `Graphics` (`image_padding_places_a_graphics_drawing_area`)
- End-to-end regression test for a complete vector field Demonstration (`vector_field_manipulate_colours_its_arrows`)

https://claude.ai/code/session_014KKhC9J96LUxCY9fFbQkzd