### PR TITLE
Support numerical-Laplace-inversion Demonstrations in Woxi Studio

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -254,7 +254,7 @@ AirportData,,🚫,,10.0,246
 GridLinesStyle,Option for specifying the style of grid lines in graphics,✅,none,6.0,247
 In,Returns a previous input expression,✅,pure,1.0,248
 Det,Computes the determinant of a matrix,✅,pure,1.0,251
-NSolve,Solves equations numerically (a x^n + c uses the same root finder as NRoots so conjugate pairs agree bit for bit),✅,pure,2.0,252
+NSolve,Solves equations numerically — a bare polynomial means poly == 0 and every root path ends in the same polish step as NRoots so conjugate pairs agree bit for bit,✅,pure,2.0,252
 Cross,Computes the generalized cross product of n-1 vectors of length n,✅,pure,3.0,253
 PDF,Probability density function,✅,pure,6.0,254
 TableForm,Formats data as a table,✅,pure,1.0,255
@@ -598,7 +598,7 @@ GraphData,,🚫,,6.0,580
 LightBlue,Named light color evaluating to RGBColor[0.87 0.94 1],✅,pure,6.0,581
 FileNameJoin,Join file path components,✅,pure,7.0,582
 ToFileName,Join directory path components into a file name string,✅,pure,1.0,
-InverseLaplaceTransform,Compute the inverse Laplace transform,✅,none,4.0,583
+InverseLaplaceTransform,Compute the inverse Laplace transform — the third argument may be an expression or a number naming the point it is taken at,✅,none,4.0,583
 InverseFunction,Represents the inverse of a function or geometric transform,✅,pure,2.0,584
 Residue,Computes the residue of an expression at a point,✅,pure,2.0,585
 PieChart,Creates a pie chart from data,✅,pure,7.0,586

--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -1615,13 +1615,39 @@ fn inverse_laplace_transform(
       });
     }
   };
+  let unevaluated = || Expr::FunctionCall {
+    name: "InverseLaplaceTransform".to_string(),
+    args: vec![expr.clone(), s_expr.clone(), t_expr.clone()].into(),
+  };
   let t = match t_expr {
     Expr::Identifier(name) => name.as_str(),
+    // A third argument that is not a plain symbol names the point (or the
+    // expression) the inverse transform is taken at: transform to a fresh
+    // variable, then substitute. `…[1/(s + 1), s, 2 u]` is `E^(-2 u)`, and a
+    // number there samples the inverse transform at that number.
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "InverseLaplaceTransform".to_string(),
-        args: vec![expr.clone(), s_expr.clone(), t_expr.clone()].into(),
-      });
+      let mut used = std::collections::HashSet::new();
+      crate::syntax::collect_identifier_names(expr, &mut used);
+      crate::syntax::collect_identifier_names(s_expr, &mut used);
+      crate::syntax::collect_identifier_names(t_expr, &mut used);
+      let mut dummy = "t$".to_string();
+      let mut suffix = 0;
+      while used.contains(&dummy) {
+        suffix += 1;
+        dummy = format!("t${suffix}");
+      }
+      let transformed = inverse_laplace_transform(
+        expr,
+        s_expr,
+        &Expr::Identifier(dummy.clone()),
+      )?;
+      if matches!(&transformed, Expr::FunctionCall { name, .. } if name == "InverseLaplaceTransform")
+      {
+        return Ok(unevaluated());
+      }
+      let substituted =
+        crate::syntax::substitute_variable(&transformed, &dummy, t_expr);
+      return crate::evaluator::evaluate_expr_to_expr(&substituted);
     }
   };
 
@@ -1978,6 +2004,29 @@ fn inverse_laplace_inner(expr: &Expr, s: &str, t: &str) -> Option<Expr> {
         });
       }
 
+      // L^-1[(s^2 + a^2)^(-1/2)] = BesselJ[0, a*t], and the hyperbolic
+      // counterpart L^-1[(s^2 - a^2)^(-1/2)] = BesselI[0, a*t] (a negative
+      // constant term).
+      if is_rational_literal(fargs[1], -1, 2)
+        && let Some(a_squared) = extract_s_squared_plus_const(fargs[0], s)
+      {
+        let (a, func) = match negative_const_magnitude(&a_squared) {
+          Some(c) => (sqrt_of_expr(&c), "BesselI"),
+          None => (sqrt_of_expr(&a_squared), "BesselJ"),
+        };
+        return Some(Expr::FunctionCall {
+          name: func.to_string(),
+          args: vec![
+            Expr::Integer(0),
+            Expr::FunctionCall {
+              name: "Times".to_string(),
+              args: vec![a, Expr::Identifier(t.to_string())].into(),
+            },
+          ]
+          .into(),
+        });
+      }
+
       // L^-1[(s - a)^(-1)] = E^(a*t) or L^-1[(s + a)^(-1)] = E^(-a*t)
       if let Expr::Integer(-1) = fargs[1] {
         // Check if fargs[0] is (s + something) or (s - something)
@@ -2212,6 +2261,26 @@ fn sqrt_of_expr(expr: &Expr) -> Expr {
 }
 
 /// Check if expr is s^2 + c where c doesn't depend on s. Returns c.
+/// True when `expr` is the exact rational literal `num/den`, in either the
+/// evaluated `Rational[num, den]` form or the parsed `num/den` division.
+fn is_rational_literal(expr: &Expr, num: i128, den: i128) -> bool {
+  match expr {
+    Expr::FunctionCall { name, args }
+      if name == "Rational" && args.len() == 2 =>
+    {
+      matches!((&args[0], &args[1]), (Expr::Integer(p), Expr::Integer(q)) if *p == num && *q == den)
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Divide,
+      left,
+      right,
+    } => {
+      matches!((left.as_ref(), right.as_ref()), (Expr::Integer(p), Expr::Integer(q)) if *p == num && *q == den)
+    }
+    _ => false,
+  }
+}
+
 fn extract_s_squared_plus_const(expr: &Expr, s: &str) -> Option<Expr> {
   if let Some((fname, fargs)) = as_func_args(expr)
     && fname == "Plus"

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -856,8 +856,10 @@ fn evaluate_function_call_ast_inner(
           for (bind_name, bind_val) in &structural_bindings {
             all_bindings.push((bind_name.as_str(), bind_val));
           }
-          let substituted_cond =
-            crate::syntax::substitute_variables(cond_expr, &all_bindings);
+          let substituted_cond = crate::syntax::substitute_pattern_bindings(
+            cond_expr,
+            &all_bindings,
+          );
           match evaluate_expr_to_expr(&substituted_cond) {
             Ok(Expr::Identifier(ref s)) if s == "True" => {}
             _ => {
@@ -880,7 +882,7 @@ fn evaluate_function_call_ast_inner(
           for (bind_name, bind_val) in &structural_bindings {
             all_bindings.push((bind_name.as_str(), bind_val));
           }
-          crate::syntax::substitute_variables(body_expr, &all_bindings)
+          crate::syntax::substitute_pattern_bindings(body_expr, &all_bindings)
         };
         // Push option context if this overload uses OptionsPattern
         let inline_opts = inline_opts_overloads
@@ -1137,8 +1139,10 @@ fn evaluate_function_call_ast_inner(
           for (bind_name, bind_val) in &structural_bindings {
             all_bindings.push((bind_name.as_str(), bind_val));
           }
-          let substituted_cond =
-            crate::syntax::substitute_variables(cond_expr, &all_bindings);
+          let substituted_cond = crate::syntax::substitute_pattern_bindings(
+            cond_expr,
+            &all_bindings,
+          );
           // Evaluate the condition - it must return True. A `?test` whose
           // test is a pure function can be stored as a FunctionCall whose
           // head is the function's *string form* (e.g. `#1 > 0 & [arg]`),
@@ -1180,7 +1184,7 @@ fn evaluate_function_call_ast_inner(
           for (bind_name, bind_val) in &structural_bindings {
             all_bindings.push((bind_name.as_str(), bind_val));
           }
-          crate::syntax::substitute_variables(body_expr, &all_bindings)
+          crate::syntax::substitute_pattern_bindings(body_expr, &all_bindings)
         };
         // Push option context if this overload uses OptionsPattern
         let inline_opts2 = inline_opts_overloads

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -4426,7 +4426,8 @@ pub fn apply_bindings(
     }
     filtered_refs.push((name.as_str(), value));
   }
-  let result = crate::syntax::substitute_variables(replacement, &filtered_refs);
+  let result =
+    crate::syntax::substitute_pattern_bindings(replacement, &filtered_refs);
   if has_opts {
     crate::OPTION_VALUE_CONTEXT.with(|ctx| {
       ctx.borrow_mut().push((String::new(), opt_pairs));
@@ -4528,14 +4529,14 @@ fn apply_replace_all_multi_ast_impl(
       // LHS Condition test: substitute, evaluate, skip the rule if False.
       if let Some(test) = lhs_extra_cond {
         let substituted =
-          crate::syntax::substitute_variables(test, &binding_refs);
+          crate::syntax::substitute_pattern_bindings(test, &binding_refs);
         match evaluate_expr_to_expr(&substituted) {
           Ok(t) if matches!(&t, Expr::Identifier(s) if s == "True") => {}
           _ => continue,
         }
       }
       let result =
-        crate::syntax::substitute_variables(replacement, &binding_refs);
+        crate::syntax::substitute_pattern_bindings(replacement, &binding_refs);
       // Inside a Hold-like context the substituted RHS stays unevaluated.
       let evaluated = if held {
         result

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -7038,7 +7038,127 @@ fn aberth_complex_roots(coeffs: &[f64]) -> Vec<(f64, f64)> {
       break;
     }
   }
+  polish_and_pair_roots(coeffs, &mut zs);
   zs
+}
+
+/// Shared final step of the numeric polynomial root finders: Newton-polish
+/// every root, snap fp noise to exact zeros and turn near-conjugate pairs into
+/// exact mirrors of each other.
+///
+/// Both root finders (Durand-Kerner in `polynomial_ast::solve` and Aberth
+/// here) end with this so `NRoots`, `NSolve` and `N[Root[…]]` report the same
+/// digits for the same polynomial. Exact conjugate pairs matter beyond
+/// cosmetics: a quadrature that sums a conjugate-symmetric set of terms then
+/// cancels its imaginary part exactly instead of leaving a residue that
+/// `Chop` cannot remove.
+///
+/// `coeffs[i]` is the coefficient of `x^i`.
+pub fn polish_and_pair_roots(coeffs: &[f64], roots: &mut [(f64, f64)]) {
+  let n = coeffs.len().saturating_sub(1);
+  if n == 0 || coeffs[n].abs() < 1e-300 {
+    return;
+  }
+  // Monic form: divide by the leading coefficient so the residual |p(z)|
+  // compared across iterates is on a fixed scale.
+  let lc = coeffs[n];
+  let monic: Vec<f64> = coeffs.iter().map(|c| c / lc).collect();
+
+  // Horner with FMA — more accurate near a root, which lets the polish step
+  // tell the correctly-rounded f64 from its neighbour.
+  let eval_p = |zr: f64, zi: f64| -> (f64, f64) {
+    let mut re = monic[n];
+    let mut im = 0.0;
+    for k in (0..n).rev() {
+      let neg_im: f64 = -im;
+      let nr = re.mul_add(zr, neg_im.mul_add(zi, monic[k]));
+      let ni = re.mul_add(zi, im * zr);
+      re = nr;
+      im = ni;
+    }
+    (re, im)
+  };
+  let eval_dp = |zr: f64, zi: f64| -> (f64, f64) {
+    let mut re = (n as f64) * monic[n];
+    let mut im = 0.0;
+    for k in (1..n).rev() {
+      let nr = re * zr - im * zi + (k as f64) * monic[k];
+      let ni = re * zi + im * zr;
+      re = nr;
+      im = ni;
+    }
+    (re, im)
+  };
+
+  // Newton steps, keeping the iterate with the smallest |p(z)|: near the root
+  // Newton may oscillate between two adjacent f64 values (both equally good).
+  for slot in roots.iter_mut() {
+    let (mut zr, mut zi) = *slot;
+    let (mut best_zr, mut best_zi) = (zr, zi);
+    let (pr0, pi0) = eval_p(zr, zi);
+    let mut best_err = pr0.hypot(pi0);
+    for _ in 0..30 {
+      let (pr, pi) = eval_p(zr, zi);
+      let (dr, di) = eval_dp(zr, zi);
+      let denom = dr * dr + di * di;
+      if denom < 1e-300 {
+        break;
+      }
+      zr -= (pr * dr + pi * di) / denom;
+      zi -= (pi * dr - pr * di) / denom;
+      let (npr, npi) = eval_p(zr, zi);
+      let err = npr.hypot(npi);
+      if err < best_err {
+        best_err = err;
+        best_zr = zr;
+        best_zi = zi;
+      }
+      if err == 0.0 {
+        break;
+      }
+    }
+    *slot = (best_zr, best_zi);
+  }
+
+  // Snap to real / round trailing fp noise.
+  for (r, i) in roots.iter_mut() {
+    let mag = r.hypot(*i).max(1.0);
+    if i.abs() < 1e-12 * mag {
+      *i = 0.0;
+    }
+    if r.abs() < 1e-12 * mag {
+      *r = 0.0;
+    }
+  }
+
+  // Match conjugate pairs: two roots sharing a real part and carrying opposite
+  // imaginary parts (within tolerance) become exact mirrors. Each root joins at
+  // most one pair, and two real roots are never paired with each other — for
+  // real coefficients a genuine pair always has a non-zero imaginary part.
+  let snap_eps = 1e-9;
+  let mut paired = vec![false; roots.len()];
+  for k in 0..roots.len() {
+    if paired[k] || roots[k].1 == 0.0 {
+      continue;
+    }
+    for j in (k + 1)..roots.len() {
+      if paired[j] || roots[j].1 == 0.0 {
+        continue;
+      }
+      if (roots[k].0 - roots[j].0).abs() < snap_eps
+        && (roots[k].1 + roots[j].1).abs() < snap_eps
+      {
+        let avg = (roots[k].0 + roots[j].0) / 2.0;
+        let mag = (roots[k].1.abs() + roots[j].1.abs()) / 2.0;
+        let k_negative = roots[k].1 < 0.0;
+        roots[k] = (avg, if k_negative { -mag } else { mag });
+        roots[j] = (avg, if k_negative { mag } else { -mag });
+        paired[k] = true;
+        paired[j] = true;
+        break;
+      }
+    }
+  }
 }
 
 /// Horner-style polynomial evaluation at a complex point `z = zr + i*zi`.

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -313,14 +313,31 @@ fn adaptive_sample(
   points
 }
 
-/// Compute a robust y-range by excluding extreme outliers.
-/// Uses IQR-based outlier removal on uniformly-spaced x samples
-/// to avoid bias from adaptive refinement near singularities.
-fn robust_y_range(
+/// True when a `PlotRange` value asks for the whole y extent: `All` itself, or
+/// `All` in the y slot of `{xrange, All}`.
+pub(crate) fn plot_range_requests_all_y(value: &Expr) -> bool {
+  let val = evaluate_expr_to_expr(value).unwrap_or_else(|_| value.clone());
+  let is_all = |e: &Expr| matches!(e, Expr::Identifier(s) if s == "All");
+  match &val {
+    e if is_all(e) => true,
+    Expr::List(items) if items.len() == 2 => is_all(&items[1]),
+    _ => false,
+  }
+}
+
+/// Compute the y-range from uniformly-spaced x samples — uniform rather than
+/// the adaptively refined plot points so a singularity can't bias the
+/// distribution.
+///
+/// `keep_outliers` is `PlotRange -> All`: report the whole extent. Otherwise
+/// extreme values are excluded by an IQR fence, which is what keeps a pole
+/// from flattening the rest of the curve into the axis.
+fn sampled_y_range(
   bodies: &[&Expr],
   var_name: &str,
   x_min: f64,
   x_max: f64,
+  keep_outliers: bool,
 ) -> (f64, f64) {
   // Evaluate at uniformly-spaced x values to get an unbiased y distribution
   let n_uniform = 200;
@@ -344,6 +361,10 @@ fn robust_y_range(
   let n = ys.len();
   if n == 1 {
     return (ys[0], ys[0]);
+  }
+
+  if keep_outliers {
+    return (ys[0], ys[n - 1]);
   }
 
   let q1 = ys[n / 4];
@@ -7868,6 +7889,9 @@ pub(crate) fn parse_background_option(expr: &Expr) -> Option<RGBColor> {
 pub(crate) struct PlotRangeOverrides {
   pub x: Option<(f64, f64)>,
   pub y: Option<(f64, f64)>,
+  /// `PlotRange -> All` on the y axis: show every sampled value instead of
+  /// the automatic range, which drops extreme outliers.
+  pub y_all: bool,
   pub aspect_ratio: Option<f64>,
 }
 
@@ -7940,6 +7964,7 @@ pub(crate) fn apply_common_plot_option(
       let (rx, ry) = parse_plot_range(replacement);
       overrides.x = rx;
       overrides.y = ry;
+      overrides.y_all = plot_range_requests_all_y(replacement);
     }
     "Axes" => {
       if let Some(axes) = parse_axes_option(replacement) {
@@ -8243,6 +8268,7 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
   let (plot_range_x, plot_range_y) = (overrides.x, overrides.y);
+  let plot_range_y_all = overrides.y_all;
 
   // Apply AspectRatio to the plotting area (not the whole image); the total
   // height is derived in generate_svg_with_options once margins are known.
@@ -8421,9 +8447,10 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       collapse_style_for_single_series(&plot_opts.plot_style);
   }
 
-  // Compute Y range using robust outlier exclusion on uniform samples
+  // Compute Y range using robust outlier exclusion on uniform samples —
+  // unless `PlotRange -> All` asked for every sampled value to be shown.
   let (y_data_min, y_data_max) =
-    robust_y_range(&bodies, &var_name, x_min, x_max);
+    sampled_y_range(&bodies, &var_name, x_min, x_max, plot_range_y_all);
 
   // Check if we have any plottable data
   let has_finite = all_points

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -63,6 +63,93 @@ fn strip_sqrt_square(expr: Expr) -> Expr {
 
 // ─── NSolve ─────────────────────────────────────────────────────────
 
+/// True when `expr` already states a (possibly quantified) condition, i.e. it
+/// is an equation, an inequality, a logical combination of those, or a literal
+/// truth value. Anything else is a bare expression that `NSolve` reads as
+/// `expr == 0`.
+fn is_relational_expr(expr: &Expr) -> bool {
+  match expr {
+    Expr::Comparison { .. } => true,
+    Expr::BinaryOp {
+      op: BinaryOperator::And | BinaryOperator::Or,
+      ..
+    } => true,
+    Expr::UnaryOp {
+      op: UnaryOperator::Not,
+      ..
+    } => true,
+    Expr::Identifier(s) | Expr::Constant(s) => s == "True" || s == "False",
+    Expr::FunctionCall { name, .. } => matches!(
+      name.as_str(),
+      "Equal"
+        | "Unequal"
+        | "Less"
+        | "LessEqual"
+        | "Greater"
+        | "GreaterEqual"
+        | "Inequality"
+        | "And"
+        | "Or"
+        | "Not"
+        | "Xor"
+        | "Nand"
+        | "Nor"
+        | "Implies"
+        | "Element"
+        | "ForAll"
+        | "Exists"
+    ),
+    _ => false,
+  }
+}
+
+/// `NSolve` accepts a bare polynomial where an equation is expected:
+/// `NSolve[poly, x]` means `NSolve[poly == 0, x]`. A list threads
+/// element-wise, so `NSolve[{p, q}, {x, y}]` is `NSolve[{p == 0, q == 0}, …]`
+/// and a mixed list keeps the parts that already are equations.
+///
+/// Returns `None` when nothing needs rewriting, so the common path stays
+/// allocation-free.
+fn equations_from_bare_polynomials(expr: &Expr) -> Option<Expr> {
+  let eq_zero = |e: &Expr| Expr::Comparison {
+    operands: vec![e.clone(), Expr::Integer(0)],
+    operators: vec![ComparisonOp::Equal],
+  };
+  match expr {
+    Expr::List(items) => {
+      if items.iter().all(is_relational_expr) {
+        return None;
+      }
+      Some(Expr::List(
+        items
+          .iter()
+          .map(|it| {
+            if is_relational_expr(it) {
+              it.clone()
+            } else {
+              eq_zero(it)
+            }
+          })
+          .collect(),
+      ))
+    }
+    _ if is_relational_expr(expr) => None,
+    _ => Some(eq_zero(expr)),
+  }
+}
+
+/// True when the optional third argument of `NSolve` is a working-precision
+/// specification (`NSolve[eqns, vars, prec]`) rather than a solution domain
+/// like `Reals`. The precision only controls how many digits the roots carry,
+/// so the solving path itself ignores it.
+fn is_precision_spec(expr: &Expr) -> bool {
+  match expr {
+    Expr::Integer(_) | Expr::Real(_) | Expr::BigInteger(_) => true,
+    Expr::Identifier(s) | Expr::Constant(s) => s == "MachinePrecision",
+    _ => false,
+  }
+}
+
 /// NSolve[equation, var] — solve an equation numerically.
 ///
 /// For quadratic polynomials, uses Kahan's numerically stable formula to
@@ -73,6 +160,27 @@ fn strip_sqrt_square(expr: Expr) -> Expr {
 /// equation contains, the way `Solve[equation]` does.
 pub fn nsolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let _head = IfunHead::new("NSolve");
+  // `NSolve[poly, x]` is `NSolve[poly == 0, x]`, and a trailing precision
+  // argument is not a domain — normalize both away before solving.
+  let normalized_owned: Vec<Expr>;
+  let args = {
+    let rewritten_first =
+      args.first().and_then(equations_from_bare_polynomials);
+    let drop_precision = args.len() == 3 && is_precision_spec(&args[2]);
+    if rewritten_first.is_some() || drop_precision {
+      let mut new_args = args.to_vec();
+      if let Some(first) = rewritten_first {
+        new_args[0] = first;
+      }
+      if drop_precision {
+        new_args.truncate(2);
+      }
+      normalized_owned = new_args;
+      normalized_owned.as_slice()
+    } else {
+      args
+    }
+  };
   // Try numerically stable quadratic formula for degree-2 polynomials
   if let Some(result) = try_nsolve_quadratic(args) {
     return result;
@@ -782,22 +890,6 @@ fn durand_kerner_roots(coeffs: &[f64]) -> Vec<(f64, f64)> {
     (re, im)
   };
 
-  // Evaluate derivative p'(z) for complex z.
-  let eval_dp = |zr: f64, zi: f64| -> (f64, f64) {
-    if n == 0 {
-      return (0.0, 0.0);
-    }
-    let mut re = (n as f64) * monic[n];
-    let mut im = 0.0;
-    for k in (1..n).rev() {
-      let nr = re * zr - im * zi + (k as f64) * monic[k];
-      let ni = re * zi + im * zr;
-      re = nr;
-      im = ni;
-    }
-    (re, im)
-  };
-
   // Initialise n distinct roots on a circle.
   // Use complex base 0.4 + 0.9i as in classic Durand-Kerner.
   let base_r = 0.4_f64;
@@ -862,73 +954,7 @@ fn durand_kerner_roots(coeffs: &[f64]) -> Vec<(f64, f64)> {
     }
   }
 
-  // Polish each root with Newton steps. Track the iterate with the smallest
-  // |p(z)| since near the root Newton may oscillate between two adjacent
-  // f64 values (both equally good). Pick the best one.
-  for k in 0..roots.len() {
-    let (mut zr, mut zi) = roots[k];
-    let (mut best_zr, mut best_zi) = (zr, zi);
-    let (pr0, pi0) = eval_p(zr, zi);
-    let mut best_err = pr0.hypot(pi0);
-    for _ in 0..30 {
-      let (pr, pi) = eval_p(zr, zi);
-      let (dr, di) = eval_dp(zr, zi);
-      let denom = dr * dr + di * di;
-      if denom < 1e-300 {
-        break;
-      }
-      let qr = (pr * dr + pi * di) / denom;
-      let qi = (pi * dr - pr * di) / denom;
-      let new_r = zr - qr;
-      let new_i = zi - qi;
-      zr = new_r;
-      zi = new_i;
-      let (npr, npi) = eval_p(zr, zi);
-      let err = npr.hypot(npi);
-      if err < best_err {
-        best_err = err;
-        best_zr = zr;
-        best_zi = zi;
-      }
-      if err == 0.0 {
-        break;
-      }
-    }
-    roots[k] = (best_zr, best_zi);
-  }
-
-  // Snap to real / round trailing fp noise.
-  for (r, i) in roots.iter_mut() {
-    let mag = r.hypot(*i).max(1.0);
-    if i.abs() < 1e-12 * mag {
-      *i = 0.0;
-    }
-    if r.abs() < 1e-12 * mag {
-      *r = 0.0;
-    }
-  }
-  // Match conjugate pairs: when two roots have the same real part (within
-  // tolerance) and opposite signs of imag part, make their imag exactly +/-.
-  let snap_eps = 1e-9;
-  for k in 0..roots.len() {
-    for j in (k + 1)..roots.len() {
-      if (roots[k].0 - roots[j].0).abs() < snap_eps
-        && (roots[k].1 + roots[j].1).abs() < snap_eps
-      {
-        let avg = ((roots[k].0) + (roots[j].0)) / 2.0;
-        let mag = (roots[k].1.abs() + roots[j].1.abs()) / 2.0;
-        roots[k].0 = avg;
-        roots[j].0 = avg;
-        if roots[k].1 < 0.0 {
-          roots[k].1 = -mag;
-          roots[j].1 = mag;
-        } else {
-          roots[k].1 = mag;
-          roots[j].1 = -mag;
-        }
-      }
-    }
-  }
+  crate::functions::math_ast::polish_and_pair_roots(coeffs, &mut roots);
   roots
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -12795,7 +12795,7 @@ fn substitute_slots_impl(expr: &Expr, values: &[Expr]) -> Expr {
 /// substitution: before substituting `value` into a body that binds a
 /// parameter P, we need to know whether P appears as a name somewhere in
 /// `value` — if so, the binding must first be alpha-renamed.
-fn collect_identifier_names(
+pub fn collect_identifier_names(
   expr: &Expr,
   out: &mut std::collections::HashSet<String>,
 ) {
@@ -13288,6 +13288,106 @@ fn rename_pattern_parts(
 /// variables in a single pass so that substituted values cannot be
 /// accidentally captured by later substitutions.
 pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
+  substitute_variables_impl(expr, bindings, false)
+}
+
+/// Substitute pattern-matched bindings into a *template*: the right-hand side
+/// of a `:=` definition or of a `:>` rule.
+///
+/// Same as [`substitute_variables`], except that a `Function` parameter which
+/// is itself one of the bound names counts as a template slot rather than as a
+/// binder. `g[f_, s_] := Function[s, f]` called as `g[expr, s]` therefore
+/// yields `Function[s, expr]`, so the `s` inside `expr` really is the pure
+/// function's argument. Parameters that are *not* bound still shadow, and are
+/// still alpha-renamed when an incoming value would otherwise be captured.
+pub fn substitute_pattern_bindings(
+  expr: &Expr,
+  bindings: &[(&str, &Expr)],
+) -> Expr {
+  substitute_variables_impl(expr, bindings, true)
+}
+
+/// Work out a pure function's parameter list while substituting into it.
+///
+/// Returns the parameter names to use, the bindings that still reach the body,
+/// and the body with any capture-avoiding renames already applied. `None` means
+/// nothing reaches the body, so the function is left exactly as it was.
+///
+/// Two rules decide each parameter's fate:
+///   * In template mode a parameter that is itself a bound name is a slot the
+///     caller filled in, so it becomes that binding's symbol and its binding
+///     keeps reaching the body.
+///   * A parameter that stays a binder shadows its own binding, and is renamed
+///     to `name$` when an incoming value mentions it — Wolfram's alpha-renaming,
+///     e.g. `Function[{x}, Function[{y}, f[x, y]]][y]` ⇒ `Function[{y$}, f[y, y$]]`.
+fn resolve_function_params<'a>(
+  params: &[String],
+  body: &Expr,
+  bindings: &[(&'a str, &'a Expr)],
+  template: bool,
+) -> Option<(Vec<String>, Vec<(&'a str, &'a Expr)>, Expr)> {
+  if bindings.is_empty() {
+    return None;
+  }
+  // Parameter names the caller supplied (template mode only). A non-symbol
+  // value can't name a parameter, so such a parameter keeps binding.
+  let supplied: Vec<Option<String>> = params
+    .iter()
+    .map(|p| {
+      if !template {
+        return None;
+      }
+      bindings
+        .iter()
+        .find(|(var_name, _)| var_name == p)
+        .and_then(|(_, value)| match value {
+          Expr::Identifier(n) => Some(n.clone()),
+          _ => None,
+        })
+    })
+    .collect();
+  let filtered: Vec<(&'a str, &'a Expr)> = bindings
+    .iter()
+    .filter(|&&(var_name, _)| {
+      !params
+        .iter()
+        .zip(&supplied)
+        .any(|(p, s)| s.is_none() && p == var_name)
+    })
+    .copied()
+    .collect();
+  if filtered.is_empty() {
+    return None;
+  }
+  let mut value_names = std::collections::HashSet::new();
+  for (_, value) in &filtered {
+    collect_identifier_names(value, &mut value_names);
+  }
+  let mut new_params = Vec::with_capacity(params.len());
+  let mut new_body = body.clone();
+  for (param, supplied_name) in params.iter().zip(&supplied) {
+    match supplied_name {
+      Some(name) => new_params.push(name.clone()),
+      None if value_names.contains(param) => {
+        let fresh = format!("{}$", param);
+        new_body = substitute_variable(
+          &new_body,
+          param,
+          &Expr::Identifier(fresh.clone()),
+        );
+        new_params.push(fresh);
+      }
+      None => new_params.push(param.clone()),
+    }
+  }
+  Some((new_params, filtered, new_body))
+}
+
+fn substitute_variables_impl(
+  expr: &Expr,
+  bindings: &[(&str, &Expr)],
+  template: bool,
+) -> Expr {
   if bindings.is_empty() {
     return expr.clone();
   }
@@ -13303,7 +13403,7 @@ pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
     Expr::List(items) => Expr::List(
       items
         .iter()
-        .map(|e| substitute_variables(e, bindings))
+        .map(|e| substitute_variables_impl(e, bindings, template))
         .collect(),
     ),
     Expr::FunctionCall { name, args } => {
@@ -13331,35 +13431,13 @@ pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
           _ => None,
         };
         if let Some(params) = param_names {
-          // Drop shadowed bindings.
-          let filtered: Vec<(&str, &Expr)> = bindings
-            .iter()
-            .filter(|&&(var_name, _)| !params.contains(&var_name.to_string()))
-            .copied()
-            .collect();
-          if filtered.is_empty() {
+          let Some((new_params, filtered, new_body)) =
+            resolve_function_params(&params, body_arg, bindings, template)
+          else {
             return expr.clone();
-          }
-          let mut value_names = std::collections::HashSet::new();
-          for (_, value) in &filtered {
-            collect_identifier_names(value, &mut value_names);
-          }
-          let mut new_params = Vec::with_capacity(params.len());
-          let mut new_body = body_arg.clone();
-          for p in &params {
-            if value_names.contains(p) {
-              let fresh = format!("{}$", p);
-              new_body = substitute_variable(
-                &new_body,
-                p,
-                &Expr::Identifier(fresh.clone()),
-              );
-              new_params.push(fresh);
-            } else {
-              new_params.push(p.clone());
-            }
-          }
-          let substituted_body = substitute_variables(&new_body, &filtered);
+          };
+          let substituted_body =
+            substitute_variables_impl(&new_body, &filtered, template);
           let new_params_arg = if matches!(params_arg, Expr::List(_)) {
             Expr::List(new_params.into_iter().map(Expr::Identifier).collect())
           } else {
@@ -13374,7 +13452,7 @@ pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
       }
       let new_args: Vec<Expr> = args
         .iter()
-        .map(|e| substitute_variables(e, bindings))
+        .map(|e| substitute_variables_impl(e, bindings, template))
         .collect();
       // Check if the function name itself is being substituted
       for &(var_name, value) in bindings {
@@ -13392,12 +13470,12 @@ pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
     }
     Expr::BinaryOp { op, left, right } => Expr::BinaryOp {
       op: *op,
-      left: Box::new(substitute_variables(left, bindings)),
-      right: Box::new(substitute_variables(right, bindings)),
+      left: Box::new(substitute_variables_impl(left, bindings, template)),
+      right: Box::new(substitute_variables_impl(right, bindings, template)),
     },
     Expr::UnaryOp { op, operand } => Expr::UnaryOp {
       op: *op,
-      operand: Box::new(substitute_variables(operand, bindings)),
+      operand: Box::new(substitute_variables_impl(operand, bindings, template)),
     },
     Expr::Comparison {
       operands,
@@ -13405,14 +13483,14 @@ pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
     } => Expr::Comparison {
       operands: operands
         .iter()
-        .map(|e| substitute_variables(e, bindings))
+        .map(|e| substitute_variables_impl(e, bindings, template))
         .collect(),
       operators: operators.clone(),
     },
     Expr::CompoundExpr(exprs) => Expr::CompoundExpr(
       exprs
         .iter()
-        .map(|e| substitute_variables(e, bindings))
+        .map(|e| substitute_variables_impl(e, bindings, template))
         .collect(),
     ),
     Expr::Association(items) => Expr::Association(
@@ -13420,8 +13498,8 @@ pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
         .iter()
         .map(|(k, v)| {
           (
-            substitute_variables(k, bindings),
-            substitute_variables(v, bindings),
+            substitute_variables_impl(k, bindings, template),
+            substitute_variables_impl(v, bindings, template),
           )
         })
         .collect(),
@@ -13430,97 +13508,73 @@ pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
       pattern,
       replacement,
     } => Expr::Rule {
-      pattern: Box::new(substitute_variables(pattern, bindings)),
-      replacement: Box::new(substitute_variables(replacement, bindings)),
+      pattern: Box::new(substitute_variables_impl(pattern, bindings, template)),
+      replacement: Box::new(substitute_variables_impl(
+        replacement,
+        bindings,
+        template,
+      )),
     },
     Expr::RuleDelayed {
       pattern,
       replacement,
     } => Expr::RuleDelayed {
-      pattern: Box::new(substitute_variables(pattern, bindings)),
-      replacement: Box::new(substitute_variables(replacement, bindings)),
+      pattern: Box::new(substitute_variables_impl(pattern, bindings, template)),
+      replacement: Box::new(substitute_variables_impl(
+        replacement,
+        bindings,
+        template,
+      )),
     },
     Expr::ReplaceAll { expr: e, rules } => Expr::ReplaceAll {
-      expr: Box::new(substitute_variables(e, bindings)),
-      rules: Box::new(substitute_variables(rules, bindings)),
+      expr: Box::new(substitute_variables_impl(e, bindings, template)),
+      rules: Box::new(substitute_variables_impl(rules, bindings, template)),
     },
     Expr::ReplaceRepeated { expr: e, rules } => Expr::ReplaceRepeated {
-      expr: Box::new(substitute_variables(e, bindings)),
-      rules: Box::new(substitute_variables(rules, bindings)),
+      expr: Box::new(substitute_variables_impl(e, bindings, template)),
+      rules: Box::new(substitute_variables_impl(rules, bindings, template)),
     },
     Expr::Map { func, list } => Expr::Map {
-      func: Box::new(substitute_variables(func, bindings)),
-      list: Box::new(substitute_variables(list, bindings)),
+      func: Box::new(substitute_variables_impl(func, bindings, template)),
+      list: Box::new(substitute_variables_impl(list, bindings, template)),
     },
     Expr::Apply { func, list } => Expr::Apply {
-      func: Box::new(substitute_variables(func, bindings)),
-      list: Box::new(substitute_variables(list, bindings)),
+      func: Box::new(substitute_variables_impl(func, bindings, template)),
+      list: Box::new(substitute_variables_impl(list, bindings, template)),
     },
     Expr::MapApply { func, list } => Expr::MapApply {
-      func: Box::new(substitute_variables(func, bindings)),
-      list: Box::new(substitute_variables(list, bindings)),
+      func: Box::new(substitute_variables_impl(func, bindings, template)),
+      list: Box::new(substitute_variables_impl(list, bindings, template)),
     },
     Expr::PrefixApply { func, arg } => Expr::PrefixApply {
-      func: Box::new(substitute_variables(func, bindings)),
-      arg: Box::new(substitute_variables(arg, bindings)),
+      func: Box::new(substitute_variables_impl(func, bindings, template)),
+      arg: Box::new(substitute_variables_impl(arg, bindings, template)),
     },
     Expr::Postfix { expr: e, func } => Expr::Postfix {
-      expr: Box::new(substitute_variables(e, bindings)),
-      func: Box::new(substitute_variables(func, bindings)),
+      expr: Box::new(substitute_variables_impl(e, bindings, template)),
+      func: Box::new(substitute_variables_impl(func, bindings, template)),
     },
     Expr::Part { expr: e, index } => Expr::Part {
-      expr: Box::new(substitute_variables(e, bindings)),
-      index: Box::new(substitute_variables(index, bindings)),
+      expr: Box::new(substitute_variables_impl(e, bindings, template)),
+      index: Box::new(substitute_variables_impl(index, bindings, template)),
     },
     Expr::Function { body } => Expr::Function {
-      body: Box::new(substitute_variables(body, bindings)),
+      body: Box::new(substitute_variables_impl(body, bindings, template)),
     },
     Expr::NamedFunction {
       params,
       body,
       bracketed,
-    } => {
-      // Filter out bindings that are shadowed by the function's own parameters
-      let filtered: Vec<(&str, &Expr)> = bindings
-        .iter()
-        .filter(|&&(var_name, _)| !params.contains(&var_name.to_string()))
-        .copied()
-        .collect();
-      if filtered.is_empty() {
-        expr.clone()
-      } else {
-        // Capture-avoiding substitution: if any of this Function's params
-        // appears as an identifier in one of the incoming binding values,
-        // rename the param to a fresh `name$` first so the new reference
-        // isn't captured. Matches Wolfram's alpha-renaming:
-        // `Function[{x}, Function[{y}, f[x,y]]][y]` ⇒
-        // `Function[{y$}, f[y, y$]]`.
-        let mut value_names = std::collections::HashSet::new();
-        for (_, value) in &filtered {
-          collect_identifier_names(value, &mut value_names);
-        }
-        let mut new_params = Vec::with_capacity(params.len());
-        let mut new_body = (**body).clone();
-        for param in params {
-          if value_names.contains(param) {
-            let fresh = format!("{}$", param);
-            new_body = substitute_variable(
-              &new_body,
-              param,
-              &Expr::Identifier(fresh.clone()),
-            );
-            new_params.push(fresh);
-          } else {
-            new_params.push(param.clone());
-          }
-        }
-        Expr::NamedFunction {
-          params: new_params,
-          body: Box::new(substitute_variables(&new_body, &filtered)),
-          bracketed: *bracketed,
-        }
-      }
-    }
+    } => match resolve_function_params(params, body, bindings, template) {
+      None => expr.clone(),
+      Some((new_params, filtered, new_body)) => Expr::NamedFunction {
+        params: new_params,
+        body: Box::new(substitute_variables_impl(
+          &new_body, &filtered, template,
+        )),
+        bracketed: *bracketed,
+      },
+    },
     Expr::PatternOptional {
       name,
       head,
@@ -13530,7 +13584,7 @@ pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
       head: head.clone(),
       default: default
         .as_ref()
-        .map(|d| Box::new(substitute_variables(d, bindings))),
+        .map(|d| Box::new(substitute_variables_impl(d, bindings, template))),
     },
     Expr::PatternTest {
       name,
@@ -13541,13 +13595,13 @@ pub fn substitute_variables(expr: &Expr, bindings: &[(&str, &Expr)]) -> Expr {
       name: name.clone(),
       head: head.clone(),
       blank_type: *blank_type,
-      test: Box::new(substitute_variables(test, bindings)),
+      test: Box::new(substitute_variables_impl(test, bindings, template)),
     },
     Expr::CurriedCall { func, args } => Expr::CurriedCall {
-      func: Box::new(substitute_variables(func, bindings)),
+      func: Box::new(substitute_variables_impl(func, bindings, template)),
       args: args
         .iter()
-        .map(|e| substitute_variables(e, bindings))
+        .map(|e| substitute_variables_impl(e, bindings, template))
         .collect(),
     },
     // Atoms that don't contain the variable

--- a/tests/cli/expressions/SetDelayed.md
+++ b/tests/cli/expressions/SetDelayed.md
@@ -6,3 +6,20 @@ Defines a delayed assignment that evaluates the RHS each time.
 $ wo 'SetDelayed[h[x_], x^3]; h[4]'
 64
 ```
+
+The right-hand side is a template: a `Function` parameter that is itself a
+pattern variable is a slot the caller fills, so the symbol passed in really
+does become the pure function's argument.
+
+```scrut
+$ wo 'q[f_, s_] := Function[s, f]; q[s^2, s][4]'
+16
+```
+
+A parameter the caller did *not* supply still binds, and is renamed when an
+incoming value would otherwise be captured by it.
+
+```scrut
+$ wo 'h[a_] := Function[y, a + y]; h[y]'
+Function[y$, y + y$]
+```

--- a/tests/cli/plotting/Plot.md
+++ b/tests/cli/plotting/Plot.md
@@ -11,6 +11,8 @@ Graphics
 
 - **`PlotRange`** — y-axis range as `{ymin, ymax}` or full
   `{{xmin, xmax}, {ymin, ymax}}`; also `All` or `Automatic`.
+  `Automatic` leaves out extreme outliers so a pole can't flatten the rest
+  of the curve; `All` shows every sampled value.
 - **`PlotStyle`** — one directive (`Red`, `Dashed`, `Thickness[0.01]`)
   or a list applied per curve.
 - **`AxesLabel`** — `{xLabel, yLabel}`.
@@ -56,5 +58,13 @@ neighbouring ticks apart:
 
 ```scrut
 $ wo 'StringContainsQ[ExportString[Plot[x, {x, 0, 0.001}], "SVG"], "0.0002"]'
+True
+```
+
+`PlotRange -> All` keeps a steep curve inside the frame — here the top tick
+reaches E^10, which the automatic range trims away:
+
+```scrut
+$ wo 'StringContainsQ[ExportString[Plot[E^x, {x, 0, 10}, PlotRange -> All], "SVG"], "20000"]'
 True
 ```

--- a/tests/cli/symbolic/InverseLaplaceTransform.md
+++ b/tests/cli/symbolic/InverseLaplaceTransform.md
@@ -6,3 +6,23 @@ Symbolic inverse Laplace transform.
 $ wo 'InverseLaplaceTransform[1/(s^2 + 1), s, t]'
 Sin[t]
 ```
+
+A square root of `s^2 + a^2` in the denominator inverts to a Bessel function.
+
+```scrut
+$ wo 'InverseLaplaceTransform[1/Sqrt[s^2 + a^2], s, t]'
+BesselJ[0, a*t]
+```
+
+The third argument names the point the inverse transform is taken at, so it
+may be an expression or a number rather than a plain symbol.
+
+```scrut
+$ wo 'InverseLaplaceTransform[1/(s + 1), s, 2 u]'
+E^(-2*u)
+```
+
+```scrut
+$ wo 'InverseLaplaceTransform[1/Sqrt[s^2 + 1], s, 1.5]'
+0.5118276717359183
+```

--- a/tests/cli/symbolic/NSolve.md
+++ b/tests/cli/symbolic/NSolve.md
@@ -7,6 +7,13 @@ $ wo 'NSolve[x^2 - 2 == 0, x]'
 {{x -> -1.4142135623730951}, {x -> 1.414213562373095}}
 ```
 
+A bare polynomial stands for the equation `poly == 0`:
+
+```scrut
+$ wo 'NSolve[x^2 - 2, x]'
+{{x -> -1.4142135623730951}, {x -> 1.414213562373095}}
+```
+
 A cubic with machine-real coefficients has one real root and a conjugate
 pair:
 

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -7294,6 +7294,78 @@ mod nsolve {
       "5"
     );
   }
+
+  // A bare polynomial in place of an equation means `poly == 0`. Previously
+  // this fell through to Solve and only produced a Solve::naqs message.
+  #[test]
+  fn bare_polynomial_means_equal_zero() {
+    assert_eq!(
+      interpret("NSolve[x^2 - 1, x]").unwrap(),
+      interpret("NSolve[x^2 - 1 == 0, x]").unwrap()
+    );
+    assert_eq!(
+      interpret("NSolve[x^3 - 2 x + 1, x]").unwrap(),
+      interpret("NSolve[x^3 - 2 x + 1 == 0, x]").unwrap()
+    );
+    // No message is emitted for the accepted form.
+    assert_eq!(interpret("NSolve[x^2 - 1, x]; $MessageList").unwrap(), "{}");
+    // A list of bare polynomials is a system of equations.
+    assert_eq!(
+      interpret("NSolve[{x + y - 3, x - y - 1}, {x, y}]").unwrap(),
+      "{{x -> 2., y -> 1.}}"
+    );
+    // Mixed lists keep the parts that already are equations.
+    assert_eq!(
+      interpret("NSolve[{x + y - 3, x - y == 1}, {x, y}]").unwrap(),
+      "{{x -> 2., y -> 1.}}"
+    );
+  }
+
+  // The optional third argument may be a working precision rather than a
+  // domain; it must not be mistaken for one.
+  #[test]
+  fn precision_third_argument() {
+    for spec in ["MachinePrecision", "20"] {
+      assert_eq!(
+        interpret(&format!("NSolve[x^2 - 2 == 0, x, {spec}]")).unwrap(),
+        interpret("NSolve[x^2 - 2 == 0, x]").unwrap()
+      );
+      // The complex roots survive — a precision is not a `Reals` domain.
+      assert_eq!(
+        interpret(&format!("Length[NSolve[x^2 + 1 == 0, x, {spec}]]")).unwrap(),
+        "2"
+      );
+    }
+  }
+
+  // Every numeric root finder ends in the same polish-and-pair step, so
+  // NSolve, NRoots and N[Root[…]] report identical digits and conjugate pairs
+  // come out exactly mirrored.
+  #[test]
+  fn conjugate_pairs_are_exact_mirrors() {
+    // Sum of all roots equals -a[n-1]/a[n] exactly when the pairs mirror.
+    assert_eq!(
+      interpret("Im[Total[x /. NSolve[x^10 - 3 x + 1 == 0, x]]]").unwrap(),
+      "0"
+    );
+    assert_eq!(
+      interpret(
+        "(x /. NSolve[x^10 - 3 x + 1 == 0, x]) == \
+         (x /. NSolve[x^10 - 3 x + 1, x])"
+      )
+      .unwrap(),
+      "True"
+    );
+    // NRoots agrees digit for digit with NSolve.
+    assert_eq!(
+      interpret(
+        "(x /. NSolve[x^10 - 3 x + 1 == 0, x]) == \
+         (x /. {ToRules[NRoots[x^10 - 3 x + 1 == 0, x]]})"
+      )
+      .unwrap(),
+      "True"
+    );
+  }
 }
 
 // NSolveValues is the numeric analogue of SolveValues: it returns the variable

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -9106,6 +9106,76 @@ mod inverse_laplace_transform {
       "InverseLaplaceTransform[Log[1 + p*q], {p, q}, {x, y}]"
     );
   }
+
+  // L^-1[1/Sqrt[s^2 + a^2]] = BesselJ[0, a*t] and its hyperbolic counterpart
+  // L^-1[1/Sqrt[s^2 - a^2]] = BesselI[0, a*t].
+  #[test]
+  fn bessel_j_at_symbolic() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/Sqrt[s^2 + a^2], s, t]").unwrap(),
+      "BesselJ[0, a*t]"
+    );
+  }
+
+  #[test]
+  fn bessel_j_at_numeric_constant() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/Sqrt[s^2 + 4], s, t]").unwrap(),
+      "BesselJ[0, 2*t]"
+    );
+  }
+
+  #[test]
+  fn bessel_j_irrational() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/Sqrt[s^2 + 2], s, t]").unwrap(),
+      "BesselJ[0, Sqrt[2]*t]"
+    );
+  }
+
+  #[test]
+  fn bessel_i_at_symbolic() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/Sqrt[s^2 - a^2], s, t]").unwrap(),
+      "BesselI[0, a*t]"
+    );
+  }
+
+  // A third argument that is not a plain symbol names the point the inverse
+  // transform is taken at, so the result comes back evaluated there.
+  #[test]
+  fn third_argument_number() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/(s + 1), s, 2.]").unwrap(),
+      interpret("E^-2.").unwrap()
+    );
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/Sqrt[s^2 + 1], s, 1.5]").unwrap(),
+      interpret("BesselJ[0, 1.5]").unwrap()
+    );
+  }
+
+  #[test]
+  fn third_argument_expression() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/(s + 1), s, 2 u]").unwrap(),
+      "E^(-2*u)"
+    );
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/(s^2 + 1), s, 2 u]").unwrap(),
+      "Sin[2*u]"
+    );
+  }
+
+  // An unrecognised transform stays unevaluated with the original third
+  // argument rather than leaking the internal placeholder variable.
+  #[test]
+  fn third_argument_expression_unevaluated() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[Sqrt[s], s, 1.]").unwrap(),
+      "InverseLaplaceTransform[Sqrt[s], s, 1.]"
+    );
+  }
 }
 
 mod laplacian {

--- a/tests/interpreter_tests/function_application.rs
+++ b/tests/interpreter_tests/function_application.rs
@@ -211,6 +211,45 @@ mod function_head {
     );
   }
 
+  // A definition's right-hand side is a template: a `Function` parameter that
+  // is itself a pattern variable is a slot the caller fills, not a binder. So
+  // `Function[s, f]` really does bind the `s` inside the expression passed as
+  // `f` — the idiom numerical-inversion code uses to turn `F(s)` into a
+  // function of `s`. Previously the parameter was alpha-renamed to `s$` and
+  // the body's `s` stayed free, so the function ignored its argument.
+  #[test]
+  fn definition_rhs_function_param_is_a_template_slot() {
+    assert_eq!(
+      interpret("qa[f_, s_] := Function[s, f]; qa[1/(1 + s^2), s]").unwrap(),
+      "Function[s, (1 + s^2)^(-1)]"
+    );
+    assert_eq!(
+      interpret("qb[f_, s_, v_] := Function[s, f][v]; qb[s^2, s, 3]").unwrap(),
+      "9"
+    );
+    // The caller may name the parameter something else entirely.
+    assert_eq!(
+      interpret("qc[f_, s_] := Function[s, f]; qc[u^2, u][4]").unwrap(),
+      "16"
+    );
+    // A delayed rule's right-hand side is the same kind of template.
+    assert_eq!(
+      interpret("qd[s^2, s] /. qd[f_, s_] :> Function[s, f][5]").unwrap(),
+      "25"
+    );
+  }
+
+  // Capture avoidance still applies to a parameter the caller did *not*
+  // supply: an incoming value mentioning `y` must not be captured by a
+  // literal `Function[y, …]` in the template.
+  #[test]
+  fn definition_rhs_alpha_renames_unsupplied_params() {
+    assert_eq!(
+      interpret("h[a_] := Function[y, a + y]; h[y]").unwrap(),
+      "Function[y$, y + y$]"
+    );
+  }
+
   // Two-stage application with the same name in inner and outer scopes
   // — the inner param (bare) gets renamed on the first step so the second
   // step doesn't see capture. Result is `x^y`, not `y^y`.

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1026,6 +1026,40 @@ mod graphics {
       ));
     }
 
+    // `PlotRange -> All` shows every sampled value. The automatic range drops
+    // extreme values as outliers, which for a steep curve cut the top off and
+    // let it run out of the frame.
+    #[test]
+    fn plot_range_all_keeps_the_whole_curve() {
+      let tick_labels = |code: &str| -> Vec<f64> {
+        export_svg(code)
+          .split("<text ")
+          .skip(1)
+          .filter_map(|t| t.split_once('>'))
+          .filter_map(|(_, r)| r.split_once("</text>"))
+          .filter_map(|(v, _)| v.trim().parse::<f64>().ok())
+          .collect()
+      };
+      // E^10 is about 22026.
+      let all = tick_labels("Plot[E^x, {x, 0, 10}, PlotRange -> All]");
+      assert!(
+        all.iter().any(|&v| v >= 20000.0),
+        "PlotRange -> All must reach the curve's maximum, ticks: {all:?}"
+      );
+      let automatic = tick_labels("Plot[E^x, {x, 0, 10}]");
+      assert!(
+        !automatic.iter().any(|&v| v >= 20000.0),
+        "the automatic range still trims outliers, ticks: {automatic:?}"
+      );
+      // An explicit range still wins over All in the y slot.
+      let explicit =
+        tick_labels("Plot[E^x, {x, 0, 10}, PlotRange -> {{0, 10}, {0, 5}}]");
+      assert!(
+        !explicit.iter().any(|&v| v > 10.0),
+        "an explicit range is respected, ticks: {explicit:?}"
+      );
+    }
+
     #[test]
     fn plot_range_reversed_bounds_normalize() {
       // Wolfram normalizes a reversed range: `PlotRange -> {3, -3}` plots
@@ -2946,6 +2980,60 @@ mod plot3d {
       assert!(
         y_min >= -20.0,
         "y-axis min tick {y_min} is too extreme; singularity should be clipped"
+      );
+    }
+
+    // End-to-end shape of a Demonstration that checks a numerical Laplace
+    // inversion against the closed form: a helper builds `Function[s, F]` from
+    // its arguments and contracts the transform sampled at quadrature nodes
+    // against their weights, the result is frozen into a definition with `=`
+    // (so the body is one expression in `t`), and both curves are plotted on
+    // top of each other. Every step of that chain used to fail somewhere.
+    #[test]
+    fn numerical_laplace_inversion_overlays_closed_form() {
+      let svg = export_svg(
+        "invert[bigf_, s_, t_] := Module[{nodes, weights}, \
+           nodes = x /. NSolve[HypergeometricPFQ[{-6, 6}, {}, x], x]; \
+           weights = Map[-# ((11)/HypergeometricPFQ[{-5, 5}, {}, #])^2/6 &, \
+             nodes]; \
+           (weights . Function[s, bigf][1/nodes/t])/t]; \
+         approx[t_] = invert[1/Sqrt[1 + s^2], s, t]; \
+         Plot[{Chop[approx[t]], \
+               InverseLaplaceTransform[1/Sqrt[1 + s^2], s, t]}, \
+           {t, 1, 6}, PlotStyle -> {{Red, Thick}, {Blue, Dashed, Thick}}]",
+      );
+      // Both curves are drawn: the quadrature in red, the exact BesselJ in
+      // blue. A complex-valued quadrature (unmatched conjugate roots) or an
+      // inverse transform left unevaluated at a number drops one of them.
+      assert!(
+        svg.contains("#FF0000"),
+        "the numerical inversion must be drawn: {svg}"
+      );
+      assert!(
+        svg.contains("rgb(0,0,255)"),
+        "the closed form must be drawn: {svg}"
+      );
+    }
+
+    // The same quadrature, checked numerically rather than through a picture:
+    // a 6-node Salzer rule reproduces BesselJ[0, t] to a few digits, and the
+    // result is real — the conjugate pairs cancel exactly.
+    #[test]
+    fn numerical_laplace_inversion_matches_bessel() {
+      let value = interpret(
+        "invert[bigf_, s_, t_] := Module[{nodes, weights}, \
+           nodes = x /. NSolve[HypergeometricPFQ[{-6, 6}, {}, x], x]; \
+           weights = Map[-# ((11)/HypergeometricPFQ[{-5, 5}, {}, #])^2/6 &, \
+             nodes]; \
+           (weights . Function[s, bigf][1/nodes/t])/t]; \
+         Chop[invert[1/Sqrt[1 + s^2], s, 2.]]",
+      )
+      .unwrap();
+      let value: f64 = value.parse().expect("a real number, got {value}");
+      let exact: f64 = interpret("BesselJ[0, 2.]").unwrap().parse().unwrap();
+      assert!(
+        (value - exact).abs() < 1e-4,
+        "6-node Salzer rule gave {value}, BesselJ[0, 2.] is {exact}"
       );
     }
   }


### PR DESCRIPTION
Checking a Wolfram Demonstration notebook against Woxi Studio turned up five
gaps that between them made its Manipulate render nothing. The notebook
builds a quadrature rule from the roots of a hypergeometric polynomial,
contracts the transform sampled at those nodes against their weights, and
plots the result against the closed-form inverse.

`NSolve` accepts a bare polynomial where an equation is expected, reading it
as `poly == 0` — a list threads element-wise, keeping any parts that already
are equations. Previously the whole pipeline stalled at the first step with
only a `Solve::naqs` message. Its optional third argument may also be a
working precision rather than a domain, which must not be mistaken for one.

Both numeric root finders (Durand-Kerner and Aberth) now end in the same
Newton-polish-and-pair step instead of only the first one, so `NSolve`,
`NRoots` and `N[Root[…]]` report the same digits and conjugate pairs come out
exactly mirrored. That last part is what makes the quadrature usable: a
conjugate-symmetric sum cancels its imaginary part exactly rather than
leaving a residue too large for `Chop` to remove, and a complex-valued
function plots as nothing at all.

The right-hand side of a `:=` definition or `:>` rule is now substituted as a
template: a `Function` parameter that is itself a pattern variable is a slot
the caller fills, not a binder, so `q[f_, s_] := Function[s, f]` really does
bind the `s` inside the expression passed as `f`. Parameters the caller did
not supply still shadow and are still alpha-renamed when an incoming value
would be captured, and genuine function application keeps its lexical
scoping.

`InverseLaplaceTransform` gained `1/Sqrt[s^2 + a^2]` -> `BesselJ[0, a t]` and
its hyperbolic counterpart, and a third argument that is an expression or a
number is now the point the transform is taken at rather than a reason to
give up — the transform runs against a fresh variable and substitutes.

On the rendering side `PlotRange -> All` shows every sampled value; it used
to fall through to the automatic range, whose outlier fence cut the top off a
steep curve and let it run out of the frame. The range now comes from one
sampling pass with the fence applied or not, so a well-behaved curve is
unaffected.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JpPUpCVYMcBHWyjUT7XT1k