### PR TITLE
Show a Pane grid cell, and rule and space a grid as asked

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,28 @@
 
 # Unreleased
 
+- Fixes driven by the plane-geometry Wolfram Demonstrations that stack a
+    numeric readout over a drawing:
+    - A `Pane[…]` grid cell shows what it holds. `Pane` only reserves an
+        area for its content, so a body laid out as
+        `Grid[{{Pane[…]}, {Graphics[…]}}]` used to print the whole
+        `Pane[…]` call as source text in place of the readout — and
+        stretch the grid to the width of that source. `Item[…]` and
+        `Text[…]` cells are peeled the same way, through the one helper
+        every display pass already shares.
+    - `Dividers -> All` rules every position of a grid, the outer edges
+        included, so the grid is drawn as a closed box. Only the
+        boundaries *between* cells were ruled before, which is what
+        `Dividers -> Center` means; the two now differ, and either can be
+        set per direction as `Dividers -> {colspec, rowspec}`.
+    - `Spacings -> {{i -> s, …}, …}` sets the gap at individual column
+        positions — position `i` is the gap to the left of column `i`, and
+        position `ncols + 1` the margin after the last column. A
+        list-valued horizontal spec used to be dropped, so a readout that
+        groups its columns with wide and tight gaps came out evenly and
+        far too widely spaced. A plain `{s1, s2, …}` names the positions
+        in order, and positions left out keep the default gap.
+
 - Fixes driven by the "Selectivity in a Semibatch Reactor" Wolfram
     Demonstration:
     - `Text` inside a `Graphics3D` scene is drawn — a labelled 3D

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -10241,7 +10241,6 @@ pub fn parse_grid_style(directives: &[Expr]) -> GridStyle {
   gs
 }
 
-/// Check if a cell is or contains an Expr::Image (unwrapping Style).
 /// The rendered SVG of a grid cell that is a graphic, and its natural
 /// size. `Grid` lays such a cell out as a picture instead of printing the
 /// expression's text form.
@@ -10284,6 +10283,51 @@ fn grid_cell_graphic(cell: &Expr) -> Option<(String, f64, f64)> {
   Some((svg, parsed.nat_w, parsed.nat_h))
 }
 
+/// The per-position half of a `Spacings` spec: `{i1 -> s1, i2 -> s2, …}`
+/// names the gap at individual positions, while a plain `{s1, s2, …}` gives
+/// them in order from the first. The result is indexed by position - 1, with
+/// `None` wherever the spec says nothing and the default gap applies.
+fn parse_position_spacings(spec: &Expr) -> Vec<Option<f64>> {
+  let Expr::List(items) = spec else {
+    return Vec::new();
+  };
+  let value = |e: &Expr| match e {
+    Expr::Integer(n) => Some(*n as f64),
+    Expr::Real(f) => Some(*f),
+    _ => None,
+  };
+  let mut out: Vec<Option<f64>> = Vec::new();
+  let mut put = |index: usize, v: f64| {
+    if out.len() <= index {
+      out.resize(index + 1, None);
+    }
+    out[index] = Some(v);
+  };
+  for (i, item) in items.iter().enumerate() {
+    match item {
+      Expr::Rule {
+        pattern,
+        replacement,
+      } => {
+        // Positions are 1-based, and a spec may name them out of order.
+        if let (Expr::Integer(pos), Some(v)) =
+          (pattern.as_ref(), value(replacement))
+          && *pos >= 1
+        {
+          put(*pos as usize - 1, v);
+        }
+      }
+      other => {
+        if let Some(v) = value(other) {
+          put(i, v);
+        }
+      }
+    }
+  }
+  out
+}
+
+/// Check if a cell is or contains an Expr::Image (unwrapping Style).
 fn unwrap_to_image(cell: &Expr) -> Option<&Expr> {
   match cell {
     Expr::Image { .. } => Some(cell),
@@ -10406,6 +10450,18 @@ fn grid_svg_styled_internal(
     }
   };
 
+  // A cell may arrive inside a wrapper that only says how to set it —
+  // `Pane[…]` reserving an area, an `Item[…]` cell, `Text[…]` choosing a
+  // font. What the cell *shows* is what they hold, so peel them before
+  // any sizing or drawing pass: otherwise the cell printed as source
+  // (`Pane[Grid[…]]`), which is how a Demonstration's readout panel used
+  // to render.
+  for row in &mut rows {
+    for cell in row.iter_mut() {
+      *cell = unwrap_display_wrappers(cell);
+    }
+  }
+
   // Parse options from remaining args
   let mut frame_outer = false; // Frame -> True: outer border only
   let mut frame_all = false; // Frame -> All: all gridlines
@@ -10414,11 +10470,22 @@ fn grid_svg_styled_internal(
   let mut col_headings: Vec<Expr> = Vec::new();
   let mut spacings_h: Option<f64> = None; // horizontal spacing override
   let mut spacings_v: Option<f64> = None; // vertical spacing override
+  // `Spacings -> {{i -> s, …}, …}` sets the gap at individual column
+  // positions: position `i` is the gap to the left of column `i`, and
+  // position `ncols + 1` the margin after the last column. Positions left
+  // out keep the default gap.
+  let mut col_spacings: Vec<Option<f64>> = Vec::new();
   // TableForm's TableSpacing maps directly to pixels (see the option below).
   let mut table_pad_x: Option<f64> = None; // per-cell horizontal padding (px)
   let mut table_row_gap: Option<f64> = None; // gap between rows (px)
   let mut dividers_col = false; // vertical divider lines between columns
   let mut dividers_row = false; // horizontal divider lines between rows
+  // `Dividers -> All` rules *every* position, the outer edges included, so
+  // a grid drawn that way is a closed box; `Dividers -> Center` rules only
+  // the boundaries between cells. These flags record which of the two was
+  // asked for, per direction.
+  let mut dividers_col_border = false; // left/right edges from `All`
+  let mut dividers_row_border = false; // top/bottom edges from `All`
   // Per-position divider specs: Some(color) = draw with color, None = don't draw
   // These use the same repeating-list pattern as backgrounds
   let mut col_dividers: Vec<Option<Color>> = Vec::new(); // vertical lines (ncols+1 positions)
@@ -10472,6 +10539,8 @@ fn grid_svg_styled_internal(
           Expr::Identifier(val) if val == "All" || val == "True" => {
             dividers_col = true;
             dividers_row = true;
+            dividers_col_border = true;
+            dividers_row_border = true;
           }
           Expr::Identifier(val) if val == "Center" => {
             dividers_col = true;
@@ -10483,6 +10552,17 @@ fn grid_svg_styled_internal(
             for (idx, spec) in items.iter().enumerate() {
               match spec {
                 Expr::Identifier(v) if v == "All" || v == "True" => {
+                  if idx == 0 {
+                    dividers_col = true;
+                    dividers_col_border = true;
+                  } else {
+                    dividers_row = true;
+                    dividers_row_border = true;
+                  }
+                }
+                // `Center` rules the boundaries between cells only, so it
+                // leaves the outer edges of the grid open.
+                Expr::Identifier(v) if v == "Center" => {
                   if idx == 0 {
                     dividers_col = true;
                   } else {
@@ -10645,6 +10725,10 @@ fn grid_svg_styled_internal(
                 match &items[0] {
                   Expr::Integer(n) => spacings_h = Some(*n as f64),
                   Expr::Real(f) => spacings_h = Some(*f),
+                  // A list gives the gap at each position individually.
+                  Expr::List(_) => {
+                    col_spacings = parse_position_spacings(&items[0]);
+                  }
                   _ => {}
                 }
               }
@@ -10771,6 +10855,45 @@ fn grid_svg_styled_internal(
   let base_row_height = font_size + pad_y;
   let frac_row_height = font_size + pad_y + 10.0; // taller for stacked fractions
 
+  // The padding a column carries on each side. A gap between two columns is
+  // one gap, so it is shared half-and-half by the columns it separates,
+  // while the gaps at the two ends belong entirely to the first and last
+  // column. Positions the spec leaves out fall back to the uniform layout:
+  // `pad_x` between columns and `pad_x / 2` at each end, i.e. `pad_x` per
+  // column however the grid is spaced.
+  let (col_pad_left, col_pad_right): (Vec<f64>, Vec<f64>) = {
+    let spacing_at = |position: usize| -> Option<f64> {
+      col_spacings
+        .get(position - 1)
+        .copied()
+        .flatten()
+        .map(|ems| ems * char_width)
+    };
+    let inner_gap = |position: usize| spacing_at(position).unwrap_or(pad_x);
+    let edge_gap =
+      |position: usize| spacing_at(position).unwrap_or(pad_x / 2.0);
+    let mut left = Vec::with_capacity(num_cols);
+    let mut right = Vec::with_capacity(num_cols);
+    for j in 0..num_cols {
+      // Column `j` (0-based) sits between positions `j + 1` and `j + 2`.
+      left.push(if j == 0 {
+        edge_gap(1)
+      } else {
+        inner_gap(j + 1) / 2.0
+      });
+      right.push(if j + 1 == num_cols {
+        edge_gap(num_cols + 1)
+      } else {
+        inner_gap(j + 2) / 2.0
+      });
+    }
+    (left, right)
+  };
+  let col_pad = |j: usize| -> f64 {
+    col_pad_left.get(j).copied().unwrap_or(pad_x / 2.0)
+      + col_pad_right.get(j).copied().unwrap_or(pad_x / 2.0)
+  };
+
   let mut col_widths: Vec<f64> = vec![0.0; num_cols];
   // Cells that span several columns are held back: their columns are sized
   // by the ordinary cells first, and only what a span still needs is added
@@ -10782,8 +10905,8 @@ fn grid_svg_styled_internal(
         continue;
       }
       let w = match grid_cell_graphic(cell) {
-        Some((_, nat_w, _)) => nat_w + pad_x,
-        None => estimate_display_width(cell) * char_width + pad_x,
+        Some((_, nat_w, _)) => nat_w + col_pad(j),
+        None => estimate_display_width(cell) * char_width + col_pad(j),
       };
       let cols = span_width(row, j);
       if cols > 1 {
@@ -10828,7 +10951,7 @@ fn grid_svg_styled_internal(
     .collect();
   for (j, dims) in col_decimal_dims.iter().enumerate() {
     if let Some((max_int, max_frac)) = dims {
-      col_widths[j] = (max_int + max_frac) * char_width + pad_x;
+      col_widths[j] = (max_int + max_frac) * char_width + col_pad(j);
     }
   }
 
@@ -10862,7 +10985,7 @@ fn grid_svg_styled_internal(
         } = img
       {
         let col_w = if j < col_widths.len() {
-          col_widths[j] - pad_x
+          col_widths[j] - col_pad(j)
         } else {
           200.0
         };
@@ -10982,7 +11105,11 @@ fn grid_svg_styled_internal(
   let total_width: f64 = grid_width + 2.0 * paren_margin;
 
   // Build SVG — add padding when frame borders are drawn so strokes aren't clipped
-  let has_frame = frame_all || frame_outer || has_per_pos_dividers;
+  let has_frame = frame_all
+    || frame_outer
+    || has_per_pos_dividers
+    || dividers_col_border
+    || dividers_row_border;
   let frame_pad: f64 = if has_frame { 0.5 } else { 0.0 };
   let svg_w = (total_width + 2.0 * frame_pad).ceil() as u32;
   let svg_h = (total_height + 2.0 * frame_pad).ceil() as u32;
@@ -11028,6 +11155,10 @@ fn grid_svg_styled_internal(
 
   // Precompute divider/frame drawing flags (needed for visual bounds below)
   let draw_outer = frame_all || frame_outer;
+  // `Dividers -> All` closes the grid on that axis: the top/bottom (or
+  // left/right) edge is ruled as well as the boundaries between cells.
+  let draw_outer_h = draw_outer || dividers_row_border;
+  let draw_outer_v = draw_outer || dividers_col_border;
   let draw_inner_h = frame_all || dividers_row;
   let draw_inner_v = frame_all || dividers_col;
   let has_row_div = !row_dividers.is_empty();
@@ -11147,16 +11278,23 @@ fn grid_svg_styled_internal(
           .copied()
           .flatten()
           .unwrap_or((0.0, 0.0));
-        let dot_x = x_offset + pad_x / 2.0 + max_int * char_width;
+        let dot_x = x_offset + col_pad_left[j] + max_int * char_width;
         match decimal_split_width(cell) {
           Some((iw, _)) => ("start", dot_x - iw * char_width),
           None => ("middle", x_offset + col_w / 2.0),
         }
       } else {
+        let span_end = (j + span_width(row, j)).min(num_cols) - 1;
         let cx = match col_align {
-          "start" => x_offset + pad_x / 2.0,
-          "end" => x_offset + col_w - pad_x / 2.0,
-          _ => x_offset + col_w / 2.0,
+          "start" => x_offset + col_pad_left[j],
+          "end" => x_offset + col_w - col_pad_right[span_end],
+          // Centred on the cell's own area, which is the column run minus
+          // the gaps on its two outer sides — the same as the middle of the
+          // run whenever those gaps are equal.
+          _ => {
+            let (l, r) = (col_pad_left[j], col_pad_right[span_end]);
+            x_offset + l + (col_w - l - r) / 2.0
+          }
         };
         (col_align, cx)
       };
@@ -11190,11 +11328,11 @@ fn grid_svg_styled_internal(
           ..
         } = img
         {
-          let avail_w = col_w - pad_x;
+          let avail_w = col_w - col_pad(j);
           let scale = avail_w / (*iw as f64);
           let draw_w = avail_w;
           let draw_h = (*ih as f64) * scale;
-          let ix = x_offset + pad_x / 2.0;
+          let ix = x_offset + col_pad_left[j];
           let vis_h = cell_bottom - cell_top;
           let iy = cell_top + (vis_h - draw_h) / 2.0;
 
@@ -11309,12 +11447,12 @@ fn grid_svg_styled_internal(
       let (should_draw, stroke) = if has_row_div {
         if let Some(Some(color)) = row_dividers.get(i) {
           (true, color.to_svg_rgb())
-        } else if is_border && draw_outer {
+        } else if is_border && draw_outer_h {
           (true, default_stroke.clone())
         } else {
           (false, String::new())
         }
-      } else if (is_border && draw_outer) || (!is_border && draw_inner_h) {
+      } else if (is_border && draw_outer_h) || (!is_border && draw_inner_h) {
         (true, default_stroke.clone())
       } else {
         (false, String::new())
@@ -11367,12 +11505,12 @@ fn grid_svg_styled_internal(
       let (should_draw, stroke) = if has_col_div {
         if let Some(Some(color)) = col_dividers.get(j) {
           (true, color.to_svg_rgb())
-        } else if is_border && draw_outer {
+        } else if is_border && draw_outer_v {
           (true, default_stroke.clone())
         } else {
           (false, String::new())
         }
-      } else if (is_border && draw_outer) || (!is_border && draw_inner_v) {
+      } else if (is_border && draw_outer_v) || (!is_border && draw_inner_v) {
         (true, default_stroke.clone())
       } else {
         (false, String::new())
@@ -13513,9 +13651,12 @@ fn render_tabular_svg_grid(
 /// `Dynamic` evaluation captures are embedded in the surrounding layout, not
 /// standalone outputs, so they are dropped from the capture buffer.
 /// Peel the wrappers that say how to *set* what they hold rather than what
-/// to show: `Text[…]`, an `Item[…]` cell, and the form wrappers. They nest
-/// in any order — `Item[Text@TraditionalForm@Framed[…], …]` — so peel until
-/// what is left is the thing that actually draws.
+/// to show: `Text[…]`, an `Item[…]` cell, a `Pane[…]` box, and the form
+/// wrappers. They nest in any order — `Item[Text@TraditionalForm@Framed[…],
+/// …]` — so peel until what is left is the thing that actually draws.
+/// `Pane[content, opts…]` only reserves an area for `content`; what is
+/// shown is `content`, so a display pass has to reach through it (a grid
+/// cell holding one used to print as `Pane[…]` source).
 ///
 /// A `TraditionalForm` around a picture or a layout only asks for its
 /// contents to be set traditionally, and the layout renderer takes it from
@@ -13530,7 +13671,7 @@ pub fn unwrap_display_wrappers(expr: &Expr) -> Expr {
       "Text" | "TraditionalForm" | "StandardForm" | "DisplayForm" => {
         args.len() == 1
       }
-      "Item" => !args.is_empty(),
+      "Item" | "Pane" => !args.is_empty(),
       _ => false,
     };
     if !pass_through {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2018,11 +2018,11 @@ fn format_top_level_result(result_expr: syntax::Expr) -> String {
   let result_expr = render_tabular_if_needed(result_expr);
   // In visual mode, render TableForm[list], MatrixForm[list], and Column[list] as SVGs
   let result_expr = if VISUAL_MODE.with(|v| *v.borrow()) {
-    // Strip the transparent Pane wrapper first so the passes below see
-    // the wrapped content (e.g. Pane[Column[{…, Graphics[…]}]] renders the
-    // column with its embedded graphic). CLI mode keeps the symbolic
-    // Pane[…] echo to match wolframscript.
-    let result_expr = unwrap_pane_or_text_if_needed(result_expr);
+    // Strip the wrappers that only say how to set what they hold, so the
+    // passes below see the wrapped content (e.g. Pane[Column[{…,
+    // Graphics[…]}]] renders the column with its embedded graphic). CLI
+    // mode keeps the symbolic Pane[…] echo to match wolframscript.
+    let result_expr = unwrap_display_pass_through(result_expr);
     let result_expr = render_interactive_pane_if_needed(result_expr);
     let result_expr = render_labeled_if_needed(result_expr);
     let result_expr = render_dynamic_if_needed(result_expr);
@@ -2754,33 +2754,12 @@ pub(crate) fn render_traditionalform_list_if_needed(
   }
 }
 
-/// Strip the transparent size wrapper `Pane[content, opts…]` so the visual
-/// render passes see the content itself. Wolfram's FrontEnd displays the
-/// wrapped content (Pane merely constrains its size), so for SVG typesetting
-/// the content is the right thing to render — otherwise e.g.
-/// `Pane[Column[{…, Graphics[…]}]]` (the shape of many Manipulate bodies)
-/// would stay a textual echo with the graphic never rendered.
-/// `Text[content]` is the same kind of wrapper: it selects the font the
-/// content is set in, not what is shown, so `Text@Pane[Column[{…}]]` — the
-/// standard Demonstrations body — has to reach the column underneath.
-/// `Text[expr, pos, …]` is the *graphics primitive* instead and is left
-/// alone.
-fn unwrap_pane_or_text_if_needed(expr: syntax::Expr) -> syntax::Expr {
-  match expr {
-    syntax::Expr::FunctionCall { ref name, ref args }
-      if (name == "Pane" && !args.is_empty())
-        || (name == "Text" && args.len() == 1) =>
-    {
-      unwrap_pane_or_text_if_needed(args[0].clone())
-    }
-    other => other,
-  }
-}
-
 /// Wrappers that say how to *set* what they hold rather than what to show:
-/// `Text[expr]`, `Item[expr, opts…]` and the form wrappers. A display pass
-/// has to see through them to reach the thing that actually draws — a
-/// `Framed[…]` inside a `Text@TraditionalForm@…` is still a framed box.
+/// `Pane[expr, opts…]`, `Text[expr]`, `Item[expr, opts…]` and the form
+/// wrappers. A display pass has to see through them to reach the thing that
+/// actually draws — a `Framed[…]` inside a `Text@TraditionalForm@…` is
+/// still a framed box, and `Pane[Column[{…, Graphics[…]}]]` (the shape of
+/// many Manipulate bodies) is still the column underneath.
 fn unwrap_display_pass_through(expr: syntax::Expr) -> syntax::Expr {
   functions::graphics::unwrap_display_wrappers(&expr)
 }
@@ -2825,7 +2804,6 @@ fn render_inline_display_wrapper(expr: syntax::Expr) -> syntax::Expr {
   // wrapper arguments, so we apply the relevant ones here for a single
   // sub-expression.
   let expr = unwrap_display_pass_through(expr);
-  let expr = unwrap_pane_or_text_if_needed(expr);
   let expr = render_interactive_pane_if_needed(expr);
   let expr = render_dynamic_if_needed(expr);
   let expr = render_grid_if_needed(expr);

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -8831,6 +8831,49 @@ mod pane_wrapper_display {
     }
   }
 
+  // A `Pane` is transparent wherever it appears, not only at the top of a
+  // body: a Demonstration lays its readout out as `Grid[{{Pane[…]},
+  // {Graphics[…]}}]`, and the pane's cell has to show what it holds.
+  // Regression: the cell printed the `Pane[…]` call as source text, which
+  // stretched the grid to the width of that source.
+  #[test]
+  fn pane_in_a_grid_cell_shows_its_content() {
+    clear_state();
+    let svg = interpret_with_stdout(
+      "Grid[{{Pane[Grid[{{\"p\", \"=\", 12}}], ImageSize -> {200, 40}, \
+         Alignment -> {Center, Center}]}, \
+        {Graphics[{Disk[]}, ImageSize -> {200, 100}]}}, \
+       Alignment -> {Center, Top}]",
+    )
+    .unwrap()
+    .graphics
+    .expect("the grid should render");
+    assert!(!svg.contains("Pane["), "the wrapper must not print: {svg}");
+    for part in ["p", "=", "12"] {
+      assert!(
+        svg.contains(&format!(">{part}<")),
+        "missing `{part}`: {svg}"
+      );
+    }
+    assert!(svg.contains("<ellipse"), "the picture row draws: {svg}");
+  }
+
+  // `Item[…]` and `Text[…]` cells are the same kind of wrapper — they say
+  // how to set a cell, not what it shows.
+  #[test]
+  fn item_and_text_grid_cells_show_their_content() {
+    clear_state();
+    let svg = interpret_with_stdout(
+      "Grid[{{Item[\"a\", Alignment -> Left], Text[\"b\"]}}]",
+    )
+    .unwrap()
+    .graphics
+    .expect("the grid should render");
+    assert!(!svg.contains("Item["), "the wrapper must not print: {svg}");
+    assert!(!svg.contains("Text["), "the wrapper must not print: {svg}");
+    assert!(svg.contains(">a<") && svg.contains(">b<"), "{svg}");
+  }
+
   // The CLI (plain `interpret`, matching wolframscript) keeps the
   // symbolic echo — the unwrap is a visual-host affordance only.
   #[test]
@@ -10565,6 +10608,157 @@ mod plot_grid {
 
 mod grid_frame_and_background {
   use super::*;
+
+  /// Every `<line>` of an SVG, as `(x1, y1, x2, y2)`.
+  fn grid_lines(svg: &str) -> Vec<(f64, f64, f64, f64)> {
+    svg
+      .lines()
+      .filter(|l| l.starts_with("<line "))
+      .map(|l| {
+        let coord = |name: &str| -> f64 {
+          l.split(&format!("{name}=\""))
+            .nth(1)
+            .and_then(|t| t.split('"').next())
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(f64::NAN)
+        };
+        (coord("x1"), coord("y1"), coord("x2"), coord("y2"))
+      })
+      .collect()
+  }
+
+  /// `Dividers -> All` rules every position, the outer edges included, so
+  /// the grid is drawn as a closed box: a two-by-two grid gets three
+  /// horizontal and three vertical lines. Regression: only the boundaries
+  /// between cells were ruled, leaving the box open on all four sides.
+  #[test]
+  fn dividers_all_closes_the_grid() {
+    let svg = export_svg(r#"Grid[{{"a", "b"}, {"c", "d"}}, Dividers -> All]"#);
+    let lines = grid_lines(&svg);
+    let horizontal: Vec<_> = lines.iter().filter(|l| l.1 == l.3).collect();
+    let vertical: Vec<_> = lines.iter().filter(|l| l.0 == l.2).collect();
+    assert_eq!(horizontal.len(), 3, "top, middle and bottom: {svg}");
+    assert_eq!(vertical.len(), 3, "left, middle and right: {svg}");
+    // The outer ones sit on the edges of the grid.
+    assert!(horizontal.iter().any(|l| l.1 == 0.0), "top edge: {svg}");
+    assert!(vertical.iter().any(|l| l.0 == 0.0), "left edge: {svg}");
+  }
+
+  /// `Dividers -> Center` rules only the boundaries *between* cells, so the
+  /// same grid keeps its outer edges open.
+  #[test]
+  fn dividers_center_leaves_the_edges_open() {
+    let svg =
+      export_svg(r#"Grid[{{"a", "b"}, {"c", "d"}}, Dividers -> Center]"#);
+    let lines = grid_lines(&svg);
+    assert_eq!(lines.len(), 2, "one horizontal and one vertical: {svg}");
+    assert!(lines.iter().all(|l| l.0 != 0.0 || l.1 != 0.0), "{svg}");
+  }
+
+  /// The two directions are set independently: `{None, All}` closes the
+  /// grid top and bottom without ruling any column boundary.
+  #[test]
+  fn dividers_all_applies_per_direction() {
+    let svg =
+      export_svg(r#"Grid[{{"a", "b"}, {"c", "d"}}, Dividers -> {None, All}]"#);
+    let lines = grid_lines(&svg);
+    assert!(lines.iter().all(|l| l.1 == l.3), "no vertical rules: {svg}");
+    assert_eq!(lines.len(), 3, "top, middle and bottom: {svg}");
+  }
+
+  /// A single-row grid ruled with `All` is still a closed box — the top and
+  /// bottom edges are the only horizontal positions it has.
+  #[test]
+  fn dividers_all_rules_a_single_row_grid() {
+    let svg = export_svg(r#"Grid[{{"a", "b"}}, Dividers -> All]"#);
+    let horizontal =
+      grid_lines(&svg).into_iter().filter(|l| l.1 == l.3).count();
+    assert_eq!(horizontal, 2, "top and bottom: {svg}");
+  }
+
+  /// The x of each `<text>` in an SVG, in document order.
+  fn text_xs(svg: &str) -> Vec<f64> {
+    svg
+      .lines()
+      .filter(|l| l.starts_with("<text "))
+      .filter_map(|l| {
+        l.split("x=\"")
+          .nth(1)
+          .and_then(|t| t.split('"').next())
+          .and_then(|v| v.parse().ok())
+      })
+      .collect()
+  }
+
+  /// `Spacings -> {{i -> s, …}, …}` sets the gap at individual column
+  /// positions: position `i` is the gap to the left of column `i`. A
+  /// Demonstration uses this to group a readout — a wide gap where the
+  /// dividers fall, tight ones inside each group. Regression: a list-valued
+  /// horizontal spec was dropped and every column got the default gap.
+  #[test]
+  fn spacings_set_individual_column_positions() {
+    let tight = export_svg(
+      r#"Grid[{{"a", "b", "c"}}, Spacings -> {{1 -> 0.2, 2 -> 0.2, 3 -> 0.2, 4 -> 0.2}, Automatic}]"#,
+    );
+    let wide = export_svg(
+      r#"Grid[{{"a", "b", "c"}}, Spacings -> {{1 -> 0.2, 2 -> 3, 3 -> 0.2, 4 -> 0.2}, Automatic}]"#,
+    );
+    let (tight_xs, wide_xs) = (text_xs(&tight), text_xs(&wide));
+    assert_eq!(tight_xs.len(), 3, "{tight}");
+    assert_eq!(wide_xs.len(), 3, "{wide}");
+    // Widening position 2 only pushes `b` (and everything after it) right.
+    assert_eq!(tight_xs[0], wide_xs[0], "column 1 is unmoved");
+    assert!(
+      wide_xs[1] - tight_xs[1] > 20.0,
+      "the gap before column 2 grew: {tight_xs:?} vs {wide_xs:?}"
+    );
+    // Coordinates are written to one decimal, so allow a rounding step.
+    assert!(
+      (wide_xs[2] - tight_xs[2] - (wide_xs[1] - tight_xs[1])).abs() < 0.2,
+      "the later columns shift by the same amount: {tight_xs:?} vs {wide_xs:?}"
+    );
+  }
+
+  /// A plain list of values names the positions in order, and positions the
+  /// spec leaves out keep the default gap — so a spec that stops short only
+  /// changes the columns it reaches.
+  #[test]
+  fn spacings_list_fills_positions_in_order() {
+    let default = export_svg(r#"Grid[{{"a", "b", "c"}}]"#);
+    let partial = export_svg(
+      r#"Grid[{{"a", "b", "c"}}, Spacings -> {{0.2, 0.2}, Automatic}]"#,
+    );
+    let (default_xs, partial_xs) = (text_xs(&default), text_xs(&partial));
+    // Positions 1 and 2 are tightened, so the first two columns move left.
+    assert!(
+      partial_xs[0] < default_xs[0],
+      "{default_xs:?} {partial_xs:?}"
+    );
+    assert!(
+      partial_xs[1] < default_xs[1],
+      "{default_xs:?} {partial_xs:?}"
+    );
+    // Position 3 was never named, so the gap between the last two columns
+    // is the default one — the pitch across it is unchanged.
+    assert!(
+      ((partial_xs[2] - partial_xs[1]) - (default_xs[2] - default_xs[1])).abs()
+        < 0.2,
+      "the unnamed gap is unchanged: {default_xs:?} vs {partial_xs:?}"
+    );
+  }
+
+  /// Without a per-position spec the layout is unchanged: a uniform
+  /// `Spacings -> h` still spaces every column equally.
+  #[test]
+  fn uniform_spacings_keeps_columns_evenly_spaced() {
+    let svg = export_svg(r#"Grid[{{"a", "b", "c"}}, Spacings -> 2]"#);
+    let xs = text_xs(&svg);
+    assert_eq!(xs.len(), 3, "{svg}");
+    assert!(
+      ((xs[1] - xs[0]) - (xs[2] - xs[1])).abs() < 0.01,
+      "equal column pitch: {xs:?}"
+    );
+  }
 
   /// `StyleForm` is the older spelling of `Style`; the front end renders
   /// them identically, so a cell written with the long option names shows

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -7163,6 +7163,76 @@ Cell[BoxData[
   }
 
   #[test]
+  fn locator_manipulate_lays_out_a_paned_readout_over_a_picture() {
+    // End-to-end regression for the plane-geometry Demonstrations that stack
+    // a numeric readout over the drawing: the body is a one-column `Grid`
+    // whose first cell is a `Pane[Style[Grid[…], …], ImageSize -> …]` and
+    // whose second is the `Graphics`. The pane's cell used to print the
+    // `Pane[…]` call as source text, which both hid the readout and stretched
+    // the widget to the width of that source.
+    let code = "Manipulate[\
+      Grid[{{Pane[Style[Grid[{{\"d\", \"\\[TildeTilde]\", \
+          NumberForm[EuclideanDistance[pt1, pt2], {5, 2}]}}, \
+          Dividers -> {{True, False, False, True}, All}, \
+          Spacings -> {{1 -> 1.3, 2 -> 0.3, 3 -> 0.3, 4 -> 1.3}, Automatic}], \
+          12, \"Label\"], \
+        ImageSize -> {200, 40}, Alignment -> {Center, Center}]}, \
+       {Graphics[{Line[{pt1, pt2}]}, ImageSize -> {200, 160}, \
+          PlotRange -> {{-1, 1}, {-1, 1}}]}}, \
+       ItemSize -> {Automatic, {2, 5}}, Alignment -> {Center, Top}], \
+      {{pt1, {-0.5, -0.5}}, {-1, -1}, {1, 1}, Locator}, \
+      {{pt2, {0.5, 0.5}}, {-1, -1}, {1, 1}, Locator}]";
+    let state = instantiate_stored_manipulate(code, "")
+      .expect("the paned-readout Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some(), "the body must render");
+    assert_eq!(state.controls.len(), 2);
+    assert!(
+      state
+        .controls
+        .iter()
+        .all(|c| matches!(c, manipulate::ControlState::Slider2D { .. }))
+    );
+
+    // Re-render through the widget's own bindings to inspect the SVG the
+    // handle was built from: the readout shows its numbers, ruled into a
+    // closed box, and the picture is drawn below it.
+    let bindings: Vec<(String, String)> = state
+      .controls
+      .iter()
+      .filter(|c| c.binds_variable())
+      .map(|c| (c.name().to_string(), c.current_code()))
+      .collect();
+    let svg = woxi::with_scoped_globals(&bindings, || {
+      woxi::interpret_with_stdout(&state.body)
+    })
+    .expect("the body must evaluate")
+    .graphics
+    .expect("the body must render a graphic");
+    assert!(!svg.contains("Pane["), "the wrapper must not print: {svg}");
+    assert!(svg.contains(">1.41<"), "the readout value: {svg}");
+    assert!(svg.contains("<polyline"), "the drawn segment: {svg}");
+    // `Dividers -> {…, All}` closes the readout top and bottom.
+    let horizontal = svg
+      .lines()
+      .filter(|l| l.starts_with("<line "))
+      .filter(|l| {
+        let v = |n: &str| {
+          l.split(&format!("{n}=\""))
+            .nth(1)
+            .map(|t| t.split('"').next().unwrap_or_default().to_string())
+        };
+        v("y1").is_some() && v("y1") == v("y2")
+      })
+      .count();
+    assert_eq!(horizontal, 2, "readout ruled top and bottom: {svg}");
+  }
+
+  #[test]
   fn quicksort_manipulate_builds_all_four_controls() {
     // End-to-end regression for the "Quicksort versus Selection Sort"
     // Demonstration. Its fourth control is a custom one — `{{li, init, ""},


### PR DESCRIPTION
Fixes found by opening a plane-geometry Wolfram Demonstration in Woxi
Studio — the kind that stacks a numeric readout over a drawing.

- A `Pane[…]` grid cell shows what it holds. `Pane` only reserves an area
  for its content, so a body laid out as `Grid[{{Pane[…]}, {Graphics[…]}}]`
  printed the whole `Pane[…]` call as source text in place of the readout,
  and stretched the grid to the width of that source. `Pane` joins the one
  helper every display pass already shares for the wrappers that say how to
  *set* what they hold rather than what to show, and grid cells are peeled
  through it — so `Item[…]` and `Text[…]` cells are fixed alongside. The
  near-duplicate top-level Pane/Text unwrapper is gone with it.

- `Dividers -> All` rules every position, the outer edges included, so the
  grid is drawn as a closed box. Only the boundaries *between* cells were
  ruled before, which is what `Dividers -> Center` means; the two now
  differ, and either can be set per direction.

- `Spacings -> {{i -> s, …}, …}` sets the gap at individual column
  positions — position `i` is the gap left of column `i`, position
  `ncols + 1` the margin after the last column. A list-valued horizontal
  spec was dropped entirely, so a readout that groups its columns with
  alternating wide and tight gaps came out evenly and far too widely
  spaced. A plain `{s1, s2, …}` names positions in order, and positions
  left out keep the default gap — which is the previous uniform layout.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019yN8CCqygxoGFzZssBfFwf