### PR TITLE
Fix field plots to honor ContourStyle, FrameLabel, Epilog, and display correct result graphic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,33 @@
 # Changelog
 
+# Unreleased
+
+- Fixes driven by a Wolfram Demonstration that solves a pair of coupled
+    reaction equations and switches between three views of the result:
+    - The picture a cell shows is the one its value *is*, not the last one
+        drawn on the way there. A body that builds several plots and then
+        picks one — `p1 = Plot[…]; p2 = ContourPlot[…]; Switch[view, 1, p1,
+        2, p2]`, the standard Demonstrations "which view?" control — was
+        displayed as whichever plot happened to be assigned last, because
+        the visual hosts (Playground, Woxi Studio, the Jupyter kernel) read
+        back the last graphic captured while evaluating.
+    - `ContourStyle` draws the contour lines: `ContourStyle -> {Thick,
+        Blue}` gives a thick blue curve instead of the default thin dark
+        grey one. The option was read only into the plot's symbolic form,
+        so the picture ignored it. It reaches the equation form
+        (`ContourPlot[lhs == rhs, …]`) too, and travels with the curve so a
+        `Show` merge keeps it.
+    - `FrameLabel` and `Epilog` reach the density and contour plots, the
+        way they already reached the function plots: the labels are written
+        outside the frame (with room reserved for them) and the epilog
+        primitives are drawn over the finished picture in data coordinates.
+        A stability diagram marking the current parameters with a red
+        `Point` came out as a bare unlabelled curve.
+    - `ImageSize -> 400 {1, 1}` sizes a plot. A plot holds its arguments,
+        so the option value arrived as an unevaluated product and was
+        dropped, leaving the default width; it is now evaluated to the
+        `{400, 400}` it describes.
+
 # 2026-08-06 - 0.3.0
 
 Between 0.2.0 and 0.3.0 the focus moved from growing the function library
@@ -207,31 +235,6 @@ described in detail in the last section.
 
 ## Demonstration-driven fixes in detail
 
-- Fixes driven by a Wolfram Demonstration that solves a pair of coupled
-    reaction equations and switches between three views of the result:
-    - The picture a cell shows is the one its value *is*, not the last one
-        drawn on the way there. A body that builds several plots and then
-        picks one — `p1 = Plot[…]; p2 = ContourPlot[…]; Switch[view, 1, p1,
-        2, p2]`, the standard Demonstrations "which view?" control — was
-        displayed as whichever plot happened to be assigned last, because
-        the visual hosts (Playground, Woxi Studio, the Jupyter kernel) read
-        back the last graphic captured while evaluating.
-    - `ContourStyle` draws the contour lines: `ContourStyle -> {Thick,
-        Blue}` gives a thick blue curve instead of the default thin dark
-        grey one. The option was read only into the plot's symbolic form,
-        so the picture ignored it. It reaches the equation form
-        (`ContourPlot[lhs == rhs, …]`) too, and travels with the curve so a
-        `Show` merge keeps it.
-    - `FrameLabel` and `Epilog` reach the density and contour plots, the
-        way they already reached the function plots: the labels are written
-        outside the frame (with room reserved for them) and the epilog
-        primitives are drawn over the finished picture in data coordinates.
-        A stability diagram marking the current parameters with a red
-        `Point` came out as a bare unlabelled curve.
-    - `ImageSize -> 400 {1, 1}` sizes a plot. A plot holds its arguments,
-        so the option value arrived as an unevaluated product and was
-        dropped, leaving the default width; it is now evaluated to the
-        `{400, 400}` it describes.
 - Fixes driven by a Wolfram Demonstration that draws a rational cyclic
     polygon inside its circumcircle:
     - `Sphere` and `Ball` draw in a two-dimensional `Graphics`: in the plane

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,31 @@
 
 # Unreleased
 
+- Fixes driven by a Wolfram Demonstration that solves a pair of coupled
+    reaction equations and switches between three views of the result:
+    - The picture a cell shows is the one its value *is*, not the last one
+        drawn on the way there. A body that builds several plots and then
+        picks one — `p1 = Plot[…]; p2 = ContourPlot[…]; Switch[view, 1, p1,
+        2, p2]`, the standard Demonstrations "which view?" control — was
+        displayed as whichever plot happened to be assigned last, because
+        the visual hosts (Playground, Woxi Studio, the Jupyter kernel) read
+        back the last graphic captured while evaluating.
+    - `ContourStyle` draws the contour lines: `ContourStyle -> {Thick,
+        Blue}` gives a thick blue curve instead of the default thin dark
+        grey one. The option was read only into the plot's symbolic form,
+        so the picture ignored it. It reaches the equation form
+        (`ContourPlot[lhs == rhs, …]`) too, and travels with the curve so a
+        `Show` merge keeps it.
+    - `FrameLabel` and `Epilog` reach the density and contour plots, the
+        way they already reached the function plots: the labels are written
+        outside the frame (with room reserved for them) and the epilog
+        primitives are drawn over the finished picture in data coordinates.
+        A stability diagram marking the current parameters with a red
+        `Point` came out as a bare unlabelled curve.
+    - `ImageSize -> 400 {1, 1}` sizes a plot. A plot holds its arguments,
+        so the option value arrived as an unevaluated product and was
+        dropped, leaving the default width; it is now evaluated to the
+        `{400, 400}` it describes.
 - Fixes driven by a Wolfram Demonstration that draws a rational cyclic
     polygon inside its circumcircle:
     - `Sphere` and `Ball` draw in a two-dimensional `Graphics`: in the plane

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -16,6 +16,11 @@ use crate::functions::plot::{
 const FIELD_GRID: usize = 100;
 const VECTOR_GRID: usize = 15;
 
+/// Default look of a contour line, used unless `ContourStyle` says otherwise.
+/// The weight is scaled by `render_width / 1000` when it is emitted.
+const CONTOUR_LINE_COLOR: &str = "#404040";
+const CONTOUR_LINE_WEIGHT: f64 = 2.5;
+
 /// Evaluate a boolean condition at (x, y) - returns true/false
 fn evaluate_condition(
   body: &Expr,
@@ -172,10 +177,18 @@ struct DensityContourOptions {
   /// `MeshFunctions -> {f1, …}`: the functions whose level curves the
   /// mesh lines are. Empty means the coordinates themselves.
   mesh_functions: Vec<Expr>,
+  /// `ContourStyle -> {Thick, Blue}`: how the contour lines are drawn.
+  /// `None` keeps the default thin dark-grey line.
+  contour_style: Option<crate::functions::plot::SeriesStyle>,
+  /// `FrameLabel -> {bottom, left}`: the labels along the frame edges.
+  frame_labels: crate::functions::plot::FrameLabels,
+  /// `Epilog -> {…}`: graphics primitives drawn over the finished plot,
+  /// in data coordinates.
+  epilog: Vec<Expr>,
 }
 
-/// Parse ImageSize, ColorFunction, Contours, ContourShading, Mesh and
-/// MeshFunctions options.
+/// Parse ImageSize, ColorFunction, Contours, ContourShading, Mesh,
+/// MeshFunctions, ContourStyle, FrameLabel and Epilog options.
 fn parse_density_contour_options(
   args: &[Expr],
   start: usize,
@@ -186,6 +199,9 @@ fn parse_density_contour_options(
   let mut contour_shading = true;
   let mut mesh: Option<usize> = None;
   let mut mesh_functions: Vec<Expr> = Vec::new();
+  let mut contour_style = None;
+  let mut frame_labels = crate::functions::plot::FrameLabels::default();
+  let mut epilog: Vec<Expr> = Vec::new();
   for opt in &args[start..] {
     if let Expr::Rule {
       pattern,
@@ -251,6 +267,25 @@ fn parse_density_contour_options(
             mesh_functions = items.iter().cloned().collect();
           }
         }
+        "ContourStyle" => {
+          contour_style =
+            crate::functions::plot::parse_style_directives(replacement);
+        }
+        "FrameLabel" => {
+          frame_labels = crate::functions::plot::parse_frame_label(replacement);
+        }
+        // Evaluate now so primitives inside (e.g. `Point[{a, b}]` marking a
+        // Manipulate's current parameters) resolve to numeric coordinates
+        // while the surrounding variable bindings are still live.
+        "Epilog" => {
+          let val = evaluate_expr_to_expr(replacement)
+            .unwrap_or_else(|_| replacement.clone());
+          epilog = match val {
+            Expr::List(ref items) => items.to_vec(),
+            Expr::Identifier(ref s) if s == "None" => Vec::new(),
+            other => vec![other],
+          };
+        }
         _ => {}
       }
     }
@@ -264,7 +299,115 @@ fn parse_density_contour_options(
     contour_shading,
     mesh,
     mesh_functions,
+    contour_style,
+    frame_labels,
+    epilog,
   }
+}
+
+impl DensityContourOptions {
+  /// Whether a `FrameLabel` was given for the bottom or the left edge —
+  /// the two that need room reserved outside the plotting area.
+  fn has_outer_frame_labels(&self) -> bool {
+    !self.frame_labels.bottom.is_empty() || !self.frame_labels.left.is_empty()
+  }
+
+  /// The stroke colour and weight for contour lines: whatever
+  /// `ContourStyle` asked for, otherwise the default thin dark grey.
+  ///
+  /// `render_contour_lines_styled` scales its weight by
+  /// `render_width / 1000`, so a thickness given in display pixels
+  /// converts by the picture's own width.
+  fn contour_stroke(&self) -> (String, f64) {
+    let style = match &self.contour_style {
+      Some(s) => s,
+      None => return (CONTOUR_LINE_COLOR.to_string(), CONTOUR_LINE_WEIGHT),
+    };
+    let color = style
+      .color
+      .map(|c| c.to_svg_rgb())
+      .unwrap_or_else(|| CONTOUR_LINE_COLOR.to_string());
+    let weight = match style.thickness {
+      Some(t) if self.svg_width > 0 => t * 1000.0 / self.svg_width as f64,
+      _ => CONTOUR_LINE_WEIGHT,
+    };
+    (color, weight)
+  }
+}
+
+/// Axes for a field plot, with room reserved outside the plotting area for
+/// whatever `FrameLabel` asks to be written there.
+fn field_plot_axes(
+  x_range: (f64, f64),
+  y_range: (f64, f64),
+  opts: &DensityContourOptions,
+) -> Result<crate::functions::plot::PlotArea, InterpreterError> {
+  let margins = opts.has_outer_frame_labels().then_some({
+    crate::functions::plot::MarginOverrides {
+      top_margin: 10 * RESOLUTION_SCALE,
+      x_label_area: (40 + 24) * RESOLUTION_SCALE,
+      y_label_area: (65 + 20) * RESOLUTION_SCALE,
+    }
+  });
+  crate::functions::plot::generate_axes_only_opts(
+    x_range,
+    y_range,
+    opts.svg_width,
+    opts.svg_height,
+    opts.full_width,
+    None,
+    margins.as_ref(),
+  )
+}
+
+/// Draw a field plot's `Epilog` primitives and `FrameLabel` text over the
+/// finished picture. Called with the closing `</svg>` already stripped, so
+/// the fragments land on top of everything drawn before them.
+fn push_field_plot_overlays(
+  svg: &mut String,
+  area: &crate::functions::plot::PlotArea,
+  opts: &DensityContourOptions,
+) {
+  if !opts.epilog.is_empty() {
+    let epilog_area = crate::functions::plot_epilog::PlotArea {
+      x0: area.plot_x0,
+      y0: area.plot_y0,
+      w: area.plot_w,
+      h: area.plot_h,
+      x_min: area.x_min,
+      x_max: area.x_max,
+      y_min: area.y_min,
+      y_max: area.y_max,
+      scale: RESOLUTION_SCALE as f64,
+    };
+    svg.push_str(&crate::functions::plot_epilog::render_epilog_svg(
+      &opts.epilog,
+      &epilog_area,
+    ));
+  }
+  if opts.frame_labels.bottom.is_empty()
+    && opts.frame_labels.left.is_empty()
+    && opts.frame_labels.top.is_empty()
+    && opts.frame_labels.right.is_empty()
+  {
+    return;
+  }
+  let (.., label_fill, title_fill) = plot_theme();
+  let mut plot_opts = crate::functions::plot::PlotOptions::default();
+  let non_empty = |s: &String| (!s.is_empty()).then(|| s.clone());
+  plot_opts.frame_label_bottom = non_empty(&opts.frame_labels.bottom);
+  plot_opts.frame_label_left = non_empty(&opts.frame_labels.left);
+  plot_opts.frame_label_top = non_empty(&opts.frame_labels.top);
+  plot_opts.frame_label_right = non_empty(&opts.frame_labels.right);
+  svg.push_str(&crate::functions::plot::plot_labels_svg(
+    &plot_opts,
+    (area.plot_x0, area.plot_y0, area.plot_w, area.plot_h),
+    (area.x_min, area.x_max, area.y_min, area.y_max),
+    0.0,
+    RESOLUTION_SCALE as f64,
+    label_fill,
+    title_fill,
+  ));
 }
 
 /// Map value to a blue-white-red color
@@ -996,30 +1139,6 @@ fn mesh_function_value(
   }
 }
 
-fn render_contour_lines(
-  svg: &mut String,
-  grid: &[Vec<f64>],
-  levels: &[f64],
-  plot_x0: f64,
-  plot_y0: f64,
-  cell_w: f64,
-  cell_h: f64,
-  render_width: u32,
-) {
-  render_contour_lines_styled(
-    svg,
-    grid,
-    levels,
-    plot_x0,
-    plot_y0,
-    cell_w,
-    cell_h,
-    render_width,
-    "#404040",
-    2.5,
-  );
-}
-
 #[allow(clippy::too_many_arguments)]
 fn render_contour_lines_styled(
   svg: &mut String,
@@ -1084,15 +1203,11 @@ pub fn density_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Use plotters for axes, then overlay the density image
-  let area = generate_axes_only(
-    (x_min, x_max),
-    (y_min, y_max),
-    opts.svg_width,
-    opts.svg_height,
-    opts.full_width,
-  )?;
+  let mut area = field_plot_axes((x_min, x_max), (y_min, y_max), &opts)?;
 
-  let mut svg = area.svg;
+  // Taken out of `area` so the geometry stays available for the overlays
+  // appended once the plot's own content is drawn.
+  let mut svg = std::mem::take(&mut area.svg);
   // Remove closing </svg> to append custom elements
   if let Some(pos) = svg.rfind("</svg>") {
     svg.truncate(pos);
@@ -1116,6 +1231,7 @@ pub fn density_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     area.plot_w,
     area.plot_h,
   );
+  push_field_plot_overlays(&mut svg, &area, &opts);
 
   svg.push_str("</svg>");
   Ok(crate::graphics_result(svg))
@@ -1351,15 +1467,11 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   // Use plotters for axes
-  let area = generate_axes_only(
-    (x_min, x_max),
-    (y_min, y_max),
-    opts.svg_width,
-    opts.svg_height,
-    opts.full_width,
-  )?;
+  let mut area = field_plot_axes((x_min, x_max), (y_min, y_max), &opts)?;
 
-  let mut svg = area.svg;
+  // Taken out of `area` so the geometry stays available for the overlays
+  // appended once the plot's own content is drawn.
+  let mut svg = std::mem::take(&mut area.svg);
   if let Some(pos) = svg.rfind("</svg>") {
     svg.truncate(pos);
   }
@@ -1398,7 +1510,8 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       0.4,
     );
   }
-  render_contour_lines(
+  let (contour_color, contour_weight) = opts.contour_stroke();
+  render_contour_lines_styled(
     &mut svg,
     &grid,
     &levels,
@@ -1407,6 +1520,8 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     cell_w,
     cell_h,
     area.render_width,
+    &contour_color,
+    contour_weight,
   );
   push_frame(
     &mut svg,
@@ -1415,6 +1530,7 @@ pub fn contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     area.plot_w,
     area.plot_h,
   );
+  push_field_plot_overlays(&mut svg, &area, &opts);
 
   svg.push_str("</svg>");
   Ok(crate::graphics_result_with_structure(svg, structure))
@@ -1456,21 +1572,31 @@ fn contour_plot_equations(
   let opts = parse_density_contour_options(args, 3);
 
   let n = FIELD_GRID + 1;
-  let area = generate_axes_only(
-    (x_min, x_max),
-    (y_min, y_max),
-    opts.svg_width,
-    opts.svg_height,
-    opts.full_width,
-  )?;
+  let mut area = field_plot_axes((x_min, x_max), (y_min, y_max), &opts)?;
 
-  let mut svg = area.svg;
+  // Taken out of `area` so the geometry stays available for the overlays
+  // appended once the plot's own content is drawn.
+  let mut svg = std::mem::take(&mut area.svg);
   if let Some(pos) = svg.rfind("</svg>") {
     svg.truncate(pos);
   }
 
   let cell_w = area.plot_w / FIELD_GRID as f64;
   let cell_h = area.plot_h / FIELD_GRID as f64;
+  let (contour_color, contour_weight) = opts.contour_stroke();
+  let series_color = opts
+    .contour_style
+    .as_ref()
+    .and_then(|s| s.color)
+    .map(|c| {
+      (
+        (c.r.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (c.g.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (c.b.clamp(0.0, 1.0) * 255.0).round() as u8,
+      )
+    })
+    .unwrap_or((0x40, 0x40, 0x40));
+  let series_thickness = opts.contour_style.as_ref().and_then(|s| s.thickness);
 
   // Alongside the standalone SVG, collect every contour chain in *data*
   // coordinates as a line series, so `Show[{ContourPlot[…], Graphics[…]}]`
@@ -1497,7 +1623,7 @@ fn contour_plot_equations(
     if !any_finite {
       continue;
     }
-    render_contour_lines(
+    render_contour_lines_styled(
       &mut svg,
       &grid,
       &[0.0],
@@ -1506,6 +1632,8 @@ fn contour_plot_equations(
       cell_w,
       cell_h,
       area.render_width,
+      &contour_color,
+      contour_weight,
     );
     let scaled_cell = 1000.0 / FIELD_GRID as f64;
     let segments =
@@ -1521,15 +1649,18 @@ fn contour_plot_equations(
         })
         .collect();
       if points.len() >= 2 {
+        // The curve carries its `ContourStyle` into the series too, so a
+        // `Show[{ContourPlot[…], …}]` re-render keeps the colour and weight
+        // the standalone picture was drawn with.
         series.push(crate::syntax::PlotSeriesData {
           points,
-          color: (0x40, 0x40, 0x40),
+          color: series_color,
           is_scatter: false,
           filling: crate::syntax::SeriesFilling::None,
           fill_color: None,
           fill_opacity: None,
           marker: None,
-          thickness: None,
+          thickness: series_thickness,
         });
       }
     }
@@ -1542,6 +1673,7 @@ fn contour_plot_equations(
     area.plot_w,
     area.plot_h,
   );
+  push_field_plot_overlays(&mut svg, &area, &opts);
 
   svg.push_str("</svg>");
   // Alongside the plot source (for `Show`), remember the symbolic form of
@@ -2036,15 +2168,11 @@ pub fn list_density_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  let area = generate_axes_only(
-    (x_min, x_max),
-    (y_min, y_max),
-    opts.svg_width,
-    opts.svg_height,
-    opts.full_width,
-  )?;
+  let mut area = field_plot_axes((x_min, x_max), (y_min, y_max), &opts)?;
 
-  let mut svg = area.svg;
+  // Taken out of `area` so the geometry stays available for the overlays
+  // appended once the plot's own content is drawn.
+  let mut svg = std::mem::take(&mut area.svg);
   if let Some(pos) = svg.rfind("</svg>") {
     svg.truncate(pos);
   }
@@ -2075,6 +2203,7 @@ pub fn list_density_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     area.plot_w,
     area.plot_h,
   );
+  push_field_plot_overlays(&mut svg, &area, &opts);
 
   svg.push_str("</svg>");
   Ok(crate::graphics_result(svg))
@@ -2315,15 +2444,11 @@ pub fn list_contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  let area = generate_axes_only(
-    (x_min, x_max),
-    (y_min, y_max),
-    opts.svg_width,
-    opts.svg_height,
-    opts.full_width,
-  )?;
+  let mut area = field_plot_axes((x_min, x_max), (y_min, y_max), &opts)?;
 
-  let mut svg = area.svg;
+  // Taken out of `area` so the geometry stays available for the overlays
+  // appended once the plot's own content is drawn.
+  let mut svg = std::mem::take(&mut area.svg);
   if let Some(pos) = svg.rfind("</svg>") {
     svg.truncate(pos);
   }
@@ -2350,7 +2475,8 @@ pub fn list_contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       opts.color_function.as_deref(),
     );
   }
-  render_contour_lines(
+  let (contour_color, contour_weight) = opts.contour_stroke();
+  render_contour_lines_styled(
     &mut svg,
     &grid,
     &levels,
@@ -2359,6 +2485,8 @@ pub fn list_contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     cell_w,
     cell_h,
     area.render_width,
+    &contour_color,
+    contour_weight,
   );
   push_frame(
     &mut svg,
@@ -2367,6 +2495,7 @@ pub fn list_contour_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     area.plot_w,
     area.plot_h,
   );
+  push_field_plot_overlays(&mut svg, &area, &opts);
 
   svg.push_str("</svg>");
   Ok(crate::graphics_result(svg))

--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -960,7 +960,7 @@ fn parse_plot_options(args: &[Expr]) -> ParsedOptions {
         }
         "GridLinesStyle" => {
           opts.grid_lines_style =
-            crate::functions::plot::parse_grid_lines_style(replacement);
+            crate::functions::plot::parse_style_directives(replacement);
         }
         _ => {}
       }

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -7197,6 +7197,18 @@ pub(crate) fn parse_image_size(
   def_w: u32,
   def_h: u32,
 ) -> Option<(u32, u32, bool)> {
+  // A plot holds its arguments, so an option value that is still an
+  // arithmetic expression never reached the evaluator: `ImageSize ->
+  // 400 {1, 1}` — the way a Demonstration asks for a square picture —
+  // arrives as `Times[400, {1, 1}]`. Evaluate it once so the shapes below
+  // see the `{400, 400}` they understand.
+  let evaluated = match value {
+    Expr::BinaryOp { .. } | Expr::FunctionCall { .. } => {
+      evaluate_expr_to_expr(value).ok()
+    }
+    _ => None,
+  };
+  let value = evaluated.as_ref().unwrap_or(value);
   let aspect = def_h as f64 / def_w as f64;
   match value {
     Expr::Integer(n) if *n > 0 => {
@@ -7648,10 +7660,12 @@ pub(crate) fn parse_axes_option(value: &Expr) -> Option<(bool, bool)> {
   }
 }
 
-/// Parse a `GridLinesStyle` option value (`Directive[Red, Dashed]`, a bare
-/// color, `{Red, Thick}`, …) into the default style for the plot's grid
-/// lines. `Automatic` / `None` keep the built-in gray.
-pub(crate) fn parse_grid_lines_style(value: &Expr) -> Option<SeriesStyle> {
+/// Parse a style option's value — `Directive[Red, Dashed]`, a bare color,
+/// `{Thick, Blue}`, … — into the style it describes. `Automatic` / `None`,
+/// and any value that sets nothing, come back as `None` so the caller keeps
+/// its built-in look. Shared by `GridLinesStyle`, `ContourStyle` and the
+/// other single-style options.
+pub(crate) fn parse_style_directives(value: &Expr) -> Option<SeriesStyle> {
   let val = evaluate_expr_to_expr(value).unwrap_or_else(|_| value.clone());
   if matches!(&val, Expr::Identifier(s) if s == "Automatic" || s == "None") {
     return None;
@@ -8062,7 +8076,7 @@ pub(crate) fn apply_common_plot_option(
       );
     }
     "GridLinesStyle" => {
-      plot_opts.grid_lines_style = parse_grid_lines_style(replacement);
+      plot_opts.grid_lines_style = parse_style_directives(replacement);
     }
     "PlotRange" => {
       let (rx, ry) = parse_plot_range(replacement);
@@ -8725,7 +8739,7 @@ fn log_scale_plot_ast(
           );
         }
         "GridLinesStyle" => {
-          plot_opts.grid_lines_style = parse_grid_lines_style(replacement);
+          plot_opts.grid_lines_style = parse_style_directives(replacement);
         }
         "PlotRange" => {
           let (_rx, ry) = parse_plot_range(replacement);

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -2224,12 +2224,13 @@ fn grid_line_props(
 /// Draw a plot's labels — `FrameLabel` on all four edges, `AxesLabel` at the
 /// ends of the axes, and the `PlotLabel` above them — into `labels_svg`.
 ///
-/// Shared by the line and scatter renderers: both draw their own axes and
-/// then inject text, and the placement rules are the same for either.
+/// Shared by the line and scatter renderers and by the density/contour
+/// family in `field_plot`: each draws its own axes and then injects text,
+/// and the placement rules are the same for all of them.
 /// `area` is the plotting rectangle `(x0, y0, w, h)` and `range` the data
 /// range `(x_min, x_max, y_min, y_max)` it maps, both in render units.
 #[allow(clippy::too_many_arguments)]
-fn plot_labels_svg(
+pub(crate) fn plot_labels_svg(
   opts: &PlotOptions,
   (plot_x0, margin_top, plot_w, plot_h): (f64, f64, f64, f64),
   (x_min, x_max, y_min, y_max): (f64, f64, f64, f64),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -904,6 +904,24 @@ pub fn get_captured_graphics() -> Option<String> {
   CAPTURED_GRAPHICS.with(|buffer| buffer.borrow().last().cloned())
 }
 
+/// Make `expr`'s own picture the one visual hosts read back, when the value
+/// a cell displays is a graphic.
+///
+/// Hosts (playground, woxi-studio, the Jupyter kernel) take the *last*
+/// entry of the capture buffer, which is the last picture drawn while
+/// evaluating — not necessarily the one the cell evaluates to. A body that
+/// builds several plots and then picks one,
+/// `p1 = Plot[…]; p2 = ContourPlot[…]; Switch[which, 1, p1, 2, p2]`, drew
+/// `p2` last, so the chosen `p1` was displayed as `p2`. Re-capturing the
+/// result's SVG puts the picked picture back at the end of the buffer.
+fn promote_result_graphics(expr: &syntax::Expr) {
+  if let syntax::Expr::Graphics { svg, .. } = expr
+    && get_captured_graphics().as_deref() != Some(svg.as_str())
+  {
+    capture_graphics(svg);
+  }
+}
+
 /// Number of entries currently in the captured-graphics buffer. Paired with
 /// `truncate_captured_graphics` so a renderer that evaluates sub-expressions
 /// (e.g. the content of a `Dynamic[…]` inside `Graphics[…]`) can drop any
@@ -1924,7 +1942,7 @@ pub fn interpret(input: &str) -> Result<String, InterpreterError> {
       Some("\0".to_string())
     }
     Some(StmtOutcome::Display(result_expr)) => {
-      Some(format_top_level_result(result_expr))
+      Some(format_top_level_result(result_expr, depth))
     }
   };
 
@@ -1951,7 +1969,10 @@ pub fn interpret(input: &str) -> Result<String, InterpreterError> {
 /// render passes (Image/Graphics/Dataset/... wrappers), SVG typesetting for
 /// visual hosts, `%` history, and the final text formatting. Returns the
 /// output string ("\0" for Null, i.e. suppressed display).
-fn format_top_level_result(result_expr: syntax::Expr) -> String {
+///
+/// `depth` is the `interpret` nesting level; only the outermost call decides
+/// which picture the cell shows (see `promote_result_graphics`).
+fn format_top_level_result(result_expr: syntax::Expr, depth: usize) -> String {
   // If the result is an Image, render it as a PNG <img> tag
   let result_expr = render_image_if_needed(result_expr);
   // Render unevaluated Graphics[{...}] FunctionCalls to SVG (e.g.
@@ -2059,6 +2080,11 @@ fn format_top_level_result(result_expr: syntax::Expr) -> String {
     }
     _ => result_expr,
   };
+  // The picture a cell shows is the one its value *is*, not the last one
+  // drawn on the way there.
+  if depth == 0 {
+    promote_result_graphics(&result_expr);
+  }
   // Generate SVG rendering of the result for playground display
   generate_output_svg(&result_expr);
   // Stash the top-level Expr so `%` / `Out[]` in a subsequent

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -631,6 +631,65 @@ mod interpreter_tests {
     assert!(svg.contains("Coin"));
   }
 
+  /// The picture a cell shows is the one its value *is*, not the last one
+  /// drawn while getting there. A Manipulate body that builds several plots
+  /// and then picks one — the standard Demonstrations "which view?" control
+  /// — used to display whichever plot was assigned last.
+  #[test]
+  fn test_displayed_graphic_is_the_result_not_the_last_drawn() {
+    clear_state();
+    // `p1` is a plot 320 wide, `p2` one 480 wide; the body returns `p1`.
+    let r = interpret_with_stdout(
+      "Module[{p1, p2, which}, \
+       which = 1; \
+       p1 = Plot[Sin[x], {x, 0, 4}, ImageSize -> 320]; \
+       p2 = Plot[Cos[x], {x, 0, 4}, ImageSize -> 480]; \
+       Switch[which, 1, p1, 2, p2]]",
+    )
+    .unwrap();
+    let svg = r.graphics.expect("expected graphics output");
+    assert!(
+      svg.starts_with("<svg width=\"320\""),
+      "expected the picked plot (320 wide), got: {}",
+      &svg[..svg.len().min(80)]
+    );
+    // …and picking the other branch shows the other plot.
+    clear_state();
+    let r = interpret_with_stdout(
+      "Module[{p1, p2, which}, \
+       which = 2; \
+       p1 = Plot[Sin[x], {x, 0, 4}, ImageSize -> 320]; \
+       p2 = Plot[Cos[x], {x, 0, 4}, ImageSize -> 480]; \
+       Switch[which, 1, p1, 2, p2]]",
+    )
+    .unwrap();
+    let svg = r.graphics.expect("expected graphics output");
+    assert!(
+      svg.starts_with("<svg width=\"480\""),
+      "expected the picked plot (480 wide), got: {}",
+      &svg[..svg.len().min(80)]
+    );
+  }
+
+  /// The same holds across the statements of one cell: the value of the
+  /// last statement is what gets displayed.
+  #[test]
+  fn test_displayed_graphic_is_the_last_statements_value() {
+    clear_state();
+    let r = interpret_with_stdout(
+      "p1 = Plot[Sin[x], {x, 0, 4}, ImageSize -> 320];\n\
+       p2 = Plot[Cos[x], {x, 0, 4}, ImageSize -> 480];\n\
+       p1",
+    )
+    .unwrap();
+    let svg = r.graphics.expect("expected graphics output");
+    assert!(
+      svg.starts_with("<svg width=\"320\""),
+      "expected the referenced plot (320 wide), got: {}",
+      &svg[..svg.len().min(80)]
+    );
+  }
+
   #[test]
   fn test_export_graphic_does_not_render_inline() {
     // Exporting a graphic (e.g. BarChart) to a file writes the file and

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -8269,6 +8269,98 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       );
     }
 
+    /// `ContourStyle` colours and thickens the contour lines. Both the
+    /// function form and the equation form draw through it — the equation
+    /// form is how a Demonstration draws a stability boundary.
+    #[test]
+    fn contour_plot_honors_contour_style() {
+      for expr in [
+        "ContourPlot[x + y, {x, 0, 4}, {y, 0, 4}, ContourShading -> False, \
+         ContourStyle -> {Thick, Blue}]",
+        "ContourPlot[y == x, {x, 0, 4}, {y, 0, 4}, \
+         ContourStyle -> {Thick, Blue}]",
+      ] {
+        let svg = export_svg(expr);
+        assert!(
+          svg.contains("stroke=\"rgb(0,0,255)\""),
+          "ContourStyle colour missing from {expr}"
+        );
+        // `Thick` is 2 display pixels; the default contour line is thinner
+        // than one, so the styled stroke must be clearly wider.
+        let widths: Vec<f64> = svg
+          .split("stroke-width=\"")
+          .skip(1)
+          .filter_map(|s| s.split('"').next()?.parse().ok())
+          .collect();
+        assert!(
+          widths.iter().any(|w| *w >= 19.0),
+          "expected a Thick contour stroke in {expr}, widths: {widths:?}"
+        );
+      }
+    }
+
+    /// The default contour line keeps its thin dark-grey look when no
+    /// `ContourStyle` is given.
+    #[test]
+    fn contour_plot_default_line_style_unchanged() {
+      let svg = export_svg("ContourPlot[y == x, {x, 0, 4}, {y, 0, 4}]");
+      assert!(
+        svg.contains("stroke=\"#404040\" stroke-width=\"9.0\""),
+        "default contour stroke changed"
+      );
+    }
+
+    /// `FrameLabel` and `Epilog` reach a contour plot the same way they
+    /// reach a function plot: the labels sit outside the frame and the
+    /// epilog primitives are drawn over the curves in data coordinates.
+    #[test]
+    fn contour_plot_honors_frame_label_and_epilog() {
+      let svg = export_svg(
+        "ContourPlot[y == x, {x, 0, 4}, {y, 0, 4}, \
+         FrameLabel -> {\"across\", \"up\"}, \
+         Epilog -> {Text[\"here\", {2, 3}], Red, PointSize[0.05], \
+         Point[{1, 1}]}]",
+      );
+      for text in [">across</text>", ">up</text>", ">here</text>"] {
+        assert!(svg.contains(text), "missing {text} in:\n{svg}");
+      }
+      assert!(
+        svg.contains("<circle") && svg.contains("rgb(255,0,0)"),
+        "expected the red Epilog point"
+      );
+    }
+
+    /// A `DensityPlot` takes the same labels and epilog — the option
+    /// parsing is shared across the whole density/contour family.
+    #[test]
+    fn density_plot_honors_frame_label_and_epilog() {
+      let svg = export_svg(
+        "DensityPlot[x + y, {x, 0, 4}, {y, 0, 4}, \
+         FrameLabel -> {\"across\", \"up\"}, Epilog -> {Text[\"here\", {2, 3}]}]",
+      );
+      for text in [">across</text>", ">up</text>", ">here</text>"] {
+        assert!(svg.contains(text), "missing {text} in a DensityPlot");
+      }
+    }
+
+    /// `ImageSize -> n {1, 1}` — a plot holds its arguments, so the option
+    /// value arrives unevaluated and has to be evaluated before it can be
+    /// read as the square size it describes.
+    #[test]
+    fn image_size_product_gives_a_square_picture() {
+      for expr in [
+        "Plot[Sin[x], {x, 0, 4}, ImageSize -> 400 {1, 1}]",
+        "ContourPlot[y == x, {x, 0, 4}, {y, 0, 4}, ImageSize -> 400 {1, 1}]",
+      ] {
+        let svg = export_svg(expr);
+        assert!(
+          svg.starts_with("<svg width=\"400\" height=\"400\""),
+          "expected a 400x400 picture for {expr}, got: {}",
+          &svg[..svg.len().min(80)]
+        );
+      }
+    }
+
     /// A pre-rendered equation ContourPlot must merge with other graphics
     /// inside Show — the curve is carried along as plot-source line series.
     #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -13152,4 +13152,74 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`ctrl1$$ = 1}, \"\\[Ellipsis]\"]"], 
     assert_ne!(pressure, render(3, 1), "the mixture control must matter");
     assert_ne!(pressure, xy, "the view control must matter");
   }
+
+  /// The Demonstrations shape that offers several views of one computation:
+  /// the body builds every plot, then a setter bar picks which to show. The
+  /// widget must display the *picked* view — it used to show whichever plot
+  /// the body drew last, so the setter looked like it did nothing. The
+  /// stability-diagram view also exercises `ContourStyle`, `FrameLabel` and
+  /// `Epilog` on a `ContourPlot`, and `ImageSize -> n {1, 1}`.
+  #[test]
+  fn view_switching_manipulate_shows_the_picked_view() {
+    let code = "Manipulate[\n\
+      Module[{p1, p2, p3},\n\
+       p1 = Plot[Sin[k x], {x, 0, 10}, Frame -> True, \
+         ImageSize -> 300 {1, 1}];\n\
+       p2 = ParametricPlot[{Cos[k t], Sin[t]}, {t, 0, 2 Pi}, Frame -> True, \
+         ImageSize -> 320 {1, 1}];\n\
+       p3 = ContourPlot[y == k x, {x, 0, 4}, {y, 0, 4}, \
+         ContourStyle -> {Thick, Blue}, ImageSize -> 340 {1, 1}, \
+         FrameLabel -> {\"rate\", \"level\"}, \
+         Epilog -> {Text[\"here\", {2, 3}], Red, PointSize[0.05], \
+         Point[{k, 2}]}];\n\
+       Switch[view, 1, p1, 2, p2, 3, p3]],\n\
+      {{k, 1, \"rate\"}, 1, 3, 0.1, Appearance -> \"Labeled\"},\n\
+      {{view, 1, \"\"}, {1 -> \"curve\", 2 -> \"phase\", 3 -> \"diagram\"}},\n\
+      TrackedSymbols :> {k, view},\n\
+      SynchronousUpdating -> False]";
+    let widget = instantiate_stored_manipulate(code, "")
+      .expect("the Manipulate must instantiate");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(widget.graphics_handle.is_some(), "a view must draw");
+    let names: Vec<&str> = widget.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["k", "view"]);
+
+    let render = |view: u32| {
+      woxi::interpret_with_stdout(&format!(
+        "k = 1; view = {view};\n{}",
+        widget.body
+      ))
+      .expect("the body must render")
+      .graphics
+      .expect("the body must produce a graphic")
+    };
+
+    // Each view sizes its own picture, so the width names which one showed.
+    for (view, width) in [(1, "300"), (2, "320"), (3, "340")] {
+      let svg = render(view);
+      assert!(
+        svg.starts_with(&format!("<svg width=\"{width}\"")),
+        "view {view} must show its own plot, got: {}",
+        &svg[..svg.len().min(80)]
+      );
+    }
+
+    // The diagram view draws through all three of its options.
+    let diagram = render(3);
+    assert!(
+      diagram.contains("stroke=\"rgb(0,0,255)\""),
+      "ContourStyle must colour the boundary"
+    );
+    for text in [">rate</text>", ">level</text>", ">here</text>"] {
+      assert!(diagram.contains(text), "missing {text} in the diagram view");
+    }
+    assert!(
+      diagram.contains("rgb(255,0,0)"),
+      "the Epilog marker must be drawn"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

This PR fixes several issues with density and contour plots discovered while implementing a Wolfram Demonstration with multiple views. The main problems were: (1) the displayed graphic was the last one drawn during evaluation, not the cell's actual result; (2) `ContourStyle`, `FrameLabel`, and `Epilog` options were not implemented for field plots; and (3) `ImageSize -> n {1, 1}` was not evaluated before parsing.

## Key Changes

- **Result graphic promotion**: Added `promote_result_graphics()` to ensure the picture a cell displays is the one its value *is*, not the last one drawn while evaluating. This fixes the common Demonstrations pattern of building multiple plots and selecting one with `Switch`.

- **ContourStyle support**: 
  - Added `contour_style` field to `DensityContourOptions`
  - Implemented `contour_stroke()` method to extract color and weight from `ContourStyle` directives
  - Removed the hardcoded `render_contour_lines()` wrapper and updated all call sites to use `render_contour_lines_styled()` with the styled parameters
  - The style is also carried into the symbolic form for `ContourPlot` equations so `Show` merges preserve it

- **FrameLabel and Epilog support**:
  - Added `frame_labels` and `epilog` fields to `DensityContourOptions`
  - Implemented `push_field_plot_overlays()` to render epilog primitives and frame labels over the finished plot
  - Implemented `field_plot_axes()` to reserve margin space when outer frame labels are present
  - Applied these overlays to all field plot variants: `DensityPlot`, `ContourPlot`, `ListDensityPlot`, `ListContourPlot`, and equation-form `ContourPlot`

- **ImageSize evaluation**: Updated `parse_image_size()` to evaluate unevaluated arithmetic expressions like `400 {1, 1}` (which arrive as `Times[400, {1, 1}]`) before parsing, so square-picture sizing works in Demonstrations.

- **Style parsing refactor**: Renamed `parse_grid_lines_style()` to `parse_style_directives()` to reflect its broader use across `GridLinesStyle`, `ContourStyle`, and other single-style options.

## Implementation Details

- The contour line weight is scaled by `render_width / 1000` to convert display pixels to the picture's coordinate system
- Default contour lines remain thin dark grey (`#404040`, weight 2.5) when no `ContourStyle` is given
- Frame labels are positioned outside the plot area with reserved margins, consistent with function plots
- Epilog primitives are evaluated while variable bindings are live (e.g., `Point[{k, 2}]` resolves to numeric coordinates in a Manipulate body)
- All changes maintain backward compatibility; plots without these options render identically to before

## Tests Added

- `contour_plot_honors_contour_style`: Verifies `ContourStyle` colors and thickens contour lines in both function and equation forms
- `contour_plot_default_line_style_unchanged`: Ensures default styling is preserved
- `contour_plot_honors_frame_label_and_epilog`: Tests label and epilog rendering on contour plots
- `density_plot_honors_frame_label_and_epilog`: Tests the same on density plots
- `image_size_product_gives_a_square_picture`: Verifies `ImageSize -> n {1, 1}` evaluation
- `test_displayed_graphic_is_the_result_not_the_last_drawn`: Regression test for the result promotion fix
- `test_displayed_graphic_is_the_last_statements_value`: Verifies correct graphic display across statements
- `view_switching_manipulate_shows_the_picked_view`: Integration test with a realistic Demonstration pattern

https://claude.ai/code/session_018yyuGJ5o7hi9Qpkd2JmV7t