### PR TITLE
Support Demonstration-style notebooks in Woxi Studio

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -2717,15 +2717,130 @@ fn collect_list_pattern_bindings(
     let (_, _, bt) = extract_pattern_info(pat);
     let is_trailing_seq = idx + 1 == n && bt >= 2;
     let accessor = list_element_accessor(base, idx, is_trailing_seq);
-    if let Expr::List(inner) = pat
-      && !is_trailing_seq
-    {
-      collect_list_pattern_bindings(inner, &accessor, out);
+    if is_trailing_seq {
+      let (name, _, _) = extract_pattern_info(pat);
+      if !name.is_empty() {
+        out.push((name, accessor));
+      }
       continue;
     }
-    let (name, _, _) = extract_pattern_info(pat);
-    if !name.is_empty() {
-      out.push((name, accessor));
+    collect_element_bindings(pat, &accessor, out);
+  }
+}
+
+/// The pattern-language heads that describe *how* to match rather than *what*
+/// shape to match. Their arguments do not sit at fixed positions of the matched
+/// expression, so `collect_element_bindings` must not index into them.
+fn is_pattern_construct_head(name: &str) -> bool {
+  matches!(
+    name,
+    "Blank"
+      | "BlankSequence"
+      | "BlankNullSequence"
+      | "PatternSequence"
+      | "PatternTest"
+      | "Optional"
+      | "Alternatives"
+      | "Except"
+      | "Repeated"
+      | "RepeatedNull"
+      | "Longest"
+      | "Shortest"
+      | "Verbatim"
+      | "OptionsPattern"
+      | "KeyValuePattern"
+  )
+}
+
+/// Bindings contributed by the element pattern `pat`, whose matched value is
+/// reached by `accessor`. Recurses through nested list patterns *and* through
+/// constructor patterns (`f[p1, p2, …]`), so `g[{h[a_, b_]}] := …` binds `a`
+/// and `b` the same way `g[{{a_, b_}}] := …` does.
+fn collect_element_bindings(
+  pat: &Expr,
+  accessor: &Expr,
+  out: &mut Vec<(String, Expr)>,
+) {
+  match pat {
+    Expr::List(inner) => collect_list_pattern_bindings(inner, accessor, out),
+    Expr::FunctionCall { name, args }
+      if name == "Pattern" && args.len() == 2 =>
+    {
+      // `x : sub` — bind `x` to the whole element, then keep destructuring
+      // `sub` at the same position.
+      if let Expr::Identifier(n) = &args[0] {
+        out.push((n.clone(), accessor.clone()));
+      }
+      collect_element_bindings(&args[1], accessor, out);
+    }
+    // `sub /; test` and `HoldPattern[sub]` wrap without moving the position.
+    Expr::FunctionCall { name, args }
+      if (name == "Condition" || name == "HoldPattern") && !args.is_empty() =>
+    {
+      collect_element_bindings(&args[0], accessor, out);
+    }
+    // A constructor pattern: argument `j` of the pattern lines up with part
+    // `j` of the matched expression. The element's `MatchQ` guard has already
+    // established that the shapes agree by the time the body reads these.
+    Expr::FunctionCall { name, args } if !is_pattern_construct_head(name) => {
+      let n = args.len();
+      // A sequence pattern (`__`/`___`) absorbs an unknown number of
+      // arguments: everything before it still counts from the front, and
+      // everything after it counts from the back. With more than one
+      // sequence no position is pinned down at all, so nothing is bound.
+      let seqs: Vec<usize> = args
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| extract_pattern_info(a).2 >= 2)
+        .map(|(j, _)| j)
+        .collect();
+      if seqs.len() > 1 {
+        return;
+      }
+      let seq = seqs.first().copied();
+      for (j, arg) in args.iter().enumerate() {
+        let index = match seq {
+          Some(k) if j == k => {
+            // The sequence variable itself spans a run of arguments. Only a
+            // trailing one has a form the body can read back — the tail of
+            // the expression, spliced in as a `Sequence`.
+            if k + 1 == n {
+              let (seq_name, _, _) = extract_pattern_info(arg);
+              if !seq_name.is_empty() {
+                out.push((
+                  seq_name,
+                  Expr::FunctionCall {
+                    name: "Apply".to_string(),
+                    args: vec![
+                      Expr::Identifier("Sequence".to_string()),
+                      Expr::FunctionCall {
+                        name: "Drop".to_string(),
+                        args: vec![accessor.clone(), Expr::Integer(k as i128)]
+                          .into(),
+                      },
+                    ]
+                    .into(),
+                  },
+                ));
+              }
+            }
+            continue;
+          }
+          Some(k) if j > k => -((n - j) as i128),
+          _ => (j + 1) as i128,
+        };
+        let arg_accessor = Expr::FunctionCall {
+          name: "Part".to_string(),
+          args: vec![accessor.clone(), Expr::Integer(index)].into(),
+        };
+        collect_element_bindings(arg, &arg_accessor, out);
+      }
+    }
+    _ => {
+      let (name, _, _) = extract_pattern_info(pat);
+      if !name.is_empty() {
+        out.push((name, accessor.clone()));
+      }
     }
   }
 }
@@ -2917,6 +3032,49 @@ fn map_part_names(pat: &Expr, path: &Expr, out: &mut Vec<(Expr, String)>) {
     Expr::List(inner) => {
       for (j, ip) in inner.iter().enumerate() {
         map_part_names(ip, &part(path, j + 1), out);
+      }
+    }
+    // Mirrors `collect_element_bindings`: names bound inside a constructor
+    // sub-pattern are read from `Part[…, j]`, so the display has to map those
+    // accessors back too.
+    Expr::FunctionCall { name, args }
+      if name == "Pattern" && args.len() == 2 =>
+    {
+      if let Expr::Identifier(n) = &args[0] {
+        out.push((path.clone(), n.clone()));
+      }
+      map_part_names(&args[1], path, out);
+    }
+    Expr::FunctionCall { name, args }
+      if (name == "Condition" || name == "HoldPattern") && !args.is_empty() =>
+    {
+      map_part_names(&args[0], path, out);
+    }
+    Expr::FunctionCall { name, args } if !is_pattern_construct_head(name) => {
+      let n = args.len();
+      let seqs: Vec<usize> = args
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| extract_pattern_info(a).2 >= 2)
+        .map(|(j, _)| j)
+        .collect();
+      if seqs.len() > 1 {
+        return;
+      }
+      let seq = seqs.first().copied();
+      for (j, ip) in args.iter().enumerate() {
+        match seq {
+          Some(k) if j == k => continue,
+          Some(k) if j > k => {
+            let neg = Expr::FunctionCall {
+              name: "Part".to_string(),
+              args: vec![path.clone(), Expr::Integer(-((n - j) as i128))]
+                .into(),
+            };
+            map_part_names(ip, &neg, out);
+          }
+          _ => map_part_names(ip, &part(path, j + 1), out),
+        }
       }
     }
     _ => {}

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -1844,9 +1844,16 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let cell_size =
     (plot_w / VECTOR_GRID as f64).min(plot_h / VECTOR_GRID as f64);
 
+  // Arrows in data coordinates, kept so `VectorPlot[…][[1]]` yields the
+  // primitives a surrounding `Graphics[{…}]` can redraw.
+  let mut primitives: Vec<Expr> = Vec::new();
   if max_mag > 0.0 {
     let arrow_scale = cell_size * 0.4 / max_mag;
     let stroke_w = render_w as f64 / 1000.0 * 1.5;
+    // The pixel-space arrow length maps back to a data-space length so the
+    // symbolic arrows have the same footprint as the drawn ones.
+    let data_scale_x = arrow_scale * (ax_max - ax_min) / plot_w;
+    let data_scale_y = arrow_scale * (ay_max - ay_min) / plot_h;
     for &(x, y, vx, vy, mag) in &vectors {
       if mag < 1e-15 {
         continue;
@@ -1864,6 +1871,30 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let r = (t * 200.0) as u8 + 50;
       let g = ((1.0 - t) * 150.0) as u8 + 50;
       let b = 100_u8;
+
+      primitives.push(Expr::List(
+        vec![
+          rgb_color((r, g, b)),
+          Expr::FunctionCall {
+            name: "Arrow".to_string(),
+            args: vec![Expr::List(
+              vec![
+                Expr::List(vec![Expr::Real(x), Expr::Real(y)].into()),
+                Expr::List(
+                  vec![
+                    Expr::Real(x + vx * data_scale_x),
+                    Expr::Real(y + vy * data_scale_y),
+                  ]
+                  .into(),
+                ),
+              ]
+              .into(),
+            )]
+            .into(),
+          },
+        ]
+        .into(),
+      ));
 
       // Arrow shaft
       svg.push_str(&format!(
@@ -1891,7 +1922,13 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   svg.push_str("</svg>");
-  Ok(crate::graphics_result(svg))
+  Ok(crate::graphics_result_with_structure(
+    svg,
+    Expr::FunctionCall {
+      name: "Graphics".to_string(),
+      args: vec![Expr::List(primitives.into())].into(),
+    },
+  ))
 }
 
 /// StreamPlot[{vx, vy}, {x, xmin, xmax}, {y, ymin, ymax}]
@@ -1946,6 +1983,10 @@ pub fn stream_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let dt = ((x_max - x_min) + (y_max - y_min)) / 2.0 / 200.0;
   let max_steps = 200;
   let stroke_w = render_w as f64 / 1000.0 * 1.5;
+  // Streamlines in data coordinates, kept so `StreamPlot[…][[1]]` yields the
+  // primitives a surrounding `Graphics[{…}]` can redraw — as in Wolfram, where
+  // part 1 of the plot is its graphics content.
+  let mut primitives: Vec<Expr> = Vec::new();
 
   for si in 0..seed_n {
     for sj in 0..seed_n {
@@ -1953,6 +1994,7 @@ pub fn stream_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let mut y = y_min + (sj as f64 + 0.5) * y_step;
 
       let mut points = Vec::new();
+      let mut coords: Vec<(f64, f64)> = vec![(x, y)];
       let (px, py) = to_px(x, y);
       points.push(format!("{:.1},{:.1}", px, py));
 
@@ -1988,6 +2030,7 @@ pub fn stream_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
         let (px, py) = to_px(x, y);
         points.push(format!("{:.1},{:.1}", px, py));
+        coords.push((x, y));
       }
 
       if points.len() > 1 {
@@ -1997,12 +2040,53 @@ pub fn stream_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           "<polyline points=\"{}\" fill=\"none\" stroke=\"rgb({r},{g},{b})\" stroke-width=\"{stroke_w:.1}\" stroke-opacity=\"0.7\"/>\n",
           points.join(" ")
         ));
+        primitives.push(styled_line(coords, (r, g, b)));
       }
     }
   }
 
   svg.push_str("</svg>");
-  Ok(crate::graphics_result(svg))
+  Ok(crate::graphics_result_with_structure(
+    svg,
+    Expr::FunctionCall {
+      name: "Graphics".to_string(),
+      args: vec![Expr::List(primitives.into())].into(),
+    },
+  ))
+}
+
+/// `{RGBColor[r, g, b], Line[{{x, y}, …}]}` — one styled streamline in data
+/// coordinates, for the symbolic form a field plot remembers.
+fn styled_line(coords: Vec<(f64, f64)>, color: (u8, u8, u8)) -> Expr {
+  let points = Expr::List(
+    coords
+      .into_iter()
+      .map(|(x, y)| Expr::List(vec![Expr::Real(x), Expr::Real(y)].into()))
+      .collect(),
+  );
+  Expr::List(
+    vec![
+      rgb_color(color),
+      Expr::FunctionCall {
+        name: "Line".to_string(),
+        args: vec![points].into(),
+      },
+    ]
+    .into(),
+  )
+}
+
+/// `RGBColor[r, g, b]` from 8-bit channel values.
+fn rgb_color((r, g, b): (u8, u8, u8)) -> Expr {
+  Expr::FunctionCall {
+    name: "RGBColor".to_string(),
+    args: vec![
+      Expr::Real(r as f64 / 255.0),
+      Expr::Real(g as f64 / 255.0),
+      Expr::Real(b as f64 / 255.0),
+    ]
+    .into(),
+  }
 }
 
 /// StreamDensityPlot: StreamPlot overlaid on DensityPlot background

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -4624,6 +4624,28 @@ fn axis_ticks(
   }
 }
 
+/// Horizontal centre for a bottom-axis tick label, shifted inwards when
+/// centring it on the tick would push part of the text outside the picture.
+/// `margins` is the room available left of `0` and right of `svg_w`; the
+/// width estimate assumes the 14px monospace face the labels are drawn in.
+fn clamp_tick_label_x(
+  x: f64,
+  label: &str,
+  svg_w: f64,
+  margins: (f64, f64),
+) -> f64 {
+  let half = label.chars().count() as f64 * 14.0 * 0.6 / 2.0;
+  let (left, right) = margins;
+  let lo = -left + half;
+  let hi = svg_w + right - half;
+  // A label wider than the picture cannot be placed without overflow; leave
+  // it centred rather than swinging it to an arbitrary side.
+  if lo > hi {
+    return x;
+  }
+  x.clamp(lo, hi)
+}
+
 fn render_axes(
   svg: &mut String,
   axes: (bool, bool),
@@ -4632,6 +4654,7 @@ fn render_axes(
   svg_h: f64,
   axes_label: &Option<(String, String)>,
   ticks: (&TickSpec, &TickSpec),
+  x_margins: (f64, f64),
 ) {
   let t = theme();
   let axis_stroke = t.axis_stroke;
@@ -4677,6 +4700,12 @@ fn render_axes(
       if axes.1 && t.abs() < step.unwrap_or(1.0) * 1e-6 {
         continue;
       }
+      // A tick sitting on the edge of the drawing area centres its label
+      // half outside the picture, where it is cut off — `-1.0` at the left
+      // edge would read as `1.0`. Nudge such a label inwards just far enough
+      // to clear the margin, the way Wolfram's image padding keeps the
+      // outermost labels whole.
+      let x = clamp_tick_label_x(x, &label, svg_w, x_margins);
       svg.push_str(&format!(
         "<text x=\"{x:.2}\" y=\"{:.2}\" fill=\"{tick_label_fill}\" font-size=\"14\" font-family=\"monospace\" text-anchor=\"middle\" dominant-baseline=\"hanging\">{label}</text>\n",
         axis_y_px + 6.0,
@@ -6829,6 +6858,7 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     svg_h,
     &axes_label,
     (&ticks_x, &ticks_y),
+    (margin_left, margin_right),
   );
 
   // Render primitives. A primitive with a drop shadow is wrapped in a
@@ -15812,9 +15842,17 @@ fn process_manipulate_var_spec(items: &[Expr]) -> Expr {
   new_items.push(items[0].clone());
   for item in &items[1..] {
     // Try to evaluate bounds; if evaluation fails, keep the original so
-    // the echoed form still round-trips.
+    // the echoed form still round-trips. A bound stated in terms of another
+    // control's variable (`{{p, init}, {r[[1]], s[[1]]}, …}`) cannot resolve
+    // here — Wolfram holds the whole Manipulate and only ever sees such a
+    // bound with the control variables in scope — so this speculative pass
+    // must stay silent rather than report `Part::partd` on the free symbol.
+    let snapshot = crate::snapshot_warnings();
+    crate::push_quiet();
     let evaluated =
       evaluate_expr_to_expr(item).unwrap_or_else(|_| item.clone());
+    crate::pop_quiet();
+    crate::restore_warnings(snapshot);
     new_items.push(evaluated);
   }
   // A 2-item spec `{var, range}` whose `range` doesn't reduce to a concrete
@@ -18537,13 +18575,24 @@ fn parse_manipulate_control(
     // behavior: a fixed binding baked into the body.
     let evaluated = crate::evaluator::evaluate_expr_to_expr(&value_expr)
       .unwrap_or_else(|_| value_expr.clone());
+    // A corner bound is often written in terms of *other* control variables
+    // (`{{p, {0, 1}}, {xrange[[1]], yrange[[1]]}, {xrange[[2]],
+    // yrange[[2]]}, Locator}` reuses two `ControlType -> None` ranges), so
+    // each corner is evaluated against the initial-value bindings the caller
+    // installed before it is read as a numeric pair. Without this the corners
+    // look non-numeric and the locator falls back to a padded box around its
+    // starting point.
     let corner_bounds: Vec<(f64, f64)> = items[1..]
       .iter()
       .filter(|it| {
         !matches!(it, Expr::Rule { .. } | Expr::RuleDelayed { .. })
           && !matches!(it, Expr::Identifier(s) if s == "Locator")
       })
-      .filter_map(list2_f64)
+      .filter_map(|it| {
+        list2_f64(it).or_else(|| {
+          list2_f64(&crate::evaluator::evaluate_expr_to_expr(it).ok()?)
+        })
+      })
       .collect();
     let auto_create = items.iter().any(|it| {
       matches!(

--- a/tests/cli/expressions/SetDelayed.md
+++ b/tests/cli/expressions/SetDelayed.md
@@ -23,3 +23,25 @@ incoming value would otherwise be captured by it.
 $ wo 'h[a_] := Function[y, a + y]; h[y]'
 Function[y$, y + y$]
 ```
+
+A list on the left-hand side destructures the argument, and it keeps
+destructuring through elements that are themselves calls: names bound inside
+`foo[…]` are as available to the body as those bound by a nested list.
+
+```scrut
+$ wo 'pair[{foo[a_, b_]}] := a + b; pair[{foo[3, 4]}]'
+7
+```
+
+```scrut
+$ wo 'edge[{f : foo[{lo_, hi_}, ___]}] := {f, lo, hi}; edge[{foo[{0, 1}, extra]}]'
+{foo[{0, 1}, extra], 0, 1}
+```
+
+An argument sequence in such an element leaves the positions around it
+readable: earlier arguments count from the front and later ones from the back.
+
+```scrut
+$ wo 'last[{foo[__, z_]}] := z; last[{foo[1, 2, 3]}]'
+3
+```

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -9091,6 +9091,59 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       ));
     }
 
+    // Part 1 of a field plot is its graphics content, so a Demonstration can
+    // lift the field into a `Graphics[{Opacity[…], StreamPlot[…][[1]]}]` of
+    // its own instead of showing the plot on its own.
+    #[test]
+    fn stream_plot_part_one_yields_line_primitives() {
+      assert_eq!(
+        interpret(
+          "Head[StreamPlot[{1, x}, {x, -1, 1}, {y, -1, 1}][[1, 1, 2]]]"
+        )
+        .unwrap(),
+        "Line"
+      );
+      assert_eq!(
+        interpret(
+          "Head[Graphics[{Opacity[0.1], \
+             StreamPlot[{1, x}, {x, -1, 1}, {y, -1, 1}][[1]]}]]"
+        )
+        .unwrap(),
+        "Graphics"
+      );
+    }
+
+    #[test]
+    fn vector_plot_part_one_yields_arrow_primitives() {
+      assert_eq!(
+        interpret(
+          "Head[VectorPlot[{1, x}, {x, -1, 1}, {y, -1, 1}][[1, 1, 2]]]"
+        )
+        .unwrap(),
+        "Arrow"
+      );
+    }
+
+    // The tick at the very edge of the plot range used to be centred on the
+    // boundary, so half of `-1.0` fell outside the picture and it read as
+    // `1.0`. It now sits far enough inside to stay whole.
+    #[test]
+    fn an_edge_tick_label_is_not_cut_off() {
+      let svg = export_svg(
+        "Graphics[{Circle[{0, 0}, 0.1]}, Axes -> True, \
+         PlotRange -> {{-1, 3}, {-2, 2}}, ImageSize -> {400, 400}]",
+      );
+      let x: f64 = svg
+        .split("</text>")
+        .find(|chunk| chunk.ends_with(">-1.0"))
+        .and_then(|chunk| chunk.rsplit("<text x=\"").next())
+        .and_then(|rest| rest.split('"').next())
+        .expect("an x tick labelled -1.0")
+        .parse()
+        .expect("a numeric x attribute");
+      assert!(x > 0.0, "the -1.0 label starts at x={x}, still clipped");
+    }
+
     #[test]
     fn stream_density_plot_basic() {
       insta::assert_snapshot!(export_svg(
@@ -16030,6 +16083,35 @@ mod manipulate {
         assert_eq!((*x_min, *y_min), (0.0, 0.0));
         assert_eq!((*x_max, *y_max), (1.0, 1.0));
         assert_eq!((*x_initial, *y_initial), (0.5, 0.5));
+      }
+      _ => panic!("expected 2D control"),
+    }
+  }
+
+  // A Locator's corner bounds are often written in terms of *other* control
+  // variables, which are only bound once the whole Manipulate is in scope.
+  #[test]
+  fn spec_locator_bounds_may_name_other_control_variables() {
+    let expr = interpret_to_expr(
+      "Manipulate[pt, \
+       {{pt, {0.2, 1}}, {xr[[1]], yr[[1]]}, {xr[[2]], yr[[2]]}, Locator}, \
+       {{xr, {-1, 3}}, ControlType -> None}, \
+       {{yr, {-2, 2}}, ControlType -> None}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed Manipulate");
+    match &spec.controls[0] {
+      ManipulateControl::Slider2D {
+        name,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        ..
+      } => {
+        assert_eq!(name, "pt");
+        assert_eq!((*x_min, *x_max), (-1.0, 3.0));
+        assert_eq!((*y_min, *y_max), (-2.0, 2.0));
       }
       _ => panic!("expected 2D control"),
     }

--- a/tests/interpreter_tests/patterns.rs
+++ b/tests/interpreter_tests/patterns.rs
@@ -4508,3 +4508,89 @@ mod repeated_pattern_variable_in_definition {
     );
   }
 }
+
+/// A list pattern whose elements are themselves *calls* (`f[{g[a_, b_]}] :=
+/// …`) has to bind the names inside those calls, exactly as it does for a
+/// nested list (`f[{{a_, b_}}] := …`). Only the list case used to recurse, so
+/// the inner names stayed symbolic in the body.
+mod call_patterns_nested_in_a_list_pattern {
+  use super::*;
+
+  #[test]
+  fn a_call_element_binds_its_arguments() {
+    assert_eq!(
+      interpret("cn1[{foo[a_, b_]}] := {a, b}; cn1[{foo[1, 2]}]").unwrap(),
+      "{1, 2}"
+    );
+  }
+
+  #[test]
+  fn binding_works_beside_a_plain_element() {
+    assert_eq!(
+      interpret("cn2[{x_, foo[a_]}] := {x, a}; cn2[{9, foo[8]}]").unwrap(),
+      "{9, 8}"
+    );
+  }
+
+  #[test]
+  fn the_element_still_has_to_match() {
+    assert_eq!(
+      interpret("cn3[{foo[a_]}] := a; cn3[{bar[1]}]").unwrap(),
+      "cn3[{bar[1]}]"
+    );
+  }
+
+  #[test]
+  fn nesting_goes_through_lists_and_calls_alike() {
+    assert_eq!(
+      interpret("cn4[{{foo[{a_, b_}]}}] := {a, b}; cn4[{{foo[{1, 2}]}}]")
+        .unwrap(),
+      "{1, 2}"
+    );
+  }
+
+  #[test]
+  fn a_trailing_argument_sequence_leaves_earlier_arguments_bindable() {
+    assert_eq!(
+      interpret("cn5[{foo[{a_, b_}, ___]}] := {a, b}; cn5[{foo[{1, 2}, 9]}]")
+        .unwrap(),
+      "{1, 2}"
+    );
+  }
+
+  #[test]
+  fn a_named_call_element_binds_both_the_whole_and_its_parts() {
+    assert_eq!(
+      interpret("cn6[{p : foo[a_, b_]}] := {p, a, b}; cn6[{foo[1, 2]}]")
+        .unwrap(),
+      "{foo[1, 2], 1, 2}"
+    );
+  }
+
+  #[test]
+  fn an_argument_after_a_sequence_is_not_bound_to_the_wrong_part() {
+    // `foo[__, z_]` cannot say where `z` lands, so the definition simply
+    // does not apply rather than reading an arbitrary argument.
+    assert_eq!(
+      interpret("cn7[{foo[__, z_]}] := z; cn7[{foo[1, 2, 3]}]").unwrap(),
+      "3"
+    );
+  }
+
+  #[test]
+  fn a_trailing_argument_sequence_binds_the_tail() {
+    assert_eq!(
+      interpret("cn9[{foo[a_, s__]}] := {a, {s}}; cn9[{foo[1, 2, 3]}]")
+        .unwrap(),
+      "{1, {2, 3}}"
+    );
+  }
+
+  #[test]
+  fn the_stored_definition_reads_back_as_written() {
+    assert_eq!(
+      interpret("cn8[{foo[a_, b_]}] := a + b; DownValues[cn8]").unwrap(),
+      "{HoldPattern[cn8[{foo[a_, b_]}]] :> a + b}"
+    );
+  }
+}


### PR DESCRIPTION
Working through a Wolfram Demonstration notebook (a Runge-Kutta stepper
built on NDSolve, StreamPlot and a Locator-driven Manipulate) surfaced
four gaps that kept it from rendering:

- A list pattern only destructured through nested *lists*, so a definition
  like `f[{g[a_, b_]}] := …` left `a` and `b` unbound in the body. Binding
  now recurses through constructor sub-patterns as well, including named
  ones (`x : g[…]`), and pins positions around an argument sequence by
  counting from the front before it and from the back after it.

- `StreamPlot[…][[1]]` and `VectorPlot[…][[1]]` stayed unevaluated: both
  returned an opaque graphic with no symbolic form. They now remember their
  streamlines/arrows as primitives in data coordinates, so lifting a field
  into a `Graphics[{Opacity[…], StreamPlot[…][[1]]}]` of one's own works
  the way it does in Wolfram.

- A Locator's corner bounds written in terms of other control variables
  (`{{p, init}, {r[[1]], s[[1]]}, …}`) were read before those variables
  existed, so the control fell back to a padded box around its starting
  point and a spurious `Part::partd` was reported. The corners are now
  evaluated against the sibling controls' initial values, and Manipulate's
  speculative pass over its bounds no longer reports messages.

- A tick label sitting on the edge of the plot range was centred on the
  boundary and cut in half by the picture edge, so `-1.0` read as `1.0`.
  Such a label is now nudged inside far enough to stay whole.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KR7R9qDk24CPjDP8XKVhvq