### PR TITLE
Enforce repeated pattern variables in definitions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,19 @@
 
 # Unreleased
 
+- Fixes driven by a Wolfram Demonstration that approximates derivatives on
+    Chebyshev–Gauss–Lobatto points:
+    - A pattern variable repeated on the left of a definition constrains the
+        arguments to be equal: `f[i_, i_] := …` no longer matches `f[1, 2]`.
+        The repeat used to be ignored, so a definition pair spelling out a
+        matrix's diagonal and off-diagonal entries collapsed onto whichever
+        rule came last — and a diagonal formula applied off the diagonal
+        divided by zero. The constraint holds for a repeat inside a list
+        pattern (`f[{a_, a_}]`) too, and alongside head constraints and
+        `?test`s on the repeated slots.
+    - `DownValues` and `Definition` print a nested argument pattern as it was
+        written: `f[g[x_]] := x` used to read back as `f[__sp0_]`, exposing
+        the placeholder such a slot is lowered to.
 - Fixes driven by a Wolfram Demonstration that draws a rational cyclic
     polygon inside its circumcircle:
     - `Sphere` and `Ball` draw in a two-dimensional `Graphics`: in the plane

--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -492,6 +492,77 @@ fn collect_binary_children(
   }
 }
 
+/// Whether `name` is a synthetic parameter slot invented while lowering a
+/// definition (list destructuring, structural patterns, options, pattern
+/// tests, upvalue/downvalue placeholders) rather than a pattern variable the
+/// user wrote. Synthetic names already carry their slot index, so they never
+/// repeat and must never be mistaken for a repeated pattern variable.
+fn is_synthetic_param(name: &str) -> bool {
+  name.is_empty()
+    || name.starts_with("_lp")
+    || name.starts_with("__sp")
+    || name.starts_with("__opts")
+    || name.starts_with("__pt")
+    || name.starts_with("_dv")
+    || name.starts_with("_up")
+}
+
+/// Constrain a definition whose argument list repeats a pattern variable
+/// (`f[i_, i_] := …`). Wolfram reads the repeat as a constraint — every
+/// occurrence has to bind the *same* expression, so `f[1, 2]` does not match
+/// `f[i_, i_]` at all — but dispatch binds parameters positionally, which on
+/// its own just lets the later slot shadow the earlier one.
+///
+/// Rather than re-implement the equality test, the repeated slots are re-keyed
+/// to synthetic `__sp…` parameters carrying a `__StructuralPattern__`
+/// condition. Dispatch already runs those through the canonical pattern
+/// matcher and drops the rule when the bindings it produces disagree with the
+/// positional ones — which is exactly the repeated-variable check.
+///
+/// The first occurrence keeps the user's name, so the body still sees the
+/// bound value. Must run before a body-level `/;` guard is parked in the first
+/// free condition slot, since it claims the repeated slots' condition slots.
+pub fn constrain_repeated_params(
+  params: &mut [String],
+  conditions: &mut [Option<Expr>],
+  heads: &[Option<String>],
+  blank_types: &[u8],
+) {
+  let mut seen: Vec<String> = Vec::new();
+  for i in 0..params.len() {
+    let name = params[i].clone();
+    if is_synthetic_param(&name) {
+      continue;
+    }
+    if !seen.contains(&name) {
+      seen.push(name);
+      continue;
+    }
+    // A repeated slot only ever holds a structural-pattern condition of its
+    // own (a `?test`); reuse that pattern so the test survives, otherwise
+    // rebuild the plain `name_`/`name_Head` pattern from the slot.
+    let pattern = match conditions.get(i).and_then(|c| c.as_ref()) {
+      Some(Expr::FunctionCall {
+        name: marker,
+        args: marker_args,
+      }) if marker == "__StructuralPattern__" && marker_args.len() == 2 => {
+        marker_args[1].clone()
+      }
+      _ => Expr::Pattern {
+        name,
+        head: heads.get(i).cloned().flatten(),
+        blank_type: blank_types.get(i).copied().unwrap_or(1),
+      },
+    };
+    let synthetic = format!("__sp{}", i);
+    conditions[i] = Some(Expr::FunctionCall {
+      name: "__StructuralPattern__".to_string(),
+      args: vec![Expr::Identifier(synthetic.clone()), pattern].into(),
+    });
+    params[i] = synthetic;
+  }
+}
+
 /// Collect all pattern variable names from an expression.
 /// Returns tuples of (name, head, is_optional) for each Pattern/PatternOptional node found.
 fn collect_pattern_vars(
@@ -1592,6 +1663,13 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
       defaults.push(None);
     }
 
+    constrain_repeated_params(
+      &mut params,
+      &mut conditions,
+      &heads,
+      &blank_types,
+    );
+
     // Check if all args are literal (non-pattern) — if so, insert at beginning
     // for priority over general patterns (matching Mathematica specificity ordering)
     let has_literal_conditions =
@@ -2370,6 +2448,13 @@ pub fn set_delayed_ast(
     let final_body = apply_list_substitutions(body);
     let body_condition_sub = body_condition.map(apply_list_substitutions);
 
+    constrain_repeated_params(
+      &mut params,
+      &mut conditions,
+      &heads,
+      &blank_types,
+    );
+
     // If there's a body-level condition (from /;), attach it to a condition slot
     if let Some(body_cond) = body_condition_sub.as_ref() {
       let mut attached = false;
@@ -2660,6 +2745,10 @@ fn build_list_pattern_match(
       args: vec![list_element_accessor(&base, eidx, false), pat.clone()].into(),
     });
   }
+  let mut bindings = Vec::new();
+  collect_list_pattern_bindings(patterns, &base, &mut bindings);
+  let (repeat_guards, bindings) = list_pattern_repeat_guards(bindings);
+  rule_conds.extend(repeat_guards);
   let combined = if rule_conds.len() == 1 {
     rule_conds.pop().unwrap()
   } else {
@@ -2668,9 +2757,33 @@ fn build_list_pattern_match(
       args: rule_conds.into(),
     }
   };
-  let mut bindings = Vec::new();
-  collect_list_pattern_bindings(patterns, &base, &mut bindings);
   (combined, bindings)
+}
+
+/// The `SameQ` guards implied by a pattern variable that a list pattern binds
+/// more than once (`f[{a_, a_}] := …`): every occurrence has to see the same
+/// element, so `f[{1, 2}]` must not match. The per-element `MatchQ` guards
+/// above check each element in isolation and cannot express that.
+///
+/// Returns one guard per repeated occurrence, comparing its element accessor
+/// against the first occurrence's, plus the deduplicated bindings (the body
+/// reads each name from the position it was first bound at).
+fn list_pattern_repeat_guards(
+  bindings: Vec<(String, Expr)>,
+) -> (Vec<Expr>, Vec<(String, Expr)>) {
+  let mut guards = Vec::new();
+  let mut first: Vec<(String, Expr)> = Vec::new();
+  for (name, accessor) in bindings {
+    if let Some((_, prev)) = first.iter().find(|(n, _)| n == &name) {
+      guards.push(Expr::Comparison {
+        operands: vec![prev.clone(), accessor],
+        operators: vec![ComparisonOp::SameQ],
+      });
+    } else {
+      first.push((name, accessor));
+    }
+  }
+  (guards, first)
 }
 
 /// Replace every subexpression structurally equal to `from` with `to`. Used to
@@ -2833,6 +2946,19 @@ fn reconstruct_list_param(
           elem_pats.push((*idx as usize, args[1].clone()));
         }
       }
+      // A repeated-variable guard (`Part[lp, i] === Part[lp, j]`, emitted for
+      // `f[{a_, a_}]`) is already implied by the reconstructed surface
+      // pattern, which shows the same name twice — displaying it as well
+      // would print a redundant `/; a === a`.
+      Expr::Comparison {
+        operands,
+        operators,
+      } if operators.iter().any(|o| matches!(o, ComparisonOp::SameQ))
+        && operands.iter().all(|o| {
+          matches!(o, Expr::FunctionCall { name: pn, args: pargs }
+            if pn == "Part"
+              && matches!(pargs.first(), Some(Expr::Identifier(id)) if id == param))
+        }) => {}
       other => guards.push(other.clone()),
     }
   }
@@ -2881,6 +3007,44 @@ fn reconstruct_list_param(
   (Expr::List(elems.into()), part_names, guards)
 }
 
+/// The surface pattern that argument slot `i` of a stored rule was written as,
+/// for `DownValues` / `Definition` display.
+///
+/// A slot whose pattern could not be expressed as a plain named blank — a
+/// nested pattern (`f[g[x_]]`), or the second occurrence of a repeated
+/// variable (`f[i_, i_]`) — is lowered to a synthetic `__sp…` parameter that
+/// keeps the original pattern inside a `__StructuralPattern__` condition.
+/// Reading it back from there prints what the user wrote instead of the
+/// internal placeholder.
+pub fn downvalue_param_pattern(
+  params: &[String],
+  conditions: &[Option<Expr>],
+  heads: &[Option<String>],
+  blank_types: &[u8],
+  i: usize,
+) -> Expr {
+  let name = params.get(i).cloned().unwrap_or_default();
+  if name.starts_with("__sp")
+    && let Some(pattern) = conditions.iter().flatten().find_map(|c| match c {
+      Expr::FunctionCall { name: marker, args }
+        if marker == "__StructuralPattern__"
+          && args.len() == 2
+          && matches!(&args[0], Expr::Identifier(p) if *p == name) =>
+      {
+        Some(args[1].clone())
+      }
+      _ => None,
+    })
+  {
+    return pattern;
+  }
+  Expr::Pattern {
+    name,
+    head: heads.get(i).and_then(|h| h.clone()),
+    blank_type: blank_types.get(i).copied().unwrap_or(1),
+  }
+}
+
 /// Rebuild a displayable DownValue (pattern args + body) for a stored rule that
 /// uses one or more lowered list-pattern parameters (`_lp{i}`), turning them
 /// back into surface `{…}` patterns and un-substituting the `Part[_lp, i]`
@@ -2921,11 +3085,13 @@ pub fn reconstruct_list_downvalue(
     {
       pattern_args.push(lit.clone());
     } else {
-      pattern_args.push(Expr::Pattern {
-        name: p.clone(),
-        head: heads.get(i).and_then(|h| h.clone()),
-        blank_type: blank_types.get(i).copied().unwrap_or(1),
-      });
+      pattern_args.push(downvalue_param_pattern(
+        params,
+        conditions,
+        heads,
+        blank_types,
+        i,
+      ));
     }
   }
   let final_body = if guards.is_empty() {

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -16357,15 +16357,17 @@ pub fn definition_text(sym: &str) -> Option<String> {
         ));
       } else {
         // Reconstruct f[x_, y_Integer] := body
-        let params_str: Vec<String> = params
-          .iter()
-          .enumerate()
-          .map(|(i, p)| {
-            if let Some(head) = heads.get(i).and_then(|h| h.as_ref()) {
-              format!("{}_{}", p, head)
-            } else {
-              format!("{}_", p)
-            }
+        let params_str: Vec<String> = (0..params.len())
+          .map(|i| {
+            expr_to_string(
+              &crate::evaluator::assignment::downvalue_param_pattern(
+                params,
+                conds,
+                heads,
+                blank_types,
+                i,
+              ),
+            )
           })
           .collect();
         lines.push(format!(

--- a/src/evaluator/dispatch/predicate_functions.rs
+++ b/src/evaluator/dispatch/predicate_functions.rs
@@ -1151,10 +1151,8 @@ pub fn dispatch_predicate_functions(
                 body,
               )
               .unwrap_or_else(|| {
-                let args: Vec<Expr> = params
-                  .iter()
-                  .enumerate()
-                  .map(|(i, p)| {
+                let args: Vec<Expr> = (0..params.len())
+                  .map(|i| {
                     // Check if this param has a literal-match condition (SameQ)
                     if let Some(Some(Expr::Comparison {
                       operands,
@@ -1167,11 +1165,13 @@ pub fn dispatch_predicate_functions(
                     {
                       return literal_val.clone();
                     }
-                    Expr::Pattern {
-                      name: p.clone(),
-                      head: heads.get(i).and_then(|h| h.clone()),
-                      blank_type: blank_types.get(i).copied().unwrap_or(1),
-                    }
+                    crate::evaluator::assignment::downvalue_param_pattern(
+                      params,
+                      conds,
+                      heads,
+                      blank_types,
+                      i,
+                    )
                   })
                   .collect();
                 (args, body.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4917,6 +4917,18 @@ fn store_function_definition(
     raw_body_expr
   };
 
+  // A pattern variable repeated across the argument list (`f[i_, i_] := …`)
+  // constrains the arguments to be identical; lower it before the definition
+  // is filed so dispatch enforces it.
+  evaluator::assignment::constrain_repeated_params(
+    &mut params,
+    &mut conditions,
+    &heads,
+    &blank_types,
+  );
+  let has_any_condition =
+    has_any_condition || conditions.iter().any(|c| c.is_some());
+
   FUNC_DEFS.with(|m| {
     let mut defs = m.borrow_mut();
     let entry = defs.entry(func_name).or_insert_with(Vec::new);

--- a/tests/interpreter_tests/patterns.rs
+++ b/tests/interpreter_tests/patterns.rs
@@ -4373,3 +4373,138 @@ mod whitespace_around_definition_parameters {
     assert_eq!(interpret("wsg[x__ ] := {x}; wsg[1, 2]").unwrap(), "{1, 2}");
   }
 }
+
+mod repeated_pattern_variable_in_definition {
+  use super::*;
+
+  // A pattern variable used twice on the left of a definition constrains the
+  // arguments to be identical — `f[1, 2]` must not match `f[i_, i_]`.
+
+  #[test]
+  fn a_repeated_variable_only_matches_equal_arguments() {
+    assert_eq!(
+      interpret("rpa[x_, x_] := x^2; {rpa[3, 3], rpa[3, 4]}").unwrap(),
+      "{9, rpa[3, 4]}"
+    );
+  }
+
+  #[test]
+  fn a_looser_rule_still_covers_the_unequal_case() {
+    // Both rules are kept; the repeated-variable one is more specific and is
+    // tried first, so the diagonal and off-diagonal calls pick different rules.
+    assert_eq!(
+      interpret(
+        "rpb[i_, i_] := \"diag\"; rpb[j_, k_] := \"off\"; \
+         {rpb[1, 1], rpb[1, 2], rpb[2, 1]}"
+      )
+      .unwrap(),
+      "{diag, off, off}"
+    );
+  }
+
+  #[test]
+  fn a_literal_definition_still_wins_over_the_repeated_variable() {
+    // The Chebyshev differentiation-matrix idiom: literal corner entries, a
+    // diagonal rule, and an off-diagonal rule.
+    assert_eq!(
+      interpret(
+        "rpc[0, 0] = \"corner\"; rpc[i_, i_] := \"diag\"; \
+         rpc[j_, k_] := \"off\"; Table[rpc[i, j], {i, 0, 2}, {j, 0, 2}]"
+      )
+      .unwrap(),
+      "{{corner, off, off}, {off, diag, off}, {off, off, diag}}"
+    );
+  }
+
+  #[test]
+  fn the_constraint_holds_for_definitions_made_inside_module() {
+    assert_eq!(
+      interpret(
+        "Module[{rpd}, rpd[i_, i_] := \"diag\"; rpd[j_, k_] := \"off\"; \
+         {rpd[1, 1], rpd[1, 2]}]"
+      )
+      .unwrap(),
+      "{diag, off}"
+    );
+  }
+
+  #[test]
+  fn the_constraint_compares_expressions_not_just_numbers() {
+    assert_eq!(
+      interpret("rpe[x_, x_] := \"same\"; {rpe[a, a], rpe[a, b]}").unwrap(),
+      "{same, rpe[a, b]}"
+    );
+    assert_eq!(
+      interpret(
+        "rpf[x_, x_] := \"same\"; {rpf[{1, 2}, {1, 2}], rpf[{1}, {2}]}"
+      )
+      .unwrap(),
+      "{same, rpf[{1}, {2}]}"
+    );
+  }
+
+  #[test]
+  fn a_head_constraint_still_applies_to_every_occurrence() {
+    assert_eq!(
+      interpret(
+        "rpg[x_Integer, x_Integer] := \"int\"; \
+         {rpg[2, 2], rpg[2, 3], rpg[2.5, 2.5]}"
+      )
+      .unwrap(),
+      "{int, rpg[2, 3], rpg[2.5, 2.5]}"
+    );
+  }
+
+  #[test]
+  fn a_pattern_test_survives_on_the_repeated_slot() {
+    assert_eq!(
+      interpret(
+        "rph[x_?IntegerQ, x_?IntegerQ] := \"int\"; \
+         {rph[2, 2], rph[2, 3], rph[2.5, 2.5]}"
+      )
+      .unwrap(),
+      "{int, rph[2, 3], rph[2.5, 2.5]}"
+    );
+  }
+
+  #[test]
+  fn three_occurrences_all_have_to_agree() {
+    assert_eq!(
+      interpret(
+        "rpi[x_, x_, x_] := \"all\"; {rpi[1, 1, 1], rpi[1, 1, 2], rpi[1, 2, 1]}"
+      )
+      .unwrap(),
+      "{all, rpi[1, 1, 2], rpi[1, 2, 1]}"
+    );
+  }
+
+  #[test]
+  fn only_the_repeated_variable_is_constrained() {
+    assert_eq!(
+      interpret("rpj[x_, x_, y_] := {x, y}; {rpj[1, 1, 2], rpj[1, 2, 3]}")
+        .unwrap(),
+      "{{1, 2}, rpj[1, 2, 3]}"
+    );
+  }
+
+  #[test]
+  fn a_repeated_variable_inside_a_list_pattern_is_constrained_too() {
+    assert_eq!(
+      interpret("rpk[{a_, a_}] := \"pair\"; {rpk[{1, 1}], rpk[{1, 2}]}")
+        .unwrap(),
+      "{pair, rpk[{1, 2}]}"
+    );
+  }
+
+  #[test]
+  fn the_stored_definition_reads_back_as_written() {
+    assert_eq!(
+      interpret("rpl[i_, i_] := \"diag\"; DownValues[rpl]").unwrap(),
+      "{HoldPattern[rpl[i_, i_]] :> diag}"
+    );
+    assert_eq!(
+      interpret("rpm[{a_, a_}] := \"pair\"; DownValues[rpm]").unwrap(),
+      "{HoldPattern[rpm[{a_, a_}]] :> pair}"
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements constraint enforcement for pattern variables that appear multiple times in a definition's argument list. When a pattern variable is repeated (e.g., `f[i_, i_] := …`), the arguments must be equal for the rule to match, matching Wolfram Language semantics.

## Key Changes

- **New `is_synthetic_param()` function**: Identifies internally-generated parameter names that should not be treated as user-written pattern variables.

- **New `constrain_repeated_params()` function**: Detects repeated pattern variables in a definition's parameter list and converts them to synthetic `__sp…` parameters with `__StructuralPattern__` conditions. The first occurrence keeps the user's name so the body sees the bound value. This approach reuses the existing pattern matcher to enforce equality constraints.

- **List pattern repeat guards**: Added `list_pattern_repeat_guards()` to handle repeated variables within list patterns (e.g., `f[{a_, a_}]`), generating `SameQ` guards that compare element accessors.

- **Pattern reconstruction for display**: New `downvalue_param_pattern()` function reconstructs the original surface pattern from synthetic parameters, ensuring `DownValues` and `Definition` print patterns as written rather than exposing internal placeholders.

- **Integration points**: The constraint function is called in three places:
  - `set_ast()` for immediate assignments
  - `set_delayed_ast()` for delayed definitions
  - `store_function_definition()` in lib.rs for all definition types

- **Display fixes**: Updated `definition_text()` and `dispatch_predicate_functions()` to use the new pattern reconstruction function.

## Notable Implementation Details

- Repeated variables are re-keyed to synthetic parameters carrying a `__StructuralPattern__` condition, allowing dispatch to run them through the canonical pattern matcher. When bindings disagree with positional ones, the rule is dropped—exactly the repeated-variable check needed.

- The constraint holds for nested patterns, multiple occurrences (3+), and alongside head constraints and `?test` predicates on the repeated slots.

- Repeated-variable guards in list patterns are filtered from display since they're already implied by the reconstructed surface pattern showing the same name twice.

- Comprehensive test coverage added for various scenarios: basic repeats, multiple rules, literal definitions, module-scoped definitions, head constraints, pattern tests, and nested list patterns.

https://claude.ai/code/session_01XFwAaPLLbxJwdo4aLYkMsC