### PR TITLE
Fix $InputFileName scoping in Get and relative path resolution

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@
 
 # Unreleased
 
+- `$InputFileName` names the file `Get` is currently reading, so a file
+    pulled in with `Get` can locate its own directory
+    (`DirectoryName[$InputFileName]`) instead of the including script's. The
+    previous value is restored when the read finishes, so nested and
+    sequential `Get`s each see their own file.
+- `Get["relative/name.wl"]` resolves against the current directory reported
+    by `Directory[]`, so a preceding `SetDirectory` is honoured.
 - Fixes driven by a Wolfram Demonstration that draws the shortest distance
     between two skew lines, a `Manipulate` whose `Graphics3D` is built out
     of unbounded objects:

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -125,6 +125,46 @@ fn virtual_current_dir() -> String {
     })
 }
 
+/// Scopes `$InputFileName` to the file a `Get` is currently reading.
+///
+/// While a file is being read it *is* the input file, so `$InputFileName`
+/// has to name it rather than the enclosing script. Restoring on drop (rather
+/// than after the evaluation) keeps nested and sequential `Get`s correct even
+/// when the read file raises an error.
+#[cfg(not(target_arch = "wasm32"))]
+struct InputFileNameGuard {
+  prev: Option<crate::StoredValue>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl InputFileNameGuard {
+  fn install(path: &std::path::Path) -> Self {
+    let value = crate::StoredValue::ExprVal(Expr::String(
+      path.to_string_lossy().into_owned(),
+    ));
+    let prev = crate::ENV
+      .with(|e| e.borrow_mut().insert("$InputFileName".to_string(), value));
+    Self { prev }
+  }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for InputFileNameGuard {
+  fn drop(&mut self) {
+    crate::ENV.with(|e| {
+      let mut env = e.borrow_mut();
+      match self.prev.take() {
+        Some(v) => {
+          env.insert("$InputFileName".to_string(), v);
+        }
+        None => {
+          env.remove("$InputFileName");
+        }
+      }
+    });
+  }
+}
+
 pub fn dispatch_io_functions(
   name: &str,
   args: &[Expr],
@@ -546,7 +586,15 @@ pub fn dispatch_io_functions(
       if crate::utils::is_standard_distribution_context(&filename) {
         return Some(Ok(Expr::Identifier("Null".to_string())));
       }
-      let content = match std::fs::read_to_string(&filename) {
+      // A relative name resolves against the virtual working directory, so a
+      // preceding `SetDirectory` is honoured the way it is in wolframscript.
+      let requested = std::path::Path::new(&filename);
+      let resolved = if requested.is_absolute() {
+        requested.to_path_buf()
+      } else {
+        std::path::PathBuf::from(virtual_current_dir()).join(requested)
+      };
+      let content = match std::fs::read_to_string(&resolved) {
         Ok(c) => c,
         Err(_) => {
           // wolframscript prints this message to stdout (verified with
@@ -559,6 +607,9 @@ pub fn dispatch_io_functions(
           return Some(Ok(Expr::Identifier("$Failed".to_string())));
         }
       };
+      // The read file is the input file for the duration of the read, so
+      // `$InputFileName` must point at it and not at the enclosing script.
+      let _input_file_name = InputFileNameGuard::install(&resolved);
       // Use interpret to evaluate the file content (handles all node types
       // including FunctionDefinition, Expression, etc.)
       let result_str = match crate::interpret(&content) {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -149,6 +149,34 @@ fn run_routes_messages_to_stdout_like_wolframscript() {
   assert_eq!(stderr, "", "no message should leak to stderr");
 }
 
+// Regression test for #422: a file pulled in with `Get` sees its own path in
+// `$InputFileName`, and the including script sees its own again afterwards.
+#[test]
+fn get_scopes_input_file_name_to_the_included_file() {
+  let dir = std::env::temp_dir().join("woxi_cli_get_input_file_name");
+  std::fs::create_dir_all(&dir).expect("create temp dir");
+  let included = dir.join("included_file.wl");
+  let main = dir.join("test.wl");
+  // Use forward slashes inside the script: on Windows a backslash in a
+  // string literal reads as an escape sequence.
+  let included_arg = included.to_string_lossy().replace('\\', "/");
+  std::fs::write(&included, "Echo[$InputFileName];\n").expect("write include");
+  std::fs::write(
+    &main,
+    format!("Get[\"{included_arg}\"];\nEcho[$InputFileName];\n"),
+  )
+  .expect("write main");
+
+  let (stdout, stderr, ok) = run_file(&main);
+  let _ = std::fs::remove_dir_all(&dir);
+  assert!(ok, "woxi run failed: stderr={}", stderr);
+  assert_eq!(
+    stdout,
+    format!(">> {included_arg}\n>> {}\n", main.display()),
+    "the included file must report its own path, the script its own"
+  );
+}
+
 #[test]
 fn run_notebook_hello_world() {
   // `woxi run` should accept a real `.nb` notebook file, evaluate its

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -295,6 +295,93 @@ mod get {
     assert_eq!(result, "\0");
     std::fs::remove_file(path).ok();
   }
+
+  // Regression test for #422: inside a file read by Get, `$InputFileName`
+  // must name that file — not the script that called Get.
+  #[test]
+  fn input_file_name_names_the_read_file() {
+    clear_state();
+    let path = write_temp("get_ifn", "getIfnInner = $InputFileName;");
+    woxi::set_system_variable("$InputFileName", "\"/outer/script.wls\"");
+    let result =
+      interpret(&format!("Get[\"{path}\"]; SameQ[getIfnInner, \"{path}\"]"))
+        .unwrap();
+    assert_eq!(result, "True");
+    std::fs::remove_file(path).ok();
+  }
+
+  #[test]
+  fn input_file_name_is_restored_after_get() {
+    clear_state();
+    let path = write_temp("get_ifn_restore", "1 + 1");
+    woxi::set_system_variable("$InputFileName", "\"/outer/script.wls\"");
+    let result =
+      interpret(&format!("Get[\"{path}\"]; $InputFileName")).unwrap();
+    assert_eq!(result, "/outer/script.wls");
+    std::fs::remove_file(path).ok();
+  }
+
+  #[test]
+  fn input_file_name_stays_unset_when_it_was_unset() {
+    clear_state();
+    let path = write_temp("get_ifn_unset", "1 + 1");
+    let result =
+      interpret(&format!("Get[\"{path}\"]; $InputFileName")).unwrap();
+    assert_eq!(result, "$InputFileName");
+    std::fs::remove_file(path).ok();
+  }
+
+  #[test]
+  fn input_file_name_is_restored_when_the_read_file_fails_to_evaluate() {
+    clear_state();
+    let path = write_temp("get_ifn_err", "Throw[1]");
+    woxi::set_system_variable("$InputFileName", "\"/outer/script.wls\"");
+    let _ = interpret(&format!("Get[\"{path}\"]"));
+    assert_eq!(interpret("$InputFileName").unwrap(), "/outer/script.wls");
+    std::fs::remove_file(path).ok();
+  }
+
+  #[test]
+  fn nested_get_restores_the_outer_input_file_name() {
+    clear_state();
+    let inner =
+      write_temp("get_ifn_nested_inner", "getIfnNestedIn = $InputFileName;");
+    let outer = write_temp(
+      "get_ifn_nested_outer",
+      &format!("Get[\"{inner}\"]; getIfnNestedOut = $InputFileName;"),
+    );
+    interpret(&format!("Get[\"{outer}\"]")).unwrap();
+    assert_eq!(
+      interpret(&format!("SameQ[getIfnNestedIn, \"{inner}\"]")).unwrap(),
+      "True"
+    );
+    assert_eq!(
+      interpret(&format!("SameQ[getIfnNestedOut, \"{outer}\"]")).unwrap(),
+      "True"
+    );
+    std::fs::remove_file(inner).ok();
+    std::fs::remove_file(outer).ok();
+  }
+
+  // A relative file name resolves against the virtual working directory, so
+  // `SetDirectory` before a `Get` is honoured.
+  #[test]
+  fn relative_name_resolves_against_the_current_directory() {
+    clear_state();
+    let path = write_temp("get_relative", "getRelativeVar = 7;");
+    let dir = temp_dir();
+    let name = std::path::Path::new(&path)
+      .file_name()
+      .unwrap()
+      .to_string_lossy()
+      .into_owned();
+    let result = interpret(&format!(
+      "SetDirectory[\"{dir}\"]; Get[\"{name}\"]; ResetDirectory[]; getRelativeVar"
+    ))
+    .unwrap();
+    assert_eq!(result, "7");
+    std::fs::remove_file(path).ok();
+  }
 }
 
 mod directory {


### PR DESCRIPTION
## Summary

This PR fixes two issues with the `Get` function:

1. `$InputFileName` now correctly names the file being read by `Get`, rather than the enclosing script. The previous value is restored when the read completes, ensuring nested and sequential `Get` calls each see their own file.
2. Relative file paths in `Get` now resolve against the current directory (as set by `SetDirectory`), matching wolframscript behavior.

## Key Changes

- **InputFileNameGuard**: Added a RAII guard struct that temporarily sets `$InputFileName` to the file being read and restores the previous value on drop. This ensures correct behavior even when the read file raises an error.
- **Path resolution**: Modified `Get` to resolve relative paths against the virtual working directory (from `SetDirectory`), while absolute paths are used as-is.
- **Comprehensive test coverage**: Added 7 regression tests covering:
  - Basic `$InputFileName` scoping in `Get`
  - Restoration after successful and failed reads
  - Nested `Get` calls
  - Relative path resolution with `SetDirectory`

## Implementation Details

- The `InputFileNameGuard` is installed before evaluating the file content and automatically restores the previous state on drop, making it exception-safe.
- Path resolution distinguishes between absolute and relative paths, with relative paths joined against the virtual current directory.
- All changes are gated behind `#[cfg(not(target_arch = "wasm32"))]` to maintain compatibility with the WASM target.

https://claude.ai/code/session_01Mqg115MrHGCFfryDP5QueS