### PR TITLE
Support GeometricTransformation and multi-line plot labels

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -4765,7 +4765,56 @@ fn tf_fraction(num: &Expr, den: &Expr) -> Expr {
   tf_box("FractionBox", vec![tf(num), tf(den)])
 }
 
+/// The positive-power form of a factor that belongs under the fraction bar —
+/// `b^-1` is `b`, `b^-2` is `b²`, and the `Rational[p, q]` coefficient an
+/// evaluated quotient carries contributes `q`. `None` for every other factor,
+/// which stays in the numerator.
+fn tf_reciprocal_factor(expr: &Expr) -> Option<Expr> {
+  let power = |base: &Expr, exp: &Expr| -> Option<Expr> {
+    let negated = match exp {
+      Expr::Integer(n) if *n < 0 => Expr::Integer(-n),
+      Expr::Real(f) if *f < 0.0 => Expr::Real(-f),
+      Expr::FunctionCall { name, args }
+        if name == "Rational"
+          && args.len() == 2
+          && matches!(&args[0], Expr::Integer(p) if *p < 0) =>
+      {
+        let Expr::Integer(p) = &args[0] else {
+          return None;
+        };
+        Expr::FunctionCall {
+          name: "Rational".to_string(),
+          args: vec![Expr::Integer(-p), args[1].clone()].into(),
+        }
+      }
+      _ => return None,
+    };
+    // `b^-1` is just `b` under the bar; anything else keeps its exponent.
+    if matches!(negated, Expr::Integer(1)) {
+      Some(base.clone())
+    } else {
+      Some(Expr::FunctionCall {
+        name: "Power".to_string(),
+        args: vec![base.clone(), negated].into(),
+      })
+    }
+  };
+  match expr {
+    Expr::FunctionCall { name, args } if name == "Power" && args.len() == 2 => {
+      power(&args[0], &args[1])
+    }
+    Expr::BinaryOp {
+      op: BinaryOperator::Power,
+      left,
+      right,
+    } => power(left, right),
+    _ => None,
+  }
+}
+
 /// TraditionalForm box of a product (already flattened factor list).
+/// Reciprocal factors are gathered under a fraction bar, so the evaluated
+/// `Times[a, Power[b, -1]]` sets as `a/b` rather than `a b⁻¹`.
 fn tf_times(expr: &Expr) -> Expr {
   let mut factors = Vec::new();
   tf_flatten_times(expr, &mut factors);
@@ -4781,14 +4830,46 @@ fn tf_times(expr: &Expr) -> Expr {
       factors[0] = Expr::Integer(-*n);
     }
   }
-  let mut items: Vec<Expr> = Vec::new();
-  for (i, f) in factors.iter().enumerate() {
-    if i > 0 {
-      items.push(tf_thin_space());
+  // A `Rational[p, q]` coefficient splits across the bar: `p` above, `q`
+  // below. It is always the leading factor of an evaluated product.
+  let mut numerators: Vec<Expr> = Vec::new();
+  let mut denominators: Vec<Expr> = Vec::new();
+  for f in &factors {
+    if let Expr::FunctionCall { name, args } = f
+      && name == "Rational"
+      && args.len() == 2
+    {
+      if !matches!(&args[0], Expr::Integer(1)) {
+        numerators.push(args[0].clone());
+      }
+      denominators.push(args[1].clone());
+      continue;
     }
-    items.push(tf_factor_boxed(f));
+    match tf_reciprocal_factor(f) {
+      Some(den) => denominators.push(den),
+      None => numerators.push(f.clone()),
+    }
   }
-  let body = tf_row(items);
+  let row_of = |parts: &[Expr]| -> Expr {
+    let mut items: Vec<Expr> = Vec::new();
+    for (i, f) in parts.iter().enumerate() {
+      if i > 0 {
+        items.push(tf_thin_space());
+      }
+      items.push(tf_factor_boxed(f));
+    }
+    tf_row(items)
+  };
+  let body = if denominators.is_empty() {
+    row_of(&numerators)
+  } else {
+    let num = if numerators.is_empty() {
+      tf_string("1")
+    } else {
+      row_of(&numerators)
+    };
+    tf_box("FractionBox", vec![num, row_of(&denominators)])
+  };
   if negative {
     tf_row(vec![tf_string("-"), body])
   } else {
@@ -5225,7 +5306,25 @@ fn tf_call(name: &str, args: &[Expr]) -> Expr {
 fn tf(expr: &Expr) -> Expr {
   match expr {
     Expr::Identifier(s) | Expr::Constant(s) => tf_string(&tf_symbol(s)),
+    // TraditionalForm *displays* a string, so it contributes its text
+    // without the quotes InputForm would show.
+    Expr::String(s) => tf_string(s),
     Expr::FunctionCall { name, args } => tf_call(name, args),
+    // A computed head — `HoldForm[f][x]`, which is how a Demonstration
+    // writes a function name it wants displayed but not applied. The head
+    // typesets as itself and the arguments follow in round brackets, the
+    // same shape an unknown named head gets.
+    Expr::CurriedCall { func, args } => {
+      let mut parts = vec![tf(func), tf_string("(")];
+      for (i, a) in args.iter().enumerate() {
+        if i > 0 {
+          parts.push(tf_string(","));
+        }
+        parts.push(tf(a));
+      }
+      parts.push(tf_string(")"));
+      tf_row(parts)
+    }
     Expr::List(items) => {
       if tf_is_matrix(items) {
         tf_row(vec![tf_string("("), tf_matrix_grid(items), tf_string(")")])

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -2258,6 +2258,26 @@ pub fn apply_replace_all_ast(
     rules
   };
 
+  // `Graphics[Plot[…]]` — the wrapper a Demonstration writes when it
+  // collects layers for a later `Show` — *is* the picture it wraps, but it
+  // only becomes one when rendered. Render it first, so a rule naming one of
+  // the picture's primitives reaches them rather than the unevaluated call.
+  if let Expr::FunctionCall { name, args: gargs } = expr
+    && (name == "Graphics" || name == "Graphics3D")
+    && gargs.len() == 1
+    && crate::functions::graphics::wraps_rendered_graphic(&gargs[0])
+  {
+    let gargs: Vec<Expr> = gargs.iter().cloned().collect();
+    let rendered = if name == "Graphics" {
+      crate::functions::graphics::graphics_ast(&gargs)
+    } else {
+      crate::functions::plot3d::graphics3d_ast(&gargs)
+    };
+    if let Ok(rendered @ Expr::Graphics { .. }) = rendered {
+      return apply_replace_all_ast(&rendered, rules);
+    }
+  }
+
   // A rendered graphic is opaque to pattern replacement except for its
   // remembered symbolic `structure`: Wolfram's `plot /. Tooltip[x_, ___] :> x`
   // rewrites the graphic's content in place. The rendering (SVG) is kept;
@@ -2272,6 +2292,53 @@ pub fn apply_replace_all_ast(
     structure,
   } = expr
   {
+    // A plot remembers its curve as sampled series rather than as symbolic
+    // primitives, so a rule naming one of those primitives — the
+    // Demonstrations idiom `plot /. L_Line :> {Red,
+    // GeometricTransformation[L, …]}`, which mirrors a curve about a line —
+    // would find nothing to match. Expand the series into the primitives the
+    // plot stands for and rewrite those. A wrapper that only remembers the
+    // picture it holds (`Graphics[Plot[…]]`) is redrawn from its rewritten
+    // structure for the same reason.
+    //
+    // Only a rule that actually changed something replaces the picture:
+    // everything else keeps the original rendering, so an unrelated rule
+    // cannot quietly turn a plot into a bag of primitives.
+    let symbolic = match (structure, source) {
+      (Some(s), _) => Some(s.as_ref().clone()),
+      (None, Some(source)) => Some(Expr::FunctionCall {
+        name: if *is_3d { "Graphics3D" } else { "Graphics" }.to_string(),
+        args: std::iter::once(Expr::List(
+          crate::functions::graphics::plot_source_primitives(source).into(),
+        ))
+        .chain(source.options.iter().cloned())
+        .collect::<Vec<_>>()
+        .into(),
+      }),
+      (None, None) => None,
+    };
+    if let Some(symbolic) = symbolic {
+      let replaced = apply_replace_all_ast(&symbolic, rules)?;
+      // Compared through `Debug`, not InputForm: a nested rendering prints
+      // as the placeholder `-Graphics-` either way, so InputForm cannot
+      // tell a rewritten inner picture from the original one.
+      if format!("{replaced:?}") != format!("{symbolic:?}")
+        && let Expr::FunctionCall { name, args } = &replaced
+        && (name == "Graphics" || name == "Graphics3D")
+      {
+        // `Graphics[…]` stays symbolic under ordinary evaluation, so the
+        // renderer is called outright.
+        let args: Vec<Expr> = args.iter().cloned().collect();
+        let rendered = if name == "Graphics" {
+          crate::functions::graphics::graphics_ast(&args)
+        } else {
+          crate::functions::plot3d::graphics3d_ast(&args)
+        };
+        if let Ok(rendered @ Expr::Graphics { .. }) = rendered {
+          return Ok(rendered);
+        }
+      }
+    }
     let new_structure = match structure {
       Some(s) => Some(Box::new(apply_replace_all_ast(s, rules)?)),
       None => None,

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -71,6 +71,10 @@ pub(crate) struct StyledLabel {
   /// tspan). `None` for a plain string, which the renderer typesets from
   /// its own inline box markers instead.
   pub markup: Option<String>,
+  /// Typeset markup for the lines *after* the first, for a label that
+  /// stacks (`Grid[{{a}, {b}}]` / `Column[{a, b}]` as a plot title). Empty
+  /// for the ordinary single-line label.
+  pub extra_lines: Vec<String>,
   pub bold: bool,
   pub italic: bool,
   pub color: Option<Color>,
@@ -96,6 +100,30 @@ impl StyledLabel {
   /// sub/superscript tspan — already follow whatever they inherit.
   pub(crate) fn svg_scaled(&self, scale: f64) -> String {
     scale_markup_lengths(&self.svg(), scale)
+  }
+
+  /// The same, with each further line of a stacked label placed below the
+  /// first — centred on `cx` (the anchor the enclosing `<text>` uses) and
+  /// `line_height` render units apart.
+  pub(crate) fn svg_scaled_stacked(
+    &self,
+    scale: f64,
+    cx: f64,
+    line_height: f64,
+  ) -> String {
+    let mut out = self.svg_scaled(scale);
+    for line in &self.extra_lines {
+      out.push_str(&format!(
+        "<tspan x=\"{cx:.1}\" dy=\"{line_height:.1}\">{}</tspan>",
+        scale_markup_lengths(line, scale)
+      ));
+    }
+    out
+  }
+
+  /// How many lines below the first this label occupies.
+  pub(crate) fn extra_line_count(&self) -> usize {
+    self.extra_lines.len()
   }
 }
 
@@ -195,6 +223,29 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
   if let Some(inner) = text_wrapper_content(expr) {
     return parse_styled_label(inner);
   }
+  // A `Grid`/`Column` title stacks: each row becomes its own line. This is
+  // how a Demonstration writes a two-line plot title (the function above,
+  // the transformed one below).
+  if matches!(expr, Expr::FunctionCall { name, args }
+      if (name == "Grid" || name == "Column") && !args.is_empty())
+  {
+    let lines = crate::functions::graphics::expr_to_svg_markup_lines(expr);
+    let (first, rest) = lines.split_first()?;
+    let text = lines
+      .iter()
+      .map(|l| svg_markup_visible_text(l))
+      .collect::<Vec<_>>()
+      .join(" ");
+    return Some(StyledLabel {
+      text,
+      markup: Some(first.clone()),
+      extra_lines: rest.to_vec(),
+      bold: false,
+      italic: false,
+      color: None,
+      font_size: None,
+    });
+  }
   if let Expr::FunctionCall { name, args } = expr
     && name == "Style"
     && !args.is_empty()
@@ -216,6 +267,7 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
     Expr::String(s) => Some(StyledLabel {
       text: s.clone(),
       markup: None,
+      extra_lines: Vec::new(),
       bold: false,
       italic: false,
       color: None,
@@ -224,6 +276,7 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
     Expr::Identifier(s) => Some(StyledLabel {
       text: s.clone(),
       markup: None,
+      extra_lines: Vec::new(),
       bold: false,
       italic: false,
       color: None,
@@ -263,6 +316,7 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
       Some(StyledLabel {
         text,
         markup,
+        extra_lines: Vec::new(),
         bold,
         italic,
         color,
@@ -280,6 +334,7 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
         Some(StyledLabel {
           text,
           markup: Some(markup),
+          extra_lines: Vec::new(),
           bold: false,
           italic: false,
           color: None,

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1868,6 +1868,27 @@ fn collect_primitives(
             None => prims.extend(inner),
           }
         }
+        // `GeometricTransformation[g, t]` draws `g` mapped through the
+        // affine transform `t` — a `{matrix, vector}` pair, a bare matrix,
+        // a `TransformationFunction[…]`, or a list of any of those (one
+        // copy per transform). A Demonstration mirrors a curve about the
+        // line `y = x` this way to draw a function's inverse.
+        "GeometricTransformation" if args.len() == 2 => {
+          let mut inner_style = style.clone();
+          let mut inner = Vec::new();
+          collect_primitives(&args[0], &mut inner_style, &mut inner, errors);
+          let transforms = parse_affine_transforms(&args[1]);
+          if transforms.is_empty() {
+            // Nothing numeric to map through: draw the content as it is.
+            prims.extend(inner);
+          } else {
+            for (m, v) in &transforms {
+              for p in &inner {
+                prims.push(affine_primitive(p, *m, *v));
+              }
+            }
+          }
+        }
 
         // `Dynamic[expr]` displays as the current value of `expr`: release
         // the hold and render the result (Dynamic is HoldFirst, so the
@@ -3683,6 +3704,94 @@ fn rotate_point(
 /// A circular disk/arc keeps its radius and only moves its center. An
 /// elliptical disk (rx != ry) cannot be represented tilted in this model, so
 /// its axes are kept axis-aligned as a best-effort approximation.
+/// The affine transforms a `GeometricTransformation` second argument names,
+/// each as a `({{a, b}, {c, d}}, {e, f})` pair mapping `p` to `m.p + v`.
+/// Accepts the `{matrix, vector}` pair Wolfram normalizes a
+/// `TransformationFunction` to, a bare matrix (no translation), the
+/// homogeneous `TransformationFunction[…]` itself, and a list of any of
+/// those — a list draws one transformed copy per entry. Empty when nothing
+/// numeric can be read out.
+fn parse_affine_transforms(expr: &Expr) -> Vec<([[f64; 2]; 2], (f64, f64))> {
+  // {{a, b}, {c, d}} — a 2×2 linear map.
+  fn matrix2(expr: &Expr) -> Option<[[f64; 2]; 2]> {
+    let Expr::List(rows) = expr else { return None };
+    if rows.len() != 2 {
+      return None;
+    }
+    let r0 = expr_to_point(&rows[0])?;
+    let r1 = expr_to_point(&rows[1])?;
+    Some([[r0.0, r0.1], [r1.0, r1.1]])
+  }
+  // The 3×3 homogeneous matrix a TransformationFunction carries.
+  fn homogeneous(expr: &Expr) -> Option<([[f64; 2]; 2], (f64, f64))> {
+    let Expr::List(rows) = expr else { return None };
+    if rows.len() != 3 {
+      return None;
+    }
+    let mut m = [[0.0; 2]; 2];
+    let mut v = [0.0; 2];
+    for (i, row) in rows.iter().take(2).enumerate() {
+      let Expr::List(cells) = row else { return None };
+      if cells.len() != 3 {
+        return None;
+      }
+      m[i][0] = expr_to_f64(&cells[0])?;
+      m[i][1] = expr_to_f64(&cells[1])?;
+      v[i] = expr_to_f64(&cells[2])?;
+    }
+    Some((m, (v[0], v[1])))
+  }
+  fn single(expr: &Expr) -> Option<([[f64; 2]; 2], (f64, f64))> {
+    if let Expr::FunctionCall { name, args } = expr
+      && name == "TransformationFunction"
+      && args.len() == 1
+    {
+      return homogeneous(&args[0]);
+    }
+    if let Expr::List(items) = expr
+      && items.len() == 2
+      && let Some(m) = matrix2(&items[0])
+      && let Some(v) = expr_to_point(&items[1])
+    {
+      return Some((m, v));
+    }
+    matrix2(expr).map(|m| (m, (0.0, 0.0)))
+  }
+  if let Some(one) = single(expr) {
+    return vec![one];
+  }
+  match expr {
+    Expr::List(items) => items.iter().filter_map(single).collect(),
+    _ => Vec::new(),
+  }
+}
+
+/// Map a primitive through the affine transform `p ↦ m.p + v`.
+///
+/// The matrix is factored (a closed-form 2×2 SVD) into
+/// `rotate(φ) ∘ scale(sx, sy) ∘ rotate(θ)`, so the transform is carried out
+/// by the same primitive-level rotate/scale/translate the explicit
+/// `Rotate`/`Scale`/`Translate` directives use — including their handling of
+/// the shapes an affine map does not leave in its own family (a circle
+/// becoming an ellipse, an arc reversing sweep under a reflection).
+fn affine_primitive(
+  prim: &Primitive,
+  m: [[f64; 2]; 2],
+  v: (f64, f64),
+) -> Primitive {
+  let (a, b, c, d) = (m[0][0], m[0][1], m[1][0], m[1][1]);
+  let (e, f, g, h) =
+    ((a + d) / 2.0, (a - d) / 2.0, (c + b) / 2.0, (c - b) / 2.0);
+  let (q, r) = ((e * e + h * h).sqrt(), (f * f + g * g).sqrt());
+  let (sx, sy) = (q + r, q - r);
+  let (a1, a2) = (g.atan2(f), h.atan2(e));
+  let (theta, phi) = ((a2 - a1) / 2.0, (a2 + a1) / 2.0);
+  let rotated = rotate_primitive(prim, 0.0, 0.0, theta);
+  let scaled = scale_primitive(&rotated, 0.0, 0.0, sx, sy);
+  let rotated = rotate_primitive(&scaled, 0.0, 0.0, phi);
+  translate_primitive(&rotated, v.0, v.1)
+}
+
 fn rotate_primitive(
   prim: &Primitive,
   cx: f64,
@@ -6365,7 +6474,7 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut plot_range_x: Option<(f64, f64)> = None;
   let mut plot_range_y: Option<(f64, f64)> = None;
   let mut background: Option<Color> = None;
-  let mut plot_label: Option<String> = None;
+  let mut plot_label: Option<Vec<String>> = None;
   // `AxesLabel -> {xlabel, ylabel}`, already typeset as SVG markup.
   let mut axes_label: Option<(String, String)> = None;
   // `FrameLabel -> {bottom, left}` (or the nested four-edge form), as SVG
@@ -6440,9 +6549,9 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           match replacement {
             Expr::Identifier(s) if s == "None" => {}
             other => {
-              let markup = expr_to_svg_markup(other);
-              if !markup.is_empty() {
-                plot_label = Some(markup);
+              let lines = expr_to_svg_markup_lines(other);
+              if lines.iter().any(|l| !l.is_empty()) {
+                plot_label = Some(lines);
               }
             }
           }
@@ -6466,9 +6575,13 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             ticks_x = TickSpec::Automatic;
             ticks_y = TickSpec::Automatic;
           }
-          Expr::List(items) if items.len() == 2 => {
+          // `Ticks -> {xspec}` states the x ticks only; the y axis keeps
+          // its default.
+          Expr::List(items) if (1..=2).contains(&items.len()) => {
             ticks_x = parse_tick_spec(&items[0]);
-            ticks_y = parse_tick_spec(&items[1]);
+            if let Some(y) = items.get(1) {
+              ticks_y = parse_tick_spec(y);
+            }
           }
           _ => {}
         },
@@ -6731,7 +6844,12 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     0.0
   } + if has_x_axis_label { 24.0 } else { 0.0 }
     + if has_right_caption { 20.0 } else { 0.0 };
-  let label_strip: f64 = if plot_label.is_some() { 26.0 } else { 0.0 };
+  // A multi-line title (a `Grid`/`Column` label) claims one further line
+  // height per extra row on top of the single-line strip.
+  let label_strip: f64 = match &plot_label {
+    Some(lines) => 26.0 + 18.0 * (lines.len().saturating_sub(1)) as f64,
+    None => 0.0,
+  };
   let margin_top: f64 = if frame { 10.0 } else { 0.0 }
     + label_strip
     + if has_y_axis_label && label_strip == 0.0 {
@@ -6804,12 +6922,20 @@ pub fn graphics_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // PlotLabel: centered above the drawing area, in the reserved strip. It
   // arrives already typeset as SVG markup (sub/superscript tspans included).
-  if let Some(label) = &plot_label {
+  if let Some(lines) = &plot_label {
     let cx = margin_left + svg_w / 2.0;
     svg.push_str(&format!(
       "<text x=\"{cx:.1}\" y=\"17\" text-anchor=\"middle\" \
-       font-family=\"sans-serif\" font-size=\"16\" fill=\"#333333\">{label}</text>\n",
+       font-family=\"sans-serif\" font-size=\"16\" fill=\"#333333\">",
     ));
+    for (i, line) in lines.iter().enumerate() {
+      if i == 0 {
+        svg.push_str(line);
+      } else {
+        svg.push_str(&format!("<tspan x=\"{cx:.1}\" dy=\"18\">{line}</tspan>"));
+      }
+    }
+    svg.push_str("</text>\n");
   }
 
   // Offset the drawing area so axes/frame labels fit in the margins
@@ -8283,6 +8409,45 @@ fn negated_markup_term(arg: &Expr) -> Option<String> {
   let mut factors = vec![positive];
   factors.extend(rest.iter().cloned());
   Some(expr_to_svg_markup(&unevaluated("Times", &factors)))
+}
+
+/// Typeset a label that may occupy several lines, one entry per line.
+/// `Grid[{{a}, {b}}]` and `Column[{a, b}]` stack their items — Demonstrations
+/// build multi-line plot titles that way — and any line that itself carries
+/// newlines (the 2D text `ToString[…, TraditionalForm]` returns) splits
+/// further. Everything else is a single line.
+pub fn expr_to_svg_markup_lines(expr: &Expr) -> Vec<String> {
+  let rows: Vec<String> = match expr {
+    Expr::FunctionCall { name, args } if name == "Grid" && !args.is_empty() => {
+      match &args[0] {
+        Expr::List(rows) => rows
+          .iter()
+          .map(|row| match row {
+            Expr::List(cells) => cells
+              .iter()
+              .map(expr_to_svg_markup)
+              .collect::<Vec<_>>()
+              .join(" "),
+            cell => expr_to_svg_markup(cell),
+          })
+          .collect(),
+        other => vec![expr_to_svg_markup(other)],
+      }
+    }
+    Expr::FunctionCall { name, args }
+      if name == "Column" && !args.is_empty() =>
+    {
+      match &args[0] {
+        Expr::List(items) => items.iter().map(expr_to_svg_markup).collect(),
+        other => vec![expr_to_svg_markup(other)],
+      }
+    }
+    other => vec![expr_to_svg_markup(other)],
+  };
+  rows
+    .iter()
+    .flat_map(|line| line.split('\n').map(str::to_string).collect::<Vec<_>>())
+    .collect()
 }
 
 pub fn expr_to_svg_markup(expr: &Expr) -> String {
@@ -10083,7 +10248,7 @@ pub(crate) fn mesh_region_to_graphics_prims(
 /// Whether a `Graphics[…]` argument is a finished picture rather than a
 /// list of primitives — an already-rendered graphic, another `Graphics`,
 /// or a call (a plot) that evaluates to one.
-fn wraps_rendered_graphic(content: &Expr) -> bool {
+pub fn wraps_rendered_graphic(content: &Expr) -> bool {
   match content {
     Expr::Graphics { .. } => true,
     Expr::FunctionCall { name, .. } if name == "Graphics" => true,
@@ -10094,6 +10259,112 @@ fn wraps_rendered_graphic(content: &Expr) -> bool {
     }
     _ => false,
   }
+}
+
+/// The drawing primitives a rendered plot's sampled series stand for —
+/// filled regions, the series colour and thickness, and the `Line` /
+/// `Point` the samples make up. `Show` merges these with the primitives of
+/// the graphics it is layering, and a structural rule (`plot /. L_Line :>
+/// …`) matches against them, which is what makes a plot's curve reachable
+/// by pattern replacement at all.
+pub fn plot_source_primitives(ps: &crate::syntax::PlotSource) -> Vec<Expr> {
+  let mut series_prims: Vec<Expr> = Vec::new();
+  for sd in &ps.series {
+    // Filled region (Filling -> …) as a Polygon underneath the curve,
+    // wrapped in its own list so the fill color/opacity directives
+    // don't leak onto the line drawn after it. FillingStyle appearance
+    // travels on the series (fill_color/fill_opacity); the defaults
+    // match the standalone plot render (series color at 0.2 opacity).
+    if !sd.is_scatter
+      && let Some(ref_y) = sd.filling.reference_y(ps.y_range.0, ps.y_range.1)
+    {
+      let (fr, fg, fb) = sd.fill_color.unwrap_or(sd.color);
+      let mut fill_prims: Vec<Expr> = vec![
+        Expr::FunctionCall {
+          name: "Opacity".to_string(),
+          args: vec![Expr::Real(sd.fill_opacity.unwrap_or(0.2))].into(),
+        },
+        Expr::FunctionCall {
+          name: "RGBColor".to_string(),
+          args: vec![
+            Expr::Real(fr as f64 / 255.0),
+            Expr::Real(fg as f64 / 255.0),
+            Expr::Real(fb as f64 / 255.0),
+          ]
+          .into(),
+        },
+      ];
+      for seg in &crate::functions::plot::split_into_segments(&sd.points) {
+        if seg.len() < 2 {
+          continue;
+        }
+        let mut coords: Vec<Expr> = seg
+          .iter()
+          .map(|&(x, y)| Expr::List(vec![Expr::Real(x), Expr::Real(y)].into()))
+          .collect();
+        let (x_last, _) = seg[seg.len() - 1];
+        let (x_first, _) = seg[0];
+        coords.push(Expr::List(
+          vec![Expr::Real(x_last), Expr::Real(ref_y)].into(),
+        ));
+        coords.push(Expr::List(
+          vec![Expr::Real(x_first), Expr::Real(ref_y)].into(),
+        ));
+        fill_prims.push(Expr::FunctionCall {
+          name: "Polygon".to_string(),
+          args: vec![Expr::List(coords.into())].into(),
+        });
+      }
+      series_prims.push(Expr::List(fill_prims.into()));
+    }
+    // Color directive
+    series_prims.push(Expr::FunctionCall {
+      name: "RGBColor".to_string(),
+      args: vec![
+        Expr::Real(sd.color.0 as f64 / 255.0),
+        Expr::Real(sd.color.1 as f64 / 255.0),
+        Expr::Real(sd.color.2 as f64 / 255.0),
+      ]
+      .into(),
+    });
+    if sd.is_scatter {
+      series_prims.push(Expr::FunctionCall {
+        name: "PointSize".to_string(),
+        args: vec![Expr::Real(0.012)].into(),
+      });
+      let coords: Vec<Expr> = sd
+        .points
+        .iter()
+        .filter(|(_, y)| y.is_finite())
+        .map(|&(x, y)| Expr::List(vec![Expr::Real(x), Expr::Real(y)].into()))
+        .collect();
+      if !coords.is_empty() {
+        series_prims.push(Expr::FunctionCall {
+          name: "Point".to_string(),
+          args: vec![Expr::List(coords.into())].into(),
+        });
+      }
+    } else {
+      series_prims.push(Expr::FunctionCall {
+        name: "AbsoluteThickness".to_string(),
+        args: vec![Expr::Real(sd.thickness.unwrap_or(1.5))].into(),
+      });
+      let segments = crate::functions::plot::split_into_segments(&sd.points);
+      for seg in &segments {
+        let coords: Vec<Expr> = seg
+          .iter()
+          .map(|&(x, y)| Expr::List(vec![Expr::Real(x), Expr::Real(y)].into()))
+          .collect();
+        if coords.len() >= 2 {
+          series_prims.push(Expr::FunctionCall {
+            name: "Line".to_string(),
+            args: vec![Expr::List(coords.into())].into(),
+          });
+        }
+      }
+    }
+  }
+  series_prims
 }
 
 pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -10204,6 +10475,27 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       Expr::Rule { .. } | Expr::RuleDelayed { .. } => arg.clone(),
       _ => evaluate_expr_to_expr(&arg).unwrap_or_else(|_| arg.clone()),
+    };
+    // The same wrapper can arrive through a *variable* — the Demonstrations
+    // idiom `g1 = Graphics[Plot[…]]; Show[g1, …]` — in which case only the
+    // evaluated value has the shape, and the arm above never saw it. Render
+    // it here as well, or its finished picture would be merged as if it
+    // were a drawing primitive and nothing would come out.
+    let expr_owned = match &expr_owned {
+      Expr::FunctionCall { name, args: gargs }
+        if (name == "Graphics" || name == "Graphics3D")
+          && !gargs.is_empty()
+          && wraps_rendered_graphic(&gargs[0]) =>
+      {
+        let gargs: Vec<Expr> = gargs.iter().cloned().collect();
+        if name == "Graphics" {
+          graphics_ast(&gargs).unwrap_or_else(|_| expr_owned.clone())
+        } else {
+          crate::functions::plot3d::graphics3d_ast(&gargs)
+            .unwrap_or_else(|_| expr_owned.clone())
+        }
+      }
+      _ => expr_owned,
     };
     if let Expr::List(items) = &expr_owned {
       let items: Vec<Expr> = items.iter().cloned().collect();
@@ -10386,111 +10678,7 @@ pub fn show_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // stacked back in the order `Show` was given them.
     let mut source_prims: Vec<Expr> = Vec::with_capacity(plot_sources.len());
     for ps in &plot_sources {
-      let mut series_prims: Vec<Expr> = Vec::new();
-      for sd in &ps.series {
-        // Filled region (Filling -> …) as a Polygon underneath the curve,
-        // wrapped in its own list so the fill color/opacity directives
-        // don't leak onto the line drawn after it. FillingStyle appearance
-        // travels on the series (fill_color/fill_opacity); the defaults
-        // match the standalone plot render (series color at 0.2 opacity).
-        if !sd.is_scatter
-          && let Some(ref_y) =
-            sd.filling.reference_y(ps.y_range.0, ps.y_range.1)
-        {
-          let (fr, fg, fb) = sd.fill_color.unwrap_or(sd.color);
-          let mut fill_prims: Vec<Expr> = vec![
-            Expr::FunctionCall {
-              name: "Opacity".to_string(),
-              args: vec![Expr::Real(sd.fill_opacity.unwrap_or(0.2))].into(),
-            },
-            Expr::FunctionCall {
-              name: "RGBColor".to_string(),
-              args: vec![
-                Expr::Real(fr as f64 / 255.0),
-                Expr::Real(fg as f64 / 255.0),
-                Expr::Real(fb as f64 / 255.0),
-              ]
-              .into(),
-            },
-          ];
-          for seg in &crate::functions::plot::split_into_segments(&sd.points) {
-            if seg.len() < 2 {
-              continue;
-            }
-            let mut coords: Vec<Expr> = seg
-              .iter()
-              .map(|&(x, y)| {
-                Expr::List(vec![Expr::Real(x), Expr::Real(y)].into())
-              })
-              .collect();
-            let (x_last, _) = seg[seg.len() - 1];
-            let (x_first, _) = seg[0];
-            coords.push(Expr::List(
-              vec![Expr::Real(x_last), Expr::Real(ref_y)].into(),
-            ));
-            coords.push(Expr::List(
-              vec![Expr::Real(x_first), Expr::Real(ref_y)].into(),
-            ));
-            fill_prims.push(Expr::FunctionCall {
-              name: "Polygon".to_string(),
-              args: vec![Expr::List(coords.into())].into(),
-            });
-          }
-          series_prims.push(Expr::List(fill_prims.into()));
-        }
-        // Color directive
-        series_prims.push(Expr::FunctionCall {
-          name: "RGBColor".to_string(),
-          args: vec![
-            Expr::Real(sd.color.0 as f64 / 255.0),
-            Expr::Real(sd.color.1 as f64 / 255.0),
-            Expr::Real(sd.color.2 as f64 / 255.0),
-          ]
-          .into(),
-        });
-        if sd.is_scatter {
-          series_prims.push(Expr::FunctionCall {
-            name: "PointSize".to_string(),
-            args: vec![Expr::Real(0.012)].into(),
-          });
-          let coords: Vec<Expr> = sd
-            .points
-            .iter()
-            .filter(|(_, y)| y.is_finite())
-            .map(|&(x, y)| {
-              Expr::List(vec![Expr::Real(x), Expr::Real(y)].into())
-            })
-            .collect();
-          if !coords.is_empty() {
-            series_prims.push(Expr::FunctionCall {
-              name: "Point".to_string(),
-              args: vec![Expr::List(coords.into())].into(),
-            });
-          }
-        } else {
-          series_prims.push(Expr::FunctionCall {
-            name: "AbsoluteThickness".to_string(),
-            args: vec![Expr::Real(sd.thickness.unwrap_or(1.5))].into(),
-          });
-          let segments =
-            crate::functions::plot::split_into_segments(&sd.points);
-          for seg in &segments {
-            let coords: Vec<Expr> = seg
-              .iter()
-              .map(|&(x, y)| {
-                Expr::List(vec![Expr::Real(x), Expr::Real(y)].into())
-              })
-              .collect();
-            if coords.len() >= 2 {
-              series_prims.push(Expr::FunctionCall {
-                name: "Line".to_string(),
-                args: vec![Expr::List(coords.into())].into(),
-              });
-            }
-          }
-        }
-      }
-      source_prims.push(Expr::List(series_prims.into()));
+      source_prims.push(Expr::List(plot_source_primitives(ps).into()));
 
       // Deliberately do NOT force a PlotRange from the plot source here: the
       // series are emitted as real Line/Point primitives, so the renderer's
@@ -10768,6 +10956,14 @@ fn span_height(rows: &[Vec<Expr>], i: usize, j: usize) -> usize {
 /// interpreted at display time), so every display path treats them alike.
 pub(crate) fn is_style_wrapper(name: &str) -> bool {
   name == "Style" || name == "StyleForm"
+}
+
+/// Heads that a `Manipulate` argument may carry while still being a static
+/// annotation row rather than a variable specification: a styled or plain
+/// text label sitting between the controls, which Wolfram tags
+/// ``Manipulate`Dump`ThisIsNotAControl`` instead of reporting as malformed.
+pub(crate) fn is_manipulate_annotation_head(name: &str) -> bool {
+  is_style_wrapper(name) || name == "Text"
 }
 
 /// Extract style info from a Style[content, directives...] cell.
@@ -15797,13 +15993,15 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::FunctionCall { name, .. } if name == "Dynamic" => {
         out_args.push(spec.clone());
       }
-      // `Delimiter`, a bare string, and `Style[…]` are static annotation
-      // rows between controls (Wolfram tags them
+      // `Delimiter`, a bare string, `Style[…]` and `Text[…]` are static
+      // annotation rows between controls (Wolfram tags them
       // Manipulate`Dump`ThisIsNotAControl), not malformed variable specs —
       // they pass through with no message, matching wolframscript.
       Expr::Identifier(s) if s == "Delimiter" => out_args.push(spec.clone()),
       Expr::String(_) => out_args.push(spec.clone()),
-      Expr::FunctionCall { name, .. } if is_style_wrapper(name) => {
+      Expr::FunctionCall { name, .. }
+        if is_manipulate_annotation_head(name) =>
+      {
         out_args.push(spec.clone());
       }
       // Control objects and layout containers grouping them — `Control[…]`,
@@ -16394,6 +16592,9 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   // to tell a static list from one that follows another control.
   let sibling_names: Vec<String> =
     initial_bindings.iter().map(|(n, _)| n.clone()).collect();
+  // Filled in on demand by the spec loop below, when a spec only parses
+  // once the body has run (see the retry there).
+  let mut post_body_bindings: Option<Vec<(String, String)>> = None;
   // A slider's bounds may be symbols the body assigns before doing
   // anything else — `Manipulate[tmin = 0; tmax = 2 Pi; …, {{t, 0}, tmin,
   // tmax}]`. Wolfram evaluates the body before laying the controls out, so
@@ -16499,9 +16700,9 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       }
       continue;
     }
-    // `Delimiter` and string / `Style[…]` arguments are static annotation
-    // rows between controls (Wolfram's `ThisIsNotAControl`), keeping their
-    // position among the control rows.
+    // `Delimiter` and string / `Style[…]` / `Text[…]` arguments are static
+    // annotation rows between controls (Wolfram's `ThisIsNotAControl`),
+    // keeping their position among the control rows.
     match spec {
       Expr::Identifier(s) if s == "Delimiter" => {
         controls.push(ManipulateControl::Divider);
@@ -16515,7 +16716,9 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         });
         continue;
       }
-      Expr::FunctionCall { name, .. } if is_style_wrapper(name) => {
+      Expr::FunctionCall { name, .. }
+        if is_manipulate_annotation_head(name) =>
+      {
         let label_runs = manipulate_label_runs(spec, false);
         controls.push(ManipulateControl::Heading {
           label: flatten_label_runs(&label_runs),
@@ -16600,9 +16803,30 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       continue;
     }
     let (spec, rename) = rewrite_compound_control_var(spec);
-    let parsed = crate::with_scoped_globals(&initial_bindings, || {
+    let parsed = match crate::with_scoped_globals(&initial_bindings, || {
       parse_manipulate_control(&spec, &sibling_names)
-    })?;
+    }) {
+      Some(parsed) => parsed,
+      None => {
+        // Wolfram evaluates the body once before laying the controls out, so
+        // a control whose choice list is a symbol the *body* fills in —
+        // `{{k, 9, " "}, choices, ControlType -> PopupMenu}` next to a
+        // `{{choices, {}}, ControlType -> None}` state variable — already has
+        // its choices in hand by then. The leading-assignment probe above
+        // only reaches assignments the body opens with, so retry against the
+        // bindings a full body run leaves behind. That run is expensive, so
+        // it happens lazily: only after a spec has actually failed, and only
+        // once per Manipulate.
+        let after_body = post_body_bindings
+          .get_or_insert_with(|| {
+            manipulate_post_body_bindings(args.first(), &initial_bindings)
+          })
+          .clone();
+        crate::with_scoped_globals(&after_body, || {
+          parse_manipulate_control(&spec, &sibling_names)
+        })?
+      }
+    };
     match parsed {
       ParsedControl::Visible {
         control: mut c,
@@ -17132,6 +17356,38 @@ fn manipulate_initial_value_bindings(specs: &[Expr]) -> Vec<(String, String)> {
       }
     })
     .collect()
+}
+
+/// Re-read a Manipulate's control/state variables after evaluating its body
+/// once, the way Wolfram initializes a `Manipulate` before laying out its
+/// controls. Only the variables that already have an initial binding are
+/// reported, each replaced by whatever the body left it holding, so the
+/// result can stand in for `initial` wholesale. A variable the body does not
+/// touch keeps its initial value, and a body that fails contributes nothing.
+fn manipulate_post_body_bindings(
+  body: Option<&Expr>,
+  initial: &[(String, String)],
+) -> Vec<(String, String)> {
+  let mut out = initial.to_vec();
+  let Some(body) = body else { return out };
+  let body = unwrap_dynamic_body(body);
+  // The body is being run outside its own controls' feedback loop, so any
+  // complaint it makes here would be a duplicate of one the frontend
+  // reports when it evaluates the body for real.
+  crate::push_quiet();
+  crate::with_scoped_globals(initial, || {
+    let _ = evaluate_expr_to_expr(body);
+    for (name, value) in out.iter_mut() {
+      let symbol = Expr::Identifier(name.clone());
+      if let Ok(evaluated) = evaluate_expr_to_expr(&symbol)
+        && !matches!(&evaluated, Expr::Identifier(s) if s == name)
+      {
+        *value = crate::syntax::expr_to_input_form(&evaluated);
+      }
+    }
+  });
+  crate::pop_quiet();
+  out
 }
 
 /// Evaluate a Manipulate bound expression to a number. A literal (`2 Pi`)

--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -892,11 +892,12 @@ fn parse_plot_options(args: &[Expr]) -> ParsedOptions {
           Expr::Identifier(v) if v == "Automatic" || v == "All" => {
             opts.ticks = true
           }
-          Expr::List(items) if items.len() == 2 => {
+          Expr::List(items) if (1..=2).contains(&items.len()) => {
             opts.ticks_x =
               crate::functions::plot::parse_explicit_ticks(&items[0]);
-            opts.ticks_y =
-              crate::functions::plot::parse_explicit_ticks(&items[1]);
+            if let Some(y) = items.get(1) {
+              opts.ticks_y = crate::functions::plot::parse_explicit_ticks(y);
+            }
           }
           _ => {}
         },

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -10,6 +10,15 @@ use crate::functions::graphics::{Color as WoxiColor, parse_color};
 use crate::functions::math_ast::try_eval_to_f64;
 use crate::syntax::PlotMarker;
 
+/// How many lines below the first a stacked `PlotLabel` (a `Grid`/`Column`
+/// title) occupies — the extra top margin every renderer has to reserve for
+/// it. Zero for the ordinary single-line title and for no title at all.
+fn plot_label_extra_lines(label: Option<&StyledLabel>) -> usize {
+  label
+    .filter(|sl| !sl.text.is_empty())
+    .map_or(0, StyledLabel::extra_line_count)
+}
+
 pub(crate) const DEFAULT_WIDTH: u32 = 360;
 pub(crate) const DEFAULT_HEIGHT: u32 = 225;
 /// Internal rendering resolution multiplier for sub-pixel precision.
@@ -2413,6 +2422,10 @@ pub(crate) fn plot_labels_svg(
       + if axes_label_y.is_some() { 1.0 } else { 0.0 };
     let ty = margin_top - title_font_size * 0.5 - stacked * font_size * 1.2;
     let fs = sl.font_size.map(|f| f * sf).unwrap_or(title_font_size);
+    // A stacked title grows upwards: its last line stays where a one-line
+    // title would sit, so whatever shares the top margin below it (the y
+    // `AxesLabel`) is not written over.
+    let ty = ty - sl.extra_line_count() as f64 * fs * 1.2;
     let fill = sl
       .color
       .as_ref()
@@ -2429,7 +2442,7 @@ pub(crate) fn plot_labels_svg(
       "<text x=\"{cx:.1}\" y=\"{ty:.1}\" text-anchor=\"middle\" \
          font-family=\"sans-serif\" font-size=\"{fs:.0}\" \
          fill=\"{fill}\"{style_attrs}>{}</text>\n",
-      sl.svg_scaled(sf)
+      sl.svg_scaled_stacked(sf, cx, fs * 1.2)
     ));
   }
 
@@ -2537,6 +2550,7 @@ fn generate_svg_with_options(
   // (they stack).
   let top_margin = 10 * s
     + if has_plot_label { 25 * s } else { 0 }
+    + plot_label_extra_lines(opts.plot_label.as_ref()) as i32 * 20 * s
     + if has_top_label { 25 * s } else { 0 }
     + if axes_label_y.is_some() { 20 * s } else { 0 };
 
@@ -3763,6 +3777,7 @@ pub(crate) fn generate_scatter_svg_with_options(
     .is_some_and(|(_, y)| !y.is_empty() && opts.axes.1);
   let margin_top = 10.0 * sf
     + if has_plot_label { 25.0 * sf } else { 0.0 }
+    + plot_label_extra_lines(opts.plot_label.as_ref()) as f64 * 20.0 * sf
     + if has_y_axes_label { 20.0 * sf } else { 0.0 };
   let margin_right = 10.0 * sf
     + axes_label_x.map_or(0.0, |label| {
@@ -4517,6 +4532,7 @@ pub(crate) fn generate_bar_svg(
 
   let has_value_labels = bar_labels.iter().any(|s| !s.is_empty());
   let top_margin = if has_plot_label { 35 * s } else { 10 * s }
+    + plot_label_extra_lines(plot_label) as i32 * 20 * s
     + if axes_label_y.is_some() { 20 * s } else { 0 };
   let has_rotated_labels = chart_labels.iter().any(|l| l.rotation.abs() > 0.01);
   // Only content drawn below the axis consumes bottom margin. Chart labels do
@@ -4881,6 +4897,10 @@ pub(crate) fn generate_bar_svg(
           0.0
         };
       let fs = sl.font_size.map(|f| f * sf).unwrap_or(title_font_size);
+      // A stacked title grows upwards: its last line stays where a one-line
+      // title would sit, so whatever shares the top margin below it (the y
+      // `AxesLabel`) is not written over.
+      let ty = ty - sl.extra_line_count() as f64 * fs * 1.2;
       let fill = sl
         .color
         .as_ref()
@@ -4897,7 +4917,7 @@ pub(crate) fn generate_bar_svg(
         "<text x=\"{cx:.1}\" y=\"{ty:.1}\" text-anchor=\"middle\" \
            font-family=\"sans-serif\" font-size=\"{fs:.0}\" \
            fill=\"{fill}\"{style_attrs}>{}</text>\n",
-        sl.svg_scaled(sf)
+        sl.svg_scaled_stacked(sf, cx, fs * 1.2)
       ));
     }
 
@@ -5011,6 +5031,7 @@ pub(crate) fn generate_horizontal_bar_svg(
   // Margins. An `AxesLabel` sits at the far end of its axis, so it takes
   // room above (the category axis) and to the right (the value axis).
   let top_margin = if has_plot_label { 38.0 * sf } else { 16.0 * sf }
+    + plot_label_extra_lines(plot_label) as f64 * 20.0 * sf
     + if x_axis_label.is_empty() {
       0.0
     } else {
@@ -5231,6 +5252,10 @@ pub(crate) fn generate_horizontal_bar_svg(
     // Place the title near the top so a clear gap remains above the bars.
     let ty = title_font_size * 1.2;
     let fs = sl.font_size.map(|f| f * sf).unwrap_or(title_font_size);
+    // A stacked title grows upwards: its last line stays where a one-line
+    // title would sit, so whatever shares the top margin below it (the y
+    // `AxesLabel`) is not written over.
+    let ty = ty - sl.extra_line_count() as f64 * fs * 1.2;
     let fill = sl
       .color
       .as_ref()
@@ -5246,7 +5271,7 @@ pub(crate) fn generate_horizontal_bar_svg(
     svg.push_str(&format!(
       "<text x=\"{cx:.2}\" y=\"{ty:.2}\" text-anchor=\"middle\" \
        font-family=\"sans-serif\" font-size=\"{fs:.0}\" fill=\"{fill}\"{style_attrs}>{}</text>\n",
-      sl.svg_scaled(sf)
+      sl.svg_scaled_stacked(sf, cx, fs * 1.2)
     ));
   }
 
@@ -5398,7 +5423,8 @@ pub(crate) fn generate_bubble_chart_svg(
     axes_label.as_ref().is_some_and(|(x, _)| !x.is_empty());
   let has_plot_label = plot_label.is_some_and(|sl| !sl.text.is_empty());
 
-  let top_margin = if has_plot_label { 35 * s } else { 10 * s };
+  let top_margin = if has_plot_label { 35 * s } else { 10 * s }
+    + plot_label_extra_lines(plot_label) as i32 * 20 * s;
   let bottom_extra = if has_x_axis_label { 24.0 * sf } else { 0.0 };
   let x_label_area = 40 * RESOLUTION_SCALE + bottom_extra as u32;
   let y_label_area = 65 * RESOLUTION_SCALE;
@@ -5781,6 +5807,10 @@ pub(crate) fn generate_bubble_chart_svg(
       let cx = plot_x0 + plot_w / 2.0;
       let ty = margin_top - title_font_size * 0.5;
       let fs = sl.font_size.map(|f| f * sf).unwrap_or(title_font_size);
+      // A stacked title grows upwards: its last line stays where a one-line
+      // title would sit, so whatever shares the top margin below it (the y
+      // `AxesLabel`) is not written over.
+      let ty = ty - sl.extra_line_count() as f64 * fs * 1.2;
       let fill = sl
         .color
         .as_ref()
@@ -5797,7 +5827,7 @@ pub(crate) fn generate_bubble_chart_svg(
         "<text x=\"{cx:.1}\" y=\"{ty:.1}\" text-anchor=\"middle\" \
            font-family=\"sans-serif\" font-size=\"{fs:.0}\" \
            fill=\"{fill}\"{style_attrs}>{}</text>\n",
-        sl.svg_scaled(sf)
+        sl.svg_scaled_stacked(sf, cx, fs * 1.2)
       ));
     }
 
@@ -6523,6 +6553,7 @@ pub(crate) fn generate_histogram_svg(
   let has_y_axes_label =
     opts.axes_label.as_ref().is_some_and(|(_, y)| !y.is_empty());
   let top_margin = if has_plot_label { 35 * s } else { 10 * s }
+    + plot_label_extra_lines(opts.plot_label.as_ref()) as i32 * 20 * s
     + if has_y_axes_label { 20 * s } else { 0 };
   let bottom_extra = if has_x_frame_label { 24.0 * sf } else { 0.0 };
   let x_label_area = 40 * RESOLUTION_SCALE + bottom_extra as u32;
@@ -6764,6 +6795,10 @@ pub(crate) fn generate_histogram_svg(
           0.0
         };
       let fs = sl.font_size.map(|f| f * sf).unwrap_or(title_font_size);
+      // A stacked title grows upwards: its last line stays where a one-line
+      // title would sit, so whatever shares the top margin below it (the y
+      // `AxesLabel`) is not written over.
+      let ty = ty - sl.extra_line_count() as f64 * fs * 1.2;
       let fill = sl
         .color
         .as_ref()
@@ -6780,7 +6815,7 @@ pub(crate) fn generate_histogram_svg(
         "<text x=\"{cx:.1}\" y=\"{ty:.1}\" text-anchor=\"middle\" \
            font-family=\"sans-serif\" font-size=\"{fs:.0}\" \
            fill=\"{fill}\"{style_attrs}>{}</text>\n",
-        sl.svg_scaled(sf)
+        sl.svg_scaled_stacked(sf, cx, fs * 1.2)
       ));
     }
 
@@ -8192,9 +8227,13 @@ pub(crate) fn apply_common_plot_option(
       }
       // `Ticks -> {xspec, yspec}`: each side is None, Automatic, or an
       // explicit list of positions (each optionally `{pos, label}`).
-      Expr::List(items) if items.len() == 2 => {
+      // The y side may be left off — `Ticks -> {xspec}` states the x ticks
+      // and leaves the y axis to its default.
+      Expr::List(items) if (1..=2).contains(&items.len()) => {
         plot_opts.ticks_x = parse_explicit_ticks(&items[0]);
-        plot_opts.ticks_y = parse_explicit_ticks(&items[1]);
+        if let Some(y) = items.get(1) {
+          plot_opts.ticks_y = parse_explicit_ticks(y);
+        }
       }
       _ => {}
     },

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -8094,10 +8094,9 @@ fn partition_tube(items: &[Expr]) -> (Option<Vec<Expr>>, Vec<Expr>) {
       Expr::FunctionCall { name, args } if name == "Tube" && tube.is_none() => {
         tube = Some(args.to_vec());
       }
-      Expr::List(_)
-      | Expr::FunctionCall {
-        name: _, args: _, ..
-      } if tube.is_none() && contains_tube(item) => {
+      Expr::List(_) | Expr::FunctionCall { .. }
+        if tube.is_none() && contains_tube(item) =>
+      {
         let (inner, rest) = take_tube_directive(item);
         tube = inner;
         kept.push(rest);

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -5465,6 +5465,25 @@ pub fn to_string_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let s = crate::syntax::expr_to_output_form_2d(&formatted);
         return Ok(Expr::String(s));
       }
+      "TraditionalForm" => {
+        // Typeset into TraditionalForm boxes and lay them out as 2D text:
+        // `Sin[x]` reads `sin(x)`, `HoldForm[f][HoldForm[x]]` reads `f(x)`,
+        // and a quotient still spans three lines the way OutputForm's
+        // fraction does. Demonstrations build their plot labels this way,
+        // pasting the pieces together with `StringJoin`.
+        let formatted =
+          crate::evaluator::dispatch::complex_and_special::apply_format_recursively(
+            &args[0],
+            "TraditionalForm",
+          );
+        let boxes =
+          crate::evaluator::dispatch::complex_and_special::expr_to_box_form_traditional(
+            &formatted,
+          );
+        return Ok(Expr::String(crate::syntax::boxes_to_output_form_2d(
+          &boxes,
+        )));
+      }
       "StandardForm" => {
         // Build the box AST via MakeBoxes (which dispatches user-defined
         // Format / MakeBoxes rules), then encode it using Wolfram's

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3090,8 +3090,8 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
       }
       result
     }
-    Rule::NumericCall => {
-      // 1[2, 3] → CurriedCall with the numeric literal as the func (matches
+    Rule::NumericCall | Rule::StringCall => {
+      // 1[2, 3] / "s"[x] → CurriedCall with the literal as the func (matches
       // the structure of `(1)[2, 3]`).
       let inner_pairs: Vec<_> = pair.into_inner().collect();
       let head_expr = pair_to_expr(inner_pairs[0].clone());
@@ -13926,6 +13926,44 @@ impl TextBox {
     let baseline = num.height();
     Self { lines, baseline }
   }
+
+  /// Place a script below and to the right of the base — the mirror of
+  /// [`superscript`](Self::superscript), used by `SubscriptBox`.
+  fn subscript(base: &Self, sub: &Self) -> Self {
+    let mut base = base.clone();
+    let mut sub = sub.clone();
+    base.normalize();
+    sub.normalize();
+
+    let bw = base.width();
+    let sw = sub.width();
+    let mut lines = Vec::with_capacity(base.height() + sub.height());
+    for l in &base.lines {
+      lines.push(format!("{}{}", l, " ".repeat(sw)));
+    }
+    for l in &sub.lines {
+      lines.push(format!("{}{}", " ".repeat(bw), l));
+    }
+    Self {
+      baseline: base.baseline,
+      lines,
+    }
+  }
+
+  /// Stack boxes vertically, left-aligned, keeping the first row's baseline.
+  fn vstack(parts: &[Self]) -> Self {
+    let mut lines = Vec::new();
+    let baseline = parts.first().map(|p| p.baseline).unwrap_or(0);
+    for part in parts {
+      let mut p = part.clone();
+      p.normalize();
+      lines.extend(p.lines);
+    }
+    if lines.is_empty() {
+      return Self::atom("");
+    }
+    Self { lines, baseline }
+  }
 }
 
 /// Renders to the final string. Trailing whitespace is stripped per line
@@ -14653,6 +14691,111 @@ fn render_times_textbox(args: &[Expr]) -> TextBox {
 pub fn expr_to_output_form_2d(expr: &Expr) -> String {
   let tb = expr_to_textbox(expr);
   tb.to_string()
+}
+
+/// Render a box tree (`RowBox`, `FractionBox`, `SuperscriptBox`, …) as the
+/// same 2D text `expr_to_output_form_2d` produces for ordinary expressions.
+/// `ToString[expr, TraditionalForm]` goes through here: the typesetter turns
+/// the expression into boxes and this lays them out, so a fraction still
+/// spans three lines while `Sin[x]` reads `sin(x)`.
+pub fn boxes_to_output_form_2d(expr: &Expr) -> String {
+  boxes_to_textbox(expr).to_string()
+}
+
+fn boxes_to_textbox(expr: &Expr) -> TextBox {
+  let items = |arg: &Expr| -> Vec<Expr> {
+    match arg {
+      Expr::List(items) => items.to_vec(),
+      other => vec![other.clone()],
+    }
+  };
+  match expr {
+    // Box atoms carry their text as strings, displayed unquoted.
+    Expr::String(s) => TextBox::atom(s),
+    Expr::FunctionCall { name, args } => match (name.as_str(), args.len()) {
+      ("RowBox", 1) => {
+        let parts: Vec<TextBox> =
+          items(&args[0]).iter().map(boxes_to_textbox).collect();
+        TextBox::hconcat(&parts)
+      }
+      ("SuperscriptBox", 2) => TextBox::superscript(
+        &boxes_to_textbox(&args[0]),
+        &boxes_to_textbox(&args[1]),
+      ),
+      ("SubscriptBox", 2) => TextBox::subscript(
+        &boxes_to_textbox(&args[0]),
+        &boxes_to_textbox(&args[1]),
+      ),
+      ("SubsuperscriptBox", 3) => TextBox::superscript(
+        &TextBox::subscript(
+          &boxes_to_textbox(&args[0]),
+          &boxes_to_textbox(&args[1]),
+        ),
+        &boxes_to_textbox(&args[2]),
+      ),
+      ("FractionBox", 2) => TextBox::fraction(
+        &boxes_to_textbox(&args[0]),
+        &boxes_to_textbox(&args[1]),
+      ),
+      ("SqrtBox", 1) => TextBox::hconcat(&[
+        TextBox::atom("\u{221A}"),
+        boxes_to_textbox(&args[0]),
+      ]),
+      ("RadicalBox", 2) => TextBox::hconcat(&[
+        TextBox::superscript(
+          &TextBox::atom("\u{221A}"),
+          &boxes_to_textbox(&args[1]),
+        ),
+        boxes_to_textbox(&args[0]),
+      ]),
+      // Over/under scripts stack their script on the far side of the base
+      // (`lim` with its variable beneath, `∑` with its bounds).
+      ("OverscriptBox", 2) => TextBox::vstack(&[
+        boxes_to_textbox(&args[1]),
+        boxes_to_textbox(&args[0]),
+      ]),
+      ("UnderscriptBox", 2) => TextBox::vstack(&[
+        boxes_to_textbox(&args[0]),
+        boxes_to_textbox(&args[1]),
+      ]),
+      ("UnderoverscriptBox", 3) => TextBox::vstack(&[
+        boxes_to_textbox(&args[2]),
+        boxes_to_textbox(&args[0]),
+        boxes_to_textbox(&args[1]),
+      ]),
+      // A grid lays its rows out one per line, columns separated by two
+      // spaces — the spacing `TableForm` uses.
+      ("GridBox", n) if n >= 1 => {
+        let rows: Vec<TextBox> = items(&args[0])
+          .iter()
+          .map(|row| {
+            let cells: Vec<TextBox> = items(row)
+              .iter()
+              .enumerate()
+              .flat_map(|(i, cell)| {
+                let mut out = Vec::new();
+                if i > 0 {
+                  out.push(TextBox::atom("  "));
+                }
+                out.push(boxes_to_textbox(cell));
+                out
+              })
+              .collect();
+            TextBox::hconcat(&cells)
+          })
+          .collect();
+        TextBox::vstack(&rows)
+      }
+      // Wrappers that only decorate what they hold.
+      (
+        "StyleBox" | "TagBox" | "InterpretationBox" | "FormBox"
+        | "AdjustmentBox" | "FrameBox" | "BoxData" | "TooltipBox",
+        n,
+      ) if n >= 1 => boxes_to_textbox(&args[0]),
+      _ => expr_to_textbox(expr),
+    },
+    other => expr_to_textbox(other),
+  }
 }
 
 /// Compose a message line around an expression rendered in 2D OutputForm,

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -156,6 +156,11 @@ ListCall = { List ~ BracketArgs+ }
 // `1[2, 3]` (an expression with an integer head, used for labelled trees).
 // Restricted to numeric literals (not Constants) and mirrors `(1)[2, 3]`.
 NumericCall = { (Real | IntegerScientific | Integer) ~ BracketArgs+ }
+// StringCall handles a string literal used as a function head, e.g.
+// `"f"[x]`, which stays unevaluated just like `1[2, 3]`. Typeset labels
+// built by hand use it to apply a box-notation string to an argument:
+// `"\!\(\*SuperscriptBox[\(f\), \(-1\)]\)"[x]`.
+StringCall = { String ~ BracketArgs+ }
 // ListExtended merges List, ListCall, and List-based PartExtract into a single
 // rule to avoid exponential backtracking. Parses List ONCE, then checks for
 // optional Part or Call suffixes.
@@ -526,6 +531,7 @@ Term = _{
   | Decrement
   | PartExtract
   | Constant
+  | StringCall
   | String
   | ListExtended
   | DerivativeNumeric
@@ -576,6 +582,7 @@ SimpleTerm = _{
   | Slot
   | OutShortcut
   | List
+  | StringCall
   | String
   | "(" ~ (&HasSpanSep ~ SpanExpr | Expression) ~ ")"
 }
@@ -595,6 +602,7 @@ TermNoImplicit = _{
   | Decrement
   | PartExtract
   | Constant
+  | StringCall
   | String
   | ListExtended
   | DerivativeNumeric

--- a/tests/cli/math/linear_algebra.md
+++ b/tests/cli/math/linear_algebra.md
@@ -5,6 +5,7 @@ normalised to `##` in this file.
 
 - [`Dot`](linear_algebra/Dot.md)
 - [`Det`](linear_algebra/Det.md)
+- [`GeometricTransformation`](linear_algebra/GeometricTransformation.md)
 - [`Inverse`](linear_algebra/Inverse.md)
 - [`Tr`](linear_algebra/Tr.md)
 - [`IdentityMatrix`](linear_algebra/IdentityMatrix.md)

--- a/tests/cli/math/linear_algebra/GeometricTransformation.md
+++ b/tests/cli/math/linear_algebra/GeometricTransformation.md
@@ -1,0 +1,20 @@
+# `GeometricTransformation`
+
+Draw graphics mapped through an affine transformation.
+
+The second argument may be a `TransformationFunction`, which is normalized to
+the `{matrix, vector}` pair of the affine map `p ↦ matrix.p + vector`.
+
+```scrut
+$ wo 'GeometricTransformation[Line[{{0, 0}, {2, 0}}], ReflectionTransform[{-1, 1}]]'
+GeometricTransformation[Line[{{0, 0}, {2, 0}}], {{{0, 1}, {1, 0}}, {0, 0}}]
+```
+
+Inside a `Graphics`, the enclosed primitives are drawn transformed. Reflecting
+in the line `y = x` swaps the coordinates of every point, which is how the
+graph of a function's inverse is drawn from the graph of the function.
+
+```scrut
+$ wo 'ExportString[Graphics[GeometricTransformation[Line[{{0, 0}, {2, 0}}], ReflectionTransform[{-1, 1}]], PlotRange -> {{-1, 3}, {-1, 3}}], "SVG"] // StringContainsQ[#, "90.00,270.00 90.00,90.00"] &'
+True
+```

--- a/tests/cli/strings/conversion/ToString.md
+++ b/tests/cli/strings/conversion/ToString.md
@@ -31,3 +31,19 @@ point (zero-padded).
 $ wo 'ToString[NumberForm[3.0, {5, 2}]]'
 3.00
 ```
+
+A second argument names the form to render in. `TraditionalForm` typesets:
+a known function takes its roman name and round brackets.
+
+```scrut
+$ wo 'ToString[Sin[x], TraditionalForm]'
+sin(x)
+```
+
+`HoldForm` keeps a symbol from evaluating while still displaying it, so a
+label can name a function and apply it without computing anything.
+
+```scrut
+$ wo 'ToString[HoldForm[g][HoldForm[x]], TraditionalForm]'
+g(x)
+```

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -3993,6 +3993,32 @@ mod curried_and_head_patterns {
   }
 
   #[test]
+  fn string_head_application_parses() {
+    // A string literal used as a head stays unevaluated, exactly like the
+    // numeric-head form above. A Demonstration writes its inverse-function
+    // label this way, applying a box-notation superscript string to the
+    // variable, so the whole surrounding expression has to parse.
+    assert_eq!(interpret("\"f\"[x]").unwrap(), "\"f\"[x]");
+    assert_eq!(interpret("Head[\"f\"[x]]").unwrap(), "\"f\"");
+    assert_eq!(interpret("{a, \"f\"[x]}").unwrap(), "{a, \"f\"[x]}");
+  }
+
+  #[test]
+  fn string_head_application_in_implicit_product() {
+    // `g "f"[x]` is `g * ("f"[x])` — the string-headed call is one factor of
+    // an implicit product, not a syntax error.
+    assert_eq!(
+      interpret("Head[g \"f\"[x]]").unwrap(),
+      "Times",
+      "the product of a symbol and a string-headed call"
+    );
+    // The same nested inside a larger call, which is where a failure used to
+    // send the parser into exponential backtracking rather than a clean
+    // rejection.
+    assert_eq!(interpret("Length[Hold[g \"f\"[x], 1, 2]]").unwrap(), "3");
+  }
+
+  #[test]
   fn head_pattern_with_integer_head() {
     // Head pattern matching descends into an integer-headed expression.
     assert_eq!(

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -7428,6 +7428,149 @@ ParametricPlot[f[t], {t, 0, 1}]]",
     /// expression, not its numeric value — through `Show`, which re-renders
     /// the plot as graphics, just as in the plot itself.
     #[test]
+    fn show_draws_a_variable_holding_graphics_wrapping_a_plot() {
+      // The Demonstrations idiom `g = Graphics[Plot[…]]; Show[g, …]`: the
+      // wrapper reaches `Show` already evaluated, and its finished picture
+      // must be shown rather than merged as if it were a drawing primitive
+      // — which drew nothing at all.
+      let svg = export_svg(
+        "g1 = Graphics[Plot[Sin[x], {x, -7, 7}]]; \
+         g2 = Graphics[Plot[Cos[x], {x, -7, 7}]]; \
+         Show[g1, {}, g2]",
+      );
+      assert!(
+        svg.matches("<polyline").count() > 1,
+        "expected both curves, got: {svg}"
+      );
+      // The same graphic on its own is drawn too.
+      let single =
+        export_svg("g = Graphics[Plot[Sin[x], {x, -7, 7}]]; Show[g]");
+      assert!(
+        single.contains("<polyline"),
+        "expected the curve, got: {single}"
+      );
+    }
+
+    #[test]
+    fn geometric_transformation_maps_its_content() {
+      // `GeometricTransformation[g, t]` draws `g` mapped through the affine
+      // transform. Every case is checked against the same 4-by-4 window, so
+      // the origin sits at (180, 180) and one unit is 45 SVG units across
+      // (y grows downwards).
+      let at = |body: &str| {
+        let svg = export_svg(&format!(
+          "Graphics[{body}, PlotRange -> {{{{-4, 4}}, {{-4, 4}}}}]"
+        ));
+        svg
+          .split("points=\"")
+          .nth(1)
+          .map(|s| s.split('"').next().unwrap_or_default().to_string())
+          .unwrap_or_default()
+      };
+      // Reflection in the line y = x maps (2, 0) to (0, 2).
+      assert_eq!(
+        at(
+          "GeometricTransformation[Line[{{0, 0}, {2, 0}}], \
+            ReflectionTransform[{-1, 1}]]"
+        ),
+        "180.00,180.00 180.00,90.00"
+      );
+      // A quarter turn maps (1, 0) to (0, 1).
+      assert_eq!(
+        at(
+          "GeometricTransformation[Line[{{0, 0}, {1, 0}}], \
+            RotationTransform[Pi/2]]"
+        ),
+        "180.00,180.00 180.00,135.00"
+      );
+      // An explicit `{matrix, vector}` pair, here a shear taking (0, 1) to
+      // (1, 1), then shifted by {1, 0}.
+      assert_eq!(
+        at(
+          "GeometricTransformation[Line[{{0, 0}, {0, 1}}], \
+            {{{1, 1}, {0, 1}}, {1, 0}}]"
+        ),
+        "225.00,180.00 270.00,135.00"
+      );
+      // A list of transforms draws one copy each.
+      let svg = export_svg(
+        "Graphics[GeometricTransformation[Line[{{0, 0}, {1, 0}}], \
+         {TranslationTransform[{0, 1}], TranslationTransform[{0, 2}]}]]",
+      );
+      assert_eq!(svg.matches("<polyline").count(), 2);
+    }
+
+    #[test]
+    fn a_plots_curve_is_reachable_by_a_structural_rule() {
+      // Wolfram keeps a plot's curve as `Line` primitives, so a rule naming
+      // one rewrites the picture — the Demonstrations idiom for drawing a
+      // function's inverse, mirroring the curve about `y = x`. The wrapper
+      // form `Graphics[Plot[…]]` behaves the same, since it *is* the picture
+      // it wraps.
+      for target in [
+        "Plot[Sin[x], {x, 0, 3}]",
+        "Graphics[Plot[Sin[x], {x, 0, 3}]]",
+      ] {
+        let svg = export_svg(&format!(
+          "{target} /. L_Line :> {{Red, \
+           GeometricTransformation[L, ReflectionTransform[{{-1, 1}}]]}}"
+        ));
+        assert!(
+          svg.contains("stroke=\"rgb(255,0,0)\""),
+          "the rule should have recoloured the curve of {target}: {svg}"
+        );
+      }
+      // A rule that matches nothing leaves the plot exactly as it was.
+      let untouched = export_svg("Plot[Sin[x], {x, 0, 3}] /. zzz -> 1");
+      let original = export_svg("Plot[Sin[x], {x, 0, 3}]");
+      assert_eq!(untouched, original);
+    }
+
+    #[test]
+    fn ticks_may_name_the_x_axis_alone() {
+      // `Ticks -> {xspec}` states the x ticks and leaves the y axis to its
+      // default, the short form a Demonstration uses to put a trigonometric
+      // plot on multiples of π.
+      let svg = export_svg(
+        "Plot[Sin[x], {x, -7, 7}, Ticks -> {Range[-2 Pi, 2 Pi, Pi]}]",
+      );
+      assert!(svg.contains(">π<"), "expected a π tick label, got: {svg}");
+      assert!(
+        !svg.contains(">-2.5<"),
+        "the default numeric x ticks should be gone"
+      );
+    }
+
+    #[test]
+    fn plot_label_grid_stacks_one_row_per_line() {
+      // A `Grid`/`Column` title stacks, rather than printing the source of
+      // the call: a Demonstration titles its plot with the parent function
+      // above and the transformed one below.
+      let svg = export_svg(
+        "Plot[Sin[x], {x, 0, 1}, \
+         PlotLabel -> Grid[{{\"first row\"}, {\"second row\"}}]]",
+      );
+      assert!(
+        !svg.contains("Grid["),
+        "the grid should be laid out, not printed: {svg}"
+      );
+      assert!(svg.contains(">first row<"), "got: {svg}");
+      // The further rows sit on their own lines, centred under the first.
+      assert!(
+        svg.contains("<tspan") && svg.contains("second row</tspan>"),
+        "expected the second row on its own line: {svg}"
+      );
+      // `Column` stacks the same way.
+      let column = export_svg(
+        "Plot[Sin[x], {x, 0, 1}, PlotLabel -> Column[{\"top\", \"bottom\"}]]",
+      );
+      assert!(
+        column.contains("bottom</tspan>"),
+        "expected a stacked Column title: {column}"
+      );
+    }
+
+    #[test]
     fn show_keeps_symbolic_tick_labels() {
       let svg = export_svg(
         "Show[ParametricPlot[{4 Cos[t], 4 Sin[t]}, {t, 0, 2 Pi}, \
@@ -18021,6 +18164,88 @@ mod manipulate {
       result.warnings.iter().all(|w| !w.contains("vsform")),
       "unexpected vsform warnings: {:?}",
       result.warnings
+    );
+  }
+
+  #[test]
+  fn spec_text_argument_is_an_annotation_row() {
+    // `Text[Row[…]]` between the controls is a static label, exactly like
+    // `Style[…]` — Wolfram tags it ThisIsNotAControl rather than reporting a
+    // malformed variable specification. Demonstrations head their slider
+    // block with the formula the sliders parameterize.
+    let expr = interpret_to_expr(
+      "Manipulate[a x, \
+       Text[Row[{Style[\"g\", Italic], \"(\", Style[\"x\", Italic], \")\"}]], \
+       {{a, 1}, 0, 2}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).unwrap();
+    match &spec.controls[0] {
+      ManipulateControl::Heading { label, label_runs } => {
+        assert_eq!(label, "g(x)");
+        // The italic runs of the formula survive into the rendered row.
+        assert!(label_runs.iter().any(|r| r.italic && r.text == "g"));
+      }
+      other => panic!("expected an annotation row, got {other:?}"),
+    }
+    assert!(matches!(
+      &spec.controls[1],
+      ManipulateControl::Continuous { name, .. } if name == "a"
+    ));
+  }
+
+  #[test]
+  fn spec_text_argument_emits_no_vsform_message() {
+    let result = woxi::interpret_with_stdout(
+      "Manipulate[a, Text[Row[{\"g\", \"(x)\"}]], {a, 0, 1}];",
+    )
+    .unwrap();
+    assert!(
+      result.warnings.iter().all(|w| !w.contains("vsform")),
+      "unexpected vsform warnings: {:?}",
+      result.warnings
+    );
+  }
+
+  #[test]
+  fn spec_choice_list_computed_by_the_body() {
+    // A popup whose choices are a symbol the *body* fills in. Wolfram runs
+    // the body once before laying the controls out, so the choices are in
+    // hand by then; the hidden `ControlType -> None` state variable only
+    // declares the symbol, starting empty.
+    let expr = interpret_to_expr(
+      "Manipulate[choices = {1 -> \"one\", 2 -> \"two\", 3 -> \"three\"}; k, \
+       {{k, 2, \"\"}, choices, ControlType -> PopupMenu}, \
+       {{choices, {}}, ControlType -> None}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed Manipulate");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete {
+        name,
+        values,
+        value_labels,
+        initial_index,
+        popup,
+        ..
+      } => {
+        assert_eq!(name, "k");
+        assert_eq!(values, &["1", "2", "3"]);
+        assert_eq!(value_labels, &["one", "two", "three"]);
+        assert_eq!(*initial_index, 1, "the spec starts the popup at 2");
+        assert!(popup, "ControlType -> PopupMenu renders a dropdown");
+      }
+      other => panic!("expected a popup control, got {other:?}"),
+    }
+    // The choices follow the sibling variable, so the frontend rebuilds them
+    // whenever the body reassigns it.
+    assert!(
+      spec
+        .dynamic_values
+        .iter()
+        .any(|(n, code)| n == "k" && code == "choices"),
+      "popup choices track the variable that holds them: {:?}",
+      spec.dynamic_values
     );
   }
 

--- a/tests/interpreter_tests/string.rs
+++ b/tests/interpreter_tests/string.rs
@@ -4648,6 +4648,51 @@ mod string_form {
     assert_eq!(interpret("ToString[255, InputForm]").unwrap(), "255");
   }
 
+  // `ToString[expr, TraditionalForm]` typesets rather than prints: a known
+  // function takes its roman name and round brackets, a `HoldForm`-headed
+  // application shows as the head applied to its argument, and a quotient
+  // still spans three lines the way OutputForm's fraction does.
+  // Demonstrations paste such pieces together with `StringJoin` to build
+  // their plot labels.
+  #[test]
+  fn to_string_traditional_form_typesets_functions() {
+    assert_eq!(
+      interpret("ToString[Sin[x], TraditionalForm]").unwrap(),
+      "sin(x)"
+    );
+    assert_eq!(
+      interpret("ToString[HoldForm[g][HoldForm[x]], TraditionalForm]").unwrap(),
+      "g(x)"
+    );
+    // A `Style` wrapper only colours the result; the text is what it holds.
+    assert_eq!(
+      interpret(
+        "ToString[Style[HoldForm[f][HoldForm[x]], Red], TraditionalForm]"
+      )
+      .unwrap(),
+      "f(x)"
+    );
+    // A string displays unquoted, so joined label pieces read as prose.
+    assert_eq!(
+      interpret("ToString[\" = \", TraditionalForm]").unwrap(),
+      " = "
+    );
+  }
+
+  #[test]
+  fn to_string_traditional_form_stacks_quotients() {
+    assert_eq!(
+      interpret("ToString[a/b, TraditionalForm]").unwrap(),
+      "a\n-\nb"
+    );
+    // The evaluated `Times[a, Power[b, -1]]` shape sets as a fraction too,
+    // rather than as a factor with a negative exponent.
+    assert_eq!(
+      interpret("ToString[Sin[x]/2, TraditionalForm]").unwrap(),
+      "sin(x)\n------\n  2"
+    );
+  }
+
   #[test]
   fn to_string_table_form_matrix() {
     assert_eq!(


### PR DESCRIPTION
This PR adds support for `GeometricTransformation` graphics primitives and improves plot label rendering to support multi-line titles via `Grid` and `Column` expressions.

## Key Changes

**GeometricTransformation Support:**
- Implemented `parse_affine_transforms()` to parse transformation specifications (bare matrices, `{matrix, vector}` pairs, `TransformationFunction` objects, and lists thereof)
- Implemented `affine_primitive()` to apply 2D affine transformations to graphics primitives using SVD factorization into rotation-scale-rotation components
- Added handling in `collect_primitives()` to render graphics mapped through affine transforms
- Enables the Demonstrations idiom of mirroring curves about `y = x` to visualize function inverses

**Multi-line Plot Labels:**
- Added `expr_to_svg_markup_lines()` to parse stacked labels from `Grid` and `Column` expressions, splitting on newlines
- Changed `plot_label` storage from `Option<String>` to `Option<Vec<String>>` to track multiple lines
- Updated SVG rendering to place additional lines as `<tspan>` elements with proper vertical spacing
- Adjusted top margin calculations to reserve space for extra label lines
- Applied same multi-line support to chart labels via `StyledLabel::svg_scaled_stacked()`

**Pattern Matching Improvements:**
- Enhanced `apply_replace_all_ast()` to render `Graphics[Plot[…]]` wrappers before pattern matching, allowing rules to reach plot primitives
- Added `plot_source_primitives()` to expand plot series into their underlying `Line`/`Point` primitives for rewriting
- Enables the Demonstrations idiom `plot /. L_Line :> {Red, GeometricTransformation[L, …]}`

**Supporting Changes:**
- Added `boxes_to_output_form_2d()` and `boxes_to_textbox()` to render box notation as 2D text for `ToString[…, TraditionalForm]`
- Improved `tf_times()` to render quotients with reciprocal factors under a fraction bar
- Added `subscript()` and `vstack()` methods to `TextBox` for box layout
- Extended `Ticks` option parsing to accept single-element lists (x-axis only)
- Made `wraps_rendered_graphic()` public for use in pattern matching
- Added support for string-headed function calls (`"f"[x]`) in the parser

**Tests:**
- Added comprehensive tests for `GeometricTransformation` with various transform types
- Added tests for plot label stacking with `Grid` and `Column`
- Added tests for pattern matching on plot curves
- Added tests for `Ticks` with single-element specification
- Added tests for `ToString[…, TraditionalForm]` with functions and quotients
- Added tests for `Show` with graphics-wrapped plots and string-headed applications

https://claude.ai/code/session_01VE3C2Akdn6hEHUmxm3qyjm