### PR TITLE
Fix Graphics rendering: frame labels, tick precision, and Show layering

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -4515,6 +4515,27 @@ fn format_tick_value(v: f64) -> String {
   s
 }
 
+/// The spacing of a tick sequence, or `None` when there are too few ticks
+/// to tell. Every label of a set carries the decimals the spacing needs,
+/// so this is what decides whether an axis reads `-1.0, -0.5, 0.0` or
+/// `-1, -0.5, 0`.
+fn tick_sequence_step(values: &[f64]) -> Option<f64> {
+  let step = values
+    .windows(2)
+    .map(|w| (w[1] - w[0]).abs())
+    .fold(f64::INFINITY, f64::min);
+  (step.is_finite() && step > 0.0).then_some(step)
+}
+
+/// Label one tick of a `step`-spaced set, the way the plot renderer does:
+/// all the labels of a set get the same number of decimals.
+fn format_tick_in_sequence(v: f64, step: Option<f64>) -> String {
+  match step {
+    Some(step) => crate::functions::plot::format_tick_with_step(v, step),
+    None => format_tick_value(v),
+  }
+}
+
 fn nice_tick_step(min: f64, max: f64, target_count: usize) -> f64 {
   let range = (max - min).abs();
   if !range.is_finite() || range <= 0.0 {
@@ -4641,7 +4662,10 @@ fn render_axes(
     svg.push_str(&format!(
       "<line x1=\"0.00\" y1=\"{axis_y_px:.2}\" x2=\"{svg_w:.2}\" y2=\"{axis_y_px:.2}\" stroke=\"{axis_stroke}\" stroke-width=\"1\"/>\n"
     ));
-    for (t, tick_label) in axis_ticks(ticks.0, bb.x_min, bb.x_max) {
+    let entries = axis_ticks(ticks.0, bb.x_min, bb.x_max);
+    let step =
+      tick_sequence_step(&entries.iter().map(|(t, _)| *t).collect::<Vec<_>>());
+    for (t, tick_label) in entries {
       let x = coord_x(t, bb, svg_w);
       if !x.is_finite() {
         continue;
@@ -4651,9 +4675,10 @@ fn render_axes(
         axis_y_px - 4.0,
         axis_y_px + 4.0
       ));
-      let label =
-        tick_label.unwrap_or_else(|| svg_escape(&format_tick_value(t)));
-      if axes.1 && label == "0" {
+      let label = tick_label
+        .unwrap_or_else(|| svg_escape(&format_tick_in_sequence(t, step)));
+      // The two axes cross at the origin, so only one of them labels it.
+      if axes.1 && t.abs() < step.unwrap_or(1.0) * 1e-6 {
         continue;
       }
       svg.push_str(&format!(
@@ -4667,7 +4692,10 @@ fn render_axes(
     svg.push_str(&format!(
       "<line x1=\"{axis_x_px:.2}\" y1=\"0.00\" x2=\"{axis_x_px:.2}\" y2=\"{svg_h:.2}\" stroke=\"{axis_stroke}\" stroke-width=\"1\"/>\n"
     ));
-    for (t, tick_label) in axis_ticks(ticks.1, bb.y_min, bb.y_max) {
+    let entries = axis_ticks(ticks.1, bb.y_min, bb.y_max);
+    let step =
+      tick_sequence_step(&entries.iter().map(|(t, _)| *t).collect::<Vec<_>>());
+    for (t, tick_label) in entries {
       let y = coord_y(t, bb, svg_h);
       if !y.is_finite() {
         continue;
@@ -4677,9 +4705,9 @@ fn render_axes(
         axis_x_px - 4.0,
         axis_x_px + 4.0
       ));
-      let label =
-        tick_label.unwrap_or_else(|| svg_escape(&format_tick_value(t)));
-      if axes.0 && label == "0" {
+      let label = tick_label
+        .unwrap_or_else(|| svg_escape(&format_tick_in_sequence(t, step)));
+      if axes.0 && t.abs() < step.unwrap_or(1.0) * 1e-6 {
         continue;
       }
       svg.push_str(&format!(
@@ -4732,6 +4760,8 @@ fn render_frame(
 
   let x_ticks = generate_ticks(bb.x_min, bb.x_max, 6);
   let y_ticks = generate_ticks(bb.y_min, bb.y_max, 6);
+  let x_step = tick_sequence_step(&x_ticks);
+  let y_step = tick_sequence_step(&y_ticks);
 
   // Bottom edge: ticks + labels
   for &t_val in &x_ticks {
@@ -4745,7 +4775,7 @@ fn render_frame(
       svg_h - 5.0
     ));
     // Label below the bottom edge
-    let label = format_tick_value(t_val);
+    let label = format_tick_in_sequence(t_val, x_step);
     svg.push_str(&format!(
       "<text x=\"{x:.2}\" y=\"{:.2}\" fill=\"{tick_label_fill}\" font-size=\"12\" font-family=\"monospace\" text-anchor=\"middle\" dominant-baseline=\"hanging\">{}</text>\n",
       svg_h + 4.0,
@@ -4777,7 +4807,7 @@ fn render_frame(
       5.0
     ));
     // Label to the left of the frame
-    let label = format_tick_value(t_val);
+    let label = format_tick_in_sequence(t_val, y_step);
     svg.push_str(&format!(
       "<text x=\"{:.2}\" y=\"{y:.2}\" fill=\"{tick_label_fill}\" font-size=\"12\" font-family=\"monospace\" text-anchor=\"end\" dominant-baseline=\"middle\">{}</text>\n",
       -4.0,
@@ -6305,8 +6335,9 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // `AxesLabel -> {xlabel, ylabel}`, already typeset as SVG markup.
   let mut axes_label: Option<(String, String)> = None;
   // `FrameLabel -> {bottom, left}` (or the nested four-edge form), as SVG
-  // markup: the captions that sit outside the frame.
-  let mut frame_label: Option<(String, String)> = None;
+  // markup: the captions that sit outside the frame, in the order
+  // bottom, left, top, right.
+  let mut frame_label: Option<(String, String, String, String)> = None;
   // `Ticks -> {xspec, yspec}`: which tick marks each axis carries.
   let mut ticks_x = TickSpec::Automatic;
   let mut ticks_y = TickSpec::Automatic;
@@ -6425,8 +6456,17 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // captions the frame edges.
         "FrameLabel" => {
           let fl = crate::functions::plot::parse_frame_label(replacement);
-          if !fl.bottom.is_empty() || !fl.left.is_empty() {
-            frame_label = Some((svg_escape(&fl.bottom), svg_escape(&fl.left)));
+          if !fl.bottom.is_empty()
+            || !fl.left.is_empty()
+            || !fl.top.is_empty()
+            || !fl.right.is_empty()
+          {
+            frame_label = Some((
+              svg_escape(&fl.bottom),
+              svg_escape(&fl.left),
+              svg_escape(&fl.top),
+              svg_escape(&fl.right),
+            ));
           }
         }
         "Frame" => {
@@ -6607,9 +6647,15 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Without tick labels the frame needs no gutter, just room for its stroke.
   let frame_gutter = frame && frame_ticks;
   let has_bottom_caption =
-    frame_label.as_ref().is_some_and(|(b, _)| !b.is_empty());
+    frame_label.as_ref().is_some_and(|(b, ..)| !b.is_empty());
   let has_left_caption =
-    frame_label.as_ref().is_some_and(|(_, l)| !l.is_empty());
+    frame_label.as_ref().is_some_and(|(_, l, ..)| !l.is_empty());
+  let has_top_caption = frame_label
+    .as_ref()
+    .is_some_and(|(_, _, t, _)| !t.is_empty());
+  let has_right_caption = frame_label
+    .as_ref()
+    .is_some_and(|(_, _, _, r)| !r.is_empty());
   // An axis whose range spans zero is drawn through the middle of the
   // picture and carries its tick labels there too, so it needs no gutter
   // beside the drawing area — only the small padding Wolfram leaves all
@@ -6649,7 +6695,8 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     6.0
   } else {
     0.0
-  } + if has_x_axis_label { 24.0 } else { 0.0 };
+  } + if has_x_axis_label { 24.0 } else { 0.0 }
+    + if has_right_caption { 20.0 } else { 0.0 };
   let label_strip: f64 = if plot_label.is_some() { 26.0 } else { 0.0 };
   let margin_top: f64 = if frame { 10.0 } else { 0.0 }
     + label_strip
@@ -6657,7 +6704,8 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       20.0
     } else {
       0.0
-    };
+    }
+    + if has_top_caption { 20.0 } else { 0.0 };
   // `ImagePadding` states the room around the drawing area outright, so it
   // replaces the margins the frame and its labels would otherwise claim
   // (Wolfram draws the tick labels inside that padding).
@@ -6805,9 +6853,9 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     render_frame(&mut svg, &bb, svg_w, svg_h, frame_ticks);
   }
 
-  // Frame captions: the bottom one centred under the axis labels, the
-  // left one rotated along the edge.
-  if let Some((bottom, left)) = &frame_label {
+  // Frame captions: the bottom/top ones centred outside their edge, the
+  // left/right ones rotated along theirs.
+  if let Some((bottom, left, top, right)) = &frame_label {
     if !bottom.is_empty() {
       svg.push_str(&format!(
         "<text x=\"{:.1}\" y=\"{:.1}\" fill=\"{}\" font-size=\"12\" font-family=\"sans-serif\" text-anchor=\"middle\">{bottom}</text>\n",
@@ -6824,6 +6872,22 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         theme().tick_label_fill,
       ));
     }
+    if !top.is_empty() {
+      svg.push_str(&format!(
+        "<text x=\"{:.1}\" y=\"{:.1}\" fill=\"{}\" font-size=\"12\" font-family=\"sans-serif\" text-anchor=\"middle\">{top}</text>\n",
+        svg_w / 2.0,
+        -(margin_top - 12.0),
+        theme().tick_label_fill,
+      ));
+    }
+    if !right.is_empty() {
+      let rx = svg_w + margin_right - 12.0;
+      let ry = svg_h / 2.0;
+      svg.push_str(&format!(
+        "<text x=\"{rx:.1}\" y=\"{ry:.1}\" fill=\"{}\" font-size=\"12\" font-family=\"sans-serif\" text-anchor=\"middle\" transform=\"rotate(90,{rx:.1},{ry:.1})\">{right}</text>\n",
+        theme().tick_label_fill,
+      ));
+    }
   }
 
   if has_margin {
@@ -6837,7 +6901,17 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let graphicsbox = gbox::graphics_box(&box_elements);
   crate::capture_graphicsbox(&graphicsbox);
 
-  Ok(crate::graphics_result(svg))
+  // Keep the symbolic `Graphics[prims, opts…]` alongside the rendering.
+  // In Wolfram a `Graphics` expression stays an expression, so a picture
+  // held in a variable can be layered by a later `Show` — without this the
+  // primitives are gone and `Show[…, g, …]` silently drops `g`.
+  let structure = Expr::FunctionCall {
+    name: "Graphics".to_string(),
+    args: std::iter::once(content)
+      .chain(args[1..].iter().cloned())
+      .collect(),
+  };
+  Ok(crate::graphics_result_with_structure(svg, structure))
 }
 
 // ── Grid SVG rendering ──────────────────────────────────────────────────
@@ -10410,19 +10484,28 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
     // Defaults inherited from the plots when the *first* graphic was a plot
     // (Wolfram takes the result's options from the first graphic): axes on,
-    // and the plot AspectRatio of 1/GoldenRatio. Explicit options passed to
-    // Show (already collected in `merged_options`) win — without the
-    // AspectRatio default a wide PlotRange collapses the render to a
-    // sliver, since the graphics renderer otherwise derives the height
-    // from the data aspect. When a raw Graphics comes first, its uniform
-    // scaling stays in charge (circles must render round).
+    // and that plot's own shape. Explicit options passed to Show (already
+    // collected in `merged_options`) win — without the AspectRatio default
+    // a wide PlotRange collapses the render to a sliver, since the graphics
+    // renderer otherwise derives the height from the data aspect. When a
+    // raw Graphics comes first, its uniform scaling stays in charge
+    // (circles must render round).
     let has_option = |opts: &[Expr], name: &str| {
       opts.iter().any(|o| {
         matches!(o, Expr::Rule { pattern, .. } if option_name(pattern) == Some(name))
       })
     };
     if first_graphic_is_plot == Some(true) {
-      if !has_option(&merged_options, "Axes") {
+      // A framed plot draws no interior axes, so the merged graphic must
+      // not grow a set of them either: `Show[ParametricPlot[…, Frame ->
+      // True], …]` keeps the frame it was given and nothing more.
+      let framed = merged_options.iter().any(|o| {
+        matches!(o, Expr::Rule { pattern, replacement }
+          if option_name(pattern) == Some("Frame")
+            && !matches!(replacement.as_ref(),
+              Expr::Identifier(s) if s == "False" || s == "None"))
+      });
+      if !has_option(&merged_options, "Axes") && !framed {
         merged_options.push(Expr::Rule {
           pattern: Box::new(Expr::Identifier("Axes".to_string())),
           replacement: Box::new(bool_expr(true)),
@@ -10436,9 +10519,19 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && matches!(replacement.as_ref(), Expr::List(v) if v.len() == 2))
       });
       if !has_option(&merged_options, "AspectRatio") && !sized_both_ways {
+        // The shape the leading plot drew itself in. `Plot`/`ListPlot`
+        // default to 1/GoldenRatio, but `ParametricPlot` and friends
+        // default to `AspectRatio -> Automatic` and size themselves from
+        // the data, so a circle stays a circle once `Show` layers other
+        // graphics on top of one.
+        let aspect = plot_sources
+          .first()
+          .map(|ps| ps.image_size.1 as f64 / ps.image_size.0 as f64)
+          .filter(|r| r.is_finite() && *r > 0.0)
+          .unwrap_or(1.0 / 1.618_033_988_749_895);
         merged_options.push(Expr::Rule {
           pattern: Box::new(Expr::Identifier("AspectRatio".to_string())),
-          replacement: Box::new(Expr::Real(1.0 / 1.618_033_988_749_895)),
+          replacement: Box::new(Expr::Real(aspect)),
         });
       }
     }
@@ -11927,9 +12020,17 @@ fn grid_svg_styled_internal(
         } else {
           theme().text_primary.to_string()
         };
+        let markup = expr_to_svg_markup(text_content);
+        // `Row[{…, "  ", …}]` spaces its parts with the string it was
+        // given, and Wolfram draws every one of those spaces. SVG collapses
+        // runs of whitespace unless the element asks it not to.
+        let space_attr = if markup.contains("  ") {
+          " xml:space=\"preserve\""
+        } else {
+          ""
+        };
         let text_elem = format!(
-          "<text x=\"{cx:.1}\" y=\"{cy:.1}\" font-family=\"sans-serif\" font-size=\"{fs}\"{fw_attr}{fst_attr} fill=\"{text_fill}\" text-anchor=\"{anchor}\" dominant-baseline=\"central\">{}</text>\n",
-          expr_to_svg_markup(text_content)
+          "<text x=\"{cx:.1}\" y=\"{cy:.1}\" font-family=\"sans-serif\" font-size=\"{fs}\"{fw_attr}{fst_attr} fill=\"{text_fill}\" text-anchor=\"{anchor}\" dominant-baseline=\"central\"{space_attr}>{markup}</text>\n",
         );
         if let Some(href) = link_href {
           svg.push_str(&format!(

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -885,7 +885,7 @@ pub(crate) fn axes_label_svg(
 /// decimals — the number the step itself needs — so an axis stepping by 0.5
 /// reads `-1.0, -0.5, 0.0, 0.5, 1.0`, not `-1, -0.5, 0, 0.5, 1`, while one
 /// stepping by 2 reads `0, 2, 4`.
-fn format_tick_with_step(v: f64, step: f64) -> String {
+pub(crate) fn format_tick_with_step(v: f64, step: f64) -> String {
   let decimals = tick_step_decimals(step);
   if decimals == 0 {
     return format_tick(v);

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -3776,6 +3776,41 @@ mod plot3d {
       assert_eq!(styled, ["diameter (cm)", "force (kN)"]);
     }
 
+    /// Every label of a tick set carries the decimals its spacing needs, so
+    /// a framed `Graphics` stepping by 0.5 reads `-1.0, -0.5, 0.0, …` —
+    /// the same as the plot renderer, and as wolframscript.
+    #[test]
+    fn a_graphics_frame_labels_its_ticks_to_a_common_precision() {
+      let svg = export_svg(
+        "Graphics[{Circle[{0, 0}, 1]}, Frame -> True, \
+         PlotRange -> {{-1, 1}, {-1, 1}}]",
+      );
+      for label in ["-1.0", "-0.5", "0.0", "0.5", "1.0"] {
+        assert!(svg.contains(&format!(">{label}</text>")), "{svg}");
+      }
+      // Integer-spaced ticks keep their plain form.
+      let svg = export_svg(
+        "Graphics[{Circle[{0, 0}, 3]}, Frame -> True, \
+         PlotRange -> {{-3, 3}, {-3, 3}}]",
+      );
+      assert!(svg.contains(">2</text>"), "{svg}");
+    }
+
+    /// `FrameLabel -> {{left, right}, {bottom, top}}` captions all four
+    /// edges of a `Graphics` frame. Regression: the graphics renderer read
+    /// only the bottom and left entries, so the top caption a merged
+    /// `Show` inherited never drew.
+    #[test]
+    fn graphics_frame_label_captions_all_four_edges() {
+      let svg = export_svg(
+        "Graphics[{Circle[{0, 0}, 1]}, Frame -> True, \
+         FrameLabel -> {{\"cl\", \"cr\"}, {\"cb\", \"ct\"}}]",
+      );
+      for caption in ["cl", "cr", "cb", "ct"] {
+        assert!(svg.contains(&format!(">{caption}</text>")), "{svg}");
+      }
+    }
+
     /// A `Graphics` frame carries the same captions, so a plot merged into
     /// a `Show` with other primitives keeps them.
     #[test]
@@ -6544,14 +6579,15 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       assert!(svg.contains("fill-opacity=\"0.3\""), "{svg}");
       assert!(svg.contains("<polyline"), "no boundary curve: {svg}");
       // The image spans x in [0, 2] and y in [-1, 1]: both axes must be
-      // labelled out that far, and no further.
-      for tick in ["2", "-1", "1"] {
+      // labelled out that far, and no further. The 0.5-spaced ticks all
+      // carry one decimal, the way Wolfram labels a tick set.
+      for tick in ["2.0", "-1.0", "1.0"] {
         assert!(
           svg.contains(&format!(">{tick}</text>")),
           "missing tick {tick}: {svg}"
         );
       }
-      assert!(!svg.contains(">3</text>"), "range too wide: {svg}");
+      assert!(!svg.contains(">3.0</text>"), "range too wide: {svg}");
       assert!(!svg.contains("NaN"), "{svg}");
     }
 
@@ -6591,6 +6627,89 @@ ParametricPlot[f[t], {t, 0, 1}]]",
         .and_then(|v| v.parse().ok())
         .unwrap_or_else(|| panic!("no stroke width: {curve}"));
       assert!(width > 1.5, "Thick was lost on merge: {curve}");
+    }
+
+    /// `ParametricPlot` defaults to `AspectRatio -> Automatic` and takes
+    /// its shape from the data, so a unit circle comes out round. `Show`
+    /// takes the merged picture's options from the first graphic, which
+    /// means that shape has to survive the merge instead of being replaced
+    /// by the 1/GoldenRatio of `Plot`.
+    #[test]
+    fn show_keeps_the_shape_a_parametric_plot_drew_itself_in() {
+      let svg = export_svg(
+        "Show[ParametricPlot[{Cos[t], Sin[t]}, {t, 0, 2 Pi}, \
+           PlotRange -> {{-1.1, 1.1}, {-1.1, 1.1}}, Frame -> True], \
+         Graphics[{PointSize[0.03], Point[{0, 0}]}], ImageSize -> 200]",
+      );
+      let attr = |name: &str| -> f64 {
+        svg
+          .split(&format!("{name}=\""))
+          .nth(1)
+          .and_then(|s| s.split('"').next())
+          .and_then(|s| s.parse().ok())
+          .unwrap_or_else(|| panic!("no {name} on the svg: {svg}"))
+      };
+      assert_eq!(
+        (attr("width"), attr("height")),
+        (200.0, 200.0),
+        "a square PlotRange must stay square through Show: {svg}"
+      );
+    }
+
+    /// A framed plot draws no interior axes, and merging other graphics
+    /// into it with `Show` must not add a set. Regression: `Show` filled in
+    /// `Axes -> True` for every leading plot, so a framed one came back
+    /// with a second, duplicated scale through the middle.
+    #[test]
+    fn show_adds_no_interior_axes_to_a_framed_plot() {
+      let svg = export_svg(
+        "Show[ParametricPlot[{Cos[t], Sin[t]}, {t, 0, 2 Pi}, \
+           PlotRange -> {{-1.1, 1.1}, {-1.1, 1.1}}, Frame -> True], \
+         Graphics[{PointSize[0.03], Point[{0, 0}]}]]",
+      );
+      assert_eq!(
+        svg.matches(">0.5</text>").count(),
+        2,
+        "the frame labels 0.5 once per axis and nothing else does: {svg}"
+      );
+    }
+
+    /// A `Graphics` expression stays an expression in Wolfram, so a picture
+    /// held in a variable can be layered by a later `Show`. Regression: the
+    /// rendering kept only its SVG, and `Show` silently dropped it.
+    #[test]
+    fn a_rendered_graphic_can_be_layered_by_a_later_show() {
+      let svg = export_svg(
+        "g = Graphics[{Blue, Disk[{0, 0}, 0.5]}, \
+           PlotRange -> {{-1, 1}, {-1, 1}}]; \
+         Show[Graphics[{Red, Circle[{0, 0}, 1]}], g]",
+      );
+      assert!(
+        svg.contains("rgb(255,0,0)"),
+        "the outer circle must draw: {svg}"
+      );
+      assert!(
+        svg.contains("rgb(0,0,255)"),
+        "the graphic held in `g` must draw too: {svg}"
+      );
+    }
+
+    /// The same holds for a picture that is itself a `Show`: the layers it
+    /// merged have to be visible when it is shown again inside another one.
+    #[test]
+    fn a_show_result_can_be_layered_by_another_show() {
+      let svg = export_svg(
+        "inner = Show[Graphics[{Blue, Circle[{0, 0}, 0.5]}, \
+             PlotRange -> {{-1, 1}, {-1, 1}}], \
+           ListPlot[{{{-0.9, -0.9}, {0.9, 0.9}}}, Joined -> True, \
+             PlotStyle -> {{Green}}]]; \
+         Show[Graphics[{Red, Circle[{0, 0}, 1]}], inner]",
+      );
+      // The outer circle, the inner one, and the line the inner `Show`
+      // merged from a plot.
+      for color in ["rgb(255,0,0)", "rgb(0,0,255)", "rgb(0,255,0)"] {
+        assert!(svg.contains(color), "{color} must draw: {svg}");
+      }
     }
 
     /// `Show` stacks its arguments in the order given — the last one on
@@ -8635,8 +8754,10 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       );
       assert!(svg.contains("<polyline"), "the contour must survive: {svg}");
       assert!(svg.contains("<polygon"), "the arrow head must draw: {svg}");
-      // The plot's own options come along, so the axes are drawn.
-      assert!(svg.contains(">1</text>"), "axis ticks expected: {svg}");
+      // The plot's own options come along, so the axes are drawn. The
+      // 0.5-spaced ticks are labelled to a common precision, as Wolfram
+      // labels them.
+      assert!(svg.contains(">1.0</text>"), "axis ticks expected: {svg}");
     }
 
     /// A shaded contour plot keeps its shading when `Show` merges it with
@@ -11426,6 +11547,20 @@ mod graphics_grid {
     .unwrap();
     let svg = result.graphics.unwrap();
     assert!(svg.contains(">area = 0.875000000</text>"), "{svg}");
+  }
+
+  /// `Row` joins its parts with the strings it was given, gaps included:
+  /// a `"  "` separator draws as two spaces. SVG collapses runs of
+  /// whitespace, so the cell has to ask it not to.
+  #[test]
+  fn grid_cell_keeps_the_spaces_a_row_was_given() {
+    clear_state();
+    let result =
+      interpret_with_stdout("Grid[{{Text@Row[{\"a\", \"  \", \"b\"}]}}]")
+        .unwrap();
+    let svg = result.graphics.unwrap();
+    assert!(svg.contains(">a  b</text>"), "{svg}");
+    assert!(svg.contains("xml:space=\"preserve\""), "{svg}");
   }
 
   /// A grid whose cells are all graphics lays the pictures out, rather


### PR DESCRIPTION
## Summary

This PR fixes several issues with graphics rendering in Woxi:

1. **Frame label support for all four edges**: `FrameLabel` now properly supports the full `{{left, right}, {bottom, top}}` syntax, allowing captions on all four edges of a frame instead of just bottom and left.

2. **Consistent tick label precision**: Tick labels in framed `Graphics` now use the same precision logic as plot renderers—all labels in a tick sequence share the same number of decimals based on the spacing between ticks (e.g., 0.5-spaced ticks show as `-1.0, -0.5, 0.0` instead of `-1, -0.5, 0`).

3. **Graphics expressions preserved through Show**: `Graphics` expressions now remain as symbolic expressions alongside their SVG rendering, allowing them to be layered by subsequent `Show` calls. Previously, only the SVG was kept, causing `Show` to silently drop graphics held in variables.

4. **Show respects framed plots**: `Show` no longer adds interior axes to plots that already have `Frame -> True`, preventing duplicate axis scales.

5. **Show preserves plot aspect ratio**: When merging graphics with `Show`, the aspect ratio from the first graphic (especially important for `ParametricPlot` which defaults to `AspectRatio -> Automatic`) is now preserved instead of being replaced with the `Plot` default of `1/GoldenRatio`.

6. **SVG whitespace preservation in Grid cells**: Grid cells containing `Row` with explicit spacing now preserve those spaces in SVG output by adding `xml:space="preserve"` when needed.

## Key Changes

- Added `tick_sequence_step()` to compute the spacing between ticks
- Added `format_tick_in_sequence()` to format ticks with consistent precision
- Extended `frame_label` from a 2-tuple to a 4-tuple to store all four edge captions
- Updated frame rendering to draw captions on top and right edges
- Modified margin calculations to account for top and right captions
- Changed `graphics_result()` to `graphics_result_with_structure()` to preserve the symbolic `Graphics` expression
- Updated `Show` logic to detect framed plots and avoid adding axes, and to use the first graphic's aspect ratio
- Added `xml:space="preserve"` attribute to Grid text elements containing multiple spaces

## Tests Added

- Regression test for frame tick label precision
- Regression test for all four frame label edges
- Regression test for preserving graphics expressions through Show
- Regression test for Show not adding axes to framed plots
- Regression test for Show preserving parametric plot aspect ratio
- Regression test for Grid cell whitespace preservation

https://claude.ai/code/session_01PjMbFzejHUhnzeAFWAXWKh