### PR TITLE
Add Specularity support and PaneSelector visibility gating

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -615,7 +615,7 @@ Divide,Divide numbers,✅,pure,1.0,572
 Around,Represent a value with uncertainty,✅,pure,12.0,573
 SaveDefinitions,Option to save definitions with output,✅,none,6.0,574
 Insert,Inserts an element at a specified position in a list,✅,pure,1.0,575
-Specularity,Graphics directive for specular highlighting,✅,none,6.0,576
+Specularity,Specifies the specular highlight of 3D surfaces,✅,pure,6.0,576
 Minimize,Global symbolic minimization of a function over variables with optional constraints and an optional Reals or Integers domain,✅,pure,5.0,577
 Begin,Begins a private context (no-op in Woxi),✅,effectful,1.0,578
 RepeatedTiming,Time expression evaluation with repeated sampling,✅,effectful,10.1,579

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1161,6 +1161,12 @@ fn apply_directive(expr: &Expr, style: &mut StyleState) -> bool {
 
   match expr {
     Expr::FunctionCall { name, args } => match name.as_str() {
+      // `Specularity` only means something in 3D. In 2D it is inert — but
+      // it still has to be consumed here, since the colour it carries is a
+      // highlight colour and letting it fall through to the generic
+      // recursion would repaint the primitives that follow
+      // (`{GrayLevel[.25], Specularity[White, 10], Disk[]}`).
+      "Specularity" if !args.is_empty() => true,
       "Opacity" if !args.is_empty() => {
         if let Some(o) = expr_to_f64(&args[0]) {
           style.opacity = o.clamp(0.0, 1.0);
@@ -15810,6 +15816,9 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // `Button[…]`, `Row[{Control[…], Spacer[…], …}]` and friends — are
       // valid Manipulate arguments (the Demonstrations layout pattern), not
       // malformed variable specs. They pass through with no message.
+      // `PaneSelector[{v -> controls, …}, sel]` is the same pattern one
+      // level up: a Demonstration whose modes need different controls
+      // swaps whole control panels as `sel` changes.
       Expr::FunctionCall { name, .. }
         if matches!(
           name.as_str(),
@@ -15820,6 +15829,8 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             | "Button"
             | "ButtonBar"
             | "Spacer"
+            | "PaneSelector"
+            | "TabView"
         ) =>
       {
         out_args.push(spec.clone());
@@ -16144,6 +16155,16 @@ pub struct ManipulateSpec {
   /// while `YinYang` is `True`). Controls with no `Enabled` option (or the
   /// trivial `Enabled -> True`) do not appear here and stay always enabled.
   pub control_enabled: Vec<(String, String)>,
+  /// Per-control visibility gating, as `(control name, condition code)`.
+  /// A `PaneSelector[{v -> controls, …}, sel]` argument swaps whole control
+  /// panels as `sel` changes, so each pane's controls are shown only while
+  /// `sel` holds that pane's value (Kepler's-conjecture packing shows one
+  /// angle slider for the disk view, four controls for the sphere view and
+  /// none for the cannonball view). Woxi's control panel is one flat list,
+  /// so the panes become conditions the frontend re-evaluates against the
+  /// live bindings, hiding the rows that do not apply. Controls outside any
+  /// pane do not appear here and stay always visible.
+  pub control_visible: Vec<(String, String)>,
   /// Continuous-control bounds that reference other control variables, as
   /// `(control name, min code, max code)`. A Demonstration like Kepler's
   /// Second Law bounds its time slider by the orbital-period variable
@@ -16281,6 +16302,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     mut displays,
     mut initialization,
     mut control_enabled,
+    mut control_visible,
     mut dynamic_bounds,
     mut dynamic_values,
     mut animation_var,
@@ -16295,6 +16317,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         inner.displays,
         inner.initialization,
         inner.control_enabled,
+        inner.control_visible,
         inner.dynamic_bounds,
         inner.dynamic_values,
         inner.animation_var,
@@ -16316,6 +16339,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         Vec::new(),
         body_displays,
         None,
+        Vec::new(),
         Vec::new(),
         Vec::new(),
         Vec::new(),
@@ -16346,6 +16370,10 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   let mut arg_items: Vec<Expr> =
     Vec::with_capacity(args.len().saturating_sub(1));
   for spec in &args[1..] {
+    // A `PaneSelector` argument shows one pane's controls at a time; the
+    // flattened list holds every pane's, so each pane's controls also pick
+    // up the condition under which they are on screen.
+    collect_pane_visibility(spec, &mut control_visible);
     match control_group_items(spec) {
       Some(items) => arg_items.extend(items),
       None => arg_items.push(spec.clone()),
@@ -16743,7 +16771,9 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     if let Some(init) = &mut initialization {
       rewrite(init);
     }
-    for (_, cond) in &mut control_enabled {
+    for (_, cond) in
+      control_enabled.iter_mut().chain(control_visible.iter_mut())
+    {
       rewrite(cond);
     }
     for (_, min_code, max_code) in &mut dynamic_bounds {
@@ -16778,6 +16808,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     displays,
     initialization,
     control_enabled,
+    control_visible,
     dynamic_bounds,
     dynamic_values,
     animation_var,
@@ -17079,15 +17110,25 @@ fn control_group_items(spec: &Expr) -> Option<Vec<Expr>> {
   for item in items.iter() {
     // A `TabView` lists its tabs as `label -> content`, and a
     // `PaneSelector` its panes as `value -> content`; only the content
-    // holds controls. (Woxi's control panel is one flat list, so neither
-    // the tabs nor the panes are reproduced — every one's controls are
-    // shown, and a variable declared in more than one pane is registered
-    // once, from the first pane that declares it.)
+    // holds controls. (Woxi's control panel is one flat list, so every
+    // pane's controls are collected into it, and a variable declared in
+    // more than one pane is registered once, from the first pane that
+    // declares it. `collect_pane_visibility` records which pane each one
+    // came from, so the frontend can still show one panel at a time.)
     let item = match (name.as_str(), item) {
       (
         "TabView" | "PaneSelector",
         Expr::Rule { replacement, .. } | Expr::RuleDelayed { replacement, .. },
-      ) => replacement.as_ref(),
+      ) => {
+        // A pane holding no control at all contributes nothing to the flat
+        // list — a placeholder pane (`3 -> " "`, the Demonstrations idiom
+        // for "this mode has no controls") must not leave a blank heading
+        // row behind.
+        if !contains_control(replacement) {
+          continue;
+        }
+        replacement.as_ref()
+      }
       _ => item,
     };
     match item {
@@ -17102,6 +17143,110 @@ fn control_group_items(spec: &Expr) -> Option<Vec<Expr>> {
     }
   }
   Some(out)
+}
+
+/// Record, for every control declared inside a `PaneSelector[{v -> content,
+/// …}, sel]` argument, the condition under which its pane is on screen
+/// (`sel == v`). Woxi lays every pane's controls out in one flat list, so
+/// these conditions are what let a frontend hide the rows belonging to the
+/// panes the selector is not showing.
+///
+/// A variable declared in several panes (a Demonstration reusing one angle
+/// slider across two modes) is visible in all of them, so its conditions
+/// are or-ed together. Only the outermost `PaneSelector` of an argument is
+/// honoured — a pane nested inside another pane keeps its parent's
+/// condition rather than gaining its own.
+fn collect_pane_visibility(spec: &Expr, out: &mut Vec<(String, String)>) {
+  let Expr::FunctionCall { name, args } = spec else {
+    return;
+  };
+  if name != "PaneSelector" {
+    // The `PaneSelector` may sit inside a layout container.
+    for arg in args.iter() {
+      collect_pane_visibility(arg, out);
+    }
+    return;
+  }
+  let (Some(Expr::List(panes)), Some(selector)) = (args.first(), args.get(1))
+  else {
+    return;
+  };
+  let selector = crate::syntax::expr_to_input_form(selector);
+  for pane in panes.iter() {
+    let (Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    }) = pane
+    else {
+      continue;
+    };
+    let cond = format!(
+      "({}) == ({})",
+      selector,
+      crate::syntax::expr_to_input_form(pattern)
+    );
+    for var in pane_control_variables(replacement) {
+      match out.iter_mut().find(|(n, _)| *n == var) {
+        Some((_, existing)) => *existing = format!("{existing} || {cond}"),
+        None => out.push((var, cond.clone())),
+      }
+    }
+  }
+}
+
+/// The control variables a `PaneSelector` pane declares: the variable of
+/// every `Control[…]` in it, plus — when the pane *is* a bare variable
+/// specification — that spec's own variable.
+fn pane_control_variables(pane: &Expr) -> Vec<String> {
+  fn walk(e: &Expr, out: &mut Vec<String>) {
+    match e {
+      Expr::FunctionCall { name, args } => {
+        if name == "Control"
+          && let Some(spec) = args.first()
+          && let Some(var) = control_spec_variable(spec)
+        {
+          out.push(var);
+          return;
+        }
+        for a in args.iter() {
+          walk(a, out);
+        }
+      }
+      Expr::List(items) => {
+        for it in items.iter() {
+          walk(it, out);
+        }
+      }
+      _ => {}
+    }
+  }
+  let mut out = Vec::new();
+  if let Some(var) = control_spec_variable(pane) {
+    out.push(var);
+  } else {
+    walk(pane, &mut out);
+  }
+  out
+}
+
+/// The variable a control specification binds: `{u, …}` or `{{u, init, …},
+/// …}`. `None` for anything that is not a variable specification.
+fn control_spec_variable(spec: &Expr) -> Option<String> {
+  let Expr::List(items) = spec else {
+    return None;
+  };
+  match items.first()? {
+    Expr::List(head) => match head.first()? {
+      Expr::Identifier(name) => Some(name.clone()),
+      _ => None,
+    },
+    Expr::Identifier(name) if items.len() >= 2 => Some(name.clone()),
+    _ => None,
+  }
 }
 
 /// Collect `(name, initial value as InputForm)` for every control spec that
@@ -17393,6 +17538,7 @@ pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     displays: Vec::new(),
     initialization: None,
     control_enabled: Vec::new(),
+    control_visible: Vec::new(),
     dynamic_bounds: Vec::new(),
     dynamic_values: Vec::new(),
     animation_var: None,
@@ -17470,6 +17616,7 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
     displays: Vec::new(),
     initialization: None,
     control_enabled: Vec::new(),
+    control_visible: Vec::new(),
     dynamic_bounds: Vec::new(),
     dynamic_values: Vec::new(),
     animation_var: None,
@@ -17545,6 +17692,7 @@ pub fn extract_locator_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     displays: Vec::new(),
     initialization: None,
     control_enabled: Vec::new(),
+    control_visible: Vec::new(),
     dynamic_bounds: Vec::new(),
     dynamic_values: Vec::new(),
     animation_var: None,
@@ -17596,6 +17744,7 @@ pub fn extract_click_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     displays: Vec::new(),
     initialization: None,
     control_enabled: Vec::new(),
+    control_visible: Vec::new(),
     dynamic_bounds: Vec::new(),
     dynamic_values: Vec::new(),
     animation_var: None,
@@ -17658,6 +17807,7 @@ pub fn extract_control_spec(expr: &Expr) -> Option<ManipulateSpec> {
     displays: Vec::new(),
     initialization: None,
     control_enabled,
+    control_visible: Vec::new(),
     dynamic_bounds: Vec::new(),
     dynamic_values: Vec::new(),
     animation_var,
@@ -19943,6 +20093,19 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
     {
       let field =
         format!(r#","enabledWhen":"{}""#, json_escape_manipulate(cond));
+      part.truncate(part.len() - 1);
+      part.push_str(&field);
+      part.push('}');
+    }
+    // A control belonging to a `PaneSelector` pane rides along with the
+    // condition under which its pane is on screen, so the frontend can hide
+    // the rows of the panes the selector is not showing.
+    if let Some((_, cond)) =
+      spec.control_visible.iter().find(|(n, _)| n == c.name())
+      && part.ends_with('}')
+    {
+      let field =
+        format!(r#","visibleWhen":"{}""#, json_escape_manipulate(cond));
       part.truncate(part.len() - 1);
       part.push_str(&field);
       part.push('}');

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -170,17 +170,22 @@ fn height_color(z_norm: f64) -> (u8, u8, u8) {
   }
 }
 
+/// The scene's single light, pointing from the surface towards the lamp
+/// (upper-left-front), normalized.
+fn light_direction() -> [f64; 3] {
+  let lx = 0.4_f64;
+  let ly = -0.5_f64;
+  let lz = 0.76_f64;
+  let len = (lx * lx + ly * ly + lz * lz).sqrt();
+  [lx / len, ly / len, lz / len]
+}
+
 /// Apply diffuse + ambient lighting
 pub(crate) fn apply_lighting(
   color: (u8, u8, u8),
   normal: [f64; 3],
 ) -> (u8, u8, u8) {
-  // Light direction: upper-left-front (normalized)
-  let lx = 0.4_f64;
-  let ly = -0.5_f64;
-  let lz = 0.76_f64;
-  let len = (lx * lx + ly * ly + lz * lz).sqrt();
-  let light = [lx / len, ly / len, lz / len];
+  let light = light_direction();
 
   let dot = normal[0] * light[0] + normal[1] * light[1] + normal[2] * light[2];
   let diffuse = dot.abs(); // use abs to light both sides
@@ -192,6 +197,50 @@ pub(crate) fn apply_lighting(
   let g = (color.1 as f64 * intensity).round() as u8;
   let b = (color.2 as f64 * intensity).round() as u8;
   (r, g, b)
+}
+
+/// Diffuse + ambient lighting with the highlight a `Specularity` directive
+/// asks for laid over it. `view_dir` points from the scene towards the
+/// viewer, so the highlight sits where the light reflects into the camera —
+/// which is what makes `Specularity[White, 10]` read as a glossy sphere
+/// rather than just a brighter one.
+pub(crate) fn apply_lighting_specular(
+  color: (u8, u8, u8),
+  normal: [f64; 3],
+  specular: Option<((u8, u8, u8), f64)>,
+  view_dir: [f64; 3],
+) -> (u8, u8, u8) {
+  let base = apply_lighting(color, normal);
+  let Some((hi, exponent)) = specular else {
+    return base;
+  };
+  let light = light_direction();
+  // Blinn-Phong: the highlight peaks where the surface normal bisects the
+  // directions to the lamp and to the viewer.
+  let half = {
+    let h = [
+      light[0] + view_dir[0],
+      light[1] + view_dir[1],
+      light[2] + view_dir[2],
+    ];
+    let len = (h[0] * h[0] + h[1] * h[1] + h[2] * h[2]).sqrt();
+    if len < 1e-12 {
+      return base;
+    }
+    [h[0] / len, h[1] / len, h[2] / len]
+  };
+  // `abs`, matching the two-sided diffuse term above: a tessellated sphere
+  // hands back outward and inward normals depending on winding.
+  let cos = (normal[0] * half[0] + normal[1] * half[1] + normal[2] * half[2])
+    .abs()
+    .clamp(0.0, 1.0);
+  let strength = cos.powf(exponent);
+  let mix = |b: u8, h: u8| {
+    (b as f64 + (h as f64 / 255.0) * strength * 255.0)
+      .round()
+      .min(255.0) as u8
+  };
+  (mix(base.0, hi.0), mix(base.1, hi.1), mix(base.2, hi.2))
 }
 
 fn parse_iterator(
@@ -1864,6 +1913,10 @@ struct StyleState3D {
   /// silhouette on: `{Opacity[0], EdgeForm[Black], Cylinder[…]}` is the
   /// Demonstrations idiom for an unfilled circle in space.
   edge_color: Option<(u8, u8, u8)>,
+  /// `Specularity[colour, exponent]`: the highlight a shiny surface throws
+  /// back at the viewer, as `(colour, exponent)`. `None` is the default
+  /// matte surface. A larger exponent tightens the highlight.
+  specular: Option<((u8, u8, u8), f64)>,
 }
 
 impl Default for StyleState3D {
@@ -1876,6 +1929,7 @@ impl Default for StyleState3D {
       capped: true,
       edges: true,
       edge_color: None,
+      specular: None,
     }
   }
 }
@@ -2024,6 +2078,17 @@ fn apply_3d_directive(expr: &Expr, style: &mut StyleState3D) -> bool {
         }
         return true;
       }
+      // `Specularity[colour]` / `Specularity[colour, exponent]` makes the
+      // surfaces that follow shiny. It never repaints them: the colour it
+      // carries is the *highlight's*, so it must be consumed here rather
+      // than fall through to the generic recursion, which would pick the
+      // colour up and use it as the face colour (a Demonstration's
+      // `{GrayLevel[.25], Specularity[White, 10], Sphere[…]}` would render
+      // white instead of dark grey).
+      "Specularity" if !args.is_empty() => {
+        style.specular = parse_specularity(args);
+        return true;
+      }
       // CapForm[None] leaves an open surface's ends open; every named form
       // ("Butt", "Square", "Round") closes them, as does the default.
       "CapForm" if args.len() == 1 => {
@@ -2091,6 +2156,38 @@ fn apply_3d_directive(expr: &Expr, style: &mut StyleState3D) -> bool {
   }
 
   false
+}
+
+/// Read a `Specularity[…]` argument list into `(highlight colour, exponent)`.
+/// The reflectance may be a colour (`Specularity[White, 10]`) or a plain
+/// number standing for that grey level (`Specularity[.5]`); the exponent
+/// defaults to Wolfram's `1`. A reflectance of zero (black) means a matte
+/// surface, i.e. no highlight at all.
+fn parse_specularity(args: &[Expr]) -> Option<((u8, u8, u8), f64)> {
+  use crate::functions::graphics::parse_color;
+  use crate::functions::math_ast::expr_to_f64;
+
+  let color = match parse_color(&args[0]) {
+    Some(c) => c,
+    None => {
+      let g = expr_to_f64(&args[0])?;
+      crate::functions::graphics::Color::new(g, g, g)
+    }
+  };
+  let rgb = (
+    (color.r.clamp(0.0, 1.0) * 255.0).round() as u8,
+    (color.g.clamp(0.0, 1.0) * 255.0).round() as u8,
+    (color.b.clamp(0.0, 1.0) * 255.0).round() as u8,
+  );
+  if rgb == (0, 0, 0) {
+    return None;
+  }
+  let exponent = args
+    .get(1)
+    .and_then(expr_to_f64)
+    .filter(|n| *n > 0.0)
+    .unwrap_or(1.0);
+  Some((rgb, exponent))
 }
 
 /// Collect 3D primitives from an expression.
@@ -4558,6 +4655,7 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             capped: true,
             edges: true,
             edge_color: None,
+            specular: None,
           },
         ),
       };
@@ -4622,7 +4720,12 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         Some(back) if facing < 0.0 => back,
         _ => prim_color,
       };
-      let color = apply_lighting(side_color, normal);
+      let color = apply_lighting_specular(
+        side_color,
+        normal,
+        prim_style.specular,
+        view_dir,
+      );
       let p0 = project(v0, &camera);
       let p1 = project(v1, &camera);
       let p2 = project(v2, &camera);

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -8197,10 +8197,9 @@ fn partition_tube(items: &[Expr]) -> (Option<Vec<Expr>>, Vec<Expr>) {
       Expr::FunctionCall { name, args } if name == "Tube" && tube.is_none() => {
         tube = Some(args.to_vec());
       }
-      Expr::List(_)
-      | Expr::FunctionCall {
-        name: _, args: _, ..
-      } if tube.is_none() && contains_tube(item) => {
+      Expr::List(_) | Expr::FunctionCall { .. }
+        if tube.is_none() && contains_tube(item) =>
+      {
         let (inner, rest) = take_tube_directive(item);
         tube = inner;
         kept.push(rest);

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -2539,6 +2539,91 @@ mod plot3d {
       insta::assert_snapshot!(export_svg("Graphics3D[Sphere[]]"));
     }
 
+    /// The red component of every shaded facet's fill, so a test can talk
+    /// about how dark or bright a surface came out. Only `<polygon>` fills
+    /// count — the white background `<rect>` is not part of the shading.
+    fn fill_reds(svg: &str) -> Vec<u32> {
+      svg
+        .split("<polygon ")
+        .skip(1)
+        .filter_map(|tag| {
+          let tag = tag.split('>').next()?;
+          tag
+            .split("fill=\"rgb(")
+            .nth(1)?
+            .split(',')
+            .next()?
+            .parse()
+            .ok()
+        })
+        .collect()
+    }
+
+    /// `Specularity[colour, n]` describes a surface's *highlight*, not its
+    /// body colour: a sphere given `{GrayLevel[.25], Specularity[White, 10]}`
+    /// (the Kepler's-conjecture cannonball stack) stays dark grey and gains a
+    /// bright spot, rather than being repainted white by the directive's own
+    /// colour.
+    #[test]
+    fn specularity_adds_a_highlight_without_repainting_the_surface() {
+      let plain =
+        export_svg("Graphics3D[{GrayLevel[.25], Sphere[]}, Boxed -> False]");
+      let shiny = export_svg(
+        "Graphics3D[{GrayLevel[.25], Specularity[White, 10], Sphere[]}, \
+         Boxed -> False]",
+      );
+      let darkest = |svg: &str| fill_reds(svg).into_iter().min().unwrap_or(0);
+      let brightest = |svg: &str| fill_reds(svg).into_iter().max().unwrap_or(0);
+      // The unlit side keeps the surface's own dark grey either way.
+      assert_eq!(
+        darkest(&plain),
+        darkest(&shiny),
+        "the highlight must not lighten the surface's own colour"
+      );
+      // A matte dark sphere never approaches white; a shiny one does.
+      assert!(
+        brightest(&plain) < 128,
+        "matte GrayLevel[.25] sphere should stay dark, got {}",
+        brightest(&plain)
+      );
+      assert!(
+        brightest(&shiny) > 250,
+        "Specularity[White, …] should add a near-white highlight, got {}",
+        brightest(&shiny)
+      );
+    }
+
+    /// A larger `Specularity` exponent concentrates the highlight, so fewer
+    /// facets are lit by it.
+    #[test]
+    fn specularity_exponent_tightens_the_highlight() {
+      let lit_facets = |exponent: &str| {
+        let svg = export_svg(&format!(
+          "Graphics3D[{{GrayLevel[.25], Specularity[White, {exponent}], \
+           Sphere[]}}, Boxed -> False]"
+        ));
+        fill_reds(&svg).into_iter().filter(|r| *r > 200).count()
+      };
+      assert!(
+        lit_facets("40") < lit_facets("4"),
+        "a higher exponent should light fewer facets"
+      );
+    }
+
+    /// `Specularity` means nothing in 2D, but it must still be consumed
+    /// there: its colour used to leak through as the fill of the primitives
+    /// that followed.
+    #[test]
+    fn specularity_is_inert_in_2d() {
+      let svg = export_svg(
+        "Graphics[{GrayLevel[.25], Specularity[White, 10], Disk[]}]",
+      );
+      assert!(
+        svg.contains("fill=\"rgb(64,64,64)\""),
+        "the disk keeps GrayLevel[.25]: {svg}"
+      );
+    }
+
     #[test]
     fn graphics3d_arrow_with_background() {
       insta::assert_snapshot!(export_svg(
@@ -17707,6 +17792,96 @@ mod manipulate {
       &spec.controls[0],
       ManipulateControl::Continuous { .. }
     ));
+  }
+
+  /// A `PaneSelector[{v -> controls, …}, sel]` argument is the Demonstrations
+  /// way of giving each mode its own control panel. It is a valid Manipulate
+  /// argument, so it must not emit `Manipulate::vsform` either.
+  #[test]
+  fn pane_selector_controls_are_not_vsform() {
+    let res = woxi::interpret_with_stdout(
+      "Manipulate[{q, a}, Control[{{q, 1}, {1, 2}, Setter}], \
+       PaneSelector[{1 -> Control[{{a, 5}, 0, 10}], 2 -> \" \"}, q]]",
+    )
+    .unwrap();
+    assert!(
+      !res.warnings.iter().any(|w| w.contains("vsform")),
+      "unexpected vsform message: {:?}",
+      res.warnings
+    );
+  }
+
+  /// Each `PaneSelector` pane's controls are collected into the one flat
+  /// control panel, but they carry the condition under which their pane is
+  /// on screen so a frontend can show one panel at a time. A variable used
+  /// by more than one pane is visible in all of them.
+  #[test]
+  fn pane_selector_controls_carry_pane_visibility() {
+    let expr = interpret_to_expr(
+      "Manipulate[{q, a, b}, Control[{{q, 1}, {1, 2, 3}, Setter}], \
+       PaneSelector[{1 -> Control[{{a, 5}, 0, 10}], \
+       2 -> Column[{Control[{{a, 5}, 0, 10}], Control[{{b, 1}, 0, 2}]}], \
+       3 -> \" \"}, q]]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    // The placeholder pane holds no control, so it leaves no row behind:
+    // the panel is the selector plus the two pane variables.
+    let names: Vec<&str> = spec.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["q", "a", "b"]);
+    assert_eq!(
+      spec.control_visible,
+      vec![
+        ("a".to_string(), "(q) == (1) || (q) == (2)".to_string()),
+        ("b".to_string(), "(q) == (2)".to_string()),
+      ]
+    );
+    // The selector itself sits outside every pane and is always shown.
+    assert!(!spec.control_visible.iter().any(|(n, _)| n == "q"));
+
+    // Resolve the conditions the way a frontend does, for each mode.
+    let conditions: Vec<Option<String>> = spec
+      .controls
+      .iter()
+      .map(|c| {
+        spec
+          .control_visible
+          .iter()
+          .find(|(n, _)| n == c.name())
+          .map(|(_, cond)| cond.clone())
+      })
+      .collect();
+    let shown = |q: &str| {
+      manipulate_enabled_states(
+        &conditions,
+        &[("q".to_string(), q.to_string())],
+      )
+    };
+    assert_eq!(shown("1"), vec![true, true, false]);
+    assert_eq!(shown("2"), vec![true, true, true]);
+    assert_eq!(shown("3"), vec![true, false, false]);
+  }
+
+  #[test]
+  fn spec_json_includes_visible_when() {
+    let expr = interpret_to_expr(
+      "Manipulate[{q, a}, Control[{{q, 1}, {1, 2}, Setter}], \
+       PaneSelector[{1 -> Control[{{a, 5}, 0, 10}], 2 -> \" \"}, q]]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).unwrap();
+    let json = manipulate_spec_to_json(&spec);
+    assert!(
+      json.contains(r#""visibleWhen":"(q) == (1)""#),
+      "json: {json}"
+    );
+    // The selector belongs to no pane and carries no condition.
+    let q_obj = json.split(r#""name":"q""#).nth(1).unwrap_or("");
+    let q_obj = q_obj.split('}').next().unwrap_or("");
+    assert!(
+      !q_obj.contains("visibleWhen"),
+      "a control outside every pane should have no visibleWhen: {q_obj}"
+    );
   }
 
   /// `Row[…]`-grouped controls are valid Manipulate arguments and must not

--- a/tests/playground/script.js
+++ b/tests/playground/script.js
@@ -337,6 +337,7 @@ function renderOutputItems(items) {
   // results arriving from the worker are ignored.
   manipulateRequests.clear()
   enabledRequests.clear()
+  visibleRequests.clear()
   // Halt any running animation timers whose widgets are about to be replaced.
   stopAllAnimators()
 
@@ -362,6 +363,11 @@ const manipulateRequests = new Map()
 // In-flight `evaluate_manipulate_enabled` requests, keyed by request id, so a
 // result can be routed back to the widget whose controls it re-gates.
 const enabledRequests = new Map()
+// The same, for the requests that decide which `PaneSelector` pane's controls
+// are on screen. Both use the same worker call — one evaluates `Enabled`
+// conditions, the other pane conditions — so the reply carries whichever list
+// its request id was registered under.
+const visibleRequests = new Map()
 let manipulateRequestCounter = 0
 
 function renderManipulate(item) {
@@ -437,6 +443,11 @@ function renderManipulate(item) {
     // `apply(on)` greys the control's DOM in or out. Re-evaluated on every
     // binding change so a control can disable itself for the current state.
     enabledControls: [],
+    // Controls belonging to a `PaneSelector` pane: `{condition, apply}` in
+    // control order, where `condition` decides whether that pane is the one
+    // on screen and `apply(on)` shows or hides the control's row. Controls
+    // outside any pane are not listed and are always shown.
+    visibleControls: [],
     // Continuous-slider drivers an Animate/ListAnimate animator can advance.
     animatables: [],
   }
@@ -494,21 +505,27 @@ function renderManipulate(item) {
     dispatchUpdate(bindings)
   }
 
-  // Re-evaluate every gated control's `Enabled` condition for the current
-  // bindings and grey the affected controls in or out. A no-op when no control
-  // has a condition.
-  function refreshEnabled(bindings) {
+  // Re-evaluate a list of gated controls' conditions for the current bindings
+  // and apply the resulting flags. A no-op when no control has a condition.
+  function refreshGated(controls, requests, bindings) {
     if (!worker) return
-    const conditions = widget.enabledControls.map((c) => c.condition)
+    const conditions = controls.map((c) => c.condition)
     if (conditions.every((c) => !c)) return
     const requestId = ++manipulateRequestCounter
-    enabledRequests.set(requestId, widget)
+    requests.set(requestId, widget)
     worker.postMessage({
       type: "evaluate_manipulate_enabled",
       requestId,
       conditions,
       bindings: bindings || buildBindings(),
     })
+  }
+
+  // Grey the controls an `Enabled -> Dynamic[…]` option has switched off in
+  // or out; show only the controls of the `PaneSelector` pane in force.
+  function refreshEnabled(bindings) {
+    refreshGated(widget.enabledControls, enabledRequests, bindings)
+    refreshGated(widget.visibleControls, visibleRequests, bindings)
   }
   widget.refreshEnabled = refreshEnabled
 
@@ -1066,6 +1083,19 @@ function renderManipulate(item) {
       })
     }
 
+    // A control that came from a `PaneSelector` pane is only on screen while
+    // the selector holds that pane's value. Every control kind builds a `row`,
+    // so the pane gate is registered once here rather than per kind.
+    if (ctrl.visibleWhen) {
+      widget.visibleControls.push({
+        condition: ctrl.visibleWhen,
+        apply: (on) => {
+          // Rows are `display: contents` in the control grid, so clearing the
+          // inline style is what puts one back rather than setting a value.
+          row.style.display = on ? "" : "none"
+        },
+      })
+    }
     controlsEl.appendChild(row)
   }
 
@@ -1252,8 +1282,13 @@ function initWorker() {
       // persisted when the "result" message first arrived.
     }
     else if (type === "manipulate_enabled_result") {
-      const widget = enabledRequests.get(e.data.requestId)
+      // The request id says which gate this reply answers: the `Enabled`
+      // conditions or the `PaneSelector` pane conditions.
+      const enabledWidget = enabledRequests.get(e.data.requestId)
+      const visibleWidget = visibleRequests.get(e.data.requestId)
       enabledRequests.delete(e.data.requestId)
+      visibleRequests.delete(e.data.requestId)
+      const widget = enabledWidget || visibleWidget
       if (!widget || !success) return
       let flags
       try {
@@ -1262,8 +1297,11 @@ function initWorker() {
         return
       }
       if (!Array.isArray(flags)) return
-      widget.enabledControls.forEach((c, i) => {
-        // Absent/undefined flag fails open (enabled).
+      const gated = enabledWidget
+        ? widget.enabledControls
+        : widget.visibleControls
+      gated.forEach((c, i) => {
+        // Absent/undefined flag fails open (enabled / on screen).
         c.apply(flags[i] !== false)
       })
     }

--- a/woxi-studio/examples/dump_manipulate.rs
+++ b/woxi-studio/examples/dump_manipulate.rs
@@ -66,8 +66,12 @@ fn main() {
       println!("=== Interactive widget #{widget_count} ===");
       println!("animated: {}", state.animated);
       println!("controls:");
-      for c in &state.controls {
-        println!("  {c:?}");
+      for (i, c) in state.controls.iter().enumerate() {
+        // A control belonging to a `PaneSelector` pane the selector is not
+        // currently showing is built but left off the panel.
+        let hidden = !state.control_is_visible.get(i).copied().unwrap_or(true);
+        let mark = if hidden { " [hidden]" } else { "" };
+        println!("  {c:?}{mark}");
       }
       if !state.state.is_empty() {
         println!("state vars:");

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -3791,17 +3791,32 @@ fn render_manipulate_widget<'a>(
   // Size the label column to the widest label so it sits snug against the
   // sliders. ~7.3px per character at the 12px caption font (monospace),
   // plus a little trailing padding; clamped so a single-glyph label still
-  // reads and a very long one can't swallow the slider.
+  // reads and a very long one can't swallow the slider. Only the rows
+  // actually on screen count — a `PaneSelector` pane that is not showing
+  // must not reserve room for its labels.
   let max_label_chars = state
     .controls
     .iter()
-    .map(manipulate_label_char_count)
+    .enumerate()
+    .filter(|(i, _)| state.control_is_visible.get(*i).copied().unwrap_or(true))
+    .map(|(_, c)| manipulate_label_char_count(c))
     .max()
     .unwrap_or(0);
   let label_col_width = (max_label_chars as f32 * 7.3 + 6.0).clamp(20.0, 220.0);
   let visible_controls: &[manipulate::ControlState] =
     if show_controls { &state.controls } else { &[] };
   for (ctrl_idx, ctrl) in visible_controls.iter().enumerate() {
+    // A control belonging to a `PaneSelector` pane the selector is not
+    // showing is left out of the panel entirely, the way Wolfram swaps one
+    // pane's controls for another's.
+    if !state
+      .control_is_visible
+      .get(ctrl_idx)
+      .copied()
+      .unwrap_or(true)
+    {
+      continue;
+    }
     // A control whose `Enabled` condition currently evaluates to `False` is
     // greyed out and swallows interaction (see `Message::Noop`).
     let enabled = state
@@ -6623,6 +6638,47 @@ mod tests {
       "span markers are layout, not displays: {:?}",
       state.displays
     );
+  }
+
+  /// A `PaneSelector` control panel — a Demonstration whose modes each need
+  /// different controls, as the closest-packing one does — shows only the
+  /// pane the selector is on. The controls of the other panes are built (so
+  /// their variables stay bound for the body) but left off the panel, and a
+  /// pane with no controls at all leaves no row behind.
+  #[test]
+  fn manipulate_pane_selector_shows_one_panel_at_a_time() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[{q, a, b}, Control[{{q, 2}, {1 -> \"one\", 2 -> \"two\", \
+       3 -> \"three\"}, Setter}], \
+       PaneSelector[{1 -> Control[{{a, 5}, 0, 10}], \
+       2 -> Column[{Control[{{a, 5}, 0, 10}], Control[{{b, 1}, 0, 2}]}], \
+       3 -> \" \"}, q]]",
+    )
+    .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    let names: Vec<&str> = state.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(
+      names,
+      vec!["q", "a", "b"],
+      "the placeholder pane must not add a row"
+    );
+    // The selector starts on pane 2, which shows both of its controls.
+    assert_eq!(state.control_is_visible, vec![true, true, true]);
+
+    // Switching the selector swaps the panel: pane 1 offers only `a`.
+    let select = |state: &mut manipulate::ManipulateState, idx: usize| {
+      if let manipulate::ControlState::Discrete { current_index, .. } =
+        &mut state.controls[0]
+      {
+        *current_index = idx;
+      }
+      state.reevaluate();
+    };
+    select(&mut state, 0);
+    assert_eq!(state.control_is_visible, vec![true, true, false]);
+    // Pane 3 is the placeholder: the selector is the only row left.
+    select(&mut state, 2);
+    assert_eq!(state.control_is_visible, vec![true, false, false]);
   }
 
   #[test]

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -304,6 +304,14 @@ pub struct ManipulateState {
   /// re-evaluation from `control_enabled` against the live bindings. Parallel
   /// to `controls`; a control indexes in with its position.
   pub control_is_enabled: Vec<bool>,
+  /// Per-control visibility condition (InputForm code), parallel to
+  /// `controls`. A control that belongs to a `PaneSelector` pane is on
+  /// screen only while the selector holds that pane's value. `None` means
+  /// the control belongs to no pane and is always shown.
+  control_visible: Vec<Option<String>>,
+  /// Whether each control is currently on screen, recomputed on every
+  /// re-evaluation from `control_visible` against the live bindings.
+  pub control_is_visible: Vec<bool>,
   /// Generation of the most recent control change. Bumped on every
   /// slider/picklist move so the throttled re-evaluation can tell whether a
   /// newer change has superseded a queued one.
@@ -346,6 +354,18 @@ impl ManipulateState {
       })
       .collect();
     let control_is_enabled = vec![true; controls.len()];
+    // …and with the pane it belongs to, for a `PaneSelector` control panel.
+    let control_visible: Vec<Option<String>> = controls
+      .iter()
+      .map(|c| {
+        spec
+          .control_visible
+          .iter()
+          .find(|(n, _)| n == c.name())
+          .map(|(_, cond)| cond.clone())
+      })
+      .collect();
+    let control_is_visible = vec![true; controls.len()];
     let mut state = ManipulateState {
       body: spec.body_code,
       initialization: spec.initialization,
@@ -367,6 +387,8 @@ impl ManipulateState {
       dynamic_values: spec.dynamic_values,
       control_enabled,
       control_is_enabled,
+      control_visible,
+      control_is_visible,
       reeval_pending: 0,
       reeval_applied: 0,
       reeval_scheduled: false,
@@ -625,6 +647,7 @@ impl ManipulateState {
     // (empty local bindings → no matrix re-embed).
     let displays = self.displays.clone();
     let control_enabled = self.control_enabled.clone();
+    let control_visible = self.control_visible.clone();
     let dynamic_bounds = self.dynamic_bounds.clone();
     let dynamic_values = self.dynamic_values.clone();
     let state_names: Vec<String> =
@@ -634,6 +657,7 @@ impl ManipulateState {
       updated_state,
       display_trees,
       enabled,
+      visible,
       resolved_bounds,
       resolved_values,
     ) = woxi::with_scoped_globals(&bindings, || {
@@ -648,6 +672,16 @@ impl ManipulateState {
         .map(|d| build_manipulate_display(d, &[]))
         .collect();
       let enabled: Vec<bool> = control_enabled
+        .iter()
+        .map(|c| match c {
+          Some(cond) => {
+            woxi::functions::graphics::manipulate_condition_enabled(cond)
+          }
+          None => true,
+        })
+        .collect();
+      // Which `PaneSelector` pane is on screen, resolved the same way.
+      let visible: Vec<bool> = control_visible
         .iter()
         .map(|c| match c {
           Some(cond) => {
@@ -677,7 +711,15 @@ impl ManipulateState {
             .map(|cols| (name.clone(), cols))
         })
         .collect();
-      (render, updated_state, trees, enabled, resolved, values)
+      (
+        render,
+        updated_state,
+        trees,
+        enabled,
+        visible,
+        resolved,
+        values,
+      )
     });
     // Keep the body's writes to the widget's own variables, so the next
     // frame (and any caption) builds on them.
@@ -688,6 +730,7 @@ impl ManipulateState {
     }
     self.display_trees = display_trees;
     self.control_is_enabled = enabled;
+    self.control_is_visible = visible;
     self.apply_dynamic_bounds(&resolved_bounds);
     // A re-resolved choice list may drop the value the body was just
     // rendered for; render again for the value the control settled on.


### PR DESCRIPTION
## Summary

This PR adds support for the `Specularity` graphics directive in 3D rendering and implements visibility gating for `PaneSelector` control panels in Manipulate expressions.

## Key Changes

### Specularity Directive (3D Graphics)
- Added `Specularity[colour, exponent]` support for 3D surfaces to render glossy highlights using Blinn-Phong lighting
- Implemented `apply_lighting_specular()` function that blends specular highlights with diffuse+ambient lighting
- Added `specular` field to `StyleState3D` to track the current highlight color and exponent
- Ensured `Specularity` is consumed as a directive (not repainted as a fill color) in both 2D and 3D contexts
- Added comprehensive tests verifying highlight behavior, exponent tightening, and 2D inertness

### PaneSelector Visibility Gating (Manipulate)
- Added `control_visible` field to `ManipulateSpec` to track per-control pane visibility conditions
- Implemented `collect_pane_visibility()` to extract visibility conditions from `PaneSelector[{v -> controls, …}, sel]` arguments
- Added helper functions `pane_control_variables()` and `control_spec_variable()` to identify controls within panes
- Controls in multiple panes have their conditions OR-ed together for proper visibility across modes
- Placeholder panes (e.g., `3 -> " "`) are properly skipped and don't create empty rows
- Updated `ManipulateState` to track `control_visible` and `control_is_visible` vectors
- Modified frontend rendering to hide/show control rows based on pane selector state
- Added `visibleWhen` field to JSON output for frontend condition evaluation

### Supporting Changes
- Refactored light direction calculation in `plot3d.rs` into reusable `light_direction()` function
- Updated all `ManipulateSpec` construction sites to initialize the new `control_visible` field
- Extended `manipulate_spec_to_json()` to include visibility conditions in control metadata
- Updated Woxi Studio's control panel rendering to respect visibility gates and label sizing

## Implementation Details

- Specularity parsing handles both color objects and grey level numbers, with exponent defaulting to 1.0
- Black specularity (0,0,0) is treated as matte (no highlight)
- Pane visibility conditions use the format `(selector) == (pane_value)` for clarity
- Frontend evaluates conditions against live bindings to dynamically show/hide control rows
- Controls outside any pane remain always visible (no condition recorded)

https://claude.ai/code/session_01QtnrDts4UhCh7Kqu39nC4z