### PR TITLE
Compose a Manipulate's grid of plots into one picture

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,27 @@
 
 # Unreleased
 
+- Fixes driven by a Wolfram Demonstration that runs a cellular automaton
+    over a dendrite and compares it with the linear case:
+    - A layout that holds pictures — `Grid[{{plot1, plot2}, …}]`, a
+        `Column` of them, a `Pane` around either — is composed into the one
+        picture a notebook shows. The visual hosts (Playground, Woxi Studio)
+        only ever reported the *last* graphic drawn while the layout was
+        evaluated, so a Manipulate body that arranges several plots in a
+        grid displayed a single one of them and dropped the rest.
+    - A `Grid`'s columns line up when its rows hold different things: the
+        caption under a picture is centred on that picture instead of
+        being packed against the left edge of the grid.
+    - `LayeredGraphPlot` and `TreePlot` draw the layered embedding they
+        name, rather than the circular one every graph got. Vertices are
+        placed by distance from a root, and the second argument (`Left`,
+        `Right`, `Top`, `Bottom`) says which edge the roots go on.
+    - `DirectedEdges -> False` draws a graph's edges as plain lines
+        instead of arrows, and `ImageSize` sizes a graph plot — a
+        Demonstration asking for a wide, short strip used to get the
+        360-point default square.
+    - `ArrayPlot` draws its `FrameLabel`, on any of the four edges, with
+        the left and right labels rotated onto theirs.
 - Fixes driven by the "Selectivity in a Semibatch Reactor" Wolfram
     Demonstration:
     - `Text` inside a `Graphics3D` scene is drawn — a labelled 3D

--- a/functions.csv
+++ b/functions.csv
@@ -1397,7 +1397,7 @@ DialogReturn,Return from a dialog,🚫,io,6.0,1401
 Skewness,Computes the skewness of a list or distribution,✅,pure,6.0,1402
 Speak,Text-to-speech output,🚫,io,7.0,1405
 StreamColorFunction,Color function for stream plots,🚫,pure,7.0,1405
-TreePlot,Plot a tree graph,🚫,pure,6.0,1405
+TreePlot,Draws a tree in layers by distance from its roots,✅,pure,6.0,1405
 Audio,Audio object from sample data or files (symbolic in the CLI; visual hosts render a graphical audio player),✅,unevaluated,11.0,1406
 ColorSeparate,Separate color channels of an image,✅,io,7.0,1409
 LogisticSigmoid,Returns the logistic sigmoid function value,✅,pure,10.0,1409
@@ -1517,7 +1517,7 @@ DedekindEta,Dedekind eta modular function,✅,pure,3.0,1525
 LineIndent,Line indentation option,✅,pure,3.0,1526
 FindDistributionParameters,Estimate distribution parameters,✅,pure,8.0,1528
 NetEncoder,Neural network encoder,✅,pure,11.0,1528
-LayeredGraphPlot,Layered graph plot,✅,pure,6.0,1529
+LayeredGraphPlot,Draws a graph in layers by distance from its roots,✅,pure,6.0,1529
 AssociationMap,Maps a function over an association; supports the operator form AssociationMap[f][data],✅,pure,10.0,1530
 Covariance,Covariance of two lists; of a single vector gives its variance; of a single matrix gives the covariance matrix of its columns; of two matrices gives their cross-covariance matrix,✅,pure,6.0,1534
 MinimalBy,Returns elements that minimize a criterion,✅,pure,10.0,1534

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -4006,18 +4006,51 @@ fn evaluate_function_call_ast_inner(
       _ => false,
     };
     if looks_like_graph_input {
+      // `LayeredGraphPlot[g, pos, opts…]` / `TreePlot[g, pos, opts…]`:
+      // the positional argument says which edge of the plot the roots go
+      // on. It is not an option, so it is taken off here and turned into
+      // the layered embedding the renderer understands.
+      let layered = matches!(name, "LayeredGraphPlot" | "TreePlot");
+      let root_pos = args[1..]
+        .iter()
+        .find(|a| !matches!(a, Expr::Rule { .. } | Expr::RuleDelayed { .. }))
+        .and_then(crate::functions::graph::layer_direction);
+      let mut forwarded: Vec<Expr> = vec![args[0].clone()];
+      forwarded.extend(
+        args[1..]
+          .iter()
+          .filter(|a| matches!(a, Expr::Rule { .. } | Expr::RuleDelayed { .. }))
+          .cloned(),
+      );
+      if layered {
+        let mut spec =
+          vec![Expr::String("LayeredDigraphEmbedding".to_string())];
+        if let Some(dir) = root_pos {
+          spec.push(Expr::Rule {
+            pattern: Box::new(Expr::String("Orientation".to_string())),
+            replacement: Box::new(Expr::Identifier(dir.symbol().to_string())),
+          });
+        }
+        forwarded.push(Expr::Rule {
+          pattern: Box::new(Expr::Identifier("GraphLayout".to_string())),
+          replacement: Box::new(Expr::List(spec.into())),
+        });
+      }
       let graph_expr = if let Expr::FunctionCall {
         name: gn,
         args: gargs,
       } = &args[0]
         && gn == "Graph"
       {
+        // The plot's own options apply on top of the graph's.
+        let mut merged: Vec<Expr> = gargs.iter().cloned().collect();
+        merged.extend(forwarded[1..].iter().cloned());
         Expr::FunctionCall {
           name: "Graph".to_string(),
-          args: gargs.clone(),
+          args: merged.into(),
         }
       } else {
-        unevaluated("Graph", args)
+        unevaluated("Graph", &forwarded)
       };
       // Evaluate the embedded Graph so any rules/edges are normalised
       // into the canonical {vertex_list, edge_list, opts…} form, then

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -2511,6 +2511,7 @@ pub fn array_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut color_rules: Vec<(f64, GfxColor)> = Vec::new();
   let mut mesh = false;
   let mut color_function: Option<String> = None;
+  let mut frame_labels = crate::functions::plot::FrameLabels::default();
 
   for opt in &args[1..] {
     if let Expr::Rule {
@@ -2549,6 +2550,11 @@ pub fn array_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           if let Some(s) = color_function_scheme_name(replacement.as_ref()) {
             color_function = Some(s);
           }
+        }
+        // An array plot is drawn inside a frame, so it takes the same
+        // `FrameLabel` a framed plot does — on any of the four edges.
+        "FrameLabel" => {
+          frame_labels = crate::functions::plot::parse_frame_label(replacement);
         }
         _ => {}
       }
@@ -2743,7 +2749,76 @@ pub fn array_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     full_width,
   );
 
+  let buf = frame_labelled_svg(&buf, svg_width, svg_height, &frame_labels);
+
   Ok(crate::graphics_result(buf))
+}
+
+/// Put a plot's `FrameLabel` text around an already-rendered picture.
+///
+/// The picture keeps its size and is inset into a larger canvas with just
+/// enough room on each labelled edge for one line of text. Left and right
+/// labels are rotated to run along their edge, the way Wolfram sets them:
+/// counter-clockwise on the left, clockwise on the right, so each reads
+/// from the outside in. Returns `svg` unchanged when there is no label.
+fn frame_labelled_svg(
+  svg: &str,
+  width: u32,
+  height: u32,
+  labels: &crate::functions::plot::FrameLabels,
+) -> String {
+  let edges = [&labels.bottom, &labels.left, &labels.top, &labels.right];
+  if edges.iter().all(|e| e.is_empty()) {
+    return svg.to_string();
+  }
+  let font_size = 14.0_f64;
+  let gutter = font_size * 1.6;
+  let pad = |present: bool| if present { gutter } else { 0.0 };
+  let (ml, mr) = (pad(!labels.left.is_empty()), pad(!labels.right.is_empty()));
+  let (mt, mb) = (pad(!labels.top.is_empty()), pad(!labels.bottom.is_empty()));
+  let (w, h) = (width as f64, height as f64);
+  let (total_w, total_h) = (w + ml + mr, h + mt + mb);
+  let fill = crate::functions::graphics::theme().text_primary;
+  let text = |x: f64, y: f64, rot: f64, label: &str| {
+    let transform = if rot == 0.0 {
+      String::new()
+    } else {
+      format!(" transform=\"rotate({rot},{x:.1},{y:.1})\"")
+    };
+    format!(
+      "<text x=\"{x:.1}\" y=\"{y:.1}\" text-anchor=\"middle\" \
+       dominant-baseline=\"central\" font-family=\"sans-serif\" \
+       font-size=\"{font_size:.0}\" fill=\"{fill}\"{transform}>{}</text>\n",
+      crate::functions::graphics::box_string_to_svg(label)
+    )
+  };
+  let mut out = format!(
+    "<svg width=\"{total_w:.0}\" height=\"{total_h:.0}\" \
+     viewBox=\"0 0 {total_w:.0} {total_h:.0}\" \
+     xmlns=\"http://www.w3.org/2000/svg\">\n"
+  );
+  // The picture itself, shifted into the space the labels leave.
+  out.push_str(&format!(
+    "<svg x=\"{ml:.1}\" y=\"{mt:.1}\" width=\"{w:.0}\" height=\"{h:.0}\" \
+     overflow=\"visible\">\n"
+  ));
+  out.push_str(svg.trim());
+  out.push_str("\n</svg>\n");
+  let (cx, cy) = (ml + w / 2.0, mt + h / 2.0);
+  if !labels.top.is_empty() {
+    out.push_str(&text(cx, mt / 2.0, 0.0, &labels.top));
+  }
+  if !labels.bottom.is_empty() {
+    out.push_str(&text(cx, mt + h + mb / 2.0, 0.0, &labels.bottom));
+  }
+  if !labels.left.is_empty() {
+    out.push_str(&text(ml / 2.0, cy, -90.0, &labels.left));
+  }
+  if !labels.right.is_empty() {
+    out.push_str(&text(ml + w + mr / 2.0, cy, 90.0, &labels.right));
+  }
+  out.push_str("</svg>\n");
+  out
 }
 
 /// MatrixPlot[matrix] - like ArrayPlot with automatic color scaling

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -222,6 +222,9 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut vertex_shape: Option<String> = None;
   let mut vertex_size_scale: f64 = 1.0;
   let mut plot_label: Option<Expr> = None;
+  let mut layered: Option<LayerDirection> = None;
+  let mut draw_directed = true;
+  let mut image_size: Option<Expr> = None;
 
   for opt in options {
     if let Expr::Rule {
@@ -277,6 +280,25 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             plot_label = Some((**replacement).clone());
           }
         }
+        // `GraphLayout -> "LayeredDigraphEmbedding"` (optionally with an
+        // `"Orientation"` sub-option) stacks the vertices in layers by
+        // distance from a root instead of spreading them on a circle.
+        // This is the embedding `LayeredGraphPlot` / `TreePlot` ask for.
+        "GraphLayout" => {
+          layered = parse_layered_layout(replacement);
+        }
+        // `DirectedEdges -> False` says how the edges are *drawn*: as
+        // plain lines rather than arrows. The underlying edges keep their
+        // direction, which is what the layering reads.
+        "DirectedEdges" => {
+          if matches!(replacement.as_ref(), Expr::Identifier(s) if s == "False")
+          {
+            draw_directed = false;
+          }
+        }
+        "ImageSize" => {
+          image_size = Some((**replacement).clone());
+        }
         _ => {}
       }
     }
@@ -285,11 +307,15 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Build petgraph for rendering
   let (graph, _index_map) = build_render_graph(&vertices, &raw_edges);
 
-  // Compute vertex positions. For a single weakly-connected component we
-  // keep the simple circular embedding; for multi-component graphs each
-  // component is laid out independently (force-directed when large enough)
-  // and the components are packed into a grid so clusters are visible.
-  let positions: Vec<(f64, f64)> = compute_layout(&graph);
+  // Compute vertex positions. A layered embedding was asked for by name;
+  // otherwise, for a single weakly-connected component we keep the simple
+  // circular embedding, and for multi-component graphs each component is
+  // laid out independently (force-directed when large enough) and the
+  // components are packed into a grid so clusters are visible.
+  let positions: Vec<(f64, f64)> = match layered {
+    Some(dir) => layered_layout(&graph, dir),
+    None => compute_layout(&graph),
+  };
 
   // Compute base radius for vertices. Kept deliberately small so labels
   // and edges remain legible; a border is drawn around each vertex so the
@@ -355,6 +381,13 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } else {
       primitives.push(default_applied_edge_color.to_expr());
     }
+
+    // `DirectedEdges -> False` draws every edge as a plain line, however
+    // the edge was given.
+    let edge_data = &RenderEdgeData {
+      directed: edge_data.directed && draw_directed,
+      ..edge_data.clone()
+    };
 
     if si == di {
       // Self-loop: circular arc that starts and ends exactly on the
@@ -710,12 +743,225 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   let content = Expr::List(primitives.into());
+  // A graph is drawn at Wolfram's 360-point default unless the caller
+  // sized it — `LayeredGraphPlot[…, ImageSize -> {200, 50}]` asks for a
+  // wide, short strip and has to get one.
   let image_size_opt = Expr::Rule {
     pattern: Box::new(Expr::Identifier("ImageSize".to_string())),
-    replacement: Box::new(Expr::Integer(360)),
+    replacement: Box::new(image_size.unwrap_or(Expr::Integer(360))),
   };
 
-  graphics_ast(&[content, image_size_opt])
+  let mut graphics_args = vec![content, image_size_opt];
+  if let Some(range) = flat_axis_plot_range(&positions, vertex_radius) {
+    graphics_args.push(range);
+  }
+  graphics_ast(&graphics_args)
+}
+
+/// A `PlotRange` that keeps a layout which is flat on one axis — a chain
+/// of vertices laid out in a straight line — from being drawn as an
+/// extremely thin strip in which the vertex dots swell to fill the image.
+/// The flat axis is opened up to a fixed fraction of the other one, about
+/// the layout's centre. `None` when both axes already have extent.
+fn flat_axis_plot_range(
+  positions: &[(f64, f64)],
+  vertex_radius: f64,
+) -> Option<Expr> {
+  /// The narrowest an axis may be, as a fraction of the wider one.
+  const MIN_ASPECT: f64 = 1.0 / 3.0;
+  let (mut x0, mut x1) = (f64::INFINITY, f64::NEG_INFINITY);
+  let (mut y0, mut y1) = (f64::INFINITY, f64::NEG_INFINITY);
+  for &(x, y) in positions {
+    x0 = x0.min(x - vertex_radius);
+    x1 = x1.max(x + vertex_radius);
+    y0 = y0.min(y - vertex_radius);
+    y1 = y1.max(y + vertex_radius);
+  }
+  if !x0.is_finite() || !y0.is_finite() {
+    return None;
+  }
+  let (w, h) = (x1 - x0, y1 - y0);
+  let widen = |lo: f64, hi: f64, want: f64| {
+    let mid = (lo + hi) / 2.0;
+    (mid - want / 2.0, mid + want / 2.0)
+  };
+  let ((x0, x1), (y0, y1)) = if w < h * MIN_ASPECT {
+    (widen(x0, x1, h * MIN_ASPECT), (y0, y1))
+  } else if h < w * MIN_ASPECT {
+    ((x0, x1), widen(y0, y1, w * MIN_ASPECT))
+  } else {
+    return None;
+  };
+  let pair =
+    |a: f64, b: f64| Expr::List(vec![Expr::Real(a), Expr::Real(b)].into());
+  Some(Expr::Rule {
+    pattern: Box::new(Expr::Identifier("PlotRange".to_string())),
+    replacement: Box::new(Expr::List(vec![pair(x0, x1), pair(y0, y1)].into())),
+  })
+}
+
+/// Where the roots of a layered embedding sit; the layers grow away from
+/// that edge. This is the second argument of `LayeredGraphPlot[g, pos]`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum LayerDirection {
+  Top,
+  Bottom,
+  Left,
+  Right,
+}
+
+/// Read a `GraphLayout` option value, returning the layer direction when
+/// it names a layered embedding. Both the bare string form
+/// (`"LayeredDigraphEmbedding"`) and the sub-option form
+/// (`{"LayeredEmbedding", "Orientation" -> Left}`) are accepted; without an
+/// orientation the roots go on top, as they do in Wolfram.
+fn parse_layered_layout(value: &Expr) -> Option<LayerDirection> {
+  let named = |s: &str| s.starts_with("Layered");
+  match value {
+    Expr::String(s) if named(s) => Some(LayerDirection::Top),
+    Expr::List(items) => {
+      let is_layered = items
+        .iter()
+        .any(|e| matches!(e, Expr::String(s) if named(s)));
+      if !is_layered {
+        return None;
+      }
+      let dir = items.iter().find_map(|e| match e {
+        Expr::Rule {
+          pattern,
+          replacement,
+        } if matches!(pattern.as_ref(), Expr::String(s) if s == "Orientation") => {
+          layer_direction(replacement)
+        }
+        _ => None,
+      });
+      Some(dir.unwrap_or(LayerDirection::Top))
+    }
+    _ => None,
+  }
+}
+
+impl LayerDirection {
+  /// The Wolfram symbol this direction is written as.
+  pub(crate) fn symbol(self) -> &'static str {
+    match self {
+      LayerDirection::Top => "Top",
+      LayerDirection::Bottom => "Bottom",
+      LayerDirection::Left => "Left",
+      LayerDirection::Right => "Right",
+    }
+  }
+}
+
+/// The symbol naming an edge of the plot, as `LayeredGraphPlot`'s second
+/// argument gives it.
+pub(crate) fn layer_direction(expr: &Expr) -> Option<LayerDirection> {
+  match expr {
+    Expr::Identifier(s) => match s.as_str() {
+      "Top" => Some(LayerDirection::Top),
+      "Bottom" => Some(LayerDirection::Bottom),
+      "Left" => Some(LayerDirection::Left),
+      "Right" => Some(LayerDirection::Right),
+      _ => None,
+    },
+    _ => None,
+  }
+}
+
+/// Layered ("hierarchical") vertex positions: every vertex sits one layer
+/// further from a root than the parent that first reached it, and the
+/// vertices of a layer are spread evenly across it. Roots are the vertices
+/// nothing points at; a graph that has none (a pure cycle) starts from its
+/// first vertex so every vertex still gets a layer.
+///
+/// Layers are one unit apart and so are the vertices within a layer, which
+/// keeps a chain a straight line of evenly spaced dots — the shape
+/// `LayeredGraphPlot` draws for a path graph.
+fn layered_layout(
+  graph: &DiGraph<usize, RenderEdgeData>,
+  dir: LayerDirection,
+) -> Vec<(f64, f64)> {
+  let n = graph.node_count();
+  if n == 0 {
+    return vec![];
+  }
+
+  let mut successors: Vec<Vec<usize>> = vec![Vec::new(); n];
+  let mut in_degree: Vec<usize> = vec![0; n];
+  for edge in graph.edge_references() {
+    let (s, d) = (edge.source().index(), edge.target().index());
+    if s == d {
+      continue;
+    }
+    successors[s].push(d);
+    in_degree[d] += 1;
+  }
+  for succ in &mut successors {
+    succ.sort_unstable();
+    succ.dedup();
+  }
+
+  // Breadth-first from every root, in vertex order, so the layering is
+  // deterministic. A vertex keeps the first (shallowest) layer it is
+  // reached at.
+  let mut layer: Vec<Option<usize>> = vec![None; n];
+  let mut order: Vec<Vec<usize>> = Vec::new();
+  let push = |layer: &mut Vec<Option<usize>>,
+              order: &mut Vec<Vec<usize>>,
+              v: usize,
+              l: usize| {
+    layer[v] = Some(l);
+    while order.len() <= l {
+      order.push(Vec::new());
+    }
+    order[l].push(v);
+  };
+  let roots: Vec<usize> = (0..n).filter(|&v| in_degree[v] == 0).collect();
+  let starts = if roots.is_empty() { vec![0] } else { roots };
+  let mut queue: std::collections::VecDeque<usize> =
+    std::collections::VecDeque::new();
+  for &r in &starts {
+    push(&mut layer, &mut order, r, 0);
+    queue.push_back(r);
+  }
+  while let Some(v) = queue.pop_front() {
+    let l = layer[v].unwrap_or(0);
+    for &w in &successors[v] {
+      if layer[w].is_none() {
+        push(&mut layer, &mut order, w, l + 1);
+        queue.push_back(w);
+      }
+    }
+  }
+  // Any vertex left unreached (an isolated cycle in another component)
+  // joins the first layer so nothing is dropped.
+  for v in 0..n {
+    if layer[v].is_none() {
+      push(&mut layer, &mut order, v, 0);
+    }
+  }
+
+  // `along` runs across a layer, `depth` from one layer to the next; both
+  // are centred on the origin before being mapped onto the axes.
+  let depth_span = (order.len() as f64 - 1.0).max(0.0);
+  let mut positions = vec![(0.0, 0.0); n];
+  for (l, members) in order.iter().enumerate() {
+    let span = members.len() as f64 - 1.0;
+    for (k, &v) in members.iter().enumerate() {
+      let along = k as f64 - span / 2.0;
+      let depth = l as f64 - depth_span / 2.0;
+      positions[v] = match dir {
+        LayerDirection::Top => (along, -depth),
+        LayerDirection::Bottom => (along, depth),
+        LayerDirection::Left => (depth, -along),
+        LayerDirection::Right => (-depth, -along),
+      };
+    }
+  }
+  positions
+    .into_iter()
+    .map(|(x, y)| (snap_coord(x), snap_coord(y)))
+    .collect()
 }
 
 /// Compute vertex positions for the rendered graph.

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -12524,11 +12524,50 @@ fn compute_grid_layout(
     }
   }
 
-  // Per-cell layout: keep natural aspect ratios, vertically center
-  // shorter cells within their row.
+  // Scaled per-cell dimensions (enforce a minimum so pathological
+  // zero-sized inputs don't vanish entirely).
+  let scaled_rows: Vec<Vec<(f64, f64)>> = parsed_rows
+    .iter()
+    .map(|row| {
+      row
+        .iter()
+        .map(|(_, _, nw, nh)| ((nw * scale).max(1.0), (nh * scale).max(1.0)))
+        .collect()
+    })
+    .collect();
+
+  // A column is as wide as its widest cell, in every row — that is what
+  // makes a `Grid`'s columns line up when the rows hold different things
+  // (a picture in one row, a caption under it in the next). Rows of
+  // uniform cells, the `GraphicsGrid` case, are unaffected.
+  let mut col_w: Vec<f64> = vec![0.0; max_cols];
+  for row in &scaled_rows {
+    for (j, (w, _)) in row.iter().enumerate() {
+      col_w[j] = col_w[j].max(*w);
+    }
+  }
+
+  // Horizontal gap: `Scaled` is resolved against the average cell width
+  // over the whole grid, so every row uses the same column pitch.
+  let cell_count = scaled_rows.iter().map(Vec::len).sum::<usize>().max(1);
+  let avg_cell_w: f64 =
+    scaled_rows.iter().flatten().map(|(w, _)| *w).sum::<f64>()
+      / cell_count as f64;
+  let h_gap = opts.h_spacing.to_px(avg_cell_w);
+  let col_x: Vec<f64> = col_w
+    .iter()
+    .scan(0.0_f64, |x, w| {
+      let here = *x;
+      *x += w + h_gap;
+      Some(here)
+    })
+    .collect();
+
+  // Per-cell layout: keep natural aspect ratios, centre each cell in its
+  // column and vertically centre shorter cells within their row.
   let mut row_layouts: Vec<GridRowLayout> = Vec::new();
 
-  for parsed_row in &parsed_rows {
+  for (parsed_row, cell_dims) in parsed_rows.iter().zip(scaled_rows.iter()) {
     if parsed_row.is_empty() {
       row_layouts.push(GridRowLayout {
         cells: Vec::new(),
@@ -12537,29 +12576,18 @@ fn compute_grid_layout(
       continue;
     }
 
-    // Scaled per-cell dimensions (enforce a minimum so pathological
-    // zero-sized inputs don't vanish entirely).
-    let cell_dims: Vec<(f64, f64)> = parsed_row
-      .iter()
-      .map(|(_, _, nw, nh)| ((nw * scale).max(1.0), (nh * scale).max(1.0)))
-      .collect();
-
     let row_h = cell_dims
       .iter()
       .map(|(_, h)| *h)
       .fold(0.0_f64, f64::max)
       .max(10.0);
 
-    // Horizontal gap: Scaled is resolved against the average cell width.
-    let avg_cell_w: f64 =
-      cell_dims.iter().map(|(w, _)| *w).sum::<f64>() / cell_dims.len() as f64;
-    let h_gap = opts.h_spacing.to_px(avg_cell_w);
-
-    let mut x = 0.0_f64;
     let mut cells = Vec::with_capacity(parsed_row.len());
-    for ((vb, inner, _, _), (cw, ch)) in parsed_row.iter().zip(cell_dims.iter())
+    for (j, ((vb, inner, _, _), (cw, ch))) in
+      parsed_row.iter().zip(cell_dims.iter()).enumerate()
     {
       let y_off = ((row_h - ch) / 2.0).max(0.0);
+      let x = col_x[j] + (col_w[j] - cw) / 2.0;
       cells.push(LayoutCell {
         x,
         y_off,
@@ -12568,16 +12596,17 @@ fn compute_grid_layout(
         view_box: vb.clone(),
         inner: inner.clone(),
       });
-      x += cw + h_gap;
     }
 
     row_layouts.push(GridRowLayout { cells, row_h });
   }
 
-  // Compute total dimensions.
-  let total_width = row_layouts
+  // Compute total dimensions. The grid is as wide as its columns, which
+  // a row that stops short of the last column does not shorten.
+  let total_width = col_x
     .iter()
-    .map(|r| r.cells.last().map_or(0.0, |c: &LayoutCell| c.x + c.w))
+    .zip(col_w.iter())
+    .map(|(x, w)| x + w)
     .fold(0.0_f64, f64::max);
   let v_gap = if !row_layouts.is_empty() {
     let avg_h = row_layouts.iter().map(|r| r.row_h).sum::<f64>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3159,6 +3159,32 @@ fn render_graphics_fc_if_needed(expr: syntax::Expr) -> syntax::Expr {
   }
 }
 
+/// Render a layout wrapper that has a picture inside it — `Grid`, `Column`,
+/// `Row`, `Labeled`, `Pane` and the panes built on them — as the single
+/// composed picture a notebook shows, rather than leaving the caller to
+/// pick one of the captured sub-pictures.
+///
+/// `None` for anything that is not such a layout, for a layout with no
+/// picture in it (a `Grid` of strings already lays out correctly as
+/// typeset text), and for a picture that is *already* one graphic —
+/// re-rendering that would only round-trip what was captured.
+fn composed_layout_svg(expr: &syntax::Expr) -> Option<String> {
+  let syntax::Expr::FunctionCall { name, .. } = expr else {
+    return None;
+  };
+  if !matches!(
+    name.as_str(),
+    "Grid" | "Column" | "Row" | "Labeled" | "Pane" | "Item" | "ClickPane"
+  ) {
+    return None;
+  }
+  if !evaluator::lays_out_a_graphic(expr) {
+    return None;
+  }
+  let svg = evaluator::expr_to_svg(expr);
+  svg.starts_with("<svg").then_some(svg)
+}
+
 /// If the result is a list (1D, 2D, or 3D) of `-Graphics-` items,
 /// or a `TableForm` wrapping such a list, combine captured SVGs into a grid.
 fn render_graphics_list_if_needed(expr: syntax::Expr) -> syntax::Expr {
@@ -3169,6 +3195,17 @@ fn render_graphics_list_if_needed(expr: syntax::Expr) -> syntax::Expr {
   let all_svgs = get_all_captured_graphics();
   if all_svgs.is_empty() {
     return expr;
+  }
+
+  // A layout that holds pictures — `Grid[{{plot1, plot2}, …}]`, a `Column`
+  // of them, a `Pane` around either — is one picture in a notebook, laid
+  // out cell by cell. Without this the captured-graphics buffer only ever
+  // reports its *last* entry, so a Manipulate body that arranges several
+  // plots in a grid (the standard Demonstrations panel) showed a single
+  // one of them and dropped the rest.
+  if let Some(composed) = composed_layout_svg(inner) {
+    clear_captured_graphics();
+    return graphics_result(composed);
   }
 
   // 1D list of Graphics

--- a/tests/cli/plotting.md
+++ b/tests/cli/plotting.md
@@ -69,6 +69,7 @@ SVG images.
 - [`GraphicsGrid`](plotting/GraphicsGrid.md)
 - [`GraphicsRow`](plotting/GraphicsRow.md)
 - [`KochCurve`](plotting/KochCurve.md)
+- [`LayeredGraphPlot`](plotting/LayeredGraphPlot.md)
 - [`ListContourPlot`](plotting/ListContourPlot.md)
 - [`ListDensityPlot`](plotting/ListDensityPlot.md)
 - [`ListLogLinearPlot`](plotting/ListLogLinearPlot.md)

--- a/tests/cli/plotting/ArrayPlot.md
+++ b/tests/cli/plotting/ArrayPlot.md
@@ -1,3 +1,16 @@
 # `ArrayPlot`
 
 Plots a matrix as a grid of colored cells.
+
+```scrut
+$ wo 'Head[ArrayPlot[{{0, 1}, {1, 0}}]]'
+Graphics
+```
+
+The plot sits in a frame, so `FrameLabel` labels its edges — written as
+`{{left, right}, {bottom, top}}`:
+
+```scrut
+$ wo 'Head[ArrayPlot[{{0, 1}, {1, 0}}, FrameLabel -> {{"", ""}, {"", "top"}}]]'
+Graphics
+```

--- a/tests/cli/plotting/LayeredGraphPlot.md
+++ b/tests/cli/plotting/LayeredGraphPlot.md
@@ -1,0 +1,25 @@
+# `LayeredGraphPlot`
+
+Draws a graph in layers: every vertex sits one layer further from a root
+than the parent that first reached it.
+
+```scrut
+$ wo 'Head[LayeredGraphPlot[{1 -> 2, 2 -> 3, 2 -> 4}]]'
+Graphics
+```
+
+The second argument says which edge of the plot the roots go on, and the
+layers grow away from it — `Left` draws the graph left to right:
+
+```scrut
+$ wo 'Head[LayeredGraphPlot[{1 -> 2, 2 -> 3, 2 -> 4}, Left]]'
+Graphics
+```
+
+`DirectedEdges -> False` draws the edges as plain lines instead of
+arrows, and `ImageSize` sizes the picture:
+
+```scrut
+$ wo 'Head[LayeredGraphPlot[{1 -> 2, 2 -> 3}, Left, DirectedEdges -> False, ImageSize -> {200, 50}]]'
+Graphics
+```

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -3180,6 +3180,264 @@ mod tests {
     }
   }
 
+  // ── Layered graph plots, framed array plots and aligned grids ──
+  //
+  // The shape a Demonstrations panel is built from: several pictures and
+  // their captions arranged in one `Grid`, inside a `Pane`.
+  mod demonstration_panel {
+    /// The rendered SVG of `expr`, with the embedded font payload removed.
+    fn svg_of(expr: &str) -> String {
+      let code = format!("ExportString[{expr}, \"SVG\"]");
+      let svg = woxi::interpret(&code).expect("interpret should succeed");
+      assert!(svg.starts_with("<svg"), "expected an SVG for {expr}: {svg}");
+      match (svg.find("<defs>"), svg.find("</defs>")) {
+        (Some(a), Some(b)) => format!("{}{}", &svg[..a], &svg[b + 7..]),
+        _ => svg,
+      }
+    }
+
+    /// Every vertex-dot centre in `svg`, in document order.
+    fn circle_centres(svg: &str) -> Vec<(f64, f64)> {
+      svg
+        .split("<ellipse ")
+        .skip(1)
+        .filter_map(|tag| {
+          let attr = |name: &str| -> Option<f64> {
+            let at = tag.find(&format!("{name}=\""))? + name.len() + 2;
+            tag[at..].split('"').next()?.parse().ok()
+          };
+          Some((attr("cx")?, attr("cy")?))
+        })
+        .collect()
+    }
+
+    /// A path graph laid out in layers with the roots on the left is a
+    /// straight horizontal line of vertices: every vertex is its own
+    /// layer, so they share a y and step evenly along x. The circular
+    /// embedding this used to fall back to put them on a ring instead.
+    #[test]
+    fn layered_graph_plot_lays_a_chain_out_in_a_line() {
+      let svg =
+        svg_of(r#"LayeredGraphPlot[{1 -> 2, 2 -> 3, 3 -> 4, 4 -> 5}, Left]"#);
+      let centres = circle_centres(&svg);
+      assert_eq!(centres.len(), 5, "one vertex circle each: {svg}");
+      let y0 = centres[0].1;
+      assert!(
+        centres.iter().all(|(_, y)| (y - y0).abs() < 1.0),
+        "a chain lies on one row: {centres:?}"
+      );
+      let mut xs: Vec<f64> = centres.iter().map(|(x, _)| *x).collect();
+      xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+      let step = xs[1] - xs[0];
+      assert!(step > 1.0, "vertices are spread apart: {xs:?}");
+      for pair in xs.windows(2) {
+        assert!(
+          (pair[1] - pair[0] - step).abs() < 1.0,
+          "layers are evenly spaced: {xs:?}"
+        );
+      }
+    }
+
+    /// Roots go on the edge the second argument names, and the layers grow
+    /// away from it: `Top` stacks the chain vertically instead.
+    #[test]
+    fn layered_graph_plot_honours_the_root_position() {
+      let svg = svg_of(r#"LayeredGraphPlot[{1 -> 2, 2 -> 3, 3 -> 4}, Top]"#);
+      let centres = circle_centres(&svg);
+      assert_eq!(centres.len(), 4);
+      let x0 = centres[0].0;
+      assert!(
+        centres.iter().all(|(x, _)| (x - x0).abs() < 1.0),
+        "with the roots on top the chain runs down one column: {centres:?}"
+      );
+    }
+
+    /// A branch gets a layer of its own: the two vertices that share a
+    /// parent sit at the same distance from the root but on different rows.
+    #[test]
+    fn layered_graph_plot_splits_a_branch_across_rows() {
+      let svg = svg_of(r#"LayeredGraphPlot[{1 -> 2, 2 -> 3, 2 -> 4}, Left]"#);
+      let centres = circle_centres(&svg);
+      assert_eq!(centres.len(), 4);
+      let mut by_x = centres.clone();
+      by_x.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+      // The two children share the last layer, so they share an x and
+      // straddle the row their parent sits on.
+      let (last_x, prev_x) = (by_x[3].0, by_x[1].0);
+      assert!((by_x[2].0 - last_x).abs() < 1.0, "one layer: {by_x:?}");
+      assert!(prev_x < last_x, "the branch is further from the root");
+      assert!(
+        (by_x[2].1 - by_x[3].1).abs() > 1.0,
+        "the two children are on different rows: {by_x:?}"
+      );
+    }
+
+    /// `DirectedEdges -> False` draws the edges as plain lines. The arrow
+    /// heads are filled polygons, so their absence is the test.
+    #[test]
+    fn directed_edges_false_drops_the_arrow_heads() {
+      let arrows = svg_of(r#"LayeredGraphPlot[{1 -> 2, 2 -> 3}, Left]"#);
+      assert!(arrows.contains("<polygon"), "arrow heads by default");
+      let plain = svg_of(
+        r#"LayeredGraphPlot[{1 -> 2, 2 -> 3}, Left, DirectedEdges -> False]"#,
+      );
+      assert!(
+        !plain.contains("<polygon"),
+        "DirectedEdges -> False leaves only lines: {plain}"
+      );
+      assert!(plain.contains("<polyline"), "the edges are still drawn");
+    }
+
+    /// A graph plot is sized by its `ImageSize`, so a Demonstration can ask
+    /// for a wide, short strip.
+    #[test]
+    fn graph_plot_honours_image_size() {
+      let svg = svg_of(
+        r#"LayeredGraphPlot[{1 -> 2, 2 -> 3}, Left, ImageSize -> {200, 50}]"#,
+      );
+      assert!(
+        svg.starts_with(r#"<svg width="200""#),
+        "ImageSize -> {{200, 50}} sets the width: {}",
+        &svg[..80.min(svg.len())]
+      );
+      let default = svg_of(r#"LayeredGraphPlot[{1 -> 2, 2 -> 3}, Left]"#);
+      assert!(
+        default.starts_with(r#"<svg width="360""#),
+        "without one the Wolfram default still applies: {}",
+        &default[..80.min(default.len())]
+      );
+    }
+
+    /// `ArrayPlot` sits in a frame, so it takes a `FrameLabel` on any of
+    /// the four edges. Left and right labels run along their edge.
+    #[test]
+    fn array_plot_draws_its_frame_labels() {
+      let svg = svg_of(
+        r#"ArrayPlot[{{0, 1}, {1, 0}},
+           FrameLabel -> {{"lft", "rgt"}, {"btm", "top"}}]"#,
+      );
+      for label in ["lft", "rgt", "btm", "top"] {
+        assert!(svg.contains(label), "{label} should be drawn: {svg}");
+      }
+      assert!(
+        svg.contains("rotate(-90") && svg.contains("rotate(90"),
+        "the side labels are rotated onto their edges: {svg}"
+      );
+    }
+
+    /// Only the labelled edges take room: an unlabelled array plot keeps
+    /// its size exactly.
+    #[test]
+    fn array_plot_without_frame_labels_is_unpadded() {
+      let plain = svg_of(r#"ArrayPlot[{{0, 1}, {1, 0}}]"#);
+      let labelled = svg_of(
+        r#"ArrayPlot[{{0, 1}, {1, 0}}, FrameLabel -> {{"", ""}, {"", "top"}}]"#,
+      );
+      let width = |svg: &str| -> u32 {
+        svg
+          .split("width=\"")
+          .nth(1)
+          .unwrap()
+          .split('"')
+          .next()
+          .unwrap()
+          .parse()
+          .unwrap()
+      };
+      let height = |svg: &str| -> u32 {
+        svg
+          .split("height=\"")
+          .nth(1)
+          .unwrap()
+          .split('"')
+          .next()
+          .unwrap()
+          .parse()
+          .unwrap()
+      };
+      assert_eq!(width(&plain), width(&labelled), "a top label adds no width");
+      assert!(
+        height(&labelled) > height(&plain),
+        "a top label adds height: {} vs {}",
+        height(&labelled),
+        height(&plain)
+      );
+    }
+
+    /// A `Grid` whose rows hold different things still lines its columns
+    /// up: the caption under a picture is centred on that picture, not
+    /// packed against the left edge.
+    #[test]
+    fn grid_columns_line_up_across_mixed_rows() {
+      let svg = svg_of(
+        r#"Grid[{{Graphics[{Disk[]}], Graphics[{Disk[]}]},
+                 {Text["aa"], Text["bb"]}}]"#,
+      );
+      // Each cell is a nested <svg x=… width=…>; a cell is centred in its
+      // column, so it is the centres that have to agree.
+      let centres: Vec<f64> = svg
+        .split("<svg x=\"")
+        .skip(1)
+        .filter_map(|t| {
+          let x: f64 = t.split('"').next()?.parse().ok()?;
+          let w: f64 = t
+            .split("width=\"")
+            .nth(1)?
+            .split('"')
+            .next()?
+            .parse()
+            .ok()?;
+          Some(x + w / 2.0)
+        })
+        .collect();
+      assert_eq!(centres.len(), 4, "four cells: {svg}");
+      assert!(
+        (centres[0] - centres[2]).abs() < 1.0,
+        "the caption is centred on the picture above it: {centres:?}"
+      );
+      assert!(
+        (centres[1] - centres[3]).abs() < 1.0,
+        "and so is the second column's: {centres:?}"
+      );
+    }
+
+    /// A layout that holds pictures is one picture: the notebook hosts
+    /// (Playground, Woxi Studio) get the whole panel composed, not just
+    /// the last plot that happened to be drawn while evaluating it.
+    #[test]
+    fn a_pane_of_a_grid_of_plots_renders_as_one_graphic() {
+      let result = woxi::interpret_with_stdout(
+        r#"Pane[Grid[{{ArrayPlot[{{0, 1}, {1, 0}}], ArrayPlot[{{1, 0}, {0, 1}}]},
+                      {Text["left"], Text["right"]}}], {500, 375}]"#,
+      )
+      .expect("interpret should succeed");
+      let svg = result.graphics.expect("the panel is a graphic");
+      assert!(svg.starts_with("<svg"), "composed SVG: {svg}");
+      for label in ["left", "right"] {
+        assert!(svg.contains(label), "{label} is part of the panel");
+      }
+      assert!(
+        svg.matches("<svg x=").count() >= 4,
+        "every cell of the grid is placed: {svg}"
+      );
+    }
+
+    /// A layout of plain text is left to the text renderer — composing it
+    /// as a picture would be a regression, not an improvement.
+    #[test]
+    fn a_pane_without_pictures_is_not_composed() {
+      let result = woxi::interpret_with_stdout(
+        r#"Pane[Grid[{{1, 2}, {3, 4}}], {200, 100}]"#,
+      )
+      .expect("interpret should succeed");
+      assert!(
+        result.graphics.is_none(),
+        "a text-only layout composes no picture: {:?}",
+        result.graphics
+      );
+    }
+  }
+
   // ── Display-only wrappers in text markup ──
   //
   // Tooltip shows its first argument (the tip only appears on hover in the


### PR DESCRIPTION
Checking a Wolfram Demonstration notebook against Woxi Studio — a
cellular automaton run over a dendrite, compared against the linear
case — turned up five gaps between its Manipulate and the panel Wolfram
draws.

The body arranges two graph plots, two array plots and four caption rows
in a `Grid`, inside a `Pane`. Only one plot reached the widget: the
captured-graphics buffer reports its last entry, and everything drawn
before it was dropped. A layout that holds pictures is now composed into
the single picture a notebook shows, through the same path
`Export[…, "SVG"]` already used. A layout of plain text still goes to
the text renderer.

A `Grid`'s columns did not line up when its rows held different things,
because each row was packed left to right at its cells' natural widths.
Columns are now as wide as their widest cell in any row and cells are
centred in them, so a caption sits under the picture it names. Rows of
uniform cells — the `GraphicsGrid` case — are unaffected.

`LayeredGraphPlot` and `TreePlot` forwarded to `Graph`, which laid every
graph out on a circle; the dendrite arrived as a ring with a chord
across it. Both now draw the layered embedding they name: vertices are
placed by distance from a root, one layer per step, and the second
argument (`Left`, `Right`, `Top`, `Bottom`) says which edge the roots go
on. A layout that comes out flat on one axis — a chain of vertices in a
straight line — has that axis opened up so the picture keeps a sane
proportion instead of becoming a thin strip of swollen dots.

`DirectedEdges -> False` draws a graph's edges as plain lines rather
than arrows, and `ImageSize` sizes a graph plot: the widget asks for a
200x50 strip and used to get the 360-point default square.

`ArrayPlot` ignored `FrameLabel` entirely. It now draws one on any of
the four edges, reusing the plot options' own `{{left, right}, {bottom,
top}}` parser, with the side labels rotated onto their edges.