### PR TITLE
Support Scaled anchors, Framed labels, Text in 3D, and Prolog/Epilog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,33 @@
 
 # Unreleased
 
+- Fixes driven by the "Selectivity in a Semibatch Reactor" Wolfram
+    Demonstration:
+    - `Text` inside a `Graphics3D` scene is drawn — a labelled 3D
+        schematic used to arrive with no lettering at all. It honours the
+        `Style` size and colour, typesets `Subscript`/`Superscript`, and
+        respects the alignment offset of `Text[expr, pos, offset]`.
+    - `Scaled[{sx, sy}]` places a `Text` or `Inset` by fraction of the
+        plot range, in `Graphics` and in a plot's `Epilog` alike. The
+        fractions used to be unreadable, dropping every such label onto
+        the origin.
+    - `Inset[Graphics3D[…], pos]` embeds a three-dimensional picture in a
+        flat one at its own size, instead of printing `-Graphics3D-`.
+    - `Framed[…]` around a label draws its box — a border, and a panel
+        when a `Background` is given — rather than printing its own
+        source over the picture. `FrameStyle -> None` keeps the panel and
+        drops the border.
+    - `Subscript`/`Superscript` in a `Text` label typeset as scripts
+        instead of falling through to the two-line `OutputForm` box.
+    - `Graphics` accepts `Prolog` and `Epilog`, drawn under and over its
+        content and taking no part in the plot range.
+    - A `Manipulate` control panel written as a `Grid` drops its
+        `SpanFromLeft` / `SpanFromAbove` cell markers; they used to
+        survive as display elements and appear as literal text under the
+        widget, one row per marker.
+    - A control label computed with `Row[Flatten[{…, Riffle[…], …}]]` is
+        evaluated before it is typeset, so the button shows the caption
+        rather than the source of the computation.
 - Fixes driven by the "Illustrative Performance Characteristics of Modern
     Motorcycles" Wolfram Demonstration:
     - `Piecewise` holds its pieces, so the value of a piece whose condition

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -627,6 +627,12 @@ enum Primitive {
     /// `Background -> colour`: a panel painted behind the label, so it
     /// stays readable over whatever it is placed on.
     background: Option<Color>,
+    /// `Framed[…]`: the colour of the border drawn around the label, or
+    /// `None` for an unframed one (including `FrameStyle -> None`).
+    frame: Option<Color>,
+    /// `x`/`y` are `Scaled[…]` fractions of the plot range, resolved when
+    /// the range is known — see [`resolve_anchor`].
+    scaled: bool,
     style: StyleState,
   },
   BezierCurvePrim {
@@ -642,6 +648,9 @@ enum Primitive {
     y: f64,
     w: f64,
     h: f64,
+    /// `x`/`y` are `Scaled[…]` fractions of the plot range, resolved when
+    /// the range is known — see [`resolve_anchor`].
+    scaled: bool,
   },
   RasterPrim {
     /// rows x cols grid of RGBA colors (row 0 = bottom in Wolfram coords)
@@ -713,6 +722,40 @@ fn expr_to_point(expr: &Expr) -> Option<(f64, f64)> {
     return Some((x, y));
   }
   None
+}
+
+/// Where a `Text`/`Inset` anchor sits, as `(x, y, scaled)`. With `scaled`
+/// set, `x`/`y` are fractions of the final plot range rather than
+/// coordinates in it: `Scaled[{0.9, 0.775}]` pins a label near the top
+/// right whatever the data turns out to span. Such an anchor cannot be
+/// resolved while primitives are collected — the range it refers to is only
+/// known once every other primitive has been seen — so the flag travels
+/// with the primitive and [`resolve_anchor`] applies it at render time.
+///
+/// `ImageScaled` measures the same fractions against the image rather than
+/// the plot range; for a picture whose image *is* its plot range the two
+/// coincide, so both read as scaled here.
+fn expr_to_anchor(expr: &Expr) -> Option<(f64, f64, bool)> {
+  if let Expr::FunctionCall { name, args } = expr
+    && (name == "Scaled" || name == "ImageScaled")
+    && args.len() == 1
+    && let Some((x, y)) = expr_to_point(&args[0])
+  {
+    return Some((x, y, true));
+  }
+  expr_to_point(expr).map(|(x, y)| (x, y, false))
+}
+
+/// A primitive's anchor in data coordinates, turning a scaled fraction into
+/// the point of the plot range it names.
+fn resolve_anchor(x: f64, y: f64, scaled: bool, bb: &BBox) -> (f64, f64) {
+  if !scaled {
+    return (x, y);
+  }
+  (
+    bb.x_min + x * (bb.x_max - bb.x_min),
+    bb.y_min + y * (bb.y_max - bb.y_min),
+  )
 }
 
 fn expr_to_point_list(expr: &Expr) -> Option<Vec<(f64, f64)>> {
@@ -2424,6 +2467,17 @@ fn graphics_text_content(expr: &Expr) -> String {
         None => parts.concat(),
       }
     }
+    // `Subscript`/`Superscript` typeset as scripts, not as the two-line
+    // OutputForm box `ToString` would give: a label reading `N` over ` D`
+    // is not what the picture is meant to show. `expr_to_label` already
+    // folds them into the Unicode script characters for plot labels, so a
+    // `Text` label written the same way reads the same way.
+    Expr::FunctionCall { name, args }
+      if (name == "Subscript" || name == "Superscript") && args.len() >= 2 =>
+    {
+      crate::functions::chart::expr_to_label(expr)
+        .unwrap_or_else(|| crate::syntax::expr_to_string(expr))
+    }
     _ => match crate::functions::string_ast::to_string_ast(
       std::slice::from_ref(expr),
     ) {
@@ -2462,14 +2516,43 @@ fn inset_primitives(
   // picture whose symbolic content was not kept — is embedded whole, at
   // its own size. That is what an inset is: the object keeps the size it
   // would have on its own, wherever the plot range puts its anchor.
-  if let Expr::Graphics {
-    svg,
-    is_3d: false,
-    structure: None,
-    ..
-  } = &args[0]
+  //
+  // A three-dimensional object goes the same way: its projection is fixed
+  // by its own `ViewPoint`, so there is nothing to re-project into this
+  // picture's coordinates. `Graphics3D[…]` that has not been rendered yet
+  // is rendered here first (a Demonstration builds its little inset scene
+  // inside the body and insets the variable), which is also what keeps it
+  // from falling through to the text path and printing `-Graphics3D-`.
+  let anchor = args.get(1).and_then(expr_to_anchor);
+  let rendered;
+  let embedded = match &args[0] {
+    Expr::Graphics {
+      svg,
+      structure: None,
+      ..
+    } => Some(svg),
+    Expr::Graphics {
+      svg, is_3d: true, ..
+    } => Some(svg),
+    // A picture given symbolically normally has its primitives folded into
+    // this one (below), which is what lets it share the coordinate system.
+    // That cannot be done from a `Scaled` anchor — the range it names is
+    // only known once every primitive is in — so such an inset is rendered
+    // to its own picture and embedded whole instead.
+    call @ Expr::FunctionCall { name, .. }
+      if name == "Graphics3D"
+        || name == "Graphics3DBox"
+        || (anchor.is_some_and(|(_, _, scaled)| scaled)
+          && (name == "Graphics" || name == "GraphicsBox")) =>
+    {
+      rendered = crate::evaluator::expr_to_svg(call);
+      (!rendered.is_empty()).then_some(&rendered)
+    }
+    _ => None,
+  };
+  if let Some(svg) = embedded
     && let Some(dims) = parse_svg_dimensions(svg)
-    && let Some((x, y)) = args.get(1).and_then(expr_to_point)
+    && let Some((x, y, scaled)) = anchor
   {
     return Some(vec![Primitive::InsetGraphic {
       svg: svg.clone(),
@@ -2477,6 +2560,7 @@ fn inset_primitives(
       y,
       w: dims.nat_w,
       h: dims.nat_h,
+      scaled,
     }]);
   }
   // The object: `Graphics[…]` (or its box form), a rendered graphic that
@@ -2589,10 +2673,21 @@ fn inset_primitives(
 fn parse_text(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
   // Text[str, {x, y}] or Text[Style[str, ...], {x, y}]
   let mut local_style = style.clone();
+  // `Framed[content, opts…]` boxes the label: a border around it and, with
+  // `Background -> colour`, a panel behind it. Peel it off first so the
+  // `Style` directives it usually wraps still reach the primitive.
+  let (framed_body, frame_opts) = match &args[0] {
+    Expr::FunctionCall { name, args: fargs }
+      if name == "Framed" && !fargs.is_empty() =>
+    {
+      (&fargs[0], &fargs[1..])
+    }
+    other => (other, &[] as &[Expr]),
+  };
   // A top-level `Style[content, dirs…]` carries text directives (font size,
   // weight, color) that apply to the whole label; peel it off and apply them
   // to the primitive, then render the inner content.
-  let content = match &args[0] {
+  let content = match framed_body {
     Expr::FunctionCall { name, args: sargs }
       if is_style_wrapper(name) && !sargs.is_empty() =>
     {
@@ -2606,26 +2701,32 @@ fn parse_text(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
   };
   let text = graphics_text_content(content);
 
-  let (x, y) = if args.len() >= 2 {
-    expr_to_point(&args[1]).unwrap_or((0.0, 0.0))
+  let (x, y, scaled) = if args.len() >= 2 {
+    expr_to_anchor(&args[1]).unwrap_or((0.0, 0.0, false))
   } else {
-    (0.0, 0.0)
+    (0.0, 0.0, false)
   };
   let offset = args.get(2).and_then(text_offset).unwrap_or((0.0, 0.0));
   // `Background -> colour`, written either as a trailing option of the
   // `Text` or as a directive of the `Style` it wraps.
-  let background_of = |opts: &[Expr]| {
+  fn option_value<'a>(opts: &'a [Expr], key: &str) -> Option<&'a Expr> {
     opts.iter().find_map(|o| match o {
       Expr::Rule {
         pattern,
         replacement,
-      } if matches!(pattern.as_ref(), Expr::Identifier(k) if k == "Background") => {
-        parse_color(replacement)
+      }
+      | Expr::RuleDelayed {
+        pattern,
+        replacement,
+      } if matches!(pattern.as_ref(), Expr::Identifier(k) if k == key) => {
+        Some(replacement.as_ref())
       }
       _ => None,
     })
-  };
-  let style_opts: &[Expr] = match &args[0] {
+  }
+  let background_of =
+    |opts: &[Expr]| option_value(opts, "Background").and_then(parse_color);
+  let style_opts: &[Expr] = match framed_body {
     Expr::FunctionCall { name, args: sargs }
       if is_style_wrapper(name) && !sargs.is_empty() =>
     {
@@ -2633,8 +2734,24 @@ fn parse_text(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
     }
     _ => &[],
   };
-  let background =
-    background_of(&args[1..]).or_else(|| background_of(style_opts));
+  let background = background_of(frame_opts)
+    .or_else(|| background_of(&args[1..]))
+    .or_else(|| background_of(style_opts));
+  // Wolfram draws a `Framed` box with a thin border unless the label asks
+  // for none; an explicit `FrameStyle -> colour` recolours it.
+  let is_framed = matches!(
+    &args[0],
+    Expr::FunctionCall { name, args: fargs } if name == "Framed" && !fargs.is_empty()
+  );
+  let frame = if is_framed {
+    match option_value(frame_opts, "FrameStyle") {
+      Some(Expr::Identifier(s)) if s == "None" => None,
+      Some(spec) => parse_color(spec).or(Some(Color::new(0.0, 0.0, 0.0))),
+      None => Some(Color::new(0.0, 0.0, 0.0)),
+    }
+  } else {
+    None
+  };
 
   prims.push(Primitive::TextPrim {
     text,
@@ -2642,6 +2759,8 @@ fn parse_text(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
     y,
     offset,
     background,
+    frame,
+    scaled,
     style: local_style,
   });
 }
@@ -3250,14 +3369,24 @@ fn rotate_primitive(
   let rv = |x: f64, y: f64| (x * cos - y * sin, x * sin + y * cos);
   match prim {
     // An inset keeps its own orientation and size; only its anchor moves.
-    Primitive::InsetGraphic { svg, x, y, w, h } => {
-      let (nx, ny) = rp(*x, *y);
+    Primitive::InsetGraphic {
+      svg,
+      x,
+      y,
+      w,
+      h,
+      scaled,
+    } => {
+      // A scaled anchor names a place in the finished frame, not a point in
+      // the data, so a transform of the coordinates leaves it where it is.
+      let (nx, ny) = if *scaled { (*x, *y) } else { rp(*x, *y) };
       Primitive::InsetGraphic {
         svg: svg.clone(),
         x: nx,
         y: ny,
         w: *w,
         h: *h,
+        scaled: *scaled,
       }
     }
     Primitive::PointSingle { x, y, style } => {
@@ -3388,15 +3517,19 @@ fn rotate_primitive(
       y,
       offset,
       background,
+      frame,
+      scaled,
       style,
     } => {
-      let (nx, ny) = rp(*x, *y);
+      let (nx, ny) = if *scaled { (*x, *y) } else { rp(*x, *y) };
       Primitive::TextPrim {
         text: text.clone(),
         x: nx,
         y: ny,
         offset: *offset,
         background: *background,
+        frame: *frame,
+        scaled: *scaled,
         style: style.clone(),
       }
     }
@@ -3446,12 +3579,20 @@ fn rotate_primitive(
 fn translate_primitive(prim: &Primitive, dx: f64, dy: f64) -> Primitive {
   let tp = |x: f64, y: f64| (x + dx, y + dy);
   match prim {
-    Primitive::InsetGraphic { svg, x, y, w, h } => Primitive::InsetGraphic {
+    Primitive::InsetGraphic {
+      svg,
+      x,
+      y,
+      w,
+      h,
+      scaled,
+    } => Primitive::InsetGraphic {
       svg: svg.clone(),
-      x: x + dx,
-      y: y + dy,
+      x: if *scaled { *x } else { x + dx },
+      y: if *scaled { *y } else { y + dy },
       w: *w,
       h: *h,
+      scaled: *scaled,
     },
     Primitive::PointSingle { x, y, style } => Primitive::PointSingle {
       x: x + dx,
@@ -3560,13 +3701,17 @@ fn translate_primitive(prim: &Primitive, dx: f64, dy: f64) -> Primitive {
       y,
       offset,
       background,
+      frame,
+      scaled,
       style,
     } => Primitive::TextPrim {
       text: text.clone(),
-      x: x + dx,
-      y: y + dy,
+      x: if *scaled { *x } else { x + dx },
+      y: if *scaled { *y } else { y + dy },
       offset: *offset,
       background: *background,
+      frame: *frame,
+      scaled: *scaled,
       style: style.clone(),
     },
     Primitive::RasterPrim {
@@ -3640,14 +3785,22 @@ fn scale_primitive(
     }
   };
   match prim {
-    Primitive::InsetGraphic { svg, x, y, w, h } => {
-      let (nx, ny) = sp(*x, *y);
+    Primitive::InsetGraphic {
+      svg,
+      x,
+      y,
+      w,
+      h,
+      scaled,
+    } => {
+      let (nx, ny) = if *scaled { (*x, *y) } else { sp(*x, *y) };
       Primitive::InsetGraphic {
         svg: svg.clone(),
         x: nx,
         y: ny,
         w: *w,
         h: *h,
+        scaled: *scaled,
       }
     }
     Primitive::PointSingle { x, y, style } => {
@@ -3775,15 +3928,19 @@ fn scale_primitive(
       y,
       offset,
       background,
+      frame,
+      scaled,
       style,
     } => {
-      let (nx, ny) = sp(*x, *y);
+      let (nx, ny) = if *scaled { (*x, *y) } else { sp(*x, *y) };
       Primitive::TextPrim {
         text: text.clone(),
         x: nx,
         y: ny,
         offset: *offset,
         background: *background,
+        frame: *frame,
+        scaled: *scaled,
         style: style.clone(),
       }
     }
@@ -4657,19 +4814,22 @@ fn render_primitive(
 ) {
   match prim {
     // The inset is embedded whole, at its own size, centred on its anchor.
-    Primitive::InsetGraphic { svg, x, y, w, h } => {
-      let cx = coord_x(*x, bb, svg_w);
-      let cy = coord_y(*y, bb, svg_h);
-      let view_box = parse_svg_dimensions(svg)
-        .map(|p| p.view_box)
-        .unwrap_or_else(|| format!("0 0 {w} {h}"));
-      out.push_str(&format!(
-        "<svg x=\"{:.2}\" y=\"{:.2}\" width=\"{w:.2}\" height=\"{h:.2}\" viewBox=\"{view_box}\" preserveAspectRatio=\"xMidYMid meet\">\n",
-        cx - w / 2.0,
-        cy - h / 2.0
+    Primitive::InsetGraphic {
+      svg,
+      x,
+      y,
+      w,
+      h,
+      scaled,
+    } => {
+      let (ax, ay) = resolve_anchor(*x, *y, *scaled, bb);
+      out.push_str(&embed_svg_centered(
+        svg,
+        coord_x(ax, bb, svg_w),
+        coord_y(ay, bb, svg_h),
+        *w,
+        *h,
       ));
-      out.push_str(strip_svg_wrapper(svg));
-      out.push_str("</svg>\n");
     }
     Primitive::PointSingle { x, y, style } => {
       let cx = coord_x(*x, bb, svg_w);
@@ -5195,6 +5355,8 @@ fn render_primitive(
       y,
       offset,
       background,
+      frame,
+      scaled,
       style,
     } => {
       let color = style.effective_color();
@@ -5211,17 +5373,25 @@ fn render_primitive(
         .unwrap_or(0);
       let text_w = longest as f64 * fs * 0.6;
       let text_h = text.split('\n').count() as f64 * fs;
-      let sx = coord_x(*x, bb, svg_w) - offset.0 * text_w / 2.0;
-      let sy = coord_y(*y, bb, svg_h) + offset.1 * text_h / 2.0;
+      let (ax, ay) = resolve_anchor(*x, *y, *scaled, bb);
+      let sx = coord_x(ax, bb, svg_w) - offset.0 * text_w / 2.0;
+      let sy = coord_y(ay, bb, svg_h) + offset.1 * text_h / 2.0;
       // `Background -> colour` paints a panel behind the label, which is
-      // what keeps a value readable over whatever it is placed on.
-      if let Some(bg) = background {
+      // what keeps a value readable over whatever it is placed on; a
+      // `Framed` label additionally gets the border drawn around it.
+      if background.is_some() || frame.is_some() {
+        let (fill, fill_opacity) = match background {
+          Some(bg) => (bg.to_svg_rgb(), bg.opacity_attr()),
+          None => ("none".to_string(), String::new()),
+        };
+        let stroke = match frame {
+          Some(fc) => format!(" stroke=\"{}\"", fc.to_svg_rgb()),
+          None => String::new(),
+        };
         out.push_str(&format!(
-          "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{text_w:.2}\" height=\"{text_h:.2}\" fill=\"{}\"{}/>\n",
+          "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{text_w:.2}\" height=\"{text_h:.2}\" fill=\"{fill}\"{fill_opacity}{stroke}/>\n",
           sx - text_w / 2.0,
           sy - text_h / 2.0,
-          bg.to_svg_rgb(),
-          bg.opacity_attr(),
         ));
       }
       let ff_attr = if style.font_family.is_empty() {
@@ -5739,6 +5909,11 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // all four sides): the room reserved around the drawing area, replacing the
   // automatic margins that the frame and its tick labels would ask for.
   let mut image_padding: Option<[f64; 4]> = None;
+  // `Prolog -> …` / `Epilog -> …`: extra primitives drawn under and over
+  // the picture's own content. Neither takes part in the plot range, so
+  // they are collected only once the range is settled.
+  let mut prolog: Option<Expr> = None;
+  let mut epilog: Option<Expr> = None;
 
   for raw_opt in &args[1..] {
     let opt =
@@ -5770,6 +5945,8 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             plot_range_y = yr;
           }
         }
+        "Prolog" => prolog = Some(replacement.clone()),
+        "Epilog" => epilog = Some(replacement.clone()),
         "PlotLabel" => {
           // Any expression can label the plot (`Row[…]`, a string, a
           // symbol). It is typeset like the rest of the graphic, so machine
@@ -5931,6 +6108,29 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some((lo, hi)) = plot_range_y {
     bb.y_min = lo;
     bb.y_max = hi;
+  }
+
+  // The plot range is settled, so the Prolog's and Epilog's own primitives
+  // can join now — under and over the content respectively — without
+  // having stretched the range they are placed against.
+  if let Some(under) = &prolog {
+    let mut under_prims = Vec::new();
+    collect_primitives(
+      under,
+      &mut StyleState::default(),
+      &mut under_prims,
+      &mut errors,
+    );
+    under_prims.append(&mut primitives);
+    primitives = under_prims;
+  }
+  if let Some(over) = &epilog {
+    collect_primitives(
+      over,
+      &mut StyleState::default(),
+      &mut primitives,
+      &mut errors,
+    );
   }
 
   // Adjust aspect ratio to match data unless explicitly set via ImageSize -> {w, h}
@@ -11838,6 +12038,34 @@ fn parse_svg_numeric_attr(svg: &str, attr: &str) -> Option<f64> {
   raw[..numeric_end].parse().ok()
 }
 
+/// The natural display size of a rendered picture, in pixels. That is the
+/// size an inset of it keeps whatever the enclosing plot range turns out to
+/// be, so it is what a caller needs before embedding one.
+pub(crate) fn svg_natural_size(svg: &str) -> Option<(f64, f64)> {
+  parse_svg_dimensions(svg).map(|p| (p.nat_w, p.nat_h))
+}
+
+/// An already-rendered picture nested inside another one: a `<svg>` element
+/// of `w`×`h` pixels centred on (`cx`, `cy`) in the enclosing picture's
+/// pixel coordinates, drawing the original through its own viewBox.
+pub(crate) fn embed_svg_centered(
+  svg: &str,
+  cx: f64,
+  cy: f64,
+  w: f64,
+  h: f64,
+) -> String {
+  let view_box = parse_svg_dimensions(svg)
+    .map(|p| p.view_box)
+    .unwrap_or_else(|| format!("0 0 {w} {h}"));
+  format!(
+    "<svg x=\"{:.2}\" y=\"{:.2}\" width=\"{w:.2}\" height=\"{h:.2}\" viewBox=\"{view_box}\" preserveAspectRatio=\"xMidYMid meet\">\n{}</svg>\n",
+    cx - w / 2.0,
+    cy - h / 2.0,
+    strip_svg_wrapper(svg),
+  )
+}
+
 /// Parse width, height, and viewBox from an SVG string
 fn parse_svg_dimensions(svg: &str) -> Option<ParsedSvg> {
   // Extract the viewBox attribute; an SVG without one (e.g. the base64-PNG
@@ -15423,6 +15651,20 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       }
       // `Spacer[…]` is pure layout between grouped controls — skip it.
       Expr::FunctionCall { name, .. } if name == "Spacer" => continue,
+      // The span markers of a `Grid` control panel say that the cell to
+      // their left (or above) stretches into this slot. Once the grid has
+      // been flattened into a list of control rows they mark nothing at
+      // all, so they are dropped rather than mistaken for display
+      // elements — which would put a literal `SpanFromLeft` under the
+      // widget, one per marker.
+      Expr::Identifier(s)
+        if matches!(
+          s.as_str(),
+          "SpanFromLeft" | "SpanFromAbove" | "SpanFromBoth" | "Null"
+        ) =>
+      {
+        continue;
+      }
       _ => {}
     }
     // Only list-shaped arguments are control specs (layout containers of
@@ -16487,6 +16729,26 @@ fn locator_range(
 /// individual runs, giving e.g. `Text[Subscript[Style["m", Italic], 1]]` →
 /// an italic `m` followed by an upright `₁`, and `Style["t", Italic]` → an
 /// italic `t`. `italic` is the style inherited from an enclosing `Style`.
+/// The items a `Row`/`Column` lays out. Written literally they are already a
+/// list; a Demonstration more often computes them — `Row[Flatten[{" ",
+/// Riffle[Subscript[Style["N", Italic], #] & /@ {"D", "U"}, " and "], " "}]]`
+/// builds a setter's caption that way — so a non-literal argument is
+/// evaluated first. Anything that does not come back as a list (a symbol
+/// with no value, say) yields `None`, leaving the label on the OutputForm
+/// path rather than printing the source of the computation.
+fn layout_parts(arg: Option<&Expr>) -> Option<Vec<Expr>> {
+  match arg? {
+    Expr::List(parts) => Some(parts.to_vec()),
+    other => match evaluate_expr_to_expr(other) {
+      Ok(ref evaluated) => match evaluated {
+        Expr::List(parts) => Some(parts.to_vec()),
+        _ => None,
+      },
+      Err(_) => None,
+    },
+  }
+}
+
 fn manipulate_label_runs(expr: &Expr, italic: bool) -> Vec<LabelRun> {
   let output_run = |italic: bool| {
     let text =
@@ -16529,8 +16791,8 @@ fn manipulate_label_runs(expr: &Expr, italic: bool) -> Vec<LabelRun> {
         .map(|a| manipulate_label_runs(a, italic))
         .unwrap_or_default(),
       // Row[{a, b, …}] — concatenate the (recursively rendered) parts.
-      "Row" => match args.first() {
-        Some(Expr::List(parts)) => parts
+      "Row" => match layout_parts(args.first()) {
+        Some(parts) => parts
           .iter()
           .flat_map(|p| manipulate_label_runs(p, italic))
           .collect(),
@@ -16538,8 +16800,8 @@ fn manipulate_label_runs(expr: &Expr, italic: bool) -> Vec<LabelRun> {
       },
       // Column[{a, b, …}] — the same, but one part per line. Demonstrations
       // label a hypothesis-test setter with a two-line column.
-      "Column" => match args.first() {
-        Some(Expr::List(parts)) => parts
+      "Column" => match layout_parts(args.first()) {
+        Some(parts) => parts
           .iter()
           .enumerate()
           .flat_map(|(i, p)| {

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -1889,6 +1889,23 @@ enum Primitive3D {
     radius: f64,
     style: StyleState3D,
   },
+  /// `Text[expr, {x, y, z}, offset]`: a label pinned to a point of the
+  /// scene. Text does not turn with the camera — it is drawn flat, facing
+  /// the viewer, at the projection of its point, which is what makes a
+  /// labelled 3D schematic readable from any view.
+  Text3D {
+    /// The label as SVG `<text>` content (already typeset and escaped).
+    label: String,
+    pos: Point3D,
+    /// Which point of the label's own box sits at `pos`, from -1
+    /// (left/bottom) to 1 (right/top). `(0, 0)` centres it.
+    offset: (f64, f64),
+    font_size: f64,
+    /// Character count of the visible text, for placing the box an
+    /// `offset` displaces.
+    width_chars: usize,
+    style: StyleState3D,
+  },
   /// A pre-tessellated triangle surface (Torus, FilledTorus, BSplineSurface,
   /// Raster3D voxels, …). `smooth` marks the ones that approximate a curved
   /// surface, whose triangle edges are internal cuts rather than outlines.
@@ -2233,6 +2250,9 @@ fn transform_primitive3d(prim: &mut Primitive3D, xf: &Affine3) {
         *p = xf.apply(*p);
       }
     }
+    Primitive3D::Text3D { pos, .. } => {
+      *pos = xf.apply(*pos);
+    }
     Primitive3D::Line3D { segments, .. } => {
       for seg in segments {
         for p in seg {
@@ -2303,6 +2323,31 @@ fn resolve_complex_indices(expr: &Expr, points: &[Expr]) -> Expr {
         .into(),
     },
     other => other.clone(),
+  }
+}
+
+/// The alignment offset of `Text[expr, pos, offset]`: a pair running from
+/// -1 (left/bottom) to 1 (right/top), written either as numbers or with the
+/// alignment symbols.
+fn parse_text3d_offset(spec: &Expr) -> Option<(f64, f64)> {
+  fn component(e: &Expr, horizontal: bool) -> Option<f64> {
+    if let Expr::Identifier(s) = e {
+      return match (s.as_str(), horizontal) {
+        ("Left", true) | ("Bottom", false) => Some(-1.0),
+        ("Center", _) | ("Automatic", _) | ("Axis", _) | ("Baseline", _) => {
+          Some(0.0)
+        }
+        ("Right", true) | ("Top", false) => Some(1.0),
+        _ => None,
+      };
+    }
+    crate::functions::math_ast::expr_to_f64(e)
+  }
+  match spec {
+    Expr::List(items) if items.len() == 2 => {
+      Some((component(&items[0], true)?, component(&items[1], false)?))
+    }
+    _ => None,
   }
 }
 
@@ -2470,6 +2515,45 @@ fn collect_3d_primitives(
               points: pts,
               style: style.clone(),
             });
+          }
+        }
+        // `Text[expr, {x, y, z}]` (optionally with an alignment offset)
+        // labels a point of the scene. The label is typeset by the same
+        // helper the 2D pictures and plot labels use, so `Subscript[N, B]`
+        // reads the same wherever it is written.
+        "Text" if args.len() >= 2 => {
+          if let Some(pos) = parse_point3d(&args[1]) {
+            let styled = crate::functions::chart::parse_styled_label(&args[0]);
+            let (label, width_chars, font_size, color) = match styled {
+              Some(s) => (
+                s.svg(),
+                s.text.chars().count(),
+                s.font_size.unwrap_or(12.0),
+                s.color,
+              ),
+              None => (String::new(), 0, 12.0, None),
+            };
+            if !label.is_empty() {
+              let mut text_style = style.clone();
+              if let Some(c) = color {
+                text_style.color = Some((
+                  (c.r.clamp(0.0, 1.0) * 255.0).round() as u8,
+                  (c.g.clamp(0.0, 1.0) * 255.0).round() as u8,
+                  (c.b.clamp(0.0, 1.0) * 255.0).round() as u8,
+                ));
+              }
+              prims.push(Primitive3D::Text3D {
+                label,
+                pos,
+                offset: args
+                  .get(2)
+                  .and_then(parse_text3d_offset)
+                  .unwrap_or((0.0, 0.0)),
+                font_size,
+                width_chars,
+                style: text_style,
+              });
+            }
           }
         }
         "Cylinder" => {
@@ -3713,6 +3797,17 @@ fn primitives_bounds(prims: &[Primitive3D]) -> [(f64, f64); 3] {
           );
         }
       }
+      Primitive3D::Text3D { pos, .. } => {
+        extend_3d(
+          pos,
+          &mut x3_min,
+          &mut x3_max,
+          &mut y3_min,
+          &mut y3_max,
+          &mut z3_min,
+          &mut z3_max,
+        );
+      }
       Primitive3D::Point3DPrim { points, .. }
       | Primitive3D::Arrow3D { points, .. } => {
         for pt in points {
@@ -3801,6 +3896,9 @@ fn enclosing_sphere_radius(prims: &[Primitive3D], center: Point3D) -> f64 {
             }
           }
         }
+      }
+      Primitive3D::Text3D { pos, .. } => {
+        radius = radius.max(dist(pos));
       }
       Primitive3D::Polygon3D { points, .. }
       | Primitive3D::Point3DPrim { points, .. }
@@ -4333,6 +4431,13 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           }
         }
       }
+      Primitive3D::Text3D { pos, .. } => {
+        let (px, py) = project(*pos, &camera);
+        px_min = px_min.min(px);
+        px_max = px_max.max(px);
+        py_min = py_min.min(py);
+        py_max = py_max.max(py);
+      }
       Primitive3D::Point3DPrim { points, .. }
       | Primitive3D::Arrow3D { points, .. } => {
         for pt in points {
@@ -4622,6 +4727,34 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // triangles above so surfaces occlude them correctly)
   for prim in &prims {
     match prim {
+      Primitive3D::Text3D {
+        label,
+        pos,
+        offset,
+        font_size,
+        width_chars,
+        style,
+      } => {
+        let fill_color = if let Some((r, g, b)) = style.color {
+          format!("rgb({r},{g},{b})")
+        } else {
+          default_prim_color.to_string()
+        };
+        let (px, py) = project(*pos, &camera);
+        let (sx, sy) = to_svg(px, py);
+        // The offset names which point of the label's box sits at the
+        // projected point, so the box moves the other way — half its width
+        // per unit across, half its height per unit up (and the vertical
+        // sign flips, SVG counting y downwards).
+        let text_w = *width_chars as f64 * font_size * 0.6;
+        let x = sx - offset.0 * text_w / 2.0;
+        let y = sy + offset.1 * font_size / 2.0;
+        svg.push_str(&format!(
+          "<text x=\"{x:.1}\" y=\"{y:.1}\" text-anchor=\"middle\" \
+           dominant-baseline=\"middle\" font-family=\"sans-serif\" \
+           font-size=\"{font_size:.1}\" fill=\"{fill_color}\">{label}</text>\n",
+        ));
+      }
       Primitive3D::Point3DPrim { points, style } => {
         let fill_color = if let Some((r, g, b)) = style.color {
           format!("rgb({r},{g},{b})")

--- a/src/functions/plot_epilog.rs
+++ b/src/functions/plot_epilog.rs
@@ -124,6 +124,43 @@ pub(crate) fn render_epilog_svg(prims: &[Expr], area: &PlotArea) -> String {
   out
 }
 
+/// A position written either as `{x, y}` or as `Scaled[{sx, sy}]` — the
+/// fraction-of-plot-range form a Demonstration pins its captions and insets
+/// with, so they stay put however the curves move. Both come back in data
+/// coordinates. `ImageScaled` measures the same fractions against the image
+/// rather than the plot range; over the plotting area the two coincide.
+fn anchor2(expr: &Expr, area: &PlotArea) -> Option<(f64, f64)> {
+  if let Expr::FunctionCall { name, args } = expr
+    && (name == "Scaled" || name == "ImageScaled")
+    && args.len() == 1
+    && let Some((sx, sy)) = point2(&args[0])
+  {
+    return Some((
+      area.x_min + sx * (area.x_max - area.x_min),
+      area.y_min + sy * (area.y_max - area.y_min),
+    ));
+  }
+  point2(expr)
+}
+
+/// The value of option `key` among a primitive's trailing `opt -> value`
+/// arguments.
+fn option_value<'a>(opts: &'a [Expr], key: &str) -> Option<&'a Expr> {
+  opts.iter().find_map(|o| match o {
+    Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    } if matches!(pattern.as_ref(), Expr::Identifier(k) if k == key) => {
+      Some(replacement.as_ref())
+    }
+    _ => None,
+  })
+}
+
 /// Try to interpret an expression as a `{x, y}` coordinate pair.
 fn point2(expr: &Expr) -> Option<(f64, f64)> {
   if let Expr::List(items) = expr
@@ -343,15 +380,28 @@ fn render_item(
         }
       }
       "Text" if args.len() >= 2 => {
-        if let Some((x, y)) = point2(&args[1]) {
+        if let Some((x, y)) = anchor2(&args[1], area) {
+          // `Framed[content, opts…]` boxes the label: a panel behind it and
+          // a border around it, both drawn before the text so the text sits
+          // on top. Peeling it off first leaves the `Style[…]` it usually
+          // wraps on the ordinary path.
+          let (body, frame_opts, is_framed) = match &args[0] {
+            Expr::FunctionCall { name, args: fargs }
+              if name == "Framed" && !fargs.is_empty() =>
+            {
+              (&fargs[0], &fargs[1..], true)
+            }
+            other => (other, &[] as &[Expr], false),
+          };
           // `Style[…]` around the content sets the text's own size and
           // colour; without one the epilog's directives still apply.
-          let styled = crate::functions::chart::parse_styled_label(&args[0]);
-          let label = styled
-            .as_ref()
-            .map(|s| s.text.clone())
-            .or_else(|| crate::functions::chart::expr_to_label(&args[0]))
-            .unwrap_or_else(|| crate::syntax::expr_to_output(&args[0]));
+          let styled = crate::functions::chart::parse_styled_label(body);
+          // A label carrying structure (`Subscript[N, D]`) is typeset into
+          // SVG markup; a plain one goes through the same path, which
+          // escapes it.
+          let label = styled.as_ref().map(|s| s.svg()).unwrap_or_else(|| {
+            svg_escape_text(&crate::syntax::expr_to_output(body))
+          });
           let font_size =
             styled.as_ref().and_then(|s| s.font_size).unwrap_or(13.0)
               * area.scale;
@@ -359,14 +409,59 @@ fn render_item(
             Some(c) => format!("fill=\"{}\"", c.to_svg_rgb()),
             None => style.fill_attrs(),
           };
+          let (px, py) = (area.px(x), area.py(y));
+          if is_framed {
+            let text_w =
+              styled.as_ref().map(|s| s.text.chars().count()).unwrap_or(0)
+                as f64
+                * font_size
+                * 0.6;
+            let background = option_value(frame_opts, "Background")
+              .and_then(parse_color)
+              .map(|c| c.to_svg_rgb())
+              .unwrap_or_else(|| "none".to_string());
+            // Wolfram draws the box with a thin border unless the label
+            // asks for none; `FrameStyle -> colour` recolours it.
+            let stroke = match option_value(frame_opts, "FrameStyle") {
+              Some(Expr::Identifier(s)) if s == "None" => String::new(),
+              Some(spec) => format!(
+                " stroke=\"{}\"",
+                parse_color(spec)
+                  .unwrap_or(Color::new(0.0, 0.0, 0.0))
+                  .to_svg_rgb()
+              ),
+              None => " stroke=\"rgb(0,0,0)\"".to_string(),
+            };
+            out.push_str(&format!(
+              "<rect x=\"{:.1}\" y=\"{:.1}\" width=\"{text_w:.1}\" height=\"{font_size:.1}\" fill=\"{background}\"{stroke}/>\n",
+              px - text_w / 2.0,
+              py - font_size / 2.0,
+            ));
+          }
           out.push_str(&format!(
-            "<text x=\"{:.1}\" y=\"{:.1}\" text-anchor=\"middle\" \
+            "<text x=\"{px:.1}\" y=\"{py:.1}\" text-anchor=\"middle\" \
              dominant-baseline=\"middle\" font-family=\"sans-serif\" \
-             font-size=\"{:.0}\" {fill}>{}</text>\n",
-            area.px(x),
-            area.py(y),
-            font_size,
-            svg_escape_text(&label),
+             font-size=\"{font_size:.0}\" {fill}>{label}</text>\n",
+          ));
+        }
+      }
+      // `Inset[picture, pos]` drops a whole other picture — often a little
+      // 3D schematic of what the curves describe — onto the plot at its own
+      // natural size.
+      "Inset" if !args.is_empty() => {
+        let anchor = args.get(1).and_then(|p| anchor2(p, area)).unwrap_or((
+          (area.x_min + area.x_max) / 2.0,
+          (area.y_min + area.y_max) / 2.0,
+        ));
+        let svg = crate::evaluator::expr_to_svg(&args[0]);
+        if let Some((w, h)) = crate::functions::graphics::svg_natural_size(&svg)
+        {
+          out.push_str(&crate::functions::graphics::embed_svg_centered(
+            &svg,
+            area.px(anchor.0),
+            area.py(anchor.1),
+            w * area.scale,
+            h * area.scale,
           ));
         }
       }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -528,6 +528,105 @@ mod graphics {
       assert_eq!(result.result, "PolarCurve[1 - Cos[t], {t, 0, a}]");
       assert!(result.graphics.is_none());
     }
+
+    /// `Scaled[{sx, sy}]` places a primitive by fraction of the plot
+    /// range rather than in the coordinates of the data, so a caption
+    /// pinned near a corner stays there whatever the data spans. The
+    /// fractions used to be unreadable, dropping every such label onto
+    /// the origin.
+    #[test]
+    fn scaled_positions_are_fractions_of_the_plot_range() {
+      let label_x = |code: &str| -> f64 {
+        let svg = export_svg(code);
+        svg
+          .split("<text ")
+          .nth(1)
+          .and_then(|t| t.split_once("x=\""))
+          .and_then(|(_, r)| r.split_once('"'))
+          .and_then(|(v, _)| v.parse().ok())
+          .expect("a positioned label")
+      };
+      // A tenth across a 360 px wide picture, whatever the data range.
+      for range in ["{{0, 10}, {0, 10}}", "{{-100, 100}, {-100, 100}}"] {
+        let x = label_x(&format!(
+          "Graphics[{{Text[\"hi\", Scaled[{{0.1, 0.9}}]]}}, \
+           PlotRange -> {range}]"
+        ));
+        assert!(
+          (x - 36.0).abs() < 1.0,
+          "a tenth across the picture, got {x} for {range}"
+        );
+      }
+    }
+
+    /// `Graphics` takes `Prolog` and `Epilog` too: extra primitives drawn
+    /// under and over its content. Neither stretches the plot range — a
+    /// point far outside it is clipped away rather than rescaling the
+    /// picture around it. Both used to be ignored entirely.
+    #[test]
+    fn a_graphics_prolog_draws_under_and_an_epilog_over() {
+      let svg = export_svg(
+        "Graphics[{Circle[]}, Prolog -> {Blue, Disk[{0, 0}, 0.5]}, \
+         Epilog -> {Red, Disk[{0, 0}, 0.2]}]",
+      );
+      let order: Vec<&str> = svg
+        .match_indices("fill=\"rgb(")
+        .map(|(i, _)| &svg[i + 10..i + 17])
+        .collect();
+      assert_eq!(
+        order,
+        vec!["0,0,255", "255,0,0"],
+        "the prolog is drawn first and the epilog last: {svg}"
+      );
+      // A far-away epilog point does not widen the range the circle set.
+      let circle = |svg: &str| -> String {
+        svg
+          .split_once("<ellipse")
+          .and_then(|(_, r)| r.split_once("/>"))
+          .expect("the circle")
+          .0
+          .to_string()
+      };
+      assert_eq!(
+        circle(&export_svg("Graphics[{Circle[]}]")),
+        circle(&export_svg(
+          "Graphics[{Circle[]}, Epilog -> Point[{100, 100}]]"
+        )),
+        "an epilog must not take part in the plot range"
+      );
+    }
+
+    /// `Inset[Graphics3D[…], pos]` embeds a whole three-dimensional
+    /// picture in a flat one, at its own size — a Demonstration puts a
+    /// little schematic of its apparatus in the corner that way. It used
+    /// to fall through to the text path and print `-Graphics3D-`.
+    #[test]
+    fn a_three_dimensional_inset_is_embedded_whole() {
+      let svg = export_svg(
+        "Graphics[{Circle[]}, Epilog -> Inset[Graphics3D[{Cuboid[]}, \
+         Boxed -> False, ImageSize -> {40, 60}], Scaled[{0.75, 0.25}]]]",
+      );
+      assert!(
+        !svg.contains("-Graphics3D-"),
+        "the inset must be drawn, not named: {svg}"
+      );
+      let nested = svg
+        .split("<svg ")
+        .nth(2)
+        .and_then(|s| s.split_once('>'))
+        .expect("a nested picture")
+        .0
+        .to_string();
+      assert!(
+        nested.contains("width=\"40.00\"")
+          && nested.contains("height=\"60.00\""),
+        "an inset keeps its own size: {nested}"
+      );
+      assert!(
+        nested.contains("x=\"250.00\"") && nested.contains("y=\"240.00\""),
+        "and sits at the scaled anchor: {nested}"
+      );
+    }
   }
 
   mod styles {
@@ -836,6 +935,63 @@ mod graphics {
         "Text[Style[\"Strahl\", 11, Italic, Blue], {10, 0.7}]",
         "}]"
       )));
+    }
+
+    /// `Subscript`/`Superscript` inside a `Text` typeset as scripts, the
+    /// same way a plot label does. They used to fall through to the
+    /// two-line OutputForm box, which put the base on one line and the
+    /// script on the next.
+    #[test]
+    fn text_typesets_subscripts_and_superscripts() {
+      let svg = export_svg(
+        "Graphics[{Text[Subscript[\"N\", \"D\"], {0, 0}], \
+         Text[Superscript[\"x\", 2], {1, 0}]}]",
+      );
+      assert!(svg.contains(">ND<"), "the subscripted label: {svg}");
+      assert!(svg.contains(">x\u{00B2}<"), "the exponent label: {svg}");
+      assert!(
+        !svg.contains("Subscript["),
+        "no label may print its own source: {svg}"
+      );
+    }
+
+    /// `Framed[…]` around a label draws a box: a border, and a panel when
+    /// the label asks for a `Background`. `FrameStyle -> None` keeps the
+    /// panel but drops the border.
+    #[test]
+    fn a_framed_label_draws_its_box() {
+      let svg = export_svg("Graphics[{Text[Framed[\"hi\"], {0, 0}]}]");
+      assert!(
+        !svg.contains("Framed["),
+        "the frame must be drawn, not printed: {svg}"
+      );
+      let rect = svg
+        .split("<rect ")
+        .nth(1)
+        .and_then(|r| r.split_once("/>"))
+        .expect("a frame rectangle")
+        .0
+        .to_string();
+      assert!(
+        rect.contains("fill=\"none\"")
+          && rect.contains("stroke=\"rgb(0,0,0)\""),
+        "an unadorned frame is a bare border: {rect}"
+      );
+      let svg = export_svg(
+        "Graphics[{Text[Framed[\"hi\", Background -> Yellow, \
+         FrameStyle -> None], {0, 0}]}]",
+      );
+      let rect = svg
+        .split("<rect ")
+        .nth(1)
+        .and_then(|r| r.split_once("/>"))
+        .expect("a frame rectangle")
+        .0
+        .to_string();
+      assert!(
+        rect.contains("fill=\"rgb(255,255,0)\"") && !rect.contains("stroke="),
+        "FrameStyle -> None leaves only the panel: {rect}"
+      );
     }
   }
 
@@ -2090,6 +2246,64 @@ mod plot3d {
       ));
     }
 
+    /// `Text[expr, {x, y, z}]` labels a point of a 3D scene, drawn flat at
+    /// the projection of its point. It used to be dropped entirely, so a
+    /// labelled schematic arrived with no lettering at all.
+    #[test]
+    fn text_labels_a_point_of_the_scene() {
+      let svg = export_svg(
+        "Graphics3D[{Cylinder[{{0, 0, 0}, {0, 0, 1}}, 0.5], \
+         Text[Style[Subscript[Style[\"N\", Italic], \"B\"], 18], \
+         {0, 0, 1.4}]}, Boxed -> False, ViewPoint -> Front]",
+      );
+      let text = svg
+        .split("<text ")
+        .nth(1)
+        .and_then(|t| t.split_once("</text>"))
+        .expect("a text label")
+        .0
+        .to_string();
+      assert!(
+        text.contains("font-size=\"18.0\""),
+        "the Style font size applies: {text}"
+      );
+      assert!(
+        text.contains("<tspan font-style=\"italic\">N</tspan>"),
+        "the base is italic: {text}"
+      );
+      assert!(
+        text.contains("baseline-shift=\"sub\""),
+        "the script is set as a subscript: {text}"
+      );
+    }
+
+    /// A label's alignment offset moves the label's own box, not the point
+    /// it names: `{0, -1.5}` puts the text above its anchor.
+    #[test]
+    fn a_text_offset_moves_the_label_off_its_point() {
+      let text_y = |code: &str| -> f64 {
+        let svg = export_svg(code);
+        svg
+          .split("<text ")
+          .nth(1)
+          .and_then(|t| t.split_once("y=\""))
+          .and_then(|(_, r)| r.split_once('"'))
+          .and_then(|(v, _)| v.parse().ok())
+          .expect("a positioned label")
+      };
+      let centred = text_y(
+        "Graphics3D[{Sphere[], Text[\"A\", {0, 0, 1}]}, Boxed -> False]",
+      );
+      let above = text_y(
+        "Graphics3D[{Sphere[], Text[\"A\", {0, 0, 1}, {0, -1.5}]}, \
+         Boxed -> False]",
+      );
+      assert!(
+        above < centred,
+        "a negative vertical offset lifts the label: {above} vs {centred}"
+      );
+    }
+
     /// `BoxRatios -> {rx, ry, rz}` sets the shape of the bounding box
     /// independently of how far the data runs along each axis, so a scene
     /// a hundred units tall over a ten-unit base draws as a cube rather
@@ -2626,6 +2840,67 @@ mod plot3d {
       assert!(svg.contains(">peak</text>"), "missing Epilog text");
       assert!(svg.contains("<ellipse"), "missing Epilog disk");
       assert!(svg.contains("<polygon"), "missing Epilog arrowhead");
+    }
+
+    /// An Epilog label may be typeset (`Subscript`) and boxed
+    /// (`Framed[…, Background -> …]`) — a Demonstration marks each curve
+    /// that way. Both used to print as their own source over the plot.
+    #[test]
+    fn plot_epilog_framed_and_typeset_labels() {
+      let svg = export_svg(
+        "Plot[Sin[x], {x, 0, 2 Pi}, Epilog -> \
+         Text[Framed[Style[Subscript[\"N\", \"D\"], 20, Blue], \
+         Background -> White, FrameStyle -> None], {Pi, 0}]]",
+      );
+      assert!(
+        !svg.contains("Framed[") && !svg.contains("Subscript["),
+        "no label may print its own source: {svg}"
+      );
+      assert!(
+        svg.contains("baseline-shift=\"sub\""),
+        "the label typesets its subscript: {svg}"
+      );
+      assert!(
+        svg.contains("fill=\"rgb(255,255,255)\""),
+        "the frame's Background paints a panel: {svg}"
+      );
+    }
+
+    /// An Epilog may pin its overlay with `Scaled[{sx, sy}]` — a fraction
+    /// of the plot range — and may inset a whole other picture, which
+    /// keeps its own size. Neither used to draw anything.
+    #[test]
+    fn plot_epilog_scaled_anchors_and_insets() {
+      let svg = export_svg(
+        "Plot[Sin[x], {x, 0, 2 Pi}, ImageSize -> 400, Epilog -> \
+         {Text[\"corner\", Scaled[{0.5, 0.5}]], \
+          Inset[Graphics[{Disk[]}, ImageSize -> {30, 30}], \
+          Scaled[{0.25, 0.75}]]}]",
+      );
+      let label = svg
+        .split("<text ")
+        .find(|t| t.contains(">corner<"))
+        .expect("the scaled label");
+      let x: f64 = label
+        .split_once("x=\"")
+        .and_then(|(_, r)| r.split_once('"'))
+        .and_then(|(v, _)| v.parse().ok())
+        .expect("a positioned label");
+      let y: f64 = label
+        .split_once("y=\"")
+        .and_then(|(_, r)| r.split_once('"'))
+        .and_then(|(v, _)| v.parse().ok())
+        .expect("a positioned label");
+      // Half across and half up the plotting area, whose extent the
+      // surrounding margins make smaller than the whole image.
+      assert!(
+        x > 0.0 && y > 0.0,
+        "the scaled label lands inside the picture: {label}"
+      );
+      assert!(
+        svg.matches("<svg ").count() >= 2,
+        "the inset is embedded as its own picture: {svg}"
+      );
     }
 
     #[test]
@@ -14105,6 +14380,78 @@ mod manipulate {
       } => {
         assert_eq!(values.len(), 2);
         assert_eq!(*initial_index, 0); // True
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
+  /// A control panel laid out as a `Grid` marks its stretched cells with
+  /// `SpanFromLeft` / `SpanFromAbove`. Once the grid is flattened into
+  /// control rows those markers name nothing, so they are dropped — they
+  /// used to be mistaken for extra display elements and rendered as a
+  /// literal `SpanFromLeft` under the widget, one per marker.
+  #[test]
+  fn spec_grid_span_markers_are_not_displays() {
+    let expr = interpret_to_expr(
+      "Manipulate[a + b, Grid[{{Control[{{a, 1}, 0, 10}], SpanFromLeft}, \
+       {Control[{{b, 2}, 0, 10}], SpanFromLeft, SpanFromLeft}}]]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("a grid control panel");
+    let names: Vec<&str> = spec.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["a", "b"]);
+    assert!(
+      spec.displays.is_empty(),
+      "span markers are layout, not displays: {:?}",
+      spec.displays
+    );
+  }
+
+  /// The two halves of a `Grid` control panel meet here: its span markers
+  /// are dropped, and a Manipulate-level `ControlType -> {…}` assigns one
+  /// type per *control*. A marker must therefore not consume a slot of
+  /// that list, or every control after the first would be typed by its
+  /// neighbour's entry.
+  #[test]
+  fn spec_grid_span_markers_do_not_shift_global_control_types() {
+    let expr = interpret_to_expr(
+      "Manipulate[a + b, Grid[{{Control[{a, {1, 2, 3}}], SpanFromLeft}, \
+       {Control[{b, {4, 5, 6}}], SpanFromLeft}}], \
+       ControlType -> {Setter, PopupMenu}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("a grid control panel");
+    let popups: Vec<(&str, bool)> = spec
+      .controls
+      .iter()
+      .map(|c| match c {
+        ManipulateControl::Discrete { name, popup, .. } => {
+          (name.as_str(), *popup)
+        }
+        other => panic!("expected a discrete control, got {other:?}"),
+      })
+      .collect();
+    assert_eq!(popups, vec![("a", false), ("b", true)]);
+  }
+
+  /// A setter's choice labels are often *computed* — `Row[Flatten[{…,
+  /// Riffle[…], …}]]` builds the caption from a list of subscripted
+  /// symbols. The list is evaluated before the label is typeset, so the
+  /// button reads `ND and NU` instead of showing the source of the
+  /// computation.
+  #[test]
+  fn spec_computed_row_labels_are_evaluated() {
+    let expr = interpret_to_expr(
+      "Manipulate[k, {{k, 1}, {1 -> Row[Flatten[{\" \", \
+       Riffle[Subscript[Style[\"N\", Italic], #] & /@ {\"D\", \"U\"}, \
+       \" and \"], \" \"}]], 2 -> \"plain\"}}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("a setter spec");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete { value_labels, .. } => {
+        assert_eq!(value_labels[0], " ND and NU ");
+        assert_eq!(value_labels[1], "plain");
       }
       other => panic!("expected a discrete control, got {other:?}"),
     }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6527,6 +6527,29 @@ mod tests {
     assert!(state.request_reeval(0), "flag must clear on an empty fire");
   }
 
+  /// A control panel written as a `Grid` — the Demonstrations layout for a
+  /// widget whose rows are not all one control wide — builds exactly the
+  /// control rows the grid names. Its `SpanFromLeft` cell markers used to
+  /// survive as display elements, so the widget grew a row of literal
+  /// `SpanFromLeft` text under the sliders.
+  #[test]
+  fn manipulate_grid_panel_has_no_span_marker_rows() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[Plot[Sin[a x], {x, 0, b}], \
+       Grid[{{Control[{{a, 1, \"rate\"}, 1, 5}], SpanFromLeft}, \
+       {\"extent:\", Control[{{b, 6}, 1, 10}], SpanFromLeft}}]]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    let names: Vec<&str> = state.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["a", "", "b"], "heading row binds no variable");
+    assert!(
+      state.displays.is_empty(),
+      "span markers are layout, not displays: {:?}",
+      state.displays
+    );
+  }
+
   #[test]
   fn manipulate_untracked_control_does_not_reeval() {
     // `TrackedSymbols :> {b}`: moving `a` changes its value but must not


### PR DESCRIPTION
Fixes driven by the "Selectivity in a Semibatch Reactor" Wolfram Demonstration, adding support for several graphics features that were previously missing or broken.

## Summary

This PR adds comprehensive support for positioning and styling graphics primitives using `Scaled` anchors (fractions of plot range), `Framed` labels with borders and backgrounds, text labels in 3D scenes, and `Prolog`/`Epilog` options in `Graphics`. These features are essential for creating polished Demonstrations with properly positioned overlays and annotations.

## Key Changes

**Scaled Anchors for Positioning**
- Added `expr_to_anchor()` function to parse both absolute coordinates and `Scaled[{sx, sy}]` fractional positions
- Added `resolve_anchor()` to convert scaled fractions to data coordinates using the final plot range
- Updated `TextPrim` and `InsetGraphic` primitives to track whether their anchors are scaled
- Modified rotation, translation, and scaling transformations to preserve scaled anchors (they name positions in the final frame, not data coordinates)
- Scaled anchors are resolved at render time once the plot range is known

**Framed Labels**
- Added `frame` field to `TextPrim` to store border color
- Implemented parsing of `Framed[content, opts…]` wrapper with support for `FrameStyle` and `Background` options
- `FrameStyle -> None` suppresses the border while keeping the background panel
- Frame rendering draws a rectangle before the text so text sits on top

**Text in 3D Graphics**
- Added `Text3D` primitive variant to support `Text[expr, {x, y, z}, offset]` in `Graphics3D`
- Implemented `parse_text3d_offset()` to handle alignment offsets using both numeric and symbolic forms (Left/Right/Center, Top/Bottom)
- Text is projected to 2D and drawn flat facing the viewer, making 3D schematics readable from any viewpoint
- Honors `Style` directives for font size and color

**Subscript/Superscript Typesetting**
- Updated `graphics_text_content()` to typeset `Subscript` and `Superscript` using Unicode script characters instead of falling through to two-line OutputForm
- Ensures consistent typesetting across plot labels, text labels, and epilog text

**Prolog and Epilog Support**
- Added `Prolog` and `Epilog` options to `Graphics` (in addition to existing plot support)
- Prolog primitives are drawn under the main content, epilog over it
- Neither takes part in plot range calculation—far-away epilog points don't rescale the picture

**3D Insets**
- `Inset[Graphics3D[…], pos]` now embeds the 3D picture whole at its own size instead of printing `-Graphics3D-`
- `Inset[Graphics[…], Scaled[pos]]` with scaled anchors is also embedded whole (cannot fold into parent coordinates)

**Plot Epilog Enhancements**
- Added `anchor2()` function to support `Scaled` positioning in plot epilogs
- Epilog `Text` now supports `Framed` with `Background` and `FrameStyle` options
- Epilog `Inset` now works with both absolute and scaled anchors

**Manipulate Grid Fixes**
- `SpanFromLeft` and `SpanFromAbove` cell markers in `Grid` control panels are now correctly identified as layout directives and dropped from display elements
- Computed row labels (e.g., `Row[Flatten[…]]`) are properly evaluated before typesetting

## Implementation Details

- The `scaled` flag travels with primitives through all transformations, allowing deferred resolution until render time
- `resolve_anchor()` is called during rendering to convert scaled fractions using the final bounding box
- Frame rectangles are drawn with `fill="none"` for borders only, or with a background color when specified
- Text width calculation uses character count × font size × 0.6 for proper box sizing
- 3D text projection uses the same camera transformation as other 3D primitives

https://claude.ai/code/session_01UHbSH4D3SeNdoWHM2AWMgK