### PR TITLE
Splice Sequence @@ list into Show/GraphicsRow-family arguments

### DIFF
--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -2363,8 +2363,25 @@ pub fn evaluate_expr_to_expr_inner(
         || name == "LocatorPane"
         || name == "ClickPane"
         {
+          // Show/GraphicsRow/GraphicsColumn/GraphicsGrid/PlotGrid/
+          // BooleanTable aren't actually HoldAll in Wolfram Language, so a
+          // `Sequence @@ list` argument must reduce to `Sequence[…]` before
+          // the flatten below can splice it (see `resolve_sequence_apply_args`).
+          let resolved: std::borrow::Cow<[Expr]> = if matches!(
+            name.as_str(),
+            "Show"
+              | "GraphicsRow"
+              | "GraphicsColumn"
+              | "GraphicsGrid"
+              | "PlotGrid"
+              | "BooleanTable"
+          ) {
+            crate::evaluator::listable::resolve_sequence_apply_args(args)?
+          } else {
+            std::borrow::Cow::Borrowed(args)
+          };
           // Flatten Sequence even in held args (unless SequenceHold)
-          let flattened = flatten_sequences(name, args);
+          let flattened = flatten_sequences(name, &resolved);
           // Honour Evaluate[...] inside HoldAll wrappers like Hold and
           // HoldForm — Evaluate forces evaluation of its argument even
           // through a hold. HoldComplete suppresses it (matching Wolfram).

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -1510,3 +1510,35 @@ pub fn flatten_sequences<'a>(
   }
   std::borrow::Cow::Owned(result)
 }
+
+/// Evaluate a top-level `Sequence @@ list` argument so it can splice.
+///
+/// `Show`, `GraphicsRow`, `GraphicsColumn`, `GraphicsGrid`, `PlotGrid` and
+/// `BooleanTable` are not `HoldAll` in Wolfram Language — Woxi dispatches
+/// them with their raw, unevaluated arguments only so each implementation
+/// can re-render child `Graphics[…]` literals at the right size. A literal
+/// `Sequence[…]` argument already splices via [`flatten_sequences`], but
+/// `Sequence @@ list` (`Expr::Apply`) only *reduces* to `Sequence[…]` once
+/// evaluated, so without this step `Show[Sequence @@ graphics]` sees a
+/// single unevaluated `Apply` argument instead of the spliced graphics.
+/// Every other argument is left untouched, preserving the hold.
+pub fn resolve_sequence_apply_args(
+  args: &[Expr],
+) -> Result<std::borrow::Cow<'_, [Expr]>, crate::InterpreterError> {
+  fn is_sequence_apply(e: &Expr) -> bool {
+    matches!(e, Expr::Apply { func, .. }
+      if matches!(func.as_ref(), Expr::Identifier(n) if n == "Sequence"))
+  }
+  if !args.iter().any(is_sequence_apply) {
+    return Ok(std::borrow::Cow::Borrowed(args));
+  }
+  let mut result = Vec::with_capacity(args.len());
+  for arg in args {
+    if is_sequence_apply(arg) {
+      result.push(crate::evaluator::evaluate_expr_to_expr(arg)?);
+    } else {
+      result.push(arg.clone());
+    }
+  }
+  Ok(std::borrow::Cow::Owned(result))
+}

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2042,6 +2042,50 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn sequence_apply_splices_into_show_and_graphics_row() {
+    // `Show`/`GraphicsRow` aren't `HoldAll` in Wolfram Language, so a
+    // `Sequence @@ list` argument must reduce to `Sequence[…]` and splice
+    // before dispatch, exactly as a literal `Sequence[…]` argument already
+    // does. These held-for-rendering-purposes functions used to see the
+    // whole `Sequence @@ list` as a single unevaluated `Apply` argument
+    // instead, so a demonstration combining several precomputed panels via
+    // `Show[Sequence @@ panels]` silently dropped every panel but the first.
+    let cases = [
+      (
+        "Head[Show[Sequence @@ {Graphics[{}], Graphics[{}]}]]",
+        "Graphics",
+      ),
+      (
+        "Head[GraphicsRow[Sequence @@ {{Graphics[{}], Graphics[{}]}}]]",
+        "Graphics",
+      ),
+      // A literal `Sequence[…]` argument keeps working alongside the
+      // Apply-shorthand form.
+      (
+        "Head[Show[Sequence[Graphics[{}], Graphics[{}]]]]",
+        "Graphics",
+      ),
+    ];
+    for (input, expected) in cases {
+      assert_eq!(
+        interpret(input).unwrap(),
+        expected,
+        "result mismatch for {input}"
+      );
+    }
+    // The spliced call must produce the same result as writing the same
+    // arguments out directly.
+    assert_eq!(
+      interpret(
+        "Show[Sequence @@ {Graphics[{Circle[]}], Graphics[{Circle[{1, 1}]}]}]"
+      )
+      .unwrap(),
+      interpret("Show[Graphics[{Circle[]}], Graphics[{Circle[{1, 1}]}]]")
+        .unwrap()
+    );
+  }
+
+  #[test]
   fn drop_shadowing_canonicalizes_with_defaults() {
     // DropShadowing arguments are matched positionally in the order
     // offset (2-element numeric list), radius (number), color (color

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6649,6 +6649,70 @@ mod tests {
     );
   }
 
+  /// A physics-style Demonstration shape: a single labeled slider driving a
+  /// multi-statement body that stacks several precomputed `Show`/`Plot`
+  /// panels into a `GraphicsRow`, with a large `Initialization :>` block
+  /// defining helper graphics and pattern-matched functions before the
+  /// widget ever renders. This mirrors the general construct category used
+  /// by many single-parameter Wolfram Demonstrations Project notebooks
+  /// (independently written, not copied from any specific one).
+  #[test]
+  fn manipulate_multi_statement_body_with_initialization_builds_one_slider() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[\
+       line5 = Graphics[{Thick, Blue, Line[{{0, k}, {0.7, k}}]}]; \
+       p1 = Plot[barrier[k, x], {x, 0, 1}, PlotStyle -> {Thick, Blue}]; \
+       GraphicsRow[{Show[pot, p1, AspectRatio -> 1], Show[eplot, line5]}, \
+       ImageSize -> {575, 450}], \
+       {{k, 0.02, \"wavenumber\"}, 0.02, 0.85}, \
+       TrackedSymbols :> {k}, \
+       Initialization :> (\
+       v0 = 1; alpha = 10; \
+       pot = Show[Graphics[{Opacity[0.15], Rectangle[{1, 0}, {2, v0}]}], Axes -> True]; \
+       eplot = Plot[Sin[x], {x, 0, 1}]; \
+       barrier[kk_, x_] := Sin[alpha Sqrt[kk] x];\
+       )]",
+    )
+    .expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a single labeled slider should build a ManipulateState");
+
+    assert_eq!(state.controls.len(), 1, "exactly one slider control");
+    let manipulate::ControlState::Continuous {
+      name,
+      label,
+      min,
+      max,
+      current,
+      ..
+    } = &state.controls[0]
+    else {
+      panic!("expected a continuous slider for `k`");
+    };
+    assert_eq!(name, "k");
+    assert_eq!(label, "wavenumber");
+    assert_eq!(*min, 0.02);
+    assert_eq!(*max, 0.85);
+    assert_eq!(*current, 0.02);
+
+    assert!(
+      state.body.contains("GraphicsRow") && state.body.contains("Show"),
+      "body should keep the multi-statement GraphicsRow/Show chain: {}",
+      state.body
+    );
+    let init = state
+      .initialization
+      .as_deref()
+      .expect("Initialization :> block should be captured");
+    assert!(
+      init.contains("barrier")
+        && init.contains("pot")
+        && init.contains("eplot"),
+      "initialization should keep every helper definition: {init}"
+    );
+    assert!(state.error.is_none(), "unexpected error: {:?}", state.error);
+  }
+
   /// A `PaneSelector` control panel — a Demonstration whose modes each need
   /// different controls, as the closest-packing one does — shows only the
   /// pane the selector is on. The controls of the other panes are built (so


### PR DESCRIPTION
## Summary
- `Show`, `GraphicsRow`, `GraphicsColumn`, `GraphicsGrid`, `PlotGrid` and `BooleanTable` are dispatched with unevaluated arguments (so each can re-render child `Graphics[...]` literals at the right size), but they aren't actually `HoldAll` in Wolfram Language.
- A literal `Sequence[...]` argument already spliced via `flatten_sequences`, but `Sequence @@ list` only *reduces* to `Sequence[...]` once evaluated — so it stayed a single unevaluated `Apply` argument and silently dropped every graphic but the first (e.g. `Show[Sequence @@ panels]` combining several precomputed Demonstration panels).
- Added `resolve_sequence_apply_args` (`src/evaluator/listable.rs`) which evaluates only a top-level `Sequence @@ list` argument for this function group before the existing Sequence-flattening step, leaving every other (genuinely held) argument untouched.

## Context
This came out of routinely checking whether Woxi Studio fully supports a random Wolfram Demonstrations Project notebook (a single-slider physics widget with a multi-statement `Manipulate` body and a large `Initialization :>` block). Both the interpreter and Woxi Studio's `ManipulateState::from_expr` already handle that notebook's exact construct shape correctly — no fix was needed there. This Sequence-splicing gap was found independently while probing the same category of `Show`/`GraphicsRow` panel-combining code during that check, and is fixed here per the project's "fix issues you stumble upon" policy. No code from the notebook itself is used or referenced.

## Test plan
- [x] `cargo test` (`sequence_apply_splices_into_show_and_graphics_row` in `tests/interpreter_tests.rs`) — new regression test for the fix
- [x] `cargo test -p woxi-studio` (`manipulate_multi_statement_body_with_initialization_builds_one_slider`) — confirms Woxi Studio already handles this Demonstration construct shape correctly
- [x] `make test` — 26,805 tests pass
- [x] `make test-studio` — 110 tests pass
- [x] `make format`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJhfb9NJjxVgXiDWWyRZLq)_