### PR TITLE
Sync Manipulate sliders after body-side-effect assignments

### DIFF
--- a/src/functions/geo_math.rs
+++ b/src/functions/geo_math.rs
@@ -285,11 +285,8 @@ impl AngleVal {
 
   /// d + m/60 + s/3600, staying exact only when all three parts are exact.
   fn from_dms(d: &Self, m: &Self, s: &Self) -> Self {
-    if let (
-      Self::Exact(dp, dq),
-      Self::Exact(mp, mq),
-      Self::Exact(sp, sq),
-    ) = (d, m, s)
+    if let (Self::Exact(dp, dq), Self::Exact(mp, mq), Self::Exact(sp, sq)) =
+      (d, m, s)
       && let Some(v) = (|| {
         let a = rat_add((*dp, *dq), (*mp, mq.checked_mul(60)?))?;
         rat_add(a, (*sp, sq.checked_mul(3600)?))

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16455,9 +16455,7 @@ impl ManipulateControl {
       | Self::IntervalSlider { name, .. }
       | Self::Trigger { name, .. }
       | Self::Locator { name, .. } => name,
-      Self::Button { .. }
-      | Self::Heading { .. }
-      | Self::Divider => "",
+      Self::Button { .. } | Self::Heading { .. } | Self::Divider => "",
     }
   }
 }
@@ -20877,10 +20875,7 @@ pub enum DisplayNode {
   /// against the live bindings, exactly like a `Button` written as a
   /// Manipulate control argument. Demonstrations use these inside a
   /// `Dynamic[…]` caption to step a variable (`n++`, `n = 1`, …).
-  Button {
-    label: Box<Self>,
-    action: String,
-  },
+  Button { label: Box<Self>, action: String },
   /// A `Spacer[w]`: `w` printer's points of horizontal space.
   Spacer { width: f64 },
   /// A text leaf with its styled runs, so `Style["…", Bold, Red]` renders

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -1924,10 +1924,7 @@ impl MeasureEvent {
   /// Whether the event carries an explicit (rigid) duration. Default events are
   /// elastic: a trailing default note stretches to fill the measure.
   fn is_explicit(&self) -> bool {
-    matches!(
-      self,
-      Self::Note(_, Some(_)) | Self::Rest(Some(_))
-    )
+    matches!(self, Self::Note(_, Some(_)) | Self::Rest(Some(_)))
   }
 }
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6716,6 +6716,38 @@ mod tests {
   }
 
   #[test]
+  fn manipulate_body_assignment_moves_the_written_controls_sliders() {
+    // A "preset" idiom several Demonstrations use: picking one control
+    // (`preset`) makes the body assign new values straight into other
+    // controls' own variables (`{a, b} = presets[[preset]]`). Wolfram
+    // treats that assignment as moving those controls' widgets, not just
+    // feeding the current render — so after the assignment runs, `a` and
+    // `b`'s sliders must show the assigned values, not their declared
+    // defaults.
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[If[preset == 1, {a, b} = {10, 20}]; a + b, \
+       {{preset, 1, \"\"}, {0, 1}}, {{a, 3}, 0, 100}, {{b, 4}, 0, 100}]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    assert_eq!(state.text_output.as_deref(), Some("30"));
+    let manipulate::ControlState::Continuous { name, current, .. } =
+      &state.controls[1]
+    else {
+      panic!("expected a continuous slider for `a`");
+    };
+    assert_eq!(name, "a");
+    assert_eq!(*current, 10.0, "slider `a` must follow the assignment");
+    let manipulate::ControlState::Continuous { name, current, .. } =
+      &state.controls[2]
+    else {
+      panic!("expected a continuous slider for `b`");
+    };
+    assert_eq!(name, "b");
+    assert_eq!(*current, 20.0, "slider `b` must follow the assignment");
+  }
+
+  #[test]
   fn animate_widget_starts_playing_and_wraps() {
     // An Animate widget auto-plays from its initial value and its animation
     // tick advances the continuous control by one step, wrapping back to

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -659,11 +659,15 @@ impl ManipulateState {
     let control_visible = self.control_visible.clone();
     let dynamic_bounds = self.dynamic_bounds.clone();
     let dynamic_values = self.dynamic_values.clone();
-    let state_names: Vec<String> =
-      self.state.iter().map(|(n, _)| n.clone()).collect();
+    // Every bound name (visible controls + hidden state), so a body that
+    // reassigns one of its own controls — a common "preset" idiom, e.g.
+    // `If[given > 0, {a, b, c} = presets[[given]]]` — moves that control's
+    // widget too, not just the value used to render this frame.
+    let binding_names: Vec<String> =
+      bindings.iter().map(|(n, _)| n.clone()).collect();
     let (
       render,
-      updated_state,
+      updated_bindings,
       display_trees,
       enabled,
       visible,
@@ -675,7 +679,7 @@ impl ManipulateState {
       // and a `Dynamic[…]` caption showing them must display what this
       // frame computed, not the previous frame's values.
       let render = woxi::interpret_with_stdout(&code);
-      let updated_state = read_manipulate_state(&state_names);
+      let updated_bindings = read_manipulate_state(&binding_names);
       let trees: Vec<_> = displays
         .iter()
         .map(|d| build_manipulate_display(d, &[]))
@@ -722,7 +726,7 @@ impl ManipulateState {
         .collect();
       (
         render,
-        updated_state,
+        updated_bindings,
         trees,
         enabled,
         visible,
@@ -731,10 +735,18 @@ impl ManipulateState {
       )
     });
     // Keep the body's writes to the widget's own variables, so the next
-    // frame (and any caption) builds on them.
-    for (name, value) in updated_state {
+    // frame (and any caption) builds on them — whether that variable is
+    // hidden state or a visible control's own slider/picker.
+    for (name, value) in updated_bindings {
       if let Some(slot) = self.state.iter_mut().find(|(n, _)| *n == name) {
         slot.1 = value;
+        continue;
+      }
+      for ctrl in &mut self.controls {
+        if ctrl.name() == name {
+          ctrl.set_current_from_code(&value);
+          break;
+        }
       }
     }
     self.display_trees = display_trees;


### PR DESCRIPTION
## Summary

While checking Woxi Studio's support for a real Wolfram Demonstrations Project notebook (downloaded via the resource system's random-page API, not committed to this repo), I found a genuine interactivity gap in `Manipulate` handling.

Some Demonstrations use a "preset" idiom where the `Manipulate` body assigns directly to one of its own control variables as a side effect, e.g.:

```
Manipulate[
  If[preset > 0, {a, b} = presets[[preset]]];
  (* ... use a, b ... *),
  {{preset, 0, "preset"}, {0, 1, 2}},
  {{a, 3}, 0, 100},
  {{b, 4}, 0, 100}
]
```

Picking a preset correctly drove the rendered output (the body re-evaluates with the new `a`/`b` values), but the `a`/`b` slider widgets themselves kept showing their declared defaults instead of snapping to the assigned values — unlike real Wolfram, where any assignment to a tracked control variable moves that control's widget too. This is exactly the mechanism the notebook I tested relies on: a preset-solid picker whose "cube height"/"cap" sliders are meant to jump to the preset's values and become read-only (`Enabled -> Dynamic[given == 0]`) — with the bug, the disabled sliders showed stale defaults instead of the actual preset configuration.

`Button` actions already had this behavior (`apply_button_action` reads back and applies mutated bindings), but the main body-reevaluation path (`reevaluate_inner`) only read back hidden `ControlType -> None` state, not visible controls. This PR extends the same read-back to every bound control, not just hidden state.

## Changes

- `woxi-studio/src/manipulate.rs`: `reevaluate_inner` now reads back the post-evaluation value of every bound control (not just hidden state vars) and applies any change to the matching widget via the existing `set_current_from_code`, mirroring what `apply_button_action` already did for button-triggered assignments.
- `woxi-studio/src/main.rs`: added a regression test (`manipulate_body_assignment_moves_the_written_controls_sliders`) with a minimal synthetic repro.

## Test plan

- [x] `cargo test -p woxi-studio` — 109/109 passed (108 pre-existing + 1 new)
- [x] `make test` (full interpreter unit-test suite) — 26,767/26,767 passed
- [x] `cargo fmt --check` / `cargo clippy -p woxi-studio --all-targets -- -D warnings` — clean
- [x] Manually verified against the downloaded Demonstration notebook: before the fix the preset-driven sliders showed their declared defaults; after the fix they show the correct preset values, and the rendered `Graphics3D` (a house-like solid built from three orthogonal projections) still renders correctly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CJgs4FNJ6yjUWoFQ99ynZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJgs4FNJ6yjUWoFQ99ynZr)_