### PR TITLE
Move binop, bool_expr to helpers.rs

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -1397,7 +1397,7 @@ pub fn dispatch_complex_and_special(
       if args.len() == 1
         && crate::functions::mesh_region::is_mesh_region(&args[0]) =>
     {
-      return Some(Ok(crate::syntax::bool_expr(true)));
+      return Some(Ok(bool_expr(true)));
     }
     "RegionBounds"
       if args.len() == 1

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -1,7 +1,7 @@
-use crate::helpers::{div2, pow2};
+use crate::helpers::{binop, bool_expr, div2, pow2};
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, binop, bool_expr,
-  expr_to_string, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
+  unevaluated,
 };
 use crate::{ENV, InterpreterError, PART_DEPTH, StoredValue, interpret};
 

--- a/src/functions/audio_ast/data.rs
+++ b/src/functions/audio_ast/data.rs
@@ -537,7 +537,7 @@ pub fn audio_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let is_audio = matches!(&args[0], Expr::FunctionCall { name, .. }
     if name == "Audio")
     && parse_audio(&args[0]).is_some();
-  Ok(crate::syntax::bool_expr(is_audio))
+  Ok(bool_expr(is_audio))
 }
 
 /// `AudioChannels[audio]` — how many channels it carries.

--- a/src/functions/audio_ast/mod.rs
+++ b/src/functions/audio_ast/mod.rs
@@ -1,4 +1,5 @@
 use crate::InterpreterError;
+use crate::helpers::bool_expr;
 use crate::syntax::{Expr, unevaluated};
 
 pub mod data;

--- a/src/functions/csv_ast.rs
+++ b/src/functions/csv_ast.rs
@@ -99,8 +99,8 @@ fn auto_convert(s: &str) -> Expr {
   // The three conventional spellings of a boolean field become True/False;
   // anything else (`tRue`) stays the text it was written as.
   match trimmed {
-    "true" | "True" | "TRUE" => return crate::syntax::bool_expr(true),
-    "false" | "False" | "FALSE" => return crate::syntax::bool_expr(false),
+    "true" | "True" | "TRUE" => return bool_expr(true),
+    "false" | "False" | "FALSE" => return bool_expr(false),
     _ => {}
   }
 

--- a/src/functions/list_helpers_ast/mod.rs
+++ b/src/functions/list_helpers_ast/mod.rs
@@ -4,8 +4,9 @@
 //! round-trips and re-parsing that the original `list_helpers.rs` functions use.
 
 use crate::InterpreterError;
+use crate::helpers::bool_expr;
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
 
 mod aggregation;

--- a/src/functions/math_ast/mod.rs
+++ b/src/functions/math_ast/mod.rs
@@ -3,10 +3,10 @@
 //! These functions work directly with `Expr` AST nodes.
 
 use crate::InterpreterError;
-use crate::helpers::{div2, neg1, pow2};
+use crate::helpers::{binop, bool_expr, div2, neg1, pow2};
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, binop, bool_expr,
-  expr_to_output, expr_to_string, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
+  expr_to_string, unevaluated,
 };
 
 mod airy;

--- a/src/functions/mesh_region.rs
+++ b/src/functions/mesh_region.rs
@@ -435,10 +435,10 @@ pub fn mesh_member(mesh: &Mesh, point: &Expr) -> Option<Expr> {
     )
     .ok()?;
     if matches!(&inside, Expr::Identifier(s) if s == "True") {
-      return Some(crate::syntax::bool_expr(true));
+      return Some(bool_expr(true));
     }
   }
-  Some(crate::syntax::bool_expr(false))
+  Some(bool_expr(false))
 }
 
 /// `MeshCoordinates`, `MeshCells`, `MeshPrimitives` and `MeshCellCount`.

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,8 +1,8 @@
 use crate::InterpreterError;
-use crate::helpers::{div2, neg1, pow2};
+use crate::helpers::{binop, bool_expr, div2, neg1, pow2};
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, binop, bool_expr,
-  expr_to_output, expr_to_string, unevaluated,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
+  expr_to_string, unevaluated,
 };
 
 // Functions are organized by categories

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -6,9 +6,9 @@ use crate::InterpreterError;
 use crate::functions::math_ast::{
   gcd_i128, is_sqrt, lcm_i128, make_sqrt, rat_reduce, rat_reduce_bigint,
 };
-use crate::helpers::pow2;
+use crate::helpers::{bool_expr, pow2};
 use crate::syntax::{
-  BinaryOperator, ComparisonOp, Expr, UnaryOperator, bool_expr, expr_to_string,
+  BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
   unevaluated,
 };
 

--- a/src/functions/timeseries_ast.rs
+++ b/src/functions/timeseries_ast.rs
@@ -532,13 +532,13 @@ pub fn regularly_sampled_q_ast(
   let times: Option<Vec<f64>> = pairs.iter().map(|(t, _)| to_time(t)).collect();
   let Some(times) = times else { return echo() };
   if times.len() < 3 {
-    return Ok(crate::syntax::bool_expr(true));
+    return Ok(bool_expr(true));
   }
   let step = times[1] - times[0];
   let even = times
     .windows(2)
     .all(|w| (w[1] - w[0] - step).abs() <= 1e-9 * step.abs().max(1.0));
-  Ok(crate::syntax::bool_expr(even))
+  Ok(bool_expr(even))
 }
 
 /// `TimeSeriesInsert[ts, {t, v}]` — add a point, keeping the path sorted.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -7,18 +7,24 @@ pub fn neg1(e: Expr) -> Expr {
   }
 }
 
-pub fn pow2(b: Expr, e: Expr) -> Expr {
+/// Helper to build a binary operation expression
+pub fn binop(op: BinaryOperator, a: Expr, b: Expr) -> Expr {
   Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(b),
-    right: Box::new(e),
-  }
-}
-
-pub fn div2(a: Expr, b: Expr) -> Expr {
-  Expr::BinaryOp {
-    op: BinaryOperator::Divide,
+    op,
     left: Box::new(a),
     right: Box::new(b),
   }
+}
+
+pub fn pow2(b: Expr, e: Expr) -> Expr {
+  binop(BinaryOperator::Power, b, e)
+}
+
+pub fn div2(a: Expr, b: Expr) -> Expr {
+  binop(BinaryOperator::Divide, a, b)
+}
+
+/// Build the boolean symbol `True` or `False`.
+pub fn bool_expr(b: bool) -> Expr {
+  Expr::Identifier(if b { "True" } else { "False" }.to_string())
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -15059,23 +15059,9 @@ pub fn replace_identifier_in_expr(
   }
 }
 
-/// Build the boolean symbol `True` or `False`.
-pub fn bool_expr(b: bool) -> Expr {
-  Expr::Identifier(if b { "True" } else { "False" }.to_string())
-}
-
 pub fn unevaluated(name: &str, args: &[Expr]) -> Expr {
   Expr::FunctionCall {
     name: name.to_string(),
     args: args.to_vec().into(),
-  }
-}
-
-/// Helper to build a binary operation expression
-pub fn binop(op: BinaryOperator, a: Expr, b: Expr) -> Expr {
-  Expr::BinaryOp {
-    op,
-    left: Box::new(a),
-    right: Box::new(b),
   }
 }


### PR DESCRIPTION
Now that we have a helpers module, it makes sense to migrate some helpers out of syntax.rs and into helpers.rs. This PR handles binop and bool_expr.