### PR TITLE
Support Demonstration notebooks with commented code and 3-D knots

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -243,7 +243,7 @@ Block,Scopes local variables within a block of code,✅,pure,1.0,188
 Alignment,Option symbol for specifying alignment in layouts,✅,pure,6.0,189
 Partition,Partitions a list into sublists of a given length (with offset padding alignment and an optional block head),✅,pure,1.0,190
 Norm,Returns the norm of a vector or matrix,✅,pure,5.0,191
-BSplineCurve,B-spline curve through control points in Graphics,✅,pure,7.0,192
+BSplineCurve,B-spline curve through control points in Graphics and Graphics3D,✅,pure,7.0,192
 PlotPoints,Option for number of sample points in plots,✅,pure,1.0,193
 Sort,Sorts a list in ascending order or by an ordering function which leaves a pair alone unless it compares False,✅,pure,1.0,194
 Series,Computes a power series expansion about a point or at Infinity,✅,pure,1.0,195

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -4280,6 +4280,29 @@ pub(crate) fn expr_to_svg(expr: &Expr) -> String {
     Expr::FunctionCall { name, args } if name == "Text" && args.len() == 1 => {
       expr_to_svg(&unquoted_display_string(&args[0]))
     }
+    // `Style[content, directives…]` shows `content`; the directives only
+    // change how it is set. The picture path has to look through the
+    // wrapper, or a styled layout — `Style[Row[{n, " leaves, ", …}],
+    // FontSize -> 16, Blue]`, how a Demonstration captions its plot —
+    // falls through to the text renderer, which prints the call's own
+    // source instead of the row it wraps. A `Style` is inherited by what
+    // it wraps, so its directives are pushed into the layout's items and
+    // the item renderer applies them there. A styled `Grid` is left to the
+    // arm below, which hands the directives to the grid renderer whole —
+    // they colour its frame and dividers, not only its cells.
+    Expr::FunctionCall { name, args }
+      if name == "Style"
+        && !args.is_empty()
+        && !matches!(&args[0], Expr::FunctionCall { name, args }
+          if (name == "Grid" || name == "TextGrid") && !args.is_empty()) =>
+    {
+      let inner = crate::functions::graphics::style_pushed_into_layout(
+        &args[0],
+        &args[1..],
+      )
+      .unwrap_or_else(|| args[0].clone());
+      expr_to_svg(&inner)
+    }
     // `Labeled[content, label]` (and `…, pos]`) puts the label beside the
     // content — below it by default. With a picture as the content the
     // FrontEnd stacks the two, so exporting one has to compose them

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -14379,7 +14379,10 @@ fn resolve_display_item(expr: &Expr) -> Expr {
 /// Style[b, Bold]}]`. Only the item list is rewritten; a separator or
 /// option argument keeps its place. `None` when the wrapped expression is
 /// not a layout with a list of items.
-fn style_pushed_into_layout(inner: &Expr, directives: &[Expr]) -> Option<Expr> {
+pub(crate) fn style_pushed_into_layout(
+  inner: &Expr,
+  directives: &[Expr],
+) -> Option<Expr> {
   if directives.is_empty() {
     return None;
   }

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -804,6 +804,8 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     mesh_mode,
     show_axes,
   )?;
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   Ok(crate::graphics3d_result_with_structure(svg, structure))
 }
@@ -1809,6 +1811,8 @@ pub fn vector_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   svg.push_str("</svg>");
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
   Ok(crate::graphics3d_result(svg))
 }
 
@@ -2861,6 +2865,17 @@ fn collect_3d_primitives(
         // surface of revolution about a polyline, one radius per vertex.
         // `curve` is a point list, a `Line[…]`, or a list of either.
         "Tube" if !args.is_empty() => {
+          // `Tube[BSplineCurve[…], r]` runs the tube along the spline, so
+          // the curve is sampled first — a tube around the bare control
+          // points would cut every corner the spline rounds.
+          let spline = match &args[0] {
+            Expr::FunctionCall { name, args: inner }
+              if name == "BSplineCurve" && !inner.is_empty() =>
+            {
+              bspline_curve_points(inner)
+            }
+            _ => None,
+          };
           let curve = match &args[0] {
             Expr::FunctionCall { name, args: inner }
               if name == "Line" && !inner.is_empty() =>
@@ -2870,13 +2885,16 @@ fn collect_3d_primitives(
             other => other.clone(),
           };
           let curve = evaluate_expr_to_expr(&curve).unwrap_or(curve);
-          let curves: Vec<Vec<Point3D>> = match parse_point3d_list(&curve) {
+          let curves: Vec<Vec<Point3D>> = match spline {
             Some(pts) => vec![pts],
-            None => match &curve {
-              Expr::List(items) => {
-                items.iter().filter_map(parse_point3d_list).collect()
-              }
-              _ => vec![],
+            None => match parse_point3d_list(&curve) {
+              Some(pts) => vec![pts],
+              None => match &curve {
+                Expr::List(items) => {
+                  items.iter().filter_map(parse_point3d_list).collect()
+                }
+                _ => vec![],
+              },
             },
           };
           for pts in curves {
@@ -2956,6 +2974,19 @@ fn collect_3d_primitives(
             style: style.clone(),
             smooth: true,
           });
+        }
+        // `BSplineCurve[{p1, …}, opts…]` draws the spline its control
+        // points define. (`Tube[BSplineCurve[…], r]` thickens the same
+        // curve — see the `Tube` arm above.)
+        "BSplineCurve" if !args.is_empty() => {
+          if let Some(pts) = bspline_curve_points(args)
+            && pts.len() >= 2
+          {
+            prims.push(Primitive3D::Line3D {
+              segments: vec![pts],
+              style: style.clone(),
+            });
+          }
         }
         "BSplineSurface" if !args.is_empty() => {
           if let Some(grid) = parse_point3d_grid(&args[0]) {
@@ -3164,6 +3195,61 @@ fn bspline_sample_weights(n: usize, num_samples: usize) -> Vec<Vec<f64>> {
         .collect()
     })
     .collect()
+}
+
+/// The polyline a `BSplineCurve[{p1, …}, opts…]` stands for: the uniform
+/// B-spline of degree `min(3, n - 1)` over its control points, sampled
+/// finely enough to read as a curve. `SplineClosed -> True` wraps the
+/// leading control points onto the end so the curve closes on itself.
+/// Arguments after the control points that are not options are ignored,
+/// the way Wolfram ignores them. `None` when the first argument is not a
+/// list of 3-D points.
+fn bspline_curve_points(args: &[Expr]) -> Option<Vec<Point3D>> {
+  let pts_expr =
+    evaluate_expr_to_expr(&args[0]).unwrap_or_else(|_| args[0].clone());
+  let control = parse_point3d_list(&pts_expr)?;
+  if control.len() < 2 {
+    return Some(control);
+  }
+  let closed = args.iter().skip(1).any(|arg| {
+    matches!(arg,
+      Expr::Rule { pattern, replacement }
+        if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "SplineClosed")
+        && matches!(replacement.as_ref(), Expr::Identifier(s) if s == "True"))
+  });
+  let control = if closed {
+    let degree = 3usize.min(control.len() - 1);
+    let mut cp = control.clone();
+    cp.extend_from_slice(&control[..degree]);
+    cp
+  } else {
+    control
+  };
+  let n = control.len();
+  // Enough samples that the curve is smooth without the tube it may feed
+  // exploding into triangles: a handful per control point, bounded.
+  let samples = (n * 6).clamp(64, 600);
+  Some(
+    bspline_sample_weights(n, samples)
+      .iter()
+      .map(|weights| {
+        let mut acc = Point3D {
+          x: 0.0,
+          y: 0.0,
+          z: 0.0,
+        };
+        for (j, &b) in weights.iter().enumerate() {
+          if b == 0.0 {
+            continue;
+          }
+          acc.x += b * control[j].x;
+          acc.y += b * control[j].y;
+          acc.z += b * control[j].z;
+        }
+        acc
+      })
+      .collect(),
+  )
 }
 
 /// Tessellate a B-spline surface from its control-point grid by sampling
@@ -4282,10 +4368,13 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   if prims.is_empty() {
-    // Even with no primitives, return the marker
+    // Even with no primitives, return the marker — with its title, since
+    // a `PlotLabel` is drawn whether or not the picture has contents.
     let empty_svg = format!(
       "<svg width=\"{svg_width}\" height=\"{svg_height}\" xmlns=\"http://www.w3.org/2000/svg\"></svg>"
     );
+    let empty_svg =
+      with_plot_label(empty_svg, &args[1..], svg_width, svg_height);
     return Ok(crate::graphics3d_result_with_structure(
       empty_svg, structure,
     ));
@@ -5119,6 +5208,11 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   svg.push_str("</svg>");
+  // A `PlotLabel` sets a title above the finished picture. `args[1..]` are
+  // the options; `args[0]` is the content, which may itself be a `Rule`
+  // (`Graphics3D[a -> b]` draws nothing but is legal) and must not be read
+  // as one.
+  let svg = with_plot_label(svg, &args[1..], svg_width, svg_height);
   Ok(crate::graphics3d_result_with_structure(svg, structure))
 }
 
@@ -5163,6 +5257,108 @@ fn axis_label_markup(expr: &Expr) -> Option<String> {
       (!markup.is_empty()).then_some(markup)
     }
   }
+}
+
+/// The height of the strip a `PlotLabel` reserves above a 3-D picture.
+/// Matches the strip the 2-D renderer reserves, so a labelled `Graphics`
+/// and a labelled `Graphics3D` set their titles at the same height.
+const PLOT_LABEL_STRIP: u32 = 26;
+
+/// The typeset markup of the `PlotLabel` an option list carries, or `None`
+/// when it carries none (`PlotLabel -> None` included). Any expression can
+/// label a plot — a string, a `Style[…]`, a `Row[…]` of computed values —
+/// so it is typeset the way every other label is rather than printed.
+fn plot_label_markup(opts: &[Expr]) -> Option<String> {
+  for opt in opts {
+    let (pattern, replacement): (&Expr, &Expr) = match opt {
+      Expr::Rule {
+        pattern,
+        replacement,
+      } => (pattern.as_ref(), replacement.as_ref()),
+      Expr::FunctionCall { name, args }
+        if name == "Rule" && args.len() == 2 =>
+      {
+        (&args[0], &args[1])
+      }
+      _ => continue,
+    };
+    if !matches!(pattern, Expr::Identifier(n) if n == "PlotLabel") {
+      continue;
+    }
+    let value = evaluate_expr_to_expr(replacement)
+      .unwrap_or_else(|_| replacement.clone());
+    if matches!(&value, Expr::Identifier(s) if s == "None" || s == "Null") {
+      return None;
+    }
+    let markup = crate::functions::graphics::expr_to_svg_markup(&value);
+    if !markup.is_empty() {
+      return Some(markup);
+    }
+  }
+  None
+}
+
+/// Set a 3-D picture's `PlotLabel` above it. The finished SVG is nested,
+/// untouched, into a canvas one label strip taller, with the label centred
+/// in the strip — the projection inside was scaled to the picture's own
+/// size, so growing the canvas rather than the drawing area leaves it
+/// exactly as it was. Returns `svg` unchanged when there is no label.
+fn with_plot_label(
+  svg: String,
+  opts: &[Expr],
+  width: u32,
+  height: u32,
+) -> String {
+  let Some(label) = plot_label_markup(opts) else {
+    return svg;
+  };
+  let total = height + PLOT_LABEL_STRIP;
+  // The strip is painted in the picture's own background so the two read
+  // as one canvas — an explicit `Background` reaches it too.
+  let bg = opts
+    .iter()
+    .find_map(|opt| match opt {
+      Expr::Rule {
+        pattern,
+        replacement,
+      } if matches!(pattern.as_ref(), Expr::Identifier(n) if n == "Background") => {
+        crate::functions::graphics::parse_color(replacement)
+      }
+      _ => None,
+    })
+    .map(|c| {
+      (
+        (c.r.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (c.g.clamp(0.0, 1.0) * 255.0).round() as u8,
+        (c.b.clamp(0.0, 1.0) * 255.0).round() as u8,
+      )
+    })
+    .unwrap_or_else(|| {
+      let (theme_bg, _, _, _, _) = crate::functions::plot::plot_theme();
+      (theme_bg.0, theme_bg.1, theme_bg.2)
+    });
+  // `width="100%"` (an `ImageSize -> Full` picture) has to stay responsive,
+  // so the outer canvas repeats whichever sizing the inner one chose.
+  let sizing = if svg.starts_with("<svg width=\"100%\"") {
+    format!(
+      "width=\"100%\" viewBox=\"0 0 {width} {total}\" \
+       preserveAspectRatio=\"xMidYMid meet\""
+    )
+  } else {
+    format!(
+      "width=\"{width}\" height=\"{total}\" viewBox=\"0 0 {width} {total}\""
+    )
+  };
+  let cx = width as f64 / 2.0;
+  format!(
+    "<svg {sizing} xmlns=\"http://www.w3.org/2000/svg\">\n\
+     <rect width=\"{width}\" height=\"{total}\" fill=\"rgb({},{},{})\"/>\n\
+     <text x=\"{cx:.1}\" y=\"17\" text-anchor=\"middle\" \
+     font-family=\"sans-serif\" font-size=\"16\" fill=\"#333333\">{label}</text>\n\
+     <g transform=\"translate(0,{PLOT_LABEL_STRIP})\">{svg}</g>\n\
+     </svg>",
+    bg.0, bg.1, bg.2,
+  )
 }
 
 /// The characters an SVG markup fragment actually shows, for width
@@ -5530,6 +5726,8 @@ pub fn list_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _mesh_mode,
     true, // show_axes: always show axes for list_plot3d
   )?;
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   Ok(crate::graphics3d_result(svg))
 }
@@ -5930,6 +6128,8 @@ pub fn revolution_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _mesh_mode,
     show_axes,
   )?;
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   Ok(crate::graphics3d_result_with_structure(svg, structure))
 }
@@ -6296,6 +6496,8 @@ pub fn region_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _mesh_mode,
     show_axes,
   )?;
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   Ok(crate::graphics3d_result(svg))
 }
@@ -6520,6 +6722,8 @@ pub fn list_point_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     svg_height,
     full_width,
   )?;
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   Ok(crate::graphics3d_result(svg))
 }
@@ -6949,6 +7153,8 @@ pub fn list_line_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     svg_height,
     full_width,
   )?;
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   Ok(crate::graphics3d_result(svg))
 }
@@ -7612,6 +7818,8 @@ pub fn spherical_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _mesh_mode,
     show_axes,
   )?;
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   Ok(crate::graphics3d_result_with_structure(svg, structure))
 }
@@ -7839,8 +8047,77 @@ pub fn discrete_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _mesh_mode,
     show_axes,
   )?;
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   Ok(crate::graphics3d_result(svg))
+}
+
+/// Split a `PlotStyle` value into the `Tube[…]` directive it carries (as
+/// that `Tube`'s arguments after the curve — its radius, when given) and
+/// what remains of the style. `Tube` asks for a shape rather than a
+/// colour, so it has to be lifted out of the directive list and applied to
+/// the curve itself. Returns `(None, style)` when there is no `Tube`.
+fn take_tube_directive(style: &Expr) -> (Option<Vec<Expr>>, Expr) {
+  match style {
+    Expr::FunctionCall { name, args } if name == "Tube" => {
+      (Some(args.to_vec()), Expr::List(vec![].into()))
+    }
+    // `{colour, Tube[r]}` and `Directive[colour, Tube[r]]` both group
+    // directives, so look inside either for the `Tube`.
+    Expr::List(items) => {
+      let (tube, kept) = partition_tube(items);
+      (tube, Expr::List(kept.into()))
+    }
+    Expr::FunctionCall { name, args } if name == "Directive" => {
+      let (tube, kept) = partition_tube(args);
+      (
+        tube,
+        Expr::FunctionCall {
+          name: name.clone(),
+          args: kept.into(),
+        },
+      )
+    }
+    other => (None, other.clone()),
+  }
+}
+
+/// The `Tube[…]` among a list of directives (its arguments) and the other
+/// directives, searched one level down as well so that a nested grouping
+/// (`{colour, Directive[Tube[r]]}`) is found too.
+fn partition_tube(items: &[Expr]) -> (Option<Vec<Expr>>, Vec<Expr>) {
+  let mut tube: Option<Vec<Expr>> = None;
+  let mut kept: Vec<Expr> = Vec::with_capacity(items.len());
+  for item in items {
+    match item {
+      Expr::FunctionCall { name, args } if name == "Tube" && tube.is_none() => {
+        tube = Some(args.to_vec());
+      }
+      Expr::List(_)
+      | Expr::FunctionCall {
+        name: _, args: _, ..
+      } if tube.is_none() && contains_tube(item) => {
+        let (inner, rest) = take_tube_directive(item);
+        tube = inner;
+        kept.push(rest);
+      }
+      other => kept.push(other.clone()),
+    }
+  }
+  (tube, kept)
+}
+
+/// Whether a directive group holds a `Tube[…]` one level down.
+fn contains_tube(expr: &Expr) -> bool {
+  let items: &[Expr] = match expr {
+    Expr::List(items) => items,
+    Expr::FunctionCall { name, args } if name == "Directive" => args,
+    _ => return false,
+  };
+  items
+    .iter()
+    .any(|i| matches!(i, Expr::FunctionCall { name, .. } if name == "Tube"))
 }
 
 /// 1-iterator (curve) form of ParametricPlot3D.
@@ -7920,9 +8197,21 @@ fn parametric_plot3d_curve_ast(
     }
   }
 
+  // `PlotStyle -> Tube[r]` asks for the curve to be drawn as a tube of
+  // radius `r` instead of as a line — how a Demonstration gives a knot its
+  // thickness. It is not a colour or a thickness, so it comes out of the
+  // style list and turns each sampled polyline into a `Tube` instead.
+  let (tube_args, plot_style) = match plot_style {
+    Some(ps) => {
+      let (tube, rest) = take_tube_directive(ps);
+      (tube, Some(rest))
+    }
+    None => (None, None),
+  };
+
   // Build a primitives list: [<style directives>, Line[pts1], Line[pts2], …]
   let mut prim_items: Vec<Expr> = Vec::new();
-  if let Some(ps) = plot_style {
+  if let Some(ps) = &plot_style {
     // Wrap whatever PlotStyle holds into a Directive[…] so that
     // collect_3d_primitives picks up nested colors/Thickness/etc.
     prim_items.push(Expr::FunctionCall {
@@ -7936,9 +8225,19 @@ fn parametric_plot3d_curve_ast(
     let mut current_segment: Vec<Expr> = Vec::new();
     let flush = |seg: &mut Vec<Expr>, sink: &mut Vec<Expr>| {
       if seg.len() >= 2 {
-        sink.push(Expr::FunctionCall {
-          name: "Line".to_string(),
-          args: vec![Expr::List(std::mem::take(seg).into())].into(),
+        let points = Expr::List(std::mem::take(seg).into());
+        sink.push(match &tube_args {
+          Some(extra) => Expr::FunctionCall {
+            name: "Tube".to_string(),
+            args: std::iter::once(points)
+              .chain(extra.iter().cloned())
+              .collect::<Vec<_>>()
+              .into(),
+          },
+          None => Expr::FunctionCall {
+            name: "Line".to_string(),
+            args: vec![points].into(),
+          },
         });
       } else {
         seg.clear();
@@ -7963,9 +8262,9 @@ fn parametric_plot3d_curve_ast(
   }
 
   if !produced_any
-    && prim_items
-      .iter()
-      .all(|e| !matches!(e, Expr::FunctionCall { name, .. } if name == "Line"))
+    && prim_items.iter().all(
+      |e| !matches!(e, Expr::FunctionCall { name, .. } if name == "Line" || name == "Tube"),
+    )
   {
     return Err(InterpreterError::EvaluationError(
       "ParametricPlot3D: parametric function produced no finite values".into(),
@@ -8324,6 +8623,8 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _mesh_mode,
     show_axes,
   )?;
+  // A `PlotLabel` sets a title above the finished picture.
+  let svg = with_plot_label(svg, args, svg_width, svg_height);
 
   Ok(crate::graphics3d_result(svg))
 }

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -744,9 +744,17 @@ ListItemRule = { ReplacementRule ~ RuleAnonSuffix? ~ RuleReplaceSuffix* ~ ("//" 
 // `/.` and `//.` bind looser than `->`, so a rule written as an argument may
 // itself be replaced in: `f[a -> 5 /. 5 -> 6]` is `f[(a -> 5) /. (5 -> 6)]`.
 RuleReplaceSuffix = { ("//." | "/.") ~ (&HasRuleOperator ~ ReplacementRule | List | ConditionExpr) }
+// Comments must be skipped explicitly by the balanced scans below.  They are
+// reachable from atomic rules (`HasSemicolon`), where pest disables the
+// implicit COMMENT rule, so a comment holding an unbalanced bracket, quote or
+// semicolon — e.g. `f[a (* end of For[ *); b]` — would otherwise derail the
+// scan and make the whole expression unparseable.  Listed first in every
+// alternation so `(*` is never mistaken for a parenthesis group.
+ScanComment = @{ "(*" ~ (ScanComment | (!"(*" ~ !"*)" ~ ANY))* ~ "*)" }
 // Scan forward looking for -> or :> at the current nesting depth
 NestedContent = _{ (
-    "<|" ~ NestedContent ~ "|>"
+    ScanComment
+  | "<|" ~ NestedContent ~ "|>"
   | "{" ~ NestedContent ~ "}"
   | "[" ~ NestedContent ~ "]"
   | "(" ~ NestedContent ~ ")"
@@ -758,7 +766,8 @@ NestedContent = _{ (
   | !("<|" | "|>" | "{" | "}" | "[" | "]" | "(" | ")" | "\u{27E6}" | "\u{27E7}" | "\u{301A}" | "\u{301B}" | "\"") ~ ANY
 )* }
 HasRuleOperator = _{ (
-    "<|" ~ NestedContent ~ "|>"
+    ScanComment
+  | "<|" ~ NestedContent ~ "|>"
   | "{" ~ NestedContent ~ "}"
   | "[" ~ NestedContent ~ "]"
   | "(" ~ NestedContent ~ ")"
@@ -774,7 +783,8 @@ HasRuleOperator = _{ (
 // is correctly detected — otherwise the non-atomic trailing `~` would skip the
 // whitespace and the `!(";"|"=")` lookahead would falsely reject the next `;`.
 HasSpanSep = _{ (
-    "<|" ~ NestedContent ~ "|>"
+    ScanComment
+  | "<|" ~ NestedContent ~ "|>"
   | "{" ~ NestedContent ~ "}"
   | "[" ~ NestedContent ~ "]"
   | "(" ~ NestedContent ~ ")"
@@ -787,7 +797,8 @@ HasSpanSep = _{ (
 // Scan forward looking for ; (compound separator, not ;;) at the current nesting depth.
 // Used as a zero-width lookahead to avoid expensive CompoundExpression backtracking.
 HasSemicolon = @{ (
-    ";;" ~ !(";" | "=")         // skip ;; span separators
+    ScanComment
+  | ";;" ~ !(";" | "=")         // skip ;; span separators
   | "<|" ~ NestedContent ~ "|>"
   | "{" ~ NestedContent ~ "}"
   | "[" ~ NestedContent ~ "]"

--- a/tests/cli/plotting/Graphics3D.md
+++ b/tests/cli/plotting/Graphics3D.md
@@ -20,3 +20,26 @@ turns or the contents move:
 $ wo 'Head[Graphics3D[Sphere[], SphericalRegion -> True]]'
 Graphics3D
 ```
+
+`PlotLabel -> label` sets a title above the picture, the same way it does
+for a 2-D `Graphics`. Any expression can be the label; it is typeset
+rather than printed:
+
+```scrut
+$ wo 'StringContainsQ[ExportString[Graphics3D[Sphere[], PlotLabel -> Style[Row[{"Torus ", "Knot"}], FontSize -> 18]], "SVG"], "Torus Knot"]'
+True
+```
+
+`BSplineCurve[{p1, p2, …}]` draws the B-spline its control points define,
+and `Tube[BSplineCurve[…], r]` runs a tube of radius `r` along that same
+curve — how a knot is given its thickness:
+
+```scrut
+$ wo 'Head[Graphics3D[BSplineCurve[{{0, 0, 0}, {1, 2, 0}, {2, 0, 1}}]]]'
+Graphics3D
+```
+
+```scrut
+$ wo 'StringContainsQ[ExportString[Graphics3D[Tube[BSplineCurve[{{0, 0, 0}, {1, 2, 0}, {2, 0, 1}}], 0.2]], "SVG"], "<polygon"]'
+True
+```

--- a/tests/cli/plotting/ParametricPlot3D.md
+++ b/tests/cli/plotting/ParametricPlot3D.md
@@ -1,3 +1,16 @@
 # `ParametricPlot3D`
 
 3D parametric plot.
+
+```scrut
+$ wo 'Head[ParametricPlot3D[{Cos[t], Sin[t], t}, {t, 0, 6}]]'
+Graphics3D
+```
+
+`PlotStyle -> Tube[r]` draws the curve as a tube of radius `r` rather than
+as a line; any colour given alongside it still applies:
+
+```scrut
+$ wo 'StringContainsQ[ExportString[ParametricPlot3D[{Cos[t], Sin[t], t/5}, {t, 0, 6.2}, PlotStyle -> {Red, Tube[0.2]}], "SVG"], "<polygon"]'
+True
+```

--- a/tests/cli/syntax.md
+++ b/tests/cli/syntax.md
@@ -234,3 +234,33 @@ $ wo 'Cases[{1, "a", 2, "b"}, _Integer]'
 $ wo 'Cases[{1, 2, 3, 4, 5}, Except[2 | 4]]'
 {1, 3, 5}
 ```
+
+
+## Comments (`(* … *)`)
+
+A comment is skipped wherever whitespace is, and what it holds is never
+read as code — not even a bracket, a quote or a semicolon left over from
+commented-out code:
+
+```scrut
+$ wo 'Hold[f[a (* endof For[ i *); b]]'
+Hold[f[a; b]]
+```
+
+```scrut
+$ wo '{1 (* a ) b *); 2}'
+{2}
+```
+
+```scrut
+$ wo 'Range[5][[2 (* [ *) ;; 3]]'
+{2, 3}
+```
+
+Comments nest, so a commented-out block that itself holds comments is
+skipped whole:
+
+```scrut
+$ wo '1 + (* outer (* inner *) still a comment *) 2'
+3
+```

--- a/tests/miscellaneous_tests/parser.rs
+++ b/tests/miscellaneous_tests/parser.rs
@@ -211,6 +211,56 @@ mod tests {
   }
 
   #[test]
+  fn test_comment_holding_a_bracket_before_a_semicolon() {
+    // Regression: the zero-width lookaheads that scan ahead for a `;` (and
+    // for `;;` / `->`) walk the source bracket by bracket, and run inside an
+    // atomic rule where pest does not skip comments for them. A comment
+    // holding an unbalanced bracket, quote or semicolon therefore threw the
+    // scan off and made the whole enclosing expression unparseable — as in
+    // `For[…] (* endof For[ ik *);`, which is ordinary Demonstration code.
+    for input in [
+      "r[a (* [ *); b]",
+      "r[a (* ] *); b]",
+      "r[a (* endof For[ ij *);]",
+      "{1 (* ) *); 2}",
+      "f[a (* \" *); b]",
+      "f[a (* ; *), b]",
+      "f[a (* [ *) ;; 2]",
+      "f[a (* -> *) -> b]",
+    ] {
+      assert!(parse(input).is_ok(), "should parse: {:?}", input);
+    }
+    // The comment is still only a comment: what it holds never changes the
+    // expression the parser builds.
+    assert_eq!(
+      woxi::interpret("Hold[f[a (* [ *); b]]").unwrap(),
+      "Hold[f[a; b]]"
+    );
+    assert_eq!(woxi::interpret("{1 (* ) *); 2}").unwrap(), "{2}");
+    assert_eq!(
+      woxi::interpret("Range[5][[2 (* [ *);; 3]]").unwrap(),
+      "{2, 3}"
+    );
+    assert_eq!(
+      woxi::interpret("{a, b} /. a (* [ *) -> 1").unwrap(),
+      "{1, b}"
+    );
+  }
+
+  #[test]
+  fn test_comment_inside_a_manipulate_control_block() {
+    // The same scan runs for every function argument, so a commented-out
+    // bracket between a `For` body and the `;` that ends it has to survive
+    // several levels of nesting.
+    let code = "Hold[Module[{a}, \
+       For[i = 1, i < 3, i++, \
+         { For[j = 1, j < 2, j++, {a = i j}] } (* endof For[ j *) \
+       ]; (* endof For[ i *) \
+       a]]";
+    assert!(parse(code).is_ok(), "should parse: {:?}", code);
+  }
+
+  #[test]
   fn test_bracket_group_still_starts_implicit_times() {
     // The `SoloBracketGroup` guard must not reject a genuine juxtaposition.
     assert_eq!(woxi::interpret("{1, 2} {3, 4}").unwrap(), "{3, 8}");

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -2671,6 +2671,186 @@ mod tests {
     }
 
     #[test]
+    fn styled_layout_keeps_its_layout_when_exported() {
+      // `Style[Row[…], …]` shows the row, styled — not the source of the
+      // call. A Demonstration captions its plot this way, and the caption
+      // used to export as the literal text `Row[{9, " leaves", …}]`.
+      let svg = svg_of(
+        "Labeled[Graphics[{Circle[]}], \
+         Style[Row[{9, \" leaves\"}], FontSize -> 16, Blue], Bottom]",
+      );
+      assert!(
+        !svg.contains(">Row<"),
+        "the caption must not export as source: {svg}"
+      );
+      assert!(svg.contains(" leaves"), "expected the row's text: {svg}");
+      assert!(
+        svg.contains("font-size=\"16\"") && svg.contains("rgb(0,0,255)"),
+        "the caption keeps the size and colour it asks for: {svg}"
+      );
+      // A styled picture is still the picture.
+      let styled = svg_of("Style[Graphics[{Disk[]}], Blue]");
+      assert!(styled.contains("<ellipse"), "expected the disk: {styled}");
+    }
+
+    #[test]
+    fn styled_grid_still_colours_its_frame() {
+      // The directives of a styled `Grid` reach its frame and dividers, not
+      // only its cells, so unwrapping `Style` must leave that path alone.
+      let svg = svg_of(
+        "Style[Grid[{{a, b}, {c, d}}, Frame -> True, Dividers -> All], Red]",
+      );
+      assert!(
+        svg.contains("stroke=\"rgb(255,0,0)\""),
+        "frame lines stay red: {svg}"
+      );
+    }
+
+    #[test]
+    fn bspline_curve_renders_in_graphics3d() {
+      // `BSplineCurve[{p1, …}]` draws the spline over its control points.
+      // Every control point sits on `z = 0`, so the drawn curve does too:
+      // a rendered curve is one made of line segments, not nothing.
+      let svg = svg_of(
+        "Graphics3D[BSplineCurve[{{0, 0, 0}, {1, 2, 0}, {2, 0, 0}, \
+         {3, 2, 0}}]]",
+      );
+      assert!(
+        svg.matches("<line").count() > 20,
+        "expected a sampled spline curve: {svg}"
+      );
+    }
+
+    #[test]
+    fn bspline_curve_closes_on_spline_closed() {
+      // `SplineClosed -> True` wraps the leading control points onto the
+      // end, so the curve comes back to where it started: a closed ring
+      // spans its control points in both directions, an open spline over
+      // the same points stops short of the wrap.
+      let open = svg_of(
+        "Graphics3D[BSplineCurve[Table[{Sin[t], Cos[t], 0}, \
+         {t, 0, 6.0, 0.5}]]]",
+      );
+      let closed = svg_of(
+        "Graphics3D[BSplineCurve[Table[{Sin[t], Cos[t], 0}, \
+         {t, 0, 6.0, 0.5}], SplineClosed -> True]]",
+      );
+      assert!(open.contains("<line"), "expected an open spline: {open}");
+      assert!(
+        closed.matches("<line").count() > open.matches("<line").count(),
+        "a closed spline runs further than the open one"
+      );
+    }
+
+    #[test]
+    fn tube_follows_a_bspline_curve() {
+      // `Tube[BSplineCurve[…], r]` is how a Demonstration gives a knot its
+      // thickness: the tube runs along the spline, so it tessellates into
+      // a surface rather than being dropped for want of a point list.
+      let svg = svg_of(
+        "Graphics3D[Tube[BSplineCurve[{{0, 0, 0}, {1, 2, 0}, {2, 0, 1}, \
+         {3, 2, 0}}], 0.2]]",
+      );
+      assert!(
+        svg.matches("<polygon").count() > 100,
+        "expected a tessellated tube around the spline: {svg}"
+      );
+    }
+
+    #[test]
+    fn parametric_plot3d_plot_style_tube_draws_a_tube() {
+      // `PlotStyle -> {colour, Tube[r]}` asks for the curve itself to be
+      // drawn as a tube of radius `r`. The colour still applies; only the
+      // `Tube` directive changes the shape.
+      let tube = svg_of(
+        "ParametricPlot3D[{Cos[t], Sin[t], t/5}, {t, 0, 6.2}, \
+         PlotStyle -> {Red, Tube[0.2]}]",
+      );
+      assert!(
+        tube.matches("<polygon").count() > 100,
+        "expected a tessellated tube: {tube}"
+      );
+      assert!(
+        tube.contains("fill=\"rgb(2"),
+        "the tube keeps the PlotStyle colour: {tube}"
+      );
+      // Without the directive the same curve is still a plain line.
+      let line = svg_of(
+        "ParametricPlot3D[{Cos[t], Sin[t], t/5}, {t, 0, 6.2}, \
+         PlotStyle -> Red]",
+      );
+      assert!(
+        !line.contains("<polygon"),
+        "a curve without Tube stays a line: {line}"
+      );
+    }
+
+    #[test]
+    fn graphics3d_draws_its_plot_label() {
+      // A 3-D picture carries a `PlotLabel` above it, exactly as a 2-D one
+      // does — the canvas grows by the label strip rather than the drawing
+      // area shrinking.
+      let plain = svg_of("Graphics3D[{Line[{{0, 0, 0}, {1, 1, 1}}]}]");
+      let labelled = svg_of(
+        "Graphics3D[{Line[{{0, 0, 0}, {1, 1, 1}}]}, \
+         PlotLabel -> \"Torus Knot\"]",
+      );
+      assert!(
+        labelled.contains("Torus Knot"),
+        "expected the plot label: {labelled}"
+      );
+      assert!(
+        !plain.contains("<text"),
+        "an unlabelled picture gains no text: {plain}"
+      );
+      assert!(
+        labelled.contains("height=\"386\""),
+        "the canvas grows by the label strip: {labelled}"
+      );
+      // `PlotLabel -> None` is how a picture asks to stay untitled.
+      let none =
+        svg_of("Graphics3D[{Line[{{0, 0, 0}, {1, 1, 1}}]}, PlotLabel -> None]");
+      assert!(!none.contains("<text"), "PlotLabel -> None draws nothing");
+    }
+
+    #[test]
+    fn plot3d_heads_draw_their_plot_label() {
+      // The label reaches every 3-D plot head, not only `Graphics3D`.
+      for code in [
+        "Plot3D[x + y, {x, 0, 1}, {y, 0, 1}, PlotLabel -> \"surface\"]",
+        "ParametricPlot3D[{Cos[t], Sin[t], t}, {t, 0, 6}, \
+         PlotLabel -> \"surface\"]",
+        "ListPointPlot3D[{{1, 2, 3}, {2, 1, 0}}, PlotLabel -> \"surface\"]",
+        "ListLinePlot3D[{{{1, 2, 3}, {2, 1, 0}}}, PlotLabel -> \"surface\"]",
+      ] {
+        let svg = svg_of(code);
+        assert!(
+          svg.contains("surface"),
+          "expected a label for {code}: {svg}"
+        );
+      }
+    }
+
+    #[test]
+    fn graphics3d_plot_label_typesets_its_expression() {
+      // The label is typeset like any other, so a `Style[Row[…]]` shows the
+      // row's text at the size and colour it asks for.
+      let svg = svg_of(
+        "Graphics3D[{Line[{{0, 0, 0}, {1, 1, 1}}]}, \
+         PlotLabel -> Style[Row[{\"Lotus \", \"Kolam\"}], FontSize -> 18, \
+         Blue]]",
+      );
+      assert!(
+        svg.contains("Lotus Kolam"),
+        "expected the row's text, not its source: {svg}"
+      );
+      assert!(
+        svg.contains("font-size=\"18\"") && svg.contains("rgb(0,0,255)"),
+        "expected the label's own size and colour: {svg}"
+      );
+    }
+
+    #[test]
     fn graphics3d_axes_carry_ticks_and_labels() {
       // `Show[Graphics3D[…], Axes -> True, AxesLabel -> {…}]`: a
       // Demonstration frames a 3D scene this way, and the axes, their tick


### PR DESCRIPTION
Checked a published Wolfram Demonstration notebook against Woxi Studio;
four gaps kept its Manipulate from rendering the way the Wolfram
FrontEnd does.

Parser: a comment holding an unbalanced bracket, quote or semicolon
derailed the zero-width lookaheads that scan for `;`, `;;` and `->` at
the current nesting depth. `HasSemicolon` is atomic, so pest disables its
implicit COMMENT rule and the scan read `(* endof For[ ik *)` as an open
bracket — which made the whole enclosing expression unparseable. The
scans (and `NestedContent`, reachable from them) now skip comments
explicitly via a `ScanComment` alternation listed first.

Graphics3D: `PlotLabel` was ignored by every 3-D plot head. The finished
picture is now nested into a canvas one label strip taller, with the
label typeset and centred in the strip, matching the 2-D renderer.

Graphics3D: `BSplineCurve[{p1, …}]` drew nothing, and
`Tube[BSplineCurve[…], r]` therefore drew nothing either. The spline is
sampled into a polyline (honouring `SplineClosed -> True`), which the
`Tube` arm now runs its surface along.

ParametricPlot3D: `PlotStyle -> {colour, Tube[r]}` drew a thin line. The
`Tube` directive is lifted out of the style list and turns each sampled
polyline into a tube; the colour still applies.

Export: `Style[Row[…], FontSize -> 16, Blue]` used as a `Labeled`
caption exported as the literal source of the call. `Style` now unwraps
on the picture path, pushing its directives into the layout it wraps so
the item renderer applies them. A styled `Grid` keeps its existing path,
where the directives also colour the frame and dividers.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BTQChp5YhZAhRtmvkJcPnb