### PR TITLE
Evaluate curried-assignment indices and stop NDSolve degrading to full symbolic eval

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -1913,6 +1913,50 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
   ))
 }
 
+/// Evaluate the non-pattern arguments of a curried assignment LHS like
+/// `Y[Np][t_]`, at every level of the chain, leaving pattern arguments
+/// (`t_`, `x_Integer`, …) untouched. Mirrors how a plain `f[a] := body`
+/// already evaluates a literal, non-pattern argument before storing the
+/// rule (see the `SameQ` condition built for that case above) — the
+/// curried form needs the same treatment so `n = 5; Y[n][t_] := 1` keys
+/// the stored rule on `Y[5]`, not on the symbol `n`.
+fn evaluate_curried_lhs_non_pattern_parts(
+  expr: &Expr,
+) -> Result<Expr, InterpreterError> {
+  match expr {
+    Expr::CurriedCall { func, args } => {
+      let new_func = evaluate_curried_lhs_non_pattern_parts(func)?;
+      let mut new_args = Vec::with_capacity(args.len());
+      for a in args {
+        if crate::evaluator::pattern_matching::contains_pattern(a) {
+          new_args.push(a.clone());
+        } else {
+          new_args.push(evaluate_expr_to_expr(a)?);
+        }
+      }
+      Ok(Expr::CurriedCall {
+        func: Box::new(new_func),
+        args: new_args,
+      })
+    }
+    Expr::FunctionCall { name, args } => {
+      let mut new_args = Vec::with_capacity(args.len());
+      for a in args {
+        if crate::evaluator::pattern_matching::contains_pattern(a) {
+          new_args.push(a.clone());
+        } else {
+          new_args.push(evaluate_expr_to_expr(a)?);
+        }
+      }
+      Ok(Expr::FunctionCall {
+        name: name.clone(),
+        args: new_args.into(),
+      })
+    }
+    other => Ok(other.clone()),
+  }
+}
+
 /// Handle SetDelayed[f[patterns...], body] — stores a function definition.
 /// This handles cases that the PEG FunctionDefinition rule doesn't parse,
 /// such as list-pattern arguments: f[{x_Integer, y_Integer}] := body.
@@ -2618,23 +2662,43 @@ pub fn set_delayed_ast(
   // SubValue form: f[a][b] := rhs (also deeper nestings like f[a][b][c])
   // Mathematica stores these under SubValues[f] and they fire when exactly
   // f[a][b] is evaluated. Record the rule keyed by the outermost head so
-  // `SubValues[f]` can return them. Dispatch (`f[1][5]` → `5`) is not yet
-  // wired up here.
-  if let Expr::CurriedCall { func, .. } = lhs {
-    let mut inner = func.as_ref();
-    let outer_head = loop {
-      match inner {
-        Expr::CurriedCall { func: f2, .. } => inner = f2.as_ref(),
-        Expr::FunctionCall { name, .. } => break Some(name.clone()),
-        _ => break None,
+  // `SubValues[f]` can return them.
+  //
+  // Like any other assignment LHS, the parts of `f[a][b]` that are not
+  // themselves patterns get evaluated before the rule is stored — this is
+  // what lets `n = 5; Y[n][t_] := 1` define a downvalue for `Y[5]` (a common
+  // idiom for building an indexed family of functions), rather than storing
+  // a rule keyed on the literal symbol `n`, which could never fire.
+  if let Expr::CurriedCall { .. } = lhs {
+    let evaluated_lhs = evaluate_curried_lhs_non_pattern_parts(lhs)?;
+    let outer_head = if let Expr::CurriedCall { func, .. } = &evaluated_lhs {
+      let mut inner = func.as_ref();
+      loop {
+        match inner {
+          Expr::CurriedCall { func: f2, .. } => inner = f2.as_ref(),
+          Expr::FunctionCall { name, .. } => break Some(name.clone()),
+          _ => break None,
+        }
       }
+    } else {
+      None
     };
     if let Some(head) = outer_head {
       SUB_VALUES.with(|m| {
-        m.borrow_mut()
-          .entry(head)
-          .or_default()
-          .push((lhs.clone(), body.clone()));
+        let mut m = m.borrow_mut();
+        let rules = m.entry(head).or_default();
+        // Redefining the same pattern replaces the old rule in place —
+        // matching `DownValues`, and how a Demonstration's Manipulate body
+        // re-evaluates on every control change, redefining each SubValue
+        // with an identical LHS on every one of those re-evaluations.
+        let lhs_str = crate::syntax::expr_to_string(&evaluated_lhs);
+        match rules
+          .iter()
+          .position(|(l, _)| crate::syntax::expr_to_string(l) == lhs_str)
+        {
+          Some(idx) => rules[idx] = (evaluated_lhs, body.clone()),
+          None => rules.push((evaluated_lhs, body.clone())),
+        }
       });
       return Ok(Expr::Identifier("Null".to_string()));
     }

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -1529,6 +1529,17 @@ enum NExpr {
   Neg(Box<Self>),
   Fn1(fn(f64) -> f64, Box<Self>),
   Fn2(fn(f64, f64) -> f64, Box<Self>, Box<Self>),
+  /// A leaf the compiler can't reduce to closed-form arithmetic — e.g. a
+  /// call to a function defined elsewhere in the session (a boundary value
+  /// pinned via `f[n][t_] := …`, say) rather than one of `compile_numeric`'s
+  /// known operators. Falls back to full symbolic evaluation, but only for
+  /// this leaf: the surrounding arithmetic stays compiled, so one
+  /// unresolved call amid an otherwise-numeric right-hand side doesn't
+  /// force the *entire* residual through the slow path on every step.
+  External {
+    template: Expr,
+    refs: Vec<(String, usize)>,
+  },
 }
 
 impl NExpr {
@@ -1551,7 +1562,53 @@ impl NExpr {
       Self::Neg(e) => -e.eval(vars),
       Self::Fn1(f, a) => f(a.eval(vars)),
       Self::Fn2(f, a, b) => f(a.eval(vars), b.eval(vars)),
+      Self::External { template, refs } => {
+        let mut substituted = template.clone();
+        for (name, idx) in refs {
+          substituted = crate::syntax::substitute_variable(
+            &substituted,
+            name,
+            &Expr::Real(vars[*idx]),
+          );
+        }
+        crate::evaluator::evaluate_expr_to_expr(&substituted)
+          .ok()
+          .and_then(|r| expr_to_f64(&r).ok())
+          .unwrap_or(f64::NAN)
+      }
     }
+  }
+}
+
+/// Every `var_names` identifier referenced anywhere inside `expr`, paired
+/// with its index — the substitutions an `NExpr::External` leaf needs to
+/// apply before handing the template to the full evaluator.
+fn collect_var_refs(
+  expr: &Expr,
+  var_names: &[String],
+  out: &mut Vec<(String, usize)>,
+) {
+  if let Expr::Identifier(name) = expr {
+    if let Some(idx) = var_names.iter().position(|n| n == name)
+      && !out.iter().any(|(n, _)| n == name)
+    {
+      out.push((name.clone(), idx));
+    }
+    return;
+  }
+  for child in expr_children(expr) {
+    collect_var_refs(child, var_names, out);
+  }
+}
+
+/// Wrap a construct `compile_numeric` doesn't otherwise reduce to
+/// closed-form arithmetic as an `NExpr::External` leaf.
+fn compile_external_leaf(expr: &Expr, var_names: &[String]) -> NExpr {
+  let mut refs = Vec::new();
+  collect_var_refs(expr, var_names, &mut refs);
+  NExpr::External {
+    template: expr.clone(),
+    refs,
   }
 }
 
@@ -1675,10 +1732,15 @@ fn compile_numeric(expr: &Expr, var_names: &[String]) -> Option<NExpr> {
             .into_iter()
             .reduce(|acc, e| NExpr::Fn2(f64::min, Box::new(acc), Box::new(e)))
         }
-        _ => None,
+        // Not one of the closed-form operators above — most commonly a
+        // call to a function the session itself defined (a fixed boundary
+        // value, a helper via `f[n_] := …`), which can only be resolved by
+        // the full evaluator. Compiled as an External leaf rather than
+        // bailing the whole residual out to the symbolic path.
+        _ => Some(compile_external_leaf(expr, var_names)),
       }
     }
-    _ => None,
+    other => Some(compile_external_leaf(other, var_names)),
   }
 }
 

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7639,6 +7639,52 @@ mod ndsolve {
       -(-2.0_f64).exp()
     );
   }
+
+  /// An orthogonal-collocation scheme (used in Demonstrations of nonlinear
+  /// heat conduction) pins one member of an indexed family of functions to
+  /// a fixed boundary value via `n = N; Y[n][t_] := c`, after the *other*
+  /// equations were already captured with a literal, still-unresolved
+  /// `Y[N][t]` call inside them. That leftover call is outside the system's
+  /// own dependent variables, so the residual can't be reduced to
+  /// closed-form arithmetic at compile time — it used to force the *whole*
+  /// right-hand side through per-step symbolic re-evaluation for every one
+  /// of the fixed grid's 1000 steps, which was slow enough to look like a
+  /// hang on a system of even a handful of equations. Only that one
+  /// unresolved call should pay the symbolic-evaluation cost now.
+  #[test]
+  fn a_pinned_external_function_does_not_blow_up_the_solve() {
+    // Y3' = 2 - Y3, Y2' = Y3 - Y2, Y1' = Y2 - Y1, all zero initial
+    // conditions: a linear cascade with a closed-form solution via
+    // repeated convolution with Exp[-t].
+    let result = interpret(
+      "eq1 = Y[1]'[t] == Y[2][t] - Y[1][t]; \
+       eq2 = Y[2]'[t] == Y[3][t] - Y[2][t]; \
+       eq3 = Y[3]'[t] == Y[4][t] - Y[3][t]; \
+       n = 4; Y[n][t_] := 2; \
+       sol = NDSolve[{eq1, eq2, eq3, Y[1][0] == 0, Y[2][0] == 0, \
+         Y[3][0] == 0}, {Y[1], Y[2], Y[3]}, {t, 0, 1}]; \
+       {Y[1][1.], Y[2][1.], Y[3][1.]} /. sol[[1]]",
+    )
+    .unwrap();
+    let nums: Vec<f64> = result
+      .trim_matches(['{', '}'])
+      .split(", ")
+      .map(|s| s.parse().expect("all three solutions are numbers"))
+      .collect();
+    let y3 = 2.0 * (1.0 - (-1.0_f64).exp());
+    let y2 = 2.0 - 2.0 * (-1.0_f64).exp() * 2.0;
+    let y1 = 2.0 - (-1.0_f64).exp() * 5.0;
+    for (value, expected, name) in [
+      (nums[0], y1, "Y[1]"),
+      (nums[1], y2, "Y[2]"),
+      (nums[2], y3, "Y[3]"),
+    ] {
+      assert!(
+        (value - expected).abs() < 1e-3,
+        "{name}(1) should be about {expected}, got {value} (in {result})"
+      );
+    }
+  }
 }
 
 mod sinh_cosh {

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -3978,6 +3978,31 @@ mod curried_and_head_patterns {
   }
 
   #[test]
+  fn curried_subvalue_index_is_evaluated_before_storing() {
+    // `n = 5; Y[n][t_] := 1` is the common idiom for pinning one member of
+    // an indexed family of functions to a constant once its index is known
+    // numerically — a boundary node in an orthogonal-collocation scheme,
+    // say. Like any other assignment LHS, the non-pattern part (`n`) is
+    // evaluated before the rule is stored, so the SubValue is keyed on
+    // `Y[5]`, not on the literal symbol `n` (which could never dispatch).
+    assert_eq!(
+      interpret("n = 5; Y[n][t_] := 1; Y[5][t]").unwrap(),
+      "1",
+      "the stored rule must key off the evaluated index"
+    );
+    assert_eq!(
+      interpret("n = 5; Y[n][t_] := 1; SubValues[Y]").unwrap(),
+      "{HoldPattern[Y[5][t_]] :> 1}"
+    );
+    // A different index must not accidentally match.
+    assert_eq!(
+      interpret("n = 5; Y[n][t_] := 1; Y[3][t]").unwrap(),
+      "Y[3][t]",
+      "an unrelated index stays unevaluated"
+    );
+  }
+
+  #[test]
   fn head_pattern_definition_symbol_head() {
     // `f[a_[b__]] := …` binds the head pattern and the argument sequence.
     assert_eq!(

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -13005,6 +13005,44 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`m$$ = 1}, \"\\[Ellipsis]\"]"], "Out
     assert_ne!(at0, render("3"), "the time control must move the pendulum");
   }
 
+  /// End-to-end regression for a nonlinear-heat-conduction-style
+  /// Demonstration built on orthogonal collocation: one node of an indexed
+  /// family of functions is pinned to a fixed boundary value with
+  /// `Y[n][t_] := 1` *after* the other equations already captured a
+  /// literal, still-unresolved `Y[n][t]` call inside them (`n` bound to the
+  /// Manipulate control's numeric value). That pattern used to be slow
+  /// enough to look like a hang: the boundary reference sat outside
+  /// `NDSolve`'s own dependent variables, so the whole right-hand side fell
+  /// back to per-step symbolic evaluation for every one of the fixed grid's
+  /// 1000 steps.
+  #[test]
+  fn pinned_boundary_node_notebook_solves_without_hanging() {
+    let nb_src = r##"Notebook[{
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[Module[{Y,eq,sol},eq=Y[1]'[t]==Y[n][t]-Y[1][t];Y[n][t_]:=1;sol=NDSolve[{eq,Y[1][0]==0},Y[1],{t,0,2}];Plot[Y[1][t]/.sol[[1]],{t,0,2}]],{{n,4,\"boundary index\"},3,6,1}]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 4}, \"\\[Ellipsis]\"]"], "Output"]
+}, Open]]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .iter()
+      .find_map(|e| e.manipulate_state.as_ref())
+      .expect("the Manipulate cell must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "the pinned-boundary system must solve: {:?}",
+      widget.error
+    );
+    assert!(widget.graphics_handle.is_some(), "the curve must draw");
+    match &widget.controls[..] {
+      [manipulate::ControlState::Continuous { name, current, .. }] => {
+        assert_eq!((name.as_str(), *current), ("n", 4.0));
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+  }
+
   /// End-to-end regression for "Nets for Regular Spherical Models": its
   /// body is a `Pane` around either a 3D model or a 2D net template, and
   /// the export path used to write the whole thing out as source rather


### PR DESCRIPTION
## Summary

This was found by testing Woxi Studio against a randomly-fetched Wolfram Demonstration (a nonlinear-heat-conduction simulation built on orthogonal collocation). It hung indefinitely when run in Woxi Studio; this PR fixes the three underlying interpreter bugs that caused it.

- **`Y[Np][t_] := 1` didn't create a working downvalue.** Like any other assignment LHS, the non-pattern parts of a curried definition `f[a][x_] := body` should be evaluated before the rule is stored — this is the standard idiom for pinning one member of an indexed family of functions to a constant once its index is known (`n = 5; Y[n][t_] := 1` should key the rule on `Y[5]`, not the literal symbol `n`). Woxi stored the rule unevaluated, so it could never dispatch.
- **Redefining an identical curried rule appended a duplicate instead of replacing it**, unlike `DownValues`. Surfaced by the fix above once repeated re-definition (e.g. across a Manipulate's re-evaluations) became meaningful.
- **NDSolve fell back to whole-tree symbolic re-evaluation whenever a residual referenced a function outside its own dependent variables** (the now-correctly-pinned boundary function, in this case). That per-step full-interpreter re-evaluation, times a 1000-point fixed grid times several RK4 stages, was slow enough on a several-equation system to look like a hang. Fixed by compiling such a leaf to a scoped `NExpr::External` node instead — the surrounding arithmetic stays compiled, and only the unresolved call pays the interpreter's dispatch cost.

Per the repo's conventions, the regression tests reconstruct the essential trigger pattern in original, reduced form rather than referencing or copying the source Demonstration notebook.

## Test plan

- [x] `make test` — all 26,778 tests pass
- [x] `cargo test -p woxi-studio --release` — all 110 tests pass, including the new notebook-level regression test
- [x] `cargo clippy --all-targets -- -D warnings` (root and `-p woxi-studio`) — clean
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01HX4U2PA199YMyybuhHExPR


---
_Generated by [Claude Code](https://claude.ai/code/session_01HX4U2PA199YMyybuhHExPR)_