### PR TITLE
Implement global times2 AST helper

### DIFF
--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -77,11 +77,6 @@ pub fn build_var_power_derivative_chain(
     return Some(Expr::Integer(0));
   }
   let dn = k - n;
-  let times = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
   let (mut result, start) = if dn == 0 {
     // The innermost factor is the literal `1` from `(k-n+1) * var^0`. The
     // chain ends with that 1 directly — no separate var factor remains.
@@ -93,22 +88,18 @@ pub fn build_var_power_derivative_chain(
     let inner_var = if dn == 1 {
       var_expr.clone()
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(var_expr.clone()),
-        right: Box::new(Expr::Integer(dn)),
-      }
+      pow2(var_expr.clone(), Expr::Integer(dn))
     };
     if n == 0 {
       return Some(inner_var);
     }
     // Innermost numeric factor is `(dn + 1) = k - n + 1`.
-    (times(Expr::Integer(dn + 1), inner_var), n - 1)
+    (times2(Expr::Integer(dn + 1), inner_var), n - 1)
   };
   // Wrap with the remaining numerics k, k-1, …, k-n+2 from outside in.
   for i in (0..start).rev() {
     let factor = k - i;
-    result = times(Expr::Integer(factor), result);
+    result = times2(Expr::Integer(factor), result);
   }
   Some(result)
 }
@@ -170,17 +161,9 @@ pub fn extract_var_power_factor(
     let factor = if matches!(sub_factor, Expr::Integer(1)) {
       const_side.clone()
     } else if l_const {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(const_side.clone()),
-        right: Box::new(sub_factor),
-      }
+      times2(const_side.clone(), sub_factor)
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(sub_factor),
-        right: Box::new(const_side.clone()),
-      }
+      times2(sub_factor, const_side.clone())
     };
     return Some((factor, p));
   }
@@ -1876,11 +1859,7 @@ fn inverse_laplace_2d(
       name: "Times".to_string(),
       args: vec![Expr::Constant("Pi".to_string()), sqrt_x(), sqrt_y()].into(),
     };
-    return Some(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(cosh),
-      right: Box::new(pi_sqrt_xy),
-    });
+    return Some(div2(cosh, pi_sqrt_xy));
   }
 
   None
@@ -2649,11 +2628,7 @@ fn inverse_mellin_inner(
   x: &Expr,
 ) -> Option<(Expr, bool)> {
   let neg = |e: Expr| make_times(vec![Expr::Integer(-1), e]);
-  let e_pow = |e: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(Expr::Identifier("E".to_string())),
-    right: Box::new(e),
-  };
+  let e_pow = |e: Expr| pow2(Expr::Identifier("E".to_string()), e);
   let is_s = |e: &Expr| matches!(e, Expr::Identifier(v) if v == sv);
   let is_pi = |e: &Expr| {
     matches!(e, Expr::Constant(c) if c == "Pi")
@@ -2956,14 +2931,10 @@ fn inverse_mellin_inner(
             .position(|c| crate::syntax::expr_to_string(c) == inv_gamma)?;
           let mut rest = consts.clone();
           rest.remove(pos);
-          let result = Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(make_plus(vec![Expr::Integer(1), x.clone()])),
-            right: Box::new(Expr::UnaryOp {
-              op: UnaryOperator::Minus,
-              operand: Box::new(a_part.clone()),
-            }),
-          };
+          let result = pow2(
+            make_plus(vec![Expr::Integer(1), x.clone()]),
+            neg1(a_part.clone()),
+          );
           if rest.is_empty() {
             return Some((result, false));
           }
@@ -4477,11 +4448,7 @@ fn simplify_domain_constraint(constraint: &Expr, var: &str) -> Expr {
     match op {
       ComparisonOp::NotEqual => {
         // Try to solve lhs == rhs for roots
-        let diff = Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(lhs.clone()),
-          right: Box::new(rhs.clone()),
-        };
+        let diff = minus2(lhs.clone(), rhs.clone());
         let diff_eval =
           crate::evaluator::evaluate_expr_to_expr(&diff).unwrap_or(diff);
 
@@ -4731,15 +4698,10 @@ fn symbolic_series_coefficient(f: &Expr, spec: &Expr) -> Option<Expr> {
     let a = coeff(arg, 1)?;
     let residual = ev(Expr::FunctionCall {
       name: "Expand".to_string(),
-      args: vec![Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(arg.clone()),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(a.clone()),
-          right: Box::new(Expr::Identifier(x.clone())),
-        }),
-      }]
+      args: vec![minus2(
+        arg.clone(),
+        times2(a.clone(), Expr::Identifier(x.clone())),
+      )]
       .into(),
     })?;
     is_int(&residual, 0).then_some(a)
@@ -4979,33 +4941,19 @@ fn gf_inner(
   // Case 0: expr doesn't depend on n => constant * 1/(1-x)
   if !depends_on(expr, n) {
     // c/(1-x)
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(expr.clone()),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(x.clone()),
-      }),
-    }));
+    return Ok(Some(div2(
+      expr.clone(),
+      minus2(Expr::Integer(1), x.clone()),
+    )));
   }
 
   // Case 1: expr = n (just the variable)
   if matches!(expr, Expr::Identifier(name) if name == n) {
     // x/(-1+x)^2  (canonical Wolfram form; (1-x)^2 = (-1+x)^2 since power is even)
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(x.clone()),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::Integer(-1)),
-          right: Box::new(x.clone()),
-        }),
-        right: Box::new(Expr::Integer(2)),
-      }),
-    }));
+    return Ok(Some(div2(
+      x.clone(),
+      pow2(plus2(Expr::Integer(-1), x.clone()), Expr::Integer(2)),
+    )));
   }
 
   // Fibonacci[n] and LucasL[n]: the classic linear-recurrence sequences share
@@ -5112,41 +5060,16 @@ fn gf_inner(
         name: fname.clone(),
         args: vec![Expr::Integer(i as i128)].into(),
       };
-      let term = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(fi),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Power,
-          left: Box::new(x.clone()),
-          right: Box::new(Expr::Integer(i as i128)),
-        }),
-      };
+      let term = times2(fi, pow2(x.clone(), Expr::Integer(i as i128)));
       subtract_terms.push(term);
     }
-    let subtracted =
-      subtract_terms.into_iter().reduce(|acc, t| Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(acc),
-        right: Box::new(t),
-      });
+    let subtracted = subtract_terms.into_iter().reduce(plus2);
     let numerator = if let Some(sub) = subtracted {
-      Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(gf_base),
-        right: Box::new(sub),
-      }
+      minus2(gf_base, sub)
     } else {
       gf_base
     };
-    let result = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numerator),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(x.clone()),
-        right: Box::new(Expr::Integer(shift as i128)),
-      }),
-    };
+    let result = div2(numerator, pow2(x.clone(), Expr::Integer(shift as i128)));
     return Ok(Some(result));
   }
 
@@ -5206,19 +5129,10 @@ fn gf_power(
   // Case: a^n where a doesn't depend on n => 1/(1 - a*x)
   if matches!(exp, Expr::Identifier(name) if name == n) && !depends_on(base, n)
   {
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(base.clone()),
-          right: Box::new(x.clone()),
-        }),
-      }),
-      right: Box::new(Expr::Integer(-1)),
-    }));
+    return Ok(Some(pow2(
+      minus2(Expr::Integer(1), times2(base.clone(), x.clone())),
+      Expr::Integer(-1),
+    )));
   }
 
   // Case: n^k where k is a positive integer => Eulerian number formula
@@ -5239,11 +5153,7 @@ fn gf_power(
     && args.len() == 1
     && matches!(&args[0], Expr::Identifier(var) if var == n)
   {
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(Expr::Constant("E".to_string())),
-      right: Box::new(x.clone()),
-    }));
+    return Ok(Some(pow2(Expr::Constant("E".to_string()), x.clone())));
   }
 
   // Case: Power[Factorial[n], -2] => 1/(n!)^2 => BesselI[0, 2*Sqrt[x]]
@@ -5257,11 +5167,10 @@ fn gf_power(
       name: "BesselI".to_string(),
       args: vec![
         Expr::Integer(0),
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(2)),
-          right: Box::new(crate::functions::math_ast::make_sqrt(x.clone())),
-        },
+        times2(
+          Expr::Integer(2),
+          crate::functions::math_ast::make_sqrt(x.clone()),
+        ),
       ]
       .into(),
     }));
@@ -5291,71 +5200,37 @@ fn gf_n_power_k(k: i128, x: &Expr) -> Result<Option<Expr>, InterpreterError> {
     let x_pow = if power == 1 {
       x.clone()
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(x.clone()),
-        right: Box::new(Expr::Integer(power)),
-      }
+      pow2(x.clone(), Expr::Integer(power))
     };
     if signed_coeff == 1 {
       num_terms.push(x_pow);
     } else if signed_coeff == -1 {
-      num_terms.push(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(x_pow),
-      });
+      num_terms.push(times2(Expr::Integer(-1), x_pow));
     } else {
-      num_terms.push(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(signed_coeff)),
-        right: Box::new(x_pow),
-      });
+      num_terms.push(times2(Expr::Integer(signed_coeff), x_pow));
     }
   }
 
   let numerator = if num_terms.len() == 1 {
     num_terms.into_iter().next().unwrap()
   } else {
-    num_terms
-      .into_iter()
-      .reduce(|acc, t| Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(acc),
-        right: Box::new(t),
-      })
-      .unwrap()
+    num_terms.into_iter().reduce(plus2).unwrap()
   };
 
   // Denominator: (-1+x)^(k+1) — canonical Wolfram form.
   // Since (1-x) = -(-1+x), we have (1-x)^(k+1) = (-1)^(k+1) * (-1+x)^(k+1).
   // When (k+1) is odd, the numerator must be negated to compensate.
-  let denominator = Expr::BinaryOp {
-    op: BinaryOperator::Power,
-    left: Box::new(Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(-1)),
-      right: Box::new(x.clone()),
-    }),
-    right: Box::new(Expr::Integer(k + 1)),
-  };
+  let denominator =
+    pow2(plus2(Expr::Integer(-1), x.clone()), Expr::Integer(k + 1));
 
   let final_numerator = if (k + 1) % 2 != 0 {
     // Odd power: negate numerator
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(-1)),
-      right: Box::new(numerator),
-    }
+    times2(Expr::Integer(-1), numerator)
   } else {
     numerator
   };
 
-  Ok(Some(Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(final_numerator),
-    right: Box::new(denominator),
-  }))
+  Ok(Some(div2(final_numerator, denominator)))
 }
 
 /// Compute Eulerian numbers A(k, j) for j = 0..k-1
@@ -5394,15 +5269,7 @@ fn gf_plus(
     }
   }
 
-  let result = result_terms
-    .into_iter()
-    .reduce(|acc, t| Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(acc),
-      right: Box::new(t),
-    })
-    .unwrap();
-
+  let result = result_terms.into_iter().reduce(plus2).unwrap();
   Ok(Some(result))
 }
 
@@ -5451,39 +5318,17 @@ fn gf_times(
     let const_product = if constants.len() == 1 {
       (*constants[0]).clone()
     } else {
-      constants
-        .iter()
-        .cloned()
-        .cloned()
-        .reduce(|acc, t| Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(acc),
-          right: Box::new(t),
-        })
-        .unwrap()
+      constants.iter().cloned().cloned().reduce(times2).unwrap()
     };
 
     let n_product = if n_dependent.len() == 1 {
       (*n_dependent[0]).clone()
     } else {
-      n_dependent
-        .iter()
-        .cloned()
-        .cloned()
-        .reduce(|acc, t| Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(acc),
-          right: Box::new(t),
-        })
-        .unwrap()
+      n_dependent.iter().cloned().cloned().reduce(times2).unwrap()
     };
 
     if let Some(inner_gf) = gf_inner(&n_product, n, x)? {
-      return Ok(Some(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(const_product),
-        right: Box::new(inner_gf),
-      }));
+      return Ok(Some(times2(const_product, inner_gf)));
     }
   }
 
@@ -5492,16 +5337,7 @@ fn gf_times(
 
   // c * a^n pattern (all together)
   let recombined = if n_dependent.len() >= 2 {
-    n_dependent
-      .iter()
-      .cloned()
-      .cloned()
-      .reduce(|acc, t| Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(acc),
-        right: Box::new(t),
-      })
-      .unwrap()
+    n_dependent.iter().cloned().cloned().reduce(times2).unwrap()
   } else if n_dependent.len() == 1 {
     (*n_dependent[0]).clone()
   } else {
@@ -5562,33 +5398,16 @@ fn gf_binomial(
     && let Expr::Integer(k) = bottom
   {
     let power = k + 1;
-    let x_pow = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(x.clone()),
-      right: Box::new(Expr::Integer(*k)),
-    };
+    let x_pow = pow2(x.clone(), Expr::Integer(*k));
     let num = if power % 2 != 0 {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(x_pow),
-      }
+      times2(Expr::Integer(-1), x_pow)
     } else {
       x_pow
     };
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(num),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::Integer(-1)),
-          right: Box::new(x.clone()),
-        }),
-        right: Box::new(Expr::Integer(power)),
-      }),
-    }));
+    return Ok(Some(div2(
+      num,
+      pow2(plus2(Expr::Integer(-1), x.clone()), Expr::Integer(power)),
+    )));
   }
 
   // Binomial[2n, n] => 1/Sqrt[1-4x]
@@ -5609,15 +5428,10 @@ fn gf_binomial(
         // 1/Sqrt[1 - 4*x]
         return Ok(Some(Expr::BinaryOp {
           op: BinaryOperator::Power,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Minus,
-            left: Box::new(Expr::Integer(1)),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Integer(4)),
-              right: Box::new(x.clone()),
-            }),
-          }),
+          left: Box::new(minus2(
+            Expr::Integer(1),
+            times2(Expr::Integer(4), x.clone()),
+          )),
           right: Box::new(Expr::FunctionCall {
             name: "Rational".to_string(),
             args: vec![Expr::Integer(-1), Expr::Integer(2)].into(),
@@ -5676,11 +5490,7 @@ fn gf_divide(
       && args.len() == 1
       && matches!(&args[0], Expr::Identifier(var) if var == n)
     {
-      return Ok(Some(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::Constant("E".to_string())),
-        right: Box::new(x.clone()),
-      }));
+      return Ok(Some(pow2(Expr::Constant("E".to_string()), x.clone())));
     }
   }
 
@@ -5698,16 +5508,8 @@ fn gf_divide(
     }
 
     // const / f(n) — rewrite as const * f(n)^(-1) and try
-    let inv_den = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(den.clone()),
-      right: Box::new(Expr::Integer(-1)),
-    };
-    let product = Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(num.clone()),
-      right: Box::new(inv_den),
-    };
+    let inv_den = pow2(den.clone(), Expr::Integer(-1));
+    let product = times2(num.clone(), inv_den);
     // Guard against infinite recursion: `gf_inner` re-extracts a numerator and
     // denominator from `product`, so if that decomposition is the same one we
     // started with (e.g. `1/(2 n + 1)`), recursing would loop forever. Give up
@@ -5835,11 +5637,7 @@ fn egf_poly_part(
           } else {
             let mut product = n_dependent.remove(0);
             for f in n_dependent {
-              product = Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(product),
-                right: Box::new(f),
-              };
+              product = times2(product, f);
             }
             product
           };
@@ -5849,19 +5647,11 @@ fn egf_poly_part(
             } else {
               let mut product = constants.remove(0);
               for ci in constants {
-                product = Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(product),
-                  right: Box::new(ci),
-                };
+                product = times2(product, ci);
               }
               product
             };
-            return Ok(Some(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(c),
-              right: Box::new(inner_poly),
-            }));
+            return Ok(Some(times2(c, inner_poly)));
           }
         }
       }
@@ -5902,15 +5692,10 @@ fn egf_inner(
   // First try the polynomial approach: EGF = E^x * P(x)
   // This produces properly factored results like E^x*(1+x) instead of E^x + E^x*x
   if let Some(poly) = egf_poly_part(expr, n, x)? {
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::Constant("E".to_string())),
-        right: Box::new(x.clone()),
-      }),
-      right: Box::new(poly),
-    }));
+    return Ok(Some(times2(
+      pow2(Expr::Constant("E".to_string()), x.clone()),
+      poly,
+    )));
   }
 
   // Handle Minus: a - b => a + (-b)
@@ -5966,15 +5751,10 @@ fn egf_inner(
       "Factorial" if fargs.len() == 1 => {
         // EGF[n!, n, x] = 1/(1-x)
         if matches!(fargs[0], Expr::Identifier(name) if name == n) {
-          return Ok(Some(Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Minus,
-              left: Box::new(Expr::Integer(1)),
-              right: Box::new(x.clone()),
-            }),
-            right: Box::new(Expr::Integer(-1)),
-          }));
+          return Ok(Some(pow2(
+            minus2(Expr::Integer(1), x.clone()),
+            Expr::Integer(-1),
+          )));
         }
       }
       // EGF[Sin[n], n, x] = E^(x*Cos[1]) * Sin[x*Sin[1]]
@@ -5995,16 +5775,8 @@ fn egf_inner(
           name: "Sin".to_string(),
           args: vec![Expr::Integer(1)].into(),
         };
-        let x_cos1 = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(x.clone()),
-          right: Box::new(cos1),
-        };
-        let x_sin1 = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(x.clone()),
-          right: Box::new(sin1),
-        };
+        let x_cos1 = times2(x.clone(), cos1);
+        let x_sin1 = times2(x.clone(), sin1);
         let sin_part = Expr::FunctionCall {
           name: "Sin".to_string(),
           args: vec![x_sin1].into(),
@@ -6017,16 +5789,8 @@ fn egf_inner(
           name: "Sinh".to_string(),
           args: vec![x_cos1].into(),
         };
-        let exp_part = Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(cosh_part),
-          right: Box::new(sinh_part),
-        };
-        return Ok(Some(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(sin_part),
-          right: Box::new(exp_part),
-        }));
+        let exp_part = plus2(cosh_part, sinh_part);
+        return Ok(Some(times2(sin_part, exp_part)));
       }
       // EGF[Cos[n], n, x] = E^(x*Cos[1]) * Cos[x*Sin[1]]
       "Cos"
@@ -6041,16 +5805,8 @@ fn egf_inner(
           name: "Sin".to_string(),
           args: vec![Expr::Integer(1)].into(),
         };
-        let x_cos1 = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(x.clone()),
-          right: Box::new(cos1),
-        };
-        let x_sin1 = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(x.clone()),
-          right: Box::new(sin1),
-        };
+        let x_cos1 = times2(x.clone(), cos1);
+        let x_sin1 = times2(x.clone(), sin1);
         let cos_part = Expr::FunctionCall {
           name: "Cos".to_string(),
           args: vec![x_sin1].into(),
@@ -6063,16 +5819,8 @@ fn egf_inner(
           name: "Sinh".to_string(),
           args: vec![x_cos1].into(),
         };
-        let exp_part = Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(cosh_part),
-          right: Box::new(sinh_part),
-        };
-        return Ok(Some(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(cos_part),
-          right: Box::new(exp_part),
-        }));
+        let exp_part = plus2(cosh_part, sinh_part);
+        return Ok(Some(times2(cos_part, exp_part)));
       }
       _ => {}
     }
@@ -6098,11 +5846,7 @@ fn egf_plus(
   }
   let mut sum = results.remove(0);
   for r in results {
-    sum = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(sum),
-      right: Box::new(r),
-    };
+    sum = plus2(sum, r);
   }
   Ok(Some(sum))
 }
@@ -6131,11 +5875,7 @@ fn egf_times(
     } else {
       let mut product = constants.remove(0);
       for ci in constants {
-        product = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(product),
-          right: Box::new(ci),
-        };
+        product = times2(product, ci);
       }
       product
     };
@@ -6144,20 +5884,12 @@ fn egf_times(
     } else {
       let mut product = n_dependent.remove(0);
       for f in n_dependent {
-        product = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(product),
-          right: Box::new(f),
-        };
+        product = times2(product, f);
       }
       product
     };
     if let Some(inner) = egf_inner(&rest, n, x)? {
-      return Ok(Some(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(c),
-        right: Box::new(inner),
-      }));
+      return Ok(Some(times2(c, inner)));
     }
     return Ok(None);
   }
@@ -6175,15 +5907,10 @@ fn egf_power(
   // Case: c^n where c doesn't depend on n => e^(c*x)
   if !depends_on(base, n) && matches!(exp, Expr::Identifier(name) if name == n)
   {
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(Expr::Constant("E".to_string())),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(base.clone()),
-        right: Box::new(x.clone()),
-      }),
-    }));
+    return Ok(Some(pow2(
+      Expr::Constant("E".to_string()),
+      times2(base.clone(), x.clone()),
+    )));
   }
 
   // Case: n^k where k is a non-negative integer
@@ -6192,15 +5919,10 @@ fn egf_power(
     && let Some(k) = egf_expr_to_nonneg_int(exp)
   {
     let poly = egf_stirling_polynomial(k, x);
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::Constant("E".to_string())),
-        right: Box::new(x.clone()),
-      }),
-      right: Box::new(poly),
-    }));
+    return Ok(Some(times2(
+      pow2(Expr::Constant("E".to_string()), x.clone()),
+      poly,
+    )));
   }
 
   Ok(None)
@@ -6278,26 +6000,14 @@ fn egf_stirling_polynomial(k: usize, x: &Expr) -> Expr {
       if s == 1 {
         x.clone()
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(s as i128)),
-          right: Box::new(x.clone()),
-        }
+        times2(Expr::Integer(s as i128), x.clone())
       }
     } else {
-      let x_power = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(x.clone()),
-        right: Box::new(Expr::Integer(shifted as i128)),
-      };
+      let x_power = pow2(x.clone(), Expr::Integer(shifted as i128));
       if s == 1 {
         x_power
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(s as i128)),
-          right: Box::new(x_power),
-        }
+        times2(Expr::Integer(s as i128), x_power)
       }
     };
     inner_terms.push(term);
@@ -6320,11 +6030,7 @@ fn egf_stirling_polynomial(k: usize, x: &Expr) -> Expr {
   if matches!(&inner, Expr::Integer(1)) {
     x.clone()
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(x.clone()),
-      right: Box::new(inner),
-    }
+    times2(x.clone(), inner)
   }
 }
 

--- a/src/evaluator/dispatch/polynomial_functions.rs
+++ b/src/evaluator/dispatch/polynomial_functions.rs
@@ -716,11 +716,7 @@ pub fn dispatch_polynomial_functions(
           // Build product of vars[indices[0]] * vars[indices[1]] * ...
           let mut product = vars[indices[0]].clone();
           for &idx in &indices[1..] {
-            product = Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(product),
-              right: Box::new(vars[idx].clone()),
-            };
+            product = times2(product, vars[idx].clone());
           }
           terms.push(product);
           // Next k-combination
@@ -793,11 +789,7 @@ pub fn dispatch_polynomial_functions(
                 Expr::Integer(1) => Expr::Identifier(var.clone()),
                 _ => pow2(Expr::Identifier(var.clone()), exp.clone()),
               };
-              term = Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(term),
-                right: Box::new(factor),
-              };
+              term = times2(term, factor);
             }
             terms.push(term);
           }
@@ -1402,13 +1394,7 @@ fn try_constrained_linear_disk_symbolic(
   };
   let plus = |x: Expr, y: Expr| -> Expr { eval(plus2(x, y)) };
   let minus = |x: Expr, y: Expr| -> Expr { eval(minus2(x, y)) };
-  let times = |x: Expr, y: Expr| -> Expr {
-    eval(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(x),
-      right: Box::new(y),
-    })
-  };
+  let times = |x: Expr, y: Expr| -> Expr { eval(times2(x, y)) };
   let div = |x: Expr, y: Expr| -> Expr { eval(div2(x, y)) };
   let neg = |x: Expr| -> Expr { eval(minus2(Expr::Integer(0), x)) };
   let square = |x: Expr| -> Expr { times(x.clone(), x) };

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -1,4 +1,6 @@
-use crate::helpers::{binop, bool_expr, div2, minus2, plus2, pow2};
+use crate::helpers::{
+  binop, bool_expr, div2, minus2, neg1, plus2, pow2, times2,
+};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
   unevaluated,

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -571,11 +571,7 @@ pub fn integrate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         && !is_negative_infinity(hi);
       if bounds_finite {
         let width = minus2(hi.clone(), lo.clone());
-        let product = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(width),
-          right: Box::new(args[0].clone()),
-        };
+        let product = times2(width, args[0].clone());
         return crate::evaluator::evaluate_expr_to_expr(&product);
       }
     }
@@ -940,11 +936,7 @@ fn hornerize_product_polys(expr: Expr) -> Expr {
       op: BinaryOperator::Times,
       left,
       right,
-    } => Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(try_horner_if_poly(left)),
-      right: Box::new(try_horner_if_poly(right)),
-    },
+    } => times2(try_horner_if_poly(left), try_horner_if_poly(right)),
     _ => expr,
   }
 }
@@ -1216,19 +1208,7 @@ fn try_definite_integral(
         args: vec![u.clone()].into(),
       };
       // u * Abs[u] / (2 a)
-      let antideriv = Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(u),
-          right: Box::new(abs_u),
-        }),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(2)),
-          right: Box::new(slope),
-        }),
-      };
+      let antideriv = div2(times2(u, abs_u), times2(Expr::Integer(2), slope));
       let at_hi = crate::syntax::substitute_variable(&antideriv, var, hi);
       let at_lo = crate::syntax::substitute_variable(&antideriv, var, lo);
       let at_hi = crate::evaluator::evaluate_expr_to_expr(&at_hi).ok()?;
@@ -1331,11 +1311,7 @@ fn try_definite_integral(
       name: "BesselJ".to_string(),
       args: vec![Expr::Integer(0), n].into(),
     };
-    return Some(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Constant("Pi".to_string())),
-      right: Box::new(bessel),
-    });
+    return Some(times2(Expr::Constant("Pi".to_string()), bessel));
   }
 
   // Euler's log-trig integrals:
@@ -2300,11 +2276,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           } else if matches!(left.as_ref(), Expr::Constant(c) if c == "E") {
             // d/dx[E^g(x)] = E^g(x) * g'(x)  (since Log[E] = 1)
             let dg = differentiate(right, var)?;
-            Ok(simplify(Expr::BinaryOp {
-              op: B::Times,
-              left: Box::new(expr.clone()),
-              right: Box::new(dg),
-            }))
+            Ok(simplify(times2(expr.clone(), dg)))
           } else if is_constant_wrt(left, var) {
             // d/dx[a^g(x)] = a^g(x) * ln(a) * g'(x)
             let dg = differentiate(right, var)?;
@@ -2935,27 +2907,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             args: vec![denom, Expr::Integer(-1)].into(),
           };
           // partial wrt first arg: -v / (u^2 + v^2)
-          let d_first = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(neg1(v)),
-            right: Box::new(inv_denom.clone()),
-          };
+          let d_first = times2(neg1(v), inv_denom.clone());
           // partial wrt second arg: u / (u^2 + v^2)
-          let d_second = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(u),
-            right: Box::new(inv_denom),
-          };
-          let term1 = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(d_first),
-            right: Box::new(du),
-          };
-          let term2 = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(d_second),
-            right: Box::new(dv),
-          };
+          let d_second = times2(u, inv_denom);
+          let term1 = times2(d_first, du);
+          let term2 = times2(d_second, dv);
           // Order the second-argument term first to match Wolfram's output,
           // e.g. ArcTan[u, v]' = u v'/(u^2+v^2) - v u'/(u^2+v^2).
           Ok(simplify(plus2(term2, term1)))
@@ -3012,11 +2968,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           let sqrt_minus = make_sqrt(f_minus_one);
           let sqrt_plus = make_sqrt(f_plus_one);
           // f'(x) / (Sqrt[f-1] * Sqrt[f+1])
-          let denom = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(sqrt_minus),
-            right: Box::new(sqrt_plus),
-          };
+          let denom = times2(sqrt_minus, sqrt_plus);
           Ok(simplify(Expr::BinaryOp {
             op: BinaryOperator::Times,
             left: Box::new(df),
@@ -3154,15 +3106,10 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(df, Expr::Integer(0)) {
             return Ok(Expr::Integer(0));
           }
-          Ok(simplify(Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(df),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Integer(2)),
-              right: Box::new(make_sqrt(args[0].clone())),
-            }),
-          }))
+          Ok(simplify(div2(
+            df,
+            times2(Expr::Integer(2), make_sqrt(args[0].clone())),
+          )))
         }
         // Abs[f(x)]: Abs is non-analytic, so wolframscript keeps the derivative
         // as the unevaluated Abs' (Derivative[1][Abs][f]) times the chain-rule
@@ -3186,11 +3133,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(df, Expr::Integer(1)) {
             Ok(deriv_expr)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(df),
-              right: Box::new(deriv_expr),
-            }))
+            Ok(simplify(times2(df, deriv_expr)))
           }
         }
         // RealAbs[f(x)]: d/dx[RealAbs[f]] = f'(x) * f / RealAbs[f]
@@ -3207,11 +3150,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             args: vec![f.clone()].into(),
           };
           let f_over_abs = div2(f, real_abs);
-          Ok(simplify(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(df),
-            right: Box::new(f_over_abs),
-          }))
+          Ok(simplify(times2(df, f_over_abs)))
         }
         // Sign derivative: D[Sign[f(x)], x] = Derivative[1][Sign][f(x)] * f'(x)
         // (Wolfram keeps the unevaluated Sign' instead of 2*DiracDelta[x])
@@ -3235,11 +3174,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(df, Expr::Integer(1)) {
             Ok(deriv_expr)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(df),
-              right: Box::new(deriv_expr),
-            }))
+            Ok(simplify(times2(df, deriv_expr)))
           }
         }
         // Cylinder-function derivatives w.r.t. the argument z:
@@ -3294,11 +3229,9 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // (J, Y, HankelH1, HankelH2) subtract.
           let numer = match name.as_str() {
             "BesselI" => simplify(plus2(f_nm1, f_np1)),
-            "BesselK" => simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Integer(-1)),
-              right: Box::new(plus2(f_nm1, f_np1)),
-            }),
+            "BesselK" => {
+              simplify(times2(Expr::Integer(-1), plus2(f_nm1, f_np1)))
+            }
             _ => simplify(minus2(f_nm1, f_np1)),
           };
           let half_diff = div2(numer, Expr::Integer(2));
@@ -3306,11 +3239,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(half_diff)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(half_diff),
-            }))
+            Ok(simplify(times2(dz, half_diff)))
           }
         }
         // ExpIntegralEi[z]: D[ExpIntegralEi[z], z] = E^z / z
@@ -3324,11 +3253,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // SinIntegral[z]: D[SinIntegral[z], z] = Sinc[z] * z'. Wolfram prints
@@ -3345,11 +3270,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(sinc)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(sinc),
-            }))
+            Ok(simplify(times2(dz, sinc)))
           }
         }
         // PolyLog[n, z]: D[_, z] = PolyLog[n-1, z] / z.
@@ -3379,11 +3300,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // ExpIntegralE[n, z]: D[_, z] = -ExpIntegralE[n-1, z].
@@ -3419,11 +3336,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(neg_e)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(neg_e),
-            }))
+            Ok(simplify(times2(dz, neg_e)))
           }
         }
         // AiryAiPrime[z] -> z AiryAi[z], AiryBiPrime[z] -> z AiryBi[z] (the
@@ -3449,11 +3362,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // CosIntegral[z] -> Cos[z]/z, SinhIntegral[z] -> Sinh[z]/z,
@@ -3476,11 +3385,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // Incomplete elliptic integrals w.r.t. the amplitude phi:
@@ -3532,11 +3437,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dphi, Expr::Integer(1)) {
             Ok(deriv)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dphi),
-              right: Box::new(deriv),
-            }))
+            Ok(simplify(times2(dphi, deriv)))
           }
         }
         // FresnelS[z]: D = Sin[(Pi z^2)/2] * z'
@@ -3547,17 +3448,14 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             return Ok(Expr::Integer(0));
           }
           // (Pi * z^2) / 2, evaluated so a compound argument's square expands.
-          let inner =
-            crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-              op: BinaryOperator::Divide,
-              left: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(Expr::Constant("Pi".to_string())),
-                right: Box::new(pow2(args[0].clone(), Expr::Integer(2))),
-              }),
-              right: Box::new(Expr::Integer(2)),
-            })
-            .unwrap_or_else(|_| args[0].clone());
+          let inner = crate::evaluator::evaluate_expr_to_expr(&div2(
+            times2(
+              Expr::Constant("Pi".to_string()),
+              pow2(args[0].clone(), Expr::Integer(2)),
+            ),
+            Expr::Integer(2),
+          ))
+          .unwrap_or_else(|_| args[0].clone());
           let outer_head = if name == "FresnelS" { "Sin" } else { "Cos" };
           let g = Expr::FunctionCall {
             name: outer_head.to_string(),
@@ -3566,11 +3464,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           Ok(if matches!(dz, Expr::Integer(1)) {
             simplify(g)
           } else {
-            simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(g),
-              right: Box::new(dz),
-            })
+            simplify(times2(g, dz))
           })
         }
         // LogGamma[z]: D = PolyGamma[0, z] * z'
@@ -3609,11 +3503,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           Ok(if matches!(dz, Expr::Integer(1)) {
             simplify(g)
           } else {
-            simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(g),
-            })
+            simplify(times2(dz, g))
           })
         }
         // PolyGamma[z] = PolyGamma[0, z] (digamma): D = PolyGamma[1, z] z'
@@ -3629,11 +3519,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           Ok(if matches!(dz, Expr::Integer(1)) {
             simplify(g)
           } else {
-            simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(g),
-            })
+            simplify(times2(dz, g))
           })
         }
         // PolyGamma[n, z], n free of var: D[PolyGamma[n, z], z] =
@@ -3659,11 +3545,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           Ok(if matches!(dz, Expr::Integer(1)) {
             simplify(g)
           } else {
-            simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(g),
-            })
+            simplify(times2(dz, g))
           })
         }
         // Beta[z, a, b] (incomplete Beta), a and b free of var:
@@ -3696,19 +3578,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           // Wolfram orders the (1-z) factor before the z factor; build the
           // product directly in that order rather than through the canonical
           // Times sorter (which would put the bare-symbol power first).
-          let g = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(omz_pow),
-            right: Box::new(z_pow),
-          };
+          let g = times2(omz_pow, z_pow);
           Ok(if matches!(dz, Expr::Integer(1)) {
             g
           } else {
-            simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(g),
-            })
+            simplify(times2(dz, g))
           })
         }
         // Hypergeometric1F1[a, b, z], a and b free of var:
@@ -3748,11 +3622,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           Ok(if matches!(dz, Expr::Integer(1)) {
             g
           } else {
-            simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(g),
-            })
+            simplify(times2(dz, g))
           })
         }
         // Hypergeometric2F1[a, b, c, z], a, b, c free of var:
@@ -3798,11 +3668,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           Ok(if matches!(dz, Expr::Integer(1)) {
             g
           } else {
-            simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(g),
-            })
+            simplify(times2(dz, g))
           })
         }
         // InverseErf[z]:  D = (Sqrt[Pi]/2) E^(InverseErf[z]^2) z'
@@ -3845,11 +3711,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           Ok(if matches!(dz, Expr::Integer(1)) {
             simplify(g)
           } else {
-            simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(g),
-            })
+            simplify(times2(dz, g))
           })
         }
         // Gamma[z]: D[Gamma[z], z] = Gamma[z] * PolyGamma[0, z]
@@ -3872,11 +3734,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // Factorial[z] = Gamma[1 + z], so
@@ -3902,11 +3760,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // Gamma[a, z] (upper incomplete), a free of var:
@@ -3927,19 +3781,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           let exp_neg_z =
             pow2(Expr::Constant("E".to_string()), neg1(z.clone()));
           // -z^(a-1) E^(-z), times z' (chain rule).
-          let core = neg1(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(z_pow),
-            right: Box::new(exp_neg_z),
-          });
+          let core = neg1(times2(z_pow, exp_neg_z));
           let full = if matches!(dz, Expr::Integer(1)) {
             core
           } else {
-            Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(core),
-            }
+            times2(dz, core)
           };
           crate::evaluator::evaluate_expr_to_expr(&full)
         }
@@ -3989,11 +3835,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // KroneckerDelta is 0 away from the discrete coincidence locus and has
@@ -4031,11 +3873,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             ]
             .into(),
           };
-          Ok(simplify(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(dz),
-            right: Box::new(pw),
-          }))
+          Ok(simplify(times2(dz, pw)))
         }
         // UnitStep[x]: D[UnitStep[x], x] = Piecewise[{{Indeterminate, x == 0}}, 0]
         // HeavisideTheta[z]: D[HeavisideTheta[z], z] = DiracDelta[z], with the
@@ -4056,11 +3894,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           };
           let dirac = crate::evaluator::evaluate_expr_to_expr(&raw_dirac)
             .unwrap_or(raw_dirac);
-          Ok(simplify(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(dz),
-            right: Box::new(dirac),
-          }))
+          Ok(simplify(times2(dz, dirac)))
         }
         "UnitStep" if args.len() == 1 => {
           let dz = differentiate(&args[0], var)?;
@@ -4090,11 +3924,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // Ramp[z]: D[Ramp[z], z] = Piecewise[{{0, z<0}, {1, z>0}}, Indeterminate]
@@ -4133,11 +3963,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // Erf[z0, z1] = Erf[z1] - Erf[z0]: differentiate the difference so
@@ -4168,19 +3994,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Expr::Integer(2),
             make_sqrt(Expr::Constant("Pi".to_string())),
           );
-          let result = simplify(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(two_over_sqrt_pi),
-            right: Box::new(exp_neg_z2),
-          });
+          let result = simplify(times2(two_over_sqrt_pi, exp_neg_z2));
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // Erfc[z]: D[Erfc[z], z] = -2*E^(-z^2)/Sqrt[Pi]
@@ -4196,19 +4014,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Expr::Integer(2),
             make_sqrt(Expr::Constant("Pi".to_string())),
           );
-          let result = simplify(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(two_over_sqrt_pi),
-            right: Box::new(neg_exp_neg_z2),
-          });
+          let result = simplify(times2(two_over_sqrt_pi, neg_exp_neg_z2));
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // Erfi[z]: D[Erfi[z], z] = 2*E^(z^2)/Sqrt[Pi]
@@ -4223,19 +4033,11 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             Expr::Integer(2),
             make_sqrt(Expr::Constant("Pi".to_string())),
           );
-          let result = simplify(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(two_over_sqrt_pi),
-            right: Box::new(exp_z2),
-          });
+          let result = simplify(times2(two_over_sqrt_pi, exp_z2));
           if matches!(dz, Expr::Integer(1)) {
             Ok(result)
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dz),
-              right: Box::new(result),
-            }))
+            Ok(simplify(times2(dz, result)))
           }
         }
         // Handle Rational[n, d] as constant
@@ -4300,11 +4102,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
               let term = if matches!(db, Expr::Integer(1)) {
                 simplify(f_at_hi)
               } else {
-                simplify(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(simplify(f_at_hi)),
-                  right: Box::new(db),
-                })
+                simplify(times2(simplify(f_at_hi), db))
               };
               terms.push(term);
             }
@@ -4313,11 +4111,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
               let term = if matches!(da, Expr::Integer(1)) {
                 simplify(f_at_lo)
               } else {
-                simplify(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(simplify(f_at_lo)),
-                  right: Box::new(da),
-                })
+                simplify(times2(simplify(f_at_lo), da))
               };
               terms.push(neg1(term));
             }
@@ -4399,11 +4193,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(&d_inner, Expr::Integer(1)) {
             Ok(simplify(deriv_expr))
           } else {
-            Ok(simplify(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(d_inner),
-              right: Box::new(deriv_expr),
-            }))
+            Ok(simplify(times2(d_inner, deriv_expr)))
           }
         }
         // General chain rule for unknown functions: D[f[g1(x),...,gn(x)], x]
@@ -4508,11 +4298,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
             if matches!(&dargs[i], Expr::Integer(1)) {
               terms.push(deriv_expr);
             } else {
-              terms.push(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(dargs[i].clone()),
-                right: Box::new(deriv_expr),
-              });
+              terms.push(times2(dargs[i].clone(), deriv_expr));
             }
           }
 
@@ -4563,11 +4349,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
         if matches!(dx, Expr::Integer(1)) {
           return Ok(result);
         } else {
-          return Ok(simplify(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(dx),
-            right: Box::new(result),
-          }));
+          return Ok(simplify(times2(dx, result)));
         }
       }
 
@@ -4629,11 +4411,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
           if matches!(&dargs[i], Expr::Integer(1)) {
             terms.push(deriv_expr);
           } else {
-            terms.push(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(dargs[i].clone()),
-              right: Box::new(deriv_expr),
-            });
+            terms.push(times2(dargs[i].clone(), deriv_expr));
           }
         }
 
@@ -4674,11 +4452,7 @@ fn differentiate(expr: &Expr, var: &str) -> Result<Expr, InterpreterError> {
         return Ok(if matches!(dg, Expr::Integer(1)) {
           deriv_expr
         } else {
-          simplify(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(dg),
-            right: Box::new(deriv_expr),
-          })
+          simplify(times2(dg, deriv_expr))
         });
       }
       Ok(Expr::FunctionCall {
@@ -4741,15 +4515,7 @@ fn make_divided(expr: Expr, divisor: Expr) -> Expr {
     {
       let num = &args[0]; // a
       let den = &args[1]; // b
-      let result = Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(den.clone()),
-          right: Box::new(expr),
-        }),
-        right: Box::new(num.clone()),
-      };
+      let result = div2(times2(den.clone(), expr), num.clone());
       simplify(result)
     }
     _ => div2(expr, divisor),
@@ -4761,11 +4527,9 @@ fn make_divided(expr: Expr, divisor: Expr) -> Expr {
 fn make_neg_divided(expr: Expr, divisor: Expr) -> Expr {
   match &divisor {
     Expr::Integer(1) => neg1(expr),
-    Expr::Integer(n) => Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(crate::functions::math_ast::make_rational(-1, *n)),
-      right: Box::new(expr),
-    },
+    Expr::Integer(n) => {
+      times2(crate::functions::math_ast::make_rational(-1, *n), expr)
+    }
     _ => div2(neg1(expr), divisor),
   }
 }
@@ -5007,20 +4771,12 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
       _ => false,
     };
     if coeff_is_nontrivial {
-      let double_arg = simplify(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(2)),
-        right: Box::new(arg.clone()),
-      });
+      let double_arg = simplify(times2(Expr::Integer(2), arg.clone()));
       let cos_double = Expr::FunctionCall {
         name: "Cos".to_string(),
         args: vec![double_arg].into(),
       };
-      let divisor = simplify(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(4)),
-        right: Box::new(coeff.clone()),
-      });
+      let divisor = simplify(times2(Expr::Integer(4), coeff.clone()));
       return Some(make_neg_divided(cos_double, divisor));
     }
   }
@@ -5040,11 +4796,8 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
     };
     let power_expr = pow2(cos_expr, Expr::Integer(new_power as i128));
     // divisor = (n+1) * a
-    let total_divisor = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(new_power as i128)),
-      right: Box::new(coeff),
-    });
+    let total_divisor =
+      simplify(times2(Expr::Integer(new_power as i128), coeff));
     return Some(make_neg_divided(power_expr, total_divisor));
   }
 
@@ -5057,11 +4810,8 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
     };
     let power_expr = pow2(sin_expr, Expr::Integer(new_power as i128));
     // divisor = (m+1) * a
-    let total_divisor = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(new_power as i128)),
-      right: Box::new(coeff),
-    });
+    let total_divisor =
+      simplify(times2(Expr::Integer(new_power as i128), coeff));
     return Some(make_divided(power_expr, total_divisor));
   }
 
@@ -5090,21 +4840,17 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
       // coefficient = binom * sign * (-1) / ((new_power) * a)
       // = -binom * sign / (new_power * a)
       let numer = -sign * binom;
-      let total_divisor = simplify(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(new_power as i128)),
-        right: Box::new(coeff.clone()),
-      });
+      let total_divisor =
+        simplify(times2(Expr::Integer(new_power as i128), coeff.clone()));
       let term = if numer == 1 {
         make_divided(cos_power_expr, total_divisor)
       } else if numer == -1 {
         make_neg_divided(cos_power_expr, total_divisor)
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(make_divided(Expr::Integer(numer), total_divisor)),
-          right: Box::new(cos_power_expr),
-        }
+        times2(
+          make_divided(Expr::Integer(numer), total_divisor),
+          cos_power_expr,
+        )
       };
       terms.push(term);
     }
@@ -5134,21 +4880,17 @@ fn try_integrate_sin_cos_product(factors: &[&Expr], var: &str) -> Option<Expr> {
       let sin_power_expr =
         pow2(sin_f.clone(), Expr::Integer(new_power as i128));
       let numer = sign * binom;
-      let total_divisor = simplify(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(new_power as i128)),
-        right: Box::new(coeff.clone()),
-      });
+      let total_divisor =
+        simplify(times2(Expr::Integer(new_power as i128), coeff.clone()));
       let term = if numer == 1 {
         make_divided(sin_power_expr, total_divisor)
       } else if numer == -1 {
         make_neg_divided(sin_power_expr, total_divisor)
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(make_divided(Expr::Integer(numer), total_divisor)),
-          right: Box::new(sin_power_expr),
-        }
+        times2(
+          make_divided(Expr::Integer(numer), total_divisor),
+          sin_power_expr,
+        )
       };
       terms.push(term);
     }
@@ -5271,21 +5013,13 @@ fn try_integrate_trig_quotient(
   };
   // Build `n/d * expr / a` with the rational coefficient reduced.
   let coeff_term = |n: i128, d: i128, expr: Expr, a: &Expr| -> Expr {
-    let divisor = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(d)),
-      right: Box::new(a.clone()),
-    });
+    let divisor = simplify(times2(Expr::Integer(d), a.clone()));
     if n == 1 {
       make_divided(expr, divisor)
     } else if n == -1 {
       make_neg_divided(expr, divisor)
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(make_divided(Expr::Integer(n), divisor)),
-        right: Box::new(expr),
-      }
+      times2(make_divided(Expr::Integer(n), divisor), expr)
     }
   };
   let wrap_call = |name: &str, inner: Expr| -> Expr {
@@ -5457,11 +5191,7 @@ fn make_gaussian_antiderivative(
     Expr::Integer(n) if *n != 1 => {
       // concrete integer a: (Sqrt[Pi/a]*Erf[Sqrt[a]*x])/2 — matches Wolfram output
       let sqrt_a = make_sqrt(coeff.clone());
-      let erf_arg = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(sqrt_a),
-        right: Box::new(var_expr),
-      };
+      let erf_arg = times2(sqrt_a, var_expr);
       let prefix =
         make_sqrt(div2(Expr::Constant("Pi".to_string()), coeff.clone()));
       (erf_arg, prefix)
@@ -5469,30 +5199,14 @@ fn make_gaussian_antiderivative(
     _ => {
       // symbolic a: (Sqrt[Pi]*Erf[Sqrt[a]*x])/(2*Sqrt[a]) — matches Wolfram output
       let sqrt_a = make_sqrt(coeff.clone());
-      let erf_arg = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(sqrt_a.clone()),
-        right: Box::new(var_expr),
-      };
+      let erf_arg = times2(sqrt_a.clone(), var_expr);
       let prefix = make_sqrt(Expr::Constant("Pi".to_string()));
       let erf_expr = Expr::FunctionCall {
         name: erf_name.to_string(),
         args: vec![erf_arg].into(),
       };
       // (Sqrt[Pi] * Erf[Sqrt[a]*x]) / (2 * Sqrt[a])
-      return Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(prefix),
-          right: Box::new(erf_expr),
-        }),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(2)),
-          right: Box::new(sqrt_a),
-        }),
-      };
+      return div2(times2(prefix, erf_expr), times2(Expr::Integer(2), sqrt_a));
     }
   };
   let erf_expr = Expr::FunctionCall {
@@ -5500,15 +5214,7 @@ fn make_gaussian_antiderivative(
     args: vec![erf_arg].into(),
   };
   // a=1 case: (Sqrt[Pi] * Erf[x]) / 2
-  Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(prefix),
-      right: Box::new(erf_expr),
-    }),
-    right: Box::new(Expr::Integer(2)),
-  }
+  div2(times2(prefix, erf_expr), Expr::Integer(2))
 }
 
 /// Match `E^(a*x^2)` with a positive (or symbolic) `a`, returning `a`. Explicit
@@ -5720,11 +5426,7 @@ fn arcsin_arccos_linear_antideriv(
   let scaled_x_sq = if p_sq == 1 {
     x_sq
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(p_sq)),
-      right: Box::new(x_sq),
-    }
+    times2(Expr::Integer(p_sq), x_sq)
   };
   let sqrt_arg = minus2(Expr::Integer(q_sq), scaled_x_sq);
   let sqrt_expr = crate::functions::math_ast::make_sqrt(sqrt_arg);
@@ -5736,11 +5438,7 @@ fn arcsin_arccos_linear_antideriv(
     div2(sqrt_expr, Expr::Integer(p))
   };
   let inverse_trig = unevaluated(fname, args);
-  let x_times_atrig = Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(Expr::Identifier(var.to_string())),
-    right: Box::new(inverse_trig),
-  };
+  let x_times_atrig = times2(Expr::Identifier(var.to_string()), inverse_trig);
   let join_op = if fname == "ArcCos" {
     BinaryOperator::Minus
   } else {
@@ -5909,20 +5607,12 @@ fn try_integrate_trig_squared(base: &Expr, var: &str) -> Option<Expr> {
     // ∫ Cosh[a*x]^2 dx = Sinh[2*a*x]/(4*a) + x/2
     if name == "Sinh" || name == "Cosh" {
       let coeff = try_match_linear_arg(&args[0], var)?;
-      let double_arg = simplify(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(2)),
-        right: Box::new(args[0].clone()),
-      });
+      let double_arg = simplify(times2(Expr::Integer(2), args[0].clone()));
       let sinh_double = Expr::FunctionCall {
         name: "Sinh".to_string(),
         args: vec![double_arg].into(),
       };
-      let four_a = simplify(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(4)),
-        right: Box::new(coeff),
-      });
+      let four_a = simplify(times2(Expr::Integer(4), coeff));
       let sinh_term = div2(sinh_double, four_a);
       let x_half = div2(Expr::Identifier(var.to_string()), Expr::Integer(2));
       return Some(Expr::BinaryOp {
@@ -5941,22 +5631,14 @@ fn try_integrate_trig_squared(base: &Expr, var: &str) -> Option<Expr> {
     }
     let coeff = try_match_linear_arg(&args[0], var)?;
     // Build: 2*a*x
-    let double_arg = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(2)),
-      right: Box::new(args[0].clone()),
-    });
+    let double_arg = simplify(times2(Expr::Integer(2), args[0].clone()));
     // sin(2*a*x)
     let sin_double = Expr::FunctionCall {
       name: "Sin".to_string(),
       args: vec![double_arg].into(),
     };
     // 4*a
-    let four_a = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(4)),
-      right: Box::new(coeff),
-    });
+    let four_a = simplify(times2(Expr::Integer(4), coeff));
     // x/2
     let x_half = div2(Expr::Identifier(var.to_string()), Expr::Integer(2));
     // sin(2*a*x)/(4*a)
@@ -6023,11 +5705,7 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
     let numer_term = if const_num == 1 {
       Expr::Identifier(var.to_string())
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(const_num)),
-        right: Box::new(Expr::Identifier(var.to_string())),
-      }
+      times2(Expr::Integer(const_num), Expr::Identifier(var.to_string()))
     };
     let const_term = if const_den == 1 {
       numer_term
@@ -6051,18 +5729,10 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
       if freq == 1 {
         Expr::Identifier(var.to_string())
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(freq)),
-          right: Box::new(Expr::Identifier(var.to_string())),
-        }
+        times2(Expr::Integer(freq), Expr::Identifier(var.to_string()))
       }
     } else {
-      simplify(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(freq)),
-        right: Box::new(arg.clone()),
-      })
+      simplify(times2(Expr::Integer(freq), arg.clone()))
     };
 
     // For sin^n: integral coefficient includes the -1 from integrating sin
@@ -6090,11 +5760,7 @@ fn try_integrate_trig_power(base: &Expr, n: i128, var: &str) -> Option<Expr> {
     let term = if matches!(&coeff, Expr::Integer(1)) {
       make_fraction_term(num, den, integrated_trig)
     } else {
-      let den_expr = simplify(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(den)),
-        right: Box::new(coeff.clone()),
-      });
+      let den_expr = simplify(times2(Expr::Integer(den), coeff.clone()));
       make_fraction_term_expr(num, den_expr, integrated_trig)
     };
     terms.push(term);
@@ -6117,11 +5783,7 @@ fn make_fraction_term(num: i128, den: i128, expr: Expr) -> Expr {
     } else if num == -1 {
       neg1(expr)
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(num)),
-        right: Box::new(expr),
-      }
+      times2(Expr::Integer(num), expr)
     }
   } else if num == 1 {
     div2(expr, Expr::Integer(den))
@@ -6130,24 +5792,9 @@ fn make_fraction_term(num: i128, den: i128, expr: Expr) -> Expr {
     neg1(div2(expr, Expr::Integer(den)))
   } else if num < 0 {
     // -(|num|*expr/den) so plus_ast displays as "- num*expr/den"
-    neg1(div2(
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-num)),
-        right: Box::new(expr),
-      },
-      Expr::Integer(den),
-    ))
+    neg1(div2(times2(Expr::Integer(-num), expr), Expr::Integer(den)))
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(num)),
-        right: Box::new(expr),
-      }),
-      right: Box::new(Expr::Integer(den)),
-    }
+    div2(times2(Expr::Integer(num), expr), Expr::Integer(den))
   }
 }
 
@@ -6158,11 +5805,7 @@ fn make_fraction_term_expr(num: i128, den_expr: Expr, expr: Expr) -> Expr {
   } else if num == -1 {
     neg1(expr)
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(num)),
-      right: Box::new(expr),
-    }
+    times2(Expr::Integer(num), expr)
   };
   div2(num_expr, den_expr)
 }
@@ -6239,11 +5882,7 @@ fn try_match_exp_over_linear(
   let ei_arg = if matches!(&linear_coeff, Expr::Integer(1)) {
     Expr::Identifier(var.to_string())
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(linear_coeff),
-      right: Box::new(Expr::Identifier(var.to_string())),
-    }
+    times2(linear_coeff, Expr::Identifier(var.to_string()))
   };
   let ei_expr = Expr::FunctionCall {
     name: "ExpIntegralEi".to_string(),
@@ -6295,11 +5934,7 @@ fn try_match_si_ci_over_linear(
       args: vec![args[0].clone()].into(),
     };
     // divisor = n * c
-    let divisor = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(n)),
-      right: Box::new(denom_const),
-    });
+    let divisor = simplify(times2(Expr::Integer(n), denom_const));
     return Some(if matches!(&divisor, Expr::Integer(1)) {
       si_expr
     } else {
@@ -6313,11 +5948,7 @@ fn try_match_si_ci_over_linear(
   let si_arg = if matches!(&linear_coeff, Expr::Integer(1)) {
     Expr::Identifier(var.to_string())
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(linear_coeff),
-      right: Box::new(Expr::Identifier(var.to_string())),
-    }
+    times2(linear_coeff, Expr::Identifier(var.to_string()))
   };
   let si_expr = Expr::FunctionCall {
     name: integral_name.to_string(),
@@ -6418,11 +6049,7 @@ fn try_integrate_inverse_sqrt(base: &Expr, var: &str) -> Option<Expr> {
       name: "Sqrt".to_string(),
       args: vec![abs_b].into(),
     });
-    let arg = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Identifier(var.to_string())),
-      right: Box::new(sqrt_ratio),
-    });
+    let arg = simplify(times2(Expr::Identifier(var.to_string()), sqrt_ratio));
     let arcsin = Expr::FunctionCall {
       name: "ArcSin".to_string(),
       args: vec![arg].into(),
@@ -6439,11 +6066,7 @@ fn try_integrate_inverse_sqrt(base: &Expr, var: &str) -> Option<Expr> {
       name: "Sqrt".to_string(),
       args: vec![b.clone()].into(),
     });
-    let arg = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Identifier(var.to_string())),
-      right: Box::new(sqrt_ratio),
-    });
+    let arg = simplify(times2(Expr::Identifier(var.to_string()), sqrt_ratio));
     let arcsinh = Expr::FunctionCall {
       name: "ArcSinh".to_string(),
       args: vec![arg].into(),
@@ -6462,7 +6085,6 @@ fn try_integrate_inverse_sqrt(base: &Expr, var: &str) -> Option<Expr> {
 /// forms are continuous, so substituting the integration bounds yields exact
 /// closed forms. Returns the antiderivative expression `F(var)`.
 fn sqrt_quadratic_antiderivative(base: &Expr, var: &str) -> Option<Expr> {
-  use BinaryOperator as B;
   let base_eval = crate::evaluator::evaluate_expr_to_expr(base)
     .unwrap_or_else(|_| base.clone());
   let var_expr = Expr::Identifier(var.to_string());
@@ -6501,15 +6123,7 @@ fn sqrt_quadratic_antiderivative(base: &Expr, var: &str) -> Option<Expr> {
   let sqrt_base = make_sqrt(base.clone());
   let x = Expr::Identifier(var.to_string());
   // First term: (x*Sqrt[base])/2.
-  let first = Expr::BinaryOp {
-    op: B::Divide,
-    left: Box::new(Expr::BinaryOp {
-      op: B::Times,
-      left: Box::new(x.clone()),
-      right: Box::new(sqrt_base),
-    }),
-    right: Box::new(Expr::Integer(2)),
-  };
+  let first = div2(times2(x.clone(), sqrt_base), Expr::Integer(2));
   // |b| for the b < 0 branch (ArcSin needs the positive coefficient).
   let abs_b = if b_neg {
     simplify(neg1(b.clone()))
@@ -6518,29 +6132,14 @@ fn sqrt_quadratic_antiderivative(base: &Expr, var: &str) -> Option<Expr> {
   };
   // arc_arg = x * Sqrt[|b|/a]
   let ratio = simplify(div2(abs_b.clone(), a.clone()));
-  let arc_arg = simplify(Expr::BinaryOp {
-    op: B::Times,
-    left: Box::new(x),
-    right: Box::new(make_sqrt(ratio)),
-  });
+  let arc_arg = simplify(times2(x, make_sqrt(ratio)));
   let arc = Expr::FunctionCall {
     name: (if b_neg { "ArcSin" } else { "ArcSinh" }).to_string(),
     args: vec![arc_arg].into(),
   };
   // Second term: (a*arc) / (2*Sqrt[|b|]).
-  let denom = simplify(Expr::BinaryOp {
-    op: B::Times,
-    left: Box::new(Expr::Integer(2)),
-    right: Box::new(make_sqrt(abs_b)),
-  });
-  let second = make_divided(
-    Expr::BinaryOp {
-      op: B::Times,
-      left: Box::new(a.clone()),
-      right: Box::new(arc),
-    },
-    denom,
-  );
+  let denom = simplify(times2(Expr::Integer(2), make_sqrt(abs_b)));
+  let second = make_divided(times2(a.clone(), arc), denom);
   Some(plus2(first, second))
 }
 
@@ -6751,11 +6350,7 @@ fn try_integrate_rational(
       } else if an == -1 {
         neg1(log_expr)
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(an)),
-          right: Box::new(log_expr),
-        }
+        times2(Expr::Integer(an), log_expr)
       }
     } else {
       // Use Rational form: Rational[an, ad] * Log[...]
@@ -6765,11 +6360,10 @@ fn try_integrate_rational(
       let frac_expr = if abs_an == 1 {
         div2(log_expr.clone(), Expr::Integer(ad))
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(crate::functions::math_ast::make_rational(abs_an, ad)),
-          right: Box::new(log_expr.clone()),
-        }
+        times2(
+          crate::functions::math_ast::make_rational(abs_an, ad),
+          log_expr.clone(),
+        )
       };
       if an < 0 { neg1(frac_expr) } else { frac_expr }
     };
@@ -6847,11 +6441,7 @@ fn try_integrate_rational(
       } else if k_g == 1 {
         make_sqrt(Expr::Integer(m))
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(k_g)),
-          right: Box::new(make_sqrt(Expr::Integer(m))),
-        }
+        times2(Expr::Integer(k_g), make_sqrt(Expr::Integer(m)))
       };
 
       // Helper: build `coeff * x` (or just `x` when coeff == 1).
@@ -6859,11 +6449,7 @@ fn try_integrate_rational(
         if coeff == 1 {
           Expr::Identifier(var.to_string())
         } else {
-          Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(coeff)),
-            right: Box::new(Expr::Identifier(var.to_string())),
-          }
+          times2(Expr::Integer(coeff), Expr::Identifier(var.to_string()))
         }
       };
 
@@ -6905,21 +6491,13 @@ fn try_integrate_rational(
       } else if k == 1 {
         make_sqrt(Expr::Integer(m))
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(k)),
-          right: Box::new(make_sqrt(Expr::Integer(m))),
-        }
+        times2(Expr::Integer(k), make_sqrt(Expr::Integer(m)))
       };
       let result_inner = div2(log_diff, outer_sqrt);
       let combined = if n == 1 {
         result_inner
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(n / overall_factor)),
-          right: Box::new(result_inner),
-        }
+        times2(Expr::Integer(n / overall_factor), result_inner)
       };
       // Combine with quotient integral if any.
       let final_expr = match quotient_integral {
@@ -7160,11 +6738,10 @@ fn try_integrate_rational(
       } else if k_reduced <= 1 {
         Some(make_sqrt(Expr::Integer(m)))
       } else {
-        Some(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(k_reduced)),
-          right: Box::new(make_sqrt(Expr::Integer(m))),
-        })
+        Some(times2(
+          Expr::Integer(k_reduced),
+          make_sqrt(Expr::Integer(m)),
+        ))
       };
 
       // Build ArcTan argument numerator: b_simplified + two_simplified * x
@@ -7172,21 +6749,19 @@ fn try_integrate_rational(
         if two_simplified == 1 {
           Expr::Identifier(var.to_string())
         } else {
-          Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(two_simplified)),
-            right: Box::new(Expr::Identifier(var.to_string())),
-          }
+          times2(
+            Expr::Integer(two_simplified),
+            Expr::Identifier(var.to_string()),
+          )
         }
       } else {
         let x_term = if two_simplified == 1 {
           Expr::Identifier(var.to_string())
         } else {
-          Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(two_simplified)),
-            right: Box::new(Expr::Identifier(var.to_string())),
-          }
+          times2(
+            Expr::Integer(two_simplified),
+            Expr::Identifier(var.to_string()),
+          )
         };
         plus2(Expr::Integer(b_simplified), x_term)
       };
@@ -7214,11 +6789,7 @@ fn try_integrate_rational(
       } else if int_factor == 1 {
         make_sqrt(Expr::Integer(m))
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(int_factor)),
-          right: Box::new(make_sqrt(Expr::Integer(m))),
-        }
+        times2(Expr::Integer(int_factor), make_sqrt(Expr::Integer(m)))
       };
 
       let arctan_term = build_arctan_term(at_num, &effective_sqrt, arctan_expr);
@@ -7266,39 +6837,25 @@ fn build_arctan_term(
       if reduced_num == 1 {
         arctan_expr.clone()
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(reduced_num)),
-          right: Box::new(arctan_expr.clone()),
-        }
+        times2(Expr::Integer(reduced_num), arctan_expr.clone())
       }
     } else if reduced_num == 1 {
       div2(arctan_expr.clone(), Expr::Integer(reduced_den))
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(reduced_num)),
-          right: Box::new(arctan_expr.clone()),
-        }),
-        right: Box::new(Expr::Integer(reduced_den)),
-      }
+      div2(
+        times2(Expr::Integer(reduced_num), arctan_expr.clone()),
+        Expr::Integer(reduced_den),
+      )
     }
   } else {
     // sqrt is Sqrt[n] - put it in denominator
     if abs_coeff == 1 {
       div2(arctan_expr.clone(), sqrt_expr.clone())
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(abs_coeff)),
-          right: Box::new(arctan_expr.clone()),
-        }),
-        right: Box::new(sqrt_expr.clone()),
-      }
+      div2(
+        times2(Expr::Integer(abs_coeff), arctan_expr.clone()),
+        sqrt_expr.clone(),
+      )
     }
   };
 
@@ -7313,20 +6870,15 @@ fn build_coeff_times_expr(num: i128, den: i128, expr: Expr) -> Expr {
     if abs_num == 1 {
       expr
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(abs_num)),
-        right: Box::new(expr),
-      }
+      times2(Expr::Integer(abs_num), expr)
     }
   } else if abs_num == 1 {
     div2(expr, Expr::Integer(den))
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(crate::functions::math_ast::make_rational(abs_num, den)),
-      right: Box::new(expr),
-    }
+    times2(
+      crate::functions::math_ast::make_rational(abs_num, den),
+      expr,
+    )
   };
 
   if num < 0 {
@@ -7532,8 +7084,6 @@ fn try_integrate_poly_times_const_exp(
   coeff: &Expr,
   var: &str,
 ) -> Option<Expr> {
-  use BinaryOperator as B;
-
   // For base E, Log[E] = 1, so rate = coeff directly.
   // For other bases, rate = coeff * Log[base].
   let rate = if matches!(base, Expr::Constant(c) if c == "E") {
@@ -7543,11 +7093,7 @@ fn try_integrate_poly_times_const_exp(
       name: "Log".to_string(),
       args: vec![base.clone()].into(),
     };
-    simplify(Expr::BinaryOp {
-      op: B::Times,
-      left: Box::new(coeff.clone()),
-      right: Box::new(log_base),
-    })
+    simplify(times2(coeff.clone(), log_base))
   };
 
   // Collect derivatives of poly until we reach 0
@@ -7592,18 +7138,10 @@ fn try_integrate_poly_times_const_exp(
           .unwrap_or_else(|_| pow2(inv_rate.clone(), Expr::Integer(k1)))
       };
 
-      let mut term = simplify(Expr::BinaryOp {
-        op: B::Times,
-        left: Box::new(deriv.clone()),
-        right: Box::new(inv_rate_factor),
-      });
+      let mut term = simplify(times2(deriv.clone(), inv_rate_factor));
 
       if k % 2 == 1 {
-        term = simplify(Expr::BinaryOp {
-          op: B::Times,
-          left: Box::new(Expr::Integer(-1)),
-          right: Box::new(term),
-        });
+        term = simplify(times2(Expr::Integer(-1), term));
       }
 
       num_terms.push(term);
@@ -7619,11 +7157,7 @@ fn try_integrate_poly_times_const_exp(
       crate::functions::polynomial_ast::expand_and_combine(&combined)
     };
 
-    let result = simplify(Expr::BinaryOp {
-      op: B::Times,
-      left: Box::new(exponential.clone()),
-      right: Box::new(numerator),
-    });
+    let result = simplify(times2(exponential.clone(), numerator));
 
     Some(result)
   } else {
@@ -7639,18 +7173,10 @@ fn try_integrate_poly_times_const_exp(
         pow2(rate.clone(), Expr::Integer(rate_power))
       };
 
-      let mut term = simplify(Expr::BinaryOp {
-        op: B::Times,
-        left: Box::new(deriv.clone()),
-        right: Box::new(rate_factor),
-      });
+      let mut term = simplify(times2(deriv.clone(), rate_factor));
 
       if k % 2 == 1 {
-        term = simplify(Expr::BinaryOp {
-          op: B::Times,
-          left: Box::new(Expr::Integer(-1)),
-          right: Box::new(term),
-        });
+        term = simplify(times2(Expr::Integer(-1), term));
       }
 
       num_terms.push(term);
@@ -7672,11 +7198,7 @@ fn try_integrate_poly_times_const_exp(
       pow2(rate, Expr::Integer(n as i128))
     };
 
-    let result_num = simplify(Expr::BinaryOp {
-      op: B::Times,
-      left: Box::new(exponential.clone()),
-      right: Box::new(numerator),
-    });
+    let result_num = simplify(times2(exponential.clone(), numerator));
 
     Some(div2(result_num, denom))
   }
@@ -7756,12 +7278,8 @@ fn try_u_substitution_binary(
     };
     // Multiply by the constant ratio
     let final_result =
-      crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(ratio),
-        right: Box::new(antideriv_of_h),
-      })
-      .ok()?;
+      crate::evaluator::evaluate_expr_to_expr(&times2(ratio, antideriv_of_h))
+        .ok()?;
     return Some(final_result);
   }
   // Strategy 2: ∫ c * f'(x) * f(x) dx = c * f(x)^2 / 2
@@ -7961,11 +7479,7 @@ fn try_integration_by_parts(factors: &[&Expr], var: &str) -> Option<Expr> {
   // When v is a fraction a/b, compute uv as (u*a)/b for proper display
   // e.g. Log[x] * (x^2/2) → (x^2*Log[x])/2 instead of x^2/2*Log[x]
   let uv = {
-    let u_times_core = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(u.clone()),
-      right: Box::new(v_core.clone()),
-    });
+    let u_times_core = simplify(times2(u.clone(), v_core.clone()));
     if let Some(ref denom) = v_denom {
       div2(u_times_core, denom.clone())
     } else {
@@ -8011,11 +7525,7 @@ fn try_integration_by_parts(factors: &[&Expr], var: &str) -> Option<Expr> {
     let inner =
       crate::functions::math_ast::subtract_ast(&[u.clone(), quotient]).ok()?;
     let inner = crate::functions::polynomial_ast::expand_and_combine(&inner);
-    let result = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(v_core),
-      right: Box::new(inner),
-    });
+    let result = simplify(times2(v_core, inner));
     return Some(result);
   }
 
@@ -8534,11 +8044,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
   // General constant check: ∫ c dy = c*y for any expression c independent of y
   // (handles compound expressions like x^2, Sin[x], etc. when integrating w.r.t. a different variable)
   if is_constant_wrt(expr, var) {
-    return Some(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(expr.clone()),
-      right: Box::new(Expr::Identifier(var.to_string())),
-    });
+    return Some(times2(expr.clone(), Expr::Identifier(var.to_string())));
   }
 
   // Closed form for `1/p(x)` with `p` an irreducible-looking degree-≥5
@@ -8575,16 +8081,12 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
 
   match expr {
     // Constant: ∫ c dx = c*x
-    Expr::Integer(n) => Some(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(*n)),
-      right: Box::new(Expr::Identifier(var.to_string())),
-    }),
-    Expr::Real(f) => Some(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Real(*f)),
-      right: Box::new(Expr::Identifier(var.to_string())),
-    }),
+    Expr::Integer(n) => {
+      Some(times2(Expr::Integer(*n), Expr::Identifier(var.to_string())))
+    }
+    Expr::Real(f) => {
+      Some(times2(Expr::Real(*f), Expr::Identifier(var.to_string())))
+    }
 
     // Variable: ∫ x dx = x^2/2, ∫ c dx = c*x
     Expr::Identifier(name) => {
@@ -8599,11 +8101,10 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
         })
       } else {
         // Constant * x
-        Some(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Identifier(name.clone())),
-          right: Box::new(Expr::Identifier(var.to_string())),
-        })
+        Some(times2(
+          Expr::Identifier(name.clone()),
+          Expr::Identifier(var.to_string()),
+        ))
       }
     }
 
@@ -8764,21 +8265,16 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                 1 => logx.clone(),
                 _ => pow2(logx.clone(), Expr::Integer(k)),
               };
-              let term = Expr::BinaryOp {
-                op: B::Times,
-                left: Box::new(Expr::Integer(coeff)),
-                right: Box::new(logpow),
-              };
+              let term = times2(Expr::Integer(coeff), logpow);
               sum = Some(match sum {
                 None => term,
                 Some(s) => plus2(s, term),
               });
             }
-            return Some(Expr::BinaryOp {
-              op: B::Times,
-              left: Box::new(Expr::Identifier(var.to_string())),
-              right: Box::new(sum.unwrap()),
-            });
+            return Some(times2(
+              Expr::Identifier(var.to_string()),
+              sum.unwrap(),
+            ));
           }
           // ∫ 1/(a + b*x)^n dx for n ≥ 2 integer → -(a+b*x)^(1-n)/(b*(n-1))
           // Wolfram keeps this factored, matching wolframscript's
@@ -8795,11 +8291,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               left: left.clone(),
               right: Box::new(new_exp.clone()),
             };
-            let divisor = simplify(Expr::BinaryOp {
-              op: B::Times,
-              left: Box::new(slope),
-              right: Box::new(new_exp),
-            });
+            let divisor = simplify(times2(slope, new_exp));
             return Some(div2(new_pow, divisor));
           }
           // ∫ x^n dx = x^(n+1)/(n+1) where n is constant
@@ -8897,11 +8389,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
             if match_neg_inverse_x_squared(exp_arg, var) {
               let var_expr = Expr::Identifier(var.to_string());
               let inv_x = pow2(var_expr.clone(), Expr::Integer(-1));
-              let term1 = Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(var_expr),
-                right: Box::new(expr.clone()),
-              };
+              let term1 = times2(var_expr, expr.clone());
               let term2 = Expr::BinaryOp {
                 op: BinaryOperator::Times,
                 left: Box::new(make_sqrt(Expr::Constant("Pi".to_string()))),
@@ -8929,11 +8417,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
             }
             // ∫ a^(c*x) dx = a^(c*x) / (c * Log[a])
             if let Some(coeff) = try_match_linear_arg(exp_arg, var) {
-              let divisor = simplify(Expr::BinaryOp {
-                op: B::Times,
-                left: Box::new(coeff),
-                right: Box::new(log_a),
-              });
+              let divisor = simplify(times2(coeff, log_a));
               return Some(div2(expr.clone(), divisor));
             }
           }
@@ -9146,15 +8630,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               name: "RealAbs".to_string(),
               args: vec![x.clone()].into(),
             };
-            Some(Expr::BinaryOp {
-              op: BinaryOperator::Divide,
-              left: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(x),
-                right: Box::new(real_abs_x),
-              }),
-              right: Box::new(Expr::Integer(2)),
-            })
+            Some(div2(times2(x, real_abs_x), Expr::Integer(2)))
           } else {
             None
           }
@@ -9228,8 +8704,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               name: head.to_string(),
               args: vec![a].into(),
             };
-            let neg =
-              |e: Expr| binop(BinaryOperator::Times, Expr::Integer(-1), e);
+            let neg = |e: Expr| times2(Expr::Integer(-1), e);
             let correction = match name.as_str() {
               "SinIntegral" => call("Cos", x.clone()),
               "CosIntegral" => neg(call("Sin", x.clone())),
@@ -9259,11 +8734,6 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
             && n == var
           {
             let x = Expr::Identifier(var.to_string());
-            let times = |a: Expr, b: Expr| Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(a),
-              right: Box::new(b),
-            };
             let sqrt = |e: Expr| Expr::FunctionCall {
               name: "Sqrt".to_string(),
               args: vec![e].into(),
@@ -9272,12 +8742,12 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
             let correction = match name.as_str() {
               // -Sqrt[1 + x^2]
               "ArcSinh" => {
-                times(Expr::Integer(-1), sqrt(plus2(Expr::Integer(1), x_sq)))
+                times2(Expr::Integer(-1), sqrt(plus2(Expr::Integer(1), x_sq)))
               }
               // -Sqrt[-1 + x] Sqrt[1 + x] (wolframscript keeps the split radical)
-              "ArcCosh" => times(
+              "ArcCosh" => times2(
                 Expr::Integer(-1),
-                times(
+                times2(
                   sqrt(plus2(Expr::Integer(-1), x.clone())),
                   sqrt(plus2(Expr::Integer(1), x.clone())),
                 ),
@@ -9292,7 +8762,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                 right: Box::new(Expr::Integer(2)),
               },
             };
-            let x_f = times(
+            let x_f = times2(
               x,
               Expr::FunctionCall {
                 name: name.clone(),
@@ -9316,22 +8786,17 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
             && n == var
           {
             let x = Expr::Identifier(var.to_string());
-            let times = |a: Expr, b: Expr| Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(a),
-              right: Box::new(b),
-            };
             let x_sq = pow2(x.clone(), Expr::Integer(2));
             let sqrt_pi = Expr::FunctionCall {
               name: "Sqrt".to_string(),
               args: vec![Expr::Constant("Pi".to_string())].into(),
             };
-            let neg = |e: Expr| times(Expr::Integer(-1), e);
+            let neg = |e: Expr| times2(Expr::Integer(-1), e);
             // exp(-x^2)/Sqrt[Pi] used by Erf/Erfc.
             let gauss = || {
               div2(
                 Expr::Integer(1),
-                times(
+                times2(
                   pow2(Expr::Constant("E".to_string()), x_sq.clone()),
                   sqrt_pi.clone(),
                 ),
@@ -9340,7 +8805,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
             // (Pi x^2)/2 argument for the Fresnel corrections.
             let fresnel_arg = || {
               div2(
-                times(Expr::Constant("Pi".to_string()), x_sq.clone()),
+                times2(Expr::Constant("Pi".to_string()), x_sq.clone()),
                 Expr::Integer(2),
               )
             };
@@ -9366,7 +8831,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                 Expr::Constant("Pi".to_string()),
               )),
             };
-            let x_f = times(
+            let x_f = times2(
               x,
               Expr::FunctionCall {
                 name: name.clone(),
@@ -9590,11 +9055,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                 "Subtract",
                 &[
                   args[0].clone(),
-                  Expr::BinaryOp {
-                    op: BinaryOperator::Times,
-                    left: Box::new(coefficient),
-                    right: Box::new(Expr::Identifier(var.to_string())),
-                  },
+                  times2(coefficient, Expr::Identifier(var.to_string())),
                 ],
               ),
               Ok(Expr::Integer(0))
@@ -9632,20 +9093,9 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
               };
               let first = if try_match_linear_arg(&u, var).is_some() {
                 // u = a*x, so u/a = x
-                Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(Expr::Identifier(var.to_string())),
-                  right: Box::new(log_log),
-                }
+                times2(Expr::Identifier(var.to_string()), log_log)
               } else {
-                make_divided(
-                  Expr::BinaryOp {
-                    op: BinaryOperator::Times,
-                    left: Box::new(u.clone()),
-                    right: Box::new(log_log),
-                  },
-                  coeff.clone(),
-                )
+                make_divided(times2(u.clone(), log_log), coeff.clone())
               };
               let li = Expr::FunctionCall {
                 name: "LogIntegral".to_string(),
@@ -9672,22 +9122,14 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                 args: const_factors.into_iter().cloned().collect(),
               }
             };
-            Some(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(const_expr),
-              right: Box::new(int_var),
-            })
+            Some(times2(const_expr, int_var))
           } else if var_factors.is_empty() {
             // All constant: ∫ c dx = c*x
             let const_expr = Expr::FunctionCall {
               name: "Times".to_string(),
               args: args.clone(),
             };
-            Some(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(const_expr),
-              right: Box::new(Expr::Identifier(var.to_string())),
-            })
+            Some(times2(const_expr, Expr::Identifier(var.to_string())))
           } else {
             // Direct-derivative products: Sec*Tan, Csc*Cot, Sech*Tanh,
             // Csch*Coth (carrying through any constant factors).
@@ -9705,11 +9147,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                   args: const_factors.iter().map(|e| (*e).clone()).collect(),
                 }
               };
-              return Some(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(const_expr),
-                right: Box::new(result),
-              });
+              return Some(times2(const_expr, result));
             }
             // Multiple variable-dependent factors: check for fraction form
             // Times[..., Power[den, -1]] → treat as numerator / denominator
@@ -9794,11 +9232,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                         .collect(),
                     }
                   };
-                  Expr::BinaryOp {
-                    op: BinaryOperator::Times,
-                    left: Box::new(const_expr),
-                    right: Box::new(result),
-                  }
+                  times2(const_expr, result)
                 }
               };
               // Try the same logic as the Divide arm
@@ -9845,11 +9279,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                     args: const_factors.into_iter().cloned().collect(),
                   }
                 };
-                return Some(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(const_expr),
-                  right: Box::new(et_result),
-                });
+                return Some(times2(const_expr, et_result));
               }
             }
             if let Some(trig_result) =
@@ -9867,11 +9297,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                     args: const_factors.into_iter().cloned().collect(),
                   }
                 };
-                return Some(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(const_expr),
-                  right: Box::new(trig_result),
-                });
+                return Some(times2(const_expr, trig_result));
               }
             }
             // Try u-substitution for pairs of variable-dependent factors
@@ -9890,11 +9316,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                     args: const_factors.into_iter().cloned().collect(),
                   }
                 };
-                Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(const_expr),
-                  right: Box::new(usub_result),
-                }
+                times2(const_expr, usub_result)
               };
               return Some(result);
             }
@@ -9912,11 +9334,7 @@ fn integrate(expr: &Expr, var: &str) -> Option<Expr> {
                     args: const_factors.into_iter().cloned().collect(),
                   }
                 };
-                Some(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(const_expr),
-                  right: Box::new(ibp_result),
-                })
+                Some(times2(const_expr, ibp_result))
               }
             } else {
               None
@@ -10449,11 +9867,7 @@ fn split_constant_factor(t: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
       }
     };
     if sign == -1 {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(product),
-      }
+      times2(Expr::Integer(-1), product)
     } else {
       product
     }
@@ -10751,12 +10165,8 @@ fn leading_power_behavior(
 
   // Combine two factors: orders add, coefficients multiply.
   let combine = |a: (f64, Expr), b: (f64, Expr)| -> Option<(f64, Expr)> {
-    let coeff = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(a.1),
-      right: Box::new(b.1),
-    })
-    .ok()?;
+    let coeff =
+      crate::evaluator::evaluate_expr_to_expr(&times2(a.1, b.1)).ok()?;
     Some((a.0 + b.0, coeff))
   };
 
@@ -11203,11 +10613,10 @@ fn limit_at_infinity(
       // The limit diverges with the sign of the leading coefficient. Leaving
       // it as `coeff * Infinity` folds to ±Infinity for a numeric coefficient
       // and keeps wolframscript's `a Infinity` for a symbolic one.
-      return crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(coeff),
-        right: Box::new(Expr::Identifier("Infinity".to_string())),
-      });
+      return crate::evaluator::evaluate_expr_to_expr(&times2(
+        coeff,
+        Expr::Identifier("Infinity".to_string()),
+      ));
     } else if order < -ORDER_EPS {
       return Ok(Expr::Integer(0));
     } else {
@@ -11306,11 +10715,7 @@ fn limit_at_infinity(
     {
       // Use identity: Limit[f^g] = E^(Limit[g * (f - 1)]) when f -> 1, g -> inf
       let f_minus_1 = minus2(base, Expr::Integer(1));
-      let product = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(exp),
-        right: Box::new(f_minus_1),
-      };
+      let product = times2(exp, f_minus_1);
       // Simplify g*(f - 1) first so a symbolic coefficient cancels (e.g.
       // n*((1 + a/n) - 1) → a); otherwise limit_ast's numeric fallback can't
       // resolve the parameterized form.
@@ -11460,11 +10865,10 @@ fn limit_at_infinity(
             if numer == -1 {
               return Ok(neg1(Expr::Constant("Pi".to_string())));
             }
-            return Ok(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Integer(numer)),
-              right: Box::new(Expr::Constant("Pi".to_string())),
-            });
+            return Ok(times2(
+              Expr::Integer(numer),
+              Expr::Constant("Pi".to_string()),
+            ));
           }
           return Ok(Expr::FunctionCall {
             name: "Times".to_string(),
@@ -13091,11 +12495,10 @@ fn limit_strategies(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     let inner = limit_ast(&inner_args)?;
     if !matches!(&inner, Expr::FunctionCall { name, .. } if name == "Limit") {
-      return crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(inner),
-      });
+      return crate::evaluator::evaluate_expr_to_expr(&times2(
+        Expr::Integer(-1),
+        inner,
+      ));
     }
     return Ok(unevaluated("Limit", args));
   }
@@ -14021,11 +13424,7 @@ pub fn residue_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let build_g = |m: i128| -> Expr {
     let shift = minus2(Expr::Identifier(var_name.clone()), z0.clone());
     let powered = pow2(shift, Expr::Integer(m));
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(powered),
-      right: Box::new(expr.clone()),
-    }
+    times2(powered, expr.clone())
   };
 
   // Fully simplify via the `Simplify` builtin (the internal `simplify` helper
@@ -17618,11 +17017,10 @@ pub fn curl_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     };
     let dsdy = differentiate_expr(&args[0], var2)?;
     let dsdx = differentiate_expr(&args[0], var1)?;
-    let neg_dsdy = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(-1)),
-      right: Box::new(dsdy),
-    })?;
+    let neg_dsdy = crate::evaluator::evaluate_expr_to_expr(&times2(
+      Expr::Integer(-1),
+      dsdy,
+    ))?;
     return Ok(Expr::List(vec![neg_dsdy, dsdx].into()));
   }
   let field = match &args[0] {
@@ -17906,11 +17304,7 @@ pub fn dt_total_differential_ast(
     if matches!(partial, Expr::Integer(0)) {
       continue;
     }
-    let term = simplify(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(partial),
-      right: Box::new(dt_of(v)),
-    });
+    let term = simplify(times2(partial, dt_of(v)));
     sum = Some(match sum {
       None => term,
       Some(acc) => plus2(acc, term),
@@ -18027,11 +17421,7 @@ fn total_differentiate(
         } else if matches!(left.as_ref(), Expr::Constant(c) if c == "E") {
           // E^g: E^g * Dt[g, x]
           let dg = total_differentiate(right, var)?;
-          Ok(simplify(Expr::BinaryOp {
-            op: B::Times,
-            left: Box::new(expr.clone()),
-            right: Box::new(dg),
-          }))
+          Ok(simplify(times2(expr.clone(), dg)))
         } else {
           // General f^g: return unevaluated
           Ok(Expr::FunctionCall {
@@ -18113,32 +17503,19 @@ fn total_differentiate(
         }
         "Log" if args.len() == 1 => {
           let df = total_differentiate(&args[0], var)?;
-          Ok(simplify(Expr::BinaryOp {
-            op: B::Times,
-            left: Box::new(pow2(args[0].clone(), Expr::Integer(-1))),
-            right: Box::new(df),
-          }))
+          Ok(simplify(times2(
+            pow2(args[0].clone(), Expr::Integer(-1)),
+            df,
+          )))
         }
         "Exp" if args.len() == 1 => {
           let df = total_differentiate(&args[0], var)?;
-          Ok(simplify(Expr::BinaryOp {
-            op: B::Times,
-            left: Box::new(expr.clone()),
-            right: Box::new(df),
-          }))
+          Ok(simplify(times2(expr.clone(), df)))
         }
         "Sqrt" if args.len() == 1 => {
           // d/dx[sqrt(f)] = f'/(2*sqrt(f))
           let df = total_differentiate(&args[0], var)?;
-          Ok(simplify(Expr::BinaryOp {
-            op: B::Divide,
-            left: Box::new(df),
-            right: Box::new(Expr::BinaryOp {
-              op: B::Times,
-              left: Box::new(Expr::Integer(2)),
-              right: Box::new(expr.clone()),
-            }),
-          }))
+          Ok(simplify(div2(df, times2(Expr::Integer(2), expr.clone()))))
         }
         "Plus" => {
           // Sum rule
@@ -18163,11 +17540,7 @@ fn total_differentiate(
             let mut product = di;
             for (j, arg) in args.iter().enumerate() {
               if j != i {
-                product = Expr::BinaryOp {
-                  op: B::Times,
-                  left: Box::new(product),
-                  right: Box::new(arg.clone()),
-                };
+                product = times2(product, arg.clone());
               }
             }
             sum_terms.push(product);
@@ -18348,15 +17721,10 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if matches!(&operands[1], Expr::Integer(0)) {
         operands[0].clone()
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(operands[0].clone()),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(-1)),
-            right: Box::new(operands[1].clone()),
-          }),
-        }
+        plus2(
+          operands[0].clone(),
+          times2(Expr::Integer(-1), operands[1].clone()),
+        )
       }
     }
     // Also handle FunctionCall "Equal"
@@ -18367,15 +17735,10 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if matches!(&eq_args[1], Expr::Integer(0)) {
         eq_args[0].clone()
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(eq_args[0].clone()),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(-1)),
-            right: Box::new(eq_args[1].clone()),
-          }),
-        }
+        plus2(
+          eq_args[0].clone(),
+          times2(Expr::Integer(-1), eq_args[1].clone()),
+        )
       }
     }
     other => other.clone(),
@@ -18468,17 +17831,9 @@ pub fn asymptotic_solve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let term = if power == 0 {
       coeff.clone()
     } else if power == 1 {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(coeff.clone()),
-        right: Box::new(t_var.clone()),
-      }
+      times2(coeff.clone(), t_var.clone())
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(coeff.clone()),
-        right: Box::new(pow2(t_var.clone(), Expr::Integer(power))),
-      }
+      times2(coeff.clone(), pow2(t_var.clone(), Expr::Integer(power)))
     };
     poly_terms.push(term);
   }
@@ -18720,23 +18075,14 @@ pub fn discrete_convolve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // g /. n -> (m - k). Both f and g are functions of the convolution variable
   // n; the discrete convolution is Sum_k f[k] g[m-k], so g's n becomes m - k
   // (NOT m — g is not a function of the output variable).
-  let m_minus_k = Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(Expr::Identifier(m_var.clone())),
-    right: Box::new(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(-1)),
-      right: Box::new(k_expr.clone()),
-    }),
-  };
+  let m_minus_k = plus2(
+    Expr::Identifier(m_var.clone()),
+    times2(Expr::Integer(-1), k_expr.clone()),
+  );
   let g_sub = crate::syntax::substitute_variable(g_expr, &n_var, &m_minus_k);
 
   // Build the product
-  let product = Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(f_sub),
-    right: Box::new(g_sub),
-  };
+  let product = times2(f_sub, g_sub);
 
   // Build Sum[product, {k, -Infinity, Infinity}]
   let sum_expr = Expr::FunctionCall {
@@ -18841,29 +18187,16 @@ pub fn frenet_serret_system_ast(
   if n == 2 {
     // 2D case
     // κ = (x'*y'' - y'*x'') / (speed_sq)^(3/2)
-    let numerator = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(r1[0].clone()),
-        right: Box::new(r2[1].clone()),
-      }),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(r1[1].clone()),
-        right: Box::new(r2[0].clone()),
-      }),
-    };
+    let numerator = minus2(
+      times2(r1[0].clone(), r2[1].clone()),
+      times2(r1[1].clone(), r2[0].clone()),
+    );
     let denom = pow2(speed_sq, div2(Expr::Integer(3), Expr::Integer(2)));
     let kappa = eval(&div2(numerator, denom))?;
 
     // N = {-T2, T1} (rotate tangent 90° counterclockwise)
     let normal = vec![
-      eval(&Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(tangent[1].clone()),
-      })?,
+      eval(&times2(Expr::Integer(-1), tangent[1].clone()))?,
       tangent[0].clone(),
     ];
 
@@ -18975,47 +18308,20 @@ fn sum_of_squares(items: &[Expr]) -> Expr {
 fn cross_product_3d(a: &[Expr], b: &[Expr]) -> Vec<Expr> {
   vec![
     // a[1]*b[2] - a[2]*b[1]
-    Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(a[1].clone()),
-        right: Box::new(b[2].clone()),
-      }),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(a[2].clone()),
-        right: Box::new(b[1].clone()),
-      }),
-    },
+    minus2(
+      times2(a[1].clone(), b[2].clone()),
+      times2(a[2].clone(), b[1].clone()),
+    ),
     // a[2]*b[0] - a[0]*b[2]
-    Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(a[2].clone()),
-        right: Box::new(b[0].clone()),
-      }),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(a[0].clone()),
-        right: Box::new(b[2].clone()),
-      }),
-    },
+    minus2(
+      times2(a[2].clone(), b[0].clone()),
+      times2(a[0].clone(), b[2].clone()),
+    ),
     // a[0]*b[1] - a[1]*b[0]
-    Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(a[0].clone()),
-        right: Box::new(b[1].clone()),
-      }),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(a[1].clone()),
-        right: Box::new(b[0].clone()),
-      }),
-    },
+    minus2(
+      times2(a[0].clone(), b[1].clone()),
+      times2(a[1].clone(), b[0].clone()),
+    ),
   ]
 }
 
@@ -19142,11 +18448,7 @@ pub fn asymptotic_integrate_ast(
         let term = if matches!(power_expr, Expr::Integer(1)) {
           integrated_val
         } else {
-          Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(integrated_val),
-            right: Box::new(power_expr),
-          }
+          times2(integrated_val, power_expr)
         };
         terms.push(crate::evaluator::evaluate_expr_to_expr(&term)?);
         if leading_only {
@@ -19268,11 +18570,7 @@ pub fn asymptotic_integrate_ast(
               )),
             }
           };
-          let term = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(factor),
-            right: Box::new(power_expr),
-          };
+          let term = times2(factor, power_expr);
           terms.push(crate::evaluator::evaluate_expr_to_expr(&term)?);
         }
 
@@ -19381,11 +18679,10 @@ fn try_exponential_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
   };
 
   // Result: base^exponent * (base^delta_exp - 1)
-  let result = Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(expr.clone()),
-    right: Box::new(minus2(pow2(base.clone(), delta_exp), Expr::Integer(1))),
-  };
+  let result = times2(
+    expr.clone(),
+    minus2(pow2(base.clone(), delta_exp), Expr::Integer(1)),
+  );
 
   Some(result)
 }
@@ -19436,19 +18733,10 @@ fn try_trig_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
   // Build (2*half_delta + Pi) / 2  for the constant part, but use direct
   // (step + Pi) / 2 to get a cleaner fraction when possible.
   // General form: half_delta + Pi/2 + arg, combined as arg + (2*half_delta ± Pi)/2
-  let const_part = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(2)),
-        right: Box::new(half_delta.clone()),
-      }),
-      right: Box::new(pi_term),
-    }),
-    right: Box::new(Expr::Integer(2)),
-  };
+  let const_part = div2(
+    plus2(times2(Expr::Integer(2), half_delta.clone()), pi_term),
+    Expr::Integer(2),
+  );
   let second_arg_expr = plus2(const_part, arg.clone());
 
   let coeff = if fn_name == "Sin" {
@@ -19833,11 +19121,7 @@ fn dot_product(a: &[Expr], b: &[Expr]) -> Expr {
   let terms: Vec<Expr> = a
     .iter()
     .zip(b.iter())
-    .map(|(ai, bi)| Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(ai.clone()),
-      right: Box::new(bi.clone()),
-    })
+    .map(|(ai, bi)| times2(ai.clone(), bi.clone()))
     .collect();
   if terms.len() == 1 {
     terms.into_iter().next().unwrap()

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -2,10 +2,6 @@
 use super::*;
 use crate::evaluator::evaluate_expr_to_expr;
 
-fn times(a: Expr, b: Expr) -> Expr {
-  binop(BinaryOperator::Times, a, b)
-}
-
 fn sqrt(a: Expr) -> Expr {
   make_sqrt(a)
 }
@@ -408,7 +404,7 @@ pub fn survival_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Simplify normalizes the negated argument the way wolframscript
   // prints it: (-m + x)/(Sqrt[2]*s) rather than -((m - x)/(Sqrt[2]*s)).
   if let Some(z) = match_erfc_half(&cdf) {
-    let neg_z = eval(call("Simplify", vec![times(int(-1), z)]))?;
+    let neg_z = eval(call("Simplify", vec![times2(int(-1), z)]))?;
     return Ok(div2(call("Erfc", vec![neg_z]), int(2)));
   }
 
@@ -564,7 +560,7 @@ pub fn quantile_distribution_closed_form(
   let log = |x: Expr| call("Log", vec![x]);
   let sqrt = |x: Expr| call("Sqrt", vec![x]);
   let power = |b: Expr, e: Expr| call("Power", vec![b, e]);
-  let neg = |x: Expr| times(int(-1), x);
+  let neg = |x: Expr| times2(int(-1), x);
   let one_minus_q = || minus2(int(1), q.clone());
 
   match dist_name {
@@ -604,7 +600,7 @@ pub fn quantile_distribution_closed_form(
       let lambda = dargs[0].clone();
       let one_minus_q = minus2(int(1), q.clone());
       let log_term = call("Log", vec![one_minus_q]);
-      let neg_log = times(int(-1), log_term);
+      let neg_log = times2(int(-1), log_term);
       let expr = div2(neg_log, lambda);
       eval(expr).ok()
     }
@@ -621,8 +617,8 @@ pub fn quantile_distribution_closed_form(
       let (a, b) = (dargs[0].clone(), dargs[1].clone());
       let pi = pi();
       let q_minus_half = minus2(q.clone(), make_rational(1, 2));
-      let tan = call("Tan", vec![times(pi, q_minus_half)]);
-      eval(plus2(a, times(b, tan))).ok()
+      let tan = call("Tan", vec![times2(pi, q_minus_half)]);
+      eval(plus2(a, times2(b, tan))).ok()
     }
     // Quantile[WeibullDistribution[k, λ], q] = λ (-Log[1 - q])^(1/k)
     "WeibullDistribution" if dargs.len() == 2 => {
@@ -635,7 +631,7 @@ pub fn quantile_distribution_closed_form(
         }
       }
       let (k, lam) = (dargs[0].clone(), dargs[1].clone());
-      eval(times(lam, power(neg(log(one_minus_q())), div2(int(1), k)))).ok()
+      eval(times2(lam, power(neg(log(one_minus_q())), div2(int(1), k)))).ok()
     }
     // Quantile[ParetoDistribution[k, α], q] = k (1 - q)^(-1/α)
     "ParetoDistribution" if dargs.len() == 2 => {
@@ -643,7 +639,7 @@ pub fn quantile_distribution_closed_form(
         return Some(infinity());
       }
       let (kmin, alpha) = (dargs[0].clone(), dargs[1].clone());
-      eval(times(kmin, power(one_minus_q(), div2(int(-1), alpha)))).ok()
+      eval(times2(kmin, power(one_minus_q(), div2(int(-1), alpha)))).ok()
     }
     // Quantile[RayleighDistribution[σ], q] = σ Sqrt[-Log[(1 - q)^2]]
     "RayleighDistribution" if dargs.len() == 1 => {
@@ -651,7 +647,7 @@ pub fn quantile_distribution_closed_form(
         return Some(infinity());
       }
       let sigma = dargs[0].clone();
-      eval(times(sigma, sqrt(neg(log(power(one_minus_q(), int(2))))))).ok()
+      eval(times2(sigma, sqrt(neg(log(power(one_minus_q(), int(2))))))).ok()
     }
     // Quantile[LaplaceDistribution[μ, β], q]: μ + β Log[2 q] for q ≤ 1/2,
     // else μ − β Log[2 (1 − q)].
@@ -666,9 +662,9 @@ pub fn quantile_distribution_closed_form(
       }
       let (mu, beta) = (dargs[0].clone(), dargs[1].clone());
       let body = if q_num <= 0.5 {
-        plus2(mu, times(beta, log(times(int(2), q.clone()))))
+        plus2(mu, times2(beta, log(times2(int(2), q.clone()))))
       } else {
-        minus2(mu, times(beta, log(times(int(2), one_minus_q()))))
+        minus2(mu, times2(beta, log(times2(int(2), one_minus_q()))))
       };
       eval(body).ok()
     }
@@ -685,7 +681,7 @@ pub fn quantile_distribution_closed_form(
       let (mu, beta) = (dargs[0].clone(), dargs[1].clone());
       eval(minus2(
         mu,
-        times(beta, log(plus2(int(-1), div2(int(1), q.clone())))),
+        times2(beta, log(plus2(int(-1), div2(int(1), q.clone())))),
       ))
       .ok()
     }
@@ -700,7 +696,7 @@ pub fn quantile_distribution_closed_form(
         }
       }
       let (mu, beta) = (dargs[0].clone(), dargs[1].clone());
-      eval(plus2(mu, times(beta, log(neg(log(one_minus_q())))))).ok()
+      eval(plus2(mu, times2(beta, log(neg(log(one_minus_q())))))).ok()
     }
     // Quantile[UniformDistribution[{a, b}], q] = (1 - q)*a + q*b
     "UniformDistribution" if dargs.len() == 1 => {
@@ -711,8 +707,8 @@ pub fn quantile_distribution_closed_form(
         _ => return None,
       };
       eval(plus2(
-        times(minus2(int(1), q.clone()), a),
-        times(q.clone(), b),
+        times2(minus2(int(1), q.clone()), a),
+        times2(q.clone(), b),
       ))
       .ok()
     }
@@ -737,7 +733,7 @@ pub fn quantile_distribution_closed_form(
         // m - Sqrt[2]*s*InverseErfc[2q]. Evaluating the result reflects
         // InverseErfc[2q] for q > 1/2 (2q > 1 → -InverseErfc[2-2q]) and folds
         // the sign, matching wolframscript while preserving the factor order.
-        let two_q = eval(times(int(2), q.clone())).ok()?;
+        let two_q = eval(times2(int(2), q.clone())).ok()?;
         let inverse_erfc = call("InverseErfc", vec![two_q]);
         let sqrt2 = call("Sqrt", vec![int(2)]);
         let factors: Vec<Expr> = match &s {
@@ -769,7 +765,7 @@ pub fn quantile_distribution_closed_form(
       }
       let (a, b) = (dargs[0].clone(), dargs[1].clone());
       let igr = call("InverseGammaRegularized", vec![a, int(0), q.clone()]);
-      eval(times(b, igr)).ok()
+      eval(times2(b, igr)).ok()
     }
     // ChiSquareDistribution[v] = GammaDistribution[v/2, 2], so the quantile is
     // 2 InverseGammaRegularized[v/2, 0, q].
@@ -785,7 +781,7 @@ pub fn quantile_distribution_closed_form(
       let half_v = eval(div2(dargs[0].clone(), int(2))).ok()?;
       let igr =
         call("InverseGammaRegularized", vec![half_v, int(0), q.clone()]);
-      eval(times(int(2), igr)).ok()
+      eval(times2(int(2), igr)).ok()
     }
     // Quantile[BetaDistribution[a, b], q] = InverseBetaRegularized[q, a, b].
     // For an exact interior q wolframscript returns an algebraic Root object,
@@ -825,15 +821,15 @@ pub fn quantile_distribution_closed_form(
         return Some(int(0));
       }
       let s = if q_num > 0.5 {
-        eval(times(int(2), one_minus_q())).ok()?
+        eval(times2(int(2), one_minus_q())).ok()?
       } else {
-        eval(times(int(2), q.clone())).ok()?
+        eval(times2(int(2), q.clone())).ok()?
       };
       let ibr = call(
         "InverseBetaRegularized",
         vec![s, div2(nu.clone(), int(2)), make_rational(1, 2)],
       );
-      let radical = sqrt(times(nu, plus2(int(-1), power(ibr, int(-1)))));
+      let radical = sqrt(times2(nu, plus2(int(-1), power(ibr, int(-1)))));
       eval(if q_num < 0.5 { neg(radical) } else { radical }).ok()
     }
     // Quantile[FRatioDistribution[n, m], q] =
@@ -863,7 +859,7 @@ pub fn quantile_distribution_closed_form(
           div2(n.clone(), int(2)),
         ],
       );
-      eval(div2(times(m, plus2(int(-1), power(ibr, int(-1)))), n)).ok()
+      eval(div2(times2(m, plus2(int(-1), power(ibr, int(-1)))), n)).ok()
     }
     "BinomialDistribution"
     | "PoissonDistribution"
@@ -918,7 +914,7 @@ pub fn inverse_survival_closed_form(
           return eval(m).ok();
         }
       }
-      let two_q = eval(times(int(2), q.clone())).ok()?;
+      let two_q = eval(times2(int(2), q.clone())).ok()?;
       let inverse_erfc = call("InverseErfc", vec![two_q]);
       let sqrt2 = call("Sqrt", vec![int(2)]);
       let factors: Vec<Expr> = match &s {
@@ -947,7 +943,7 @@ pub fn inverse_survival_closed_form(
       }
       let igr =
         call("InverseGammaRegularized", vec![dargs[0].clone(), q.clone()]);
-      eval(times(dargs[1].clone(), igr)).ok()
+      eval(times2(dargs[1].clone(), igr)).ok()
     }
     // ChiSquareDistribution[v] = GammaDistribution[v/2, 2]
     "ChiSquareDistribution" if dargs.len() == 1 => {
@@ -963,7 +959,7 @@ pub fn inverse_survival_closed_form(
         "InverseGammaRegularized",
         vec![div2(dargs[0].clone(), int(2)), q.clone()],
       );
-      eval(times(int(2), igr)).ok()
+      eval(times2(int(2), igr)).ok()
     }
     // Distributions whose survival inverse shares the InverseCDF[dist, 1 - q]
     // form (verified against wolframscript): delegate to the quantile.
@@ -1242,11 +1238,11 @@ fn pdf_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // 1/(E^((x - mu)^2/(2*sigma^2)) * Sqrt[2*Pi] * sigma)
   let diff = minus2(x, mu);
   let diff_sq = pow2(diff, int(2));
-  let two_sigma_sq = times(int(2), pow2(sigma.clone(), int(2)));
+  let two_sigma_sq = times2(int(2), pow2(sigma.clone(), int(2)));
   let exponent = div2(diff_sq, two_sigma_sq);
   let exp_part = pow2(e(), exponent);
-  let sqrt_part = sqrt(times(int(2), pi()));
-  let denominator = times(times(exp_part, sqrt_part), sigma);
+  let sqrt_part = sqrt(times2(int(2), pi()));
+  let denominator = times2(times2(exp_part, sqrt_part), sigma);
   let result = div2(int(1), denominator);
   eval(result)
 }
@@ -1294,7 +1290,7 @@ fn pdf_exponential(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let lambda = dargs[0].clone();
 
   let density =
-    eval(div2(lambda.clone(), pow2(e(), times(lambda, x.clone()))))?;
+    eval(div2(lambda.clone(), pow2(e(), times2(lambda, x.clone()))))?;
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
 
   eval(piecewise(vec![(density, cond)], int(0)))
@@ -1310,7 +1306,7 @@ fn pdf_poisson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let mu = dargs[0].clone();
 
   let numerator = pow2(mu.clone(), x.clone());
-  let denominator = times(pow2(e(), mu), factorial(x.clone()));
+  let denominator = times2(pow2(e(), mu), factorial(x.clone()));
   let density = eval(div2(numerator, denominator))?;
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
 
@@ -1337,15 +1333,17 @@ fn pdf_meixner(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   let xm = minus2(x, m); // x - m
   let i = Expr::Identifier("I".to_string());
-  let iy = div2(times(i, xm.clone()), a.clone()); // I (x-m)/a
-  let two_pow = pow2(int(2), plus2(int(-1), times(int(2), d.clone())));
-  let e_part = pow2(e(), div2(times(b.clone(), xm), a.clone()));
+  let iy = div2(times2(i, xm.clone()), a.clone()); // I (x-m)/a
+  let two_pow = pow2(int(2), plus2(int(-1), times2(int(2), d.clone())));
+  let e_part = pow2(e(), div2(times2(b.clone(), xm), a.clone()));
   let cos_part =
-    pow2(unary_fn("Cos", div2(b, int(2))), times(int(2), d.clone()));
+    pow2(unary_fn("Cos", div2(b, int(2))), times2(int(2), d.clone()));
   let g1 = unary_fn("Gamma", minus2(d.clone(), iy.clone()));
   let g2 = unary_fn("Gamma", plus2(d.clone(), iy));
-  let numerator = times(times(times(times(two_pow, e_part), cos_part), g1), g2);
-  let denominator = times(times(a, pi()), unary_fn("Gamma", times(int(2), d)));
+  let numerator =
+    times2(times2(times2(times2(two_pow, e_part), cos_part), g1), g2);
+  let denominator =
+    times2(times2(a, pi()), unary_fn("Gamma", times2(int(2), d)));
   eval(div2(numerator, denominator))
 }
 
@@ -1367,13 +1365,13 @@ fn pdf_poisson_consul(
   let lam = dargs[1].clone();
   let k = x.clone();
 
-  let klam = times(k.clone(), lam);
+  let klam = times2(k.clone(), lam);
   let klam_m = plus2(klam.clone(), m.clone()); // k lam + m
   // E^(-(k lam) - m)
-  let exp_part = pow2(e(), minus2(times(int(-1), klam), m.clone()));
+  let exp_part = pow2(e(), minus2(times2(int(-1), klam), m.clone()));
   // (k lam + m)^(-1 + k)
   let pow_part = pow2(klam_m, plus2(int(-1), k.clone()));
-  let numerator = times(times(exp_part, m), pow_part);
+  let numerator = times2(times2(exp_part, m), pow_part);
   let density = eval(div2(numerator, factorial(k.clone())))?;
   let cond = comparison(k, ComparisonOp::GreaterEqual, int(0));
   eval(piecewise(vec![(density, cond)], int(0)))
@@ -1395,13 +1393,13 @@ fn pdf_skellam(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let ratio_pow = pow2(div2(a.clone(), b.clone()), div2(x.clone(), int(2)));
   let exp_part = pow2(
     e(),
-    plus2(times(int(-1), a.clone()), times(int(-1), b.clone())),
+    plus2(times2(int(-1), a.clone()), times2(int(-1), b.clone())),
   );
   let bessel = call(
     "BesselI",
-    vec![x, times(int(2), unary_fn("Sqrt", times(a, b)))],
+    vec![x, times2(int(2), unary_fn("Sqrt", times2(a, b)))],
   );
-  eval(times(times(ratio_pow, exp_part), bessel))
+  eval(times2(times2(ratio_pow, exp_part), bessel))
 }
 
 /// CDF[SkellamDistribution[a, b], k] =
@@ -1417,9 +1415,9 @@ fn cdf_skellam(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let marcum = call(
     "MarcumQ",
     vec![
-      times(int(-1), unary_fn("Floor", x)),
-      times(sqrt2.clone(), unary_fn("Sqrt", a)),
-      times(sqrt2, unary_fn("Sqrt", b)),
+      times2(int(-1), unary_fn("Floor", x)),
+      times2(sqrt2.clone(), unary_fn("Sqrt", a)),
+      times2(sqrt2, unary_fn("Sqrt", b)),
     ],
   );
   eval(minus2(int(1), marcum))
@@ -1459,7 +1457,7 @@ fn pdf_binomial(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     eval(minus2(int(1), p))?,
     eval(minus2(n.clone(), x.clone()))?,
   );
-  let density = eval(times(binom, times(p_k, q_nk)))?;
+  let density = eval(times2(binom, times2(p_k, q_nk)))?;
   // 0 <= k <= n.
   let cond = Expr::Comparison {
     operands: vec![int(0), x, n],
@@ -1493,7 +1491,7 @@ fn pdf_hypergeometric(
   // Pre-evaluate the density expression so e.g. Binomial[100 - 50, ...]
   // collapses to Binomial[50, ...]. Piecewise holds its arguments, so we
   // can't rely on a subsequent global pass to simplify these.
-  let numerator = times(
+  let numerator = times2(
     binom(ns.clone(), x.clone()),
     binom(
       eval(minus2(nt.clone(), ns))?,
@@ -1586,7 +1584,7 @@ fn pdf_binormal(dargs: &[Expr], xy: Expr) -> Result<Expr, InterpreterError> {
   let q = plus2(
     minus2(
       pow2(u.clone(), int(2)),
-      times(int(2), times(rho.clone(), times(u, v.clone()))),
+      times2(int(2), times2(rho.clone(), times2(u, v.clone()))),
     ),
     pow2(v, int(2)),
   );
@@ -1594,11 +1592,11 @@ fn pdf_binormal(dargs: &[Expr], xy: Expr) -> Result<Expr, InterpreterError> {
   let one_minus_rho_sq = minus2(int(1), pow2(rho.clone(), int(2)));
   let _ = &rho;
   let exponent =
-    div2(times(int(-1), q), times(int(2), one_minus_rho_sq.clone()));
+    div2(times2(int(-1), q), times2(int(2), one_minus_rho_sq.clone()));
   // PDF = E^exponent / (2 Pi Sqrt[1 - rho^2] sigma1 sigma2)
-  let denom = times(
-    times(int(2), pi()),
-    times(sqrt(one_minus_rho_sq), times(sigma1, sigma2)),
+  let denom = times2(
+    times2(int(2), pi()),
+    times2(sqrt(one_minus_rho_sq), times2(sigma1, sigma2)),
   );
   let numer = pow2(e(), exponent);
   eval(div2(numer, denom))
@@ -1618,7 +1616,7 @@ fn pdf_cauchy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // 1 / (Pi * b * (1 + ((x - a) / b)^2))
   let diff = minus2(x, a);
   let ratio = div2(diff, b.clone());
-  let denom = times(times(pi(), b), plus2(int(1), pow2(ratio, int(2))));
+  let denom = times2(times2(pi(), b), plus2(int(1), pow2(ratio, int(2))));
   eval(div2(int(1), denom))
 }
 
@@ -1631,7 +1629,7 @@ fn pdf_geometric(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let p = dargs[0].clone();
   let one_minus_p = minus2(int(1), p.clone());
-  let density = eval(times(pow2(one_minus_p, x.clone()), p))?;
+  let density = eval(times2(pow2(one_minus_p, x.clone()), p))?;
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
   eval(piecewise(vec![(density, cond)], int(0)))
 }
@@ -1646,8 +1644,10 @@ fn pdf_log_series(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let t = dargs[0].clone();
   let log_1mt = unary_fn("Log", minus2(int(1), t.clone()));
-  let density =
-    times(int(-1), div2(pow2(t, x.clone()), times(x.clone(), log_1mt)));
+  let density = times2(
+    int(-1),
+    div2(pow2(t, x.clone()), times2(x.clone(), log_1mt)),
+  );
   // For a concrete integer k, pick the branch directly. Feeding k = 0 through
   // the piecewise would evaluate the density (k in the denominator) and emit a
   // spurious Power::infy message even though the 0 branch is selected.
@@ -1669,13 +1669,13 @@ fn pdf_nakagami(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let m = dargs[0].clone();
   let w = dargs[1].clone();
   // numerator = 2 (m/w)^m x^(-1 + 2 m)
-  let numer = times(
-    times(int(2), pow2(div2(m.clone(), w.clone()), m.clone())),
-    pow2(x.clone(), plus2(int(-1), times(int(2), m.clone()))),
+  let numer = times2(
+    times2(int(2), pow2(div2(m.clone(), w.clone()), m.clone())),
+    pow2(x.clone(), plus2(int(-1), times2(int(2), m.clone()))),
   );
   // denominator = E^((m x^2)/w) Gamma[m]
-  let denom = times(
-    pow2(e(), div2(times(m.clone(), pow2(x.clone(), int(2))), w)),
+  let denom = times2(
+    pow2(e(), div2(times2(m.clone(), pow2(x.clone(), int(2))), w)),
     unary_fn("Gamma", m),
   );
   let density = div2(numer, denom);
@@ -1698,7 +1698,7 @@ fn cdf_nakagami(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     vec![
       m.clone(),
       int(0),
-      div2(times(m, pow2(x.clone(), int(2))), w),
+      div2(times2(m, pow2(x.clone(), int(2))), w),
     ],
   );
   let cond = comparison(x, ComparisonOp::Greater, int(0));
@@ -1716,9 +1716,9 @@ fn pdf_log_logistic(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let g = dargs[0].clone();
   let s = dargs[1].clone();
   // numerator = g x^(-1 + g)
-  let numer = times(g.clone(), pow2(x.clone(), plus2(int(-1), g.clone())));
+  let numer = times2(g.clone(), pow2(x.clone(), plus2(int(-1), g.clone())));
   // denominator = s^g (1 + (x/s)^g)^2
-  let denom = times(
+  let denom = times2(
     pow2(s.clone(), g.clone()),
     pow2(plus2(int(1), pow2(div2(x.clone(), s), g)), int(2)),
   );
@@ -1746,7 +1746,7 @@ fn cdf_log_logistic(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let g = dargs[0].clone();
   let s = dargs[1].clone();
   let value = pow2(
-    plus2(int(1), pow2(div2(x.clone(), s), times(int(-1), g))),
+    plus2(int(1), pow2(div2(x.clone(), s), times2(int(-1), g))),
     int(-1),
   );
   // Concrete x <= 0 is outside the support; return 0 directly. At x = 0 the
@@ -1965,7 +1965,7 @@ fn cdf_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   };
 
   // Erfc[(mu - x) / (Sqrt[2] * sigma)] / 2
-  let erfc_arg = div2(minus2(mu, x), times(sqrt(int(2)), sigma));
+  let erfc_arg = div2(minus2(mu, x), times2(sqrt(int(2)), sigma));
   let erfc_call = call("Erfc", vec![erfc_arg]);
   let result = div2(erfc_call, int(2));
   eval(result)
@@ -2025,7 +2025,7 @@ fn cdf_exponential(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let lambda = dargs[0].clone();
 
-  let value = eval(minus2(int(1), pow2(e(), times(neg1(lambda), x.clone()))))?;
+  let value = eval(minus2(int(1), pow2(e(), times2(neg1(lambda), x.clone()))))?;
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
 
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -2224,8 +2224,8 @@ fn pdf_gamma(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // E^(-x/beta)
   let exp_part = pow2(e(), neg1(div2(x.clone(), beta.clone())));
   // beta^alpha * Gamma[alpha]
-  let denom = times(pow2(beta, alpha.clone()), call("Gamma", vec![alpha]));
-  let value = eval(div2(times(x_part, exp_part), denom))?;
+  let denom = times2(pow2(beta, alpha.clone()), call("Gamma", vec![alpha]));
+  let value = eval(div2(times2(x_part, exp_part), denom))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
 }
@@ -2266,8 +2266,8 @@ fn pdf_inverse_gamma(
   // E^(b/x)
   let exp_part = pow2(e(), div2(b, x.clone()));
   // x * Gamma[a]
-  let denom = times(x.clone(), call("Gamma", vec![a]));
-  let value = eval(div2(bx_a, times(exp_part, denom)))?;
+  let denom = times2(x.clone(), call("Gamma", vec![a]));
+  let value = eval(div2(bx_a, times2(exp_part, denom)))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
 }
@@ -2304,7 +2304,7 @@ fn pdf_logistic(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let exp_val = pow2(e(), div2(minus2(m, x), s.clone()));
   // (1 + E^(...))^2
   let denom_sq = pow2(plus2(int(1), exp_val.clone()), int(2));
-  let value = div2(exp_val, times(denom_sq, s));
+  let value = div2(exp_val, times2(denom_sq, s));
   eval(value)
 }
 
@@ -2345,10 +2345,11 @@ fn pdf_inverse_chi_square(
   // 2^(n/2)
   let two_part = pow2(int(2), div2(n.clone(), int(2)));
   // E^(1/(2*x))
-  let exp_part = pow2(e(), div2(int(1), times(int(2), x.clone())));
+  let exp_part = pow2(e(), div2(int(1), times2(int(2), x.clone())));
   // Gamma[n/2]
   let gamma_part = call("Gamma", vec![div2(n, int(2))]);
-  let value = eval(div2(x_part, times(two_part, times(exp_part, gamma_part))))?;
+  let value =
+    eval(div2(x_part, times2(two_part, times2(exp_part, gamma_part))))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
 }
@@ -2367,7 +2368,7 @@ fn cdf_inverse_chi_square(
 
   let value = call(
     "GammaRegularized",
-    vec![div2(n, int(2)), div2(int(1), times(int(2), x.clone()))],
+    vec![div2(n, int(2)), div2(int(1), times2(int(2), x.clone()))],
   );
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -2395,7 +2396,7 @@ fn pdf_frechet(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let xb_part = pow2(xb.clone(), neg1(plus2(int(1), a.clone())));
   // E^((x-c)/b)^(-a)
   let exp_part = pow2(e(), pow2(xb, neg1(a.clone())));
-  let value = eval(div2(times(a, xb_part), times(b, exp_part)))?;
+  let value = eval(div2(times2(a, xb_part), times2(b, exp_part)))?;
   let cond = comparison(x, ComparisonOp::Greater, threshold);
   eval(piecewise(vec![(value, cond)], int(0)))
 }
@@ -2474,14 +2475,14 @@ fn pdf_gompertz_makeham(
   let x0 = dargs[1].clone();
 
   // l*x
-  let lx = times(l.clone(), x.clone());
+  let lx = times2(l.clone(), x.clone());
   // E^(l*x)
   let e_lx = pow2(e(), lx.clone());
   // (1 - E^(l*x))*x0
-  let inner = times(minus2(int(1), e_lx), x0.clone());
+  let inner = times2(minus2(int(1), e_lx), x0.clone());
   // l*x + (1 - E^(l*x))*x0
   let exp_arg = plus2(lx, inner);
-  let value = eval(times(times(pow2(e(), exp_arg), l), x0))?;
+  let value = eval(times2(times2(pow2(e(), exp_arg), l), x0))?;
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
 }
@@ -2499,8 +2500,8 @@ fn cdf_gompertz_makeham(
   let l = dargs[0].clone();
   let x0 = dargs[1].clone();
 
-  let e_lx = pow2(e(), times(l, x.clone()));
-  let inner = times(minus2(int(1), e_lx), x0);
+  let e_lx = pow2(e(), times2(l, x.clone()));
+  let inner = times2(minus2(int(1), e_lx), x0);
   let value = minus2(int(1), pow2(e(), inner));
   let value = eval(value)?;
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
@@ -2524,14 +2525,14 @@ fn pdf_inverse_gaussian(
   let numer = sqrt(div2(l.clone(), pow2(x.clone(), int(3))));
   // l*(-m+x)^2 / (2*m^2*x)
   let exp_arg = div2(
-    times(l, pow2(minus2(x.clone(), m.clone()), int(2))),
-    times(int(2), times(pow2(m, int(2)), x.clone())),
+    times2(l, pow2(minus2(x.clone(), m.clone()), int(2))),
+    times2(int(2), times2(pow2(m, int(2)), x.clone())),
   );
   // E^(exp_arg)
   let exp_part = pow2(e(), exp_arg);
   // Sqrt[2*Pi]
-  let sqrt_2pi = sqrt(times(int(2), pi()));
-  let value = eval(div2(numer, times(exp_part, sqrt_2pi)))?;
+  let sqrt_2pi = sqrt(times2(int(2), pi()));
+  let value = eval(div2(numer, times2(exp_part, sqrt_2pi)))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
 }
@@ -2553,18 +2554,18 @@ fn cdf_inverse_gaussian(
   let sqrt_lx = sqrt(div2(l.clone(), x.clone()));
   // Erfc[((m - x)*Sqrt[l/x])/(Sqrt[2]*m)]/2
   let erfc1_arg = div2(
-    times(minus2(m.clone(), x.clone()), sqrt_lx.clone()),
-    times(sqrt(int(2)), m.clone()),
+    times2(minus2(m.clone(), x.clone()), sqrt_lx.clone()),
+    times2(sqrt(int(2)), m.clone()),
   );
   let erfc1 = div2(call("Erfc", vec![erfc1_arg]), int(2));
   // E^((2*l)/m) * Erfc[(Sqrt[l/x]*(m + x))/(Sqrt[2]*m)]/2
-  let exp_part = pow2(e(), div2(times(int(2), l), m.clone()));
+  let exp_part = pow2(e(), div2(times2(int(2), l), m.clone()));
   let erfc2_arg = div2(
-    times(sqrt_lx, plus2(m.clone(), x.clone())),
-    times(sqrt(int(2)), m),
+    times2(sqrt_lx, plus2(m.clone(), x.clone())),
+    times2(sqrt(int(2)), m),
   );
   let erfc2 = div2(call("Erfc", vec![erfc2_arg]), int(2));
-  let value = eval(plus2(erfc1, times(exp_part, erfc2)))?;
+  let value = eval(plus2(erfc1, times2(exp_part, erfc2)))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
 }
@@ -3164,7 +3165,7 @@ pub fn expectation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Check for linear expressions: a*x + b
   if let Some((a, b)) = extract_linear(expr, &var_name) {
     // E[a*x + b] = a*E[x] + b
-    let result = plus2(times(a, mean), b);
+    let result = plus2(times2(a, mean), b);
     return eval(result);
   }
 
@@ -3177,13 +3178,13 @@ pub fn expectation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mu = mean.clone();
     let sigma_sq = variance.clone();
     // exponent = μ t + σ² t² / 2
-    let mu_t = times(mu, t.clone());
+    let mu_t = times2(mu, t.clone());
     let half = call("Rational", vec![int(1), int(2)]);
     let sigma_sq_t_sq_half =
-      times(times(sigma_sq, pow2(t.clone(), int(2))), half);
+      times2(times2(sigma_sq, pow2(t.clone(), int(2))), half);
     let exponent = plus2(mu_t, sigma_sq_t_sq_half);
     let mgf = pow2(Expr::Identifier("E".to_string()), exponent);
-    return eval(times(c, mgf));
+    return eval(times2(c, mgf));
   }
 
   // Polynomial integrands: exact raw moments (the numerical fallback
@@ -3606,7 +3607,7 @@ fn try_expectation_censored(
     let mid_integral = call(
       "Integrate",
       vec![
-        times(expr.clone(), pdf.clone()),
+        times2(expr.clone(), pdf.clone()),
         Expr::List(
           vec![Expr::Identifier(var.to_string()), a.clone(), b.clone()].into(),
         ),
@@ -3640,8 +3641,8 @@ fn try_expectation_censored(
     let f_at_a = substitute_var(expr, var, &a);
     let f_at_b = substitute_var(expr, var, &b);
     let total = plus2(
-      times(f_at_a, p_below),
-      plus2(eval(mid_integral)?, times(f_at_b, p_above)),
+      times2(f_at_a, p_below),
+      plus2(eval(mid_integral)?, times2(f_at_b, p_above)),
     );
     return Ok(Some(eval(total)?));
   }
@@ -3716,7 +3717,7 @@ fn try_expectation_probability_distribution(
   }
 
   // Build Integrate[expr * pdf, iter1, iter2, …]
-  let integrand = times(expr.clone(), pdf_sub);
+  let integrand = times2(expr.clone(), pdf_sub);
   let mut integrate_args: Vec<Expr> = Vec::with_capacity(1 + new_iters.len());
   integrate_args.push(integrand);
   integrate_args.extend(new_iters);
@@ -3850,9 +3851,9 @@ pub fn distribution_mean_variance(
       let (k, m, s) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
       // Mean = m; Var = k^(2/k) s^2 Gamma[3/k] / Gamma[1/k]
       let var = div2(
-        times(
+        times2(
           pow2(k.clone(), div2(int(2), k.clone())),
-          times(
+          times2(
             pow2(s, int(2)),
             call("Gamma", vec![div2(int(3), k.clone())]),
           ),
@@ -3870,7 +3871,7 @@ pub fn distribution_mean_variance(
       let (nu, lam) = (dargs[0].clone(), dargs[1].clone());
       // Mean = v + l, Var = 2 v + 4 l
       let mean = plus2(nu.clone(), lam.clone());
-      let var = plus2(times(int(2), nu), times(int(4), lam));
+      let var = plus2(times2(int(2), nu), times2(int(4), lam));
       Ok((mean, var))
     }
     "BetaPrimeDistribution" if dargs.len() == 4 => {
@@ -3909,7 +3910,7 @@ pub fn distribution_mean_variance(
       // Mean = Piecewise[{{p/(q-1), q > 1}}, Infinity]; the 3-arg form scales
       // this by the scale parameter s.
       let mean_value = if dargs.len() == 3 {
-        eval(times(scale.clone(), mean_base))?
+        eval(times2(scale.clone(), mean_base))?
       } else {
         mean_base
       };
@@ -3927,14 +3928,14 @@ pub fn distribution_mean_variance(
       // Var = Piecewise[{{p(p+q-1)/((q-2)(q-1)^2), q > 2}}, Indeterminate];
       // the 3-arg form scales this by s^2.
       let var_base = div2(
-        times(p.clone(), plus2(plus2(int(-1), p.clone()), q.clone())),
-        times(
+        times2(p.clone(), plus2(plus2(int(-1), p.clone()), q.clone())),
+        times2(
           plus2(int(-2), q.clone()),
           pow2(plus2(int(-1), q.clone()), int(2)),
         ),
       );
       let var_value = if dargs.len() == 3 {
-        eval(times(pow2(scale.clone(), int(2)), var_base))?
+        eval(times2(pow2(scale.clone(), int(2)), var_base))?
       } else {
         var_base
       };
@@ -3956,14 +3957,15 @@ pub fn distribution_mean_variance(
       }
       let (a, b, n) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
       // Mean = a n / (a + b)
-      let mean = div2(times(a.clone(), n.clone()), plus2(a.clone(), b.clone()));
+      let mean =
+        div2(times2(a.clone(), n.clone()), plus2(a.clone(), b.clone()));
       // Var = a b n (a + b + n) / ((a + b)^2 (1 + a + b))
       let var = div2(
-        times(
-          times(a.clone(), b.clone()),
-          times(n.clone(), plus2(plus2(a.clone(), b.clone()), n)),
+        times2(
+          times2(a.clone(), b.clone()),
+          times2(n.clone(), plus2(plus2(a.clone(), b.clone()), n)),
         ),
-        times(
+        times2(
           pow2(plus2(a.clone(), b.clone()), int(2)),
           plus2(int(1), plus2(a, b)),
         ),
@@ -3979,8 +3981,8 @@ pub fn distribution_mean_variance(
       let (k, t, m) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
       let polygamma = |n: i128| call("PolyGamma", vec![int(n), k.clone()]);
       // Mean = m + t PolyGamma[0, k]; Variance = t^2 PolyGamma[1, k].
-      let mean = plus2(m, times(t.clone(), polygamma(0)));
-      let var = times(pow2(t, int(2)), polygamma(1));
+      let mean = plus2(m, times2(t.clone(), polygamma(0)));
+      let var = times2(pow2(t, int(2)), polygamma(1));
       Ok((mean, var))
     }
     "LogGammaDistribution" => {
@@ -3994,7 +3996,7 @@ pub fn distribution_mean_variance(
       let mean_val = plus2(
         plus2(
           int(-1),
-          pow2(minus2(int(1), b.clone()), times(int(-1), a.clone())),
+          pow2(minus2(int(1), b.clone()), times2(int(-1), a.clone())),
         ),
         m,
       );
@@ -4005,10 +4007,10 @@ pub fn distribution_mean_variance(
       // Var = Piecewise[{{(1-2b)^(-a) - (1-b)^(-2a), b < 1/2}}, Infinity]
       let var_val = minus2(
         pow2(
-          minus2(int(1), times(int(2), b.clone())),
-          times(int(-1), a.clone()),
+          minus2(int(1), times2(int(2), b.clone())),
+          times2(int(-1), a.clone()),
         ),
-        pow2(minus2(int(1), b.clone()), times(int(-2), a)),
+        pow2(minus2(int(1), b.clone()), times2(int(-2), a)),
       );
       let var = piecewise(
         vec![(
@@ -4028,15 +4030,15 @@ pub fn distribution_mean_variance(
       if dargs.len() == 2 {
         // Mean = (a + b + 4 m)/6; Variance = ((-a+5b-4m)(-5a+b+4m))/252.
         let mean = eval(div2(
-          plus2(plus2(a.clone(), b.clone()), times(int(4), m.clone())),
+          plus2(plus2(a.clone(), b.clone()), times2(int(4), m.clone())),
           int(6),
         ))?;
         let f1 = plus2(
-          plus2(times(int(-1), a.clone()), times(int(5), b.clone())),
-          times(int(-4), m.clone()),
+          plus2(times2(int(-1), a.clone()), times2(int(5), b.clone())),
+          times2(int(-4), m.clone()),
         );
-        let f2 = plus2(plus2(times(int(-5), a), b), times(int(4), m));
-        let var = eval(div2(times(f1, f2), int(252)))?;
+        let f2 = plus2(plus2(times2(int(-5), a), b), times2(int(4), m));
+        let var = eval(div2(times2(f1, f2), int(252)))?;
         Ok((mean, var))
       } else {
         // Mean = (a + b + g m)/(2 + g);
@@ -4046,7 +4048,7 @@ pub fn distribution_mean_variance(
         //   differently from wolframscript (the known sum-vs-sum Times
         //   ordering divergence).
         let mean = eval(div2(
-          plus2(plus2(a.clone(), b.clone()), times(g.clone(), m.clone())),
+          plus2(plus2(a.clone(), b.clone()), times2(g.clone(), m.clone())),
           plus2(int(2), g.clone()),
         ))?;
         let numeric = [&a, &b, &m, &g]
@@ -4055,23 +4057,23 @@ pub fn distribution_mean_variance(
         let f1 = call(
           "Plus",
           vec![
-            times(int(-1), a.clone()),
+            times2(int(-1), a.clone()),
             b.clone(),
-            times(b.clone(), g.clone()),
-            times(int(-1), times(g.clone(), m.clone())),
+            times2(b.clone(), g.clone()),
+            times2(int(-1), times2(g.clone(), m.clone())),
           ],
         );
         let f2 = call(
           "Plus",
           vec![
             b,
-            times(int(-1), times(a, plus2(int(1), g.clone()))),
-            times(g.clone(), m),
+            times2(int(-1), times2(a, plus2(int(1), g.clone()))),
+            times2(g.clone(), m),
           ],
         );
         let var_expr = div2(
-          times(f1, f2),
-          times(pow2(plus2(int(2), g.clone()), int(2)), plus2(int(3), g)),
+          times2(f1, f2),
+          times2(pow2(plus2(int(2), g.clone()), int(2)), plus2(int(3), g)),
         );
         let var = if numeric { eval(var_expr)? } else { var_expr };
         Ok((mean, var))
@@ -4087,12 +4089,12 @@ pub fn distribution_mean_variance(
       // Mean = a/(k + a k); Variance = a/((1+a)^2 (2+a) k^2).
       let mean = eval(div2(
         a.clone(),
-        plus2(k.clone(), times(a.clone(), k.clone())),
+        plus2(k.clone(), times2(a.clone(), k.clone())),
       ))?;
       let var = eval(div2(
         a.clone(),
-        times(
-          times(pow2(plus2(int(1), a.clone()), int(2)), plus2(int(2), a)),
+        times2(
+          times2(pow2(plus2(int(1), a.clone()), int(2)), plus2(int(2), a)),
           pow2(k, int(2)),
         ),
       ))?;
@@ -4107,8 +4109,9 @@ pub fn distribution_mean_variance(
       let (a, b) = (dargs[0].clone(), dargs[1].clone());
       let beta = |y: Expr| call("Beta", vec![b.clone(), y]);
       // Mean = b Beta[b, 1 + 1/a]; raw 2nd moment = b Beta[b, 1 + 2/a].
-      let mean = times(b.clone(), beta(plus2(int(1), div2(int(1), a.clone()))));
-      let raw2 = times(b.clone(), beta(plus2(int(1), div2(int(2), a))));
+      let mean =
+        times2(b.clone(), beta(plus2(int(1), div2(int(1), a.clone()))));
+      let raw2 = times2(b.clone(), beta(plus2(int(1), div2(int(2), a))));
       // Variance = E[x^2] - Mean^2.
       let var = eval(minus2(raw2, pow2(mean.clone(), int(2))))?;
       Ok((mean, var))
@@ -4122,7 +4125,7 @@ pub fn distribution_mean_variance(
       let (a, b, n) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
       let a_minus_1 = plus2(int(-1), a.clone());
       // Mean = Piecewise[{{b n/(a-1), a > 1}}, Infinity]
-      let mean_val = div2(times(b.clone(), n.clone()), a_minus_1.clone());
+      let mean_val = div2(times2(b.clone(), n.clone()), a_minus_1.clone());
       let mean = piecewise(
         vec![(
           mean_val,
@@ -4131,11 +4134,11 @@ pub fn distribution_mean_variance(
         infinity(),
       );
       // Var = Piecewise[{{b(a+b-1)n(a+n-1)/((a-2)(a-1)^2), a > 2}}, Infinity]
-      let num = times(
-        times(b.clone(), plus2(plus2(int(-1), a.clone()), b)),
-        times(n.clone(), plus2(plus2(int(-1), a.clone()), n)),
+      let num = times2(
+        times2(b.clone(), plus2(plus2(int(-1), a.clone()), b)),
+        times2(n.clone(), plus2(plus2(int(-1), a.clone()), n)),
       );
-      let den = times(plus2(int(-2), a.clone()), pow2(a_minus_1, int(2)));
+      let den = times2(plus2(int(-2), a.clone()), pow2(a_minus_1, int(2)));
       let var_val = div2(num, den);
       let var = piecewise(
         vec![(var_val, comparison(a, ComparisonOp::Greater, int(2)))],
@@ -4156,8 +4159,8 @@ pub fn distribution_mean_variance(
           ));
         }
       };
-      let mean = div2(times(plus2(a.clone(), b.clone()), n.clone()), int(2));
-      let var = div2(times(pow2(minus2(b, a), int(2)), n), int(12));
+      let mean = div2(times2(plus2(a.clone(), b.clone()), n.clone()), int(2));
+      let var = div2(times2(pow2(minus2(b, a), int(2)), n), int(12));
       Ok((mean, var))
     }
     "NormalDistribution" => {
@@ -4232,7 +4235,7 @@ pub fn distribution_mean_variance(
       }
       let p = dargs[0].clone();
       // Mean = p, Var = p(1-p)
-      let var = times(p.clone(), minus2(int(1), p.clone()));
+      let var = times2(p.clone(), minus2(int(1), p.clone()));
       Ok((p, var))
     }
     "SkellamDistribution" => {
@@ -4255,7 +4258,7 @@ pub fn distribution_mean_variance(
       let (t, p) = (dargs[0].clone(), dargs[1].clone());
       let one_minus_p = minus2(int(1), p.clone());
       let mean = div2(t.clone(), one_minus_p.clone());
-      let var = div2(times(plus2(int(1), p), t), pow2(one_minus_p, int(2)));
+      let var = div2(times2(plus2(int(1), p), t), pow2(one_minus_p, int(2)));
       Ok((mean, var))
     }
     "ChiDistribution" => {
@@ -4272,11 +4275,11 @@ pub fn distribution_mean_variance(
       let g_kp1 = unary_fn("Gamma", div2(plus2(int(1), k.clone()), int(2)));
       let g_k = unary_fn("Gamma", div2(k.clone(), int(2)));
       let mean_raw =
-        div2(times(unary_fn("Sqrt", int(2)), g_kp1.clone()), g_k.clone());
+        div2(times2(unary_fn("Sqrt", int(2)), g_kp1.clone()), g_k.clone());
       let mean = eval(unary_fn("Simplify", mean_raw))?;
       let var_raw = minus2(
         k,
-        div2(times(int(2), pow2(g_kp1, int(2))), pow2(g_k, int(2))),
+        div2(times2(int(2), pow2(g_kp1, int(2))), pow2(g_k, int(2))),
       );
       let var = eval(unary_fn("Simplify", var_raw))?;
       Ok((mean, var))
@@ -4290,8 +4293,8 @@ pub fn distribution_mean_variance(
       let n = dargs[0].clone();
       let p = dargs[1].clone();
       // Mean = n*p, Var = n*(1-p)*p
-      let mean = times(n.clone(), p.clone());
-      let var = times(times(n, minus2(int(1), p.clone())), p);
+      let mean = times2(n.clone(), p.clone());
+      let var = times2(times2(n, minus2(int(1), p.clone())), p);
       Ok((mean, var))
     }
     "GammaDistribution" => {
@@ -4303,8 +4306,8 @@ pub fn distribution_mean_variance(
       let alpha = dargs[0].clone();
       let beta = dargs[1].clone();
       // Mean = alpha*beta, Var = alpha*beta^2
-      let mean = times(alpha.clone(), beta.clone());
-      let var = times(alpha, pow2(beta, int(2)));
+      let mean = times2(alpha.clone(), beta.clone());
+      let var = times2(alpha, pow2(beta, int(2)));
       Ok((mean, var))
     }
     "HypergeometricDistribution" => {
@@ -4319,17 +4322,17 @@ pub fn distribution_mean_variance(
       let ns = dargs[1].clone();
       let nt = dargs[2].clone();
       // Mean = (n*ns)/nt.
-      let mean = div2(times(n.clone(), ns.clone()), nt.clone());
+      let mean = div2(times2(n.clone(), ns.clone()), nt.clone());
       // Var = (n*ns*(1 - ns/nt)*(nt - n)) / ((nt - 1)*nt).
       let var = div2(
-        times(
-          times(
-            times(n.clone(), ns.clone()),
+        times2(
+          times2(
+            times2(n.clone(), ns.clone()),
             minus2(int(1), div2(ns, nt.clone())),
           ),
           minus2(nt.clone(), n),
         ),
-        times(minus2(nt.clone(), int(1)), nt),
+        times2(minus2(nt.clone(), int(1)), nt),
       );
       Ok((mean, var))
     }
@@ -4345,8 +4348,8 @@ pub fn distribution_mean_variance(
       let ab = plus2(a.clone(), b.clone());
       let mean = div2(a.clone(), ab.clone());
       let var = div2(
-        times(a, b),
-        times(pow2(ab.clone(), int(2)), plus2(ab, int(1))),
+        times2(a, b),
+        times2(pow2(ab.clone(), int(2)), plus2(ab, int(1))),
       );
       Ok((mean, var))
     }
@@ -4373,7 +4376,7 @@ pub fn distribution_mean_variance(
         div2(nu.clone(), plus2(int(-2), nu.clone()))
       } else {
         div2(
-          times(pow2(s, int(2)), nu.clone()),
+          times2(pow2(s, int(2)), nu.clone()),
           plus2(int(-2), nu.clone()),
         )
       };
@@ -4403,12 +4406,12 @@ pub fn distribution_mean_variance(
       );
       // Var = Piecewise[{{(2 m^2 (-2 + m + n)) /
       //                   ((-4 + m) (-2 + m)^2 n), m > 4}}, Indeterminate]
-      let var_num = times(
-        times(int(2), pow2(m.clone(), int(2))),
+      let var_num = times2(
+        times2(int(2), pow2(m.clone(), int(2))),
         plus2(plus2(int(-2), m.clone()), n.clone()),
       );
-      let var_den = times(
-        times(
+      let var_den = times2(
+        times2(
           plus2(int(-4), m.clone()),
           pow2(plus2(int(-2), m.clone()), int(2)),
         ),
@@ -4437,10 +4440,10 @@ pub fn distribution_mean_variance(
         plus2(mu.clone(), div2(pow2(sigma.clone(), int(2)), int(2))),
       );
       // Var = E^(2*mu + sigma^2) * (E^(sigma^2) - 1)
-      let var = times(
+      let var = times2(
         pow2(
           Expr::Identifier("E".to_string()),
-          plus2(times(int(2), mu), pow2(sigma.clone(), int(2))),
+          plus2(times2(int(2), mu), pow2(sigma.clone(), int(2))),
         ),
         minus2(
           pow2(Expr::Identifier("E".to_string()), pow2(sigma, int(2))),
@@ -4458,7 +4461,7 @@ pub fn distribution_mean_variance(
       let k = dargs[0].clone();
       // Mean = k, Var = 2*k
       let mean = k.clone();
-      let var = times(int(2), k);
+      let var = times2(int(2), k);
       Ok((mean, var))
     }
     "ParetoDistribution" if dargs.len() == 3 => pareto3_mean_variance(dargs),
@@ -4474,7 +4477,7 @@ pub fn distribution_mean_variance(
       // Mean = Piecewise[{{a*k/(-1+a), a > 1}}, Indeterminate]
       let mean = piecewise(
         vec![(
-          div2(times(a.clone(), k.clone()), plus2(int(-1), a.clone())),
+          div2(times2(a.clone(), k.clone()), plus2(int(-1), a.clone())),
           comparison(a.clone(), ComparisonOp::Greater, int(1)),
         )],
         indeterminate(),
@@ -4483,8 +4486,8 @@ pub fn distribution_mean_variance(
       let var = piecewise(
         vec![(
           div2(
-            times(a.clone(), pow2(k, int(2))),
-            times(
+            times2(a.clone(), pow2(k, int(2))),
+            times2(
               plus2(int(-2), a.clone()),
               pow2(plus2(int(-1), a.clone()), int(2)),
             ),
@@ -4504,7 +4507,7 @@ pub fn distribution_mean_variance(
       let a = dargs[0].clone();
       let b = dargs[1].clone();
       // Mean = b * Gamma[1 + 1/a]; the 3-argument form adds the location m.
-      let base_mean = times(
+      let base_mean = times2(
         b.clone(),
         call("Gamma", vec![plus2(int(1), div2(int(1), a.clone()))]),
       );
@@ -4514,7 +4517,7 @@ pub fn distribution_mean_variance(
         base_mean
       };
       // Var = b^2 * (Gamma[1 + 2/a] - Gamma[1 + 1/a]^2)
-      let var = times(
+      let var = times2(
         pow2(b, int(2)),
         minus2(
           call("Gamma", vec![plus2(int(1), div2(int(2), a.clone()))]),
@@ -4534,7 +4537,7 @@ pub fn distribution_mean_variance(
       let mean = div2(int(1), theta.clone());
       // Variance = (Pi - 2) / (2 * theta^2). Built as (-2 + Pi)/(...) so
       // the rendered output matches wolframscript's canonical ordering.
-      let var = div2(plus2(int(-2), pi()), times(int(2), pow2(theta, int(2))));
+      let var = div2(plus2(int(-2), pi()), times2(int(2), pow2(theta, int(2))));
       Ok((mean, var))
     }
     "InverseGaussianDistribution" => {
@@ -4562,7 +4565,7 @@ pub fn distribution_mean_variance(
       };
       // Mean = mu; Variance = beta^2 * Pi^2 / 3.
       let mean = mu;
-      let var = div2(times(pow2(beta, int(2)), pow2(pi(), int(2))), int(3));
+      let var = div2(times2(pow2(beta, int(2)), pow2(pi(), int(2))), int(3));
       Ok((mean, var))
     }
     "HypoexponentialDistribution" => {
@@ -4607,10 +4610,10 @@ pub fn distribution_mean_variance(
       // Mean = a + b * EulerGamma
       let mean = plus2(
         a,
-        times(b.clone(), Expr::Constant("EulerGamma".to_string())),
+        times2(b.clone(), Expr::Constant("EulerGamma".to_string())),
       );
       // Variance = b^2 * Pi^2 / 6
-      let var = div2(times(pow2(b, int(2)), pow2(pi(), int(2))), int(6));
+      let var = div2(times2(pow2(b, int(2)), pow2(pi(), int(2))), int(6));
       Ok((mean, var))
     }
     "StableDistribution" => {
@@ -4632,9 +4635,9 @@ pub fn distribution_mean_variance(
       // Type 1: Mean = mu
       let mean_branch = match &type_ {
         Expr::Integer(0) => {
-          let tan_arg = div2(times(alpha.clone(), pi()), int(2));
+          let tan_arg = div2(times2(alpha.clone(), pi()), int(2));
           let tan_term = call("Tan", vec![tan_arg]);
-          minus2(mu.clone(), times(times(beta, sigma.clone()), tan_term))
+          minus2(mu.clone(), times2(times2(beta, sigma.clone()), tan_term))
         }
         _ => mu.clone(),
       };
@@ -4655,7 +4658,7 @@ pub fn distribution_mean_variance(
       // is 2 * sigma^2. Holds for both type parametrisations.
       let var = piecewise(
         vec![(
-          times(int(2), pow2(sigma, int(2))),
+          times2(int(2), pow2(sigma, int(2))),
           comparison(alpha, ComparisonOp::Equal, int(2)),
         )],
         indet,
@@ -4682,7 +4685,7 @@ pub fn distribution_mean_variance(
       );
       // Variance = Piecewise[{{b^2/((-2 + a)*(-1 + a)^2), a > 2}},
       //                      Indeterminate]
-      let denom = times(
+      let denom = times2(
         plus2(int(-2), a.clone()),
         pow2(plus2(int(-1), a.clone()), int(2)),
       );
@@ -4703,7 +4706,7 @@ pub fn distribution_mean_variance(
       let xi = dargs[1].clone();
       // Mean = (E^xi * Gamma[0, xi]) / lambda
       let gamma_0_xi = call("Gamma", vec![int(0), xi.clone()]);
-      let mean = div2(times(pow2(e(), xi), gamma_0_xi), lambda.clone());
+      let mean = div2(times2(pow2(e(), xi), gamma_0_xi), lambda.clone());
       // Variance has no simple closed form in elementary functions;
       // GompertzMakehamDistribution is intentionally absent from the
       // Variance dispatch list, so this placeholder is never returned
@@ -4730,7 +4733,7 @@ pub fn distribution_mean_variance(
       // Mean = Piecewise[{{μ + b * Gamma[1 - 1/a], 1 < a}}, Infinity]
       let gamma_1_minus_inv_a =
         call("Gamma", vec![minus2(int(1), div2(int(1), a.clone()))]);
-      let b_gamma = times(b.clone(), gamma_1_minus_inv_a.clone());
+      let b_gamma = times2(b.clone(), gamma_1_minus_inv_a.clone());
       let mean_value = match &mu {
         Some(m) => plus2(m.clone(), b_gamma),
         None => b_gamma,
@@ -4748,7 +4751,7 @@ pub fn distribution_mean_variance(
         call("Gamma", vec![minus2(int(1), div2(int(2), a.clone()))]);
       let var = piecewise(
         vec![(
-          times(
+          times2(
             pow2(b, int(2)),
             minus2(gamma_1_minus_2_a, pow2(gamma_1_minus_inv_a, int(2))),
           ),
@@ -4791,15 +4794,15 @@ pub fn distribution_mean_variance(
       // Mean = m + a d Tan[b/2]
       let mean = plus2(
         m,
-        times(
-          times(a.clone(), d.clone()),
+        times2(
+          times2(a.clone(), d.clone()),
           unary_fn("Tan", div2(b.clone(), int(2))),
         ),
       );
       // Variance = a^2 d Sec[b/2]^2 / 2
       let var = div2(
-        times(
-          times(pow2(a, int(2)), d),
+        times2(
+          times2(pow2(a, int(2)), d),
           pow2(unary_fn("Sec", div2(b, int(2))), int(2)),
         ),
         int(2),
@@ -4816,14 +4819,14 @@ pub fn distribution_mean_variance(
       let n = dargs[1].clone();
       let n2 = pow2(n.clone(), int(2));
       // Mean = E^(m + n^2/2) Sqrt[Pi/2]
-      let mean = times(
+      let mean = times2(
         pow2(e(), plus2(m.clone(), div2(n2.clone(), int(2)))),
         sqrt(div2(pi(), int(2))),
       );
       // Variance = E^(2 m + n^2) (2 E^(n^2) - Pi/2)
-      let var = times(
-        pow2(e(), plus2(times(int(2), m), n2.clone())),
-        minus2(times(int(2), pow2(e(), n2)), div2(pi(), int(2))),
+      let var = times2(
+        pow2(e(), plus2(times2(int(2), m), n2.clone())),
+        minus2(times2(int(2), pow2(e(), n2)), div2(pi(), int(2))),
       );
       Ok((mean, var))
     }
@@ -4850,16 +4853,19 @@ pub fn distribution_mean_variance(
       let t = dargs[0].clone();
       let log_1mt = unary_fn("Log", minus2(int(1), t.clone()));
       // Mean = -(t/((1 - t) Log[1 - t]))
-      let mean = times(
-        int(-1),
-        div2(t.clone(), times(minus2(int(1), t.clone()), log_1mt.clone())),
-      );
-      // Var = -((t (t + Log[1 - t])) / ((-1 + t)^2 Log[1 - t]^2))
-      let var = times(
+      let mean = times2(
         int(-1),
         div2(
-          times(t.clone(), plus2(t.clone(), log_1mt.clone())),
-          times(pow2(plus2(int(-1), t), int(2)), pow2(log_1mt, int(2))),
+          t.clone(),
+          times2(minus2(int(1), t.clone()), log_1mt.clone()),
+        ),
+      );
+      // Var = -((t (t + Log[1 - t])) / ((-1 + t)^2 Log[1 - t]^2))
+      let var = times2(
+        int(-1),
+        div2(
+          times2(t.clone(), plus2(t.clone(), log_1mt.clone())),
+          times2(pow2(plus2(int(-1), t), int(2)), pow2(log_1mt, int(2))),
         ),
       );
       Ok((mean, var))
@@ -4877,9 +4883,9 @@ pub fn distribution_mean_variance(
         vec![m.clone(), call("Rational", vec![int(1), int(2)])],
       );
       // Mean = (Sqrt[w] Pochhammer[m, 1/2])/Sqrt[m]
-      let mean = div2(times(sqrt(w.clone()), poch.clone()), sqrt(m.clone()));
+      let mean = div2(times2(sqrt(w.clone()), poch.clone()), sqrt(m.clone()));
       // Var = w - (w Pochhammer[m, 1/2]^2)/m
-      let var = minus2(w.clone(), div2(times(w, pow2(poch, int(2))), m));
+      let var = minus2(w.clone(), div2(times2(w, pow2(poch, int(2))), m));
       Ok((mean, var))
     }
     "LogLogisticDistribution" => {
@@ -4893,7 +4899,7 @@ pub fn distribution_mean_variance(
       let csc = |arg: Expr| call("Csc", vec![arg]);
       // Mean = Piecewise[{{(Pi s Csc[Pi/g])/g, g > 1}}, Indeterminate]
       let mean_val = div2(
-        times(times(pi(), s.clone()), csc(div2(pi(), g.clone()))),
+        times2(times2(pi(), s.clone()), csc(div2(pi(), g.clone()))),
         g.clone(),
       );
       let mean = piecewise(
@@ -4906,13 +4912,13 @@ pub fn distribution_mean_variance(
       // Var = Piecewise[{{(Pi s^2 (-(Pi Csc[Pi/g]^2) + 2 g Csc[(2 Pi)/g]))/g^2,
       //   g > 2}}, Indeterminate]
       let csc1 = csc(div2(pi(), g.clone()));
-      let csc2 = csc(div2(times(int(2), pi()), g.clone()));
+      let csc2 = csc(div2(times2(int(2), pi()), g.clone()));
       let inner = plus2(
-        times(int(-1), times(pi(), pow2(csc1, int(2)))),
-        times(times(int(2), g.clone()), csc2),
+        times2(int(-1), times2(pi(), pow2(csc1, int(2)))),
+        times2(times2(int(2), g.clone()), csc2),
       );
       let var_val = div2(
-        times(times(pi(), pow2(s, int(2))), inner),
+        times2(times2(pi(), pow2(s, int(2))), inner),
         pow2(g.clone(), int(2)),
       );
       let var = piecewise(
@@ -4935,7 +4941,7 @@ pub fn distribution_mean_variance(
       let mu = dargs[0].clone();
       let b = dargs[1].clone();
       // Mean = mu, Var = 2*b^2
-      let var = times(int(2), pow2(b, int(2)));
+      let var = times2(int(2), pow2(b, int(2)));
       Ok((mu, var))
     }
     "RayleighDistribution" => {
@@ -4946,9 +4952,9 @@ pub fn distribution_mean_variance(
       }
       let s = dargs[0].clone();
       // Mean = Sqrt[Pi/2] * s
-      let mean = times(sqrt(div2(pi(), int(2))), s.clone());
+      let mean = times2(sqrt(div2(pi(), int(2))), s.clone());
       // Var = (2 - Pi/2) * s^2
-      let var = times(minus2(int(2), div2(pi(), int(2))), pow2(s, int(2)));
+      let var = times2(minus2(int(2), div2(pi(), int(2))), pow2(s, int(2)));
       Ok((mean, var))
     }
     "LevyDistribution" => {
@@ -4971,7 +4977,7 @@ pub fn distribution_mean_variance(
       // Mean = (2 + d) / (d (1 + d))
       let mean = div2(
         plus2(int(2), d.clone()),
-        times(d.clone(), plus2(int(1), d.clone())),
+        times2(d.clone(), plus2(int(1), d.clone())),
       );
       // Variance = 2/d^2 - (1 + d)^(-2)
       let var = minus2(
@@ -4991,15 +4997,15 @@ pub fn distribution_mean_variance(
       // Mean = (2 + a^2) / (2 l)
       let mean = div2(
         plus2(int(2), pow2(a.clone(), int(2))),
-        times(int(2), l.clone()),
+        times2(int(2), l.clone()),
       );
       // Variance = (a^2 (4 + 5 a^2)) / (4 l^2)
       let var = div2(
-        times(
+        times2(
           pow2(a.clone(), int(2)),
-          plus2(int(4), times(int(5), pow2(a.clone(), int(2)))),
+          plus2(int(4), times2(int(5), pow2(a.clone(), int(2)))),
         ),
-        times(int(4), pow2(l, int(2))),
+        times2(int(4), pow2(l, int(2))),
       );
       Ok((mean, var))
     }
@@ -5038,7 +5044,7 @@ pub fn distribution_mean_variance(
       // Mean = n*(1-p)/p, Var = n*(1-p)/p^2
       // Express variance as Times[n, (1-p), p^(-2)] so Sqrt can extract p^(-1)
       let one_minus_p = minus2(int(1), p.clone());
-      let mean = div2(times(n.clone(), one_minus_p.clone()), p.clone());
+      let mean = div2(times2(n.clone(), one_minus_p.clone()), p.clone());
       let var = call("Times", vec![n, one_minus_p, pow2(p, int(-2))]);
       Ok((mean, var))
     }
@@ -5066,16 +5072,16 @@ pub fn distribution_mean_variance(
       let a = dargs[1].clone();
       let b = dargs[2].clone();
       // Mean = b * Gamma[(-1 + a)/a] * Gamma[1/a + p] / Gamma[p]
-      let mean = times(
-        times(b.clone(), gamma(div2(minus2(a.clone(), int(1)), a.clone()))),
+      let mean = times2(
+        times2(b.clone(), gamma(div2(minus2(a.clone(), int(1)), a.clone()))),
         div2(
           gamma(plus2(div2(int(1), a.clone()), p.clone())),
           gamma(p.clone()),
         ),
       );
       // Var = -Mean^2 + b^2 * Gamma[(-2+a)/a] * Gamma[2/a + p] / Gamma[p]
-      let second_moment = times(
-        times(
+      let second_moment = times2(
+        times2(
           pow2(b, int(2)),
           gamma(div2(minus2(a.clone(), int(2)), a.clone())),
         ),
@@ -5097,8 +5103,8 @@ pub fn distribution_mean_variance(
 
       // Mean = Piecewise[{{m*(l+n)/((m-2)*n), m > 2}}, Indeterminate]
       let mean_expr = div2(
-        times(m.clone(), plus2(l.clone(), n.clone())),
-        times(plus2(int(-2), m.clone()), n.clone()),
+        times2(m.clone(), plus2(l.clone(), n.clone())),
+        times2(plus2(int(-2), m.clone()), n.clone()),
       );
       let mean = piecewise(
         vec![(
@@ -5110,18 +5116,18 @@ pub fn distribution_mean_variance(
 
       // Variance = Piecewise[{{2*m^2*((l+n)^2 + (m-2)*(2*l+n)) / ((m-4)*(m-2)^2*n^2), m > 4}}, Indeterminate]
       let l_plus_n = plus2(l.clone(), n.clone());
-      let var_num = times(
-        times(int(2), pow2(m.clone(), int(2))),
+      let var_num = times2(
+        times2(int(2), pow2(m.clone(), int(2))),
         plus2(
           pow2(l_plus_n, int(2)),
-          times(
+          times2(
             plus2(int(-2), m.clone()),
-            plus2(times(int(2), l), n.clone()),
+            plus2(times2(int(2), l), n.clone()),
           ),
         ),
       );
-      let var_den = times(
-        times(
+      let var_den = times2(
+        times2(
           plus2(int(-4), m.clone()),
           pow2(plus2(int(-2), m.clone()), int(2)),
         ),
@@ -5151,7 +5157,7 @@ pub fn distribution_mean_variance(
       let a2_minus_b2 =
         minus2(pow2(a.clone(), int(2)), pow2(b.clone(), int(2)));
       let sqrt_a2_minus_b2 = sqrt(a2_minus_b2.clone());
-      let k_arg = times(sqrt_a2_minus_b2.clone(), d.clone());
+      let k_arg = times2(sqrt_a2_minus_b2.clone(), d.clone());
       let bk1 = besselk(int(1), k_arg.clone());
       let bk2 = besselk(int(2), k_arg.clone());
       let bk3 = besselk(int(3), k_arg);
@@ -5160,8 +5166,8 @@ pub fn distribution_mean_variance(
       let mean = plus2(
         m,
         div2(
-          times(times(b.clone(), d.clone()), bk2.clone()),
-          times(sqrt_a2_minus_b2, bk1.clone()),
+          times2(times2(b.clone(), d.clone()), bk2.clone()),
+          times2(sqrt_a2_minus_b2, bk1.clone()),
         ),
       );
 
@@ -5169,13 +5175,13 @@ pub fn distribution_mean_variance(
       //          - b^2*d^2*BesselK[2,z]^2/((a^2-b^2)*BesselK[1,z]^2)
       //          + b^2*d^2*BesselK[3,z]/((a^2-b^2)*BesselK[1,z])
       let sqrt_ab = sqrt(a2_minus_b2.clone());
-      let b2d2 = times(pow2(b, int(2)), pow2(d.clone(), int(2)));
-      let term1 = div2(times(d, bk2.clone()), times(sqrt_ab, bk1.clone()));
+      let b2d2 = times2(pow2(b, int(2)), pow2(d.clone(), int(2)));
+      let term1 = div2(times2(d, bk2.clone()), times2(sqrt_ab, bk1.clone()));
       let term2 = div2(
-        times(b2d2.clone(), pow2(bk2, int(2))),
-        times(a2_minus_b2.clone(), pow2(bk1.clone(), int(2))),
+        times2(b2d2.clone(), pow2(bk2, int(2))),
+        times2(a2_minus_b2.clone(), pow2(bk1.clone(), int(2))),
       );
-      let term3 = div2(times(b2d2, bk3), times(a2_minus_b2, bk1));
+      let term3 = div2(times2(b2d2, bk3), times2(a2_minus_b2, bk1));
       let var = plus2(minus2(term1, term2), term3);
       Ok((mean, var))
     }
@@ -5202,8 +5208,8 @@ pub fn distribution_mean_variance(
           // Mean = (delta*mu - gamma*sigma)/delta
           let mean = div2(
             minus2(
-              times(delta.clone(), mu),
-              times(gamma.clone(), sigma.clone()),
+              times2(delta.clone(), mu),
+              times2(gamma.clone(), sigma.clone()),
             ),
             delta.clone(),
           );
@@ -5214,18 +5220,24 @@ pub fn distribution_mean_variance(
         "SL" => {
           // Mean = mu + E^((1 - 2*delta*gamma)/(2*delta^2)) * sigma
           let exp_arg = div2(
-            minus2(int(1), times(int(2), times(delta.clone(), gamma.clone()))),
-            times(int(2), pow2(delta.clone(), int(2))),
+            minus2(
+              int(1),
+              times2(int(2), times2(delta.clone(), gamma.clone())),
+            ),
+            times2(int(2), pow2(delta.clone(), int(2))),
           );
-          let mean = plus2(mu, times(pow2(e(), exp_arg), sigma.clone()));
+          let mean = plus2(mu, times2(pow2(e(), exp_arg), sigma.clone()));
           // Var = E^((1 - 2*delta*gamma)/delta^2) * (-1 + E^(1/delta^2)) * sigma^2
           let exp_arg2 = div2(
-            minus2(int(1), times(int(2), times(delta.clone(), gamma))),
+            minus2(int(1), times2(int(2), times2(delta.clone(), gamma))),
             pow2(delta.clone(), int(2)),
           );
           let inv_delta_sq = div2(int(1), pow2(delta.clone(), int(2)));
-          let var = times(
-            times(pow2(e(), exp_arg2), minus2(pow2(e(), inv_delta_sq), int(1))),
+          let var = times2(
+            times2(
+              pow2(e(), exp_arg2),
+              minus2(pow2(e(), inv_delta_sq), int(1)),
+            ),
             pow2(sigma, int(2)),
           );
           Ok((mean, var))
@@ -5235,17 +5247,18 @@ pub fn distribution_mean_variance(
           // (Wolfram expands Sinh differently, so this is added to skip list)
           let delta_sq = pow2(delta.clone(), int(2));
           let exp_half =
-            pow2(e(), div2(int(1), times(int(2), delta_sq.clone())));
+            pow2(e(), div2(int(1), times2(int(2), delta_sq.clone())));
           let sinh_gd = call("Sinh", vec![div2(gamma.clone(), delta.clone())]);
-          let mean = minus2(mu, times(sigma.clone(), times(exp_half, sinh_gd)));
+          let mean =
+            minus2(mu, times2(sigma.clone(), times2(exp_half, sinh_gd)));
           // Var = (sigma^2/2) * (Exp[1/delta^2] - 1) * (Exp[1/delta^2]*Cosh[2*gamma/delta] + 1)
           let exp_full = pow2(e(), div2(int(1), delta_sq));
-          let cosh_2gd = call("Cosh", vec![div2(times(int(2), gamma), delta)]);
-          let var = times(
+          let cosh_2gd = call("Cosh", vec![div2(times2(int(2), gamma), delta)]);
+          let var = times2(
             div2(pow2(sigma, int(2)), int(2)),
-            times(
+            times2(
               minus2(exp_full.clone(), int(1)),
-              plus2(times(exp_full, cosh_2gd), int(1)),
+              plus2(times2(exp_full, cosh_2gd), int(1)),
             ),
           );
           Ok((mean, var))
@@ -5543,7 +5556,7 @@ fn pdf_beta(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     pow2(minus2(int(1), x.clone()), minus2(b.clone(), int(1)));
   // Beta[a, b]
   let beta_fn = call("Beta", vec![a, b]);
-  let value = eval(div2(times(x_part, one_minus_x_part), beta_fn))?;
+  let value = eval(div2(times2(x_part, one_minus_x_part), beta_fn))?;
   let cond =
     comparison3(int(0), ComparisonOp::Less, x, ComparisonOp::Less, int(1));
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -5582,18 +5595,18 @@ fn pdf_pert(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let real_arg = matches!(x, Expr::Real(_) | Expr::BigFloat(..));
   let width = minus2(b.clone(), a.clone());
   let e_low = div2(
-    times(g.clone(), minus2(m.clone(), a.clone())),
+    times2(g.clone(), minus2(m.clone(), a.clone())),
     width.clone(),
   );
   let e_high = div2(
-    times(g.clone(), minus2(b.clone(), m.clone())),
+    times2(g.clone(), minus2(b.clone(), m.clone())),
     width.clone(),
   );
   let beta_call = call(
     "Beta",
     vec![plus2(int(1), e_low.clone()), plus2(int(1), e_high.clone())],
   );
-  let powers = times(
+  let powers = times2(
     pow2(minus2(b.clone(), x.clone()), e_high),
     pow2(minus2(x.clone(), a.clone()), e_low),
   );
@@ -5601,10 +5614,10 @@ fn pdf_pert(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // keeps (b-a)^(-1-g) as a leading factor — matching wolframscript's
   // displayed shapes.
   let value = if dargs.len() == 2 {
-    div2(powers, times(pow2(width, int(5)), beta_call))
+    div2(powers, times2(pow2(width, int(5)), beta_call))
   } else {
     div2(
-      times(pow2(width, minus2(int(-1), g.clone()).clone()), powers),
+      times2(pow2(width, minus2(int(-1), g.clone()).clone()), powers),
       beta_call,
     )
   };
@@ -5628,10 +5641,10 @@ fn cdf_pert(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let real_arg = matches!(x, Expr::Real(_) | Expr::BigFloat(..));
   let width = minus2(b.clone(), a.clone());
   let e_low = div2(
-    times(g.clone(), minus2(m.clone(), a.clone())),
+    times2(g.clone(), minus2(m.clone(), a.clone())),
     width.clone(),
   );
-  let e_high = div2(times(g, minus2(b.clone(), m)), width.clone());
+  let e_high = div2(times2(g, minus2(b.clone(), m)), width.clone());
   let reg = call(
     "BetaRegularized",
     vec![
@@ -5679,8 +5692,8 @@ fn pdf_power(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     };
     return Ok(Expr::Real(v));
   }
-  let value = times(
-    times(a.clone(), pow2(k.clone(), a.clone())),
+  let value = times2(
+    times2(a.clone(), pow2(k.clone(), a.clone())),
     pow2(x.clone(), minus2(a, int(1))),
   );
   let real_arg = matches!(x, Expr::Real(_) | Expr::BigFloat(..));
@@ -5724,7 +5737,7 @@ fn cdf_power(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     };
     return Ok(Expr::Real(v));
   }
-  let value = pow2(times(k.clone(), x.clone()), a.clone());
+  let value = pow2(times2(k.clone(), x.clone()), a.clone());
   let cond1 = comparison3(
     int(0),
     ComparisonOp::Less,
@@ -5755,7 +5768,7 @@ fn pdf_kumaraswamy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     minus2(int(1), pow2(x.clone(), a.clone())),
     minus2(b.clone(), int(1)),
   );
-  let value = times(times(a, b), times(x_pow, one_minus));
+  let value = times2(times2(a, b), times2(x_pow, one_minus));
   let cond =
     comparison3(int(0), ComparisonOp::Less, x, ComparisonOp::Less, int(1));
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -5792,11 +5805,11 @@ fn pdf_loggamma(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let (a, b, m) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
   // 1 - m + x
-  let shifted = plus2(plus2(int(1), times(int(-1), m.clone())), x.clone());
+  let shifted = plus2(plus2(int(1), times2(int(-1), m.clone())), x.clone());
   let num = pow2(unary_fn("Log", shifted.clone()), minus2(a.clone(), int(1)));
-  let den = times(
+  let den = times2(
     pow2(b.clone(), a.clone()),
-    times(
+    times2(
       pow2(shifted, div2(plus2(int(1), b.clone()), b)),
       unary_fn("Gamma", a),
     ),
@@ -5815,7 +5828,7 @@ fn cdf_loggamma(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     ));
   }
   let (a, b, m) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
-  let shifted = plus2(plus2(int(1), times(int(-1), m.clone())), x.clone());
+  let shifted = plus2(plus2(int(1), times2(int(-1), m.clone())), x.clone());
   let reg = call(
     "GammaRegularized",
     vec![a, int(0), div2(unary_fn("Log", shifted), b)],
@@ -5871,7 +5884,7 @@ fn cdf_student_t(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     }
     3 => {
       let (m, s, nu) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
-      let s2nu = times(pow2(s, int(2)), nu.clone());
+      let s2nu = times2(pow2(s, int(2)), nu.clone());
       (nu, s2nu, pow2(minus2(x.clone(), m.clone()), int(2)), m)
     }
     _ => {
@@ -5932,8 +5945,8 @@ fn pdf_student_t_impl(
   let beta = call("Beta", vec![div2(nu.clone(), int(2)), div2(int(1), int(2))]);
   // Denominator: [s *] Sqrt[nu] * Beta[nu/2, 1/2].
   let denominator = match &loc_scale {
-    Some((_, s)) => times(s.clone(), times(sqrt(nu.clone()), beta)),
-    None => times(sqrt(nu), beta),
+    Some((_, s)) => times2(s.clone(), times2(sqrt(nu.clone()), beta)),
+    None => times2(sqrt(nu), beta),
   };
   eval(div2(numerator, denominator))
 }
@@ -5952,14 +5965,14 @@ fn pdf_lognormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let log_x = call("Log", vec![x.clone()]);
   let exponent = div2(
     pow2(minus2(log_x, mu), int(2)),
-    times(int(2), pow2(sigma.clone(), int(2))),
+    times2(int(2), pow2(sigma.clone(), int(2))),
   );
-  let denom = times(
-    times(
+  let denom = times2(
+    times2(
       pow2(Expr::Identifier("E".to_string()), exponent),
-      sqrt(times(int(2), Expr::Identifier("Pi".to_string()))),
+      sqrt(times2(int(2), Expr::Identifier("Pi".to_string()))),
     ),
-    times(sigma, x.clone()),
+    times2(sigma, x.clone()),
   );
   let pdf_val = div2(int(1), denom);
 
@@ -5980,7 +5993,7 @@ fn cdf_lognormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   // Erfc[-(Log[x] - mu) / (Sqrt[2] * sigma)] / 2
   let log_x = call("Log", vec![x.clone()]);
-  let arg = neg1(div2(minus2(log_x, mu), times(sqrt(int(2)), sigma)));
+  let arg = neg1(div2(minus2(log_x, mu), times2(sqrt(int(2)), sigma)));
   let cdf_val = div2(call("Erfc", vec![arg]), int(2));
 
   // Piecewise[{{cdf_val, x > 0}}, 0]
@@ -6005,7 +6018,7 @@ fn pdf_chi_square(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let exp_part = pow2(e(), div2(x.clone(), int(2)));
   // Gamma[k/2]
   let gamma_part = call("Gamma", vec![div2(k, int(2))]);
-  let denom = times(times(two_power, exp_part), gamma_part);
+  let denom = times2(times2(two_power, exp_part), gamma_part);
   let pdf_val = div2(x_power, denom);
 
   let cond = comparison(x, ComparisonOp::Greater, int(0));
@@ -6026,8 +6039,8 @@ fn pdf_f_ratio(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let m = dargs[1].clone();
 
   // n^(n/2) * m^(m/2) * x^(n/2 - 1)
-  let numer = times(
-    times(
+  let numer = times2(
+    times2(
       pow2(n.clone(), div2(n.clone(), int(2))),
       pow2(m.clone(), div2(m.clone(), int(2))),
     ),
@@ -6035,12 +6048,12 @@ fn pdf_f_ratio(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   );
   // (m + n*x)^((n+m)/2)
   let denom_power = pow2(
-    plus2(m.clone(), times(n.clone(), x.clone())),
+    plus2(m.clone(), times2(n.clone(), x.clone())),
     div2(plus2(n.clone(), m.clone()), int(2)),
   );
   // Beta[n/2, m/2]
   let beta = call("Beta", vec![div2(n, int(2)), div2(m, int(2))]);
-  let pdf_val = div2(numer, times(denom_power, beta));
+  let pdf_val = div2(numer, times2(denom_power, beta));
 
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(pdf_val, cond)], int(0)))
@@ -6058,7 +6071,7 @@ fn cdf_f_ratio(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let m = dargs[1].clone();
 
   // n x / (n x + m)
-  let nx = times(n.clone(), x.clone());
+  let nx = times2(n.clone(), x.clone());
   let arg = div2(nx.clone(), plus2(nx, m.clone()));
   let reg = call(
     "BetaRegularized",
@@ -6085,7 +6098,7 @@ fn pdf_waring_yule(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   if dargs.len() == 1 {
     let a = dargs[0].clone();
-    let pmf = times(
+    let pmf = times2(
       a.clone(),
       call("Beta", vec![plus2(int(1), a), plus2(int(1), x.clone())]),
     );
@@ -6103,7 +6116,7 @@ fn pdf_waring_yule(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let poch =
     |first: Expr, second: Expr| call("Pochhammer", vec![first, second]);
   // a * Pochhammer[b, k] / Pochhammer[a + b, 1 + k]
-  let numer = times(a.clone(), poch(b.clone(), x.clone()));
+  let numer = times2(a.clone(), poch(b.clone(), x.clone()));
   let denom = poch(plus2(a, b), plus2(int(1), x.clone()));
   let pmf = div2(numer, denom);
 
@@ -6121,7 +6134,7 @@ fn cdf_waring_yule(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     let a = dargs[0].clone();
     let floor_k = call("Floor", vec![x.clone()]);
     let beta = call("Beta", vec![a.clone(), plus2(int(2), floor_k)]);
-    let cdf = minus2(int(1), times(a, beta));
+    let cdf = minus2(int(1), times2(a, beta));
     let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
     return eval(piecewise(vec![(cdf, cond)], int(0)));
   }
@@ -6180,17 +6193,17 @@ fn pdf_pareto(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       // (a ((k - m + x)/k)^(-1 - a)) / k
       let inner =
         div2(plus2(minus2(k.clone(), m.clone()), x.clone()), k.clone());
-      div2(times(a.clone(), pow2(inner, minus2(int(-1), a))), k)
+      div2(times2(a.clone(), pow2(inner, minus2(int(-1), a))), k)
     } else {
       // (a (-m + x)^(-1 + 1/g) (1 + (k/(-m + x))^(-1/g))^(-1 - a)) / (g k^(1/g))
       let g = dargs[2].clone();
       let inv_g = div2(int(1), g.clone());
       let xm = minus2(x.clone(), m.clone());
       let factor1 = pow2(xm.clone(), plus2(int(-1), inv_g.clone()));
-      let inner2 = pow2(div2(k.clone(), xm), times(int(-1), inv_g.clone()));
+      let inner2 = pow2(div2(k.clone(), xm), times2(int(-1), inv_g.clone()));
       let factor2 = pow2(plus2(int(1), inner2), minus2(int(-1), a.clone()));
-      let num = times(a, times(factor1, factor2));
-      let den = times(g, pow2(k, inv_g));
+      let num = times2(a, times2(factor1, factor2));
+      let den = times2(g, pow2(k, inv_g));
       div2(num, den)
     };
     return eval(piecewise(vec![(body, cond)], int(0)));
@@ -6204,8 +6217,8 @@ fn pdf_pareto(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let a = dargs[1].clone();
 
   // a * k^a * x^(-1-a)
-  let pdf_val = times(
-    times(a.clone(), pow2(k.clone(), a.clone())),
+  let pdf_val = times2(
+    times2(a.clone(), pow2(k.clone(), a.clone())),
     pow2(x.clone(), neg1(plus2(int(1), a))),
   );
   let cond = comparison(x, ComparisonOp::GreaterEqual, k);
@@ -6223,7 +6236,7 @@ fn cdf_pareto(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       }
     });
     let cond = comparison(x.clone(), ComparisonOp::GreaterEqual, m.clone());
-    let neg_a = times(int(-1), a);
+    let neg_a = times2(int(-1), a);
     let body = if dargs.len() == 3 {
       // 1 - (1 + (-m + x)/k)^(-a)
       minus2(
@@ -6274,8 +6287,9 @@ fn pdf_weibull(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   // a * (xv/b)^(a-1) / (b * E^((xv/b)^a))
   let xb = div2(xv, b.clone());
-  let numerator = times(a.clone(), pow2(xb.clone(), minus2(a.clone(), int(1))));
-  let denom = times(b, pow2(e(), pow2(xb, a)));
+  let numerator =
+    times2(a.clone(), pow2(xb.clone(), minus2(a.clone(), int(1))));
+  let denom = times2(b, pow2(e(), pow2(xb, a)));
   let pdf_val = div2(numerator, denom);
 
   eval(piecewise(vec![(pdf_val, cond)], int(0)))
@@ -6387,8 +6401,10 @@ fn pdf_laplace(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let mu = dargs[0].clone();
   let b = dargs[1].clone();
   let abs_diff = call("Abs", vec![minus2(x, mu)]);
-  let pdf_val =
-    div2(pow2(e(), neg1(div2(abs_diff, b.clone()))), times(int(2), b));
+  let pdf_val = div2(
+    pow2(e(), neg1(div2(abs_diff, b.clone()))),
+    times2(int(2), b),
+  );
   eval(pdf_val)
 }
 
@@ -6417,9 +6433,9 @@ fn pdf_rayleigh(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let sigma = dargs[0].clone();
   let s2 = pow2(sigma, int(2));
-  let pdf_val = times(
+  let pdf_val = times2(
     div2(x.clone(), s2.clone()),
-    pow2(e(), neg1(div2(pow2(x.clone(), int(2)), times(int(2), s2)))),
+    pow2(e(), neg1(div2(pow2(x.clone(), int(2)), times2(int(2), s2)))),
   );
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(pdf_val, cond)], int(0)))
@@ -6436,7 +6452,7 @@ fn cdf_rayleigh(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let s2 = pow2(sigma, int(2));
   let cdf_val = minus2(
     int(1),
-    pow2(e(), neg1(div2(pow2(x.clone(), int(2)), times(int(2), s2)))),
+    pow2(e(), neg1(div2(pow2(x.clone(), int(2)), times2(int(2), s2)))),
   );
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(cdf_val, cond)], int(0)))
@@ -6488,16 +6504,16 @@ fn pdf_multinomial(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   for j in 1..m {
     partial_sum = plus2(partial_sum, xs[j].clone());
     let binom = call("Binomial", vec![partial_sum.clone(), xs[j].clone()]);
-    coeff = times(coeff, binom);
+    coeff = times2(coeff, binom);
   }
 
   // Build product: p1^x1 * p2^x2 * ... * pm^xm
   let mut prob_product = pow2(probs[0].clone(), xs[0].clone());
   for j in 1..m {
-    prob_product = times(prob_product, pow2(probs[j].clone(), xs[j].clone()));
+    prob_product = times2(prob_product, pow2(probs[j].clone(), xs[j].clone()));
   }
 
-  let pdf_val = times(coeff, prob_product);
+  let pdf_val = times2(coeff, prob_product);
 
   // Conditions: sum(xi) == n and all xi >= 0
   let sum_xs = {
@@ -6932,14 +6948,14 @@ pub fn process_slice_distribution(
     "WienerProcess" if dargs.len() == 2 => Some(call(
       "NormalDistribution",
       vec![
-        times(dargs[0].clone(), t.clone()),
-        times(dargs[1].clone(), sqrt_t),
+        times2(dargs[0].clone(), t.clone()),
+        times2(dargs[1].clone(), sqrt_t),
       ],
     )),
     // Counting and noise processes with directly parameterized slices.
     "PoissonProcess" if dargs.len() == 1 => Some(call(
       "PoissonDistribution",
-      vec![times(dargs[0].clone(), t.clone())],
+      vec![times2(dargs[0].clone(), t.clone())],
     )),
     "BinomialProcess" if dargs.len() == 1 => Some(call(
       "BinomialDistribution",
@@ -6963,29 +6979,29 @@ pub fn process_slice_distribution(
         "NormalDistribution",
         vec![
           m.clone(),
-          div2(sp.clone(), call("Sqrt", vec![times(int(2), th.clone())])),
+          div2(sp.clone(), call("Sqrt", vec![times2(int(2), th.clone())])),
         ],
       ))
     }
     "OrnsteinUhlenbeckProcess" if dargs.len() == 4 => {
       let (m, sp, th, x0) = (&dargs[0], &dargs[1], &dargs[2], &dargs[3]);
-      let decay = pow2(e(), times(times(int(-1), th.clone()), t.clone()));
+      let decay = pow2(e(), times2(times2(int(-1), th.clone()), t.clone()));
       let mu = plus2(
         m.clone(),
-        times(plus2(x0.clone(), times(int(-1), m.clone())), decay),
+        times2(plus2(x0.clone(), times2(int(-1), m.clone())), decay),
       );
       let var = div2(
-        times(
+        times2(
           plus2(
             int(1),
-            times(
+            times2(
               int(-1),
-              pow2(e(), times(times(int(-2), th.clone()), t.clone())),
+              pow2(e(), times2(times2(int(-2), th.clone()), t.clone())),
             ),
           ),
           pow2(sp.clone(), int(2)),
         ),
-        times(int(2), th.clone()),
+        times2(int(2), th.clone()),
       );
       Some(call(
         "NormalDistribution",
@@ -7004,33 +7020,33 @@ pub fn process_slice_distribution(
       }
       let (t1, a) = (&p1[0], &p1[1]);
       let (t2, b) = (&p2[0], &p2[1]);
-      let span = plus2(t2.clone(), times(int(-1), t1.clone()));
-      let up = plus2(t.clone(), times(int(-1), t1.clone()));
-      let down = plus2(t2.clone(), times(int(-1), t.clone()));
+      let span = plus2(t2.clone(), times2(int(-1), t1.clone()));
+      let up = plus2(t.clone(), times2(int(-1), t1.clone()));
+      let down = plus2(t2.clone(), times2(int(-1), t.clone()));
       let mu = plus2(
-        div2(times(a.clone(), down.clone()), span.clone()),
-        div2(times(b.clone(), up.clone()), span.clone()),
+        div2(times2(a.clone(), down.clone()), span.clone()),
+        div2(times2(b.clone(), up.clone()), span.clone()),
       );
       // The scale factor stays outside the radical, matching
       // wolframscript's SliceDistribution display
       // s*Sqrt[((t - t1)*(-t + t2))/(-t1 + t2)].
       let sigma =
-        times(sp.clone(), call("Sqrt", vec![div2(times(up, down), span)]));
+        times2(sp.clone(), call("Sqrt", vec![div2(times2(up, down), span)]));
       Some(call("NormalDistribution", vec![mu, sigma]))
     }
     "GeometricBrownianMotionProcess" if dargs.len() == 3 => {
       let (m, s, x0) = (&dargs[0], &dargs[1], &dargs[2]);
       let drift = plus2(
         m.clone(),
-        times(
+        times2(
           call("Rational", vec![int(-1), int(2)]),
           pow2(s.clone(), int(2)),
         ),
       );
-      let mu = plus2(times(drift, t.clone()), call("Log", vec![x0.clone()]));
+      let mu = plus2(times2(drift, t.clone()), call("Log", vec![x0.clone()]));
       Some(call(
         "LogNormalDistribution",
-        vec![mu, times(s.clone(), sqrt_t)],
+        vec![mu, times2(s.clone(), sqrt_t)],
       ))
     }
     _ => None,
@@ -7139,7 +7155,7 @@ fn fptd_probs(f: &Fptd, count: usize) -> Result<Vec<Expr>, InterpreterError> {
       (0..dim)
         .map(|b| {
           let terms: Vec<Expr> = (0..dim)
-            .map(|a| times(v[a].clone(), m[a][b].clone()))
+            .map(|a| times2(v[a].clone(), m[a][b].clone()))
             .collect();
           eval(call("Plus", terms))
         })
@@ -7149,7 +7165,7 @@ fn fptd_probs(f: &Fptd, count: usize) -> Result<Vec<Expr>, InterpreterError> {
     let terms: Vec<Expr> = v
       .iter()
       .zip(r.iter())
-      .map(|(a, b)| times(a.clone(), b.clone()))
+      .map(|(a, b)| times2(a.clone(), b.clone()))
       .collect();
     eval(call("Plus", terms))
   };
@@ -7182,7 +7198,7 @@ fn fptd_moments(f: &Fptd) -> Result<Option<(Expr, Expr)>, InterpreterError> {
       Expr::List(
         (0..dim)
           .map(|b| {
-            let mut entry = times(int(-1), taboo.q[a][b].clone());
+            let mut entry = times2(int(-1), taboo.q[a][b].clone());
             if a == b {
               entry = plus2(int(1), entry);
             }
@@ -7212,9 +7228,9 @@ fn fptd_moments(f: &Fptd) -> Result<Option<(Expr, Expr)>, InterpreterError> {
   let mut rhs2 = Vec::with_capacity(dim);
   for a in 0..dim {
     let qh: Vec<Expr> = (0..dim)
-      .map(|b| times(taboo.q[a][b].clone(), h[b].clone()))
+      .map(|b| times2(taboo.q[a][b].clone(), h[b].clone()))
       .collect();
-    rhs2.push(eval(plus2(int(1), times(int(2), call("Plus", qh))))?);
+    rhs2.push(eval(plus2(int(1), times2(int(2), call("Plus", qh))))?);
   }
   let Some(m2) = solve(rhs2)? else {
     return Ok(None);
@@ -7224,7 +7240,7 @@ fn fptd_moments(f: &Fptd) -> Result<Option<(Expr, Expr)>, InterpreterError> {
       "Plus",
       v.iter()
         .zip(w.iter())
-        .map(|(a, b)| times(a.clone(), b.clone()))
+        .map(|(a, b)| times2(a.clone(), b.clone()))
         .collect::<Vec<_>>(),
     )
   };
@@ -7234,7 +7250,7 @@ fn fptd_moments(f: &Fptd) -> Result<Option<(Expr, Expr)>, InterpreterError> {
     let pm2 = inner(&taboo.start, &m2);
     (
       eval(plus2(int(1), ph.clone()))?,
-      eval(plus2(plus2(int(1), times(int(2), ph)), pm2))?,
+      eval(plus2(plus2(int(1), times2(int(2), ph)), pm2))?,
     )
   } else {
     let others: Vec<usize> = (0..f.n).filter(|&k| k != f.target).collect();
@@ -7242,7 +7258,7 @@ fn fptd_moments(f: &Fptd) -> Result<Option<(Expr, Expr)>, InterpreterError> {
     (h[pos].clone(), m2[pos].clone())
   };
   let variance =
-    eval(plus2(second, times(int(-1), pow2(mean.clone(), int(2)))))?;
+    eval(plus2(second, times2(int(-1), pow2(mean.clone(), int(2)))))?;
   Ok(Some((mean, variance)))
 }
 
@@ -7357,7 +7373,7 @@ fn boole_sum(probs: &[Expr], term_lhs: impl Fn(usize) -> (Expr, Expr)) -> Expr {
     terms.push(if matches!(p, Expr::Integer(1)) {
       boole
     } else {
-      times(p.clone(), boole)
+      times2(p.clone(), boole)
     });
   }
   match terms.len() {
@@ -7480,7 +7496,7 @@ pub fn dmp_stationary_mean(
   let terms: Vec<Expr> = pi
     .iter()
     .enumerate()
-    .map(|(k, p)| times(int(k as i128 + 1), p.clone()))
+    .map(|(k, p)| times2(int(k as i128 + 1), p.clone()))
     .collect();
   Ok(Some(eval(call("Plus", terms))?))
 }
@@ -7528,12 +7544,16 @@ fn wakeby_quantile_body(dargs: &[Expr], q: &Expr) -> Expr {
     dargs[3].clone(),
     dargs[4].clone(),
   );
-  let one_minus_q = plus2(int(1), times(int(-1), q.clone()));
-  let rise =
-    |expo: Expr| plus2(int(1), times(int(-1), pow2(one_minus_q.clone(), expo)));
+  let one_minus_q = plus2(int(1), times2(int(-1), q.clone()));
+  let rise = |expo: Expr| {
+    plus2(int(1), times2(int(-1), pow2(one_minus_q.clone(), expo)))
+  };
   plus2(
-    plus2(m, div2(times(a, rise(b.clone())), b)),
-    times(int(-1), div2(times(g, rise(times(int(-1), d.clone()))), d)),
+    plus2(m, div2(times2(a, rise(b.clone())), b)),
+    times2(
+      int(-1),
+      div2(times2(g, rise(times2(int(-1), d.clone()))), d),
+    ),
   )
 }
 
@@ -7619,7 +7639,7 @@ fn wakeby_mean_variance(
   let mean_body = plus2(
     plus2(
       div2(a.clone(), one_plus_b.clone()),
-      div2(g.clone(), plus2(int(1), times(int(-1), d.clone()))),
+      div2(g.clone(), plus2(int(1), times2(int(-1), d.clone()))),
     ),
     m,
   );
@@ -7628,12 +7648,12 @@ fn wakeby_mean_variance(
     plus2(
       div2(
         pow2(a.clone(), int(2)),
-        times(
+        times2(
           pow2(one_plus_b.clone(), int(2)),
-          plus2(int(1), times(int(2), b.clone())),
+          plus2(int(1), times2(int(2), b.clone())),
         ),
       ),
-      times(
+      times2(
         int(-1),
         div2(
           call("Times", vec![int(2), a, g.clone()]),
@@ -7641,18 +7661,18 @@ fn wakeby_mean_variance(
             "Times",
             vec![
               one_plus_b,
-              plus2(plus2(int(1), b), times(int(-1), d.clone())),
+              plus2(plus2(int(1), b), times2(int(-1), d.clone())),
               dm1.clone(),
             ],
           ),
         ),
       ),
     ),
-    times(
+    times2(
       int(-1),
       div2(
         pow2(g, int(2)),
-        times(pow2(dm1, int(2)), plus2(int(-1), times(int(2), d.clone()))),
+        times2(pow2(dm1, int(2)), plus2(int(-1), times2(int(2), d.clone()))),
       ),
     ),
   );
@@ -7750,8 +7770,8 @@ fn compound_poisson_mean_variance(
   // Unknown inner distributions bail silently to an unevaluated echo.
   let (im, iv) = distribution_mean_variance(inner_name, inner_args)?;
   let lam = dargs[0].clone();
-  let mean = eval(times(lam.clone(), im.clone()))?;
-  let variance = eval(times(lam, plus2(iv, pow2(im, int(2)))))?;
+  let mean = eval(times2(lam.clone(), im.clone()))?;
+  let variance = eval(times2(lam, plus2(iv, pow2(im, int(2)))))?;
   Ok((mean, variance))
 }
 
@@ -7812,8 +7832,8 @@ fn hoyt_pdf(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     vec![
       int(0),
       div2(
-        times(
-          plus2(int(1), times(int(-1), pow2(q.clone(), int(4)))),
+        times2(
+          plus2(int(1), times2(int(-1), pow2(q.clone(), int(4)))),
           x2.clone(),
         ),
         four_q2_w.clone(),
@@ -7822,14 +7842,14 @@ fn hoyt_pdf(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   );
   let gaussian = pow2(
     e(),
-    times(
+    times2(
       int(-1),
-      div2(times(pow2(one_plus_q2.clone(), int(2)), x2), four_q2_w),
+      div2(times2(pow2(one_plus_q2.clone(), int(2)), x2), four_q2_w),
     ),
   );
   let value = div2(
     call("Times", vec![one_plus_q2, x.clone(), bessel, gaussian]),
-    times(q, w),
+    times2(q, w),
   );
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -7849,7 +7869,7 @@ fn hoyt_mean_variance(
   let one_plus_q2 = plus2(int(1), pow2(q.clone(), int(2)));
   let elliptic = call(
     "EllipticE",
-    vec![plus2(int(1), times(int(-1), pow2(q, int(2))))],
+    vec![plus2(int(1), times2(int(-1), pow2(q, int(2))))],
   );
   let sqrt = |e: Expr| call("Sqrt", vec![e]);
   let mean = call(
@@ -7860,15 +7880,15 @@ fn hoyt_mean_variance(
       elliptic.clone(),
     ],
   );
-  let variance = times(
+  let variance = times2(
     w,
     plus2(
       int(1),
-      times(
+      times2(
         int(-1),
         div2(
-          times(int(2), pow2(elliptic, int(2))),
-          times(pi(), one_plus_q2),
+          times2(int(2), pow2(elliptic, int(2))),
+          times2(pi(), one_plus_q2),
         ),
       ),
     ),
@@ -7946,9 +7966,9 @@ fn variance_gamma_pdf(
   );
   let sqrt_pi = call("Sqrt", vec![pi()]);
   let gamma_l = call("Gamma", vec![l.clone()]);
-  let half_minus_l = plus2(div2(int(1), int(2)), times(int(-1), l.clone()));
-  let a2b2 = times(
-    plus2(a.clone(), times(int(-1), b.clone())),
+  let half_minus_l = plus2(div2(int(1), int(2)), times2(int(-1), l.clone()));
+  let a2b2 = times2(
+    plus2(a.clone(), times2(int(-1), b.clone())),
     plus2(a.clone(), b.clone()),
   );
   // Branch value for a signed distance d = ±(x - μ).
@@ -7962,30 +7982,33 @@ fn variance_gamma_pdf(
           pow2(a2b2.clone(), l.clone()),
           pow2(
             e(),
-            times(b.clone(), plus2(times(int(-1), m.clone()), x.clone())),
+            times2(b.clone(), plus2(times2(int(-1), m.clone()), x.clone())),
           ),
           pow2(d.clone(), plus2(div2(int(-1), int(2)), l.clone())),
           call(
             "BesselK",
-            vec![plus2(div2(int(-1), int(2)), l.clone()), times(a.clone(), d)],
+            vec![
+              plus2(div2(int(-1), int(2)), l.clone()),
+              times2(a.clone(), d),
+            ],
           ),
         ],
       ),
-      times(sqrt_pi.clone(), gamma_l.clone()),
+      times2(sqrt_pi.clone(), gamma_l.clone()),
     )
   };
-  let above = branch(plus2(times(int(-1), m.clone()), x.clone()));
-  let below = branch(plus2(m.clone(), times(int(-1), x.clone())));
+  let above = branch(plus2(times2(int(-1), m.clone()), x.clone()));
+  let below = branch(plus2(m.clone(), times2(int(-1), x.clone())));
   let point = div2(
     call(
       "Times",
       vec![
-        pow2(a.clone(), plus2(int(1), times(int(-2), l.clone()))),
+        pow2(a.clone(), plus2(int(1), times2(int(-2), l.clone()))),
         pow2(a2b2, l.clone()),
         call("Gamma", vec![plus2(div2(int(-1), int(2)), l.clone())]),
       ],
     ),
-    times(times(int(2), sqrt_pi), gamma_l),
+    times2(times2(int(2), sqrt_pi), gamma_l),
   );
   let inf = infinity();
   let cond_above = comparison(x.clone(), ComparisonOp::Greater, m.clone());
@@ -8037,12 +8060,12 @@ fn variance_gamma_mean_variance(
     dargs[2].clone(),
     dargs[3].clone(),
   );
-  let amb = plus2(a.clone(), times(int(-1), b.clone()));
+  let amb = plus2(a.clone(), times2(int(-1), b.clone()));
   let apb = plus2(a.clone(), b.clone());
   let mean = plus2(
     div2(
       call("Times", vec![int(2), b.clone(), l.clone()]),
-      times(amb.clone(), apb.clone()),
+      times2(amb.clone(), apb.clone()),
     ),
     m,
   );
@@ -8051,7 +8074,7 @@ fn variance_gamma_mean_variance(
       "Times",
       vec![int(2), plus2(pow2(a, int(2)), pow2(b, int(2))), l],
     ),
-    times(pow2(amb, int(2)), pow2(apb, int(2))),
+    times2(pow2(amb, int(2)), pow2(apb, int(2))),
   );
   Ok((eval(mean)?, eval(variance)?))
 }
@@ -8108,10 +8131,10 @@ struct TsallisParts {
 
 fn tsallis_parts(m: &Expr, b: &Expr, q: &Expr, x: &Expr) -> TsallisParts {
   let sqrt = |e: Expr| call("Sqrt", vec![e]);
-  let two_pi = times(int(2), pi());
-  let m_minus_x = plus2(m.clone(), times(int(-1), x.clone()));
+  let two_pi = times2(int(2), pi());
+  let m_minus_x = plus2(m.clone(), times2(int(-1), x.clone()));
   let qm1 = plus2(int(-1), q.clone());
-  let one_mq = plus2(int(1), times(int(-1), q.clone()));
+  let one_mq = plus2(int(1), times2(int(-1), q.clone()));
   // Gaussian branch: 1/(b E^((m-x)^2/(2 b^2)) Sqrt[2 Pi])
   let gaussian = pow2(
     call(
@@ -8122,7 +8145,7 @@ fn tsallis_parts(m: &Expr, b: &Expr, q: &Expr, x: &Expr) -> TsallisParts {
           e(),
           div2(
             pow2(m_minus_x.clone(), int(2)),
-            times(int(2), pow2(b.clone(), int(2))),
+            times2(int(2), pow2(b.clone(), int(2))),
           ),
         ),
         sqrt(two_pi.clone()),
@@ -8135,8 +8158,8 @@ fn tsallis_parts(m: &Expr, b: &Expr, q: &Expr, x: &Expr) -> TsallisParts {
     plus2(
       int(1),
       div2(
-        times(qm1.clone(), pow2(m_minus_x.clone(), int(2))),
-        times(int(2), pow2(b.clone(), int(2))),
+        times2(qm1.clone(), pow2(m_minus_x.clone(), int(2))),
+        times2(int(2), pow2(b.clone(), int(2))),
       ),
     ),
     pow2(one_mq.clone(), int(-1)),
@@ -8157,8 +8180,8 @@ fn tsallis_parts(m: &Expr, b: &Expr, q: &Expr, x: &Expr) -> TsallisParts {
         b.clone(),
         sqrt(two_pi.clone()),
         gamma(div2(
-          plus2(int(3), times(int(-1), q.clone())),
-          times(int(2), qm1.clone()),
+          plus2(int(3), times2(int(-1), q.clone())),
+          times2(int(2), qm1.clone()),
         )),
       ],
     ),
@@ -8184,9 +8207,9 @@ fn tsallis_parts(m: &Expr, b: &Expr, q: &Expr, x: &Expr) -> TsallisParts {
   );
   // (Sqrt[(1-q)/b^2] (-m+x))/Sqrt[2]
   let compact_arg = div2(
-    times(
+    times2(
       sqrt(div2(one_mq, pow2(b.clone(), int(2)))),
-      plus2(times(int(-1), m.clone()), x.clone()),
+      plus2(times2(int(-1), m.clone()), x.clone()),
     ),
     sqrt(int(2)),
   );
@@ -8293,8 +8316,8 @@ fn tsallis_qgaussian_cdf(
       call(
         "Erf",
         vec![div2(
-          plus2(times(int(-1), m.clone()), x.clone()),
-          times(call("Sqrt", vec![int(2)]), b.clone()),
+          plus2(times2(int(-1), m.clone()), x.clone()),
+          times2(call("Sqrt", vec![int(2)]), b.clone()),
         )],
       ),
     ),
@@ -8322,8 +8345,8 @@ fn tsallis_qgaussian_mean_variance(
   let indet = indeterminate();
   let inf = infinity();
   let var_core = div2(
-    times(int(2), pow2(b.clone(), int(2))),
-    plus2(int(5), times(int(-3), q.clone())),
+    times2(int(2), pow2(b.clone(), int(2))),
+    plus2(int(5), times2(int(-3), q.clone())),
   );
   match try_eval_to_f64(&q) {
     Some(qv) => {
@@ -8412,31 +8435,31 @@ fn tukey_lambda_pdf_cdf(
   // The variable the closed forms are written in: x or (x - μ)/σ.
   let y: Expr = if scaled {
     eval(div2(
-      plus2(times(int(-1), dargs[1].clone()), x.clone()),
+      plus2(times2(int(-1), dargs[1].clone()), x.clone()),
       dargs[2].clone(),
     ))?
   } else {
     x.clone()
   };
   let sq = |e: &Expr| pow2(e.clone(), int(2));
-  let lam2y2 = |lam: &Expr, y: &Expr| times(sq(lam), sq(y));
+  let lam2y2 = |lam: &Expr, y: &Expr| times2(sq(lam), sq(y));
   // (value, condition) pairs plus default per λ; None = no closed form.
-  let e_neg = |arg: Expr| pow2(e(), times(int(-1), arg));
+  let e_neg = |arg: Expr| pow2(e(), times2(int(-1), arg));
   let branches: Option<(Vec<(Expr, Expr)>, Expr)> = if lv == 0.0 {
     // Logistic: full support, no Piecewise.
     let value = if want_pdf {
       if scaled {
         // E^((μ-x)/σ)/(σ (1 + E^((μ-x)/σ))^2)
         let z = eval(div2(
-          plus2(dargs[1].clone(), times(int(-1), x.clone())),
+          plus2(dargs[1].clone(), times2(int(-1), x.clone())),
           dargs[2].clone(),
         ))?;
         div2(
           pow2(e(), z.clone()),
-          times(dargs[2].clone(), sq(&plus2(int(1), pow2(e(), z)))),
+          times2(dargs[2].clone(), sq(&plus2(int(1), pow2(e(), z)))),
         )
       } else {
-        times(
+        times2(
           e_neg(y.clone()),
           pow2(plus2(int(1), e_neg(y.clone())), int(-2)),
         )
@@ -8456,21 +8479,24 @@ fn tukey_lambda_pdf_cdf(
     );
     if want_pdf {
       let v = div2(
-        plus2(int(1), times(int(-1), c.clone())),
-        times(int(2), call("Sqrt", vec![plus2(int(2), times(int(-1), c))])),
+        plus2(int(1), times2(int(-1), c.clone())),
+        times2(
+          int(2),
+          call("Sqrt", vec![plus2(int(2), times2(int(-1), c))]),
+        ),
       );
       Some((vec![(v, cond)], int(0)))
     } else {
       let inner = plus2(
         int(4),
-        times(
+        times2(
           y.clone(),
-          call("Sqrt", vec![plus2(int(8), times(int(-1), sq(&y)))]),
+          call("Sqrt", vec![plus2(int(8), times2(int(-1), sq(&y)))]),
         ),
       );
       // Float λ folds the 1/8 into a 0.125 prefactor, like wolframscript.
       let v = if matches!(&lam, Expr::Real(_)) {
-        times(Expr::Real(0.125), inner)
+        times2(Expr::Real(0.125), inner)
       } else {
         div2(inner, int(8))
       };
@@ -8486,7 +8512,7 @@ fn tukey_lambda_pdf_cdf(
       div2(int(1), int(2))
     };
     let half_width = eval(half_width)?;
-    let lo = eval(times(int(-1), half_width.clone()))?;
+    let lo = eval(times2(int(-1), half_width.clone()))?;
     let cond = comparison3(
       lo.clone(),
       ComparisonOp::LessEqual,
@@ -8498,7 +8524,7 @@ fn tukey_lambda_pdf_cdf(
       let v = eval(div2(lam.clone(), int(2)))?;
       Some((vec![(v, cond)], int(0)))
     } else {
-      let v = div2(plus2(int(1), times(lam.clone(), y.clone())), int(2));
+      let v = div2(plus2(int(1), times2(lam.clone(), y.clone())), int(2));
       let below = comparison(y.clone(), ComparisonOp::Less, lo);
       Some((vec![(v, cond), (int(0), below)], int(1)))
     }
@@ -8508,7 +8534,7 @@ fn tukey_lambda_pdf_cdf(
       let v = div2(
         plus2(
           int(1),
-          times(
+          times2(
             int(-1),
             pow2(
               call("Sqrt", vec![plus2(int(1), div2(sq(&y), int(4)))]),
@@ -8525,7 +8551,7 @@ fn tukey_lambda_pdf_cdf(
           plus2(int(-2), y.clone()),
           call("Sqrt", vec![plus2(int(4), sq(&y))]),
         ),
-        times(int(2), y.clone()),
+        times2(int(2), y.clone()),
       );
       Some((vec![(v, cond)], div2(int(1), int(2))))
     }
@@ -8545,7 +8571,7 @@ fn tukey_lambda_pdf_cdf(
     eval(default)?,
   ))?;
   if want_pdf && scaled {
-    Ok(times(pw, pow2(dargs[2].clone(), int(-1))))
+    Ok(times2(pw, pow2(dargs[2].clone(), int(-1))))
   } else {
     Ok(pw)
   }
@@ -8572,16 +8598,16 @@ fn tukey_lambda_mean_variance(
   };
   let var_core = div2(
     plus2(
-      times(int(-2), pow2(factorial(lam.clone()), int(2))),
-      times(int(2), factorial(times(int(2), lam.clone()))),
+      times2(int(-2), pow2(factorial(lam.clone()), int(2))),
+      times2(int(2), factorial(times2(int(2), lam.clone()))),
     ),
-    times(
+    times2(
       pow2(lam.clone(), int(2)),
-      factorial(plus2(int(1), times(int(2), lam.clone()))),
+      factorial(plus2(int(1), times2(int(2), lam.clone()))),
     ),
   );
   let sigma2 = if dargs.len() == 3 {
-    times(pow2(dargs[2].clone(), int(2)), var_core.clone())
+    times2(pow2(dargs[2].clone(), int(2)), var_core.clone())
   } else {
     var_core.clone()
   };
@@ -8592,7 +8618,7 @@ fn tukey_lambda_mean_variance(
         // Logistic limit: the factorial template divides by λ².
         let core = div2(pow2(pi(), int(2)), int(3));
         let scaled_core = if dargs.len() == 3 {
-          times(pow2(dargs[2].clone(), int(2)), core)
+          times2(pow2(dargs[2].clone(), int(2)), core)
         } else {
           core
         };
@@ -8676,7 +8702,7 @@ fn pdf_hotelling(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     "Beta",
     vec![
       half(pp.clone()),
-      half(plus2(plus2(int(1), m.clone()), times(int(-1), pp.clone()))),
+      half(plus2(plus2(int(1), m.clone()), times2(int(-1), pp.clone()))),
     ],
   );
   let value = if num(&pp).is_some() && num(&m).is_some() {
@@ -8693,13 +8719,16 @@ fn pdf_hotelling(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     let coeff_expr = div2(
       pow2(
         me.clone(),
-        half(plus2(plus2(int(1), me.clone()), times(int(-1), pe.clone()))),
+        half(plus2(
+          plus2(int(1), me.clone()),
+          times2(int(-1), pe.clone()),
+        )),
       ),
       call(
         "Beta",
         vec![
           half(pe.clone()),
-          half(plus2(plus2(int(1), me.clone()), times(int(-1), pe))),
+          half(plus2(plus2(int(1), me.clone()), times2(int(-1), pe))),
         ],
       ),
     );
@@ -8715,7 +8744,7 @@ fn pdf_hotelling(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       eval(div2(
         pow2(
           m.clone(),
-          half(plus2(plus2(int(1), m.clone()), times(int(-1), pp.clone()))),
+          half(plus2(plus2(int(1), m.clone()), times2(int(-1), pp.clone()))),
         ),
         beta,
       ))?
@@ -8727,20 +8756,20 @@ fn pdf_hotelling(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     );
     let is_zero = num(&expo).is_some_and(|v| v == 0.0);
     if is_zero {
-      times(coeff, tail)
+      times2(coeff, tail)
     } else {
       call("Times", vec![coeff, pow2(x.clone(), expo), tail])
     }
   } else {
     div2(
-      times(
+      times2(
         pow2(div2(x.clone(), m.clone()), half(pp.clone())),
         pow2(
           div2(m.clone(), plus2(m.clone(), x.clone())),
           half(plus2(int(1), m.clone())),
         ),
       ),
-      times(x.clone(), beta),
+      times2(x.clone(), beta),
     )
   };
   let cond = comparison(x, ComparisonOp::Greater, int(0));
@@ -8761,12 +8790,12 @@ fn cdf_hotelling(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   };
   let (pp, m) = (dargs[0].clone(), dargs[1].clone());
   let half = |e: Expr| div2(e, int(2));
-  let k = plus2(plus2(int(1), m.clone()), times(int(-1), pp.clone()));
+  let k = plus2(plus2(int(1), m.clone()), times2(int(-1), pp.clone()));
   let z = div2(
-    times(k.clone(), x.clone()),
-    times(
+    times2(k.clone(), x.clone()),
+    times2(
       m.clone(),
-      plus2(k.clone(), div2(times(k.clone(), x.clone()), m.clone())),
+      plus2(k.clone(), div2(times2(k.clone(), x.clone()), m.clone())),
     ),
   );
   let value = call("BetaRegularized", vec![z, half(pp), half(k)]);
@@ -8791,8 +8820,8 @@ fn hotelling_mean_variance(
   // Mean: (m p)/(-1 + m - p) when -1 + m - p > 0. For numeric
   // parameters the condition is decided up front so a dead branch never
   // evaluates (avoiding spurious Power::infy at the boundary).
-  let dof = plus2(plus2(int(-1), m.clone()), times(int(-1), pp.clone()));
-  let mean_value = div2(times(m.clone(), pp.clone()), dof.clone());
+  let dof = plus2(plus2(int(-1), m.clone()), times2(int(-1), pp.clone()));
+  let mean_value = div2(times2(m.clone(), pp.clone()), dof.clone());
   let mean = match numeric {
     Some((pv, mv)) => {
       if mv - pv - 1.0 > 0.0 {
@@ -8816,10 +8845,10 @@ fn hotelling_mean_variance(
       pp.clone(),
     ],
   );
-  let var_den = times(
-    plus2(plus2(int(-3), m.clone()), times(int(-1), pp.clone())),
+  let var_den = times2(
+    plus2(plus2(int(-3), m.clone()), times2(int(-1), pp.clone())),
     pow2(
-      plus2(plus2(int(1), times(int(-1), m.clone())), pp.clone()),
+      plus2(plus2(int(1), times2(int(-1), m.clone())), pp.clone()),
       int(2),
     ),
   );
@@ -8915,15 +8944,15 @@ fn pdf_benini(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let (a, b, sg) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
   let lg = benini_log(&x, &sg);
   let hazard = plus2(
-    times(a.clone(), pow2(x.clone(), int(-1))),
-    times(
-      times(times(int(2), b.clone()), lg.clone()),
+    times2(a.clone(), pow2(x.clone(), int(-1))),
+    times2(
+      times2(times2(int(2), b.clone()), lg.clone()),
       pow2(x.clone(), int(-1)),
     ),
   );
   let quad = pow2(
     e(),
-    times(times(int(-1), b.clone()), pow2(lg.clone(), int(2))),
+    times2(times2(int(-1), b.clone()), pow2(lg.clone(), int(2))),
   );
   let value = if try_eval_to_f64(&a).is_some() {
     call(
@@ -8932,16 +8961,16 @@ fn pdf_benini(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
         pow2(sg.clone(), a.clone()),
         hazard,
         quad,
-        pow2(x.clone(), times(int(-1), a)),
+        pow2(x.clone(), times2(int(-1), a)),
       ],
     )
   } else {
-    times(
+    times2(
       pow2(
         e(),
         plus2(
-          times(times(int(-1), a), lg.clone()),
-          times(times(int(-1), b), pow2(lg, int(2))),
+          times2(times2(int(-1), a), lg.clone()),
+          times2(times2(int(-1), b), pow2(lg, int(2))),
         ),
       ),
       hazard,
@@ -8972,21 +9001,21 @@ fn cdf_benini(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
         pow2(sg.clone(), a.clone()),
         pow2(
           e(),
-          times(times(int(-1), b.clone()), pow2(lg.clone(), int(2))),
+          times2(times2(int(-1), b.clone()), pow2(lg.clone(), int(2))),
         ),
-        pow2(x.clone(), times(int(-1), a)),
+        pow2(x.clone(), times2(int(-1), a)),
       ],
     )
   } else {
     pow2(
       e(),
       plus2(
-        times(times(int(-1), a), lg.clone()),
-        times(times(int(-1), b), pow2(lg, int(2))),
+        times2(times2(int(-1), a), lg.clone()),
+        times2(times2(int(-1), b), pow2(lg, int(2))),
       ),
     )
   };
-  let value = plus2(int(1), times(int(-1), survival));
+  let value = plus2(int(1), times2(int(-1), survival));
   let cond = comparison(x, ComparisonOp::GreaterEqual, sg);
   eval(piecewise(vec![(value, cond)], int(0)))
 }
@@ -9011,10 +9040,10 @@ fn benini_mean_variance(
       e(),
       div2(
         pow2(base.clone(), int(2)),
-        times(int(denom_scale), b.clone()),
+        times2(int(denom_scale), b.clone()),
       ),
     );
-    let erfc = call("Erfc", vec![div2(base, times(int(2), sqrt_b.clone()))]);
+    let erfc = call("Erfc", vec![div2(base, times2(int(2), sqrt_b.clone()))]);
     (expo, erfc)
   };
   let (e1, erfc1) = shifted(1, 4);
@@ -9025,7 +9054,7 @@ fn benini_mean_variance(
         "Times",
         vec![e1.clone(), sqrt_pi.clone(), sg.clone(), erfc1.clone()],
       ),
-      times(int(2), sqrt_b.clone()),
+      times2(int(2), sqrt_b.clone()),
     ),
   );
   let (e2, erfc2) = shifted(2, 4);
@@ -9041,7 +9070,7 @@ fn benini_mean_variance(
       "Times",
       vec![sqrt_pi, pow2(sg, int(2)), call("Plus", vec![t1, t2, t3])],
     ),
-    times(int(4), b),
+    times2(int(4), b),
   );
   Ok((eval(mean)?, eval(variance)?))
 }
@@ -9093,10 +9122,10 @@ fn pdf_vonmises(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   };
   let (m, k) = (dargs[0].clone(), dargs[1].clone());
   let pi = pi();
-  let cos = call("Cos", vec![plus2(m.clone(), times(int(-1), x.clone()))]);
+  let cos = call("Cos", vec![plus2(m.clone(), times2(int(-1), x.clone()))]);
   let bessel = call("BesselI", vec![int(0), k.clone()]);
-  let value = times(
-    pow2(e(), times(k, cos)),
+  let value = times2(
+    pow2(e(), times2(k, cos)),
     pow2(call("Times", vec![int(2), pi.clone(), bessel]), int(-1)),
   );
   let cond = comparison3(
@@ -9171,7 +9200,7 @@ fn hyperexponential_numeric_terms(
   let mut groups: Vec<(f64, Expr, Vec<Expr>)> = Vec::new();
   for (i, v) in vals.iter().enumerate() {
     let coeff = if scale_by_rate {
-      times(probs[i].clone(), rates[i].clone())
+      times2(probs[i].clone(), rates[i].clone())
     } else {
       probs[i].clone()
     };
@@ -9216,7 +9245,9 @@ fn pdf_hyperexponential(
       None => probs
         .iter()
         .zip(rates.iter())
-        .map(|(p, l)| coxian_exp_term(times(l.clone(), p.clone()), None, l, &x))
+        .map(|(p, l)| {
+          coxian_exp_term(times2(l.clone(), p.clone()), None, l, &x)
+        })
         .collect(),
     };
   let value = call("Plus", terms);
@@ -9243,13 +9274,13 @@ fn cdf_hyperexponential(
   match hyperexponential_numeric_terms(&probs, &rates, false) {
     Some(groups) => {
       for (c, rate) in groups {
-        let neg = eval(times(int(-1), c))?;
+        let neg = eval(times2(int(-1), c))?;
         terms.push(coxian_exp_term(neg, None, &rate, &x));
       }
     }
     None => {
       for (p, l) in probs.iter().zip(rates.iter()) {
-        terms.push(coxian_exp_term(times(int(-1), p.clone()), None, l, &x));
+        terms.push(coxian_exp_term(times2(int(-1), p.clone()), None, l, &x));
       }
     }
   }
@@ -9269,7 +9300,7 @@ fn hyperexponential_mean_variance(
     ));
   };
   let term =
-    |p: &Expr, l: &Expr, k: i128| times(p.clone(), pow2(l.clone(), int(k)));
+    |p: &Expr, l: &Expr, k: i128| times2(p.clone(), pow2(l.clone(), int(k)));
   let mean = call(
     "Plus",
     probs
@@ -9278,7 +9309,7 @@ fn hyperexponential_mean_variance(
       .map(|(p, l)| term(p, l, -1))
       .collect::<Vec<_>>(),
   );
-  let second = times(
+  let second = times2(
     int(2),
     call(
       "Plus",
@@ -9289,7 +9320,7 @@ fn hyperexponential_mean_variance(
         .collect::<Vec<_>>(),
     ),
   );
-  let variance = plus2(second, times(int(-1), pow2(mean.clone(), int(2))));
+  let variance = plus2(second, times2(int(-1), pow2(mean.clone(), int(2))));
   Ok((eval(mean)?, eval(variance)?))
 }
 
@@ -9340,7 +9371,7 @@ fn coxian_checked(dargs: &[Expr]) -> Option<(Vec<Expr>, Vec<Expr>)> {
 /// to reproduce wolframscript's symbolic moment forms.
 fn coxian_weights(alphas: &[Expr]) -> Vec<Expr> {
   let m = alphas.len() + 1;
-  let one_minus = |a: &Expr| plus2(int(1), times(int(-1), a.clone()));
+  let one_minus = |a: &Expr| plus2(int(1), times2(int(-1), a.clone()));
   let product = |fs: Vec<Expr>| -> Expr {
     match fs.len() {
       0 => int(1),
@@ -9386,14 +9417,14 @@ fn coxian_mean_variance(
   };
   let m = rates.len();
   let mean_terms: Vec<Expr> = (1..=m)
-    .map(|k| times(weights[k - 1].clone(), inv_sum(k)))
+    .map(|k| times2(weights[k - 1].clone(), inv_sum(k)))
     .collect();
   let mean = call("Plus", mean_terms.clone());
   let e2_terms: Vec<Expr> = (1..=m)
     .map(|k| {
       if k == 1 {
-        times(
-          times(int(2), weights[0].clone()),
+        times2(
+          times2(int(2), weights[0].clone()),
           pow2(rates[0].clone(), int(-2)),
         )
       } else {
@@ -9402,12 +9433,12 @@ fn coxian_mean_variance(
           .map(|r| pow2(r.clone(), int(-2)))
           .collect();
         parts.push(pow2(inv_sum(k), int(2)));
-        times(weights[k - 1].clone(), call("Plus", parts))
+        times2(weights[k - 1].clone(), call("Plus", parts))
       }
     })
     .collect();
   let mut var_terms = e2_terms;
-  var_terms.push(times(int(-1), pow2(mean.clone(), int(2))));
+  var_terms.push(times2(int(-1), pow2(mean.clone(), int(2))));
   let variance = call("Plus", var_terms);
   Ok((eval(mean)?, eval(variance)?))
 }
@@ -9488,10 +9519,10 @@ fn coxian_exp_term(
   rate: &Expr,
   x: &Expr,
 ) -> Expr {
-  let e_part = pow2(e(), times(times(int(-1), rate.clone()), x.clone()));
+  let e_part = pow2(e(), times2(times2(int(-1), rate.clone()), x.clone()));
   match xpow {
-    Some(p) => times(times(coeff, p), e_part),
-    None => times(coeff, e_part),
+    Some(p) => times2(times2(coeff, p), e_part),
+    None => times2(coeff, e_part),
   }
 }
 
@@ -9519,7 +9550,7 @@ fn pdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     order
       .iter()
       .map(|&i| {
-        let c = eval(times(coeffs[i].clone(), rates[i].clone()))?;
+        let c = eval(times2(coeffs[i].clone(), rates[i].clone()))?;
         Ok(coxian_exp_term(c, None, &rates[i], &x))
       })
       .collect::<Result<_, InterpreterError>>()?
@@ -9531,10 +9562,10 @@ fn pdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       .map(|k| {
         let mut fact = int(1);
         for j in 2..k {
-          fact = times(fact, int(j as i128));
+          fact = times2(fact, int(j as i128));
         }
         let c = eval(div2(
-          times(weights[k - 1].clone(), pow2(lam.clone(), int(k as i128))),
+          times2(weights[k - 1].clone(), pow2(lam.clone(), int(k as i128))),
           fact,
         ))?;
         let xpow = if k == 1 {
@@ -9577,7 +9608,7 @@ fn cdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     let val = |i: usize| try_eval_to_f64(&rates[i]).unwrap();
     order.sort_by(|&a, &b| val(b).partial_cmp(&val(a)).unwrap());
     for &i in &order {
-      let c = eval(times(int(-1), coeffs[i].clone()))?;
+      let c = eval(times2(int(-1), coeffs[i].clone()))?;
       terms.push(coxian_exp_term(c, None, &rates[i], &x));
     }
     default = int(0);
@@ -9590,12 +9621,12 @@ fn cdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     for j in 0..m {
       let mut fact = int(1);
       for f in 2..=j {
-        fact = times(fact, int(f as i128));
+        fact = times2(fact, int(f as i128));
       }
       let wsum = unevaluated("Plus", &weights[j..]);
-      let c = eval(times(
+      let c = eval(times2(
         int(-1),
-        div2(times(wsum, pow2(lam.clone(), int(j as i128))), fact),
+        div2(times2(wsum, pow2(lam.clone(), int(j as i128))), fact),
       ))?;
       let xpow = if j == 0 {
         None
@@ -9687,9 +9718,9 @@ fn pdf_hypoexponential(
     .iter()
     .zip(coeffs.iter())
     .map(|((rate, _), c)| {
-      times(
-        times(c.clone(), rate.clone()),
-        pow2(e(), times(times(int(-1), rate.clone()), x.clone())),
+      times2(
+        times2(c.clone(), rate.clone()),
+        pow2(e(), times2(times2(int(-1), rate.clone()), x.clone())),
       )
     })
     .collect();
@@ -9716,9 +9747,9 @@ fn cdf_hypoexponential(
   let coeffs = hypoexponential_coefficients(&rates)?;
   let mut terms: Vec<Expr> = vec![int(1)];
   for ((rate, _), c) in rates.iter().zip(coeffs.iter()) {
-    terms.push(times(
-      times(int(-1), c.clone()),
-      pow2(e(), times(times(int(-1), rate.clone()), x.clone())),
+    terms.push(times2(
+      times2(int(-1), c.clone()),
+      pow2(e(), times2(times2(int(-1), rate.clone()), x.clone())),
     ));
   }
   let value = call("Plus", terms);
@@ -9782,18 +9813,18 @@ fn pdf_negative_multinomial(
   // Numerator: (1 - Σp)^n * p1^x1 * ... * pk^xk * Pochhammer[n, Σx]
   let mut numer = pow2(negative_multinomial_success(&probs), n.clone());
   for (p, xi) in probs.iter().zip(xs.iter()) {
-    numer = times(numer, pow2(p.clone(), xi.clone()));
+    numer = times2(numer, pow2(p.clone(), xi.clone()));
   }
   let mut sum_xs = xs[0].clone();
   for xi in xs.iter().skip(1) {
     sum_xs = plus2(sum_xs, xi.clone());
   }
-  numer = times(numer, call("Pochhammer", vec![n, sum_xs]));
+  numer = times2(numer, call("Pochhammer", vec![n, sum_xs]));
 
   // Denominator: x1! * ... * xk!
   let mut denom = factorial(xs[0].clone());
   for xi in xs.iter().skip(1) {
-    denom = times(denom, factorial(xi.clone()));
+    denom = times2(denom, factorial(xi.clone()));
   }
   let pdf_val = div2(numer, denom);
 
@@ -9928,10 +9959,10 @@ fn pdf_multivariate_poisson(
   // Pre-evaluate the numeric-parameter subexpressions so the final
   // Piecewise doesn't leak unsimplified literals (`E^(1 + 2 + 3)` etc).
   // The symbolic `x`, `y` are kept intact.
-  let neg_mu0 = eval(times(int(-1), mu0.clone()))?;
-  let neg_mu1_mu2_over_mu0 = eval(times(
+  let neg_mu0 = eval(times2(int(-1), mu0.clone()))?;
+  let neg_mu1_mu2_over_mu0 = eval(times2(
     int(-1),
-    div2(times(mu1.clone(), mu2.clone()), mu0.clone()),
+    div2(times2(mu1.clone(), mu2.clone()), mu0.clone()),
   ))?;
   let sum_mu_eval = eval(plus2(plus2(mu0.clone(), mu1.clone()), mu2.clone()))?;
 
@@ -9941,20 +9972,20 @@ fn pdf_multivariate_poisson(
   // Piecewise matches wolframscript's display.
   let y_minus_x_canon = eval(minus2(yv.clone(), xv.clone()))?;
   let mu2_pow_y_minus_x = pow2(mu2.clone(), y_minus_x_canon);
-  let neg_x = times(int(-1), xv.clone());
+  let neg_x = times2(int(-1), xv.clone());
   let one_minus_x_plus_y = plus2(minus2(int(1), xv.clone()), yv.clone());
   let hypergeometric_u = call(
     "HypergeometricU",
     vec![neg_x, one_minus_x_plus_y, neg_mu1_mu2_over_mu0],
   );
   let numerator =
-    times(times(neg_mu0_pow_x, mu2_pow_y_minus_x), hypergeometric_u);
+    times2(times2(neg_mu0_pow_x, mu2_pow_y_minus_x), hypergeometric_u);
 
   // Denominator: E^(μ_0+μ_1+μ_2) · x! · y!
   let exp_sum = pow2(e(), sum_mu_eval);
   let x_fact = factorial(xv.clone());
   let y_fact = factorial(yv.clone());
-  let denominator = times(times(exp_sum, x_fact), y_fact);
+  let denominator = times2(times2(exp_sum, x_fact), y_fact);
 
   let pdf_val = div2(numerator, denominator);
 
@@ -9993,8 +10024,8 @@ pub fn multinomial_mean_variance(
   let mut means = Vec::new();
   let mut variances = Vec::new();
   for p in &probs {
-    let mean_i = times(n.clone(), p.clone());
-    let var_i = times(times(n.clone(), p.clone()), minus2(int(1), p.clone()));
+    let mean_i = times2(n.clone(), p.clone());
+    let var_i = times2(times2(n.clone(), p.clone()), minus2(int(1), p.clone()));
     means.push(eval(mean_i)?);
     variances.push(eval(var_i)?);
   }
@@ -10014,14 +10045,14 @@ pub fn negative_multinomial_mean_variance(
   let mut means = Vec::with_capacity(probs.len());
   let mut variances = Vec::with_capacity(probs.len());
   for p in probs.iter() {
-    means.push(eval(div2(times(n.clone(), p.clone()), q.clone()))?);
+    means.push(eval(div2(times2(n.clone(), p.clone()), q.clone()))?);
     // The numerator factor 1 - Σ_{j≠i} p_j is built as q + p_i: symbolically
     // it cancels to wolframscript's subtracted form, and for machine floats
     // it reproduces wolframscript's fold order (1 - (0.2 + 0.4) + 0.2 differs
     // from 1 - 0.4 in the last bit).
     let others = plus2(q.clone(), p.clone());
     variances.push(eval(div2(
-      times(times(n.clone(), p.clone()), others),
+      times2(times2(n.clone(), p.clone()), others),
       pow2(q.clone(), int(2)),
     ))?);
   }
@@ -10043,7 +10074,7 @@ pub fn negative_multinomial_covariance(
     let mut row = Vec::with_capacity(probs.len());
     for (j, pj) in probs.iter().enumerate() {
       let entry = if i == j {
-        times(
+        times2(
           n.clone(),
           plus2(
             div2(pow2(pi.clone(), int(2)), pow2(q.clone(), int(2))),
@@ -10052,7 +10083,7 @@ pub fn negative_multinomial_covariance(
         )
       } else {
         div2(
-          times(times(n.clone(), pi.clone()), pj.clone()),
+          times2(times2(n.clone(), pi.clone()), pj.clone()),
           pow2(q.clone(), int(2)),
         )
       };
@@ -10189,13 +10220,13 @@ pub fn wishart_mean_variance(
     let mut mean_row = Vec::with_capacity(p);
     let mut var_row = Vec::with_capacity(p);
     for j in 0..p {
-      mean_row.push(eval(times(nu.clone(), sig_exprs[i][j].clone()))?);
+      mean_row.push(eval(times2(nu.clone(), sig_exprs[i][j].clone()))?);
       // ν (σ_ij^2 + σ_ii σ_jj)
-      var_row.push(eval(times(
+      var_row.push(eval(times2(
         nu.clone(),
         plus2(
           pow2(sig_exprs[i][j].clone(), int(2)),
-          times(sig_exprs[i][i].clone(), sig_exprs[j][j].clone()),
+          times2(sig_exprs[i][i].clone(), sig_exprs[j][j].clone()),
         ),
       ))?);
     }
@@ -10264,7 +10295,7 @@ fn dirichlet_total(alphas: &[Expr]) -> Expr {
 /// α0^2 (1 + α0), as an unevaluated reciprocal `α0^-2 (1 + α0)^-1`.
 fn dirichlet_moment_denominator(alphas: &[Expr]) -> Expr {
   let total = dirichlet_total(alphas);
-  times(
+  times2(
     pow2(total.clone(), int(-2)),
     pow2(plus2(int(1), total), int(-1)),
   )
@@ -10284,7 +10315,7 @@ pub fn dirichlet_mean_variance(
   let mut means = Vec::with_capacity(alphas.len() - 1);
   let mut variances = Vec::with_capacity(alphas.len() - 1);
   for (i, alpha_i) in alphas.iter().enumerate().take(alphas.len() - 1) {
-    means.push(eval(times(alpha_i.clone(), pow2(total.clone(), int(-1))))?);
+    means.push(eval(times2(alpha_i.clone(), pow2(total.clone(), int(-1))))?);
     let others = call(
       "Plus",
       alphas
@@ -10294,7 +10325,10 @@ pub fn dirichlet_mean_variance(
         .map(|(_, a)| a.clone())
         .collect::<Vec<_>>(),
     );
-    variances.push(eval(times(times(alpha_i.clone(), others), denom.clone()))?);
+    variances.push(eval(times2(
+      times2(alpha_i.clone(), others),
+      denom.clone(),
+    ))?);
   }
   Ok((Expr::List(means.into()), Expr::List(variances.into())))
 }
@@ -10315,13 +10349,13 @@ pub fn dirichlet_covariance(dargs: &[Expr]) -> Result<Expr, InterpreterError> {
     for j in 0..k {
       let numer = if i == j {
         plus2(
-          times(int(-1), pow2(alphas[i].clone(), int(2))),
-          times(alphas[i].clone(), total.clone()),
+          times2(int(-1), pow2(alphas[i].clone(), int(2))),
+          times2(alphas[i].clone(), total.clone()),
         )
       } else {
-        times(int(-1), times(alphas[i].clone(), alphas[j].clone()))
+        times2(int(-1), times2(alphas[i].clone(), alphas[j].clone()))
       };
-      row.push(eval(times(numer, denom.clone()))?);
+      row.push(eval(times2(numer, denom.clone()))?);
     }
     rows.push(Expr::List(row.into()));
   }
@@ -10358,18 +10392,18 @@ fn pdf_dirichlet(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // x1^(α1-1) ⋯ xk^(αk-1) (1-Σxi)^(α(k+1)-1) · Gamma[α0] / ∏ Gamma[αi]
   let mut value = pow2(xs[0].clone(), minus2(alphas[0].clone(), int(1)));
   for (xi, alpha_i) in xs.iter().zip(alphas.iter()).skip(1) {
-    value = times(value, pow2(xi.clone(), minus2(alpha_i.clone(), int(1))));
+    value = times2(value, pow2(xi.clone(), minus2(alpha_i.clone(), int(1))));
   }
-  value = times(
+  value = times2(
     value,
     pow2(
       last.clone(),
       minus2(alphas[alphas.len() - 1].clone(), int(1)),
     ),
   );
-  value = times(value, gamma(dirichlet_total(&alphas)));
+  value = times2(value, gamma(dirichlet_total(&alphas)));
   for alpha_i in alphas.iter() {
-    value = times(value, pow2(gamma(alpha_i.clone()), int(-1)));
+    value = times2(value, pow2(gamma(alpha_i.clone()), int(-1)));
   }
 
   // x1 > 0 && … && xk > 0 && 1 - Σxi > 0 (the open simplex).
@@ -10401,7 +10435,7 @@ fn pdf_negative_binomial(
   let n_minus_1 = plus2(int(-1), n.clone());
   let k_plus_n_minus_1 = call("Plus", vec![int(-1), x.clone(), n.clone()]);
   let binom = call("Binomial", vec![k_plus_n_minus_1, n_minus_1]);
-  let pdf_val = times(times(pow2(one_minus_p, x.clone()), pow2(p, n)), binom);
+  let pdf_val = times2(times2(pow2(one_minus_p, x.clone()), pow2(p, n)), binom);
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
   eval(piecewise(vec![(pdf_val, cond)], int(0)))
 }
@@ -10415,9 +10449,9 @@ fn pdf_half_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let t = dargs[0].clone();
   // (2*t) / (E^((t^2 * x^2) / Pi) * Pi)
-  let numerator = times(int(2), t.clone());
-  let exponent = div2(times(pow2(t, int(2)), pow2(x.clone(), int(2))), pi());
-  let denominator = times(pow2(e(), exponent), pi());
+  let numerator = times2(int(2), t.clone());
+  let exponent = div2(times2(pow2(t, int(2)), pow2(x.clone(), int(2))), pi());
+  let denominator = times2(pow2(e(), exponent), pi());
   let pdf_val = div2(numerator, denominator);
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(pdf_val, cond)], int(0)))
@@ -10431,7 +10465,7 @@ fn cdf_half_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     ));
   }
   let t = dargs[0].clone();
-  let erf_arg = div2(times(t, x.clone()), sqrt(pi()));
+  let erf_arg = div2(times2(t, x.clone()), sqrt(pi()));
   let erf_val = call("Erf", vec![erf_arg]);
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(erf_val, cond)], int(0)))
@@ -10453,7 +10487,7 @@ fn pdf_chi(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let exp_part = pow2(e(), div2(pow2(x.clone(), int(2)), int(2)));
   // Gamma[n/2]
   let gamma_part = call("Gamma", vec![div2(n, int(2))]);
-  let pdf_val = eval(div2(times(exp2, x_pow), times(exp_part, gamma_part)))?;
+  let pdf_val = eval(div2(times2(exp2, x_pow), times2(exp_part, gamma_part)))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(pdf_val, cond)], int(0)))
 }
@@ -10521,13 +10555,13 @@ fn pdf_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   {
     let diff = minus2(x, mu);
     let numer = sigma.clone();
-    let denom = times(pi(), plus2(pow2(sigma, int(2)), pow2(diff, int(2))));
+    let denom = times2(pi(), plus2(pow2(sigma, int(2)), pow2(diff, int(2))));
     return eval(div2(numer, denom));
   }
 
   // alpha=2: Normal(mu, sigma*Sqrt[2])
   if matches!(&alpha_eval, Expr::Integer(2)) {
-    let s = times(sigma, sqrt(int(2)));
+    let s = times2(sigma, sqrt(int(2)));
     let cauchy_args = vec![mu, s];
     return pdf_normal(&cauchy_args, x);
   }
@@ -10577,7 +10611,7 @@ fn cdf_stable(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   // alpha=2: Normal CDF
   if matches!(&alpha_eval, Expr::Integer(2)) {
-    let s = times(sigma, sqrt(int(2)));
+    let s = times2(sigma, sqrt(int(2)));
     let normal_args = vec![mu, s];
     return cdf_normal(&normal_args, x);
   }
@@ -10608,9 +10642,9 @@ fn pdf_arcsin(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // density = 1 / (Pi * Sqrt[(x - a) * (b - x)])
   let density = div2(
     int(1),
-    times(
+    times2(
       pi(),
-      sqrt(times(
+      sqrt(times2(
         minus2(x.clone(), a.clone()),
         minus2(b.clone(), x.clone()),
       )),
@@ -10647,7 +10681,7 @@ fn pdf_pascal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // (1-p)^(k-n)
   let one_minus_p_k_n = pow2(minus2(int(1), p), minus2(x.clone(), n.clone()));
 
-  let density = times(times(binom, p_n), one_minus_p_k_n);
+  let density = times2(times2(binom, p_n), one_minus_p_k_n);
 
   // k >= n
   let cond = call("GreaterEqual", vec![x, n]);
@@ -10668,12 +10702,12 @@ fn pdf_dagum(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let b = dargs[2].clone();
 
   // a*p * x^(a*p - 1) * (1 + (x/b)^a)^(-1-p) / b^(a*p)
-  let ap = times(a.clone(), p.clone());
+  let ap = times2(a.clone(), p.clone());
   let x_to_ap_minus_1 = pow2(x.clone(), minus2(ap.clone(), int(1)));
   let x_over_b_to_a = pow2(div2(x.clone(), b.clone()), a.clone());
   let bracket = pow2(plus2(int(1), x_over_b_to_a), minus2(int(-1), p));
   let b_to_ap = pow2(b, ap.clone());
-  let density = div2(times(times(ap, x_to_ap_minus_1), bracket), b_to_ap);
+  let density = div2(times2(times2(ap, x_to_ap_minus_1), bracket), b_to_ap);
 
   // x > 0
   let cond = call("Greater", vec![x, int(0)]);
@@ -10702,18 +10736,18 @@ fn pdf_hyperbolic(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   // numerator: Sqrt[a^2 - b^2] * E^(b*(x-m) - a*Sqrt[d^2 + (x-m)^2])
   let exponent = minus2(
-    times(b, x_minus_m.clone()),
-    times(
+    times2(b, x_minus_m.clone()),
+    times2(
       a.clone(),
       sqrt(plus2(pow2(d.clone(), int(2)), pow2(x_minus_m, int(2)))),
     ),
   );
-  let numerator = times(sqrt_a2_minus_b2.clone(), pow2(e(), exponent));
+  let numerator = times2(sqrt_a2_minus_b2.clone(), pow2(e(), exponent));
 
   // denominator: 2*a*d*BesselK[1, Sqrt[a^2-b^2]*d]
-  let denominator = times(
-    times(int(2), times(a, d.clone())),
-    besselk(int(1), times(sqrt_a2_minus_b2, d)),
+  let denominator = times2(
+    times2(int(2), times2(a, d.clone())),
+    besselk(int(1), times2(sqrt_a2_minus_b2, d)),
   );
 
   eval(div2(numerator, denominator))
@@ -10746,24 +10780,30 @@ fn pdf_noncentral_f(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let n_half = pow2(n.clone(), half(n.clone()));
   let x_pow = pow2(x.clone(), half(plus2(int(-2), n.clone())));
   let bracket = pow2(
-    plus2(m.clone(), times(n.clone(), x.clone())),
-    half(plus2(times(int(-1), m.clone()), times(int(-1), n.clone()))),
+    plus2(m.clone(), times2(n.clone(), x.clone())),
+    half(plus2(
+      times2(int(-1), m.clone()),
+      times2(int(-1), n.clone()),
+    )),
   );
   let hyp = hyp1f1(
     half(plus2(m.clone(), n.clone())),
     half(n.clone()),
     div2(
-      times(times(l.clone(), n), x.clone()),
-      times(int(2), plus2(m.clone(), times(dargs[0].clone(), x.clone()))),
+      times2(times2(l.clone(), n), x.clone()),
+      times2(
+        int(2),
+        plus2(m.clone(), times2(dargs[0].clone(), x.clone())),
+      ),
     ),
   );
 
   let numerator =
-    times(times(times(m_half, n_half), times(x_pow, bracket)), hyp);
+    times2(times2(times2(m_half, n_half), times2(x_pow, bracket)), hyp);
 
   // denominator: E^(l/2) * Beta[n/2, m/2]
   let denominator =
-    times(pow2(e(), half(l)), beta(half(dargs[0].clone()), half(m)));
+    times2(pow2(e(), half(l)), beta(half(dargs[0].clone()), half(m)));
 
   let density = div2(numerator, denominator);
 
@@ -10802,14 +10842,14 @@ fn pdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       // where z = gamma + delta*(-mu + x)/sigma
       let z = plus2(
         gamma,
-        div2(times(delta.clone(), neg_mu_plus_x), sigma.clone()),
+        div2(times2(delta.clone(), neg_mu_plus_x), sigma.clone()),
       );
       let density = div2(
         delta,
-        times(
-          times(
+        times2(
+          times2(
             pow2(e(), div2(pow2(z, int(2)), int(2))),
-            sqrt(times(int(2), pi())),
+            sqrt(times2(int(2), pi())),
           ),
           sigma,
         ),
@@ -10820,13 +10860,13 @@ fn pdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       // PDF = delta / (E^(z^2/2) * Sqrt[2*Pi] * (-mu + x))
       // where z = gamma + delta*Log[(-mu + x)/sigma], for x > mu
       let log_t = call("Log", vec![div2(neg_mu_plus_x.clone(), sigma)]);
-      let z = plus2(gamma, times(delta.clone(), log_t));
+      let z = plus2(gamma, times2(delta.clone(), log_t));
       let density = div2(
         delta,
-        times(
-          times(
+        times2(
+          times2(
             pow2(e(), div2(pow2(z, int(2)), int(2))),
-            sqrt(times(int(2), pi())),
+            sqrt(times2(int(2), pi())),
           ),
           neg_mu_plus_x,
         ),
@@ -10839,13 +10879,13 @@ fn pdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       // where z = gamma + delta*ArcSinh[(-mu + x)/sigma]
       let arcsinh_t =
         call("ArcSinh", vec![div2(neg_mu_plus_x.clone(), sigma.clone())]);
-      let z = plus2(gamma, times(delta.clone(), arcsinh_t));
+      let z = plus2(gamma, times2(delta.clone(), arcsinh_t));
       let density = div2(
         delta,
-        times(
-          times(
+        times2(
+          times2(
             pow2(e(), div2(pow2(z, int(2)), int(2))),
-            sqrt(times(int(2), pi())),
+            sqrt(times2(int(2), pi())),
           ),
           sqrt(plus2(pow2(sigma, int(2)), pow2(neg_mu_plus_x, int(2)))),
         ),
@@ -10859,15 +10899,15 @@ fn pdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
         plus2(plus2(mu.clone(), sigma.clone()), neg1(x.clone()));
       let log_arg = div2(neg_mu_plus_x.clone(), mu_plus_sigma_minus_x.clone());
       let log_t = call("Log", vec![log_arg]);
-      let z = plus2(gamma, times(delta.clone(), log_t));
+      let z = plus2(gamma, times2(delta.clone(), log_t));
       let density = div2(
-        times(delta, sigma.clone()),
-        times(
-          times(
+        times2(delta, sigma.clone()),
+        times2(
+          times2(
             pow2(e(), div2(pow2(z, int(2)), int(2))),
-            sqrt(times(int(2), pi())),
+            sqrt(times2(int(2), pi())),
           ),
-          times(mu_plus_sigma_minus_x, neg_mu_plus_x),
+          times2(mu_plus_sigma_minus_x, neg_mu_plus_x),
         ),
       );
       let cond = comparison3(
@@ -10938,12 +10978,12 @@ fn cdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   // Distribute negative sign: (-gamma - delta*h) / Sqrt[2]
   let neg_gamma = neg1(gamma.clone());
-  let neg_delta_h = neg1(times(delta.clone(), h_of_t.clone()));
+  let neg_delta_h = neg1(times2(delta.clone(), h_of_t.clone()));
   let erfc_arg = div2(plus2(neg_gamma, neg_delta_h), sqrt(int(2)));
   let cdf_val = div2(call("Erfc", vec![erfc_arg]), int(2));
 
   // Also build (1 + Erf[(gamma + delta*h) / Sqrt[2]]) / 2 form (used by Wolfram for some types)
-  let erf_arg = div2(plus2(gamma, times(delta, h_of_t)), sqrt(int(2)));
+  let erf_arg = div2(plus2(gamma, times2(delta, h_of_t)), sqrt(int(2)));
   let cdf_erf = div2(plus2(int(1), call("Erf", vec![erf_arg])), int(2));
 
   match type_str.as_str() {
@@ -11166,8 +11206,8 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ("ExponentialDistribution", [a]) => {
       let total = sum_expr()?;
       eval(plus2(
-        times(int(-1), times(total, a.clone())),
-        times(int(n), log_of(a.clone())),
+        times2(int(-1), times2(total, a.clone())),
+        times2(int(n), log_of(a.clone())),
       ))
     }
     // -n*m + Sum[x]*Log[m] - Sum[Log[x!]]
@@ -11180,11 +11220,11 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
       let total = sum_expr()?;
       let mut terms =
-        vec![times(int(-n), m.clone()), times(total, log_of(m.clone()))];
+        vec![times2(int(-n), m.clone()), times2(total, log_of(m.clone()))];
       for x in data {
         let fact = eval(factorial(x.clone()))?;
         if !matches!(fact, Expr::Integer(1)) {
-          terms.push(times(int(-1), log_of(fact)));
+          terms.push(times2(int(-1), log_of(fact)));
         }
       }
       eval(call("Plus", terms))
@@ -11206,12 +11246,12 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Evaluate each term individually but keep the raw Plus order
       // (Log[1 - p] first): full evaluation reorders the sum away from
       // wolframscript's Log[1 - p] + 3*Log[p] / -Log[3/2] - 3*Log[3]
-      let log_q = eval(log_of(plus2(int(1), times(int(-1), p.clone()))))?;
+      let log_q = eval(log_of(plus2(int(1), times2(int(-1), p.clone()))))?;
       let log_p = eval(log_of(p.clone()))?;
       let term = |c: i128, l: Expr| -> Result<Expr, InterpreterError> {
         match c {
           1 => Ok(l),
-          c => eval(times(int(c), l)),
+          c => eval(times2(int(c), l)),
         }
       };
       Ok(match (zeros, ones) {
@@ -11235,21 +11275,21 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "Plus",
         data
           .iter()
-          .map(|x| times(x.clone(), x.clone()))
+          .map(|x| times2(x.clone(), x.clone()))
           .collect::<Vec<_>>(),
       ))?;
       let total = sum_expr()?;
       let poly = plus2(
-        plus2(sq_total, times(times(int(-2), total), m.clone())),
-        times(int(n), times(m.clone(), m.clone())),
+        plus2(sq_total, times2(times2(int(-2), total), m.clone())),
+        times2(int(n), times2(m.clone(), m.clone())),
       );
       let half_log_2pi = div2(plus2(log_of(int(2)), log_of(pi())), int(2));
       let result = plus2(
-        times(
+        times2(
           make_rational(-1, 2),
-          div2(poly, times(s.clone(), s.clone())),
+          div2(poly, times2(s.clone(), s.clone())),
         ),
-        times(int(-n), plus2(half_log_2pi, log_of(s.clone()))),
+        times2(int(-n), plus2(half_log_2pi, log_of(s.clone()))),
       );
       eval(result)
     }
@@ -11304,7 +11344,7 @@ fn extract_polynomial_in_var(
       }
       _ if !contains_variable(&rest, var) => {
         // Fully constant term: fold rest into the coefficient
-        out.push((0, times(c, rest.clone())));
+        out.push((0, times2(c, rest.clone())));
         continue;
       }
       _ => return None,
@@ -11358,7 +11398,7 @@ fn distribution_raw_moment(
           e => Some(pow2(base.clone(), int(e))),
         };
         match (pow_of(&a, i), pow_of(&b, k - i)) {
-          (Some(x), Some(y)) => times(x, y),
+          (Some(x), Some(y)) => times2(x, y),
           (Some(x), None) => x,
           (None, Some(y)) => y,
           (None, None) => int(1),
@@ -11388,23 +11428,23 @@ fn distribution_raw_moment(
             eval(plus2(pow2(s.clone(), int(2)), pow2(m.clone(), int(2)))).ok()
           }
           // m*(m^2 + 3*s^2), kept raw so Times isn't distributed
-          3 => Some(times(
+          3 => Some(times2(
             m.clone(),
             plus2(
               pow2(m.clone(), int(2)),
-              times(int(3), pow2(s.clone(), int(2))),
+              times2(int(3), pow2(s.clone(), int(2))),
             ),
           )),
           // m^4 + 6*m^2*s^2 + 3*s^4
           4 => Some(plus2(
             plus2(
               pow2(m.clone(), int(4)),
-              times(
+              times2(
                 int(6),
-                times(pow2(m.clone(), int(2)), pow2(s.clone(), int(2))),
+                times2(pow2(m.clone(), int(2)), pow2(s.clone(), int(2))),
               ),
             ),
-            times(int(3), pow2(s.clone(), int(4))),
+            times2(int(3), pow2(s.clone(), int(4))),
           )),
           // General order: E[X^k] = Σ_{j even} C(k,j) (j-1)!! m^(k-j) s^j.
           // wolframscript factors out m for odd k (every m-power is odd) and
@@ -11454,7 +11494,7 @@ fn distribution_raw_moment(
             } else {
               call("Plus", terms)
             };
-            Some(if odd { times(m.clone(), inner) } else { inner })
+            Some(if odd { times2(m.clone(), inner) } else { inner })
           }
         };
       }
@@ -11505,15 +11545,15 @@ fn distribution_raw_moment(
     "LogNormalDistribution" if dargs.len() == 2 => {
       let (m, s) = (dargs[0].clone(), dargs[1].clone());
       let exponent = plus2(
-        times(int(k), m),
-        div2(times(int(k * k), pow2(s, int(2))), int(2)),
+        times2(int(k), m),
+        div2(times2(int(k * k), pow2(s, int(2))), int(2)),
       );
       eval(pow2(e(), exponent)).ok()
     }
     // E[x^k] = b^k Gamma[1 + k/a]
     "WeibullDistribution" if dargs.len() == 2 => {
       let (a, b) = (dargs[0].clone(), dargs[1].clone());
-      let result = times(
+      let result = times2(
         pow2(b.clone(), int(k)),
         call("Gamma", vec![plus2(int(1), div2(int(k), a.clone()))]),
       );
@@ -11529,7 +11569,7 @@ fn distribution_raw_moment(
     "HalfNormalDistribution" if dargs.len() == 1 => {
       let t = dargs[0].clone();
       let result = div2(
-        times(
+        times2(
           pow2(pi(), div2(int(k - 1), int(2))),
           call("Gamma", vec![div2(int(k + 1), int(2))]),
         ),
@@ -11555,7 +11595,7 @@ fn distribution_raw_moment(
             1 => mu.clone(),
             j => pow2(mu.clone(), int(j as i128)),
           };
-          if c == 1 { p } else { times(int(c), p) }
+          if c == 1 { p } else { times2(int(c), p) }
         })
         .collect();
       eval(call("Plus", terms)).ok()
@@ -11600,7 +11640,7 @@ fn polynomial_expectation(
   let mut terms: Vec<Expr> = Vec::with_capacity(poly.len());
   for (k, c) in &poly {
     let moment = distribution_raw_moment(dist_name, dargs, *k)?;
-    terms.push(times(c.clone(), moment));
+    terms.push(times2(c.clone(), moment));
   }
   eval(call("Plus", terms)).ok()
 }
@@ -11670,14 +11710,14 @@ pub fn transformed_distribution_ast(
   let dist_call = |name: &str, params: Vec<Expr>| call(name, params);
   let linear = |e: &Expr| -> Result<Expr, InterpreterError> {
     // a*e + b
-    eval(plus2(times(a.clone(), e.clone()), b.clone()))
+    eval(plus2(times2(a.clone(), e.clone()), b.clone()))
   };
 
   match (dist_name, dargs) {
     ("NormalDistribution", [m, s]) => {
       let new_m = linear(m)?;
       let abs_a = frac_to_rational_expr((af.0.abs(), af.1));
-      let new_s = eval(times(abs_a, s.clone()))?;
+      let new_s = eval(times2(abs_a, s.clone()))?;
       Ok(dist_call("NormalDistribution", vec![new_m, new_s]))
     }
     ("NormalDistribution", []) => {
@@ -11699,7 +11739,7 @@ pub fn transformed_distribution_ast(
       Ok(dist_call("ExponentialDistribution", vec![new_l]))
     }
     ("GammaDistribution", [al, be]) if a_positive && bf.0 == 0 => {
-      let new_be = eval(times(a.clone(), be.clone()))?;
+      let new_be = eval(times2(a.clone(), be.clone()))?;
       Ok(dist_call("GammaDistribution", vec![al.clone(), new_be]))
     }
     _ => Ok(unevaluated(args)),
@@ -11764,7 +11804,7 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     if matches!(&mu[i], Expr::Integer(0)) {
       Ok(vars[i].clone())
     } else {
-      eval(plus2(times(int(-1), mu[i].clone()), vars[i].clone()))
+      eval(plus2(times2(int(-1), mu[i].clone()), vars[i].clone()))
     }
   };
 
@@ -11776,7 +11816,7 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       neg1(sq)
     } else if !first_scaled_seen {
       first_scaled_seen = true;
-      times(make_rational(-1, variances[i]), sq)
+      times2(make_rational(-1, variances[i]), sq)
     } else {
       neg1(div2(sq, int(variances[i])))
     };
@@ -11791,7 +11831,7 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     // 2*Pi, 2*Sqrt[det]*Pi, or (2*sqrt)*Pi when det is a perfect square
     let sqrt_det = eval(call("Sqrt", vec![int(det)]))?;
     match &sqrt_det {
-      Expr::Integer(s) => times(int(2 * s), pi()),
+      Expr::Integer(s) => times2(int(2 * s), pi()),
       _ => call("Times", vec![int(2), sqrt_det, pi()]),
     }
   } else {
@@ -12161,7 +12201,7 @@ fn histogram_pdf_cdf(
         let ramp_offset = if is_zero(&lo) {
           x.clone()
         } else {
-          call("Plus", vec![eval(times(int(-1), lo.clone()))?, x.clone()])
+          call("Plus", vec![eval(times2(int(-1), lo.clone()))?, x.clone()])
         };
         // (cum + w·(x - lo))·Boole[…]; the first bin has no accumulated mass.
         terms.push(if is_zero(&cum) {
@@ -12178,7 +12218,7 @@ fn histogram_pdf_cdf(
             ],
           )
         });
-        cum = eval(plus2(cum, times(w.clone(), minus2(hi, lo))))?;
+        cum = eval(plus2(cum, times2(w.clone(), minus2(hi, lo))))?;
       } else {
         terms.push(call("Times", vec![w.clone(), boole(cond)]));
       }
@@ -12423,7 +12463,7 @@ fn pdf_product_distribution(
         let sq = square(v);
         terms.push(if !first_scaled_seen {
           first_scaled_seen = true;
-          times(make_rational(-1, 2), sq)
+          times2(make_rational(-1, 2), sq)
         } else {
           neg1(div2(sq, int(2)))
         });
@@ -12433,7 +12473,7 @@ fn pdf_product_distribution(
         terms.push(if *l == 1 {
           neg1(v.clone())
         } else {
-          times(int(-l), v.clone())
+          times2(int(-l), v.clone())
         });
         conds.push(Expr::Comparison {
           operands: vec![v, int(0)],
@@ -12451,7 +12491,7 @@ fn pdf_product_distribution(
       if rate_product == 1 {
         e_pow
       } else {
-        times(int(rate_product), e_pow)
+        times2(int(rate_product), e_pow)
       }
     }
     1 => {
@@ -12459,12 +12499,12 @@ fn pdf_product_distribution(
         // 2/Sqrt[2*Pi] folds to Sqrt[2/Pi], printed as a postfix factor
         call("Times", vec![e_pow, sqrt(div2(int(2), pi()))])
       } else if rate_product == 1 {
-        div2(e_pow, sqrt(times(int(2), pi())))
+        div2(e_pow, sqrt(times2(int(2), pi())))
       } else {
-        div2(times(int(rate_product), e_pow), sqrt(times(int(2), pi())))
+        div2(times2(int(rate_product), e_pow), sqrt(times2(int(2), pi())))
       }
     }
-    _ => div2(e_pow, times(int(2), pi())),
+    _ => div2(e_pow, times2(int(2), pi())),
   };
 
   if conds.is_empty() {
@@ -12646,7 +12686,7 @@ fn pdf_uniform_sum(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // Numeric point: evaluate the inclusion-exclusion sum directly
   if let Some(j) = numeric_floor(&x) {
     if j < 0 || j >= n {
-      return eval(times(int(0), x)); // 0 or 0. matching x's exactness
+      return eval(times2(int(0), x)); // 0 or 0. matching x's exactness
     }
     let piece = inclusion_exclusion_piece(n, j, n - 1, fact(n - 1), &x, false);
     return eval(piece);
@@ -12710,10 +12750,10 @@ fn cdf_uniform_sum(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   if let Some(j) = numeric_floor(&x) {
     if j < 0 {
-      return eval(times(int(0), x));
+      return eval(times2(int(0), x));
     }
     if j >= n {
-      return eval(plus2(int(1), times(int(0), x)));
+      return eval(plus2(int(1), times2(int(0), x)));
     }
     let piece = inclusion_exclusion_piece(n, j, n, fact(n), &x, false);
     return eval(piece);
@@ -12961,11 +13001,11 @@ fn beta_prime_general_body(
   x: &Expr,
 ) -> Result<Expr, InterpreterError> {
   let xs = div2(x.clone(), s.clone());
-  let x_pow = pow2(xs.clone(), plus2(int(-1), times(w.clone(), p.clone())));
-  let neg_pq = plus2(times(int(-1), p.clone()), times(int(-1), q.clone()));
+  let x_pow = pow2(xs.clone(), plus2(int(-1), times2(w.clone(), p.clone())));
+  let neg_pq = plus2(times2(int(-1), p.clone()), times2(int(-1), q.clone()));
   let bracket = pow2(plus2(int(1), pow2(xs, w.clone())), neg_pq);
-  let num = times(w.clone(), times(x_pow, bracket));
-  let den = times(s.clone(), call("Beta", vec![p.clone(), q.clone()]));
+  let num = times2(w.clone(), times2(x_pow, bracket));
+  let den = times2(s.clone(), call("Beta", vec![p.clone(), q.clone()]));
   eval(div2(num, den))
 }
 
@@ -13183,7 +13223,7 @@ fn pdf_noncentral_chi_square(
   // E^((-l - x)/2)
   let e_part = |at: &Expr| -> Result<Expr, InterpreterError> {
     let inner = eval(div2(
-      plus2(times(int(-1), lam.clone()), times(int(-1), at.clone())),
+      plus2(times2(int(-1), lam.clone()), times2(int(-1), at.clone())),
       int(2),
     ))?;
     Ok(pow2(e(), inner))
@@ -13242,7 +13282,7 @@ fn pdf_noncentral_chi_square(
           "Hypergeometric0F1Regularized",
           vec![
             int(v / 2),
-            eval(div2(times(lam.clone(), at.clone()), int(4)))?,
+            eval(div2(times2(lam.clone(), at.clone()), int(4)))?,
           ],
         ));
         Ok(Some(raw_div(
@@ -13252,7 +13292,7 @@ fn pdf_noncentral_chi_square(
       }
       Some(1) if numeric_lam => {
         // Cosh[Sqrt[l] Sqrt[x]] / (Sqrt[2 Pi] Sqrt[x])
-        let arg = eval(times(sqrt(lam.clone()), sqrt(at.clone())))?;
+        let arg = eval(times2(sqrt(lam.clone()), sqrt(at.clone())))?;
         Ok(Some(raw_div(
           call("Times", vec![e_part(at)?, call("Cosh", vec![arg])]),
           call(
@@ -13263,8 +13303,8 @@ fn pdf_noncentral_chi_square(
       }
       Some(3) if numeric_lam => {
         // Sinh[Sqrt[l] Sqrt[x]] / Sqrt[2 l Pi]
-        let arg = eval(times(sqrt(lam.clone()), sqrt(at.clone())))?;
-        let den = eval(sqrt(times(times(int(2), lam.clone()), pi())))?;
+        let arg = eval(times2(sqrt(lam.clone()), sqrt(at.clone())))?;
+        let den = eval(sqrt(times2(times2(int(2), lam.clone()), pi())))?;
         Ok(Some(raw_div(
           call("Times", vec![e_part(at)?, call("Sinh", vec![arg])]),
           den,
@@ -13284,7 +13324,7 @@ fn pdf_noncentral_chi_square(
                 "Hypergeometric0F1Regularized",
                 vec![
                   half_nu.clone(),
-                  raw_div(times(lam.clone(), at.clone()), int(4)),
+                  raw_div(times2(lam.clone(), at.clone()), int(4)),
                 ],
               ),
             ],
@@ -13485,7 +13525,7 @@ fn cdf_exponential_power(
     vec![m.clone(), call("Times", vec![int(-1), x.clone()])],
   );
   let piece = half_reg(diff_minus)?;
-  let default = eval(plus2(int(1), times(int(-1), half_reg(diff_plus)?)))?;
+  let default = eval(plus2(int(1), times2(int(-1), half_reg(diff_plus)?)))?;
   let cond = comparison(x, ComparisonOp::Less, m);
   Ok(piecewise(vec![(piece, cond)], default))
 }
@@ -13531,7 +13571,7 @@ fn pdf_rice(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       ),
       call("Times", vec![int(2), square(&b)]),
     );
-    let bessel_arg = eval(div2(times(a.clone(), at.clone()), square(&b)))?;
+    let bessel_arg = eval(div2(times2(a.clone(), at.clone()), square(&b)))?;
     eval(div2(
       call(
         "Times",
@@ -13610,7 +13650,7 @@ pub fn rice_mean_variance(
     // k = a^2/(2 b^2) as an exact fraction p/q; wolframscript pulls
     // the common denominator out of the Bessel sum:
     // sum = (q + p) I_0(k/2) + p I_1(k/2), all integer coefficients
-    let k = eval(div2(square(a), times(int(2), square(b))))?;
+    let k = eval(div2(square(a), times2(int(2), square(b))))?;
     let (pn, qd) = match &k {
       Expr::Integer(v) => (*v, 1i128),
       Expr::FunctionCall { name, args } if name == "Rational" => {
@@ -13629,7 +13669,7 @@ pub fn rice_mean_variance(
         let laguerre = call(
           "Times",
           vec![
-            pow2(e(), eval(times(int(-1), half_k.clone()))?),
+            pow2(e(), eval(times2(int(-1), half_k.clone()))?),
             call(
               "Plus",
               vec![
@@ -13655,7 +13695,7 @@ pub fn rice_mean_variance(
         let var = eval(call(
           "Plus",
           vec![
-            eval(plus2(square(a), times(int(2), square(b))))?,
+            eval(plus2(square(a), times2(int(2), square(b))))?,
             call(
               "Times",
               vec![
@@ -13673,11 +13713,11 @@ pub fn rice_mean_variance(
     };
     if pn == 0 {
       // Rayleigh case: mean = b Sqrt[Pi/2], var = 2 b^2 - pi b^2/2
-      let mean = eval(times(b.clone(), sqrt_half_pi.clone()))?;
+      let mean = eval(times2(b.clone(), sqrt_half_pi.clone()))?;
       let var = eval(call(
         "Plus",
         vec![
-          times(int(2), square(b)),
+          times2(int(2), square(b)),
           call(
             "Times",
             vec![int(-1), div2(call("Times", vec![pi(), square(b)]), int(2))],
@@ -13720,7 +13760,7 @@ pub fn rice_mean_variance(
     let denominator = if rd == 1 {
       eval(e_half)?
     } else {
-      eval(times(int(rd), e_half))?
+      eval(times2(int(rd), e_half))?
     };
     // Single-factor denominators print without parentheses
     let den_str = expr_to_string(&denominator);
@@ -13732,9 +13772,9 @@ pub fn rice_mean_variance(
     let mean =
       Expr::Raw(format!("({})/{}", expr_to_string(&numerator), den_str));
     // Var = base - Pi sum^2 / (q^2 2 e^k / b^2)
-    let base = eval(plus2(square(a), times(int(2), square(b))))?;
+    let base = eval(plus2(square(a), times2(int(2), square(b))))?;
     let denom = eval(div2(
-      times(int(2 * qd * qd), pow2(e(), k.clone())),
+      times2(int(2 * qd * qd), pow2(e(), k.clone())),
       square(b),
     ))?;
     let var = Expr::Raw(format!(
@@ -13768,7 +13808,7 @@ pub fn rice_mean_variance(
     "Plus",
     vec![
       square(a),
-      times(int(2), square(b)),
+      times2(int(2), square(b)),
       call(
         "Times",
         vec![
@@ -14068,7 +14108,7 @@ fn min_stable_mean_variance(
   let mean_gumbel = || {
     plus2(
       a.clone(),
-      times(int(-1), times(b.clone(), euler_gamma.clone())),
+      times2(int(-1), times2(b.clone(), euler_gamma.clone())),
     )
   };
   let var_gumbel = || {
@@ -14167,7 +14207,7 @@ fn min_stable_mean_variance(
               vec![
                 comparison(g.clone(), ComparisonOp::NotEqual, int(0)),
                 comparison(
-                  times(int(2), g.clone()),
+                  times2(int(2), g.clone()),
                   ComparisonOp::Less,
                   int(1),
                 ),
@@ -14424,7 +14464,7 @@ fn max_stable_mean_variance(
   g: &Expr,
 ) -> Result<(Expr, Expr), InterpreterError> {
   let euler_gamma = Expr::Identifier("EulerGamma".to_string());
-  let mean_gumbel = || plus2(a.clone(), times(b.clone(), euler_gamma.clone()));
+  let mean_gumbel = || plus2(a.clone(), times2(b.clone(), euler_gamma.clone()));
   let one_minus_g = call(
     "Plus",
     vec![int(1), call("Times", vec![int(-1), g.clone()])],
@@ -14530,16 +14570,16 @@ fn pdf_triangular(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     // Times[coef, factor] keeps the linear factor unexpanded
     let coef1 = eval(div2(
       int(2),
-      times(
-        plus2(b.clone(), times(int(-1), a.clone())),
-        plus2(c.clone(), times(int(-1), a.clone())),
+      times2(
+        plus2(b.clone(), times2(int(-1), a.clone())),
+        plus2(c.clone(), times2(int(-1), a.clone())),
       ),
     ))?;
     let coef2 = eval(div2(
       int(2),
-      times(
-        plus2(b.clone(), times(int(-1), a.clone())),
-        plus2(b.clone(), times(int(-1), c.clone())),
+      times2(
+        plus2(b.clone(), times2(int(-1), a.clone())),
+        plus2(b.clone(), times2(int(-1), c.clone())),
       ),
     ))?;
     (
@@ -14641,16 +14681,16 @@ fn cdf_triangular(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let (p1, p2) = if numeric {
     let coef1 = eval(div2(
       int(1),
-      times(
-        plus2(b.clone(), times(int(-1), a.clone())),
-        plus2(c.clone(), times(int(-1), a.clone())),
+      times2(
+        plus2(b.clone(), times2(int(-1), a.clone())),
+        plus2(c.clone(), times2(int(-1), a.clone())),
       ),
     ))?;
     let coef2 = eval(div2(
       int(1),
-      times(
-        plus2(b.clone(), times(int(-1), a.clone())),
-        plus2(b.clone(), times(int(-1), c.clone())),
+      times2(
+        plus2(b.clone(), times2(int(-1), a.clone())),
+        plus2(b.clone(), times2(int(-1), c.clone())),
       ),
     ))?;
     (
@@ -14772,10 +14812,10 @@ fn triangular_mean_variance(
         "Plus",
         vec![
           pow2(a.clone(), int(2)),
-          times(int(-1), times(a.clone(), b.clone())),
+          times2(int(-1), times2(a.clone(), b.clone())),
           pow2(b.clone(), int(2)),
-          times(int(-1), times(a.clone(), c.clone())),
-          times(int(-1), times(b.clone(), c.clone())),
+          times2(int(-1), times2(a.clone(), c.clone())),
+          times2(int(-1), times2(b.clone(), c.clone())),
           pow2(c, int(2)),
         ],
       ),
@@ -14814,7 +14854,7 @@ fn maxwell_term(
       den_factors.push(int(c));
     }
     den_factors.push(e_part);
-    den_factors.push(call("Sqrt", vec![times(int(2), pi())]));
+    den_factors.push(call("Sqrt", vec![times2(int(2), pi())]));
     div2(num_expr, call("Times", den_factors))
   } else {
     // (p Sqrt[2/Pi] num)/(m E-part)
@@ -14863,7 +14903,7 @@ fn pdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       e(),
       eval(div2(
         pow2(at.clone(), int(2)),
-        times(int(2), pow2(s.clone(), int(2))),
+        times2(int(2), pow2(s.clone(), int(2))),
       ))?,
     );
     // Exact rational scale: 1/s^3 in wolframscript's canonical
@@ -14888,7 +14928,7 @@ fn pdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
             e(),
             div2(
               pow2(at.clone(), int(2)),
-              times(int(2), pow2(s.clone(), int(2))),
+              times2(int(2), pow2(s.clone(), int(2))),
             ),
           ),
           pow2(s.clone(), int(3)),
@@ -14931,7 +14971,7 @@ fn cdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
         e(),
         eval(div2(
           pow2(at.clone(), int(2)),
-          times(int(2), pow2(s.clone(), int(2))),
+          times2(int(2), pow2(s.clone(), int(2))),
         ))?,
       );
       let term1 = neg1(maxwell_term(sq, sp, at.clone(), e_part));
@@ -14960,7 +15000,7 @@ fn cdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
                     e(),
                     div2(
                       pow2(at.clone(), int(2)),
-                      times(int(2), pow2(s.clone(), int(2))),
+                      times2(int(2), pow2(s.clone(), int(2))),
                     ),
                   ),
                   s.clone(),
@@ -15014,20 +15054,23 @@ fn pdf_birnbaum_saunders(
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     // exponent (-1 + l at)^2 / (2 a^2 l at)
     let exponent = div2(
-      pow2(plus2(int(-1), times(l.clone(), at.clone())), int(2)),
-      times(
-        times(int(2), pow2(a.clone(), int(2))),
-        times(l.clone(), at.clone()),
+      pow2(plus2(int(-1), times2(l.clone(), at.clone())), int(2)),
+      times2(
+        times2(int(2), pow2(a.clone(), int(2))),
+        times2(l.clone(), at.clone()),
       ),
     );
-    let denom = times(
-      times(int(2), a.clone()),
-      times(
-        times(pow2(e(), exponent), call("Sqrt", vec![times(int(2), pi())])),
-        call("Sqrt", vec![times(l.clone(), pow2(at.clone(), int(3)))]),
+    let denom = times2(
+      times2(int(2), a.clone()),
+      times2(
+        times2(
+          pow2(e(), exponent),
+          call("Sqrt", vec![times2(int(2), pi())]),
+        ),
+        call("Sqrt", vec![times2(l.clone(), pow2(at.clone(), int(3)))]),
       ),
     );
-    eval(div2(plus2(int(1), times(l.clone(), at.clone())), denom))
+    eval(div2(plus2(int(1), times2(l.clone(), at.clone())), denom))
   };
   if ms_numeric(&x).is_some() {
     if ms_numeric(&x).is_some_and(|v| v <= 0.0) {
@@ -15063,10 +15106,10 @@ fn cdf_birnbaum_saunders(
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     // Erf[(-1 + l at)/(Sqrt[2] a Sqrt[l at])]
     let erf_arg = div2(
-      plus2(int(-1), times(l.clone(), at.clone())),
-      times(
-        times(call("Sqrt", vec![int(2)]), a.clone()),
-        call("Sqrt", vec![times(l.clone(), at.clone())]),
+      plus2(int(-1), times2(l.clone(), at.clone())),
+      times2(
+        times2(call("Sqrt", vec![int(2)]), a.clone()),
+        call("Sqrt", vec![times2(l.clone(), at.clone())]),
       ),
     );
     eval(div2(plus2(int(1), call("Erf", vec![erf_arg])), int(2)))
@@ -15097,14 +15140,14 @@ fn pdf_levy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let m = dargs[0].clone();
   let s = dargs[1].clone();
-  let shift = |at: &Expr| plus2(times(int(-1), m.clone()), at.clone());
+  let shift = |at: &Expr| plus2(times2(int(-1), m.clone()), at.clone());
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     let sh = shift(at);
     let num = pow2(div2(s.clone(), sh.clone()), div2(int(3), int(2)));
-    let denom = times(
-      times(
-        pow2(e(), div2(s.clone(), times(int(2), sh))),
-        call("Sqrt", vec![times(int(2), pi())]),
+    let denom = times2(
+      times2(
+        pow2(e(), div2(s.clone(), times2(int(2), sh))),
+        call("Sqrt", vec![times2(int(2), pi())]),
       ),
       s.clone(),
     );
@@ -15136,7 +15179,7 @@ fn cdf_levy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let m = dargs[0].clone();
   let s = dargs[1].clone();
-  let shift = |at: &Expr| plus2(times(int(-1), m.clone()), at.clone());
+  let shift = |at: &Expr| plus2(times2(int(-1), m.clone()), at.clone());
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     let erfc_arg = div2(
       call("Sqrt", vec![div2(s.clone(), shift(at))]),
@@ -15169,10 +15212,10 @@ fn pdf_lindley(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let d = dargs[0].clone();
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
-    let num = times(pow2(d.clone(), int(2)), plus2(int(1), at.clone()));
-    let denom = times(
+    let num = times2(pow2(d.clone(), int(2)), plus2(int(1), at.clone()));
+    let denom = times2(
       plus2(int(1), d.clone()),
-      pow2(e(), times(d.clone(), at.clone())),
+      pow2(e(), times2(d.clone(), at.clone())),
     );
     eval(div2(num, denom))
   };
@@ -15202,10 +15245,10 @@ fn cdf_lindley(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let d = dargs[0].clone();
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     // 1 - (1 + d + d x)/((1 + d) E^(d x))
-    let num = plus2(plus2(int(1), d.clone()), times(d.clone(), at.clone()));
-    let denom = times(
+    let num = plus2(plus2(int(1), d.clone()), times2(d.clone(), at.clone()));
+    let denom = times2(
       plus2(int(1), d.clone()),
-      pow2(e(), times(d.clone(), at.clone())),
+      pow2(e(), times2(d.clone(), at.clone())),
     );
     eval(minus2(int(1), div2(num, denom)))
   };
@@ -15322,7 +15365,7 @@ fn pdf_wigner_semicircle(
   if !matches!(&x, Expr::Identifier(_)) {
     return Ok(unevaluated(dargs, x));
   }
-  let lo = eval(plus2(a.clone(), times(int(-1), r.clone())))?;
+  let lo = eval(plus2(a.clone(), times2(int(-1), r.clone())))?;
   let hi = eval(plus2(a.clone(), r.clone()))?;
   let cond =
     comparison3(lo, ComparisonOp::Less, x.clone(), ComparisonOp::Less, hi);
@@ -15415,7 +15458,7 @@ fn cdf_wigner_semicircle(
   if !matches!(&x, Expr::Identifier(_)) {
     return Ok(unevaluated(dargs, x));
   }
-  let lo = eval(plus2(a.clone(), times(int(-1), r.clone())))?;
+  let lo = eval(plus2(a.clone(), times2(int(-1), r.clone())))?;
   let hi = eval(plus2(a.clone(), r.clone()))?;
   let cond_in = comparison3(
     lo,
@@ -15465,7 +15508,7 @@ fn sech_arg(m: &Expr, s: &Expr, x: &Expr) -> Result<Expr, InterpreterError> {
   };
   eval(div2(
     call("Times", vec![pi(), diff]),
-    times(int(2), s.clone()),
+    times2(int(2), s.clone()),
   ))
 }
 
@@ -15481,7 +15524,7 @@ fn pdf_sech(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     return Ok(unevaluated(dargs, x));
   }
   let arg = sech_arg(&m, &s, &x)?;
-  eval(div2(call("Sech", vec![arg]), times(int(2), s)))
+  eval(div2(call("Sech", vec![arg]), times2(int(2), s)))
 }
 
 /// CDF[SechDistribution[m, s], x] =
@@ -15546,7 +15589,7 @@ fn pdf_moyal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
           "Plus",
           vec![m.clone(), call("Times", vec![int(-1), at.clone()])],
         ),
-        times(int(2), s.clone()),
+        times2(int(2), s.clone()),
       ))?;
       call(
         "Plus",
@@ -15563,7 +15606,7 @@ fn pdf_moyal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
         )
       };
       let z = eval(div2(diff.clone(), s.clone()))?;
-      let z_half = eval(div2(diff, times(int(2), s.clone())))?;
+      let z_half = eval(div2(diff, times2(int(2), s.clone())))?;
       call(
         "Plus",
         vec![
@@ -15582,7 +15625,7 @@ fn pdf_moyal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     }
     // wolframscript orders the numeric scale before Sqrt[2 Pi] but a
     // symbolic one after it
-    let sqrt_2pi = call("Sqrt", vec![times(int(2), pi())]);
+    let sqrt_2pi = call("Sqrt", vec![times2(int(2), pi())]);
     let den = if den_factors.is_empty() {
       sqrt_2pi
     } else if ms_numeric(&s).is_some() {
@@ -15620,7 +15663,7 @@ fn cdf_moyal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
         vec![call("Times", vec![int(-1), m.clone()]), at.clone()],
       )
     };
-    let z_half = eval(div2(diff, times(int(2), s.clone())))?;
+    let z_half = eval(div2(diff, times2(int(2), s.clone())))?;
     Ok(call(
       "Erfc",
       vec![div2(
@@ -15703,19 +15746,19 @@ fn pdf_borel_tanner(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       call(
         "Times",
         vec![
-          pow2(a.clone(), plus2(x.clone(), times(int(-1), n.clone()))),
+          pow2(a.clone(), plus2(x.clone(), times2(int(-1), n.clone()))),
           n.clone(),
           pow2(
             x.clone(),
-            plus2(plus2(x.clone(), times(int(-1), n.clone())), int(-1)),
+            plus2(plus2(x.clone(), times2(int(-1), n.clone())), int(-1)),
           ),
         ],
       ),
       call(
         "Times",
         vec![
-          pow2(e(), times(a.clone(), x.clone())),
-          factorial(plus2(x.clone(), times(int(-1), n.clone()))),
+          pow2(e(), times2(a.clone(), x.clone())),
+          factorial(plus2(x.clone(), times2(int(-1), n.clone()))),
         ],
       ),
     ));
@@ -15797,7 +15840,7 @@ fn pdf_borel_tanner(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     call(
       "Times",
       vec![
-        pow2(e(), eval(times(a.clone(), x.clone()))?),
+        pow2(e(), eval(times2(a.clone(), x.clone()))?),
         factorial(call("Plus", vec![neg_n_expr, x.clone()])),
       ],
     ),
@@ -15812,9 +15855,12 @@ fn borel_tanner_mean_variance(
   a: &Expr,
   n: &Expr,
 ) -> Result<(Expr, Expr), InterpreterError> {
-  let one_minus_a = plus2(int(1), times(int(-1), a.clone()));
+  let one_minus_a = plus2(int(1), times2(int(-1), a.clone()));
   let mean = eval(div2(n.clone(), one_minus_a.clone()))?;
-  let var = eval(div2(times(a.clone(), n.clone()), pow2(one_minus_a, int(3))))?;
+  let var = eval(div2(
+    times2(a.clone(), n.clone()),
+    pow2(one_minus_a, int(3)),
+  ))?;
   Ok((mean, var))
 }
 
@@ -15829,7 +15875,7 @@ fn benktander_valid(
     let bound = av * (av + 1.0) / 2.0;
     if bv > bound {
       let bound_expr =
-        eval(div2(times(a.clone(), plus2(a.clone(), int(1))), int(2)))?;
+        eval(div2(times2(a.clone(), plus2(a.clone(), int(1))), int(2)))?;
       crate::emit_message(&format!(
         "BenktanderGibratDistribution::lsseq: Parameter {} at position 2 in {} is expected to be less than or equal to {}.",
         expr_to_string(b),
@@ -15876,21 +15922,24 @@ fn pdf_benktander_gibrat(
       call(
         "Times",
         vec![
-          pow2(x.clone(), eval(plus2(int(-2), times(int(-1), a.clone())))?),
+          pow2(x.clone(), eval(plus2(int(-2), times2(int(-1), a.clone())))?),
           call(
             "Plus",
             vec![
-              div2(times(int(-2), b.clone()), a.clone()),
+              div2(times2(int(-2), b.clone()), a.clone()),
               call(
                 "Times",
                 vec![
                   plus2(
                     plus2(int(1), a.clone()),
-                    times(times(int(2), b.clone()), log_x(&x)),
+                    times2(times2(int(2), b.clone()), log_x(&x)),
                   ),
                   plus2(
                     int(1),
-                    div2(times(times(int(2), b.clone()), log_x(&x)), a.clone()),
+                    div2(
+                      times2(times2(int(2), b.clone()), log_x(&x)),
+                      a.clone(),
+                    ),
                   ),
                 ],
               ),
@@ -15898,7 +15947,7 @@ fn pdf_benktander_gibrat(
           ),
         ],
       ),
-      pow2(e(), times(b.clone(), pow2(log_x(&x), int(2)))),
+      pow2(e(), times2(b.clone(), pow2(log_x(&x), int(2)))),
     ));
   }
   if !matches!(&x, Expr::Identifier(_)) {
@@ -15929,7 +15978,7 @@ fn pdf_benktander_gibrat(
     call("Times", vec![f1, f2])
   };
   let bracket = call("Plus", vec![t1, product]);
-  let e_part = pow2(e(), eval(times(b.clone(), pow2(log_x(&x), int(2))))?);
+  let e_part = pow2(e(), eval(times2(b.clone(), pow2(log_x(&x), int(2))))?);
   let body = if numeric {
     // (...)/(E^(b Log[x]^2) x^(2 + a))
     div2(
@@ -15992,7 +16041,7 @@ fn cdf_benktander_gibrat(
         div2(call("Times", vec![int(2), b.clone(), log_x(at)]), a.clone()),
       ],
     ))?;
-    let e_part = pow2(e(), eval(times(b.clone(), pow2(log_x(at), int(2))))?);
+    let e_part = pow2(e(), eval(times2(b.clone(), pow2(log_x(at), int(2))))?);
     let fraction = if numeric {
       div2(
         f2,
@@ -16064,7 +16113,7 @@ fn benktander_gibrat_mean_variance(
   );
   let e_part = pow2(
     e(),
-    eval(div2(pow2(a_minus_1, int(2)), times(int(4), b.clone())))?,
+    eval(div2(pow2(a_minus_1, int(2)), times2(int(4), b.clone())))?,
   );
   let var = if numeric {
     // Sqrt[Pi/b] merges for numeric b
@@ -16202,9 +16251,9 @@ fn gumbel_mean_variance(
   };
   let mean = eval(plus2(
     a,
-    times(
+    times2(
       int(-1),
-      times(b.clone(), Expr::Identifier("EulerGamma".to_string())),
+      times2(b.clone(), Expr::Identifier("EulerGamma".to_string())),
     ),
   ))?;
   let var = eval(div2(
@@ -16229,14 +16278,16 @@ fn pdf_skew_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     let xm = plus2(neg1(m.clone()), at.clone());
     let sqrt2 = sqrt(int(2));
-    let erfc_arg =
-      neg1(div2(times(a.clone(), xm.clone()), times(sqrt2, s.clone())));
+    let erfc_arg = neg1(div2(
+      times2(a.clone(), xm.clone()),
+      times2(sqrt2, s.clone()),
+    ));
     let num = call("Erfc", vec![erfc_arg]);
     let gauss = pow2(
       e(),
-      div2(pow2(xm, int(2)), times(int(2), pow2(s.clone(), int(2)))),
+      div2(pow2(xm, int(2)), times2(int(2), pow2(s.clone(), int(2)))),
     );
-    let denom = times(times(gauss, sqrt(times(int(2), pi()))), s.clone());
+    let denom = times2(times2(gauss, sqrt(times2(int(2), pi()))), s.clone());
     eval(div2(num, denom))
   };
   if ms_numeric(&x).is_some() {
@@ -16265,7 +16316,7 @@ fn cdf_skew_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
         "Erfc",
         vec![div2(
           minus2(m.clone(), at.clone()),
-          times(sqrt(int(2)), s.clone()),
+          times2(sqrt(int(2)), s.clone()),
         )],
       ),
       int(2),
@@ -16274,7 +16325,7 @@ fn cdf_skew_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       "OwenT",
       vec![div2(minus2(at.clone(), m.clone()), s.clone()), a.clone()],
     );
-    eval(minus2(phi, times(int(2), owen)))
+    eval(minus2(phi, times2(int(2), owen)))
   };
   if ms_numeric(&x).is_some() {
     return body(&x);
@@ -16302,14 +16353,14 @@ fn skew_normal_mean_variance(
   let mean = eval(plus2(
     m,
     div2(
-      times(times(a, sqrt(div2(int(2), pi()))), s.clone()),
+      times2(times2(a, sqrt(div2(int(2), pi()))), s.clone()),
       sqrt(plus2(int(1), a2.clone())),
     ),
   ))?;
-  let var = eval(times(
+  let var = eval(times2(
     minus2(
       int(1),
-      div2(times(int(2), a2.clone()), times(plus2(int(1), a2), pi())),
+      div2(times2(int(2), a2.clone()), times2(plus2(int(1), a2), pi())),
     ),
     pow2(s, int(2)),
   ))?;
@@ -16343,7 +16394,10 @@ fn pdf_zipf(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       "Times",
       vec![
         coeff,
-        pow2(at.clone(), eval(plus2(int(-1), times(int(-1), r.clone())))?),
+        pow2(
+          at.clone(),
+          eval(plus2(int(-1), times2(int(-1), r.clone())))?,
+        ),
       ],
     ))
   };
@@ -16674,13 +16728,13 @@ fn benford_mean_variance(
   let factorial = eval(factorial(b.clone()))?;
   let mean = eval(plus2(
     b.clone(),
-    times(int(-1), div2(call("Log", vec![factorial]), log_b.clone())),
+    times2(int(-1), div2(call("Log", vec![factorial]), log_b.clone())),
   ))?;
   // Variance = Sum[d^2 Log[1 + 1/d]/Log[b], {d, 1, b-1}] - Mean^2.
   let mut terms: Vec<Expr> = Vec::new();
   for d in 1..b_int {
     let inner = eval(plus2(int(1), div2(int(1), int(d))))?;
-    terms.push(times(
+    terms.push(times2(
       pow2(int(d), int(2)),
       div2(call("Log", vec![inner]), log_b.clone()),
     ));
@@ -16688,7 +16742,7 @@ fn benford_mean_variance(
   let second_moment = eval(call("Plus", terms))?;
   let variance = eval(plus2(
     second_moment,
-    times(int(-1), pow2(mean.clone(), int(2))),
+    times2(int(-1), pow2(mean.clone(), int(2))),
   ))?;
   Ok((mean, variance))
 }
@@ -16723,19 +16777,19 @@ fn pdf_benktander_weibull(
   // E^((a (1 - x^b))/b) x^(b-2) (1 - b + a x^b).
   let body = |t: &Expr| -> Result<Expr, InterpreterError> {
     let exponent = div2(
-      times(
+      times2(
         a.clone(),
-        plus2(int(1), times(int(-1), pow2(t.clone(), b.clone()))),
+        plus2(int(1), times2(int(-1), pow2(t.clone(), b.clone()))),
       ),
       b.clone(),
     );
     let e_factor = pow2(e(), exponent);
     let x_factor = pow2(t.clone(), plus2(int(-2), b.clone()));
     let poly = plus2(
-      plus2(int(1), times(int(-1), b.clone())),
-      times(a.clone(), pow2(t.clone(), b.clone())),
+      plus2(int(1), times2(int(-1), b.clone())),
+      times2(a.clone(), pow2(t.clone(), b.clone())),
     );
-    eval(times(e_factor, times(x_factor, poly)))
+    eval(times2(e_factor, times2(x_factor, poly)))
   };
   if let Some(xv) = ms_numeric(&x) {
     if xv < 1.0 {
@@ -16777,15 +16831,15 @@ fn cdf_benktander_weibull(
   // 1 - E^((a (1 - x^b))/b) x^(b-1).
   let body = |t: &Expr| -> Result<Expr, InterpreterError> {
     let exponent = div2(
-      times(
+      times2(
         a.clone(),
-        plus2(int(1), times(int(-1), pow2(t.clone(), b.clone()))),
+        plus2(int(1), times2(int(-1), pow2(t.clone(), b.clone()))),
       ),
       b.clone(),
     );
     let e_factor = pow2(e(), exponent);
     let x_factor = pow2(t.clone(), plus2(int(-1), b.clone()));
-    eval(plus2(int(1), times(int(-1), times(e_factor, x_factor))))
+    eval(plus2(int(1), times2(int(-1), times2(e_factor, x_factor))))
   };
   if let Some(xv) = ms_numeric(&x) {
     if xv < 1.0 {
@@ -16821,16 +16875,16 @@ fn benktander_weibull_mean_variance(
   let exp_int = call(
     "ExpIntegralE",
     vec![
-      plus2(int(1), times(int(-1), div2(int(1), b.clone()))),
+      plus2(int(1), times2(int(-1), div2(int(1), b.clone()))),
       div2(a.clone(), b.clone()),
     ],
   );
   let numer = plus2(
     int(-1),
     div2(
-      times(
-        times(int(2), a.clone()),
-        times(pow2(e(), div2(a.clone(), b.clone())), exp_int),
+      times2(
+        times2(int(2), a.clone()),
+        times2(pow2(e(), div2(a.clone(), b.clone())), exp_int),
       ),
       b.clone(),
     ),
@@ -16851,12 +16905,12 @@ fn pdf_singh_maddala(
     ));
   }
   let (q, a, b) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
-  let aq = times(a.clone(), q.clone());
+  let aq = times2(a.clone(), q.clone());
   let x_pow = pow2(x.clone(), minus2(a.clone(), int(1)));
   let x_over_b_to_a = pow2(div2(x.clone(), b.clone()), a.clone());
   let bracket = pow2(plus2(int(1), x_over_b_to_a), minus2(int(-1), q));
   let b_to_a = pow2(b, a);
-  let density = div2(times(times(aq, x_pow), bracket), b_to_a);
+  let density = div2(times2(times2(aq, x_pow), bracket), b_to_a);
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(density, cond)], int(0)))
 }
@@ -16876,7 +16930,7 @@ fn cdf_singh_maddala(
   let x_over_b_to_a = pow2(div2(x.clone(), b), a);
   let body = minus2(
     int(1),
-    pow2(plus2(int(1), x_over_b_to_a), times(int(-1), q)),
+    pow2(plus2(int(1), x_over_b_to_a), times2(int(-1), q)),
   );
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(body, cond)], int(0)))
@@ -16894,16 +16948,16 @@ fn singh_maddala_mean_variance(
     ));
   }
   let (q, a, b) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
-  let aq = times(a.clone(), q.clone());
+  let aq = times2(a.clone(), q.clone());
   let inv_a = div2(int(1), a.clone());
   let two_a = div2(int(2), a.clone());
   let g_q = gamma(q.clone());
   let g_1_inv_a = gamma(plus2(int(1), inv_a.clone()));
-  let g_q_inv_a = gamma(plus2(times(int(-1), inv_a), q.clone()));
+  let g_q_inv_a = gamma(plus2(times2(int(-1), inv_a), q.clone()));
 
   // Mean = b Gamma[1 + 1/a] Gamma[-1/a + q] / Gamma[q], for a q > 1.
   let mean_expr = div2(
-    times(times(b.clone(), g_1_inv_a.clone()), g_q_inv_a.clone()),
+    times2(times2(b.clone(), g_1_inv_a.clone()), g_q_inv_a.clone()),
     g_q.clone(),
   );
   let mean = piecewise(
@@ -16917,11 +16971,11 @@ fn singh_maddala_mean_variance(
   // Variance = b^2 (Gamma[1 + 2/a] Gamma[q] Gamma[-2/a + q]
   //   - Gamma[1 + 1/a]^2 Gamma[-1/a + q]^2) / Gamma[q]^2, for a q > 2.
   let g_2_a = gamma(plus2(int(1), two_a.clone()));
-  let g_q_2a = gamma(plus2(times(int(-1), two_a), q.clone()));
-  let term1 = times(times(g_2_a, g_q.clone()), g_q_2a);
-  let term2 = times(pow2(g_1_inv_a, int(2)), pow2(g_q_inv_a, int(2)));
+  let g_q_2a = gamma(plus2(times2(int(-1), two_a), q.clone()));
+  let term1 = times2(times2(g_2_a, g_q.clone()), g_q_2a);
+  let term2 = times2(pow2(g_1_inv_a, int(2)), pow2(g_q_inv_a, int(2)));
   let var_expr = div2(
-    times(pow2(b, int(2)), minus2(term1, term2)),
+    times2(pow2(b, int(2)), minus2(term1, term2)),
     pow2(g_q, int(2)),
   );
   let variance = piecewise(
@@ -16945,16 +16999,16 @@ fn beta_prime4_mean_variance(
   );
   let inv_b = div2(int(1), b.clone());
   let two_b = div2(int(2), b.clone());
-  let bq = times(b.clone(), q.clone());
+  let bq = times2(b.clone(), q.clone());
   let g_p = gamma(p.clone());
   let g_q = gamma(q.clone());
   let g_1b_p = gamma(plus2(inv_b.clone(), p.clone()));
-  let g_1b_q = gamma(plus2(times(int(-1), inv_b), q.clone()));
+  let g_1b_q = gamma(plus2(times2(int(-1), inv_b), q.clone()));
 
   // Mean = a Gamma[1/b + p] Gamma[-1/b + q] / (Gamma[p] Gamma[q]), for 1 < b q.
   let mean_val = div2(
-    times(times(a.clone(), g_1b_p.clone()), g_1b_q.clone()),
-    times(g_p.clone(), g_q.clone()),
+    times2(times2(a.clone(), g_1b_p.clone()), g_1b_q.clone()),
+    times2(g_p.clone(), g_q.clone()),
   );
   let mean = piecewise(
     vec![(mean_val, comparison(int(1), ComparisonOp::Less, bq.clone()))],
@@ -16964,12 +17018,12 @@ fn beta_prime4_mean_variance(
   // Variance = a^2 (Gamma[p] Gamma[2/b + p] Gamma[q] Gamma[-2/b + q]
   //   - Gamma[1/b + p]^2 Gamma[-1/b + q]^2) / (Gamma[p]^2 Gamma[q]^2), b q > 2.
   let g_2b_p = gamma(plus2(two_b.clone(), p.clone()));
-  let g_2b_q = gamma(plus2(times(int(-1), two_b), q.clone()));
-  let term1 = times(times(times(g_p.clone(), g_2b_p), g_q.clone()), g_2b_q);
-  let term2 = times(pow2(g_1b_p, int(2)), pow2(g_1b_q, int(2)));
+  let g_2b_q = gamma(plus2(times2(int(-1), two_b), q.clone()));
+  let term1 = times2(times2(times2(g_p.clone(), g_2b_p), g_q.clone()), g_2b_q);
+  let term2 = times2(pow2(g_1b_p, int(2)), pow2(g_1b_q, int(2)));
   let var_val = div2(
-    times(pow2(a, int(2)), minus2(term1, term2)),
-    times(pow2(g_p, int(2)), pow2(g_q, int(2))),
+    times2(pow2(a, int(2)), minus2(term1, term2)),
+    times2(pow2(g_p, int(2)), pow2(g_q, int(2))),
   );
   let variance = piecewise(
     vec![(var_val, comparison(bq, ComparisonOp::Greater, int(2)))],
@@ -16997,8 +17051,8 @@ fn pareto3_mean_variance(
   let variance = piecewise(
     vec![(
       div2(
-        times(a.clone(), pow2(k, int(2))),
-        times(
+        times2(a.clone(), pow2(k, int(2))),
+        times2(
           plus2(int(-2), a.clone()),
           pow2(plus2(int(-1), a.clone()), int(2)),
         ),
@@ -17030,7 +17084,7 @@ fn pareto4_mean_variance(
       plus2(
         m,
         div2(
-          times(times(k.clone(), g_amg.clone()), g_1pg.clone()),
+          times2(times2(k.clone(), g_amg.clone()), g_1pg.clone()),
           g_a.clone(),
         ),
       ),
@@ -17040,16 +17094,16 @@ fn pareto4_mean_variance(
   );
   // Variance = k^2 (-(Gamma[a-g]^2 Gamma[1+g]^2) + Gamma[a] Gamma[a-2g] Gamma[1+2g])
   //   / Gamma[a]^2, for a > 2 g.
-  let g_am2g = gamma(minus2(a.clone(), times(int(2), g.clone()))); // Gamma[a - 2 g]
-  let g_1p2g = gamma(plus2(int(1), times(int(2), g.clone()))); // Gamma[1 + 2 g]
-  let term_neg = times(pow2(g_amg, int(2)), pow2(g_1pg, int(2)));
-  let term_pos = times(times(g_a.clone(), g_am2g), g_1p2g);
+  let g_am2g = gamma(minus2(a.clone(), times2(int(2), g.clone()))); // Gamma[a - 2 g]
+  let g_1p2g = gamma(plus2(int(1), times2(int(2), g.clone()))); // Gamma[1 + 2 g]
+  let term_neg = times2(pow2(g_amg, int(2)), pow2(g_1pg, int(2)));
+  let term_pos = times2(times2(g_a.clone(), g_am2g), g_1p2g);
   let var_num =
-    times(pow2(k, int(2)), plus2(times(int(-1), term_neg), term_pos));
+    times2(pow2(k, int(2)), plus2(times2(int(-1), term_neg), term_pos));
   let variance = piecewise(
     vec![(
       div2(var_num, pow2(g_a, int(2))),
-      comparison(a, ComparisonOp::Greater, times(int(2), g)),
+      comparison(a, ComparisonOp::Greater, times2(int(2), g)),
     )],
     indeterminate(),
   );

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -1059,19 +1059,17 @@ fn struve_half_integer_closed_form(
   two_nu: i64,
   z: &Expr,
 ) -> Option<Result<Expr, InterpreterError>> {
-  use BinaryOperator as B;
   let call1 = |name: &str, e: Expr| Expr::FunctionCall {
     name: name.to_string(),
     args: vec![e].into(),
   };
   let int = Expr::Integer;
-  let times = |a, b| binop(B::Times, a, b);
-  let neg = |a| binop(B::Times, int(-1), a);
+  let neg = |a| times2(int(-1), a);
   let pi = || Expr::Constant("Pi".to_string());
   let sqrt = |e: Expr| call1("Sqrt", e);
   let z = || z.clone();
   let sqrt_z = || sqrt(z());
-  let sqrt_2pi = || sqrt(times(int(2), pi())); // Sqrt[2 Pi]
+  let sqrt_2pi = || sqrt(times2(int(2), pi())); // Sqrt[2 Pi]
   let sqrt_2_over_pi = || sqrt(div2(int(2), pi())); // Sqrt[2/Pi]
   let sqrt_pi_over_2 = || sqrt(div2(pi(), int(2))); // Sqrt[Pi/2]
   // c(z), s(z): Cos/Sin for H, Cosh/Sinh for L.
@@ -1083,23 +1081,23 @@ fn struve_half_integer_closed_form(
   let expr = match two_nu {
     1 => {
       // +-Sqrt[2 Pi]/(Pi Sqrt[z]) -/+ Sqrt[2/Pi] c[z]/Sqrt[z]
-      let a = div2(sqrt_2pi(), times(pi(), sqrt_z()));
-      let b = div2(times(sqrt_2_over_pi(), cz()), sqrt_z());
+      let a = div2(sqrt_2pi(), times2(pi(), sqrt_z()));
+      let b = div2(times2(sqrt_2_over_pi(), cz()), sqrt_z());
       if is_l { plus2(neg(a), b) } else { minus2(a, b) }
     }
     -1 => {
       // Sqrt[2/Pi] s[z]/Sqrt[z]
-      div2(times(sqrt_2_over_pi(), sz()), sqrt_z())
+      div2(times2(sqrt_2_over_pi(), sz()), sqrt_z())
     }
     3 if !is_l => {
       // (Sqrt[2 Pi]/z^(3/2) + Sqrt[Pi/2] Sqrt[z])/Pi
       //   + Sqrt[2/Pi] (-(Cos[z]/z) - Sin[z])/Sqrt[z]
       let a = div2(
-        plus2(div2(sqrt_2pi(), z_32()), times(sqrt_pi_over_2(), sqrt_z())),
+        plus2(div2(sqrt_2pi(), z_32()), times2(sqrt_pi_over_2(), sqrt_z())),
         pi(),
       );
       let inner = minus2(neg(div2(cz(), z())), sz());
-      let b = div2(times(sqrt_2_over_pi(), inner), sqrt_z());
+      let b = div2(times2(sqrt_2_over_pi(), inner), sqrt_z());
       plus2(a, b)
     }
     3 => {
@@ -1108,25 +1106,25 @@ fn struve_half_integer_closed_form(
       let a = neg(div2(
         plus2(
           neg(div2(sqrt_2pi(), z_32())),
-          times(sqrt_pi_over_2(), sqrt_z()),
+          times2(sqrt_pi_over_2(), sqrt_z()),
         ),
         pi(),
       ));
       let b = div2(
-        plus2(div2(times(int(-2), cz()), z()), times(int(2), sz())),
-        times(sqrt_2pi(), sqrt_z()),
+        plus2(div2(times2(int(-2), cz()), z()), times2(int(2), sz())),
+        times2(sqrt_2pi(), sqrt_z()),
       );
       plus2(a, b)
     }
     -3 if !is_l => {
       // -((Sqrt[2/Pi] (-Cos[z] + Sin[z]/z))/Sqrt[z])
       let inner = plus2(neg(cz()), div2(sz(), z()));
-      neg(div2(times(sqrt_2_over_pi(), inner), sqrt_z()))
+      neg(div2(times2(sqrt_2_over_pi(), inner), sqrt_z()))
     }
     -3 => {
       // (2 Cosh[z] - (2 Sinh[z])/z)/(Sqrt[2 Pi] Sqrt[z])
-      let num = minus2(times(int(2), cz()), div2(times(int(2), sz()), z()));
-      div2(num, times(sqrt_2pi(), sqrt_z()))
+      let num = minus2(times2(int(2), cz()), div2(times2(int(2), sz()), z()));
+      div2(num, times2(sqrt_2pi(), sqrt_z()))
     }
     _ => return None,
   };
@@ -1786,7 +1784,7 @@ fn weber_e_integer_closed_form(
 /// AngerJ[ν, 0] closed form: Sin[ν*Pi] / (ν*Pi).
 fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
   let pi = Expr::Constant("Pi".to_string());
-  let nu_pi = binop(BinaryOperator::Times, nu.clone(), pi.clone());
+  let nu_pi = times2(nu.clone(), pi.clone());
   let sin_nu_pi = Expr::FunctionCall {
     name: "Sin".to_string(),
     args: vec![nu_pi.clone()].into(),
@@ -1797,7 +1795,7 @@ fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
 /// WeberE[ν, 0] closed form: (1 - Cos[ν*Pi]) / (ν*Pi).
 fn weber_e_at_zero_symbolic(nu: &Expr) -> Expr {
   let pi = Expr::Constant("Pi".to_string());
-  let nu_pi = binop(BinaryOperator::Times, nu.clone(), pi.clone());
+  let nu_pi = times2(nu.clone(), pi.clone());
   let cos_nu_pi = Expr::FunctionCall {
     name: "Cos".to_string(),
     args: vec![nu_pi.clone()].into(),
@@ -2538,7 +2536,7 @@ pub fn appell_f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       name: "Power".to_string(),
       args: vec![one_minus_y, args[2].clone()].into(),
     };
-    let denom = binop(BinaryOperator::Times, factor_x, factor_y);
+    let denom = times2(factor_x, factor_y);
     let result = div2(one, denom);
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }

--- a/src/functions/math_ast/mod.rs
+++ b/src/functions/math_ast/mod.rs
@@ -3,7 +3,9 @@
 //! These functions work directly with `Expr` AST nodes.
 
 use crate::InterpreterError;
-use crate::helpers::{binop, bool_expr, div2, minus2, neg1, plus2, pow2};
+use crate::helpers::{
+  binop, bool_expr, div2, minus2, neg1, plus2, pow2, times2,
+};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
   expr_to_string, unevaluated,

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -2225,7 +2225,7 @@ fn covariance_pair(xs: &[Expr], ys: &[Expr]) -> Result<Expr, InterpreterError> {
       name: "Conjugate".to_string(),
       args: vec![dy].into(),
     };
-    let product = binop(BinaryOperator::Times, dx, conj_dy);
+    let product = times2(dx, conj_dy);
     let val = crate::evaluator::evaluate_expr_to_expr(&product)?;
     terms.push(val);
   }
@@ -2254,7 +2254,6 @@ fn symbolic_covariance(
   xs: &[Expr],
   ys: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  use BinaryOperator as B;
   let n = xs.len();
   let conj = |e: &Expr| Expr::FunctionCall {
     name: "Conjugate".to_string(),
@@ -2263,16 +2262,14 @@ fn symbolic_covariance(
   let result = if n == 2 {
     let dx = minus2(xs[0].clone(), xs[1].clone());
     let dy = minus2(conj(&ys[0]), conj(&ys[1]));
-    div2(binop(B::Times, dx, dy), Expr::Integer(2))
+    div2(times2(dx, dy), Expr::Integer(2))
   } else {
     let sum_x = unevaluated("Plus", xs);
     let mut terms = Vec::with_capacity(n);
     for (x, y) in xs.iter().zip(ys.iter()) {
-      let coeff = minus2(
-        binop(B::Times, Expr::Integer(n as i128), x.clone()),
-        sum_x.clone(),
-      );
-      terms.push(binop(B::Times, coeff, conj(y)));
+      let coeff =
+        minus2(times2(Expr::Integer(n as i128), x.clone()), sum_x.clone());
+      terms.push(times2(coeff, conj(y)));
     }
     div2(
       Expr::FunctionCall {
@@ -2324,9 +2321,8 @@ pub fn covariance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && name == "BinormalDistribution"
     && let Some((_, _, s1, s2, rho)) = binormal_params(dargs)
   {
-    use BinaryOperator as B;
     let sq = |s: Expr| pow2(s, Expr::Integer(2));
-    let off = binop(B::Times, rho, binop(B::Times, s1.clone(), s2.clone()));
+    let off = times2(rho, times2(s1.clone(), s2.clone()));
     let matrix = Expr::List(
       vec![
         Expr::List(vec![sq(s1.clone()), off.clone()].into()),
@@ -3202,7 +3198,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     return Ok(unevaluated("Correlation", args));
   }
-  let var_product = binop(BinaryOperator::Times, var_x, var_y);
+  let var_product = times2(var_x, var_y);
   let denom = Expr::FunctionCall {
     name: "Sqrt".to_string(),
     args: vec![var_product].into(),
@@ -3786,26 +3782,18 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // PolyaAeppli: Kurtosis = 3 + (1 + 10 p + p^2)/((1 + p) t).
   if let Some((t, p)) = two_params_of(&args[0], "PolyaAeppliDistribution") {
-    use BinaryOperator as B;
     let num = plus2(
-      plus2(
-        Expr::Integer(1),
-        binop(B::Times, Expr::Integer(10), p.clone()),
-      ),
+      plus2(Expr::Integer(1), times2(Expr::Integer(10), p.clone())),
       pow2(p.clone(), Expr::Integer(2)),
     );
-    let den = binop(B::Times, plus2(Expr::Integer(1), p), t);
+    let den = times2(plus2(Expr::Integer(1), p), t);
     let result = plus2(Expr::Integer(3), div2(num, den));
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
   // Geometric: Kurtosis = 3 + (6 - 6 p + p^2)/(1 - p).
   if let Some(p) = one_param_of(&args[0], "GeometricDistribution") {
-    use BinaryOperator as B;
     let num = plus2(
-      plus2(
-        Expr::Integer(6),
-        binop(B::Times, Expr::Integer(-6), p.clone()),
-      ),
+      plus2(Expr::Integer(6), times2(Expr::Integer(-6), p.clone())),
       pow2(p.clone(), Expr::Integer(2)),
     );
     let den = minus2(Expr::Integer(1), p);
@@ -3815,15 +3803,11 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Negative-binomial family: Kurtosis = 3 + (6 - 6 p + p^2)/(scale (1 - p)),
   // scale = r (NegativeBinomial) or n (Pascal). Binomial has its own numerator.
   {
-    use BinaryOperator as B;
     let one_minus_p = |p: &Expr| minus2(Expr::Integer(1), p.clone());
     // 6 - 6 p + p^2
     let nb_num = |p: &Expr| {
       plus2(
-        plus2(
-          Expr::Integer(6),
-          binop(B::Times, Expr::Integer(-6), p.clone()),
-        ),
+        plus2(Expr::Integer(6), times2(Expr::Integer(-6), p.clone())),
         pow2(p.clone(), Expr::Integer(2)),
       )
     };
@@ -3831,11 +3815,11 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if let Some((r, p)) =
       two_params_of(&args[0], "NegativeBinomialDistribution")
     {
-      let result = three_plus(nb_num(&p), binop(B::Times, one_minus_p(&p), r));
+      let result = three_plus(nb_num(&p), times2(one_minus_p(&p), r));
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
     if let Some((n, p)) = two_params_of(&args[0], "PascalDistribution") {
-      let result = three_plus(nb_num(&p), binop(B::Times, n, one_minus_p(&p)));
+      let result = three_plus(nb_num(&p), times2(n, one_minus_p(&p)));
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
     if let Some((n, p)) = two_params_of(&args[0], "BinomialDistribution") {
@@ -3894,20 +3878,16 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // PolyaAeppli: Skewness = (1 + 4 p + p^2)/((1 + p) Sqrt[(1 + p) t]).
   if let Some((t, p)) = two_params_of(&args[0], "PolyaAeppliDistribution") {
-    use BinaryOperator as B;
     let one_plus_p = plus2(Expr::Integer(1), p.clone());
     let num = plus2(
-      plus2(
-        Expr::Integer(1),
-        binop(B::Times, Expr::Integer(4), p.clone()),
-      ),
+      plus2(Expr::Integer(1), times2(Expr::Integer(4), p.clone())),
       pow2(p, Expr::Integer(2)),
     );
     let sqrt = Expr::FunctionCall {
       name: "Sqrt".to_string(),
-      args: vec![binop(B::Times, one_plus_p.clone(), t)].into(),
+      args: vec![times2(one_plus_p.clone(), t)].into(),
     };
-    let den = binop(B::Times, one_plus_p, sqrt);
+    let den = times2(one_plus_p, sqrt);
     let result = div2(num, den);
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
@@ -3925,7 +3905,6 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // scale being r (NegativeBinomial) or n (Pascal). Binomial has the (1 - 2 p)
   // form. Built directly so the compact shapes are preserved.
   {
-    use BinaryOperator as B;
     let sqrt = |e| Expr::FunctionCall {
       name: "Sqrt".to_string(),
       args: vec![e].into(),
@@ -3936,22 +3915,19 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       let result = div2(
         minus2(Expr::Integer(2), p.clone()),
-        sqrt(binop(B::Times, one_minus_p(&p), r)),
+        sqrt(times2(one_minus_p(&p), r)),
       );
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
     if let Some((n, p)) = two_params_of(&args[0], "PascalDistribution") {
       let result = div2(
         minus2(Expr::Integer(2), p.clone()),
-        sqrt(binop(B::Times, n, one_minus_p(&p))),
+        sqrt(times2(n, one_minus_p(&p))),
       );
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
     if let Some((n, p)) = two_params_of(&args[0], "BinomialDistribution") {
-      let num = minus2(
-        Expr::Integer(1),
-        binop(B::Times, Expr::Integer(2), p.clone()),
-      );
+      let num = minus2(Expr::Integer(1), times2(Expr::Integer(2), p.clone()));
       let scale = Expr::FunctionCall {
         name: "Times".to_string(),
         args: vec![n, one_minus_p(&p), p.clone()].into(),
@@ -3979,7 +3955,7 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         args: vec![Expr::Integer(-3), Expr::Integer(2)].into(),
       }),
     };
-    binop(BinaryOperator::Times, m3, m2_pow)
+    times2(m3, m2_pow)
   } else {
     // Compute m3 / m2^(3/2) symbolically
     let m2_pow = pow2(m2, div2(Expr::Integer(3), Expr::Integer(2)));
@@ -6867,11 +6843,7 @@ pub fn covariance_function_data(
   let h_us = h.unsigned_abs() as usize;
   let mut terms = Vec::new();
   for t in 0..(n - h_us) {
-    terms.push(binop(
-      BinaryOperator::Times,
-      dev(&items[t]),
-      dev(&items[t + h_us]),
-    ));
+    terms.push(times2(dev(&items[t]), dev(&items[t + h_us])));
   }
   let sum = Expr::FunctionCall {
     name: "Plus".to_string(),
@@ -6909,13 +6881,7 @@ pub fn absolute_correlation_function_ast(
   let single = |h: i128| -> Result<Expr, InterpreterError> {
     let h_us = h.unsigned_abs() as usize;
     let terms: Vec<Expr> = (0..(n - h_us))
-      .map(|t| {
-        binop(
-          BinaryOperator::Times,
-          items[t].clone(),
-          items[t + h_us].clone(),
-        )
-      })
+      .map(|t| times2(items[t].clone(), items[t + h_us].clone()))
       .collect();
     crate::evaluator::evaluate_expr_to_expr(&div2(
       Expr::FunctionCall {
@@ -6990,7 +6956,6 @@ fn process_covariance(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
     name: n.to_string(),
     args: a.into(),
   };
-  let times2 = |a: Expr, b: Expr| binop(BinaryOperator::Times, a, b);
   let neg = |a: Expr| times2(Expr::Integer(-1), a);
   let sq = |a: &Expr| pow2(a.clone(), Expr::Integer(2));
   let min = call("Min", vec![t1.clone(), t2.clone()]);
@@ -7111,7 +7076,7 @@ pub fn biweight_midvariance_ast(
     Some(_) => return Ok(Expr::Identifier("Indeterminate".to_string())),
     None => return unevaluated(),
   }
-  let scale = binop(BinaryOperator::Times, c, mad);
+  let scale = times2(c, mad);
   let mut num_terms: Vec<Expr> = Vec::new();
   let mut den_terms: Vec<Expr> = Vec::new();
   for x in items.iter() {
@@ -7125,18 +7090,13 @@ pub fn biweight_midvariance_ast(
     }
     let u2 = pow2(u.clone(), Expr::Integer(2));
     let one_minus = minus2(Expr::Integer(1), u2.clone());
-    num_terms.push(binop(
-      BinaryOperator::Times,
+    num_terms.push(times2(
       pow2(dev, Expr::Integer(2)),
       pow2(one_minus.clone(), Expr::Integer(4)),
     ));
-    den_terms.push(binop(
-      BinaryOperator::Times,
+    den_terms.push(times2(
       one_minus,
-      minus2(
-        Expr::Integer(1),
-        binop(BinaryOperator::Times, Expr::Integer(5), u2),
-      ),
+      minus2(Expr::Integer(1), times2(Expr::Integer(5), u2)),
     ));
   }
   if den_terms.is_empty() {
@@ -7147,11 +7107,7 @@ pub fn biweight_midvariance_ast(
     args: ts.into(),
   };
   ev(&div2(
-    binop(
-      BinaryOperator::Times,
-      Expr::Integer(items.len() as i128),
-      total(num_terms),
-    ),
+    times2(Expr::Integer(items.len() as i128), total(num_terms)),
     pow2(total(den_terms), Expr::Integer(2)),
   ))
 }
@@ -7166,7 +7122,6 @@ pub fn process_correlation(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
     name: n.to_string(),
     args: a.into(),
   };
-  let times2 = |a: Expr, b: Expr| binop(BinaryOperator::Times, a, b);
   let neg = |a: Expr| times2(Expr::Integer(-1), a);
   let sq = |a: &Expr| pow2(a.clone(), Expr::Integer(2));
   let min = call("Min", vec![t1.clone(), t2.clone()]);
@@ -7252,7 +7207,6 @@ pub fn process_absolute_correlation(
     name: n.to_string(),
     args: a.into(),
   };
-  let times2 = |a: Expr, b: Expr| binop(BinaryOperator::Times, a, b);
   let neg = |a: Expr| times2(Expr::Integer(-1), a);
   let sq = |a: &Expr| pow2(a.clone(), Expr::Integer(2));
   let min = call("Min", vec![t1.clone(), t2.clone()]);

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,5 +1,7 @@
 use crate::InterpreterError;
-use crate::helpers::{binop, bool_expr, div2, minus2, neg1, plus2, pow2};
+use crate::helpers::{
+  binop, bool_expr, div2, minus2, neg1, plus2, pow2, times2,
+};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
   expr_to_string, unevaluated,

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -2167,11 +2167,7 @@ fn negate_expr(expr: &Expr) -> Expr {
       op: UnaryOperator::Minus,
       operand,
     } => *operand.clone(),
-    _ => Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(-1)),
-      right: Box::new(expr.clone()),
-    },
+    _ => times2(Expr::Integer(-1), expr.clone()),
   }
 }
 
@@ -2201,11 +2197,7 @@ fn solve_constant_coefficient_ode(
       match &forcing {
         None => forcing = Some(evaluated),
         Some(existing) => {
-          forcing = Some(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(existing.clone()),
-            right: Box::new(evaluated),
-          });
+          forcing = Some(plus2(existing.clone(), evaluated));
         }
       }
     }
@@ -2234,11 +2226,10 @@ fn solve_constant_coefficient_ode(
     )
     .or_else(|| variation_of_parameters(&coeffs, &roots, forcing_expr, x_name));
     if let Some(part) = particular {
-      return Ok(crate::functions::calculus_ast::simplify(Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(homogeneous),
-        right: Box::new(part),
-      }));
+      return Ok(crate::functions::calculus_ast::simplify(plus2(
+        homogeneous,
+        part,
+      )));
     }
   }
 
@@ -2269,11 +2260,6 @@ fn variation_of_parameters(
     return None;
   }
   let x = || Expr::Identifier(x_name.to_string());
-  let times = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
   // E^(r x), reduced to 1 for r == 0.
   let exp_rx = |r: f64| -> Expr {
     if r.abs() < 1e-10 {
@@ -2286,7 +2272,7 @@ fn variation_of_parameters(
     match (&a, &b) {
       (Expr::Integer(1), _) => b,
       (_, Expr::Integer(1)) => a,
-      _ => times(a, b),
+      _ => times2(a, b),
     }
   };
 
@@ -2324,7 +2310,7 @@ fn variation_of_parameters(
   let a2 = f64_to_nice_expr(coeffs[2]);
   let integrate_with = |y: &Expr| -> Option<Expr> {
     let integrand = div2(
-      times(y.clone(), g.clone()),
+      times2(y.clone(), g.clone()),
       mul(a2.clone(), wronskian.clone()),
     );
     // Canonicalize first so the integrator sees simplified products
@@ -2346,11 +2332,7 @@ fn variation_of_parameters(
 
   // y_p = -y1 ∫ y2 g/(a2 W) + y2 ∫ y1 g/(a2 W); expand so products like
   // -Cos (ArcTanh[Sin] - Sin) + Sin (-Cos) cancel across the two halves.
-  let y_p = Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(times(negate_expr(&y1), int1)),
-    right: Box::new(times(y2, int2)),
-  };
+  let y_p = plus2(times2(negate_expr(&y1), int1), times2(y2, int2));
   let y_p = crate::evaluator::evaluate_function_call_ast(
     "Expand",
     std::slice::from_ref(&y_p),
@@ -2621,21 +2603,13 @@ fn build_homogeneous_solution(
           } else {
             pow2(x.clone(), Expr::Integer(k as i128))
           };
-          term = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(x_power),
-            right: Box::new(term),
-          };
+          term = times2(x_power, term);
         }
 
         // Multiply by E^(r*x) if r != 0
         if real.abs() > 1e-10 {
           let exp_term = make_exp_term(*real, x_name);
-          term = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(exp_term),
-            right: Box::new(term),
-          };
+          term = times2(exp_term, term);
         }
 
         terms.push(term);
@@ -2648,30 +2622,14 @@ fn build_homogeneous_solution(
       let c2 = make_c(c_idx);
       c_idx += 1;
 
-      let cos_term = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(c1),
-        right: Box::new(make_trig_term("Cos", *imag, x_name)),
-      };
-      let sin_term = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(c2),
-        right: Box::new(make_trig_term("Sin", *imag, x_name)),
-      };
+      let cos_term = times2(c1, make_trig_term("Cos", *imag, x_name));
+      let sin_term = times2(c2, make_trig_term("Sin", *imag, x_name));
 
-      let trig_sum = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(cos_term),
-        right: Box::new(sin_term),
-      };
+      let trig_sum = plus2(cos_term, sin_term);
 
       let term = if real.abs() > 1e-10 {
         let exp_term = make_exp_term(*real, x_name);
-        Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(exp_term),
-          right: Box::new(trig_sum),
-        }
+        times2(exp_term, trig_sum)
       } else {
         trig_sum
       };
@@ -2691,11 +2649,7 @@ fn build_homogeneous_solution(
   // Sum all terms
   let mut result = terms.remove(0);
   for term in terms {
-    result = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(result),
-      right: Box::new(term),
-    };
+    result = plus2(result, term);
   }
   result
 }
@@ -2715,11 +2669,7 @@ fn make_exp_term(r: f64, x_name: &str) -> Expr {
   let exponent = if matches!(&r_expr, Expr::Integer(1)) {
     x
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(r_expr),
-      right: Box::new(x),
-    }
+    times2(r_expr, x)
   };
   pow2(Expr::Constant("E".to_string()), exponent)
 }
@@ -2731,11 +2681,7 @@ fn make_trig_term(func: &str, beta: f64, x_name: &str) -> Expr {
   let arg = if matches!(&beta_expr, Expr::Integer(1)) {
     x
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(beta_expr),
-      right: Box::new(x),
-    }
+    times2(beta_expr, x)
   };
   Expr::FunctionCall {
     name: func.to_string(),
@@ -2794,25 +2740,13 @@ fn solve_first_order_linear(
   for term in terms {
     match term.order {
       1 => {
-        a1 = Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(a1),
-          right: Box::new(term.coefficient.clone()),
-        };
+        a1 = plus2(a1, term.coefficient.clone());
       }
       0 => {
-        a0 = Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(a0),
-          right: Box::new(term.coefficient.clone()),
-        };
+        a0 = plus2(a0, term.coefficient.clone());
       }
       -1 => {
-        forcing = Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(forcing),
-          right: Box::new(term.coefficient.clone()),
-        };
+        forcing = plus2(forcing, term.coefficient.clone());
       }
       _ => {
         return Err(InterpreterError::EvaluationError(
@@ -2844,11 +2778,7 @@ fn solve_first_order_linear(
       q_expr,
       Expr::Identifier(x_name.to_string()),
     ])?;
-    return Ok(Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(integral),
-      right: Box::new(make_c(1)),
-    });
+    return Ok(plus2(integral, make_c(1)));
   }
 
   // Case 2: y' + a*y = 0 (constant coefficient, homogeneous)
@@ -2860,11 +2790,7 @@ fn solve_first_order_linear(
     // y = E^(-a*x)*C[1]
     let neg_p = negate_expr(&p_expr);
     let exp_term = make_exp_term_expr(&neg_p, x_name);
-    return Ok(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(exp_term),
-      right: Box::new(make_c(1)),
-    });
+    return Ok(times2(exp_term, make_c(1)));
   }
 
   // Case 3: General integrating factor method
@@ -2877,11 +2803,8 @@ fn solve_first_order_linear(
 
   let mu = pow2(Expr::Constant("E".to_string()), p_integral.clone());
 
-  let mu_q = crate::functions::calculus_ast::simplify(Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(mu.clone()),
-    right: Box::new(q_expr),
-  });
+  let mu_q =
+    crate::functions::calculus_ast::simplify(times2(mu.clone(), q_expr));
 
   let mu_q_integral = crate::functions::calculus_ast::integrate_ast(&[
     mu_q,
@@ -2897,21 +2820,13 @@ fn solve_first_order_linear(
   // (E^(3x)/3 + C[1])/E^(2x) -> E^x/3 + C[1]/E^(2x). Each product is simplified
   // (not fully expanded), so a grouped particular like (-Cos[x]+3Sin[x])/10
   // stays grouped rather than splitting into separate terms.
-  let particular = crate::functions::calculus_ast::simplify(Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(inv_mu.clone()),
-    right: Box::new(mu_q_integral),
-  });
-  let homogeneous = crate::functions::calculus_ast::simplify(Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(inv_mu),
-    right: Box::new(make_c(1)),
-  });
-  Ok(Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(particular),
-    right: Box::new(homogeneous),
-  })
+  let particular = crate::functions::calculus_ast::simplify(times2(
+    inv_mu.clone(),
+    mu_q_integral,
+  ));
+  let homogeneous =
+    crate::functions::calculus_ast::simplify(times2(inv_mu, make_c(1)));
+  Ok(plus2(particular, homogeneous))
 }
 
 /// Create E^(expr*x) for symbolic expressions
@@ -2920,11 +2835,7 @@ fn make_exp_term_expr(coeff: &Expr, x_name: &str) -> Expr {
   let exponent = match coeff {
     Expr::Integer(1) => x,
     Expr::Integer(-1) => neg1(x),
-    _ => Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(coeff.clone()),
-      right: Box::new(x),
-    },
+    _ => times2(coeff.clone(), x),
   };
   pow2(Expr::Constant("E".to_string()), exponent)
 }
@@ -2952,11 +2863,10 @@ fn find_particular_solution(
     // If a_0 = 0 but a_1 != 0, try y_p = c*x
     if coeffs.len() > 1 && coeffs[1].abs() > 1e-15 {
       let c = -val / coeffs[1];
-      return Some(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(f64_to_nice_expr(c)),
-        right: Box::new(Expr::Identifier(x_name.to_string())),
-      });
+      return Some(times2(
+        f64_to_nice_expr(c),
+        Expr::Identifier(x_name.to_string()),
+      ));
     }
   }
   None
@@ -4229,11 +4139,7 @@ fn try_linear_first_order_pde_body(
     let exponent = if c_eff == 1 {
       n_var(xn)
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(c_eff)),
-        right: Box::new(n_var(xn)),
-      }
+      times2(Expr::Integer(c_eff), n_var(xn))
     };
     pow2(Expr::Constant("E".to_string()), exponent)
   };
@@ -4244,17 +4150,9 @@ fn try_linear_first_order_pde_body(
     let bx = if b == 1 {
       n_var(xn)
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-b)),
-        right: Box::new(n_var(xn)),
-      }
+      times2(Expr::Integer(-b), n_var(xn))
     };
-    Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(bx),
-      right: Box::new(n_var(yn)),
-    }
+    plus2(bx, n_var(yn))
   };
   let c1_applied = Expr::CurriedCall {
     func: Box::new(Expr::FunctionCall {
@@ -4266,11 +4164,7 @@ fn try_linear_first_order_pde_body(
   let body = if matches!(&exp_part, Expr::Integer(1)) {
     c1_applied
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(exp_part),
-      right: Box::new(c1_applied),
-    }
+    times2(exp_part, c1_applied)
   };
   Some(body)
 }
@@ -4322,22 +4216,10 @@ fn try_direct_linear_pde_body(
     let coeff = make_neg_b_over_a(b, a);
     let bx = match &coeff {
       Expr::Integer(1) => n_var(xn),
-      Expr::Integer(n) => Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(*n)),
-        right: Box::new(n_var(xn)),
-      },
-      other => Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(other.clone()),
-        right: Box::new(n_var(xn)),
-      },
+      Expr::Integer(n) => times2(Expr::Integer(*n), n_var(xn)),
+      other => times2(other.clone(), n_var(xn)),
     };
-    Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(n_var(yn)),
-      right: Box::new(bx),
-    }
+    plus2(n_var(yn), bx)
   };
   let c1_applied = Expr::CurriedCall {
     func: Box::new(Expr::FunctionCall {
@@ -4353,22 +4235,10 @@ fn try_direct_linear_pde_body(
   let coeff = make_c_over_a(c, a);
   let head_term = match &coeff {
     Expr::Integer(1) => n_var(xn),
-    Expr::Integer(n) => Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(*n)),
-      right: Box::new(n_var(xn)),
-    },
-    other => Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(other.clone()),
-      right: Box::new(n_var(xn)),
-    },
+    Expr::Integer(n) => times2(Expr::Integer(*n), n_var(xn)),
+    other => times2(other.clone(), n_var(xn)),
   };
-  Some(Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(head_term),
-    right: Box::new(c1_applied),
-  })
+  Some(plus2(head_term, c1_applied))
 }
 
 /// `-b/a` reduced to either an `Integer` (if `a` divides `b`) or a
@@ -4498,11 +4368,7 @@ fn try_euler_pde_body(
   let log_term = if c == 1 {
     log_x
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(c)),
-      right: Box::new(log_x),
-    }
+    times2(Expr::Integer(c), log_x)
   };
   let y_over_x = div2(n_var(yn), n_var(xn));
   let c1_applied = Expr::CurriedCall {
@@ -4512,11 +4378,7 @@ fn try_euler_pde_body(
     }),
     args: vec![y_over_x],
   };
-  let body = Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(log_term),
-    right: Box::new(c1_applied),
-  };
+  let body = plus2(log_term, c1_applied);
   Some(body)
 }
 

--- a/src/functions/rsolve_ast.rs
+++ b/src/functions/rsolve_ast.rs
@@ -313,11 +313,6 @@ fn solve_logistic_map(
     name: "Cos".to_string(),
     args: vec![arg].into(),
   };
-  let times = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
 
   match ics.len() {
     0 => {
@@ -327,24 +322,19 @@ fn solve_logistic_map(
         args: vec![Expr::Integer(1)].into(),
       };
       let exp2 = pow2(Expr::Integer(2), n_var);
-      let body = times(
+      let body = times2(
         crate::functions::math_ast::make_rational(-1, 2),
-        cos(times(exp2, c1)),
+        cos(times2(exp2, c1)),
       );
-      Some(Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(crate::functions::math_ast::make_rational(1, 2)),
-        right: Box::new(body),
-      })
+      Some(plus2(crate::functions::math_ast::make_rational(1, 2), body))
     }
     1 => {
       let (k0, c) = &ics[0];
       // theta = ArcCos[1 - 2 c], evaluated so e.g. 1 - 2*(1/10) -> 4/5.
-      let inner = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(times(Expr::Integer(-2), c.clone())),
-      })
+      let inner = crate::evaluator::evaluate_expr_to_expr(&plus2(
+        Expr::Integer(1),
+        times2(Expr::Integer(-2), c.clone()),
+      ))
       .ok()?;
       let theta =
         crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
@@ -356,27 +346,12 @@ fn solve_logistic_map(
       let exponent = if *k0 == 0 {
         n_var.clone()
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::Integer(-k0)),
-          right: Box::new(n_var.clone()),
-        }
+        plus2(Expr::Integer(-k0), n_var.clone())
       };
       let exp2 = pow2(Expr::Integer(2), exponent);
       // (1 - Cos[2^(n-k0)*theta]) / 2
-      let numerator = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(Expr::UnaryOp {
-          op: UnaryOperator::Minus,
-          operand: Box::new(cos(times(exp2, theta))),
-        }),
-      };
-      Some(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(numerator),
-        right: Box::new(Expr::Integer(2)),
-      })
+      let numerator = plus2(Expr::Integer(1), neg1(cos(times2(exp2, theta))));
+      Some(div2(numerator, Expr::Integer(2)))
     }
     _ => None, // over-determined
   }
@@ -416,10 +391,7 @@ fn collect_terms_with_forcing(
     forcing.push(if sign >= 0 {
       e.clone()
     } else {
-      Expr::UnaryOp {
-        op: UnaryOperator::Minus,
-        operand: Box::new(e.clone()),
-      }
+      neg1(e.clone())
     });
     true
   };
@@ -555,14 +527,10 @@ fn solve_first_order_arithmetic(
     1 => forcing.remove(0),
     _ => crate::functions::math_ast::plus_ast(&forcing).ok()?,
   };
-  let d = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(Expr::UnaryOp {
-      op: UnaryOperator::Minus,
-      operand: Box::new(forcing_total),
-    }),
-    right: Box::new(Expr::Integer(c_hi)),
-  })
+  let d = crate::evaluator::evaluate_expr_to_expr(&div2(
+    neg1(forcing_total),
+    Expr::Integer(c_hi),
+  ))
   .ok()?;
   if crate::functions::polynomial_ast::contains_var(&d, var_name) {
     return None; // index-dependent forcing — not an arithmetic progression
@@ -570,20 +538,13 @@ fn solve_first_order_arithmetic(
 
   let n = Expr::Identifier(var_name.to_string());
   // d * n
-  let dn = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-    op: BinaryOperator::Times,
-    left: Box::new(d.clone()),
-    right: Box::new(n.clone()),
-  })
-  .ok()?;
+  let dn =
+    crate::evaluator::evaluate_expr_to_expr(&times2(d.clone(), n.clone()))
+      .ok()?;
 
   // Build the Plus terms in wolframscript's display order with a raw BinaryOp
   // (the canonical sorter would reorder, e.g. `C[1] + n` instead of `n + C[1]`).
-  let raw_plus = |a: Expr, b: Expr| Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(a),
-    right: Box::new(b),
-  };
+  let raw_plus = |a: Expr, b: Expr| plus2(a, b);
   match ics.len() {
     0 => {
       // d*n + C[1]
@@ -599,15 +560,10 @@ fn solve_first_order_arithmetic(
     1 => {
       // a[n] = v + d*(n - k0) = (v - d*k0) + d*n, with the constant first.
       let (k0, v) = &ics[0];
-      let constant = crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(v.clone()),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(d),
-          right: Box::new(Expr::Integer(*k0)),
-        }),
-      })
+      let constant = crate::evaluator::evaluate_expr_to_expr(&minus2(
+        v.clone(),
+        times2(d, Expr::Integer(*k0)),
+      ))
       .ok()?;
       if matches!(&dn, Expr::Integer(0)) {
         return Some(constant);
@@ -1051,17 +1007,10 @@ fn build_fib_lucas_combination(
     let mut iter = factors.into_iter();
     let mut term = iter.next().unwrap();
     for f in iter {
-      term = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(term),
-        right: Box::new(f),
-      };
+      term = times2(term, f);
     }
     if m == -1 {
-      term = Expr::UnaryOp {
-        op: UnaryOperator::Minus,
-        operand: Box::new(term),
-      };
+      term = neg1(term);
     }
     terms.push(term);
   }
@@ -1074,11 +1023,7 @@ fn build_fib_lucas_combination(
   if denom == 1 {
     Some(numerator)
   } else {
-    Some(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numerator),
-      right: Box::new(Expr::Integer(denom)),
-    })
+    Some(div2(numerator, Expr::Integer(denom)))
   }
 }
 
@@ -1118,26 +1063,15 @@ fn build_first_order_with_ic(
   let exponent = if off == 0 {
     n_var
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(off)),
-      right: Box::new(n_var),
-    }
+    plus2(Expr::Integer(off), n_var)
   };
   let power = pow2(Expr::Integer(rn), exponent);
   let result = if v == 1 {
     power
   } else if v == -1 {
-    Expr::UnaryOp {
-      op: UnaryOperator::Minus,
-      operand: Box::new(power),
-    }
+    neg1(power)
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(v)),
-      right: Box::new(power),
-    }
+    times2(Expr::Integer(v), power)
   };
   Some(result)
 }
@@ -1215,11 +1149,7 @@ fn build_partial_solution(
   let term1 = if matches!(&r1_pow_n, Expr::Integer(1)) {
     c1.clone()
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(r1_pow_n.clone()),
-      right: Box::new(c1.clone()),
-    }
+    times2(r1_pow_n.clone(), c1.clone())
   };
 
   // Term 2: v * r_2^n  (collapsing on v == 1 / -1 / r_2 == 1)
@@ -1228,31 +1158,17 @@ fn build_partial_solution(
   } else if v == 1 {
     r2_pow_n.clone()
   } else if v == -1 {
-    Expr::UnaryOp {
-      op: UnaryOperator::Minus,
-      operand: Box::new(r2_pow_n.clone()),
-    }
+    neg1(r2_pow_n.clone())
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(v)),
-      right: Box::new(r2_pow_n.clone()),
-    }
+    times2(Expr::Integer(v), r2_pow_n.clone())
   };
 
   // Term 3: -C[1] * r_2^n
-  let neg_c1_r2n = Expr::UnaryOp {
-    op: UnaryOperator::Minus,
-    operand: Box::new(if matches!(&r2_pow_n, Expr::Integer(1)) {
-      c1.clone()
-    } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(r2_pow_n),
-        right: Box::new(c1.clone()),
-      }
-    }),
-  };
+  let neg_c1_r2n = neg1(if matches!(&r2_pow_n, Expr::Integer(1)) {
+    c1.clone()
+  } else {
+    times2(r2_pow_n, c1.clone())
+  });
 
   crate::functions::math_ast::plus_ast(&[term1, term2, neg_c1_r2n]).ok()
 }
@@ -1290,11 +1206,7 @@ fn build_general_solution(
       };
       let exponent = if single_root {
         // `-1 + n` (constant first) to match wolframscript's display order.
-        Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::Integer(-1)),
-          right: Box::new(Expr::Identifier(var_name.to_string())),
-        }
+        plus2(Expr::Integer(-1), Expr::Identifier(var_name.to_string()))
       } else {
         Expr::Identifier(var_name.to_string())
       };
@@ -1316,11 +1228,7 @@ fn build_general_solution(
     let mut iter = factors.into_iter();
     let mut term = iter.next().unwrap();
     for f in iter {
-      term = Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(term),
-        right: Box::new(f),
-      };
+      term = times2(term, f);
     }
     terms.push(term);
   }
@@ -1747,19 +1655,12 @@ fn build_solution(
       let mut iter = factors.into_iter();
       let mut t = iter.next().unwrap();
       for f in iter {
-        t = Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(t),
-          right: Box::new(f),
-        };
+        t = times2(t, f);
       }
       t
     };
     if num < 0 {
-      term = Expr::UnaryOp {
-        op: UnaryOperator::Minus,
-        operand: Box::new(term),
-      };
+      term = neg1(term);
     }
 
     terms.push(term);
@@ -1780,11 +1681,7 @@ fn build_solution(
   if common_denom == 1 {
     Some(numerator)
   } else {
-    Some(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numerator),
-      right: Box::new(Expr::Integer(common_denom)),
-    })
+    Some(div2(numerator, Expr::Integer(common_denom)))
   }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -28,6 +28,10 @@ pub fn pow2(b: Expr, e: Expr) -> Expr {
   binop(BinaryOperator::Power, b, e)
 }
 
+pub fn times2(a: Expr, b: Expr) -> Expr {
+  binop(BinaryOperator::Times, a, b)
+}
+
 pub fn div2(a: Expr, b: Expr) -> Expr {
   binop(BinaryOperator::Divide, a, b)
 }


### PR DESCRIPTION
This adds a times2 AST helper to construct BinaryOperator::Times expressions, completing the set of BinaryOperator helpers. It also applies the existing helpers in more places.