### PR TITLE
Fix FindRoot on held derivatives, add 2-D scattered Interpolation, force RadioButtonBar layout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,38 @@
 
 # Unreleased
 
+- Fixes driven by a Wolfram Demonstration on a cylindrical cavity resonator,
+    which locates a Bessel function's stationary points and interpolates a
+    field built on a 2-D grid:
+    - `FindRoot[eqn, {var, x0}]` evaluates `eqn` once, with `var` still a
+        free symbol, before substituting any numeric trial value. `FindRoot`
+        is `HoldAll` (so `var` isn't looked up as an OwnValue before the
+        search starts), so `eqn` used to arrive — and stay — with any held
+        computation it wrote unevaluated, most commonly a derivative:
+        `FindRoot[D[f[x], x] == 0, {x, x0}]`, the standard "extremum of f"
+        idiom (and `FindRoot[D[BesselJ[m, r], r] == 0, {r,
+        BesselJZero[n, k]}]` specifically), substituted its trial value
+        straight into the raw `D[f[x], x]`, landing the number inside `D`'s
+        variable slot (`D[f[3.8], 3.8]`) and failing with `D::ivar` on every
+        iteration. The multivariate form (`FindRoot[{eqns}, {{x, x0}, …}]`)
+        already evaluated its equations up front; the single-variable form
+        now does the same.
+    - `Interpolation[data]` accepts 2-D data given as a flat list of
+        `{x, y, z}` triples — the shape
+        `Flatten[Table[Table[{x, y, f[x, y]}, {y, ys}], {x, xs}], 1]` (or the
+        equivalent built with `Join`) produces — recovering the grid from the
+        distinct x/y coordinates and interpolating it the same way
+        `ListInterpolation`'s implicit integer grid already did (tensor-
+        product local Lagrange, any order 1–3, `InterpolationOrder ->
+        {orderX, orderY}` honoured per axis). This data shape used to reach
+        a generic numeric-conversion helper shared with `NDSolve` and fail
+        with a message that named the wrong caller
+        (`NDSolve: cannot convert {1., 1., 2.} to numeric value"`); that
+        helper's error is now caller-agnostic.
+    - Woxi Studio: `Control[{…, ControlType -> RadioButtonBar}]` forces the
+        row of buttons the way `ControlType -> SetterBar` already did, so a
+        `RadioButtonBar` with more choices than the automatic split allows
+        keeps its bar instead of silently falling back to a dropdown.
 - `$VersionNumber` is a `Real` — the Wolfram Language version Woxi aims to
     be compatible with (`15.`) — instead of the Woxi build's git version as
     a `String`. Scripts gate language features on it

--- a/functions.csv
+++ b/functions.csv
@@ -418,7 +418,7 @@ Most,Returns the list without its last element,✅,pure,5.0,379
 StringReplace,Replaces occurrences of substrings in a string; RegularExpression backreferences expand before a delayed replacement is evaluated,✅,pure,2.0,380
 ControlType,Option for specifying the type of control in Manipulate,✅,pure,6.0,381
 Pick,Picks elements from a list based on a selector,✅,pure,5.1,382
-Interpolation,Constructs an interpolation of data (an exact query point over exact data gives an exact value; outside the data range the boundary piece is extrapolated),✅,pure,2.0,383
+Interpolation,Constructs an interpolation of data — 1-D {x y} pairs/values or 2-D {x y z} triples tiling a complete grid (an exact query point over exact data gives an exact value; outside the data range the boundary piece is extrapolated),✅,pure,2.0,383
 HoldPattern,Keeps a pattern from evaluating while staying transparent to matching and to replacement rules,✅,pure,3.0,384
 Top,Symbol for top alignment,✅,pure,1.0,385
 HypergeometricPFQ,Generalized hypergeometric function pFq,✅,pure,3.0,386

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16234,9 +16234,10 @@ pub enum ManipulateControl {
     /// `ControlType -> PopupMenu`: always render a dropdown, even when the
     /// choice count is small enough for a SetterBar.
     popup: bool,
-    /// `ControlType -> SetterBar`: always render the row of buttons, even
-    /// when there are more choices than the automatic split would put in a
-    /// bar. The heuristic only decides for a spec that stays silent.
+    /// `ControlType -> SetterBar` or `-> RadioButtonBar`: always render the
+    /// row of buttons, even when there are more choices than the automatic
+    /// split would put in a bar. The heuristic only decides for a spec that
+    /// stays silent.
     setter_bar: bool,
     /// `ControlType -> Slider`: render a slider that steps through the
     /// choices by index, the way Wolfram draws a slider over a discrete
@@ -19577,7 +19578,15 @@ fn parse_manipulate_control(
           label,
           label_runs,
           popup: control_type.as_deref() == Some("PopupMenu"),
-          setter_bar: control_type.as_deref() == Some("SetterBar"),
+          // `SetterBar` and `RadioButtonBar` both always draw the full row
+          // of buttons (a row of highlighted setters, or of radio dots)
+          // regardless of choice count — unlike a spec that stays silent,
+          // which the automatic SetterBar/PopupMenu split
+          // (`renders_as_setter_bar`, in woxi-studio) only applies to.
+          setter_bar: matches!(
+            control_type.as_deref(),
+            Some("SetterBar" | "RadioButtonBar")
+          ),
           slider: matches!(
             control_type.as_deref(),
             Some("Slider" | "VerticalSlider" | "Manipulator")

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -3108,7 +3108,12 @@ fn exprs_match(a: &Expr, b: &Expr) -> bool {
 
 // ─── NDSolve RK4 Helpers ──────────────────────────────────────────────
 
-/// Convert Expr to f64
+/// Convert Expr to f64.
+///
+/// Shared by `NDSolve` and every other caller in this module that needs a
+/// plain numeric value from an expression (`Interpolation`, `DSolve`'s
+/// numeric fallbacks, …) — the error text below must stay caller-agnostic
+/// rather than naming any one of them.
 fn expr_to_f64(expr: &Expr) -> Result<f64, InterpreterError> {
   match expr {
     Expr::Integer(n) => Ok(*n as f64),
@@ -3129,7 +3134,7 @@ fn expr_to_f64(expr: &Expr) -> Result<f64, InterpreterError> {
         BinaryOperator::Divide => Ok(l / r),
         BinaryOperator::Power => Ok(l.powf(r)),
         _ => Err(InterpreterError::EvaluationError(
-          "NDSolve: cannot convert expression to numeric value".into(),
+          "cannot convert expression to a numeric value".into(),
         )),
       }
     }
@@ -3155,7 +3160,7 @@ fn expr_to_f64(expr: &Expr) -> Result<f64, InterpreterError> {
       Ok(result)
     }
     _ => Err(InterpreterError::EvaluationError(format!(
-      "NDSolve: cannot convert {} to numeric value",
+      "cannot convert {} to a numeric value",
       crate::syntax::expr_to_string(expr)
     ))),
   }
@@ -3201,10 +3206,26 @@ pub fn interpolation_ast(
     return Ok(unevaluated(head, args));
   }
 
-  // Extract InterpolationOrder option (default 3)
+  // Extract InterpolationOrder option (default 3). A 2-D grid may give one
+  // order per axis (`InterpolationOrder -> {orderX, orderY}`); a bare
+  // integer applies to both.
   let mut interp_order: i128 = 3;
+  let mut interp_order_xy: Option<(i128, i128)> = None;
   let data_arg = &args[0];
 
+  let mut apply_interpolation_order = |replacement: &Expr| {
+    if let Some(n) = crate::functions::math_ast::expr_to_i128(replacement) {
+      interp_order = n;
+    } else if let Expr::List(items) = replacement
+      && items.len() == 2
+      && let (Some(a), Some(b)) = (
+        crate::functions::math_ast::expr_to_i128(&items[0]),
+        crate::functions::math_ast::expr_to_i128(&items[1]),
+      )
+    {
+      interp_order_xy = Some((a, b));
+    }
+  };
   for opt in args.iter().skip(1) {
     match opt {
       Expr::Rule {
@@ -3213,9 +3234,8 @@ pub fn interpolation_ast(
       } => {
         if let Expr::Identifier(name) = pattern.as_ref()
           && name == "InterpolationOrder"
-          && let Some(n) = crate::functions::math_ast::expr_to_i128(replacement)
         {
-          interp_order = n;
+          apply_interpolation_order(replacement);
         }
       }
       Expr::FunctionCall {
@@ -3224,10 +3244,8 @@ pub fn interpolation_ast(
       } if name == "Rule" && rule_args.len() == 2 => {
         if let Expr::Identifier(opt_name) = &rule_args[0]
           && opt_name == "InterpolationOrder"
-          && let Some(n) =
-            crate::functions::math_ast::expr_to_i128(&rule_args[1])
         {
-          interp_order = n;
+          apply_interpolation_order(&rule_args[1]);
         }
       }
       _ => {}
@@ -3285,6 +3303,24 @@ pub fn interpolation_ast(
     && let Some(grid) = as_2d_scalar_grid(data_list)
   {
     return Ok(build_2d_list_interpolation(&grid, interp_order, head));
+  }
+
+  // `Interpolation` (not `ListInterpolation`, whose triples are raw grid
+  // rows — see above) of a flat `{x, y, z}` list — the shape
+  // `Flatten[Table[Table[{x, y, f[x, y]}, {y, ys}], {x, xs}], 1]` (or the
+  // equivalent built with `Join`) produces — is 2-D scattered data. It
+  // interpolates like `ListInterpolation`'s grid once the distinct x/y
+  // coordinates recover the grid structure; see `try_2d_scattered_interpolation`.
+  if head != "ListInterpolation"
+    && matches!(&data_list[0], Expr::List(items) if items.len() == 3)
+    && let Some(result) = try_2d_scattered_interpolation(
+      data_list,
+      interp_order_xy.map_or(interp_order, |(a, _)| a),
+      interp_order_xy.map_or(interp_order, |(_, b)| b),
+      head,
+    )?
+  {
+    return Ok(result);
   }
 
   // Determine format: list of values or list of {x, y} pairs
@@ -3464,6 +3500,374 @@ fn build_2d_list_interpolation(
   }
 }
 
+/// The relative tolerance two coordinates must fall within to count as "the
+/// same" grid line — generous enough for the roundoff two different `Table`
+/// passes over the same arithmetic can leave, tight enough not to merge
+/// genuinely distinct samples.
+fn same_coordinate(a: f64, b: f64) -> bool {
+  (a - b).abs() <= 1e-9 * a.abs().max(b.abs()).max(1.0)
+}
+
+/// Detect a flat `{x, y, z}` triple list that tiles a complete rectangular
+/// grid over its distinct x and y coordinates — the shape
+/// `Flatten[Table[Table[{x, y, f[x, y]}, {y, ys}], {x, xs}], 1]` (or the
+/// equivalent built with `Join`) produces — and build the 2-D
+/// `InterpolatingFunction` for it: `InterpolatingFunction[{{xmin, xmax},
+/// {ymin, ymax}}, grid, {orderX, orderY}, {xcoords, ycoords}]`, the explicit-
+/// coordinate counterpart of `build_2d_list_interpolation`'s implicit
+/// integer grid.
+///
+/// Returns `Ok(None)` when the data isn't in this shape (a non-triple entry,
+/// a non-numeric coordinate, or coordinates that don't tile a full grid) so
+/// the caller falls back to its other formats. Genuinely scattered, non-grid
+/// 2-D data — which Wolfram interpolates via Delaunay triangulation — is not
+/// supported here.
+fn try_2d_scattered_interpolation(
+  data_list: &[Expr],
+  order_x: i128,
+  order_y: i128,
+  head: &str,
+) -> Result<Option<Expr>, InterpreterError> {
+  // At least a 2x2 grid is needed for either axis to interpolate at all.
+  if data_list.len() < 4 {
+    return Ok(None);
+  }
+  let mut triples: Vec<(Expr, f64, Expr, f64, Expr, f64)> =
+    Vec::with_capacity(data_list.len());
+  for item in data_list {
+    let Expr::List(parts) = item else {
+      return Ok(None);
+    };
+    if parts.len() != 3 {
+      return Ok(None);
+    }
+    let (Ok(x), Ok(y), Ok(z)) = (
+      interp_value_to_f64(&parts[0]),
+      interp_value_to_f64(&parts[1]),
+      interp_value_to_f64(&parts[2]),
+    ) else {
+      return Ok(None);
+    };
+    triples.push((
+      parts[0].clone(),
+      x,
+      parts[1].clone(),
+      y,
+      parts[2].clone(),
+      z,
+    ));
+  }
+
+  // Distinct x/y values, sorted, each keeping the first expression seen for
+  // it (so an exact/integer coordinate stays exact).
+  let mut xs_pairs: Vec<(f64, Expr)> = Vec::new();
+  let mut ys_pairs: Vec<(f64, Expr)> = Vec::new();
+  for (xe, x, ye, y, _ze, _z) in &triples {
+    if !xs_pairs.iter().any(|(xv, _)| same_coordinate(*xv, *x)) {
+      xs_pairs.push((*x, xe.clone()));
+    }
+    if !ys_pairs.iter().any(|(yv, _)| same_coordinate(*yv, *y)) {
+      ys_pairs.push((*y, ye.clone()));
+    }
+  }
+  xs_pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+  ys_pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+  let nr = xs_pairs.len();
+  let nc = ys_pairs.len();
+  // Fewer than 2 distinct values along an axis, or a point count that isn't
+  // the full nr*nc product, means this isn't a complete rectangular grid.
+  if nr < 2 || nc < 2 || nr * nc != triples.len() {
+    return Ok(None);
+  }
+
+  let mut grid: Vec<Vec<Option<Expr>>> = vec![vec![None; nc]; nr];
+  for (_xe, x, _ye, y, ze, z) in &triples {
+    let Some(i) = xs_pairs.iter().position(|(xv, _)| same_coordinate(*xv, *x))
+    else {
+      return Ok(None);
+    };
+    let Some(j) = ys_pairs.iter().position(|(yv, _)| same_coordinate(*yv, *y))
+    else {
+      return Ok(None);
+    };
+    if grid[i][j].is_some() {
+      // Duplicate (x, y) — not a well-formed grid.
+      return Ok(None);
+    }
+    grid[i][j] = Some(exact_coordinate(ze, *z));
+  }
+  if grid.iter().flatten().any(Option::is_none) {
+    // A combination of some x with some y is missing — a partial grid,
+    // which is genuinely scattered data this path does not support.
+    return Ok(None);
+  }
+
+  let x_exprs: Vec<Expr> = xs_pairs
+    .iter()
+    .map(|(v, e)| exact_coordinate(e, *v))
+    .collect();
+  let y_exprs: Vec<Expr> = ys_pairs
+    .iter()
+    .map(|(v, e)| exact_coordinate(e, *v))
+    .collect();
+  let grid_exprs: Vec<Vec<Expr>> = grid
+    .into_iter()
+    .map(|row| row.into_iter().map(Option::unwrap).collect())
+    .collect();
+
+  let want_r = order_x.clamp(1, 3) as usize;
+  let want_c = order_y.clamp(1, 3) as usize;
+  let order_r = want_r.min(nr - 1);
+  let order_c = want_c.min(nc - 1);
+  if order_r < want_r || order_c < want_c {
+    crate::emit_message(&format!(
+      "{head}::inhr: Requested order is too high; order has been reduced to {{{order_r}, {order_c}}}."
+    ));
+  }
+
+  let domain = Expr::List(
+    vec![
+      Expr::List(vec![x_exprs[0].clone(), x_exprs[nr - 1].clone()].into()),
+      Expr::List(vec![y_exprs[0].clone(), y_exprs[nc - 1].clone()].into()),
+    ]
+    .into(),
+  );
+  let grid_expr = Expr::List(
+    grid_exprs
+      .into_iter()
+      .map(|row| Expr::List(row.into()))
+      .collect(),
+  );
+  let orders = Expr::List(
+    vec![
+      Expr::Integer(order_r as i128),
+      Expr::Integer(order_c as i128),
+    ]
+    .into(),
+  );
+  let coords = Expr::List(
+    vec![Expr::List(x_exprs.into()), Expr::List(y_exprs.into())].into(),
+  );
+
+  Ok(Some(Expr::FunctionCall {
+    name: "InterpolatingFunction".to_string(),
+    args: vec![domain, grid_expr, orders, coords].into(),
+  }))
+}
+
+/// Evaluate a 2-D grid `InterpolatingFunction` whose coordinates are
+/// explicit (rather than the implicit integer grid
+/// `evaluate_interpolating_function_2d` assumes) — the form
+/// `try_2d_scattered_interpolation` builds from a flat `{x, y, z}` triple
+/// list. Otherwise identical: tensor-product local Lagrange interpolation,
+/// exact at grid points.
+fn evaluate_interpolating_function_2d_explicit(
+  domain: &Expr,
+  grid_rows: &[Expr],
+  orders: &[Expr],
+  coords: &[Expr],
+  call_args: &[Expr],
+) -> Result<Expr, InterpreterError> {
+  let order_r = match &orders[0] {
+    Expr::Integer(n) => *n as usize,
+    _ => 1,
+  };
+  let order_c = match &orders[1] {
+    Expr::Integer(n) => *n as usize,
+    _ => 1,
+  };
+
+  let (Expr::List(x_coord_exprs), Expr::List(y_coord_exprs)) =
+    (&coords[0], &coords[1])
+  else {
+    return Err(InterpreterError::EvaluationError(
+      "InterpolatingFunction: invalid coordinates".into(),
+    ));
+  };
+  let xs: Vec<f64> = x_coord_exprs
+    .iter()
+    .map(|e| interp_value_to_f64(e).unwrap_or(f64::NAN))
+    .collect();
+  let ys: Vec<f64> = y_coord_exprs
+    .iter()
+    .map(|e| interp_value_to_f64(e).unwrap_or(f64::NAN))
+    .collect();
+  let nr = xs.len();
+  let nc = ys.len();
+
+  let mut vals: Vec<Vec<f64>> = Vec::with_capacity(nr);
+  let mut exprs: Vec<Vec<Expr>> = Vec::with_capacity(nr);
+  for row in grid_rows {
+    let Expr::List(cells) = row else {
+      return Err(InterpreterError::EvaluationError(
+        "InterpolatingFunction: invalid 2-D grid".into(),
+      ));
+    };
+    let mut rv = Vec::with_capacity(cells.len());
+    let mut re = Vec::with_capacity(cells.len());
+    for c in cells {
+      rv.push(match c {
+        Expr::Integer(n) => *n as f64,
+        Expr::Real(f) => *f,
+        _ => interp_value_to_f64(c).unwrap_or(f64::NAN),
+      });
+      re.push(c.clone());
+    }
+    vals.push(rv);
+    exprs.push(re);
+  }
+
+  let unevaluated = || Expr::CurriedCall {
+    func: Box::new(Expr::FunctionCall {
+      name: "InterpolatingFunction".to_string(),
+      args: vec![
+        domain.clone(),
+        Expr::List(grid_rows.to_vec().into()),
+        Expr::List(orders.to_vec().into()),
+        Expr::List(coords.to_vec().into()),
+      ]
+      .into(),
+    }),
+    args: call_args.to_vec(),
+  };
+
+  if nr == 0 || nc == 0 {
+    return Ok(unevaluated());
+  }
+
+  if call_args.len() == 1
+    && let Expr::String(prop) = &call_args[0]
+  {
+    match prop.as_str() {
+      "Domain" => return Ok(domain.clone()),
+      "Coordinates" => {
+        return Ok(Expr::List(
+          vec![
+            Expr::List(x_coord_exprs.clone()),
+            Expr::List(y_coord_exprs.clone()),
+          ]
+          .into(),
+        ));
+      }
+      "Grid" => {
+        let mut pts = Vec::with_capacity(nr * nc);
+        for xe in x_coord_exprs {
+          for ye in y_coord_exprs {
+            pts.push(Expr::List(vec![xe.clone(), ye.clone()].into()));
+          }
+        }
+        return Ok(Expr::List(pts.into()));
+      }
+      "ValuesOnGrid" => return Ok(Expr::List(grid_rows.to_vec().into())),
+      "InterpolationOrder" => return Ok(Expr::List(orders.to_vec().into())),
+      _ => {}
+    }
+  }
+
+  let coord_args: Vec<Expr> = match call_args {
+    [Expr::List(pair)] if pair.len() == 2 => pair.to_vec(),
+    other => other.to_vec(),
+  };
+  if coord_args.len() != 2 {
+    return Ok(unevaluated());
+  }
+  let coord_exprs: Vec<Expr> = coord_args
+    .iter()
+    .map(|a| {
+      crate::evaluator::evaluate_expr_to_expr(a).unwrap_or_else(|_| a.clone())
+    })
+    .collect();
+  let coord = |e: &Expr| -> Option<f64> {
+    match e {
+      Expr::Integer(n) => Some(*n as f64),
+      Expr::Real(f) => Some(*f),
+      _ if is_exact_number(e) => interp_value_to_f64(e).ok(),
+      _ => None,
+    }
+  };
+  let (Some(x), Some(y)) = (coord(&coord_exprs[0]), coord(&coord_exprs[1]))
+  else {
+    return Ok(unevaluated());
+  };
+
+  // Exact grid point: return the stored entry, preserving its type only
+  // when both query coordinates were given as exact integers (matching
+  // `evaluate_interpolating_function_2d`).
+  let int_coords = coord_exprs.iter().all(|a| matches!(a, Expr::Integer(_)));
+  if let (Some(i), Some(j)) = (
+    xs.iter().position(|&xv| same_coordinate(xv, x)),
+    ys.iter().position(|&yv| same_coordinate(yv, y)),
+  ) {
+    let entry = &exprs[i][j];
+    if int_coords {
+      return Ok(entry.clone());
+    }
+    return Ok(Expr::Real(vals[i][j]));
+  }
+
+  let (x_lo, x_hi) = (xs[0].min(xs[nr - 1]), xs[0].max(xs[nr - 1]));
+  let (y_lo, y_hi) = (ys[0].min(ys[nc - 1]), ys[0].max(ys[nc - 1]));
+  if x < x_lo || x > x_hi || y < y_lo || y > y_hi {
+    crate::emit_message(&format!(
+      "InterpolatingFunction::dmval: Input value {{{}, {}}} lies outside the range of data in the interpolating function. Extrapolation will be used.",
+      crate::syntax::format_expr(
+        &coord_exprs[0],
+        crate::syntax::ExprForm::Output
+      ),
+      crate::syntax::format_expr(
+        &coord_exprs[1],
+        crate::syntax::ExprForm::Output
+      )
+    ));
+  }
+
+  let col_interp: Vec<f64> = vals
+    .iter()
+    .map(|row| interp_1d_xy_f64(&ys, row, y, order_c))
+    .collect();
+  let result = interp_1d_xy_f64(&xs, &col_interp, x, order_r);
+  Ok(Expr::Real(result))
+}
+
+/// 1-D local Lagrange interpolation of `(xs[i], ys[i])` samples at
+/// arbitrary (not necessarily unit-spaced) coordinates, evaluated at
+/// `x_val`. The explicit-coordinate counterpart of `interp_1d_f64`, which
+/// assumes samples at integer positions `1..=n`; shares its window
+/// selection (`lagrange_window`) so results agree wherever the spacing
+/// happens to be uniform.
+fn interp_1d_xy_f64(xs: &[f64], ys: &[f64], x_val: f64, order: usize) -> f64 {
+  let n = xs.len();
+  if n == 1 {
+    return ys[0];
+  }
+  // Binary search for the interval containing x_val (or nearest, for a
+  // point outside the range, so extrapolation uses the boundary stencil).
+  let mut lo = 0usize;
+  let mut hi = n - 1;
+  while lo < hi - 1 {
+    let mid = usize::midpoint(lo, hi);
+    if x_val < xs[mid] {
+      hi = mid;
+    } else {
+      lo = mid;
+    }
+  }
+  let eff_order = order.min(n - 1).max(1);
+  let (start, end) = lagrange_window(n, lo, eff_order);
+  let m = end - start;
+  let mut result = 0.0;
+  for i in 0..m {
+    let mut basis = 1.0;
+    for j in 0..m {
+      if j != i {
+        basis *= (x_val - xs[start + j]) / (xs[start + i] - xs[start + j]);
+      }
+    }
+    result += ys[start + i] * basis;
+  }
+  result
+}
+
 /// 1-D local Lagrange interpolation of `values` (sampled at positions
 /// `1..=values.len()`) at `coord`, using `order + 1` nearest samples. Mirrors
 /// the point-selection of `lagrange_interpolate` so 2-D results match the 1-D
@@ -3615,6 +4019,27 @@ pub fn evaluate_interpolating_function(
     && let Expr::List(grid_rows) = &func_args[1]
   {
     return evaluate_interpolating_function_2d(grid_rows, orders, call_args);
+  }
+
+  // 2-D grid form with explicit coordinates: InterpolatingFunction[{{xmin,
+  // xmax}, {ymin, ymax}}, grid, {orderX, orderY}, {xcoords, ycoords}] —
+  // `try_2d_scattered_interpolation`'s output.
+  if func_args.len() == 4
+    && let Expr::List(orders) = &func_args[2]
+    && orders.len() == 2
+    && let Expr::List(grid_rows) = &func_args[1]
+    && let Expr::List(coords) = &func_args[3]
+    && coords.len() == 2
+    && matches!(&coords[0], Expr::List(_))
+    && matches!(&coords[1], Expr::List(_))
+  {
+    return evaluate_interpolating_function_2d_explicit(
+      &func_args[0],
+      grid_rows,
+      orders,
+      coords,
+      call_args,
+    );
   }
 
   if !(2..=4).contains(&func_args.len()) || call_args.len() != 1 {

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -5,6 +5,7 @@ use crate::functions::calculus_ast::{is_constant_wrt, simplify};
 use crate::functions::math_ast::{
   make_rational, n_ast, try_eval_to_f64, try_extract_complex_float,
 };
+use crate::{ENV, StoredValue};
 
 /// In Solve context, simplify Sqrt[expr^(2n)] → expr^n since ± handles the sign.
 /// Also simplifies products containing such terms.
@@ -5674,7 +5675,7 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if let Some((re0, im0)) = try_extract_complex_f64(&x_start_expr)
     && im0 != 0.0
   {
-    let func = build_find_root_func(&args[0]);
+    let func = build_find_root_func(&args[0], &[&var_name]);
     let deriv =
       crate::functions::calculus_ast::differentiate_expr(&func, &var_name)
         .ok()
@@ -5723,7 +5724,7 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let use_secant = use_secant || x1_opt.is_some();
 
   // Extract the function to find root of: expr or lhs - rhs for equations
-  let func = build_find_root_func(&args[0]);
+  let func = build_find_root_func(&args[0], &[&var]);
 
   // Secant method when requested
   if use_secant {
@@ -5880,9 +5881,23 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Convert FindRoot's first argument into the function whose root we
 /// seek. For equations `lhs == rhs` this is `lhs - rhs`; otherwise the
-/// expression is used directly.
-fn build_find_root_func(arg: &Expr) -> Expr {
-  match arg {
+/// expression is used directly. `vars` are every search variable the
+/// caller is solving for — see `evaluate_with_vars_localized`.
+///
+/// FindRoot is `HoldAll` (so the iteration variable isn't looked up as an
+/// OwnValue before the search starts), which means this raw `lhs - rhs`
+/// still contains any held computation the equation wrote — most commonly
+/// `D[f[x], x]`, an unevaluated derivative. Substituting a numeric trial
+/// value straight into that raw form would land the number inside `D[…]`'s
+/// variable slot (`D[f[3.8], 3.8]`) and fail with `D::ivar`. Evaluating once
+/// here — with the search variable(s) still free symbols — resolves `D`,
+/// `Integrate`, `Sum`, etc. into a plain closed-form expression first, the
+/// same way `find_root_multivariate` already does per equation; only that
+/// closed form is substituted into afterwards. An expression that fails to
+/// evaluate (e.g. it stays opaque) is used as written, matching the
+/// multivariate path's fallback.
+fn build_find_root_func(arg: &Expr, vars: &[&str]) -> Expr {
+  let raw = match arg {
     Expr::Comparison {
       operands,
       operators,
@@ -5898,7 +5913,43 @@ fn build_find_root_func(arg: &Expr) -> Expr {
       minus2(fargs[0].clone(), fargs[1].clone())
     }
     other => other.clone(),
+  };
+  evaluate_with_vars_localized(&raw, vars)
+}
+
+/// Evaluate `expr` with each of `vars`' global bindings temporarily
+/// removed, restoring them all afterward regardless of the outcome —
+/// `Block[vars, expr]`'s scoping, applied to a single speculative
+/// evaluation rather than a full dynamic-scope body.
+///
+/// `build_find_root_func` needs exactly this: FindRoot's search variable(s)
+/// must be free while the equation's held computation resolves (so
+/// `D[f[x], x]` becomes a closed form in `x`), but must not pick up
+/// whatever unrelated global value `x` happens to carry — `x = "prior
+/// result"; FindRoot[f[x] == 0, {x, x0}]` searches fresh, the same as
+/// Wolfram's `HoldAll`, rather than evaluating `f["prior result"]` and
+/// reporting `FindRoot::nlnum`.
+fn evaluate_with_vars_localized(expr: &Expr, vars: &[&str]) -> Expr {
+  let saved: Vec<(&str, Option<StoredValue>)> = vars
+    .iter()
+    .map(|v| (*v, ENV.with(|e| e.borrow_mut().remove(*v))))
+    .collect();
+  let result = crate::evaluator::evaluate_expr_to_expr(expr)
+    .unwrap_or_else(|_| expr.clone());
+  for (v, prev) in saved {
+    ENV.with(|e| {
+      let mut env = e.borrow_mut();
+      match prev {
+        Some(val) => {
+          env.insert(v.to_string(), val);
+        }
+        None => {
+          env.remove(v);
+        }
+      }
+    });
   }
+  result
 }
 
 /// Try to evaluate `expr` to a complex `(re, im)` pair using f64
@@ -6328,21 +6379,21 @@ fn find_root_multivariate(
   let n = vars.len();
 
   // Equations as f_i = lhs - rhs (or bare expression). Each side is
-  // evaluated symbolically first so user-defined functions expand through
-  // their downvalues (`r[s, t, 0, 1]` becomes its explicit formula) —
-  // FindRoot holds its arguments, so this is the first chance to do so.
-  // An expression that fails to evaluate stays as written and is handled
-  // numerically per iteration point instead.
+  // evaluated symbolically first — with every search variable localized, see
+  // `evaluate_with_vars_localized` — so user-defined functions expand
+  // through their downvalues (`r[s, t, 0, 1]` becomes its explicit formula)
+  // and a variable that happens to carry a stale global value elsewhere
+  // still searches fresh. FindRoot holds its arguments, so this is the
+  // first chance to do so. An expression that fails to evaluate stays as
+  // written and is handled numerically per iteration point instead.
+  let var_refs: Vec<&str> = vars.iter().map(String::as_str).collect();
   let eqns: Vec<Expr> = match eqns_arg {
-    Expr::List(es) => es.iter().map(build_find_root_func).collect(),
-    other => vec![build_find_root_func(other)],
+    Expr::List(es) => es
+      .iter()
+      .map(|e| build_find_root_func(e, &var_refs))
+      .collect(),
+    other => vec![build_find_root_func(other, &var_refs)],
   };
-  let eqns: Vec<Expr> = eqns
-    .iter()
-    .map(|f| {
-      crate::evaluator::evaluate_expr_to_expr(f).unwrap_or_else(|_| f.clone())
-    })
-    .collect();
   if eqns.len() != n {
     return Err(InterpreterError::EvaluationError(
       "FindRoot: number of equations must match number of variables".into(),

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -8235,6 +8235,54 @@ mod find_root {
       r.warnings
     );
   }
+
+  // Regression: FindRoot is HoldAll (so the search variable isn't looked up
+  // as an OwnValue before the iteration starts), so its equation argument
+  // arrives unevaluated — still containing a raw `D[f[x], x]`. Substituting
+  // a numeric trial value straight into that raw form used to land the
+  // number inside D's variable slot (`D[f[3.], 3.]`) and fail with
+  // `D::ivar`, so every derivative-based FindRoot (the standard
+  // "extremum of f" idiom, `FindRoot[D[f[x], x] == 0, {x, x0}]`) errored
+  // out. The objective is now evaluated once — with the variable still
+  // free — before any substitution, exactly like the already-correct
+  // multivariate path.
+  #[test]
+  fn derivative_equation_evaluates_before_substitution() {
+    assert_eq!(
+      interpret("FindRoot[D[Sin[x], x] == 0, {x, 1}]").unwrap(),
+      "{x -> 1.5707963267948966}"
+    );
+  }
+
+  #[test]
+  fn derivative_equation_no_ivar_message() {
+    use woxi::interpret_with_stdout;
+    let r =
+      interpret_with_stdout("FindRoot[D[Sin[x], x] == 0, {x, 1}]").unwrap();
+    assert!(
+      r.warnings.iter().all(|w| !w.contains("D::ivar")),
+      "the derivative must resolve before substitution, not after: {:?}",
+      r.warnings
+    );
+  }
+
+  // The same pattern with a special function (the Demonstrations idiom this
+  // was found from: locating a Bessel function's stationary points via
+  // `FindRoot[D[BesselJ[m, r], r] == 0, {r, BesselJZero[n, k]}]`). The
+  // result is a genuine root of `BesselJ`'s derivative — cross-checked here
+  // via `D[BesselJ[0, r], r] == -BesselJ[1, r]`, so its root is exactly
+  // `BesselJZero[1, 1]`.
+  #[test]
+  fn derivative_of_special_function_equation() {
+    assert_eq!(
+      interpret("FindRoot[D[BesselJ[0, r], r] == 0, {r, 3}]").unwrap(),
+      "{r -> 3.831705970207513}"
+    );
+    assert_eq!(
+      interpret("N[BesselJZero[1, 1]]").unwrap(),
+      "3.8317059702075125"
+    );
+  }
 }
 
 mod replace {

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -10627,6 +10627,132 @@ mod list_interpolation {
   }
 }
 
+// `Interpolation` (not `ListInterpolation`, whose 3-wide rows are raw grid
+// values, not `{x, y, z}` coordinates) of a flat `{x, y, z}` triple list —
+// the shape `Flatten[Table[Table[{x, y, f[x, y]}, {y, ys}], {x, xs}], 1]`
+// (or the equivalent built with `Join`) produces. Regression: this used to
+// raise "cannot convert {1., 1., 2.} to a numeric value" because the triple
+// format wasn't recognised at all; the distinct x/y coordinates now recover
+// the grid so it interpolates the same way `ListInterpolation`'s implicit
+// integer grid does.
+mod interpolation_2d_scattered {
+  use super::*;
+
+  // f(x, y) = x + 2y is exactly linear, so both an exact grid point and an
+  // interpolated point reproduce it exactly.
+  #[test]
+  fn exact_grid_point_keeps_integer_type() {
+    assert_eq!(
+      interpret(
+        "Interpolation[Flatten[Table[{x, y, x + 2 y}, {x, 0, 3}, {y, 0, 3}], 1], \
+         InterpolationOrder -> 1][1, 1]"
+      )
+      .unwrap(),
+      "3"
+    );
+  }
+
+  #[test]
+  fn bilinear_of_a_linear_function_is_exact() {
+    assert_eq!(
+      interpret(
+        "Interpolation[Flatten[Table[{x, y, x + 2 y}, {x, 0, 3}, {y, 0, 3}], 1], \
+         InterpolationOrder -> 1][2.5, 1.5]"
+      )
+      .unwrap(),
+      "5.5"
+    );
+  }
+
+  // f(x, y) = x^2 doesn't depend on y, so bilinear interpolation reduces to
+  // plain 1-D linear interpolation in x between the bracketing grid columns:
+  // at x = 2.5 that's (4 + 9)/2 = 6.5, the same at every y.
+  #[test]
+  fn bilinear_interpolates_within_a_cell() {
+    assert_eq!(
+      interpret(
+        "f = Interpolation[Flatten[Table[{x, y, x^2}, {x, 0, 4}, {y, 0, 4}], 1], \
+         InterpolationOrder -> 1]; f[2.5, 1]"
+      )
+      .unwrap(),
+      "6.5"
+    );
+    assert_eq!(
+      interpret(
+        "f = Interpolation[Flatten[Table[{x, y, x^2}, {x, 0, 4}, {y, 0, 4}], 1], \
+         InterpolationOrder -> 1]; f[2.5, 3]"
+      )
+      .unwrap(),
+      "6.5"
+    );
+  }
+
+  // Default order 3, clamped per axis to the 3x3 grid's `dim - 1 = 2` (the
+  // same reduction `grid_default_order` exercises for `ListInterpolation`),
+  // interpolates the quadratic x^2 + y^2 exactly at the midpoint.
+  #[test]
+  fn default_order_is_reduced_and_still_exact_for_a_quadratic() {
+    woxi::clear_state();
+    assert_eq!(
+      interpret(
+        "Interpolation[Flatten[Table[{x, y, x^2 + y^2}, {x, 0, 2}, {y, 0, 2}], 1]][1.5, 1.5]"
+      )
+      .unwrap(),
+      "4.5"
+    );
+    let msgs = woxi::get_captured_messages_raw();
+    assert!(
+      msgs.iter().any(|m| m.contains(
+        "Interpolation::inhr: Requested order is too high; order has been reduced to {2, 2}."
+      )),
+      "expected 2-D inhr {{2, 2}}, got {msgs:?}"
+    );
+  }
+
+  #[test]
+  fn property_domain() {
+    assert_eq!(
+      interpret(
+        "Interpolation[Flatten[Table[{x, y, x + y}, {x, 0, 3}, {y, 0, 3}], 1]][\"Domain\"]"
+      )
+      .unwrap(),
+      "{{0, 3}, {0, 3}}"
+    );
+  }
+
+  // A per-axis `InterpolationOrder -> {orderX, orderY}` is honoured
+  // separately for each dimension.
+  #[test]
+  fn per_axis_interpolation_order() {
+    assert_eq!(
+      interpret(
+        "Interpolation[Flatten[Table[{x, y, x + 2 y}, {x, 0, 3}, {y, 0, 3}], 1], \
+         InterpolationOrder -> {1, 1}][2, 3]"
+      )
+      .unwrap(),
+      "8"
+    );
+  }
+
+  // Fewer than four points, or a triple list whose coordinates don't tile a
+  // complete rectangular grid, isn't a shape this path supports (and isn't
+  // the `Flatten[Table[Table[…]]]` idiom that reaches it in practice); it
+  // falls back to the ordinary (non-grid) handling rather than being
+  // silently misread as one, and no longer names the wrong caller in its
+  // error when that fallback also can't make sense of it.
+  #[test]
+  fn incomplete_grid_does_not_crash_or_blame_ndsolve() {
+    let err = interpret("Interpolation[{{1, 1, 2}, {1, 2, 3}, {2, 1, 4}}]")
+      .unwrap_err()
+      .to_string();
+    assert!(
+      !err.contains("NDSolve"),
+      "a numeric-conversion failure reached from Interpolation must not \
+       blame NDSolve: {err}"
+    );
+  }
+}
+
 mod trig_expand {
   use super::*;
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6690,6 +6690,38 @@ mod tests {
     assert_eq!(state.control_is_visible, vec![true, false, false]);
   }
 
+  /// A `PaneSelector` keyed by strings (`"a" -> …`, `"b" -> …`) rather than
+  /// integers — the Demonstrations idiom for a mode picker whose Setter
+  /// labels double as the pane keys. String comparison must be exact (a
+  /// pane keyed `"a"` is not shown when the selector reads the *symbol* `a`
+  /// or an unrelated string), so this exercises the same visibility gating
+  /// as `manipulate_pane_selector_shows_one_panel_at_a_time` with a
+  /// different key type rather than assuming it falls out for free.
+  #[test]
+  fn manipulate_pane_selector_switches_on_string_keys() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[{mode, a, b}, \
+       Control[{{mode, \"first\"}, {\"first\", \"second\"}, Setter}], \
+       PaneSelector[{\"first\" -> Control[{{a, 5}, 0, 10}], \
+       \"second\" -> Control[{{b, 1}, 0, 2}]}, mode]]",
+    )
+    .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    let names: Vec<&str> = state.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["mode", "a", "b"]);
+    // The selector starts on "first", so only `a`'s row shows.
+    assert_eq!(state.control_is_visible, vec![true, true, false]);
+
+    // Switching the Setter to "second" swaps the panel to `b`.
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[0]
+    {
+      *current_index = 1;
+    }
+    state.reevaluate();
+    assert_eq!(state.control_is_visible, vec![true, false, true]);
+  }
+
   #[test]
   fn manipulate_untracked_control_does_not_reeval() {
     // `TrackedSymbols :> {b}`: moving `a` changes its value but must not
@@ -13584,6 +13616,45 @@ Cell[BoxData["Manipulate[Module[{s = 2. r/n, pts}, pts = Table[{{x, y}, {y, -x}}
       .map(|_| Some(svg::Handle::from_memory(Vec::new())))
       .collect();
     assert!(renders_as_setter_bar(&icons, &handles));
+  }
+
+  /// An explicit `ControlType -> RadioButtonBar` keeps its row of radio
+  /// buttons even past the automatic SetterBar/PopupMenu split — the same
+  /// forcing `ControlType -> SetterBar` already gets (see
+  /// `demonstration_panel_with_escaped_glyphs_opens_live`). Six single-word
+  /// choices are past that split (`renders_as_setter_bar` is false for this
+  /// exact list above), so without the explicit type Woxi would draw a
+  /// dropdown where Wolfram always draws the bar.
+  #[test]
+  fn radio_button_bar_control_type_forces_the_bar() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[shape, {{shape, \"triangle\"}, \
+       {\"triangle\", \"square\", \"pentagon\", \"hexagon\", \"heptagon\", \
+       \"octagon\"}, ControlType -> RadioButtonBar}]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Discrete {
+          value_labels,
+          setter_bar,
+          popup,
+          ..
+        },
+      ] => {
+        assert!(
+          !renders_as_setter_bar(value_labels, &vec![None; value_labels.len()]),
+          "the automatic split must pick a dropdown for this list, so the \
+           forced bar below is actually exercising ControlType"
+        );
+        assert!(
+          *setter_bar && !*popup,
+          "ControlType -> RadioButtonBar must force the bar layout"
+        );
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
   }
 
   /// A control's caption: Wolfram writes the variable's own name when the


### PR DESCRIPTION
## Summary

Checked whether Woxi Studio fully supports a random Wolfram Demonstrations Project notebook ("Cylindrical Cavity Resonator," which locates a resonant cavity mode's field extrema and visualizes the energy density). Found and fixed three gaps:

- **`FindRoot` on a held derivative equation** (`FindRoot[D[f[x], x] == 0, {x, x0}]`) raised `D::ivar` and never solved. `FindRoot` is `HoldAll`, so the raw equation still contained an unevaluated `D[...]` call; substituting a numeric trial value directly into it landed the number inside `D`'s variable slot instead of evaluating the derivative first. Fixed by evaluating the objective once — with the search variable(s) still free (localized like `Block`) — before any substitution, matching the already-correct multivariate path. This is exactly the pattern the demonstration uses to find a Bessel function's stationary points via `FindRoot[D[BesselJ[m, r], r] == 0, {r, BesselJZero[n, k]}]`.
- **`Interpolation` of 2-D scattered data given as a flat `{x, y, z}` triple list** — the standard `Flatten[Table[Table[{x, y, f[x, y]}, {y, ys}], {x, xs}], 1]` idiom — wasn't recognized at all and raised a numeric-conversion error mislabeled as coming from `NDSolve`. Implemented detection (recovering the grid from distinct x/y coordinates) plus tensor-product Lagrange interpolation, with per-axis `InterpolationOrder -> {ox, oy}` support and `Domain`/`Grid`/`Coordinates`/`ValuesOnGrid`/`InterpolationOrder` property queries.
- **Woxi Studio: `ControlType -> RadioButtonBar`** didn't force the bar layout the way `-> SetterBar` already did — with more choices than the automatic split allows, it silently collapsed to a dropdown, diverging from Wolfram's always-a-row `RadioButtonBar`.

## Test plan

- [x] `make test` — 26786/26786 passed, 0 failed
- [x] `make test-studio` — 111/111 passed (includes two new regression tests: `radio_button_bar_control_type_forces_the_bar`, plus PaneSelector string-key coverage)
- [x] `make format` — clean
- [x] Regression tests added in `tests/interpreter_tests/algebra.rs` and `tests/interpreter_tests/calculus.rs`
- [x] `functions.csv` updated for the `Interpolation` changes
- [x] `changelog.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011K4SLmhiTwB79D65g9xUp3

---
_Generated by [Claude Code](https://claude.ai/code/session_011K4SLmhiTwB79D65g9xUp3)_