### PR TITLE
Solve polynomial systems by elimination and radical equations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,31 @@
 
 # Unreleased
 
+- Fixes driven by a Wolfram Demonstration that constructs the centre of a
+    circle with compasses alone, each step drawing the circle through two
+    points that two earlier circles cross at:
+    - A system of polynomial equations is solved by eliminating one
+        variable at a time, dividing one equation into another for as long
+        as the divisor's leading coefficient is a number and falling back
+        to a resultant when it is not. Solving one equation for one
+        variable and substituting — what the solver used to do — turns a
+        quadratic into a radical that then has to be eliminated all over
+        again, and that step dropped solutions: two circles crossing twice
+        reported one of the two crossings twice over, and with the inexact
+        coordinates a slider produces the whole system came back
+        unsolved. Touching circles still report the point they share
+        twice, since it counts twice.
+    - `Resultant` multiplies its result out, rather than reporting the
+        products the Sylvester determinant is assembled from.
+    - An equation carrying a root of the unknown — `Sqrt[2 x + 3] == x`,
+        `Sqrt[x + 5] - Sqrt[x] == 1` — is solved by putting one root on its
+        own, raising both sides to its index, and keeping the answers that
+        survive the original equation. Such an equation used to be read as
+        if the root were not there, which answered `Sqrt[2 x + 3] == x`
+        with `x == 0`. Undoing a square root likewise keeps only the
+        answers that survive, so `Sqrt[x] == -1`, which nothing solves,
+        no longer reports `x == 1`.
+
 - Fixes driven by a Wolfram Demonstration that draws a diatomic molecule as
     a three-dimensional schematic beside an energy plot:
     - `Scale[g, s]` in a `Graphics3D` scales about the centre of `g`'s

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -8094,10 +8094,9 @@ fn partition_tube(items: &[Expr]) -> (Option<Vec<Expr>>, Vec<Expr>) {
       Expr::FunctionCall { name, args } if name == "Tube" && tube.is_none() => {
         tube = Some(args.to_vec());
       }
-      Expr::List(_)
-      | Expr::FunctionCall {
-        name: _, args: _, ..
-      } if tube.is_none() && contains_tube(item) => {
+      Expr::List(_) | Expr::FunctionCall { .. }
+        if tube.is_none() && contains_tube(item) =>
+      {
         let (inner, rest) = take_tube_directive(item);
         tube = inner;
         kept.push(rest);

--- a/src/functions/polynomial_ast/polynomial_q.rs
+++ b/src/functions/polynomial_ast/polynomial_q.rs
@@ -174,7 +174,7 @@ fn collect_poly_vars(
 }
 
 /// Recursively check whether an expression is a polynomial in `var`.
-fn is_polynomial(expr: &Expr, var: &str) -> bool {
+pub(crate) fn is_polynomial(expr: &Expr, var: &str) -> bool {
   match expr {
     Expr::Integer(_) | Expr::Real(_) | Expr::Constant(_) => true,
     Expr::Identifier(_) => true, // either it IS the variable or a constant symbol – both ok

--- a/src/functions/polynomial_ast/resultant.rs
+++ b/src/functions/polynomial_ast/resultant.rs
@@ -139,9 +139,12 @@ pub fn resultant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Compute symbolic determinant
   let det = symbolic_determinant(&matrix);
 
-  // Simplify the result
-  let simplified = crate::evaluator::evaluate_expr_to_expr(&det)?;
-  Ok(simplified)
+  // The determinant is built as a sum of products of the entries, which
+  // leaves it in the nested form those products happen to have. The
+  // resultant is a polynomial in the coefficients and is reported as one,
+  // so multiply the products out and collect like powers.
+  let expanded = expand_and_combine(&det);
+  crate::evaluator::evaluate_expr_to_expr(&expanded)
 }
 
 /// Reduce all integer coefficients of `expr` modulo `p` (via PolynomialMod),

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2081,6 +2081,11 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if let Some(result) = solve_linear_symbolic(eqs, &var_names) {
         return Ok(result);
       }
+      // Nonlinear polynomial systems are eliminated with resultants, which
+      // keeps every intermediate a polynomial.
+      if let Some(result) = try_solve_polynomial_system(eqs, &var_names) {
+        return Ok(result);
+      }
       // High-degree coupled systems (e.g. a quintic in x plus a quintic
       // in y with x-dependent coefficients) blow up in the
       // Reduce-based path because Woxi has no multivariate Root form.
@@ -2481,6 +2486,12 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Pi*C[1], Element[C[1], Integers]]}` for Tan/Cot.
   if let Some(result) = try_solve_trig_eq(&args[0], var) {
     return Ok(result);
+  }
+
+  // Equations carrying a root of the unknown: raise them away and keep the
+  // roots that survive the original equation.
+  if let Some(result) = try_solve_radical_equation(&poly, &args[0], var) {
+    return result;
   }
 
   // Expand and collect polynomial coefficients
@@ -3215,6 +3226,454 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Ok(unevaluated("Solve", args))
     }
   }
+}
+
+/// Solve a system of polynomial equations by eliminating variables with
+/// resultants.
+///
+/// Solving one equation for one variable and substituting — what the generic
+/// `Reduce` path does — introduces a radical as soon as that equation is
+/// quadratic in the variable, and the radical then has to be eliminated all
+/// over again from the equations it was substituted into. Elimination by
+/// resultant keeps every intermediate a polynomial: `Resultant[p, q, v]`
+/// vanishes exactly at those values of the remaining variables for which `p`
+/// and `q` have a common root in `v`, so the system loses a variable and
+/// stays a polynomial system.
+///
+/// Returns `None` for anything this cannot settle — a non-polynomial or
+/// parameterised equation, a system that stays underdetermined, a polynomial
+/// Woxi cannot solve in radicals — which leaves the caller on its previous
+/// path.
+fn try_solve_polynomial_system(eqs: &[Expr], vars: &[String]) -> Option<Expr> {
+  // One variable is the ordinary single-equation case, and a system with
+  // fewer equations than variables is underdetermined.
+  if vars.len() < 2 || eqs.len() < vars.len() || vars.len() > MAX_SYSTEM_VARS {
+    return None;
+  }
+  let mut polys = Vec::with_capacity(eqs.len());
+  for eq in eqs {
+    let (lhs, rhs, op) =
+      crate::functions::polynomial_ast::reduce::extract_comparison(eq)?;
+    if !matches!(op, crate::functions::polynomial_ast::reduce::CompOp::Equal) {
+      return None;
+    }
+    let poly = expand_and_combine(&Expr::BinaryOp {
+      op: BinaryOperator::Minus,
+      left: Box::new(lhs),
+      right: Box::new(rhs),
+    });
+    // Every symbol has to be one of the unknowns: a free parameter leaves
+    // the solutions symbolic, and a symbolic solution cannot be checked
+    // against the equations it did not come from.
+    let mut free = Vec::new();
+    collect_solve_vars(&poly, &mut free);
+    if free.iter().any(|f| !vars.contains(f)) {
+      return None;
+    }
+    if !vars
+      .iter()
+      .all(|v| crate::functions::polynomial_ast::is_polynomial(&poly, v))
+    {
+      return None;
+    }
+    polys.push(poly);
+  }
+
+  let solutions = poly_system_solutions(&polys, vars)?;
+  if solutions.is_empty() {
+    return Some(Expr::List(Vec::new().into()));
+  }
+  let mut wrapped: Vec<Expr> = solutions
+    .into_iter()
+    .map(|values| {
+      Expr::List(
+        vars
+          .iter()
+          .zip(values)
+          .map(|(v, value)| Expr::Rule {
+            pattern: Box::new(Expr::Identifier(v.clone())),
+            replacement: Box::new(value),
+          })
+          .collect(),
+      )
+    })
+    .collect();
+  // Real solutions come before complex ones, as everywhere else in Solve.
+  wrapped.sort_by_key(|sol| if contains_complex(sol) { 1 } else { 0 });
+  Some(Expr::List(wrapped.into()))
+}
+
+/// More variables than this and the eliminations multiply out of hand.
+const MAX_SYSTEM_VARS: usize = 4;
+
+/// The largest Sylvester matrix an elimination step is allowed to build.
+/// Two cubics already produce a degree-9 polynomial in the variable that
+/// survives, which is past what Solve reports in radicals anyway.
+const MAX_SYLVESTER_SIZE: i128 = 8;
+
+/// Values for `vars`, in order, at every common root of `polys`.
+///
+/// `var` (the last one) is eliminated first: the equations containing it are
+/// divided into one another until only one still does, and what falls out
+/// are equations in the remaining variables. Those are solved by recursion,
+/// and each of their solutions is put back into the original equations,
+/// which then only leave `var` to solve for.
+fn poly_system_solutions(
+  polys: &[Expr],
+  vars: &[String],
+) -> Option<Vec<Vec<Expr>>> {
+  let (var, outer_vars) = vars.split_last()?;
+
+  // Eliminate `var` down to a single equation. Every step replaces the
+  // higher-degree of two equations with one of strictly lower degree in
+  // `var`, so this terminates.
+  let mut working: Vec<Expr> = polys.to_vec();
+  loop {
+    let mut in_var: Vec<usize> = (0..working.len())
+      .filter(|i| max_power_int(&working[*i], var).unwrap_or(0) > 0)
+      .collect();
+    if in_var.len() < 2 {
+      break;
+    }
+    in_var.sort_by_key(|i| max_power_int(&working[*i], var).unwrap_or(0));
+    let divisor = in_var[0];
+    let dividend = in_var[1];
+    working[dividend] =
+      eliminate_var(&working[dividend], &working[divisor], var)?;
+  }
+
+  let mut solved_for_var: Option<&Expr> = None;
+  let mut reduced: Vec<Expr> = Vec::new();
+  for poly in &working {
+    if max_power_int(poly, var).unwrap_or(0) > 0 {
+      solved_for_var = Some(poly);
+    } else if !is_zero_expr(poly) {
+      reduced.push(poly.clone());
+    }
+  }
+  // Nothing left to pin `var` down: the system is underdetermined.
+  let solved_for_var = solved_for_var?;
+
+  if outer_vars.is_empty() {
+    // A leftover equation in no variable at all is either the trivial
+    // `0 == 0`, already dropped, or a contradiction.
+    if reduced.iter().any(|p| !is_zero_expr(p)) {
+      return Some(Vec::new());
+    }
+    let mut result: Vec<Vec<Expr>> = Vec::new();
+    for value in roots_of_last_variable(polys, solved_for_var, var)? {
+      for _ in 0..root_multiplicity(polys, &value, var) {
+        result.push(vec![value.clone()]);
+      }
+    }
+    return Some(result);
+  }
+
+  if reduced.is_empty() {
+    return None;
+  }
+  let outer_solutions = poly_system_solutions(&reduced, outer_vars)?;
+
+  let mut result: Vec<Vec<Expr>> = Vec::new();
+  let mut index = 0;
+  while index < outer_solutions.len() {
+    // Solutions repeat in the reduced system when several points of the
+    // full system share those outer values, and also when the point they
+    // share counts more than once.
+    let outer = &outer_solutions[index];
+    let mut outer_multiplicity = 0;
+    while index < outer_solutions.len()
+      && solution_values_equal(outer, &outer_solutions[index])
+    {
+      outer_multiplicity += 1;
+      index += 1;
+    }
+
+    let substituted: Vec<Expr> = polys
+      .iter()
+      .map(|p| substitute_values(p, outer_vars, outer))
+      .collect();
+    let pivot = substituted
+      .iter()
+      .filter(|p| max_power_int(p, var).unwrap_or(0) > 0)
+      .min_by_key(|p| max_power_int(p, var).unwrap_or(i128::MAX))?;
+    for value in roots_of_last_variable(&substituted, pivot, var)? {
+      for _ in
+        0..outer_multiplicity * root_multiplicity(&substituted, &value, var)
+      {
+        let mut full = outer.clone();
+        full.push(value.clone());
+        result.push(full);
+      }
+    }
+  }
+  Some(result)
+}
+
+/// How often the solution at `value` counts.
+///
+/// A curve can meet the line the other variables were fixed to twice over
+/// while still crossing the other curve just once — the circle `x^2 + y^2
+/// == 1` touches `x == 1` twice, but meets `(x - 1)^2 + (y - 1)^2 == 1`
+/// transversally there. So the count is the smallest multiplicity `value`
+/// has among the equations, not the one the equation solved for it happens
+/// to report.
+fn root_multiplicity(polys: &[Expr], value: &Expr, var: &str) -> usize {
+  let mut multiplicity = usize::MAX;
+  for poly in polys {
+    if max_power_int(poly, var).unwrap_or(0) <= 0 {
+      continue;
+    }
+    let Some(roots) = univariate_roots(poly, var) else {
+      continue;
+    };
+    let count = roots.iter().filter(|r| values_equal(r, value)).count();
+    if count > 0 {
+      multiplicity = multiplicity.min(count);
+    }
+  }
+  if multiplicity == usize::MAX {
+    1
+  } else {
+    multiplicity
+  }
+}
+
+/// The distinct roots of `pivot` in `var` that satisfy every polynomial in
+/// `polys`. How often each counts is `root_multiplicity`'s business.
+fn roots_of_last_variable(
+  polys: &[Expr],
+  pivot: &Expr,
+  var: &str,
+) -> Option<Vec<Expr>> {
+  let vars = [var.to_string()];
+  let mut roots: Vec<Expr> = Vec::new();
+  for value in univariate_roots(pivot, var)? {
+    if roots.iter().any(|kept| values_equal(kept, &value)) {
+      continue;
+    }
+    if polys
+      .iter()
+      .all(|p| poly_vanishes_at(p, &vars, std::slice::from_ref(&value)))
+    {
+      roots.push(value);
+    }
+  }
+  Some(roots)
+}
+
+/// Combine `dividend` and `divisor` into an equation of strictly lower
+/// degree in `var` that every common root of the two still satisfies.
+///
+/// Polynomial division does it whenever the divisor's leading coefficient is
+/// a number, and then the step is reversible — no root is gained or lost,
+/// and the remainder of two circles is the line through their intersections,
+/// which is far better conditioned than anything built from their squares.
+/// A leading coefficient that itself depends on the other variables would
+/// need dividing through by an expression that may vanish, so those go to
+/// the resultant instead, which eliminates `var` outright.
+fn eliminate_var(dividend: &Expr, divisor: &Expr, var: &str) -> Option<Expr> {
+  let var_expr = Expr::Identifier(var.to_string());
+  if leading_coefficient_is_numeric(divisor, var) {
+    let remainder =
+      crate::functions::polynomial_ast::polynomial_remainder_ast(&[
+        dividend.clone(),
+        divisor.clone(),
+        var_expr,
+      ])
+      .ok()?;
+    return Some(drop_rounding_noise(&expand_and_combine(&remainder)));
+  }
+  let dividend_degree = max_power_int(dividend, var)?;
+  let divisor_degree = max_power_int(divisor, var)?;
+  if dividend_degree + divisor_degree > MAX_SYLVESTER_SIZE {
+    return None;
+  }
+  let eliminated = crate::functions::polynomial_ast::resultant_ast(&[
+    dividend.clone(),
+    divisor.clone(),
+    var_expr,
+  ])
+  .ok()?;
+  let eliminated = drop_rounding_noise(&expand_and_combine(&eliminated));
+  // A resultant that vanishes identically means the two equations share a
+  // whole curve, so the system is not zero-dimensional.
+  if is_zero_expr(&eliminated) {
+    return None;
+  }
+  Some(eliminated)
+}
+
+/// Drop the terms of an eliminated equation that are made of nothing but
+/// rounding error.
+///
+/// Terms that cancel exactly in exact arithmetic only cancel to within a
+/// rounding error in inexact arithmetic, and what is left behind claims the
+/// eliminated variable is still there — with a coefficient small enough that
+/// dividing by it swamps the equation in noise. A term more than twelve
+/// orders of magnitude below the largest one in the same equation is that
+/// leftover, not a coefficient anybody wrote. Exact equations are left
+/// alone: nothing there is approximate.
+fn drop_rounding_noise(poly: &Expr) -> Expr {
+  if !contains_inexact_number(poly) {
+    return poly.clone();
+  }
+  let terms = collect_additive_terms(poly);
+  let magnitudes: Vec<f64> = terms.iter().map(term_magnitude).collect();
+  let largest = magnitudes.iter().copied().fold(0.0, f64::max);
+  if largest == 0.0 {
+    return poly.clone();
+  }
+  let kept: Vec<Expr> = terms
+    .iter()
+    .zip(&magnitudes)
+    .filter(|(_, magnitude)| **magnitude > 1e-12 * largest)
+    .map(|(term, _)| term.clone())
+    .collect();
+  if kept.len() == terms.len() {
+    return poly.clone();
+  }
+  if kept.is_empty() {
+    return Expr::Integer(0);
+  }
+  expand_and_combine(&build_sum(kept))
+}
+
+/// The size of a term's numeric part, taking anything symbolic as a factor
+/// of one.
+fn term_magnitude(term: &Expr) -> f64 {
+  let mut magnitude = 1.0;
+  for factor in collect_multiplicative_factors(term) {
+    if let Some((re, im)) = try_extract_complex_f64(&factor) {
+      magnitude *= re.hypot(im);
+    }
+  }
+  magnitude
+}
+
+/// Whether any number in `expr` is a machine-precision one.
+fn contains_inexact_number(expr: &Expr) -> bool {
+  match expr {
+    Expr::Real(_) => true,
+    Expr::List(items) => items.iter().any(contains_inexact_number),
+    Expr::FunctionCall { args, .. } => args.iter().any(contains_inexact_number),
+    Expr::BinaryOp { left, right, .. } => {
+      contains_inexact_number(left) || contains_inexact_number(right)
+    }
+    Expr::UnaryOp { operand, .. } => contains_inexact_number(operand),
+    _ => false,
+  }
+}
+
+/// Whether the coefficient of the highest power of `var` in `poly` is a
+/// number other than zero.
+fn leading_coefficient_is_numeric(poly: &Expr, var: &str) -> bool {
+  let Some(degree) = max_power_int(poly, var) else {
+    return false;
+  };
+  let Ok(leading) = crate::functions::polynomial_ast::coefficient_ast(&[
+    poly.clone(),
+    Expr::Identifier(var.to_string()),
+    Expr::Integer(degree),
+  ]) else {
+    return false;
+  };
+  let Ok(leading) = crate::evaluator::evaluate_expr_to_expr(&leading) else {
+    return false;
+  };
+  match try_extract_complex_f64(&leading) {
+    Some((re, im)) => re != 0.0 || im != 0.0,
+    None => false,
+  }
+}
+
+/// The roots of `poly` (as `poly == 0`) in `var`, with multiplicity, or
+/// `None` when Solve cannot report them explicitly.
+fn univariate_roots(poly: &Expr, var: &str) -> Option<Vec<Expr>> {
+  let equation = Expr::Comparison {
+    operands: vec![poly.clone(), Expr::Integer(0)],
+    operators: vec![ComparisonOp::Equal],
+  };
+  let solved =
+    solve_ast(&[equation, Expr::Identifier(var.to_string())]).ok()?;
+  let Expr::List(ref solutions) = solved else {
+    return None;
+  };
+  let mut roots = Vec::with_capacity(solutions.len());
+  for solution in solutions.iter() {
+    let Expr::List(rules) = solution else {
+      return None;
+    };
+    let [Expr::Rule { replacement, .. }] = rules.as_slice() else {
+      return None;
+    };
+    // A root reported as an unsolved `Root[…]` object is no use for
+    // substituting back into the remaining equations.
+    if expr_to_string(replacement).contains("Root[") {
+      return None;
+    }
+    roots.push(replacement.as_ref().clone());
+  }
+  Some(roots)
+}
+
+/// Substitute `values` for `vars` in `expr` and evaluate.
+fn substitute_values(expr: &Expr, vars: &[String], values: &[Expr]) -> Expr {
+  let mut substituted = expr.clone();
+  for (var, value) in vars.iter().zip(values) {
+    substituted = crate::syntax::substitute_variable(&substituted, var, value);
+  }
+  let evaluated = crate::evaluator::evaluate_expr_to_expr(&substituted)
+    .unwrap_or(substituted);
+  expand_and_combine(&evaluated)
+}
+
+/// Whether `poly` is zero once `values` are substituted for `vars`.
+///
+/// An exact substitution may leave a root such as `Sqrt[7]/2` in a form that
+/// does not collapse to a literal zero, and an inexact one never lands on
+/// zero exactly, so the residual is weighed against the size of the terms it
+/// cancelled between.
+fn poly_vanishes_at(poly: &Expr, vars: &[String], values: &[Expr]) -> bool {
+  let substituted = substitute_values(poly, vars, values);
+  if is_zero_expr(&substituted) {
+    return true;
+  }
+  let Some((re, im)) = try_extract_complex_f64(&substituted) else {
+    return false;
+  };
+  let mut scale: f64 = 1.0;
+  for term in collect_additive_terms(&substituted) {
+    if let Some((tre, tim)) = try_extract_complex_f64(&term) {
+      scale += tre.hypot(tim);
+    }
+  }
+  re.hypot(im) <= 1e-9 * scale
+}
+
+/// Whether `expr` is the literal zero left by a cancellation.
+fn is_zero_expr(expr: &Expr) -> bool {
+  matches!(expr, Expr::Integer(0)) || matches!(expr, Expr::Real(r) if *r == 0.0)
+}
+
+/// Whether two values name the same number — structurally, or numerically
+/// for the inexact ones that never match structurally.
+fn values_equal(a: &Expr, b: &Expr) -> bool {
+  if expr_to_string(a) == expr_to_string(b) {
+    return true;
+  }
+  let (Some((are, aim)), Some((bre, bim))) =
+    (try_extract_complex_f64(a), try_extract_complex_f64(b))
+  else {
+    return false;
+  };
+  let scale = 1.0 + are.hypot(aim).max(bre.hypot(bim));
+  (are - bre).hypot(aim - bim) <= 1e-9 * scale
+}
+
+/// Whether two solutions assign the same values to every variable.
+fn solution_values_equal(a: &[Expr], b: &[Expr]) -> bool {
+  a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| values_equal(x, y))
 }
 
 /// Highest power of `var` in `eq` (treated as `lhs - rhs`). Returns
@@ -4034,7 +4493,7 @@ fn try_solve_inverse_function(
       let inverse_exp = Expr::BinaryOp {
         op: BinaryOperator::Divide,
         left: Box::new(Expr::Integer(1)),
-        right: Box::new(exp),
+        right: Box::new(exp.clone()),
       };
       let inverse_rhs = Expr::BinaryOp {
         op: BinaryOperator::Power,
@@ -4047,7 +4506,15 @@ fn try_solve_inverse_function(
         operands: vec![base, simplified_rhs],
         operators: vec![ComparisonOp::Equal],
       };
-      return Some(solve_ast(&[new_eq, Expr::Identifier(var.to_string())]));
+      let solved = solve_ast(&[new_eq, Expr::Identifier(var.to_string())]);
+      // An even root takes only its principal value, so undoing it can
+      // produce an answer the equation itself does not have.
+      return Some(match rational_parts(&exp) {
+        Some((_, denominator)) if denominator % 2 == 0 => {
+          keep_solutions_satisfying(solved, eq, var)
+        }
+        _ => solved,
+      });
     }
     if !is_constant_wrt(&exp, var) && is_constant_wrt(&base, var) {
       // b^x == val (bare-var exponent, constant base): the full complex
@@ -4265,10 +4732,46 @@ fn try_solve_inverse_function(
     };
 
     // Recursively solve the resulting equation
-    Some(solve_ast(&[new_eq, Expr::Identifier(var.to_string())]))
+    let solved = solve_ast(&[new_eq, Expr::Identifier(var.to_string())]);
+    // `Sqrt` is never negative, so squaring the equation away can produce
+    // an answer the equation itself does not have.
+    Some(if name == "Sqrt" {
+      keep_solutions_satisfying(solved, eq, var)
+    } else {
+      solved
+    })
   } else {
     None
   }
+}
+
+/// Drop the solutions that do not satisfy `equation`. A solution that
+/// cannot be checked is kept: it would have to be dropped on a suspicion.
+fn keep_solutions_satisfying(
+  solved: Result<Expr, InterpreterError>,
+  equation: &Expr,
+  var: &str,
+) -> Result<Expr, InterpreterError> {
+  let solved = solved?;
+  let Expr::List(ref solutions) = solved else {
+    return Ok(solved);
+  };
+  let mut kept: Vec<Expr> = Vec::new();
+  for solution in solutions.iter() {
+    let value = match solution {
+      Expr::List(rules) => match rules.as_slice() {
+        [Expr::Rule { replacement, .. }] => Some(replacement.as_ref()),
+        _ => None,
+      },
+      _ => None,
+    };
+    if value.and_then(|value| equation_holds_at(equation, var, value))
+      != Some(false)
+    {
+      kept.push(solution.clone());
+    }
+  }
+  Ok(Expr::List(kept.into()))
 }
 
 /// Try to solve a non-polynomial equation by factoring out common
@@ -4278,6 +4781,203 @@ fn try_solve_inverse_function(
 /// - Common base: `(a²+x²)`, min exponent: `1/2`
 /// - After factoring out `(a²+x²)^(1/2)`: `2*k*q*(a²+x²) - 6*k*q*x²`
 /// - Solve the remaining polynomial: `x = ±a/Sqrt[2]`
+/// Solve an equation that takes a root of the unknown.
+///
+/// One radical term is put on its own and both sides are raised to that
+/// root's index, which clears it; what is left is solved as usual and each
+/// answer is put back into the equation it came from. That last step is not
+/// a formality — raising to a power throws away which branch of the root was
+/// meant, so `Sqrt[2 x + 3] == x` picks up an `x == -1` that solves the
+/// squared equation and not the original one. Anything that cannot be
+/// checked that way is left to the caller rather than reported on trust.
+fn try_solve_radical_equation(
+  poly: &Expr,
+  equation: &Expr,
+  var: &str,
+) -> Option<Result<Expr, InterpreterError>> {
+  if has_inequality(equation) {
+    return None;
+  }
+  let (_, _, CompOp::Equal) =
+    crate::functions::polynomial_ast::reduce::extract_comparison(equation)?
+  else {
+    return None;
+  };
+  let terms = collect_additive_terms(&expand_and_combine(poly));
+  let radical_terms = terms
+    .iter()
+    .filter(|term| radical_index(term, var).is_some())
+    .count();
+  if radical_terms == 0 || terms.len() < 2 {
+    return None;
+  }
+  let isolated = terms
+    .iter()
+    .position(|term| radical_index(term, var).is_some())?;
+  let index = radical_index(&terms[isolated], var)?;
+  if index > MAX_RADICAL_INDEX {
+    return None;
+  }
+
+  let rest = build_sum(
+    terms
+      .iter()
+      .enumerate()
+      .filter(|(position, _)| *position != isolated)
+      .map(|(_, term)| negate_expr(term))
+      .collect(),
+  );
+  let raise = |base: &Expr| {
+    crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
+      op: BinaryOperator::Power,
+      left: Box::new(base.clone()),
+      right: Box::new(Expr::Integer(index)),
+    })
+    .ok()
+  };
+  let cleared = expand_and_combine(&Expr::BinaryOp {
+    op: BinaryOperator::Minus,
+    left: Box::new(raise(&terms[isolated])?),
+    right: Box::new(raise(&rest)?),
+  });
+  // Raising has to leave fewer roots behind than it found, or the equation
+  // would come straight back here and never settle.
+  let left_over = collect_additive_terms(&cleared)
+    .iter()
+    .filter(|term| radical_index(term, var).is_some())
+    .count();
+  if left_over >= radical_terms {
+    return None;
+  }
+
+  let cleared_equation = Expr::Comparison {
+    operands: vec![cleared, Expr::Integer(0)],
+    operators: vec![ComparisonOp::Equal],
+  };
+  let solved =
+    solve_ast(&[cleared_equation, Expr::Identifier(var.to_string())]).ok()?;
+  let Expr::List(ref candidates) = solved else {
+    return None;
+  };
+  let mut kept: Vec<Expr> = Vec::new();
+  for candidate in candidates.iter() {
+    let Expr::List(rules) = candidate else {
+      return None;
+    };
+    let [Expr::Rule { replacement, .. }] = rules.as_slice() else {
+      return None;
+    };
+    if equation_holds_at(equation, var, replacement)? {
+      kept.push(candidate.clone());
+    }
+  }
+  Some(Ok(Expr::List(kept.into())))
+}
+
+/// Roots beyond this index are left alone: raising to them makes a
+/// polynomial no solver reports in radicals anyway.
+const MAX_RADICAL_INDEX: i128 = 4;
+
+/// The index of the root `term` takes of the unknown — 2 for a square root,
+/// 3 for a cube root — or `None` for a term that takes none. A term under
+/// several roots at once reports the index that clears all of them.
+fn radical_index(term: &Expr, var: &str) -> Option<i128> {
+  let root_here = |expr: &Expr| -> Option<i128> {
+    if let Some(inner) = is_sqrt(expr) {
+      return (!is_constant_wrt(inner, var)).then_some(2);
+    }
+    let (base, exponent) = extract_base_and_exp(expr);
+    if is_constant_wrt(&base, var) {
+      return None;
+    }
+    match rational_parts(&exponent) {
+      Some((_, denominator)) if denominator > 1 => Some(denominator),
+      _ => None,
+    }
+  };
+  fn walk(
+    expr: &Expr,
+    root_here: &dyn Fn(&Expr) -> Option<i128>,
+    index: &mut Option<i128>,
+  ) {
+    if let Some(root) = root_here(expr) {
+      *index = Some(match *index {
+        None => root,
+        Some(current) => lcm_i128(current, root),
+      });
+    }
+    match expr {
+      Expr::BinaryOp { left, right, .. } => {
+        walk(left, root_here, index);
+        walk(right, root_here, index);
+      }
+      Expr::UnaryOp { operand, .. } => walk(operand, root_here, index),
+      Expr::FunctionCall { args, .. } => {
+        for arg in args.iter() {
+          walk(arg, root_here, index);
+        }
+      }
+      _ => {}
+    }
+  }
+  let mut index = None;
+  walk(term, &root_here, &mut index);
+  index
+}
+
+/// An exponent written as a ratio of two integers, however it is spelled.
+fn rational_parts(exponent: &Expr) -> Option<(i128, i128)> {
+  match exponent {
+    Expr::FunctionCall { name, args }
+      if name == "Rational" && args.len() == 2 =>
+    {
+      match (&args[0], &args[1]) {
+        (Expr::Integer(numerator), Expr::Integer(denominator)) => {
+          Some((*numerator, *denominator))
+        }
+        _ => None,
+      }
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Divide,
+      left,
+      right,
+    } => match (left.as_ref(), right.as_ref()) {
+      (Expr::Integer(numerator), Expr::Integer(denominator)) => {
+        Some((*numerator, *denominator))
+      }
+      _ => None,
+    },
+    _ => None,
+  }
+}
+
+/// Whether `equation` holds with `value` put in for `var`, or `None` when
+/// that cannot be decided.
+fn equation_holds_at(equation: &Expr, var: &str, value: &Expr) -> Option<bool> {
+  let (lhs, rhs, CompOp::Equal) =
+    crate::functions::polynomial_ast::reduce::extract_comparison(equation)?
+  else {
+    return None;
+  };
+  let at_value = |side: &Expr| {
+    let substituted = crate::syntax::substitute_variable(side, var, value);
+    quietly(|| crate::evaluator::evaluate_expr_to_expr(&substituted)).ok()
+  };
+  let left = at_value(&lhs)?;
+  let right = at_value(&rhs)?;
+  if expr_to_string(&left) == expr_to_string(&right) {
+    return Some(true);
+  }
+  // An exact root only cancels to a literal zero once it is worked out, and
+  // an inexact one never quite does, so the two sides are compared as
+  // numbers against the size of what they are made of.
+  let (left_re, left_im) = try_extract_complex_f64(&left)?;
+  let (right_re, right_im) = try_extract_complex_f64(&right)?;
+  let scale = 1.0 + left_re.hypot(left_im).max(right_re.hypot(right_im));
+  Some((left_re - right_re).hypot(left_im - right_im) <= 1e-9 * scale)
+}
+
 fn try_solve_factoring_powers(
   expanded: &Expr,
   var: &str,

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -3228,17 +3228,15 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 }
 
-/// Solve a system of polynomial equations by eliminating variables with
-/// resultants.
+/// Solve a system of polynomial equations by eliminating one variable at a
+/// time.
 ///
 /// Solving one equation for one variable and substituting — what the generic
 /// `Reduce` path does — introduces a radical as soon as that equation is
 /// quadratic in the variable, and the radical then has to be eliminated all
-/// over again from the equations it was substituted into. Elimination by
-/// resultant keeps every intermediate a polynomial: `Resultant[p, q, v]`
-/// vanishes exactly at those values of the remaining variables for which `p`
-/// and `q` have a common root in `v`, so the system loses a variable and
-/// stays a polynomial system.
+/// over again from the equations it was substituted into. Combining whole
+/// equations instead keeps every intermediate a polynomial, so the system
+/// loses a variable and stays a polynomial system.
 ///
 /// Returns `None` for anything this cannot settle — a non-polynomial or
 /// parameterised equation, a system that stays underdetermined, a polynomial
@@ -4774,13 +4772,6 @@ fn keep_solutions_satisfying(
   Ok(Expr::List(kept.into()))
 }
 
-/// Try to solve a non-polynomial equation by factoring out common
-/// sub-expressions with fractional exponents.
-///
-/// For example: `2*k*q*(a²+x²)^(3/2) - 6*k*q*x²*(a²+x²)^(1/2) == 0`
-/// - Common base: `(a²+x²)`, min exponent: `1/2`
-/// - After factoring out `(a²+x²)^(1/2)`: `2*k*q*(a²+x²) - 6*k*q*x²`
-/// - Solve the remaining polynomial: `x = ±a/Sqrt[2]`
 /// Solve an equation that takes a root of the unknown.
 ///
 /// One radical term is put on its own and both sides are raised to that
@@ -4978,6 +4969,13 @@ fn equation_holds_at(equation: &Expr, var: &str, value: &Expr) -> Option<bool> {
   Some((left_re - right_re).hypot(left_im - right_im) <= 1e-9 * scale)
 }
 
+/// Try to solve a non-polynomial equation by factoring out common
+/// sub-expressions with fractional exponents.
+///
+/// For example: `2*k*q*(a²+x²)^(3/2) - 6*k*q*x²*(a²+x²)^(1/2) == 0`
+/// - Common base: `(a²+x²)`, min exponent: `1/2`
+/// - After factoring out `(a²+x²)^(1/2)`: `2*k*q*(a²+x²) - 6*k*q*x²`
+/// - Solve the remaining polynomial: `x = ±a/Sqrt[2]`
 fn try_solve_factoring_powers(
   expanded: &Expr,
   var: &str,

--- a/tests/cli/math/polynomials/Resultant.md
+++ b/tests/cli/math/polynomials/Resultant.md
@@ -6,3 +6,11 @@ Resultant of two polynomials in a given variable.
 $ wo 'Resultant[x^2 - 1, x + 1, x]'
 0
 ```
+
+The resultant of two polynomials in more than one variable is a polynomial
+in the variables that are left, reported multiplied out:
+
+```scrut
+$ wo 'Resultant[x^2 + y^2 - 1, (x - 1)^2 + (y - 1)^2 - 1, y]'
+-8*x + 8*x^2
+```

--- a/tests/cli/symbolic/Solve.md
+++ b/tests/cli/symbolic/Solve.md
@@ -172,3 +172,45 @@ equations:
 $ wo 'Solve[Table[BernoulliB[n, z], {n, 3, 3}] == 0]'
 {{z -> 0}, {z -> 1/2}, {z -> 1}}
 ```
+
+A system of polynomial equations is solved by eliminating one variable at a
+time. Two circles meet in the two points on the line through their
+intersections:
+
+```scrut
+$ wo 'Solve[{x^2 + y^2 == 1, (x - 1)^2 + (y - 1)^2 == 1}, {x, y}]'
+{{x -> 0, y -> 1}, {x -> 1, y -> 0}}
+```
+
+Circles that only touch meet in one point, which counts twice, and circles
+too far apart to meet at all still meet over the complex numbers:
+
+```scrut
+$ wo 'Solve[{x^2 + y^2 == 1, (x - 2)^2 + y^2 == 1}, {x, y}]'
+{{x -> 1, y -> 0}, {x -> 1, y -> 0}}
+```
+
+```scrut
+$ wo 'Solve[{x^2 + y^2 == 1, (x - 5)^2 + y^2 == 1}, {x, y}]'
+{{x -> 5/2, y -> -1/2*I*Sqrt[21]}, {x -> 5/2, y -> I/2*Sqrt[21]}}
+```
+
+An equation carrying a root of the unknown is raised to that root's index,
+and the answers that only solve the raised equation are dropped again:
+
+```scrut
+$ wo 'Solve[Sqrt[x] == x, x]'
+{{x -> 0}, {x -> 1}}
+```
+
+```scrut
+$ wo 'Solve[Sqrt[2 x + 3] == x, x]'
+{{x -> 3}}
+```
+
+`Sqrt` is the principal root, so it never equals a negative number:
+
+```scrut
+$ wo 'Solve[Sqrt[x] == -1, x]'
+{}
+```

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -4694,6 +4694,104 @@ mod solve {
     );
   }
 
+  // Two conics are intersected by dividing one equation into the other,
+  // which for two circles leaves the line through their intersections.
+  #[test]
+  fn two_circles_meeting_twice() {
+    assert_eq!(
+      interpret("Solve[{x^2 + y^2 == 1, (x - 1)^2 + (y - 1)^2 == 1}, {x, y}]")
+        .unwrap(),
+      "{{x -> 0, y -> 1}, {x -> 1, y -> 0}}"
+    );
+    // The conjunction spelling of the same system.
+    assert_eq!(
+      interpret("Solve[x^2 + y^2 == 1 && (x - 1)^2 + (y - 1)^2 == 1, {x, y}]")
+        .unwrap(),
+      "{{x -> 0, y -> 1}, {x -> 1, y -> 0}}"
+    );
+  }
+
+  // Both intersections share an x coordinate, so eliminating y leaves a
+  // squared factor rather than two separate roots.
+  #[test]
+  fn two_circles_meeting_above_each_other() {
+    assert_eq!(
+      interpret("Solve[{(x + 1)^2 + y^2 == 2, (x - 1)^2 + y^2 == 2}, {x, y}]")
+        .unwrap(),
+      "{{x -> 0, y -> -1}, {x -> 0, y -> 1}}"
+    );
+    assert_eq!(
+      interpret("Solve[{x^2 + y^2 == 4, (x - 3)^2 + y^2 == 4}, {x, y}]")
+        .unwrap(),
+      "{{x -> 3/2, y -> -1/2*Sqrt[7]}, {x -> 3/2, y -> Sqrt[7]/2}}"
+    );
+  }
+
+  // Touching circles meet in one point, which counts twice.
+  #[test]
+  fn two_circles_touching() {
+    assert_eq!(
+      interpret("Solve[{x^2 + y^2 == 1, (x - 2)^2 + y^2 == 1}, {x, y}]")
+        .unwrap(),
+      "{{x -> 1, y -> 0}, {x -> 1, y -> 0}}"
+    );
+  }
+
+  // Circles too far apart to meet still meet over the complex numbers.
+  #[test]
+  fn two_circles_meeting_nowhere_real() {
+    assert_eq!(
+      interpret("Solve[{x^2 + y^2 == 1, (x - 5)^2 + y^2 == 1}, {x, y}]")
+        .unwrap(),
+      "{{x -> 5/2, y -> -1/2*I*Sqrt[21]}, {x -> 5/2, y -> I/2*Sqrt[21]}}"
+    );
+  }
+
+  // Inexact coefficients are what a Demonstration computing intersections
+  // from a slider position hands the solver.
+  #[test]
+  fn two_circles_with_inexact_coefficients() {
+    assert_eq!(
+      interpret("Solve[{x^2 + y^2 == 1., x^2 + (y - 1.)^2 == 0.49}, {x, y}]")
+        .unwrap(),
+      "{{x -> -0.6557247898318318, y -> 0.755}, \
+       {x -> 0.6557247898318318, y -> 0.755}}"
+    );
+    // Two equal circles whose intersections sit above each other: the
+    // squared factor this leaves is what a floating-point elimination has
+    // to get through without turning a double root into a complex pair.
+    assert_eq!(
+      interpret(
+        "Solve[{(x - 2.)^2 + y^2 == 2., (x - 4.)^2 + y^2 == 2.}, {x, y}]"
+      )
+      .unwrap(),
+      "{{x -> 3., y -> -1.}, {x -> 3., y -> 1.}}"
+    );
+  }
+
+  // A sphere cut by two planes, which needs two eliminations in a row.
+  #[test]
+  fn nonlinear_system_in_three_variables() {
+    assert_eq!(
+      interpret(
+        "Solve[{x + y + z == 6, x^2 + y^2 + z^2 == 14, x - y == 1}, \
+         {x, y, z}]"
+      )
+      .unwrap(),
+      "{{x -> 2, y -> 1, z -> 3}, {x -> 3, y -> 2, z -> 1}}"
+    );
+  }
+
+  // A circle and a parabola touching: the tangency counts twice even
+  // though each equation on its own has a simple root there.
+  #[test]
+  fn parabolas_touching() {
+    assert_eq!(
+      interpret("Solve[{y == x^2, y == 2 x^2}, {x, y}]").unwrap(),
+      "{{x -> 0, y -> 0}, {x -> 0, y -> 0}}"
+    );
+  }
+
   #[test]
   fn linear_system_with_and_in_list() {
     // Solve[{eq1 && eq2}, {x, y}] should behave like
@@ -4866,6 +4964,59 @@ mod solve {
       interpret("Solve[Sqrt[x + 1] == 4, x]").unwrap(),
       "{{x -> 15}}"
     );
+  }
+
+  // A root of the unknown on both sides is squared away, and the roots that
+  // only solve the squared equation are dropped again.
+  #[test]
+  fn solve_sqrt_equation_with_unknown_on_both_sides() {
+    assert_eq!(
+      interpret("Solve[Sqrt[x] == x, x]").unwrap(),
+      "{{x -> 0}, {x -> 1}}"
+    );
+    // Squaring turns this into x^2 - 2 x - 3 == 0, whose root -1 solves the
+    // squared equation and not this one.
+    assert_eq!(
+      interpret("Solve[Sqrt[2 x + 3] == x, x]").unwrap(),
+      "{{x -> 3}}"
+    );
+    assert_eq!(
+      interpret("Solve[x + Sqrt[x] == 6, x]").unwrap(),
+      "{{x -> 4}}"
+    );
+    assert_eq!(
+      interpret("Solve[Sqrt[1 - x^2] == 1 - x, x]").unwrap(),
+      "{{x -> 0}, {x -> 1}}"
+    );
+    assert_eq!(
+      interpret("Solve[Sqrt[1 - x^2] == x + 1, x]").unwrap(),
+      "{{x -> -1}, {x -> 0}}"
+    );
+    assert_eq!(
+      interpret("Solve[Sqrt[4 - x^2] == x - 2, x]").unwrap(),
+      "{{x -> 2}}"
+    );
+  }
+
+  // Two roots take two squarings, one after the other.
+  #[test]
+  fn solve_equation_with_two_square_roots() {
+    assert_eq!(
+      interpret("Solve[Sqrt[x + 5] - Sqrt[x] == 1, x]").unwrap(),
+      "{{x -> 4}}"
+    );
+    assert_eq!(
+      interpret("Solve[Sqrt[x] == Sqrt[3 x - 2], x]").unwrap(),
+      "{{x -> 1}}"
+    );
+  }
+
+  // `Sqrt` is the principal root, so it never equals a negative number —
+  // squaring the equation away must not invent the root that would.
+  #[test]
+  fn solve_sqrt_equal_to_a_negative_number() {
+    assert_eq!(interpret("Solve[Sqrt[x] == -1, x]").unwrap(), "{}");
+    assert_eq!(interpret("Solve[Sqrt[x - 3] == -2, x]").unwrap(), "{}");
   }
 
   // Abs[f(x)] == c → f == c ∪ f == -c.

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -8927,6 +8927,70 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
   }
 
   #[test]
+  fn compass_construction_manipulate_builds_widget() {
+    // End-to-end regression for a Demonstration that constructs with
+    // compasses alone: the initialization crosses two circles through
+    // `Solve`, a setter bar steps through the construction, and the body
+    // picks that step's graphics out of the list the function returns.
+    let code = "Manipulate[\
+      Graphics[steps[t, r][[step]], PlotRange -> 2, ImageSize -> {300, 300}], \
+      {{t, Pi/2, \"turn\"}, 0, 2 Pi}, \
+      {{r, 0.7, \"reach\"}, 0.5, 1.2, Appearance -> \"Labeled\"}, \
+      Control[{{step, 2, \"step\"}, {1, 2}}], \
+      TrackedSymbols :> {t, r, step}, \
+      Initialization :> (steps[t_, r_] := \
+        Module[{p, sol, x, y, hits}, \
+          p = {Cos[t], Sin[t]}; \
+          sol = Quiet[Solve[x^2 + y^2 == 1 && \
+            (x - p[[1]])^2 + (y - p[[2]])^2 == r^2, {x, y}]]; \
+          hits = {{x, y} /. sol[[1]], {x, y} /. sol[[2]]}; \
+          {{Circle[], Circle[p, r]}, \
+           {Circle[], Circle[p, r], PointSize[0.03], \
+            Point[hits[[1]]], Point[hits[[2]]]}}]), \
+      SaveDefinitions -> True]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the compass-construction Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the initial render must draw the construction"
+    );
+
+    // Two sliders and the setter bar the construction steps through.
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Continuous { label: turn, .. },
+        manipulate::ControlState::Continuous { label: reach, .. },
+        manipulate::ControlState::Discrete {
+          values,
+          current_index,
+          ..
+        },
+      ] => {
+        assert_eq!((turn.as_str(), reach.as_str()), ("turn", "reach"));
+        assert_eq!(values, &vec!["1".to_string(), "2".to_string()]);
+        assert_eq!(*current_index, 1);
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    // Turning the point re-crosses the circles rather than leaving the
+    // intersections unsolved, which would draw no points at all.
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[0]
+    {
+      *current = 2.5;
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+  }
+
+  #[test]
   fn oscilloscope_manipulate_builds_full_widget() {
     // End-to-end regression for the "Oscilloscope with Two Signal Inputs"
     // Demonstration: the loaded Input cell must build a live widget with


### PR DESCRIPTION
## Summary

This PR adds two major improvements to the `Solve` function:

1. **Polynomial system solving via resultant elimination**: Systems of polynomial equations are now solved by eliminating variables one at a time using resultants, keeping all intermediates as polynomials. This avoids the radical explosion that occurred when solving one equation for one variable and substituting.

2. **Radical equation handling**: Equations containing roots of the unknown (e.g., `Sqrt[2x + 3] == x`) are now solved by isolating the radical, raising both sides to clear it, and then filtering solutions to keep only those that satisfy the original equation.

## Key Changes

- **`try_solve_polynomial_system`**: New function that solves systems of polynomial equations by iteratively eliminating variables using resultants or polynomial division. Handles up to 4 variables and validates that all equations are polynomial in all unknowns.

- **`poly_system_solutions`**: Recursive elimination algorithm that reduces a system by eliminating the last variable first, solving the reduced system, then substituting back to find values for the eliminated variable. Properly tracks root multiplicities.

- **`eliminate_var`**: Chooses between polynomial division (when the divisor's leading coefficient is numeric) and resultant elimination (when it depends on other variables), with safeguards against Sylvester matrix explosion.

- **`try_solve_radical_equation`**: New function that handles equations with radical terms by isolating one radical, raising to its index, and verifying solutions against the original equation to eliminate spurious roots introduced by the raising operation.

- **`try_solve_inverse_function`**: Enhanced to verify solutions when solving even roots (which only take principal values) and square roots, filtering out extraneous solutions.

- **Utility functions**: Added helpers for checking polynomial properties, extracting rational exponents, computing root multiplicities, handling numerical noise in eliminated equations, and verifying solutions.

- **`Resultant` function**: Modified to return the multiplied-out result rather than the symbolic determinant form, making it more suitable for use in elimination algorithms.

## Notable Implementation Details

- The elimination algorithm terminates because each step replaces the higher-degree equation with one of strictly lower degree in the variable being eliminated.

- Root multiplicities are tracked correctly: a point where two curves meet counts according to the minimum multiplicity across all equations, not just the one solved for the final variable.

- Numerical noise from floating-point elimination is filtered by dropping terms more than 12 orders of magnitude below the largest term.

- Solutions are verified by substituting back into the original equations, with numerical tolerance of 1e-9 relative to the scale of the equation.

- The implementation respects that `Sqrt` is the principal root and never equals negative numbers, filtering out spurious solutions from squaring.

## Tests Added

- Two circles intersecting at two points
- Circles touching (double root)
- Circles too far apart (complex solutions)
- Inexact coefficients from sliders
- Three-variable system (sphere cut by two planes)
- Parabolas touching
- Radical equations with various forms
- Equations with multiple square roots
- Edge case: `Sqrt[x] == -1` (empty solution set)

https://claude.ai/code/session_019ZGG7HxjCjogeHPQ2jwwdG