### PR TITLE
Support Manipulate-level ControlType and fix Piecewise/FindRoot

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,23 @@
 
 # Unreleased
 
+- Fixes driven by the "Illustrative Performance Characteristics of Modern
+    Motorcycles" Wolfram Demonstration:
+    - `Piecewise` holds its pieces, so the value of a piece whose condition
+        is `False` is never evaluated. This is what makes the construct a
+        guard: `Piecewise[{{f[w], 0 <= w <= wmax}}, 0]` no longer calls `f`
+        out of range, and the messages that call emitted are gone.
+    - `FindRoot` falls back to a difference quotient when the symbolic
+        derivative does not reduce to a number at the current iterate —
+        differentiating a non-smooth function leaves `Derivative[1, 0][Max][…]`
+        standing. It used to give up with `FindRoot::nlnum` and return
+        unevaluated. Messages emitted by the discarded attempt (`D::ivar`
+        and friends) no longer reach the user.
+    - A `ControlType -> …` given to the `Manipulate` itself types every
+        control that does not pick one, and a list value assigns one type per
+        control in spec order. The Demonstrations idiom — controls laid out in
+        a `Grid[…]`, typed once for the whole panel — now renders the dropdowns
+        the author asked for instead of over-wide SetterBars.
 - Fixes driven by a Wolfram Demonstration that draws a complex function as
     a colored vector field:
     - `ColorData[name, "ColorFunction"]` gives the gradient's color

--- a/functions.csv
+++ b/functions.csv
@@ -226,7 +226,7 @@ Position,Finds all positions of a pattern in a list,✅,pure,1.0,218
 Union,Returns sorted union of lists or a key-merge of associations,✅,pure,1.0,219
 While,Evaluates an expression repeatedly while a condition is true,✅,pure,1.0,220
 FrameLabel,Axis labels for framed charts (alias for AxesLabel),✅,pure,2.0,221
-FindRoot,Numerically finds a root of an equation using a damped Newton iteration — honours MaxIterations and reports non-convergence or a singular derivative (WorkingPrecision and the accuracy goals are accepted but ignored),✅,pure,1.0,222
+FindRoot,Numerically finds a root of an equation using a damped Newton iteration — the derivative is symbolic where that reduces to a number and a difference quotient otherwise; honours MaxIterations and reports non-convergence or a singular derivative (WorkingPrecision and the accuracy goals are accepted but ignored),✅,pure,1.0,222
 Image,Constructs an image from pixel data,✅,pure,7.0,223
 ColorData,"Named color data: the categories; the CSS colours of the ""HTML"" scheme; the colors of indexed schemes 1 (generated) 2 3 and 97; named gradients give a ColorDataFunction sampling the scheme (e.g. ColorData[""TemperatureMap""][0.5]), sample directly via ColorData[name, t], read the ""ColorFunction"" and ""Range"" properties, and render ""Image"" swatches (Rainbow-family control points sampled from Wolfram; the remaining gradients are approximations)",✅,pure,6.0,224
 Binomial,Returns the binomial coefficient,✅,pure,1.0,225
@@ -243,7 +243,7 @@ RightArrow,Typesetting arrow symbol,🚫,none,3.0,235
 Interval,Represents a closed real interval with auto-merged sub-intervals,✅,pure,3.0,236
 Offset,Represents a position offset by a specified number of printers points,✅,pure,3.0,237
 ReplaceRepeated,Applies replacement rules repeatedly until fixed point or the MaxIterations bound,✅,pure,1.0,238
-Piecewise,Represents a piecewise function,✅,pure,5.1,239
+Piecewise,Represents a piecewise function; the pieces are held so the value of a piece whose condition is False is never evaluated,✅,pure,5.1,239
 Yellow,Named color evaluating to RGBColor[1 1 0],✅,pure,5.1,240
 Left,Symbol for left alignment,✅,pure,1.0,241
 ConstantArray,Creates an array of repeated elements,✅,pure,6.0,242

--- a/src/functions/control_flow_ast.rs
+++ b/src/functions/control_flow_ast.rs
@@ -63,10 +63,18 @@ pub fn piecewise_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  // Force evaluation of the first argument so a stored variable holding a
-  // pair list (or `Piecewise[Table[…]]` with FunctionCall instead of
-  // PrefixApply head) resolves to the underlying List before we inspect it.
-  let evaluated_first = evaluate_expr_to_expr(&args[0])?;
+  // `Piecewise` holds its arguments: the value of a piece whose condition is
+  // False must never be evaluated, so that a guard like
+  // `Piecewise[{{f[x], 0 <= x <= xmax}}, 0]` protects `f` from being called
+  // out of range at all (the loop below evaluates each value only once its
+  // condition has selected the piece). A first argument that is *already* a
+  // list of pairs is therefore walked as written; only an indirect one (a
+  // symbol holding the list, `Piecewise[Table[…]]`, …) is evaluated first to
+  // get at the pairs.
+  let evaluated_first = match &args[0] {
+    Expr::List(_) => args[0].clone(),
+    other => evaluate_expr_to_expr(other)?,
+  };
   let pairs = match &evaluated_first {
     Expr::List(items) => items.clone(),
     _ => {
@@ -91,6 +99,17 @@ pub fn piecewise_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut true_default: Option<Expr> = None;
 
   for pair in pairs {
+    // A piece given indirectly (a symbol holding `{value, condition}`)
+    // resolves here; a literal pair keeps its value held until its condition
+    // selects it.
+    let resolved;
+    let pair = match pair {
+      Expr::List(items) if items.len() == 2 => pair,
+      other => {
+        resolved = evaluate_expr_to_expr(other)?;
+        &resolved
+      }
+    };
     match pair {
       Expr::List(items) if items.len() == 2 => {
         let cond = evaluate_expr_to_expr(&items[1])?;

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -15253,6 +15253,10 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       }
     })
     .collect();
+  // A `ControlType -> …` given to the Manipulate itself sets the type of every
+  // control that does not choose one; push it into the specs now that they are
+  // flattened, so they parse through the single per-spec path below.
+  let arg_items = apply_global_control_type(arg_items);
   // A control's bounds may reference *other* control variables — Kepler's
   // Second Law bounds its time sliders by the orbital period (`{{t, 0, …},
   // 0, P, .01}` with `{{P, 20, …}, .1, 50, .01}` further down). Collect
@@ -15598,6 +15602,117 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     appearance_none,
     tracked_symbols,
   })
+}
+
+/// Whether `s` names one of Wolfram's control types, i.e. a value
+/// `ControlType -> …` accepts (which a variable spec may also carry as a bare
+/// marker, as in `{u, {1, 2, 3}, SetterBar}`).
+fn is_control_type_name(s: &str) -> bool {
+  matches!(
+    s,
+    "Locator"
+      | "Slider"
+      | "Slider2D"
+      | "VerticalSlider"
+      | "Manipulator"
+      | "InputField"
+      | "PopupMenu"
+      | "Setter"
+      | "SetterBar"
+      | "RadioButton"
+      | "RadioButtonBar"
+      | "Toggler"
+      | "TogglerBar"
+      | "Checkbox"
+      | "CheckboxBar"
+      | "Opener"
+      | "OpenerBar"
+      | "ColorSlider"
+      | "ColorSetter"
+      | "IntervalSlider"
+      | "Animator"
+      | "Trigger"
+      | "Automatic"
+  )
+}
+
+/// Whether a variable spec picks its own control type, either as a
+/// `ControlType -> …` option or as a bare marker after the head.
+fn spec_declares_control_type(items: &[Expr]) -> bool {
+  items.iter().any(is_control_type_rule)
+    || items
+      .iter()
+      .skip(1)
+      .any(|it| matches!(it, Expr::Identifier(s) if is_control_type_name(s)))
+}
+
+/// Push a Manipulate-level `ControlType -> …` option down into the variable
+/// specs, which is where the control type is read from.
+///
+/// `Manipulate[body, {u, …}, {v, …}, ControlType -> PopupMenu]` gives *every*
+/// control that does not choose a type of its own a popup menu — the
+/// Demonstrations idiom for laying controls out in a `Grid[…]` and then
+/// setting their type once. A list value assigns one type per control, in the
+/// order the specs appear (`ControlType -> {Slider, PopupMenu}`); controls
+/// past the end of the list keep their default. `Automatic` means "decide as
+/// usual", so it is left off entirely.
+fn apply_global_control_type(items: Vec<Expr>) -> Vec<Expr> {
+  let global = items.iter().find_map(|it| {
+    let (Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    }) = it
+    else {
+      return None;
+    };
+    matches!(pattern.as_ref(), Expr::Identifier(s) if s == "ControlType")
+      .then(|| replacement.as_ref().clone())
+  });
+  let Some(global) = global else {
+    return items;
+  };
+  let per_spec = match &global {
+    Expr::List(types) => Some(types.to_vec()),
+    Expr::Identifier(_) => None,
+    // Anything else is not a control type at all — leave the specs alone.
+    _ => return items,
+  };
+  let mut spec_index = 0usize;
+  items
+    .into_iter()
+    .map(|item| {
+      let Expr::List(spec) = &item else {
+        return item;
+      };
+      let index = spec_index;
+      spec_index += 1;
+      let control_type = match &per_spec {
+        Some(types) => match types.get(index) {
+          Some(t) => t.clone(),
+          None => return item,
+        },
+        None => global.clone(),
+      };
+      if !matches!(&control_type, Expr::Identifier(s) if is_control_type_name(s) && s != "Automatic")
+        || spec_declares_control_type(spec)
+      {
+        return item;
+      }
+      let extended: Vec<Expr> = spec
+        .iter()
+        .cloned()
+        .chain(std::iter::once(Expr::Rule {
+          pattern: Box::new(Expr::Identifier("ControlType".to_string())),
+          replacement: Box::new(control_type),
+        }))
+        .collect();
+      Expr::List(extended.into())
+    })
+    .collect()
 }
 
 /// Whether a control-spec item is a `ControlType -> …` option rule.
@@ -16938,34 +17053,6 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
   // selects a compound control. The control type may also appear as a bare
   // identifier in the spec (`{u, {1, 2, 3}, SetterBar}`). The bounds are
   // the non-option, non-control-type items after the head.
-  let is_control_type_name = |s: &str| {
-    matches!(
-      s,
-      "Locator"
-        | "Slider"
-        | "Slider2D"
-        | "VerticalSlider"
-        | "Manipulator"
-        | "InputField"
-        | "PopupMenu"
-        | "Setter"
-        | "SetterBar"
-        | "RadioButton"
-        | "RadioButtonBar"
-        | "Toggler"
-        | "TogglerBar"
-        | "Checkbox"
-        | "CheckboxBar"
-        | "Opener"
-        | "OpenerBar"
-        | "ColorSlider"
-        | "ColorSetter"
-        | "IntervalSlider"
-        | "Animator"
-        | "Trigger"
-        | "Automatic"
-    )
-  };
   let control_type = items
     .iter()
     .find_map(|it| match it {

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -5228,9 +5228,19 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       converged = true;
       break;
     }
-    // Compute derivative: symbolic if available, else numerical
-    let fpx = if let Some(ref d) = deriv_expr {
-      find_root_eval_at(d, &var, x)?
+    // Compute derivative: symbolic if available, else numerical. A symbolic
+    // derivative that does not reduce to a number *at this iterate* is no
+    // better than having none — differentiating a non-smooth function leaves
+    // heads like `Derivative[1, 0][Max][…]` standing, and a `Piecewise`
+    // branch outside its condition gives `Indeterminate`. Wolfram falls back
+    // to a difference quotient there rather than giving up on the solve, so
+    // an unusable symbolic derivative drops through to the numerical branch.
+    let symbolic_fpx = deriv_expr
+      .as_ref()
+      .and_then(|d| quietly(|| find_root_eval_at(d, &var, x)).ok())
+      .filter(|v| v.is_finite());
+    let fpx = if let Some(fpx) = symbolic_fpx {
+      fpx
     } else {
       // 4th-order central difference for high-precision derivative
       let h = x.abs().max(1.0) * 1e-4;
@@ -5641,6 +5651,23 @@ fn find_root_eval_at(
   }
 }
 
+/// Run `probe` with every message it emits discarded.
+///
+/// FindRoot's symbolic derivative is speculative: when it does not reduce to a
+/// number the iteration falls back to a difference quotient, so whatever the
+/// attempt complained about on the way (`D::ivar` from differentiating a
+/// user function at an already-substituted point, a division by zero in a
+/// branch that is never used, …) is internal bookkeeping. wolframscript
+/// reports none of it, so neither does Woxi.
+fn quietly<T>(probe: impl FnOnce() -> T) -> T {
+  let snapshot = crate::snapshot_warnings();
+  crate::push_quiet();
+  let result = probe();
+  crate::pop_quiet();
+  crate::restore_warnings(snapshot);
+  result
+}
+
 /// Parse a number from an expression for FindRoot starting point.
 fn find_root_eval_number(expr: &Expr) -> Result<f64, InterpreterError> {
   match expr {
@@ -5824,7 +5851,9 @@ fn find_root_multivariate(
     for (i, row) in jac.iter().enumerate() {
       for (j, dij) in row.iter().enumerate() {
         let entry = match dij {
-          Some(d) => find_root_eval_multivar(d, &vars, &x).ok(),
+          Some(d) => quietly(|| find_root_eval_multivar(d, &vars, &x))
+            .ok()
+            .filter(|v| v.is_finite()),
           None => None,
         };
         jm[i][j] = match entry {

--- a/tests/cli/functions/Piecewise.md
+++ b/tests/cli/functions/Piecewise.md
@@ -7,3 +7,20 @@ Defines a piecewise-defined expression from a list of
 $ wo 'Piecewise[{{1, x > 0}}] /. x -> 1'
 1
 ```
+
+The pieces are held: the value of a piece whose condition is `False` is never
+evaluated, which is what makes the construct usable as a guard.  Here `1/x` is
+not divided by zero:
+
+```scrut
+$ wo 'Piecewise[{{1/x, x != 0}}, 0] /. x -> 0'
+0
+```
+
+The same guard keeps a tabulated curve inside its own data range, so querying
+outside it emits no extrapolation warning:
+
+```scrut
+$ wo 'f = Interpolation[{{0, 0}, {1, 2}, {2, 0}}, InterpolationOrder -> 1]; g[w_] := Piecewise[{{f[w], 0 <= w <= 2}}, 0]; {g[1], g[5]}'
+{2, 0}
+```

--- a/tests/cli/studio.md
+++ b/tests/cli/studio.md
@@ -96,7 +96,11 @@ control binds its variable to a draggable point (or list of points),
 rendered as one X/Y slider pair per point; `LocatorAutoCreate -> True`
 additionally offers adding and removing points.  Discrete choices whose
 rule label is a graphic (`"+" -> myIcon[2]`) show the rendered icon in
-the SetterBar.  A
+the SetterBar.  Controls may be grouped in a `Row[…]`, `Column[…]`, or
+`Grid[…]` argument, and a `ControlType -> …` given to the `Manipulate`
+itself types every control that does not pick one (a list value,
+`ControlType -> {Slider, PopupMenu}`, assigns one type per control in
+spec order).  A
 `ControlType -> None` variable has no slider but stays live, mutable
 state: extra display arguments such as a trailing
 `Dynamic[Panel[Grid[… Checkbox …]]]` are rendered as interactive

--- a/tests/cli/symbolic/FindRoot.md
+++ b/tests/cli/symbolic/FindRoot.md
@@ -50,3 +50,12 @@ $ wo 'FindRoot[x^2 + 1, {x, 1}]'
 FindRoot::jsing: Encountered a singular Jacobian at the point {x} = {0.}. Try perturbing the initial point(s).
 {x -> 0.}
 ```
+
+The derivative is taken symbolically where that works.  A non-smooth function
+has none — differentiating `Max` leaves `Derivative[1, 0][Max][…]` standing —
+so the iteration falls back to a difference quotient and still converges:
+
+```scrut
+$ wo 'FindRoot[Max[x, 2 x] - 6, {x, 1}]'
+{x -> 3.}
+```

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -7792,6 +7792,64 @@ mod find_root {
   }
 
   #[test]
+  fn non_smooth_function_falls_back_to_numeric_derivative() {
+    // Differentiating a non-smooth function leaves `Derivative[1, 0][Max][…]`
+    // standing, so the symbolic derivative never reduces to a number. That is
+    // no worse than having no symbolic derivative at all: the iteration falls
+    // back to a difference quotient and still converges. Regression: the
+    // unusable derivative propagated its error out of the Newton loop, so the
+    // call emitted FindRoot::nlnum and returned unevaluated.
+    assert_eq!(
+      interpret("FindRoot[Max[x, 2 x] - 6, {x, 1}]").unwrap(),
+      "{x -> 3.}"
+    );
+  }
+
+  #[test]
+  fn non_smooth_function_reports_no_internal_messages() {
+    use woxi::interpret_with_stdout;
+    // The failed symbolic-derivative attempt is internal bookkeeping —
+    // differentiating a user function at an already-substituted point makes
+    // `D` complain about a numeric "variable". None of that reaches the user
+    // (wolframscript reports nothing either).
+    let result = interpret_with_stdout(
+      "netthrust[v_] := Max[Map[# v &, {1, 2}]] - 6; \
+       FindRoot[netthrust[u], {u, 1}]",
+    )
+    .unwrap();
+    assert_eq!(result.result, "{u -> 3.}");
+    assert!(
+      result.warnings.is_empty(),
+      "unexpected messages: {:?}",
+      result.warnings
+    );
+  }
+
+  #[test]
+  fn piecewise_guarded_interpolation() {
+    use woxi::interpret_with_stdout;
+    // The shape a Demonstration uses to solve for a vehicle's top speed: a
+    // tabulated curve wrapped in a `Piecewise` range guard, maximised over a
+    // set of gear ratios, minus a drag term. Neither the `Piecewise` nor the
+    // `Max` survives symbolic differentiation, so the whole solve rides on the
+    // numeric-derivative fallback.
+    let result = interpret_with_stdout(
+      "torque = Interpolation[{{0, 0}, {50, 100}, {100, 60}, {150, 0}}, \
+                              InterpolationOrder -> 1]; \
+       gear[w_] := Piecewise[{{torque[w], 0 <= w <= 150}}, 0]; \
+       thrust[v_] := Max[Map[gear[# v] &, {1, 2}]] - v^2/40; \
+       FindRoot[thrust[v], {v, 60}]",
+    )
+    .unwrap();
+    assert_eq!(result.result, "{v -> 60.52450587883597}");
+    assert!(
+      result.warnings.is_empty(),
+      "unexpected messages: {:?}",
+      result.warnings
+    );
+  }
+
+  #[test]
   fn quadratic_larger_start() {
     assert_eq!(
       interpret("FindRoot[x^2 - 10^5 x + 1 == 0, {x, 10^6}]").unwrap(),

--- a/tests/interpreter_tests/control_flow.rs
+++ b/tests/interpreter_tests/control_flow.rs
@@ -2376,6 +2376,60 @@ mod piecewise {
   }
 
   #[test]
+  fn unreachable_piece_value_is_never_evaluated() {
+    // Piecewise holds its pieces: the value of a piece whose condition is
+    // False is never touched, which is what makes the idiom a *guard* —
+    // `1/x` must not be evaluated at `x = 0`. Regression: the pair list was
+    // evaluated up front, so every guarded value ran anyway and emitted the
+    // messages the guard exists to prevent.
+    let result =
+      interpret_with_stdout("Piecewise[{{1/x, x != 0}}, 0] /. x -> 0").unwrap();
+    assert_eq!(result.result, "0");
+    assert!(
+      result.warnings.is_empty(),
+      "unexpected messages: {:?}",
+      result.warnings
+    );
+  }
+
+  #[test]
+  fn range_guard_keeps_interpolation_in_bounds() {
+    // The Demonstrations shape of the same guard: a tabulated curve queried
+    // only inside its own data range. Outside it the piece drops, so no
+    // extrapolation warning is emitted.
+    let result = interpret_with_stdout(
+      "f = Interpolation[{{0, 0}, {1, 2}, {2, 0}}, InterpolationOrder -> 1]; \
+       g[w_] := Piecewise[{{f[w], 0 <= w <= 2}}, 0]; \
+       {g[1], g[5]}",
+    )
+    .unwrap();
+    assert_eq!(result.result, "{2, 0}");
+    assert!(
+      result.warnings.is_empty(),
+      "unexpected messages: {:?}",
+      result.warnings
+    );
+  }
+
+  #[test]
+  fn indirect_pieces_still_resolve() {
+    // A first argument that is not already a list of pairs — a symbol holding
+    // one, or a `Table` that builds one — is evaluated to get at the pieces.
+    assert_eq!(
+      interpret("pairs = {{1, False}, {2, True}}; Piecewise[pairs]").unwrap(),
+      "2"
+    );
+    assert_eq!(
+      interpret("Piecewise[Table[{i, i > 2}, {i, 1, 3}]]").unwrap(),
+      "3"
+    );
+    assert_eq!(
+      interpret("pair = {7, True}; Piecewise[{pair}]").unwrap(),
+      "7"
+    );
+  }
+
+  #[test]
   fn true_after_symbolic_becomes_default() {
     // A True condition after symbolic ones makes its value the new
     // default and drops everything behind it

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -14695,6 +14695,88 @@ mod manipulate {
     );
   }
 
+  /// `ControlType -> …` given to the *Manipulate itself* sets the type of
+  /// every control that does not choose one. Regression: the Demonstrations
+  /// layout idiom — controls arranged in a `Grid[…]` and then typed once for
+  /// the whole panel — left every control on its automatic type, so long
+  /// choice labels rendered as an unreadably wide SetterBar instead of the
+  /// dropdown the author asked for.
+  #[test]
+  fn spec_manipulate_level_control_type_applies_to_every_control() {
+    let expr = interpret_to_expr(
+      "Manipulate[{style, size}, \
+       Grid[{{Control[{{style, \"cruiser\", \"style\"}, \
+                       {\"sport bike\", \"cruiser\", \"sport tourer\"}}], \
+              Control[{{size, 80, \"size\"}, Range[40, 140, 20]}]}}, \
+            Spacings -> {2, 0.5}], \
+       ControlType -> PopupMenu, SaveDefinitions -> True]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert_eq!(spec.controls.len(), 2);
+    for control in &spec.controls {
+      match control {
+        ManipulateControl::Discrete { name, popup, .. } => {
+          assert!(*popup, "{name} should render as a dropdown");
+        }
+        other => panic!("expected discrete control, got {other:?}"),
+      }
+    }
+  }
+
+  /// A list value assigns one control type per spec, in the order the specs
+  /// appear; a spec past the end of the list keeps its default.
+  #[test]
+  fn spec_manipulate_level_control_type_list_applies_positionally() {
+    let expr = interpret_to_expr(
+      "Manipulate[{a, b, c}, {a, {1, 2, 3}}, {b, {4, 5, 6}}, {c, {7, 8, 9}}, \
+       ControlType -> {SetterBar, PopupMenu}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    let popups: Vec<bool> = spec
+      .controls
+      .iter()
+      .map(|c| match c {
+        ManipulateControl::Discrete { popup, .. } => *popup,
+        other => panic!("expected discrete control, got {other:?}"),
+      })
+      .collect();
+    assert_eq!(popups, [false, true, false]);
+  }
+
+  /// A spec that names its own control type keeps it — the Manipulate-level
+  /// option only fills in the ones that stay silent. `Automatic` means "decide
+  /// as usual", so it changes nothing either.
+  #[test]
+  fn spec_own_control_type_wins_over_manipulate_level_one() {
+    let expr = interpret_to_expr(
+      "Manipulate[{a, b}, {a, {1, 2, 3}, SetterBar}, {b, {4, 5, 6}}, \
+       ControlType -> PopupMenu]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    let popups: Vec<bool> = spec
+      .controls
+      .iter()
+      .map(|c| match c {
+        ManipulateControl::Discrete { popup, .. } => *popup,
+        other => panic!("expected discrete control, got {other:?}"),
+      })
+      .collect();
+    assert_eq!(popups, [false, true]);
+
+    let expr = interpret_to_expr(
+      "Manipulate[a, {a, {1, 2, 3}}, ControlType -> Automatic]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert!(matches!(
+      &spec.controls[0],
+      ManipulateControl::Discrete { popup: false, .. }
+    ));
+  }
+
   /// A body wrapped in `Dynamic[…]` evaluates as its first argument — the
   /// wrapper only adds FrontEnd tracking hints.
   #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6939,6 +6939,96 @@ Cell[BoxData[
   }
 
   #[test]
+  fn grid_laid_out_controls_take_the_manipulate_level_control_type() {
+    // End-to-end for the Demonstrations control-panel shape: the controls sit
+    // in a `Grid[…]` and the panel picks their type once, for all of them.
+    // Both would otherwise fall to their automatic type — a SetterBar, which
+    // for choices this long is unreadably wide — and the body's range guard
+    // has to keep the tabulated curve inside its own data range.
+    let nb_src = r##"Notebook[{
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"curve", "=", RowBox[{"Interpolation", "[",
+   RowBox[{
+    RowBox[{"{", RowBox[{
+      RowBox[{"{", RowBox[{"0", ",", "0"}], "}"}], ",",
+      RowBox[{"{", RowBox[{"1", ",", "2"}], "}"}], ",",
+      RowBox[{"{", RowBox[{"2", ",", "0"}], "}"}]}], "}"}], ",",
+    RowBox[{"InterpolationOrder", "\[Rule]", "1"}]}], "]"}]}], ";",
+  RowBox[{RowBox[{"guarded", "[", "w_", "]"}], ":=",
+   RowBox[{"Piecewise", "[",
+    RowBox[{
+     RowBox[{"{", RowBox[{"{",
+       RowBox[{RowBox[{"curve", "[", "w", "]"}], ",",
+        RowBox[{"0", "\[LessEqual]", "w", "\[LessEqual]", "2"}]}], "}"}], "}"}],
+     ",", "0"}], "]"}]}]}]], "Input"],
+Cell[BoxData[
+ RowBox[{"Manipulate", "[",
+  RowBox[{
+   RowBox[{"Plot", "[",
+    RowBox[{
+     RowBox[{"scale", " ",
+      RowBox[{"guarded", "[", RowBox[{"t", "+", "shift"}], "]"}]}], ",",
+     RowBox[{"{", RowBox[{"t", ",", "0", ",", "2"}], "}"}]}], "]"}], ",",
+   RowBox[{"Grid", "[",
+    RowBox[{"{", RowBox[{"{",
+      RowBox[{
+       RowBox[{"Control", "[",
+        RowBox[{"{",
+         RowBox[{
+          RowBox[{"{", RowBox[{"scale", ",", "1", ",", "\"\<vertical scale\>\""}], "}"}],
+          ",", RowBox[{"{", RowBox[{"1", ",", "2", ",", "3"}], "}"}]}], "}"}], "]"}],
+       ",",
+       RowBox[{"Control", "[",
+        RowBox[{"{",
+         RowBox[{
+          RowBox[{"{", RowBox[{"shift", ",", "0", ",", "\"\<horizontal shift\>\""}], "}"}],
+          ",", RowBox[{"Range", "[", RowBox[{"0", ",", "1", ",", "0.5"}], "]"}]}], "}"}], "]"}]}],
+      "}"}], "}"}], "]"}], ",",
+   RowBox[{"ControlType", "\[Rule]", "PopupMenu"}], ",",
+   RowBox[{"SaveDefinitions", "\[Rule]", "True"}]}], "]"}]], "Input"]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let definitions = editors[0].content.text();
+    woxi::interpret(&definitions).expect("the definitions must evaluate");
+
+    let widget = instantiate_stored_manipulate(&editors[1].content.text(), "")
+      .expect("the Manipulate must build a widget");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "the guarded plot must render"
+    );
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Discrete {
+          name: first,
+          popup: first_popup,
+          ..
+        },
+        manipulate::ControlState::Discrete {
+          name: second,
+          popup: second_popup,
+          ..
+        },
+      ] => {
+        assert_eq!(first, "scale");
+        assert_eq!(second, "shift");
+        assert!(
+          *first_popup && *second_popup,
+          "the panel's ControlType must reach both controls"
+        );
+      }
+      other => panic!("expected two discrete controls, got {other:?}"),
+    }
+  }
+
+  #[test]
   fn lorentz_oscillator_manipulate_labels_its_frequency_axis() {
     // End-to-end regression for the "Lorentz Oscillator Model for Optical
     // Constants" Demonstration: ten sliders separated by blank annotation


### PR DESCRIPTION
## Summary

This PR fixes three issues discovered while testing the "Illustrative Performance Characteristics of Modern Motorcycles" Wolfram Demonstration:

1. **Piecewise now properly holds its pieces** — values of pieces whose conditions are `False` are no longer evaluated, making it usable as a guard
2. **FindRoot falls back to numeric derivatives** when symbolic derivatives don't reduce to numbers (e.g., for non-smooth functions)
3. **Manipulate-level ControlType option** now propagates to individual controls that don't specify their own type

## Key Changes

### Piecewise Guard Semantics
- Modified `piecewise_ast()` to avoid eagerly evaluating the pair list when it's already a literal `List`
- Only indirect references (symbols, `Table` expressions, etc.) are evaluated to resolve the pairs
- Individual piece values are only evaluated once their conditions have selected them
- This prevents guards like `Piecewise[{{f[w], 0 <= w <= wmax}}, 0]` from calling `f` out of range

### FindRoot Numeric Derivative Fallback
- Added `quietly()` helper to suppress internal messages from speculative symbolic derivative attempts
- Modified Newton iteration to check if symbolic derivatives reduce to finite numbers; if not, falls back to 4th-order central difference
- Prevents `FindRoot::nlnum` errors when differentiating non-smooth functions (e.g., `Max`, `Piecewise` outside conditions)
- User no longer sees internal messages like `D::ivar` from the failed symbolic attempt

### Manipulate ControlType Propagation
- Extracted `is_control_type_name()` as a reusable helper function
- Added `apply_global_control_type()` to push Manipulate-level `ControlType -> …` options into individual control specs
- Supports both single type (`ControlType -> PopupMenu`) and list of types (`ControlType -> {SetterBar, PopupMenu}`)
- Specs that already declare their own control type are not overridden
- `Automatic` is treated as "no preference" and left off entirely
- Enables the Demonstrations idiom of laying controls in a `Grid[…]` and typing them once for the whole panel

## Testing

Added comprehensive test coverage:
- Unit tests for each Piecewise guard scenario (unreachable pieces, range guards, indirect references)
- Unit tests for FindRoot with non-smooth functions and Piecewise-guarded interpolations
- Unit tests for Manipulate-level ControlType (single type, list of types, spec override, Automatic)
- End-to-end integration test in woxi-studio demonstrating the full Demonstrations pattern
- CLI documentation tests for Piecewise and FindRoot behavior

https://claude.ai/code/session_01VMGo2ZcJCvA7gvV1evKHVW