### PR TITLE
Make astronomy ephemerides platform-independent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,9 +136,10 @@ flate2 = "1.0"
 # already pulls in so no duplicate copy is linked.
 ttf-parser = "0.25"
 geographiclib-rs = "0.2"
-# Pure-Rust math for domain coloring: `atan2`/`pow` from the platform libm
-# differ by ULPs between macOS and glibc, which flips 8-bit color rounding
-# at .5 boundaries and breaks the SVG snapshots across platforms.
+# Pure-Rust math for domain coloring and the astronomy ephemerides: the
+# transcendentals of the platform libm differ by ULPs between macOS, glibc
+# and MSVC, which flips 8-bit color rounding at .5 boundaries and moves the
+# last digit of a position, so the snapshots break across platforms.
 libm = "0.2"
 num-bigint = "0.4.6"
 num-prime = "0.5"

--- a/src/functions/astronomy_ast.rs
+++ b/src/functions/astronomy_ast.rs
@@ -35,11 +35,19 @@ const AU_KM: f64 = 149_597_870.7;
 const EARTH_RADIUS_KM: f64 = 6378.14;
 const EARTH_FLATTENING_RATIO: f64 = 0.99664719;
 
+// Every transcendental below goes through `libm` rather than the `f64`
+// methods: the platform libms round the last ULP differently (macOS vs
+// glibc vs MSVC), which moved the final digit of an altitude or an
+// eclipse time depending on where the tests ran. libm is pure Rust and
+// therefore bit-identical everywhere, including wasm32.
 fn sin_d(x: f64) -> f64 {
-  (x * DEG).sin()
+  libm::sin(x * DEG)
 }
 fn cos_d(x: f64) -> f64 {
-  (x * DEG).cos()
+  libm::cos(x * DEG)
+}
+fn tan_d(x: f64) -> f64 {
+  libm::tan(x * DEG)
 }
 
 /// Reduce an angle in degrees to [0, 360).
@@ -231,8 +239,9 @@ fn sun_ra_dec(jde: f64) -> (f64, f64) {
   // Apparent positions use the true obliquity; the 0.00256 cos Ω term of
   // Meeus 25.8 is folded into deps well enough at this accuracy.
   let eps = mean_obliquity(t) + deps;
-  let ra = norm360(f64::atan2(cos_d(eps) * sin_d(lambda), cos_d(lambda)) / DEG);
-  let dec = (sin_d(eps) * sin_d(lambda)).asin() / DEG;
+  let ra =
+    norm360(libm::atan2(cos_d(eps) * sin_d(lambda), cos_d(lambda)) / DEG);
+  let dec = libm::asin(sin_d(eps) * sin_d(lambda)) / DEG;
   (ra, dec)
 }
 
@@ -466,14 +475,13 @@ fn sun_ra_dec_dist(jde: f64) -> (f64, f64, f64) {
 
 /// Ecliptic (λ, β) → equatorial (α, δ), all in degrees.
 fn ecliptic_to_equatorial(lambda: f64, beta: f64, eps: f64) -> (f64, f64) {
-  let ra = f64::atan2(
-    sin_d(lambda) * cos_d(eps) - (beta * DEG).tan() * sin_d(eps),
+  let ra = libm::atan2(
+    sin_d(lambda) * cos_d(eps) - tan_d(beta) * sin_d(eps),
     cos_d(lambda),
   ) / DEG;
-  let dec = (sin_d(beta) * cos_d(eps)
-    + cos_d(beta) * sin_d(eps) * sin_d(lambda))
-  .asin()
-    / DEG;
+  let dec = libm::asin(
+    sin_d(beta) * cos_d(eps) + cos_d(beta) * sin_d(eps) * sin_d(lambda),
+  ) / DEG;
   (norm360(ra), dec)
 }
 
@@ -504,10 +512,7 @@ fn refraction_deg(true_altitude: f64) -> f64 {
   if true_altitude < -1.0 {
     return 0.0;
   }
-  let arcminutes = 1.02
-    / (true_altitude + 10.3 / (true_altitude + 5.11))
-      .to_radians()
-      .tan();
+  let arcminutes = 1.02 / tan_d(true_altitude + 10.3 / (true_altitude + 5.11));
   arcminutes / 60.0
 }
 
@@ -523,15 +528,15 @@ fn topocentric_ra_dec(
   lon: f64,
   jd_ut: f64,
 ) -> (f64, f64) {
-  let u = (EARTH_FLATTENING_RATIO * (lat * DEG).tan()).atan() / DEG;
+  let u = libm::atan(EARTH_FLATTENING_RATIO * tan_d(lat)) / DEG;
   let rho_sin_phi = EARTH_FLATTENING_RATIO * sin_d(u);
   let rho_cos_phi = cos_d(u);
   let sin_pi = EARTH_RADIUS_KM / distance_km;
   let h = apparent_gst_deg(jd_ut) + lon - ra; // local hour angle
   let denom = cos_d(dec) - rho_cos_phi * sin_pi * cos_d(h);
-  let delta_ra = f64::atan2(-rho_cos_phi * sin_pi * sin_d(h), denom) / DEG;
+  let delta_ra = libm::atan2(-rho_cos_phi * sin_pi * sin_d(h), denom) / DEG;
   let dec_topo =
-    f64::atan2((sin_d(dec) - rho_sin_phi * sin_pi) * cos_d(delta_ra), denom)
+    libm::atan2((sin_d(dec) - rho_sin_phi * sin_pi) * cos_d(delta_ra), denom)
       / DEG;
   (norm360(ra + delta_ra), dec_topo)
 }
@@ -549,13 +554,13 @@ fn equatorial_to_horizontal(
   let lst = apparent_gst_deg(jd_ut) + lon;
   let h = lst - ra; // local hour angle
   let alt =
-    (sin_d(lat) * sin_d(dec) + cos_d(lat) * cos_d(dec) * cos_d(h)).asin() / DEG;
+    libm::asin(sin_d(lat) * sin_d(dec) + cos_d(lat) * cos_d(dec) * cos_d(h))
+      / DEG;
   // Meeus measures azimuth from South; add 180° for the from-North
   // convention used by SunPosition.
-  let az_south = f64::atan2(
-    sin_d(h),
-    cos_d(h) * sin_d(lat) - (dec * DEG).tan() * cos_d(lat),
-  ) / DEG;
+  let az_south =
+    libm::atan2(sin_d(h), cos_d(h) * sin_d(lat) - tan_d(dec) * cos_d(lat))
+      / DEG;
   (norm360(az_south + 180.0), alt)
 }
 
@@ -743,10 +748,10 @@ fn moon_illumination(jde: f64) -> (f64, f64) {
 
   // Geocentric elongation (Meeus 48.2)
   let cos_psi = cos_d(beta_m) * cos_d(lambda_m - lambda_s);
-  let psi = cos_psi.clamp(-1.0, 1.0).acos();
+  let psi = libm::acos(cos_psi.clamp(-1.0, 1.0));
   // Phase angle (48.3)
-  let i = f64::atan2(r * psi.sin(), delta - r * psi.cos());
-  let frac = (1.0 + i.cos()) / 2.0;
+  let i = libm::atan2(r * libm::sin(psi), delta - r * libm::cos(psi));
+  let frac = (1.0 + libm::cos(i)) / 2.0;
   (frac, norm360(lambda_m - lambda_s))
 }
 
@@ -921,7 +926,7 @@ fn sun_rise_set(jd_day: f64, lat: f64, lon: f64) -> Option<(f64, f64)> {
   if !(-1.0..=1.0).contains(&cos_h) {
     return None;
   }
-  let big_h0 = cos_h.acos() / DEG;
+  let big_h0 = libm::acos(cos_h) / DEG;
 
   // Meeus uses west longitudes positive; ours are east-positive.
   let mut m0 = (ra_0 - lon - theta0) / 360.0;
@@ -960,10 +965,9 @@ fn sun_rise_set(jd_day: f64, lat: f64, lon: f64) -> Option<(f64, f64)> {
       let dec = interp(dec_m, dec_0, dec_p, n);
       let h = norm360(theta + lon - ra); // local hour angle
       let h_signed = if h > 180.0 { h - 360.0 } else { h };
-      let alt = (sin_d(lat) * sin_d(dec)
-        + cos_d(lat) * cos_d(dec) * cos_d(h_signed))
-      .asin()
-        / DEG;
+      let alt = libm::asin(
+        sin_d(lat) * sin_d(dec) + cos_d(lat) * cos_d(dec) * cos_d(h_signed),
+      ) / DEG;
       let dm = (alt - h0) / (360.0 * cos_d(dec) * cos_d(lat) * sin_d(h_signed));
       *m += dm;
     }

--- a/tests/interpreter_tests/astronomy.rs
+++ b/tests/interpreter_tests/astronomy.rs
@@ -3,6 +3,12 @@ use super::*;
 // Astronomical computations are checked against dates with well-known
 // ephemeris values (eclipses, phases, solstice positions). All results
 // follow Woxi's datetime convention: UTC instants, TimeZone 0.
+//
+// The full-precision literals below are exact for every platform because
+// the ephemerides go through `libm` rather than the platform's own
+// transcendentals — the macOS/glibc/MSVC ULP differences used to move the
+// last digit of an altitude, so the same assert passed locally and failed
+// on CI (see the comment above `sin_d` in src/functions/astronomy_ast.rs).
 
 mod moon_phase {
   use super::*;
@@ -13,7 +19,7 @@ mod moon_phase {
     // moon (Jan 25)
     assert_eq!(
       interpret("MoonPhase[DateObject[{2024, 1, 20, 12, 0, 0}]]").unwrap(),
-      "0.7431388863547352"
+      "0.7431388863547354"
     );
   }
 
@@ -121,7 +127,7 @@ mod positions {
          DateObject[{2024, 6, 21, 18, 0, 0}]]"
       )
       .unwrap(),
-      "{Quantity[184.03630805505907, AngularDegrees], \
+      "{Quantity[184.03630805505904, AngularDegrees], \
        Quantity[73.29603980924757, AngularDegrees]}"
     );
   }
@@ -138,7 +144,7 @@ mod positions {
       )
       .unwrap(),
       "{Quantity[0.02278659255310904, HoursOfRightAscension], \
-       Quantity[0.14579656380289838, AngularDegrees]}"
+       Quantity[0.1457965638028984, AngularDegrees]}"
     );
   }
 
@@ -150,7 +156,7 @@ mod positions {
       )
       .unwrap(),
       "{Quantity[193.00948969195917, AngularDegrees], \
-       Quantity[13.155723958468354, AngularDegrees]}"
+       Quantity[13.155723958468359, AngularDegrees]}"
     );
   }
 
@@ -162,8 +168,8 @@ mod positions {
          DateObject[{2024, 6, 21, 6, 0, 0}]]"
       )
       .unwrap(),
-      "{Quantity[191.86509647088556, AngularDegrees], \
-       Quantity[20.317781062057147, AngularDegrees]}"
+      "{Quantity[191.86509647088562, AngularDegrees], \
+       Quantity[20.31778106205714, AngularDegrees]}"
     );
   }
 

--- a/tests/interpreter_tests/batch_wrappers.rs
+++ b/tests/interpreter_tests/batch_wrappers.rs
@@ -11193,12 +11193,20 @@ mod batch_unevaluated_wrappers_2 {
   #[test]
   fn create_directory_no_args() {
     let result = interpret("CreateDirectory[]").unwrap();
-    // Should return a string path (temp directory)
+    // Should return the path of a freshly created temp directory. The
+    // separator is platform-specific (`\` on Windows), so check the file
+    // name rather than a slash-prefixed substring.
+    let path = std::path::Path::new(&result);
     assert!(
-      result.contains("/woxi_"),
-      "Expected a path, got: {}",
+      path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with("woxi_")),
+      "Expected a woxi_* temp path, got: {}",
       result
     );
+    assert!(path.is_dir(), "Expected an existing directory: {}", result);
+    let _ = std::fs::remove_dir_all(path);
   }
 
   /// Every call creates a *new* directory. Regression: the name was fixed


### PR DESCRIPTION
## Why

Both CI workflows are red on `main`:

- **Rust CI** (Linux) fails every push on `astronomy::positions::moon_position_horizon`
  (`20.31778106205715` vs the committed `20.317781062057147`).
- **Nightly** `test-windows` fails on the same test plus
  `sun_position_bare_lat_lon_list` and `batch_unevaluated_wrappers_2::create_directory_no_args`.

## What

- `src/functions/astronomy_ast.rs` called the platform's `sin`/`cos`/`tan`/`asin`/`acos`/`atan`/`atan2`,
  whose last ULP differs between macOS, glibc and MSVC. Every one of them now goes through `libm`
  (pure Rust, bit-identical everywhere — the same reason `field_plot.rs` already uses it for domain
  coloring). Added a `tan_d` helper alongside `sin_d`/`cos_d`.
- Updated the five unit-test expectations whose last digit shifted to the libm value. All are
  last-ULP moves; accuracy versus wolframscript is unchanged, and `tests/cli/astronomy.md`'s regexes
  (which pin only the digits both engines agree on) still match.
- `create_directory_no_args` asserted the temp path contains `/woxi_`, which cannot hold on Windows.
  It now checks the path's file name, asserts the directory exists, and removes it afterwards.

## Test

`make test` (26484 tests), `make lint`, `make format-check` all pass locally; the astronomy CLI
snapshots were checked by hand against the regexes.