### PR TITLE
Typeset derivatives and reciprocal powers the Wolfram way

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,19 @@
     is rounded — `%` and `Out[]` still hold the full value, and `woxi eval`
     keeps the round-trip InputForm that `wolframscript -code` prints.
 
+- Fixes driven by a Wolfram Demonstration that trisects an angle with a
+    cubic curve, labelling its polar plot with the curve's equation and
+    logarithmic derivative:
+    - `TraditionalForm` sets a derivative with prime marks. `f'` holds as
+        `Derivative[1][f]`, and that head was showing through as
+        `Derivative(1, f)` instead of `f′`. Orders past three, and the
+        multivariate `Derivative[1, 0][f]`, spell the order out as a
+        parenthesised superscript.
+    - `TraditionalForm` puts a negative exponent under a fraction bar, so
+        `1/x` sets as a fraction rather than `x⁻¹`. A product already did
+        this for its reciprocal factors; a lone power did not, which left
+        `1/Cos[θ/3]^3` reading as `cos(θ/3)⁻³`.
+
 - Fixes driven by a Wolfram Demonstration that highlights the smallest
     triangle among optimally placed points in the unit square, whose
     coordinates are tabulated as exact algebraic numbers:

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -4741,6 +4741,17 @@ fn tf_power(base: &Expr, exp: &Expr) -> Expr {
   if is_half {
     return tf_box("SqrtBox", vec![tf(base)]);
   }
+  // A negative exponent goes under a fraction bar: `x^-1` sets as `1/x` and
+  // `Cos[x]^-3` as `1/cos³(x)`. This is the same reciprocal handling a
+  // product already gets (see `tf_reciprocal_factor`), which `Times[a, b^-1]`
+  // reaches through `tf_times` — a lone power has to do it here, otherwise
+  // `1/x` (parsed as `Power[x, -1]`) would set as `x⁻¹`.
+  if let Some(denominator) = tf_reciprocal_factor(&Expr::FunctionCall {
+    name: "Power".to_string(),
+    args: vec![base.clone(), exp.clone()].into(),
+  }) {
+    return tf_box("FractionBox", vec![tf_string("1"), tf(&denominator)]);
+  }
   let negative_number = matches!(base, Expr::Integer(n) if *n < 0)
     || matches!(base, Expr::Real(f) if *f < 0.0);
   let base_box = if tf_needs_paren_factor(base)
@@ -4763,6 +4774,51 @@ fn tf_power(base: &Expr, exp: &Expr) -> Expr {
 
 fn tf_fraction(num: &Expr, den: &Expr) -> Expr {
   tf_box("FractionBox", vec![tf(num), tf(den)])
+}
+
+/// TraditionalForm boxes for the derivative `Derivative[orders…][func]`.
+///
+/// `Derivative` is the head `f'` carries, and a front end never shows that
+/// head: a single order sets as prime marks (`f′`, `f″`, `f‴`), a higher or
+/// multivariate order as a parenthesised superscript (`f^(4)`, `f^(1,0)`).
+/// `None` when `orders` are not all non-negative integers, in which case the
+/// caller falls back to the generic `head(args)` rendering.
+fn tf_derivative_boxes(orders: &[Expr], func: &Expr) -> Option<Expr> {
+  if orders.is_empty() {
+    return None;
+  }
+  let counts: Option<Vec<i128>> = orders
+    .iter()
+    .map(|o| match o {
+      Expr::Integer(n) if *n >= 0 => Some(*n),
+      _ => None,
+    })
+    .collect();
+  let counts = counts?;
+  // The differentiated function keeps the bracketing it would get as a
+  // factor, so `Derivative[1][f + g]` sets as `(f + g)′`.
+  let base = if tf_needs_paren_factor(func) {
+    tf_parens(tf(func))
+  } else {
+    tf(func)
+  };
+  let script = match counts.as_slice() {
+    // Wolfram writes up to three primes; beyond that the order is spelled
+    // out in parentheses because the marks stop being countable.
+    [n @ 1..=3] => tf_string(&"\u{2032}".repeat(*n as usize)),
+    _ => {
+      let mut parts = vec![tf_string("(")];
+      for (i, n) in counts.iter().enumerate() {
+        if i > 0 {
+          parts.push(tf_string(","));
+        }
+        parts.push(tf_string(&n.to_string()));
+      }
+      parts.push(tf_string(")"));
+      tf_row(parts)
+    }
+  };
+  Some(tf_box("SuperscriptBox", vec![base, script]))
 }
 
 /// The positive-power form of a factor that belongs under the fraction bar —
@@ -5284,6 +5340,28 @@ fn tf_call(name: &str, args: &[Expr]) -> Expr {
     "Superscript" if args.len() == 2 => {
       tf_box("SuperscriptBox", vec![tf(&args[0]), tf(&args[1])])
     }
+    // A single-order derivative arrives flattened: `f''[x]` is held as
+    // `Derivative[2, f, x]`, so the order leads, the differentiated function
+    // follows, and anything after that is what the derivative is applied to.
+    // (The multivariate `Derivative[1, 0][f]` keeps its curried shape and is
+    // handled in `tf`.)
+    "Derivative" if args.len() >= 2 => {
+      match tf_derivative_boxes(&args[..1], &args[1]) {
+        None => tf_generic_call(name, args),
+        Some(boxes) if args.len() == 2 => boxes,
+        Some(boxes) => {
+          let mut parts = vec![boxes, tf_string("(")];
+          for (i, a) in args[2..].iter().enumerate() {
+            if i > 0 {
+              parts.push(tf_string(","));
+            }
+            parts.push(tf(a));
+          }
+          parts.push(tf_string(")"));
+          tf_row(parts)
+        }
+      }
+    }
     _ => {
       if let Some(disp) = tf_known_func(name) {
         let mut items: Vec<Expr> = vec![tf_string(disp), tf_string("(")];
@@ -5315,6 +5393,16 @@ fn tf(expr: &Expr) -> Expr {
     // typesets as itself and the arguments follow in round brackets, the
     // same shape an unknown named head gets.
     Expr::CurriedCall { func, args } => {
+      // `Derivative[n₁, …, nₖ][f]` — a multivariate derivative keeps the
+      // curried shape, and typesets as `f^(n₁,…,nₖ)` rather than exposing
+      // the `Derivative` head.
+      if let Expr::FunctionCall { name, args: orders } = func.as_ref()
+        && name == "Derivative"
+        && args.len() == 1
+        && let Some(boxes) = tf_derivative_boxes(orders, &args[0])
+      {
+        return boxes;
+      }
       let mut parts = vec![tf(func), tf_string("(")];
       for (i, a) in args.iter().enumerate() {
         if i > 0 {

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -3108,6 +3108,104 @@ mod tests {
     }
 
     #[test]
+    fn negative_power_sets_as_a_fraction() {
+      // TraditionalForm puts a negative exponent under a fraction bar:
+      // `1/x` parses as `Power[x, -1]` and must not set as `x⁻¹`.
+      let boxes = tf("1/x");
+      assert!(boxes.contains("FractionBox"), "1/x is a fraction: {boxes}");
+      assert!(!boxes.contains("SuperscriptBox"), "no `x⁻¹`: {boxes}");
+      // The exponent's magnitude stays on the denominator.
+      let boxes = tf("x^-2");
+      assert!(boxes.contains("FractionBox"), "x⁻² is a fraction: {boxes}");
+      assert!(boxes.contains("\"2\""), "denominator keeps `²`: {boxes}");
+      assert!(!boxes.contains("\"-\""), "no minus in the script: {boxes}");
+      // Composite bases keep their own rendering under the bar — the trig
+      // exponent still sits on the function name (`1/cos³(x)`).
+      let boxes = tf("Cos[x]^-3");
+      assert!(boxes.contains("FractionBox"), "reciprocal power: {boxes}");
+      assert!(boxes.contains("\"cos\""), "cos under the bar: {boxes}");
+    }
+
+    #[test]
+    fn positive_power_stays_a_superscript() {
+      // The fraction rule must not swallow ordinary exponents.
+      let boxes = tf("x^2");
+      assert!(boxes.contains("SuperscriptBox"), "x² is a script: {boxes}");
+      assert!(!boxes.contains("FractionBox"), "not a fraction: {boxes}");
+    }
+
+    #[test]
+    fn derivative_sets_as_prime_marks() {
+      // `f'` is held as `Derivative[1][f]`, and no front end shows that head:
+      // orders 1–3 typeset as prime marks on the function name.
+      for (code, primes) in [("r'", 1), ("f''", 2), ("g'''", 3)] {
+        let boxes = tf(code);
+        assert!(
+          boxes.contains(&"\u{2032}".repeat(primes)),
+          "{code} carries {primes} prime(s): {boxes}"
+        );
+        assert!(
+          !boxes.contains("Derivative"),
+          "{code} hides the Derivative head: {boxes}"
+        );
+      }
+    }
+
+    #[test]
+    fn applied_derivative_keeps_its_argument() {
+      // `f''[x]` → `f″(x)`: the primes stay on the name, the argument
+      // follows in round brackets like any other call.
+      let boxes = tf("f''[x]");
+      assert!(boxes.contains("\u{2032}\u{2032}"), "two primes: {boxes}");
+      assert!(boxes.contains("\"x\""), "argument kept: {boxes}");
+      assert!(!boxes.contains("Derivative"), "head hidden: {boxes}");
+    }
+
+    #[test]
+    fn high_order_derivative_uses_a_parenthesised_order() {
+      // Past three, the marks stop being countable and Wolfram spells the
+      // order out: `f⁽⁴⁾`.
+      let boxes = tf("Derivative[4][f]");
+      assert!(boxes.contains("\"4\""), "order shown: {boxes}");
+      assert!(!boxes.contains('\u{2032}'), "no prime marks: {boxes}");
+      assert!(!boxes.contains("Derivative"), "head hidden: {boxes}");
+    }
+
+    #[test]
+    fn multivariate_derivative_lists_its_orders() {
+      // `Derivative[1, 0][f][x, y]` → `f⁽¹’⁰⁾(x, y)`.
+      let boxes = tf("Derivative[1, 0][f][x, y]");
+      assert!(boxes.contains("\"1\"") && boxes.contains("\"0\""));
+      assert!(
+        boxes.contains("\"x\"") && boxes.contains("\"y\""),
+        "arguments kept: {boxes}"
+      );
+      assert!(!boxes.contains("Derivative"), "head hidden: {boxes}");
+    }
+
+    #[test]
+    fn typeset_svg_shows_a_logarithmic_derivative() {
+      // The shape a Wolfram Demonstration labels a polar curve with: the
+      // logarithmic derivative `r′/r` over a fraction bar, and the curve's
+      // own equation as a reciprocal power. Both go through the typeset
+      // SVG the Studio draws into a Manipulate cell.
+      let svg = tf_svg("TraditionalForm[r'/r == Tan[t/3]]");
+      assert!(svg.contains('\u{2032}'), "prime drawn: {svg}");
+      assert!(!svg.contains(">Derivative<"), "head hidden: {svg}");
+      let svg = tf_svg("TraditionalForm[r == 1/Cos[t/3]^3]");
+      assert!(svg.contains(">cos<"), "cos drawn: {svg}");
+      assert!(!svg.contains(">-3<"), "no negative exponent: {svg}");
+    }
+
+    #[test]
+    fn symbolic_derivative_order_falls_back_to_the_head() {
+      // An order that is not a literal count has no prime rendering, so the
+      // generic `head(args)` form stands in rather than a wrong script.
+      let boxes = tf("Derivative[n][f]");
+      assert!(boxes.contains("Derivative"), "head shown: {boxes}");
+    }
+
+    #[test]
     fn unknown_function_uses_parentheses() {
       // Preserves the MakeBoxes contract: F[x] → RowBox[{F, (, x, )}].
       let boxes = tf("F[x]");

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -10261,6 +10261,79 @@ TrackedSymbols->Manipulate,\n ControlPlacement -> Left,SaveDefinitions->True,Aut
     }
   }
 
+  /// The widget shape a plane-geometry Demonstration uses: a `Text @
+  /// Column` that stacks the curve's polar equation and its logarithmic
+  /// derivative as `TraditionalForm` labels above a `Show` of a
+  /// `PolarPlot` and the construction lines, driven by a labeled slider
+  /// and a True/False setter under `TrackedSymbols :> {…}`.
+  ///
+  /// The equations are what makes this shape demanding: `r'` holds as
+  /// `Derivative[1][r]` and `1/Cos[t]^2` as `Power[Cos[t], -2]`, neither
+  /// of which a front end shows literally.
+  #[test]
+  fn polar_curve_with_derivative_labels_builds_its_widget() {
+    let code = "Manipulate[\n\
+Module[{p = Exp[a/2] {Cos[a], Sin[a]}, n},\n\
+  n = Normalize[{-Tan[a], 1}];\n\
+  Text @ Column[{\n\
+    TraditionalForm[r == 1/Cos[t/2]^2],\n\
+    TraditionalForm[r' == D[1/Cos[t/2]^2, t]],\n\
+    TraditionalForm[r'/r == Simplify[D[1/Cos[t/2]^2, t]/(1/Cos[t/2]^2)]],\n\
+    Show[\n\
+      PolarPlot[Exp[t/2], {t, 0, 2 Pi}, PlotStyle -> {Blue, Thickness[0.004]}],\n\
+      Graphics[{\n\
+        If[marks, {Text[\"P\", p, {0, -2 Sign@Last@p}]}, {}],\n\
+        Thickness[0.004],\n\
+        {Red, Line[{{0, 0}, p}]},\n\
+        {Darker@Green, Line[{p, p + len n}]}}],\n\
+      ImageSize -> {320, 220}, PlotRange -> {{-8, 8}, {-4, 12}}]},\n\
+    Alignment -> Center]],\n\
+{{a, Pi/2, \"\\[Theta]\"}, 0, 2 Pi, Appearance -> \"Labeled\"},\n\
+{{len, 2, \"length of normal\"}, 0., 3, Appearance -> \"Labeled\"},\n\
+{marks, {True, False}},\n\
+TrackedSymbols :> {a, len, marks}]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the labeled column and its polar plot must render"
+    );
+    let labels: Vec<&str> = state
+      .controls
+      .iter()
+      .map(|c| match c {
+        manipulate::ControlState::Continuous { label, .. } => label.as_str(),
+        manipulate::ControlState::Discrete { label, .. } => label.as_str(),
+        other => panic!("unexpected control: {other:?}"),
+      })
+      .collect();
+    assert_eq!(labels, ["\u{03B8}", "length of normal", "marks"]);
+    match &state.controls[0] {
+      manipulate::ControlState::Continuous {
+        min, max, current, ..
+      } => {
+        assert!(*min == 0.0 && *max > 6.2, "θ spans a full turn");
+        assert!((*current - std::f64::consts::FRAC_PI_2).abs() < 1e-9);
+      }
+      other => panic!("θ must be a slider: {other:?}"),
+    }
+    // Dragging the angle past the construction's starting point has to
+    // redraw rather than error out.
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[0]
+    {
+      *current = 4.0;
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+  }
+
   /// End-to-end regression for the "Trigonometric Sums as Parametric
   /// Curves" Demonstration. Its initialization cells write the partial
   /// sums as typeset `∑` boxes, which have to come back as


### PR DESCRIPTION
Checked a randomly drawn Wolfram Demonstration — one that trisects an
angle with a cubic curve — against Woxi Studio. The notebook itself came
through fine: all 42 cells parse, the `Manipulate` builds its two labeled
sliders and its True/False setter, and the polar plot with its
construction lines renders. What was wrong were the two `TraditionalForm`
labels the Demonstration stacks above that plot, because
`TraditionalForm` was missing two conventions a front end always applies.

**Derivatives set as prime marks.** `f'` holds as `Derivative[1][f]`, and
that head was showing through as `Derivative(1, f)`. Orders one to three
now typeset as prime marks on the function name; past that, and for the
multivariate `Derivative[1, 0][f]`, the order is spelled out as a
parenthesised superscript, matching where Wolfram switches notation. An
order that is not a literal count keeps the generic `head(args)` form
rather than guessing.

**Negative exponents go under a fraction bar.** `1/x` sets as a fraction
rather than `x⁻¹`. A product already did this for its reciprocal factors
(`Times[a, b^-1]` → `a/b`), but a lone power did not, which left
`1/Cos[θ/3]^3` reading as `cos(θ/3)⁻³` instead of `1/cos³(θ/3)`.
Composite bases keep their own rendering under the bar, so the trig
exponent still sits on the function name.

Only the box/SVG typesetting changes — the InputForm text `woxi eval`
prints is untouched.

### Before / after

The Demonstration's label column, rendered through the Studio pipeline:

| before | after |
| --- | --- |
| `r = cos(θ/3)^-3` | `r = 1/cos³(θ/3)` |
| `Derivative (1, r) = …` | `r′ = …` |
| `Derivative (1, r)/r = tan(θ/3)` | `r′/r = tan(θ/3)` |

### Tests

- Eight cases in the `traditional_form_boxes` suite: the fraction rule and
    that it leaves positive exponents alone, prime marks for orders one to
    three, an applied derivative keeping its argument, the high-order and
    multivariate superscripts, the symbolic-order fallback, and an
    end-to-end check on the typeset SVG.
- A Studio widget test for the shape this Demonstration uses — a
    `Text @ Column` of `TraditionalForm` equations above a `Show` of a
    `PolarPlot` and its construction lines, driven by a labeled slider and
    a True/False setter under `TrackedSymbols :> {…}` — including a
    re-render after moving the slider. It is written against a different
    curve rather than copying the Demonstration's source.

`cargo test` (26,721 tests), `cargo test -p woxi-studio` (107 tests) and
`cargo clippy --all-targets` are clean; `cargo fmt --check` passes. The
CLI doc tests (`make test-cli`) were not run — `scrut` and `wolframscript`
are both unavailable in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qgq4fVK5qm8WoNb3jgHN7x)_