### PR TITLE
Render Grid/Framed/Labeled choice appearances and unwrap Dynamic in Manipulate labels

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,22 @@
 
 # Unreleased
 
+- Fixes driven by a Wolfram Demonstration on cellular-automaton patch
+    reentry, whose interactive widget sets a control's per-choice appearance
+    with a small `Grid` and drives a step-counter button's label with a
+    `Dynamic`:
+    - Woxi Studio: a `Grid`/`TableForm`/`TextGrid` used as a setter's
+        per-choice appearance function (rather than a plain string) now
+        typesets its cells — joined by a space within a row, by a newline
+        between rows — instead of falling through to the choice's raw
+        source dump, options and all. `Framed` and `Labeled` wrappers around
+        a choice's content are unwrapped the same way. A choice that
+        legitimately renders to nothing (a blank `Grid` marking "no flag
+        set" among a family of choices that each flip one cell on) now stays
+        blank rather than falling back to its source, too.
+    - Woxi Studio: a `Dynamic[…]` wrapped around a control's own label (a
+        step-counter button framing a live `Dynamic[Row[…]]`) now typesets
+        the wrapped content instead of the `Dynamic[…]` call's own source.
 - Fixes driven by a Wolfram Demonstration on a cylindrical cavity resonator,
     which locates a Bessel function's stationary points and interpolates a
     field built on a 2-D grid:

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -18400,6 +18400,42 @@ fn layout_parts(arg: Option<&Expr>) -> Option<Vec<Expr>> {
   }
 }
 
+/// Renders a `Grid`/`TableForm`/`TextGrid` row list as label runs: each
+/// row's non-blank cells joined by a space, rows joined by a newline.
+fn grid_label_runs(rows: &[Expr], italic: bool) -> Vec<LabelRun> {
+  let mut out = Vec::new();
+  for row in rows {
+    let cells = layout_parts(Some(row)).unwrap_or_else(|| vec![row.clone()]);
+    let mut row_runs: Vec<LabelRun> = Vec::new();
+    for cell in &cells {
+      let cell_runs = manipulate_label_runs(cell, italic);
+      if flatten_label_runs(&cell_runs).trim().is_empty() {
+        continue;
+      }
+      if !row_runs.is_empty() {
+        row_runs.push(LabelRun {
+          text: " ".to_string(),
+          italic,
+          ..Default::default()
+        });
+      }
+      row_runs.extend(cell_runs);
+    }
+    if row_runs.is_empty() {
+      continue;
+    }
+    if !out.is_empty() {
+      out.push(LabelRun {
+        text: "\n".to_string(),
+        italic,
+        ..Default::default()
+      });
+    }
+    out.extend(row_runs);
+  }
+  out
+}
+
 fn manipulate_label_runs(expr: &Expr, italic: bool) -> Vec<LabelRun> {
   let mut runs = manipulate_label_runs_inner(expr, italic);
   // A label is text a widget draws, so the private-use code points Wolfram
@@ -18487,11 +18523,41 @@ fn manipulate_label_runs_inner(expr: &Expr, italic: bool) -> Vec<LabelRun> {
       // displays its label (the tip only appears on hover in the Wolfram
       // FrontEnd), so a control spec like
       // `{{v, True, Tooltip["source", "Show source"]}, {True, False}}`
-      // labels the control "source".
-      "Text" | "DisplayForm" | "TraditionalForm" | "Tooltip" => args
+      // labels the control "source". `Framed[content, …]` keeps only its
+      // content — the frame itself has no text to typeset.
+      // `Dynamic[content]` inside a label (a Demonstration's step counter
+      // buttons often frame one) only exists to keep `content` live; a
+      // static label typesets `content` itself rather than the `Dynamic[…]`
+      // wrapper's own source.
+      "Text" | "DisplayForm" | "TraditionalForm" | "Tooltip" | "Framed"
+      | "Dynamic" => args
         .first()
         .map(|a| manipulate_label_runs(a, italic))
         .unwrap_or_default(),
+      // `Labeled[content, label, …]` draws its label alongside the content
+      // (by default below it); a Demonstration's setter option can pair a
+      // picture with a caption this way. Placement specs (a 3rd argument, or
+      // a list of labels) are ignored — only the first label is shown.
+      "Labeled" => {
+        let mut runs = args
+          .first()
+          .map(|a| manipulate_label_runs(a, italic))
+          .unwrap_or_default();
+        if let Some(label_arg) = args.get(1) {
+          let label_runs = manipulate_label_runs(label_arg, italic);
+          if !flatten_label_runs(&label_runs).trim().is_empty() {
+            if !runs.is_empty() {
+              runs.push(LabelRun {
+                text: "\n".to_string(),
+                italic,
+                ..Default::default()
+              });
+            }
+            runs.extend(label_runs);
+          }
+        }
+        runs
+      }
       // Row[{a, b, …}] — concatenate the (recursively rendered) parts.
       "Row" => match layout_parts(args.first()) {
         Some(parts) => parts
@@ -18519,6 +18585,16 @@ fn manipulate_label_runs_inner(expr: &Expr, italic: bool) -> Vec<LabelRun> {
             runs
           })
           .collect(),
+        _ => output_run(italic),
+      },
+      // Grid[{{a, b, …}, …}, …] / TableForm / TextGrid — a Demonstration
+      // uses a small grid as a setter's per-choice appearance function (e.g.
+      // marking which edge of a patch a rule reflects). Cells render as
+      // their own label runs, joined by a space within a row and by a
+      // newline between rows; blank cells (Grid pads a ragged table with
+      // `""`) drop out rather than leaving stray spaces.
+      "Grid" | "TableForm" | "TextGrid" => match layout_parts(args.first()) {
+        Some(rows) => grid_label_runs(&rows, italic),
         _ => output_run(italic),
       },
       "Subscript" => script_runs(args, italic, false),
@@ -19816,7 +19892,13 @@ fn discrete_choice_label(expr: &Expr) -> String {
     }
     other => {
       let flat = flatten_label_runs(&manipulate_label_runs(other, false));
-      if flat.is_empty() {
+      // A structural head (Grid/Row/Column/…) can legitimately typeset to
+      // nothing — e.g. a Grid whose cells are all `""`, marking "no flag
+      // set" among a family of choices that each flip one cell on. Only an
+      // unrecognized head's empty result means "couldn't render", which
+      // falls back to its source so the choice still shows something.
+      let structural = matches!(other, Expr::FunctionCall { name, .. } if is_text_layout_head(name));
+      if flat.is_empty() && !structural {
         crate::syntax::expr_to_input_form(other)
       } else {
         flat

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -17202,6 +17202,78 @@ mod manipulate {
     }
   }
 
+  /// A control's custom appearance function (`Button[label, action] &`, the
+  /// way a Demonstration draws its own "advance" button) often wraps live
+  /// content — a step counter — in its own `Dynamic[…]`. The label used to
+  /// typeset that wrapper's own source (`Dynamic[t\[Rule]t + 1]`) instead of
+  /// the counter it names.
+  #[test]
+  fn spec_button_appearance_unwraps_dynamic_label_content() {
+    let expr = interpret_to_expr(
+      "Manipulate[k, {{g, False, \"advance\"}, \
+       Button[Framed[Dynamic[Row[{t, Style[\"\\[Rule]\", 12], t + 1}]]], g \
+       = True] &, ControlPlacement -> Left}, {{t, 0}, ControlType -> \
+       None}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("a button spec");
+    match &spec.controls[0] {
+      ManipulateControl::Button { label, action, .. } => {
+        assert_eq!(label, "t\u{2192}t + 1");
+        assert_eq!(action, "g = True");
+      }
+      other => panic!("expected a button control, got {other:?}"),
+    }
+  }
+
+  /// A choice's appearance function can be a small `Grid` rather than a
+  /// string — a Demonstration marking which side of a shape a toggle flips
+  /// draws a two-row grid with the flipped side named in one cell and its
+  /// axis below it, the rest of the grid left blank. `Grid` used to miss
+  /// the structural label renderer (only `Row`/`Column` were handled) and
+  /// fall through to the choice's raw source dump, options and all.
+  #[test]
+  fn spec_grid_choice_labels_render_their_cells() {
+    let expr = interpret_to_expr(
+      "Manipulate[k, {{k, {0, 0}}, {{0, 0} -> Grid[{{\"\", \"\"}, {\"\", \
+       \"\"}}, ItemSize -> {5, 1}], {1, 0} -> Grid[{{\"left\", \"\"}, \
+       {\"column\", \"\"}}, ItemSize -> {5, 1}], {0, 1} -> \
+       Grid[{{\"\", \"right\"}, {\"\", \"column\"}}, ItemSize -> {5, 1}]}}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("a setter spec");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete { value_labels, .. } => {
+        // Blank cells drop out entirely rather than leaving stray spaces or
+        // the grid's `ItemSize` option leaking into the text.
+        assert_eq!(value_labels[0], "");
+        assert_eq!(value_labels[1], "left\ncolumn");
+        assert_eq!(value_labels[2], "right\ncolumn");
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
+  /// `Framed` and `Labeled` wrappers around a choice's content typeset the
+  /// content itself (and, for `Labeled`, the caption below it) instead of
+  /// falling through to their own source dump.
+  #[test]
+  fn spec_framed_and_labeled_choice_labels_render_their_content() {
+    let expr = interpret_to_expr(
+      "Manipulate[k, {{k, 1}, {1 -> Framed[Style[\"on\", Bold]], \
+       2 -> Labeled[\"circle\", \"shape\"]}}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("a setter spec");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete { value_labels, .. } => {
+        assert_eq!(value_labels[0], "on");
+        assert_eq!(value_labels[1], "circle\nshape");
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
   /// A `Setter` / `Toggler` control type offers one widget per value, the
   /// way `SetterBar` and `RadioButton` already do. Before these were
   /// recognised as control-type names they were read as a *bound*, the


### PR DESCRIPTION
## Summary

Checked a published Wolfram Demonstration on cellular-automaton patch reentry against Woxi Studio. Its "reversals" setter draws each choice's appearance with a small `Grid` (marking which edge of a patch flips, via columns/rows), and its step-advance button frames a live `Dynamic[Row[...]]` counter as its own label.

- `manipulate_label_runs_inner` only handled `Row`/`Column` among the heads `is_text_layout_head` steers away from icon rendering — `Grid`, `TableForm`, `TextGrid`, `Framed`, and `Labeled` fell through to the generic fallback and dumped their raw source (options included) straight onto the control instead of typesetting. Added structural rendering for all of them.
- Added `Dynamic` to the same "unwrap and recurse" family: a `Dynamic[content]` inside a label only exists to keep `content` live, so a static label now typesets `content` itself instead of the `Dynamic[…]` call's own source.
- A `Grid` that legitimately renders to nothing (a blank grid marking "no flag set" among a family of choices that each flip one cell on) now stays blank instead of incorrectly falling back to its raw source — done by checking whether the head is one of the now-structurally-handled ones before treating an empty render as "couldn't render".

Per repo convention, the triggering Demonstration notebook itself is not referenced or included (not part of this repo, and copyrighted) — the new tests use independently written, structurally equivalent examples.

## Test plan

- [x] Added unit tests in `tests/interpreter_tests/graphics.rs` covering `Grid`/`Framed`/`Labeled` choice-label rendering (including the all-blank-grid case) and `Dynamic`-wrapped button labels.
- [x] `make test` (26,818 tests) passes.
- [x] `make format` run.
- [x] Verified end-to-end against the actual Demonstration notebook via `woxi-studio`'s `dump_manipulate` example: the "reversals" setter now shows readable labels (e.g. `"left\ncolumn"`) instead of raw `Grid[...]` source, the all-blank choice renders as an empty label instead of source dump, and the step button now shows `"t→t + 1\nt + 1→t + 2"` instead of `"Dynamic[t→t + 1]\nDynamic[t + 1→t + 2]"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EjW8RKbbymy1uk1oE7Wd2

---
_Generated by [Claude Code](https://claude.ai/code/session_017EjW8RKbbymy1uk1oE7Wd2)_