### PR TITLE
Fix TraditionalForm degrading to HoldComplete in Manipulate captions

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1704,6 +1704,45 @@ fn box_escape_to_expr(box_src: &str) -> Option<Expr> {
   string_to_expr(&text).ok()
 }
 
+/// Undo `escape_string_for_input_form`'s `\"`/`\\` escaping of a `\!\(\*
+/// boxes\)` escape's content. Named-character escapes (`\[Name]`) are left
+/// untouched — they're valid box-source syntax on their own, not part of
+/// this string-quoting layer.
+fn unescape_box_source(s: &str) -> String {
+  let mut out = String::with_capacity(s.len());
+  let mut chars = s.chars().peekable();
+  while let Some(c) = chars.next() {
+    if c != '\\' {
+      out.push(c);
+      continue;
+    }
+    match chars.peek() {
+      Some('"') => {
+        out.push('"');
+        chars.next();
+      }
+      Some('\\') => {
+        out.push('\\');
+        chars.next();
+      }
+      Some('n') => {
+        out.push('\n');
+        chars.next();
+      }
+      Some('t') => {
+        out.push('\t');
+        chars.next();
+      }
+      Some('r') => {
+        out.push('\r');
+        chars.next();
+      }
+      _ => out.push('\\'),
+    }
+  }
+  out
+}
+
 /// Split `s` at its last top-level comma (one not nested in brackets or
 /// inside a string). `None` when there is no such comma.
 fn split_last_top_level_comma(s: &str) -> Option<(&str, &str)> {
@@ -2650,9 +2689,14 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
           return expr;
         }
         // `\!\(\*boxes\)` — the FrontEnd's "interpret these boxes" escape,
-        // which is what `InputForm` writes for a typeset expression.
+        // which is what `InputForm` writes for a typeset expression. Its
+        // string literals are `\"`-escaped (the way `escape_string_for_
+        // input_form` writes them, so the whole `\!\(…\)` token survives
+        // being re-tokenized as source); undo that before handing the text
+        // to the box-source readers, which expect the bare `"` delimiters
+        // real `.nb` box data uses.
         if let Some(box_src) = inner.trim_start().strip_prefix("\\*")
-          && let Some(expr) = box_escape_to_expr(box_src)
+          && let Some(expr) = box_escape_to_expr(&unescape_box_source(box_src))
         {
           return expr;
         }

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -2811,6 +2811,26 @@ mod traditional_form {
       "Column[{a, TraditionalForm[x + y]}]"
     );
   }
+
+  // A `TraditionalForm` of a symbolic product typesets to a `RowBox` of
+  // *string* atoms ("Pi", " ", "p", …), and `InputForm` `\"`-escapes those
+  // quotes so the whole `\!\(…\)` token survives being re-tokenized as
+  // source — exactly what Woxi Studio does to serialize and re-evaluate a
+  // Manipulate body on every frame. The box-source readers expect the bare
+  // `"` delimiters real `.nb` box data uses, so without undoing that
+  // escaping first, reading the text back degraded to an opaque
+  // `HoldComplete` dump of its own source instead of the original
+  // `TraditionalForm[…]`.
+  #[test]
+  fn input_form_box_escape_round_trips_escaped_string_atoms() {
+    let serialized =
+      interpret("ToString[InputForm[TraditionalForm[Pi*p*q]]]").unwrap();
+    assert!(
+      serialized.contains("\\\"Pi\\\""),
+      "expected escaped string atoms in: {serialized}"
+    );
+    assert_eq!(interpret(&serialized).unwrap(), "TraditionalForm[p*Pi*q]");
+  }
 }
 
 mod batch_symbols {


### PR DESCRIPTION
## Summary

- Checked a randomly fetched Wolfram Demonstration ("Area of the Arbelos") against Woxi Studio's Manipulate-widget pipeline, using an original re-implementation of its construct set (not the notebook's own code, which is copyrighted) — a `Manipulate` with two labeled sliders, a `Column` of a `Text`/`Row`/`TraditionalForm`/`NumberForm` caption over a `Graphics` of angle-ranged `Disk`/`Circle` sectors.
- Found that the caption rendered as a raw `HoldComplete[RowBox[...]]` dump instead of typeset math whenever `TraditionalForm` wrapped a product of symbols (e.g. `TraditionalForm[Pi*p*q]`) nested inside `Row`/`Text`.
- Root cause: `InputForm` `\"`-escapes a `TraditionalForm`'s embedded `RowBox` string atoms (`"Pi"`, `" "`, ...) so the whole `\!\(\*boxes\)` escape survives being re-tokenized as source — which is exactly what Woxi Studio does every frame to serialize and re-evaluate a Manipulate body. The box-source readers that turn that escape back into an expression expected the bare `"` delimiters real `.nb` box data uses, so the escaped quotes broke their string-boundary tracking and the read side fell back to `HoldComplete`.
- Fixed by unescaping the `\!\(\*boxes\)` escape's content (undoing `escape_string_for_input_form`'s `\"`/`\\` quoting) before handing it to the box-source readers.
- Verified the fix against the actual Woxi Studio Manipulate pipeline (`woxi-studio/examples/dump_manipulate`): the caption now renders as a proper typeset SVG instead of the garbled text dump.

## Test plan

- [x] Added `input_form_box_escape_round_trips_escaped_string_atoms` regression test in `tests/interpreter_tests/syntax.rs`
- [x] `cargo test` (full default-member suite): all passing (24779 + 573 + 1250 + 27 + 187 tests)
- [x] `make format`
- [x] Manually verified via `woxi-studio/examples/dump_manipulate` that the fix renders correctly in the actual Manipulate widget pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Ey63F4SGagFPMWhy7jvGsB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ey63F4SGagFPMWhy7jvGsB)_