### PR TITLE
Render nested, generated and narrow parametric curves

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -4597,7 +4597,16 @@ fn parse_tick_spec(expr: &Expr) -> TickSpec {
           Expr::List(pair) if pair.len() >= 2 => {
             Some((expr_to_f64(&pair[0])?, Some(expr_to_svg_markup(&pair[1]))))
           }
-          other => Some((expr_to_f64(other)?, None)),
+          // A bare position is labelled with the expression standing at
+          // it, so `Ticks -> {{-Pi, 0, Pi}, …}` reads "-π", "0", "π"
+          // rather than the numeric value it evaluates to.
+          other => {
+            let pos = expr_to_f64(other)?;
+            Some((
+              pos,
+              Some(crate::functions::plot::bare_tick_label(other, pos)),
+            ))
+          }
         })
         .collect(),
     ),

--- a/src/functions/parametric_plot.rs
+++ b/src/functions/parametric_plot.rs
@@ -1,5 +1,7 @@
 #[allow(unused_imports)]
 use super::*;
+use std::cmp::Ordering;
+
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{
@@ -90,6 +92,178 @@ enum CurveSrc<'a> {
   Whole(&'a Expr),
 }
 
+/// Whether a list node can be read as a curve or as a grouping of curves.
+/// Wolfram lets the curve specification be nested to any depth — the
+/// grouping only steers styling — so `{{fx, fy}, …}` and
+/// `{{{fx, fy}, …}}` both denote the same set of curves.
+fn is_curve_or_group(expr: &Expr) -> bool {
+  match expr {
+    // A pair is either a curve `{fx, fy}` or a group of two curves;
+    // `collect_curves` decides which when it descends.
+    Expr::List(items) if items.len() == 2 => true,
+    Expr::List(items) if !items.is_empty() => {
+      items.iter().all(is_curve_or_group)
+    }
+    _ => false,
+  }
+}
+
+/// Flatten a (possibly nested) curve specification into individual curves,
+/// appending them to `out`. Returns whether the shape was understood.
+fn collect_curves<'a>(expr: &'a Expr, out: &mut Vec<CurveSrc<'a>>) -> bool {
+  let Expr::List(items) = expr else {
+    return false;
+  };
+  if items.is_empty() {
+    return false;
+  }
+  // Every element being curve-shaped makes this a grouping level — which
+  // is how the ambiguous `{{a, b}, {c, d}}` resolves to two curves.
+  if items.iter().all(is_curve_or_group) {
+    return items.iter().all(|item| collect_curves(item, out));
+  }
+  if items.len() == 2 {
+    out.push(CurveSrc::Pair(&items[0], &items[1]));
+    return true;
+  }
+  false
+}
+
+/// Bisection passes used to smooth out an under-resolved curve. Each pass
+/// halves the flagged intervals, so six passes shrink a step by 64×.
+const MAX_REFINEMENT_DEPTH: usize = 6;
+
+/// One sampled parameter value together with the coordinate pair of every
+/// curve there (`None` when the body did not evaluate to coordinates).
+type Sample = (f64, Option<Vec<(f64, f64)>>);
+
+/// Whether the middle of a sampled triple is far enough off the straight
+/// line between its neighbours that the interval needs more points. The
+/// measure is the deviation relative to the neighbours' separation, so it
+/// is independent of the coordinate scale.
+fn needs_refinement(a: &Sample, b: &Sample, c: &Sample) -> bool {
+  let (Some(ra), Some(rb), Some(rc)) = (&a.1, &b.1, &c.1) else {
+    // A gap in the samples is a discontinuity (or a domain boundary);
+    // refining pins down where it actually starts.
+    return true;
+  };
+  if ra.len() != rb.len() || rb.len() != rc.len() {
+    return true;
+  }
+  let span = c.0 - a.0;
+  if span == 0.0 {
+    return false;
+  }
+  let u = (b.0 - a.0) / span;
+  ra.iter().zip(rb).zip(rc).any(|((p0, p1), p2)| {
+    if !p0.0.is_finite()
+      || !p0.1.is_finite()
+      || !p1.0.is_finite()
+      || !p1.1.is_finite()
+      || !p2.0.is_finite()
+      || !p2.1.is_finite()
+    {
+      return true;
+    }
+    let interp = (p0.0 + (p2.0 - p0.0) * u, p0.1 + (p2.1 - p0.1) * u);
+    let deviation = (p1.0 - interp.0).hypot(p1.1 - interp.1);
+    let separation = (p2.0 - p0.0).hypot(p2.1 - p0.1).max(1e-10);
+    deviation / separation > 0.05
+  })
+}
+
+/// Adaptively sample a parametric curve: lay down a uniform grid, then
+/// bisect the intervals where the polyline visibly departs from the curve.
+/// A uniform grid alone leaves a curve polygonal whenever the part that
+/// bends is a small slice of the parameter range (e.g. `{t, -1000, 1000}`
+/// for a curve shaped near `t == 0`), which is why Wolfram refines instead
+/// of sampling a fixed grid.
+fn adaptive_samples<F>(
+  sample: F,
+  t_min: f64,
+  t_max: f64,
+  initial_n: usize,
+  max_total: usize,
+) -> Vec<Sample>
+where
+  F: Fn(f64) -> Option<Vec<(f64, f64)>>,
+{
+  let initial_n = initial_n.max(2);
+  let step = (t_max - t_min) / (initial_n - 1) as f64;
+  let mut samples: Vec<Sample> = (0..initial_n)
+    .map(|i| {
+      let t = t_min + i as f64 * step;
+      (t, sample(t))
+    })
+    .collect();
+
+  let min_span = (t_max - t_min).abs() * 1e-10;
+  for _ in 0..MAX_REFINEMENT_DEPTH {
+    if samples.len() >= max_total {
+      break;
+    }
+    let budget = max_total - samples.len();
+    let mut added: Vec<Sample> = Vec::new();
+    for triple in samples.windows(3) {
+      if added.len() >= budget {
+        break;
+      }
+      if (triple[2].0 - triple[0].0).abs() < min_span {
+        continue;
+      }
+      if !needs_refinement(&triple[0], &triple[1], &triple[2]) {
+        continue;
+      }
+      for (left, right) in [(&triple[0], &triple[1]), (&triple[1], &triple[2])]
+      {
+        let mid = (left.0 + right.0) / 2.0;
+        // Neighbouring triples share an interval, so the same midpoint
+        // comes up twice; skipping it saves evaluating the body again.
+        if mid > left.0
+          && mid < right.0
+          && added.last().is_none_or(|last| last.0 != mid)
+        {
+          added.push((mid, sample(mid)));
+        }
+      }
+    }
+    if added.is_empty() {
+      break;
+    }
+    samples.extend(added);
+    samples.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
+    samples.dedup_by(|a, b| a.0 == b.0);
+  }
+
+  samples
+}
+
+/// Split the per-parameter samples into one point series per curve, keeping
+/// a gap (as a non-finite point) wherever the body did not evaluate.
+fn samples_to_series(samples: Vec<Sample>) -> Vec<Vec<(f64, f64)>> {
+  // The curve count comes from the first sample that evaluated.
+  let n_curves = samples
+    .iter()
+    .find_map(|(_, row)| row.as_ref().map(|r| r.len()))
+    .unwrap_or(1);
+  let mut series = vec![Vec::with_capacity(samples.len()); n_curves];
+  for (_, row) in samples {
+    match row {
+      Some(r) if r.len() == n_curves => {
+        for (curve, point) in series.iter_mut().zip(r) {
+          curve.push(point);
+        }
+      }
+      _ => {
+        for curve in series.iter_mut() {
+          curve.push((f64::NAN, f64::NAN));
+        }
+      }
+    }
+  }
+  series
+}
+
 /// Sample a whole-expression curve at parameter `t`. The evaluated body may
 /// be a single coordinate pair (one curve) or a list of coordinate pairs
 /// (one sample per curve, e.g. `ReIm[{c1, c2, c3}]`); either way one row of
@@ -158,118 +332,81 @@ pub fn parametric_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Parse iterator: {t, tmin, tmax}
   let (var_name, t_min, t_max) = parse_iterator(iter_spec, "ParametricPlot")?;
 
-  // Collect curve bodies. Wolfram accepts either a single curve
-  // `{fx, fy}` or any number of curves `{{fx1,fy1}, {fx2,fy2}, …}`.
-  // The previous form-check required `items.len() == 2`, which
-  // rejected 3+ curves; relax it to inspect the *inner* shape so
-  // arbitrarily many curves work (regression for mathics doc-044
-  // `ParametricPlot[{{Sin[u], Cos[u]}, {0.6 Sin[u], 0.6 Cos[u]},
-  // {0.2 Sin[u], 0.2 Cos[u]}}, {u, 0, 2 Pi}, …]`).
-  let curves: Vec<CurveSrc> = match body {
-    Expr::List(items) if !items.is_empty() => {
-      // If every item is a 2-element list, treat as multi-curve.
-      let all_pairs = items
-        .iter()
-        .all(|i| matches!(i, Expr::List(inner) if inner.len() == 2));
-      if all_pairs && items.len() != 2 {
-        // Clearly multi-curve (3+ curves).
-        items
-          .iter()
-          .filter_map(|item| {
-            if let Expr::List(pair) = item
-              && pair.len() == 2
-            {
-              return Some(CurveSrc::Pair(&pair[0], &pair[1]));
-            }
-            None
-          })
-          .collect()
-      } else if items.len() == 2 {
-        if matches!(&items[0], Expr::List(inner) if inner.len() == 2)
-          && matches!(&items[1], Expr::List(inner) if inner.len() == 2)
-        {
-          // Ambiguous-looking `{{a,b}, {c,d}}` resolves to two curves.
-          items
-            .iter()
-            .filter_map(|item| {
-              if let Expr::List(pair) = item
-                && pair.len() == 2
-              {
-                return Some(CurveSrc::Pair(&pair[0], &pair[1]));
-              }
-              None
-            })
-            .collect()
-        } else {
-          // Single curve: {fx, fy}
-          vec![CurveSrc::Pair(&items[0], &items[1])]
-        }
-      } else {
-        return Err(InterpreterError::EvaluationError(
-          "ParametricPlot: first argument must be {fx, fy}".into(),
-        ));
-      }
+  // Collect curve bodies. Wolfram accepts a single curve `{fx, fy}` or
+  // any number of curves nested to any depth, e.g.
+  // `{{fx1,fy1}, {fx2,fy2}, …}` and `{Table[{fx, fy}, {i, …}]}` — the
+  // extra grouping levels only matter for styling, so they are flattened
+  // away here.
+  let mut syntactic = Vec::new();
+  let is_list_body = matches!(body, Expr::List(_));
+  let syntactic_ok = is_list_body && collect_curves(body, &mut syntactic);
+
+  // The first argument is held, so a generated specification such as
+  // `{Table[{fx, fy}, {i, …}]}` only takes curve shape once evaluated.
+  // Evaluate it (the plot variable stays symbolic) and retry, matching
+  // Wolfram, which samples the held body rather than requiring
+  // `Evaluate[…]` around it.
+  let evaluated_body: Option<Expr> = if is_list_body && !syntactic_ok {
+    evaluate_expr_to_expr(body).ok()
+  } else {
+    None
+  };
+
+  let curves: Vec<CurveSrc> = if syntactic_ok {
+    syntactic
+  } else if is_list_body {
+    let mut collected = Vec::new();
+    let ok = evaluated_body
+      .as_ref()
+      .is_some_and(|ev| collect_curves(ev, &mut collected));
+    if !ok {
+      return Err(InterpreterError::EvaluationError(
+        "ParametricPlot: first argument must be {fx, fy}".into(),
+      ));
     }
+    collected
+  } else {
     // A non-list body (e.g. `f[t]` or `BSplineFunction[…][t]`) is a curve
     // whose coordinate pair only materialises once `t` is numeric; sample
     // the whole expression instead of decomposing it into components.
-    _ => vec![CurveSrc::Whole(body)],
+    vec![CurveSrc::Whole(body)]
   };
 
   // Sample at least NUM_SAMPLES points; an explicit larger PlotPoints
   // raises the resolution. (Wolfram refines a coarse PlotPoints setting
   // adaptively, so a smaller explicit value must not reduce smoothness.)
+  // The uniform grid is the starting point; intervals where it would
+  // render the curve as a polygon get bisected on top of it.
   let num_samples = plot_opts.plot_points.max(NUM_SAMPLES);
-  let step = (t_max - t_min) / (num_samples - 1) as f64;
+  let max_total = num_samples.saturating_mul(2);
   let mut all_points: Vec<Vec<(f64, f64)>> = Vec::with_capacity(curves.len());
 
   for curve in &curves {
-    match curve {
-      CurveSrc::Pair(fx, fy) => {
-        let mut points = Vec::with_capacity(num_samples);
-        for i in 0..num_samples {
-          let t = t_min + i as f64 * step;
-          let pt = match (
-            evaluate_at_point(fx, &var_name, t),
-            evaluate_at_point(fy, &var_name, t),
-          ) {
-            (Some(x), Some(y)) => Some((x, y)),
-            _ => None,
-          };
-          points.push(pt.unwrap_or((f64::NAN, f64::NAN)));
-        }
-        all_points.push(points);
-      }
-      CurveSrc::Whole(b) => {
-        // The whole body is evaluated once per sample; each sample may
-        // yield one coordinate pair or one pair per curve (e.g.
-        // `ReIm[{c1, c2, c3}]`). The curve count comes from the first
-        // sample that evaluates successfully.
-        let rows: Vec<Option<Vec<(f64, f64)>>> = (0..num_samples)
-          .map(|i| sample_whole_rows(b, &var_name, t_min + i as f64 * step))
-          .collect();
-        let n_curves = rows
-          .iter()
-          .find_map(|r| r.as_ref().map(|v| v.len()))
-          .unwrap_or(1);
-        let mut pts = vec![Vec::with_capacity(num_samples); n_curves];
-        for row in rows {
-          match row {
-            Some(r) if r.len() == n_curves => {
-              for (k, p) in r.into_iter().enumerate() {
-                pts[k].push(p);
-              }
-            }
-            _ => {
-              for series in pts.iter_mut() {
-                series.push((f64::NAN, f64::NAN));
-              }
-            }
-          }
-        }
-        all_points.extend(pts);
-      }
-    }
+    // Each sample yields one coordinate pair, or one pair per curve when
+    // the whole body is sampled (e.g. `ReIm[{c1, c2, c3}]`).
+    let samples = match curve {
+      CurveSrc::Pair(fx, fy) => adaptive_samples(
+        |t| match (
+          evaluate_at_point(fx, &var_name, t),
+          evaluate_at_point(fy, &var_name, t),
+        ) {
+          (Some(x), Some(y)) => Some(vec![(x, y)]),
+          _ => None,
+        },
+        t_min,
+        t_max,
+        num_samples,
+        max_total,
+      ),
+      CurveSrc::Whole(b) => adaptive_samples(
+        |t| sample_whole_rows(b, &var_name, t),
+        t_min,
+        t_max,
+        num_samples,
+        max_total,
+      ),
+    };
+    all_points.extend(samples_to_series(samples));
   }
 
   // Compute ranges (explicit PlotRange components override the data extents)

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -7831,7 +7831,7 @@ pub(crate) fn parse_explicit_ticks(value: &Expr) -> Option<Vec<(f64, String)>> {
 /// *expression*, typeset — `Ticks -> {{0, Pi/2, Pi, 3 Pi/2, 2 Pi}, …}` reads
 /// "0", "π/2", "π", "3π/2", "2π" — so only a literal number is labelled by
 /// its value; anything symbolic is set the way the expression is written.
-fn bare_tick_label(e: &Expr, pos: f64) -> String {
+pub(crate) fn bare_tick_label(e: &Expr, pos: f64) -> String {
   fn is_literal_number(e: &Expr) -> bool {
     match e {
       Expr::Integer(_)
@@ -8338,6 +8338,21 @@ fn eval_body_var_symbolic(body: &Expr, var: &str) -> Expr {
   eval_body_vars_symbolic(body, &[var])
 }
 
+/// Expand a held generator such as `Table[f[i, x], {i, …}]` into the list of
+/// curves it produces. The plot body is held, so such a generator only takes
+/// list shape once evaluated; Wolfram plots one curve per element of the
+/// result. Returns `None` when the body is already a list or does not
+/// generate one, leaving plain `Plot[f[x], …]` untouched.
+fn expand_generated_bodies(body: &Expr, var: &str) -> Option<Expr> {
+  if matches!(body, Expr::List(_)) {
+    return None;
+  }
+  match eval_body_var_symbolic(body, var) {
+    evaluated @ Expr::List(_) => Some(evaluated),
+    _ => None,
+  }
+}
+
 /// As [`eval_body_var_symbolic`], for a body in several plot variables.
 fn eval_body_vars_symbolic(body: &Expr, vars: &[&str]) -> Expr {
   let saved: Vec<(&str, Option<crate::StoredValue>)> = vars
@@ -8548,6 +8563,18 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // list inside it (e.g. `Highlighted[{Sin[x], Cos[x]}, …]`) is split into
   // individual curves below rather than sampled as one non-numeric expression.
   let body = peel_plot_wrappers(body);
+
+  // `Plot[Table[f[i, x], {i, …}], …]` names its curves only after the
+  // generator runs; expand it so each element becomes its own curve
+  // instead of being sampled as one expression yielding a list.
+  let generated_storage;
+  let body: &Expr = match expand_generated_bodies(body, &var_name) {
+    Some(expanded) => {
+      generated_storage = expanded;
+      &generated_storage
+    }
+    None => body,
+  };
 
   // Collect function bodies: a single function or a (possibly nested) list of
   // functions. Wolfram flattens nested lists into individual curves, so
@@ -8882,10 +8909,17 @@ fn log_scale_plot_ast(
     ));
   }
 
+  // A held generator such as `Table[f[i, x], {i, …}]` only takes list
+  // shape once evaluated; Wolfram plots one curve per element of the
+  // resulting list, so evaluate a non-list body (the plot variable stays
+  // symbolic) and use the list when there is one. Bodies that stay
+  // scalar keep their held form, so plain `Plot[f[x], …]` is unaffected.
+  let expanded_body = expand_generated_bodies(body, &var_name);
+
   // Collect function bodies
-  let bodies: Vec<&Expr> = match body {
+  let bodies: Vec<&Expr> = match expanded_body.as_ref().unwrap_or(body) {
     Expr::List(items) => items.iter().collect(),
-    _ => vec![body],
+    scalar => vec![scalar],
   };
 
   if (legends_automatic || legends_expressions)

--- a/tests/cli/plotting/ParametricPlot.md
+++ b/tests/cli/plotting/ParametricPlot.md
@@ -8,3 +8,18 @@ Graphics
 ```
 
 Accepts the same options as `Plot`.
+
+Several curves are given as a list of `{fx, fy}` pairs, nested to any depth —
+the grouping only steers styling:
+
+```scrut
+$ wo 'Head[ParametricPlot[{{{Cos[t], Sin[t]}, {2 Cos[t], 2 Sin[t]}}}, {t, 0, 2 Pi}]]'
+Graphics
+```
+
+The curve specification is held, so one built by `Table` needs no `Evaluate`:
+
+```scrut
+$ wo 'Head[ParametricPlot[Table[{a Cos[t], a Sin[t]}, {a, 1, 3}], {t, 0, 2 Pi}]]'
+Graphics
+```

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -3326,6 +3326,24 @@ mod plot3d {
   mod plot_misc {
     use super::*;
 
+    /// The plotted function is held, so a `Table` generating the curves
+    /// only becomes a list once evaluated. Wolfram draws one curve per
+    /// entry either way, so writing `Evaluate` must not change the result.
+    #[test]
+    fn plot_table_generated_curves() {
+      let generated = export_svg("Plot[Table[Sin[i x], {i, 1, 3}], {x, 0, 3}]");
+      let curves = generated
+        .split("points=\"")
+        .skip(1)
+        .filter(|s| s.split('"').next().unwrap_or("").split(' ').count() > 20)
+        .count();
+      assert_eq!(curves, 3, "expected one curve per Table entry");
+      assert_eq!(
+        generated,
+        export_svg("Plot[Evaluate[Table[Sin[i x], {i, 1, 3}]], {x, 0, 3}]")
+      );
+    }
+
     #[test]
     fn plot_unevaluatable_returns_graphics() {
       // When the function can't be numerically evaluated, Plot still returns
@@ -3942,6 +3960,26 @@ mod plot3d {
       );
       assert!(ticks.contains(&"one".to_string()), "{ticks:?}");
       assert!(ticks.contains(&"three".to_string()), "{ticks:?}");
+    }
+
+    /// Bare tick positions label themselves in a plain `Graphics` too —
+    /// which is the path `Show` re-renders a merged plot through, so an
+    /// explicit `Ticks` setting survives being combined with other
+    /// primitives.
+    #[test]
+    fn graphics_labels_a_symbolic_tick_position_with_its_expression() {
+      let svg = export_svg(
+        "Graphics[{Line[{{-4, 0}, {4, 0}}]}, Axes -> True, \
+         Ticks -> {{-Pi, 0, Pi}, {-1, 0, 1}}]",
+      );
+      assert!(svg.contains(">π<"), "expected a π tick label: {svg}");
+      assert!(svg.contains(">-π<"), "expected a -π tick label: {svg}");
+      assert!(
+        !svg.contains("3.14159"),
+        "a symbolic tick must not be labelled by value: {svg}"
+      );
+      // A literal position still labels itself.
+      assert!(svg.contains(">-1<"), "expected a -1 tick label: {svg}");
     }
 
     /// A tick given as a bare position is labelled with that *expression*
@@ -7269,6 +7307,136 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       assert_eq!(
         long_polylines, 2,
         "expected two sampled curves from the whole-body ReIm form"
+      );
+    }
+
+    /// Counts the sampled polylines a plot SVG drew, ignoring the short
+    /// strokes that make up axes, ticks and frames.
+    fn sampled_curve_count(svg: &str) -> usize {
+      svg
+        .split("points=\"")
+        .skip(1)
+        .filter(|s| s.split('"').next().unwrap_or("").split(' ').count() > 20)
+        .count()
+    }
+
+    /// A curve specification may be nested to any depth — the grouping only
+    /// steers styling — so an extra pair of braces around a list of curves
+    /// still draws every one of them.
+    #[test]
+    fn parametric_plot_nested_curve_list() {
+      let svg = export_svg(
+        "ParametricPlot[{{{Sin[t], Cos[t]}, {2 Sin[t], 2 Cos[t]}, \
+         {3 Sin[t], 3 Cos[t]}}}, {t, 0, 2 Pi}]",
+      );
+      assert_eq!(
+        sampled_curve_count(&svg),
+        3,
+        "expected all three curves of the nested specification"
+      );
+    }
+
+    /// The curve specification is held, so a generated one only takes curve
+    /// shape once evaluated. Wolfram samples the held body, so `Table` in
+    /// the first argument must not need an explicit `Evaluate`.
+    #[test]
+    fn parametric_plot_table_generated_curves() {
+      let generated = export_svg(
+        "ParametricPlot[{Table[{a Sin[t], a Cos[t]}, {a, 1, 3}]}, \
+         {t, 0, 2 Pi}]",
+      );
+      assert_eq!(
+        sampled_curve_count(&generated),
+        3,
+        "expected one curve per Table entry"
+      );
+      // Same curves as writing the list out by hand.
+      let explicit = export_svg(
+        "ParametricPlot[{{Sin[t], Cos[t]}, {2 Sin[t], 2 Cos[t]}, \
+         {3 Sin[t], 3 Cos[t]}}, {t, 0, 2 Pi}]",
+      );
+      assert_eq!(generated, explicit);
+    }
+
+    /// A specification that is neither a curve nor a grouping of curves is
+    /// still an error rather than a silently empty plot.
+    #[test]
+    fn parametric_plot_rejects_non_curve_specification() {
+      let err = interpret("ParametricPlot[{1, 2, 3}, {t, 0, 1}]").unwrap_err();
+      assert!(
+        format!("{err}").contains("first argument must be"),
+        "unexpected error: {err}"
+      );
+    }
+
+    /// Sampling is refined where the polyline would depart from the curve,
+    /// so a curve that only bends over a small slice of a wide parameter
+    /// range still renders smoothly instead of as a few long chords.
+    #[test]
+    fn parametric_plot_refines_a_narrow_feature() {
+      // ArcTan saturates away from the origin: on {t, -1000, 1000} the
+      // whole shape lives in |t| < 10, a half-percent of the range.
+      let svg = export_svg(
+        "ParametricPlot[{ArcTan[t + 1] - ArcTan[t - 1], \
+         ArcTan[t + 1] + ArcTan[t - 1]}, {t, -1000, 1000}]",
+      );
+      let points: Vec<(f64, f64)> = svg
+        .split("points=\"")
+        .skip(1)
+        .max_by_key(|s| s.split('"').next().unwrap_or("").len())
+        .expect("a sampled curve")
+        .split('"')
+        .next()
+        .unwrap()
+        .split(' ')
+        .filter_map(|p| {
+          let (x, y) = p.split_once(',')?;
+          Some((x.parse().ok()?, y.parse().ok()?))
+        })
+        .collect();
+      // Points were added on top of the uniform grid, which is what tells
+      // refinement apart from plain sampling.
+      assert!(
+        points.len() > 500,
+        "expected the uniform grid to be refined, got {} points",
+        points.len()
+      );
+      // The turn from one sampled segment to the next stays gentle: no
+      // corner sharper than ~15° survives on a smooth curve. Segments too
+      // short to be seen are skipped — in the saturated tails the rounding
+      // of coordinates to the SVG grid, not the sampling, sets their
+      // direction.
+      let sharp_corners = points
+        .windows(3)
+        .filter(|w| {
+          let (a, b, c) = (w[0], w[1], w[2]);
+          let (u, v) = ((b.0 - a.0, b.1 - a.1), (c.0 - b.0, c.1 - b.1));
+          let (lu, lv) = (u.0.hypot(u.1), v.0.hypot(v.1));
+          if lu < 5.0 || lv < 5.0 {
+            return false;
+          }
+          (u.0 * v.0 + u.1 * v.1) / (lu * lv) < 0.966
+        })
+        .count();
+      assert_eq!(
+        sharp_corners, 0,
+        "adaptive sampling should leave no visible corners"
+      );
+    }
+
+    /// `Ticks` positions given as bare expressions are labelled with the
+    /// expression, not its numeric value — through `Show`, which re-renders
+    /// the plot as graphics, just as in the plot itself.
+    #[test]
+    fn show_keeps_symbolic_tick_labels() {
+      let svg = export_svg(
+        "Show[ParametricPlot[{4 Cos[t], 4 Sin[t]}, {t, 0, 2 Pi}, \
+         Ticks -> {{-Pi, 0, Pi}, {-Pi, 0, Pi}}], Graphics[{Point[{0, 0}]}]]",
+      );
+      assert!(svg.contains(">π<"), "expected a π tick label");
+      assert!(
+        !svg.contains("3.14159"),
+        "π ticks should not be labelled numerically"
       );
     }
 


### PR DESCRIPTION
Checking a Wolfram Demonstration against Woxi Studio turned up four gaps
that between them left its Manipulate unrenderable, and its plot polygonal
once it did render.

ParametricPlot rejected a curve specification nested deeper than one
level. Wolfram lets the specification nest to any depth — the grouping
only steers styling — so flatten it recursively instead of pattern
matching a fixed shape.

The specification is also held, so one built by `Table` only takes curve
shape once evaluated. ParametricPlot now evaluates a held body (with the
plot variable left symbolic) and retries, and Plot/LogPlot expand a
generated body the same way rather than sampling it as one expression
yielding a list, which drew nothing at all.

ParametricPlot sampled a fixed uniform grid, which renders a curve as a
few long chords whenever the part that bends is a small slice of the
parameter range. Refine the grid by bisecting the intervals where the
polyline departs from the curve, as Wolfram does. The uniform grid stays
the starting point, so plots that were already smooth are unchanged.

Finally, a bare `Ticks` position is labelled with the expression standing
at it. Plot did that already; Graphics did not, so an explicit
`Ticks -> {{-Pi, 0, Pi}, …}` read as "3.14159" once Show re-rendered a
plot as graphics.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ERxEnMJRFYJ84awN3Mmzjx