### PR TITLE
Accept Item-wrapped control panels in Manipulate

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16044,7 +16044,10 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // malformed variable specs. They pass through with no message.
       // `PaneSelector[{v -> controls, …}, sel]` is the same pattern one
       // level up: a Demonstration whose modes need different controls
-      // swaps whole control panels as `sel` changes.
+      // swaps whole control panels as `sel` changes. `Item[Column[…], opts]`
+      // is the same layout pattern wrapped in a grid-alignment `Item[…]`
+      // (a Demonstration lining up its whole control panel inside an outer
+      // `Grid`), not a control itself.
       Expr::FunctionCall { name, .. }
         if matches!(
           name.as_str(),
@@ -16057,6 +16060,7 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             | "Spacer"
             | "PaneSelector"
             | "TabView"
+            | "Item"
         ) =>
       {
         out_args.push(spec.clone());
@@ -17514,6 +17518,16 @@ fn control_group_items(spec: &Expr) -> Option<Vec<Expr>> {
       _ => false,
     }
   }
+  // `Item[content, opts…]` is a grid-alignment wrapper (the Demonstrations
+  // idiom for lining up a whole control panel inside an outer `Grid`), not
+  // a layout container in its own right — unwrap it to reach the container
+  // it dresses up.
+  let spec = match spec {
+    Expr::FunctionCall { name, args } if name == "Item" && !args.is_empty() => {
+      &args[0]
+    }
+    _ => spec,
+  };
   let Expr::FunctionCall { name, args } = spec else {
     return None;
   };

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -18309,6 +18309,39 @@ mod manipulate {
     );
   }
 
+  /// `Item[Column[{…controls…}], opts]` (a Demonstration lining its whole
+  /// control panel up inside an outer `Grid` cell via `Item`'s alignment
+  /// options) is a control-grouping layout container wearing a grid-item
+  /// wrapper, not a malformed variable spec — it must not emit
+  /// `Manipulate::vsform` either.
+  #[test]
+  fn item_wrapped_controls_are_not_vsform() {
+    let res = woxi::interpret_with_stdout(
+      "Manipulate[x, Item[Column[{Control[{x, 0, 1}]}], Alignment -> Center]]",
+    )
+    .unwrap();
+    assert!(
+      !res.warnings.iter().any(|w| w.contains("vsform")),
+      "unexpected vsform message: {:?}",
+      res.warnings
+    );
+  }
+
+  /// The control inside an `Item[…]`-wrapped layout container flattens into
+  /// the widget's control panel exactly like an unwrapped `Row`/`Column`/
+  /// `Grid` would, so Woxi Studio actually renders a working slider for it.
+  #[test]
+  fn item_wrapped_controls_flatten_into_the_control_panel() {
+    let expr = interpret_to_expr(
+      "Manipulate[x, Item[Grid[{{Control[{{x, 5}, 0, 10}]}}], \
+       Alignment -> Center]]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert_eq!(spec.controls.len(), 1);
+    assert_eq!(spec.controls[0].name(), "x");
+  }
+
   /// Each `PaneSelector` pane's controls are collected into the one flat
   /// control panel, but they carry the condition under which their pane is
   /// on screen so a frontend can show one panel at a time. A variable used


### PR DESCRIPTION
## Summary

- As part of the recurring "test a random Wolfram Demonstration against Woxi Studio" routine, a randomly-selected Demonstration notebook (an interactive Euler-Bernoulli beam analysis) surfaced a real gap: its `Manipulate[…]` lines a whole control panel (a `Column`/`Grid` of `Control[…]`s) up inside an outer `Grid` cell by wrapping it in `Item[…, Alignment -> …]`. This is a common Demonstrations layout idiom for grid-aligning a control panel.
- Woxi treated that `Item[…]` wrapper as a malformed variable specification: it emitted a spurious `Manipulate::vsform` message during plain evaluation, and Woxi Studio's widget builder (`extract_manipulate_spec` / `control_group_items`) failed to flatten the controls inside it at all, so none of the sliders would render.
- Fixed both code paths to unwrap `Item[content, opts]` to its `content` before matching, exactly like the existing `Row`/`Column`/`Grid`/`PaneSelector`/`TabView` handling.

(The source notebook itself is not included here — per project convention, only the generic fix and generic regression tests are committed.)

## Test plan

- [x] Added `item_wrapped_controls_are_not_vsform` — asserts `Manipulate[x, Item[Column[{Control[…]}], opts]]` produces no `Manipulate::vsform` warning.
- [x] Added `item_wrapped_controls_flatten_into_the_control_panel` — asserts `extract_manipulate_spec` actually flattens the `Item`-wrapped control into the widget's control panel (so Woxi Studio renders a working slider).
- [x] `cargo test` — full suite passes (26,778 tests, 0 failures).
- [x] `cargo check -p woxi-studio` — compiles cleanly.
- [x] Re-ran the original (uncommitted) Demonstration notebook through `woxi run` before/after: the `Manipulate::vsform` warnings are gone after the fix.
- [x] `make format`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016Tk8QUhicje3WTMyEsLcEJ


---
_Generated by [Claude Code](https://claude.ai/code/session_016Tk8QUhicje3WTMyEsLcEJ)_