### PR TITLE
Add regression test for labeled-slider Manipulate with multi-series ListLinePlot

### DIFF
--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -7264,6 +7264,112 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`a$$ = 1}, \"…\"]"], "Output"]
     );
   }
 
+  /// A stored Manipulate whose body composes `Tooltip`-wrapped series
+  /// (one built with `Table`, one with `NestList`/`Partition`) into a
+  /// `ListLinePlot` with a `PlotLabel` assembled from `ToString`/
+  /// `NumberForm` string concatenation, driven by three
+  /// `Appearance -> "Labeled"` sliders — the shape of a typical Wolfram
+  /// Demonstrations finance/growth calculator. This must open live with
+  /// all three sliders recognized and the plot drawn.
+  #[test]
+  fn demonstration_labeled_sliders_drive_multi_series_line_plot() {
+    let nb_src = r##"Notebook[{
+Cell[BoxData["growthSeries[base_, pct_, periods_] := N[Table[base (1 + pct/100)^k, {k, 1, periods}]]"], "Input"],
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[
+ ListLinePlot[
+   {Tooltip[growthSeries[base, pct, periods], \"compounded\"],
+    Tooltip[Last /@ Partition[NestList[# + base pct/100 &, base, periods], 3], \"linear\"]},
+   PlotLabel -> \"base $\" <> ToString[NumberForm[base, {6, 0}]] <> \" at \" <>
+     ToString[NumberForm[pct, {4, 2}]] <> \"%\",
+   Frame -> {True, True, False, False},
+   FrameLabel -> {\"period\", \"value\"},
+   ImageSize -> {400, 300},
+   AxesOrigin -> {0, 0}],
+ {{base, 1000, \"base amount\"}, 200, 5000, 100, Appearance -> \"Labeled\"},
+ {{pct, 5, \"growth percent\"}, 1, 20, 0.5, Appearance -> \"Labeled\"},
+ {{periods, 10, \"periods\"}, 2, 30, 1, Appearance -> \"Labeled\"},
+ SaveDefinitions -> True]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`base$$ = 1000, $CellContext`pct$$ = 5, $CellContext`periods$$ = 10}, \"…\"]"], "Output"]
+}, Open]]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .iter()
+      .find_map(|e| e.manipulate_state.as_ref())
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "the multi-series ListLinePlot must draw"
+    );
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name: base,
+          label: base_label,
+          min: base_min,
+          max: base_max,
+          current: base_now,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: pct,
+          label: pct_label,
+          min: pct_min,
+          max: pct_max,
+          current: pct_now,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: periods,
+          label: periods_label,
+          min: periods_min,
+          max: periods_max,
+          current: periods_now,
+          ..
+        },
+      ] => {
+        assert_eq!(
+          (
+            base.as_str(),
+            base_label.as_str(),
+            *base_min,
+            *base_max,
+            *base_now
+          ),
+          ("base", "base amount", 200.0, 5000.0, 1000.0)
+        );
+        assert_eq!(
+          (
+            pct.as_str(),
+            pct_label.as_str(),
+            *pct_min,
+            *pct_max,
+            *pct_now
+          ),
+          ("pct", "growth percent", 1.0, 20.0, 5.0)
+        );
+        assert_eq!(
+          (
+            periods.as_str(),
+            periods_label.as_str(),
+            *periods_min,
+            *periods_max,
+            *periods_now
+          ),
+          ("periods", "periods", 2.0, 30.0, 10.0)
+        );
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+  }
+
   #[test]
   fn demonstration_compatibility_checkboxes_render_as_a_card() {
     // The metadata cells at the end of every Demonstration submission


### PR DESCRIPTION
## Summary

- Verified Woxi Studio's support for a randomly-sampled Wolfram Demonstrations Project notebook (a `Manipulate`-driven finance/growth calculator using `NestList`, `Partition`, `Table`, `ListLinePlot`, `Tooltip`, and `NumberForm`-formatted strings). All of the notebook's constructs (function definitions with `N[]`, `NestList`/`Partition`/`Last /@`, `Table` list arithmetic, `ListLinePlot` with `Tooltip`-wrapped series, a `PlotLabel` built from `ToString`/`NumberForm` string concatenation with `NumberPadding`/`DigitBlock`/`NumberPoint`, and a `Manipulate` with `Appearance -> "Labeled"` sliders plus `SaveDefinitions -> True`) already work correctly — no source fixes were needed.
- Added a self-authored regression test (`demonstration_labeled_sliders_drive_multi_series_line_plot` in `woxi-studio/src/main.rs`) that locks in this coverage: it loads a stored `Manipulate` combining `Table`- and `NestList`/`Partition`-built series wrapped in `Tooltip`, plotted with `ListLinePlot`, with a `NumberForm`-based `PlotLabel`, driven by three labeled sliders, and asserts the widget opens live with all three sliders recognized and the plot drawn.

Per project convention, the test reproduces the *shape* of the Demonstration (not its literal formulas or wording) — it uses different variable names, a different growth calculation, and original prose.

## Test plan

- [x] `cargo test --release -p woxi-studio demonstration_labeled_sliders_drive_multi_series_line_plot` — passes
- [x] `make test` (26,815 interpreter unit tests) — all pass
- [x] `make test-studio` (114 Woxi Studio tests) — all pass
- [x] `make format` — no additional changes needed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FC6w7e49wT1yW5aXeZo8hb

---
_Generated by [Claude Code](https://claude.ai/code/session_01FC6w7e49wT1yW5aXeZo8hb)_