### PR TITLE
Follow dependent Manipulate controls, and slide over choice lists

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,24 @@
 
 # Unreleased
 
+- Manipulate improvements (driven by the "Recursive Exercises" Wolfram
+    Demonstrations, which nest circles inside circles):
+    - The leading assignments a body makes before anything else are
+        evaluated with the control variables at their initial values, the
+        way Wolfram evaluates the body before laying the controls out.
+        A body opening with `u = {…, ss[-1., 1., n, dc]}`, where `ss`
+        recurses down to a literal-`1` base case, used to recurse on a
+        symbolic depth that never reached the base case, so extraction
+        never returned and no widget appeared at all.
+    - A choice list built from another control's variable
+        (`Range[1, If[flat, 3, 6], 1]`) is re-resolved against the live
+        bindings, so a level setter offering six levels flat narrows to
+        three in 3D. A selected value the narrowed list no longer offers
+        falls back to the last one it does, and the body is rendered again
+        for it. Previously the list was fixed at build time.
+    - `ControlType -> Slider` over a choice list renders a slider that
+        steps through the choices, matching Wolfram; a twenty-entry
+        colour-scheme list used to become a dropdown.
 - Fixes driven by the "Mass with a Spring and a Rubber Band" Wolfram
     Demonstration:
     - Substituting an `NDSolve` solution into a derivative

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -14893,6 +14893,10 @@ pub enum ManipulateControl {
     /// `ControlType -> PopupMenu`: always render a dropdown, even when the
     /// choice count is small enough for a SetterBar.
     popup: bool,
+    /// `ControlType -> Slider`: render a slider that steps through the
+    /// choices by index, the way Wolfram draws a slider over a discrete
+    /// domain. Without it a twenty-entry list would become a dropdown.
+    slider: bool,
   },
   /// A 2D control (`ControlType -> Slider2D`, or a 2D range spec
   /// `{u, {xmin, ymin}, {xmax, ymax}}`). Binds its variable to a 2-vector
@@ -15035,6 +15039,13 @@ pub struct ManipulateSpec {
   /// these code fragments against the live bindings after every change and
   /// updates the slider range to follow. A `None` side is static.
   pub dynamic_bounds: Vec<(String, Option<String>, Option<String>)>,
+  /// Discrete-control choice lists that reference other control variables,
+  /// as `(control name, values code)`. A Demonstration whose level setter
+  /// reads `Range[1, If[flat, 3, 6], 1]` offers six levels flat and three
+  /// in 3D, so the choices stored on the control are only the ones the
+  /// initial values produce — the frontend re-evaluates this code fragment
+  /// against the live bindings after every change and rebuilds the choices.
+  pub dynamic_values: Vec<(String, String)>,
   /// The variable animated by a `ControlType -> Trigger`/`Animator` control
   /// spec. Wolfram renders those as play buttons that sweep the variable
   /// over its range; the widget's animation targets this variable instead
@@ -15078,6 +15089,9 @@ enum ParsedControl {
     enabled: Option<String>,
     min_code: Option<String>,
     max_code: Option<String>,
+    /// A discrete choice list that references other control variables
+    /// (re-resolved live by the frontend, like `min_code`/`max_code`).
+    values_code: Option<String>,
     animate: Option<bool>,
   },
   /// A `Locator` control with no widget. It contributes a fixed `name =
@@ -15140,6 +15154,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     mut initialization,
     mut control_enabled,
     mut dynamic_bounds,
+    mut dynamic_values,
     mut animation_var,
   ) = match inner {
     Some(inner) => {
@@ -15153,6 +15168,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         inner.initialization,
         inner.control_enabled,
         inner.dynamic_bounds,
+        inner.dynamic_values,
         inner.animation_var,
       )
     }
@@ -15172,6 +15188,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         Vec::new(),
         body_displays,
         None,
+        Vec::new(),
         Vec::new(),
         Vec::new(),
         None,
@@ -15241,16 +15258,29 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   // while the specs are parsed, so those bounds resolve to their build-time
   // numbers regardless of declaration order.
   let initial_bindings = manipulate_initial_value_bindings(&arg_items);
+  // The same names, as the set a control's choice list is checked against
+  // to tell a static list from one that follows another control.
+  let sibling_names: Vec<String> =
+    initial_bindings.iter().map(|(n, _)| n.clone()).collect();
   // A slider's bounds may be symbols the body assigns before doing
   // anything else — `Manipulate[tmin = 0; tmax = 2 Pi; …, {{t, 0}, tmin,
   // tmax}]`. Wolfram evaluates the body before laying the controls out, so
   // those names are bound by the time the slider is built. Running the
   // leading run of plain assignments is enough to resolve them, and cannot
   // do anything the body would not have done anyway.
+  //
+  // The control variables are installed while those assignments run, since
+  // Wolfram evaluates the body at their initial values. Without them a
+  // leading assignment that calls a recursive helper on a control variable
+  // — `u = {…, ss[-1., 1., n, dc]}` in front of a nested-circles
+  // Demonstration — recurses on a symbolic depth that never reaches the
+  // base case, and the widget never appears.
   if let Some(body) = args.first() {
-    for stmt in leading_assignments(body) {
-      let _ = evaluate_expr_to_expr(stmt);
-    }
+    crate::with_scoped_globals(&initial_bindings, || {
+      for stmt in leading_assignments(body) {
+        let _ = evaluate_expr_to_expr(stmt);
+      }
+    });
   }
   // A `ButtonBar`'s buttons are computed — `ButtonBar[Table[…]]` builds one
   // per vertex of a graph, labelling each from a list the `Initialization`
@@ -15413,7 +15443,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     }
     let (spec, rename) = rewrite_compound_control_var(spec);
     let parsed = crate::with_scoped_globals(&initial_bindings, || {
-      parse_manipulate_control(&spec)
+      parse_manipulate_control(&spec, &sibling_names)
     })?;
     match parsed {
       ParsedControl::Visible {
@@ -15421,6 +15451,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         enabled,
         min_code,
         max_code,
+        values_code,
         animate,
       } => {
         if let Some((orig, orig_form, synth)) = &rename {
@@ -15449,6 +15480,9 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         }
         if min_code.is_some() || max_code.is_some() {
           dynamic_bounds.push((c.name().to_string(), min_code, max_code));
+        }
+        if let Some(code) = values_code {
+          dynamic_values.push((c.name().to_string(), code));
         }
         controls.push(c);
       }
@@ -15481,7 +15515,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
             control: mut c,
             enabled: enabled2,
             ..
-          }) = parse_manipulate_control(&Expr::List(promoted.into()))
+          }) = parse_manipulate_control(&Expr::List(promoted.into()), &[])
           {
             if let ManipulateControl::Slider2D { write_callback, .. } = &mut c {
               write_callback.clone_from(callback);
@@ -15551,6 +15585,9 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         rewrite(code);
       }
     }
+    for (_, code) in &mut dynamic_values {
+      rewrite(code);
+    }
     for (_, value) in fixed.iter_mut().chain(state.iter_mut()) {
       rewrite(value);
     }
@@ -15573,6 +15610,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization,
     control_enabled,
     dynamic_bounds,
+    dynamic_values,
     animation_var,
     animated,
     animation_running,
@@ -15841,6 +15879,75 @@ pub fn manipulate_eval_bound_code(code: &str) -> Option<f64> {
   crate::functions::math_ast::try_eval_to_f64(&expr).filter(|v| v.is_finite())
 }
 
+/// Whether `expr` mentions any of `names` as a symbol. Used to tell a
+/// choice list that merely needs evaluating (`Range[20]`) from one that
+/// follows another control (`Range[1, If[flat, 3, 6], 1]`) and so has to be
+/// rebuilt on every change.
+fn expr_references_any(expr: &Expr, names: &[String]) -> bool {
+  names
+    .iter()
+    .any(|n| crate::functions::plot::expr_mentions_var(expr, n))
+}
+
+/// Split a discrete control's choice list into the three parallel columns
+/// the frontends consume: the value bound to the variable, its display
+/// label, and (for a rule label that is itself a graphic) a rendered icon.
+///
+/// A choice may be given as a rule `value -> "label"` (e.g. a SetterBar
+/// spec `{True -> "Yin-Yang", False -> "alternate image"}`). In that case
+/// the left side is the value bound to the variable and the right side is
+/// only the display label, so the binding never sees the whole rule.
+fn discrete_choice_columns(
+  items: &[Expr],
+) -> (Vec<String>, Vec<String>, Vec<Option<String>>) {
+  let mut values = Vec::with_capacity(items.len());
+  let mut labels = Vec::with_capacity(items.len());
+  let mut svgs = Vec::with_capacity(items.len());
+  for item in items {
+    match discrete_choice_rule(item) {
+      Some((value, label)) => {
+        values.push(crate::syntax::expr_to_input_form(value));
+        // A rule label that is itself a graphic (the crosshair icons of
+        // the Demonstrations site) renders as an SVG icon; its text column
+        // falls back to the bound value so a non-graphical frontend still
+        // shows something short and meaningful.
+        let svg = discrete_choice_label_svg(label);
+        labels.push(if svg.is_some() {
+          discrete_choice_label(value)
+        } else {
+          discrete_choice_label(label)
+        });
+        svgs.push(svg);
+      }
+      None => {
+        values.push(crate::syntax::expr_to_input_form(item));
+        labels.push(discrete_choice_label(item));
+        svgs.push(None);
+      }
+    }
+  }
+  (values, labels, svgs)
+}
+
+/// Re-resolve a discrete control's choice-list code against the
+/// interpreter's current globals (installed by the caller via
+/// `with_scoped_globals`), returning the same three columns
+/// [`discrete_choice_columns`] builds. `None` when the code no longer
+/// evaluates to a non-empty list, in which case the control keeps the
+/// choices it already has.
+pub fn manipulate_eval_values_code(
+  code: &str,
+) -> Option<(Vec<String>, Vec<String>, Vec<Option<String>>)> {
+  let expr = crate::interpret_to_expr(code).ok()?;
+  let evaluated = crate::evaluator::evaluate_expr_to_expr(&expr).ok()?;
+  let items = match &evaluated {
+    Expr::List(items) => items,
+    _ => return None,
+  };
+  let columns = discrete_choice_columns(items);
+  (!columns.0.is_empty()).then_some(columns)
+}
+
 /// Synthesize a plain symbol name for a compound (non-Identifier) control
 /// variable. `Subscript[signal, 1]` → `signal$1`; any other compound head
 /// sanitizes its whole InputForm, mapping non-symbol characters to `$`.
@@ -16006,6 +16113,7 @@ pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled: Vec::new(),
     dynamic_bounds: Vec::new(),
+    dynamic_values: Vec::new(),
     animation_var: None,
     animated: true,
     animation_running: true,
@@ -16081,6 +16189,7 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled: Vec::new(),
     dynamic_bounds: Vec::new(),
+    dynamic_values: Vec::new(),
     animation_var: None,
     animated: true,
     animation_running: true,
@@ -16155,6 +16264,7 @@ pub fn extract_locator_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled: Vec::new(),
     dynamic_bounds: Vec::new(),
+    dynamic_values: Vec::new(),
     animation_var: None,
     animated: false,
     animation_running: true,
@@ -16205,6 +16315,7 @@ pub fn extract_click_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled: Vec::new(),
     dynamic_bounds: Vec::new(),
+    dynamic_values: Vec::new(),
     animation_var: None,
     animated: false,
     animation_running: true,
@@ -16234,19 +16345,20 @@ pub fn extract_control_spec(expr: &Expr) -> Option<ManipulateSpec> {
   if !matches!(&args[0], Expr::List(items) if !items.is_empty()) {
     return None;
   }
-  let (control, enabled, animate) = match parse_manipulate_control(&args[0])? {
-    ParsedControl::Visible {
-      control,
-      enabled,
-      animate,
-      ..
-    } => (control, enabled, animate),
-    // A hidden control (`ControlType -> None` / Locator) has no widget and
-    // nothing to display on its own — fall back to the plain output path.
-    ParsedControl::Fixed { .. }
-    | ParsedControl::State { .. }
-    | ParsedControl::StateWithControl { .. } => return None,
-  };
+  let (control, enabled, animate) =
+    match parse_manipulate_control(&args[0], &[])? {
+      ParsedControl::Visible {
+        control,
+        enabled,
+        animate,
+        ..
+      } => (control, enabled, animate),
+      // A hidden control (`ControlType -> None` / Locator) has no widget and
+      // nothing to display on its own — fall back to the plain output path.
+      ParsedControl::Fixed { .. }
+      | ParsedControl::State { .. }
+      | ParsedControl::StateWithControl { .. } => return None,
+    };
   // Display the bound variable so the control's effect is visible.
   let body_code = control.name().to_string();
   let control_enabled = match enabled {
@@ -16264,6 +16376,7 @@ pub fn extract_control_spec(expr: &Expr) -> Option<ManipulateSpec> {
     initialization: None,
     control_enabled,
     dynamic_bounds: Vec::new(),
+    dynamic_values: Vec::new(),
     animation_var,
     animated: animate.is_some(),
     animation_running: animate.unwrap_or(true),
@@ -16715,8 +16828,14 @@ fn unicode_script_char(c: char, superscript: bool) -> Option<char> {
   Some(mapped)
 }
 
-/// Parse a single variable-spec list into a `ParsedControl`.
-fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
+/// Parse a single variable-spec list into a `ParsedControl`. `siblings`
+/// names the Manipulate's other control variables, so a choice list built
+/// from one of them can be marked for live re-resolution; pass an empty
+/// slice for a standalone `Control[…]`, which has no siblings.
+fn parse_manipulate_control(
+  spec: &Expr,
+  siblings: &[String],
+) -> Option<ParsedControl> {
   let items = match spec {
     Expr::List(items) => items,
     _ => return None,
@@ -16889,6 +17008,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
         enabled,
         min_code: None,
         max_code: None,
+        values_code: None,
         animate: None,
       });
     }
@@ -16908,6 +17028,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
         enabled,
         min_code: None,
         max_code: None,
+        values_code: None,
         animate: None,
       });
     }
@@ -17032,6 +17153,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
         enabled,
         min_code: None,
         max_code: None,
+        values_code: None,
         animate: Some(running),
       });
     }
@@ -17077,6 +17199,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
       enabled,
       min_code: None,
       max_code: None,
+      values_code: None,
       animate: None,
     });
   }
@@ -17112,6 +17235,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
       enabled,
       min_code: None,
       max_code: None,
+      values_code: None,
       animate: None,
     });
   }
@@ -17152,37 +17276,8 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
       None
     };
     if let Some(value_items) = value_items {
-      // A choice may be given as a rule `value -> "label"` (e.g. a SetterBar
-      // spec `{True -> "Yin-Yang", False -> "alternate image"}`). In that
-      // case the left side is the value bound to the variable and the right
-      // side is only the display label. Split the two so the binding sees the
-      // real value, not the whole rule.
-      let mut values = Vec::with_capacity(value_items.len());
-      let mut value_labels = Vec::with_capacity(value_items.len());
-      let mut value_label_svgs = Vec::with_capacity(value_items.len());
-      for item in value_items.iter() {
-        match discrete_choice_rule(item) {
-          Some((value, label)) => {
-            values.push(crate::syntax::expr_to_input_form(value));
-            // A rule label that is itself a graphic (the crosshair icons
-            // of the Demonstrations site) renders as an SVG icon; its text
-            // column falls back to the bound value so a non-graphical
-            // frontend still shows something short and meaningful.
-            let svg = discrete_choice_label_svg(label);
-            value_labels.push(if svg.is_some() {
-              discrete_choice_label(value)
-            } else {
-              discrete_choice_label(label)
-            });
-            value_label_svgs.push(svg);
-          }
-          None => {
-            values.push(crate::syntax::expr_to_input_form(item));
-            value_labels.push(discrete_choice_label(item));
-            value_label_svgs.push(None);
-          }
-        }
-      }
+      let (values, value_labels, value_label_svgs) =
+        discrete_choice_columns(&value_items);
       if values.is_empty() {
         return None;
       }
@@ -17193,6 +17288,13 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
         }
         None => 0,
       };
+      // A choice list built from another control's variable (`Range[1,
+      // If[flat, 3, 6], 1]`) only holds for that variable's current value;
+      // keep its code so the frontend can rebuild the choices whenever the
+      // other control moves.
+      let values_code = (bounds.len() == 1
+        && expr_references_any(bounds[0], siblings))
+      .then(|| crate::syntax::expr_to_input_form(bounds[0]));
       return Some(ParsedControl::Visible {
         control: ManipulateControl::Discrete {
           name,
@@ -17203,10 +17305,15 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
           label,
           label_runs,
           popup: control_type.as_deref() == Some("PopupMenu"),
+          slider: matches!(
+            control_type.as_deref(),
+            Some("Slider" | "VerticalSlider" | "Manipulator")
+          ),
         },
         enabled,
         min_code: None,
         max_code: None,
+        values_code,
         animate: None,
       });
     }
@@ -17343,6 +17450,7 @@ fn parse_manipulate_control(spec: &Expr) -> Option<ParsedControl> {
     enabled,
     min_code,
     max_code,
+    values_code: None,
     animate,
   })
 }
@@ -17981,6 +18089,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
         label,
         label_runs,
         popup,
+        slider,
       } => {
         let value_parts: Vec<String> = values
           .iter()
@@ -17991,6 +18100,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           .map(|v| format!(r#""{}""#, json_escape_manipulate(v)))
           .collect();
         let popup_json = if *popup { r#","popup":true"# } else { "" };
+        let slider_json = if *slider { r#","slider":true"# } else { "" };
         // Icon labels (rule right sides that are graphics) ride along as
         // rendered SVG, parallel to `values`; omitted when all-text.
         let svg_json = if value_label_svgs.iter().any(Option::is_some) {
@@ -18008,7 +18118,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           String::new()
         };
         ctrl_parts.push(format!(
-          r#"{{"kind":"discrete","name":"{}","label":"{}","labelRuns":{},"values":[{}],"valueLabels":[{}],"initialIndex":{}{}{}}}"#,
+          r#"{{"kind":"discrete","name":"{}","label":"{}","labelRuns":{},"values":[{}],"valueLabels":[{}],"initialIndex":{}{}{}{}}}"#,
           json_escape_manipulate(name),
           json_escape_manipulate(label),
           label_runs_to_json(label_runs),
@@ -18016,6 +18126,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           label_parts.join(","),
           initial_index,
           popup_json,
+          slider_json,
           svg_json,
         ));
       }
@@ -18178,6 +18289,17 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           json_escape_manipulate(code)
         ));
       }
+      part.truncate(part.len() - 1);
+      part.push_str(&field);
+      part.push('}');
+    }
+    // A choice list that follows another control rides along the same way.
+    if let Some((_, code)) =
+      spec.dynamic_values.iter().find(|(n, _)| n == c.name())
+      && part.ends_with('}')
+    {
+      let field =
+        format!(r#","valuesCode":"{}""#, json_escape_manipulate(code));
       part.truncate(part.len() - 1);
       part.push_str(&field);
       part.push('}');

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -14101,6 +14101,119 @@ mod manipulate {
     }
   }
 
+  /// The leading assignments a Manipulate body makes before anything else
+  /// are evaluated with the control variables at their initial values, the
+  /// way Wolfram evaluates the body before laying the controls out. A
+  /// nested-circles Demonstration opens its body with `u = {…, ss[-1., 1.,
+  /// n, dc]}`, where `ss` recurses down to a literal-`1` base case: with
+  /// `n` left symbolic that recursion branches without ever reaching the
+  /// base case, so extraction never returned and no widget appeared.
+  #[test]
+  fn spec_leading_assignments_see_the_initial_control_values() {
+    woxi::interpret(
+      "depth[0] := {}\n\
+       depth[k_] := {k, depth[k - 1], depth[k - 1]}",
+    )
+    .unwrap();
+    let expr = interpret_to_expr(
+      "Manipulate[tree = depth[n]; Length[Flatten[tree]], \
+       {{n, 3, \"depth\"}, Range[1, 5], ControlType -> Setter}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert_eq!(spec.controls.len(), 1);
+    // The assignment ran at `n = 3`, so the helper terminated and left the
+    // depth-3 tree behind for the body to reuse.
+    assert_eq!(woxi::interpret("Length[Flatten[tree]]").unwrap(), "7");
+  }
+
+  /// `ControlType -> Slider` over a *choice list* keeps the choices but
+  /// asks for a slider that steps through them by index — how Wolfram
+  /// draws a twenty-entry colour-scheme picker. Without the flag the
+  /// frontends fell back to a dropdown, since twenty entries are far too
+  /// many for a setter bar.
+  #[test]
+  fn spec_slider_control_type_over_a_choice_list() {
+    let expr = interpret_to_expr(
+      "Manipulate[c, {{c, 1, \"scheme\"}, Range[20], ControlType -> Slider}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("slider over choices");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete {
+        values,
+        slider,
+        popup,
+        ..
+      } => {
+        assert_eq!(values.len(), 20);
+        assert!(*slider, "ControlType -> Slider asks for a slider");
+        assert!(!*popup);
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+    assert!(manipulate_spec_to_json(&spec).contains(r#""slider":true"#));
+
+    // A choice list with no such option keeps its default rendering.
+    let expr = interpret_to_expr("Manipulate[c, {{c, 1}, Range[20]}]").unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("plain choice list");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete { slider, .. } => assert!(!*slider),
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+    assert!(!manipulate_spec_to_json(&spec).contains("slider"));
+  }
+
+  /// A choice list built from another control's variable (`Range[1,
+  /// If[flat, 3, 6], 1]`) is only valid for that variable's current value,
+  /// so its code is kept for the frontend to re-resolve — the same way a
+  /// continuous bound that follows another control is. A list that merely
+  /// needs evaluating (`Range[20]`) is static and carries no code.
+  #[test]
+  fn spec_choice_list_following_another_control() {
+    let expr = interpret_to_expr(
+      "Manipulate[{n, flat}, \
+       {{n, 2, \"level\"}, Range[1, If[flat, 3, 6], 1], \
+        ControlType -> Setter}, \
+       {{flat, False, \"flat\"}, {True, False}}, \
+       {{c, 1, \"scheme\"}, Range[20]}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("dynamic choice list");
+    assert_eq!(
+      spec.dynamic_values,
+      vec![("n".to_string(), "Range[1, If[flat, 3, 6], 1]".to_string())],
+      "only the list that mentions another control is dynamic"
+    );
+    // At build time `flat` is False, so the setter offers all six levels.
+    match &spec.controls[0] {
+      ManipulateControl::Discrete { values, .. } => {
+        assert_eq!(values, &["1", "2", "3", "4", "5", "6"]);
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+    // Re-resolving against the 3D binding narrows it to three.
+    let (values, labels, svgs) = woxi::with_scoped_globals(
+      &[("flat".to_string(), "True".to_string())],
+      || {
+        woxi::functions::graphics::manipulate_eval_values_code(
+          "Range[1, If[flat, 3, 6], 1]",
+        )
+      },
+    )
+    .expect("the narrowed list must resolve");
+    assert_eq!(values, vec!["1", "2", "3"]);
+    assert_eq!(labels, vec!["1", "2", "3"]);
+    assert_eq!(svgs, vec![None, None, None]);
+
+    // The code rides along in the JSON the Playground consumes.
+    let json = manipulate_spec_to_json(&spec);
+    assert!(
+      json.contains(r#""valuesCode":"Range[1, If[flat, 3, 6], 1]""#),
+      "got: {json}"
+    );
+  }
+
   /// `Setter` also enumerates a numeric range into one choice per value,
   /// like the other per-value control types.
   #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -3844,6 +3844,7 @@ fn render_manipulate_widget<'a>(
         value_label_svgs,
         current_index,
         popup,
+        slider: as_slider,
       } => {
         let label_widget = manipulate_label_widget(
           label_runs,
@@ -3852,6 +3853,33 @@ fn render_manipulate_widget<'a>(
           label_col_width,
           enabled,
         );
+        // `ControlType -> Slider` over a discrete domain: a slider that
+        // steps through the choices by index, which is how Wolfram draws a
+        // twenty-entry colour-scheme picker. Dragging sends the choice at
+        // the new index, so the update handler needs no special case.
+        if *as_slider && value_labels.len() > 1 {
+          let last = value_labels.len() - 1;
+          let choices = value_labels.clone();
+          let mut s =
+            slider(0..=last as u32, *current_index as u32, move |i| {
+              match choices.get(i as usize) {
+                Some(choice) if enabled => Message::ManipulateDiscreteChanged(
+                  cell_idx,
+                  ctrl_idx,
+                  choice.clone(),
+                ),
+                _ => Message::Noop,
+              }
+            })
+            .step(1u32)
+            .width(Fill);
+          if !enabled {
+            s = s.style(disabled_slider_style);
+          }
+          let control_row = row![label_widget, s].align_y(Center).spacing(8);
+          controls_col = controls_col.push(control_row);
+          continue;
+        }
         // A boolean domain — `{v, {True, False}}` in either order — renders
         // as a checkbox, matching the Wolfram FrontEnd (which shows a
         // checkbox rather than a two-button setter for True/False).
@@ -7137,6 +7165,150 @@ Cell[BoxData[
       })
       .collect();
     assert_eq!(names, vec!["n", "nt"]);
+  }
+
+  /// End-to-end regression for the shape the "Recursive Exercises"
+  /// Demonstrations share: a recursive family of nested `Disk`s whose
+  /// level setter offers fewer levels once the 3D view is on, a colour
+  /// index picked by a slider over a twenty-entry list, and two controls
+  /// greyed out while the 3D view is showing.
+  ///
+  /// Both control shapes were wrong before: the level setter kept all six
+  /// choices in 3D (its list was resolved once, at build time), and the
+  /// twenty-entry colour list became a dropdown because nothing carried
+  /// the `ControlType -> Slider` request through to the widget.
+  #[test]
+  fn nested_disks_manipulate_follows_its_dependent_controls() {
+    woxi::interpret(
+      "ring[c_, r_] := {White, Disk[c, r]}\n\
+       nest[a_, b_, 1, _] := ring[{(a + b)/2, 0}, (b - a)/2]\n\
+       nest[a_, b_, k_, sch_] := {ring[{(a + b)/2, 0}, (b - a)/2], \
+         nest[a, (a + b)/2, k - 1, sch], nest[(a + b)/2, b, k - 1, sch], \
+         ColorData[sch, \"ColorList\"][[9 - k]], \
+         Disk[{(a + b)/2, (b - a)/3}, (b - a)/6], \
+         Disk[{(a + b)/2, -(b - a)/3}, (b - a)/6]}",
+    )
+    .expect("the recursive helpers must define");
+
+    let code = "Manipulate[\
+      shapes = {ring[{0, 0}, 1], nest[-1., 1., lvl, sch]}; \
+      edge = If[wide, 0.01, 0.002]; \
+      If[solid, \
+        Graphics3D[{EdgeForm[Thickness[edge]], Opacity[0.5], \
+          (shapes /. Disk[{px_, py_}, pr_] :> Sphere[{px, py, 0}, pr])}, \
+         Boxed -> False, ViewPoint -> {0, 0, 1}], \
+        Graphics[{EdgeForm[Thickness[edge]], shapes}, PlotRange -> All]], \
+      {{lvl, 2, \"level\"}, Range[1, If[solid, 3, 6], 1], \
+        ControlType -> Setter}, \
+      {{solid, False, \"3D version\"}, {True, False}, Enabled -> (lvl < 4)}, \
+      {{wide, False, \"thick\"}, {True, False}, Enabled -> !solid}, \
+      {{sch, 1, \"disks color\"}, Range[20], ControlType -> Slider, \
+        Enabled -> !solid}, \
+      SaveDefinitions -> True, TrackedSymbols -> Manipulate]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the nested-disks Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some(), "the disks must render");
+
+    let discrete =
+      |state: &manipulate::ManipulateState, idx: usize| match &state.controls
+        [idx]
+      {
+        manipulate::ControlState::Discrete {
+          values,
+          current_index,
+          slider,
+          ..
+        } => (values.clone(), *current_index, *slider),
+        other => panic!("expected a discrete control, got {other:?}"),
+      };
+
+    // Flat: six levels, and the colour picker asks for a slider rather
+    // than the dropdown twenty choices would otherwise get.
+    assert_eq!(discrete(&state, 0).0.len(), 6);
+    assert_eq!(discrete(&state, 0).1, 1, "level starts at 2");
+    let (colours, colour_index, colour_slider) = discrete(&state, 3);
+    assert_eq!(colours.len(), 20);
+    assert_eq!(colour_index, 0);
+    assert!(colour_slider, "ControlType -> Slider must reach the widget");
+    assert_eq!(
+      state.control_is_enabled,
+      vec![true, true, true, true],
+      "nothing is greyed out while the flat view is showing"
+    );
+
+    // Switching to 3D narrows the level setter to three choices, keeps the
+    // selected level (2 is still offered), and greys out the two controls
+    // whose `Enabled` conditions read the 3D flag.
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[1]
+    {
+      *current_index = 0; // True
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "3D render failed: {:?}", state.error);
+    assert!(state.graphics_handle.is_some(), "the spheres must render");
+    assert_eq!(discrete(&state, 0).0, vec!["1", "2", "3"]);
+    assert_eq!(discrete(&state, 0).1, 1, "level 2 survives the narrowing");
+    assert_eq!(
+      state.control_is_enabled,
+      vec![true, true, false, false],
+      "thickness and colour are disabled in 3D"
+    );
+
+    // Switching back restores all six levels.
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[1]
+    {
+      *current_index = 1; // False
+    }
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "flat re-render failed: {:?}",
+      state.error
+    );
+    assert_eq!(discrete(&state, 0).0.len(), 6);
+  }
+
+  /// A selected choice that the narrowed list no longer offers falls back
+  /// to the last one it does, and the body is rendered again for it — so
+  /// the graphic on screen always matches the control below it.
+  #[test]
+  fn narrowed_choice_list_clamps_a_dropped_selection() {
+    let code = "Manipulate[k, \
+      {{k, 5, \"k\"}, Range[1, If[few, 2, 5], 1], ControlType -> Setter}, \
+      {{few, False, \"few\"}, {True, False}}]";
+    let mut state =
+      instantiate_stored_manipulate(code, "").expect("the widget must build");
+    assert_eq!(state.text_output.as_deref(), Some("5"));
+
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[1]
+    {
+      *current_index = 0; // few = True
+    }
+    state.reevaluate();
+    match &state.controls[0] {
+      manipulate::ControlState::Discrete {
+        values,
+        current_index,
+        ..
+      } => {
+        assert_eq!(values, &["1", "2"]);
+        assert_eq!(*current_index, 1, "5 is gone, so the last choice wins");
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+    assert_eq!(
+      state.text_output.as_deref(),
+      Some("2"),
+      "the output follows the value the control settled on"
+    );
   }
 
   #[test]

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -49,6 +49,9 @@ pub enum ControlState {
     /// `ControlType -> PopupMenu`: always render a dropdown, even when the
     /// choice count is small enough for a SetterBar.
     popup: bool,
+    /// `ControlType -> Slider`: render a slider stepping through the
+    /// choices by index rather than a setter bar or dropdown.
+    slider: bool,
   },
   /// A 2D slider binding its variable to a `{x, y}` pair.
   Slider2D {
@@ -290,6 +293,10 @@ pub struct ManipulateState {
   /// bindings on every re-evaluation so a slider range can follow another
   /// control (Kepler's time sliders are bounded by the orbital period `P`).
   dynamic_bounds: Vec<(String, Option<String>, Option<String>)>,
+  /// Per-control choice lists that follow another control's variable
+  /// (InputForm code), re-resolved on every change the way
+  /// `dynamic_bounds` are.
+  dynamic_values: Vec<(String, String)>,
   /// Per-control `Enabled` condition (InputForm code), parallel to `controls`.
   /// `None` means the control has no condition and is always enabled.
   control_enabled: Vec<Option<String>>,
@@ -357,6 +364,7 @@ impl ManipulateState {
       tracked_symbols: spec.tracked_symbols,
       animation_var: spec.animation_var,
       dynamic_bounds: spec.dynamic_bounds,
+      dynamic_values: spec.dynamic_values,
       control_enabled,
       control_is_enabled,
       reeval_pending: 0,
@@ -596,6 +604,18 @@ impl ManipulateState {
   ///
   /// [`from_expr`]: Self::from_expr
   pub fn reevaluate(&mut self) {
+    self.reevaluate_inner(true);
+  }
+
+  /// The body of [`reevaluate`]. `allow_retry` guards the single re-run
+  /// that a re-resolved choice list can trigger: when the new list drops
+  /// the selected value, the output just rendered was for a value the
+  /// control no longer offers, so it is rendered once more for the value
+  /// the control settled on. The re-run cannot cascade — it resolves the
+  /// same lists against bindings that already satisfy them.
+  ///
+  /// [`reevaluate`]: Self::reevaluate
+  fn reevaluate_inner(&mut self, allow_retry: bool) {
     let bindings = self.bindings();
     let code = self.body.clone();
 
@@ -606,7 +626,8 @@ impl ManipulateState {
     let displays = self.displays.clone();
     let control_enabled = self.control_enabled.clone();
     let dynamic_bounds = self.dynamic_bounds.clone();
-    let (render, display_trees, enabled, resolved_bounds) =
+    let dynamic_values = self.dynamic_values.clone();
+    let (render, display_trees, enabled, resolved_bounds, resolved_values) =
       woxi::with_scoped_globals(&bindings, || {
         let trees: Vec<_> = displays
           .iter()
@@ -633,11 +654,32 @@ impl ManipulateState {
             (name.clone(), eval(min_code), eval(max_code))
           })
           .collect();
-        (woxi::interpret_with_stdout(&code), trees, enabled, resolved)
+        // Likewise for choice lists built from another control's variable
+        // (a level setter offering fewer levels in 3D).
+        let values: Vec<(String, _)> = dynamic_values
+          .iter()
+          .filter_map(|(name, values_code)| {
+            woxi::functions::graphics::manipulate_eval_values_code(values_code)
+              .map(|cols| (name.clone(), cols))
+          })
+          .collect();
+        (
+          woxi::interpret_with_stdout(&code),
+          trees,
+          enabled,
+          resolved,
+          values,
+        )
       });
     self.display_trees = display_trees;
     self.control_is_enabled = enabled;
     self.apply_dynamic_bounds(&resolved_bounds);
+    // A re-resolved choice list may drop the value the body was just
+    // rendered for; render again for the value the control settled on.
+    if self.apply_dynamic_values(&resolved_values) && allow_retry {
+      self.reevaluate_inner(false);
+      return;
+    }
 
     // Double-buffer the render: build the new SVG handle in a local and only
     // swap the cached field once the replacement is ready, rather than nulling
@@ -722,6 +764,50 @@ impl ManipulateState {
       *current = current.clamp(*min, *max);
     }
   }
+
+  /// Replace each named discrete control's choices with the freshly
+  /// resolved list, so a setter bar follows the control it references (a
+  /// level setter drops from six choices to three once the 3D view is on).
+  /// The selected value is kept when it survives into the new list;
+  /// otherwise the selection clamps to the last remaining choice, which is
+  /// what Wolfram shows when the current level falls off the end.
+  fn apply_dynamic_values(
+    &mut self,
+    resolved: &[(String, (Vec<String>, Vec<String>, Vec<Option<String>>))],
+  ) -> bool {
+    let mut selection_moved = false;
+    for (name, (new_values, new_labels, new_svgs)) in resolved {
+      let Some(ControlState::Discrete {
+        values,
+        value_labels,
+        value_label_svgs,
+        current_index,
+        ..
+      }) = self.controls.iter_mut().find(
+        |c| matches!(c, ControlState::Discrete { name: n, .. } if n == name),
+      )
+      else {
+        continue;
+      };
+      if values == new_values {
+        continue;
+      }
+      let selected = values.get(*current_index).cloned();
+      values.clone_from(new_values);
+      value_labels.clone_from(new_labels);
+      *value_label_svgs = new_svgs
+        .iter()
+        .map(|s| {
+          s.as_ref()
+            .map(|svg| svg::Handle::from_memory(svg.as_bytes().to_vec()))
+        })
+        .collect();
+      let kept = selected.and_then(|v| values.iter().position(|nv| *nv == v));
+      *current_index = kept.unwrap_or_else(|| values.len().saturating_sub(1));
+      selection_moved |= kept.is_none();
+    }
+    selection_moved
+  }
 }
 
 fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
@@ -761,6 +847,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         value_label_svgs,
         initial_index,
         popup,
+        slider,
       } => ControlState::Discrete {
         name: name.clone(),
         label: label.clone(),
@@ -776,6 +863,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
           .collect(),
         current_index: *initial_index,
         popup: *popup,
+        slider: *slider,
       },
       ManipulateControl::Slider2D {
         name,


### PR DESCRIPTION
Driven by the "Recursive Exercises" Wolfram Demonstrations, which nest
circles inside circles and drive them from four interdependent controls.

Woxi Studio built no widget at all for them: the body opens with a
leading assignment that calls a recursive helper on a control variable
(`u = {…, ss[-1., 1., n, dc]}`), and those assignments ran before the
control variables were bound. With the recursion depth left symbolic the
helper branched without ever reaching its literal-`1` base case, so spec
extraction never returned. They now run with the control variables at
their initial values, the way Wolfram evaluates the body before laying
the controls out.

Two control shapes were also wrong once the widget did build:

- A choice list built from another control's variable
  (`Range[1, If[flat, 3, 6], 1]`) was resolved once, at build time, so a
  level setter kept all six levels after the 3D view narrowed it to
  three. Its code now rides along on the spec — as a continuous bound
  following another control already did — and the frontend re-resolves it
  against the live bindings. A selected value the narrowed list no longer
  offers falls back to the last one it does, and the body is rendered
  again for it so the graphic matches the control below it.

- `ControlType -> Slider` over a choice list was dropped, so a
  twenty-entry colour-scheme list rendered as a dropdown where Wolfram
  draws a slider. The request now reaches the widget, which steps through
  the choices by index.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NkcSYm1uN1XUsZe5LQeo7U