### PR TITLE
Fix Do/Table bare iterator count for non-literal expressions

### DIFF
--- a/src/functions/list_helpers_ast/construction.rs
+++ b/src/functions/list_helpers_ast/construction.rs
@@ -188,6 +188,21 @@ pub fn table_ast(
   body: &Expr,
   iter_spec: &Expr,
 ) -> Result<Expr, InterpreterError> {
+  // A bare (non-list) iterator spec may be a symbol or expression that
+  // evaluates to a repeat count (`Table[x, n]`, `Table[x, 2 + 3]`), not just
+  // a literal integer. Resolve it before dispatching so the arms below only
+  // have to deal with already-evaluated forms; the caller (table_iterators_
+  // invalid) has already confirmed a bare spec resolves to a number.
+  let resolved_spec;
+  let iter_spec: &Expr = if matches!(
+    iter_spec,
+    Expr::List(_) | Expr::Integer(_) | Expr::BigInteger(_)
+  ) {
+    iter_spec
+  } else {
+    resolved_spec = crate::evaluator::evaluate_expr_to_expr(iter_spec)?;
+    &resolved_spec
+  };
   match iter_spec {
     Expr::Integer(_) | Expr::BigInteger(_) => {
       // Simple form: Table[expr, n]
@@ -1099,6 +1114,21 @@ fn restore_loop_var(var_name: &str, prev: Option<crate::StoredValue>) {
 /// Do[expr, {i, max}] -> execute with i from 1 to max
 /// Do[expr, {i, min, max}] -> execute with i from min to max
 pub fn do_ast(body: &Expr, iter_spec: &Expr) -> Result<Expr, InterpreterError> {
+  // A bare (non-list) iterator spec may be a symbol or expression that
+  // evaluates to a repeat count (`Do[expr, n]`, `Do[expr, 500 - iStart]`),
+  // not just a literal integer. Resolve it before dispatching, mirroring
+  // table_ast; the caller (table_iterators_invalid) has already confirmed a
+  // bare spec resolves to a number.
+  let resolved_spec;
+  let iter_spec: &Expr = if matches!(
+    iter_spec,
+    Expr::List(_) | Expr::Integer(_) | Expr::BigInteger(_)
+  ) {
+    iter_spec
+  } else {
+    resolved_spec = crate::evaluator::evaluate_expr_to_expr(iter_spec)?;
+    &resolved_spec
+  };
   match iter_spec {
     Expr::Integer(_) | Expr::BigInteger(_) => {
       let n = expr_to_i128(iter_spec).unwrap_or(0);

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -201,6 +201,45 @@ mod table_do_raw_iterator {
   }
 }
 
+mod table_do_bare_count {
+  use super::*;
+
+  // A bare (non-list) iterator spec need not be a literal integer: a symbol
+  // or an arbitrary expression that evaluates to a non-negative integer is
+  // also a valid repeat count (regression test: these used to raise
+  // "invalid iterator specification" because only literal Expr::Integer was
+  // recognized).
+  #[test]
+  fn table_bare_symbol_count() {
+    clear_state();
+    assert_eq!(interpret("n = 3; Table[x, n]").unwrap(), "{x, x, x}");
+  }
+
+  #[test]
+  fn table_bare_expression_count() {
+    clear_state();
+    assert_eq!(
+      interpret("iStart = 5; Table[x, 8 - iStart]").unwrap(),
+      "{x, x, x}"
+    );
+  }
+
+  #[test]
+  fn do_bare_symbol_count() {
+    clear_state();
+    let r = woxi::interpret_with_stdout("n = 3; Do[Print[1], n]").unwrap();
+    assert_eq!(r.stdout, "1\n1\n1\n");
+  }
+
+  #[test]
+  fn do_bare_expression_count() {
+    clear_state();
+    let r = woxi::interpret_with_stdout("iStart = 5; Do[Print[1], 8 - iStart]")
+      .unwrap();
+    assert_eq!(r.stdout, "1\n1\n1\n");
+  }
+}
+
 mod table_symbolic_bounds {
   use super::*;
 


### PR DESCRIPTION
## Summary

- `Do[expr, n]` and `Table[expr, n]` (the bare, non-list repeat-count form) only recognized a literal `Integer` for `n`. When `n` was a symbol or an arithmetic expression (e.g. `Do[expr, 500 - iStart]`), evaluation raised `"invalid iterator specification"` instead of evaluating the count first.
- Fixed in `table_ast`/`do_ast` (`src/functions/list_helpers_ast/construction.rs`) by evaluating a bare, non-list iterator spec before dispatching, mirroring how the `{n}` list form already evaluates its bound. The pre-existing `table_iterators_invalid` validation already guarantees a bare spec resolves to a number before either function is called, so this only changes behavior for previously-erroring inputs.

This surfaced while checking whether Woxi Studio can fully evaluate a randomly selected Wolfram Demonstration notebook ("Distributions Using Slice Sampling"). Its slice-sampling routine defines a helper that runs `Do[…, 500 - iStart]` with a bare arithmetic iterator count, which previously failed. With the fix, all 6 input cells in that notebook now evaluate successfully (was 1 success / 4 no-output / 1 error before).

## Test plan

- [x] Added regression tests in `tests/interpreter_tests/list.rs` (`table_do_bare_count` module) covering `Table`/`Do` with a bare symbol count and a bare arithmetic-expression count.
- [x] `make test` — 26780/26780 unit tests pass.
- [x] `make format`.
- [x] Manually verified `Do[Print[1], 3]`, `Table[x, 3]`, and `Do[Print[i], {3, 1, 5}]` (raw-object `::itraw` case) still behave the same as before.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01SCAdHWH1k2tBkiCdA9zfjh

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCAdHWH1k2tBkiCdA9zfjh)_