### PR TITLE
Make $VersionNumber a Real representing Wolfram Language version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 # Unreleased
 
+- `$VersionNumber` is a `Real` — the Wolfram Language version Woxi aims to
+    be compatible with (`15.`) — instead of the Woxi build's git version as
+    a `String`. Scripts gate language features on it
+    (`If[$VersionNumber >= 8, …]`), which only works for a number. The Woxi
+    build stays available through `$Version`.
+
 - Fixes driven by a Wolfram Demonstration that draws the shortest distance
     between two skew lines, a `Manipulate` whose `Graphics3D` is built out
     of unbounded objects:

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -1,6 +1,10 @@
 #[allow(unused_imports)]
 use super::*;
 
+/// Version of the Wolfram Language that Woxi aims to be compatible with,
+/// reported by `$VersionNumber` (major and minor part only, as in Wolfram).
+pub const WOLFRAM_LANGUAGE_VERSION: f64 = 15.0;
+
 /// Dispatch function call to built-in implementations (AST version).
 /// This is the AST equivalent of the string-based function dispatch.
 /// IMPORTANT: This function must NOT call interpret() to avoid infinite recursion.
@@ -474,9 +478,11 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
         .or_else(os_user_name)
         .map(Expr::String)
     }
-    "$VersionNumber" => {
-      Some(Expr::String(env!("WOXI_GIT_VERSION").to_string()))
-    }
+    // A `Real` like in Wolfram (e.g. `15.`), *not* the Woxi git version —
+    // scripts use it to gate on available language features
+    // (e.g. `If[$VersionNumber >= 8, …]`), which only works for a number.
+    // The Woxi build itself is reported by `$Version`.
+    "$VersionNumber" => Some(Expr::Real(WOLFRAM_LANGUAGE_VERSION)),
     // `$Version` is a human-readable banner — Wolfram returns e.g.
     // "14.3.0 for Mac OS X ARM (64-bit) (...)". Woxi has no notion of
     // such a string; surface the git version with a "Woxi " prefix so

--- a/tests/interpreter_tests/math/numeric.rs
+++ b/tests/interpreter_tests/math/numeric.rs
@@ -1109,11 +1109,27 @@ mod precision {
 
   #[test]
   fn version_number() {
-    // $VersionNumber should return the git-describe output of the Woxi repo
-    // (e.g. "v0.1.0-1234-gabcdef" or similar). Just check it's non-empty.
-    let result = interpret("$VersionNumber").unwrap();
-    assert!(!result.is_empty());
-    assert_ne!(result, "$VersionNumber");
+    // $VersionNumber is the Wolfram Language version Woxi is compatible
+    // with, as a Real — not the Woxi build (that's `$Version`).
+    assert_eq!(interpret("$VersionNumber").unwrap(), "15.");
+  }
+
+  #[test]
+  fn version_number_head_is_real() {
+    assert_eq!(interpret("Head[$VersionNumber]").unwrap(), "Real");
+  }
+
+  #[test]
+  fn version_number_is_comparable() {
+    // Scripts gate language features on the version, e.g.
+    // `If[$VersionNumber >= 8, …]` — that requires a numeric value.
+    assert_eq!(interpret("$VersionNumber >= 8").unwrap(), "True");
+    assert_eq!(interpret("$VersionNumber >= 14.1").unwrap(), "True");
+    assert_eq!(interpret("NumberQ[$VersionNumber]").unwrap(), "True");
+    assert_eq!(
+      interpret("If[$VersionNumber >= 8, \"new\", \"old\"]").unwrap(),
+      "new"
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Changed `$VersionNumber` from returning the Woxi git version as a string to returning a `Real` number representing the Wolfram Language version that Woxi aims to be compatible with (15.0). This aligns with Wolfram Language semantics where scripts use `$VersionNumber` to gate language features via numeric comparisons.

## Key Changes

- **src/evaluator/listable.rs**: 
  - Added `WOLFRAM_LANGUAGE_VERSION` constant set to 15.0
  - Changed `$VersionNumber` to return `Expr::Real(WOLFRAM_LANGUAGE_VERSION)` instead of `Expr::String(env!("WOXI_GIT_VERSION"))`
  - Updated comments to clarify that `$VersionNumber` is the language version (for feature gating), while `$Version` reports the Woxi build

- **tests/interpreter_tests/math/numeric.rs**:
  - Updated `version_number` test to assert `$VersionNumber` equals `"15."` (the Real representation)
  - Added `version_number_head_is_real` test to verify the type is `Real`
  - Added `version_number_is_comparable` test to verify numeric comparisons work correctly, including:
    - Comparison operators (`>=`)
    - `NumberQ` predicate
    - Conditional logic using version checks

- **changelog.md**: Documented the breaking change with rationale

## Implementation Details

The change ensures that scripts can properly gate language features using idiomatic Wolfram Language patterns like `If[$VersionNumber >= 8, …]`, which requires a numeric value. The Woxi build information remains available through `$Version` as a human-readable string.

https://claude.ai/code/session_01JZLq7jfEaDSdmCW3UiAFLX