### PR TITLE
Support non-linear pattern variables in function definitions

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -386,6 +386,22 @@ pub fn rule_dominates(
       strictly_tighter = true;
     }
   }
+  // Repeated pattern variables are an equality constraint between positions,
+  // so a non-linear rule (`f[i_, i_]`) matches a strict subset of the linear
+  // rule with the same shape (`f[j_, k_]`) and must be tried first. Every pair
+  // `b` forces equal, `a` must force equal too.
+  let a_pairs =
+    crate::evaluator::pattern_matching::repeated_param_pairs(a_params);
+  let b_pairs =
+    crate::evaluator::pattern_matching::repeated_param_pairs(b_params);
+  for pair in &b_pairs {
+    if !a_pairs.contains(pair) {
+      return false;
+    }
+  }
+  if a_pairs.iter().any(|p| !b_pairs.contains(p)) {
+    strictly_tighter = true;
+  }
   // Every guard of `b` must also guard `a`, else `a` accepts inputs `b` rejects.
   // Compare guards by their string form (Expr has no PartialEq).
   let a_guard_strs: Vec<String> =

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -122,32 +122,74 @@ fn promote_lists_for_substitution(values: &mut [Expr]) {
   }
 }
 
+/// Whether assigning `candidate` to parameter `param_idx` agrees with what an
+/// earlier slot of the same pattern-variable name already consumed. A
+/// non-linear pattern like `f[a__, a__]` repeats a name across slots, and the
+/// repeated slots must receive the same arguments — so a split that breaks the
+/// repeat is rejected here and the caller backtracks to the next one.
+fn repeat_ok(
+  params: &[String],
+  assigned: &[Vec<Expr>],
+  param_idx: usize,
+  candidate: &[Expr],
+) -> bool {
+  let Some(name) = params.get(param_idx) else {
+    return true;
+  };
+  if name.is_empty() || name.starts_with('_') {
+    return true;
+  }
+  for (i, prev) in assigned.iter().enumerate() {
+    if params.get(i).map(String::as_str) != Some(name.as_str()) {
+      continue;
+    }
+    if prev.len() != candidate.len()
+      || !prev
+        .iter()
+        .zip(candidate)
+        .all(|(a, b)| crate::evaluator::pattern_matching::expr_equal(a, b))
+    {
+      return false;
+    }
+  }
+  true
+}
+
 /// Distribute function call args to params using backtracking,
 /// handling BlankSequence/BlankNullSequence params that consume variable numbers of args.
+/// `assigned` carries the args already given to params `0..param_idx` so a
+/// repeated pattern variable can reject (and backtrack past) a split that
+/// gives its slots different arguments.
 fn distribute_args_to_params(
   args: &[Expr],
+  params: &[String],
   blank_types: &[u8],
   param_heads: &[Option<String>],
   param_defaults: &[Option<Expr>],
   param_idx: usize,
+  assigned: &[Vec<Expr>],
 ) -> Option<Vec<Vec<Expr>>> {
   stacker::maybe_grow(2 * 1024 * 1024, 4 * 1024 * 1024, || {
     distribute_args_to_params_impl(
       args,
+      params,
       blank_types,
       param_heads,
       param_defaults,
       param_idx,
+      assigned,
     )
   })
 }
 
 fn distribute_args_to_params_impl(
   args: &[Expr],
+  params: &[String],
   blank_types: &[u8],
   param_heads: &[Option<String>],
   param_defaults: &[Option<Expr>],
   param_idx: usize,
+  assigned: &[Vec<Expr>],
 ) -> Option<Vec<Vec<Expr>>> {
   if param_idx >= blank_types.len() {
     return if args.is_empty() { Some(vec![]) } else { None };
@@ -188,12 +230,19 @@ fn distribute_args_to_params_impl(
       {
         continue;
       }
+      if !repeat_ok(params, assigned, param_idx, seq_args) {
+        continue;
+      }
+      let mut next_assigned = assigned.to_vec();
+      next_assigned.push(seq_args.to_vec());
       if let Some(mut rest) = distribute_args_to_params(
         &args[count..],
+        params,
         blank_types,
         param_heads,
         param_defaults,
         param_idx + 1,
+        &next_assigned,
       ) {
         rest.insert(0, seq_args.to_vec());
         return Some(rest);
@@ -204,17 +253,21 @@ fn distribute_args_to_params_impl(
     // Regular param: consume 0 or 1 args
     if args.is_empty() {
       // Try using default
-      if param_defaults[param_idx].is_some()
-        && let Some(mut rest) = distribute_args_to_params(
+      if param_defaults[param_idx].is_some() {
+        let mut next_assigned = assigned.to_vec();
+        next_assigned.push(vec![]);
+        if let Some(mut rest) = distribute_args_to_params(
           args,
+          params,
           blank_types,
           param_heads,
           param_defaults,
           param_idx + 1,
-        )
-      {
-        rest.insert(0, vec![]);
-        return Some(rest);
+          &next_assigned,
+        ) {
+          rest.insert(0, vec![]);
+          return Some(rest);
+        }
       }
       return None;
     }
@@ -224,14 +277,22 @@ fn distribute_args_to_params_impl(
     {
       return None;
     }
+    let taken = vec![args[0].clone()];
+    if !repeat_ok(params, assigned, param_idx, &taken) {
+      return None;
+    }
+    let mut next_assigned = assigned.to_vec();
+    next_assigned.push(taken.clone());
     if let Some(mut rest) = distribute_args_to_params(
       &args[1..],
+      params,
       blank_types,
       param_heads,
       param_defaults,
       param_idx + 1,
+      &next_assigned,
     ) {
-      rest.insert(0, vec![args[0].clone()]);
+      rest.insert(0, taken);
       return Some(rest);
     }
     None
@@ -700,10 +761,12 @@ fn evaluate_function_call_ast_inner(
         // Distribute args to params using backtracking for sequence patterns
         let distribution = distribute_args_to_params(
           args,
+          params,
           blank_types,
           param_heads,
           param_defaults,
           0,
+          &[],
         );
         let mut effective_args = match distribution {
           Some(dist) => {
@@ -766,6 +829,15 @@ fn evaluate_function_call_ast_inner(
           }
           None => continue,
         };
+
+        // A non-linear pattern (`f[i_, i_]`) only matches when its repeated
+        // slots receive the same argument.
+        if !crate::evaluator::pattern_matching::repeated_params_agree(
+          params,
+          &effective_args,
+        ) {
+          continue;
+        }
 
         // Check conditions
         let mut conditions_met = true;
@@ -1045,6 +1117,15 @@ fn evaluate_function_call_ast_inner(
           }
           effective
         };
+
+        // A non-linear pattern (`f[i_, i_]`) only matches when its repeated
+        // slots receive the same argument.
+        if !crate::evaluator::pattern_matching::repeated_params_agree(
+          params,
+          &effective_args,
+        ) {
+          continue;
+        }
 
         // Check all conditions (if any) by substituting params with args and evaluating
         let mut conditions_met = true;

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -62,6 +62,58 @@ fn bindings_compatible_with_context(bindings: &[(String, Expr)]) -> bool {
   })
 }
 
+/// Whether a stored parameter name is a real pattern variable rather than one
+/// of the synthetic slots the assignment machinery introduces (list-pattern
+/// `_lp…`, structural-pattern `__sp…`, `__opts…`, upvalue `_up…`, and the
+/// empty guard-only slots). Only real variables carry the repeated-name
+/// constraint of a non-linear pattern.
+fn is_named_pattern_param(name: &str) -> bool {
+  !name.is_empty() && !name.starts_with('_')
+}
+
+/// Enforce the equality constraint of a non-linear pattern such as
+/// `f[i_, i_]`: every position sharing a pattern-variable name must receive
+/// the same argument. Wolfram only fires such a definition when the repeated
+/// slots agree, so `f[1, 2]` must not match `f[i_, i_]`.
+///
+/// `params` and `args` are positional; trailing guard-only slots in `params`
+/// (which have no argument) are ignored.
+pub(crate) fn repeated_params_agree(params: &[String], args: &[Expr]) -> bool {
+  let mut seen: Vec<(&str, &Expr)> = Vec::new();
+  for (name, arg) in params.iter().zip(args.iter()) {
+    if !is_named_pattern_param(name) {
+      continue;
+    }
+    match seen.iter().find(|(n, _)| *n == name.as_str()) {
+      Some((_, first)) => {
+        if !expr_equal(first, arg) {
+          return false;
+        }
+      }
+      None => seen.push((name.as_str(), arg)),
+    }
+  }
+  true
+}
+
+/// The set of position pairs a rule forces to be equal, as index pairs
+/// `(i, j)` with `i < j` sharing a pattern-variable name. Used to order
+/// non-linear definitions ahead of the structurally identical linear ones.
+pub(crate) fn repeated_param_pairs(params: &[String]) -> Vec<(usize, usize)> {
+  let mut pairs = Vec::new();
+  for i in 0..params.len() {
+    if !is_named_pattern_param(&params[i]) {
+      continue;
+    }
+    for j in (i + 1)..params.len() {
+      if params[i] == params[j] {
+        pairs.push((i, j));
+      }
+    }
+  }
+  pairs
+}
+
 /// Merge new bindings into existing bindings, checking for consistency.
 /// If a variable name already has a binding, the new value must be
 /// structurally equal. Returns false if there is a conflict.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4938,10 +4938,18 @@ fn store_function_definition(
       // unconditional rule would wrongly delete the guarded rule. In Wolfram,
       // `f[a_,b_] := f[b,a] /; a>b` and `f[a_,b_] := …` are distinct
       // DownValues and both are retained.
+      let new_repeats =
+        evaluator::pattern_matching::repeated_param_pairs(&params);
       entry.retain(|(p, conds, d, h, bt, body)| {
         p.len() != arity
           || bt != &blank_types
           || h != &heads
+          // Repeated pattern variables are part of the pattern, not just a
+          // naming choice: `f[i_, i_]` constrains its two slots to be equal
+          // while `f[j_, k_]` does not, so they are distinct DownValues and
+          // neither redefines the other.
+          || evaluator::pattern_matching::repeated_param_pairs(p)
+            != new_repeats
           // Optional (defaulted) positions distinguish overloads: `f[x_, y_]`
           // and `f[x_, y_:0]` are separate DownValues, so keep an existing rule
           // whose optional-arg pattern differs from the new one's.

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -4031,3 +4031,131 @@ mod curried_and_head_patterns {
     );
   }
 }
+
+/// Non-linear (repeated-variable) definition patterns such as `f[i_, i_]`.
+/// The repeated name is an equality constraint between the two slots, so the
+/// rule only fires when both arguments agree, it is strictly more specific
+/// than the same shape with distinct names, and it is a *different*
+/// DownValue — defining one must not delete the other. All expectations
+/// match wolframscript.
+mod repeated_pattern_variables {
+  use super::*;
+
+  #[test]
+  fn repeated_variable_requires_equal_arguments() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"f[i_, i_] := "same"; {f[1, 1], f[1, 2]}"#).unwrap(),
+      "{same, f[1, 2]}"
+    );
+    // Non-numeric and structured arguments compare the same way.
+    clear_state();
+    assert_eq!(
+      interpret(r#"g[x_, x_] := "same"; {g[a, a], g[a, b]}"#).unwrap(),
+      "{same, g[a, b]}"
+    );
+    clear_state();
+    assert_eq!(
+      interpret(
+        r#"h[x_, x_] := "same"; {h[{1, 2}, {1, 2}], h[{1, 2}, {1, 3}]}"#
+      )
+      .unwrap(),
+      "{same, h[{1, 2}, {1, 3}]}"
+    );
+  }
+
+  /// A repeat among three slots constrains only the repeated pair.
+  #[test]
+  fn repeated_variable_among_several_slots() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"k[a_, a_, c_] := "rep"; {k[1, 1, 9], k[1, 2, 9]}"#).unwrap(),
+      "{rep, k[1, 2, 9]}"
+    );
+    // Three-way repeat: all three must agree.
+    clear_state();
+    assert_eq!(
+      interpret(r#"m[a_, a_, a_] := "all"; {m[2, 2, 2], m[2, 2, 3]}"#).unwrap(),
+      "{all, m[2, 2, 3]}"
+    );
+  }
+
+  /// The non-linear rule and the linear rule of the same shape are distinct
+  /// DownValues; neither redefinition deletes the other, and the non-linear
+  /// one is tried first regardless of the order they were entered in.
+  #[test]
+  fn repeated_and_distinct_variable_rules_coexist() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "p[i_, i_] := \"same\"; p[j_, k_] := \"diff\"; \
+         {p[1, 1], p[1, 2], Length[DownValues[p]]}"
+      )
+      .unwrap(),
+      "{same, diff, 2}"
+    );
+    // Entered the other way round, specificity still puts `q[i_, i_]` first.
+    clear_state();
+    assert_eq!(
+      interpret(
+        "q[j_, k_] := \"diff\"; q[i_, i_] := \"same\"; \
+         {q[1, 1], q[1, 2], Length[DownValues[q]]}"
+      )
+      .unwrap(),
+      "{same, diff, 2}"
+    );
+  }
+
+  /// Renaming the pattern variables of an otherwise identical rule *does*
+  /// redefine it — only the repeat structure makes two rules distinct.
+  #[test]
+  fn alpha_renamed_linear_rule_still_replaces() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "r[j_, k_] := \"first\"; r[p_, q_] := \"second\"; \
+         {r[1, 2], Length[DownValues[r]]}"
+      )
+      .unwrap(),
+      "{second, 1}"
+    );
+  }
+
+  /// A literal-argument definition still outranks a repeated-variable rule
+  /// covering the same slots, and the repeated rule outranks the fully
+  /// general one — the layering a differentiation-matrix definition relies
+  /// on, including when the head is a `Module` local.
+  #[test]
+  fn literal_then_repeated_then_general_layering() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "d[0, 0] = 99; d[i_, i_] := 10 i; d[j_, k_] := 0; \
+         Table[d[i, j], {i, 0, 2}, {j, 0, 2}]"
+      )
+      .unwrap(),
+      "{{99, 0, 0}, {0, 10, 0}, {0, 0, 20}}"
+    );
+    // Same layering on a Module-local symbol, where the head is renamed.
+    clear_state();
+    assert_eq!(
+      interpret(
+        "Module[{d}, d[0, 0] = 99; d[i_, i_] := 10 i; d[j_, k_] := 0; \
+         Table[d[i, j], {i, 0, 2}, {j, 0, 2}]]"
+      )
+      .unwrap(),
+      "{{99, 0, 0}, {0, 10, 0}, {0, 0, 20}}"
+    );
+  }
+
+  /// Repeated variables constrain sequence patterns the same way.
+  #[test]
+  fn repeated_sequence_variable() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"s[a__, a__] := "dup"; {s[1, 2, 1, 2], s[1, 2, 3, 4]}"#)
+        .unwrap(),
+      "{dup, s[1, 2, 3, 4]}"
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implement support for non-linear (repeated-variable) pattern definitions such as `f[i_, i_]`, where a pattern variable name appears in multiple slots. These definitions enforce an equality constraint: the rule only matches when all slots with the same variable name receive identical arguments.

## Key Changes

- **Pattern matching validation**: Added `repeated_params_agree()` function to verify that repeated pattern variables receive equal arguments during function dispatch
- **Backtracking distribution**: Enhanced `distribute_args_to_params()` to track assigned arguments and reject splits that violate repeat constraints via the new `repeat_ok()` check
- **Rule specificity ordering**: Extended `rule_dominates()` to recognize that non-linear rules are strictly more specific than their linear counterparts (e.g., `f[i_, i_]` dominates `f[j_, k_]`) and must be tried first
- **Definition storage**: Modified `store_function_definition()` to treat repeated pattern variables as part of the pattern signature, so `f[i_, i_]` and `f[j_, k_]` are distinct DownValues that don't overwrite each other
- **Comprehensive test coverage**: Added 6 test cases covering equality constraints, multi-slot patterns, coexistence with linear rules, alpha-renaming behavior, layering with literals, and sequence patterns

## Implementation Details

- Repeated pattern variables are identified by checking if a parameter name is non-empty and doesn't start with underscore (distinguishing them from synthetic slots like `_lp`, `__sp`, etc.)
- The `repeat_ok()` function validates during backtracking that a candidate argument split matches what was already assigned to earlier slots with the same name
- Rule dominance now considers repeat constraint pairs: a rule with more equality constraints is strictly more specific
- All behavior matches Wolfram Language semantics as verified against wolframscript

https://claude.ai/code/session_01FzJ7HRuRxWuv2jYKLSzoCa