### PR TITLE
Render checkbox grids with captions in Demonstrations

### DIFF
--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -8094,10 +8094,9 @@ fn partition_tube(items: &[Expr]) -> (Option<Vec<Expr>>, Vec<Expr>) {
       Expr::FunctionCall { name, args } if name == "Tube" && tube.is_none() => {
         tube = Some(args.to_vec());
       }
-      Expr::List(_)
-      | Expr::FunctionCall {
-        name: _, args: _, ..
-      } if tube.is_none() && contains_tube(item) => {
+      Expr::List(_) | Expr::FunctionCall { .. }
+        if tube.is_none() && contains_tube(item) =>
+      {
         let (inner, rest) = take_tube_directive(item);
         tube = inner;
         kept.push(rest);

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -464,9 +464,77 @@ fn prime_marks(s: &str) -> Option<usize> {
   Some(count)
 }
 
+/// The plain text a display-only box shows, or `None` when the box is not
+/// simple display text.
+///
+/// Styling wrappers (`StyleBox`, `TagBox`, …) are unwrapped down to the
+/// string literal they decorate. Box expressions nest string literals one
+/// level deeper than ordinary arguments — the FrontEnd writes the displayed
+/// string `label` as `"\"label\""` — so every quoting layer is stripped.
+fn display_text(s: &str) -> Option<String> {
+  let s = s.trim();
+  for head in ["StyleBox", "TagBox", "FormBox", "AdjustmentBox", "FrameBox"] {
+    if let Some(rest) = s.strip_prefix(&format!("{head}[")) {
+      let (inner, _) = find_matching_bracket(rest).ok()?;
+      let first = split_top_level_commas(inner).into_iter().next()?;
+      return display_text(first);
+    }
+  }
+  if !(s.starts_with('"') && s.ends_with('"') && s.len() >= 2) {
+    return None;
+  }
+  let mut text = s.to_string();
+  while text.starts_with('"') && text.ends_with('"') && text.len() >= 2 {
+    text = extract_string_content(&text);
+  }
+  Some(text)
+}
+
+/// Render a `CheckboxBox[value, {off, on}]` as a glyph.
+///
+/// `args` are the box's positional arguments. When `with_label` is set and
+/// the `on` alternative is a string, it is appended as the checkbox's label
+/// (`CheckboxBox[False, {False, "Mathematics"}]` → `☐ Mathematics`). Rows
+/// that carry their own label text pass `false` so the label is not
+/// repeated.
+fn render_checkbox(args: &[String], with_label: bool) -> String {
+  let value = args.first().map(|a| a.trim()).unwrap_or("");
+  let mut checked = value == "True";
+  let mut label = None;
+  if let Some(alts) = args.get(1) {
+    let alts = alts.trim();
+    if let Some(inner) =
+      alts.strip_prefix('{').and_then(|a| a.strip_suffix('}'))
+    {
+      let alt_parts = split_top_level_commas(inner);
+      let off = alt_parts.first().map(|p| p.trim());
+      if let Some(on) = alt_parts.get(1).map(|p| p.trim()) {
+        // With degenerate alternatives ({False, False}) fall back to
+        // the truthiness of the value itself.
+        if off != Some(on) {
+          checked = value == on;
+        }
+        if with_label
+          && on.starts_with('"')
+          && on.ends_with('"')
+          && on.len() >= 2
+        {
+          label = Some(extract_string_content(on));
+        }
+      }
+    }
+  }
+  let mark = if checked { "\u{2611}" } else { "\u{2610}" };
+  match label {
+    Some(l) => format!("{mark} {l}"),
+    None => mark.to_string(),
+  }
+}
+
 /// Recognise the typeset box heads that the FrontEnd uses to pretty-print
 /// expressions (`FractionBox`, `SuperscriptBox`, `SqrtBox`, `TagBox`,
 /// `GridBox`, …) and convert them back into evaluable InputForm text.
+///
 /// Returns `None` if `s` does not start with one of those heads.
 fn extract_typeset_box(s: &str) -> Option<String> {
   fn split_args(head: &str, s: &str) -> Option<Vec<String>> {
@@ -517,6 +585,55 @@ fn extract_typeset_box(s: &str) -> Option<String> {
         // Unescape any remaining `\"` pairs.
         let unit_name = unit_name.replace("\\\"", "");
         return Some(format!("Quantity[{number}, \"{unit_name}\"]"));
+      }
+    }
+    // `TemplateBox[{parts…}, "RowDefault"]` is the box form of
+    // `Row[{parts…}]` — the FrontEnd lays the parts out side by side.
+    // Demonstration metadata cells pair a checkbox with its caption this way
+    // (`{CheckboxBox[…], " ", StyleBox["\"Supported in cloud\""]}`), so the
+    // generic "first element only" fallback below would drop the caption and
+    // leave a bare glyph. Only rows whose non-checkbox parts are plain
+    // display text are joined: the category picker wraps its captions in
+    // collapsible `PaneSelectorBox` chrome instead, which has no useful flat
+    // rendering, so those keep falling back to the first element.
+    if tag == "RowDefault" {
+      let first = args[0].trim();
+      let first_inner = first
+        .strip_prefix('{')
+        .and_then(|s| s.strip_suffix('}'))
+        .unwrap_or(first);
+      let parts = split_top_level_commas(first_inner);
+      // Render every non-checkbox part as display text; bail out as soon as
+      // one has no such rendering.
+      let captions: Option<Vec<Option<String>>> = parts
+        .iter()
+        .map(|part| {
+          let part = part.trim();
+          if part.starts_with("CheckboxBox[") {
+            Some(None)
+          } else {
+            display_text(part).map(Some)
+          }
+        })
+        .collect();
+      if let Some(captions) = captions
+        && captions
+          .iter()
+          .any(|c| c.as_ref().is_some_and(|t| !t.trim().is_empty()))
+      {
+        // The row supplies the caption, so a checkbox contributes only its
+        // glyph — its `on` alternative would just repeat the caption.
+        let mut out = String::new();
+        for (part, caption) in parts.iter().zip(&captions) {
+          match caption {
+            Some(text) => out.push_str(text),
+            None => out.push_str(&render_checkbox(
+              &split_args("CheckboxBox", part.trim()).unwrap_or_default(),
+              false,
+            )),
+          }
+        }
+        return Some(out.trim().to_string());
       }
     }
     // Fallback: first positional argument is the displayed value.
@@ -650,35 +767,7 @@ fn extract_typeset_box(s: &str) -> Option<String> {
       // render a checkbox glyph, labelled with the `on` alternative when
       // it is a string (`CheckboxBox[False, {False, "Mathematics"}]` →
       // `☐ Mathematics`).
-      "CheckboxBox" if !args.is_empty() => {
-        let value = args[0].trim();
-        let mut checked = value == "True";
-        let mut label = None;
-        if let Some(alts) = args.get(1) {
-          let alts = alts.trim();
-          if let Some(inner) =
-            alts.strip_prefix('{').and_then(|a| a.strip_suffix('}'))
-          {
-            let alt_parts = split_top_level_commas(inner);
-            let off = alt_parts.first().map(|p| p.trim());
-            if let Some(on) = alt_parts.get(1).map(|p| p.trim()) {
-              // With degenerate alternatives ({False, False}) fall back to
-              // the truthiness of the value itself.
-              if off != Some(on) {
-                checked = value == on;
-              }
-              if on.starts_with('"') && on.ends_with('"') && on.len() >= 2 {
-                label = Some(extract_string_content(on));
-              }
-            }
-          }
-        }
-        let mark = if checked { "\u{2611}" } else { "\u{2610}" };
-        match label {
-          Some(l) => format!("{mark} {l}"),
-          None => mark.to_string(),
-        }
-      }
+      "CheckboxBox" if !args.is_empty() => render_checkbox(&args, true),
       // `GridBox[{{r11, r12, …}, {r21, …}, …}, opts…]` → the raw rows as a
       // list literal. The rows themselves may contain box expressions, so
       // recurse into each cell.
@@ -2314,11 +2403,60 @@ fn parse_raw_array_u8(raw: &[u8]) -> Option<(u32, u32, u8, &[u8])> {
   Some((height, width, channels, pixels))
 }
 
+/// Collect the checkbox entries of an already-extracted grid, i.e. the
+/// nested list of `☐ label` / `☑ label` strings `extract_cell_content`
+/// leaves behind for a `GridBox` of checkboxes. Entries are appended in
+/// source order as `[ ] label` / `[x] label`; anything that is not a
+/// checkbox glyph is skipped (the trailing `""` padding cells of a ragged
+/// category grid, for instance).
+fn collect_checkbox_glyphs(s: &str, out: &mut Vec<String>) {
+  let t = s.trim();
+  if let Some(inner) = t.strip_prefix('{').and_then(|r| r.strip_suffix('}')) {
+    let mut grew = false;
+    for part in split_top_level_commas(inner) {
+      let part = part.trim();
+      let is_entry = part.starts_with('{')
+        || part.starts_with('\u{2610}')
+        || part.starts_with('\u{2611}');
+      if !is_entry {
+        // The labels are unquoted, so one containing a comma ("Systems,
+        // Models & Methods") was split by the enclosing list — stitch the
+        // fragment back onto the entry it came from.
+        if grew && let Some(last) = out.last_mut() {
+          last.push_str(", ");
+          last.push_str(part.trim_matches('"').trim());
+        }
+        continue;
+      }
+      let before = out.len();
+      collect_checkbox_glyphs(part, out);
+      grew = out.len() > before;
+    }
+    return;
+  }
+  let t = t.trim_matches('"').trim();
+  if let Some(label) = t.strip_prefix('\u{2611}') {
+    out.push(format!("[x] {}", label.trim()).trim_end().to_string());
+  } else if let Some(label) = t.strip_prefix('\u{2610}') {
+    out.push(format!("[ ] {}", label.trim()).trim_end().to_string());
+  }
+}
+
 /// Render a stored `CheckboxBox[…]` output (the Demonstrations category /
 /// compatibility pickers) as plain text: one `[x] label` / `[ ] label`
-/// entry per checkbox, in source order. Returns `None` when the content
-/// holds no CheckboxBox.
+/// entry per checkbox, in source order. Accepts both the raw box text and
+/// the glyph grid `extract_cell_content` produces from it. Returns `None`
+/// when the content holds no checkbox.
 pub fn stored_output_checkbox_text(content: &str) -> Option<String> {
+  if !content.contains("CheckboxBox[") {
+    let mut lines = Vec::new();
+    collect_checkbox_glyphs(content, &mut lines);
+    return if lines.is_empty() {
+      None
+    } else {
+      Some(lines.join("\n"))
+    };
+  }
   let mut lines = Vec::new();
   let mut rest = content;
   while let Some(idx) = rest.find("CheckboxBox[") {
@@ -3348,6 +3486,53 @@ Cell["Chapter 2", "Chapter"]
       "[ ] Mathematics\n[x] Life Sciences\n[ ]"
     );
     assert!(stored_output_checkbox_text("{1, 2}").is_none());
+  }
+
+  #[test]
+  fn test_stored_output_checkbox_text_reads_extracted_glyph_grid() {
+    // `parse_notebook` already turns the checkbox boxes into glyphs, so the
+    // Studio only ever sees the extracted grid — it must render from that
+    // form too, rather than falling back to showing the raw braces.
+    let content = "{{{{\u{2610} Mathematics}, {\u{2611} Life Sciences}}, \
+       {{\u{2610} Systems, Models & Methods}, {\"\"}}}}";
+    assert_eq!(
+      stored_output_checkbox_text(content).unwrap(),
+      "[ ] Mathematics\n[x] Life Sciences\n[ ] Systems, Models & Methods"
+    );
+    // A lone unlabelled checkbox (the compatibility pickers) still renders.
+    assert_eq!(
+      stored_output_checkbox_text("{{{{\u{2611}}}}}").unwrap(),
+      "[x]"
+    );
+    assert!(stored_output_checkbox_text("{{1, 2}, {3, 4}}").is_none());
+  }
+
+  #[test]
+  fn test_extract_cell_content_row_default_checkbox_caption() {
+    // Demonstrations compatibility pickers put the caption next to the
+    // checkbox in a `RowDefault` row, and leave the checkbox's own
+    // alternatives degenerate — the caption must not be dropped.
+    assert_eq!(
+      extract_cell_content(
+        r#"BoxData[TemplateBox[{CheckboxBox[True, {False, False}], "\" \"", StyleBox["\"Supported in cloud\"", FontSize -> 12, StripOnInput -> False]}, "RowDefault"]]"#
+      ),
+      "\u{2611} Supported in cloud"
+    );
+    // When the row *and* the checkbox carry the label, it appears once.
+    assert_eq!(
+      extract_cell_content(
+        r#"BoxData[TemplateBox[{CheckboxBox[False, {False, "Triangles"}], "\" \"", StyleBox["\"Triangles\"", FontSize -> 12]}, "RowDefault"]]"#
+      ),
+      "\u{2610} Triangles"
+    );
+    // A row whose caption is wrapped in collapsible chrome has no flat
+    // rendering; fall back to the leading element (the labelled checkbox).
+    assert_eq!(
+      extract_cell_content(
+        r#"BoxData[TemplateBox[{CheckboxBox[False, {False, "Mathematics"}], "\" \"", StyleBox[DynamicModuleBox[{Typeset`var$$ = False}, PaneSelectorBox[{False -> "\"Mathematics\""}, Dynamic[Typeset`var$$]]]]}, "RowDefault"]]"#
+      ),
+      "\u{2610} Mathematics"
+    );
   }
 
   #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6970,6 +6970,125 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`a$$ = 1}, \"…\"]"], "Output"]
   }
 
   #[test]
+  fn demonstration_compatibility_checkboxes_render_as_a_card() {
+    // The metadata cells at the end of every Demonstration submission
+    // notebook pair a checkbox with a caption in a `RowDefault` row. They
+    // must open as a rendered checkbox card rather than as the raw nested
+    // braces the box extraction leaves behind.
+    let nb_src = r#"Notebook[{
+Cell[BoxData[TagBox[GridBox[{{TagBox[GridBox[{{TemplateBox[{CheckboxBox[True, {False, False}], "\" \"", StyleBox["\"Supported in cloud\"", FontSize -> 12]}, "RowDefault"]}}], "Column"]}}], "Grid"]], "Output"]
+}]"#;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let cell = match &nb.cells[0] {
+      CellEntry::Single(c) => c.clone(),
+      _ => panic!("expected a single cell"),
+    };
+    assert_eq!(cell.content, "{{{{\u{2611} Supported in cloud}}}}");
+    let editor = stored_output_editor(&cell)
+      .expect("a checkbox grid must render as a stored graphic");
+    assert!(editor.stored_graphic);
+    let svg = editor.graphics_svg.expect("the card is an SVG");
+    assert!(
+      svg.contains("Supported in cloud"),
+      "the caption must survive into the card: {svg}"
+    );
+    assert!(
+      svg.contains("[x]"),
+      "the checkbox must show as ticked: {svg}"
+    );
+  }
+
+  #[test]
+  fn hinged_dissection_notebook_opens_with_its_widget() {
+    // End-to-end regression for the shape of Demonstration that animates a
+    // hinged dissection: an initialization cell defines the pieces and a
+    // `helper[k_, opts___]` wrapper that forwards its options to
+    // `Graphics`, and the Manipulate swings each piece with `Rotate` about
+    // its own hinge, driven by a labelled slider.
+    let nb_src = r#"Notebook[{
+Cell[BoxData["squareA = Polygon[{{0, 0}, {1, 0}, {1, 1}, {0, 1}}];\nsquareB = Polygon[{{1, 0}, {2, 0}, {2, 1}, {1, 1}}];\nswing[k_, opts___] := Graphics[{RGBColor[1, 0, 0], squareA, RGBColor[0, 0, 1], Rotate[squareB, k Pi/2, {1, 0}]}, opts]"], "Input"],
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[swing[k, PlotRange -> {{-1.5, 2.5}, {-1.5, 2.5}}, ImageSize -> {300, 300}], {{k, 0, \"swing\"}, 0, 1}, SaveDefinitions -> True]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`k$$ = 0.}, \"…\"]"], "Output"]
+}, Open]]
+}]"#;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let mut widget = editors
+      .into_iter()
+      .find_map(|e| e.manipulate_state)
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+
+    // `SaveDefinitions -> True` is a Manipulate option, not a control.
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name,
+          label,
+          min,
+          max,
+          current,
+          ..
+        },
+      ] => {
+        assert_eq!(name, "k");
+        assert_eq!(label, "swing");
+        assert_eq!((*min, *max, *current), (0.0, 1.0, 0.0));
+      }
+      other => panic!("expected one labelled slider, got {other:?}"),
+    }
+
+    // The iced handle doesn't expose its bytes, so re-render the body
+    // through the widget's own bindings to inspect the SVG.
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      let code = match w.initialization.as_deref() {
+        Some(init) => format!("{init}; {}", w.body),
+        None => w.body.clone(),
+      };
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&code)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the pieces must render")
+    };
+
+    // The helper's `opts___` reaches Graphics, so ImageSize is honoured.
+    assert!(widget.graphics_handle.is_some());
+    let unswung = render(&widget);
+    assert!(
+      unswung.contains("width=\"300\"") && unswung.contains("height=\"300\""),
+      "ImageSize must pass through opts___: {unswung}"
+    );
+
+    // Swinging the hinge through a quarter turn moves the blue square: its
+    // far edge rotates from x = 2 up to y = 1 above the hinge at {1, 0}.
+    match &mut widget.controls[0] {
+      manipulate::ControlState::Continuous { current, .. } => *current = 1.0,
+      other => panic!("expected continuous control, got {other:?}"),
+    }
+    widget.reevaluate();
+    assert!(widget.error.is_none());
+    assert!(widget.graphics_handle.is_some());
+    assert_ne!(
+      unswung,
+      render(&widget),
+      "Rotate about the hinge must change the rendered geometry"
+    );
+  }
+
+  #[test]
   fn two_circular_windows_notebook_opens_with_its_widget() {
     // End-to-end regression for the "Two Circular Windows" Demonstration.
     // Its cell stores `c[[1]]` as a bracketed subscript box, and the body


### PR DESCRIPTION
## Summary

This change improves the rendering of checkbox grids in Wolfram Demonstrations, particularly for metadata cells that pair checkboxes with captions. The FrontEnd uses `RowDefault` template boxes to lay out checkboxes alongside their labels, but the previous implementation would drop the captions and render only the checkbox glyphs.

## Key Changes

- **Extract display text from styling wrappers**: Added `display_text()` function to unwrap styling boxes (`StyleBox`, `TagBox`, `FormBox`, etc.) and extract plain text content, handling the FrontEnd's double-quoting convention for box expressions.

- **Refactor checkbox rendering**: Extracted checkbox rendering logic into a new `render_checkbox()` function that handles both labeled and unlabeled checkboxes. This function is now called from two contexts:
  - Direct `CheckboxBox` extraction (with label)
  - `RowDefault` row rendering (without label to avoid duplication)

- **Handle `RowDefault` template boxes**: Added special handling in `extract_typeset_box()` to recognize `TemplateBox[{parts…}, "RowDefault"]` as the box form of `Row[{parts…}]`. When a row contains checkboxes paired with plain text captions, they are now rendered together (e.g., `☑ Supported in cloud`) instead of dropping the caption.

- **Parse extracted glyph grids**: Extended `stored_output_checkbox_text()` to accept both raw box text and the glyph grid that `extract_cell_content()` produces. Added `collect_checkbox_glyphs()` to recursively extract checkbox entries from nested list structures, handling ragged grids and labels containing commas.

## Notable Implementation Details

- The `RowDefault` fallback only activates when non-checkbox parts have valid display text renderings, allowing rows with complex chrome (like `PaneSelectorBox`) to fall back to the first element.
- Checkbox labels in rows are rendered without their `on` alternative to avoid duplication when the row caption already provides the label.
- The glyph grid parser handles edge cases like comma-separated labels that were split by the enclosing list structure.

## Tests Added

- `test_stored_output_checkbox_text_reads_extracted_glyph_grid`: Verifies checkbox grid parsing from extracted glyph form
- `test_extract_cell_content_row_default_checkbox_caption`: Tests checkbox-caption pairing in `RowDefault` rows with various styling scenarios
- `demonstration_compatibility_checkboxes_render_as_a_card`: End-to-end test ensuring metadata cells render as proper checkbox cards
- `hinged_dissection_notebook_opens_with_its_widget`: Regression test for Manipulate widget with graphics and slider controls

https://claude.ai/code/session_01FMqKd4hUVYvmp7bfHpNMpS