### PR TITLE
Implement global call, call1 AST helpers

### DIFF
--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -324,12 +324,10 @@ pub fn dispatch_linear_algebra_functions(
       // A dense identity contains no structural zeros to preserve, so the
       // usual SparseArray conversion produces the same CSR form as
       // wolframscript's IdentityMatrix[n, SparseArray].
-      return Some(crate::evaluator::evaluate_expr_to_expr(
-        &Expr::FunctionCall {
-          name: "SparseArray".to_string(),
-          args: vec![dense].into(),
-        },
-      ));
+      return Some(crate::evaluator::evaluate_expr_to_expr(&call(
+        "SparseArray",
+        vec![dense],
+      )));
     }
     // IdentityMatrix[n, type] with an unsupported structural type (neither a
     // list nor SparseArray) stays unevaluated with wolframscript's message.
@@ -597,10 +595,7 @@ pub fn dispatch_linear_algebra_functions(
       if let Expr::List(v) = &args[0] {
         let n = v.len();
         if n > 0 {
-          let dot_vv = Expr::FunctionCall {
-            name: "Dot".to_string(),
-            args: vec![args[0].clone(), args[0].clone()].into(),
-          };
+          let dot_vv = call("Dot", vec![args[0].clone(), args[0].clone()]);
           let mut rows = Vec::with_capacity(n);
           for i in 0..n {
             let mut row = Vec::with_capacity(n);
@@ -610,26 +605,10 @@ pub fn dispatch_linear_algebra_functions(
               } else {
                 Expr::Integer(0)
               };
-              let vi_vj = Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(v[i].clone()),
-                right: Box::new(v[j].clone()),
-              };
-              let two_vi_vj = Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(Expr::Integer(2)),
-                right: Box::new(vi_vj),
-              };
-              let frac = Expr::BinaryOp {
-                op: BinaryOperator::Divide,
-                left: Box::new(two_vi_vj),
-                right: Box::new(dot_vv.clone()),
-              };
-              let entry = Expr::BinaryOp {
-                op: BinaryOperator::Minus,
-                left: Box::new(delta),
-                right: Box::new(frac),
-              };
+              let vi_vj = times2(v[i].clone(), v[j].clone());
+              let two_vi_vj = times2(Expr::Integer(2), vi_vj);
+              let frac = div2(two_vi_vj, dot_vv.clone());
+              let entry = minus2(delta, frac);
               row.push(entry);
             }
             rows.push(Expr::List(row.into()));
@@ -642,12 +621,10 @@ pub fn dispatch_linear_algebra_functions(
     // ScalingMatrix[{s1, …, sn}] → DiagonalMatrix of the scale factors.
     "ScalingMatrix" if args.len() == 1 => {
       if let Expr::List(_) = &args[0] {
-        return Some(crate::evaluator::evaluate_expr_to_expr(
-          &Expr::FunctionCall {
-            name: "DiagonalMatrix".to_string(),
-            args: vec![args[0].clone()].into(),
-          },
-        ));
+        return Some(crate::evaluator::evaluate_expr_to_expr(&call(
+          "DiagonalMatrix",
+          vec![args[0].clone()],
+        )));
       }
     }
     // ScalingMatrix[s, v] → matrix scaling by factor s along direction v:
@@ -658,15 +635,8 @@ pub fn dispatch_linear_algebra_functions(
         let n = v.len();
         if n > 0 {
           let s = &args[0];
-          let dot_vv = Expr::FunctionCall {
-            name: "Dot".to_string(),
-            args: vec![args[1].clone(), args[1].clone()].into(),
-          };
-          let s_minus_1 = Expr::BinaryOp {
-            op: BinaryOperator::Minus,
-            left: Box::new(s.clone()),
-            right: Box::new(Expr::Integer(1)),
-          };
+          let dot_vv = call("Dot", vec![args[1].clone(), args[1].clone()]);
+          let s_minus_1 = minus2(s.clone(), Expr::Integer(1));
           let mut rows = Vec::with_capacity(n);
           for i in 0..n {
             let mut row = Vec::with_capacity(n);
@@ -676,31 +646,12 @@ pub fn dispatch_linear_algebra_functions(
               } else {
                 Expr::Integer(0)
               };
-              let vi_vj = Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(v[i].clone()),
-                right: Box::new(v[j].clone()),
-              };
-              let numer = Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(s_minus_1.clone()),
-                right: Box::new(vi_vj),
-              };
-              let frac = Expr::BinaryOp {
-                op: BinaryOperator::Divide,
-                left: Box::new(numer),
-                right: Box::new(dot_vv.clone()),
-              };
-              let sum = Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(delta),
-                right: Box::new(frac),
-              };
+              let vi_vj = times2(v[i].clone(), v[j].clone());
+              let numer = times2(s_minus_1.clone(), vi_vj);
+              let frac = div2(numer, dot_vv.clone());
+              let sum = plus2(delta, frac);
               // Together so e.g. 1 + (s − 1)/2 renders as (1 + s)/2.
-              row.push(Expr::FunctionCall {
-                name: "Together".to_string(),
-                args: vec![sum].into(),
-              });
+              row.push(call("Together", vec![sum]));
             }
             rows.push(Expr::List(row.into()));
           }
@@ -769,11 +720,10 @@ pub fn dispatch_linear_algebra_functions(
         && let Expr::List(eigenvals) = &list_expr
       {
         for ev in eigenvals {
-          let n_val =
-            crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-              name: "N".to_string(),
-              args: vec![ev.clone()].into(),
-            });
+          let n_val = crate::evaluator::evaluate_expr_to_expr(&call(
+            "N",
+            vec![ev.clone()],
+          ));
           match n_val {
             Ok(Expr::Real(f)) if f > 0.0 => continue,
             Ok(Expr::Integer(n)) if n > 0 => continue,
@@ -803,17 +753,11 @@ pub fn dispatch_linear_algebra_functions(
           }
         }
         // Build the Hermitian part: (m + ConjugateTranspose[m]) / 2.
-        let conj_t = Expr::FunctionCall {
-          name: "ConjugateTranspose".to_string(),
-          args: vec![args[0].clone()].into(),
-        };
+        let conj_t = call("ConjugateTranspose", vec![args[0].clone()]);
         let herm = Expr::FunctionCall {
           name: "Divide".to_string(),
           args: vec![
-            Expr::FunctionCall {
-              name: "Plus".to_string(),
-              args: vec![args[0].clone(), conj_t].into(),
-            },
+            call("Plus", vec![args[0].clone(), conj_t]),
             Expr::Integer(2),
           ]
           .into(),
@@ -826,14 +770,10 @@ pub fn dispatch_linear_algebra_functions(
           let mut has_pos = false;
           let mut has_neg = false;
           for ev in eigenvals.iter() {
-            let n_val = evaluate_expr_to_expr(&Expr::FunctionCall {
-              name: "N".to_string(),
-              args: vec![Expr::FunctionCall {
-                name: "Re".to_string(),
-                args: vec![ev.clone()].into(),
-              }]
-              .into(),
-            });
+            let n_val = evaluate_expr_to_expr(&call(
+              "N",
+              vec![call("Re", vec![ev.clone()])],
+            ));
             match n_val {
               Ok(Expr::Real(f)) if f > 0.0 => has_pos = true,
               Ok(Expr::Real(f)) if f < 0.0 => has_neg = true,
@@ -1000,10 +940,7 @@ pub fn dispatch_linear_algebra_functions(
                     name: "Plus".to_string(),
                     args: vec![
                       elem.clone(),
-                      Expr::FunctionCall {
-                        name: "Times".to_string(),
-                        args: vec![Expr::Integer(-1), x.clone()].into(),
-                      },
+                      call("Times", vec![Expr::Integer(-1), x.clone()]),
                     ]
                     .into(),
                   };
@@ -1169,10 +1106,10 @@ pub fn dispatch_linear_algebra_functions(
       {
         return Some(Ok(unevaluated("MatrixExp", args)));
       }
-      return Some(evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Dot".to_string(),
-        args: vec![exp, args[1].clone()].into(),
-      }));
+      return Some(evaluate_expr_to_expr(&call(
+        "Dot",
+        vec![exp, args[1].clone()],
+      )));
     }
     "MatrixLog" if args.len() == 1 => {
       return Some(crate::functions::linear_algebra_ast::matrix_function_ast(
@@ -1314,18 +1251,9 @@ pub fn dispatch_linear_algebra_functions(
         && u.len() == 2
         && v.len() == 2
       {
-        let times = |a: Expr, b: Expr| Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![a, b].into(),
-        };
-        let plus = |a: Expr, b: Expr| Expr::FunctionCall {
-          name: "Plus".to_string(),
-          args: vec![a, b].into(),
-        };
-        let sq = |a: Expr| Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![a, Expr::Integer(2)].into(),
-        };
+        let times = |a: Expr, b: Expr| call("Times", vec![a, b]);
+        let plus = |a: Expr, b: Expr| call("Plus", vec![a, b]);
+        let sq = |a: Expr| call("Power", vec![a, Expr::Integer(2)]);
         let neg = |a: Expr| times(Expr::Integer(-1), a);
         let (ux, uy, vx, vy) =
           (u[0].clone(), u[1].clone(), v[0].clone(), v[1].clone());
@@ -1336,17 +1264,8 @@ pub fn dispatch_linear_algebra_functions(
           neg(times(uy.clone(), vx.clone())),
         );
         let normsq = times(plus(sq(ux), sq(uy)), plus(sq(vx), sq(vy)));
-        let inv_d = Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![
-            Expr::FunctionCall {
-              name: "Sqrt".to_string(),
-              args: vec![normsq].into(),
-            },
-            Expr::Integer(-1),
-          ]
-          .into(),
-        };
+        let inv_d =
+          call("Power", vec![call1("Sqrt", normsq), Expr::Integer(-1)]);
         let cos = times(dot, inv_d.clone());
         let sin = times(cross, inv_d);
         let mat = Expr::List(
@@ -1365,10 +1284,7 @@ pub fn dispatch_linear_algebra_functions(
         && uu.len() >= 2
         && uu.len() == vv.len()
       {
-        let theta = Expr::FunctionCall {
-          name: "VectorAngle".to_string(),
-          args: vec![pair[0].clone(), pair[1].clone()].into(),
-        };
+        let theta = call("VectorAngle", vec![pair[0].clone(), pair[1].clone()]);
         return Some(rotation_matrix_plane(&theta, &pair[0], &pair[1]));
       }
       return Some(Ok(unevaluated("RotationMatrix", args)));
@@ -1376,18 +1292,9 @@ pub fn dispatch_linear_algebra_functions(
     "RotationMatrix" if args.len() == 1 => {
       // 2D rotation matrix: {{Cos[θ], -Sin[θ]}, {Sin[θ], Cos[θ]}}
       let theta = &args[0];
-      let cos = Expr::FunctionCall {
-        name: "Cos".to_string(),
-        args: vec![theta.clone()].into(),
-      };
-      let sin = Expr::FunctionCall {
-        name: "Sin".to_string(),
-        args: vec![theta.clone()].into(),
-      };
-      let neg_sin = Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), sin.clone()].into(),
-      };
+      let cos = call1("Cos", theta.clone());
+      let sin = call1("Sin", theta.clone());
+      let neg_sin = call("Times", vec![Expr::Integer(-1), sin.clone()]);
       let mat = Expr::List(
         vec![
           Expr::List(vec![cos.clone(), neg_sin].into()),
@@ -1483,11 +1390,10 @@ pub fn dispatch_linear_algebra_functions(
         last_row[n] = Expr::Integer(1);
         rows.push(Expr::List(last_row.into()));
         let matrix = Expr::List(rows.into());
-        let evaluated =
-          crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-            name: "TransformationFunction".to_string(),
-            args: vec![matrix].into(),
-          });
+        let evaluated = crate::evaluator::evaluate_expr_to_expr(&call(
+          "TransformationFunction",
+          vec![matrix],
+        ));
         return Some(evaluated);
       }
       return Some(Ok(unevaluated("TranslationTransform", args)));
@@ -1546,30 +1452,14 @@ pub fn dispatch_linear_algebra_functions(
           None => (Expr::Integer(0), Expr::Integer(1)),
         };
         // scale = (ymax - ymin)/(max - min)
-        let num = Expr::FunctionCall {
-          name: "Subtract".to_string(),
-          args: vec![ymax_i.clone(), ymin_i.clone()].into(),
-        };
-        let den = Expr::FunctionCall {
-          name: "Subtract".to_string(),
-          args: vec![max_i.clone(), min_i.clone()].into(),
-        };
-        let scale = Expr::FunctionCall {
-          name: "Divide".to_string(),
-          args: vec![num, den].into(),
-        };
+        let num = call("Subtract", vec![ymax_i.clone(), ymin_i.clone()]);
+        let den = call("Subtract", vec![max_i.clone(), min_i.clone()]);
+        let scale = call("Divide", vec![num, den]);
         // translate = ymin - min * scale
-        let translate = Expr::FunctionCall {
-          name: "Subtract".to_string(),
-          args: vec![
-            ymin_i,
-            Expr::FunctionCall {
-              name: "Times".to_string(),
-              args: vec![min_i, scale.clone()].into(),
-            },
-          ]
-          .into(),
-        };
+        let translate = call(
+          "Subtract",
+          vec![ymin_i, call("Times", vec![min_i, scale.clone()])],
+        );
         scales.push(scale);
         translates.push(translate);
       }
@@ -1585,12 +1475,10 @@ pub fn dispatch_linear_algebra_functions(
       last_row[n] = Expr::Integer(1);
       rows.push(Expr::List(last_row.into()));
       let matrix = Expr::List(rows.into());
-      return Some(crate::evaluator::evaluate_expr_to_expr(
-        &Expr::FunctionCall {
-          name: "TransformationFunction".to_string(),
-          args: vec![matrix].into(),
-        },
-      ));
+      return Some(crate::evaluator::evaluate_expr_to_expr(&call(
+        "TransformationFunction",
+        vec![matrix],
+      )));
     }
     // TransformationMatrix[TransformationFunction[m]] → m. Extracts the
     // homogeneous matrix from a transformation; any other argument (a plain
@@ -1643,10 +1531,10 @@ pub fn dispatch_linear_algebra_functions(
           );
         }
       }
-      return Some(Ok(Expr::FunctionCall {
-        name: "GeometricTransformation".to_string(),
-        args: vec![args[0].clone(), transform].into(),
-      }));
+      return Some(Ok(call(
+        "GeometricTransformation",
+        vec![args[0].clone(), transform],
+      )));
     }
     // RotationTransform[angle] → TransformationFunction[2D rotation matrix in homogeneous coords]
     // RotationTransform[angle, {cx, cy}] → rotation about point {cx, cy}
@@ -1662,22 +1550,10 @@ pub fn dispatch_linear_algebra_functions(
         && u.len() == 2
         && v.len() == 2
       {
-        let times = |a: Expr, b: Expr| Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![a, b].into(),
-        };
-        let plus = |a: Expr, b: Expr| Expr::FunctionCall {
-          name: "Plus".to_string(),
-          args: vec![a, b].into(),
-        };
-        let sq = |e: &Expr| Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![e.clone(), Expr::Integer(2)].into(),
-        };
-        let sqrt = |e: Expr| Expr::FunctionCall {
-          name: "Sqrt".to_string(),
-          args: vec![e].into(),
-        };
+        let times = |a: Expr, b: Expr| call("Times", vec![a, b]);
+        let plus = |a: Expr, b: Expr| call("Plus", vec![a, b]);
+        let sq = |e: &Expr| call("Power", vec![e.clone(), Expr::Integer(2)]);
+        let sqrt = |e: Expr| call1("Sqrt", e);
         let dot = plus(
           times(u[0].clone(), v[0].clone()),
           times(u[1].clone(), v[1].clone()),
@@ -1689,16 +1565,8 @@ pub fn dispatch_linear_algebra_functions(
         let nu = sqrt(plus(sq(&u[0]), sq(&u[1])));
         let nv = sqrt(plus(sq(&v[0]), sq(&v[1])));
         let denom = times(nu, nv);
-        let cos_t = Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(dot),
-          right: Box::new(denom.clone()),
-        };
-        let sin_t = Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(cross),
-          right: Box::new(denom),
-        };
+        let cos_t = div2(dot, denom.clone());
+        let sin_t = div2(cross, denom);
         let neg_sin = times(Expr::Integer(-1), sin_t.clone());
         let matrix = Expr::List(
           vec![
@@ -1710,12 +1578,10 @@ pub fn dispatch_linear_algebra_functions(
           ]
           .into(),
         );
-        return Some(crate::evaluator::evaluate_expr_to_expr(
-          &Expr::FunctionCall {
-            name: "TransformationFunction".to_string(),
-            args: vec![matrix].into(),
-          },
-        ));
+        return Some(crate::evaluator::evaluate_expr_to_expr(&call(
+          "TransformationFunction",
+          vec![matrix],
+        )));
       }
       // Three-dimensional axis form RotationTransform[theta, {x, y, z}]:
       // rotation by theta about the axis through the origin (Rodrigues'
@@ -1731,18 +1597,9 @@ pub fn dispatch_linear_algebra_functions(
         return Some(Ok(unevaluated("RotationTransform", args)));
       }
       let theta = &args[0];
-      let cos_t = Expr::FunctionCall {
-        name: "Cos".to_string(),
-        args: vec![theta.clone()].into(),
-      };
-      let sin_t = Expr::FunctionCall {
-        name: "Sin".to_string(),
-        args: vec![theta.clone()].into(),
-      };
-      let neg_sin_t = Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), sin_t.clone()].into(),
-      };
+      let cos_t = call1("Cos", theta.clone());
+      let sin_t = call1("Sin", theta.clone());
+      let neg_sin_t = call("Times", vec![Expr::Integer(-1), sin_t.clone()]);
       // Default last column is the zero translation
       let (tx, ty) = if args.len() == 2 {
         if let Expr::List(center) = &args[1]
@@ -1753,30 +1610,15 @@ pub fn dispatch_linear_algebra_functions(
           // Translation column for rotation about {cx,cy}:
           // tx = cx - cx*cos + cy*sin
           // ty = cy - cx*sin - cy*cos
-          let neg_cx_cos = Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![Expr::Integer(-1), cx.clone(), cos_t.clone()].into(),
-          };
-          let cy_sin = Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![cy.clone(), sin_t.clone()].into(),
-          };
-          let tx_e = Expr::FunctionCall {
-            name: "Plus".to_string(),
-            args: vec![cx.clone(), neg_cx_cos, cy_sin].into(),
-          };
-          let neg_cx_sin = Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![Expr::Integer(-1), cx.clone(), sin_t.clone()].into(),
-          };
-          let neg_cy_cos = Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![Expr::Integer(-1), cy.clone(), cos_t.clone()].into(),
-          };
-          let ty_e = Expr::FunctionCall {
-            name: "Plus".to_string(),
-            args: vec![cy.clone(), neg_cx_sin, neg_cy_cos].into(),
-          };
+          let neg_cx_cos =
+            call("Times", vec![Expr::Integer(-1), cx.clone(), cos_t.clone()]);
+          let cy_sin = call("Times", vec![cy.clone(), sin_t.clone()]);
+          let tx_e = call("Plus", vec![cx.clone(), neg_cx_cos, cy_sin]);
+          let neg_cx_sin =
+            call("Times", vec![Expr::Integer(-1), cx.clone(), sin_t.clone()]);
+          let neg_cy_cos =
+            call("Times", vec![Expr::Integer(-1), cy.clone(), cos_t.clone()]);
+          let ty_e = call("Plus", vec![cy.clone(), neg_cx_sin, neg_cy_cos]);
           (tx_e, ty_e)
         } else {
           // Non-list or wrong-dim center: leave unevaluated.
@@ -1798,11 +1640,10 @@ pub fn dispatch_linear_algebra_functions(
         .into(),
       );
       // Evaluate the matrix to simplify trig functions (e.g. Cos[Pi/4] → 1/Sqrt[2])
-      let evaluated =
-        crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "TransformationFunction".to_string(),
-          args: vec![matrix].into(),
-        });
+      let evaluated = crate::evaluator::evaluate_expr_to_expr(&call(
+        "TransformationFunction",
+        vec![matrix],
+      ));
       return Some(evaluated);
     }
     // AffineTransform[m] or AffineTransform[{m, v}] →
@@ -1869,11 +1710,10 @@ pub fn dispatch_linear_algebra_functions(
       last_row[n] = Expr::Integer(1);
       rows.push(Expr::List(last_row.into()));
       let matrix = Expr::List(rows.into());
-      let evaluated =
-        crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "TransformationFunction".to_string(),
-          args: vec![matrix].into(),
-        });
+      let evaluated = crate::evaluator::evaluate_expr_to_expr(&call(
+        "TransformationFunction",
+        vec![matrix],
+      ));
       return Some(evaluated);
     }
     // LinearFractionalTransform[{m, v, w, b}] → the projective transform
@@ -1929,21 +1769,17 @@ pub fn dispatch_linear_algebra_functions(
           last_row.push(b.clone());
           rows.push(Expr::List(last_row.into()));
           let matrix = Expr::List(rows.into());
-          return Some(crate::evaluator::evaluate_expr_to_expr(
-            &Expr::FunctionCall {
-              name: "TransformationFunction".to_string(),
-              args: vec![matrix].into(),
-            },
-          ));
+          return Some(crate::evaluator::evaluate_expr_to_expr(&call(
+            "TransformationFunction",
+            vec![matrix],
+          )));
         }
         // Plain (n+1)x(n+1) homogeneous matrix form.
         Expr::List(_) if is_matrix(&args[0]) => {
-          return Some(crate::evaluator::evaluate_expr_to_expr(
-            &Expr::FunctionCall {
-              name: "TransformationFunction".to_string(),
-              args: vec![args[0].clone()].into(),
-            },
-          ));
+          return Some(crate::evaluator::evaluate_expr_to_expr(&call(
+            "TransformationFunction",
+            vec![args[0].clone()],
+          )));
         }
         _ => return unevaluated(),
       }
@@ -1975,15 +1811,8 @@ pub fn dispatch_linear_algebra_functions(
           row[i] = scales[i].clone();
           // Translation column: ci - si*ci = ci*(1 - si)
           if let Some(c) = center {
-            let translation = Expr::BinaryOp {
-              op: BinaryOperator::Minus,
-              left: Box::new(c[i].clone()),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(scales[i].clone()),
-                right: Box::new(c[i].clone()),
-              }),
-            };
+            let translation =
+              minus2(c[i].clone(), times2(scales[i].clone(), c[i].clone()));
             row[n] = translation;
           }
           rows.push(Expr::List(row.into()));
@@ -1992,11 +1821,10 @@ pub fn dispatch_linear_algebra_functions(
         last_row[n] = Expr::Integer(1);
         rows.push(Expr::List(last_row.into()));
         let matrix = Expr::List(rows.into());
-        let evaluated =
-          crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-            name: "TransformationFunction".to_string(),
-            args: vec![matrix].into(),
-          });
+        let evaluated = crate::evaluator::evaluate_expr_to_expr(&call(
+          "TransformationFunction",
+          vec![matrix],
+        ));
         return Some(evaluated);
       }
       return Some(Ok(unevaluated("ScalingTransform", args)));
@@ -2019,18 +1847,9 @@ pub fn dispatch_linear_algebra_functions(
         Some(Expr::List(c)) if c.len() == n => Some(c.clone()),
         Some(_) => return uneval(),
       };
-      let power = |b: Expr, e: i128| Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![b, Expr::Integer(e)].into(),
-      };
-      let times = |factors: Vec<Expr>| Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: factors.into(),
-      };
-      let plus = |terms: Vec<Expr>| Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: terms.into(),
-      };
+      let power = |b: Expr, e: i128| call("Power", vec![b, Expr::Integer(e)]);
+      let times = |factors: Vec<Expr>| call("Times", factors);
+      let plus = |terms: Vec<Expr>| call("Plus", terms);
       let vv = plus(v.iter().map(|vi| power(vi.clone(), 2)).collect());
       let s_minus_1 = plus(vec![args[0].clone(), Expr::Integer(-1)]);
       let m_entry = |i: usize, j: usize| {
@@ -2048,10 +1867,7 @@ pub fn dispatch_linear_algebra_functions(
       };
       // Collect each entry over a common denominator, so a symbolic factor
       // gives wolframscript's (1 + s)/2 rather than 1 + (-1 + s)/2.
-      let simplify = |e: Expr| Expr::FunctionCall {
-        name: "Simplify".to_string(),
-        args: vec![e].into(),
-      };
+      let simplify = |e: Expr| call("Simplify", vec![e]);
       let mut rows = Vec::with_capacity(n + 1);
       for i in 0..n {
         let mut row: Vec<Expr> =
@@ -2071,12 +1887,10 @@ pub fn dispatch_linear_algebra_functions(
       let mut last_row = vec![Expr::Integer(0); n + 1];
       last_row[n] = Expr::Integer(1);
       rows.push(Expr::List(last_row.into()));
-      return Some(crate::evaluator::evaluate_expr_to_expr(
-        &Expr::FunctionCall {
-          name: "TransformationFunction".to_string(),
-          args: vec![Expr::List(rows.into())].into(),
-        },
-      ));
+      return Some(crate::evaluator::evaluate_expr_to_expr(&call(
+        "TransformationFunction",
+        vec![Expr::List(rows.into())],
+      )));
     }
     // ReflectionTransform[v] → reflection in the hyperplane through the origin
     // perpendicular to v. The linear part is M = I - 2 (v⊗v)/(v·v), embedded in
@@ -2099,18 +1913,9 @@ pub fn dispatch_linear_algebra_functions(
       if n == 0 {
         return unevaluated();
       }
-      let power = |b: Expr, e: i128| Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![b, Expr::Integer(e)].into(),
-      };
-      let times = |factors: Vec<Expr>| Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: factors.into(),
-      };
-      let plus = |terms: Vec<Expr>| Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: terms.into(),
-      };
+      let power = |b: Expr, e: i128| call("Power", vec![b, Expr::Integer(e)]);
+      let times = |factors: Vec<Expr>| call("Times", factors);
+      let plus = |terms: Vec<Expr>| call("Plus", terms);
       // v·v
       let vv = plus(v.iter().map(|vi| power(vi.clone(), 2)).collect());
       // Linear part M[i][j] = delta_ij - 2 v_i v_j / (v·v).
@@ -2152,12 +1957,10 @@ pub fn dispatch_linear_algebra_functions(
       last_row[n] = Expr::Integer(1);
       rows.push(Expr::List(last_row.into()));
       let matrix = Expr::List(rows.into());
-      return Some(crate::evaluator::evaluate_expr_to_expr(
-        &Expr::FunctionCall {
-          name: "TransformationFunction".to_string(),
-          args: vec![matrix].into(),
-        },
-      ));
+      return Some(crate::evaluator::evaluate_expr_to_expr(&call(
+        "TransformationFunction",
+        vec![matrix],
+      )));
     }
     // ShearingTransform[phi, e, n] → TransformationFunction[ homogeneous shear ]
     // A point x is mapped to x + Tan[phi] (nhat·x) ep, where nhat = n/Norm[n]
@@ -2182,28 +1985,12 @@ pub fn dispatch_linear_algebra_functions(
         let norm = |v: &[Expr]| -> Expr {
           let squares: Vec<Expr> = v
             .iter()
-            .map(|c| Expr::FunctionCall {
-              name: "Power".to_string(),
-              args: vec![c.clone(), Expr::Integer(2)].into(),
-            })
+            .map(|c| call("Power", vec![c.clone(), Expr::Integer(2)]))
             .collect();
-          Expr::FunctionCall {
-            name: "Sqrt".to_string(),
-            args: vec![Expr::FunctionCall {
-              name: "Plus".to_string(),
-              args: squares.into(),
-            }]
-            .into(),
-          }
+          call1("Sqrt", call("Plus", squares))
         };
-        let times = |factors: Vec<Expr>| Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: factors.into(),
-        };
-        let recip = |x: Expr| Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![x, Expr::Integer(-1)].into(),
-        };
+        let times = |factors: Vec<Expr>| call("Times", factors);
+        let recip = |x: Expr| call("Power", vec![x, Expr::Integer(-1)]);
         // nhat = n / Norm[n]
         let norm_n = norm(n);
         let nhat: Vec<Expr> = n
@@ -2238,20 +2025,14 @@ pub fn dispatch_linear_algebra_functions(
           .iter()
           .map(|c| times(vec![c.clone(), recip(norm_eperp.clone())]))
           .collect();
-        let tan_phi = Expr::FunctionCall {
-          name: "Tan".to_string(),
-          args: vec![phi.clone()].into(),
-        };
+        let tan_phi = call("Tan", vec![phi.clone()]);
         // Build (d+1)x(d+1) homogeneous matrix.
         let m_entry = |i: usize, j: usize| {
           // off[i][j] = Tan[phi] * ep[i] * nhat[j]
           let off =
             times(vec![tan_phi.clone(), ep[i].clone(), nhat[j].clone()]);
           if i == j {
-            Expr::FunctionCall {
-              name: "Plus".to_string(),
-              args: vec![Expr::Integer(1), off].into(),
-            }
+            call("Plus", vec![Expr::Integer(1), off])
           } else {
             off
           }
@@ -2262,10 +2043,7 @@ pub fn dispatch_linear_algebra_functions(
           for j in 0..d {
             // Simplify so that e.g. 1 + (-1/2) collapses to 1/2 (matching
             // Wolfram), while symbolic forms like Sqrt[3/5] are preserved.
-            row.push(Expr::FunctionCall {
-              name: "Simplify".to_string(),
-              args: vec![m_entry(i, j)].into(),
-            });
+            row.push(call("Simplify", vec![m_entry(i, j)]));
           }
           // Translation column p - M·p, zero when there is no centre.
           row.push(match &center {
@@ -2294,16 +2072,12 @@ pub fn dispatch_linear_algebra_functions(
         // numeric in Wolfram — promote every entry to machine precision.
         use crate::functions::math_ast::contains_inexact_real as is_inexact;
         if args.iter().any(is_inexact) {
-          matrix = Expr::FunctionCall {
-            name: "N".to_string(),
-            args: vec![matrix].into(),
-          };
+          matrix = call1("N", matrix);
         }
-        let evaluated =
-          crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-            name: "TransformationFunction".to_string(),
-            args: vec![matrix].into(),
-          });
+        let evaluated = crate::evaluator::evaluate_expr_to_expr(&call(
+          "TransformationFunction",
+          vec![matrix],
+        ));
         return Some(evaluated);
       }
       return Some(Ok(unevaluated("ShearingTransform", args)));
@@ -2343,12 +2117,9 @@ pub fn dispatch_linear_algebra_functions(
               match det {
                 Ok(d) => {
                   let sign = if (i + j) % 2 == 0 { 1 } else { -1 };
-                  let cofactor = evaluate_expr_to_expr(&Expr::BinaryOp {
-                    op: BinaryOperator::Times,
-                    left: Box::new(Expr::Integer(sign)),
-                    right: Box::new(d),
-                  })
-                  .unwrap_or(Expr::Integer(0));
+                  let cofactor =
+                    evaluate_expr_to_expr(&times2(Expr::Integer(sign), d))
+                      .unwrap_or(Expr::Integer(0));
                   row.push(cofactor);
                 }
                 Err(e) => return Some(Err(e)),
@@ -2519,10 +2290,8 @@ pub fn dispatch_linear_algebra_functions(
               }
               _ => {
                 // Try numeric evaluation
-                let nval = evaluate_expr_to_expr(&Expr::FunctionCall {
-                  name: "N".to_string(),
-                  args: vec![evaluated.clone()].into(),
-                });
+                let nval =
+                  evaluate_expr_to_expr(&call1("N", evaluated.clone()));
                 if let Ok(Expr::Real(v)) = nval
                   && v < 0.0
                 {
@@ -2571,10 +2340,8 @@ pub fn dispatch_linear_algebra_functions(
                 }
               }
               _ => {
-                let nval = evaluate_expr_to_expr(&Expr::FunctionCall {
-                  name: "N".to_string(),
-                  args: vec![evaluated.clone()].into(),
-                });
+                let nval =
+                  evaluate_expr_to_expr(&call1("N", evaluated.clone()));
                 if let Ok(Expr::Real(v)) = nval {
                   v < 0.0
                 } else {
@@ -2626,10 +2393,8 @@ pub fn dispatch_linear_algebra_functions(
                 }
               }
               _ => {
-                let nval = evaluate_expr_to_expr(&Expr::FunctionCall {
-                  name: "N".to_string(),
-                  args: vec![evaluated.clone()].into(),
-                });
+                let nval =
+                  evaluate_expr_to_expr(&call1("N", evaluated.clone()));
                 if let Ok(Expr::Real(v)) = nval {
                   v > 0.0
                 } else {
@@ -2662,20 +2427,15 @@ pub fn dispatch_linear_algebra_functions(
           for i in 0..n {
             for j in i..n {
               // Check M[i][j] == Conjugate[M[j][i]]
-              let conj = evaluate_expr_to_expr(&Expr::FunctionCall {
-                name: "Conjugate".to_string(),
-                args: vec![matrix[j][i].clone()].into(),
-              })
+              let conj = evaluate_expr_to_expr(&call(
+                "Conjugate",
+                vec![matrix[j][i].clone()],
+              ))
               .unwrap_or(matrix[j][i].clone());
-              let diff = evaluate_expr_to_expr(&Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(matrix[i][j].clone()),
-                right: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(Expr::Integer(-1)),
-                  right: Box::new(conj),
-                }),
-              })
+              let diff = evaluate_expr_to_expr(&plus2(
+                matrix[i][j].clone(),
+                times2(Expr::Integer(-1), conj),
+              ))
               .unwrap_or(Expr::Integer(1));
               if !is_zero_expr(&diff) {
                 return Some(Ok(bool_expr(false)));
@@ -2703,17 +2463,14 @@ pub fn dispatch_linear_algebra_functions(
           for i in 0..n {
             for j in i..n {
               // Check M[i][j] == -Conjugate[M[j][i]]
-              let conj = evaluate_expr_to_expr(&Expr::FunctionCall {
-                name: "Conjugate".to_string(),
-                args: vec![matrix[j][i].clone()].into(),
-              })
+              let conj = evaluate_expr_to_expr(&call(
+                "Conjugate",
+                vec![matrix[j][i].clone()],
+              ))
               .unwrap_or(matrix[j][i].clone());
-              let sum = evaluate_expr_to_expr(&Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(matrix[i][j].clone()),
-                right: Box::new(conj),
-              })
-              .unwrap_or(Expr::Integer(1));
+              let sum =
+                evaluate_expr_to_expr(&plus2(matrix[i][j].clone(), conj))
+                  .unwrap_or(Expr::Integer(1));
               if !is_zero_expr(&sum) {
                 return Some(Ok(bool_expr(false)));
               }
@@ -2741,10 +2498,10 @@ pub fn dispatch_linear_algebra_functions(
           let mut ct = vec![vec![Expr::Integer(0); n]; n];
           for i in 0..n {
             for j in 0..n {
-              ct[i][j] = evaluate_expr_to_expr(&Expr::FunctionCall {
-                name: "Conjugate".to_string(),
-                args: vec![matrix[j][i].clone()].into(),
-              })
+              ct[i][j] = evaluate_expr_to_expr(&call(
+                "Conjugate",
+                vec![matrix[j][i].clone()],
+              ))
               .unwrap_or(matrix[j][i].clone());
             }
           }
@@ -2887,10 +2644,8 @@ pub fn dispatch_linear_algebra_functions(
             for j in 0..n {
               if let Expr::List(row_j) = &rows[j] {
                 // Check m[i][j] + m[j][i] == 0
-                let sum = Expr::FunctionCall {
-                  name: "Plus".to_string(),
-                  args: vec![row_i[j].clone(), row_j[i].clone()].into(),
-                };
+                let sum =
+                  call("Plus", vec![row_i[j].clone(), row_j[i].clone()]);
                 let evaluated = evaluate_expr_to_expr(&sum).unwrap_or(sum);
                 if !matches!(evaluated, Expr::Integer(0)) {
                   is_antisymmetric = false;
@@ -2988,11 +2743,7 @@ pub fn dispatch_linear_algebra_functions(
           let sqrt_n =
             evaluate_expr_to_expr(&sqrt_n_expr).unwrap_or(sqrt_n_expr);
           // Compute 1/Sqrt[n] once (evaluated)
-          let inv_sqrt_n_expr = Expr::BinaryOp {
-            op: BinaryOperator::Divide,
-            left: Box::new(Expr::Integer(1)),
-            right: Box::new(sqrt_n.clone()),
-          };
+          let inv_sqrt_n_expr = div2(Expr::Integer(1), sqrt_n.clone());
           let inv_sqrt_n =
             evaluate_expr_to_expr(&inv_sqrt_n_expr).unwrap_or(inv_sqrt_n_expr);
 
@@ -3007,19 +2758,14 @@ pub fn dispatch_linear_algebra_functions(
                       inv_sqrt_n.clone()
                     } else if v == -1 {
                       // Use Times[-1, inv_sqrt_n] so display matches -(1/Sqrt[n])
-                      let entry = Expr::FunctionCall {
-                        name: "Times".to_string(),
-                        args: vec![Expr::Integer(-1), inv_sqrt_n.clone()]
-                          .into(),
-                      };
+                      let entry = call(
+                        "Times",
+                        vec![Expr::Integer(-1), inv_sqrt_n.clone()],
+                      );
                       evaluate_expr_to_expr(&entry).unwrap_or(entry)
                     } else {
                       // v / Sqrt[n]
-                      let entry = Expr::BinaryOp {
-                        op: BinaryOperator::Divide,
-                        left: Box::new(Expr::Integer(v)),
-                        right: Box::new(sqrt_n.clone()),
-                      };
+                      let entry = div2(Expr::Integer(v), sqrt_n.clone());
                       evaluate_expr_to_expr(&entry).unwrap_or(entry)
                     }
                   })
@@ -3050,24 +2796,12 @@ pub fn dispatch_linear_algebra_functions(
       if let Expr::List(v) = &args[1]
         && !v.is_empty()
       {
-        let times = |xs: Vec<Expr>| Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: xs.into(),
-        };
-        let plus = |xs: Vec<Expr>| Expr::FunctionCall {
-          name: "Plus".to_string(),
-          args: xs.into(),
-        };
-        let sq = |a: Expr| Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![a, Expr::Integer(2)].into(),
-        };
+        let times = |xs: Vec<Expr>| call("Times", xs);
+        let plus = |xs: Vec<Expr>| call("Plus", xs);
+        let sq = |a: Expr| call("Power", vec![a, Expr::Integer(2)]);
         let vdotv = plus(v.iter().cloned().map(sq).collect());
         let s_minus_1 = plus(vec![args[0].clone(), Expr::Integer(-1)]);
-        let inv = Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![vdotv, Expr::Integer(-1)].into(),
-        };
+        let inv = call("Power", vec![vdotv, Expr::Integer(-1)]);
         let factor = times(vec![s_minus_1, inv]);
         let n = v.len();
         let rows: Vec<Expr> = (0..n)
@@ -3143,15 +2877,9 @@ pub fn dispatch_linear_algebra_functions(
               ]
               .into(),
             };
-            Expr::FunctionCall {
-              name: "Cos".to_string(),
-              args: vec![angle].into(),
-            }
+            call1("Cos", angle)
           };
-          let times = |a: Expr, b: Expr| Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![a, b].into(),
-          };
+          let times = |a: Expr, b: Expr| call("Times", vec![a, b]);
           let mut rows = Vec::with_capacity(n as usize);
           for i in 1..=n {
             let mut row = Vec::with_capacity(n as usize);
@@ -3217,10 +2945,7 @@ pub fn dispatch_linear_algebra_functions(
           name: "Power".to_string(),
           args: vec![
             Expr::Integer(n as i128),
-            Expr::FunctionCall {
-              name: "Rational".to_string(),
-              args: vec![Expr::Integer(-1), Expr::Integer(2)].into(),
-            },
+            call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
           ]
           .into(),
         };
@@ -3249,40 +2974,27 @@ pub fn dispatch_linear_algebra_functions(
                 Expr::FunctionCall {
                   name: "Times".to_string(),
                   args: vec![
-                    Expr::FunctionCall {
-                      name: "Rational".to_string(),
-                      args: vec![Expr::Integer(snum), Expr::Integer(sden)]
-                        .into(),
-                    },
+                    call(
+                      "Rational",
+                      vec![Expr::Integer(snum), Expr::Integer(sden)],
+                    ),
                     Expr::Identifier("Pi".to_string()),
                   ]
                   .into(),
                 }
               };
               // Build (Cos[angle] + I*Sin[angle]) / Sqrt[n]
-              let cos_part = Expr::FunctionCall {
-                name: "Cos".to_string(),
-                args: vec![angle.clone()].into(),
-              };
+              let cos_part = call1("Cos", angle.clone());
               let sin_part = Expr::FunctionCall {
                 name: "Times".to_string(),
                 args: vec![
                   Expr::Identifier("I".to_string()),
-                  Expr::FunctionCall {
-                    name: "Sin".to_string(),
-                    args: vec![angle].into(),
-                  },
+                  call1("Sin", angle),
                 ]
                 .into(),
               };
-              let omega = Expr::FunctionCall {
-                name: "Plus".to_string(),
-                args: vec![cos_part, sin_part].into(),
-              };
-              let entry = Expr::FunctionCall {
-                name: "Times".to_string(),
-                args: vec![omega, inv_sqrt_n.clone()].into(),
-              };
+              let omega = call("Plus", vec![cos_part, sin_part]);
+              let entry = call("Times", vec![omega, inv_sqrt_n.clone()]);
               row.push(entry);
             }
           }
@@ -3493,10 +3205,7 @@ fn lu_decomposition_ast(mat: &Expr) -> Result<Expr, InterpreterError> {
   let rows = match mat {
     Expr::List(rows) => rows,
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "LUDecomposition".to_string(),
-        args: vec![mat.clone()].into(),
-      });
+      return Ok(call("LUDecomposition", vec![mat.clone()]));
     }
   };
 
@@ -3505,10 +3214,7 @@ fn lu_decomposition_ast(mat: &Expr) -> Result<Expr, InterpreterError> {
     let empty = Expr::List(vec![].into());
     let perm_data = Expr::List(
       vec![
-        Expr::FunctionCall {
-          name: "Cycles".to_string(),
-          args: vec![Expr::List(vec![].into())].into(),
-        },
+        call("Cycles", vec![Expr::List(vec![].into())]),
         Expr::Identifier("Infinity".into()),
       ]
       .into(),
@@ -3535,10 +3241,7 @@ fn lu_decomposition_ast(mat: &Expr) -> Result<Expr, InterpreterError> {
       }
       matrix.push(cols.to_vec());
     } else {
-      return Ok(Expr::FunctionCall {
-        name: "LUDecomposition".to_string(),
-        args: vec![mat.clone()].into(),
-      });
+      return Ok(call("LUDecomposition", vec![mat.clone()]));
     }
   }
 
@@ -3612,10 +3315,7 @@ fn lu_decomposition_ast(mat: &Expr) -> Result<Expr, InterpreterError> {
         name: "Times".to_string(),
         args: vec![
           matrix[i][k].clone(),
-          Expr::FunctionCall {
-            name: "Power".to_string(),
-            args: vec![pivot_val.clone(), Expr::Integer(-1)].into(),
-          },
+          call("Power", vec![pivot_val.clone(), Expr::Integer(-1)]),
         ]
         .into(),
       })
@@ -3623,23 +3323,17 @@ fn lu_decomposition_ast(mat: &Expr) -> Result<Expr, InterpreterError> {
 
       // Update row i: A[i][j] -= L[i][k] * A[k][j] for j > k
       for j in (k + 1)..n {
-        let product = evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![l_ik.clone(), matrix[k][j].clone()].into(),
-        })
-        .unwrap_or(Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![l_ik.clone(), matrix[k][j].clone()].into(),
-        });
+        let product = evaluate_expr_to_expr(&call(
+          "Times",
+          vec![l_ik.clone(), matrix[k][j].clone()],
+        ))
+        .unwrap_or(call("Times", vec![l_ik.clone(), matrix[k][j].clone()]));
 
         let new_val = evaluate_expr_to_expr(&Expr::FunctionCall {
           name: "Plus".to_string(),
           args: vec![
             matrix[i][j].clone(),
-            Expr::FunctionCall {
-              name: "Times".to_string(),
-              args: vec![Expr::Integer(-1), product].into(),
-            },
+            call("Times", vec![Expr::Integer(-1), product]),
           ]
           .into(),
         })
@@ -3731,14 +3425,10 @@ fn lu_decomposition_ast(mat: &Expr) -> Result<Expr, InterpreterError> {
 fn lu_structured_matrix(head: &str, n: usize, payload: Expr) -> Expr {
   let dims =
     Expr::List(vec![Expr::Integer(n as i128), Expr::Integer(n as i128)].into());
-  Expr::FunctionCall {
-    name: head.to_string(),
-    args: vec![Expr::FunctionCall {
-      name: "StructuredArray`StructuredData".to_string(),
-      args: vec![dims, payload].into(),
-    }]
-    .into(),
-  }
+  call(
+    head,
+    vec![call("StructuredArray`StructuredData", vec![dims, payload])],
+  )
 }
 
 /// Convert a row permutation (0-indexed `pivots[i]` = original row now at
@@ -3763,18 +3453,12 @@ fn lu_pivots_to_cycles(pivots: &[usize]) -> Expr {
       cycles.push(Expr::List(cycle.into()));
     }
   }
-  Expr::FunctionCall {
-    name: "Cycles".to_string(),
-    args: vec![Expr::List(cycles.into())].into(),
-  }
+  call("Cycles", vec![Expr::List(cycles.into())])
 }
 
 /// Numeric value of an expression (integer, real, or rational) via `N`.
 fn lu_num(e: &Expr) -> Option<f64> {
-  match evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "N".to_string(),
-    args: vec![e.clone()].into(),
-  }) {
+  match evaluate_expr_to_expr(&call1("N", e.clone())) {
     Ok(Expr::Real(r)) => Some(r),
     Ok(Expr::Integer(i)) => Some(i as f64),
     _ => None,
@@ -3799,10 +3483,7 @@ fn lu_infinity_condition(matrix: &[Vec<Expr>]) -> Expr {
   );
   let norm_a = lu_infinity_norm(matrix);
 
-  let inv = match evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Inverse".to_string(),
-    args: vec![orig].into(),
-  }) {
+  let inv = match evaluate_expr_to_expr(&call("Inverse", vec![orig])) {
     Ok(e) => e,
     _ => return Expr::Identifier("Infinity".into()),
   };
@@ -4014,10 +3695,7 @@ fn binary_dissimilarity_ast(
   let (list_a, list_b) = match (a, b) {
     (Expr::List(la), Expr::List(lb)) if la.len() == lb.len() => (la, lb),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: name.to_string(),
-        args: vec![a.clone(), b.clone()].into(),
-      });
+      return Ok(call(name, vec![a.clone(), b.clone()]));
     }
   };
 
@@ -4039,10 +3717,7 @@ fn binary_dissimilarity_ast(
   }
   for (ai, bi) in list_a.iter().zip(list_b.iter()) {
     let (Some(av), Some(bv)) = (as_bool(ai), as_bool(bi)) else {
-      return Ok(Expr::FunctionCall {
-        name: name.to_string(),
-        args: vec![a.clone(), b.clone()].into(),
-      });
+      return Ok(call(name, vec![a.clone(), b.clone()]));
     };
     match (av, bv) {
       (true, true) => n11 += 1,
@@ -4063,10 +3738,7 @@ fn binary_dissimilarity_ast(
     "SokalSneathDissimilarity" => (2 * (n10 + n01), n11 + 2 * (n10 + n01)),
     "YuleDissimilarity" => (2 * n10 * n01, n11 * n00 + n10 * n01),
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: name.to_string(),
-        args: vec![a.clone(), b.clone()].into(),
-      });
+      return Ok(call(name, vec![a.clone(), b.clone()]));
     }
   };
 
@@ -4108,10 +3780,10 @@ fn matrix_minimal_polynomial(
   let mut powers: Vec<Expr> = Vec::with_capacity(n + 1);
   powers.push(identity);
   for i in 1..=n {
-    let prod = evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Dot".to_string(),
-      args: vec![powers[i - 1].clone(), matrix.clone()].into(),
-    })
+    let prod = evaluate_expr_to_expr(&call(
+      "Dot",
+      vec![powers[i - 1].clone(), matrix.clone()],
+    ))
     .ok()?;
     powers.push(prod);
   }
@@ -4151,39 +3823,24 @@ fn matrix_minimal_polynomial(
       let lead = coeffs[k].clone();
       let mut terms: Vec<Expr> = Vec::with_capacity(k + 1);
       for (i, c) in coeffs.iter().enumerate() {
-        let coeff = Expr::FunctionCall {
-          name: "Divide".to_string(),
-          args: vec![c.clone(), lead.clone()].into(),
-        };
+        let coeff = call("Divide", vec![c.clone(), lead.clone()]);
         let term = if i == 0 {
           coeff
         } else {
           let xpow = if i == 1 {
             x.clone()
           } else {
-            Expr::FunctionCall {
-              name: "Power".to_string(),
-              args: vec![x.clone(), Expr::Integer(i as i128)].into(),
-            }
+            call("Power", vec![x.clone(), Expr::Integer(i as i128)])
           };
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![coeff, xpow].into(),
-          }
+          call("Times", vec![coeff, xpow])
         };
         terms.push(term);
       }
-      let poly = Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: terms.into(),
-      };
+      let poly = call("Plus", terms);
       // Expand so a matrix with symbolic entries flattens to the wolframscript
       // term form (e.g. -(b c) + a d - a x - d x + x^2 rather than the factored
       // -(b c) + a d + (-a - d) x + x^2); harmless for numeric entries.
-      return Some(evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Expand".to_string(),
-        args: vec![poly].into(),
-      }));
+      return Some(evaluate_expr_to_expr(&call("Expand", vec![poly])));
     }
   }
   None
@@ -4278,15 +3935,13 @@ fn matrix_power_block_symbolic(rows: &[Expr], n_expr: &Expr) -> Option<Expr> {
       1 => {
         let i = comp[0];
         let entry = matrix[i][i].clone();
-        result[i][i] =
-          match crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-            op: BinaryOperator::Power,
-            left: Box::new(entry),
-            right: Box::new(n_expr.clone()),
-          }) {
-            Ok(v) => v,
-            Err(_) => return None,
-          };
+        result[i][i] = match crate::evaluator::evaluate_expr_to_expr(&pow2(
+          entry,
+          n_expr.clone(),
+        )) {
+          Ok(v) => v,
+          Err(_) => return None,
+        };
       }
       2 => {
         let i = comp[0];
@@ -4368,21 +4023,11 @@ fn matrix_power_2x2_symbolic_block(
     let base = if re == 0 && im == 1 {
       Expr::Identifier("I".to_string())
     } else if re == 0 {
-      Expr::FunctionCall {
-        name: "Complex".to_string(),
-        args: vec![Expr::Integer(0), Expr::Integer(im)].into(),
-      }
+      call("Complex", vec![Expr::Integer(0), Expr::Integer(im)])
     } else {
-      Expr::FunctionCall {
-        name: "Complex".to_string(),
-        args: vec![Expr::Integer(re), Expr::Integer(im)].into(),
-      }
+      call("Complex", vec![Expr::Integer(re), Expr::Integer(im)])
     };
-    Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(base),
-      right: Box::new(n_expr.clone()),
-    }
+    pow2(base, n_expr.clone())
   };
   let lam1_n = lam_power(re_part, im_part);
   let lam2_n = lam_power(re_part, -im_part);
@@ -4391,24 +4036,21 @@ fn matrix_power_2x2_symbolic_block(
   let lambda_diff = if k == 1 {
     Expr::Identifier("I".to_string())
   } else {
-    Expr::FunctionCall {
-      name: "Complex".to_string(),
-      args: vec![Expr::Integer(0), Expr::Integer(k)].into(),
-    }
+    call("Complex", vec![Expr::Integer(0), Expr::Integer(k)])
   };
   // For each scalar Complex factor `q = (a + b·I) / (k·I)` we'd build
   // and evaluate. Instead, compute the coefficient matrices c_1, c_2
   // numerically (each entry is a Complex rational), then assemble the
   // result via Plus of scalar·Power terms.
 
-  let lambda_1 = Expr::FunctionCall {
-    name: "Complex".to_string(),
-    args: vec![Expr::Integer(re_part), Expr::Integer(im_part)].into(),
-  };
-  let lambda_2 = Expr::FunctionCall {
-    name: "Complex".to_string(),
-    args: vec![Expr::Integer(re_part), Expr::Integer(-im_part)].into(),
-  };
+  let lambda_1 = call(
+    "Complex",
+    vec![Expr::Integer(re_part), Expr::Integer(im_part)],
+  );
+  let lambda_2 = call(
+    "Complex",
+    vec![Expr::Integer(re_part), Expr::Integer(-im_part)],
+  );
   let mat_expr = |ai: i128| Expr::Integer(ai);
   let eval = crate::evaluator::evaluate_expr_to_expr;
 
@@ -4417,38 +4059,17 @@ fn matrix_power_2x2_symbolic_block(
   let build_entry = |entry_int: i128, is_diag: bool| -> Option<Expr> {
     let entry = mat_expr(entry_int);
     let c1_num_raw = if is_diag {
-      Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(entry.clone()),
-        right: Box::new(lambda_2.clone()),
-      }
+      minus2(entry.clone(), lambda_2.clone())
     } else {
       entry.clone()
     };
     let c2_num_raw = if is_diag {
-      Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(lambda_1.clone()),
-        right: Box::new(entry.clone()),
-      }
+      minus2(lambda_1.clone(), entry.clone())
     } else {
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), entry.clone()].into(),
-      }
+      call("Times", vec![Expr::Integer(-1), entry.clone()])
     };
-    let c1 = eval(&Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(c1_num_raw),
-      right: Box::new(lambda_diff.clone()),
-    })
-    .ok()?;
-    let c2 = eval(&Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(c2_num_raw),
-      right: Box::new(lambda_diff.clone()),
-    })
-    .ok()?;
+    let c1 = eval(&div2(c1_num_raw, lambda_diff.clone())).ok()?;
+    let c2 = eval(&div2(c2_num_raw, lambda_diff.clone())).ok()?;
     // Build `c1 * λ_1^n + c2 * λ_2^n` without evaluating the Power
     // sub-expressions (so `(-I)^n` survives intact).
     let t1 = if matches!(&c1, Expr::Integer(1)) {
@@ -4456,30 +4077,21 @@ fn matrix_power_2x2_symbolic_block(
     } else if matches!(&c1, Expr::Integer(0)) {
       Expr::Integer(0)
     } else {
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![c1, lam1_n.clone()].into(),
-      }
+      call("Times", vec![c1, lam1_n.clone()])
     };
     let t2 = if matches!(&c2, Expr::Integer(1)) {
       lam2_n.clone()
     } else if matches!(&c2, Expr::Integer(0)) {
       Expr::Integer(0)
     } else {
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![c2, lam2_n.clone()].into(),
-      }
+      call("Times", vec![c2, lam2_n.clone()])
     };
     let sum = if matches!(&t1, Expr::Integer(0)) {
       t2
     } else if matches!(&t2, Expr::Integer(0)) {
       t1
     } else {
-      Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: vec![t1, t2].into(),
-      }
+      call("Plus", vec![t1, t2])
     };
     eval(&sum).ok()
   };
@@ -4494,18 +4106,9 @@ fn matrix_power_2x2_symbolic_block(
 /// Builds an elementary 3x3 active rotation matrix about the given Cartesian
 /// axis (1 = x, 2 = y, 3 = z) by `angle`.
 fn elementary_rotation(axis: i128, angle: &Expr) -> Expr {
-  let c = Expr::FunctionCall {
-    name: "Cos".to_string(),
-    args: vec![angle.clone()].into(),
-  };
-  let s = Expr::FunctionCall {
-    name: "Sin".to_string(),
-    args: vec![angle.clone()].into(),
-  };
-  let neg_s = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![Expr::Integer(-1), s.clone()].into(),
-  };
+  let c = call1("Cos", angle.clone());
+  let s = call1("Sin", angle.clone());
+  let neg_s = call("Times", vec![Expr::Integer(-1), s.clone()]);
   let zero = Expr::Integer(0);
   let one = Expr::Integer(1);
   let rows: [[Expr; 3]; 3] = match axis {
@@ -4641,28 +4244,19 @@ fn rotation_transform_3d_axis(
     return None;
   }
   let int = Expr::Integer;
-  let call = |name: &str, args: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  };
+  let call = |name: &str, args: Vec<Expr>| call(name, args);
   let times = |a: Expr, b: Expr| call("Times", vec![a, b]);
   let plus = |xs: Vec<Expr>| call("Plus", xs);
   let neg = |e: Expr| times(int(-1), e);
   let sq = |e: &Expr| call("Power", vec![e.clone(), int(2)]);
 
   // Normalized axis u_i = axis_i / Sqrt[sum axis_i^2].
-  let norm = call("Sqrt", vec![plus(axis.iter().map(sq).collect())]);
-  let u: Vec<Expr> = axis
-    .iter()
-    .map(|a| Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(a.clone()),
-      right: Box::new(norm.clone()),
-    })
-    .collect();
+  let norm = call1("Sqrt", plus(axis.iter().map(sq).collect()));
+  let u: Vec<Expr> =
+    axis.iter().map(|a| div2(a.clone(), norm.clone())).collect();
 
-  let cos = call("Cos", vec![theta.clone()]);
-  let sin = call("Sin", vec![theta.clone()]);
+  let cos = call1("Cos", theta.clone());
+  let sin = call1("Sin", theta.clone());
   let one_minus_cos = plus(vec![int(1), neg(cos.clone())]);
 
   // Skew-symmetric cross-product matrix [u]ₓ entries.
@@ -4714,10 +4308,7 @@ fn rotation_matrix_plane(
     Expr::List(items) => items.len(),
     _ => return Ok(Expr::Integer(0)),
   };
-  let call = |name: &str, args: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  };
+  let call = |name: &str, args: Vec<Expr>| call(name, args);
   // Orthonormal frame {e1, e2} spanning the rotation plane.
   let e1 = evaluate_expr_to_expr(&call("Normalize", vec![u.clone()]))?;
   let vdot = evaluate_expr_to_expr(&call("Dot", vec![v.clone(), e1.clone()]))?;
@@ -4731,11 +4322,9 @@ fn rotation_matrix_plane(
       vec![Expr::Identifier("Times".to_string()), a.clone(), b.clone()],
     )
   };
-  let sin = call("Sin", vec![theta.clone()]);
-  let cos_m1 = call(
-    "Plus",
-    vec![call("Cos", vec![theta.clone()]), Expr::Integer(-1)],
-  );
+  let sin = call1("Sin", theta.clone());
+  let cos_m1 =
+    call("Plus", vec![call1("Cos", theta.clone()), Expr::Integer(-1)]);
   let anti = call("Subtract", vec![outer(&e2, &e1), outer(&e1, &e2)]);
   let sym = call("Plus", vec![outer(&e1, &e1), outer(&e2, &e2)]);
   let id = call("IdentityMatrix", vec![Expr::Integer(n as i128)]);
@@ -5048,10 +4637,7 @@ fn lyapunov_solve_common(
     } else if q.d == 1 {
       Expr::Integer(q.n)
     } else {
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(q.n), Expr::Integer(q.d)].into(),
-      }
+      call("Rational", vec![Expr::Integer(q.n), Expr::Integer(q.d)])
     }
   };
   let rows: Vec<Expr> = (0..n)
@@ -5105,10 +4691,6 @@ fn lyapunov_symbolic_diagonal(
   if crows.len() != n {
     return None;
   }
-  let fc = |name: &str, fargs: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: fargs.into(),
-  };
   // Shape-check every row up front so no messages are emitted for
   // malformed input, then solve entrywise.
   for crow in crows.iter() {
@@ -5126,14 +4708,17 @@ fn lyapunov_symbolic_diagonal(
     };
     let mut out_cells: Vec<Expr> = Vec::with_capacity(n);
     for (j, cij) in ccells.iter().enumerate() {
-      let conj = fc("Conjugate", vec![diag[j].clone()]);
+      let conj = call1("Conjugate", diag[j].clone());
       let denom = if discrete {
-        fc(
+        call(
           "Plus",
-          vec![Expr::Integer(-1), fc("Times", vec![diag[i].clone(), conj])],
+          vec![
+            Expr::Integer(-1),
+            call("Times", vec![diag[i].clone(), conj]),
+          ],
         )
       } else {
-        fc("Plus", vec![diag[i].clone(), conj])
+        call("Plus", vec![diag[i].clone(), conj])
       };
       let denom = match crate::evaluator::evaluate_expr_to_expr(&denom) {
         Ok(d) => d,
@@ -5146,9 +4731,9 @@ fn lyapunov_symbolic_diagonal(
         ));
         return Some(Ok(unevaluated(name, args)));
       }
-      let entry = fc(
+      let entry = call(
         "Times",
-        vec![cij.clone(), fc("Power", vec![denom, Expr::Integer(-1)])],
+        vec![cij.clone(), call("Power", vec![denom, Expr::Integer(-1)])],
       );
       match crate::evaluator::evaluate_expr_to_expr(&entry) {
         Ok(e) => out_cells.push(e),
@@ -5179,12 +4764,7 @@ fn control_structure_matrix(
   ssm: &Expr,
   observability: bool,
 ) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: fname.to_string(),
-      args: vec![ssm.clone()].into(),
-    })
-  };
+  let unevaluated = || Ok(call(fname, vec![ssm.clone()]));
   // Parse StateSpaceModel[{a, b, c, d}] (d optional for our purposes).
   let Expr::FunctionCall { name, args } = ssm else {
     return unevaluated();
@@ -5223,10 +4803,10 @@ fn control_structure_matrix(
     return unevaluated();
   }
   let dot = |x: &Expr, y: &Expr| -> Result<Expr, InterpreterError> {
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Dot".to_string(),
-      args: vec![x.clone(), y.clone()].into(),
-    })
+    crate::evaluator::evaluate_expr_to_expr(&call(
+      "Dot",
+      vec![x.clone(), y.clone()],
+    ))
   };
   let a = mats[0].clone();
   if observability {

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -1,5 +1,5 @@
 use crate::helpers::{
-  binop, bool_expr, div2, minus2, neg1, plus2, pow2, times2,
+  binop, bool_expr, call, call1, div2, minus2, neg1, plus2, pow2, times2,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,

--- a/src/functions/boolean_ast.rs
+++ b/src/functions/boolean_ast.rs
@@ -37,10 +37,7 @@ pub fn and_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match remaining.len() {
     0 => Ok(bool_expr(true)),
     1 => Ok(remaining.into_iter().next().unwrap()),
-    _ => Ok(Expr::FunctionCall {
-      name: "And".to_string(),
-      args: remaining.into(),
-    }),
+    _ => Ok(call("And", remaining)),
   }
 }
 
@@ -87,10 +84,7 @@ pub fn or_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match remaining.len() {
     0 => Ok(bool_expr(false)),
     1 => Ok(remaining.into_iter().next().unwrap()),
-    _ => Ok(Expr::FunctionCall {
-      name: "Or".to_string(),
-      args: remaining.into(),
-    }),
+    _ => Ok(call("Or", remaining)),
   }
 }
 
@@ -212,10 +206,7 @@ pub fn xor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let core = if remaining.len() == 1 {
     remaining.into_iter().next().unwrap()
   } else {
-    Expr::FunctionCall {
-      name: "Xor".to_string(),
-      args: remaining.into(),
-    }
+    call("Xor", remaining)
   };
 
   // An odd number of True operands negates the result:
@@ -246,10 +237,7 @@ pub fn xnor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // Two or more operands keep the Xnor head; an odd True count negates it:
   //   Xnor[a, b] stays Xnor[a, b],  Xnor[a, b, True] -> Not[Xnor[a, b]].
-  let core = Expr::FunctionCall {
-    name: "Xnor".to_string(),
-    args: remaining.into(),
-  };
+  let core = call("Xnor", remaining);
   if odd_true { not_ast(&[core]) } else { Ok(core) }
 }
 
@@ -415,10 +403,7 @@ pub fn which_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         for j in ((i + 2)..args.len()).step_by(1) {
           remaining.push(args[j].clone());
         }
-        return Ok(Expr::FunctionCall {
-          name: "Which".to_string(),
-          args: remaining.into(),
-        });
+        return Ok(call("Which", remaining));
       }
     }
   }
@@ -454,10 +439,7 @@ pub fn while_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             Err(InterpreterError::BreakSignal) => break,
             Err(InterpreterError::ContinueSignal) => {}
             Err(InterpreterError::ReturnValue(val)) => {
-              return Ok(Expr::FunctionCall {
-                name: "Return".to_string(),
-                args: vec![*val].into(),
-              });
+              return Ok(call("Return", vec![*val]));
             }
             Err(e) => return Err(e),
           }
@@ -895,10 +877,7 @@ pub fn boole_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match as_bool(&evaluated) {
     Some(true) => Ok(Expr::Integer(1)),
     Some(false) => Ok(Expr::Integer(0)),
-    None => Ok(Expr::FunctionCall {
-      name: "Boole".to_string(),
-      args: vec![evaluated].into(),
-    }),
+    None => Ok(call("Boole", vec![evaluated])),
   }
 }
 
@@ -954,10 +933,7 @@ pub fn implies_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           {
             Ok(bool_expr(true))
           } else {
-            Ok(Expr::FunctionCall {
-              name: "Implies".to_string(),
-              args: vec![a, b].into(),
-            })
+            Ok(call("Implies", vec![a, b]))
           }
         }
       }
@@ -992,10 +968,7 @@ pub fn nand_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // A lone surviving operand collapses to its negation: Nand[a, True] -> !a.
     1 => not_ast(&[remaining.into_iter().next().unwrap()]),
     // Some symbolic: Nand[remaining...]
-    _ => Ok(Expr::FunctionCall {
-      name: "Nand".to_string(),
-      args: remaining.into(),
-    }),
+    _ => Ok(call("Nand", remaining)),
   }
 }
 
@@ -1026,10 +999,7 @@ pub fn nor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // A lone surviving operand collapses to its negation: Nor[a, False] -> !a.
     1 => not_ast(&[remaining.into_iter().next().unwrap()]),
     // Some symbolic: Nor[remaining...]
-    _ => Ok(Expr::FunctionCall {
-      name: "Nor".to_string(),
-      args: remaining.into(),
-    }),
+    _ => Ok(call("Nor", remaining)),
   }
 }
 
@@ -1077,36 +1047,24 @@ pub fn equivalent_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if remaining.len() == 1 {
       return Ok(remaining.into_iter().next().unwrap());
     }
-    return Ok(Expr::FunctionCall {
-      name: "And".to_string(),
-      args: remaining.into(),
-    });
+    return Ok(call("And", remaining));
   }
   if has_false {
     let negated: Vec<Expr> = remaining
       .into_iter()
-      .map(|e| Expr::FunctionCall {
-        name: "Not".to_string(),
-        args: vec![e].into(),
-      })
+      .map(|e| call("Not", vec![e]))
       .collect();
     if negated.len() == 1 {
       return Ok(negated.into_iter().next().unwrap());
     }
-    return Ok(Expr::FunctionCall {
-      name: "And".to_string(),
-      args: negated.into(),
-    });
+    return Ok(call("And", negated));
   }
   // No boolean literal: a single distinct operand (e.g. Equivalent[a, a]) is
   // vacuously True; otherwise keep the deduplicated chain symbolic.
   if remaining.len() <= 1 {
     return Ok(bool_expr(true));
   }
-  Ok(Expr::FunctionCall {
-    name: "Equivalent".to_string(),
-    args: remaining.into(),
-  })
+  Ok(call("Equivalent", remaining))
 }
 
 /// Evaluate `body` over every True/False assignment of each variable group,
@@ -1388,10 +1346,7 @@ fn canonicalize_dnf(expr: &Expr) -> Expr {
     if parts.len() == 1 {
       parts.into_iter().next().unwrap()
     } else {
-      Expr::FunctionCall {
-        name: "And".to_string(),
-        args: parts.into(),
-      }
+      call("And", parts)
     }
   };
 
@@ -1399,10 +1354,7 @@ fn canonicalize_dnf(expr: &Expr) -> Expr {
   if rebuilt.len() == 1 {
     rebuilt.into_iter().next().unwrap()
   } else {
-    Expr::FunctionCall {
-      name: "Or".to_string(),
-      args: rebuilt.into(),
-    }
+    call("Or", rebuilt)
   }
 }
 
@@ -1443,14 +1395,7 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
           let b = eliminate_connectives(&args[1]);
           Expr::FunctionCall {
             name: "Or".to_string(),
-            args: vec![
-              b,
-              Expr::FunctionCall {
-                name: "Not".to_string(),
-                args: vec![a].into(),
-              },
-            ]
-            .into(),
+            args: vec![b, call("Not", vec![a])].into(),
           }
         }
         "Equivalent" if args.len() >= 2 => {
@@ -1465,21 +1410,12 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
             Expr::FunctionCall {
               name: "Or".to_string(),
               args: vec![
-                Expr::FunctionCall {
-                  name: "And".to_string(),
-                  args: vec![a.clone(), b.clone()].into(),
-                },
+                call("And", vec![a.clone(), b.clone()]),
                 Expr::FunctionCall {
                   name: "And".to_string(),
                   args: vec![
-                    Expr::FunctionCall {
-                      name: "Not".to_string(),
-                      args: vec![a.clone()].into(),
-                    },
-                    Expr::FunctionCall {
-                      name: "Not".to_string(),
-                      args: vec![b.clone()].into(),
-                    },
+                    call("Not", vec![a.clone()]),
+                    call("Not", vec![b.clone()]),
                   ]
                   .into(),
                 },
@@ -1496,10 +1432,7 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
                   .into(),
               }));
             }
-            Expr::FunctionCall {
-              name: "And".to_string(),
-              args: pairs.into(),
-            }
+            call("And", pairs)
           }
         }
         "Xor" if args.len() >= 2 => {
@@ -1514,25 +1447,11 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
               args: vec![
                 Expr::FunctionCall {
                   name: "And".to_string(),
-                  args: vec![
-                    a.clone(),
-                    Expr::FunctionCall {
-                      name: "Not".to_string(),
-                      args: vec![b.clone()].into(),
-                    },
-                  ]
-                  .into(),
+                  args: vec![a.clone(), call("Not", vec![b.clone()])].into(),
                 },
                 Expr::FunctionCall {
                   name: "And".to_string(),
-                  args: vec![
-                    b.clone(),
-                    Expr::FunctionCall {
-                      name: "Not".to_string(),
-                      args: vec![a.clone()].into(),
-                    },
-                  ]
-                  .into(),
+                  args: vec![b.clone(), call("Not", vec![a.clone()])].into(),
                 },
               ]
               .into(),
@@ -1541,10 +1460,8 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
             // Reduce: Xor[a, b, c, ...] → Xor[Xor[a, b], c, ...]
             let mut result = elim_args[0].clone();
             for arg in &elim_args[1..] {
-              result = eliminate_connectives(&Expr::FunctionCall {
-                name: "Xor".to_string(),
-                args: vec![result, arg.clone()].into(),
-              });
+              result =
+                eliminate_connectives(&call("Xor", vec![result, arg.clone()]));
             }
             result
           }
@@ -1555,11 +1472,7 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
             args.iter().map(eliminate_connectives).collect();
           Expr::FunctionCall {
             name: "Not".to_string(),
-            args: vec![Expr::FunctionCall {
-              name: "And".to_string(),
-              args: elim_args.into(),
-            }]
-            .into(),
+            args: vec![call("And", elim_args)].into(),
           }
         }
         "Nor" if args.len() >= 2 => {
@@ -1568,11 +1481,7 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
             args.iter().map(eliminate_connectives).collect();
           Expr::FunctionCall {
             name: "Not".to_string(),
-            args: vec![Expr::FunctionCall {
-              name: "Or".to_string(),
-              args: elim_args.into(),
-            }]
-            .into(),
+            args: vec![call("Or", elim_args)].into(),
           }
         }
         "If" if args.len() == 3 => {
@@ -1580,23 +1489,11 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
           let a = eliminate_connectives(&args[0]);
           let b = eliminate_connectives(&args[1]);
           let c = eliminate_connectives(&args[2]);
-          let not_a = Expr::FunctionCall {
-            name: "Not".to_string(),
-            args: vec![a.clone()].into(),
-          };
+          let not_a = call("Not", vec![a.clone()]);
           Expr::FunctionCall {
             name: "Or".to_string(),
-            args: vec![
-              Expr::FunctionCall {
-                name: "And".to_string(),
-                args: vec![a, b].into(),
-              },
-              Expr::FunctionCall {
-                name: "And".to_string(),
-                args: vec![not_a, c].into(),
-              },
-            ]
-            .into(),
+            args: vec![call("And", vec![a, b]), call("And", vec![not_a, c])]
+              .into(),
           }
         }
         // Majority[e₁, …, eₙ] holds when more than half its arguments do,
@@ -1616,10 +1513,7 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
                 .into(),
             })
             .collect();
-          Expr::FunctionCall {
-            name: "Or".to_string(),
-            args: clauses.into(),
-          }
+          call("Or", clauses)
         }
         "And" | "Or" | "Not" => {
           let new_args: Vec<Expr> =
@@ -1638,10 +1532,7 @@ fn eliminate_connectives(expr: &Expr) -> Expr {
       operand,
     } => {
       let inner = eliminate_connectives(operand);
-      Expr::FunctionCall {
-        name: "Not".to_string(),
-        args: vec![inner].into(),
-      }
+      call("Not", vec![inner])
     }
     _ => expr.clone(),
   }
@@ -1669,10 +1560,7 @@ fn apply_not_inward(inner: &Expr) -> Expr {
     } if inner_name == "And" => {
       let new_args: Vec<Expr> =
         inner_args.iter().map(apply_not_inward).collect();
-      Expr::FunctionCall {
-        name: "Or".to_string(),
-        args: new_args.into(),
-      }
+      call("Or", new_args)
     }
     // Not[Or[a, b, ...]] → And[Not[a], Not[b], ...]
     Expr::FunctionCall {
@@ -1681,10 +1569,7 @@ fn apply_not_inward(inner: &Expr) -> Expr {
     } if inner_name == "Or" => {
       let new_args: Vec<Expr> =
         inner_args.iter().map(apply_not_inward).collect();
-      Expr::FunctionCall {
-        name: "And".to_string(),
-        args: new_args.into(),
-      }
+      call("And", new_args)
     }
     // Not[True] → False, Not[False] → True
     Expr::Identifier(s) if s == "True" => bool_expr(false),
@@ -1692,10 +1577,7 @@ fn apply_not_inward(inner: &Expr) -> Expr {
     // Not[other] → Not[other] (keep as-is, recurse into inner)
     other => {
       let recurse = push_not_inward(other);
-      Expr::FunctionCall {
-        name: "Not".to_string(),
-        args: vec![recurse].into(),
-      }
+      call("Not", vec![recurse])
     }
   }
 }
@@ -1783,10 +1665,7 @@ fn distribute_and_over_or(expr: &Expr) -> Expr {
           if group.len() == 1 {
             group.into_iter().next().unwrap()
           } else {
-            Expr::FunctionCall {
-              name: "And".to_string(),
-              args: group.into(),
-            }
+            call("And", group)
           }
         })
         .collect();
@@ -1794,10 +1673,7 @@ fn distribute_and_over_or(expr: &Expr) -> Expr {
       if or_terms.len() == 1 {
         or_terms.into_iter().next().unwrap()
       } else {
-        Expr::FunctionCall {
-          name: "Or".to_string(),
-          args: or_terms.into(),
-        }
+        call("Or", or_terms)
       }
     }
     Expr::FunctionCall { name, args } if name == "Or" => {
@@ -1822,10 +1698,7 @@ fn distribute_and_over_or(expr: &Expr) -> Expr {
       if result.len() == 1 {
         result.into_iter().next().unwrap()
       } else {
-        Expr::FunctionCall {
-          name: "Or".to_string(),
-          args: result.into(),
-        }
+        call("Or", result)
       }
     }
     Expr::FunctionCall { name, args } => {
@@ -1864,10 +1737,7 @@ fn simplify_cnf(expr: &Expr) -> Expr {
       } else if simplified.len() == 1 {
         simplified.into_iter().next().unwrap()
       } else {
-        Expr::FunctionCall {
-          name: "And".to_string(),
-          args: simplified.into(),
-        }
+        call("And", simplified)
       }
     }
     _ => expr.clone(),
@@ -1972,10 +1842,7 @@ fn distribute_or_over_and(expr: &Expr) -> Expr {
           if group.len() == 1 {
             group.into_iter().next().unwrap()
           } else {
-            Expr::FunctionCall {
-              name: "Or".to_string(),
-              args: group.into(),
-            }
+            call("Or", group)
           }
         })
         .collect();
@@ -1983,10 +1850,7 @@ fn distribute_or_over_and(expr: &Expr) -> Expr {
       if and_terms.len() == 1 {
         and_terms.into_iter().next().unwrap()
       } else {
-        Expr::FunctionCall {
-          name: "And".to_string(),
-          args: and_terms.into(),
-        }
+        call("And", and_terms)
       }
     }
     Expr::FunctionCall { name, args } if name == "And" => {
@@ -2009,10 +1873,7 @@ fn distribute_or_over_and(expr: &Expr) -> Expr {
       if result.len() == 1 {
         result.into_iter().next().unwrap()
       } else {
-        Expr::FunctionCall {
-          name: "And".to_string(),
-          args: result.into(),
-        }
+        call("And", result)
       }
     }
     Expr::FunctionCall { name, args } => {
@@ -2040,10 +1901,7 @@ fn bc_negate_literal(e: &Expr) -> Expr {
       op: UnaryOperator::Not,
       operand,
     } => (**operand).clone(),
-    _ => Expr::FunctionCall {
-      name: "Not".to_string(),
-      args: vec![e.clone()].into(),
-    },
+    _ => call("Not", vec![e.clone()]),
   }
 }
 
@@ -2057,11 +1915,7 @@ fn bc_demorgan_clause(clause: &Expr, clause_head: &str, dual: &str) -> Expr {
     let negated: Vec<Expr> = args.iter().map(bc_negate_literal).collect();
     return Expr::FunctionCall {
       name: "Not".to_string(),
-      args: vec![Expr::FunctionCall {
-        name: dual.to_string(),
-        args: negated.into(),
-      }]
-      .into(),
+      args: vec![call(dual, negated)].into(),
     };
   }
   clause.clone()
@@ -2102,10 +1956,7 @@ fn bc_to_sheffer(
   clause_head: &str,
   sheffer: &str,
 ) -> Expr {
-  let call = |name: &str, args: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  };
+  let call = |name: &str, args: Vec<Expr>| call(name, args);
   let clause = |c: &Expr| match c {
     Expr::FunctionCall { name, args } if name == clause_head => {
       call(sheffer, args.iter().cloned().collect())
@@ -2167,10 +2018,7 @@ fn bc_conjunction(variables: &[String], mask: usize) -> Expr {
   match chosen.len() {
     0 => bool_expr(true),
     1 => chosen.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "And".to_string(),
-      args: chosen.into(),
-    },
+    _ => call("And", chosen),
   }
 }
 
@@ -2214,16 +2062,10 @@ fn bc_algebraic_normal_form(variables: &[String], table: &[bool]) -> Expr {
   let joined = match terms.len() {
     0 => return bool_expr(constant),
     1 => terms.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Xor".to_string(),
-      args: terms.into(),
-    },
+    _ => call("Xor", terms),
   };
   if constant {
-    Expr::FunctionCall {
-      name: "Not".to_string(),
-      args: vec![joined].into(),
-    }
+    call("Not", vec![joined])
   } else {
     joined
   }
@@ -2272,10 +2114,7 @@ fn bc_drop_redundant_clauses(
   while i < kept.len() && kept.len() > 1 {
     let mut without = kept.clone();
     without.remove(i);
-    let candidate = Expr::FunctionCall {
-      name: top.to_string(),
-      args: without.clone().into(),
-    };
+    let candidate = call(top, without.clone());
     if bc_truth_table(&candidate, variables)?.as_deref() == Some(table) {
       kept = without;
     } else {
@@ -2285,10 +2124,7 @@ fn bc_drop_redundant_clauses(
   Ok(if kept.len() == 1 {
     kept.into_iter().next().unwrap()
   } else {
-    Expr::FunctionCall {
-      name: top.to_string(),
-      args: kept.into(),
-    }
+    call(top, kept)
   })
 }
 
@@ -2484,10 +2320,7 @@ fn reduce_cnf_clauses(expr: &Expr) -> Expr {
     let rebuilt = if kept.len() == 1 {
       kept.remove(0)
     } else {
-      Expr::FunctionCall {
-        name: "Or".to_string(),
-        args: kept.into(),
-      }
+      call("Or", kept)
     };
     reduced.push((keys, rebuilt));
   }
@@ -2506,10 +2339,7 @@ fn reduce_cnf_clauses(expr: &Expr) -> Expr {
   match survivors.len() {
     0 => bool_expr(true),
     1 => survivors.remove(0),
-    _ => Expr::FunctionCall {
-      name: "And".to_string(),
-      args: survivors.into(),
-    },
+    _ => call("And", survivors),
   }
 }
 
@@ -2852,10 +2682,7 @@ fn implicants_to_expr(
     } else if literals.len() == 1 {
       literals.remove(0)
     } else {
-      Expr::FunctionCall {
-        name: "And".to_string(),
-        args: literals.into(),
-      }
+      call("And", literals)
     };
     terms.push(term);
   }
@@ -2863,10 +2690,7 @@ fn implicants_to_expr(
   if terms.len() == 1 {
     Ok(terms.remove(0))
   } else {
-    Ok(Expr::FunctionCall {
-      name: "Or".to_string(),
-      args: terms.into(),
-    })
+    Ok(call("Or", terms))
   }
 }
 
@@ -3118,10 +2942,7 @@ fn exactly_k_dnf(vars: &[String], k: usize) -> Expr {
     terms.push(if literals.len() == 1 {
       literals.remove(0)
     } else {
-      Expr::FunctionCall {
-        name: "And".to_string(),
-        args: literals.into(),
-      }
+      call("And", literals)
     });
   }
   or_of(terms)
@@ -3148,10 +2969,7 @@ fn at_most_k_dnf(vars: &[String], kmax: usize) -> Expr {
     terms.push(if literals.len() == 1 {
       literals.remove(0)
     } else {
-      Expr::FunctionCall {
-        name: "And".to_string(),
-        args: literals.into(),
-      }
+      call("And", literals)
     });
   }
   or_of(terms)
@@ -3182,10 +3000,7 @@ fn minterms_to_dnf(vars: &[String], count_set: &[usize]) -> Expr {
       terms.push(if literals.len() == 1 {
         literals.remove(0)
       } else {
-        Expr::FunctionCall {
-          name: "And".to_string(),
-          args: literals.into(),
-        }
+        call("And", literals)
       });
     }
   }
@@ -3237,10 +3052,7 @@ fn or_of(mut terms: Vec<Expr>) -> Expr {
   if terms.len() == 1 {
     return terms.remove(0);
   }
-  Expr::FunctionCall {
-    name: "Or".to_string(),
-    args: terms.into(),
-  }
+  call("Or", terms)
 }
 
 /// VectorLess[{v1, v2, ...}] - componentwise strict less-than comparison
@@ -3603,10 +3415,7 @@ pub fn majority_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   sorted.sort_by(|a, b| {
     (-crate::functions::list_helpers_ast::compare_exprs(a, b)).cmp(&0)
   });
-  Ok(Expr::FunctionCall {
-    name: "Majority".to_string(),
-    args: sorted.into(),
-  })
+  Ok(call("Majority", sorted))
 }
 
 /// BooleanMinterms[spec, {v1, ...}] — the disjunction of minterms given
@@ -3729,20 +3538,14 @@ pub fn boolean_minterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if literals.len() == 1 {
         literals.into_iter().next().unwrap()
       } else {
-        Expr::FunctionCall {
-          name: "And".to_string(),
-          args: literals.into(),
-        }
+        call("And", literals)
       }
     })
     .collect();
   let result = match terms.len() {
     0 => bool_expr(false),
     1 => terms.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Or".to_string(),
-      args: terms.into(),
-    },
+    _ => call("Or", terms),
   };
   evaluate_expr_to_expr(&result)
 }
@@ -3760,11 +3563,7 @@ pub fn unate_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return unevaluated();
   }
   let eval = crate::evaluator::evaluate_expr_to_expr;
-  let fc = |name: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: a.into(),
-  };
-  let vars = match eval(&fc("BooleanVariables", vec![args[0].clone()]))? {
+  let vars = match eval(&call1("BooleanVariables", args[0].clone()))? {
     Expr::List(ref v) => v.to_vec(),
     _ => return unevaluated(),
   };
@@ -3805,7 +3604,7 @@ pub fn unate_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         )),
       })
       .collect();
-    table.push(eval(&fc(
+    table.push(eval(&call(
       "ReplaceAll",
       vec![args[0].clone(), Expr::List(rules.into())],
     ))?);
@@ -3950,20 +3749,14 @@ pub fn boolean_maxterms_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if literals.len() == 1 {
         literals.into_iter().next().unwrap()
       } else {
-        Expr::FunctionCall {
-          name: "Or".to_string(),
-          args: literals.into(),
-        }
+        call("Or", literals)
       }
     })
     .collect();
   let result = match terms.len() {
     0 => bool_expr(true),
     1 => terms.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "And".to_string(),
-      args: terms.into(),
-    },
+    _ => call("And", terms),
   };
   evaluate_expr_to_expr(&result)
 }
@@ -4007,10 +3800,10 @@ fn boolean_quantifier(
         )),
       })
       .collect();
-    branches.push(eval(&Expr::FunctionCall {
-      name: "ReplaceAll".to_string(),
-      args: vec![args[0].clone(), Expr::List(rules.into())].into(),
-    })?);
+    branches.push(eval(&call(
+      "ReplaceAll",
+      vec![args[0].clone(), Expr::List(rules.into())],
+    ))?);
   }
   // wolframscript returns minimized results (x || x collapses, absorption
   // applies), so run the combined expression through BooleanMinimize.
@@ -4018,10 +3811,7 @@ fn boolean_quantifier(
     name: if conjunct { "And" } else { "Or" }.to_string(),
     args: branches.into(),
   })?;
-  eval(&Expr::FunctionCall {
-    name: "BooleanMinimize".to_string(),
-    args: vec![combined].into(),
-  })
+  eval(&call("BooleanMinimize", vec![combined]))
 }
 
 pub fn conjunction_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/confirm_ast.rs
+++ b/src/functions/confirm_ast.rs
@@ -41,13 +41,6 @@ fn symbol(s: &str) -> Expr {
   Expr::Identifier(s.to_string())
 }
 
-fn call(name: &str, args: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  }
-}
-
 fn failure(tag: &str, pairs: Vec<(&str, Expr)>) -> Expr {
   let assoc =
     Expr::Association(pairs.into_iter().map(|(k, v)| (string(k), v)).collect());
@@ -337,10 +330,10 @@ fn exception_object(tags: Vec<Expr>, payload: Option<Expr>) -> Expr {
   }
   pairs.push((string("ExceptionValidated"), symbol("True")));
   pairs.push((string("ExceptionSystemVersion"), string("1")));
-  Expr::FunctionCall {
-    name: "Exception".to_string(),
-    args: vec![Expr::List(tags.into()), Expr::Association(pairs)].into(),
-  }
+  call(
+    "Exception",
+    vec![Expr::List(tags.into()), Expr::Association(pairs)],
+  )
 }
 
 /// The exception wolframscript builds when the specification is not a tag:

--- a/src/functions/geo_math.rs
+++ b/src/functions/geo_math.rs
@@ -285,11 +285,8 @@ impl AngleVal {
 
   /// d + m/60 + s/3600, staying exact only when all three parts are exact.
   fn from_dms(d: &Self, m: &Self, s: &Self) -> Self {
-    if let (
-      Self::Exact(dp, dq),
-      Self::Exact(mp, mq),
-      Self::Exact(sp, sq),
-    ) = (d, m, s)
+    if let (Self::Exact(dp, dq), Self::Exact(mp, mq), Self::Exact(sp, sq)) =
+      (d, m, s)
       && let Some(v) = (|| {
         let a = rat_add((*dp, *dq), (*mp, mq.checked_mul(60)?))?;
         rat_add(a, (*sp, sq.checked_mul(3600)?))

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -114,10 +114,7 @@ impl Color {
   /// Convert to an Expr (RGBColor or GrayLevel) for embedding in Graphics expressions.
   pub(crate) fn to_expr(self) -> Expr {
     if (self.r - self.g).abs() < 1e-14 && (self.g - self.b).abs() < 1e-14 {
-      Expr::FunctionCall {
-        name: "GrayLevel".to_string(),
-        args: vec![Expr::Real(self.r)].into(),
-      }
+      call1("GrayLevel", Expr::Real(self.r))
     } else {
       Expr::FunctionCall {
         name: "RGBColor".to_string(),
@@ -9902,10 +9899,7 @@ fn parse_box_to_expr(cs: &[char]) -> Expr {
   match units.len() {
     0 => Expr::String(String::new()),
     1 => units.pop().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "RowBox".to_string(),
-      args: vec![Expr::List(units.into())].into(),
-    },
+    _ => call1("RowBox", Expr::List(units.into())),
   }
 }
 
@@ -10191,14 +10185,8 @@ pub(crate) fn mesh_region_to_graphics_prims(
 
   let mut result = Vec::new();
   // Add default styling
-  result.push(Expr::FunctionCall {
-    name: "EdgeForm".to_string(),
-    args: vec![Color::gray(0.4).to_expr()].into(),
-  });
-  result.push(Expr::FunctionCall {
-    name: "FaceForm".to_string(),
-    args: vec![Color::new(0.626, 0.836, 0.919).to_expr()].into(),
-  });
+  result.push(call1("EdgeForm", Color::gray(0.4).to_expr()));
+  result.push(call1("FaceForm", Color::new(0.626, 0.836, 0.919).to_expr()));
 
   for prim in prims {
     if let Expr::FunctionCall { name, args } = prim
@@ -10223,10 +10211,7 @@ pub(crate) fn mesh_region_to_graphics_prims(
             })
             .collect();
           if points.len() >= 3 {
-            result.push(Expr::FunctionCall {
-              name: "Polygon".to_string(),
-              args: vec![Expr::List(points.into())].into(),
-            });
+            result.push(call1("Polygon", Expr::List(points.into())));
           }
         }
       }
@@ -10274,10 +10259,7 @@ pub fn plot_source_primitives(ps: &crate::syntax::PlotSource) -> Vec<Expr> {
     {
       let (fr, fg, fb) = sd.fill_color.unwrap_or(sd.color);
       let mut fill_prims: Vec<Expr> = vec![
-        Expr::FunctionCall {
-          name: "Opacity".to_string(),
-          args: vec![Expr::Real(sd.fill_opacity.unwrap_or(0.2))].into(),
-        },
+        call1("Opacity", Expr::Real(sd.fill_opacity.unwrap_or(0.2))),
         Expr::FunctionCall {
           name: "RGBColor".to_string(),
           args: vec![
@@ -10304,10 +10286,7 @@ pub fn plot_source_primitives(ps: &crate::syntax::PlotSource) -> Vec<Expr> {
         coords.push(Expr::List(
           vec![Expr::Real(x_first), Expr::Real(ref_y)].into(),
         ));
-        fill_prims.push(Expr::FunctionCall {
-          name: "Polygon".to_string(),
-          args: vec![Expr::List(coords.into())].into(),
-        });
+        fill_prims.push(call1("Polygon", Expr::List(coords.into())));
       }
       series_prims.push(Expr::List(fill_prims.into()));
     }
@@ -10322,10 +10301,7 @@ pub fn plot_source_primitives(ps: &crate::syntax::PlotSource) -> Vec<Expr> {
       .into(),
     });
     if sd.is_scatter {
-      series_prims.push(Expr::FunctionCall {
-        name: "PointSize".to_string(),
-        args: vec![Expr::Real(0.012)].into(),
-      });
+      series_prims.push(call1("PointSize", Expr::Real(0.012)));
       let coords: Vec<Expr> = sd
         .points
         .iter()
@@ -10333,16 +10309,13 @@ pub fn plot_source_primitives(ps: &crate::syntax::PlotSource) -> Vec<Expr> {
         .map(|&(x, y)| Expr::List(vec![Expr::Real(x), Expr::Real(y)].into()))
         .collect();
       if !coords.is_empty() {
-        series_prims.push(Expr::FunctionCall {
-          name: "Point".to_string(),
-          args: vec![Expr::List(coords.into())].into(),
-        });
+        series_prims.push(call1("Point", Expr::List(coords.into())));
       }
     } else {
-      series_prims.push(Expr::FunctionCall {
-        name: "AbsoluteThickness".to_string(),
-        args: vec![Expr::Real(sd.thickness.unwrap_or(1.5))].into(),
-      });
+      series_prims.push(call1(
+        "AbsoluteThickness",
+        Expr::Real(sd.thickness.unwrap_or(1.5)),
+      ));
       let segments = crate::functions::plot::split_into_segments(&sd.points);
       for seg in &segments {
         let coords: Vec<Expr> = seg
@@ -10350,10 +10323,7 @@ pub fn plot_source_primitives(ps: &crate::syntax::PlotSource) -> Vec<Expr> {
           .map(|&(x, y)| Expr::List(vec![Expr::Real(x), Expr::Real(y)].into()))
           .collect();
         if coords.len() >= 2 {
-          series_prims.push(Expr::FunctionCall {
-            name: "Line".to_string(),
-            args: vec![Expr::List(coords.into())].into(),
-          });
+          series_prims.push(call1("Line", Expr::List(coords.into())));
         }
       }
     }
@@ -12943,10 +12913,7 @@ fn dataset_list_to_svg(items: &[Expr]) -> Option<String> {
               .iter()
               .find(|(k, _)| expr_to_svg_markup(k) == *h)
               .map(|(_, v)| v.clone())
-              .unwrap_or(Expr::FunctionCall {
-                name: "Missing".to_string(),
-                args: vec![].into(),
-              })
+              .unwrap_or(call("Missing", vec![]))
           })
           .collect()
       } else {
@@ -14344,10 +14311,7 @@ fn tabular_list_of_assocs_to_svg(
               .iter()
               .find(|(k, _)| expr_to_svg_markup(k) == *h)
               .map(|(_, v)| v.clone())
-              .unwrap_or(Expr::FunctionCall {
-                name: "Missing".to_string(),
-                args: vec![].into(),
-              })
+              .unwrap_or(call("Missing", vec![]))
           })
           .collect()
       } else {
@@ -14424,17 +14388,11 @@ fn tabular_column_assoc_to_svg(
       .iter()
       .map(|(_, v)| {
         if let Expr::List(items) = v {
-          items.get(i).cloned().unwrap_or(Expr::FunctionCall {
-            name: "Missing".to_string(),
-            args: vec![].into(),
-          })
+          items.get(i).cloned().unwrap_or(call("Missing", vec![]))
         } else if i == 0 {
           v.clone()
         } else {
-          Expr::FunctionCall {
-            name: "Missing".to_string(),
-            args: vec![].into(),
-          }
+          call("Missing", vec![])
         }
       })
       .collect();
@@ -14672,10 +14630,7 @@ pub fn unwrap_display_wrappers(expr: &Expr) -> Expr {
     && !matches!(&current, Expr::FunctionCall { name, .. }
       if matches!(name.as_str(), "Grid" | "Column" | "Row" | "Framed"))
   {
-    current = Expr::FunctionCall {
-      name: "TraditionalForm".to_string(),
-      args: vec![current].into(),
-    };
+    current = call1("TraditionalForm", current);
   }
   current
 }
@@ -15852,10 +15807,7 @@ pub fn koch_curve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     .map(|(x, y)| Expr::List(vec![Expr::Real(*x), Expr::Real(*y)].into()))
     .collect();
 
-  Ok(Expr::FunctionCall {
-    name: "Line".to_string(),
-    args: vec![Expr::List(point_exprs.into())].into(),
-  })
+  Ok(call1("Line", Expr::List(point_exprs.into())))
 }
 
 // ─── LinearGradientFilling ──────────────────────────────────────────
@@ -15972,10 +15924,7 @@ pub fn drop_shadowing_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         name: "Opacity".to_string(),
         args: vec![
           crate::functions::make_rational(1, 3),
-          Expr::FunctionCall {
-            name: "ThemeColor".to_string(),
-            args: vec![Expr::Identifier("Foreground".to_string())].into(),
-          },
+          call1("ThemeColor", Expr::Identifier("Foreground".to_string())),
         ]
         .into(),
       }),
@@ -15992,14 +15941,8 @@ pub fn linear_gradient_filling_ast(
     // LinearGradientFilling[] → default black to white
     let stops = vec![Expr::Integer(0), Expr::Integer(1)];
     let colors = vec![
-      Expr::FunctionCall {
-        name: "GrayLevel".to_string(),
-        args: vec![Expr::Integer(0)].into(),
-      },
-      Expr::FunctionCall {
-        name: "GrayLevel".to_string(),
-        args: vec![Expr::Integer(1)].into(),
-      },
+      call1("GrayLevel", Expr::Integer(0)),
+      call1("GrayLevel", Expr::Integer(1)),
     ];
     (
       stops,
@@ -16052,10 +15995,10 @@ pub fn linear_gradient_filling_ast(
       }
       // Single non-list color arg
       other => {
-        return Ok(Expr::FunctionCall {
-          name: "LinearGradientFilling".to_string(),
-          args: vec![other.clone(), angle, space].into(),
-        });
+        return Ok(call(
+          "LinearGradientFilling",
+          vec![other.clone(), angle, space],
+        ));
       }
     }
   };
@@ -16066,10 +16009,7 @@ pub fn linear_gradient_filling_ast(
     replacement: Box::new(Expr::List(colors.into())),
   };
 
-  Ok(Expr::FunctionCall {
-    name: "LinearGradientFilling".to_string(),
-    args: vec![rule, angle, space].into(),
-  })
+  Ok(call("LinearGradientFilling", vec![rule, angle, space]))
 }
 
 /// Manipulate[expr, {u, umin, umax}, …] — interactive control construct.
@@ -16183,10 +16123,7 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  Ok(Expr::FunctionCall {
-    name: "Manipulate".to_string(),
-    args: out_args.into(),
-  })
+  Ok(call("Manipulate", out_args))
 }
 
 /// Process a single Manipulate/Control variable specification list,
@@ -16257,10 +16194,7 @@ fn process_manipulate_var_spec(items: &[Expr]) -> Expr {
     && needs_dynamic
   {
     let range = new_items.pop().unwrap();
-    new_items.push(Expr::FunctionCall {
-      name: "Dynamic".to_string(),
-      args: vec![range].into(),
-    });
+    new_items.push(call1("Dynamic", range));
   }
   Expr::List(new_items.into())
 }
@@ -16285,10 +16219,7 @@ pub fn control_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   for extra in args.iter().skip(1) {
     out_args.push(extra.clone());
   }
-  Ok(Expr::FunctionCall {
-    name: "Control".to_string(),
-    args: out_args.into(),
-  })
+  Ok(call("Control", out_args))
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -16455,9 +16386,7 @@ impl ManipulateControl {
       | Self::IntervalSlider { name, .. }
       | Self::Trigger { name, .. }
       | Self::Locator { name, .. } => name,
-      Self::Button { .. }
-      | Self::Heading { .. }
-      | Self::Divider => "",
+      Self::Button { .. } | Self::Heading { .. } | Self::Divider => "",
     }
   }
 }
@@ -19755,10 +19684,7 @@ fn parse_manipulate_control(
     // storing it.
     && let built = crate::syntax::substitute_slots(
       body,
-      &[Expr::FunctionCall {
-        name: "Dynamic".to_string(),
-        args: vec![Expr::Identifier(name.clone())].into(),
-      }],
+      &[call1("Dynamic", Expr::Identifier(name.clone()))],
     )
     && let Expr::FunctionCall {
       name: built_name,
@@ -20877,10 +20803,7 @@ pub enum DisplayNode {
   /// against the live bindings, exactly like a `Button` written as a
   /// Manipulate control argument. Demonstrations use these inside a
   /// `Dynamic[…]` caption to step a variable (`n++`, `n = 1`, …).
-  Button {
-    label: Box<Self>,
-    action: String,
-  },
+  Button { label: Box<Self>, action: String },
   /// A `Spacer[w]`: `w` printer's points of horizontal space.
   Spacer { width: f64 },
   /// A text leaf with its styled runs, so `Style["…", Bold, Red]` renders
@@ -21418,10 +21341,7 @@ fn space_filling_curve(
     })
     .collect();
   let _ = name;
-  Expr::FunctionCall {
-    name: "Line".to_string(),
-    args: vec![Expr::List(point_exprs.into())].into(),
-  }
+  call1("Line", Expr::List(point_exprs.into()))
 }
 
 /// The curve order, or None (after emitting ::intpm) for invalid input.
@@ -21642,22 +21562,12 @@ pub fn sierpinski_curve_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       )
     })
     .collect();
-  Ok(Expr::FunctionCall {
-    name: "Line".to_string(),
-    args: vec![Expr::List(point_exprs.into())].into(),
-  })
+  Ok(call1("Line", Expr::List(point_exprs.into())))
 }
 
 #[cfg(test)]
 mod manipulate_label_tests {
   use super::*;
-
-  fn call(name: &str, args: Vec<Expr>) -> Expr {
-    Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.into(),
-    }
-  }
 
   fn runs(expr: &Expr) -> Vec<LabelRun> {
     manipulate_label_runs(expr, false)
@@ -21703,7 +21613,7 @@ mod manipulate_label_tests {
       vec![Expr::String("m".into()), Expr::Identifier("Italic".into())],
     );
     let subscript = call("Subscript", vec![styled, Expr::Integer(1)]);
-    let label = call("Text", vec![subscript]);
+    let label = call1("Text", subscript);
     assert_eq!(runs(&label), vec![run("m", true), run("\u{2081}", false)]);
   }
 
@@ -21729,9 +21639,9 @@ mod manipulate_label_tests {
       "Style",
       vec![Expr::String("a".into()), Expr::Identifier("Italic".into())],
     );
-    let row = call(
+    let row = call1(
       "Row",
-      vec![Expr::List(vec![italic_a, Expr::String("b".into())].into())],
+      Expr::List(vec![italic_a, Expr::String("b".into())].into()),
     );
     assert_eq!(runs(&row), vec![run("a", true), run("b", false)]);
     assert_eq!(flatten_label_runs(&runs(&row)), "ab");
@@ -21740,7 +21650,7 @@ mod manipulate_label_tests {
   /// `Derivative[n][f]` — a slider labelled `y'(0)` in a Demonstration.
   fn derivative(order: i128, func: Expr) -> Expr {
     Expr::CurriedCall {
-      func: Box::new(call("Derivative", vec![Expr::Integer(order)])),
+      func: Box::new(call1("Derivative", Expr::Integer(order))),
       args: vec![func],
     }
   }
@@ -21751,14 +21661,14 @@ mod manipulate_label_tests {
       "Style",
       vec![Expr::String("y".into()), Expr::Identifier("Italic".into())],
     );
-    let label = call(
+    let label = call1(
       "Text",
-      vec![call(
+      call1(
         "Row",
-        vec![Expr::List(
+        Expr::List(
           vec![derivative(1, italic_y), Expr::String("(0)".into())].into(),
-        )],
-      )],
+        ),
+      ),
     );
     assert_eq!(
       runs(&label),

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -596,10 +596,7 @@ pub fn image_aspect_ratio_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if den == 1 {
       Expr::Integer(num)
     } else {
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(num), Expr::Integer(den)].into(),
-      }
+      call("Rational", vec![Expr::Integer(num), Expr::Integer(den)])
     }
   }
   if let Expr::Image { width, height, .. } = &args[0] {
@@ -1073,14 +1070,11 @@ pub fn color_negate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         }
       }
       match cargs.len() {
-        1 => Ok(Expr::FunctionCall {
-          name: "GrayLevel".to_string(),
-          args: vec![negate_component(&cargs[0])?].into(),
-        }),
-        2 => Ok(Expr::FunctionCall {
-          name: "GrayLevel".to_string(),
-          args: vec![negate_component(&cargs[0])?, cargs[1].clone()].into(),
-        }),
+        1 => Ok(call1("GrayLevel", negate_component(&cargs[0])?)),
+        2 => Ok(call(
+          "GrayLevel",
+          vec![negate_component(&cargs[0])?, cargs[1].clone()],
+        )),
         _ => Err(InterpreterError::EvaluationError(
           "ColorNegate: GrayLevel must have 1 or 2 arguments".into(),
         )),
@@ -2803,10 +2797,7 @@ pub fn dominant_colors_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let centers = kmeans_1d(&grays, k, 20);
         let colors: Vec<Expr> = centers
           .iter()
-          .map(|c| Expr::FunctionCall {
-            name: "GrayLevel".to_string(),
-            args: vec![Expr::Real(c[0])].into(),
-          })
+          .map(|c| call1("GrayLevel", Expr::Real(c[0])))
           .collect();
         return Ok(Expr::List(colors.into()));
       }
@@ -3293,20 +3284,14 @@ pub fn color_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(a) = alpha {
           gargs.push(Expr::Real(a));
         }
-        return Ok(Expr::FunctionCall {
-          name: "GrayLevel".to_string(),
-          args: gargs.into(),
-        });
+        return Ok(call("GrayLevel", gargs));
       }
       "RGB" => {
         let mut rargs = vec![Expr::Real(r), Expr::Real(g), Expr::Real(b)];
         if let Some(a) = alpha {
           rargs.push(Expr::Real(a));
         }
-        return Ok(Expr::FunctionCall {
-          name: "RGBColor".to_string(),
-          args: rargs.into(),
-        });
+        return Ok(call("RGBColor", rargs));
       }
       "CMYK" => {
         let (c, m, y, k) = rgb_to_cmyk(r, g, b);
@@ -3315,10 +3300,7 @@ pub fn color_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(a) = alpha {
           cargs.push(Expr::Real(a));
         }
-        return Ok(Expr::FunctionCall {
-          name: "CMYKColor".to_string(),
-          args: cargs.into(),
-        });
+        return Ok(call("CMYKColor", cargs));
       }
       // "HSB" produces the Hue[h, s, b(, a)] directive.
       "HSB" | "Hue" => {
@@ -3327,10 +3309,7 @@ pub fn color_convert_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if let Some(a) = alpha {
           hargs.push(Expr::Real(a));
         }
-        return Ok(Expr::FunctionCall {
-          name: "Hue".to_string(),
-          args: hargs.into(),
-        });
+        return Ok(call("Hue", hargs));
       }
       _ => {}
     }
@@ -4228,12 +4207,11 @@ fn median_filter_body(args: &[Expr]) -> Result<Expr, InterpreterError> {
               window.push(get(yy, xx));
             }
           }
-          let med =
-            crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-              name: "Median".to_string(),
-              args: vec![Expr::List(window.into())].into(),
-            })
-            .unwrap_or_else(|_| get(y, x));
+          let med = crate::evaluator::evaluate_expr_to_expr(&call(
+            "Median",
+            vec![Expr::List(window.into())],
+          ))
+          .unwrap_or_else(|_| get(y, x));
           new_row.push(med);
         }
         rows.push(Expr::List(new_row.into()));
@@ -4247,10 +4225,10 @@ fn median_filter_body(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let lo = i.saturating_sub(r);
       let hi = if i + r < n { i + r } else { n - 1 };
       let window: Vec<Expr> = elems[lo..=hi].to_vec();
-      let med = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Median".to_string(),
-        args: vec![Expr::List(window.into())].into(),
-      })
+      let med = crate::evaluator::evaluate_expr_to_expr(&call(
+        "Median",
+        vec![Expr::List(window.into())],
+      ))
       .unwrap_or_else(|_| elems[i].clone());
       result.push(med);
     }
@@ -4626,12 +4604,11 @@ fn aggregating_filter_ast(
               window.push(get(yy, xx));
             }
           }
-          let mean =
-            crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-              name: agg.to_string(),
-              args: vec![Expr::List(window.into())].into(),
-            })
-            .unwrap_or_else(|_| get(y, x));
+          let mean = crate::evaluator::evaluate_expr_to_expr(&call(
+            agg,
+            vec![Expr::List(window.into())],
+          ))
+          .unwrap_or_else(|_| get(y, x));
           new_row.push(mean);
         }
         rows.push(Expr::List(new_row.into()));
@@ -4645,10 +4622,10 @@ fn aggregating_filter_ast(
       let lo = i.saturating_sub(r);
       let hi = if i + r < n { i + r } else { n - 1 };
       let window: Vec<Expr> = elems[lo..=hi].to_vec();
-      let mean = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: agg.to_string(),
-        args: vec![Expr::List(window.into())].into(),
-      })
+      let mean = crate::evaluator::evaluate_expr_to_expr(&call(
+        agg,
+        vec![Expr::List(window.into())],
+      ))
       .unwrap_or_else(|_| elems[i].clone());
       result.push(mean);
     }
@@ -6421,10 +6398,10 @@ pub fn threshold_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   } else {
     (
       ThreshMethod::Hard,
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(1), Expr::Integer(10_000_000_000)].into(),
-      },
+      call(
+        "Rational",
+        vec![Expr::Integer(1), Expr::Integer(10_000_000_000)],
+      ),
     )
   };
   // When the data array contains any inexact value (Real/BigFloat), the whole
@@ -6533,21 +6510,15 @@ enum ThreshMethod {
 /// wolframscript. The caller (`apply`) handles real-promotion of the array.
 fn threshold_one_method(x: &Expr, t: &Expr, method: ThreshMethod) -> Expr {
   // Helper constructors for the symbolic forms.
-  fn call(name: &str, args: Vec<Expr>) -> Expr {
-    Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.into(),
-    }
-  }
   let pow = |b: Expr, e: i128| call("Power", vec![b, Expr::Integer(e)]);
-  let abs_x = call("Abs", vec![x.clone()]);
+  let abs_x = call1("Abs", x.clone());
   let expr = match method {
     ThreshMethod::Hard | ThreshMethod::Firm => return threshold_one(x, t),
     // Sign[x] * Max[|x| - t, 0]
     ThreshMethod::Soft => call(
       "Times",
       vec![
-        call("Sign", vec![x.clone()]),
+        call1("Sign", x.clone()),
         call(
           "Max",
           vec![
@@ -6586,7 +6557,7 @@ fn threshold_one_method(x: &Expr, t: &Expr, method: ThreshMethod) -> Expr {
         call(
           "Times",
           vec![
-            call("Sign", vec![x.clone()]),
+            call1("Sign", x.clone()),
             call(
               "Sqrt",
               vec![call(
@@ -8526,10 +8497,10 @@ pub fn color_balance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   // Resolve the reference → target pair from the three accepted spellings.
-  let white = Expr::FunctionCall {
-    name: "RGBColor".to_string(),
-    args: vec![Expr::Integer(1), Expr::Integer(1), Expr::Integer(1)].into(),
-  };
+  let white = call(
+    "RGBColor",
+    vec![Expr::Integer(1), Expr::Integer(1), Expr::Integer(1)],
+  );
   let (source_expr, target_expr) = match args.len() {
     2 => match &args[1] {
       Expr::Rule {
@@ -8933,10 +8904,7 @@ pub fn crossing_detect_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           .collect::<Vec<_>>()
           .into(),
       );
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "SparseArray".to_string(),
-        args: vec![dense].into(),
-      })
+      crate::evaluator::evaluate_expr_to_expr(&call1("SparseArray", dense))
     }
     // 2-D numeric matrix → binary SparseArray matrix. (In one dimension
     // the 8-neighborhood reduces to the two adjacent elements.)
@@ -8979,10 +8947,7 @@ pub fn crossing_detect_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           .collect::<Vec<_>>()
           .into(),
       );
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "SparseArray".to_string(),
-        args: vec![dense].into(),
-      })
+      crate::evaluator::evaluate_expr_to_expr(&call1("SparseArray", dense))
     }
     _ => unevaluated(),
   }
@@ -9221,13 +9186,11 @@ fn image_measurement(
       }
       .into(),
     )),
-    "AspectRatio" => {
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Divide".to_string(),
-        args: vec![Expr::Integer(h as i128), Expr::Integer(w as i128)].into(),
-      })
-      .ok()
-    }
+    "AspectRatio" => crate::evaluator::evaluate_expr_to_expr(&call(
+      "Divide",
+      vec![Expr::Integer(h as i128), Expr::Integer(w as i128)],
+    ))
+    .ok(),
     "DataType" => Some(Expr::String(
       match image_type {
         ImageType::Bit => "Bit",

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -215,11 +215,8 @@ fn adjoint_matrix(matrix: &[Vec<Expr>]) -> Vec<Vec<Expr>> {
       row
         .iter()
         .map(|e| {
-          evaluate_expr_to_expr(&Expr::FunctionCall {
-            name: "Conjugate".to_string(),
-            args: vec![e.clone()].into(),
-          })
-          .unwrap_or_else(|_| e.clone())
+          evaluate_expr_to_expr(&call1("Conjugate", e.clone()))
+            .unwrap_or_else(|_| e.clone())
         })
         .collect()
     })
@@ -247,10 +244,7 @@ pub fn orthogonalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // 1/Sqrt[6] and Sqrt[2/3]) that plain evaluation leaves un-reduced; run the
   // Simplify builtin so they collapse to canonical radicals.
   let simplify_full = |e: Expr| -> Expr {
-    let s = Expr::FunctionCall {
-      name: "Simplify".to_string(),
-      args: vec![e].into(),
-    };
+    let s = call("Simplify", vec![e]);
     evaluate_expr_to_expr(&s).unwrap_or_else(|_| Expr::Integer(0))
   };
   let is_rational = |e: &Expr| {
@@ -270,11 +264,8 @@ pub fn orthogonalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if !complex {
       return e.clone();
     }
-    evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Conjugate".to_string(),
-      args: vec![e.clone()].into(),
-    })
-    .unwrap_or_else(|_| e.clone())
+    evaluate_expr_to_expr(&call1("Conjugate", e.clone()))
+      .unwrap_or_else(|_| e.clone())
   };
 
   let mut result: Vec<Vec<Expr>> = Vec::new();
@@ -397,11 +388,7 @@ fn eval_add(a: &Expr, b: &Expr) -> Expr {
 fn fallback_plus(a: &Expr, b: &Expr) -> Expr {
   match crate::functions::math_ast::plus_ast(&[a.clone(), b.clone()]) {
     Ok(r) => r,
-    Err(_) => Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(a.clone()),
-      right: Box::new(b.clone()),
-    },
+    Err(_) => plus2(a.clone(), b.clone()),
   }
 }
 
@@ -412,11 +399,7 @@ fn eval_mul(a: &Expr, b: &Expr) -> Expr {
       None => {
         match crate::functions::math_ast::times_ast(&[a.clone(), b.clone()]) {
           Ok(r) => r,
-          Err(_) => Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(a.clone()),
-            right: Box::new(b.clone()),
-          },
+          Err(_) => times2(a.clone(), b.clone()),
         }
       }
     },
@@ -426,11 +409,7 @@ fn eval_mul(a: &Expr, b: &Expr) -> Expr {
     (Expr::Real(x), Expr::Real(y)) => Expr::Real(x * y),
     _ => match crate::functions::math_ast::times_ast(&[a.clone(), b.clone()]) {
       Ok(r) => r,
-      Err(_) => Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(a.clone()),
-        right: Box::new(b.clone()),
-      },
+      Err(_) => times2(a.clone(), b.clone()),
     },
   }
 }
@@ -451,11 +430,7 @@ fn eval_sub(a: &Expr, b: &Expr) -> Expr {
 fn fallback_sub(a: &Expr, b: &Expr) -> Expr {
   match crate::functions::math_ast::subtract_ast(&[a.clone(), b.clone()]) {
     Ok(r) => r,
-    Err(_) => Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(a.clone()),
-      right: Box::new(b.clone()),
-    },
+    Err(_) => minus2(a.clone(), b.clone()),
   }
 }
 
@@ -678,10 +653,7 @@ pub fn block_diagonal_matrix_ast(
     ]
     .into(),
   };
-  Ok(Expr::FunctionCall {
-    name: "BlockDiagonalMatrix".to_string(),
-    args: vec![structured].into(),
-  })
+  Ok(call("BlockDiagonalMatrix", vec![structured]))
 }
 
 /// An explicit number: the only entries wolframscript accepts when recovering
@@ -730,10 +702,10 @@ fn cauchy_generating_vectors(
   for row in mat {
     let mut sr = Vec::with_capacity(row.len());
     for e in row {
-      sr.push(evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![e.clone(), Expr::Integer(-1)].into(),
-      })?);
+      sr.push(evaluate_expr_to_expr(&call(
+        "Power",
+        vec![e.clone(), Expr::Integer(-1)],
+      ))?);
     }
     s.push(sr);
   }
@@ -741,14 +713,8 @@ fn cauchy_generating_vectors(
   let sub = |a: &Expr, b: &Expr| -> Result<Expr, InterpreterError> {
     evaluate_expr_to_expr(&Expr::FunctionCall {
       name: "Plus".to_string(),
-      args: vec![
-        a.clone(),
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(-1), b.clone()].into(),
-        },
-      ]
-      .into(),
+      args: vec![a.clone(), call("Times", vec![Expr::Integer(-1), b.clone()])]
+        .into(),
     })
   };
 
@@ -760,10 +726,8 @@ fn cauchy_generating_vectors(
 
   for (i, row) in s.iter().enumerate() {
     for (j, sij) in row.iter().enumerate() {
-      let want = evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: vec![x[i].clone(), y[j].clone()].into(),
-      })?;
+      let want =
+        evaluate_expr_to_expr(&call("Plus", vec![x[i].clone(), y[j].clone()]))?;
       let diff = sub(sij, &want)?;
       if is_zero_expr(&diff) {
         continue;
@@ -913,10 +877,8 @@ pub fn cauchy_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // No entry may have a vanishing denominator.
   for xi in &x {
     for yj in &y {
-      let sum = evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: vec![xi.clone(), yj.clone()].into(),
-      })?;
+      let sum =
+        evaluate_expr_to_expr(&call("Plus", vec![xi.clone(), yj.clone()]))?;
       if is_zero_expr(&sum) {
         crate::emit_message(&format!(
           "CauchyMatrix::cmvecs: A Cauchy matrix could not be constructed from the vectors {} and {}.",
@@ -945,10 +907,7 @@ pub fn cauchy_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ]
     .into(),
   };
-  Ok(Expr::FunctionCall {
-    name: "CauchyMatrix".to_string(),
-    args: vec![structured].into(),
-  })
+  Ok(call("CauchyMatrix", vec![structured]))
 }
 
 /// The dense m x n matrix with entry (i, j) equal to 1/(x_i + y_j).
@@ -960,10 +919,7 @@ fn cauchy_dense(x: &[Expr], y: &[Expr]) -> Result<Expr, InterpreterError> {
       row.push(evaluate_expr_to_expr(&Expr::FunctionCall {
         name: "Power".to_string(),
         args: vec![
-          Expr::FunctionCall {
-            name: "Plus".to_string(),
-            args: vec![xi.clone(), yj.clone()].into(),
-          },
+          call("Plus", vec![xi.clone(), yj.clone()]),
           Expr::Integer(-1),
         ]
         .into(),
@@ -1017,10 +973,7 @@ pub fn dot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
   if let (Some(ma), Some(mb)) = (extract_tf(&args[0]), extract_tf(&args[1])) {
     let product = dot_ast(&[ma, mb])?;
-    return Ok(Expr::FunctionCall {
-      name: "TransformationFunction".to_string(),
-      args: vec![product].into(),
-    });
+    return Ok(call("TransformationFunction", vec![product]));
   }
 
   // Incompatible shapes emit ::dotsh and return the unevaluated form.
@@ -1821,11 +1774,10 @@ pub fn permutation_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let perm_list = match &args[0] {
     Expr::List(items) => items.iter().cloned().collect::<Vec<_>>(),
     cycles @ Expr::FunctionCall { name, .. } if name == "Cycles" => {
-      let converted =
-        crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "PermutationList".to_string(),
-          args: vec![cycles.clone()].into(),
-        })?;
+      let converted = crate::evaluator::evaluate_expr_to_expr(&call(
+        "PermutationList",
+        vec![cycles.clone()],
+      ))?;
       match &converted {
         Expr::List(items) => items.iter().cloned().collect(),
         _ => return unevaluated(),
@@ -1899,7 +1851,7 @@ impl CoefficientPlacement {
 /// through half a turn, putting the reversed coefficients in the first column;
 /// and `Top` is the transpose of `Left`.
 pub fn companion_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let call = || Ok(unevaluated("CompanionMatrix", args));
+  let unevaluated = || Ok(unevaluated("CompanionMatrix", args));
   let render =
     |e: &Expr| crate::syntax::format_expr(e, crate::syntax::ExprForm::Output);
   // A list first argument is a coefficient vector, so the only other argument
@@ -1908,10 +1860,10 @@ pub fn companion_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let (variable, placement_arg) = match (&args[0], args.len()) {
     (Expr::List(_), 1) => (None, None),
     (Expr::List(_), 2) => (None, Some(&args[1])),
-    (Expr::List(_), _) => return call(),
+    (Expr::List(_), _) => return unevaluated(),
     (_, 2) => (Some(&args[1]), None),
     (_, 3) => (Some(&args[1]), Some(&args[2])),
-    _ => return call(),
+    _ => return unevaluated(),
   };
   let placement = match placement_arg {
     None => CoefficientPlacement::Right,
@@ -1923,7 +1875,7 @@ pub fn companion_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
            coefficients must be Top, Bottom, Left or Right.",
           render(e)
         ));
-        return call();
+        return unevaluated();
       }
     },
   };
@@ -1931,7 +1883,7 @@ pub fn companion_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let coeffs: Vec<Expr> = match variable {
     None => match &args[0] {
       Expr::List(c) => c.to_vec(),
-      _ => return call(),
+      _ => return unevaluated(),
     },
     Some(var) => {
       let clorpoly = || {
@@ -1949,21 +1901,21 @@ pub fn companion_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // gives a single coefficient — neither has a companion matrix.
       let Expr::List(c) = &list else {
         clorpoly();
-        return call();
+        return unevaluated();
       };
       if c.len() < 2 {
         clorpoly();
-        return call();
+        return unevaluated();
       }
       // Divide through by the leading coefficient to make the polynomial
       // monic, then drop it: a degree-n polynomial has an n x n matrix.
       let lead = c.last().expect("checked non-empty");
       let mut monic = Vec::with_capacity(c.len() - 1);
       for coeff in &c[..c.len() - 1] {
-        monic.push(evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "Divide".to_string(),
-          args: vec![coeff.clone(), lead.clone()].into(),
-        })?);
+        monic.push(evaluate_expr_to_expr(&call(
+          "Divide",
+          vec![coeff.clone(), lead.clone()],
+        ))?);
       }
       monic
     }
@@ -1982,10 +1934,10 @@ pub fn companion_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if i >= 1 {
       row[i - 1] = Expr::Integer(1); // subdiagonal
     }
-    row[n - 1] = evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![Expr::Integer(-1), c.clone()].into(),
-    })?;
+    row[n - 1] = evaluate_expr_to_expr(&call(
+      "Times",
+      vec![Expr::Integer(-1), c.clone()],
+    ))?;
     matrix.push(row);
   }
   if matches!(
@@ -2032,10 +1984,10 @@ pub fn vandermonde_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let entry = match j {
         0 => Expr::Integer(1),
         1 => x.clone(),
-        _ => crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![x.clone(), Expr::Integer(j as i128)].into(),
-        })?,
+        _ => crate::evaluator::evaluate_expr_to_expr(&call(
+          "Power",
+          vec![x.clone(), Expr::Integer(j as i128)],
+        ))?,
       };
       row.push(entry);
     }
@@ -2239,18 +2191,13 @@ pub fn cross_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           Expr::List(row.into())
         })
         .collect();
-      let det = evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Det".to_string(),
-        args: vec![Expr::List(minor.into())].into(),
-      })?;
+      let det =
+        evaluate_expr_to_expr(&call("Det", vec![Expr::List(minor.into())]))?;
       // Sign (-1)^(n + (i+1)).
       let component = if (n + i + 1).is_multiple_of(2) {
         det
       } else {
-        evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(-1), det].into(),
-        })?
+        evaluate_expr_to_expr(&call("Times", vec![Expr::Integer(-1), det]))?
       };
       result.push(component);
     }
@@ -2325,10 +2272,7 @@ pub fn conjugate_transpose_ast(
         && j < cols.len()
       {
         // Apply Conjugate
-        let conj = evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "Conjugate".to_string(),
-          args: vec![cols[j].clone()].into(),
-        })?;
+        let conj = evaluate_expr_to_expr(&call1("Conjugate", cols[j].clone()))?;
         row.push(conj);
       }
     }
@@ -2353,11 +2297,7 @@ pub fn projection_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let fvu = apply(f, &[v.clone(), u])?;
     let fvv = apply(f, &[v.clone(), v.clone()])?;
     let scalar = div2(fvu, fvv);
-    let result = Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(scalar),
-      right: Box::new(v),
-    };
+    let result = times2(scalar, v);
     return evaluate_expr_to_expr(&result);
   }
   if args.len() != 2 {
@@ -2372,24 +2312,11 @@ pub fn projection_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !matches!(&args[0], Expr::List(_)) && !matches!(&args[1], Expr::List(_)) {
     let u = args[0].clone();
     let v = args[1].clone();
-    let conj_v = Expr::FunctionCall {
-      name: "Conjugate".to_string(),
-      args: vec![v.clone()].into(),
-    };
-    let dot_cv_u = Expr::FunctionCall {
-      name: "Dot".to_string(),
-      args: vec![conj_v.clone(), u].into(),
-    };
-    let dot_cv_v = Expr::FunctionCall {
-      name: "Dot".to_string(),
-      args: vec![conj_v, v.clone()].into(),
-    };
+    let conj_v = call1("Conjugate", v.clone());
+    let dot_cv_u = call("Dot", vec![conj_v.clone(), u]);
+    let dot_cv_v = call("Dot", vec![conj_v, v.clone()]);
     let scalar = div2(dot_cv_u, dot_cv_v);
-    let result = Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(scalar),
-      right: Box::new(v),
-    };
+    let result = times2(scalar, v);
     return evaluate_expr_to_expr(&result);
   }
   let u = match &args[0] {
@@ -2411,12 +2338,7 @@ pub fn projection_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let conj_v: Vec<Expr> = v
     .iter()
-    .map(|vi| {
-      evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Conjugate".to_string(),
-        args: vec![vi.clone()].into(),
-      })
-    })
+    .map(|vi| evaluate_expr_to_expr(&call1("Conjugate", vi.clone())))
     .collect::<Result<_, _>>()?;
   let mut cvu = Expr::Integer(0);
   for (cv, ui) in conj_v.iter().zip(u.iter()) {
@@ -2515,10 +2437,7 @@ pub fn fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if matches!(&basis[j], Expr::Integer(1)) {
       terms.push(coeff_expr);
     } else {
-      terms.push(Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![coeff_expr, basis[j].clone()].into(),
-      });
+      terms.push(call("Times", vec![coeff_expr, basis[j].clone()]));
     }
   }
 
@@ -2526,10 +2445,7 @@ pub fn fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if terms.len() == 1 {
     Ok(terms.into_iter().next().unwrap())
   } else {
-    Ok(Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    })
+    Ok(call("Plus", terms))
   }
 }
 
@@ -2951,25 +2867,16 @@ pub fn characteristic_polynomial_int(
       let pow = if i == 1 {
         var.clone()
       } else {
-        Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![var.clone(), Expr::Integer(i as i128)].into(),
-        }
+        call("Power", vec![var.clone(), Expr::Integer(i as i128)])
       };
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![coeff_expr, pow].into(),
-      }
+      call("Times", vec![coeff_expr, pow])
     };
     terms.push(term);
   }
   if terms.is_empty() {
     return Some(Ok(Expr::Integer(0)));
   }
-  let sum = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  };
+  let sum = call("Plus", terms);
   Some(crate::evaluator::evaluate_expr_to_expr(&sum))
 }
 
@@ -3171,10 +3078,10 @@ fn divide_exact_root(root: &Expr, d: i128) -> Option<Expr> {
       operand,
     } => {
       let pos = divide_exact_root(operand, d)?;
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), pos].into(),
-      })
+      crate::evaluator::evaluate_expr_to_expr(&call(
+        "Times",
+        vec![Expr::Integer(-1), pos],
+      ))
       .ok()
     }
     Expr::FunctionCall { name, args }
@@ -3183,10 +3090,10 @@ fn divide_exact_root(root: &Expr, d: i128) -> Option<Expr> {
         && matches!(&args[0], Expr::Integer(-1)) =>
     {
       let pos = divide_exact_root(&args[1], d)?;
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), pos].into(),
-      })
+      crate::evaluator::evaluate_expr_to_expr(&call(
+        "Times",
+        vec![Expr::Integer(-1), pos],
+      ))
       .ok()
     }
     _ => crate::evaluator::evaluate_expr_to_expr(&div2(
@@ -3236,28 +3143,19 @@ fn quadratic_eigenvalues(b_coeff: i128, c_coeff: i128) -> Vec<Expr> {
       }
       factors.push(Expr::Constant("I".to_string()));
       if inner != 1 {
-        factors.push(Expr::FunctionCall {
-          name: "Sqrt".to_string(),
-          args: vec![Expr::Integer(inner as i128)].into(),
-        });
+        factors.push(call("Sqrt", vec![Expr::Integer(inner as i128)]));
       }
       if factors.len() == 1 {
         factors.remove(0)
       } else {
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: factors.into(),
-        }
+        call("Times", factors)
       }
     };
     let with_real = |re: i128, imag: Expr| -> Expr {
       if re == 0 {
         imag
       } else {
-        Expr::FunctionCall {
-          name: "Plus".to_string(),
-          args: vec![Expr::Integer(re), imag].into(),
-        }
+        call("Plus", vec![Expr::Integer(re), imag])
       }
     };
     let outer = outer as i128;
@@ -3506,43 +3404,22 @@ pub fn eigenvalues_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let disc = Expr::FunctionCall {
       name: "Plus".to_string(),
       args: vec![
-        Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![a.clone(), Expr::Integer(2)].into(),
-        },
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(4), b.clone(), c.clone()].into(),
-        },
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(-2), a.clone(), d.clone()].into(),
-        },
-        Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![d.clone(), Expr::Integer(2)].into(),
-        },
+        call("Power", vec![a.clone(), Expr::Integer(2)]),
+        call("Times", vec![Expr::Integer(4), b.clone(), c.clone()]),
+        call("Times", vec![Expr::Integer(-2), a.clone(), d.clone()]),
+        call("Power", vec![d.clone(), Expr::Integer(2)]),
       ]
       .into(),
     };
-    let sqrt_disc = Expr::FunctionCall {
-      name: "Sqrt".to_string(),
-      args: vec![disc].into(),
-    };
-    let trace = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: vec![a, d].into(),
-    };
+    let sqrt_disc = call("Sqrt", vec![disc]);
+    let trace = call("Plus", vec![a, d]);
     let lambda_minus = Expr::BinaryOp {
       op: BinaryOperator::Divide,
       left: Box::new(Expr::FunctionCall {
         name: "Plus".to_string(),
         args: vec![
           trace.clone(),
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![Expr::Integer(-1), sqrt_disc.clone()].into(),
-          },
+          call("Times", vec![Expr::Integer(-1), sqrt_disc.clone()]),
         ]
         .into(),
       }),
@@ -3550,10 +3427,7 @@ pub fn eigenvalues_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     };
     let lambda_plus = Expr::BinaryOp {
       op: BinaryOperator::Divide,
-      left: Box::new(Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: vec![trace, sqrt_disc].into(),
-      }),
+      left: Box::new(call("Plus", vec![trace, sqrt_disc])),
       right: Box::new(Expr::Integer(2)),
     };
     let lm = crate::evaluator::evaluate_expr_to_expr(&lambda_minus)?;
@@ -3656,10 +3530,7 @@ fn symbolic_rotation_eigenvalues(matrix: &[Vec<Expr>]) -> Option<Vec<Expr>> {
     return None;
   }
   // bottom-left must equal `-(top-right)`
-  let neg_b = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![Expr::Integer(-1), b.clone()].into(),
-  };
+  let neg_b = call("Times", vec![Expr::Integer(-1), b.clone()]);
   let neg_b_eval = crate::evaluator::evaluate_expr_to_expr(&neg_b).ok()?;
   if expr_to_string(c) != expr_to_string(&neg_b_eval) {
     return None;
@@ -3676,26 +3547,11 @@ fn symbolic_rotation_eigenvalues(matrix: &[Vec<Expr>]) -> Option<Vec<Expr>> {
   // to an unreduced `Power[I, 2]`, whereas `Complex × Complex` does proper
   // complex arithmetic (e.g. I*I -> -1). So Eigenvalues[{{2, I}, {-I, 2}}]
   // = {3, 1}, not {2 - I^2, 2 + I^2}.
-  let i = Expr::FunctionCall {
-    name: "Complex".to_string(),
-    args: vec![Expr::Integer(0), Expr::Integer(1)].into(),
-  };
-  let i_b = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![i, b.clone()].into(),
-  };
-  let minus_ib = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![Expr::Integer(-1), i_b.clone()].into(),
-  };
-  let lo = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: vec![a.clone(), minus_ib].into(),
-  };
-  let hi = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: vec![a.clone(), i_b].into(),
-  };
+  let i = call("Complex", vec![Expr::Integer(0), Expr::Integer(1)]);
+  let i_b = call("Times", vec![i, b.clone()]);
+  let minus_ib = call("Times", vec![Expr::Integer(-1), i_b.clone()]);
+  let lo = call("Plus", vec![a.clone(), minus_ib]);
+  let hi = call("Plus", vec![a.clone(), i_b]);
   let lo = crate::evaluator::evaluate_expr_to_expr(&lo).ok()?;
   let hi = crate::evaluator::evaluate_expr_to_expr(&hi).ok()?;
   Some(vec![lo, hi])
@@ -3911,27 +3767,18 @@ fn make_root_exprs(coeffs: &[i128]) -> Vec<Expr> {
     let var_pow = match i {
       0 => None,
       1 => Some(slot.clone()),
-      _ => Some(Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![slot.clone(), Expr::Integer(i as i128)].into(),
-      }),
+      _ => Some(call("Power", vec![slot.clone(), Expr::Integer(i as i128)])),
     };
     terms.push(match (var_pow, c) {
       (None, c) => Expr::Integer(c),
       (Some(p), 1) => p,
-      (Some(p), c) => Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(c), p].into(),
-      },
+      (Some(p), c) => call("Times", vec![Expr::Integer(c), p]),
     });
   }
   let body = match terms.len() {
     0 => Expr::Integer(0),
     1 => terms.remove(0),
-    _ => Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    },
+    _ => call("Plus", terms),
   };
   let func = Expr::Function {
     body: Box::new(body),
@@ -4171,10 +4018,7 @@ fn complex_2x2_eigenvectors(
           name: "Plus".to_string(),
           args: vec![
             num_minuend.clone(),
-            Expr::FunctionCall {
-              name: "Times".to_string(),
-              args: vec![Expr::Integer(-1), num_subtrahend.clone()].into(),
-            },
+            call("Times", vec![Expr::Integer(-1), num_subtrahend.clone()]),
           ]
           .into(),
         }),
@@ -4215,10 +4059,7 @@ fn complex_2x2_eigenvectors(
           name: "Plus".to_string(),
           args: vec![
             d.clone(),
-            Expr::FunctionCall {
-              name: "Times".to_string(),
-              args: vec![Expr::Integer(-1), a.clone()].into(),
-            },
+            call("Times", vec![Expr::Integer(-1), a.clone()]),
           ]
           .into(),
         }
@@ -4298,10 +4139,7 @@ fn integer_eigenvectors(
         vecs.into_iter().map(|v| Expr::List(v.into())).collect(),
       ));
     }
-    return Ok(Expr::FunctionCall {
-      name: "Eigenvectors".to_string(),
-      args: vec![matrix_to_expr(matrix.to_vec())].into(),
-    });
+    return Ok(call("Eigenvectors", vec![matrix_to_expr(matrix.to_vec())]));
   }
 
   if !all_integer && n == 3 {
@@ -4311,18 +4149,12 @@ fn integer_eigenvectors(
         vecs.into_iter().map(|v| Expr::List(v.into())).collect(),
       ));
     }
-    return Ok(Expr::FunctionCall {
-      name: "Eigenvectors".to_string(),
-      args: vec![matrix_to_expr(matrix.to_vec())].into(),
-    });
+    return Ok(call("Eigenvectors", vec![matrix_to_expr(matrix.to_vec())]));
   }
 
   if !all_integer {
     // Can't handle symbolic eigenvalues for n > 3
-    return Ok(Expr::FunctionCall {
-      name: "Eigenvectors".to_string(),
-      args: vec![matrix_to_expr(matrix.to_vec())].into(),
-    });
+    return Ok(call("Eigenvectors", vec![matrix_to_expr(matrix.to_vec())]));
   }
 
   // All integer eigenvalues: compute null spaces
@@ -5053,17 +4885,10 @@ pub fn drazin_inverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let a_expr = matrix_to_expr(matrix.clone());
 
   let dot = |x: &Expr, y: &Expr| {
-    evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Dot".to_string(),
-      args: vec![x.clone(), y.clone()].into(),
-    })
+    evaluate_expr_to_expr(&call("Dot", vec![x.clone(), y.clone()]))
   };
-  let unary = |name: &str, m: &Expr| {
-    evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: name.to_string(),
-      args: vec![m.clone()].into(),
-    })
-  };
+  let unary =
+    |name: &str, m: &Expr| evaluate_expr_to_expr(&call(name, vec![m.clone()]));
   let rank = |m: &Expr| -> Option<usize> {
     match unary("MatrixRank", m) {
       Ok(Expr::Integer(r)) if r >= 0 => Some(r as usize),
@@ -5177,10 +5002,7 @@ fn simplify_expr(e: &Expr) -> Expr {
     | Expr::BigInteger(_)
     | Expr::Identifier(_) => evaluated,
     _ => {
-      match evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Simplify".to_string(),
-        args: vec![evaluated.clone()].into(),
-      }) {
+      match evaluate_expr_to_expr(&call("Simplify", vec![evaluated.clone()])) {
         Ok(r) => r,
         Err(_) => evaluated,
       }
@@ -5430,10 +5252,7 @@ pub fn levi_civita_tensor_sparse_ast(
   // Delegate to SparseArray[rules, {n, n, ..., n}] to get the same internal
   // representation that wolframscript emits.
   let dims = Expr::List(vec![Expr::Integer(n as i128); n].into());
-  let sparse_call = Expr::FunctionCall {
-    name: "SparseArray".to_string(),
-    args: vec![Expr::List(rules.into()), dims].into(),
-  };
+  let sparse_call = call("SparseArray", vec![Expr::List(rules.into()), dims]);
   crate::evaluator::evaluate_expr_to_expr(&sparse_call)
 }
 
@@ -6174,10 +5993,10 @@ pub fn root_approximant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // No algebraic relation within the degree budget: fall back to the exact
   // rational the machine real represents, as wolframscript does.
-  crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Rationalize".to_string(),
-    args: vec![Expr::Real(x), Expr::Integer(0)].into(),
-  })
+  crate::evaluator::evaluate_expr_to_expr(&call(
+    "Rationalize",
+    vec![Expr::Real(x), Expr::Integer(0)],
+  ))
 }
 
 /// Build `Root[poly, k, 0]` for the integer polynomial with the given ascending
@@ -6210,28 +6029,19 @@ fn build_root_from_coeffs(coeffs: &[i128], x: f64) -> Option<Expr> {
     let var_pow = match i {
       0 => None,
       1 => Some(slot.clone()),
-      _ => Some(Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![slot.clone(), Expr::Integer(i as i128)].into(),
-      }),
+      _ => Some(call("Power", vec![slot.clone(), Expr::Integer(i as i128)])),
     };
     let term = match (var_pow, coeff) {
       (None, coeff) => Expr::Integer(coeff),
       (Some(p), 1) => p,
-      (Some(p), coeff) => Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(coeff), p].into(),
-      },
+      (Some(p), coeff) => call("Times", vec![Expr::Integer(coeff), p]),
     };
     terms.push(term);
   }
   let body = match terms.len() {
     0 => return None,
     1 => terms.remove(0),
-    _ => Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    },
+    _ => call("Plus", terms),
   };
   let body = crate::evaluator::evaluate_expr_to_expr(&body).ok()?;
   let func = Expr::Function {
@@ -6240,17 +6050,16 @@ fn build_root_from_coeffs(coeffs: &[i128], x: f64) -> Option<Expr> {
 
   // Pick the root index k (1-based, wolframscript's ordering) whose numeric
   // value is closest to x, by numericising each Root[func, k, 0].
-  let make_root = |k: usize| Expr::FunctionCall {
-    name: "Root".to_string(),
-    args: vec![func.clone(), Expr::Integer(k as i128), Expr::Integer(0)].into(),
+  let make_root = |k: usize| {
+    call(
+      "Root",
+      vec![func.clone(), Expr::Integer(k as i128), Expr::Integer(0)],
+    )
   };
   let mut best_k = 0usize;
   let mut best_dist = f64::MAX;
   for k in 1..=degree {
-    let n_expr = Expr::FunctionCall {
-      name: "N".to_string(),
-      args: vec![make_root(k)].into(),
-    };
+    let n_expr = call("N", vec![make_root(k)]);
     if let Ok(v) = crate::evaluator::evaluate_expr_to_expr(&n_expr)
       && let Some(rv) = try_eval_to_f64(&v)
     {
@@ -6642,14 +6451,10 @@ pub fn vector_angle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Check for zero vectors — Norm[{0,...}] = 0 → Indeterminate
-  let norm_u_expr = evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Norm".to_string(),
-    args: vec![args[0].clone()].into(),
-  })?;
-  let norm_v_expr = evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Norm".to_string(),
-    args: vec![args[1].clone()].into(),
-  })?;
+  let norm_u_expr =
+    evaluate_expr_to_expr(&call("Norm", vec![args[0].clone()]))?;
+  let norm_v_expr =
+    evaluate_expr_to_expr(&call("Norm", vec![args[1].clone()]))?;
   if matches!(norm_u_expr, Expr::Integer(0))
     || matches!(norm_v_expr, Expr::Integer(0))
   {
@@ -6664,44 +6469,19 @@ pub fn vector_angle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let complex =
     contains_imaginary_unit(&args[0]) || contains_imaginary_unit(&args[1]);
   let second = if complex {
-    evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Conjugate".to_string(),
-      args: vec![args[1].clone()].into(),
-    })?
+    evaluate_expr_to_expr(&call1("Conjugate", args[1].clone()))?
   } else {
     args[1].clone()
   };
-  let dot_expr = Expr::FunctionCall {
-    name: "Dot".to_string(),
-    args: vec![args[0].clone(), second].into(),
-  };
-  let norm_u = Expr::FunctionCall {
-    name: "Norm".to_string(),
-    args: vec![args[0].clone()].into(),
-  };
-  let norm_v = Expr::FunctionCall {
-    name: "Norm".to_string(),
-    args: vec![args[1].clone()].into(),
-  };
-  let denom = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![norm_u, norm_v].into(),
-  };
+  let dot_expr = call("Dot", vec![args[0].clone(), second]);
+  let norm_u = call("Norm", vec![args[0].clone()]);
+  let norm_v = call("Norm", vec![args[1].clone()]);
+  let denom = call("Times", vec![norm_u, norm_v]);
   let ratio = Expr::FunctionCall {
     name: "Times".to_string(),
-    args: vec![
-      dot_expr,
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![denom, Expr::Integer(-1)].into(),
-      },
-    ]
-    .into(),
+    args: vec![dot_expr, call("Power", vec![denom, Expr::Integer(-1)])].into(),
   };
-  let result = Expr::FunctionCall {
-    name: "ArcCos".to_string(),
-    args: vec![ratio].into(),
-  };
+  let result = call("ArcCos", vec![ratio]);
   evaluate_expr_to_expr(&result)
 }
 
@@ -6743,20 +6523,12 @@ pub fn dihedral_angle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return unevaluated();
   }
   // Edge direction e = p2 - p1.
-  let edge = evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Subtract".to_string(),
-    args: vec![p2.clone(), p1.clone()].into(),
-  })?;
+  let edge =
+    evaluate_expr_to_expr(&call("Subtract", vec![p2.clone(), p1.clone()]))?;
   // Component of v perpendicular to the edge: v - Projection[v, e].
   let perp = |v: &Expr| -> Result<Expr, InterpreterError> {
-    let proj = Expr::FunctionCall {
-      name: "Projection".to_string(),
-      args: vec![v.clone(), edge.clone()].into(),
-    };
-    evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Subtract".to_string(),
-      args: vec![v.clone(), proj].into(),
-    })
+    let proj = call("Projection", vec![v.clone(), edge.clone()]);
+    evaluate_expr_to_expr(&call("Subtract", vec![v.clone(), proj]))
   };
   let v1p = perp(&v1)?;
   let v2p = perp(&v2)?;
@@ -6796,10 +6568,10 @@ pub fn solid_angle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     {
       return unevaluated();
     }
-    vecs.push(evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Subtract".to_string(),
-      args: vec![u.clone(), args[0].clone()].into(),
-    })?);
+    vecs.push(evaluate_expr_to_expr(&call(
+      "Subtract",
+      vec![u.clone(), args[0].clone()],
+    ))?);
   }
   let d = vecs.len();
   // Full-dimensional cones only: a lower-dimensional wedge has zero measure.
@@ -6814,18 +6586,9 @@ pub fn solid_angle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     2 => vector_angle_ast(&[vecs[0].clone(), vecs[1].clone()]),
     // Trihedral solid angle (Van Oosterom–Strackee).
     3 => {
-      let dot = |a: &Expr, b: &Expr| Expr::FunctionCall {
-        name: "Dot".to_string(),
-        args: vec![a.clone(), b.clone()].into(),
-      };
-      let norm = |a: &Expr| Expr::FunctionCall {
-        name: "Norm".to_string(),
-        args: vec![a.clone()].into(),
-      };
-      let times = |factors: Vec<Expr>| Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: factors.into(),
-      };
+      let dot = |a: &Expr, b: &Expr| call("Dot", vec![a.clone(), b.clone()]);
+      let norm = |a: &Expr| call("Norm", vec![a.clone()]);
+      let times = |factors: Vec<Expr>| call("Times", factors);
       let (v1, v2, v3) = (&vecs[0], &vecs[1], &vecs[2]);
       let num = Expr::FunctionCall {
         name: "Abs".to_string(),
@@ -6850,10 +6613,7 @@ pub fn solid_angle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       };
       evaluate_expr_to_expr(&times(vec![
         Expr::Integer(2),
-        Expr::FunctionCall {
-          name: "ArcTan".to_string(),
-          args: vec![den, num].into(),
-        },
+        call("ArcTan", vec![den, num]),
       ]))
     }
     _ => unevaluated(),
@@ -7084,10 +6844,7 @@ pub fn linear_model_fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if matches!(&basis[j], Expr::Integer(1)) {
       terms.push(coeff_expr);
     } else {
-      terms.push(Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![coeff_expr, basis[j].clone()].into(),
-      });
+      terms.push(call("Times", vec![coeff_expr, basis[j].clone()]));
     }
   }
   let fitted_expr = if terms.len() == 1 {
@@ -7098,10 +6855,7 @@ pub fn linear_model_fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // `m["BestFit"]` and `m["Function"]` with the basis terms sorted by
     // primary function name (Cos before Sin, etc.), not in the input
     // basis order.
-    let raw = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    };
+    let raw = call("Plus", terms);
     evaluate_expr_to_expr(&raw).unwrap_or(raw)
   };
 
@@ -7207,10 +6961,7 @@ pub fn linear_model_fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ),
   ]);
 
-  Ok(Expr::FunctionCall {
-    name: "FittedModel".to_string(),
-    args: vec![assoc].into(),
-  })
+  Ok(call("FittedModel", vec![assoc]))
 }
 
 /// NonlinearModelFit[data, model, params, var] — fits a (possibly nonlinear)
@@ -7274,10 +7025,10 @@ pub fn nonlinear_model_fit_ast(
   };
 
   // The fitted function: the model with the parameter rules substituted.
-  let fitted_expr = evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "ReplaceAll".to_string(),
-    args: vec![model.clone(), param_rules.clone()].into(),
-  })?;
+  let fitted_expr = evaluate_expr_to_expr(&call(
+    "ReplaceAll",
+    vec![model.clone(), param_rules.clone()],
+  ))?;
 
   let assoc = Expr::Association(vec![
     (
@@ -7303,10 +7054,7 @@ pub fn nonlinear_model_fit_ast(
     (Expr::String("BestFit".to_string()), fitted_expr),
   ]);
 
-  Ok(Expr::FunctionCall {
-    name: "FittedModel".to_string(),
-    args: vec![assoc].into(),
-  })
+  Ok(call("FittedModel", vec![assoc]))
 }
 
 /// `LinearModelFit[{X, y}]` — design-matrix form. Fits `y ≈ X · β` directly,
@@ -7438,18 +7186,12 @@ fn linear_model_fit_design_matrix_form(
   let terms: Vec<Expr> = coeffs
     .iter()
     .enumerate()
-    .map(|(j, c)| Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![Expr::Real(*c), basis[j].clone()].into(),
-    })
+    .map(|(j, c)| call("Times", vec![Expr::Real(*c), basis[j].clone()]))
     .collect();
   let fitted_expr = if terms.len() == 1 {
     terms.into_iter().next().unwrap()
   } else {
-    let raw = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    };
+    let raw = call("Plus", terms);
     evaluate_expr_to_expr(&raw).unwrap_or(raw)
   };
   let function_form = Expr::Function {
@@ -7519,10 +7261,7 @@ fn linear_model_fit_design_matrix_form(
     ),
   ]);
 
-  Ok(Expr::FunctionCall {
-    name: "FittedModel".to_string(),
-    args: vec![assoc].into(),
-  })
+  Ok(call("FittedModel", vec![assoc]))
 }
 
 /// LogitModelFit[data, {1, x, x^2, ...}, x] — logistic regression.
@@ -7660,19 +7399,13 @@ pub fn logit_model_fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if matches!(&basis[j], Expr::Integer(1)) {
       linear_terms.push(coeff_expr);
     } else {
-      linear_terms.push(Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![coeff_expr, basis[j].clone()].into(),
-      });
+      linear_terms.push(call("Times", vec![coeff_expr, basis[j].clone()]));
     }
   }
   let linear_expr = if linear_terms.len() == 1 {
     linear_terms.into_iter().next().unwrap()
   } else {
-    Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: linear_terms.into(),
-    }
+    call("Plus", linear_terms)
   };
 
   // Build logistic: 1 / (1 + Exp[-linear])
@@ -7689,11 +7422,8 @@ pub fn logit_model_fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               Expr::Integer(1),
               Expr::FunctionCall {
                 name: "Exp".to_string(),
-                args: vec![Expr::FunctionCall {
-                  name: "Times".to_string(),
-                  args: vec![Expr::Integer(-1), linear_expr].into(),
-                }]
-                .into(),
+                args: vec![call("Times", vec![Expr::Integer(-1), linear_expr])]
+                  .into(),
               },
             ]
             .into(),
@@ -7747,10 +7477,7 @@ pub fn logit_model_fit_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ),
   ]);
 
-  Ok(Expr::FunctionCall {
-    name: "FittedModel".to_string(),
-    args: vec![assoc].into(),
-  })
+  Ok(call("FittedModel", vec![assoc]))
 }
 
 /// Solve a linear system Ax = b using Gaussian elimination with partial pivoting.
@@ -8016,10 +7743,7 @@ pub fn cholesky_decomposition_ast(
   let mut u = vec![vec![zero; n]; n];
 
   let conj = |e: &Expr| -> Result<Expr, InterpreterError> {
-    eval_expr(&Expr::FunctionCall {
-      name: "Conjugate".to_string(),
-      args: vec![e.clone()].into(),
-    })
+    eval_expr(&call1("Conjugate", e.clone()))
   };
 
   for j in 0..n {
@@ -8141,10 +7865,7 @@ pub fn qr_decomposition_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     .iter()
     .any(|row| row.iter().any(contains_imaginary_unit));
   let conj = |e: &Expr| -> Result<Expr, InterpreterError> {
-    eval_expr(&Expr::FunctionCall {
-      name: "Conjugate".to_string(),
-      args: vec![e.clone()].into(),
-    })
+    eval_expr(&call1("Conjugate", e.clone()))
   };
   let dot = |a: &[Expr], b: &[Expr]| -> Result<Expr, InterpreterError> {
     if complex {
@@ -8199,15 +7920,10 @@ pub fn qr_decomposition_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       r_entries[i][j] = eval_expr(&div2(unum.clone(), norm.clone()))?;
       let coeff = eval_expr(&div2(unum, norm_sq.clone()))?;
       for k in 0..n {
-        u[j][k] = eval_expr(&Expr::BinaryOp {
-          op: BinaryOperator::Minus,
-          left: Box::new(u[j][k].clone()),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(coeff.clone()),
-            right: Box::new(u[i][k].clone()),
-          }),
-        })?;
+        u[j][k] = eval_expr(&minus2(
+          u[j][k].clone(),
+          times2(coeff.clone(), u[i][k].clone()),
+        ))?;
       }
     }
   }
@@ -8390,10 +8106,10 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
         right,
       } => {
         flatten(left, out);
-        out.push(Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![right.as_ref().clone(), Expr::Integer(-1)].into(),
-        });
+        out.push(call(
+          "Power",
+          vec![right.as_ref().clone(), Expr::Integer(-1)],
+        ));
       }
       _ => out.push(e.clone()),
     }
@@ -8621,16 +8337,8 @@ fn simplify_radical_factor(expr: &Expr) -> Expr {
 fn eval_dot_product(a: &[Expr], b: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut sum = Expr::Integer(0);
   for (ai, bi) in a.iter().zip(b.iter()) {
-    let prod = Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(ai.clone()),
-      right: Box::new(bi.clone()),
-    };
-    sum = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(sum),
-      right: Box::new(prod),
-    };
+    let prod = times2(ai.clone(), bi.clone());
+    sum = plus2(sum, prod);
   }
   eval_expr(&sum)
 }
@@ -9022,16 +8730,10 @@ fn build_wedge_tensor(
       for (slot, &p_idx) in perm.iter().enumerate() {
         factors.push(vectors[p_idx][indices[slot]].clone());
       }
-      let term = Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: factors.into(),
-      };
+      let term = call("Times", factors);
       terms.push(term);
     }
-    let sum_expr = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    };
+    let sum_expr = call("Plus", terms);
     return evaluate_expr_to_expr(&sum_expr);
   }
 
@@ -9157,10 +8859,7 @@ pub fn design_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             pattern: Box::new(var.clone()),
             replacement: Box::new(predictors[var_idx].clone()),
           };
-          expr = Expr::FunctionCall {
-            name: "ReplaceAll".to_string(),
-            args: vec![expr, rule].into(),
-          };
+          expr = call("ReplaceAll", vec![expr, rule]);
         }
       }
       let substituted = evaluate_expr_to_expr(&expr)?;
@@ -9223,10 +8922,7 @@ pub fn singular_value_list_ast(
 
   // Eigenvalues of the smaller Gram matrix (m.m^H or m^H.m); both share
   // the nonzero spectrum
-  let ct = Expr::FunctionCall {
-    name: "ConjugateTranspose".to_string(),
-    args: vec![args[0].clone()].into(),
-  };
+  let ct = call("ConjugateTranspose", vec![args[0].clone()]);
   let gram_args = if nrows <= ncols {
     vec![args[0].clone(), ct]
   } else {
@@ -9234,11 +8930,7 @@ pub fn singular_value_list_ast(
   };
   let eigenvalues = evaluate_expr_to_expr(&Expr::FunctionCall {
     name: "Eigenvalues".to_string(),
-    args: vec![Expr::FunctionCall {
-      name: "Dot".to_string(),
-      args: gram_args.into(),
-    }]
-    .into(),
+    args: vec![call("Dot", gram_args)].into(),
   })?;
   let eig_items = match &eigenvalues {
     Expr::List(items) => items,
@@ -9270,10 +8962,7 @@ pub fn singular_value_list_ast(
     // Use the Sqrt head (not make_sqrt's Power form): the Power
     // simplifier splits Sqrt[a*b/c] into radical products, while
     // wolframscript keeps the nested Sqrt[(a*b)/c] form
-    values.push(evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Sqrt".to_string(),
-      args: vec![e.clone()].into(),
-    })?);
+    values.push(evaluate_expr_to_expr(&call("Sqrt", vec![e.clone()]))?);
   }
 
   match take {
@@ -9358,10 +9047,7 @@ pub fn matrix_function_ast(
               if func == "Log" && is_zero(c) {
                 return log_zero_bail(args);
               }
-              new_cs.push(evaluate_expr_to_expr(&Expr::FunctionCall {
-                name: func.to_string(),
-                args: vec![c.clone()].into(),
-              })?);
+              new_cs.push(evaluate_expr_to_expr(&call(func, vec![c.clone()]))?);
             } else {
               new_cs.push(c.clone());
             }
@@ -9377,10 +9063,7 @@ pub fn matrix_function_ast(
   }
 
   let make = |head: &str, args: Vec<Expr>| -> Result<Expr, InterpreterError> {
-    evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: head.to_string(),
-      args: args.into(),
-    })
+    evaluate_expr_to_expr(&call(head, args))
   };
 
   let evals = make("Eigenvalues", vec![mat.clone()])?;
@@ -9399,10 +9082,7 @@ pub fn matrix_function_ast(
     "Plus",
     vec![
       l1.clone(),
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), l2.clone()].into(),
-      },
+      call("Times", vec![Expr::Integer(-1), l2.clone()]),
     ],
   )?;
 
@@ -9418,10 +9098,7 @@ pub fn matrix_function_ast(
       "Plus",
       vec![
         f_l,
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(-1), l1.clone(), fp_l.clone()].into(),
-        },
+        call("Times", vec![Expr::Integer(-1), l1.clone(), fp_l.clone()]),
       ],
     )?;
     (fp_l, beta)
@@ -9433,10 +9110,7 @@ pub fn matrix_function_ast(
       "Plus",
       vec![
         f_l1.clone(),
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(-1), f_l2.clone()].into(),
-        },
+        call("Times", vec![Expr::Integer(-1), f_l2.clone()]),
       ],
     )?;
     let alpha = make("Divide", vec![alpha_num, diff.clone()])?;
@@ -9444,14 +9118,8 @@ pub fn matrix_function_ast(
     let beta_num = make(
       "Plus",
       vec![
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![l1.clone(), f_l2.clone()].into(),
-        },
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(-1), l2.clone(), f_l1.clone()].into(),
-        },
+        call("Times", vec![l1.clone(), f_l2.clone()]),
+        call("Times", vec![Expr::Integer(-1), l2.clone(), f_l1.clone()]),
       ],
     )?;
     let beta = make("Divide", vec![beta_num, diff])?;
@@ -9552,10 +9220,8 @@ pub fn jordan_decomposition_ast(
     return Ok(unevaluated(args));
   }
 
-  let eigen = evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Eigenvalues".to_string(),
-    args: vec![args[0].clone()].into(),
-  })?;
+  let eigen =
+    evaluate_expr_to_expr(&call("Eigenvalues", vec![args[0].clone()]))?;
   let (l1, l2) = match &eigen {
     Expr::List(ls) if ls.len() == 2 => (ls[0].clone(), ls[1].clone()),
     _ => return Ok(unevaluated(args)),
@@ -9568,12 +9234,7 @@ pub fn jordan_decomposition_ast(
   // Times[-1, Times[I, ...]] flattens so the printer gives -I*Sqrt[2]
   // instead of -(I*Sqrt[2]).
   let ev = |e: Expr| -> Result<Expr, InterpreterError> {
-    let simplify = |x: Expr| {
-      evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Simplify".to_string(),
-        args: vec![x].into(),
-      })
-    };
+    let simplify = |x: Expr| evaluate_expr_to_expr(&call("Simplify", vec![x]));
     let result = simplify(simplify(evaluate_expr_to_expr(&e)?)?)?;
     let inner = match &result {
       Expr::UnaryOp {
@@ -9614,10 +9275,7 @@ pub fn jordan_decomposition_ast(
     {
       let mut flat = vec![Expr::Integer(-1)];
       flat.extend(factors);
-      return Ok(Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: flat.into(),
-      });
+      return Ok(call("Times", flat));
     }
     Ok(result)
   };
@@ -9630,14 +9288,7 @@ pub fn jordan_decomposition_ast(
 
   let sub = |x: Expr, y: Expr| Expr::FunctionCall {
     name: "Plus".to_string(),
-    args: vec![
-      x,
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), y].into(),
-      },
-    ]
-    .into(),
+    args: vec![x, call("Times", vec![Expr::Integer(-1), y])].into(),
   };
   let matrix = |c1: (Expr, Expr), c2: (Expr, Expr)| {
     Expr::List(
@@ -9860,10 +9511,7 @@ fn build_jordan_matrix(blocks: &[(Expr, usize)], n: usize) -> Expr {
 /// when either part does not evaluate to a number.
 fn numeric_re_im(e: &Expr) -> Option<(f64, f64)> {
   let component = |head: &str| -> Option<f64> {
-    let call = Expr::FunctionCall {
-      name: head.to_string(),
-      args: vec![e.clone()].into(),
-    };
+    let call = call(head, vec![e.clone()]);
     let value = crate::evaluator::evaluate_expr_to_expr(&call).ok()?;
     try_eval_to_f64(&value)
   };
@@ -9889,10 +9537,7 @@ fn subtract_scalar_from_diagonal(
           name: "Plus".to_string(),
           args: vec![
             cell.clone(),
-            Expr::FunctionCall {
-              name: "Times".to_string(),
-              args: vec![Expr::Integer(-1), lam.clone()].into(),
-            },
+            call("Times", vec![Expr::Integer(-1), lam.clone()]),
           ]
           .into(),
         };
@@ -9909,10 +9554,7 @@ fn subtract_scalar_from_diagonal(
 /// Replace the constant/identifier spelling of the imaginary unit with a
 /// `Complex[0, 1]` literal throughout an expression.
 fn replace_constant_i(e: &Expr) -> Expr {
-  let complex_i = || Expr::FunctionCall {
-    name: "Complex".to_string(),
-    args: vec![Expr::Integer(0), Expr::Integer(1)].into(),
-  };
+  let complex_i = || call("Complex", vec![Expr::Integer(0), Expr::Integer(1)]);
   match e {
     Expr::Constant(c) if c == "I" => complex_i(),
     Expr::Identifier(c) if c == "I" => complex_i(),
@@ -9936,10 +9578,7 @@ fn replace_constant_i(e: &Expr) -> Expr {
 /// Rank of a matrix via the evaluator's MatrixRank (handles exact, radical
 /// and float entries alike), or None when it does not reduce to an integer.
 fn matrix_rank_of(matrix: &[Vec<Expr>]) -> Option<usize> {
-  let call = Expr::FunctionCall {
-    name: "MatrixRank".to_string(),
-    args: vec![matrix_to_expr(matrix.to_vec())].into(),
-  };
+  let call = call("MatrixRank", vec![matrix_to_expr(matrix.to_vec())]);
   match crate::evaluator::evaluate_expr_to_expr(&call).ok()? {
     Expr::Integer(r) if r >= 0 => Some(r as usize),
     _ => None,
@@ -9952,10 +9591,10 @@ fn evaluated_matrix_product(
   a: &[Vec<Expr>],
   b: &[Vec<Expr>],
 ) -> Option<Vec<Vec<Expr>>> {
-  let dot = Expr::FunctionCall {
-    name: "Dot".to_string(),
-    args: vec![matrix_to_expr(a.to_vec()), matrix_to_expr(b.to_vec())].into(),
-  };
+  let dot = call(
+    "Dot",
+    vec![matrix_to_expr(a.to_vec()), matrix_to_expr(b.to_vec())],
+  );
   let product = crate::evaluator::evaluate_expr_to_expr(&dot).ok()?;
   expr_to_matrix(&product)
 }
@@ -10316,10 +9955,7 @@ fn gq_to_expr(q: &GQNum) -> Option<Expr> {
   if q.im.is_zero() {
     return Some(q_part(&q.re));
   }
-  let complex = Expr::FunctionCall {
-    name: "Complex".to_string(),
-    args: vec![q_part(&q.re), q_part(&q.im)].into(),
-  };
+  let complex = call("Complex", vec![q_part(&q.re), q_part(&q.im)]);
   crate::evaluator::evaluate_expr_to_expr(&complex).ok()
 }
 
@@ -10479,10 +10115,10 @@ fn expr_mod_m(e: &Expr, m: i128) -> Result<i128, bool> {
     // Inexact entries reduce through Rationalize (0.5 → 1/2 works mod 5,
     // 0.1 → 1/10 does not), matching wolframscript.
     Expr::Real(_) => {
-      let rat = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Rationalize".to_string(),
-        args: vec![e.clone()].into(),
-      })
+      let rat = crate::evaluator::evaluate_expr_to_expr(&call(
+        "Rationalize",
+        vec![e.clone()],
+      ))
       .map_err(|_| false)?;
       if matches!(rat, Expr::Real(_)) {
         return Err(true);
@@ -10509,10 +10145,9 @@ fn emit_frobenius_nmod(matrix: &[Vec<Expr>], m: i128) {
             .iter()
             .map(|cell| match expr_mod_m(cell, m) {
               Ok(v) => Expr::Integer(v),
-              Err(_) => Expr::FunctionCall {
-                name: "PolynomialMod".to_string(),
-                args: vec![cell.clone(), Expr::Integer(m)].into(),
-              },
+              Err(_) => {
+                call("PolynomialMod", vec![cell.clone(), Expr::Integer(m)])
+              }
             })
             .collect::<Vec<_>>()
             .into(),
@@ -10586,10 +10221,7 @@ pub fn frobenius_reduce_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Some(Expr::Integer(m)) if *m >= 1 => {
       let m = *m;
       let is_prime = matches!(
-        crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "PrimeQ".to_string(),
-          args: vec![Expr::Integer(m)].into(),
-        }),
+        crate::evaluator::evaluate_expr_to_expr(&call("PrimeQ", vec![Expr::Integer(m)])),
         Ok(Expr::Identifier(ref t)) if t == "True"
       );
       if !is_prime {
@@ -10675,11 +10307,8 @@ fn structured_matrix(head: &str, n: usize, payload: Expr) -> Expr {
     Expr::List(vec![Expr::Integer(n as i128), Expr::Integer(n as i128)].into());
   Expr::FunctionCall {
     name: head.to_string(),
-    args: vec![Expr::FunctionCall {
-      name: "StructuredArray`StructuredData".to_string(),
-      args: vec![dims, payload].into(),
-    }]
-    .into(),
+    args: vec![call("StructuredArray`StructuredData", vec![dims, payload])]
+      .into(),
   }
 }
 
@@ -10996,14 +10625,7 @@ pub fn coordinate_transform_ast(
     _ => return Ok(unevaluated(args)),
   };
 
-  let times = |fs: Vec<Expr>| Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: fs.into(),
-  };
-  let call = |head: &str, fargs: Vec<Expr>| Expr::FunctionCall {
-    name: head.to_string(),
-    args: fargs.into(),
-  };
+  let times = |fs: Vec<Expr>| call("Times", fs);
   let sq = |e: &Expr| pow2(e.clone(), Expr::Integer(2));
   let norm = |coords: &[&Expr]| {
     call(
@@ -12227,10 +11849,7 @@ fn symmetrized_array(dims: &[usize], rules: Vec<Expr>, tag: Expr) -> Expr {
     ]
     .into(),
   };
-  Expr::FunctionCall {
-    name: "SymmetrizedArray".to_string(),
-    args: vec![structured_data].into(),
-  }
+  call("SymmetrizedArray", vec![structured_data])
 }
 
 /// Symmetrize[t] / Symmetrize[t, sym] — project the array `t` onto a symmetry,
@@ -12243,11 +11862,11 @@ fn symmetrized_array(dims: &[usize], rules: Vec<Expr>, tag: Expr) -> Expr {
 /// the term under `Antisymmetric` and conjugates it under `Hermitian`. Entries
 /// that come out zero are dropped, and `ZeroSymmetric` stores nothing at all.
 pub fn symmetrize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  let call = || unevaluated("Symmetrize", args);
+  let unevaluated = || unevaluated("Symmetrize", args);
   let render =
     |e: &Expr| crate::syntax::format_expr(e, crate::syntax::ExprForm::Output);
   let Some(dims) = tensor_dims(&args[0]) else {
-    return Ok(call());
+    return Ok(unevaluated());
   };
   // A scalar has no slots to permute.
   if dims.is_empty() {
@@ -12261,7 +11880,7 @@ pub fn symmetrize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         "Symmetrize::symm: Invalid symmetry specification {}.",
         render(args.get(1).unwrap_or(&args[0]))
       ));
-      return Ok(call());
+      return Ok(unevaluated());
     }
     Err(SymmetryError::BeyondRank(slot)) => {
       crate::emit_message(&format!(
@@ -12269,7 +11888,7 @@ pub fn symmetrize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
          tensor rank {}.",
         slot, rank
       ));
-      return Ok(call());
+      return Ok(unevaluated());
     }
   };
   // Permuting two slots only makes sense when they are the same length.
@@ -12288,7 +11907,7 @@ pub fn symmetrize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         dims.iter().map(|&d| Expr::Integer(d as i128)).collect()
       ))
     ));
-    return Ok(call());
+    return Ok(unevaluated());
   }
 
   let tag = symmetry_tag(kind, &slots);
@@ -12329,31 +11948,21 @@ pub fn symmetrize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let mut term = flat[pos_to_linear(&permuted, &dims)].clone();
       if flips {
         term = match kind {
-          SymmetryKind::Antisymmetric => Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![Expr::Integer(-1), term].into(),
-          },
-          SymmetryKind::Hermitian => Expr::FunctionCall {
-            name: "Conjugate".to_string(),
-            args: vec![term].into(),
-          },
+          SymmetryKind::Antisymmetric => {
+            call("Times", vec![Expr::Integer(-1), term])
+          }
+          SymmetryKind::Hermitian => call1("Conjugate", term),
           _ => term,
         };
       }
       terms.push(term);
     }
     let count = terms.len() as i128;
-    let sum = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    };
+    let sum = call("Plus", terms);
     let average = Expr::FunctionCall {
       name: "Times".to_string(),
       args: vec![
-        Expr::FunctionCall {
-          name: "Rational".to_string(),
-          args: vec![Expr::Integer(1), Expr::Integer(count)].into(),
-        },
+        call("Rational", vec![Expr::Integer(1), Expr::Integer(count)]),
         sum,
       ]
       .into(),
@@ -12473,17 +12082,12 @@ fn symmetrized_array_entries(
       let mut entry = value.clone();
       if odd {
         entry = match kind {
-          SymmetryKind::Antisymmetric => {
-            evaluate_expr_to_expr(&Expr::FunctionCall {
-              name: "Times".to_string(),
-              args: vec![Expr::Integer(-1), entry].into(),
-            })?
-          }
+          SymmetryKind::Antisymmetric => evaluate_expr_to_expr(&call(
+            "Times",
+            vec![Expr::Integer(-1), entry],
+          ))?,
           SymmetryKind::Hermitian => {
-            evaluate_expr_to_expr(&Expr::FunctionCall {
-              name: "Conjugate".to_string(),
-              args: vec![entry].into(),
-            })?
+            evaluate_expr_to_expr(&call1("Conjugate", entry))?
           }
           _ => entry,
         };

--- a/src/functions/list_helpers_ast/mod.rs
+++ b/src/functions/list_helpers_ast/mod.rs
@@ -4,7 +4,9 @@
 //! round-trips and re-parsing that the original `list_helpers.rs` functions use.
 
 use crate::InterpreterError;
-use crate::helpers::bool_expr;
+use crate::helpers::{
+  bool_expr, call, call1, div2, minus2, neg1, plus2, pow2, times2,
+};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -452,30 +452,15 @@ fn telescope_linear_pair(
   let mut factors: Vec<Expr> = Vec::new();
   let mut konst: i128 = 1;
   for j in (lo + 1)..=hi {
-    factors.push(Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(max_expr.clone()),
-      right: Box::new(Expr::Integer(j)),
-    });
+    factors.push(plus2(max_expr.clone(), Expr::Integer(j)));
     konst = konst.checked_mul(k0 + j - 1)?; // overflow — leave symbolic
   }
-  let prod = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: factors.into(),
-  };
+  let prod = call("Times", factors);
   // a > b: (Π (n+j)) / konst ; a < b: konst / (Π (n+j)).
   Some(if a > b {
-    Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(prod),
-      right: Box::new(Expr::Integer(konst)),
-    }
+    div2(prod, Expr::Integer(konst))
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Integer(konst)),
-      right: Box::new(prod),
-    }
+    div2(Expr::Integer(konst), prod)
   })
 }
 
@@ -491,11 +476,8 @@ fn monic_linear_int_shifts(poly: &Expr, var_name: &str) -> Option<Vec<i128>> {
     return Some(vec![a]);
   }
   let factor_list =
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "FactorList".to_string(),
-      args: vec![poly.clone()].into(),
-    })
-    .ok()?;
+    crate::evaluator::evaluate_expr_to_expr(&call1("FactorList", poly.clone()))
+      .ok()?;
   let Expr::List(ref entries) = factor_list else {
     return None;
   };
@@ -533,13 +515,9 @@ fn rational_telescoping_product(
   k0: i128,
 ) -> Result<Option<Expr>, InterpreterError> {
   let eval = crate::evaluator::evaluate_expr_to_expr;
-  let call = |name: &str, arg: Expr| Expr::FunctionCall {
-    name: name.to_string(),
-    args: vec![arg].into(),
-  };
-  let together = eval(&call("Together", body.clone()))?;
-  let num = eval(&call("Numerator", together.clone()))?;
-  let den = eval(&call("Denominator", together))?;
+  let together = eval(&call1("Together", body.clone()))?;
+  let num = eval(&call1("Numerator", together.clone()))?;
+  let den = eval(&call1("Denominator", together))?;
   // Factor numerator and denominator into monic linear integer-root factors.
   //   Product[(k-1)(k+1)/k^2, {k, 2, n}] = (1/n) * ((n+1)/2) = (1+n)/(2n).
   // Both sides must factor completely and share the same number of factors so
@@ -566,10 +544,7 @@ fn rational_telescoping_product(
   let result = if factors.len() == 1 {
     factors.pop().unwrap()
   } else {
-    Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: factors.into(),
-    }
+    call("Times", factors)
   };
   Ok(Some(eval(&result)?))
 }
@@ -614,10 +589,10 @@ fn coeff_to_ratio(e: &Expr) -> Option<(i128, i128)> {
 /// leading entry nonzero), or None when `poly` is not a polynomial with
 /// rational coefficients.
 fn integer_coefficient_list(poly: &Expr, var_name: &str) -> Option<Vec<i128>> {
-  let list = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "CoefficientList".to_string(),
-    args: vec![poly.clone(), Expr::Identifier(var_name.to_string())].into(),
-  })
+  let list = crate::evaluator::evaluate_expr_to_expr(&call(
+    "CoefficientList",
+    vec![poly.clone(), Expr::Identifier(var_name.to_string())],
+  ))
   .ok()?;
   let Expr::List(ref items) = list else {
     return None;
@@ -723,10 +698,6 @@ fn infinite_integer_root_product(
     return Ok(None);
   }
   let eval = crate::evaluator::evaluate_expr_to_expr;
-  let call1 = |name: &str, arg: Expr| Expr::FunctionCall {
-    name: name.to_string(),
-    args: vec![arg].into(),
-  };
   let together = eval(&call1("Together", body.clone()))?;
   let num = eval(&call1("Numerator", together.clone()))?;
   let den = eval(&call1("Denominator", together))?;
@@ -754,11 +725,7 @@ fn infinite_integer_root_product(
       .into(),
     })
   };
-  let lead_diff = eval(&Expr::BinaryOp {
-    op: BinaryOperator::Minus,
-    left: Box::new(coeff(&num)?),
-    right: Box::new(coeff(&den)?),
-  })?;
+  let lead_diff = eval(&minus2(coeff(&num)?, coeff(&den)?))?;
   if !matches!(lead_diff, Expr::Integer(0)) {
     return Ok(None);
   }
@@ -785,23 +752,10 @@ fn infinite_integer_root_product(
       if rden.iter().any(|&s| s >= n0) {
         return Ok(None);
       }
-      let gamma = |k: i128| Expr::FunctionCall {
-        name: "Gamma".to_string(),
-        args: vec![Expr::Integer(n0 - k)].into(),
-      };
+      let gamma = |k: i128| call1("Gamma", Expr::Integer(n0 - k));
       let num_factors: Vec<Expr> = rden.iter().map(|&s| gamma(s)).collect();
       let den_factors: Vec<Expr> = rnum.iter().map(|&r| gamma(r)).collect();
-      let result = Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: num_factors.into(),
-        }),
-        right: Box::new(Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: den_factors.into(),
-        }),
-      };
+      let result = div2(call("Times", num_factors), call("Times", den_factors));
       Ok(Some(eval(&result)?))
     }
   }
@@ -840,10 +794,7 @@ fn linear_shift_of_var(body: &Expr, var_name: &str) -> Option<Expr> {
   Some(if consts.len() == 1 {
     consts.remove(0)
   } else {
-    Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: consts.into(),
-    }
+    call("Plus", consts)
   })
 }
 
@@ -1051,18 +1002,11 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 args: vec![
                   Expr::Integer(1),
                   max_expr.clone(),
-                  Expr::FunctionCall {
-                    name: "Times".to_string(),
-                    args: vec![Expr::Integer(-1), min_expr.clone()].into(),
-                  },
+                  call("Times", vec![Expr::Integer(-1), min_expr.clone()]),
                 ]
                 .into(),
               })?;
-            let power = Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(body.clone()),
-              right: Box::new(count),
-            };
+            let power = pow2(body.clone(), count);
             return crate::evaluator::evaluate_expr_to_expr(&power);
           }
 
@@ -1076,10 +1020,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               if max_concrete.is_none() {
                 // Product[k, {k, concrete_min, symbolic_max}]
                 // = max! / (min-1)!
-                let n_factorial = Expr::FunctionCall {
-                  name: "Factorial".to_string(),
-                  args: vec![max_expr.clone()].into(),
-                };
+                let n_factorial = call1("Factorial", max_expr.clone());
                 if min_val == 1 {
                   return Ok(n_factorial);
                 }
@@ -1092,11 +1033,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 if denom == 1 {
                   return Ok(n_factorial);
                 }
-                return Ok(Expr::BinaryOp {
-                  op: BinaryOperator::Divide,
-                  left: Box::new(n_factorial),
-                  right: Box::new(Expr::Integer(denom)),
-                });
+                return Ok(div2(n_factorial, Expr::Integer(denom)));
               }
             } else if max_concrete.is_none() {
               // Product[k, {k, sym_min, sym_max}]
@@ -1106,15 +1043,10 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 args: vec![
                   min_expr.clone(),
                   // 1 - min + max
-                  Expr::BinaryOp {
-                    op: BinaryOperator::Plus,
-                    left: Box::new(Expr::BinaryOp {
-                      op: BinaryOperator::Minus,
-                      left: Box::new(Expr::Integer(1)),
-                      right: Box::new(min_expr.clone()),
-                    }),
-                    right: Box::new(max_expr.clone()),
-                  },
+                  plus2(
+                    minus2(Expr::Integer(1), min_expr.clone()),
+                    max_expr.clone(),
+                  ),
                 ]
                 .into(),
               });
@@ -1132,12 +1064,10 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && !max_is_infinity
             && let Some(a) = linear_shift_of_var(body, &var_name)
           {
-            let one_plus_a =
-              crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-                op: BinaryOperator::Plus,
-                left: Box::new(Expr::Integer(1)),
-                right: Box::new(a.clone()),
-              })?;
+            let one_plus_a = crate::evaluator::evaluate_expr_to_expr(&plus2(
+              Expr::Integer(1),
+              a.clone(),
+            ))?;
             let positive_number = match &one_plus_a {
               Expr::Integer(p) => *p >= 1,
               Expr::FunctionCall { name, args }
@@ -1151,19 +1081,11 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             };
             if positive_number {
               // Gamma[1 + a + n] / Gamma[1 + a]
-              let gamma = |arg: Expr| Expr::FunctionCall {
-                name: "Gamma".to_string(),
-                args: vec![arg].into(),
-              };
-              let result = Expr::BinaryOp {
-                op: BinaryOperator::Divide,
-                left: Box::new(gamma(Expr::BinaryOp {
-                  op: BinaryOperator::Plus,
-                  left: Box::new(one_plus_a.clone()),
-                  right: Box::new(max_expr.clone()),
-                })),
-                right: Box::new(gamma(one_plus_a)),
-              };
+              let gamma = |arg: Expr| call1("Gamma", arg);
+              let result = div2(
+                gamma(plus2(one_plus_a.clone(), max_expr.clone())),
+                gamma(one_plus_a),
+              );
               return crate::evaluator::evaluate_expr_to_expr(&result);
             }
             // A genuinely symbolic shift keeps the Pochhammer form; a
@@ -1172,10 +1094,10 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               || matches!(&one_plus_a,
                 Expr::FunctionCall { name, .. } if name == "Rational");
             if !is_number {
-              return Ok(Expr::FunctionCall {
-                name: "Pochhammer".to_string(),
-                args: vec![one_plus_a, max_expr.clone()].into(),
-              });
+              return Ok(call(
+                "Pochhammer",
+                vec![one_plus_a, max_expr.clone()],
+              ));
             }
           }
 
@@ -1213,19 +1135,10 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             {
               // Product[c^i, {i, 1, n}] = c^((n*(1+n))/2)
               let n = max_expr.clone();
-              let exponent = Expr::BinaryOp {
-                op: BinaryOperator::Divide,
-                left: Box::new(Expr::BinaryOp {
-                  op: BinaryOperator::Times,
-                  left: Box::new(n.clone()),
-                  right: Box::new(Expr::BinaryOp {
-                    op: BinaryOperator::Plus,
-                    left: Box::new(Expr::Integer(1)),
-                    right: Box::new(n),
-                  }),
-                }),
-                right: Box::new(Expr::Integer(2)),
-              };
+              let exponent = div2(
+                times2(n.clone(), plus2(Expr::Integer(1), n)),
+                Expr::Integer(2),
+              );
               return Ok(Expr::BinaryOp {
                 op: BinaryOperator::Power,
                 left: base.clone(),
@@ -1238,10 +1151,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             {
               return Ok(Expr::BinaryOp {
                 op: BinaryOperator::Power,
-                left: Box::new(Expr::FunctionCall {
-                  name: "Factorial".to_string(),
-                  args: vec![max_expr.clone()].into(),
-                }),
+                left: Box::new(call1("Factorial", max_expr.clone())),
                 right: exp.clone(),
               });
             }
@@ -1269,10 +1179,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 args: vec![
                   dbody,
                   Expr::Identifier(var_name.clone()),
-                  Expr::FunctionCall {
-                    name: "Power".to_string(),
-                    args: vec![body.clone(), Expr::Integer(-1)].into(),
-                  },
+                  call("Power", vec![body.clone(), Expr::Integer(-1)]),
                 ]
                 .into(),
               }]
@@ -1294,38 +1201,23 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               {
                 let c_is_one = matches!(&c, Expr::Integer(1));
                 let base = if c_is_one {
-                  Expr::FunctionCall {
-                    name: "Factorial".to_string(),
-                    args: vec![max_expr.clone()].into(),
-                  }
+                  call1("Factorial", max_expr.clone())
                 } else {
                   Expr::FunctionCall {
                     name: "Gamma".to_string(),
-                    args: vec![Expr::BinaryOp {
-                      op: BinaryOperator::Plus,
-                      left: Box::new(Expr::Integer(1)),
-                      right: Box::new(max_expr.clone()),
-                    }]
-                    .into(),
+                    args: vec![plus2(Expr::Integer(1), max_expr.clone())]
+                      .into(),
                   }
                 };
                 let pow_part = if p == 1 {
                   base
                 } else {
-                  Expr::BinaryOp {
-                    op: BinaryOperator::Power,
-                    left: Box::new(base),
-                    right: Box::new(Expr::Integer(p)),
-                  }
+                  pow2(base, Expr::Integer(p))
                 };
                 // Coefficient c^n. wolframscript renders a *unit fraction* 1/b as
                 // a denominator power (Product[k/2] -> Gamma[1+n]/2^n), but keeps
                 // any other coefficient as c^n (Product[2k/3] -> (2/3)^n Gamma).
-                let pow_n = |b: &Expr| Expr::BinaryOp {
-                  op: BinaryOperator::Power,
-                  left: Box::new(b.clone()),
-                  right: Box::new(max_expr.clone()),
-                };
+                let pow_n = |b: &Expr| pow2(b.clone(), max_expr.clone());
                 let unit_fraction_den = match &c {
                   Expr::FunctionCall { name, args }
                     if name == "Rational" && args.len() == 2 =>
@@ -1340,16 +1232,9 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
                 let result = if c_is_one {
                   pow_part
                 } else if let Some(b) = unit_fraction_den {
-                  Expr::BinaryOp {
-                    op: BinaryOperator::Divide,
-                    left: Box::new(pow_part),
-                    right: Box::new(pow_n(&Expr::Integer(b))),
-                  }
+                  div2(pow_part, pow_n(&Expr::Integer(b)))
                 } else {
-                  Expr::FunctionCall {
-                    name: "Times".to_string(),
-                    args: vec![pow_n(&c), pow_part].into(),
-                  }
+                  call("Times", vec![pow_n(&c), pow_part])
                 };
                 return crate::evaluator::evaluate_expr_to_expr(&result);
               }
@@ -1366,14 +1251,10 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && matches!(max_expr, Expr::Identifier(s) if s == "Infinity")
             && body_is_one_plus_one_over_var_squared(body, &var_name)
           {
-            return Ok(Expr::BinaryOp {
-              op: BinaryOperator::Divide,
-              left: Box::new(Expr::FunctionCall {
-                name: "Sinh".to_string(),
-                args: vec![Expr::Constant("Pi".to_string())].into(),
-              }),
-              right: Box::new(Expr::Constant("Pi".to_string())),
-            });
+            return Ok(div2(
+              call1("Sinh", Expr::Constant("Pi".to_string())),
+              Expr::Constant("Pi".to_string()),
+            ));
           }
 
           // Closed form for ∏_{k=2}^∞ (1 - 1/k⁴) = Sinh[π] / (4 π).
@@ -1385,18 +1266,10 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             && matches!(max_expr, Expr::Identifier(s) if s == "Infinity")
             && body_is_one_minus_one_over_var_quartic(body, &var_name)
           {
-            return Ok(Expr::BinaryOp {
-              op: BinaryOperator::Divide,
-              left: Box::new(Expr::FunctionCall {
-                name: "Sinh".to_string(),
-                args: vec![Expr::Constant("Pi".to_string())].into(),
-              }),
-              right: Box::new(Expr::BinaryOp {
-                op: BinaryOperator::Times,
-                left: Box::new(Expr::Integer(4)),
-                right: Box::new(Expr::Constant("Pi".to_string())),
-              }),
-            });
+            return Ok(div2(
+              call1("Sinh", Expr::Constant("Pi".to_string())),
+              times2(Expr::Integer(4), Expr::Constant("Pi".to_string())),
+            ));
           }
 
           // Constant body over an infinite range: convergence depends on the
@@ -1502,11 +1375,7 @@ pub fn product_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Fold into nested Times
         let mut result = values.remove(0);
         for val in values {
-          result = Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(result),
-            right: Box::new(val),
-          };
+          result = times2(result, val);
         }
         return crate::evaluator::evaluate_expr_to_expr(&result);
       }
@@ -1975,10 +1844,7 @@ fn regularized_infinite_sum(
   }
   let mut terms: Vec<Expr> = Vec::with_capacity(coefficients.len());
   for (k, coefficient) in coefficients.iter().enumerate() {
-    let zeta = Expr::FunctionCall {
-      name: "Zeta".to_string(),
-      args: vec![Expr::Integer(-(k as i128))].into(),
-    };
+    let zeta = call1("Zeta", Expr::Integer(-(k as i128)));
     // Zeta[1] is a pole, so a 1/n-like term has no regularized value here.
     let value = if alternating {
       // -(1 - 2^(k+1)) Zeta[-k]
@@ -1998,16 +1864,10 @@ fn regularized_infinite_sum(
     } else {
       zeta
     };
-    terms.push(Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![coefficient.clone(), value].into(),
-    });
+    terms.push(call("Times", vec![coefficient.clone(), value]));
   }
   let canonical =
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    })?;
+    crate::evaluator::evaluate_expr_to_expr(&call("Plus", terms))?;
   // A pole (`Zeta[1]`, from a `1/n` term) leaves `ComplexInfinity` or an
   // unevaluated `Zeta` behind instead of a value; either means the summand is
   // outside the scheme's reach.
@@ -2032,11 +1892,10 @@ fn regularized_infinite_sum(
       let term = crate::evaluator::evaluate_expr_to_expr(
         &crate::syntax::substitute_variable(body, var, &Expr::Integer(n)),
       )?;
-      let negated =
-        crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(-1), term].into(),
-        })?;
+      let negated = crate::evaluator::evaluate_expr_to_expr(&call(
+        "Times",
+        vec![Expr::Integer(-1), term],
+      ))?;
       result = crate::functions::math_ast::plus_ast(&[result, negated])?;
     }
   }
@@ -2079,10 +1938,7 @@ fn strip_alternating_factor(body: &Expr, var: &str) -> Option<Expr> {
   Some(match rest.len() {
     0 => Expr::Integer(1),
     1 => rest.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: rest.into(),
-    },
+    _ => call("Times", rest),
   })
 }
 
@@ -2132,10 +1988,10 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let body_in_fresh =
       crate::syntax::substitute_variable(&args[0], var_name, &fresh);
     // Upper bound: var - 1, built as `(-1) + var` for canonical Plus form.
-    let upper = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: vec![Expr::Integer(-1), Expr::Identifier(var_name.clone())].into(),
-    };
+    let upper = call(
+      "Plus",
+      vec![Expr::Integer(-1), Expr::Identifier(var_name.clone())],
+    );
     let iter_spec =
       Expr::List(vec![fresh.clone(), Expr::Integer(1), upper].into());
     let inner_sum = sum_ast(&[body_in_fresh, iter_spec])?;
@@ -2303,10 +2159,7 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if items.len() == 3 {
         let diff = crate::functions::math_ast::plus_ast(&[
           items[2].clone(),
-          Expr::UnaryOp {
-            op: UnaryOperator::Minus,
-            operand: Box::new(items[1].clone()),
-          },
+          neg1(items[1].clone()),
         ]);
         if let Ok(diff_expr) = diff {
           let diff_eval = crate::evaluator::evaluate_expr_to_expr(&diff_expr);
@@ -2321,11 +2174,10 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
               let iter_val = if j == 0 {
                 min_eval.clone()
               } else {
-                crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-                  op: BinaryOperator::Plus,
-                  left: Box::new(min_eval.clone()),
-                  right: Box::new(Expr::Integer(j)),
-                })?
+                crate::evaluator::evaluate_expr_to_expr(&plus2(
+                  min_eval.clone(),
+                  Expr::Integer(j),
+                ))?
               };
               let substituted =
                 crate::syntax::substitute_variable(body, &var_name, &iter_val);
@@ -2580,29 +2432,15 @@ fn try_binomial_theorem_sum(
   let r = match r_factors.len() {
     0 => Expr::Integer(1),
     1 => r_factors.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: r_factors.into(),
-    },
+    _ => call("Times", r_factors),
   };
-  let one_plus_r = Expr::BinaryOp {
-    op: BinaryOperator::Plus,
-    left: Box::new(Expr::Integer(1)),
-    right: Box::new(r),
-  };
+  let one_plus_r = plus2(Expr::Integer(1), r);
   let base = crate::evaluator::evaluate_expr_to_expr(&one_plus_r).ok()?;
   // 1 + r == 0 (r == -1): the alternating sum is KroneckerDelta[N].
   let term = if matches!(base, Expr::Integer(0)) {
-    Expr::FunctionCall {
-      name: "KroneckerDelta".to_string(),
-      args: vec![n].into(),
-    }
+    call1("KroneckerDelta", n)
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(base),
-      right: Box::new(n),
-    }
+    pow2(base, n)
   };
 
   Some(term)
@@ -2619,20 +2457,9 @@ fn try_symbolic_sum(
   // If body doesn't contain the iteration variable, it's a constant sum:
   // Sum[c, {var, min, max}] = c * (max - min + 1)
   if !crate::functions::polynomial_ast::contains_var(body, var_name) {
-    let count = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Minus,
-        left: Box::new(max_expr.clone()),
-        right: Box::new(min_expr.clone()),
-      }),
-    };
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(body.clone()),
-      right: Box::new(count),
-    }));
+    let count =
+      plus2(Expr::Integer(1), minus2(max_expr.clone(), min_expr.clone()));
+    return Ok(Some(times2(body.clone(), count)));
   }
 
   // Linearity over a constant factor: Sum[c * f(k), ...] = c * Sum[f(k), ...].
@@ -2670,10 +2497,7 @@ fn try_symbolic_sum(
         let inner_body = if var_factors.len() == 1 {
           var_factors[0].clone()
         } else {
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: var_factors.into(),
-          }
+          call("Times", var_factors)
         };
         if let Some(inner_sum) = try_symbolic_sum(
           &inner_body,
@@ -2685,10 +2509,7 @@ fn try_symbolic_sum(
         )? {
           let mut all = const_factors;
           all.push(inner_sum);
-          let result = Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: all.into(),
-          };
+          let result = call("Times", all);
           return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
         }
       }
@@ -2703,23 +2524,11 @@ fn try_symbolic_sum(
     && args.len() == 1
     && matches!(&args[0], Expr::Identifier(v) if v == var_name)
   {
-    let fib = |arg: Expr| Expr::FunctionCall {
-      name: "Fibonacci".to_string(),
-      args: vec![arg].into(),
-    };
-    let result = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(fib(Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(max_expr.clone()),
-        right: Box::new(Expr::Integer(2)),
-      })),
-      right: Box::new(fib(Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(min_expr.clone()),
-        right: Box::new(Expr::Integer(1)),
-      })),
-    };
+    let fib = |arg: Expr| call1("Fibonacci", arg);
+    let result = minus2(
+      fib(plus2(max_expr.clone(), Expr::Integer(2))),
+      fib(plus2(min_expr.clone(), Expr::Integer(1))),
+    );
     return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
   }
 
@@ -2736,25 +2545,13 @@ fn try_symbolic_sum(
     && args.len() == 1
     && matches!(&args[0], Expr::Identifier(v) if v == var_name)
   {
-    let fib = |arg: Expr| Expr::FunctionCall {
-      name: "Fibonacci".to_string(),
-      args: vec![arg].into(),
-    };
-    let shift = |e: &Expr, d: i128| Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(e.clone()),
-      right: Box::new(Expr::Integer(d)),
-    };
-    let prod = |a: Expr, b: Expr| Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(a),
-      right: Box::new(b),
-    };
-    let result = Expr::BinaryOp {
-      op: BinaryOperator::Minus,
-      left: Box::new(prod(fib(max_expr.clone()), fib(shift(max_expr, 1)))),
-      right: Box::new(prod(fib(shift(min_expr, -1)), fib(min_expr.clone()))),
-    };
+    let fib = |arg: Expr| call1("Fibonacci", arg);
+    let shift = |e: &Expr, d: i128| plus2(e.clone(), Expr::Integer(d));
+    let prod = |a: Expr, b: Expr| times2(a, b);
+    let result = minus2(
+      prod(fib(max_expr.clone()), fib(shift(max_expr, 1))),
+      prod(fib(shift(min_expr, -1)), fib(min_expr.clone())),
+    );
     return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
   }
 
@@ -2774,15 +2571,8 @@ fn try_symbolic_sum(
     && crate::syntax::expr_to_string(&args[0])
       == crate::syntax::expr_to_string(max_expr)
   {
-    let two_n = Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(2)),
-      right: Box::new(max_expr.clone()),
-    };
-    let result = Expr::FunctionCall {
-      name: "Binomial".to_string(),
-      args: vec![two_n, max_expr.clone()].into(),
-    };
+    let two_n = times2(Expr::Integer(2), max_expr.clone());
+    let result = call("Binomial", vec![two_n, max_expr.clone()]);
     return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
   }
 
@@ -2797,19 +2587,10 @@ fn try_symbolic_sum(
   if let Some(1) = min_concrete {
     if matches!(body, Expr::Identifier(name) if name == var_name) {
       let n = max_expr.clone();
-      return Ok(Some(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(n.clone()),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::Integer(1)),
-            right: Box::new(n),
-          }),
-        }),
-        right: Box::new(Expr::Integer(2)),
-      }));
+      return Ok(Some(div2(
+        times2(n.clone(), plus2(Expr::Integer(1), n)),
+        Expr::Integer(2),
+      )));
     }
 
     // Sum[k^2, {k, 1, n}] = n*(1 + n)*(1 + 2*n)/6
@@ -2822,31 +2603,13 @@ fn try_symbolic_sum(
       && matches!(exp.as_ref(), Expr::Integer(2))
     {
       let n = max_expr.clone();
-      return Ok(Some(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(n.clone()),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(Expr::Integer(1)),
-              right: Box::new(n.clone()),
-            }),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::Integer(1)),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Integer(2)),
-              right: Box::new(n),
-            }),
-          }),
-        }),
-        right: Box::new(Expr::Integer(6)),
-      }));
+      return Ok(Some(div2(
+        times2(
+          times2(n.clone(), plus2(Expr::Integer(1), n.clone())),
+          plus2(Expr::Integer(1), times2(Expr::Integer(2), n)),
+        ),
+        Expr::Integer(6),
+      )));
     }
 
     // Sum[k^3, {k, 1, n}] = (n*(1 + n)/2)^2
@@ -2860,23 +2623,13 @@ fn try_symbolic_sum(
     {
       let n = max_expr.clone();
       // (n*(1+n)/2)^2
-      return Ok(Some(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(n.clone()),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Plus,
-              left: Box::new(Expr::Integer(1)),
-              right: Box::new(n),
-            }),
-          }),
-          right: Box::new(Expr::Integer(2)),
-        }),
-        right: Box::new(Expr::Integer(2)),
-      }));
+      return Ok(Some(pow2(
+        div2(
+          times2(n.clone(), plus2(Expr::Integer(1), n)),
+          Expr::Integer(2),
+        ),
+        Expr::Integer(2),
+      )));
     }
 
     // Sum[k^4, {k, 1, n}] = n*(1+n)*(1+2*n)*(-1+3*n+3*n^2)/30
@@ -2890,50 +2643,21 @@ fn try_symbolic_sum(
     {
       let n = max_expr.clone();
       // n*(1+n)*(1+2*n)*(-1+3*n+3*n^2)/30
-      let n_plus_1 = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(n.clone()),
-      };
-      let one_plus_2n = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(2)),
-          right: Box::new(n.clone()),
-        }),
-      };
-      let neg1_plus_3n_plus_3n2 = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(3)),
-            right: Box::new(n.clone()),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(3)),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(n.clone()),
-              right: Box::new(Expr::Integer(2)),
-            }),
-          }),
-        }),
-      };
-      let numerator = Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![n, n_plus_1, one_plus_2n, neg1_plus_3n_plus_3n2].into(),
-      };
-      return Ok(Some(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(numerator),
-        right: Box::new(Expr::Integer(30)),
-      }));
+      let n_plus_1 = plus2(Expr::Integer(1), n.clone());
+      let one_plus_2n =
+        plus2(Expr::Integer(1), times2(Expr::Integer(2), n.clone()));
+      let neg1_plus_3n_plus_3n2 = plus2(
+        Expr::Integer(-1),
+        plus2(
+          times2(Expr::Integer(3), n.clone()),
+          times2(Expr::Integer(3), pow2(n.clone(), Expr::Integer(2))),
+        ),
+      );
+      let numerator = call(
+        "Times",
+        vec![n, n_plus_1, one_plus_2n, neg1_plus_3n_plus_3n2],
+      );
+      return Ok(Some(div2(numerator, Expr::Integer(30))));
     }
 
     // Sum[k^5, {k, 1, n}] = n^2*(1+n)^2*(-1+2*n+2*n^2)/12
@@ -2947,50 +2671,19 @@ fn try_symbolic_sum(
     {
       let n = max_expr.clone();
       // n^2*(1+n)^2*(-1+2*n+2*n^2)/12
-      let n_sq = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(n.clone()),
-        right: Box::new(Expr::Integer(2)),
-      };
-      let n_plus_1_sq = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::Integer(1)),
-          right: Box::new(n.clone()),
-        }),
-        right: Box::new(Expr::Integer(2)),
-      };
-      let neg1_plus_2n_plus_2n2 = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(2)),
-            right: Box::new(n.clone()),
-          }),
-          right: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Times,
-            left: Box::new(Expr::Integer(2)),
-            right: Box::new(Expr::BinaryOp {
-              op: BinaryOperator::Power,
-              left: Box::new(n),
-              right: Box::new(Expr::Integer(2)),
-            }),
-          }),
-        }),
-      };
-      let numerator = Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![n_sq, n_plus_1_sq, neg1_plus_2n_plus_2n2].into(),
-      };
-      return Ok(Some(Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(numerator),
-        right: Box::new(Expr::Integer(12)),
-      }));
+      let n_sq = pow2(n.clone(), Expr::Integer(2));
+      let n_plus_1_sq =
+        pow2(plus2(Expr::Integer(1), n.clone()), Expr::Integer(2));
+      let neg1_plus_2n_plus_2n2 = plus2(
+        Expr::Integer(-1),
+        plus2(
+          times2(Expr::Integer(2), n.clone()),
+          times2(Expr::Integer(2), pow2(n, Expr::Integer(2))),
+        ),
+      );
+      let numerator =
+        call("Times", vec![n_sq, n_plus_1_sq, neg1_plus_2n_plus_2n2]);
+      return Ok(Some(div2(numerator, Expr::Integer(12))));
     }
 
     // Sum[HarmonicNumber[k], {k, 1, n}]      = HyperHarmonicNumber[2, n]
@@ -3018,10 +2711,7 @@ fn try_symbolic_sum(
         _ => false,
       };
       if ok {
-        return Ok(Some(Expr::FunctionCall {
-          name: "HyperHarmonicNumber".to_string(),
-          args: hhn.into(),
-        }));
+        return Ok(Some(call("HyperHarmonicNumber", hhn)));
       }
     }
 
@@ -3062,20 +2752,11 @@ fn try_symbolic_sum(
         // For c=2: (-1 + 2^n)/2^n
         let c = base.as_ref();
         let n = max_expr.clone();
-        let c_to_n = Expr::BinaryOp {
-          op: BinaryOperator::Power,
-          left: Box::new(c.clone()),
-          right: Box::new(n),
-        };
-        return Ok(Some(Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Plus,
-            left: Box::new(Expr::Integer(-1)),
-            right: Box::new(c_to_n.clone()),
-          }),
-          right: Box::new(c_to_n),
-        }));
+        let c_to_n = pow2(c.clone(), n);
+        return Ok(Some(div2(
+          plus2(Expr::Integer(-1), c_to_n.clone()),
+          c_to_n,
+        )));
       }
     }
   }
@@ -3120,40 +2801,12 @@ fn try_symbolic_sum(
       _ => None,
     };
     if let Some(q) = q_opt {
-      let one_plus_max = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(max_expr.clone()),
-      };
-      let c_to_q = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(*base.clone()),
-        right: Box::new(q.clone()),
-      };
-      let c_to_q_times_top = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(*base.clone()),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(q),
-          right: Box::new(one_plus_max),
-        }),
-      };
-      let numer = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(c_to_q_times_top),
-      };
-      let denom = Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(c_to_q),
-      };
-      let result = Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(numer),
-        right: Box::new(denom),
-      };
+      let one_plus_max = plus2(Expr::Integer(1), max_expr.clone());
+      let c_to_q = pow2(*base.clone(), q.clone());
+      let c_to_q_times_top = pow2(*base.clone(), times2(q, one_plus_max));
+      let numer = plus2(Expr::Integer(-1), c_to_q_times_top);
+      let denom = plus2(Expr::Integer(-1), c_to_q);
+      let result = div2(numer, denom);
       return Ok(Some(
         crate::evaluator::evaluate_expr_to_expr(&result).unwrap_or(result),
       ));
@@ -3167,27 +2820,13 @@ fn try_symbolic_sum(
     // Sum[k, {k, a, n}] = (a+n)*(n-a+1)/2
     let a = min_expr.clone();
     let n = max_expr.clone();
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(a.clone()),
-          right: Box::new(n.clone()),
-        }),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::BinaryOp {
-            op: BinaryOperator::Minus,
-            left: Box::new(n),
-            right: Box::new(a),
-          }),
-          right: Box::new(Expr::Integer(1)),
-        }),
-      }),
-      right: Box::new(Expr::Integer(2)),
-    }));
+    return Ok(Some(div2(
+      times2(
+        plus2(a.clone(), n.clone()),
+        plus2(minus2(n, a), Expr::Integer(1)),
+      ),
+      Expr::Integer(2),
+    )));
   }
 
   Ok(None)
@@ -3298,10 +2937,7 @@ fn match_geometric_base(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
     Some(match consts.len() {
       0 => Expr::Integer(1),
       1 => consts.into_iter().next().unwrap(),
-      _ => Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: consts.into(),
-      },
+      _ => call("Times", consts),
     })
   }
   // Returns the effective geometric base of `f` if `f == base^(c*var)` with
@@ -3337,11 +2973,7 @@ fn match_geometric_base(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
     if !matches!(&coeff, Expr::Integer(_) | Expr::BigInteger(_)) {
       return None;
     }
-    let eff = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(base),
-      right: Box::new(coeff),
-    };
+    let eff = pow2(base, coeff);
     Some(crate::evaluator::evaluate_expr_to_expr(&eff).unwrap_or(eff))
   };
   let mut factors = Vec::new();
@@ -3376,10 +3008,7 @@ fn match_geometric_base(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
   let coeff = match coeff_factors.len() {
     0 => Expr::Integer(1),
     1 => coeff_factors.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: coeff_factors.into(),
-    },
+    _ => call("Times", coeff_factors),
   };
   Some((coeff, base))
 }
@@ -3433,10 +3062,7 @@ fn match_geometric_symbolic_exp(
       if ok && var_seen == 1 && !q_factors.is_empty() {
         let q = match q_factors.len() {
           1 => q_factors.into_iter().next().unwrap(),
-          _ => Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: q_factors.into(),
-          },
+          _ => call("Times", q_factors),
         };
         // Reject a plain-integer q — that is the strict matcher's job.
         if !matches!(&q, Expr::Integer(_) | Expr::BigInteger(_)) {
@@ -3461,10 +3087,7 @@ fn match_geometric_symbolic_exp(
   let coeff = match coeff_factors.len() {
     0 => Expr::Integer(1),
     1 => coeff_factors.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: coeff_factors.into(),
-    },
+    _ => call("Times", coeff_factors),
   };
   Some((coeff, eff_base))
 }
@@ -3533,12 +3156,8 @@ fn match_arith_geometric(body: &Expr, var_name: &str) -> Option<(i128, Expr)> {
           && matches!(&args[1], Expr::Identifier(n) if n == var_name))
   };
   let recip = |e: &Expr| -> Expr {
-    crate::evaluator::evaluate_expr_to_expr(&Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(e.clone()),
-      right: Box::new(Expr::Integer(-1)),
-    })
-    .unwrap_or_else(|_| e.clone())
+    crate::evaluator::evaluate_expr_to_expr(&pow2(e.clone(), Expr::Integer(-1)))
+      .unwrap_or_else(|_| e.clone())
   };
   let is_const =
     |e: &Expr| crate::functions::calculus_ast::is_constant_wrt(e, var_name);
@@ -3644,10 +3263,7 @@ fn linear_coeff_of_var(exp: &Expr, var_name: &str) -> Option<Expr> {
   Some(match consts.len() {
     0 => Expr::Integer(1),
     1 => consts.remove(0),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: consts.into(),
-    },
+    _ => call("Times", consts),
   })
 }
 
@@ -3694,20 +3310,12 @@ fn match_log_geometric(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
           name: "Power".to_string(),
           args: vec![
             args[0].clone(),
-            Expr::BinaryOp {
-              op: BinaryOperator::Times,
-              left: Box::new(Expr::Integer(-1)),
-              right: Box::new(args[1].clone()),
-            },
+            times2(Expr::Integer(-1), args[1].clone()),
           ]
           .into(),
         })
       }
-      other => out.push(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(other.clone()),
-        right: Box::new(Expr::Integer(-1)),
-      }),
+      other => out.push(pow2(other.clone(), Expr::Integer(-1))),
     }
   }
   fn collect(e: &Expr, out: &mut Vec<Expr>) {
@@ -3773,11 +3381,7 @@ fn match_log_geometric(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
     if !matches!(coeff, Expr::Integer(_) | Expr::BigInteger(_)) {
       return None;
     }
-    let eff = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(base),
-      right: Box::new(coeff),
-    };
+    let eff = pow2(base, coeff);
     Some(crate::evaluator::evaluate_expr_to_expr(&eff).unwrap_or(eff))
   }
   let is_recip_var = |f: &Expr| -> bool {
@@ -3829,19 +3433,12 @@ fn match_log_geometric(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
   let base = if bases.len() == 1 {
     bases.pop().unwrap()
   } else {
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: bases.into(),
-    })
-    .ok()?
+    crate::evaluator::evaluate_expr_to_expr(&call("Times", bases)).ok()?
   };
   let coeff = match coeff_factors.len() {
     0 => Expr::Integer(1),
     1 => coeff_factors.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: coeff_factors.into(),
-    },
+    _ => call("Times", coeff_factors),
   };
   Some((coeff, base))
 }
@@ -3942,10 +3539,7 @@ fn match_exponential_base(body: &Expr, var_name: &str) -> Option<(Expr, Expr)> {
   let coeff = match coeff_factors.len() {
     0 => Expr::Integer(1),
     1 => coeff_factors.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: coeff_factors.into(),
-    },
+    _ => call("Times", coeff_factors),
   };
   Some((coeff, base))
 }
@@ -3994,14 +3588,11 @@ fn tr_coeff_list(
   var_name: &str,
   op: &str,
 ) -> Option<Vec<(i128, i128)>> {
-  let part = Expr::FunctionCall {
-    name: op.to_string(),
-    args: vec![body.clone()].into(),
-  };
-  let cl = Expr::FunctionCall {
-    name: "CoefficientList".to_string(),
-    args: vec![part, Expr::Identifier(var_name.to_string())].into(),
-  };
+  let part = call1(op, body.clone());
+  let cl = call(
+    "CoefficientList",
+    vec![part, Expr::Identifier(var_name.to_string())],
+  );
   let evaled = crate::evaluator::evaluate_expr_to_expr(&cl).ok()?;
   let Expr::List(items) = &evaled else {
     return None;
@@ -4069,10 +3660,7 @@ fn try_telescoping_rational_sum(
   // the form 1/Q by inverting the body: if body^-1 is a polynomial Q, the
   // summand is 1/Q.
   if num.is_empty() {
-    let recip = Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![body.clone(), Expr::Integer(-1)].into(),
-    };
+    let recip = call("Power", vec![body.clone(), Expr::Integer(-1)]);
     if let Some(q) = tr_coeff_list(&recip, var_name, "Together").map(&trim)
       && q.len() > 1
     {
@@ -4220,10 +3808,7 @@ fn try_rational_pole_telescoping_sum(
     .map(&trim)
     .unwrap_or_default();
   if num.is_empty() {
-    let recip = Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![body.clone(), Expr::Integer(-1)].into(),
-    };
+    let recip = call("Power", vec![body.clone(), Expr::Integer(-1)]);
     if let Some(q) = tr_coeff_list(&recip, var_name, "Together").map(&trim)
       && q.len() > 1
     {
@@ -4363,20 +3948,9 @@ fn try_infinite_sum(
     && crate::functions::math_ast::try_eval_to_f64(&base)
       .is_none_or(|bf| bf.abs() < 1.0)
   {
-    let one_minus_base = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(base),
-      }),
-    };
-    let closed = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(coeff),
-      right: Box::new(one_minus_base),
-    };
+    let one_minus_base =
+      plus2(Expr::Integer(1), times2(Expr::Integer(-1), base));
+    let closed = div2(coeff, one_minus_base);
     return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&closed)?));
   }
 
@@ -4389,11 +3963,7 @@ fn try_infinite_sum(
     && let Some((coeff, eff_base)) =
       match_geometric_symbolic_exp(body, var_name)
   {
-    let neg_one_plus_base = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(-1)),
-      right: Box::new(eff_base),
-    };
+    let neg_one_plus_base = plus2(Expr::Integer(-1), eff_base);
     let closed = Expr::BinaryOp {
       op: BinaryOperator::Divide,
       left: Box::new(crate::functions::math_ast::times_ast(&[
@@ -4414,26 +3984,11 @@ fn try_infinite_sum(
     && let Some(bf) = crate::functions::math_ast::try_eval_to_f64(&base)
     && bf.abs() < 1.0
   {
-    let one_minus_base = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(1)),
-      right: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(-1)),
-        right: Box::new(base.clone()),
-      }),
-    };
+    let one_minus_base =
+      plus2(Expr::Integer(1), times2(Expr::Integer(-1), base.clone()));
     let closed = Expr::FunctionCall {
       name: "Times".to_string(),
-      args: vec![
-        coeff,
-        Expr::BinaryOp {
-          op: BinaryOperator::Divide,
-          left: Box::new(base),
-          right: Box::new(one_minus_base),
-        },
-      ]
-      .into(),
+      args: vec![coeff, div2(base, one_minus_base)].into(),
     };
     return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&closed)?));
   }
@@ -4452,27 +4007,15 @@ fn try_infinite_sum(
     let base_pow_min = if min == 1 {
       base.clone()
     } else {
-      Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(base.clone()),
-        right: Box::new(Expr::Integer(min)),
-      }
+      pow2(base.clone(), Expr::Integer(min))
     };
     let numer = crate::functions::math_ast::times_ast(&[
       Expr::Integer(-1),
       coeff,
       base_pow_min,
     ])?;
-    let denom = Expr::BinaryOp {
-      op: BinaryOperator::Plus,
-      left: Box::new(Expr::Integer(-1)),
-      right: Box::new(base),
-    };
-    let closed = Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numer),
-      right: Box::new(denom),
-    };
+    let denom = plus2(Expr::Integer(-1), base);
+    let closed = div2(numer, denom);
     return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&closed)?));
   }
 
@@ -4484,22 +4027,13 @@ fn try_infinite_sum(
   // wolframscript canonicalizes those results to a different (though
   // equivalent) form.
   if let Some((coeff, base)) = match_exponential_base(body, var_name) {
-    let e_to_base = Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![Expr::Constant("E".to_string()), base].into(),
-    };
+    let e_to_base = call("Power", vec![Expr::Constant("E".to_string()), base]);
     if min == 0 {
-      let result = Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![coeff, e_to_base].into(),
-      };
+      let result = call("Times", vec![coeff, e_to_base]);
       return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
     }
     if min == 1 && matches!(coeff, Expr::Integer(1)) {
-      let result = Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: vec![e_to_base, Expr::Integer(-1)].into(),
-      };
+      let result = call("Plus", vec![e_to_base, Expr::Integer(-1)]);
       return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
     }
   }
@@ -4541,10 +4075,7 @@ fn try_infinite_sum(
         Ok(e)
       }
     };
-    let f_call = Expr::FunctionCall {
-      name: func.to_string(),
-      args: vec![series.base.clone()].into(),
-    };
+    let f_call = call1(func, series.base.clone());
     let mut terms = vec![signed(f_call, negate)?];
     // Subtract the head terms x^(2k+p)/(2k+p)! for k = 0 .. shift-1; each
     // carries its own alternating sign from the re-indexed series.
@@ -4555,19 +4086,12 @@ fn try_infinite_sum(
       } else if exponent == 1 {
         series.base.clone()
       } else {
-        Expr::BinaryOp {
-          op: BinaryOperator::Power,
-          left: Box::new(series.base.clone()),
-          right: Box::new(Expr::Integer(exponent)),
-        }
+        pow2(series.base.clone(), Expr::Integer(exponent))
       };
       let head = if exponent > 1 {
         crate::functions::math_ast::divide_ast(&[
           head,
-          Expr::FunctionCall {
-            name: "Factorial".to_string(),
-            args: vec![Expr::Integer(exponent)].into(),
-          },
+          call1("Factorial", Expr::Integer(exponent)),
         ])?
       } else {
         head
@@ -4587,11 +4111,10 @@ fn try_infinite_sum(
       outer.push(series.coeff.clone());
     }
     if series.base_off != series.fact_off {
-      outer.push(Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(series.base.clone()),
-        right: Box::new(Expr::Integer(series.base_off - series.fact_off)),
-      });
+      outer.push(pow2(
+        series.base.clone(),
+        Expr::Integer(series.base_off - series.fact_off),
+      ));
     }
     let closed = if outer.is_empty() {
       inner
@@ -4621,21 +4144,10 @@ fn try_infinite_sum(
     // -coeff * Log[1 - base]
     let log_term = Expr::FunctionCall {
       name: "Log".to_string(),
-      args: vec![Expr::BinaryOp {
-        op: BinaryOperator::Plus,
-        left: Box::new(Expr::Integer(1)),
-        right: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::Integer(-1)),
-          right: Box::new(base),
-        }),
-      }]
-      .into(),
+      args: vec![plus2(Expr::Integer(1), times2(Expr::Integer(-1), base))]
+        .into(),
     };
-    let closed = Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![Expr::Integer(-1), coeff, log_term].into(),
-    };
+    let closed = call("Times", vec![Expr::Integer(-1), coeff, log_term]);
     return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&closed)?));
   }
 
@@ -4646,10 +4158,7 @@ fn try_infinite_sum(
     && let Some((sign, s)) = match_alternating_reciprocal_power(body, var_name)
     && s >= 1
   {
-    let eta = Expr::FunctionCall {
-      name: "DirichletEta".to_string(),
-      args: vec![Expr::Integer(s as i128)].into(),
-    };
+    let eta = call1("DirichletEta", Expr::Integer(s as i128));
     let result = if sign < 0 {
       crate::functions::math_ast::times_ast(&[Expr::Integer(-1), eta])?
     } else {
@@ -4674,10 +4183,7 @@ fn try_infinite_sum(
       && let Some(rf) = crate::functions::math_ast::try_eval_to_f64(&r)
       && rf.abs() < 1.0
     {
-      let result = Expr::FunctionCall {
-        name: "PolyLog".to_string(),
-        args: vec![Expr::Integer(-p), r].into(),
-      };
+      let result = call("PolyLog", vec![Expr::Integer(-p), r]);
       return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
     }
     // First-order symbolic case Sum[k r^k, {k, 1, Inf}] = r/(-1 + r)^2.
@@ -4689,31 +4195,18 @@ fn try_infinite_sum(
       && !is_exact
       && crate::functions::math_ast::try_eval_to_f64(&r).is_none()
     {
-      let denom = Expr::BinaryOp {
-        op: BinaryOperator::Power,
-        left: Box::new(Expr::BinaryOp {
-          op: BinaryOperator::Plus,
-          left: Box::new(Expr::Integer(-1)),
-          right: Box::new(r.clone()),
-        }),
-        right: Box::new(Expr::Integer(2)),
-      };
-      let closed = Expr::BinaryOp {
-        op: BinaryOperator::Divide,
-        left: Box::new(r),
-        right: Box::new(denom),
-      };
+      let denom = pow2(plus2(Expr::Integer(-1), r.clone()), Expr::Integer(2));
+      let closed = div2(r, denom);
       return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&closed)?));
     }
   }
 
   // Try Leibniz formula: Sum[(-1)^k / (2k+1), {k, 0, Infinity}] = Pi/4
   if min == 0 && is_leibniz_body(body, var_name) {
-    return Ok(Some(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::Constant("Pi".to_string())),
-      right: Box::new(Expr::Integer(4)),
-    }));
+    return Ok(Some(div2(
+      Expr::Constant("Pi".to_string()),
+      Expr::Integer(4),
+    )));
   }
 
   // Sums over the odd positive integers 1, 3, 5, …:
@@ -4731,10 +4224,7 @@ fn try_infinite_sum(
     } else {
       "DirichletLambda"
     };
-    let call = Expr::FunctionCall {
-      name: func.to_string(),
-      args: vec![Expr::Integer(s as i128)].into(),
-    };
+    let call = call1(func, Expr::Integer(s as i128));
     let result = if sign < 0 {
       crate::functions::math_ast::times_ast(&[Expr::Integer(-1), call])?
     } else {
@@ -4751,15 +4241,8 @@ fn try_infinite_sum(
     && let Some((a, s)) = match_scaled_reciprocal_power(body, var_name)
     && s >= 2
   {
-    let zeta = Expr::FunctionCall {
-      name: "Zeta".to_string(),
-      args: vec![Expr::Integer(s as i128)].into(),
-    };
-    let a_pow = Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(a),
-      right: Box::new(Expr::Integer(-(s as i128))),
-    };
+    let zeta = call1("Zeta", Expr::Integer(s as i128));
+    let a_pow = pow2(a, Expr::Integer(-(s as i128)));
     let result = crate::functions::math_ast::times_ast(&[zeta, a_pow])?;
     return Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?));
   }
@@ -4829,10 +4312,7 @@ fn try_infinite_sum(
     }
     // Odd s >= 3: no known closed form in terms of Pi (returns Zeta[s])
     if s >= 3 && s % 2 == 1 {
-      return Ok(Some(Expr::FunctionCall {
-        name: "Zeta".to_string(),
-        args: vec![Expr::Integer(s as i128)].into(),
-      }));
+      return Ok(Some(call1("Zeta", Expr::Integer(s as i128))));
     }
   }
 
@@ -4841,10 +4321,7 @@ fn try_infinite_sum(
   // Sum[n^s] = Zeta[-s]. Numeric exponents are handled by the reciprocal-power
   // path above; here we only take over when the exponent is symbolic.
   if let Some(zeta_arg) = match_symbolic_p_series_exponent(body, var_name)? {
-    return Ok(Some(Expr::FunctionCall {
-      name: "Zeta".to_string(),
-      args: vec![zeta_arg].into(),
-    }));
+    return Ok(Some(call1("Zeta", zeta_arg)));
   }
 
   // Sum[1/c^i, {i, 1, Infinity}] = 1/(c-1) for integer c > 1
@@ -4969,10 +4446,7 @@ fn match_alternating_reciprocal_power(
   let numerator = match rest_num.len() {
     0 => one.clone(),
     1 => rest_num.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: rest_num.into(),
-    },
+    _ => call("Times", rest_num),
   };
   let remaining = if den.is_empty() {
     numerator
@@ -4980,16 +4454,9 @@ fn match_alternating_reciprocal_power(
     let denominator = if den.len() == 1 {
       den.into_iter().next().unwrap()
     } else {
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: den.into(),
-      }
+      call("Times", den)
     };
-    Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numerator),
-      right: Box::new(denominator),
-    }
+    div2(numerator, denominator)
   };
   let s = match_reciprocal_power(&remaining, var_name)?;
   Some((sign, s))
@@ -5113,10 +4580,7 @@ fn match_factorial_trig_series(
   let numerator = match coeff_num.len() {
     0 => Expr::Integer(1),
     1 => coeff_num.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: coeff_num.into(),
-    },
+    _ => call("Times", coeff_num),
   };
   let coeff = if coeff_den.is_empty() {
     numerator
@@ -5124,16 +4588,9 @@ fn match_factorial_trig_series(
     let denominator = if coeff_den.len() == 1 {
       coeff_den.into_iter().next().unwrap()
     } else {
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: coeff_den.into(),
-      }
+      call("Times", coeff_den)
     };
-    Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numerator),
-      right: Box::new(denominator),
-    }
+    div2(numerator, denominator)
   };
 
   Some(FactorialTrigSeries {
@@ -5214,10 +4671,7 @@ fn match_scaled_reciprocal_power(
   let numerator = match num.len() {
     0 => Expr::Integer(1),
     1 => num.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: num.into(),
-    },
+    _ => call("Times", num),
   };
   let remaining = if den.is_empty() {
     numerator
@@ -5225,27 +4679,16 @@ fn match_scaled_reciprocal_power(
     let denominator = if den.len() == 1 {
       den.into_iter().next().unwrap()
     } else {
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: den.into(),
-      }
+      call("Times", den)
     };
-    Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numerator),
-      right: Box::new(denominator),
-    }
+    div2(numerator, denominator)
   };
   let (base, s) = match_reciprocal_power_general(&remaining, var_name)?;
   if !crate::functions::polynomial_ast::contains_var(&base, var_name) {
     return None;
   }
   // a = base / n must be constant w.r.t. n (so base == a*n with no offset).
-  let ratio = Expr::BinaryOp {
-    op: BinaryOperator::Divide,
-    left: Box::new(base),
-    right: Box::new(Expr::Identifier(var_name.to_string())),
-  };
+  let ratio = div2(base, Expr::Identifier(var_name.to_string()));
   let a = crate::evaluator::evaluate_expr_to_expr(&ratio).ok()?;
   if crate::functions::polynomial_ast::contains_var(&a, var_name)
     || matches!(a, Expr::Integer(1))
@@ -5292,10 +4735,7 @@ fn match_odd_reciprocal(
   let numerator = match rest_num.len() {
     0 => Expr::Integer(1),
     1 => rest_num.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: rest_num.into(),
-    },
+    _ => call("Times", rest_num),
   };
   let remaining = if den.is_empty() {
     numerator
@@ -5303,16 +4743,9 @@ fn match_odd_reciprocal(
     let denominator = if den.len() == 1 {
       den.into_iter().next().unwrap()
     } else {
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: den.into(),
-      }
+      call("Times", den)
     };
-    Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(numerator),
-      right: Box::new(denominator),
-    }
+    div2(numerator, denominator)
   };
 
   let (base, s) = match_reciprocal_power_general(&remaining, var_name)?;
@@ -5520,10 +4953,7 @@ fn zeta_even(s: i64) -> Result<Expr, InterpreterError> {
       match n.to_i128() {
         Some(v) => (v, 1i128),
         None => {
-          return Ok(Expr::FunctionCall {
-            name: "Sum".to_string(),
-            args: vec![].into(),
-          });
+          return Ok(call("Sum", vec![]));
         }
       }
     }
@@ -5533,18 +4963,12 @@ fn zeta_even(s: i64) -> Result<Expr, InterpreterError> {
       match (expr_to_i128(&args[0]), expr_to_i128(&args[1])) {
         (Some(n), Some(d)) => (n, d),
         _ => {
-          return Ok(Expr::FunctionCall {
-            name: "Sum".to_string(),
-            args: vec![].into(),
-          });
+          return Ok(call("Sum", vec![]));
         }
       }
     }
     _ => {
-      return Ok(Expr::FunctionCall {
-        name: "Sum".to_string(),
-        args: vec![].into(),
-      });
+      return Ok(call("Sum", vec![]));
     }
   };
 
@@ -5575,39 +4999,22 @@ fn zeta_even(s: i64) -> Result<Expr, InterpreterError> {
   let pi_power = if s == 1 {
     Expr::Identifier("Pi".to_string())
   } else {
-    Expr::BinaryOp {
-      op: BinaryOperator::Power,
-      left: Box::new(Expr::Identifier("Pi".to_string())),
-      right: Box::new(Expr::Integer(s as i128)),
-    }
+    pow2(Expr::Identifier("Pi".to_string()), Expr::Integer(s as i128))
   };
 
   if final_num == 1 && final_den == 1 {
     Ok(pi_power)
   } else if final_den == 1 {
-    Ok(Expr::BinaryOp {
-      op: BinaryOperator::Times,
-      left: Box::new(Expr::Integer(final_num)),
-      right: Box::new(pi_power),
-    })
+    Ok(times2(Expr::Integer(final_num), pi_power))
   } else if final_num == 1 {
     // 1/d * Pi^s => Pi^s / d
-    Ok(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(pi_power),
-      right: Box::new(Expr::Integer(final_den)),
-    })
+    Ok(div2(pi_power, Expr::Integer(final_den)))
   } else {
     // n/d * Pi^s => (n * Pi^s) / d
-    Ok(Expr::BinaryOp {
-      op: BinaryOperator::Divide,
-      left: Box::new(Expr::BinaryOp {
-        op: BinaryOperator::Times,
-        left: Box::new(Expr::Integer(final_num)),
-        right: Box::new(pi_power),
-      }),
-      right: Box::new(Expr::Integer(final_den)),
-    })
+    Ok(div2(
+      times2(Expr::Integer(final_num), pi_power),
+      Expr::Integer(final_den),
+    ))
   }
 }
 
@@ -5635,10 +5042,6 @@ pub fn angle_path_3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   let eval = crate::evaluator::evaluate_expr_to_expr;
-  let fc = |name: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: a.into(),
-  };
   let zero = || Expr::Integer(0);
   // Real step data gives a real origin ({0., 0., 0.}), like wolframscript.
   fn contains_real(e: &Expr) -> bool {
@@ -5698,21 +5101,21 @@ pub fn angle_path_3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let negated = Expr::List(
       angles
         .iter()
-        .map(|a| fc("Times", vec![Expr::Integer(-1), a.clone()]))
+        .map(|a| call("Times", vec![Expr::Integer(-1), a.clone()]))
         .collect(),
     );
-    let rotation = eval(&fc("RollPitchYawMatrix", vec![negated]))?;
+    let rotation = eval(&call1("RollPitchYawMatrix", negated))?;
     if !matches!(&rotation, Expr::List(_)) {
       // Symbolic angles keep the whole call unevaluated.
       return unevaluated();
     }
-    frame = eval(&fc("Dot", vec![rotation, frame.clone()]))?;
+    frame = eval(&call("Dot", vec![rotation, frame.clone()]))?;
     let mut direction =
-      eval(&fc("Part", vec![frame.clone(), Expr::Integer(1)]))?;
+      eval(&call("Part", vec![frame.clone(), Expr::Integer(1)]))?;
     if let Some(d) = dist {
-      direction = eval(&fc("Times", vec![d.clone(), direction]))?;
+      direction = eval(&call("Times", vec![d.clone(), direction]))?;
     }
-    point = eval(&fc("Plus", vec![point.clone(), direction]))?;
+    point = eval(&call("Plus", vec![point.clone(), direction]))?;
     points.push(point.clone());
   }
   Ok(Expr::List(points.into()))

--- a/src/functions/math_ast/bessel.rs
+++ b/src/functions/math_ast/bessel.rs
@@ -104,17 +104,15 @@ pub fn bessel_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     let pos_n = -n;
     let parity = pos_n.unsigned_abs() & 1;
-    let positive_call = Expr::FunctionCall {
-      name: "BesselJ".to_string(),
-      args: vec![Expr::Integer(pos_n), z_expr.clone()].into(),
-    };
+    let positive_call =
+      call("BesselJ", vec![Expr::Integer(pos_n), z_expr.clone()]);
     return if parity == 0 {
       Ok(positive_call)
     } else {
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), positive_call].into(),
-      })
+      crate::evaluator::evaluate_expr_to_expr(&call(
+        "Times",
+        vec![Expr::Integer(-1), positive_call],
+      ))
     };
   }
 
@@ -177,44 +175,28 @@ fn wrap_with_sqrt_factor_rationalised(
   z_expr: &Expr,
 ) -> Result<Expr, InterpreterError> {
   // Build Distribute[2*p, Plus] / (Sqrt[2*Pi] * Sqrt[z]).
-  let two_p = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![Expr::Integer(2), p.clone()].into(),
-  };
-  let distributed = Expr::FunctionCall {
-    name: "Distribute".to_string(),
-    args: vec![two_p, Expr::Identifier("Plus".to_string())].into(),
-  };
-  let denom = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "Sqrt".to_string(),
-        args: vec![Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(2), Expr::Identifier("Pi".to_string())]
-            .into(),
-        }]
-        .into(),
-      },
-      Expr::FunctionCall {
-        name: "Sqrt".to_string(),
-        args: vec![z_expr.clone()].into(),
-      },
-    ]
-    .into(),
-  };
-  let expr = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![
-      distributed,
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![denom, Expr::Integer(-1)].into(),
-      },
-    ]
-    .into(),
-  };
+  let two_p = call("Times", vec![Expr::Integer(2), p.clone()]);
+  let distributed = call(
+    "Distribute",
+    vec![two_p, Expr::Identifier("Plus".to_string())],
+  );
+  let denom = call(
+    "Times",
+    vec![
+      call1(
+        "Sqrt",
+        call(
+          "Times",
+          vec![Expr::Integer(2), Expr::Identifier("Pi".to_string())],
+        ),
+      ),
+      call1("Sqrt", z_expr.clone()),
+    ],
+  );
+  let expr = call(
+    "Times",
+    vec![distributed, call("Power", vec![denom, Expr::Integer(-1)])],
+  );
   crate::evaluator::evaluate_expr_to_expr(&expr)
 }
 
@@ -237,8 +219,8 @@ fn half_int_bessel_polynomial(
   trig_neg: &str,
   sign: BesselSign,
 ) -> Result<Expr, InterpreterError> {
-  let mut prev = trig_call(trig_neg, z_expr); // P_{-1}
-  let mut curr = trig_call(trig_pos, z_expr); // P_{1}
+  let mut prev = call1(trig_neg, z_expr.clone()); // P_{-1}
+  let mut curr = call1(trig_pos, z_expr.clone()); // P_{1}
   let raw = if m == 1 {
     curr
   } else if m == -1 {
@@ -278,13 +260,6 @@ fn half_int_bessel_polynomial(
   }
 }
 
-fn trig_call(name: &str, z_expr: &Expr) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: vec![z_expr.clone()].into(),
-  }
-}
-
 /// One step of the half-integer Bessel polynomial recurrence.
 ///
 /// J family, forward: P_{m+2} = (m/z) * P_m - P_{m-2}
@@ -305,28 +280,20 @@ fn bessel_poly_recurrence(
     (BesselSign::I, true) => (-coef, 1), // -(m/z) P_m + P_other
     (BesselSign::I, false) => (coef, 1), // (m/z) P_m + P_other
   };
-  let expr = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![
+  let expr = call(
+    "Plus",
+    vec![
+      call(
+        "Times",
+        vec![
           Expr::Integer(a_coef),
-          Expr::FunctionCall {
-            name: "Power".to_string(),
-            args: vec![z_expr.clone(), Expr::Integer(-1)].into(),
-          },
+          call("Power", vec![z_expr.clone(), Expr::Integer(-1)]),
           p_n.clone(),
-        ]
-        .into(),
-      },
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(b_coef), p_other.clone()].into(),
-      },
-    ]
-    .into(),
-  };
+        ],
+      ),
+      call("Times", vec![Expr::Integer(b_coef), p_other.clone()]),
+    ],
+  );
   crate::evaluator::evaluate_expr_to_expr(&expr)
 }
 
@@ -335,40 +302,29 @@ fn wrap_with_sqrt_factor(
   p: &Expr,
   z_expr: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  let expr = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![
-      Expr::FunctionCall {
-        name: "Sqrt".to_string(),
-        args: vec![Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![
+  let expr = call(
+    "Times",
+    vec![
+      call1(
+        "Sqrt",
+        call(
+          "Times",
+          vec![
             Expr::Integer(2),
-            Expr::FunctionCall {
-              name: "Power".to_string(),
-              args: vec![Expr::Identifier("Pi".to_string()), Expr::Integer(-1)]
-                .into(),
-            },
-          ]
-          .into(),
-        }]
-        .into(),
-      },
+            call(
+              "Power",
+              vec![Expr::Identifier("Pi".to_string()), Expr::Integer(-1)],
+            ),
+          ],
+        ),
+      ),
       p.clone(),
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "Sqrt".to_string(),
-            args: vec![z_expr.clone()].into(),
-          },
-          Expr::Integer(-1),
-        ]
-        .into(),
-      },
-    ]
-    .into(),
-  };
+      call(
+        "Power",
+        vec![call1("Sqrt", z_expr.clone()), Expr::Integer(-1)],
+      ),
+    ],
+  );
   crate::evaluator::evaluate_expr_to_expr(&expr)
 }
 
@@ -755,10 +711,7 @@ pub fn bessel_k_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Expr::Integer(n) = n_expr
     && *n < 0
   {
-    return Ok(Expr::FunctionCall {
-      name: "BesselK".to_string(),
-      args: vec![Expr::Integer(-n), z_expr.clone()].into(),
-    });
+    return Ok(call("BesselK", vec![Expr::Integer(-n), z_expr.clone()]));
   }
 
   Ok(unevaluated("BesselK", args))
@@ -795,25 +748,20 @@ fn bessel_k_polynomial(
   let mut m_cur: i128 = 1;
   while m_cur < m {
     // P_{m_cur+2} = (m_cur/z) * curr + prev
-    let next_expr = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![
+    let next_expr = call(
+      "Plus",
+      vec![
+        call(
+          "Times",
+          vec![
             Expr::Integer(m_cur),
-            Expr::FunctionCall {
-              name: "Power".to_string(),
-              args: vec![z_expr.clone(), Expr::Integer(-1)].into(),
-            },
+            call("Power", vec![z_expr.clone(), Expr::Integer(-1)]),
             curr.clone(),
-          ]
-          .into(),
-        },
+          ],
+        ),
         prev.clone(),
-      ]
-      .into(),
-    };
+      ],
+    );
     let next = crate::evaluator::evaluate_expr_to_expr(&next_expr)?;
     prev = curr;
     curr = next;
@@ -829,53 +777,36 @@ fn wrap_bessel_k_factor(
   p: &Expr,
   z_expr: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  let expr = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![
+  let expr = call(
+    "Times",
+    vec![
       // Sqrt[Pi/2]
-      Expr::FunctionCall {
-        name: "Sqrt".to_string(),
-        args: vec![Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![
+      call1(
+        "Sqrt",
+        call(
+          "Times",
+          vec![
             Expr::Identifier("Pi".to_string()),
-            Expr::FunctionCall {
-              name: "Power".to_string(),
-              args: vec![Expr::Integer(2), Expr::Integer(-1)].into(),
-            },
-          ]
-          .into(),
-        }]
-        .into(),
-      },
+            call("Power", vec![Expr::Integer(2), Expr::Integer(-1)]),
+          ],
+        ),
+      ),
       p.clone(),
       // 1 / E^z = E^(-z)
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![
+      call(
+        "Power",
+        vec![
           Expr::Constant("E".to_string()),
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![Expr::Integer(-1), z_expr.clone()].into(),
-          },
-        ]
-        .into(),
-      },
+          call("Times", vec![Expr::Integer(-1), z_expr.clone()]),
+        ],
+      ),
       // 1 / Sqrt[z]
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "Sqrt".to_string(),
-            args: vec![z_expr.clone()].into(),
-          },
-          Expr::Integer(-1),
-        ]
-        .into(),
-      },
-    ]
-    .into(),
-  };
+      call(
+        "Power",
+        vec![call1("Sqrt", z_expr.clone()), Expr::Integer(-1)],
+      ),
+    ],
+  );
   crate::evaluator::evaluate_expr_to_expr(&expr)
 }
 
@@ -1010,11 +941,10 @@ pub fn bessel_y_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && let Expr::Integer(n) = n_expr
   {
     return if *n == 0 {
-      Ok(Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), Expr::Identifier("Infinity".to_string())]
-          .into(),
-      })
+      Ok(call(
+        "Times",
+        vec![Expr::Integer(-1), Expr::Identifier("Infinity".to_string())],
+      ))
     } else {
       Ok(Expr::Identifier("ComplexInfinity".to_string()))
     };
@@ -1057,10 +987,10 @@ pub fn bessel_y_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let p =
       half_int_bessel_polynomial(-n_num, z_expr, "Sin", "Cos", BesselSign::J)?;
     let p_signed = if sign < 0 {
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), p].into(),
-      })?
+      crate::evaluator::evaluate_expr_to_expr(&call(
+        "Times",
+        vec![Expr::Integer(-1), p],
+      ))?
     } else {
       p
     };
@@ -1072,17 +1002,15 @@ pub fn bessel_y_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && *n < 0
   {
     let pos_n = -n;
-    let positive_call = Expr::FunctionCall {
-      name: "BesselY".to_string(),
-      args: vec![Expr::Integer(pos_n), z_expr.clone()].into(),
-    };
+    let positive_call =
+      call("BesselY", vec![Expr::Integer(pos_n), z_expr.clone()]);
     return if pos_n.unsigned_abs() & 1 == 0 {
       Ok(positive_call)
     } else {
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), positive_call].into(),
-      })
+      crate::evaluator::evaluate_expr_to_expr(&call(
+        "Times",
+        vec![Expr::Integer(-1), positive_call],
+      ))
     };
   }
 
@@ -1253,22 +1181,18 @@ fn coulomb_wave_reduce(
       && try_eval_to_f64(eta).is_some()
       && try_eval_to_f64(z).is_some()
     {
-      let fc = |name: &str, a: Vec<Expr>| Expr::FunctionCall {
-        name: name.to_string(),
-        args: a.into(),
-      };
       return match kind {
         CoulombKind::F => coulomb_f_numeric(l_int, eta, z),
         CoulombKind::G => {
           let hplus = coulomb_hplus_expr(l_int, eta, z);
-          crate::evaluator::evaluate_expr_to_expr(&fc("Re", vec![hplus]))
+          crate::evaluator::evaluate_expr_to_expr(&call1("Re", hplus))
         }
         CoulombKind::H1 => crate::evaluator::evaluate_expr_to_expr(
           &coulomb_hplus_expr(l_int, eta, z),
         ),
         CoulombKind::H2 => {
           let hplus = coulomb_hplus_expr(l_int, eta, z);
-          crate::evaluator::evaluate_expr_to_expr(&fc("Conjugate", vec![hplus]))
+          crate::evaluator::evaluate_expr_to_expr(&call1("Conjugate", hplus))
         }
       };
     }
@@ -1278,31 +1202,14 @@ fn coulomb_wave_reduce(
   // L == 0: the spherical functions collapse to elementary form.
   if matches!(l, Expr::Integer(0)) {
     let elem = match kind {
-      CoulombKind::F => Expr::FunctionCall {
-        name: "Sin".to_string(),
-        args: vec![z.clone()].into(),
-      },
-      CoulombKind::G => Expr::FunctionCall {
-        name: "Cos".to_string(),
-        args: vec![z.clone()].into(),
-      },
+      CoulombKind::F => call1("Sin", z.clone()),
+      CoulombKind::G => call1("Cos", z.clone()),
       // E^(I z) and E^(-I z).
-      CoulombKind::H1 => Expr::FunctionCall {
-        name: "Exp".to_string(),
-        args: vec![Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![i_unit(), z.clone()].into(),
-        }]
-        .into(),
-      },
-      CoulombKind::H2 => Expr::FunctionCall {
-        name: "Exp".to_string(),
-        args: vec![Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(-1), i_unit(), z.clone()].into(),
-        }]
-        .into(),
-      },
+      CoulombKind::H1 => call1("Exp", call("Times", vec![i_unit(), z.clone()])),
+      CoulombKind::H2 => call1(
+        "Exp",
+        call("Times", vec![Expr::Integer(-1), i_unit(), z.clone()]),
+      ),
     };
     return crate::evaluator::evaluate_expr_to_expr(&elem);
   }
@@ -1313,10 +1220,7 @@ fn coulomb_wave_reduce(
     CoulombKind::H1 => "SphericalHankelH1",
     CoulombKind::H2 => "SphericalHankelH2",
   };
-  let sph = Expr::FunctionCall {
-    name: sph_name.to_string(),
-    args: vec![l.clone(), z.clone()].into(),
-  };
+  let sph = call(sph_name, vec![l.clone(), z.clone()]);
   // Leading factors before z: F -> none, G -> -1, H1 -> I, H2 -> -I.
   let mut factors: Vec<Expr> = match kind {
     CoulombKind::F => vec![],
@@ -1326,10 +1230,7 @@ fn coulomb_wave_reduce(
   };
   factors.push(z.clone());
   factors.push(sph);
-  let result = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: factors.into(),
-  };
+  let result = call("Times", factors);
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
 
@@ -1339,65 +1240,61 @@ fn coulomb_wave_reduce(
 /// with sigma_L = Arg[Gamma[L+1+i eta]] the Coulomb phase shift. G = Re(H+),
 /// H1 = H+, H2 = Conjugate(H+). Uses the evaluator's complex WhittakerW/Gamma.
 fn coulomb_hplus_expr(l: i128, eta: &Expr, rho: &Expr) -> Expr {
-  let fc = |name: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: a.into(),
-  };
   let i_unit = Expr::Identifier("I".to_string());
   // (-i)^L
-  let neg_i_pow = fc(
+  let neg_i_pow = call(
     "Power",
     vec![
-      fc("Times", vec![Expr::Integer(-1), i_unit.clone()]),
+      call("Times", vec![Expr::Integer(-1), i_unit.clone()]),
       Expr::Integer(l),
     ],
   );
   // e^(pi eta / 2)
-  let exp_norm = fc(
+  let exp_norm = call1(
     "Exp",
-    vec![fc(
+    call(
       "Times",
       vec![
-        fc("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
+        call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
         Expr::Constant("Pi".to_string()),
         eta.clone(),
       ],
-    )],
+    ),
   );
   // e^(i sigma_L), sigma_L = Arg[Gamma[L+1 + i eta]]
-  let sigma = fc(
+  let sigma = call1(
     "Arg",
-    vec![fc(
+    call1(
       "Gamma",
-      vec![fc(
+      call(
         "Plus",
         vec![
           Expr::Integer(l + 1),
-          fc("Times", vec![i_unit.clone(), eta.clone()]),
+          call("Times", vec![i_unit.clone(), eta.clone()]),
         ],
-      )],
-    )],
+      ),
+    ),
   );
-  let exp_phase = fc("Exp", vec![fc("Times", vec![i_unit.clone(), sigma])]);
+  let exp_phase = call1("Exp", call("Times", vec![i_unit.clone(), sigma]));
   // WhittakerW[-i eta, L+1/2, -2 i rho]
-  let whittaker = fc(
+  let whittaker = call(
     "WhittakerW",
     vec![
-      fc(
+      call(
         "Times",
         vec![Expr::Integer(-1), i_unit.clone(), eta.clone()],
       ),
-      fc(
+      call(
         "Plus",
         vec![
           Expr::Integer(l),
-          fc("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
+          call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
         ],
       ),
-      fc("Times", vec![Expr::Integer(-2), i_unit, rho.clone()]),
+      call("Times", vec![Expr::Integer(-2), i_unit, rho.clone()]),
     ],
   );
-  fc("Times", vec![neg_i_pow, exp_norm, exp_phase, whittaker])
+  call("Times", vec![neg_i_pow, exp_norm, exp_phase, whittaker])
 }
 
 /// Numeric CoulombF[L, eta, rho] for a non-negative integer order L and real
@@ -1412,72 +1309,68 @@ fn coulomb_f_numeric(
   eta: &Expr,
   rho: &Expr,
 ) -> Result<Expr, InterpreterError> {
-  let fc = |name: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: a.into(),
-  };
   let i_unit = Expr::Identifier("I".to_string());
   let l1 = Expr::Integer(l + 1);
   let two_l2 = Expr::Integer(2 * l + 2);
 
   // C_L(eta) factors.
-  let two_pow_l = fc("Power", vec![Expr::Integer(2), Expr::Integer(l)]);
+  let two_pow_l = call("Power", vec![Expr::Integer(2), Expr::Integer(l)]);
   // e^(-pi eta / 2)
-  let exp_norm = fc(
+  let exp_norm = call1(
     "Exp",
-    vec![fc(
+    call(
       "Times",
       vec![
-        fc("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
+        call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
         Expr::Constant("Pi".to_string()),
         eta.clone(),
       ],
-    )],
+    ),
   );
   // |Gamma[L+1 + i eta]|
-  let abs_gamma = fc(
+  let abs_gamma = call1(
     "Abs",
-    vec![fc(
+    call1(
       "Gamma",
-      vec![fc(
+      call(
         "Plus",
-        vec![l1.clone(), fc("Times", vec![i_unit.clone(), eta.clone()])],
-      )],
-    )],
+        vec![l1.clone(), call("Times", vec![i_unit.clone(), eta.clone()])],
+      ),
+    ),
   );
-  let inv_gamma_2l2 = fc(
+  let inv_gamma_2l2 = call(
     "Power",
-    vec![fc("Gamma", vec![two_l2.clone()]), Expr::Integer(-1)],
+    vec![call1("Gamma", two_l2.clone()), Expr::Integer(-1)],
   );
 
   // rho^(L+1) e^(-i rho) 1F1(L+1 - i eta; 2L+2; 2 i rho)
-  let rho_pow = fc("Power", vec![rho.clone(), l1.clone()]);
-  let exp_rho = fc(
+  let rho_pow = call("Power", vec![rho.clone(), l1.clone()]);
+  let exp_rho = call1(
     "Exp",
-    vec![fc(
+    call(
       "Times",
       vec![Expr::Integer(-1), i_unit.clone(), rho.clone()],
-    )],
+    ),
   );
-  let hyp = fc(
+  let hyp = call(
     "Hypergeometric1F1",
     vec![
-      fc(
+      call(
         "Plus",
         vec![
           l1,
-          fc(
+          call(
             "Times",
             vec![Expr::Integer(-1), i_unit.clone(), eta.clone()],
           ),
         ],
       ),
       two_l2,
-      fc("Times", vec![Expr::Integer(2), i_unit, rho.clone()]),
+      call("Times", vec![Expr::Integer(2), i_unit, rho.clone()]),
     ],
   );
 
-  let product = fc(
+  let product = call(
     "Times",
     vec![
       two_pow_l,
@@ -1489,7 +1382,7 @@ fn coulomb_f_numeric(
       hyp,
     ],
   );
-  crate::evaluator::evaluate_expr_to_expr(&fc("Re", vec![product]))
+  crate::evaluator::evaluate_expr_to_expr(&call1("Re", product))
 }
 
 pub fn spherical_bessel_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
@@ -1549,11 +1442,10 @@ pub fn spherical_bessel_j_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   if has_real && let (Some(n_val), Some(z_val)) = (n_f64, z_f64) {
-    let bessel_result =
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "BesselJ".to_string(),
-        args: vec![Expr::Real(n_val + 0.5), Expr::Real(z_val)].into(),
-      })?;
+    let bessel_result = crate::evaluator::evaluate_expr_to_expr(&call(
+      "BesselJ",
+      vec![Expr::Real(n_val + 0.5), Expr::Real(z_val)],
+    ))?;
     if let Some(bj) = try_eval_to_f64(&bessel_result) {
       let result = (std::f64::consts::PI / (2.0 * z_val)).sqrt() * bj;
       return Ok(Expr::Real(result));
@@ -1580,15 +1472,9 @@ fn build_hankel(
   }
   // Try numeric evaluation: compute BesselJ + sign*I*BesselY
   let j_result =
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: j_name.to_string(),
-      args: args.to_vec().into(),
-    })?;
+    crate::evaluator::evaluate_expr_to_expr(&call(j_name, args.to_vec()))?;
   let y_result =
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: y_name.to_string(),
-      args: args.to_vec().into(),
-    })?;
+    crate::evaluator::evaluate_expr_to_expr(&call(y_name, args.to_vec()))?;
   // Only proceed if both evaluated to numbers
   let j_val = try_eval_to_f64(&j_result);
   let y_val = try_eval_to_f64(&y_result);
@@ -1596,24 +1482,19 @@ fn build_hankel(
     && j.is_finite()
     && y.is_finite()
   {
-    let expr = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: vec![
+    let expr = call(
+      "Plus",
+      vec![
         Expr::Real(j),
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![
-            Expr::FunctionCall {
-              name: "Complex".to_string(),
-              args: vec![Expr::Integer(0), Expr::Integer(sign)].into(),
-            },
+        call(
+          "Times",
+          vec![
+            call("Complex", vec![Expr::Integer(0), Expr::Integer(sign)]),
             Expr::Real(y),
-          ]
-          .into(),
-        },
-      ]
-      .into(),
-    };
+          ],
+        ),
+      ],
+    );
     return crate::evaluator::evaluate_expr_to_expr(&expr);
   }
   Ok(unevaluated(name, args))
@@ -1668,11 +1549,10 @@ pub fn spherical_bessel_y_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && let (Some(n_val), Some(z_val)) = (n_f64, z_f64)
     && z_val > 0.0
   {
-    let bessel_result =
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "BesselY".to_string(),
-        args: vec![Expr::Real(n_val + 0.5), Expr::Real(z_val)].into(),
-      })?;
+    let bessel_result = crate::evaluator::evaluate_expr_to_expr(&call(
+      "BesselY",
+      vec![Expr::Real(n_val + 0.5), Expr::Real(z_val)],
+    ))?;
     if let Some(by) = try_eval_to_f64(&bessel_result) {
       let result = (std::f64::consts::PI / (2.0 * z_val)).sqrt() * by;
       return Ok(Expr::Real(result));
@@ -1914,10 +1794,7 @@ pub fn kelvin_ber_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(build_complex_float_expr(rr, ri));
   }
   // KelvinBer[z] = KelvinBer[0, z] for exact/symbolic z (matches wolframscript).
-  Ok(Expr::FunctionCall {
-    name: "KelvinBer".to_string(),
-    args: vec![Expr::Integer(0), args[0].clone()].into(),
-  })
+  Ok(call("KelvinBer", vec![Expr::Integer(0), args[0].clone()]))
 }
 
 /// KelvinBei[x] - imaginary part of BesselJ[0, x·e^(3πI/4)].
@@ -1961,10 +1838,7 @@ pub fn kelvin_bei_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(build_complex_float_expr(rr, ri));
   }
   // KelvinBei[z] = KelvinBei[0, z] for exact/symbolic z (matches wolframscript).
-  Ok(Expr::FunctionCall {
-    name: "KelvinBei".to_string(),
-    args: vec![Expr::Integer(0), args[0].clone()].into(),
-  })
+  Ok(call("KelvinBei", vec![Expr::Integer(0), args[0].clone()]))
 }
 
 /// Real-valued `ker(x)` via the standard power series (DLMF 10.65.6).
@@ -2202,10 +2076,7 @@ pub fn kelvin_ker_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(build_complex_float_expr(rr, ri));
   }
   // KelvinKer[z] = KelvinKer[0, z] for exact/symbolic z (matches wolframscript).
-  Ok(Expr::FunctionCall {
-    name: "KelvinKer".to_string(),
-    args: vec![Expr::Integer(0), args[0].clone()].into(),
-  })
+  Ok(call("KelvinKer", vec![Expr::Integer(0), args[0].clone()]))
 }
 
 /// KelvinKei[x] - imaginary part of e^(-Pi·I/2)·BesselK[0, x·e^(Pi I/4)].
@@ -2251,8 +2122,5 @@ pub fn kelvin_kei_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(build_complex_float_expr(rr, ri));
   }
   // KelvinKei[z] = KelvinKei[0, z] for exact/symbolic z (matches wolframscript).
-  Ok(Expr::FunctionCall {
-    name: "KelvinKei".to_string(),
-    args: vec![Expr::Integer(0), args[0].clone()].into(),
-  })
+  Ok(call("KelvinKei", vec![Expr::Integer(0), args[0].clone()]))
 }

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -6,19 +6,12 @@ fn sqrt(a: Expr) -> Expr {
   make_sqrt(a)
 }
 
-fn call(name: &str, args: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  }
-}
-
 fn factorial(a: Expr) -> Expr {
-  call("Factorial", vec![a])
+  call1("Factorial", a)
 }
 
 fn gamma(z: Expr) -> Expr {
-  call("Gamma", vec![z])
+  call1("Gamma", z)
 }
 
 fn e() -> Expr {
@@ -405,7 +398,7 @@ pub fn survival_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // prints it: (-m + x)/(Sqrt[2]*s) rather than -((m - x)/(Sqrt[2]*s)).
   if let Some(z) = match_erfc_half(&cdf) {
     let neg_z = eval(call("Simplify", vec![times2(int(-1), z)]))?;
-    return Ok(div2(call("Erfc", vec![neg_z]), int(2)));
+    return Ok(div2(call1("Erfc", neg_z), int(2)));
   }
 
   eval(minus2(int(1), cdf))
@@ -435,7 +428,7 @@ pub fn hazard_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         && matches!(&dargs[0], Expr::Integer(0))
         && matches!(&dargs[1], Expr::Integer(1))));
   if is_std_normal && matches!(&x, Expr::Identifier(_)) {
-    let sqrt = |e: Expr| call("Sqrt", vec![e]);
+    let sqrt = |e: Expr| call1("Sqrt", e);
     return Ok(div2(
       sqrt(div2(int(2), pi())),
       call(
@@ -456,7 +449,7 @@ pub fn hazard_function_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   let simplify_ratio = |p: Expr, s: Expr| -> Result<Expr, InterpreterError> {
-    eval(call("Simplify", vec![div2(p, s)]))
+    eval(call1("Simplify", div2(p, s)))
   };
 
   let pdf = pdf_ast(args)?;
@@ -557,8 +550,8 @@ pub fn quantile_distribution_closed_form(
   let is_exact_q = !matches!(q, Expr::Real(_));
 
   // Builders for the elementary inverse-CDF formulas below.
-  let log = |x: Expr| call("Log", vec![x]);
-  let sqrt = |x: Expr| call("Sqrt", vec![x]);
+  let log = |x: Expr| call1("Log", x);
+  let sqrt = |x: Expr| call1("Sqrt", x);
   let power = |b: Expr, e: Expr| call("Power", vec![b, e]);
   let neg = |x: Expr| times2(int(-1), x);
   let one_minus_q = || minus2(int(1), q.clone());
@@ -599,7 +592,7 @@ pub fn quantile_distribution_closed_form(
       }
       let lambda = dargs[0].clone();
       let one_minus_q = minus2(int(1), q.clone());
-      let log_term = call("Log", vec![one_minus_q]);
+      let log_term = call1("Log", one_minus_q);
       let neg_log = times2(int(-1), log_term);
       let expr = div2(neg_log, lambda);
       eval(expr).ok()
@@ -617,7 +610,7 @@ pub fn quantile_distribution_closed_form(
       let (a, b) = (dargs[0].clone(), dargs[1].clone());
       let pi = pi();
       let q_minus_half = minus2(q.clone(), make_rational(1, 2));
-      let tan = call("Tan", vec![times2(pi, q_minus_half)]);
+      let tan = call1("Tan", times2(pi, q_minus_half));
       eval(plus2(a, times2(b, tan))).ok()
     }
     // Quantile[WeibullDistribution[k, λ], q] = λ (-Log[1 - q])^(1/k)
@@ -734,8 +727,8 @@ pub fn quantile_distribution_closed_form(
         // InverseErfc[2q] for q > 1/2 (2q > 1 → -InverseErfc[2-2q]) and folds
         // the sign, matching wolframscript while preserving the factor order.
         let two_q = eval(times2(int(2), q.clone())).ok()?;
-        let inverse_erfc = call("InverseErfc", vec![two_q]);
-        let sqrt2 = call("Sqrt", vec![int(2)]);
+        let inverse_erfc = call1("InverseErfc", two_q);
+        let sqrt2 = call1("Sqrt", int(2));
         let factors: Vec<Expr> = match &s {
           Expr::Integer(1) => vec![sqrt2, inverse_erfc],
           _ => vec![sqrt2, s.clone(), inverse_erfc],
@@ -915,8 +908,8 @@ pub fn inverse_survival_closed_form(
         }
       }
       let two_q = eval(times2(int(2), q.clone())).ok()?;
-      let inverse_erfc = call("InverseErfc", vec![two_q]);
-      let sqrt2 = call("Sqrt", vec![int(2)]);
+      let inverse_erfc = call1("InverseErfc", two_q);
+      let sqrt2 = call1("Sqrt", int(2));
       let factors: Vec<Expr> = match &s {
         Expr::Integer(1) => vec![sqrt2, inverse_erfc],
         _ => vec![sqrt2, s.clone(), inverse_erfc],
@@ -1336,14 +1329,12 @@ fn pdf_meixner(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let iy = div2(times2(i, xm.clone()), a.clone()); // I (x-m)/a
   let two_pow = pow2(int(2), plus2(int(-1), times2(int(2), d.clone())));
   let e_part = pow2(e(), div2(times2(b.clone(), xm), a.clone()));
-  let cos_part =
-    pow2(unary_fn("Cos", div2(b, int(2))), times2(int(2), d.clone()));
-  let g1 = unary_fn("Gamma", minus2(d.clone(), iy.clone()));
-  let g2 = unary_fn("Gamma", plus2(d.clone(), iy));
+  let cos_part = pow2(call1("Cos", div2(b, int(2))), times2(int(2), d.clone()));
+  let g1 = gamma(minus2(d.clone(), iy.clone()));
+  let g2 = gamma(plus2(d.clone(), iy));
   let numerator =
     times2(times2(times2(times2(two_pow, e_part), cos_part), g1), g2);
-  let denominator =
-    times2(times2(a, pi()), unary_fn("Gamma", times2(int(2), d)));
+  let denominator = times2(times2(a, pi()), gamma(times2(int(2), d)));
   eval(div2(numerator, denominator))
 }
 
@@ -1377,10 +1368,6 @@ fn pdf_poisson_consul(
   eval(piecewise(vec![(density, cond)], int(0)))
 }
 
-fn unary_fn(name: &str, arg: Expr) -> Expr {
-  call(name, vec![arg])
-}
-
 /// PDF[SkellamDistribution[a, b], k] =
 ///   (a/b)^(k/2) * E^(-a-b) * BesselI[k, 2 Sqrt[a b]]   (for all integers k).
 fn pdf_skellam(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
@@ -1397,7 +1384,7 @@ fn pdf_skellam(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   );
   let bessel = call(
     "BesselI",
-    vec![x, times2(int(2), unary_fn("Sqrt", times2(a, b)))],
+    vec![x, times2(int(2), call1("Sqrt", times2(a, b)))],
   );
   eval(times2(times2(ratio_pow, exp_part), bessel))
 }
@@ -1411,13 +1398,13 @@ fn cdf_skellam(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     ));
   }
   let (a, b) = (dargs[0].clone(), dargs[1].clone());
-  let sqrt2 = unary_fn("Sqrt", int(2));
+  let sqrt2 = call1("Sqrt", int(2));
   let marcum = call(
     "MarcumQ",
     vec![
-      times2(int(-1), unary_fn("Floor", x)),
-      times2(sqrt2.clone(), unary_fn("Sqrt", a)),
-      times2(sqrt2, unary_fn("Sqrt", b)),
+      times2(int(-1), call1("Floor", x)),
+      times2(sqrt2.clone(), call1("Sqrt", a)),
+      times2(sqrt2, call1("Sqrt", b)),
     ],
   );
   eval(minus2(int(1), marcum))
@@ -1643,7 +1630,7 @@ fn pdf_log_series(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     ));
   }
   let t = dargs[0].clone();
-  let log_1mt = unary_fn("Log", minus2(int(1), t.clone()));
+  let log_1mt = call1("Log", minus2(int(1), t.clone()));
   let density = times2(
     int(-1),
     div2(pow2(t, x.clone()), times2(x.clone(), log_1mt)),
@@ -1676,7 +1663,7 @@ fn pdf_nakagami(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // denominator = E^((m x^2)/w) Gamma[m]
   let denom = times2(
     pow2(e(), div2(times2(m.clone(), pow2(x.clone(), int(2))), w)),
-    unary_fn("Gamma", m),
+    gamma(m),
   );
   let density = div2(numer, denom);
   let cond = comparison(x, ComparisonOp::Greater, int(0));
@@ -1966,7 +1953,7 @@ fn cdf_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 
   // Erfc[(mu - x) / (Sqrt[2] * sigma)] / 2
   let erfc_arg = div2(minus2(mu, x), times2(sqrt(int(2)), sigma));
-  let erfc_call = call("Erfc", vec![erfc_arg]);
+  let erfc_call = call1("Erfc", erfc_arg);
   let result = div2(erfc_call, int(2));
   eval(result)
 }
@@ -2042,7 +2029,7 @@ fn cdf_poisson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let mu = dargs[0].clone();
 
   // GammaRegularized[Floor[k] + 1, mu]
-  let floor_k_plus_1 = plus2(call("Floor", vec![x.clone()]), int(1));
+  let floor_k_plus_1 = plus2(call1("Floor", x.clone()), int(1));
   let value = call("GammaRegularized", vec![floor_k_plus_1, mu]);
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
 
@@ -2087,7 +2074,7 @@ fn cdf_binomial(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let n = dargs[0].clone();
   let p = dargs[1].clone();
 
-  let floor_k = call("Floor", vec![x.clone()]);
+  let floor_k = call1("Floor", x.clone());
   // BetaRegularized[1 - p, n - Floor[k], 1 + Floor[k]] is the regularized
   // incomplete beta form of the binomial CDF; it collapses to the exact
   // rational at numeric points and stays symbolic otherwise.
@@ -2123,11 +2110,11 @@ fn cdf_log_series(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     ));
   }
   let t = dargs[0].clone();
-  let log_1mt = unary_fn("Log", minus2(int(1), t.clone()));
+  let log_1mt = call1("Log", minus2(int(1), t.clone()));
   // Beta[t, 1 + Floor[k], 0] — the incomplete beta B_t(1 + Floor[k], 0).
   let beta = call(
     "Beta",
-    vec![t, plus2(int(1), unary_fn("Floor", x.clone())), int(0)],
+    vec![t, plus2(int(1), call1("Floor", x.clone())), int(0)],
   );
   let value = plus2(int(1), div2(beta, log_1mt));
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(1));
@@ -2143,7 +2130,7 @@ fn cdf_geometric(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let p = dargs[0].clone();
   let one_minus_p = minus2(int(1), p);
-  let floor_k_plus_1 = plus2(call("Floor", vec![x.clone()]), int(1));
+  let floor_k_plus_1 = plus2(call1("Floor", x.clone()), int(1));
   let value = minus2(int(1), pow2(one_minus_p, floor_k_plus_1));
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -2164,7 +2151,7 @@ fn cdf_negative_binomial(
   }
   let n = dargs[0].clone();
   let p = dargs[1].clone();
-  let floor_k = call("Floor", vec![x.clone()]);
+  let floor_k = call1("Floor", x.clone());
   let value = call("BetaRegularized", vec![p, n, plus2(int(1), floor_k)]);
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -2182,7 +2169,7 @@ fn cdf_pascal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let n = dargs[0].clone();
   let p = dargs[1].clone();
-  let floor_k = call("Floor", vec![x.clone()]);
+  let floor_k = call1("Floor", x.clone());
   // 1 - n + Floor[k]
   let third = plus2(minus2(int(1), n.clone()), floor_k);
   let value = call("BetaRegularized", vec![p, n.clone(), third]);
@@ -2202,7 +2189,7 @@ fn cdf_cauchy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     }
   };
   // 1/2 + ArcTan[(x - a) / b] / Pi
-  let arctan = call("ArcTan", vec![div2(minus2(x, a), b)]);
+  let arctan = call1("ArcTan", div2(minus2(x, a), b));
   eval(plus2(
     call("Rational", vec![int(1), int(2)]),
     div2(arctan, pi()),
@@ -2224,7 +2211,7 @@ fn pdf_gamma(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // E^(-x/beta)
   let exp_part = pow2(e(), neg1(div2(x.clone(), beta.clone())));
   // beta^alpha * Gamma[alpha]
-  let denom = times2(pow2(beta, alpha.clone()), call("Gamma", vec![alpha]));
+  let denom = times2(pow2(beta, alpha.clone()), gamma(alpha));
   let value = eval(div2(times2(x_part, exp_part), denom))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -2266,7 +2253,7 @@ fn pdf_inverse_gamma(
   // E^(b/x)
   let exp_part = pow2(e(), div2(b, x.clone()));
   // x * Gamma[a]
-  let denom = times2(x.clone(), call("Gamma", vec![a]));
+  let denom = times2(x.clone(), gamma(a));
   let value = eval(div2(bx_a, times2(exp_part, denom)))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -2347,7 +2334,7 @@ fn pdf_inverse_chi_square(
   // E^(1/(2*x))
   let exp_part = pow2(e(), div2(int(1), times2(int(2), x.clone())));
   // Gamma[n/2]
-  let gamma_part = call("Gamma", vec![div2(n, int(2))]);
+  let gamma_part = gamma(div2(n, int(2)));
   let value =
     eval(div2(x_part, times2(two_part, times2(exp_part, gamma_part))))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
@@ -2557,14 +2544,14 @@ fn cdf_inverse_gaussian(
     times2(minus2(m.clone(), x.clone()), sqrt_lx.clone()),
     times2(sqrt(int(2)), m.clone()),
   );
-  let erfc1 = div2(call("Erfc", vec![erfc1_arg]), int(2));
+  let erfc1 = div2(call1("Erfc", erfc1_arg), int(2));
   // E^((2*l)/m) * Erfc[(Sqrt[l/x]*(m + x))/(Sqrt[2]*m)]/2
   let exp_part = pow2(e(), div2(times2(int(2), l), m.clone()));
   let erfc2_arg = div2(
     times2(sqrt_lx, plus2(m.clone(), x.clone())),
     times2(sqrt(int(2)), m),
   );
-  let erfc2 = div2(call("Erfc", vec![erfc2_arg]), int(2));
+  let erfc2 = div2(call1("Erfc", erfc2_arg), int(2));
   let value = eval(plus2(erfc1, times2(exp_part, erfc2)))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(value, cond)], int(0)))
@@ -2613,7 +2600,7 @@ pub fn probability_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && pairs.len() >= 2
   {
     if let Some(result) = try_joint_probability_discrete(event, &pairs)? {
-      return eval(call("Together", vec![result]));
+      return eval(call1("Together", result));
     }
     return unevaluated();
   }
@@ -2684,7 +2671,7 @@ pub fn probability_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Parse the event condition and compute probability
   let result = probability_from_event(event, var_name, dist, is_discrete)?;
   // Apply Together to normalize fractions (e.g. 1 - E^(-2) → (-1 + E^2)/E^2)
-  eval(call("Together", vec![result]))
+  eval(call1("Together", result))
 }
 
 /// True when `event` is a comparison chain (inequality/equality) or a logical
@@ -3552,7 +3539,7 @@ pub fn n_probability_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if matches!(&prob, Expr::FunctionCall { name, .. } if name == "Probability") {
     return Ok(unevaluated("NProbability", args));
   }
-  eval(call("N", vec![prob]))
+  eval(call1("N", prob))
 }
 
 /// Numerical wrapper for `Expectation` — returns `N[Expectation[…]]`.
@@ -3561,7 +3548,7 @@ pub fn n_expectation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if matches!(&exp, Expr::FunctionCall { name, .. } if name == "Expectation") {
     return Ok(unevaluated("NExpectation", args));
   }
-  eval(call("N", vec![exp]))
+  eval(call1("N", exp))
 }
 
 /// Implements `Expectation[f(x), x ~ CensoredDistribution[{a, b}, base]]`.
@@ -3853,12 +3840,9 @@ pub fn distribution_mean_variance(
       let var = div2(
         times2(
           pow2(k.clone(), div2(int(2), k.clone())),
-          times2(
-            pow2(s, int(2)),
-            call("Gamma", vec![div2(int(3), k.clone())]),
-          ),
+          times2(pow2(s, int(2)), gamma(div2(int(3), k.clone()))),
         ),
-        call("Gamma", vec![pow2(k, int(-1))]),
+        gamma(pow2(k, int(-1))),
       );
       Ok((m, var))
     }
@@ -4272,16 +4256,16 @@ pub fn distribution_mean_variance(
       // Simplify re-combines the Sqrt ratios that arise from evaluating the
       // half-integer Gammas (e.g. Sqrt[Pi]/Sqrt[2] -> Sqrt[Pi/2]).
       let k = dargs[0].clone();
-      let g_kp1 = unary_fn("Gamma", div2(plus2(int(1), k.clone()), int(2)));
-      let g_k = unary_fn("Gamma", div2(k.clone(), int(2)));
+      let g_kp1 = gamma(div2(plus2(int(1), k.clone()), int(2)));
+      let g_k = gamma(div2(k.clone(), int(2)));
       let mean_raw =
-        div2(times2(unary_fn("Sqrt", int(2)), g_kp1.clone()), g_k.clone());
-      let mean = eval(unary_fn("Simplify", mean_raw))?;
+        div2(times2(call1("Sqrt", int(2)), g_kp1.clone()), g_k.clone());
+      let mean = eval(call1("Simplify", mean_raw))?;
       let var_raw = minus2(
         k,
         div2(times2(int(2), pow2(g_kp1, int(2))), pow2(g_k, int(2))),
       );
-      let var = eval(unary_fn("Simplify", var_raw))?;
+      let var = eval(call1("Simplify", var_raw))?;
       Ok((mean, var))
     }
     "BinomialDistribution" => {
@@ -4507,10 +4491,8 @@ pub fn distribution_mean_variance(
       let a = dargs[0].clone();
       let b = dargs[1].clone();
       // Mean = b * Gamma[1 + 1/a]; the 3-argument form adds the location m.
-      let base_mean = times2(
-        b.clone(),
-        call("Gamma", vec![plus2(int(1), div2(int(1), a.clone()))]),
-      );
+      let base_mean =
+        times2(b.clone(), gamma(plus2(int(1), div2(int(1), a.clone()))));
       let mean = if dargs.len() == 3 {
         plus2(dargs[2].clone(), base_mean)
       } else {
@@ -4520,8 +4502,8 @@ pub fn distribution_mean_variance(
       let var = times2(
         pow2(b, int(2)),
         minus2(
-          call("Gamma", vec![plus2(int(1), div2(int(2), a.clone()))]),
-          pow2(call("Gamma", vec![plus2(int(1), div2(int(1), a))]), int(2)),
+          gamma(plus2(int(1), div2(int(2), a.clone()))),
+          pow2(gamma(plus2(int(1), div2(int(1), a))), int(2)),
         ),
       );
       Ok((mean, var))
@@ -4636,7 +4618,7 @@ pub fn distribution_mean_variance(
       let mean_branch = match &type_ {
         Expr::Integer(0) => {
           let tan_arg = div2(times2(alpha.clone(), pi()), int(2));
-          let tan_term = call("Tan", vec![tan_arg]);
+          let tan_term = call1("Tan", tan_arg);
           minus2(mu.clone(), times2(times2(beta, sigma.clone()), tan_term))
         }
         _ => mu.clone(),
@@ -4731,8 +4713,7 @@ pub fn distribution_mean_variance(
         None
       };
       // Mean = Piecewise[{{μ + b * Gamma[1 - 1/a], 1 < a}}, Infinity]
-      let gamma_1_minus_inv_a =
-        call("Gamma", vec![minus2(int(1), div2(int(1), a.clone()))]);
+      let gamma_1_minus_inv_a = gamma(minus2(int(1), div2(int(1), a.clone())));
       let b_gamma = times2(b.clone(), gamma_1_minus_inv_a.clone());
       let mean_value = match &mu {
         Some(m) => plus2(m.clone(), b_gamma),
@@ -4747,8 +4728,7 @@ pub fn distribution_mean_variance(
       );
       // Var = Piecewise[{{b^2 * (Gamma[1 - 2/a] - Gamma[1 - 1/a]^2), a > 2}}, Infinity]
       // (Variance is translation-invariant — μ drops out.)
-      let gamma_1_minus_2_a =
-        call("Gamma", vec![minus2(int(1), div2(int(2), a.clone()))]);
+      let gamma_1_minus_2_a = gamma(minus2(int(1), div2(int(2), a.clone())));
       let var = piecewise(
         vec![(
           times2(
@@ -4796,14 +4776,14 @@ pub fn distribution_mean_variance(
         m,
         times2(
           times2(a.clone(), d.clone()),
-          unary_fn("Tan", div2(b.clone(), int(2))),
+          call1("Tan", div2(b.clone(), int(2))),
         ),
       );
       // Variance = a^2 d Sec[b/2]^2 / 2
       let var = div2(
         times2(
           times2(pow2(a, int(2)), d),
-          pow2(unary_fn("Sec", div2(b, int(2))), int(2)),
+          pow2(call1("Sec", div2(b, int(2))), int(2)),
         ),
         int(2),
       );
@@ -4851,7 +4831,7 @@ pub fn distribution_mean_variance(
         ));
       }
       let t = dargs[0].clone();
-      let log_1mt = unary_fn("Log", minus2(int(1), t.clone()));
+      let log_1mt = call1("Log", minus2(int(1), t.clone()));
       // Mean = -(t/((1 - t) Log[1 - t]))
       let mean = times2(
         int(-1),
@@ -4896,7 +4876,7 @@ pub fn distribution_mean_variance(
       }
       let g = dargs[0].clone();
       let s = dargs[1].clone();
-      let csc = |arg: Expr| call("Csc", vec![arg]);
+      let csc = |arg: Expr| call1("Csc", arg);
       // Mean = Piecewise[{{(Pi s Csc[Pi/g])/g, g > 1}}, Indeterminate]
       let mean_val = div2(
         times2(times2(pi(), s.clone()), csc(div2(pi(), g.clone()))),
@@ -5624,7 +5604,7 @@ fn pdf_pert(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let cond = comparison3(a, ComparisonOp::Less, x, ComparisonOp::Less, b);
   let result = eval(piecewise(vec![(value, cond)], int(0)))?;
   if real_arg {
-    return eval(unary_fn("N", result));
+    return eval(call1("N", result));
   }
   Ok(result)
 }
@@ -5663,7 +5643,7 @@ fn cdf_pert(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let cond2 = comparison(x, ComparisonOp::GreaterEqual, b);
   let result = eval(piecewise(vec![(reg, cond1), (int(1), cond2)], int(0)))?;
   if real_arg {
-    return eval(unary_fn("N", result));
+    return eval(call1("N", result));
   }
   Ok(result)
 }
@@ -5708,7 +5688,7 @@ fn pdf_power(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // wolframscript numericizes the whole result for machine-real arguments
   // (0. and 1. outside the support), unlike most other distributions.
   if real_arg {
-    return eval(unary_fn("N", result));
+    return eval(call1("N", result));
   }
   Ok(result)
 }
@@ -5749,7 +5729,7 @@ fn cdf_power(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let cond2 = comparison(x, ComparisonOp::Greater, pow2(k, int(-1)));
   let result = eval(piecewise(vec![(value, cond1), (int(1), cond2)], int(0)))?;
   if real_arg {
-    return eval(unary_fn("N", result));
+    return eval(call1("N", result));
   }
   Ok(result)
 }
@@ -5806,13 +5786,10 @@ fn pdf_loggamma(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let (a, b, m) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
   // 1 - m + x
   let shifted = plus2(plus2(int(1), times2(int(-1), m.clone())), x.clone());
-  let num = pow2(unary_fn("Log", shifted.clone()), minus2(a.clone(), int(1)));
+  let num = pow2(call1("Log", shifted.clone()), minus2(a.clone(), int(1)));
   let den = times2(
     pow2(b.clone(), a.clone()),
-    times2(
-      pow2(shifted, div2(plus2(int(1), b.clone()), b)),
-      unary_fn("Gamma", a),
-    ),
+    times2(pow2(shifted, div2(plus2(int(1), b.clone()), b)), gamma(a)),
   );
   let value = div2(num, den);
   let cond = comparison(x, ComparisonOp::GreaterEqual, m);
@@ -5831,7 +5808,7 @@ fn cdf_loggamma(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let shifted = plus2(plus2(int(1), times2(int(-1), m.clone())), x.clone());
   let reg = call(
     "GammaRegularized",
-    vec![a, int(0), div2(unary_fn("Log", shifted), b)],
+    vec![a, int(0), div2(call1("Log", shifted), b)],
   );
   let cond = comparison(x, ComparisonOp::GreaterEqual, m);
   eval(piecewise(vec![(reg, cond)], int(0)))
@@ -5962,7 +5939,7 @@ fn pdf_lognormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let sigma = dargs[1].clone();
 
   // 1 / (E^((Log[x] - mu)^2 / (2*sigma^2)) * Sqrt[2*Pi] * sigma * x)
-  let log_x = call("Log", vec![x.clone()]);
+  let log_x = call1("Log", x.clone());
   let exponent = div2(
     pow2(minus2(log_x, mu), int(2)),
     times2(int(2), pow2(sigma.clone(), int(2))),
@@ -5992,9 +5969,9 @@ fn cdf_lognormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let sigma = dargs[1].clone();
 
   // Erfc[-(Log[x] - mu) / (Sqrt[2] * sigma)] / 2
-  let log_x = call("Log", vec![x.clone()]);
+  let log_x = call1("Log", x.clone());
   let arg = neg1(div2(minus2(log_x, mu), times2(sqrt(int(2)), sigma)));
-  let cdf_val = div2(call("Erfc", vec![arg]), int(2));
+  let cdf_val = div2(call1("Erfc", arg), int(2));
 
   // Piecewise[{{cdf_val, x > 0}}, 0]
   let cond = comparison(x, ComparisonOp::Greater, int(0));
@@ -6017,7 +5994,7 @@ fn pdf_chi_square(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // E^(x/2)
   let exp_part = pow2(e(), div2(x.clone(), int(2)));
   // Gamma[k/2]
-  let gamma_part = call("Gamma", vec![div2(k, int(2))]);
+  let gamma_part = gamma(div2(k, int(2)));
   let denom = times2(times2(two_power, exp_part), gamma_part);
   let pdf_val = div2(x_power, denom);
 
@@ -6132,7 +6109,7 @@ fn pdf_waring_yule(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
 fn cdf_waring_yule(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   if dargs.len() == 1 {
     let a = dargs[0].clone();
-    let floor_k = call("Floor", vec![x.clone()]);
+    let floor_k = call1("Floor", x.clone());
     let beta = call("Beta", vec![a.clone(), plus2(int(2), floor_k)]);
     let cdf = minus2(int(1), times2(a, beta));
     let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
@@ -6146,7 +6123,7 @@ fn cdf_waring_yule(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let a = dargs[0].clone();
   let b = dargs[1].clone();
 
-  let floor_k = call("Floor", vec![x.clone()]);
+  let floor_k = call1("Floor", x.clone());
   let idx = plus2(int(1), floor_k);
   let poch =
     |first: Expr, second: Expr| call("Pochhammer", vec![first, second]);
@@ -6374,7 +6351,7 @@ fn cdf_discrete_uniform(
     }
   };
   let n = eval(plus2(minus2(imax.clone(), imin.clone()), int(1)))?;
-  let floor_x = call("Floor", vec![x.clone()]);
+  let floor_x = call1("Floor", x.clone());
   let cdf_val = div2(plus2(minus2(floor_x, imin.clone()), int(1)), n);
   let cond_low = comparison(x.clone(), ComparisonOp::Less, imin.clone());
   let cond_mid = comparison3(
@@ -6649,7 +6626,7 @@ fn failure_read_once_form(bexpr: &Expr) -> Option<Expr> {
     Expr::Integer(i) => Some(Expr::Identifier(format!("{PREFIX}{i}"))),
     _ => None,
   });
-  let minimized = eval(call("BooleanMinimize", vec![to_symbol])).ok()?;
+  let minimized = eval(call1("BooleanMinimize", to_symbol)).ok()?;
   Some(map_leaves(&minimized, &|e| match e {
     Expr::Identifier(s) => s
       .strip_prefix(PREFIX)
@@ -6943,7 +6920,7 @@ pub fn process_slice_distribution(
   dargs: &[Expr],
   t: &Expr,
 ) -> Option<Expr> {
-  let sqrt_t = call("Sqrt", vec![t.clone()]);
+  let sqrt_t = call1("Sqrt", t.clone());
   match proc_name {
     "WienerProcess" if dargs.len() == 2 => Some(call(
       "NormalDistribution",
@@ -6963,7 +6940,7 @@ pub fn process_slice_distribution(
     )),
     // A Bernoulli process' slice does not depend on the time.
     "BernoulliProcess" if dargs.len() == 1 => {
-      Some(call("BernoulliDistribution", vec![dargs[0].clone()]))
+      Some(call1("BernoulliDistribution", dargs[0].clone()))
     }
     // White noise is the underlying distribution at every time.
     "WhiteNoiseProcess"
@@ -6979,7 +6956,7 @@ pub fn process_slice_distribution(
         "NormalDistribution",
         vec![
           m.clone(),
-          div2(sp.clone(), call("Sqrt", vec![times2(int(2), th.clone())])),
+          div2(sp.clone(), call1("Sqrt", times2(int(2), th.clone()))),
         ],
       ))
     }
@@ -7003,10 +6980,7 @@ pub fn process_slice_distribution(
         ),
         times2(int(2), th.clone()),
       );
-      Some(call(
-        "NormalDistribution",
-        vec![mu, call("Sqrt", vec![var])],
-      ))
+      Some(call("NormalDistribution", vec![mu, call1("Sqrt", var)]))
     }
     // BrownianBridgeProcess[s, {t1, a}, {t2, b}] — the interpolating
     // Gaussian bridge.
@@ -7031,7 +7005,7 @@ pub fn process_slice_distribution(
       // wolframscript's SliceDistribution display
       // s*Sqrt[((t - t1)*(-t + t2))/(-t1 + t2)].
       let sigma =
-        times2(sp.clone(), call("Sqrt", vec![div2(times2(up, down), span)]));
+        times2(sp.clone(), call1("Sqrt", div2(times2(up, down), span)));
       Some(call("NormalDistribution", vec![mu, sigma]))
     }
     "GeometricBrownianMotionProcess" if dargs.len() == 3 => {
@@ -7043,7 +7017,7 @@ pub fn process_slice_distribution(
           pow2(s.clone(), int(2)),
         ),
       );
-      let mu = plus2(times2(drift, t.clone()), call("Log", vec![x0.clone()]));
+      let mu = plus2(times2(drift, t.clone()), call1("Log", x0.clone()));
       Some(call(
         "LogNormalDistribution",
         vec![mu, times2(s.clone(), sqrt_t)],
@@ -7871,7 +7845,7 @@ fn hoyt_mean_variance(
     "EllipticE",
     vec![plus2(int(1), times2(int(-1), pow2(q, int(2))))],
   );
-  let sqrt = |e: Expr| call("Sqrt", vec![e]);
+  let sqrt = |e: Expr| call1("Sqrt", e);
   let mean = call(
     "Times",
     vec![
@@ -7964,8 +7938,8 @@ fn variance_gamma_pdf(
     dargs[2].clone(),
     dargs[3].clone(),
   );
-  let sqrt_pi = call("Sqrt", vec![pi()]);
-  let gamma_l = call("Gamma", vec![l.clone()]);
+  let sqrt_pi = call1("Sqrt", pi());
+  let gamma_l = gamma(l.clone());
   let half_minus_l = plus2(div2(int(1), int(2)), times2(int(-1), l.clone()));
   let a2b2 = times2(
     plus2(a.clone(), times2(int(-1), b.clone())),
@@ -8005,7 +7979,7 @@ fn variance_gamma_pdf(
       vec![
         pow2(a.clone(), plus2(int(1), times2(int(-2), l.clone()))),
         pow2(a2b2, l.clone()),
-        call("Gamma", vec![plus2(div2(int(-1), int(2)), l.clone())]),
+        gamma(plus2(div2(int(-1), int(2)), l.clone())),
       ],
     ),
     times2(times2(int(2), sqrt_pi), gamma_l),
@@ -8130,7 +8104,7 @@ struct TsallisParts {
 }
 
 fn tsallis_parts(m: &Expr, b: &Expr, q: &Expr, x: &Expr) -> TsallisParts {
-  let sqrt = |e: Expr| call("Sqrt", vec![e]);
+  let sqrt = |e: Expr| call1("Sqrt", e);
   let two_pi = times2(int(2), pi());
   let m_minus_x = plus2(m.clone(), times2(int(-1), x.clone()));
   let qm1 = plus2(int(-1), q.clone());
@@ -8317,7 +8291,7 @@ fn tsallis_qgaussian_cdf(
         "Erf",
         vec![div2(
           plus2(times2(int(-1), m.clone()), x.clone()),
-          times2(call("Sqrt", vec![int(2)]), b.clone()),
+          times2(call1("Sqrt", int(2)), b.clone()),
         )],
       ),
     ),
@@ -8480,10 +8454,7 @@ fn tukey_lambda_pdf_cdf(
     if want_pdf {
       let v = div2(
         plus2(int(1), times2(int(-1), c.clone())),
-        times2(
-          int(2),
-          call("Sqrt", vec![plus2(int(2), times2(int(-1), c))]),
-        ),
+        times2(int(2), call1("Sqrt", plus2(int(2), times2(int(-1), c)))),
       );
       Some((vec![(v, cond)], int(0)))
     } else {
@@ -8491,7 +8462,7 @@ fn tukey_lambda_pdf_cdf(
         int(4),
         times2(
           y.clone(),
-          call("Sqrt", vec![plus2(int(8), times2(int(-1), sq(&y)))]),
+          call1("Sqrt", plus2(int(8), times2(int(-1), sq(&y)))),
         ),
       );
       // Float λ folds the 1/8 into a 0.125 prefactor, like wolframscript.
@@ -8536,10 +8507,7 @@ fn tukey_lambda_pdf_cdf(
           int(1),
           times2(
             int(-1),
-            pow2(
-              call("Sqrt", vec![plus2(int(1), div2(sq(&y), int(4)))]),
-              int(-1),
-            ),
+            pow2(call1("Sqrt", plus2(int(1), div2(sq(&y), int(4)))), int(-1)),
           ),
         ),
         sq(&y),
@@ -8549,7 +8517,7 @@ fn tukey_lambda_pdf_cdf(
       let v = div2(
         plus2(
           plus2(int(-2), y.clone()),
-          call("Sqrt", vec![plus2(int(4), sq(&y))]),
+          call1("Sqrt", plus2(int(4), sq(&y))),
         ),
         times2(int(2), y.clone()),
       );
@@ -9031,8 +8999,8 @@ fn benini_mean_variance(
     ));
   };
   let (a, b, sg) = (dargs[0].clone(), dargs[1].clone(), dargs[2].clone());
-  let sqrt_pi = call("Sqrt", vec![pi()]);
-  let sqrt_b = call("Sqrt", vec![b.clone()]);
+  let sqrt_pi = call1("Sqrt", pi());
+  let sqrt_b = call1("Sqrt", b.clone());
   // Shared pieces for shift k: E^((-k+a)^2/(4β)) and Erfc[(-k+a)/(2√β)].
   let shifted = |k: i128, denom_scale: i128| -> (Expr, Expr) {
     let base = plus2(int(-k), a.clone());
@@ -10466,7 +10434,7 @@ fn cdf_half_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let t = dargs[0].clone();
   let erf_arg = div2(times2(t, x.clone()), sqrt(pi()));
-  let erf_val = call("Erf", vec![erf_arg]);
+  let erf_val = call1("Erf", erf_arg);
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(erf_val, cond)], int(0)))
 }
@@ -10486,7 +10454,7 @@ fn pdf_chi(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // E^(x^2/2)
   let exp_part = pow2(e(), div2(pow2(x.clone(), int(2)), int(2)));
   // Gamma[n/2]
-  let gamma_part = call("Gamma", vec![div2(n, int(2))]);
+  let gamma_part = gamma(div2(n, int(2)));
   let pdf_val = eval(div2(times2(exp2, x_pow), times2(exp_part, gamma_part)))?;
   let cond = comparison(x, ComparisonOp::Greater, int(0));
   eval(piecewise(vec![(pdf_val, cond)], int(0)))
@@ -10878,7 +10846,7 @@ fn pdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       // PDF = delta / (E^(z^2/2) * Sqrt[2*Pi] * Sqrt[sigma^2 + (-mu + x)^2])
       // where z = gamma + delta*ArcSinh[(-mu + x)/sigma]
       let arcsinh_t =
-        call("ArcSinh", vec![div2(neg_mu_plus_x.clone(), sigma.clone())]);
+        call1("ArcSinh", div2(neg_mu_plus_x.clone(), sigma.clone()));
       let z = plus2(gamma, times2(delta.clone(), arcsinh_t));
       let density = div2(
         delta,
@@ -10898,7 +10866,7 @@ fn pdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       let mu_plus_sigma_minus_x =
         plus2(plus2(mu.clone(), sigma.clone()), neg1(x.clone()));
       let log_arg = div2(neg_mu_plus_x.clone(), mu_plus_sigma_minus_x.clone());
-      let log_t = call("Log", vec![log_arg]);
+      let log_t = call1("Log", log_arg);
       let z = plus2(gamma, times2(delta.clone(), log_t));
       let density = div2(
         times2(delta, sigma.clone()),
@@ -10962,8 +10930,8 @@ fn cdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // where h depends on type
   let h_of_t = match type_str.as_str() {
     "SN" => t.clone(),
-    "SL" => call("Log", vec![t.clone()]),
-    "SU" => call("ArcSinh", vec![t.clone()]),
+    "SL" => call1("Log", t.clone()),
+    "SU" => call1("ArcSinh", t.clone()),
     "SB" => {
       let mu_plus_sigma_minus_x =
         plus2(plus2(mu.clone(), sigma.clone()), neg1(x.clone()));
@@ -10980,11 +10948,11 @@ fn cdf_johnson(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let neg_gamma = neg1(gamma.clone());
   let neg_delta_h = neg1(times2(delta.clone(), h_of_t.clone()));
   let erfc_arg = div2(plus2(neg_gamma, neg_delta_h), sqrt(int(2)));
-  let cdf_val = div2(call("Erfc", vec![erfc_arg]), int(2));
+  let cdf_val = div2(call1("Erfc", erfc_arg), int(2));
 
   // Also build (1 + Erf[(gamma + delta*h) / Sqrt[2]]) / 2 form (used by Wolfram for some types)
   let erf_arg = div2(plus2(gamma, times2(delta, h_of_t)), sqrt(int(2)));
-  let cdf_erf = div2(plus2(int(1), call("Erf", vec![erf_arg])), int(2));
+  let cdf_erf = div2(plus2(int(1), call1("Erf", erf_arg)), int(2));
 
   match type_str.as_str() {
     "SN" => eval(cdf_val),
@@ -11197,7 +11165,7 @@ pub fn log_likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let n = data.len() as i128;
 
-  let log_of = |e: Expr| call("Log", vec![e]);
+  let log_of = |e: Expr| call1("Log", e);
   let sum_expr =
     || -> Result<Expr, InterpreterError> { eval(unevaluated("Plus", data)) };
 
@@ -11555,7 +11523,7 @@ fn distribution_raw_moment(
       let (a, b) = (dargs[0].clone(), dargs[1].clone());
       let result = times2(
         pow2(b.clone(), int(k)),
-        call("Gamma", vec![plus2(int(1), div2(int(k), a.clone()))]),
+        gamma(plus2(int(1), div2(int(k), a.clone()))),
       );
       if numeric(&a) && numeric(&b) {
         eval(result).ok()
@@ -11571,7 +11539,7 @@ fn distribution_raw_moment(
       let result = div2(
         times2(
           pow2(pi(), div2(int(k - 1), int(2))),
-          call("Gamma", vec![div2(int(k + 1), int(2))]),
+          gamma(div2(int(k + 1), int(2))),
         ),
         pow2(t, int(k)),
       );
@@ -11707,7 +11675,6 @@ pub fn transformed_distribution_ast(
   }
   let a_positive = af.0 > 0;
 
-  let dist_call = |name: &str, params: Vec<Expr>| call(name, params);
   let linear = |e: &Expr| -> Result<Expr, InterpreterError> {
     // a*e + b
     eval(plus2(times2(a.clone(), e.clone()), b.clone()))
@@ -11718,29 +11685,29 @@ pub fn transformed_distribution_ast(
       let new_m = linear(m)?;
       let abs_a = frac_to_rational_expr((af.0.abs(), af.1));
       let new_s = eval(times2(abs_a, s.clone()))?;
-      Ok(dist_call("NormalDistribution", vec![new_m, new_s]))
+      Ok(call("NormalDistribution", vec![new_m, new_s]))
     }
     ("NormalDistribution", []) => {
       let new_m = eval(b.clone())?;
       let new_s = frac_to_rational_expr((af.0.abs(), af.1));
-      Ok(dist_call("NormalDistribution", vec![new_m, new_s]))
+      Ok(call("NormalDistribution", vec![new_m, new_s]))
     }
     ("UniformDistribution", [Expr::List(bounds)]) if bounds.len() == 2 => {
       let p = linear(&bounds[0])?;
       let q = linear(&bounds[1])?;
       let (lo, hi) = if a_positive { (p, q) } else { (q, p) };
-      Ok(dist_call(
+      Ok(call(
         "UniformDistribution",
         vec![Expr::List(vec![lo, hi].into())],
       ))
     }
     ("ExponentialDistribution", [l]) if a_positive && bf.0 == 0 => {
       let new_l = eval(div2(l.clone(), a.clone()))?;
-      Ok(dist_call("ExponentialDistribution", vec![new_l]))
+      Ok(call1("ExponentialDistribution", new_l))
     }
     ("GammaDistribution", [al, be]) if a_positive && bf.0 == 0 => {
       let new_be = eval(times2(a.clone(), be.clone()))?;
-      Ok(dist_call("GammaDistribution", vec![al.clone(), new_be]))
+      Ok(call("GammaDistribution", vec![al.clone(), new_be]))
     }
     _ => Ok(unevaluated(args)),
   }
@@ -11829,14 +11796,14 @@ fn pdf_multinormal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let det: i128 = variances.iter().product();
   let denominator = if k == 2 {
     // 2*Pi, 2*Sqrt[det]*Pi, or (2*sqrt)*Pi when det is a perfect square
-    let sqrt_det = eval(call("Sqrt", vec![int(det)]))?;
+    let sqrt_det = eval(call1("Sqrt", int(det)))?;
     match &sqrt_det {
       Expr::Integer(s) => times2(int(2 * s), pi()),
       _ => call("Times", vec![int(2), sqrt_det, pi()]),
     }
   } else {
     // k == 3: 2*Sqrt[2*det]*Pi^(3/2)
-    let sqrt_part = eval(call("Sqrt", vec![int(2 * det)]))?;
+    let sqrt_part = eval(call1("Sqrt", int(2 * det)))?;
     let pi_pow = pow2(pi(), make_rational(3, 2));
     match &sqrt_part {
       Expr::Integer(s) => call("Times", vec![int(2 * s), pi_pow]),
@@ -12148,7 +12115,7 @@ fn histogram_pdf_cdf(
   cumulative: bool,
 ) -> Option<Result<Expr, InterpreterError>> {
   let (weights, edges) = histogram_parts(dargs)?;
-  let boole = |cond: Expr| call("Boole", vec![cond]);
+  let boole = |cond: Expr| call1("Boole", cond);
   // At a numeric point the sum is evaluated down to its value; at a symbolic
   // point the built form is returned as-is, preserving wolframscript's term
   // order (CDF leads with Boole[x >= last] and the bins follow ascending),
@@ -12483,7 +12450,7 @@ fn pdf_product_distribution(
     }
   }
   let e_pow = pow2(Expr::Identifier("E".to_string()), call("Plus", terms));
-  let sqrt = |e: Expr| call("Sqrt", vec![e]);
+  let sqrt = |e: Expr| call1("Sqrt", e);
 
   // Assemble the density with wolframscript's coefficient shapes
   let value = match normal_count {
@@ -13210,7 +13177,7 @@ fn pdf_noncentral_chi_square(
   }
   let (nu, lam) = (dargs[0].clone(), dargs[1].clone());
   let raw_div = |a: Expr, b: Expr| div2(a, b);
-  let sqrt = |e: Expr| call("Sqrt", vec![e]);
+  let sqrt = |e: Expr| call1("Sqrt", e);
   let int_of = |e: &Expr| -> Option<i128> {
     match e {
       Expr::Integer(v) => Some(*v),
@@ -13294,7 +13261,7 @@ fn pdf_noncentral_chi_square(
         // Cosh[Sqrt[l] Sqrt[x]] / (Sqrt[2 Pi] Sqrt[x])
         let arg = eval(times2(sqrt(lam.clone()), sqrt(at.clone())))?;
         Ok(Some(raw_div(
-          call("Times", vec![e_part(at)?, call("Cosh", vec![arg])]),
+          call("Times", vec![e_part(at)?, call1("Cosh", arg)]),
           call(
             "Times",
             vec![sqrt(call("Times", vec![int(2), pi()])), sqrt(at.clone())],
@@ -13306,7 +13273,7 @@ fn pdf_noncentral_chi_square(
         let arg = eval(times2(sqrt(lam.clone()), sqrt(at.clone())))?;
         let den = eval(sqrt(times2(times2(int(2), lam.clone()), pi())))?;
         Ok(Some(raw_div(
-          call("Times", vec![e_part(at)?, call("Sinh", vec![arg])]),
+          call("Times", vec![e_part(at)?, call1("Sinh", arg)]),
           den,
         )))
       }
@@ -13398,9 +13365,9 @@ fn cdf_noncentral_chi_square(
       "MarcumQ",
       vec![
         eval(div2(nu.clone(), int(2)))?,
-        eval(call("Sqrt", vec![lam.clone()]))?,
+        eval(call1("Sqrt", lam.clone()))?,
         int(0),
-        call("Sqrt", vec![at.clone()]),
+        call1("Sqrt", at.clone()),
       ],
     ))
   };
@@ -13454,16 +13421,13 @@ fn pdf_exponential_power(
 
   // 2 k^(1/k) s Gamma[1 + 1/k], with the k = 2 Sqrt[2 Pi] merge
   let coef: Vec<Expr> = if matches!(&k, Expr::Integer(2)) {
-    vec![
-      s.clone(),
-      call("Sqrt", vec![call("Times", vec![int(2), pi()])]),
-    ]
+    vec![s.clone(), call1("Sqrt", call("Times", vec![int(2), pi()]))]
   } else {
     vec![
       int(2),
       pow2(k.clone(), pow2(k.clone(), int(-1))),
       s.clone(),
-      call("Gamma", vec![plus2(int(1), pow2(k.clone(), int(-1)))]),
+      gamma(plus2(int(1), pow2(k.clone(), int(-1)))),
     ]
   };
   let branch = |diff: Expr| -> Result<Expr, InterpreterError> {
@@ -13644,7 +13608,7 @@ pub fn rice_mean_variance(
   b: &Expr,
 ) -> Result<(Expr, Expr), InterpreterError> {
   let square = |e: &Expr| pow2(e.clone(), int(2));
-  let sqrt_half_pi = call("Sqrt", vec![div2(pi(), int(2))]);
+  let sqrt_half_pi = call1("Sqrt", div2(pi(), int(2)));
   let numeric_params = rice_numeric(a).is_some() && rice_numeric(b).is_some();
   if numeric_params {
     // k = a^2/(2 b^2) as an exact fraction p/q; wolframscript pulls
@@ -14117,7 +14081,6 @@ fn min_stable_mean_variance(
       int(6),
     )
   };
-  let gamma_of = |inner: Expr| call("Gamma", vec![inner]);
   let one_minus_g = call(
     "Plus",
     vec![int(1), call("Times", vec![int(-1), g.clone()])],
@@ -14131,7 +14094,7 @@ fn min_stable_mean_variance(
         call("Times", vec![a.clone(), g.clone()]),
         call(
           "Times",
-          vec![int(-1), b.clone(), gamma_of(one_minus_g.clone())],
+          vec![int(-1), b.clone(), gamma(one_minus_g.clone())],
         ),
       ],
     ),
@@ -14150,8 +14113,8 @@ fn min_stable_mean_variance(
         call(
           "Plus",
           vec![
-            gamma_of(one_minus_2g),
-            call("Times", vec![int(-1), pow2(gamma_of(one_minus_g), int(2))]),
+            gamma(one_minus_2g),
+            call("Times", vec![int(-1), pow2(gamma(one_minus_g), int(2))]),
           ],
         ),
       ],
@@ -14476,10 +14439,7 @@ fn max_stable_mean_variance(
       vec![
         call("Times", vec![int(-1), b.clone()]),
         call("Times", vec![a.clone(), g.clone()]),
-        call(
-          "Times",
-          vec![b.clone(), call("Gamma", vec![one_minus_g.clone()])],
-        ),
+        call("Times", vec![b.clone(), gamma(one_minus_g.clone())]),
       ],
     ),
     g.clone(),
@@ -14801,11 +14761,11 @@ fn triangular_mean_variance(
   // 2-argument form TriangularDistribution[{a, b}] (mode c = (a+b)/2) to
   // wolframscript's Mean (a+b)/2 and Variance (b-a)^2/24, while leaving the
   // genuine 3-parameter forms unchanged.
-  let mean = eval(unary_fn(
+  let mean = eval(call1(
     "Simplify",
     div2(plus2(plus2(a.clone(), b.clone()), c.clone()), int(3)),
   ))?;
-  let var = eval(unary_fn(
+  let var = eval(call1(
     "Simplify",
     div2(
       call(
@@ -14854,7 +14814,7 @@ fn maxwell_term(
       den_factors.push(int(c));
     }
     den_factors.push(e_part);
-    den_factors.push(call("Sqrt", vec![times2(int(2), pi())]));
+    den_factors.push(call1("Sqrt", times2(int(2), pi())));
     div2(num_expr, call("Times", den_factors))
   } else {
     // (p Sqrt[2/Pi] num)/(m E-part)
@@ -14862,7 +14822,7 @@ fn maxwell_term(
     if r_num != 1 {
       num_factors.push(int(r_num));
     }
-    num_factors.push(call("Sqrt", vec![div2(int(2), pi())]));
+    num_factors.push(call1("Sqrt", div2(int(2), pi())));
     num_factors.push(numerator);
     let den = if m > 1 {
       call("Times", vec![int(m), e_part])
@@ -14897,7 +14857,7 @@ fn pdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     return Ok(unevaluated(dargs, x));
   }
   let s = dargs[0].clone();
-  let sqrt_2_pi = call("Sqrt", vec![div2(int(2), pi())]);
+  let sqrt_2_pi = call1("Sqrt", div2(int(2), pi()));
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     let e_part = pow2(
       e(),
@@ -14961,7 +14921,7 @@ fn cdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     return Ok(unevaluated(dargs, x));
   }
   let s = dargs[0].clone();
-  let sqrt_2_pi = call("Sqrt", vec![div2(int(2), pi())]);
+  let sqrt_2_pi = call1("Sqrt", div2(int(2), pi()));
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     if ms_numeric(at).is_none()
       && let Some((sp, sq)) = maxwell_rational(&s)
@@ -14979,7 +14939,7 @@ fn cdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
         "Erf",
         vec![eval(div2(
           at.clone(),
-          call("Times", vec![call("Sqrt", vec![int(2)]), s.clone()]),
+          call("Times", vec![call1("Sqrt", int(2)), s.clone()]),
         ))?],
       );
       return Ok(call("Plus", vec![term1, erf]));
@@ -15013,7 +14973,7 @@ fn cdf_maxwell(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
           "Erf",
           vec![div2(
             at.clone(),
-            call("Times", vec![call("Sqrt", vec![int(2)]), s.clone()]),
+            call("Times", vec![call1("Sqrt", int(2)), s.clone()]),
           )],
         ),
       ],
@@ -15063,11 +15023,8 @@ fn pdf_birnbaum_saunders(
     let denom = times2(
       times2(int(2), a.clone()),
       times2(
-        times2(
-          pow2(e(), exponent),
-          call("Sqrt", vec![times2(int(2), pi())]),
-        ),
-        call("Sqrt", vec![times2(l.clone(), pow2(at.clone(), int(3)))]),
+        times2(pow2(e(), exponent), call1("Sqrt", times2(int(2), pi()))),
+        call1("Sqrt", times2(l.clone(), pow2(at.clone(), int(3)))),
       ),
     );
     eval(div2(plus2(int(1), times2(l.clone(), at.clone())), denom))
@@ -15108,11 +15065,11 @@ fn cdf_birnbaum_saunders(
     let erf_arg = div2(
       plus2(int(-1), times2(l.clone(), at.clone())),
       times2(
-        times2(call("Sqrt", vec![int(2)]), a.clone()),
-        call("Sqrt", vec![times2(l.clone(), at.clone())]),
+        times2(call1("Sqrt", int(2)), a.clone()),
+        call1("Sqrt", times2(l.clone(), at.clone())),
       ),
     );
-    eval(div2(plus2(int(1), call("Erf", vec![erf_arg])), int(2)))
+    eval(div2(plus2(int(1), call1("Erf", erf_arg)), int(2)))
   };
   if ms_numeric(&x).is_some() {
     if ms_numeric(&x).is_some_and(|v| v <= 0.0) {
@@ -15147,7 +15104,7 @@ fn pdf_levy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     let denom = times2(
       times2(
         pow2(e(), div2(s.clone(), times2(int(2), sh))),
-        call("Sqrt", vec![times2(int(2), pi())]),
+        call1("Sqrt", times2(int(2), pi())),
       ),
       s.clone(),
     );
@@ -15182,10 +15139,10 @@ fn cdf_levy(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   let shift = |at: &Expr| plus2(times2(int(-1), m.clone()), at.clone());
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     let erfc_arg = div2(
-      call("Sqrt", vec![div2(s.clone(), shift(at))]),
-      call("Sqrt", vec![int(2)]),
+      call1("Sqrt", div2(s.clone(), shift(at))),
+      call1("Sqrt", int(2)),
     );
-    eval(call("Erfc", vec![erfc_arg]))
+    eval(call1("Erfc", erfc_arg))
   };
   if let (Some(mv), Some(xv)) = (ms_numeric(&m), ms_numeric(&x)) {
     if xv <= mv {
@@ -15273,7 +15230,7 @@ pub fn maxwell_mean_variance(
 ) -> Result<(Expr, Expr), InterpreterError> {
   let mean = eval(call(
     "Times",
-    vec![int(2), call("Sqrt", vec![div2(int(2), pi())]), s.clone()],
+    vec![int(2), call1("Sqrt", div2(int(2), pi())), s.clone()],
   ))?;
   let var = if ms_numeric(s).is_some() {
     eval(div2(
@@ -15343,7 +15300,7 @@ fn pdf_wigner_semicircle(
       ],
     );
     eval(div2(
-      call("Times", vec![int(2), call("Sqrt", vec![inner])]),
+      call("Times", vec![int(2), call1("Sqrt", inner)]),
       call("Times", vec![pi(), r.clone()]),
     ))
   };
@@ -15415,7 +15372,7 @@ fn cdf_wigner_semicircle(
     );
     // The x-before-Sqrt factor order matches wolframscript, so the
     // middle term stays raw with evaluated subparts
-    let sqrt_part = call("Sqrt", vec![eval(inner)?]);
+    let sqrt_part = call1("Sqrt", eval(inner)?);
     let denom = eval(call("Times", vec![pi(), r.clone()]))?;
     let arcsin_arg = eval(div2(d.clone(), r.clone()))?;
     Ok(call(
@@ -15433,7 +15390,7 @@ fn cdf_wigner_semicircle(
           },
           denom,
         ),
-        div2(call("ArcSin", vec![arcsin_arg]), pi()),
+        div2(call1("ArcSin", arcsin_arg), pi()),
       ],
     ))
   };
@@ -15524,7 +15481,7 @@ fn pdf_sech(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     return Ok(unevaluated(dargs, x));
   }
   let arg = sech_arg(&m, &s, &x)?;
-  eval(div2(call("Sech", vec![arg]), times2(int(2), s)))
+  eval(div2(call1("Sech", arg), times2(int(2), s)))
 }
 
 /// CDF[SechDistribution[m, s], x] =
@@ -15541,7 +15498,7 @@ fn cdf_sech(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   let arg = sech_arg(&m, &s, &x)?;
   eval(div2(
-    call("Times", vec![int(2), call("ArcTan", vec![pow2(e(), arg)])]),
+    call("Times", vec![int(2), call1("ArcTan", pow2(e(), arg))]),
     pi(),
   ))
 }
@@ -15625,7 +15582,7 @@ fn pdf_moyal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     }
     // wolframscript orders the numeric scale before Sqrt[2 Pi] but a
     // symbolic one after it
-    let sqrt_2pi = call("Sqrt", vec![times2(int(2), pi())]);
+    let sqrt_2pi = call1("Sqrt", times2(int(2), pi()));
     let den = if den_factors.is_empty() {
       sqrt_2pi
     } else if ms_numeric(&s).is_some() {
@@ -15668,7 +15625,7 @@ fn cdf_moyal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       "Erfc",
       vec![div2(
         int(1),
-        call("Times", vec![call("Sqrt", vec![int(2)]), pow2(e(), z_half)]),
+        call("Times", vec![call1("Sqrt", int(2)), pow2(e(), z_half)]),
       )],
     ))
   };
@@ -15700,7 +15657,7 @@ pub fn moyal_mean_variance(
     "Plus",
     vec![
       Expr::Identifier("EulerGamma".to_string()),
-      call("Log", vec![int(2)]),
+      call1("Log", int(2)),
     ],
   );
   let mean = if matches!(&m, Expr::Integer(0)) && matches!(&s, Expr::Integer(1))
@@ -15907,7 +15864,7 @@ fn pdf_benktander_gibrat(
   if !benktander_valid(&a, &b, &dist)? {
     return Ok(uneval(dargs, x));
   }
-  let log_x = |at: &Expr| call("Log", vec![at.clone()]);
+  let log_x = |at: &Expr| call1("Log", at.clone());
   let numeric = ms_numeric(&a).is_some() && ms_numeric(&b).is_some();
 
   if ms_numeric(&x).is_some() {
@@ -16031,7 +15988,7 @@ fn cdf_benktander_gibrat(
   if !benktander_valid(&a, &b, &dist)? {
     return Ok(uneval(dargs, x));
   }
-  let log_x = |at: &Expr| call("Log", vec![at.clone()]);
+  let log_x = |at: &Expr| call1("Log", at.clone());
   let numeric = ms_numeric(&a).is_some() && ms_numeric(&b).is_some();
   let body = |at: &Expr| -> Result<Expr, InterpreterError> {
     let f2 = eval(call(
@@ -16108,7 +16065,7 @@ fn benktander_gibrat_mean_variance(
     "Erfc",
     vec![eval(div2(
       a_minus_1.clone(),
-      call("Times", vec![int(2), call("Sqrt", vec![b.clone()])]),
+      call("Times", vec![int(2), call1("Sqrt", b.clone())]),
     ))?],
   );
   let e_part = pow2(
@@ -16127,7 +16084,7 @@ fn benktander_gibrat_mean_variance(
             vec![
               a.clone(),
               e_part,
-              call("Sqrt", vec![eval(div2(pi(), b.clone()))?]),
+              call1("Sqrt", eval(div2(pi(), b.clone()))?),
               erfc,
             ],
           ),
@@ -16143,11 +16100,8 @@ fn benktander_gibrat_mean_variance(
         vec![
           int(-1),
           div2(
-            call(
-              "Times",
-              vec![a.clone(), e_part, call("Sqrt", vec![pi()]), erfc],
-            ),
-            call("Sqrt", vec![b.clone()]),
+            call("Times", vec![a.clone(), e_part, call1("Sqrt", pi()), erfc]),
+            call1("Sqrt", b.clone()),
           ),
         ],
       ),
@@ -16282,7 +16236,7 @@ fn pdf_skew_normal(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       times2(a.clone(), xm.clone()),
       times2(sqrt2, s.clone()),
     ));
-    let num = call("Erfc", vec![erfc_arg]);
+    let num = call1("Erfc", erfc_arg);
     let gauss = pow2(
       e(),
       div2(pow2(xm, int(2)), times2(int(2), pow2(s.clone(), int(2)))),
@@ -16441,12 +16395,11 @@ fn cdf_zipf(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   };
   let s1 = eval(plus2(int(1), r.clone()))?; // 1 + r
   let norm = match &n {
-    None => call("Zeta", vec![s1.clone()]),
+    None => call1("Zeta", s1.clone()),
     Some(n) => call("HarmonicNumber", vec![n.clone(), s1.clone()]),
   };
   let hn = |at: Expr| -> Result<Expr, InterpreterError> {
-    let harmonic =
-      call("HarmonicNumber", vec![call("Floor", vec![at]), s1.clone()]);
+    let harmonic = call("HarmonicNumber", vec![call1("Floor", at), s1.clone()]);
     eval(div2(harmonic, norm.clone()))
   };
   // Numeric argument: the support is the positive integers (bounded above by n
@@ -16623,7 +16576,7 @@ fn pdf_benford(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   // Log[1 + 1/d] / Log[b].
   let body = |d: &Expr| -> Result<Expr, InterpreterError> {
     let inner = eval(plus2(int(1), div2(int(1), d.clone())))?;
-    eval(div2(call("Log", vec![inner]), call("Log", vec![b.clone()])))
+    eval(div2(call1("Log", inner), call1("Log", b.clone())))
   };
   if let Some(xv) = ms_numeric(&x) {
     let in_support = xv >= 1.0 && xv.fract() == 0.0 && xv <= bv - 1.0;
@@ -16662,10 +16615,7 @@ fn cdf_benford(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   }
   // Log[1 + Floor[x]] / Log[b] at the given point.
   let body = |floor_plus_one: Expr| -> Result<Expr, InterpreterError> {
-    eval(div2(
-      call("Log", vec![floor_plus_one]),
-      call("Log", vec![b.clone()]),
-    ))
+    eval(div2(call1("Log", floor_plus_one), call1("Log", b.clone())))
   };
   if let Some(xv) = ms_numeric(&x) {
     if xv < 1.0 {
@@ -16680,7 +16630,7 @@ fn cdf_benford(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
   if !matches!(&x, Expr::Identifier(_)) {
     return Ok(unevaluated(dargs, x));
   }
-  let floor_x = call("Floor", vec![x.clone()]);
+  let floor_x = call1("Floor", x.clone());
   let main = body(eval(plus2(int(1), floor_x))?)?;
   Ok(piecewise(
     vec![
@@ -16723,12 +16673,12 @@ fn benford_mean_variance(
     ));
   }
   let b_int = bv as i128;
-  let log_b = call("Log", vec![b.clone()]);
+  let log_b = call1("Log", b.clone());
   // Mean = b - Log[b!]/Log[b].
   let factorial = eval(factorial(b.clone()))?;
   let mean = eval(plus2(
     b.clone(),
-    times2(int(-1), div2(call("Log", vec![factorial]), log_b.clone())),
+    times2(int(-1), div2(call1("Log", factorial), log_b.clone())),
   ))?;
   // Variance = Sum[d^2 Log[1 + 1/d]/Log[b], {d, 1, b-1}] - Mean^2.
   let mut terms: Vec<Expr> = Vec::new();
@@ -16736,7 +16686,7 @@ fn benford_mean_variance(
     let inner = eval(plus2(int(1), div2(int(1), int(d))))?;
     terms.push(times2(
       pow2(int(d), int(2)),
-      div2(call("Log", vec![inner]), log_b.clone()),
+      div2(call1("Log", inner), log_b.clone()),
     ));
   }
   let second_moment = eval(call("Plus", terms))?;
@@ -17135,10 +17085,10 @@ fn truncated_normalization(
   let at = |x: &Expr| -> Result<Expr, InterpreterError> {
     cdf_ast(&[base.clone(), x.clone()])
   };
-  crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Subtract".to_string(),
-    args: vec![at(hi)?, at(lo)?].into(),
-  })
+  crate::evaluator::evaluate_expr_to_expr(&call(
+    "Subtract",
+    vec![at(hi)?, at(lo)?],
+  ))
 }
 
 /// `Mean`/`Variance` of a truncated distribution, by integrating the
@@ -17160,14 +17110,8 @@ pub fn truncated_mean_variance(
     }
     let integrand = Expr::FunctionCall {
       name: "Times".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![x.clone(), Expr::Integer(k)].into(),
-        },
-        density,
-      ]
-      .into(),
+      args: vec![call("Power", vec![x.clone(), Expr::Integer(k)]), density]
+        .into(),
     };
     let integral =
       crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
@@ -17182,12 +17126,10 @@ pub fn truncated_mean_variance(
     {
       return Ok(None);
     }
-    Ok(Some(crate::evaluator::evaluate_expr_to_expr(
-      &Expr::FunctionCall {
-        name: "Divide".to_string(),
-        args: vec![integral, z.clone()].into(),
-      },
-    )?))
+    Ok(Some(crate::evaluator::evaluate_expr_to_expr(&call(
+      "Divide",
+      vec![integral, z.clone()],
+    ))?))
   };
 
   let (Some(m1), Some(m2)) = (moment(1)?, moment(2)?) else {
@@ -17196,14 +17138,7 @@ pub fn truncated_mean_variance(
   let variance =
     crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
       name: "Subtract".to_string(),
-      args: vec![
-        m2,
-        Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![m1.clone(), Expr::Integer(2)].into(),
-        },
-      ]
-      .into(),
+      args: vec![m2, call("Power", vec![m1.clone(), Expr::Integer(2)])].into(),
     })?;
   Ok(Some((m1, variance)))
 }
@@ -17221,10 +17156,7 @@ pub fn truncated_distribution_value(
   };
   let z = truncated_normalization(&lo, &hi, &base)?;
   let eval = |name: &str, args: Vec<Expr>| -> Result<Expr, InterpreterError> {
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.into(),
-    })
+    crate::evaluator::evaluate_expr_to_expr(&call(name, args))
   };
   // Whether x lies in the kept interval, when that is decidable.
   let inside = |x: &Expr| -> Option<bool> {
@@ -17328,10 +17260,7 @@ pub fn censored_distribution_value(
     return Ok(None);
   };
   let eval = |name: &str, args: Vec<Expr>| -> Result<Expr, InterpreterError> {
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.into(),
-    })
+    crate::evaluator::evaluate_expr_to_expr(&call(name, args))
   };
   let decides =
     |a: &Expr, op: crate::syntax::ComparisonOp, b: &Expr| -> Option<bool> {
@@ -17383,10 +17312,7 @@ pub fn censored_mean_variance(
   };
   let x = Expr::Identifier("Global`censx".to_string());
   let eval = |name: &str, args: Vec<Expr>| -> Result<Expr, InterpreterError> {
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.into(),
-    })
+    crate::evaluator::evaluate_expr_to_expr(&call(name, args))
   };
 
   let moment = |k: i128| -> Result<Option<Expr>, InterpreterError> {
@@ -17394,9 +17320,8 @@ pub fn censored_mean_variance(
     if matches!(&density, Expr::FunctionCall { name, .. } if name == "PDF") {
       return Ok(None);
     }
-    let power = |base_expr: &Expr| Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![base_expr.clone(), Expr::Integer(k)].into(),
+    let power = |base_expr: &Expr| {
+      call("Power", vec![base_expr.clone(), Expr::Integer(k)])
     };
     let integral = eval(
       "Integrate",
@@ -17432,13 +17357,7 @@ pub fn censored_mean_variance(
   };
   let variance = eval(
     "Subtract",
-    vec![
-      m2,
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![m1.clone(), Expr::Integer(2)].into(),
-      },
-    ],
+    vec![m2, call("Power", vec![m1.clone(), Expr::Integer(2)])],
   )?;
   Ok(Some((m1, variance)))
 }

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -44,34 +44,31 @@ pub fn q_pochhammer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let qk = if k == 0 {
       Expr::Integer(1)
     } else {
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![q.clone(), Expr::Integer(k as i128)].into(),
-      })?
+      crate::evaluator::evaluate_expr_to_expr(&call(
+        "Power",
+        vec![q.clone(), Expr::Integer(k as i128)],
+      ))?
     };
     // Compute a * q^k
-    let aqk = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![a.clone(), qk].into(),
-    })?;
+    let aqk = crate::evaluator::evaluate_expr_to_expr(&call(
+      "Times",
+      vec![a.clone(), qk],
+    ))?;
     // Compute 1 - a*q^k
     let factor =
       crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
         name: "Plus".to_string(),
         args: vec![
           Expr::Integer(1),
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![Expr::Integer(-1), aqk].into(),
-          },
+          call("Times", vec![Expr::Integer(-1), aqk]),
         ]
         .into(),
       })?;
     // Multiply into result
-    result = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![result, factor].into(),
-    })?;
+    result = crate::evaluator::evaluate_expr_to_expr(&call(
+      "Times",
+      vec![result, factor],
+    ))?;
   }
 
   Ok(result)
@@ -82,12 +79,7 @@ pub fn q_pochhammer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// arguments (no closed form), evaluates to a machine number only when an
 /// argument is inexact (e.g. under N), and is 1 when a == 0.
 fn q_pochhammer_infinite(a: &Expr, q: &Expr) -> Result<Expr, InterpreterError> {
-  let unevaluated = || {
-    Ok(Expr::FunctionCall {
-      name: "QPochhammer".to_string(),
-      args: vec![a.clone(), q.clone()].into(),
-    })
-  };
+  let unevaluated = || Ok(call("QPochhammer", vec![a.clone(), q.clone()]));
 
   // QPochhammer[0, q] = 1 (every factor is 1).
   if matches!(a, Expr::Integer(0)) {
@@ -178,10 +170,7 @@ pub fn mittag_leffler_e_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 fn mittag_leffler_unevaluated(args: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: "MittagLefflerE".to_string(),
-    args: args.into(),
-  }
+  call("MittagLefflerE", args)
 }
 
 fn mittag_leffler_two_arg(
@@ -221,35 +210,26 @@ fn mittag_leffler_two_arg(
           name: "Plus".to_string(),
           args: vec![
             Expr::Integer(1),
-            Expr::FunctionCall {
-              name: "Times".to_string(),
-              args: vec![Expr::Integer(-1), z.clone()].into(),
-            },
+            call("Times", vec![Expr::Integer(-1), z.clone()]),
           ]
           .into(),
         };
-        return crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![one_minus_z, Expr::Integer(-1)].into(),
-        });
+        return crate::evaluator::evaluate_expr_to_expr(&call(
+          "Power",
+          vec![one_minus_z, Expr::Integer(-1)],
+        ));
       }
       1 => {
         // E^z
-        return crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![Expr::Identifier("E".to_string()), z.clone()].into(),
-        });
+        return crate::evaluator::evaluate_expr_to_expr(&call(
+          "Power",
+          vec![Expr::Identifier("E".to_string()), z.clone()],
+        ));
       }
       2 => {
         // Cosh[Sqrt[z]]
-        let sqrt_z = Expr::FunctionCall {
-          name: "Sqrt".to_string(),
-          args: vec![z.clone()].into(),
-        };
-        return crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-          name: "Cosh".to_string(),
-          args: vec![sqrt_z].into(),
-        });
+        let sqrt_z = call1("Sqrt", z.clone());
+        return crate::evaluator::evaluate_expr_to_expr(&call1("Cosh", sqrt_z));
       }
       _ => {}
     }
@@ -275,14 +255,7 @@ fn mittag_leffler_three_arg(
   if is_expr_zero(z) {
     return crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
       name: "Power".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "Gamma".to_string(),
-          args: vec![beta.clone()].into(),
-        },
-        Expr::Integer(-1),
-      ]
-      .into(),
+      args: vec![call1("Gamma", beta.clone()), Expr::Integer(-1)].into(),
     });
   }
 
@@ -689,10 +662,7 @@ pub fn meijer_g_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           args: vec![
             Expr::Integer(3),
             Expr::Identifier("E".to_string()),
-            Expr::FunctionCall {
-              name: "ExpIntegralEi".to_string(),
-              args: vec![Expr::Integer(-1)].into(),
-            },
+            call1("ExpIntegralEi", Expr::Integer(-1)),
           ]
           .into(),
         },
@@ -1059,12 +1029,8 @@ fn struve_half_integer_closed_form(
   two_nu: i64,
   z: &Expr,
 ) -> Option<Result<Expr, InterpreterError>> {
-  let call1 = |name: &str, e: Expr| Expr::FunctionCall {
-    name: name.to_string(),
-    args: vec![e].into(),
-  };
   let int = Expr::Integer;
-  let neg = |a| times2(int(-1), a);
+  let neg = |a: Expr| times2(int(-1), a);
   let pi = || Expr::Constant("Pi".to_string());
   let sqrt = |e: Expr| call1("Sqrt", e);
   let z = || z.clone();
@@ -1421,10 +1387,10 @@ pub fn triangle_wave_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if sd == 1 {
           return Ok(Expr::Integer(sn));
         }
-        return Ok(Expr::FunctionCall {
-          name: "Rational".to_string(),
-          args: vec![Expr::Integer(sn), Expr::Integer(sd)].into(),
-        });
+        return Ok(call(
+          "Rational",
+          vec![Expr::Integer(sn), Expr::Integer(sd)],
+        ));
       }
       // Float input
       if let Some(t) = expr_to_f64(&args[0]) {
@@ -1487,10 +1453,10 @@ pub fn sawtooth_wave_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         if sd == 1 {
           return Ok(Expr::Integer(sn));
         }
-        return Ok(Expr::FunctionCall {
-          name: "Rational".to_string(),
-          args: vec![Expr::Integer(sn), Expr::Integer(sd)].into(),
-        });
+        return Ok(call(
+          "Rational",
+          vec![Expr::Integer(sn), Expr::Integer(sd)],
+        ));
       }
       // Float input
       if let Some(t) = expr_to_f64(&args[0]) {
@@ -1767,10 +1733,7 @@ fn weber_e_integer_closed_form(
   }
 
   // - StruveH[|n|, z]
-  let struve = Expr::FunctionCall {
-    name: "StruveH".to_string(),
-    args: vec![Expr::Integer(m), z.clone()].into(),
-  };
+  let struve = call("StruveH", vec![Expr::Integer(m), z.clone()]);
   terms.push(times_ast(&[Expr::Integer(-1), struve])?);
 
   let mut result = plus_ast(&terms)?;
@@ -1785,10 +1748,7 @@ fn weber_e_integer_closed_form(
 fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
   let pi = Expr::Constant("Pi".to_string());
   let nu_pi = times2(nu.clone(), pi.clone());
-  let sin_nu_pi = Expr::FunctionCall {
-    name: "Sin".to_string(),
-    args: vec![nu_pi.clone()].into(),
-  };
+  let sin_nu_pi = call1("Sin", nu_pi.clone());
   div2(sin_nu_pi, nu_pi)
 }
 
@@ -1796,10 +1756,7 @@ fn anger_j_at_zero_symbolic(nu: &Expr) -> Expr {
 fn weber_e_at_zero_symbolic(nu: &Expr) -> Expr {
   let pi = Expr::Constant("Pi".to_string());
   let nu_pi = times2(nu.clone(), pi.clone());
-  let cos_nu_pi = Expr::FunctionCall {
-    name: "Cos".to_string(),
-    args: vec![nu_pi.clone()].into(),
-  };
+  let cos_nu_pi = call1("Cos", nu_pi.clone());
   let one_minus_cos = minus2(Expr::Integer(1), cos_nu_pi);
   div2(one_minus_cos, nu_pi)
 }
@@ -1969,27 +1926,21 @@ fn wigner_d_symbolic(
     } else {
       // Half-integer case: represent as Rational.
       let num = (2.0 * coef).round() as i128;
-      Some(Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(num), Expr::Integer(2)].into(),
-      })?
+      Some(call("Rational", vec![Expr::Integer(num), Expr::Integer(2)]))?
     };
     let exponent = Expr::FunctionCall {
       name: "Times".to_string(),
       args: vec![Expr::Identifier("I".to_string()), coef_expr, ang.clone()]
         .into(),
     };
-    Some(Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![Expr::Constant("E".to_string()), exponent].into(),
-    })
+    Some(call(
+      "Power",
+      vec![Expr::Constant("E".to_string()), exponent],
+    ))
   };
   let e1 = exp_factor(m1, phi)?;
   let e2 = exp_factor(m2, psi)?;
-  Some(Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![e1, d, e2].into(),
-  })
+  Some(call("Times", vec![e1, d, e2]))
 }
 
 /// Symbolic small d-matrix d^j_{m1,m2}(theta). `j2 = 2j`, `m1_2 = 2*m1`,
@@ -2022,31 +1973,19 @@ fn wigner_d_small_symbolic(
   }
   // Prefactor: Sqrt[(j+m1)!(j-m1)!(j+m2)!(j-m2)!].
   let pref_under = fact(jpm1) * fact(jmm1) * fact(jpm2) * fact(jmm2);
-  let prefactor = Expr::FunctionCall {
-    name: "Sqrt".to_string(),
-    args: vec![Expr::Integer(pref_under)].into(),
-  };
+  let prefactor = call1("Sqrt", Expr::Integer(pref_under));
 
   // Build half-angle expressions Cos[theta/2], Sin[theta/2].
   let half_theta = Expr::FunctionCall {
     name: "Times".to_string(),
     args: vec![
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
-      },
+      call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
       theta.clone(),
     ]
     .into(),
   };
-  let cos_ht = Expr::FunctionCall {
-    name: "Cos".to_string(),
-    args: vec![half_theta.clone()].into(),
-  };
-  let sin_ht = Expr::FunctionCall {
-    name: "Sin".to_string(),
-    args: vec![half_theta].into(),
-  };
+  let cos_ht = call1("Cos", half_theta.clone());
+  let sin_ht = call1("Sin", half_theta);
 
   // Build the sum.
   let mut terms: Vec<Expr> = Vec::new();
@@ -2076,34 +2015,28 @@ fn wigner_d_small_symbolic(
     } else if cos_power == 1 {
       cos_ht.clone()
     } else {
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![cos_ht.clone(), Expr::Integer(cos_power as i128)].into(),
-      }
+      call(
+        "Power",
+        vec![cos_ht.clone(), Expr::Integer(cos_power as i128)],
+      )
     };
     let sin_term = if sin_power == 0 {
       Expr::Integer(1)
     } else if sin_power == 1 {
       sin_ht.clone()
     } else {
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![sin_ht.clone(), Expr::Integer(sin_power as i128)].into(),
-      }
+      call(
+        "Power",
+        vec![sin_ht.clone(), Expr::Integer(sin_power as i128)],
+      )
     };
     // coefficient = sign / denom (Rational).
     let coeff = if denom == 1 {
       Expr::Integer(sign)
     } else {
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(sign), Expr::Integer(denom)].into(),
-      }
+      call("Rational", vec![Expr::Integer(sign), Expr::Integer(denom)])
     };
-    terms.push(Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![coeff, cos_term, sin_term].into(),
-    });
+    terms.push(call("Times", vec![coeff, cos_term, sin_term]));
   }
 
   let sum = if terms.is_empty() {
@@ -2111,15 +2044,9 @@ fn wigner_d_small_symbolic(
   } else if terms.len() == 1 {
     terms.into_iter().next().unwrap()
   } else {
-    Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    }
+    call("Plus", terms)
   };
-  Some(Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![prefactor, sum].into(),
-  })
+  Some(call("Times", vec![prefactor, sum]))
 }
 
 /// Compute the Wigner (small) d-matrix element d^j_{m1,m2}(theta).
@@ -2336,27 +2263,15 @@ fn norlund_b_poly_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let mut terms: Vec<Expr> = Vec::with_capacity(n + 1);
   for k in 0..=n {
-    let binom = Expr::FunctionCall {
-      name: "Binomial".to_string(),
-      args: vec![Expr::Integer(n as i128), Expr::Integer(k as i128)].into(),
-    };
-    let nb = Expr::FunctionCall {
-      name: "NorlundB".to_string(),
-      args: vec![Expr::Integer(k as i128), a.clone()].into(),
-    };
-    let x_pow = Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![x.clone(), Expr::Integer((n - k) as i128)].into(),
-    };
-    terms.push(Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![binom, nb, x_pow].into(),
-    });
+    let binom = call(
+      "Binomial",
+      vec![Expr::Integer(n as i128), Expr::Integer(k as i128)],
+    );
+    let nb = call("NorlundB", vec![Expr::Integer(k as i128), a.clone()]);
+    let x_pow = call("Power", vec![x.clone(), Expr::Integer((n - k) as i128)]);
+    terms.push(call("Times", vec![binom, nb, x_pow]));
   }
-  let sum = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  };
+  let sum = call("Plus", terms);
   crate::evaluator::evaluate_expr_to_expr(&sum)
 }
 
@@ -2377,15 +2292,9 @@ fn evaluate_norlund_symbolic(
       let a_pow = if k == 1 {
         a.clone()
       } else {
-        Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![a.clone(), Expr::Integer(k as i128)].into(),
-        }
+        call("Power", vec![a.clone(), Expr::Integer(k as i128)])
       };
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![coeff, a_pow].into(),
-      }
+      call("Times", vec![coeff, a_pow])
     };
     terms.push(term);
   }
@@ -2395,10 +2304,7 @@ fn evaluate_norlund_symbolic(
   if terms.len() == 1 {
     return crate::evaluator::evaluate_expr_to_expr(&terms.pop().unwrap());
   }
-  let sum = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  };
+  let sum = call("Plus", terms);
   crate::evaluator::evaluate_expr_to_expr(&sum)
 }
 
@@ -2528,14 +2434,8 @@ pub fn appell_f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let one = Expr::Integer(1);
     let one_minus_x = minus2(one.clone(), args[4].clone());
     let one_minus_y = minus2(one.clone(), args[5].clone());
-    let factor_x = Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![one_minus_x, args[1].clone()].into(),
-    };
-    let factor_y = Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![one_minus_y, args[2].clone()].into(),
-    };
+    let factor_x = call("Power", vec![one_minus_x, args[1].clone()]);
+    let factor_y = call("Power", vec![one_minus_y, args[2].clone()]);
     let denom = times2(factor_x, factor_y);
     let result = div2(one, denom);
     return crate::evaluator::evaluate_expr_to_expr(&result);
@@ -3257,38 +3157,17 @@ pub fn effective_interest_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
   if p_is_zero {
     // -1 + E^r
-    let e_r = Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![Expr::Identifier("E".to_string()), r.clone()].into(),
-    };
-    let expr = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: vec![Expr::Integer(-1), e_r].into(),
-    };
+    let e_r = call("Power", vec![Expr::Identifier("E".to_string()), r.clone()]);
+    let expr = call("Plus", vec![Expr::Integer(-1), e_r]);
     return crate::evaluator::evaluate_expr_to_expr(&expr);
   }
 
   // General form: (1 + p*r)^(1/p) - 1.
-  let pr = Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![p.clone(), r.clone()].into(),
-  };
-  let one_plus_pr = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: vec![Expr::Integer(1), pr].into(),
-  };
-  let inv_p = Expr::FunctionCall {
-    name: "Power".to_string(),
-    args: vec![p.clone(), Expr::Integer(-1)].into(),
-  };
-  let pow = Expr::FunctionCall {
-    name: "Power".to_string(),
-    args: vec![one_plus_pr, inv_p].into(),
-  };
-  let expr = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: vec![Expr::Integer(-1), pow].into(),
-  };
+  let pr = call("Times", vec![p.clone(), r.clone()]);
+  let one_plus_pr = call("Plus", vec![Expr::Integer(1), pr]);
+  let inv_p = call("Power", vec![p.clone(), Expr::Integer(-1)]);
+  let pow = call("Power", vec![one_plus_pr, inv_p]);
+  let expr = call("Plus", vec![Expr::Integer(-1), pow]);
   crate::evaluator::evaluate_expr_to_expr(&expr)
 }
 

--- a/src/functions/math_ast/mod.rs
+++ b/src/functions/math_ast/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::InterpreterError;
 use crate::helpers::{
-  binop, bool_expr, div2, minus2, neg1, plus2, pow2, times2,
+  binop, bool_expr, call, call1, div2, minus2, neg1, plus2, pow2, times2,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -7604,10 +7604,6 @@ pub fn parametric_window_ast(
     return uneval();
   };
   let eval = crate::evaluator::evaluate_expr_to_expr;
-  let fc = |n: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: n.to_string(),
-    args: a.into(),
-  };
   let rational = |p: i128, q: i128| Expr::FunctionCall {
     name: "Rational".to_string(),
     args: vec![Expr::Integer(p), Expr::Integer(q)].into(),
@@ -7625,17 +7621,17 @@ pub fn parametric_window_ast(
   }
   let expr = match name {
     // 1/(1 + (2 α x)²)
-    "CauchyWindow" => fc(
+    "CauchyWindow" => call(
       "Power",
       vec![
-        fc(
+        call(
           "Plus",
           vec![
             Expr::Integer(1),
-            fc(
+            call(
               "Power",
               vec![
-                fc(
+                call(
                   "Times",
                   vec![Expr::Integer(2), alpha_expr, args[0].clone()],
                 ),
@@ -7648,43 +7644,43 @@ pub fn parametric_window_ast(
       ],
     ),
     // E^(-2 α |x|)
-    "PoissonWindow" => fc(
+    "PoissonWindow" => call(
       "Power",
       vec![
         Expr::Identifier("E".to_string()),
-        fc(
+        call(
           "Times",
           vec![
             Expr::Integer(-2),
             alpha_expr,
-            fc("Abs", vec![args[0].clone()]),
+            call("Abs", vec![args[0].clone()]),
           ],
         ),
       ],
     ),
     // 31/50 - (12/25)|x| + (19/50)Cos[2 π x]
-    _ => fc(
+    _ => call(
       "Plus",
       vec![
         rational(31, 50),
-        fc(
+        call(
           "Times",
-          vec![rational(-12, 25), fc("Abs", vec![args[0].clone()])],
+          vec![rational(-12, 25), call1("Abs", args[0].clone())],
         ),
-        fc(
+        call(
           "Times",
           vec![
             rational(19, 50),
-            fc(
+            call1(
               "Cos",
-              vec![fc(
+              call(
                 "Times",
                 vec![
                   Expr::Integer(2),
                   Expr::Identifier("Pi".to_string()),
                   args[0].clone(),
                 ],
-              )],
+              ),
             ),
           ],
         ),

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -419,10 +419,7 @@ fn total_parts(expr: &Expr) -> Option<(Option<&str>, &[Expr])> {
 fn total_rebuild(head: Option<&str>, items: Vec<Expr>) -> Expr {
   match head {
     None => Expr::List(items.into()),
-    Some(name) => Expr::FunctionCall {
-      name: name.to_string(),
-      args: items.into(),
-    },
+    Some(name) => call(name, items),
   }
 }
 
@@ -586,10 +583,7 @@ pub(crate) fn mixture_weighted_component_quantity(
   if weights.is_empty() || weights.len() != dists.len() {
     return Ok(None);
   }
-  let call = |name: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: a.into(),
-  };
+  let call = |name: &str, a: Vec<Expr>| call(name, a);
   // Distribute the normalizing weight into every term — Σ (w_i/W) q(d_i) —
   // rather than dividing the summed numerator, so the result matches
   // wolframscript's form (e.g. `1/(2 Sqrt[2 Pi]) + …` instead of `(… )/2`).
@@ -622,10 +616,7 @@ fn mixture_variance(dargs: &[Expr]) -> Result<Option<Expr>, InterpreterError> {
   if weights.is_empty() || weights.len() != dists.len() {
     return Ok(None);
   }
-  let call = |name: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: a.into(),
-  };
+  let call = |name: &str, a: Vec<Expr>| call(name, a);
   let resolved = |q: &Expr| {
     !matches!(q, Expr::FunctionCall { name, .. }
       if name == "Mean" || name == "Variance")
@@ -684,10 +675,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match &args[0] {
     Expr::List(items) => {
       if items.is_empty() {
-        return Ok(Expr::FunctionCall {
-          name: "Mean".to_string(),
-          args: vec![Expr::List(vec![].into())].into(),
-        });
+        return Ok(call("Mean", vec![Expr::List(vec![].into())]));
       }
       // Try to compute exact integer sum first
       let mut int_sum: Option<i128> = Some(0);
@@ -712,10 +700,10 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         } else {
           // Return as Rational
           let (num, denom) = rat_reduce(sum, count);
-          Ok(Expr::FunctionCall {
-            name: "Rational".to_string(),
-            args: vec![Expr::Integer(num), Expr::Integer(denom)].into(),
-          })
+          Ok(call(
+            "Rational",
+            vec![Expr::Integer(num), Expr::Integer(denom)],
+          ))
         }
       } else {
         // Check for list-of-lists (matrix) → compute column-wise mean
@@ -726,10 +714,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Plus canonical-sorts its operands, changing the f64 summation
         // order for real entries (Mean[{23.1, 24.4, 21.8, 25.5}] must stay
         // exactly 23.7 like wolframscript's left-to-right Total).
-        let sum_expr = Expr::FunctionCall {
-          name: "Total".to_string(),
-          args: vec![Expr::List(items.clone())].into(),
-        };
+        let sum_expr = call("Total", vec![Expr::List(items.clone())]);
         let evaluated_sum = crate::evaluator::evaluate_expr_to_expr(&sum_expr)?;
         let n = items.len() as i128;
         // A rational sum folds to an exact rational (e.g. Mean[{1/4, 1/8}]
@@ -994,10 +979,7 @@ pub fn mean_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } if dist_name == "QuantityDistribution" && dargs.len() == 2 => {
       // Mean[QuantityDistribution[dist, unit]] = Quantity[Mean[dist], unit]
       let inner_mean = mean_ast(&[dargs[0].clone()])?;
-      Ok(Expr::FunctionCall {
-        name: "Quantity".to_string(),
-        args: vec![inner_mean, dargs[1].clone()].into(),
-      })
+      Ok(call("Quantity", vec![inner_mean, dargs[1].clone()]))
     }
     Expr::Association(pairs) => {
       let values: Vec<Expr> = pairs.iter().map(|(_, v)| v.clone()).collect();
@@ -1046,11 +1028,7 @@ fn standby_component_moments(
     }
     terms.push(m);
   }
-  crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  })
-  .map(Some)
+  crate::evaluator::evaluate_expr_to_expr(&call("Plus", terms)).map(Some)
 }
 
 /// Mean of columns in a list-of-lists (matrix)
@@ -1066,10 +1044,7 @@ fn mean_columnwise(rows: &[Expr]) -> Result<Expr, InterpreterError> {
     })
     .collect();
   if row_vecs.is_empty() {
-    return Ok(Expr::FunctionCall {
-      name: "Mean".to_string(),
-      args: vec![Expr::List(rows.to_vec().into())].into(),
-    });
+    return Ok(call("Mean", vec![Expr::List(rows.to_vec().into())]));
   }
   let ncols = row_vecs[0].len();
   let nrows = row_vecs.len();
@@ -1141,10 +1116,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             expr_to_string(&args[0])
           ));
         }
-        return Ok(Expr::FunctionCall {
-          name: "Variance".to_string(),
-          args: vec![args[0].clone()].into(),
-        });
+        return Ok(call("Variance", vec![args[0].clone()]));
       }
       // Try all-integer exact path (Integer and BigInteger). Computed in
       // BigInt so the squared deviations don't overflow i128.
@@ -1414,10 +1386,7 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Variance[QuantityDistribution[dist, unit]] = Quantity[Variance[dist], unit^2]
       let inner_var = variance_ast(&[dargs[0].clone()])?;
       let unit_sq = pow2(dargs[1].clone(), Expr::Integer(2));
-      Ok(Expr::FunctionCall {
-        name: "Quantity".to_string(),
-        args: vec![inner_var, unit_sq].into(),
-      })
+      Ok(call("Quantity", vec![inner_var, unit_sq]))
     }
     // Random-process time slices delegate to their slice distribution.
     Expr::CurriedCall { func, args: targs } if targs.len() == 1 => {
@@ -1466,10 +1435,7 @@ fn variance_columnwise(rows: &[Expr]) -> Result<Expr, InterpreterError> {
     })
     .collect();
   if row_vecs.is_empty() {
-    return Ok(Expr::FunctionCall {
-      name: "Variance".to_string(),
-      args: vec![Expr::List(rows.to_vec().into())].into(),
-    });
+    return Ok(call("Variance", vec![Expr::List(rows.to_vec().into())]));
   }
   let ncols = row_vecs[0].len();
   let mut col_vars = Vec::new();
@@ -1702,10 +1668,8 @@ fn thread_sqrt_into_piecewise(
     Expr::Integer(0)
   };
   let new_default = sqrt_of_value(&default, is_dist)?;
-  let result = Expr::FunctionCall {
-    name: "Piecewise".to_string(),
-    args: vec![Expr::List(new_pairs.into()), new_default].into(),
-  };
+  let result =
+    call("Piecewise", vec![Expr::List(new_pairs.into()), new_default]);
   Ok(Some(crate::evaluator::evaluate_expr_to_expr(&result)?))
 }
 
@@ -1885,10 +1849,10 @@ fn geometric_mean_columnwise(rows: &[Expr]) -> Result<Expr, InterpreterError> {
     })
     .collect();
   if row_vecs.is_empty() {
-    return Ok(Expr::FunctionCall {
-      name: "GeometricMean".to_string(),
-      args: vec![Expr::List(rows.to_vec().into())].into(),
-    });
+    return Ok(call(
+      "GeometricMean",
+      vec![Expr::List(rows.to_vec().into())],
+    ));
   }
   let ncols = row_vecs[0].len();
   let mut col_means = Vec::with_capacity(ncols);
@@ -2016,10 +1980,7 @@ fn harmonic_mean_symbolic(items: &[Expr]) -> Result<Expr, InterpreterError> {
     .iter()
     .map(|x| div2(Expr::Integer(1), x.clone()))
     .collect();
-  let sum = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: recips.into(),
-  })?;
+  let sum = crate::evaluator::evaluate_expr_to_expr(&call("Plus", recips))?;
   let n = items.len() as i128;
   crate::evaluator::evaluate_expr_to_expr(&div2(Expr::Integer(n), sum))
 }
@@ -2037,10 +1998,7 @@ fn harmonic_mean_columnwise(rows: &[Expr]) -> Result<Expr, InterpreterError> {
     })
     .collect();
   if row_vecs.is_empty() {
-    return Ok(Expr::FunctionCall {
-      name: "HarmonicMean".to_string(),
-      args: vec![Expr::List(rows.to_vec().into())].into(),
-    });
+    return Ok(call("HarmonicMean", vec![Expr::List(rows.to_vec().into())]));
   }
   let ncols = row_vecs[0].len();
   let mut col_means = Vec::with_capacity(ncols);
@@ -2221,19 +2179,13 @@ fn covariance_pair(xs: &[Expr], ys: &[Expr]) -> Result<Expr, InterpreterError> {
   for (x, y) in xs.iter().zip(ys.iter()) {
     let dx = minus2(x.clone(), mean_x.clone());
     let dy = minus2(y.clone(), mean_y.clone());
-    let conj_dy = Expr::FunctionCall {
-      name: "Conjugate".to_string(),
-      args: vec![dy].into(),
-    };
+    let conj_dy = call1("Conjugate", dy);
     let product = times2(dx, conj_dy);
     let val = crate::evaluator::evaluate_expr_to_expr(&product)?;
     terms.push(val);
   }
 
-  let sum_expr = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  };
+  let sum_expr = call("Plus", terms);
   let sum_val = crate::evaluator::evaluate_expr_to_expr(&sum_expr)?;
   let result = div2(sum_val, Expr::Integer((n - 1) as i128));
   crate::evaluator::evaluate_expr_to_expr(&result)
@@ -2255,10 +2207,7 @@ fn symbolic_covariance(
   ys: &[Expr],
 ) -> Result<Expr, InterpreterError> {
   let n = xs.len();
-  let conj = |e: &Expr| Expr::FunctionCall {
-    name: "Conjugate".to_string(),
-    args: vec![e.clone()].into(),
-  };
+  let conj = |e: &Expr| call1("Conjugate", e.clone());
   let result = if n == 2 {
     let dx = minus2(xs[0].clone(), xs[1].clone());
     let dy = minus2(conj(&ys[0]), conj(&ys[1]));
@@ -2271,13 +2220,7 @@ fn symbolic_covariance(
         minus2(times2(Expr::Integer(n as i128), x.clone()), sum_x.clone());
       terms.push(times2(coeff, conj(y)));
     }
-    div2(
-      Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: terms.into(),
-      },
-      Expr::Integer((n * (n - 1)) as i128),
-    )
+    div2(call("Plus", terms), Expr::Integer((n * (n - 1)) as i128))
   };
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
@@ -2603,14 +2546,8 @@ pub fn kendall_tau_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let expr = Expr::FunctionCall {
     name: "Divide".to_string(),
-    args: vec![
-      Expr::Integer(num),
-      Expr::FunctionCall {
-        name: "Sqrt".to_string(),
-        args: vec![Expr::Integer(denom_sq)].into(),
-      },
-    ]
-    .into(),
+    args: vec![Expr::Integer(num), call1("Sqrt", Expr::Integer(denom_sq))]
+      .into(),
   };
   crate::evaluator::evaluate_expr_to_expr(&expr)
 }
@@ -2687,10 +2624,10 @@ pub fn hoeffding_d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let k = (n - 2) * (n - 3) * d1 + d2 - 2 * (n - 2) * d3;
     let den = 16 * n * (n - 1) * (n - 2) * (n - 3) * (n - 4);
     if exact {
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Divide".to_string(),
-        args: vec![Expr::Integer(30 * k), Expr::Integer(den)].into(),
-      })
+      crate::evaluator::evaluate_expr_to_expr(&call(
+        "Divide",
+        vec![Expr::Integer(30 * k), Expr::Integer(den)],
+      ))
       .unwrap_or(Expr::Integer(0))
     } else {
       Expr::Real(30.0 * k as f64 / den as f64)
@@ -2914,10 +2851,10 @@ pub fn goodman_kruskal_gamma_ast(
       return Ok(Expr::Identifier("Indeterminate".to_string()));
     }
     if exact {
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Divide".to_string(),
-        args: vec![Expr::Integer(num), Expr::Integer(den)].into(),
-      })
+      crate::evaluator::evaluate_expr_to_expr(&call(
+        "Divide",
+        vec![Expr::Integer(num), Expr::Integer(den)],
+      ))
     } else {
       Ok(Expr::Real(num as f64 / den as f64))
     }
@@ -2973,10 +2910,7 @@ pub fn blomqvist_beta_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     if exact || a * b == 0 {
       crate::evaluator::evaluate_expr_to_expr(&div2(
         Expr::Integer(num),
-        Expr::FunctionCall {
-          name: "Sqrt".to_string(),
-          args: vec![Expr::Integer(a * b)].into(),
-        },
+        call1("Sqrt", Expr::Integer(a * b)),
       ))
     } else {
       Ok(Expr::Real(num as f64 / ((a * b) as f64).sqrt()))
@@ -2998,10 +2932,7 @@ fn correlation_from_covariance(cov_rows: &[Expr]) -> Option<Expr> {
     }
     cov.push(row.to_vec());
   }
-  let call = |name: &str, args: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  };
+  let call = |name: &str, args: Vec<Expr>| call(name, args);
   let mut result = Vec::with_capacity(n);
   for i in 0..n {
     let mut row = Vec::with_capacity(n);
@@ -3126,28 +3057,16 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let w0 = ys[0].clone();
       let w1 = ys[1].clone();
       let diff = |a: &Expr, b: &Expr| minus2(a.clone(), b.clone());
-      let conj = |e: &Expr| Expr::FunctionCall {
-        name: "Conjugate".to_string(),
-        args: vec![e.clone()].into(),
-      };
-      let times = |a: Expr, b: Expr| Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![a, b].into(),
-      };
+      let conj = |e: &Expr| call1("Conjugate", e.clone());
+      let times = |a: Expr, b: Expr| call("Times", vec![a, b]);
       let conj_diff = |a: &Expr, b: &Expr| minus2(conj(a), conj(b));
       let v_diff = diff(&v0, &v1);
       let w_diff = diff(&w0, &w1);
       let v_conj_diff = conj_diff(&v0, &v1);
       let w_conj_diff = conj_diff(&w0, &w1);
       let numer = times(v_diff.clone(), w_conj_diff.clone());
-      let sqrt_v = Expr::FunctionCall {
-        name: "Sqrt".to_string(),
-        args: vec![times(v_diff, v_conj_diff)].into(),
-      };
-      let sqrt_w = Expr::FunctionCall {
-        name: "Sqrt".to_string(),
-        args: vec![times(w_diff, w_conj_diff)].into(),
-      };
+      let sqrt_v = call1("Sqrt", times(v_diff, v_conj_diff));
+      let sqrt_w = call1("Sqrt", times(w_diff, w_conj_diff));
       let denom = times(sqrt_v, sqrt_w);
       // Return without re-evaluating to preserve the Times factor order
       // inside each Sqrt (which Woxi's canonical sort would otherwise
@@ -3199,10 +3118,7 @@ pub fn correlation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(unevaluated("Correlation", args));
   }
   let var_product = times2(var_x, var_y);
-  let denom = Expr::FunctionCall {
-    name: "Sqrt".to_string(),
-    args: vec![var_product].into(),
-  };
+  let denom = call1("Sqrt", var_product);
   let result = div2(cov_xy, denom);
   crate::evaluator::evaluate_expr_to_expr(&result)
 }
@@ -3251,14 +3167,11 @@ fn distribution_raw_moment(
   var: &str,
 ) -> Result<Option<Expr>, InterpreterError> {
   let powered = pow2(Expr::Identifier(var.to_string()), Expr::Integer(n));
-  let distributed = Expr::FunctionCall {
-    name: "Distributed".to_string(),
-    args: vec![Expr::Identifier(var.to_string()), dist.clone()].into(),
-  };
-  let exp = Expr::FunctionCall {
-    name: "Expectation".to_string(),
-    args: vec![powered, distributed].into(),
-  };
+  let distributed = call(
+    "Distributed",
+    vec![Expr::Identifier(var.to_string()), dist.clone()],
+  );
+  let exp = call("Expectation", vec![powered, distributed]);
   let result = crate::evaluator::evaluate_expr_to_expr(&exp)?;
   if matches!(&result, Expr::FunctionCall { name, .. } if name == "Expectation")
   {
@@ -3370,18 +3283,12 @@ fn skellam_central_moment(a: &Expr, b: &Expr, n: i128) -> Expr {
     for &p in &lambda {
       factors.push(kappa(p));
     }
-    terms.push(Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: factors.into(),
-    });
+    terms.push(call("Times", factors));
   }
   if terms.is_empty() {
     return Expr::Integer(0);
   }
-  Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  }
+  call("Plus", terms)
 }
 
 fn distribution_moment(
@@ -3458,10 +3365,7 @@ fn distribution_moment(
             ]
             .into(),
           },
-          Expr::FunctionCall {
-            name: "BernoulliB".to_string(),
-            args: vec![Expr::Integer(n)].into(),
-          },
+          call("BernoulliB", vec![Expr::Integer(n)]),
           pow2(Expr::Identifier("Pi".to_string()), Expr::Integer(n)),
           pow2(b, Expr::Integer(n)),
         ]
@@ -3488,14 +3392,7 @@ fn distribution_moment(
     } else {
       let diff = Expr::FunctionCall {
         name: "Plus".to_string(),
-        args: vec![
-          b,
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![Expr::Integer(-1), a].into(),
-          },
-        ]
-        .into(),
+        args: vec![b, call("Times", vec![Expr::Integer(-1), a])].into(),
       };
       let num = pow2(diff, Expr::Integer(n));
       // 2^n * (n + 1), kept symbolic so large n does not overflow.
@@ -3524,10 +3421,7 @@ fn distribution_moment(
         name: "Times".to_string(),
         args: vec![
           pow2(Expr::Integer(-1), Expr::Integer(n / 2)),
-          Expr::FunctionCall {
-            name: "EulerE".to_string(),
-            args: vec![Expr::Integer(n)].into(),
-          },
+          call("EulerE", vec![Expr::Integer(n)]),
           pow2(s, Expr::Integer(n)),
         ]
         .into(),
@@ -3550,28 +3444,16 @@ fn distribution_moment(
       Expr::Integer(1)
     } else {
       pow2(
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(-1), mean.clone()].into(),
-        },
+        call("Times", vec![Expr::Integer(-1), mean.clone()]),
         Expr::Integer(n - k),
       )
     };
-    terms.push(Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![binom, neg_mean_pow, raw].into(),
-    });
+    terms.push(call("Times", vec![binom, neg_mean_pow, raw]));
   }
-  let sum = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  };
+  let sum = call("Plus", terms);
   // Expand so symbolic-parameter results collapse to their reduced form
   // (e.g. the Normal third central moment cancels to 0, Poisson's to m).
-  let expanded = Expr::FunctionCall {
-    name: "Expand".to_string(),
-    args: vec![sum].into(),
-  };
+  let expanded = call("Expand", vec![sum]);
   Ok(Some(crate::evaluator::evaluate_expr_to_expr(&expanded)?))
 }
 
@@ -3661,10 +3543,7 @@ pub fn central_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Sum and divide by n
-  let sum_expr = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  };
+  let sum_expr = call("Plus", terms);
   let sum_val = crate::evaluator::evaluate_expr_to_expr(&sum_expr)?;
   let result = div2(sum_val, Expr::Integer(n as i128));
   crate::evaluator::evaluate_expr_to_expr(&result)
@@ -3702,10 +3581,7 @@ pub fn cumulant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       }
     }
     let result = cumulant_from_raw_moments(&mu, r)?;
-    let expanded = Expr::FunctionCall {
-      name: "Expand".to_string(),
-      args: vec![result].into(),
-    };
+    let expanded = call("Expand", vec![result]);
     return crate::evaluator::evaluate_expr_to_expr(&expanded);
   }
 
@@ -3723,10 +3599,7 @@ pub fn cumulant_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let powered = pow2(item.clone(), Expr::Integer(j as i128));
       terms.push(crate::evaluator::evaluate_expr_to_expr(&powered)?);
     }
-    let sum_expr = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    };
+    let sum_expr = call("Plus", terms);
     let div = div2(sum_expr, Expr::Integer(n));
     crate::evaluator::evaluate_expr_to_expr(&div)
   };
@@ -3826,15 +3699,9 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // 3 + (1 - 6 (1 - p) p)/(n (1 - p) p)
       let num = minus2(
         Expr::Integer(1),
-        Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: vec![Expr::Integer(6), one_minus_p(&p), p.clone()].into(),
-        },
+        call("Times", vec![Expr::Integer(6), one_minus_p(&p), p.clone()]),
       );
-      let den = Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![n, one_minus_p(&p), p.clone()].into(),
-      };
+      let den = call("Times", vec![n, one_minus_p(&p), p.clone()]);
       let result = three_plus(num, den);
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
@@ -3853,10 +3720,7 @@ pub fn kurtosis_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// results are unaffected.
 fn maybe_expand_for_distribution(arg: &Expr, result: Expr) -> Expr {
   if as_distribution(arg).is_some() {
-    Expr::FunctionCall {
-      name: "Expand".to_string(),
-      args: vec![result].into(),
-    }
+    call("Expand", vec![result])
   } else {
     result
   }
@@ -3883,10 +3747,7 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       plus2(Expr::Integer(1), times2(Expr::Integer(4), p.clone())),
       pow2(p, Expr::Integer(2)),
     );
-    let sqrt = Expr::FunctionCall {
-      name: "Sqrt".to_string(),
-      args: vec![times2(one_plus_p.clone(), t)].into(),
-    };
+    let sqrt = call1("Sqrt", times2(one_plus_p.clone(), t));
     let den = times2(one_plus_p, sqrt);
     let result = div2(num, den);
     return crate::evaluator::evaluate_expr_to_expr(&result);
@@ -3894,10 +3755,7 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Geometric: Skewness = (2 - p)/Sqrt[1 - p]. Built directly to preserve the
   // compact form (the generic moment ratio leaves CentralMoment unevaluated).
   if let Some(p) = one_param_of(&args[0], "GeometricDistribution") {
-    let sqrt = Expr::FunctionCall {
-      name: "Sqrt".to_string(),
-      args: vec![minus2(Expr::Integer(1), p.clone())].into(),
-    };
+    let sqrt = call1("Sqrt", minus2(Expr::Integer(1), p.clone()));
     let result = div2(minus2(Expr::Integer(2), p), sqrt);
     return crate::evaluator::evaluate_expr_to_expr(&result);
   }
@@ -3905,10 +3763,7 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // scale being r (NegativeBinomial) or n (Pascal). Binomial has the (1 - 2 p)
   // form. Built directly so the compact shapes are preserved.
   {
-    let sqrt = |e| Expr::FunctionCall {
-      name: "Sqrt".to_string(),
-      args: vec![e].into(),
-    };
+    let sqrt = |e| call1("Sqrt", e);
     let one_minus_p = |p: &Expr| minus2(Expr::Integer(1), p.clone());
     if let Some((r, p)) =
       two_params_of(&args[0], "NegativeBinomialDistribution")
@@ -3928,10 +3783,7 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
     if let Some((n, p)) = two_params_of(&args[0], "BinomialDistribution") {
       let num = minus2(Expr::Integer(1), times2(Expr::Integer(2), p.clone()));
-      let scale = Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![n, one_minus_p(&p), p.clone()].into(),
-      };
+      let scale = call("Times", vec![n, one_minus_p(&p), p.clone()]);
       let result = div2(num, sqrt(scale));
       return crate::evaluator::evaluate_expr_to_expr(&result);
     }
@@ -3950,10 +3802,10 @@ pub fn skewness_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let m2_pow = Expr::BinaryOp {
       op: BinaryOperator::Power,
       left: Box::new(m2),
-      right: Box::new(Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(-3), Expr::Integer(2)].into(),
-      }),
+      right: Box::new(call(
+        "Rational",
+        vec![Expr::Integer(-3), Expr::Integer(2)],
+      )),
     };
     times2(m3, m2_pow)
   } else {
@@ -3986,18 +3838,9 @@ pub fn root_mean_square_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && !items.is_empty()
     && items.iter().all(|r| matches!(r, Expr::List(_)))
   {
-    let squared = Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![args[0].clone(), Expr::Integer(2)].into(),
-    };
-    let mean = Expr::FunctionCall {
-      name: "Mean".to_string(),
-      args: vec![squared].into(),
-    };
-    let sqrt = Expr::FunctionCall {
-      name: "Sqrt".to_string(),
-      args: vec![mean].into(),
-    };
+    let squared = call("Power", vec![args[0].clone(), Expr::Integer(2)]);
+    let mean = call1("Mean", squared);
+    let sqrt = call1("Sqrt", mean);
     return crate::evaluator::evaluate_expr_to_expr(&sqrt);
   }
   match &args[0] {
@@ -4065,21 +3908,12 @@ pub fn root_mean_square_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // it.
       let squares: Vec<Expr> = items
         .iter()
-        .map(|item| Expr::FunctionCall {
-          name: "Power".to_string(),
-          args: vec![item.clone(), Expr::Integer(2)].into(),
-        })
+        .map(|item| call("Power", vec![item.clone(), Expr::Integer(2)]))
         .collect();
       let mean_square = Expr::FunctionCall {
         name: "Divide".to_string(),
-        args: vec![
-          Expr::FunctionCall {
-            name: "Plus".to_string(),
-            args: squares.into(),
-          },
-          Expr::Integer(items.len() as i128),
-        ]
-        .into(),
+        args: vec![call("Plus", squares), Expr::Integer(items.len() as i128)]
+          .into(),
       };
       Ok(crate::evaluator::evaluate_expr_to_expr(&make_sqrt(
         mean_square,
@@ -4182,10 +4016,7 @@ pub fn quantile_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && name == "ErlangDistribution"
     && dargs.len() == 2
   {
-    let gamma = Expr::FunctionCall {
-      name: "GammaDistribution".to_string(),
-      args: erlang_gamma_dargs(dargs)?.into(),
-    };
+    let gamma = call("GammaDistribution", erlang_gamma_dargs(dargs)?);
     let mut new_args = args.to_vec();
     new_args[0] = gamma;
     return quantile_ast(&new_args);
@@ -4362,14 +4193,8 @@ fn quantile_parametric(
   d: &Expr,
 ) -> Result<Expr, InterpreterError> {
   use crate::evaluator::evaluate_expr_to_expr as ev;
-  let plus = |x: Expr, y: Expr| Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: vec![x, y].into(),
-  };
-  let times = |x: Expr, y: Expr| Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![x, y].into(),
-  };
+  let plus = |x: Expr, y: Expr| call("Plus", vec![x, y]);
+  let times = |x: Expr, y: Expr| call("Times", vec![x, y]);
   // q must be numeric (Integer, Rational, or Real); otherwise leave symbolic.
   if try_eval_to_f64(q).is_none() {
     return Ok(Expr::FunctionCall {
@@ -4393,10 +4218,7 @@ fn quantile_parametric(
   let nb = ev(&plus(Expr::Integer(n), b.clone()))?;
   let x = ev(&plus(a.clone(), times(nb, q.clone())))?;
   // k = Floor[x]
-  let k_expr = ev(&Expr::FunctionCall {
-    name: "Floor".to_string(),
-    args: vec![x.clone()].into(),
-  })?;
+  let k_expr = ev(&call("Floor", vec![x.clone()]))?;
   let k = match &k_expr {
     Expr::Integer(v) => *v,
     other => try_eval_to_f64(other)
@@ -4465,10 +4287,10 @@ pub fn moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Raise each element to power r and evaluate, then compute mean
   let mut powered = Vec::with_capacity(items.len());
   for x in items {
-    let p = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![x.clone(), r.clone()].into(),
-    })?;
+    let p = crate::evaluator::evaluate_expr_to_expr(&call(
+      "Power",
+      vec![x.clone(), r.clone()],
+    ))?;
     powered.push(p);
   }
 
@@ -4488,10 +4310,7 @@ fn factorial_moment_of_distribution(
   dargs: &[Expr],
   r: i128,
 ) -> Option<Expr> {
-  let times = |fs: Vec<Expr>| Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: fs.into(),
-  };
+  let times = |fs: Vec<Expr>| call("Times", fs);
   let r_factorial: i128 = (1..=r).product::<i128>().max(1);
   match (name, dargs) {
     // Poisson: E[X^(r)] = lambda^r (the defining property).
@@ -4591,36 +4410,24 @@ fn factorial_moment_via_expectation(
       factors.push(if i == 0 {
         var_expr.clone()
       } else {
-        Expr::FunctionCall {
-          name: "Plus".to_string(),
-          args: vec![var_expr.clone(), Expr::Integer(-i)].into(),
-        }
+        call("Plus", vec![var_expr.clone(), Expr::Integer(-i)])
       });
     }
-    Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: factors.into(),
-    }
+    call("Times", factors)
   };
 
   // Expand into a monomial sum so Expectation resolves each moment exactly.
   let polynomial =
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Expand".to_string(),
-      args: vec![falling].into(),
-    })?;
+    crate::evaluator::evaluate_expr_to_expr(&call("Expand", vec![falling]))?;
 
-  let distributed = Expr::FunctionCall {
-    name: "Distributed".to_string(),
-    args: vec![var_expr, dist.clone()].into(),
-  };
+  let distributed = call("Distributed", vec![var_expr, dist.clone()]);
   // Route through the main evaluator (rather than calling expectation_ast
   // directly) so the exact symbolic-moment path is taken instead of the
   // numerical-integration fallback.
-  let result = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Expectation".to_string(),
-    args: vec![polynomial, distributed].into(),
-  })?;
+  let result = crate::evaluator::evaluate_expr_to_expr(&call(
+    "Expectation",
+    vec![polynomial, distributed],
+  ))?;
 
   // If Expectation could not resolve, it returns an Expectation[...] call.
   if matches!(&result, Expr::FunctionCall { name, .. } if name == "Expectation")
@@ -4684,22 +4491,16 @@ pub fn factorial_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           if k == 0 {
             x.clone()
           } else {
-            Expr::FunctionCall {
-              name: "Plus".to_string(),
-              args: vec![x.clone(), Expr::Integer(-k)].into(),
-            }
+            call("Plus", vec![x.clone(), Expr::Integer(-k)])
           }
         })
         .collect();
-      return crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: factors.into(),
-      });
+      return crate::evaluator::evaluate_expr_to_expr(&call("Times", factors));
     }
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "FactorialPower".to_string(),
-      args: vec![x.clone(), r.clone()].into(),
-    })
+    crate::evaluator::evaluate_expr_to_expr(&call(
+      "FactorialPower",
+      vec![x.clone(), r.clone()],
+    ))
   };
 
   let mut terms = Vec::with_capacity(items.len());
@@ -4716,12 +4517,9 @@ pub fn factorial_moment_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         for (x, r) in coords.iter().zip(orders.iter()) {
           factors.push(factorial_power(x, r)?);
         }
-        terms.push(crate::evaluator::evaluate_expr_to_expr(
-          &Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: factors.into(),
-          },
-        )?);
+        terms.push(crate::evaluator::evaluate_expr_to_expr(&call(
+          "Times", factors,
+        ))?);
       }
     }
     r => {
@@ -4749,16 +4547,10 @@ pub fn mean_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut abs_devs = Vec::new();
     for item in items {
       let diff = minus2(item.clone(), mean_expr.clone());
-      let abs_diff = Expr::FunctionCall {
-        name: "Abs".to_string(),
-        args: vec![diff].into(),
-      };
+      let abs_diff = call("Abs", vec![diff]);
       abs_devs.push(abs_diff);
     }
-    let sum = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: abs_devs.into(),
-    };
+    let sum = call("Plus", abs_devs);
     let result = div2(sum, Expr::Integer(n));
     crate::evaluator::evaluate_expr_to_expr(&result)
   } else {
@@ -4780,10 +4572,7 @@ pub fn median_deviation_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let mut abs_devs = Vec::new();
     for item in items {
       let diff = minus2(item.clone(), median_expr.clone());
-      let abs_diff = Expr::FunctionCall {
-        name: "Abs".to_string(),
-        args: vec![diff].into(),
-      };
+      let abs_diff = call("Abs", vec![diff]);
       abs_devs.push(crate::evaluator::evaluate_expr_to_expr(&abs_diff)?);
     }
     // Return median of the absolute deviations
@@ -5001,10 +4790,7 @@ fn format_location_test_result(
                     name: "Rule".to_string(),
                     args: vec![
                       Expr::Integer(2),
-                      Expr::FunctionCall {
-                        name: "GrayLevel".to_string(),
-                        args: vec![Expr::Real(0.7)].into(),
-                      },
+                      call("GrayLevel", vec![Expr::Real(0.7)]),
                     ]
                     .into(),
                   },
@@ -5012,10 +4798,7 @@ fn format_location_test_result(
                     name: "Rule".to_string(),
                     args: vec![
                       Expr::Integer(2),
-                      Expr::FunctionCall {
-                        name: "GrayLevel".to_string(),
-                        args: vec![Expr::Real(0.7)].into(),
-                      },
+                      call("GrayLevel", vec![Expr::Real(0.7)]),
                     ]
                     .into(),
                   },
@@ -5080,10 +4863,7 @@ pub fn likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Compute PDF[dist, xi] for each data point
   let mut pdf_values = Vec::with_capacity(data.len());
   for xi in data {
-    let pdf_expr = Expr::FunctionCall {
-      name: "PDF".to_string(),
-      args: vec![dist.clone(), xi.clone()].into(),
-    };
+    let pdf_expr = call("PDF", vec![dist.clone(), xi.clone()]);
     let pdf_val = crate::evaluator::evaluate_expr_to_expr(&pdf_expr)?;
     pdf_values.push(pdf_val);
   }
@@ -5092,10 +4872,7 @@ pub fn likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let product = if pdf_values.len() == 1 {
     pdf_values.into_iter().next().unwrap()
   } else {
-    let product_expr = Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: pdf_values.into(),
-    };
+    let product_expr = call("Times", pdf_values);
     crate::evaluator::evaluate_expr_to_expr(&product_expr)?
   };
 
@@ -5105,10 +4882,7 @@ pub fn likelihood_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(num_to_expr(val));
     }
     // Try N[product]
-    let n_expr = Expr::FunctionCall {
-      name: "N".to_string(),
-      args: vec![product.clone()].into(),
-    };
+    let n_expr = call1("N", product.clone());
     if let Ok(result) = crate::evaluator::evaluate_expr_to_expr(&n_expr)
       && try_eval_to_f64(&result).is_some()
     {
@@ -5322,10 +5096,10 @@ pub fn longitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let coords = extract_geo_coords(&args[0]);
   match coords {
-    Some((_, lon)) => Ok(Expr::FunctionCall {
-      name: "Quantity".to_string(),
-      args: vec![lon, Expr::String("AngularDegrees".to_string())].into(),
-    }),
+    Some((_, lon)) => Ok(call(
+      "Quantity",
+      vec![lon, Expr::String("AngularDegrees".to_string())],
+    )),
     None => Ok(unevaluated("Longitude", args)),
   }
 }
@@ -5337,10 +5111,10 @@ pub fn latitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   let coords = extract_geo_coords(&args[0]);
   match coords {
-    Some((lat, _)) => Ok(Expr::FunctionCall {
-      name: "Quantity".to_string(),
-      args: vec![lat, Expr::String("AngularDegrees".to_string())].into(),
-    }),
+    Some((lat, _)) => Ok(call(
+      "Quantity",
+      vec![lat, Expr::String("AngularDegrees".to_string())],
+    )),
     None => Ok(unevaluated("Latitude", args)),
   }
 }
@@ -5373,14 +5147,14 @@ pub fn latitude_longitude_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   match extract_geo_coords(&args[0]) {
     Some((lat, lon)) => Ok(Expr::List(
       vec![
-        Expr::FunctionCall {
-          name: "Quantity".to_string(),
-          args: vec![lat, Expr::String("AngularDegrees".to_string())].into(),
-        },
-        Expr::FunctionCall {
-          name: "Quantity".to_string(),
-          args: vec![lon, Expr::String("AngularDegrees".to_string())].into(),
-        },
+        call(
+          "Quantity",
+          vec![lat, Expr::String("AngularDegrees".to_string())],
+        ),
+        call(
+          "Quantity",
+          vec![lon, Expr::String("AngularDegrees".to_string())],
+        ),
       ]
       .into(),
     )),
@@ -6390,10 +6164,7 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
                 name: "Plus".to_string(),
                 args: vec![
                   n.clone(),
-                  Expr::FunctionCall {
-                    name: "Rational".to_string(),
-                    args: vec![Expr::Integer(-1), Expr::Integer(2)].into(),
-                  },
+                  call("Rational", vec![Expr::Integer(-1), Expr::Integer(2)]),
                 ]
                 .into(),
               },
@@ -6411,10 +6182,7 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
             name: "Power".to_string(),
             args: vec![
               Expr::Constant("E".to_string()),
-              Expr::FunctionCall {
-                name: "Times".to_string(),
-                args: vec![Expr::Integer(-1), n].into(),
-              },
+              call("Times", vec![Expr::Integer(-1), n]),
             ]
             .into(),
           },
@@ -6429,10 +6197,7 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
         && args.len() == 1
         && is_pure_var(&args[0], var) =>
     {
-      Some(Expr::FunctionCall {
-        name: "Log".to_string(),
-        args: vec![Expr::Identifier(var.to_string())].into(),
-      })
+      Some(call("Log", vec![Expr::Identifier(var.to_string())]))
     }
 
     // Power[base, exp] - handle var^k, k^var, etc.
@@ -6469,10 +6234,7 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
       left,
       right,
     } => {
-      let neg_right = Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), *right.clone()].into(),
-      };
+      let neg_right = call("Times", vec![Expr::Integer(-1), *right.clone()]);
       asymptotic_sum(&[*left.clone(), neg_right], var)
     }
 
@@ -6487,10 +6249,7 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
       if result_factors.len() == 1 {
         Some(result_factors.into_iter().next().unwrap())
       } else {
-        Some(Expr::FunctionCall {
-          name: "Times".to_string(),
-          args: result_factors.into(),
-        })
+        Some(call("Times", result_factors))
       }
     }
 
@@ -6502,10 +6261,7 @@ fn discrete_asymptotic_leading(expr: &Expr, var: &str) -> Option<Expr> {
     } => {
       let l = discrete_asymptotic_leading(left, var)?;
       let r = discrete_asymptotic_leading(right, var)?;
-      Some(Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![l, r].into(),
-      })
+      Some(call("Times", vec![l, r]))
     }
 
     // BinaryOp Divide
@@ -6587,10 +6343,7 @@ fn stirling_approx(var: &str) -> Expr {
             name: "Plus".to_string(),
             args: vec![
               n.clone(),
-              Expr::FunctionCall {
-                name: "Rational".to_string(),
-                args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
-              },
+              call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
             ]
             .into(),
           },
@@ -6598,19 +6351,16 @@ fn stirling_approx(var: &str) -> Expr {
         .into(),
       },
       // Sqrt[2*Pi]
-      make_sqrt(Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(2), Expr::Constant("Pi".to_string())].into(),
-      }),
+      make_sqrt(call(
+        "Times",
+        vec![Expr::Integer(2), Expr::Constant("Pi".to_string())],
+      )),
       // E^(-n)
       Expr::FunctionCall {
         name: "Power".to_string(),
         args: vec![
           Expr::Constant("E".to_string()),
-          Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: vec![Expr::Integer(-1), n].into(),
-          },
+          call("Times", vec![Expr::Integer(-1), n]),
         ]
         .into(),
       },
@@ -6717,10 +6467,7 @@ fn asymptotic_sum(terms: &[Expr], var: &str) -> Option<Expr> {
     } else if (order - best_order).abs() < 1e-10 {
       // Same order - need to add them (e.g. 3n^2 + 5n^2 -> 8n^2)
       // For simplicity, if they have the same growth order, keep as sum
-      best_expr = Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: vec![best_expr, asym].into(),
-      };
+      best_expr = call("Plus", vec![best_expr, asym]);
     }
   }
   Some(best_expr)
@@ -6768,10 +6515,7 @@ fn asymptotic_binomial(
           Expr::FunctionCall {
             name: "Plus".to_string(),
             args: vec![
-              Expr::FunctionCall {
-                name: "Rational".to_string(),
-                args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
-              },
+              call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
               n.clone(),
             ]
             .into(),
@@ -6830,10 +6574,10 @@ pub fn covariance_function_data(
     crate::emit_message(&format!(
       "CovarianceFunction::bdlag: The lag specification {h} should be a symbol, an integer with magnitude less than the length of the data or a range specification indicating such integers."
     ));
-    return Some(Ok(Expr::FunctionCall {
-      name: "CovarianceFunction".to_string(),
-      args: vec![data.clone(), lag.clone()].into(),
-    }));
+    return Some(Ok(call(
+      "CovarianceFunction",
+      vec![data.clone(), lag.clone()],
+    )));
   }
   let mean = match mean_ast(&[Expr::List(items.to_vec().into())]) {
     Ok(m) => m,
@@ -6845,10 +6589,7 @@ pub fn covariance_function_data(
   for t in 0..(n - h_us) {
     terms.push(times2(dev(&items[t]), dev(&items[t + h_us])));
   }
-  let sum = Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  };
+  let sum = call("Plus", terms);
   let result = div2(sum, Expr::Integer(n as i128));
   Some(crate::evaluator::evaluate_expr_to_expr(&result))
 }
@@ -6884,10 +6625,7 @@ pub fn absolute_correlation_function_ast(
       .map(|t| times2(items[t].clone(), items[t + h_us].clone()))
       .collect();
     crate::evaluator::evaluate_expr_to_expr(&div2(
-      Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: terms.into(),
-      },
+      call("Plus", terms),
       Expr::Integer(n as i128),
     ))
   };
@@ -6952,10 +6690,7 @@ fn process_covariance(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
   let Expr::FunctionCall { name, args } = proc else {
     return None;
   };
-  let call = |n: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: n.to_string(),
-    args: a.into(),
-  };
+  let call = |n: &str, a: Vec<Expr>| call(n, a);
   let neg = |a: Expr| times2(Expr::Integer(-1), a);
   let sq = |a: &Expr| pow2(a.clone(), Expr::Integer(2));
   let min = call("Min", vec![t1.clone(), t2.clone()]);
@@ -7061,16 +6796,13 @@ pub fn biweight_midvariance_ast(
     _ => return unevaluated(),
   };
   let ev = crate::evaluator::evaluate_expr_to_expr;
-  let call = |n: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: n.to_string(),
-    args: a.into(),
-  };
-  let median = ev(&call("Median", vec![args[0].clone()]))?;
+  let call = |n: &str, a: Vec<Expr>| call(n, a);
+  let median = ev(&call1("Median", args[0].clone()))?;
   let deviations: Vec<Expr> = items
     .iter()
     .map(|x| call("Abs", vec![minus2(x.clone(), median.clone())]))
     .collect();
-  let mad = ev(&call("Median", vec![Expr::List(deviations.into())]))?;
+  let mad = ev(&call1("Median", Expr::List(deviations.into())))?;
   match try_eval_to_f64(&mad) {
     Some(v) if v != 0.0 => {}
     Some(_) => return Ok(Expr::Identifier("Indeterminate".to_string())),
@@ -7102,10 +6834,7 @@ pub fn biweight_midvariance_ast(
   if den_terms.is_empty() {
     return Ok(Expr::Identifier("Indeterminate".to_string()));
   }
-  let total = |ts: Vec<Expr>| Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: ts.into(),
-  };
+  let total = |ts: Vec<Expr>| call("Plus", ts);
   ev(&div2(
     times2(Expr::Integer(items.len() as i128), total(num_terms)),
     pow2(total(den_terms), Expr::Integer(2)),
@@ -7118,10 +6847,7 @@ pub fn process_correlation(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
   let Expr::FunctionCall { name, args } = proc else {
     return None;
   };
-  let call = |n: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: n.to_string(),
-    args: a.into(),
-  };
+  let call = |n: &str, a: Vec<Expr>| call(n, a);
   let neg = |a: Expr| times2(Expr::Integer(-1), a);
   let sq = |a: &Expr| pow2(a.clone(), Expr::Integer(2));
   let min = call("Min", vec![t1.clone(), t2.clone()]);
@@ -7129,10 +6855,9 @@ pub fn process_correlation(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
     // The scale cancels for all three counting/Brownian cases.
     ("WienerProcess", [_, _])
     | ("PoissonProcess", [_])
-    | ("BinomialProcess", [_]) => Some(div2(
-      min,
-      call("Sqrt", vec![times2(t1.clone(), t2.clone())]),
-    )),
+    | ("BinomialProcess", [_]) => {
+      Some(div2(min, call1("Sqrt", times2(t1.clone(), t2.clone()))))
+    }
     ("OrnsteinUhlenbeckProcess", [_, _, th]) => Some(pow2(
       Expr::Constant("E".to_string()),
       neg(times2(
@@ -7164,12 +6889,12 @@ pub fn process_correlation(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
         times2(plus2(neg(ta.clone()), tb.clone()), min),
       );
       let leg = |t: &Expr| {
-        call(
+        call1(
           "Sqrt",
-          vec![times2(
+          times2(
             plus2(t.clone(), neg(ta.clone())),
             plus2(neg(t.clone()), tb.clone()),
-          )],
+          ),
         )
       };
       Some(div2(numer, times2(leg(t1), leg(t2))))
@@ -7184,8 +6909,8 @@ pub fn process_correlation(proc: &Expr, t1: &Expr, t2: &Expr) -> Option<Expr> {
       Some(div2(
         bump(min),
         times2(
-          call("Sqrt", vec![bump(t1.clone())]),
-          call("Sqrt", vec![bump(t2.clone())]),
+          call1("Sqrt", bump(t1.clone())),
+          call1("Sqrt", bump(t2.clone())),
         ),
       ))
     }
@@ -7203,10 +6928,7 @@ pub fn process_absolute_correlation(
   let Expr::FunctionCall { name, args } = proc else {
     return None;
   };
-  let call = |n: &str, a: Vec<Expr>| Expr::FunctionCall {
-    name: n.to_string(),
-    args: a.into(),
-  };
+  let call = |n: &str, a: Vec<Expr>| call(n, a);
   let neg = |a: Expr| times2(Expr::Integer(-1), a);
   let sq = |a: &Expr| pow2(a.clone(), Expr::Integer(2));
   let min = call("Min", vec![t1.clone(), t2.clone()]);
@@ -7377,20 +7099,14 @@ fn eval_once(e: Expr) -> Expr {
 
 // ─── AST builder helpers ────────────────────────────────────────────────
 
-fn fc(name: &str, args: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  }
-}
 fn cf_plus(xs: Vec<Expr>) -> Expr {
-  fc("Plus", xs)
+  call("Plus", xs)
 }
 fn cf_times(xs: Vec<Expr>) -> Expr {
-  fc("Times", xs)
+  call("Times", xs)
 }
 fn cf_pow(b: Expr, e: Expr) -> Expr {
-  fc("Power", vec![b, e])
+  call("Power", vec![b, e])
 }
 fn cf_div(n: Expr, d: Expr) -> Expr {
   div2(n, d)
@@ -7399,7 +7115,7 @@ fn cf_neg(x: Expr) -> Expr {
   cf_times(vec![Expr::Integer(-1), x])
 }
 fn cf_abs(x: Expr) -> Expr {
-  fc("Abs", vec![x])
+  call1("Abs", x)
 }
 fn cf_abs_diff(s: &Expr, t: &Expr) -> Expr {
   cf_abs(cf_plus(vec![s.clone(), cf_neg(t.clone())]))
@@ -7444,7 +7160,7 @@ fn cov_ma1(b: &Expr, sigma2: &Expr, s: &Expr, t: &Expr) -> Expr {
     ]
     .into(),
   );
-  fc(
+  call(
     "Piecewise",
     vec![Expr::List(vec![case1, case0].into()), Expr::Integer(0)],
   )
@@ -7508,7 +7224,7 @@ fn cov_arma11(a: &Expr, b: &Expr, sigma2: &Expr, s: &Expr, t: &Expr) -> Expr {
     ]
     .into(),
   );
-  fc(
+  call(
     "Piecewise",
     vec![Expr::List(vec![case].into()), default_value],
   )
@@ -7539,10 +7255,7 @@ pub fn characteristic_function_ast(
   // special cases match Identifier("I")
   let i_unit = || Expr::Identifier("I".to_string());
   let e_sym = || Expr::Identifier("E".to_string());
-  let call = |name: &str, fargs: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: fargs.into(),
-  };
+  let call = |name: &str, fargs: Vec<Expr>| call(name, fargs);
   // E^(I*t) and E^(I*c*t)
   let e_it = |factors: Vec<Expr>| {
     let mut f = vec![i_unit()];
@@ -7926,7 +7639,7 @@ pub fn characteristic_function_ast(
                 Expr::Integer(-1),
                 b.clone(),
                 t.clone(),
-                call("Sign", vec![t.clone()]),
+                call1("Sign", t.clone()),
               ],
             ),
           ],
@@ -7940,7 +7653,7 @@ pub fn characteristic_function_ast(
         e_sym(),
         call(
           "Times",
-          vec![Expr::Integer(-1), t.clone(), call("Sign", vec![t.clone()])],
+          vec![Expr::Integer(-1), t.clone(), call1("Sign", t.clone())],
         ),
       ),
       true,
@@ -7975,10 +7688,7 @@ pub fn moment_generating_function_ast(
   let t = args[1].clone();
 
   let e_sym = || Expr::Identifier("E".to_string());
-  let call = |name: &str, fargs: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: fargs.into(),
-  };
+  let call = |name: &str, fargs: Vec<Expr>| call(name, fargs);
   // E^t and E^(c*t)
   let e_t = |factors: Vec<Expr>| {
     if factors.is_empty() {
@@ -8343,10 +8053,7 @@ fn is_e_base(e: &Expr) -> bool {
 ///   E^X → X,  base^(-a) → -(a Log[base]),  base^exp → exp Log[base],
 ///   otherwise → Log[f].
 fn cgf_term(f: &Expr) -> Expr {
-  let log = |e: Expr| Expr::FunctionCall {
-    name: "Log".to_string(),
-    args: vec![e].into(),
-  };
+  let log = |e: Expr| call("Log", vec![e]);
   if let Some((base, exp)) = as_power_pair(f) {
     if is_e_base(base) {
       exp.clone()
@@ -8355,15 +8062,9 @@ fn cgf_term(f: &Expr) -> Expr {
       operand,
     } = exp
     {
-      neg1(Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![(**operand).clone(), log(base.clone())].into(),
-      })
+      neg1(call("Times", vec![(**operand).clone(), log(base.clone())]))
     } else {
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![exp.clone(), log(base.clone())].into(),
-      }
+      call("Times", vec![exp.clone(), log(base.clone())])
     }
   } else {
     log(f.clone())
@@ -8389,14 +8090,8 @@ pub fn cumulant_generating_function_ast(
   let t = args[1].clone();
 
   let e_sym = || Expr::Identifier("E".to_string());
-  let call = |name: &str, fargs: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: fargs.into(),
-  };
-  let log = |e: Expr| Expr::FunctionCall {
-    name: "Log".to_string(),
-    args: vec![e].into(),
-  };
+  let call = |name: &str, fargs: Vec<Expr>| call(name, fargs);
+  let log = |e: Expr| call("Log", vec![e]);
 
   let (dist_name, dargs) = match &args[0] {
     Expr::FunctionCall { name, args } => (name.as_str(), args.as_slice()),
@@ -8512,10 +8207,7 @@ pub fn factorial_moment_generating_function_ast(
   if args.len() != 2 {
     return Ok(uneval());
   }
-  let log_t = Expr::FunctionCall {
-    name: "Log".to_string(),
-    args: vec![args[1].clone()].into(),
-  };
+  let log_t = call("Log", vec![args[1].clone()]);
   // Symbolic NormalDistribution keeps E^(m Log[t] + (s^2 Log[t]^2)/2)
   // unfolded like wolframscript (evaluation would extract t^m; both
   // engines only do that folding for numeric m).
@@ -8526,10 +8218,7 @@ pub fn factorial_moment_generating_function_ast(
     && dargs.iter().all(|d| matches!(d, Expr::Identifier(_)))
   {
     let (m, sd) = (dargs[0].clone(), dargs[1].clone());
-    let times = |f: Vec<Expr>| Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: f.into(),
-    };
+    let times = |f: Vec<Expr>| call("Times", f);
     let sq = |e: Expr| pow2(e, Expr::Integer(2));
     return Ok(pow2(
       Expr::Identifier("E".to_string()),
@@ -8567,18 +8256,17 @@ pub fn central_moment_generating_function_ast(
   {
     return Ok(uneval());
   }
-  let mean = crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Mean".to_string(),
-    args: vec![args[0].clone()].into(),
-  })?;
+  let mean = crate::evaluator::evaluate_expr_to_expr(&call(
+    "Mean",
+    vec![args[0].clone()],
+  ))?;
   if matches!(&mean, Expr::FunctionCall { name, .. } if name == "Mean") {
     return Ok(uneval());
   }
-  let damp_exponent =
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![Expr::Integer(-1), mean.clone(), args[1].clone()].into(),
-    })?;
+  let damp_exponent = crate::evaluator::evaluate_expr_to_expr(&call(
+    "Times",
+    vec![Expr::Integer(-1), mean.clone(), args[1].clone()],
+  ))?;
   // UniformDistribution keeps wolframscript's numerator order
   // (-E^(a t) + E^(b t)); a re-evaluated product would resort it.
   if let Expr::FunctionCall { name, args: dargs } = &args[0]
@@ -8590,15 +8278,9 @@ pub fn central_moment_generating_function_ast(
     let (a, b) = (minmax[0].clone(), minmax[1].clone());
     let symbolic = matches!(&args[1], Expr::Identifier(_))
       && minmax.iter().all(|d| matches!(d, Expr::Identifier(_)));
-    let times = |f: Vec<Expr>| Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: f.into(),
-    };
+    let times = |f: Vec<Expr>| call("Times", f);
     let e_pow = |e: Expr| pow2(Expr::Identifier("E".to_string()), e);
-    let half = Expr::FunctionCall {
-      name: "Rational".to_string(),
-      args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
-    };
+    let half = call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]);
     let t = args[1].clone();
     let expr = div2(
       Expr::FunctionCall {
@@ -8618,14 +8300,7 @@ pub fn central_moment_generating_function_ast(
           args: vec![times(vec![Expr::Integer(-1), a.clone()]), b.clone()]
             .into(),
         },
-        e_pow(times(vec![
-          half,
-          Expr::FunctionCall {
-            name: "Plus".to_string(),
-            args: vec![a, b].into(),
-          },
-          t.clone(),
-        ])),
+        e_pow(times(vec![half, call("Plus", vec![a, b]), t.clone()])),
         t,
       ]),
     );
@@ -8662,10 +8337,7 @@ pub fn central_moment_generating_function_ast(
     if matches!(damp_exponent, Expr::Integer(0)) {
       return Ok(mgf);
     }
-    let raw = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: vec![expo, damp_exponent].into(),
-    };
+    let raw = call("Plus", vec![expo, damp_exponent]);
     // Keep wolframscript's exponent order (MGF exponent first, then
     // -mean*t) unless evaluation cancels terms — then use the
     // simplified exponent (e.g. the Normal case collapses to
@@ -8689,10 +8361,7 @@ pub fn central_moment_generating_function_ast(
     return Ok(pow2(Expr::Identifier("E".to_string()), exponent));
   }
   let damp = pow2(Expr::Identifier("E".to_string()), damp_exponent);
-  crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: vec![damp, mgf].into(),
-  })
+  crate::evaluator::evaluate_expr_to_expr(&call("Times", vec![damp, mgf]))
 }
 
 // ─── CorrelationFunction ─────────────────────────────────────────────
@@ -8739,32 +8408,20 @@ pub fn correlation_function_ast(
     name: "Plus".to_string(),
     args: vec![
       x.clone(),
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: vec![Expr::Integer(-1), mean.clone()].into(),
-      },
+      call("Times", vec![Expr::Integer(-1), mean.clone()]),
     ]
     .into(),
   };
   let sum = |terms: Vec<Expr>| -> Result<Expr, InterpreterError> {
-    crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    })
+    crate::evaluator::evaluate_expr_to_expr(&call("Plus", terms))
   };
   let len = data.len();
   let num_terms: Vec<Expr> = (0..len - lag)
-    .map(|i| Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![dev(&data[i]), dev(&data[i + lag])].into(),
-    })
+    .map(|i| call("Times", vec![dev(&data[i]), dev(&data[i + lag])]))
     .collect();
   let den_terms: Vec<Expr> = data
     .iter()
-    .map(|x| Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![dev(x), dev(x)].into(),
-    })
+    .map(|x| call("Times", vec![dev(x), dev(x)]))
     .collect();
   let numerator = sum(num_terms)?;
   let denominator = sum(den_terms)?;
@@ -9059,10 +8716,10 @@ pub fn cycle_index_polynomial_ast(
   let terms: Vec<Expr> = type_counts
     .into_iter()
     .map(|(mult, count)| {
-      let mut factors: Vec<Expr> = vec![Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(count), Expr::Integer(order)].into(),
-      }];
+      let mut factors: Vec<Expr> = vec![call(
+        "Rational",
+        vec![Expr::Integer(count), Expr::Integer(order)],
+      )];
       for (k, &m) in mult.iter().enumerate().skip(1) {
         if m == 0 {
           continue;
@@ -9074,16 +8731,10 @@ pub fn cycle_index_polynomial_ast(
           pow2(base, Expr::Integer(m as i128))
         });
       }
-      Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: factors.into(),
-      }
+      call("Times", factors)
     })
     .collect();
-  crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  })
+  crate::evaluator::evaluate_expr_to_expr(&call("Plus", terms))
 }
 
 /// Expand PermutationGroup generators into the full group via BFS closure.
@@ -9321,10 +8972,8 @@ pub fn group_stabilizer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       _ => return Ok(unevaluated()),
     }
   }
-  let permutation_group = |gens: Vec<Expr>| Expr::FunctionCall {
-    name: "PermutationGroup".to_string(),
-    args: vec![Expr::List(gens.into())].into(),
-  };
+  let permutation_group =
+    |gens: Vec<Expr>| call("PermutationGroup", vec![Expr::List(gens.into())]);
   if let Expr::FunctionCall { name, args: gargs } = &args[0]
     && gargs.len() == 1
     && let Expr::Integer(n) = &gargs[0]
@@ -9412,10 +9061,6 @@ fn erlang_b_symbolic(
   name: &str,
   args: &[Expr],
 ) -> Option<Result<Expr, InterpreterError>> {
-  let fc = |name: &str, fargs: Vec<Expr>| Expr::FunctionCall {
-    name: name.to_string(),
-    args: fargs.into(),
-  };
   let plausible_symbol = |e: &Expr| {
     !matches!(e, Expr::String(_) | Expr::List(_))
       && try_eval_to_f64(e).is_none()
@@ -9454,23 +9099,23 @@ fn erlang_b_symbolic(
   }
   let (c, a) = (args[0].clone(), args[1].clone());
   // a^c * E^(-a) / Gamma[1 + c, a]
-  let body = fc(
+  let body = call(
     "Times",
     vec![
-      fc("Power", vec![a.clone(), c.clone()]),
-      fc(
+      call("Power", vec![a.clone(), c.clone()]),
+      call(
         "Power",
         vec![
           Expr::Constant("E".to_string()),
-          fc("Times", vec![Expr::Integer(-1), a.clone()]),
+          call("Times", vec![Expr::Integer(-1), a.clone()]),
         ],
       ),
-      fc(
+      call(
         "Power",
         vec![
-          fc(
+          call(
             "Gamma",
-            vec![fc("Plus", vec![Expr::Integer(1), c.clone()]), a.clone()],
+            vec![call("Plus", vec![Expr::Integer(1), c.clone()]), a.clone()],
           ),
           Expr::Integer(-1),
         ],
@@ -9491,10 +9136,10 @@ fn erlang_b_symbolic(
   };
   let mut conds: Vec<Expr> = Vec::new();
   if c_num.is_none() {
-    conds.push(fc("Element", vec![c.clone(), integers()]));
+    conds.push(call("Element", vec![c.clone(), integers()]));
   }
   if a_num.is_none() {
-    conds.push(fc("Element", vec![a.clone(), reals()]));
+    conds.push(call("Element", vec![a.clone(), reals()]));
     conds.push(positive(&a));
   }
   if c_num.is_none() {
@@ -9503,9 +9148,9 @@ fn erlang_b_symbolic(
   let cond = if conds.len() == 1 {
     conds.pop().unwrap()
   } else {
-    fc("And", conds)
+    call("And", conds)
   };
-  Some(Ok(fc(
+  Some(Ok(call(
     "Piecewise",
     vec![
       Expr::List(vec![Expr::List(vec![body, cond].into())].into()),
@@ -9656,10 +9301,7 @@ fn erlang_common(
     } else if q.d == 1 {
       Expr::Integer(q.n)
     } else {
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(q.n), Expr::Integer(q.d)].into(),
-      }
+      call("Rational", vec![Expr::Integer(q.n), Expr::Integer(q.d)])
     }
   };
   if waiting {
@@ -9810,11 +9452,7 @@ fn central_feature_index(keys: &[Expr]) -> Result<usize, InterpreterError> {
       return Some(p);
     }
     let evaluated =
-      crate::evaluator::evaluate_expr_to_expr(&Expr::FunctionCall {
-        name: "N".to_string(),
-        args: vec![e.clone()].into(),
-      })
-      .ok()?;
+      crate::evaluator::evaluate_expr_to_expr(&call1("N", e.clone())).ok()?;
     expr_to_complex_parts(&evaluated)
   };
 

--- a/src/functions/math_ast/triangles.rs
+++ b/src/functions/math_ast/triangles.rs
@@ -11,13 +11,6 @@
 #[allow(unused_imports)]
 use super::*;
 
-fn fc(name: &str, args: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  }
-}
-
 fn eval(e: Expr) -> Result<Expr, InterpreterError> {
   crate::evaluator::evaluate_expr_to_expr(&e)
 }
@@ -158,16 +151,16 @@ fn symbolic_angle_ok(e: &Expr) -> bool {
 /// Vertices {{0,0}, {c,0}, {cx,cy}} as an evaluated Triangle expression.
 fn triangle(c: Expr, cx: Expr, cy: Expr) -> Result<Expr, InterpreterError> {
   let zero = || Expr::Integer(0);
-  Ok(fc(
+  Ok(call1(
     "Triangle",
-    vec![Expr::List(
+    Expr::List(
       vec![
         Expr::List(vec![zero(), zero()].into()),
         Expr::List(vec![eval(c)?, zero()].into()),
         Expr::List(vec![eval(cx)?, eval(cy)?].into()),
       ]
       .into(),
-    )],
+    ),
   ))
 }
 
@@ -210,34 +203,34 @@ fn two_angle_triangle(
   // Csc/Cot forms wolframscript displays (`c*Csc[a]*Sin[a + b]`,
   // `c*Cot[a]*Sin[b]`). Numeric angles evaluate these to the same values
   // the plain Sin-quotient forms produce.
-  let gamma = fc(
+  let gamma = call(
     "Plus",
     vec![
       Expr::Identifier("Pi".to_string()),
-      fc("Times", vec![Expr::Integer(-1), alpha.clone()]),
-      fc("Times", vec![Expr::Integer(-1), beta.clone()]),
+      call("Times", vec![Expr::Integer(-1), alpha.clone()]),
+      call("Times", vec![Expr::Integer(-1), beta.clone()]),
     ],
   );
   let (c, cx, cy) = if side_is_included {
     // ASA: the given side is c; apex = c Sin[β]/Sin[γ] * (Cos[α], Sin[α]).
     (
       side.clone(),
-      fc(
+      call(
         "Times",
         vec![
           side.clone(),
-          fc("Cos", vec![alpha.clone()]),
-          fc("Csc", vec![gamma.clone()]),
-          fc("Sin", vec![beta.clone()]),
+          call1("Cos", alpha.clone()),
+          call1("Csc", gamma.clone()),
+          call1("Sin", beta.clone()),
         ],
       ),
-      fc(
+      call(
         "Times",
         vec![
           side.clone(),
-          fc("Csc", vec![gamma]),
-          fc("Sin", vec![alpha.clone()]),
-          fc("Sin", vec![beta.clone()]),
+          call1("Csc", gamma),
+          call1("Sin", alpha.clone()),
+          call1("Sin", beta.clone()),
         ],
       ),
     )
@@ -245,23 +238,23 @@ fn two_angle_triangle(
     // AAS: the given side is a (opposite α); c = a Sin[γ] Csc[α],
     // apex = (a Sin[β] Cot[α], a Sin[β]).
     (
-      fc(
+      call(
         "Times",
         vec![
           side.clone(),
-          fc("Csc", vec![alpha.clone()]),
-          fc("Sin", vec![gamma]),
+          call1("Csc", alpha.clone()),
+          call1("Sin", gamma),
         ],
       ),
-      fc(
+      call(
         "Times",
         vec![
           side.clone(),
-          fc("Cot", vec![alpha.clone()]),
-          fc("Sin", vec![beta.clone()]),
+          call1("Cot", alpha.clone()),
+          call1("Sin", beta.clone()),
         ],
       ),
-      fc("Times", vec![side.clone(), fc("Sin", vec![beta.clone()])]),
+      call("Times", vec![side.clone(), call1("Sin", beta.clone())]),
     )
   };
   triangle(c, cx, cy)
@@ -302,41 +295,41 @@ pub fn sas_triangle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   {
     return unevaluated();
   }
-  let c = fc(
+  let c = call(
     "Sqrt",
-    vec![fc(
+    vec![call(
       "Plus",
       vec![
-        fc("Power", vec![a.clone(), Expr::Integer(2)]),
-        fc("Power", vec![b.clone(), Expr::Integer(2)]),
-        fc(
+        call("Power", vec![a.clone(), Expr::Integer(2)]),
+        call("Power", vec![b.clone(), Expr::Integer(2)]),
+        call(
           "Times",
           vec![
             Expr::Integer(-2),
             a.clone(),
             b.clone(),
-            fc("Cos", vec![gamma.clone()]),
+            call1("Cos", gamma.clone()),
           ],
         ),
       ],
     )],
   );
   let c_eval = eval(c)?;
-  let inv_c = fc("Power", vec![c_eval.clone(), Expr::Integer(-1)]);
-  let cx = fc(
+  let inv_c = call("Power", vec![c_eval.clone(), Expr::Integer(-1)]);
+  let cx = call(
     "Times",
     vec![
-      fc(
+      call(
         "Plus",
         vec![
-          fc("Power", vec![b.clone(), Expr::Integer(2)]),
-          fc(
+          call("Power", vec![b.clone(), Expr::Integer(2)]),
+          call(
             "Times",
             vec![
               Expr::Integer(-1),
               a.clone(),
               b.clone(),
-              fc("Cos", vec![gamma.clone()]),
+              call1("Cos", gamma.clone()),
             ],
           ),
         ],
@@ -344,9 +337,9 @@ pub fn sas_triangle_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       inv_c.clone(),
     ],
   );
-  let cy = fc(
+  let cy = call(
     "Times",
-    vec![a.clone(), b.clone(), fc("Sin", vec![gamma.clone()]), inv_c],
+    vec![a.clone(), b.clone(), call1("Sin", gamma.clone()), inv_c],
   );
   triangle(c_eval, cx, cy)
 }
@@ -410,16 +403,16 @@ pub fn triangle_measurement_ast(
   let (bx, by) = &coords[1];
   let (cx, cy) = &coords[2];
   let diff = |u: &Expr, v: &Expr| {
-    fc(
+    call(
       "Plus",
-      vec![u.clone(), fc("Times", vec![Expr::Integer(-1), v.clone()])],
+      vec![u.clone(), call("Times", vec![Expr::Integer(-1), v.clone()])],
     )
   };
-  let twice_signed_area = fc(
+  let twice_signed_area = call(
     "Plus",
     vec![
-      fc("Times", vec![diff(bx, ax), diff(cy, ay)]),
-      fc("Times", vec![Expr::Integer(-1), diff(cx, ax), diff(by, ay)]),
+      call("Times", vec![diff(bx, ax), diff(cy, ay)]),
+      call("Times", vec![Expr::Integer(-1), diff(cx, ax), diff(by, ay)]),
     ],
   );
   let signed = eval(twice_signed_area.clone())?;
@@ -430,40 +423,34 @@ pub fn triangle_measurement_ast(
     ));
     return unevaluated();
   }
-  let area = fc(
+  let area = call(
     "Times",
     vec![
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
-      },
-      fc("Abs", vec![twice_signed_area]),
+      call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
+      call1("Abs", twice_signed_area),
     ],
   );
 
   let dist = |p: &(Expr, Expr), q: &(Expr, Expr)| {
-    fc(
+    call1(
       "Sqrt",
-      vec![fc(
+      call(
         "Plus",
         vec![
-          fc("Power", vec![diff(&p.0, &q.0), Expr::Integer(2)]),
-          fc("Power", vec![diff(&p.1, &q.1), Expr::Integer(2)]),
+          call("Power", vec![diff(&p.0, &q.0), Expr::Integer(2)]),
+          call("Power", vec![diff(&p.1, &q.1), Expr::Integer(2)]),
         ],
-      )],
+      ),
     )
   };
   let side_a = dist(&coords[1], &coords[2]);
   let side_b = dist(&coords[0], &coords[2]);
   let side_c = dist(&coords[0], &coords[1]);
   let half = |e: Expr| {
-    fc(
+    call(
       "Times",
       vec![
-        Expr::FunctionCall {
-          name: "Rational".to_string(),
-          args: vec![Expr::Integer(1), Expr::Integer(2)].into(),
-        },
+        call("Rational", vec![Expr::Integer(1), Expr::Integer(2)]),
         e,
       ],
     )
@@ -471,36 +458,39 @@ pub fn triangle_measurement_ast(
 
   let result = match prop.as_str() {
     "Area" => area,
-    "Perimeter" => fc("Plus", vec![side_a, side_b, side_c]),
+    "Perimeter" => call("Plus", vec![side_a, side_b, side_c]),
     // Term-wise halves so rational parts fold (1/2 + 1/2 + Sqrt[2]/2 →
     // 1 + 1/Sqrt[2], matching wolframscript's display).
     "Semiperimeter" => {
-      fc("Plus", vec![half(side_a), half(side_b), half(side_c)])
+      call("Plus", vec![half(side_a), half(side_b), half(side_c)])
     }
     // r = Area / s
-    "Inradius" => fc(
+    "Inradius" => call(
       "Times",
       vec![
         area,
-        fc(
+        call(
           "Power",
           vec![
-            fc("Plus", vec![half(side_a), half(side_b), half(side_c)]),
+            call("Plus", vec![half(side_a), half(side_b), half(side_c)]),
             Expr::Integer(-1),
           ],
         ),
       ],
     ),
     // R = a b c / (4 Area)
-    "Circumradius" => fc(
+    "Circumradius" => call(
       "Times",
       vec![
         side_a,
         side_b,
         side_c,
-        fc(
+        call(
           "Power",
-          vec![fc("Times", vec![Expr::Integer(4), area]), Expr::Integer(-1)],
+          vec![
+            call("Times", vec![Expr::Integer(4), area]),
+            Expr::Integer(-1),
+          ],
         ),
       ],
     ),

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -1,6 +1,6 @@
 use crate::InterpreterError;
 use crate::helpers::{
-  binop, bool_expr, div2, minus2, neg1, plus2, pow2, times2,
+  binop, bool_expr, call, call1, div2, minus2, neg1, plus2, pow2, times2,
 };
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -454,18 +454,17 @@ fn axes_to_music_pitch(position: i128, midi: i128) -> Expr {
   let natural_midi = (octave + 1) * 12 + DIATONIC_BASE_SEMITONE[letter_idx];
   let accidental = midi - natural_midi;
   // Keys are alphabetical (Accidental, Key, MIDINumber), matching Wolfram.
-  Expr::FunctionCall {
-    name: "MusicPitch".to_string(),
-    args: vec![Expr::Association(vec![
+  call1(
+    "MusicPitch",
+    Expr::Association(vec![
       (Expr::String("Accidental".into()), Expr::Integer(accidental)),
       (
         Expr::String("Key".into()),
         Expr::String(DIATONIC_LETTERS[letter_idx].to_string()),
       ),
       (Expr::String("MIDINumber".into()), Expr::Integer(midi)),
-    ])]
-    .into(),
-  }
+    ]),
+  )
 }
 
 /// Decode a MIDI number into the canonical arithmetic pitch object
@@ -480,15 +479,14 @@ fn midi_to_music_pitch(midi: i128) -> Expr {
   let key = spelling.as_bytes()[0] as char;
   // Every chromatic name is either natural or a single sharp.
   let accidental = spelling.len() as i128 - 1;
-  Expr::FunctionCall {
-    name: "MusicPitch".to_string(),
-    args: vec![Expr::Association(vec![
+  call1(
+    "MusicPitch",
+    Expr::Association(vec![
       (Expr::String("Accidental".into()), Expr::Integer(accidental)),
       (Expr::String("Key".into()), Expr::String(key.to_string())),
       (Expr::String("MIDINumber".into()), Expr::Integer(midi)),
-    ])]
-    .into(),
-  }
+    ]),
+  )
 }
 
 /// Whether a summand (possibly negated or integer-scaled) is a bare-semitone
@@ -893,10 +891,7 @@ pub fn try_music_chord_plus_interval(args: &[Expr]) -> Option<Expr> {
   )]);
   let mut new_args = vec![pitch_list];
   new_args.extend(cargs.iter().skip(1).cloned());
-  Some(Expr::FunctionCall {
-    name: "MusicChord".to_string(),
-    args: new_args.into(),
-  })
+  Some(call("MusicChord", new_args))
 }
 
 /// Heads of the computational-music containers/events whose pitches are
@@ -1034,16 +1029,15 @@ pub fn music_pitch_midi(expr: &Expr) -> Option<i128> {
 /// A `MusicPitch[<|…|>]` / `MusicDuration[<|…|>]` / … object wrapping a
 /// key-ordered association.
 fn music_assoc(head: &str, pairs: Vec<(&str, Expr)>) -> Expr {
-  Expr::FunctionCall {
-    name: head.to_string(),
-    args: vec![Expr::Association(
+  call1(
+    head,
+    Expr::Association(
       pairs
         .into_iter()
         .map(|(k, v)| (Expr::String(k.to_string()), v))
         .collect(),
-    )]
-    .into(),
-  }
+    ),
+  )
 }
 
 /// Look up a string key in an association's `(key, value)` pairs.
@@ -1736,10 +1730,7 @@ fn times_of(mut factors: Vec<Expr>) -> Expr {
   match factors.len() {
     0 => Expr::Integer(1),
     1 => factors.pop().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: factors.into(),
-    },
+    _ => call("Times", factors),
   }
 }
 
@@ -1778,10 +1769,7 @@ pub fn music_duration_plus_terms(args: &[Expr]) -> Option<Vec<Expr>> {
   let mut products = Vec::with_capacity(flat.len());
   for term in &flat {
     let (coeff, value) = music_duration_summand(term)?;
-    products.push(Expr::FunctionCall {
-      name: "Times".to_string(),
-      args: vec![coeff, value].into(),
-    });
+    products.push(call("Times", vec![coeff, value]));
   }
   Some(products)
 }
@@ -1924,10 +1912,7 @@ impl MeasureEvent {
   /// Whether the event carries an explicit (rigid) duration. Default events are
   /// elastic: a trailing default note stretches to fill the measure.
   fn is_explicit(&self) -> bool {
-    matches!(
-      self,
-      Self::Note(_, Some(_)) | Self::Rest(Some(_))
-    )
+    matches!(self, Self::Note(_, Some(_)) | Self::Rest(Some(_)))
   }
 }
 
@@ -2109,10 +2094,10 @@ pub fn music_measure(args: &[Expr]) -> Option<Expr> {
       format_ratio(total),
       capacity.0,
     ));
-    return Some(Expr::FunctionCall {
-      name: "MusicMeasure".to_string(),
-      args: vec![Expr::List(events_raw.clone()), timesig.clone()].into(),
-    });
+    return Some(call(
+      "MusicMeasure",
+      vec![Expr::List(events_raw.clone()), timesig.clone()],
+    ));
   }
 
   // Fill the measure to exactly `capacity` beats.
@@ -2327,10 +2312,7 @@ mod tests {
   // on structure / rendering to a string.
 
   fn head_with_c4(name: &str) -> Expr {
-    Expr::FunctionCall {
-      name: name.to_string(),
-      args: vec![Expr::String("C4".to_string())].into(),
-    }
+    call(name, vec![Expr::String("C4".to_string())])
   }
 
   fn is_true(expr: &Expr) -> bool {
@@ -2354,15 +2336,9 @@ mod tests {
   #[test]
   fn music_object_q_rejects_non_objects() {
     assert!(is_false(&music_object_q(&[Expr::Integer(3)])));
-    assert!(is_false(&music_object_q(&[Expr::FunctionCall {
-      name: "List".to_string(),
-      args: vec![].into(),
-    }])));
+    assert!(is_false(&music_object_q(&[call("List", vec![])])));
     // MusicPlot/MusicTransform/MusicMeasurements are operations, not objects.
-    assert!(is_false(&music_object_q(&[Expr::FunctionCall {
-      name: "MusicPlot".to_string(),
-      args: vec![].into(),
-    }])));
+    assert!(is_false(&music_object_q(&[call("MusicPlot", vec![])])));
   }
 
   #[test]
@@ -2480,26 +2456,19 @@ mod tests {
     assert_eq!(frequency_to_midi(f64::INFINITY), None);
   }
 
-  fn func(name: &str, args: Vec<Expr>) -> Expr {
-    Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.into(),
-    }
-  }
-
   #[test]
   fn music_pitch_canonicalizes_frequency() {
     // Frequencies fix no letter spelling and keep their MIDI number:
     // A4 = 440 Hz = MIDI 69; 200 Hz is nearest G3 = MIDI 55.
     expect_midi_pitch(
-      music_pitch(&[func(
+      music_pitch(&[call(
         "Quantity",
         vec![Expr::Integer(440), Expr::String("Hertz".into())],
       )]),
       69,
     );
     expect_midi_pitch(
-      music_pitch(&[func(
+      music_pitch(&[call(
         "Quantity",
         vec![Expr::Integer(200), Expr::String("Hertz".into())],
       )]),
@@ -2507,7 +2476,7 @@ mod tests {
     );
     // Identifier unit spelling and the "Hz" abbreviation are both accepted.
     expect_midi_pitch(
-      music_pitch(&[func(
+      music_pitch(&[call(
         "Quantity",
         vec![Expr::Real(440.0), Expr::Identifier("Hertz".into())],
       )]),
@@ -2515,7 +2484,7 @@ mod tests {
     );
     // A non-frequency Quantity has no pitch interpretation.
     assert!(
-      music_pitch(&[func(
+      music_pitch(&[call(
         "Quantity",
         vec![Expr::Integer(440), Expr::String("Meters".into())]
       )])
@@ -2526,16 +2495,13 @@ mod tests {
   #[test]
   fn music_pitch_canonicalizes_soundnote() {
     // SoundNote numbers pitches relative to middle C (0), so 0 -> MIDI 60.
+    expect_midi_pitch(music_pitch(&[call1("SoundNote", Expr::Integer(0))]), 60);
     expect_midi_pitch(
-      music_pitch(&[func("SoundNote", vec![Expr::Integer(0)])]),
-      60,
-    );
-    expect_midi_pitch(
-      music_pitch(&[func("SoundNote", vec![Expr::Integer(-5)])]),
+      music_pitch(&[call1("SoundNote", Expr::Integer(-5))]),
       55,
     );
     expect_midi_pitch(
-      music_pitch(&[func("SoundNote", vec![Expr::String("A4".into())])]),
+      music_pitch(&[call1("SoundNote", Expr::String("A4".into()))]),
       69,
     );
   }
@@ -2543,8 +2509,7 @@ mod tests {
   #[test]
   fn music_pitch_extracts_note_pitch() {
     // A raw MusicNote spec resolves to the spelled note-pitch object …
-    let result =
-      music_pitch(&[func("MusicNote", vec![Expr::String("G3".into())])]);
+    let result = music_pitch(&[call1("MusicNote", Expr::String("G3".into()))]);
     match &result {
       Some(Expr::FunctionCall { name, args }) if name == "MusicPitch" => {
         match &args[..] {
@@ -2563,24 +2528,24 @@ mod tests {
       other => panic!("expected MusicPitch[<|…|>], got {other:?}"),
     }
     // … while a canonical note returns its stored pitch object verbatim.
-    let stored = func(
+    let stored = call1(
       "MusicNote",
-      vec![Expr::Association(vec![(
+      Expr::Association(vec![(
         Expr::String("Pitch".into()),
-        func(
+        call1(
           "MusicPitch",
-          vec![Expr::Association(vec![(
+          Expr::Association(vec![(
             Expr::String("MIDINumber".into()),
             Expr::Integer(55),
-          )])],
+          )]),
         ),
-      )])],
+      )]),
     );
     expect_midi_pitch(music_pitch(&[stored]), 55);
   }
 
   fn named_pitch(name: &str) -> Expr {
-    func("MusicPitch", vec![Expr::String(name.into())])
+    call1("MusicPitch", Expr::String(name.into()))
   }
 
   /// Assert that `try_music_pitch_plus` produced the canonical association form
@@ -2623,7 +2588,7 @@ mod tests {
     let result = try_music_pitch_plus(&[
       named_pitch("Bb"),
       named_pitch("A#"),
-      func("Times", vec![Expr::Integer(-1), named_pitch("C")]),
+      call("Times", vec![Expr::Integer(-1), named_pitch("C")]),
     ]);
     expect_pitch_sum(result, 1, "G", 80);
   }
@@ -2635,7 +2600,7 @@ mod tests {
     // once.
     let partial = try_music_pitch_plus(&[
       named_pitch("Bb"),
-      func("Times", vec![Expr::Integer(-1), named_pitch("C")]),
+      call("Times", vec![Expr::Integer(-1), named_pitch("C")]),
     ])
     .unwrap();
     let result = try_music_pitch_plus(&[named_pitch("A#"), partial]);
@@ -2671,8 +2636,8 @@ mod tests {
     // collects to `p` on the ordinary path).
     assert!(
       try_music_pitch_plus(&[
-        func("Times", vec![Expr::Integer(2), named_pitch("C")]),
-        func("Times", vec![Expr::Integer(-1), named_pitch("C")]),
+        call("Times", vec![Expr::Integer(2), named_pitch("C")]),
+        call("Times", vec![Expr::Integer(-1), named_pitch("C")]),
       ])
       .is_none()
     );
@@ -2683,7 +2648,7 @@ mod tests {
     // Octaveless `C` defaults to octave 4, so `C - C4` cancels to a Unison.
     let result = try_music_pitch_plus(&[
       named_pitch("C"),
-      func("Times", vec![Expr::Integer(-1), named_pitch("C4")]),
+      call("Times", vec![Expr::Integer(-1), named_pitch("C4")]),
     ]);
     match &result {
       Some(Expr::FunctionCall { name, args }) if name == "MusicInterval" => {
@@ -2722,7 +2687,7 @@ mod tests {
   }
 
   fn named_interval(spec: &str) -> Expr {
-    func("MusicInterval", vec![Expr::String(spec.into())])
+    call1("MusicInterval", Expr::String(spec.into()))
   }
 
   #[test]
@@ -2734,20 +2699,20 @@ mod tests {
     );
     // Bare-semitone interval: 5 semitones is the simplest perfect fourth.
     assert_eq!(
-      music_interval_axes(&func("MusicInterval", vec![Expr::Integer(5)])),
+      music_interval_axes(&call1("MusicInterval", Expr::Integer(5))),
       Some((3, 5)),
     );
     // Compound (octave-plus) interval via the canonical association form.
-    let assoc = func(
+    let assoc = call1(
       "MusicInterval",
-      vec![Expr::Association(vec![
+      Expr::Association(vec![
         (Expr::String("Semitones".into()), Expr::Integer(4)),
         (
           Expr::String("Name".into()),
           Expr::String("MajorThird".into()),
         ),
         (Expr::String("CompoundOctaves".into()), Expr::Integer(1)),
-      ])],
+      ]),
     );
     assert_eq!(music_interval_axes(&assoc), Some((9, 16)));
   }
@@ -2785,15 +2750,15 @@ mod tests {
   #[test]
   fn music_chord_plus_interval_transposes_every_tone() {
     // MusicChord[{C4, E4, G4}] + MusicInterval[5] -> {F4, A4, C5}.
-    let chord = func(
+    let chord = call1(
       "MusicChord",
-      vec![Expr::List(
+      Expr::List(
         vec![named_pitch("C4"), named_pitch("E4"), named_pitch("G4")].into(),
-      )],
+      ),
     );
     let result = try_music_chord_plus_interval(&[
       chord,
-      func("MusicInterval", vec![Expr::Integer(5)]),
+      call1("MusicInterval", Expr::Integer(5)),
     ])
     .expect("chord + interval should transpose");
     let Expr::FunctionCall { name, args } = &result else {
@@ -2833,7 +2798,7 @@ mod tests {
     expect_pitch_sum(
       try_music_pitch_plus(&[
         named_pitch("C"),
-        func("MusicInterval", vec![Expr::Integer(8)]),
+        call1("MusicInterval", Expr::Integer(8)),
       ]),
       1,
       "G",
@@ -2843,7 +2808,7 @@ mod tests {
     expect_pitch_sum(
       try_music_pitch_plus(&[
         named_pitch("Eb"),
-        func("MusicInterval", vec![Expr::Integer(8)]),
+        call1("MusicInterval", Expr::Integer(8)),
       ]),
       0,
       "B",
@@ -2857,15 +2822,12 @@ mod tests {
     assert!(
       try_music_chord_plus_interval(&[
         named_pitch("C"),
-        func("MusicInterval", vec![Expr::Integer(5)]),
+        call1("MusicInterval", Expr::Integer(5)),
       ])
       .is_none()
     );
     // A bare chord with no interval is left for the normal path.
-    let chord = func(
-      "MusicChord",
-      vec![Expr::List(vec![named_pitch("C4")].into())],
-    );
+    let chord = call1("MusicChord", Expr::List(vec![named_pitch("C4")].into()));
     assert!(try_music_chord_plus_interval(&[chord]).is_none());
   }
 }

--- a/src/functions/periodic_table_plot.rs
+++ b/src/functions/periodic_table_plot.rs
@@ -364,10 +364,7 @@ pub fn periodic_table_plot_ast(
       if let (Some(i), Some(spec)) = (spec_idx, spec) {
         echo_args[i] = spec;
       }
-      return Ok(Expr::FunctionCall {
-        name: "PeriodicTablePlot".to_string(),
-        args: echo_args.into(),
-      });
+      return Ok(call("PeriodicTablePlot", echo_args));
     }
   };
   let elements = elements_layout();
@@ -474,12 +471,6 @@ pub fn periodic_table_plot_ast(
 /// `PeriodicTablePlot["Phase"]` (the swatch colours are wolframscript's
 /// exact values).
 fn phase_legended(graphics: Expr) -> Expr {
-  fn call(name: &str, args: Vec<Expr>) -> Expr {
-    Expr::FunctionCall {
-      name: name.to_string(),
-      args: args.into(),
-    }
-  }
   let rgb = |r: f64, g: f64, b: f64| {
     call(
       "RGBColor",

--- a/src/functions/polynomial_ast/function_expand.rs
+++ b/src/functions/polynomial_ast/function_expand.rs
@@ -73,7 +73,7 @@ fn mk_id(name: &str) -> Expr {
 }
 
 fn mk_plus(a: Expr, b: Expr) -> Expr {
-  mk_call("Plus", vec![a, b])
+  call("Plus", vec![a, b])
 }
 
 /// The additive terms of `e` if its head is `Plus` (either the `Plus[…]` call
@@ -202,7 +202,7 @@ fn negate_if_negative(t: &Expr) -> Option<Expr> {
     Some(match factors.len() {
       0 => mk_int(1),
       1 => factors.into_iter().next().unwrap(),
-      _ => mk_call("Times", factors),
+      _ => call("Times", factors),
     })
   };
   match t {
@@ -373,7 +373,7 @@ fn is_exact_positive_constant(e: &Expr) -> bool {
   if !crate::functions::predicate_ast::is_numeric_q(e) || contains_real(e) {
     return false;
   }
-  let value = mk_call("N", vec![e.clone()]);
+  let value = call1("N", e.clone());
   matches!(
     crate::evaluator::evaluate_expr_to_expr(&value),
     Ok(Expr::Real(r)) if r > 0.0
@@ -450,11 +450,9 @@ fn split_sqrt_of_square_difference(radicand: &Expr) -> Option<Expr> {
     let scale = squarefree_kernel(cb.0 * cb.1);
     let scaled_b = ratio_sqrt(ratio_times(cb, (scale, 1)))?;
     let scaled_a = match ca {
-      Some(ca) => {
-        mk_call("Sqrt", vec![mk_exact_ratio(ratio_times(ca, (scale, 1)))])
-      }
-      None if scale == 1 => mk_call("Sqrt", vec![a_sq.clone()]),
-      None => mk_call("Sqrt", vec![mk_times(mk_int(scale), a_sq.clone())]),
+      Some(ca) => call1("Sqrt", mk_exact_ratio(ratio_times(ca, (scale, 1)))),
+      None if scale == 1 => call1("Sqrt", a_sq.clone()),
+      None => call1("Sqrt", mk_times(mk_int(scale), a_sq.clone())),
     };
     (
       (1, scale),
@@ -468,13 +466,12 @@ fn split_sqrt_of_square_difference(radicand: &Expr) -> Option<Expr> {
   // Each side is expanded, so `Sqrt[9 - 4 (x + 1)^2]` prints as
   // `Sqrt[1 - 2 x] Sqrt[5 + 2 x]` rather than keeping the shifted square.
   let first = split_sqrt_of_square_difference(&minus)
-    .unwrap_or_else(|| mk_call("Sqrt", vec![mk_call("Expand", vec![minus])]));
-  let split =
-    mk_times(first, mk_call("Sqrt", vec![mk_call("Expand", vec![plus])]));
+    .unwrap_or_else(|| call1("Sqrt", call1("Expand", minus)));
+  let split = mk_times(first, call1("Sqrt", call1("Expand", plus)));
   Some(if prefactor == (1, 1) {
     split
   } else {
-    mk_times(mk_call("Sqrt", vec![mk_exact_ratio(prefactor)]), split)
+    mk_times(call1("Sqrt", mk_exact_ratio(prefactor)), split)
   })
 }
 
@@ -525,9 +522,8 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
     && args.len() == 1
     && is_multiple_of_inverse_trig(&args[0])
   {
-    let trig =
-      mk_call("TrigExpand", vec![mk_call(name, vec![args[0].clone()])]);
-    let expanded = mk_call("Expand", vec![trig]);
+    let trig = call1("TrigExpand", call1(name, args[0].clone()));
+    let expanded = call1("Expand", trig);
     if let Ok(result) = crate::evaluator::evaluate_expr_to_expr(&expanded) {
       if is_clean_polynomial(&result) {
         return Some(result);
@@ -544,7 +540,7 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
 
   // FunctionExpand[Sqrt[a^2 - b^2]] = Sqrt[a - b] Sqrt[a + b].
   {
-    let call = mk_call(name, args.to_vec());
+    let call = call(name, args.to_vec());
     if let Some(radicand) = as_sqrt_radicand(&call)
       && let Some(split) = split_sqrt_of_square_difference(radicand)
     {
@@ -560,11 +556,11 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
       {
         let coeff = mk_div(
           mk_power(mk_int(-1), mk_int(*m)),
-          mk_call("Factorial", vec![mk_int(*m - 1)]),
+          call("Factorial", vec![mk_int(*m - 1)]),
         );
         Some(mk_times(
           coeff,
-          mk_call("PolyGamma", vec![mk_int(*m - 1), args[1].clone()]),
+          call("PolyGamma", vec![mk_int(*m - 1), args[1].clone()]),
         ))
       } else {
         None
@@ -576,8 +572,8 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
       let a = &args[0];
       let n = &args[1];
       Some(mk_div(
-        mk_call("Gamma", vec![mk_plus(a.clone(), n.clone())]),
-        mk_call("Gamma", vec![a.clone()]),
+        call1("Gamma", mk_plus(a.clone(), n.clone())),
+        call1("Gamma", a.clone()),
       ))
     }
 
@@ -625,10 +621,10 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
         }
         // Symbolic n (2-argument form only): the Gamma-function ratio.
         _ if h.is_none() => Some(mk_div(
-          mk_call("Gamma", vec![mk_plus(mk_int(1), x.clone())]),
-          mk_call(
+          call("Gamma", vec![mk_plus(mk_int(1), x.clone())]),
+          call(
             "Gamma",
-            vec![mk_call(
+            vec![call(
               "Plus",
               vec![mk_int(1), mk_times(mk_int(-1), n.clone()), x.clone()],
             )],
@@ -643,17 +639,14 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
       let a = &args[0];
       let b = &args[1];
       Some(mk_div(
-        mk_times(
-          mk_call("Gamma", vec![a.clone()]),
-          mk_call("Gamma", vec![b.clone()]),
-        ),
-        mk_call("Gamma", vec![mk_plus(a.clone(), b.clone())]),
+        mk_times(call1("Gamma", a.clone()), call1("Gamma", b.clone())),
+        call("Gamma", vec![mk_plus(a.clone(), b.clone())]),
       ))
     }
 
     // Factorial[n] (i.e. n!) → Gamma[1 + n]
     "Factorial" if args.len() == 1 => {
-      Some(mk_call("Gamma", vec![mk_plus(mk_int(1), args[0].clone())]))
+      Some(call("Gamma", vec![mk_plus(mk_int(1), args[0].clone())]))
     }
 
     // Abs[z]^(2m) → (Re[z]^2 + Im[z]^2)^m (the squared-modulus identity). Only
@@ -672,8 +665,8 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
       };
       let z = &a[0];
       let sq_sum = mk_plus(
-        mk_power(mk_call("Re", vec![z.clone()]), mk_int(2)),
-        mk_power(mk_call("Im", vec![z.clone()]), mk_int(2)),
+        mk_power(call1("Re", z.clone()), mk_int(2)),
+        mk_power(call1("Im", z.clone()), mk_int(2)),
       );
       let m = e / 2;
       let result = if m == 1 {
@@ -688,20 +681,20 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
     // Re[z] / Im[z] distribute over a sum: Re[a + b] → Re[a] + Re[b].
     "Re" | "Im" if args.len() == 1 => {
       let terms = as_plus_terms(&args[0])?;
-      Some(mk_call(
+      Some(call(
         "Plus",
-        terms.into_iter().map(|t| mk_call(name, vec![t])).collect(),
+        terms.into_iter().map(|t| call1(name, t)).collect(),
       ))
     }
 
     // Multinomial[a1, …, ak] = (a1 + … + ak)! / (a1! ⋯ ak!) →
     //   Gamma[1 + a1 + … + ak] / (Gamma[1 + a1] ⋯ Gamma[1 + ak]).
     "Multinomial" if !args.is_empty() => {
-      let sum = mk_call("Plus", args.to_vec());
-      let numerator = mk_call("Gamma", vec![mk_plus(mk_int(1), sum)]);
+      let sum = call("Plus", args.to_vec());
+      let numerator = call("Gamma", vec![mk_plus(mk_int(1), sum)]);
       let denominator = args
         .iter()
-        .map(|a| mk_call("Gamma", vec![mk_plus(mk_int(1), a.clone())]))
+        .map(|a| call("Gamma", vec![mk_plus(mk_int(1), a.clone())]))
         .reduce(mk_times)
         .unwrap_or_else(|| mk_int(1));
       Some(mk_div(numerator, denominator))
@@ -717,12 +710,12 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
         let n = &args[0];
         let k = &args[1];
         Some(mk_div(
-          mk_call("Gamma", vec![mk_plus(mk_int(1), n.clone())]),
+          call("Gamma", vec![mk_plus(mk_int(1), n.clone())]),
           mk_times(
-            mk_call("Gamma", vec![mk_plus(mk_int(1), k.clone())]),
-            mk_call(
+            call("Gamma", vec![mk_plus(mk_int(1), k.clone())]),
+            call(
               "Gamma",
-              vec![mk_call(
+              vec![call(
                 "Plus",
                 vec![mk_int(1), mk_times(mk_int(-1), k.clone()), n.clone()],
               )],
@@ -738,11 +731,11 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
       Some(mk_div(
         mk_times(
           mk_power(mk_int(2), mk_times(mk_int(2), n.clone())),
-          mk_call("Gamma", vec![mk_plus(mk_ratio(1, 2), n.clone())]),
+          call1("Gamma", mk_plus(mk_ratio(1, 2), n.clone())),
         ),
         mk_times(
-          mk_call("Sqrt", vec![mk_id("Pi")]),
-          mk_call("Gamma", vec![mk_plus(mk_int(2), n.clone())]),
+          call1("Sqrt", mk_id("Pi")),
+          call1("Gamma", mk_plus(mk_int(2), n.clone())),
         ),
       ))
     }
@@ -751,7 +744,7 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
     "Subfactorial" if args.len() == 1 => {
       let n = &args[0];
       Some(mk_div(
-        mk_call("Gamma", vec![mk_plus(mk_int(1), n.clone()), mk_int(-1)]),
+        call("Gamma", vec![mk_plus(mk_int(1), n.clone()), mk_int(-1)]),
         mk_id("E"),
       ))
     }
@@ -761,20 +754,20 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
       mk_ratio(1, 2),
       mk_plus(
         mk_int(1),
-        mk_times(mk_int(-1), mk_call("Cos", vec![args[0].clone()])),
+        mk_times(mk_int(-1), call1("Cos", args[0].clone())),
       ),
     )),
 
     // InverseHaversine[x] → 2 * ArcSin[Sqrt[x]]
     "InverseHaversine" if args.len() == 1 => Some(mk_times(
       mk_int(2),
-      mk_call("ArcSin", vec![mk_call("Sqrt", vec![args[0].clone()])]),
+      call("ArcSin", vec![call1("Sqrt", args[0].clone())]),
     )),
 
     // InverseGudermannian[x] → Log[Tan[Pi/4 + x/2]]
-    "InverseGudermannian" if args.len() == 1 => Some(mk_call(
+    "InverseGudermannian" if args.len() == 1 => Some(call(
       "Log",
-      vec![mk_call(
+      vec![call(
         "Tan",
         vec![mk_plus(
           mk_times(mk_ratio(1, 4), mk_id("Pi")),
@@ -784,10 +777,9 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
     )),
 
     // Sinc[x] → Sin[x] / x
-    "Sinc" if args.len() == 1 => Some(mk_div(
-      mk_call("Sin", vec![args[0].clone()]),
-      args[0].clone(),
-    )),
+    "Sinc" if args.len() == 1 => {
+      Some(mk_div(call1("Sin", args[0].clone()), args[0].clone()))
+    }
 
     // LogisticSigmoid[x] → 1/(1 + E^(-x)), i.e. (1 + E^(-x))^(-1).
     "LogisticSigmoid" if args.len() == 1 => Some(mk_power(
@@ -799,12 +791,9 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
     )),
 
     // ChebyshevT[n, x] → Cos[n * ArcCos[x]]
-    "ChebyshevT" if args.len() == 2 => Some(mk_call(
+    "ChebyshevT" if args.len() == 2 => Some(call(
       "Cos",
-      vec![mk_times(
-        args[0].clone(),
-        mk_call("ArcCos", vec![args[1].clone()]),
-      )],
+      vec![mk_times(args[0].clone(), call1("ArcCos", args[1].clone()))],
     )),
 
     // ChebyshevU[n, x] → Sin[(1 + n) * ArcCos[x]] / (Sqrt[1 - x] * Sqrt[1 + x])
@@ -812,19 +801,16 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
       let n = &args[0];
       let x = &args[1];
       Some(mk_div(
-        mk_call(
+        call(
           "Sin",
           vec![mk_times(
             mk_plus(mk_int(1), n.clone()),
-            mk_call("ArcCos", vec![x.clone()]),
+            call1("ArcCos", x.clone()),
           )],
         ),
         mk_times(
-          mk_call(
-            "Sqrt",
-            vec![mk_plus(mk_int(1), mk_times(mk_int(-1), x.clone()))],
-          ),
-          mk_call("Sqrt", vec![mk_plus(mk_int(1), x.clone())]),
+          call1("Sqrt", mk_plus(mk_int(1), mk_times(mk_int(-1), x.clone()))),
+          call1("Sqrt", mk_plus(mk_int(1), x.clone())),
         ),
       ))
     }
@@ -833,7 +819,7 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
     // where GoldenRatio = (1 + Sqrt[5]) / 2
     "Fibonacci" if args.len() == 1 => {
       let n = &args[0];
-      let sqrt5 = mk_call("Sqrt", vec![mk_int(5)]);
+      let sqrt5 = call1("Sqrt", mk_int(5));
       let golden = mk_times(mk_ratio(1, 2), mk_plus(mk_int(1), sqrt5.clone()));
       let inv_golden = mk_times(
         mk_int(2),
@@ -846,7 +832,7 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
             mk_int(-1),
             mk_times(
               mk_power(inv_golden, n.clone()),
-              mk_call("Cos", vec![mk_times(n.clone(), mk_id("Pi"))]),
+              call("Cos", vec![mk_times(n.clone(), mk_id("Pi"))]),
             ),
           ),
         ),
@@ -857,7 +843,7 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
     // LucasL[n] → GoldenRatio^n + (-1/GoldenRatio)^n * Cos[n*Pi]
     "LucasL" if args.len() == 1 => {
       let n = &args[0];
-      let sqrt5 = mk_call("Sqrt", vec![mk_int(5)]);
+      let sqrt5 = call1("Sqrt", mk_int(5));
       let golden = mk_times(mk_ratio(1, 2), mk_plus(mk_int(1), sqrt5.clone()));
       let inv_golden =
         mk_times(mk_int(2), mk_power(mk_plus(mk_int(1), sqrt5), mk_int(-1)));
@@ -865,7 +851,7 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
         mk_power(golden, n.clone()),
         mk_times(
           mk_power(inv_golden, n.clone()),
-          mk_call("Cos", vec![mk_times(n.clone(), mk_id("Pi"))]),
+          call("Cos", vec![mk_times(n.clone(), mk_id("Pi"))]),
         ),
       ))
     }
@@ -877,7 +863,7 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
         && ra.len() == 2
         && let (Expr::Integer(1), Expr::Integer(2)) = (&ra[0], &ra[1])
       {
-        return Some(mk_call("Sqrt", vec![mk_id("Pi")]));
+        return Some(call1("Sqrt", mk_id("Pi")));
       }
       None
     }
@@ -885,7 +871,7 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
     // HarmonicNumber[n] -> EulerGamma + PolyGamma[0, 1 + n].
     "HarmonicNumber" if args.len() == 1 => Some(mk_plus(
       mk_id("EulerGamma"),
-      mk_call(
+      call(
         "PolyGamma",
         vec![mk_int(0), mk_plus(mk_int(1), args[0].clone())],
       ),
@@ -899,9 +885,9 @@ fn try_expand_function(name: &str, args: &[Expr]) -> Option<Expr> {
       let arg = mk_plus(mk_int(1), args[0].clone());
       let hurwitz =
         try_expand_function("HurwitzZeta", &[r.clone(), arg.clone()])
-          .unwrap_or_else(|| mk_call("HurwitzZeta", vec![r.clone(), arg]));
+          .unwrap_or_else(|| call("HurwitzZeta", vec![r.clone(), arg]));
       Some(mk_plus(
-        mk_call("Zeta", vec![r.clone()]),
+        call1("Zeta", r.clone()),
         mk_times(mk_int(-1), hurwitz),
       ))
     }
@@ -973,9 +959,9 @@ fn try_gamma_ratio_in_times(factors: &[Expr]) -> Option<Expr> {
   // Gamma[A]/Gamma[B] = Pochhammer[B, k] for k > 0, 1/Pochhammer[A, -k] for
   // k < 0, and 1 for k == 0.
   let poch = match k.cmp(&0) {
-    std::cmp::Ordering::Greater => mk_call("Pochhammer", vec![b, mk_int(k)]),
+    std::cmp::Ordering::Greater => call("Pochhammer", vec![b, mk_int(k)]),
     std::cmp::Ordering::Less => {
-      mk_power(mk_call("Pochhammer", vec![a, mk_int(-k)]), mk_int(-1))
+      mk_power(call("Pochhammer", vec![a, mk_int(-k)]), mk_int(-1))
     }
     std::cmp::Ordering::Equal => mk_int(1),
   };
@@ -989,7 +975,7 @@ fn try_gamma_ratio_in_times(factors: &[Expr]) -> Option<Expr> {
   Some(if rest.len() == 1 {
     rest.remove(0)
   } else {
-    mk_call("Times", rest)
+    call("Times", rest)
   })
 }
 

--- a/src/functions/polynomial_ast/helpers.rs
+++ b/src/functions/polynomial_ast/helpers.rs
@@ -35,14 +35,6 @@ pub fn extract_exponent_map(var_factors: &[Expr]) -> HashMap<String, i128> {
   map
 }
 
-/// Build a FunctionCall expression.
-pub fn mk_call(name: &str, args: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  }
-}
-
 /// Build an Integer expression.
 pub fn mk_int(n: i128) -> Expr {
   Expr::Integer(n)
@@ -50,20 +42,17 @@ pub fn mk_int(n: i128) -> Expr {
 
 /// Build a `Rational[n, d]` expression.
 pub fn mk_ratio(n: i128, d: i128) -> Expr {
-  Expr::FunctionCall {
-    name: "Rational".to_string(),
-    args: vec![Expr::Integer(n), Expr::Integer(d)].into(),
-  }
+  call("Rational", vec![Expr::Integer(n), Expr::Integer(d)])
 }
 
 /// Build `Times[a, b]`.
 pub fn mk_times(a: Expr, b: Expr) -> Expr {
-  mk_call("Times", vec![a, b])
+  call("Times", vec![a, b])
 }
 
 /// Build `Power[base, exp]`.
 pub fn mk_power(base: Expr, exp: Expr) -> Expr {
-  mk_call("Power", vec![base, exp])
+  call("Power", vec![base, exp])
 }
 
 // ─── Ascending trimmed polynomial coefficient vectors ────────────────

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -6,7 +6,7 @@ use crate::InterpreterError;
 use crate::functions::math_ast::{
   gcd_i128, is_sqrt, lcm_i128, make_sqrt, rat_reduce, rat_reduce_bigint,
 };
-use crate::helpers::{bool_expr, div2, minus2, neg1, plus2, pow2};
+use crate::helpers::{bool_expr, call, call1, div2, minus2, neg1, plus2, pow2};
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
   unevaluated,

--- a/src/functions/polynomial_ast/symmetric_reduction.rs
+++ b/src/functions/polynomial_ast/symmetric_reduction.rs
@@ -16,21 +16,11 @@ fn eval(e: Expr) -> Result<Expr, InterpreterError> {
   crate::evaluator::evaluate_expr_to_expr(&e)
 }
 
-fn call(name: &str, args: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: args.into(),
-  }
-}
-
 fn sum(terms: Vec<Expr>) -> Expr {
   match terms.len() {
     0 => Expr::Integer(0),
     1 => terms.into_iter().next().unwrap(),
-    _ => Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: terms.into(),
-    },
+    _ => call("Plus", terms),
   }
 }
 
@@ -172,10 +162,7 @@ pub fn power_symmetric_polynomial_ast(
         terms.push(match factors.len() {
           0 => Expr::Integer(1),
           1 => factors.into_iter().next().unwrap(),
-          _ => Expr::FunctionCall {
-            name: "Times".to_string(),
-            args: factors.into(),
-          },
+          _ => call("Times", factors),
         });
       }
       eval(sum(terms))
@@ -272,10 +259,7 @@ pub fn augmented_symmetric_polynomial_ast(
       .collect();
     let term = match factors.len() {
       1 => factors.into_iter().next().unwrap(),
-      _ => Expr::FunctionCall {
-        name: "Times".to_string(),
-        args: factors.into(),
-      },
+      _ => call("Times", factors),
     };
     terms.push(term);
   }

--- a/src/functions/polynomial_ast/to_radicals.rs
+++ b/src/functions/polynomial_ast/to_radicals.rs
@@ -75,7 +75,7 @@ fn mk_plus(args: Vec<Expr>) -> Expr {
   if args.len() == 1 {
     args.into_iter().next().unwrap()
   } else {
-    mk_call("Plus", args)
+    call("Plus", args)
   }
 }
 
@@ -208,7 +208,7 @@ fn classify_term(term: &Expr) -> Option<(usize, Expr)> {
         let coeff = if coeff_parts.len() == 1 {
           coeff_parts.into_iter().next().unwrap()
         } else {
-          mk_call("Times", coeff_parts)
+          call("Times", coeff_parts)
         };
 
         if let Expr::Slot(1) = slot_part {
@@ -246,14 +246,14 @@ fn root_to_radical(
   let k = match k_expr {
     Expr::Integer(n) => *n,
     _ => {
-      return Ok(mk_call("Root", vec![func.clone(), k_expr.clone()]));
+      return Ok(call("Root", vec![func.clone(), k_expr.clone()]));
     }
   };
 
   let body_raw = match func {
     Expr::Function { body } => body.as_ref(),
     _ => {
-      return Ok(mk_call("Root", vec![func.clone(), k_expr.clone()]));
+      return Ok(call("Root", vec![func.clone(), k_expr.clone()]));
     }
   };
   // Evaluate the body to normalize it into FunctionCall form (Plus, Times, Power)
@@ -264,7 +264,7 @@ fn root_to_radical(
   let coeffs = match extract_poly_coefficients(body) {
     Some(c) => c,
     None => {
-      return Ok(mk_call("Root", vec![func.clone(), k_expr.clone()]));
+      return Ok(call("Root", vec![func.clone(), k_expr.clone()]));
     }
   };
 
@@ -300,18 +300,18 @@ fn root_to_radical(
 
       let idx = (k as usize) - 1;
       if idx >= evaluated_roots.len() {
-        Ok(mk_call("Root", vec![func.clone(), k_expr.clone()]))
+        Ok(call("Root", vec![func.clone(), k_expr.clone()]))
       } else {
         Ok(evaluated_roots.remove(idx))
       }
     }
-    None => Ok(mk_call("Root", vec![func.clone(), k_expr.clone()])),
+    None => Ok(call("Root", vec![func.clone(), k_expr.clone()])),
   }
 }
 
 /// Solve linear: a0 + a1*x = 0 → x = -a0/a1
 fn solve_linear(coeffs: &[Expr]) -> Option<Vec<Expr>> {
-  Some(vec![mk_call(
+  Some(vec![call(
     "Times",
     vec![
       mk_int(-1),
@@ -394,7 +394,7 @@ fn solve_cubic(coeffs: &[Expr]) -> Option<Vec<Expr>> {
       mk_times(mk_int(2), mk_power(a2.clone(), mk_int(3))),
       mk_times(
         mk_int(-9),
-        mk_call("Times", vec![a3.clone(), a2.clone(), a1.clone()]),
+        call("Times", vec![a3.clone(), a2.clone(), a1.clone()]),
       ),
       mk_times(
         mk_int(27),
@@ -528,8 +528,8 @@ fn nth_root_of_unity(
       mk_times(mk_ratio(num, den), Expr::Identifier("Pi".to_string()))
     };
     Some(mk_plus(vec![
-      mk_call("Cos", vec![angle.clone()]),
-      mk_times(i_val.clone(), mk_call("Sin", vec![angle])),
+      call1("Cos", angle.clone()),
+      mk_times(i_val.clone(), call1("Sin", angle)),
     ]))
   }
 }

--- a/src/functions/trig_factor_ast.rs
+++ b/src/functions/trig_factor_ast.rs
@@ -18,25 +18,12 @@ pub fn trig_factor_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(factor(&args[0]).unwrap_or_else(|| args[0].clone()))
 }
 
-fn trig_call(head: &str, arg: Expr) -> Expr {
-  Expr::FunctionCall {
-    name: head.to_string(),
-    args: vec![arg].into(),
-  }
-}
-
 fn times(fs: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: fs.into(),
-  }
+  call("Times", fs)
 }
 
 fn plus(ts: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: ts.into(),
-  }
+  call("Plus", ts)
 }
 
 fn div(a: Expr, b: i128) -> Expr {
@@ -64,10 +51,7 @@ fn square(e: Expr) -> Expr {
 }
 
 fn sqrt2() -> Expr {
-  Expr::FunctionCall {
-    name: "Sqrt".to_string(),
-    args: vec![Expr::Integer(2)].into(),
-  }
+  call1("Sqrt", Expr::Integer(2))
 }
 
 fn pi_quarter() -> Expr {
@@ -109,16 +93,13 @@ fn sin_pm(v: &Expr, plus_quarter: bool) -> (Expr, i32) {
     } else {
       neg1(pi_quarter())
     });
-    (trig_call("Sin", plus(terms)), 1)
+    (call1("Sin", plus(terms)), 1)
   } else if plus_quarter {
     // Sin[v + Pi/4] == Sin[Pi/4 + v]
-    (trig_call("Sin", plus(vec![pi_quarter(), v.clone()])), 1)
+    (call1("Sin", plus(vec![pi_quarter(), v.clone()])), 1)
   } else {
     // Sin[v - Pi/4] == -Sin[Pi/4 - v]
-    (
-      trig_call("Sin", plus(vec![pi_quarter(), neg1(v.clone())])),
-      -1,
-    )
+    (call1("Sin", plus(vec![pi_quarter(), neg1(v.clone())])), -1)
   }
 }
 
@@ -206,8 +187,8 @@ fn factor(expr: &Expr) -> Option<Expr> {
       // 2*Cos[u]*Sin[u]
       times(vec![
         Expr::Integer(2),
-        trig_call("Cos", u.clone()),
-        trig_call("Sin", u),
+        call1("Cos", u.clone()),
+        call1("Sin", u),
       ])
     } else {
       // Cos[2u] = 2*Sin[Pi/4 - u]*Sin[Pi/4 + u]
@@ -223,8 +204,8 @@ fn factor(expr: &Expr) -> Option<Expr> {
   {
     return Some(times(vec![
       Expr::Integer(2),
-      trig_call("Cosh", u.clone()),
-      trig_call("Sinh", u),
+      call1("Cosh", u.clone()),
+      call1("Sinh", u),
     ]));
   }
 
@@ -246,7 +227,7 @@ fn factor(expr: &Expr) -> Option<Expr> {
         two_sin_sq(&h, true)
       } else {
         // 2*Cos[h]^2
-        times(vec![Expr::Integer(2), square(trig_call("Cos", h))])
+        times(vec![Expr::Integer(2), square(call1("Cos", h))])
       });
     }
     if let Some(inner) = negated(b)
@@ -258,7 +239,7 @@ fn factor(expr: &Expr) -> Option<Expr> {
         two_sin_sq(&h, false)
       } else {
         // 2*Sin[h]^2
-        times(vec![Expr::Integer(2), square(trig_call("Sin", h))])
+        times(vec![Expr::Integer(2), square(call1("Sin", h))])
       });
     }
   }
@@ -311,11 +292,7 @@ fn factor(expr: &Expr) -> Option<Expr> {
     // Fold the overall sign into the leading coefficient (-2, not -(2 ...))
     // to match Wolfram's printed form.
     let cos_sin = |k: i128, c: Expr, s: Expr| {
-      times(vec![
-        Expr::Integer(k),
-        trig_call("Cos", c),
-        trig_call("Sin", s),
-      ])
+      times(vec![Expr::Integer(k), call1("Cos", c), call1("Sin", s)])
     };
     return Some(match (na, nb) {
       (false, false) => cos_sin(2, hd, hs), // +Sin[p] +Sin[q]
@@ -375,9 +352,9 @@ fn factor(expr: &Expr) -> Option<Expr> {
   if let Some((k, u)) = const_and_cosh(a, b).or_else(|| const_and_cosh(b, a)) {
     let h = halved(&u).unwrap_or_else(|| div(u.clone(), 2));
     return Some(if k == 1 {
-      times(vec![Expr::Integer(2), square(trig_call("Cosh", h))])
+      times(vec![Expr::Integer(2), square(call1("Cosh", h))])
     } else {
-      times(vec![Expr::Integer(2), square(trig_call("Sinh", h))])
+      times(vec![Expr::Integer(2), square(call1("Sinh", h))])
     });
   }
 
@@ -407,7 +384,7 @@ fn factor(expr: &Expr) -> Option<Expr> {
     let hd = half_diff(&ua, &ub); // x/2 - y/2
     let hs = half_sum(&ua, &ub); // x/2 + y/2
     let prod = |k: i128, h1: &str, a1: Expr, h2: &str, a2: Expr| {
-      times(vec![Expr::Integer(k), trig_call(h1, a1), trig_call(h2, a2)])
+      times(vec![Expr::Integer(k), call1(h1, a1), call1(h2, a2)])
     };
     return Some(if sa {
       // Both Sinh: the product is Cosh * Sinh.

--- a/src/functions/ztransform_ast.rs
+++ b/src/functions/ztransform_ast.rs
@@ -61,7 +61,7 @@ pub fn z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && let Some(a) = linear_coeff_in_n(&fargs[0], &n_var)
     && is_constant_wrt(&a, &z_var)
   {
-    let cos_a = func("Cos", a.clone());
+    let cos_a = call1("Cos", a.clone());
     // 1 + z^2 - 2 z Cos[a]
     let den = plus(vec![
       Expr::Integer(1),
@@ -69,7 +69,7 @@ pub fn z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       times(vec![Expr::Integer(-2), z.clone(), cos_a.clone()]),
     ]);
     let num = if name == "Sin" {
-      times(vec![z.clone(), func("Sin", a)])
+      times(vec![z.clone(), call1("Sin", a)])
     } else {
       times(vec![
         z.clone(),
@@ -99,17 +99,14 @@ pub fn z_transform_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       return Ok(unevaluated(args));
     }
     let exponent = if p == 1 {
-      Expr::FunctionCall {
-        name: "Power".to_string(),
-        args: vec![z.clone(), Expr::Integer(-1)].into(),
-      }
+      call("Power", vec![z.clone(), Expr::Integer(-1)])
     } else {
       div2(Expr::Integer(p), z.clone())
     };
-    return Ok(Expr::FunctionCall {
-      name: "Power".to_string(),
-      args: vec![Expr::Identifier("E".to_string()), exponent].into(),
-    });
+    return Ok(call(
+      "Power",
+      vec![Expr::Identifier("E".to_string()), exponent],
+    ));
   }
 
   // Symbolic base: fixed templates for k = 0, 1, 2 (c must be 1)
@@ -386,28 +383,15 @@ fn as_power(expr: &Expr) -> Option<(Expr, Expr)> {
 }
 
 fn plus(terms: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: terms.into(),
-  }
+  call("Plus", terms)
 }
 
 fn times(factors: Vec<Expr>) -> Expr {
-  Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: factors.into(),
-  }
+  call("Times", factors)
 }
 
 fn power(base: Expr, exp: i128) -> Expr {
   pow2(base, Expr::Integer(exp))
-}
-
-fn func(name: &str, arg: Expr) -> Expr {
-  Expr::FunctionCall {
-    name: name.to_string(),
-    args: vec![arg].into(),
-  }
 }
 
 /// If `arg` is exactly `a * n` — degree one in `n` with no constant term and
@@ -633,10 +617,7 @@ pub fn inverse_z_transform_ast(
     _ => return Ok(unevaluated(args)),
   };
   let n = Expr::Identifier(n_var.clone());
-  let factorial_n = Expr::FunctionCall {
-    name: "Factorial".to_string(),
-    args: vec![n.clone()].into(),
-  };
+  let factorial_n = call("Factorial", vec![n.clone()]);
 
   // E^(1/z) → 1/n!, E^(c/z) → c^n/n!
   if let Some((base, exp)) = as_power(&args[0])
@@ -683,10 +664,7 @@ pub fn inverse_z_transform_ast(
 
   // Constant with respect to z: c → c*DiscreteDelta[n]
   if is_constant_wrt(&args[0], &z_var) {
-    let delta = Expr::FunctionCall {
-      name: "DiscreteDelta".to_string(),
-      args: vec![n.clone()].into(),
-    };
+    let delta = call("DiscreteDelta", vec![n.clone()]);
     return Ok(match &args[0] {
       Expr::Integer(1) => delta,
       c => times(vec![c.clone(), delta]),
@@ -946,10 +924,10 @@ fn format_inverse_result(
       return Ok(Some(if coef.1 == 1 {
         Expr::Integer(coef.0)
       } else {
-        Expr::FunctionCall {
-          name: "Rational".to_string(),
-          args: vec![Expr::Integer(coef.0), Expr::Integer(coef.1)].into(),
-        }
+        call(
+          "Rational",
+          vec![Expr::Integer(coef.0), Expr::Integer(coef.1)],
+        )
       }));
     }
     return Ok(None);
@@ -1075,16 +1053,10 @@ pub fn fourier_coefficient_ast(
     if f.1 == 1 {
       Expr::Integer(f.0)
     } else {
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(f.0), Expr::Integer(f.1)].into(),
-      }
+      call("Rational", vec![Expr::Integer(f.0), Expr::Integer(f.1)])
     }
   };
-  let times = |fs: Vec<Expr>| Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: fs.into(),
-  };
+  let times = |fs: Vec<Expr>| call("Times", fs);
   let pow = |b: Expr, e: i128| pow2(b, Expr::Integer(e));
   let i_unit = || Expr::Identifier("I".to_string());
   let pi = || Expr::Constant("Pi".to_string());
@@ -1093,10 +1065,7 @@ pub fn fourier_coefficient_ast(
 
   // Pure constant: c*DiscreteDelta[n]
   if c1.0 == 0 && c2.0 == 0 && c3.0 == 0 {
-    let delta = Expr::FunctionCall {
-      name: "DiscreteDelta".to_string(),
-      args: vec![n_arg.clone()].into(),
-    };
+    let delta = call("DiscreteDelta", vec![n_arg.clone()]);
     let result = if c0 == (1, 1) {
       delta
     } else {
@@ -1130,10 +1099,7 @@ pub fn fourier_coefficient_ast(
     match terms.len() {
       0 => Expr::Integer(0),
       1 => terms.remove(0),
-      _ => Expr::FunctionCall {
-        name: "Plus".to_string(),
-        args: terms.into(),
-      },
+      _ => call("Plus", terms),
     }
   };
 
@@ -1166,23 +1132,19 @@ pub fn fourier_coefficient_ast(
   }
   // t^3: (c3*I*(-1)^n*(-6 + n^2*Pi^2))/n^3
   if let Some(ci) = coeff_i(c3) {
-    let bracket = Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: vec![
+    let bracket = call(
+      "Plus",
+      vec![
         Expr::Integer(-6),
         times(vec![pow(n_expr(), 2), pow(pi(), 2)]),
-      ]
-      .into(),
-    };
+      ],
+    );
     general_terms.push(div2(times(vec![ci, m1n(), bracket]), pow(n_expr(), 3)));
   }
   let general = match general_terms.len() {
     0 => Expr::Integer(0),
     1 => general_terms.remove(0),
-    _ => Expr::FunctionCall {
-      name: "Plus".to_string(),
-      args: general_terms.into(),
-    },
+    _ => call("Plus", general_terms),
   };
 
   // Numeric n: pick the branch and evaluate
@@ -1199,14 +1161,13 @@ pub fn fourier_coefficient_ast(
     operands: vec![n_arg.clone(), Expr::Integer(0)],
     operators: vec![ComparisonOp::Equal],
   };
-  Ok(Expr::FunctionCall {
-    name: "Piecewise".to_string(),
-    args: vec![
+  Ok(call(
+    "Piecewise",
+    vec![
       Expr::List(vec![Expr::List(vec![zero_piece, cond].into())].into()),
       general,
-    ]
-    .into(),
-  })
+    ],
+  ))
 }
 
 // ─── FourierSinCoefficient / FourierCosCoefficient ───────────────────
@@ -1254,14 +1215,8 @@ pub fn fourier_sin_cos_coefficient_ast(
   }
   let (k, c) = nonzero[0];
 
-  let times = |fs: Vec<Expr>| Expr::FunctionCall {
-    name: "Times".to_string(),
-    args: fs.into(),
-  };
-  let plus = |ts: Vec<Expr>| Expr::FunctionCall {
-    name: "Plus".to_string(),
-    args: ts.into(),
-  };
+  let times = |fs: Vec<Expr>| call("Times", fs);
+  let plus = |ts: Vec<Expr>| call("Plus", ts);
   let pow = |b: Expr, e: i128| pow2(b, Expr::Integer(e));
   let pi = || Expr::Constant("Pi".to_string());
   let n_e = || n_arg.clone();
@@ -1271,10 +1226,7 @@ pub fn fourier_sin_cos_coefficient_ast(
     if f.1 == 1 {
       Expr::Integer(f.0)
     } else {
-      Expr::FunctionCall {
-        name: "Rational".to_string(),
-        args: vec![Expr::Integer(f.0), Expr::Integer(f.1)].into(),
-      }
+      call("Rational", vec![Expr::Integer(f.0), Expr::Integer(f.1)])
     }
   };
   // 2 - 2*(-1)^n + (-1)^n*n^2*Pi^2
@@ -1329,13 +1281,7 @@ pub fn fourier_sin_cos_coefficient_ast(
   } else {
     match k {
       // 2*DiscreteDelta[n]
-      0 => times(vec![
-        scaled(2),
-        Expr::FunctionCall {
-          name: "DiscreteDelta".to_string(),
-          args: vec![n_e()].into(),
-        },
-      ]),
+      0 => times(vec![scaled(2), call("DiscreteDelta", vec![n_e()])]),
       // (2*(-1 + (-1)^n))/(n^2*Pi)
       1 => div2(
         times(vec![scaled(2), plus(vec![Expr::Integer(-1), m1()])]),

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -36,6 +36,17 @@ pub fn div2(a: Expr, b: Expr) -> Expr {
   binop(BinaryOperator::Divide, a, b)
 }
 
+pub fn call(name: &str, args: Vec<Expr>) -> Expr {
+  Expr::FunctionCall {
+    name: name.to_string(),
+    args: args.into(),
+  }
+}
+
+pub fn call1(name: &str, arg: Expr) -> Expr {
+  call(name, vec![arg])
+}
+
 /// Build the boolean symbol `True` or `False`.
 pub fn bool_expr(b: bool) -> Expr {
   Expr::Identifier(if b { "True" } else { "False" }.to_string())


### PR DESCRIPTION
This PR adds a call and call1 AST helper and starts using them. Some existing helpers are removed and renamed, e.g. unary_fn, func, fc, mk_call, trig_call.  Some unrelated cargo fmt changes are included to fix CI / format failures.