### PR TITLE
Add GridLinesStyle option and fix scatter plot grid/axes rendering

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -876,7 +876,7 @@ QPochhammer,q-Pochhammer symbol; finite QPochhammer[a;q;n]; infinite QPochhammer
 DictionaryLookup,Requires external services or GUI infrastructure,🚫,io,6.0,872
 EdgeStyle,Option for styling edges in graphs,✅,none,8.0,873
 FunctionExpand,Expands special functions into simpler forms,✅,pure,3.0,874
-BernoulliB,Returns the nth Bernoulli number,✅,pure,1.0,876
+BernoulliB,Returns the nth Bernoulli number (or the nth Bernoulli polynomial in x with the two-argument form),✅,pure,1.0,876
 Wronskian,Compute the Wronskian determinant of a list of functions,✅,pure,7.0,876
 PlanetData,,🚫,,10.0,877
 FunctionDomain,Find the domain of a function,✅,pure,10.0,878

--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -903,6 +903,13 @@ fn parse_plot_options(args: &[Expr]) -> ParsedOptions {
         "Frame" => {
           opts.frame = crate::functions::plot::parse_frame_option(replacement)
         }
+        "Axes" => {
+          if let Some(axes) =
+            crate::functions::plot::parse_axes_option(replacement)
+          {
+            opts.axes = axes;
+          }
+        }
         "ImagePadding" => {
           opts.image_padding =
             crate::functions::plot::parse_image_padding(replacement)
@@ -950,6 +957,10 @@ fn parse_plot_options(args: &[Expr]) -> ParsedOptions {
             &mut opts.grid_lines_y,
             &mut opts.grid_y_lines,
           );
+        }
+        "GridLinesStyle" => {
+          opts.grid_lines_style =
+            crate::functions::plot::parse_grid_lines_style(replacement);
         }
         _ => {}
       }

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -88,6 +88,39 @@ fn n_eval_arbitrary_precision_form(
   n_eval_arbitrary(expr, precision)
 }
 
+/// Does `N` leave the right operand of `op` exact?
+///
+/// Wolfram's `N` never numericizes an exact rational exponent: `N[x^2]` stays
+/// `x^2` (not `x^2.`) and `N[Sqrt[x]]` stays `Sqrt[x]`. Keeping the exponent
+/// exact is what lets `Solve`/`NSolve` still recognise `N[poly]` as a
+/// polynomial — `N[BernoulliB[20, z]] == 0` is solvable only because the
+/// `z^20` term keeps its integer exponent. A non-rational exponent is still
+/// numericized (`N[x^Pi]` → `x^3.14159…`).
+fn keeps_exact_exponent(op: BinaryOperator, exponent: &Expr) -> bool {
+  op == BinaryOperator::Power && is_exact_rational(exponent)
+}
+
+/// Is this an exact rational literal (integer, big integer, `p/q`, or a
+/// negation of one)?
+fn is_exact_rational(expr: &Expr) -> bool {
+  match expr {
+    Expr::Integer(_) | Expr::BigInteger(_) => true,
+    Expr::FunctionCall { name, args } if name == "Rational" => {
+      args.len() == 2 && args.iter().all(is_exact_rational)
+    }
+    Expr::UnaryOp {
+      op: UnaryOperator::Minus,
+      operand,
+    } => is_exact_rational(operand),
+    Expr::BinaryOp {
+      op: BinaryOperator::Divide,
+      left,
+      right,
+    } => is_exact_rational(left) && is_exact_rational(right),
+    _ => false,
+  }
+}
+
 /// Recursively convert an expression to numeric (Real) form
 pub fn n_eval(expr: &Expr) -> Result<Expr, InterpreterError> {
   match expr {
@@ -211,10 +244,15 @@ pub fn n_eval(expr: &Expr) -> Result<Expr, InterpreterError> {
       if let Some(v) = try_eval_to_f64(expr) {
         return Ok(Expr::Real(v));
       }
+      let new_right = if keeps_exact_exponent(*op, right) {
+        (**right).clone()
+      } else {
+        n_eval(right)?
+      };
       let new_expr = Expr::BinaryOp {
         op: *op,
         left: Box::new(n_eval(left)?),
-        right: Box::new(n_eval(right)?),
+        right: Box::new(new_right),
       };
       // Re-evaluate to allow numeric simplification (e.g. complex powers)
       let result = match crate::evaluator::evaluate_expr_to_expr(&new_expr) {
@@ -271,6 +309,24 @@ pub fn n_eval(expr: &Expr) -> Result<Expr, InterpreterError> {
       pattern: pattern.clone(),
       replacement: Box::new(n_eval(replacement)?),
     }),
+    // Comparison (`==`, `<`, …): N maps over the operands, so
+    // `N[x == 1/3]` → `x == 0.333333`. Solve/NSolve rely on this to see
+    // the inexact coefficients of `N[eqn]`.
+    Expr::Comparison {
+      operands,
+      operators,
+    } => {
+      let new_operands: Result<Vec<Expr>, _> =
+        operands.iter().map(n_eval).collect();
+      let new_expr = Expr::Comparison {
+        operands: new_operands?,
+        operators: operators.clone(),
+      };
+      Ok(match crate::evaluator::evaluate_expr_to_expr(&new_expr) {
+        Ok(result) => result,
+        Err(_) => new_expr,
+      })
+    }
     Expr::Identifier(_) | Expr::Constant(_) => {
       if let Some(v) = try_eval_to_f64(expr) {
         return Ok(Expr::Real(v));
@@ -1146,6 +1202,22 @@ fn n_eval_arbitrary_partial(
   rm: astro_float::RoundingMode,
   cc: &mut astro_float::Consts,
 ) -> Result<Expr, InterpreterError> {
+  // An exact zero stays exact under `N[expr, p]` (Head Integer, Precision
+  // Infinity), just like at the top level — `N[x == 0, 10]` is `x == 0`.
+  if matches!(expr, Expr::Integer(0))
+    || matches!(expr, Expr::BigInteger(n) if n.sign() == num_bigint::Sign::NoSign)
+  {
+    return Ok(Expr::Integer(0));
+  }
+  // Lists are handled element-wise so nested lists (e.g. inside an
+  // equation) pick up the precision tag too.
+  if let Expr::List(items) = expr {
+    let results: Result<Vec<Expr>, _> = items
+      .iter()
+      .map(|e| n_eval_arbitrary_partial(e, precision, bits, rm, cc))
+      .collect();
+    return Ok(Expr::List(results?.into()));
+  }
   // A machine-precision Real already carries the maximum information
   // an f64 can hold — N cannot recover more digits from it, so leave
   // it alone (matches wolframscript: `N[F[1.2, 2/9], $MachinePrecision]`
@@ -1217,11 +1289,30 @@ fn n_eval_arbitrary_partial(
     }
     Expr::BinaryOp { op, left, right } => {
       let l = n_eval_arbitrary_partial(left, precision, bits, rm, cc)?;
-      let r = n_eval_arbitrary_partial(right, precision, bits, rm, cc)?;
+      let r = if keeps_exact_exponent(*op, right) {
+        (**right).clone()
+      } else {
+        n_eval_arbitrary_partial(right, precision, bits, rm, cc)?
+      };
       Ok(Expr::BinaryOp {
         op: *op,
         left: Box::new(l),
         right: Box::new(r),
+      })
+    }
+    // Comparison chains: N maps over the operands (`N[x == 1/3, 5]` →
+    // `x == 0.33333`).
+    Expr::Comparison {
+      operands,
+      operators,
+    } => {
+      let new_operands: Result<Vec<Expr>, _> = operands
+        .iter()
+        .map(|o| n_eval_arbitrary_partial(o, precision, bits, rm, cc))
+        .collect();
+      Ok(Expr::Comparison {
+        operands: new_operands?,
+        operators: operators.clone(),
       })
     }
     Expr::UnaryOp { op, operand } => {

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -1692,6 +1692,9 @@ pub(crate) struct PlotOptions {
   pub grid_x_lines: Vec<GridLine>,
   /// Explicit horizontal grid lines. Replace automatic `grid_lines_y` lines.
   pub grid_y_lines: Vec<GridLine>,
+  /// `GridLinesStyle -> Directive[…]`: the default style for every grid line
+  /// that carries no style of its own. `None` = the built-in gray.
+  pub grid_lines_style: Option<SeriesStyle>,
   /// Use frame (left+bottom border) instead of axes
   pub frame: bool,
   /// `Evaluated -> True`: work the body out once, with the plot variable
@@ -1778,6 +1781,7 @@ impl Default for PlotOptions {
       grid_lines_x: false,
       grid_x_lines: Vec::new(),
       grid_y_lines: Vec::new(),
+      grid_lines_style: None,
       frame: false,
       evaluated: false,
       ticks_x: None,
@@ -2052,6 +2056,51 @@ fn render_dash_overlays(
 /// look of the solid grid lines (`rgb(102,102,102)` at 50% opacity over a white
 /// background), since dash overlays carry no opacity.
 const DEFAULT_GRID_DASH_RGB: (u8, u8, u8) = (179, 179, 179);
+
+/// Resolve one axis' grid-line positions into `(position, style)` pairs.
+///
+/// Explicit positions (with their optional per-line directives) take
+/// precedence over the evenly spaced automatic lines that `GridLines ->
+/// Automatic` draws at `step` intervals. Lines that carry no style of their
+/// own inherit `default_style` (the plot's `GridLinesStyle`).
+fn resolve_grid_lines(
+  explicit: &[GridLine],
+  automatic: bool,
+  min: f64,
+  max: f64,
+  step: f64,
+  default_style: Option<&SeriesStyle>,
+) -> Vec<(f64, SeriesStyle)> {
+  let inherit = |style: &SeriesStyle| -> SeriesStyle {
+    match default_style {
+      Some(d)
+        if style.color.is_none()
+          && style.thickness.is_none()
+          && style.dashing.is_none() =>
+      {
+        d.clone()
+      }
+      _ => style.clone(),
+    }
+  };
+  if !explicit.is_empty() {
+    return explicit
+      .iter()
+      .map(|g| (g.pos, inherit(&g.style)))
+      .collect();
+  }
+  if !automatic || step <= 0.0 || !step.is_finite() {
+    return Vec::new();
+  }
+  let style = inherit(&SeriesStyle::default());
+  let mut v = Vec::new();
+  let mut pos = (min / step).ceil() * step;
+  while pos <= max {
+    v.push((pos, style.clone()));
+    pos += step;
+  }
+  v
+}
 
 /// Resolve a grid line's style into rendering properties:
 /// `(optional rgb, stroke width in render units, optional dash fractions)`.
@@ -2566,24 +2615,14 @@ fn generate_svg_with_options(
         let grid_color = RGBColor(0x66, 0x66, 0x66).mix(0.5);
 
         // Horizontal (y) grid lines.
-        let y_grid: Vec<(f64, SeriesStyle)> = if !opts.grid_y_lines.is_empty() {
-          opts
-            .grid_y_lines
-            .iter()
-            .map(|g| (g.pos, g.style.clone()))
-            .collect()
-        } else if opts.grid_lines_y {
-          let grid_step = nice_step(y_max - y_min, AXIS_TICK_TARGET);
-          let mut v = Vec::new();
-          let mut gy = (y_min / grid_step).ceil() * grid_step;
-          while gy <= y_max {
-            v.push((gy, SeriesStyle::default()));
-            gy += grid_step;
-          }
-          v
-        } else {
-          Vec::new()
-        };
+        let y_grid = resolve_grid_lines(
+          &opts.grid_y_lines,
+          opts.grid_lines_y,
+          y_min,
+          y_max,
+          nice_step(y_max - y_min, AXIS_TICK_TARGET),
+          opts.grid_lines_style.as_ref(),
+        );
         if !log_y {
           let tol = (y_max - y_min).abs() * 1e-9;
           for (gy, style) in &y_grid {
@@ -2616,28 +2655,18 @@ fn generate_svg_with_options(
         }
 
         // Vertical (x) grid lines.
-        let x_grid: Vec<(f64, SeriesStyle)> = if !opts.grid_x_lines.is_empty() {
-          opts
-            .grid_x_lines
-            .iter()
-            .map(|g| (g.pos, g.style.clone()))
-            .collect()
-        } else if opts.grid_lines_x {
-          let grid_step = if date_axis {
+        let x_grid = resolve_grid_lines(
+          &opts.grid_x_lines,
+          opts.grid_lines_x,
+          x_min,
+          x_max,
+          if date_axis {
             nice_date_step(x_max - x_min)
           } else {
             nice_step(x_max - x_min, AXIS_TICK_TARGET)
-          };
-          let mut v = Vec::new();
-          let mut gx = (x_min / grid_step).ceil() * grid_step;
-          while gx <= x_max {
-            v.push((gx, SeriesStyle::default()));
-            gx += grid_step;
-          }
-          v
-        } else {
-          Vec::new()
-        };
+          },
+          opts.grid_lines_style.as_ref(),
+        );
         if !log_x {
           let tol = (x_max - x_min).abs() * 1e-9;
           for (gx, style) in &x_grid {
@@ -3646,6 +3675,10 @@ pub(crate) fn generate_scatter_svg_with_options(
   let (bg_color, dark_gray, light_gray, label_fill, title_default_fill) =
     plot_theme();
 
+  // Dashed grid lines can't be drawn through plotters, so they are collected
+  // here and emitted as `stroke-dasharray` polylines once the chart is done.
+  let mut dashed_overlays: Vec<DashedOverlay> = Vec::new();
+
   let mut buf = String::new();
   {
     let root = SVGBackend::with_string(&mut buf, (render_width, render_height))
@@ -3671,16 +3704,29 @@ pub(crate) fn generate_scatter_svg_with_options(
     let y_major = nice_step(y_max - y_min, AXIS_TICK_TARGET);
     let x_minor_step = x_major / 5.0;
     let y_minor_step = y_major / 5.0;
+    // `Axes -> False` hides the axis line, its ticks and its labels — as in
+    // the line renderer, a framed plot still labels its frame edges.
+    let (show_x_axis, show_y_axis) = opts.axes;
+    let (tick_axis_x, tick_axis_y) = if opts.frame {
+      (true, true)
+    } else {
+      (show_x_axis, show_y_axis)
+    };
     // An axis given explicit `Ticks` draws them itself, after the chart.
-    let x_tick_count = if opts.ticks_x.is_some() {
+    let x_tick_count = if opts.ticks_x.is_some() || !tick_axis_x {
       0
     } else {
       ((x_max - x_min) / x_minor_step).round() as usize + 1
     };
-    let y_tick_count = if opts.ticks_y.is_some() {
+    let y_tick_count = if opts.ticks_y.is_some() || !tick_axis_y {
       0
     } else {
       ((y_max - y_min) / y_minor_step).round() as usize + 1
+    };
+    let axis_style = if opts.frame || show_x_axis || show_y_axis {
+      dark_gray.stroke_width(RESOLUTION_SCALE)
+    } else {
+      ShapeStyle::from(&bg_color).stroke_width(0)
     };
 
     chart
@@ -3702,20 +3748,108 @@ pub(crate) fn generate_scatter_svg_with_options(
           String::new()
         }
       })
-      .axis_style(dark_gray.stroke_width(RESOLUTION_SCALE))
+      .axis_style(axis_style)
       .label_style(
         ("sans-serif", RESOLUTION_SCALE as f64 * 18.0)
           .into_font()
           .color(&dark_gray),
       )
-      .set_tick_mark_size(LabelAreaPosition::Left, tick)
-      .set_tick_mark_size(LabelAreaPosition::Bottom, tick)
+      .set_tick_mark_size(
+        LabelAreaPosition::Left,
+        if tick_axis_y { tick } else { 0 },
+      )
+      .set_tick_mark_size(
+        LabelAreaPosition::Bottom,
+        if tick_axis_x { tick } else { 0 },
+      )
       .draw()
       .map_err(|e| InterpreterError::EvaluationError(format!("Plot: {e}")))?;
 
-    // Origin lines
+    // Grid lines, drawn before the points so they sit behind the data.
+    // Same rules as the line renderer: explicit positions beat the evenly
+    // spaced automatic ones, dashed lines are deferred to stroke-dasharray
+    // overlays emitted at the end.
+    {
+      let grid_color = RGBColor(0x66, 0x66, 0x66).mix(0.5);
+      let y_grid = resolve_grid_lines(
+        &opts.grid_y_lines,
+        opts.grid_lines_y,
+        y_min,
+        y_max,
+        y_major,
+        opts.grid_lines_style.as_ref(),
+      );
+      let y_tol = (y_max - y_min).abs() * 1e-9;
+      for (gy, style) in &y_grid {
+        if *gy < y_min - y_tol || *gy > y_max + y_tol {
+          continue;
+        }
+        let (rgb, stroke_w, dash) = grid_line_props(style);
+        if let Some(dashes) = dash {
+          dashed_overlays.push(DashedOverlay {
+            color: rgb.unwrap_or(DEFAULT_GRID_DASH_RGB),
+            stroke_w,
+            dashes,
+            points: vec![(x_min, *gy), (x_max, *gy)],
+          });
+          continue;
+        }
+        let shape = match rgb {
+          Some((r, g, b)) => RGBColor(r, g, b).stroke_width(stroke_w),
+          None => grid_color.stroke_width(stroke_w),
+        };
+        chart
+          .draw_series(std::iter::once(PathElement::new(
+            vec![(x_min, *gy), (x_max, *gy)],
+            shape,
+          )))
+          .map_err(|e| {
+            InterpreterError::EvaluationError(format!("Plot: {e}"))
+          })?;
+      }
+
+      let x_grid = resolve_grid_lines(
+        &opts.grid_x_lines,
+        opts.grid_lines_x,
+        x_min,
+        x_max,
+        x_major,
+        opts.grid_lines_style.as_ref(),
+      );
+      let x_tol = (x_max - x_min).abs() * 1e-9;
+      for (gx, style) in &x_grid {
+        if *gx < x_min - x_tol || *gx > x_max + x_tol {
+          continue;
+        }
+        let (rgb, stroke_w, dash) = grid_line_props(style);
+        if let Some(dashes) = dash {
+          dashed_overlays.push(DashedOverlay {
+            color: rgb.unwrap_or(DEFAULT_GRID_DASH_RGB),
+            stroke_w,
+            dashes,
+            points: vec![(*gx, y_min), (*gx, y_max)],
+          });
+          continue;
+        }
+        let shape = match rgb {
+          Some((r, g, b)) => RGBColor(r, g, b).stroke_width(stroke_w),
+          None => grid_color.stroke_width(stroke_w),
+        };
+        chart
+          .draw_series(std::iter::once(PathElement::new(
+            vec![(*gx, y_min), (*gx, y_max)],
+            shape,
+          )))
+          .map_err(|e| {
+            InterpreterError::EvaluationError(format!("Plot: {e}"))
+          })?;
+      }
+    }
+
+    // Origin lines — the axes drawn through zero. `Axes -> False` drops
+    // them along with the axis ticks and labels.
     let origin_line = light_gray.stroke_width(RESOLUTION_SCALE);
-    if y_min < 0.0 && y_max > 0.0 {
+    if show_x_axis && y_min < 0.0 && y_max > 0.0 {
       chart
         .draw_series(std::iter::once(PathElement::new(
           vec![(x_min, 0.0), (x_max, 0.0)],
@@ -3723,7 +3857,7 @@ pub(crate) fn generate_scatter_svg_with_options(
         )))
         .map_err(|e| InterpreterError::EvaluationError(format!("Plot: {e}")))?;
     }
-    if x_min < 0.0 && x_max > 0.0 {
+    if show_y_axis && x_min < 0.0 && x_max > 0.0 {
       chart
         .draw_series(std::iter::once(PathElement::new(
           vec![(0.0, y_min), (0.0, y_max)],
@@ -3858,6 +3992,24 @@ pub(crate) fn generate_scatter_svg_with_options(
   let plot_y0 = margin_top;
   let plot_w = render_width as f64 - margin_left - margin_right - y_label_area;
   let plot_h = render_height as f64 - margin_top - margin_bottom - x_label_area;
+
+  // Deferred dashed grid lines, as single stroke-dasharray polylines.
+  if !dashed_overlays.is_empty()
+    && let Some(pos) = buf.rfind("</svg>")
+  {
+    let overlay_svg = render_dash_overlays(
+      &dashed_overlays,
+      plot_x0,
+      plot_y0,
+      plot_w,
+      plot_h,
+      x_min,
+      x_max,
+      y_min,
+      y_max,
+    );
+    buf.insert_str(pos, &overlay_svg);
+  }
 
   // Epilog primitives sit over the points, as in the line renderer.
   inject_epilog(
@@ -7356,6 +7508,44 @@ pub(crate) fn apply_grid_side(
   }
 }
 
+/// Parse an `Axes` option value into `(show_x, show_y)`. Accepts `True` /
+/// `False` and the per-axis `{xbool, ybool}` form; anything else (e.g.
+/// `Automatic`) leaves the current setting alone.
+pub(crate) fn parse_axes_option(value: &Expr) -> Option<(bool, bool)> {
+  let is_true = |e: &Expr| matches!(e, Expr::Identifier(s) if s == "True");
+  match value {
+    Expr::Identifier(s) if s == "True" => Some((true, true)),
+    Expr::Identifier(s) if s == "False" => Some((false, false)),
+    Expr::List(items) if items.len() == 2 => {
+      Some((is_true(&items[0]), is_true(&items[1])))
+    }
+    _ => None,
+  }
+}
+
+/// Parse a `GridLinesStyle` option value (`Directive[Red, Dashed]`, a bare
+/// color, `{Red, Thick}`, …) into the default style for the plot's grid
+/// lines. `Automatic` / `None` keep the built-in gray.
+pub(crate) fn parse_grid_lines_style(value: &Expr) -> Option<SeriesStyle> {
+  let val = evaluate_expr_to_expr(value).unwrap_or_else(|_| value.clone());
+  if matches!(&val, Expr::Identifier(s) if s == "Automatic" || s == "None") {
+    return None;
+  }
+  let mut style = SeriesStyle::default();
+  match &val {
+    Expr::List(items) => {
+      for item in items.iter() {
+        apply_style_directive(item, &mut style);
+      }
+    }
+    other => apply_style_directive(other, &mut style),
+  }
+  (style.color.is_some()
+    || style.thickness.is_some()
+    || style.dashing.is_some())
+  .then_some(style)
+}
+
 /// Parse a PlotRange option value into (x_range, y_range) overrides.
 ///
 /// Supported forms:
@@ -7743,22 +7933,17 @@ pub(crate) fn apply_common_plot_option(
         &mut plot_opts.grid_y_lines,
       );
     }
+    "GridLinesStyle" => {
+      plot_opts.grid_lines_style = parse_grid_lines_style(replacement);
+    }
     "PlotRange" => {
       let (rx, ry) = parse_plot_range(replacement);
       overrides.x = rx;
       overrides.y = ry;
     }
     "Axes" => {
-      let parse_bool =
-        |e: &Expr| matches!(e, Expr::Identifier(s) if s == "True");
-      match replacement {
-        Expr::Identifier(s) if s == "True" => plot_opts.axes = (true, true),
-        Expr::Identifier(s) if s == "False" => plot_opts.axes = (false, false),
-        // {xbool, ybool}: independent per-axis control
-        Expr::List(items) if items.len() == 2 => {
-          plot_opts.axes = (parse_bool(&items[0]), parse_bool(&items[1]));
-        }
-        _ => {}
+      if let Some(axes) = parse_axes_option(replacement) {
+        plot_opts.axes = axes;
       }
     }
     "AspectRatio" => {
@@ -8407,6 +8592,9 @@ fn log_scale_plot_ast(
             &mut plot_opts.grid_lines_y,
             &mut plot_opts.grid_y_lines,
           );
+        }
+        "GridLinesStyle" => {
+          plot_opts.grid_lines_style = parse_grid_lines_style(replacement);
         }
         "PlotRange" => {
           let (_rx, ry) = parse_plot_range(replacement);

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -1550,10 +1550,12 @@ fn modular_solution_branches(
   Some(branches)
 }
 
-/// Thread an equality whose operands are all equal-length lists into the
-/// element-wise scalar equations (Wolfram's automatic listability of
-/// `Equal` inside Solve): `{a, b} == {c, d}` → `[a == c, b == d]`.
-/// Returns `None` when the expression is not such a list-valued equality.
+/// Thread an equality with at least one list operand into the element-wise
+/// scalar equations (Wolfram's automatic listability of `Equal` inside
+/// Solve): `{a, b} == {c, d}` → `[a == c, b == d]`. Scalar operands are
+/// broadcast across the list, so `{a, b} == 0` → `[a == 0, b == 0]` — the
+/// shape `Solve[N[Table[…] == 0, 10]]` produces. All list operands must
+/// have the same length. Returns `None` when no operand is a list.
 fn thread_list_equation(eq: &Expr) -> Option<Vec<Expr>> {
   let operands: Vec<&Expr> = match eq {
     Expr::Comparison {
@@ -1569,17 +1571,16 @@ fn thread_list_equation(eq: &Expr) -> Option<Vec<Expr>> {
     }
     _ => return None,
   };
-  let mut rows: Vec<Vec<Expr>> = Vec::with_capacity(operands.len());
+  // Length of the list operands; scalars broadcast to it.
   let mut len: Option<usize> = None;
   for op in &operands {
-    let Expr::List(items) = op else { return None };
-    let row = items.to_vec();
-    match len {
-      None => len = Some(row.len()),
-      Some(l) if l == row.len() => {}
-      _ => return None,
+    if let Expr::List(items) = op {
+      match len {
+        None => len = Some(items.len()),
+        Some(l) if l == items.len() => {}
+        _ => return None,
+      }
     }
-    rows.push(row);
   }
   let n = len?;
   if n == 0 {
@@ -1588,8 +1589,14 @@ fn thread_list_equation(eq: &Expr) -> Option<Vec<Expr>> {
   Some(
     (0..n)
       .map(|i| Expr::Comparison {
-        operands: rows.iter().map(|r| r[i].clone()).collect(),
-        operators: vec![ComparisonOp::Equal; rows.len() - 1],
+        operands: operands
+          .iter()
+          .map(|op| match op {
+            Expr::List(items) => items[i].clone(),
+            scalar => (*scalar).clone(),
+          })
+          .collect(),
+        operators: vec![ComparisonOp::Equal; operands.len() - 1],
       })
       .collect(),
   )

--- a/tests/cli/math/number_theory/BernoulliB.md
+++ b/tests/cli/math/number_theory/BernoulliB.md
@@ -6,3 +6,28 @@ Bernoulli number.
 $ wo 'BernoulliB[4]'
 -1/30
 ```
+
+With a second argument it is the Bernoulli *polynomial* `B_n(x)`.
+
+```scrut
+$ wo 'BernoulliB[2, x]'
+1/6 - x + x^2
+```
+
+```scrut
+$ wo 'BernoulliB[3, z]'
+z/2 - (3*z^2)/2 + z^3
+```
+
+`N` numericizes the coefficients but leaves the exponents exact, so the
+result is still a polynomial that `Solve` can find the roots of.
+
+```scrut
+$ wo 'N[BernoulliB[3, z]]'
+0.5*z - 1.5*z^2 + z^3
+```
+
+```scrut
+$ wo 'Solve[N[BernoulliB[3, z]] == 0, z]'
+{{z -> 0.}, {z -> 0.5}, {z -> 1.}}
+```

--- a/tests/cli/symbolic/Solve.md
+++ b/tests/cli/symbolic/Solve.md
@@ -156,3 +156,19 @@ $ wo 'Solve[x^4 == 16 && x > 0, x]'
 $ wo 'Solve[1 == f^2 (3 - f) && 0 <= f <= 1, f]'
 {{f -> Root[1 - 3*#1^2 + #1^3 & , 2, 0]}}
 ```
+
+An equation with a list on one side threads over that list, so a scalar on
+the other side is compared against every element:
+
+```scrut
+$ wo 'Solve[{x - 1, y - 2} == 0, {x, y}]'
+{{x -> 1, y -> 2}}
+```
+
+That makes `Solve[Table[…] == 0]` work, with the variable inferred from the
+equations:
+
+```scrut
+$ wo 'Solve[Table[BernoulliB[n, z], {n, 3, 3}] == 0]'
+{{z -> 0}, {z -> 1/2}, {z -> 1}}
+```

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -4753,6 +4753,36 @@ mod solve {
     );
   }
 
+  /// A scalar side of a list equation broadcasts over the list, so
+  /// `{e1, e2} == 0` stands for `e1 == 0 && e2 == 0`. `Solve[Table[…] == 0]`
+  /// (the Roots-of-the-Bernoulli-Polynomials Demonstration) relies on it,
+  /// including in the one-argument form that auto-detects the variable.
+  #[test]
+  fn solve_broadcasts_scalar_across_list_equation() {
+    assert_eq!(
+      interpret("Solve[{x^2 - 1} == 0, x]").unwrap(),
+      "{{x -> -1}, {x -> 1}}"
+    );
+    // One-argument form: the variable comes from the threaded equations.
+    assert_eq!(
+      interpret("Solve[{x^2 - 1} == 0]").unwrap(),
+      "{{x -> -1}, {x -> 1}}"
+    );
+    // Several elements make a system, one equation per element.
+    assert_eq!(
+      interpret("Solve[{x - 1, y - 2} == 0, {x, y}]").unwrap(),
+      "{{x -> 1, y -> 2}}"
+    );
+    // The scalar can sit on the left just as well.
+    assert_eq!(interpret("Solve[0 == {x - 3}, x]").unwrap(), "{{x -> 3}}");
+    // Table[…] == 0 is the Demonstration's shape: a one-element list of a
+    // numericized polynomial, solved without naming the variable.
+    assert_eq!(
+      interpret("Solve[N[Table[BernoulliB[n, z], {n, 3, 3}] == 0]]").unwrap(),
+      "{{z -> 0.}, {z -> 0.5}, {z -> 1.}}"
+    );
+  }
+
   #[test]
   fn solve_pure_cubic_symbolic() {
     assert_eq!(

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -14066,6 +14066,50 @@ mod manipulate {
     }
   }
 
+  /// The Roots-of-the-Bernoulli-Polynomials Demonstration lays its two
+  /// controls out with `Row[{Control@{…}, Spacer[…], Control@{…}}]`: a
+  /// labelled slider and a `{True, False}` picker. Both must survive the
+  /// Row wrapper with their bounds, step and initial value intact.
+  #[test]
+  fn spec_row_of_labelled_slider_and_boolean_picker() {
+    let expr = interpret_to_expr(
+      "Manipulate[{n, flag}, \
+       Row[{Control@{{n, 20, \"roots\"}, 1, 60, 1, Appearance -> \"Labeled\"}, \
+       Spacer[25], Control@{flag, {True, False}}}]]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("row-wrapped controls");
+    let names: Vec<&str> = spec.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["n", "flag"]);
+    match &spec.controls[0] {
+      ManipulateControl::Continuous {
+        label,
+        min,
+        max,
+        step,
+        initial,
+        ..
+      } => {
+        assert_eq!(label, "roots");
+        assert_eq!((*min, *max), (1.0, 60.0));
+        assert_eq!(*step, Some(1.0));
+        assert_eq!(*initial, 20.0);
+      }
+      other => panic!("expected a continuous control, got {other:?}"),
+    }
+    match &spec.controls[1] {
+      ManipulateControl::Discrete {
+        values,
+        initial_index,
+        ..
+      } => {
+        assert_eq!(values.len(), 2);
+        assert_eq!(*initial_index, 0); // True
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
   /// A `Setter` / `Toggler` control type offers one widget per value, the
   /// way `SetterBar` and `RadioButton` already do. Before these were
   /// recognised as control-type names they were read as a *bound*, the
@@ -19636,6 +19680,61 @@ mod demonstration_plot_layout {
     assert!(
       svg.contains(">y\u{2032}(t)<"),
       "the left frame label needs its prime: {svg}"
+    );
+  }
+
+  /// The whole body of the Roots-of-the-Bernoulli-Polynomials
+  /// Demonstration: numericize a Bernoulli polynomial, solve it for its
+  /// complex roots, and scatter-plot them with a dashed red grid line on
+  /// the symmetry axis. Every step used to fail — `N` destroyed the
+  /// exponents, `Solve` rejected the list-valued equation, and the scatter
+  /// renderer ignored `GridLines` / `GridLinesStyle` / `Axes`.
+  #[test]
+  fn bernoulli_root_scatter_with_styled_grid_line() {
+    clear_state();
+    let svg = export_svg(
+      "Module[{sol}, \
+       sol = Solve[N[Table[BernoulliB[n, z], {n, 8, 8}] == 0, 10]]; \
+       ListPlot[{{Re@z, Im@z} /. sol}, PlotRange -> {{-12, 12}, {-8, 8}}, \
+       GridLines -> {{1/2}, None}, \
+       GridLinesStyle -> Directive[Red, Dashed], \
+       Axes -> True, ImageSize -> {550, 400}]]",
+    );
+    // All eight roots of B_8 are plotted.
+    assert_eq!(
+      svg.matches("<circle").count(),
+      8,
+      "every root should be drawn: {svg}"
+    );
+    // The symmetry axis at x = 1/2, red and dashed.
+    assert!(
+      svg.contains("stroke=\"rgb(255,0,0)\"")
+        && svg.contains("stroke-dasharray="),
+      "the x = 1/2 grid line should be red and dashed: {svg}"
+    );
+  }
+
+  /// The same body with the Demonstration's `axes` checkbox off: the plot
+  /// keeps its points but loses the axes, their ticks and their labels.
+  #[test]
+  fn bernoulli_root_scatter_without_axes() {
+    clear_state();
+    let svg = export_svg(
+      "Module[{sol}, \
+       sol = Solve[N[Table[BernoulliB[n, z], {n, 8, 8}] == 0, 10]]; \
+       ListPlot[{{Re@z, Im@z} /. sol}, PlotRange -> {{-12, 12}, {-8, 8}}, \
+       GridLines -> {{1/2}, None}, \
+       GridLinesStyle -> Directive[Red, Dashed], \
+       Axes -> False, ImageSize -> {550, 400}]]",
+    );
+    assert_eq!(svg.matches("<circle").count(), 8, "points dropped: {svg}");
+    assert!(
+      !svg.contains("<text"),
+      "Axes -> False should leave no tick labels: {svg}"
+    );
+    assert!(
+      svg.contains("stroke-dasharray="),
+      "the grid line is independent of the axes: {svg}"
     );
   }
 }

--- a/tests/interpreter_tests/math/numeric.rs
+++ b/tests/interpreter_tests/math/numeric.rs
@@ -1365,6 +1365,7 @@ mod overflow_safety {
 
 mod cases {
   use super::super::super::case_helpers::assert_case;
+  use woxi::interpret;
 
   #[test]
   fn real_valued_number_q_1() {
@@ -1596,6 +1597,57 @@ mod cases {
       r#"3.1415926535897932384626433832795028842`20."#,
     );
   }
+
+  /// `N` leaves an exact rational exponent alone: `N[x^2]` is `x^2`, not
+  /// `x^2.`. Numericizing the exponent stops `Solve`/`NSolve` from
+  /// recognising `N[poly]` as a polynomial at all.
+  #[test]
+  fn n_keeps_exact_integer_exponents() {
+    assert_eq!(interpret("N[x^2]").unwrap(), "x^2");
+    assert_eq!(interpret("N[x^2/2]").unwrap(), "0.5*x^2");
+    assert_eq!(interpret("N[-x^3]").unwrap(), "-1.*x^3");
+    assert_eq!(interpret("N[x^-2]").unwrap(), "x^(-2)");
+    // A rational exponent is exact too, so Sqrt stays Sqrt.
+    assert_eq!(interpret("N[Sqrt[x]]").unwrap(), "Sqrt[x]");
+    assert_eq!(interpret("N[x^(1/2)]").unwrap(), "Sqrt[x]");
+    // The arbitrary-precision form keeps the exponent exact as well.
+    assert_eq!(interpret("N[x^2/2, 10]").unwrap(), "0.5`10.*x^2");
+    // A non-rational exponent is still numericized.
+    assert_eq!(interpret("N[x^Pi]").unwrap(), "x^3.141592653589793");
+  }
+
+  /// `N` maps over the operands of a comparison, so an equation picks up
+  /// inexact coefficients (`N[x == 1/3]` → `x == 0.333333`).
+  #[test]
+  fn n_threads_over_comparisons() {
+    assert_eq!(interpret("N[x == 1/3]").unwrap(), "x == 0.3333333333333333");
+    assert_eq!(interpret("N[x < 1/4]").unwrap(), "x < 0.25");
+    assert_eq!(interpret("N[x == 1/4, 5]").unwrap(), "x == 0.25`5.");
+    // An exact zero stays exact on either side, as in wolframscript.
+    assert_eq!(interpret("N[x == 0, 10]").unwrap(), "x == 0");
+    // A whole polynomial equation becomes inexact term by term while the
+    // exponents stay integral — the shape Solve needs.
+    assert_eq!(
+      interpret("N[x^2/2 + x/4 == 0]").unwrap(),
+      "0.25*x + 0.5*x^2 == 0."
+    );
+  }
+
+  /// `N[BernoulliB[n, z]]` must stay a polynomial in `z` so `Solve` can
+  /// find its roots numerically (the Roots-of-the-Bernoulli-Polynomials
+  /// Demonstration builds exactly this).
+  #[test]
+  fn n_of_polynomial_stays_solvable() {
+    assert_eq!(
+      interpret("N[BernoulliB[4, z]]").unwrap(),
+      "-0.03333333333333333 + z^2 - 2.*z^3 + z^4"
+    );
+    assert_eq!(
+      interpret("Solve[N[BernoulliB[3, z]] == 0, z]").unwrap(),
+      "{{z -> 0.}, {z -> 0.5}, {z -> 1.}}"
+    );
+  }
+
   #[test]
   fn number_form_1() {
     assert_case(

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -2062,6 +2062,88 @@ mod tests {
       );
     }
 
+    /// A point (non-joined) `ListPlot` draws its grid lines too — the
+    /// scatter renderer used to ignore `GridLines` entirely.
+    #[test]
+    fn scatter_list_plot_draws_grid_lines() {
+      let plain = woxi::interpret(
+        r#"ExportString[ListPlot[{{0., 0.}, {1., 1.}}], "SVG"]"#,
+      )
+      .expect("interpret should succeed");
+      let gridded = woxi::interpret(
+        r#"ExportString[ListPlot[{{0., 0.}, {1., 1.}},
+          GridLines -> {{0.5}, None}], "SVG"]"#,
+      )
+      .expect("interpret should succeed");
+      let count = |svg: &str| {
+        svg
+          .lines()
+          .filter(|l| l.contains("opacity=\"0.5\"") && l.contains("<polyline"))
+          .count()
+      };
+      assert_eq!(
+        count(&gridded),
+        count(&plain) + 1,
+        "GridLines -> {{{{0.5}}, None}} should add exactly one grid line"
+      );
+    }
+
+    /// `GridLinesStyle` styles every grid line that has no directive of its
+    /// own, for both the line and the scatter renderer.
+    #[test]
+    fn grid_lines_style_applies_to_plot_grid() {
+      for code in [
+        r#"ExportString[ListPlot[{{0., 0.}, {1., 1.}},
+           GridLines -> {{0.5}, None},
+           GridLinesStyle -> Directive[Red, Dashed]], "SVG"]"#,
+        r#"ExportString[Plot[x, {x, 0, 1}, GridLines -> {{0.5}, None},
+           GridLinesStyle -> Directive[Red, Dashed]], "SVG"]"#,
+      ] {
+        let svg = woxi::interpret(code).expect("interpret should succeed");
+        assert!(
+          svg.contains("stroke=\"rgb(255,0,0)\"")
+            && svg.contains("stroke-dasharray="),
+          "grid line not styled red/dashed: {code}"
+        );
+      }
+      // A per-line directive still wins over the plot-wide default.
+      let svg = woxi::interpret(
+        r#"ExportString[ListPlot[{{0., 0.}, {1., 1.}},
+          GridLines -> {{{0.5, Blue}}, None},
+          GridLinesStyle -> Directive[Red, Dashed]], "SVG"]"#,
+      )
+      .expect("interpret should succeed");
+      assert!(
+        svg.contains("stroke=\"#0000FF\"")
+          && !svg.contains("stroke=\"rgb(255,0,0)\""),
+        "per-line style should override GridLinesStyle: {svg}"
+      );
+    }
+
+    /// `Axes -> False` hides the axes of a `ListPlot`, which the scatter
+    /// renderer used to draw regardless.
+    #[test]
+    fn list_plot_honours_axes_option() {
+      let with_axes = woxi::interpret(
+        r#"ExportString[ListPlot[{{-1., -1.}, {1., 1.}}, Axes -> True], "SVG"]"#,
+      )
+      .expect("interpret should succeed");
+      let without = woxi::interpret(
+        r#"ExportString[ListPlot[{{-1., -1.}, {1., 1.}}, Axes -> False], "SVG"]"#,
+      )
+      .expect("interpret should succeed");
+      assert!(
+        with_axes.contains("<text"),
+        "axes should carry tick labels: {with_axes}"
+      );
+      assert!(
+        !without.contains("<text"),
+        "Axes -> False should drop the axes and their labels: {without}"
+      );
+      // The data points survive either way.
+      assert!(without.contains("<circle"), "points dropped: {without}");
+    }
+
     #[test]
     fn grid_lines_are_solid_single_polylines() {
       // Each grid line must be ONE solid polyline (WL grid lines are solid by


### PR DESCRIPTION
## Summary

This PR adds support for the `GridLinesStyle` option to customize grid line appearance in plots, and fixes several issues with the scatter plot (`ListPlot`) renderer:
- Grid lines were completely ignored in scatter plots
- The `Axes` option was not respected
- The `N` function was destroying polynomial structure by numericizing exponents
- `Solve` couldn't handle list-valued equations with scalar operands

## Key Changes

### Plot Rendering
- **Added `GridLinesStyle` option**: New `grid_lines_style` field in `PlotOptions` allows setting a default style for all grid lines that don't have their own directive. Supports `Directive[Red, Dashed]` and similar syntax.
- **Extracted `resolve_grid_lines` function**: Unified grid line resolution logic for both line and scatter renderers. Handles precedence (explicit lines beat automatic), style inheritance, and dashed line deferral.
- **Fixed scatter plot grid rendering**: `ListPlot` now properly draws grid lines using the same logic as `Plot`, including support for dashed lines via `stroke-dasharray` overlays.
- **Fixed scatter plot axes handling**: `Axes -> False` now properly hides axes, ticks, and labels in `ListPlot`. Origin lines (axes through zero) are also controlled by the `Axes` option.
- **Improved axis styling**: Axes are now hidden when `Axes -> False` by setting stroke width to 0, rather than always drawing them.

### Numeric Evaluation (`N`)
- **Preserve exact rational exponents**: `N[x^2]` now stays `x^2` (not `x^2.`), and `N[Sqrt[x]]` stays `Sqrt[x]`. This is critical for `Solve`/`NSolve` to recognize `N[polynomial]` as a polynomial.
- **Thread over comparisons**: `N[x == 1/3]` now correctly becomes `x == 0.333...`, allowing equations to pick up inexact coefficients while preserving polynomial structure.
- **Handle exact zeros**: `N[x == 0, 10]` stays `x == 0` (exact), matching Wolfram behavior.

### Solve Enhancement
- **Support list-valued equations with scalar operands**: `Solve[{x^2 - 1} == 0, x]` and `Solve[Table[...] == 0]` now work by broadcasting scalars across list operands. This enables the Roots-of-the-Bernoulli-Polynomials Demonstration pattern: `Solve[N[Table[BernoulliB[n, z], {n, 8, 8}] == 0]]`.

## Implementation Details

- `resolve_grid_lines()` consolidates grid line logic: explicit positions take precedence, automatic lines fill gaps at regular intervals, and lines without their own style inherit from `grid_lines_style`.
- Style inheritance is selective: a line only inherits the default style if it has no color, thickness, or dashing of its own.
- Dashed grid lines are collected and emitted as SVG `stroke-dasharray` polylines at the end, since the plotters library doesn't support dashing directly.
- `parse_axes_option()` and `parse_grid_lines_style()` helper functions extract option parsing logic for reuse across renderers.
- The `keeps_exact_exponent()` check ensures `N` only preserves exponents that are exact rationals (integers, fractions, or their negations).

## Tests Added

- Scatter plot grid line rendering
- `GridLinesStyle` application to both line and scatter plots
- Per-line style precedence over plot-wide `GridLinesStyle`
- `Axes -> False` behavior in scatter plots
- `N` preservation of exact exponents and polynomial structure
- `Solve` with list-valued equations and scalar operands
- Full Bernoulli polynomial root-finding demonstration

https://claude.ai/code/session_01SVitbH9AkziGQEBRMd3DTM