### PR TITLE
Draw a circumcircle and mask the labels over its chords

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,24 @@
 
 # Unreleased
 
+- Fixes driven by a Wolfram Demonstration that draws a rational cyclic
+    polygon inside its circumcircle:
+    - `Sphere` and `Ball` draw in a two-dimensional `Graphics`: in the plane
+        a sphere is the circle bounding it and a ball the filled disk. Both
+        used to be dropped, and since `Circumsphere` returns a `Sphere`
+        whatever the dimension, a picture built around a circumcircle came
+        out with no circle at all. A list of centres draws one per point,
+        and `Ball[2]` is the unit disk at the origin.
+    - A `Style` around a label paints its `Background` behind the text —
+        `Style[Text[…], 12, Background -> White]` is what keeps a distance
+        label readable over the line it sits on. Only a `Background` written
+        on the `Text` itself was drawn before.
+    - A square factor too large to reach by trial division comes out of a
+        radical: `Sqrt[100003^2 * 115]` is `100003 Sqrt[115]`. `Sqrt` and the
+        `c Sqrt[r]` merge used to look for square factors to different
+        depths, so each rewrote what the other produced and halving such a
+        coefficient — the `Mean` of two points carrying a radical — never
+        returned.
 - Fixes driven by the "Selectivity in a Semibatch Reactor" Wolfram
     Demonstration:
     - `Text` inside a `Graphics3D` scene is drawn — a labelled 3D

--- a/functions.csv
+++ b/functions.csv
@@ -282,7 +282,7 @@ RowBox,Represents a horizontal row of boxes for typesetting,✅,pure,3.0,277
 Round,Returns the nearest integer to a number,✅,pure,1.0,279
 Button,Interactive button element (stays symbolic in script mode),✅,unevaluated,6.0,280
 Gray,Named color evaluating to GrayLevel[0.5],✅,pure,5.1,281
-Sphere,3D sphere graphics primitive,✅,none,6.0,282
+Sphere,Sphere graphics primitive; a circle in two dimensions,✅,none,6.0,282
 Get,Reads and evaluates a file returning the last result,✅,effectful,1.0,283
 Quiet,Evaluate expression suppressing messages,✅,contextual,6.0,284
 Joined,Option for joining points in list plots,✅,none,6.0,285

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -227,6 +227,11 @@ struct StyleState {
   font_weight: String,
   font_style: String,
   font_family: String, // empty string means SVG default
+  /// `Background -> colour` carried by a `Style` around a label, as in
+  /// `Style[Text[…], Background -> White]`. It paints the panel behind the
+  /// text — the same panel `Text[…, Background -> colour]` asks for — and
+  /// means nothing to the other primitives, which never read it.
+  text_background: Option<Color>,
   /// `Arrowheads[…]`: where the heads of the arrows that follow sit, how
   /// big they are and — for a custom head — what to draw there. `None`
   /// keeps Wolfram's default: one head at the tip.
@@ -401,6 +406,7 @@ impl Default for StyleState {
       font_weight: "normal".to_string(),
       font_style: "normal".to_string(),
       font_family: String::new(),
+      text_background: None,
       arrowheads: None,
     }
   }
@@ -1445,6 +1451,13 @@ fn apply_text_style_rule(
       }
       false
     }
+    "Background" => match parse_background(replacement) {
+      Some(color) => {
+        style.text_background = Some(color);
+        true
+      }
+      None => false,
+    },
     "FontFamily" => match replacement {
       Expr::String(s) => {
         style.font_family = s.clone();
@@ -1579,6 +1592,9 @@ fn collect_primitives(
         }
         "Disk" => {
           parse_disk(args, style, prims);
+        }
+        "Sphere" | "Ball" => {
+          parse_sphere(name == "Ball", args, style, prims);
         }
         "Rectangle" => {
           parse_rectangle(args, style, prims);
@@ -2056,6 +2072,76 @@ fn parse_disk(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
     rx,
     ry,
     style: style.clone(),
+  });
+}
+
+/// `Sphere[…]` and `Ball[…]` inside a two-dimensional `Graphics`. The region
+/// functions hand back spheres and balls whatever the dimension —
+/// `Circumsphere` of three points in the plane is a `Sphere` — and in the
+/// plane a sphere is the circle bounding it and a ball the filled disk, so
+/// each draws as its planar namesake. A centre with any other number of
+/// coordinates belongs to a `Graphics3D` and draws nothing here.
+fn parse_sphere(
+  filled: bool,
+  args: &[Expr],
+  style: &StyleState,
+  prims: &mut Vec<Primitive>,
+) {
+  // `Sphere[n]` / `Ball[n]` is the unit sphere/ball at the origin in `n`
+  // dimensions; only the planar one has anything to draw.
+  if let [Expr::Integer(dimension)] = args {
+    if *dimension == 2 {
+      emit_sphere(filled, (0.0, 0.0), 1.0, style, prims);
+    }
+    return;
+  }
+  let Some(radius) = (match args.get(1) {
+    Some(r) => expr_to_f64(r),
+    None => Some(1.0),
+  }) else {
+    return;
+  };
+  // One centre, or a list of them — `Sphere[{p1, p2}, r]` draws one sphere
+  // of radius `r` around each point.
+  let centers: Vec<(f64, f64)> = match args.first() {
+    Some(Expr::List(items))
+      if !items.is_empty()
+        && items.iter().all(|i| matches!(i, Expr::List(_))) =>
+    {
+      items.iter().filter_map(expr_to_point).collect()
+    }
+    Some(single) => expr_to_point(single).into_iter().collect(),
+    None => Vec::new(),
+  };
+  for center in centers {
+    emit_sphere(filled, center, radius, style, prims);
+  }
+}
+
+fn emit_sphere(
+  filled: bool,
+  (cx, cy): (f64, f64),
+  r: f64,
+  style: &StyleState,
+  prims: &mut Vec<Primitive>,
+) {
+  prims.push(if filled {
+    Primitive::Disk {
+      cx,
+      cy,
+      rx: r,
+      ry: r,
+      style: style.clone(),
+    }
+  } else {
+    Primitive::CircleArc {
+      cx,
+      cy,
+      rx: r,
+      ry: r,
+      angles: None,
+      style: style.clone(),
+    }
   });
 }
 
@@ -2726,17 +2812,13 @@ fn parse_text(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
   }
   let background_of =
     |opts: &[Expr]| option_value(opts, "Background").and_then(parse_color);
-  let style_opts: &[Expr] = match framed_body {
-    Expr::FunctionCall { name, args: sargs }
-      if is_style_wrapper(name) && !sargs.is_empty() =>
-    {
-      &sargs[1..]
-    }
-    _ => &[],
-  };
+  // A `Style` the label is written inside — around the `Text` or around its
+  // content — leaves its background in the style state, which is how
+  // `Style[Text[…], Background -> White]` keeps a distance label legible over
+  // the line it sits on.
   let background = background_of(frame_opts)
     .or_else(|| background_of(&args[1..]))
-    .or_else(|| background_of(style_opts));
+    .or(local_style.text_background);
   // Wolfram draws a `Framed` box with a thin border unless the label asks
   // for none; an explicit `FrameStyle -> colour` recolours it.
   let is_framed = matches!(

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -765,49 +765,6 @@ pub fn sign_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(unevaluated("Sign", args))
 }
 
-/// Extract the largest easily-found perfect-square factor from a non-negative
-/// BigInt: returns `(outside, inside)` with `n == outside^2 * inside`, so
-/// `Sqrt[n] = outside * Sqrt[inside]`. Square factors from primes below a
-/// bound are pulled out by trial division; a leftover whole-square cofactor
-/// (e.g. a large prime squared) is caught by a final `isqrt` check. A cofactor
-/// that is square-free over the bound but not itself a perfect square stays
-/// in `inside` (matching wolframscript, which also can't factor large semiprimes
-/// cheaply).
-fn extract_square_factor_big(n: &BigInt) -> (BigInt, BigInt) {
-  let zero = BigInt::from(0);
-  let one = BigInt::from(1);
-  let mut outside = BigInt::from(1);
-  let mut inside = n.clone();
-  const BOUND: u64 = 100_000;
-  let mut factor: u64 = 2;
-  while factor <= BOUND {
-    let fbig = BigInt::from(factor);
-    if &fbig * &fbig > inside {
-      break;
-    }
-    let mut count: u64 = 0;
-    while &inside % &fbig == zero {
-      inside /= &fbig;
-      count += 1;
-    }
-    if count >= 2 {
-      outside *= fbig.pow((count / 2) as u32);
-    }
-    if count % 2 == 1 {
-      inside *= &fbig;
-    }
-    factor += 1;
-  }
-  if inside > one {
-    let r = inside.sqrt();
-    if &r * &r == inside {
-      outside *= &r;
-      inside = BigInt::from(1);
-    }
-  }
-  (outside, inside)
-}
-
 /// Sqrt[x] - Square root
 pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() != 1 {
@@ -918,36 +875,11 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if &r * &r == bn {
         return Ok(bigint_to_expr(r));
       }
-      // Partial extraction (e.g. Sqrt[12] = 2*Sqrt[3]) runs in u64, so only
-      // when n fits u64 — casting a larger i128 to u64 would truncate.
-      if *n <= u64::MAX as i128 {
-        let mut outside = 1u64;
-        let mut inside = *n as u64;
-        let mut factor = 2u64;
-        while factor * factor <= inside {
-          while inside.is_multiple_of(factor * factor) {
-            outside *= factor;
-            inside /= factor * factor;
-          }
-          factor += 1;
-        }
-        if outside > 1 && inside > 1 {
-          return Ok(Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![
-              Expr::Integer(outside as i128),
-              make_sqrt(Expr::Integer(inside as i128)),
-            ]
-            .into(),
-          });
-        }
-      } else {
-        // Larger than u64: extract square factors in BigInt.
-        let (outside, inside) = extract_square_factor_big(&bn);
-        if outside > BigInt::from(1) {
-          let sqrt_part = make_sqrt(bigint_to_expr(inside));
-          return times_ast(&[bigint_to_expr(outside), sqrt_part]);
-        }
+      // Partial extraction, e.g. Sqrt[12] = 2*Sqrt[3].
+      let (outside, inside) = extract_square_factor_big(&bn);
+      if outside > BigInt::from(1) {
+        let sqrt_part = make_sqrt(bigint_to_expr(inside));
+        return times_ast(&[bigint_to_expr(outside), sqrt_part]);
       }
       // Not a perfect square, return symbolic
       Ok(make_sqrt(args[0].clone()))
@@ -970,69 +902,11 @@ pub fn sqrt_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::FunctionCall { name, args: rargs }
       if name == "Rational" && rargs.len() == 2 =>
     {
-      // Only the u64 fast path here; a numerator/denominator that fits i128 but
-      // exceeds u64 (e.g. 7*10^30) would truncate on `as u64`, so it falls
-      // through to the BigInt path below.
-      if let (Expr::Integer(n), Expr::Integer(d)) = (&rargs[0], &rargs[1])
-        && *n >= 0
-        && *d > 0
-        && *n <= u64::MAX as i128
-        && *d <= u64::MAX as i128
-      {
-        // Extract perfect square factors from numerator and denominator
-        let extract_square_factor = |val: u64| -> (u64, u64) {
-          let mut outside = 1u64;
-          let mut inside = val;
-          let mut factor = 2u64;
-          while factor * factor <= inside {
-            while inside.is_multiple_of(factor * factor) {
-              outside *= factor;
-              inside /= factor * factor;
-            }
-            factor += 1;
-          }
-          (outside, inside)
-        };
-        let (n_out, n_in) = extract_square_factor(*n as u64);
-        let (d_out, d_in) = extract_square_factor(*d as u64);
-        // Result: (n_out / d_out) * Sqrt[n_in / d_in]
-        if n_in == 1 && d_in == 1 {
-          // Perfect square: just a rational
-          return Ok(make_rational(n_out as i128, d_out as i128));
-        }
-        if d_in == 1 {
-          // Result: (n_out / d_out) * Sqrt[n_in]
-          let sqrt_part = make_sqrt(Expr::Integer(n_in as i128));
-          if n_out == 1 && d_out == 1 {
-            return Ok(sqrt_part);
-          }
-          let coeff = make_rational(n_out as i128, d_out as i128);
-          return times_ast(&[coeff, sqrt_part]);
-        } else if n_in == 1 {
-          // Result: (n_out / d_out) * Power[d_in, -1/2].
-          // Use Power[d, -1/2] (Wolfram's normal form for Sqrt[1/d])
-          // rather than BinaryOp Divide, so structural equality with
-          // 1/Sqrt[d] (which evaluates to Power[d, -1/2]) holds.
-          let power =
-            power_ast(&[Expr::Integer(d_in as i128), make_rational(-1, 2)])?;
-          if n_out == 1 && d_out == 1 {
-            return Ok(power);
-          }
-          let coeff = make_rational(n_out as i128, d_out as i128);
-          return times_ast(&[coeff, power]);
-        } else {
-          // General case: (n_out / d_out) * Sqrt[n_in / d_in]
-          let sqrt_part = make_sqrt(make_rational(n_in as i128, d_in as i128));
-          if n_out == 1 && d_out == 1 {
-            return Ok(sqrt_part);
-          }
-          let coeff = make_rational(n_out as i128, d_out as i128);
-          return times_ast(&[coeff, sqrt_part]);
-        }
-      }
-      // BigInt fallback for rational arguments whose numerator/denominator is a
-      // BigInteger or exceeds u64 (e.g. Sqrt[2744*10^90/729] = 14*10^45/27 *
-      // Sqrt[14], reached via Skewness/Correlation of large-integer lists).
+      // Numerator and denominator each give up their square factor, leaving
+      // `(n_out / d_out) * Sqrt[n_in / d_in]`. Everything runs in BigInt, so a
+      // numerator past i128 (e.g. Sqrt[2744*10^90/729] = 14*10^45/27 *
+      // Sqrt[14], reached via Skewness/Correlation of large-integer lists) is
+      // handled by the same code as a small one.
       let to_big = |e: &Expr| -> Option<BigInt> {
         match e {
           Expr::Integer(v) if *v >= 0 => Some(BigInt::from(*v)),

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -895,40 +895,91 @@ pub fn rat_reduce_bigint(n: &BigInt, d: &BigInt) -> (BigInt, BigInt) {
   if d.is_negative() { (-n, -d) } else { (n, d) }
 }
 
-/// Extract the largest easily-found perfect-square factor from a positive
-/// i128: returns `(outside, inside)` with `n == outside^2 * inside`, so
-/// `Sqrt[n] = outside * Sqrt[inside]`. Square factors of primes below a
-/// bound come out by trial division; a leftover whole-square cofactor
-/// (e.g. a large prime squared) is caught by a final integer-sqrt check.
-/// A cofactor that is square-free over the bound but not a perfect square
-/// stays in `inside` (matching wolframscript, which also can't factor
-/// large semiprimes cheaply).
-pub fn extract_square_factor_i128(n: i128) -> (i128, i128) {
-  let mut outside: i128 = 1;
-  let mut inside = n.max(1);
-  let mut f: i128 = 2;
-  while f <= 100_000 && f.saturating_mul(f) <= inside {
-    let mut count = 0u32;
-    while inside % f == 0 {
-      inside /= f;
+/// Primes up to here are stripped by trial division before anything more
+/// expensive is tried.
+const SQUARE_FACTOR_TRIAL_BOUND: u64 = 100_000;
+
+/// Past this size the leftover cofactor is left inside the radical rather
+/// than handed to the general factoriser: the work Pollard's rho needs grows
+/// as the fourth root of the number, so a bound keeps a stray big radicand
+/// from stalling an evaluation.
+const SQUARE_FACTOR_FACTORISE_BITS: u64 = 80;
+
+/// Extract the largest perfect-square factor from a positive integer:
+/// returns `(outside, inside)` with `n == outside^2 * inside`, so
+/// `Sqrt[n] = outside * Sqrt[inside]`. Small primes come out by trial
+/// division, and whatever survives is factored properly, so a square factor
+/// too large to reach by trial division (`100003^2 * 115` →
+/// `100003 * Sqrt[115]`) still comes out. Only a cofactor past
+/// [`SQUARE_FACTOR_FACTORISE_BITS`] stays in `inside` unexamined.
+///
+/// This is the one place a radical is reduced. Every caller — `Sqrt` of an
+/// integer, of a rational, and the `c * Sqrt[r]` merge in `times_ast` —
+/// goes through it, so they always agree on how far a radical reduces.
+/// While they disagreed the merge rewrote a radical that `Sqrt` promptly
+/// reduced further, and the two rewrote each other forever.
+pub fn extract_square_factor_big(n: &BigInt) -> (BigInt, BigInt) {
+  let one = BigInt::from(1);
+  if n <= &one {
+    return (one, n.clone());
+  }
+  let mut outside = BigInt::from(1);
+  let mut inside = BigInt::from(1);
+  let mut rest = n.clone();
+
+  let mut f: u64 = 2;
+  while f <= SQUARE_FACTOR_TRIAL_BOUND {
+    let fb = BigInt::from(f);
+    if &fb * &fb > rest {
+      break;
+    }
+    let mut count: u32 = 0;
+    while (&rest % &fb).is_zero() {
+      rest /= &fb;
       count += 1;
     }
     if count >= 2 {
-      outside *= f.pow(count / 2);
+      outside *= fb.pow(count / 2);
     }
     if count % 2 == 1 {
-      inside *= f;
+      inside *= &fb;
     }
     f += 1;
   }
-  if inside > 1 {
-    let r = (inside as u128).isqrt() as i128;
-    if r.saturating_mul(r) == inside {
+
+  if rest > one {
+    let r = rest.sqrt();
+    if &r * &r == rest {
       outside *= r;
-      inside = 1;
+    } else if rest.bits() <= SQUARE_FACTOR_FACTORISE_BITS {
+      let Some(rest_uint) = rest.to_biguint() else {
+        return (outside, inside * rest);
+      };
+      for (prime, exponent) in num_prime::nt_funcs::factorize(rest_uint) {
+        let prime = BigInt::from(prime);
+        if exponent >= 2 {
+          outside *= prime.pow(exponent as u32 / 2);
+        }
+        if exponent % 2 == 1 {
+          inside *= &prime;
+        }
+      }
+    } else {
+      inside *= rest;
     }
   }
   (outside, inside)
+}
+
+/// [`extract_square_factor_big`] for an i128 radicand. Non-positive input
+/// has no square factor to give, so it reports `(1, 1)`.
+pub fn extract_square_factor_i128(n: i128) -> (i128, i128) {
+  let (outside, inside) = extract_square_factor_big(&BigInt::from(n.max(1)));
+  // Both factors divide `n`, so both fit wherever `n` did.
+  (
+    i128::try_from(&outside).unwrap_or(1),
+    i128::try_from(&inside).unwrap_or(n.max(1)),
+  )
 }
 
 /// Create a rational or integer result from numerator/denominator

--- a/tests/cli/math/arithmetic/Sqrt.md
+++ b/tests/cli/math/arithmetic/Sqrt.md
@@ -12,6 +12,27 @@ $ wo 'Sqrt[0]'
 0
 ```
 
+A square factor comes out of the radical even when it is far too large to
+find by trial division — `1150069001035` is `100003^2 * 115`:
+
+```scrut
+$ wo 'Sqrt[1150069001035]'
+100003*Sqrt[115]
+```
+
+```scrut
+$ wo 'Sqrt[1150069001035]/2'
+(100003*Sqrt[115])/2
+```
+
+A radicand with no repeated prime factor stays whole — `15485599740329` is
+`999983 * 15485863`:
+
+```scrut
+$ wo 'Sqrt[15485599740329]'
+Sqrt[15485599740329]
+```
+
 `\[Sqrt]` is a prefix operator binding to the next factor, with `^`, `!`
 and `[[…]]` binding tighter than the radical:
 

--- a/tests/cli/plotting/Graphics.md
+++ b/tests/cli/plotting/Graphics.md
@@ -10,6 +10,29 @@ $ wo 'Head[Graphics[{Red, Disk[]}]]'
 Graphics
 ```
 
+`Sphere` and `Ball` are drawn here too — in the plane a sphere is the circle
+bounding it and a ball the filled disk. That is how the circumcircle of
+three points reaches a picture, since `Circumsphere` returns a `Sphere`
+whatever the dimension:
+
+```scrut
+$ wo 'Circumsphere[{{0, 0}, {4, 0}, {0, 3}}]'
+Sphere[{2, 3/2}, 5/2]
+```
+
+```scrut
+$ wo 'StringCount[ExportString[Graphics[{Circumsphere[{{0, 0}, {4, 0}, {0, 3}}]}], "SVG"], "<ellipse"]'
+1
+```
+
+A `Style` around a label paints its `Background` behind the text, which is
+how a label stays readable over whatever it is placed on:
+
+```scrut
+$ wo 'StringContainsQ[ExportString[Graphics[{Line[{{0, 0}, {4, 4}}], Style[Text["8", {2, 2}], Background -> White]}], "SVG"], "<rect"]'
+True
+```
+
 ### Options
 
 - **`ImageSize`**, **`PlotRange`**, **`AspectRatio`**, **`Axes`**,

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -250,6 +250,85 @@ mod graphics {
       ));
     }
 
+    // A `Sphere` in the plane is the circle bounding it and a `Ball` the
+    // filled disk, so both draw in a two-dimensional `Graphics`. Regression:
+    // they were dropped, and a Demonstration that drew a circumcircle (which
+    // `Circumsphere` returns as a `Sphere` whatever the dimension) came out
+    // with no circle at all.
+    #[test]
+    fn sphere_in_2d_graphics_draws_a_circle() {
+      let svg = export_svg("Graphics[{Sphere[{1, 2}, 3]}]");
+      assert!(
+        svg.contains("<ellipse") && svg.contains("fill=\"none\""),
+        "planar Sphere should stroke a circle outline:\n{svg}"
+      );
+    }
+
+    #[test]
+    fn ball_in_2d_graphics_draws_a_filled_disk() {
+      let svg = export_svg("Graphics[{Ball[{1, 2}, 3]}]");
+      assert!(
+        svg.contains("<ellipse") && !svg.contains("fill=\"none\""),
+        "planar Ball should fill a disk:\n{svg}"
+      );
+    }
+
+    #[test]
+    fn sphere_defaults_to_unit_radius() {
+      insta::assert_snapshot!(export_svg("Graphics[{Sphere[{0, 0}]}]"));
+    }
+
+    // `Sphere[{p1, p2, …}, r]` is one sphere of radius `r` per centre.
+    #[test]
+    fn sphere_accepts_a_list_of_centers() {
+      let svg = export_svg("Graphics[{Sphere[{{0, 0}, {3, 0}, {6, 0}}, 1]}]");
+      assert_eq!(
+        svg.matches("<ellipse").count(),
+        3,
+        "one circle per centre:\n{svg}"
+      );
+    }
+
+    // `Ball[n]` / `Sphere[n]` is the unit ball/sphere at the origin in `n`
+    // dimensions; only the planar one has anything to draw here.
+    #[test]
+    fn ball_by_dimension_draws_only_in_the_plane() {
+      let planar = export_svg("Graphics[{Ball[2]}]");
+      assert!(planar.contains("<ellipse"), "Ball[2] is a disk:\n{planar}");
+      let solid = export_svg("Graphics[{Ball[3]}]");
+      assert!(
+        !solid.contains("<ellipse"),
+        "Ball[3] is not a planar region:\n{solid}"
+      );
+    }
+
+    // A three-dimensional centre belongs to a `Graphics3D` and contributes
+    // nothing to a flat picture — not even a plot range.
+    #[test]
+    fn sphere_with_3d_center_draws_nothing_in_2d() {
+      let svg = export_svg("Graphics[{Sphere[{1, 2, 3}, 1]}]");
+      assert!(
+        !svg.contains("<ellipse"),
+        "a 3D sphere has no planar drawing:\n{svg}"
+      );
+    }
+
+    // `Circumsphere` of three planar points returns `Sphere[centre, r]`, and
+    // that is what a Demonstration hands to `Graphics` to draw a circumcircle.
+    #[test]
+    fn circumsphere_of_planar_points_draws_the_circumcircle() {
+      let svg =
+        export_svg("Graphics[{Circumsphere[{{0, 0}, {4, 0}, {0, 3}}]}]");
+      // Centre {2, 3/2}, radius 5/2: a round circle filling the picture.
+      assert!(
+        svg.contains("<ellipse") && svg.contains("fill=\"none\""),
+        "circumcircle should be stroked:\n{svg}"
+      );
+      let rx = svg.split("rx=\"").nth(1).and_then(|s| s.split('"').next());
+      let ry = svg.split("ry=\"").nth(1).and_then(|s| s.split('"').next());
+      assert_eq!(rx, ry, "a circumcircle is round:\n{svg}");
+    }
+
     #[test]
     fn disk_sector_yin_yang() {
       insta::assert_snapshot!(export_svg(
@@ -829,6 +908,57 @@ mod graphics {
       ));
     }
 
+    /// A `Style` *around* the label carries `Background` just as one inside
+    /// it does: `Style[Text[…], 12, Background -> White]` paints a panel
+    /// behind the text, which is what hides the line a distance label sits
+    /// on. Regression: only a `Background` written on the `Text` itself (or
+    /// on a `Style` of its content) was drawn, so those labels came out with
+    /// the chord running through them.
+    #[test]
+    fn style_around_text_paints_its_background() {
+      let svg = export_svg(
+        "Graphics[{Line[{{0, 0}, {4, 4}}], \
+          Style[Text[\"abc\", {2, 2}], 12, Background -> White]}]",
+      );
+      let panel = svg
+        .lines()
+        .find(|l| l.starts_with("<rect"))
+        .unwrap_or_else(|| panic!("no background panel in {svg}"));
+      assert!(
+        panel.contains("fill=\"rgb(255,255,255)\""),
+        "the panel takes the background colour: {panel}"
+      );
+    }
+
+    /// The same background written on the `Text` still wins over the one the
+    /// surrounding `Style` supplies.
+    #[test]
+    fn text_background_option_beats_the_surrounding_style() {
+      let svg = export_svg(
+        "Graphics[{Style[Text[\"abc\", {0, 0}, Background -> Red], \
+          Background -> White]}]",
+      );
+      let panel = svg
+        .lines()
+        .find(|l| l.starts_with("<rect"))
+        .unwrap_or_else(|| panic!("no background panel in {svg}"));
+      assert!(
+        panel.contains("fill=\"rgb(255,0,0)\""),
+        "the label's own background wins: {panel}"
+      );
+    }
+
+    /// `Background` styles a label, not the primitives beside it — a shape
+    /// under the same `Style` keeps its own colour and grows no panel.
+    #[test]
+    fn style_background_does_not_paint_behind_shapes() {
+      let svg = export_svg(
+        "Graphics[{Style[{Red, Disk[{0, 0}, 1]}, Background -> White]}]",
+      );
+      assert!(!svg.contains("<rect"), "no panel behind a shape:\n{svg}");
+      assert!(svg.contains("rgb(255,0,0)"), "the disk stays red:\n{svg}");
+    }
+
     /// `Inset[graphic, pos, opos, size]` draws the picture inside this
     /// one — scaled into its box and moved to `pos` — instead of writing
     /// the object's text form. `{Automatic, dir}` turns it to face `dir`.
@@ -1091,6 +1221,57 @@ mod graphics {
           Text[\"Origin\", {0, -0.8}]
         }, ImageSize -> 400]"
       ));
+    }
+
+    /// The picture a Demonstration about cyclic polygons draws: the
+    /// circumcircle of the vertices (a `Sphere`, which is what
+    /// `Circumsphere` returns in the plane), every chord between them, each
+    /// chord's length written over it on a panel that hides the line, and a
+    /// subscripted name beside each vertex. Every one of those pieces went
+    /// missing or came out wrong at some point; this keeps the whole figure
+    /// together.
+    #[test]
+    fn labelled_cyclic_polygon_draws_circle_chords_and_masked_labels() {
+      let svg = export_svg(
+        "Show[{
+           Graphics[{Circumsphere[{{14, 0}, {0, 0}, {5, 12}}]}],
+           Graphics[{
+             Map[{Line[{{14, 0}, {0, 0}, {5, 12}}[[#]]],
+                  Style[Text[Apply[EuclideanDistance, \
+                              {{14, 0}, {0, 0}, {5, 12}}[[#]]], \
+                             Mean[{{14, 0}, {0, 0}, {5, 12}}[[#]]]], \
+                        12, Background -> White]} &, Subsets[Range[3], {2}]],
+             Table[{PointSize[0.015], \
+                    Point[{{14, 0}, {0, 0}, {5, 12}}[[n]]], \
+                    Text[Subscript[\"M\", n], \
+                         1.1 {{14, 0}, {0, 0}, {5, 12}}[[n]]]}, {n, 3}]}]},
+         ImageSize -> {400, 400}]",
+      );
+      assert_eq!(
+        svg.matches("<ellipse").count(),
+        1,
+        "the circumcircle is drawn once:\n{svg}"
+      );
+      assert_eq!(
+        svg.matches("<polyline").count(),
+        3,
+        "one chord per pair of vertices:\n{svg}"
+      );
+      assert_eq!(
+        svg.matches("fill=\"rgb(255,255,255)\"").count(),
+        3,
+        "each length sits on a panel that hides its chord:\n{svg}"
+      );
+      // 13 and 14 are exact; the third chord is Sqrt[194].
+      for length in ["13", "14"] {
+        assert!(
+          svg.contains(&format!(">{length}</text>")),
+          "chord length {length} missing:\n{svg}"
+        );
+      }
+      for name in ["M\u{2081}", "M\u{2082}", "M\u{2083}"] {
+        assert!(svg.contains(name), "vertex label {name} missing:\n{svg}");
+      }
     }
 
     #[test]
@@ -15161,6 +15342,59 @@ mod manipulate {
       &spec.controls[0],
       ManipulateControl::Discrete { popup: true, .. }
     ));
+  }
+
+  /// The control shape a Demonstration built around a cyclic polygon writes:
+  /// four stepped integer sliders with italic one-letter labels and a
+  /// fractional starting value, alongside options (`Appearance`, `ImageSize`,
+  /// `SaveDefinitions`, `ControlPlacement`) that name no variable and must
+  /// not become controls of their own.
+  #[test]
+  fn spec_labelled_stepped_sliders_beside_layout_options() {
+    let slider = |name: &str, initial: &str| {
+      format!(
+        "{{{{{name}, {initial}, Style[\"{name}\", Italic]}}, -10, 10, 1, \
+         Appearance -> \"Labeled\", ImageSize -> Small}}"
+      )
+    };
+    let expr = interpret_to_expr(&format!(
+      "Manipulate[x + y + z + k, {}, {}, {}, {}, \
+       SaveDefinitions -> True, ControlPlacement -> Left]",
+      slider("x", "1/2"),
+      slider("y", "1/2"),
+      slider("z", "1/2"),
+      slider("k", "1"),
+    ))
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert_eq!(spec.controls.len(), 4, "options bind no variable");
+    let expected_initial = [0.5, 0.5, 0.5, 1.0];
+    for (control, (name, initial)) in spec
+      .controls
+      .iter()
+      .zip(["x", "y", "z", "k"].iter().zip(expected_initial))
+    {
+      match control {
+        ManipulateControl::Continuous {
+          name: got,
+          min,
+          max,
+          step,
+          initial: got_initial,
+          label,
+          label_runs,
+        } => {
+          assert_eq!(got, name);
+          assert_eq!((*min, *max), (-10.0, 10.0));
+          assert_eq!(*step, Some(1.0), "the slider steps by whole numbers");
+          assert_eq!(*got_initial, initial);
+          assert_eq!(label, name);
+          assert_eq!(label_runs.len(), 1);
+          assert!(label_runs[0].italic, "the variable is set in italics");
+        }
+        other => panic!("expected a continuous control, got {other:?}"),
+      }
+    }
   }
 
   /// `LocatorAutoCreate -> {min, max}` bounds how many points the user may

--- a/tests/interpreter_tests/math/misc.rs
+++ b/tests/interpreter_tests/math/misc.rs
@@ -2028,6 +2028,48 @@ mod radical_coefficient_merge {
     );
   }
 
+  // A square factor too large to reach by trial division still comes out, and
+  // `Sqrt` and the `c * Sqrt[r]` merge agree about it.
+  //
+  // Regression: the merge stopped looking for square factors at 100000 while
+  // `Sqrt` kept going, so `Sqrt[100003^2 * 115]/2` reduced one way, was
+  // rebuilt the other, and the two rewrote each other forever — halving a
+  // coefficient carrying a radical (a `Mean` of two such points) never
+  // returned.
+  #[test]
+  fn large_square_factors_come_out_of_a_radical() {
+    assert_eq!(
+      interpret("InputForm[Sqrt[1150069001035]]").unwrap(),
+      "InputForm[100003*Sqrt[115]]",
+      "1150069001035 == 100003^2 * 115"
+    );
+    // Halving a coefficient that carries the radical: the shape is already
+    // canonical, so only the coefficient changes.
+    assert_eq!(
+      interpret("InputForm[(100003*Sqrt[115])/2]").unwrap(),
+      "InputForm[(100003*Sqrt[115])/2]"
+    );
+    assert_eq!(
+      interpret("InputForm[Mean[{Sqrt[115]/7, Sqrt[115]/11}]]").unwrap(),
+      "InputForm[(9*Sqrt[115])/77]"
+    );
+    assert_eq!(
+      interpret("InputForm[Sqrt[1150069001035]/2]").unwrap(),
+      "InputForm[(100003*Sqrt[115])/2]"
+    );
+    // Two distinct large primes leave nothing square to take out.
+    assert_eq!(
+      interpret("InputForm[Sqrt[15485599740329]]").unwrap(),
+      "InputForm[Sqrt[15485599740329]]",
+      "15485599740329 == 999983 * 15485863, square-free"
+    );
+    // The same factorisation reaches the rational form.
+    assert_eq!(
+      interpret("InputForm[Sqrt[1150069001035/4]]").unwrap(),
+      "InputForm[(100003*Sqrt[115])/2]"
+    );
+  }
+
   // wolframscript pulls a positive numeric factor out of a product radicand
   // as its own radical, and only when the rest is NOT numeric.
   #[test]

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__graphics__primitives__sphere_defaults_to_unit_radius.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__graphics__primitives__sphere_defaults_to_unit_radius.snap
@@ -1,0 +1,7 @@
+---
+source: tests/interpreter_tests/graphics.rs
+expression: "export_svg(\"Graphics[{Sphere[{0, 0}]}]\")"
+---
+<svg width="360" height="360" viewBox="0 0 360 360" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<ellipse cx="180.00" cy="180.00" rx="166.67" ry="166.67" fill="none" stroke="rgb(0,0,0)" stroke-width="1.44"/>
+</svg>


### PR DESCRIPTION
Checking a Wolfram Demonstration notebook against Woxi Studio — a rational
cyclic polygon drawn inside its circumcircle, with every chord labelled by
its length — turned up three gaps that between them left the widget with no
circle, unreadable labels, and one slider position that never finished
evaluating.

`Sphere` and `Ball` are drawn in a two-dimensional `Graphics`: in the plane
a sphere is the circle bounding it and a ball the filled disk. Both used to
be dropped, contributing not even a plot range, and since `Circumsphere`
returns a `Sphere` whatever the dimension, a picture built around a
circumcircle came out with no circle at all. A list of centres draws one
per point, and `Ball[2]` is the unit disk at the origin; a three-dimensional
centre still belongs to a `Graphics3D` and draws nothing.

A `Style` around a label now paints its `Background` behind the text.
`Style[Text[…], 12, Background -> White]` is what keeps a distance label
readable over the chord it sits on — only a `Background` written on the
`Text` itself was drawn before, so those labels had the line running
through them. The style state carries it, which also retires the separate
lookup for a `Style` inside the label.

A square factor too large to reach by trial division now comes out of a
radical, so `Sqrt[100003^2 * 115]` is `100003 Sqrt[115]`. `Sqrt` and the
`c Sqrt[r]` merge in `times_ast` looked for square factors to different
depths — the merge stopped at 100000, `Sqrt` did not — so each rewrote what
the other produced and the two never converged: halving a coefficient that
carried a radical, which is what taking the `Mean` of two such points does,
ran forever. Both, and the two further copies of the same extraction, now
share one routine that strips small primes by trial division and factors
what survives, leaving only a cofactor past 80 bits unexamined.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DGPLZPHx9oRrzCtMBZpJPC