### PR TITLE
Read and run every cell of the Introduction to Calculus notebooks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,14 @@
         read, so a `Plot` legend written as an inline cell
         (`"\!\(\*Cell[\"f[x]\", …]\)"`) stays one string instead of ending
         at its first inner quote.
+    - `expr /. lhs -> rhs`, where `lhs` is a literal call rather than a
+        pattern, rewrites every subexpression equal to `lhs` structurally.
+        It used to fall through to a textual replacement that dropped the
+        brackets the substituted expression needs, silently changing the
+        result: `π r[t]^2 h[t]/3 /. r[t] -> h[t]/2` — the substitution the
+        "Related Rates" chapter makes — came out as `π h[t]^2/12` instead
+        of `π h[t]^3/12`, and `r[t]^2 /. r[t] -> q[t] + 1` as
+        `1 + q[t]^2` instead of `(1 + q[t])^2`.
     - `c = 4; (* c = 6 *); c` evaluates: several `;` in a row with only
         space or a comment between them separate the same two statements,
         with the empty statement `Null` between them. `;;` still parses as

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,47 @@
     - Woxi Studio: a `Dynamic[…]` wrapped around a control's own label (a
         step-counter button framing a live `Dynamic[Row[…]]`) now typesets
         the wrapped content instead of the `Dynamic[…]` call's own source.
+- Fixes driven by opening Wolfram's *Introduction to Calculus* ebook (41
+    notebooks) in Woxi Studio. Every cell that could not be read or run is
+    now read and run; what remains are computations Woxi does not carry out
+    as far as Wolfram does.
+    - `∫ f ⅆx` and `∫_a^b f ⅆx` are read back as `Integrate[f, x]` and
+        `Integrate[f, {x, a, b}]`. The integral sign takes the rest of its
+        row as the body, the way the `∑`/`∏` operators already did, and the
+        `ⅆx` closing that body names the integration variable. The whole
+        "Separable Differential Equations", "Indefinite Integrals" and
+        "Average Value of a Function" chapters are written this way and
+        every such cell used to fail to parse.
+    - `ⅆx` on its own is the differential `DifferentialD[x]`, so the
+        differentials the "Linear Approximations" chapter states its error
+        estimates in (`ⅆarea == 2 π r ⅆr`, then `sol /. {r -> 50,
+        ⅆr -> 0.1}`) stay symbolic and can be replaced. The character is a
+        Unicode *letter*, so `ⅆarea` used to read as one symbol name.
+    - A typeset `Piecewise` — the `⎧` brace, stored as a `GridBox` of
+        value/condition rows — comes back as a `Piecewise[…]` call instead
+        of a nested list, so `RevolutionPlot3D` of one has a function to
+        sample.
+    - A quote inside a cell's string literal stays escaped when the cell is
+        read, so a `Plot` legend written as an inline cell
+        (`"\!\(\*Cell[\"f[x]\", …]\)"`) stays one string instead of ending
+        at its first inner quote.
+    - `c = 4; (* c = 6 *); c` evaluates: several `;` in a row with only
+        space or a comment between them separate the same two statements,
+        with the empty statement `Null` between them. `;;` still parses as
+        `Span`.
+    - `DifferenceDelta[Cos[f], …]` — and so `Limit[DifferenceQuotient[
+        Cos[x], {x, h}], h -> 0]` — is the cosine's own. The sine of the
+        mean was given the half-turn phase shift that only the `Sin` case
+        needs (to write its cosine as a sine), which turned the result back
+        into the *sine's* difference: the derivative of `Cos` came out as
+        `Cos[x]`, and the intermediate quotient was numerically wrong.
+    - Woxi Studio: a derivative sets as prime marks (`f′[x]`, `f″[x]`,
+        `f⁽⁴⁾[x]`, `f⁽¹˒⁰⁾[x, y]`) in an evaluated cell, the way a notebook
+        shows it. `TraditionalForm` already hid the `Derivative` head;
+        StandardForm — what a cell's result is typeset with — did not, so
+        every derivative of an undefined function read as
+        `Derivative[1][f][x]`.
+
 - Fixes driven by a Wolfram Demonstration on a cylindrical cavity resonator,
     which locates a Bessel function's stationary points and interpolates a
     field built on a 2-D grid:

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -3109,6 +3109,88 @@ fn wrap_list_number_display_box(elems: Vec<Expr>, head: &str) -> Expr {
   call("TagBox", vec![braced, Expr::Identifier(head.to_string())])
 }
 
+/// StandardForm boxes for a derivative — `f′[x]`, `f′′[x]`, `f⁽⁴⁾[x]`,
+/// `f⁽¹’⁰⁾[x, y]` — or `None` when `expr` is not one, or its orders are not
+/// literal counts (`Derivative[n][f]` has no prime marks to set).
+///
+/// A single-order derivative arrives flattened (`f''[x]` is held as
+/// `Derivative[2, f, x]`); a multivariate one keeps the curried shape
+/// `Derivative[1, 0][f][x, y]`.
+fn derivative_boxes(expr: &Expr) -> Option<Expr> {
+  let (orders, func, applied): (&[Expr], &Expr, &[Expr]) = match expr {
+    Expr::FunctionCall { name, args }
+      if name == "Derivative" && args.len() >= 2 =>
+    {
+      (&args[..1], &args[1], &args[2..])
+    }
+    Expr::CurriedCall { func, args } => match func.as_ref() {
+      Expr::FunctionCall { name, args: orders } if name == "Derivative" => {
+        if args.len() != 1 {
+          return None;
+        }
+        (&orders[..], &args[0], &[])
+      }
+      // The same derivative applied to its arguments: the head is the
+      // curried `Derivative[n₁, …][f]` above.
+      Expr::CurriedCall {
+        func: inner,
+        args: fargs,
+      } if fargs.len() == 1 => match inner.as_ref() {
+        Expr::FunctionCall { name, args: orders } if name == "Derivative" => {
+          (&orders[..], &fargs[0], &args[..])
+        }
+        _ => return None,
+      },
+      _ => return None,
+    },
+    _ => return None,
+  };
+
+  let counts: Option<Vec<i128>> = orders
+    .iter()
+    .map(|o| match o {
+      Expr::Integer(n) if *n >= 0 => Some(*n),
+      _ => None,
+    })
+    .collect();
+  let counts = counts?;
+  let script = if let [n @ 1..=3] = counts.as_slice() {
+    Expr::String("\u{2032}".repeat(*n as usize))
+  } else {
+    let mut parts = vec![Expr::String("(".to_string())];
+    for (i, n) in counts.iter().enumerate() {
+      if i > 0 {
+        parts.push(Expr::String(",".to_string()));
+      }
+      parts.push(Expr::String(n.to_string()));
+    }
+    parts.push(Expr::String(")".to_string()));
+    call1("RowBox", Expr::List(parts.into()))
+  };
+  let primed = Expr::FunctionCall {
+    name: "SuperscriptBox".to_string(),
+    args: vec![expr_to_box_form(func), script].into(),
+  };
+  if applied.is_empty() {
+    return Some(primed);
+  }
+  let mut parts = vec![primed, Expr::String("[".to_string())];
+  if applied.len() == 1 {
+    parts.push(expr_to_box_form(&applied[0]));
+  } else {
+    let mut inner = Vec::new();
+    for (i, arg) in applied.iter().enumerate() {
+      if i > 0 {
+        inner.push(Expr::String(",".to_string()));
+      }
+      inner.push(expr_to_box_form(arg));
+    }
+    parts.push(call1("RowBox", Expr::List(inner.into())));
+  }
+  parts.push(Expr::String("]".to_string()));
+  Some(call1("RowBox", Expr::List(parts.into())))
+}
+
 pub fn expr_to_box_form(expr: &Expr) -> Expr {
   // MakeBoxes has HoldAllComplete, so a postfix `expr // f` arg is
   // delivered as `Expr::Postfix { expr, func }` rather than being
@@ -3134,6 +3216,13 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
   if let Expr::FunctionCall { name, args } = expr
     && let Some(boxed) = number_display_form_box(name, args)
   {
+    return boxed;
+  }
+  // `f'[x]` is held as `Derivative[1][f][x]`, and no notebook shows that
+  // head: the order sets as prime marks on the differentiated function.
+  // Without this the whole call fell through to its plain text, so every
+  // derivative of an undefined function read as `Derivative[1][f][x]`.
+  if let Some(boxed) = derivative_boxes(expr) {
     return boxed;
   }
   match expr {

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -2405,6 +2405,19 @@ pub fn apply_replace_all_ast(
     {
       return Ok(result);
     }
+    // A rule whose left side is a literal expression rather than a pattern
+    // (`r[t] -> h[t]/2`, the substitution a related-rates problem writes)
+    // rewrites every subexpression equal to it. Without this the rewrite fell
+    // through to the textual replacement below, which drops the brackets the
+    // replacement needs: `π r[t]^2 h[t]/3 /. r[t] -> h[t]/2` came out as
+    // `π h[t]^2/12` — the substituted radius silently lost its square.
+    if !matches!(stripped, Expr::Identifier(_))
+      && !contains_pattern(&stripped)
+      && let Some(result) =
+        replace_literal_subexpr(expr, &stripped, replacement)
+    {
+      return Ok(result);
+    }
   }
 
   // Extract pattern and replacement strings for string-based matching
@@ -2515,6 +2528,27 @@ pub fn apply_replace_repeated_ast_with_max(
     }
   }
   Ok(current)
+}
+
+/// Replace every subexpression structurally equal to `target` with
+/// `replacement`. `None` when `target` occurs nowhere, so the caller can fall
+/// through to the other matching strategies.
+fn replace_literal_subexpr(
+  expr: &Expr,
+  target: &Expr,
+  replacement: &Expr,
+) -> Option<Expr> {
+  let hit = std::cell::Cell::new(false);
+  let result =
+    crate::functions::string_ast::map_expr_tree(expr, &|node: &Expr| {
+      if expr_equal(node, target) {
+        hit.set(true);
+        Some(replacement.clone())
+      } else {
+        None
+      }
+    });
+  hit.get().then_some(result)
 }
 
 /// Check if two Expr values are structurally equal

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -17820,22 +17820,26 @@ fn try_trig_delta(expr: &Expr, var: &str, step: &Expr) -> Option<Expr> {
   let half_delta =
     crate::evaluator::evaluate_expr_to_expr(&half_delta_raw).ok()?;
 
-  // Build second Sin argument:
-  // For Sin: arg + (step + Pi)/2  (= arg + half_delta + Pi/2, combined fraction)
-  // For Cos: arg + (step - Pi)/2
-  // We construct (step ± Pi)/2 as a single fraction, then add arg.
-  let pi_term = if fn_name == "Sin" {
-    Expr::Constant("Pi".to_string())
+  // Build the second Sin argument. The mean of the two arguments is
+  // `arg + half_delta`, so:
+  //   Δ Sin[f] = 2 Sin[d] Cos[f + d]   with d = half_delta
+  //   Δ Cos[f] = -2 Sin[d] Sin[f + d]
+  // Wolfram writes that cosine as `Sin[Pi/2 + …]`, hence the extra half-turn
+  // for `Sin` — `arg + (2*half_delta + Pi)/2` as one combined fraction. `Cos`
+  // is already a sine and takes no phase shift; giving it one turned the
+  // result back into the derivative of the *sine* (`Sin[θ - Pi/2]` is
+  // `-Cos[θ]`, not `-Sin[θ]`).
+  let const_part = if fn_name == "Sin" {
+    div2(
+      plus2(
+        times2(Expr::Integer(2), half_delta.clone()),
+        Expr::Constant("Pi".to_string()),
+      ),
+      Expr::Integer(2),
+    )
   } else {
-    neg1(Expr::Constant("Pi".to_string()))
+    half_delta.clone()
   };
-  // Build (2*half_delta + Pi) / 2  for the constant part, but use direct
-  // (step + Pi) / 2 to get a cleaner fraction when possible.
-  // General form: half_delta + Pi/2 + arg, combined as arg + (2*half_delta ± Pi)/2
-  let const_part = div2(
-    plus2(times2(Expr::Integer(2), half_delta.clone()), pi_term),
-    Expr::Integer(2),
-  );
   let second_arg_expr = plus2(const_part, arg.clone());
 
   let coeff = if fn_name == "Sin" {

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -709,6 +709,16 @@ fn extract_typeset_box(s: &str) -> Option<String> {
     // positional-argument matches below see the box's real arity.
     args.retain(|a| !is_option_arg(a));
     let conv = |a: &str| extract_cell_content(a);
+    // The `⎧` brace a `Piecewise` is typeset with is a `GridBox` holding the
+    // `\[Piecewise]` character beside a `GridBox` of value/condition rows —
+    // reading it as a plain nested list would hand a plot a list where it
+    // expects a function.
+    if head == "GridBox"
+      && let Some(piecewise) =
+        args.first().and_then(|rows| piecewise_from_grid(rows))
+    {
+      return Some(piecewise);
+    }
     return Some(match head {
       // `FractionBox[a, b]` → `(a)/(b)`. The parentheses preserve operator
       // precedence around composite numerators / denominators.
@@ -974,6 +984,121 @@ fn big_operator_head(base: &str) -> Option<&'static str> {
   }
 }
 
+/// The items of a `{a, b, …}` list literal, unwrapped and trimmed.
+fn braced_list_items(s: &str) -> Option<Vec<&str>> {
+  let inner = s.trim().strip_prefix('{')?.strip_suffix('}')?;
+  Some(
+    split_top_level_commas(inner)
+      .into_iter()
+      .map(str::trim)
+      .collect(),
+  )
+}
+
+/// `Piecewise[{{v1, c1}, …}]` from the rows of the `GridBox` a piecewise
+/// function is typeset as: one row holding the `\[Piecewise]` brace beside
+/// an inner `GridBox` of value/condition pairs. The pair tagged
+/// `PiecewiseDefault` is the value outside every condition — Wolfram writes
+/// an unset default as `Null`, which is its own default (`0`) and so is
+/// dropped rather than passed on.
+fn piecewise_from_grid(rows_text: &str) -> Option<String> {
+  let [row] = braced_list_items(rows_text)?[..] else {
+    return None;
+  };
+  let [brace, grid] = braced_list_items(row)?[..] else {
+    return None;
+  };
+  if brace.trim().trim_matches('"').trim() != r"\[Piecewise]" {
+    return None;
+  }
+  let inner = positional_box_args("GridBox", grid)?;
+  let mut pieces = Vec::new();
+  let mut default = None;
+  for pair in braced_list_items(inner.first()?)? {
+    let [value, condition] = braced_list_items(pair)?[..] else {
+      return None;
+    };
+    if condition.contains("PiecewiseDefault") {
+      let value = extract_cell_content(value);
+      if value.trim() != "Null" {
+        default = Some(value);
+      }
+      continue;
+    }
+    pieces.push(format!(
+      "{{{}, {}}}",
+      extract_cell_content(value),
+      extract_cell_content(condition)
+    ));
+  }
+  let pieces = pieces.join(", ");
+  Some(match default {
+    Some(default) => format!("Piecewise[{{{pieces}}}, {default}]"),
+    None => format!("Piecewise[{{{pieces}}}]"),
+  })
+}
+
+/// Is this box the typeset integral sign?
+fn is_integral_sign(s: &str) -> bool {
+  let s = s.trim();
+  let s = s
+    .strip_prefix('"')
+    .and_then(|b| b.strip_suffix('"'))
+    .unwrap_or(s)
+    .trim();
+  s == r"\[Integral]" || s == "\u{222B}"
+}
+
+/// The limits of a typeset integral sign, when `s` is one: `None` for the
+/// indefinite `∫`, `Some((lo, hi))` for the `SubsuperscriptBox["∫", lo, hi]`
+/// a definite integral is written as. `None` for anything that is not an
+/// integral sign at all.
+fn integral_limits(s: &str) -> Option<Option<(String, String)>> {
+  if let Some(args) =
+    positional_box_args("SubsuperscriptBox", s).filter(|a| a.len() == 3)
+  {
+    return is_integral_sign(&args[0]).then(|| {
+      Some((
+        extract_cell_content(&args[1]),
+        extract_cell_content(&args[2]),
+      ))
+    });
+  }
+  is_integral_sign(s).then_some(None)
+}
+
+/// The variable of a `RowBox[{"\[DifferentialD]", x}]` — the typeset `ⅆx`
+/// that closes an integral body and names its integration variable.
+fn differential_variable(s: &str) -> Option<String> {
+  let inner = s.trim().strip_prefix("RowBox[")?.strip_suffix(']')?;
+  let inner = inner.trim().strip_prefix('{')?.strip_suffix('}')?;
+  let args = split_top_level_commas(inner);
+  if args.len() != 2 {
+    return None;
+  }
+  let head = args[0].trim().trim_matches('"').trim();
+  (head == r"\[DifferentialD]" || head == "\u{2146}" || head == "\u{F74C}")
+    .then(|| extract_cell_content(args[1]))
+}
+
+/// Split the boxes that follow an integral sign into the integrand and the
+/// variable of the `ⅆx` that closes them. The FrontEnd normally groups the
+/// whole body in a row of its own, so a single `RowBox` is unwrapped first.
+fn split_integral_body(parts: &[&str]) -> Option<(String, String)> {
+  if let [only] = parts
+    && let Some(inner) = only.trim().strip_prefix("RowBox[")
+    && let Some(inner) = inner.strip_suffix(']')
+    && let Some(inner) = inner.trim().strip_prefix('{')
+    && let Some(inner) = inner.strip_suffix('}')
+  {
+    return split_integral_body(&split_top_level_commas(inner));
+  }
+  let (last, rest) = parts.split_last()?;
+  let var = differential_variable(last)?;
+  let integrand = extract_rowbox_content(&rest.join(","));
+  (!integrand.trim().is_empty()).then_some((integrand, var))
+}
+
 /// Split an iterator underscript (`n=1`) at its top-level `=`, ignoring
 /// the two-character operators that merely end in `=` (`==`, `<=`, …).
 fn split_iterator_assignment(s: &str) -> Option<(&str, &str)> {
@@ -1061,6 +1186,22 @@ fn extract_rowbox_content(s: &str) -> String {
       result.push_str(&format!("{head}[{body}, {iterator}]"));
       break;
     }
+    // The integral sign also takes the rest of the row as its body; the `ⅆx`
+    // that closes the body names the integration variable, and a
+    // `SubsuperscriptBox` sign carries the limits of a definite integral.
+    if i + 1 < parts.len()
+      && let Some(limits) = integral_limits(part)
+      && let Some((integrand, var)) = split_integral_body(&parts[i + 1..])
+    {
+      let iterator = match limits {
+        Some((lo, hi)) => {
+          format!("{{{}, {}, {}}}", var.trim(), lo.trim(), hi.trim())
+        }
+        None => var.trim().to_string(),
+      };
+      result.push_str(&format!("Integrate[{integrand}, {iterator}]"));
+      break;
+    }
     // The partial-derivative operator takes the rest of the row as its
     // operand, the same way a big operator does.
     if i + 1 < parts.len()
@@ -1082,7 +1223,7 @@ fn extract_rowbox_content(s: &str) -> String {
         // to the ASCII operator `>=` the way a bare `"\[GreaterEqual]"`
         // element between two operands does.
         if inner.starts_with("\\\"") {
-          unescape_string(inner)
+          string_literal_source(inner)
         } else {
           unescape_code_string(inner)
         }
@@ -1513,6 +1654,23 @@ fn extract_string_content(s: &str) -> String {
     }
   } else {
     s.to_string()
+  }
+}
+
+/// The cell source for a box element that is itself a quoted string.
+///
+/// Unescaping such an element yields the string's *value*; any quote inside
+/// that value has to be escaped again for the result to read back as a single
+/// literal. A `Plot` legend written as an inline cell — `"\!\(\*Cell[\"f[x]\",
+/// ExpressionUUID->\"…\"]\)"` — otherwise ends its string at the first inner
+/// quote and leaves the rest of the option as stray tokens.
+fn string_literal_source(inner: &str) -> String {
+  let value = unescape_string(inner);
+  match value.strip_prefix('"').and_then(|v| v.strip_suffix('"')) {
+    Some(body) if body.contains('"') => {
+      format!("\"{}\"", body.replace('"', "\\\""))
+    }
+    _ => value,
   }
 }
 
@@ -3903,6 +4061,130 @@ Cell[BoxData["2"], "Output", ExpressionUUID -> "bbb"]
       }
       CellEntry::Single(_) => panic!("Expected cell group"),
     }
+  }
+
+  /// `∫ (1/y) ⅆy == ∫ x ⅆx + c`, the way the "Separable Differential
+  /// Equations" chapter of *Introduction to Calculus* writes it. The
+  /// integral sign takes the rest of its row as the body, and the `ⅆy`
+  /// closing that body names the integration variable.
+  #[test]
+  fn indefinite_integral_boxes_become_integrate() {
+    let nb = r#"Notebook[{
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[Integral]",
+   RowBox[{
+    RowBox[{"(", RowBox[{"1", "/", "y"}], ")"}],
+    RowBox[{"\[DifferentialD]", "y"}]}]}], "\[Equal]",
+  RowBox[{
+   RowBox[{"\[Integral]",
+    RowBox[{"x", RowBox[{"\[DifferentialD]", "x"}]}]}], "+", "c"}]}]], "Input"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    let CellEntry::Single(cell) = &parsed.cells[0] else {
+      panic!("expected a single cell");
+    };
+    assert_eq!(
+      cell.content, "Integrate[(1/y), y]==Integrate[x, x]+c",
+      "the ⅆ-closed integral body must name the integration variable"
+    );
+  }
+
+  /// A definite integral writes its limits on the sign itself:
+  /// `∫_0^2 (x^2 + 1) ⅆx` is `Integrate[x^2 + 1, {x, 0, 2}]`.
+  #[test]
+  fn definite_integral_boxes_carry_their_limits() {
+    let nb = r#"Notebook[{
+Cell[BoxData[
+ RowBox[{
+  SubsuperscriptBox["\[Integral]", "0", "2"],
+  RowBox[{
+   RowBox[{"(", RowBox[{SuperscriptBox["x", "2"], "+", "1"}], ")"}],
+   RowBox[{"\[DifferentialD]", "x"}]}]}]], "Input"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    let CellEntry::Single(cell) = &parsed.cells[0] else {
+      panic!("expected a single cell");
+    };
+    assert_eq!(cell.content, "Integrate[((x)^(2)+1), {x, 0, 2}]");
+  }
+
+  /// Without an integral sign the differential is content of its own:
+  /// `ⅆarea == 2 π r ⅆr` is an equation between differentials, so the
+  /// `ⅆ` has to survive into the cell's source.
+  #[test]
+  fn bare_differential_survives_the_conversion() {
+    let nb = r#"Notebook[{
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[DifferentialD]", "area"}], "==",
+  RowBox[{"2", "\[Pi]", " ", "r", " ",
+   RowBox[{"\[DifferentialD]", "r"}]}]}]], "Input"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    let CellEntry::Single(cell) = &parsed.cells[0] else {
+      panic!("expected a single cell");
+    };
+    assert!(
+      cell.content.matches('\u{F74C}').count() == 2,
+      "both differentials must survive: {}",
+      cell.content
+    );
+  }
+
+  /// The `⎧` brace of a typeset `Piecewise` must come back as a
+  /// `Piecewise[…]` call — `RevolutionPlot3D` of a nested list has no
+  /// function to sample.
+  #[test]
+  fn piecewise_brace_becomes_a_piecewise_call() {
+    let nb = r#"Notebook[{
+Cell[BoxData[
+ RowBox[{"RevolutionPlot3D", "[",
+  RowBox[{
+   TagBox[GridBox[{
+      {"\[Piecewise]", GridBox[{
+         {RowBox[{"f", "[", RowBox[{"x", "+", "6"}], "]"}],
+          RowBox[{RowBox[{"-", "6"}], "<=", "x", "<=", RowBox[{"-", "2"}]}]},
+         {"Null", TagBox["True", "PiecewiseDefault", AutoDelete->True]}
+        }, Selectable->True]}
+     }, Selectable->True], "Piecewise", DeleteWithContents->True], ",",
+   RowBox[{"{", RowBox[{"x", ",", RowBox[{"-", "6"}], ",", "6"}], "}"}]}],
+  "]"}]], "Input"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    let CellEntry::Single(cell) = &parsed.cells[0] else {
+      panic!("expected a single cell");
+    };
+    assert_eq!(
+      cell.content,
+      "RevolutionPlot3D[Piecewise[{{f[x+6], -6<=x<=-2}}],{x,-6,6}]"
+    );
+  }
+
+  /// A `Plot` legend written as an inline cell carries quotes inside its
+  /// string; they have to stay escaped or the option reads as stray tokens.
+  #[test]
+  fn quotes_inside_a_string_literal_stay_escaped() {
+    let nb = r#"Notebook[{
+Cell[BoxData[
+ RowBox[{"Plot", "[",
+  RowBox[{"x", ",",
+   RowBox[{"{", RowBox[{"x", ",", "0", ",", "1"}], "}"}], ",",
+   RowBox[{"PlotLegends", "\[Rule]",
+    RowBox[{"{", "\"\<\!\(\*Cell[\"f[x]\",ExpressionUUID->\"abc\"]\)\>\"", "}"}]}]}],
+  "]"}]], "Input"]
+}]"#;
+    let parsed = parse_notebook(nb).unwrap();
+    let CellEntry::Single(cell) = &parsed.cells[0] else {
+      panic!("expected a single cell");
+    };
+    assert!(
+      cell
+        .content
+        .contains(r#"{"\!\(\*Cell[\"f[x]\",ExpressionUUID->\"abc\"]\)"}"#),
+      "the legend must stay one string literal: {}",
+      cell.content
+    );
   }
 
   #[test]

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3492,6 +3492,32 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
         args: vec![operand].into(),
       }
     }
+    // `ⅆx`: the differential of the following factor. It has no value of its
+    // own — `ⅆarea == 2 π r ⅆr` stays an equation between differentials — and
+    // `∫ … ⅆx` is turned into `Integrate[…, x]` before it reaches the parser.
+    Rule::DifferentialPrefix => {
+      let inners: Vec<_> = pair.into_inner().collect();
+      let mut operand = pair_to_expr(inners[1].clone());
+      for suffix in &inners[2..] {
+        match suffix.as_rule() {
+          Rule::PartIndexSuffix => {
+            operand = apply_part_index_suffix(operand, suffix.clone());
+          }
+          Rule::ImplicitPowerSuffix => {
+            operand = Expr::BinaryOp {
+              op: BinaryOperator::Power,
+              left: Box::new(operand),
+              right: Box::new(implicit_power_exponent(suffix.clone())),
+            };
+          }
+          _ => {}
+        }
+      }
+      Expr::FunctionCall {
+        name: "DifferentialD".to_string(),
+        args: vec![operand].into(),
+      }
+    }
     Rule::Increment => {
       // x++ -> Increment[x]; chained `x++++` -> Increment[Increment[x]].
       // Grammar emits one base pair followed by N `IncrementOp` pairs

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -125,7 +125,7 @@ PatternName = @{ (ASCII_ALPHA | LETTER | PrivateUseLetter) ~ (ASCII_ALPHANUMERIC
 // Matches \[Name] syntax or direct Unicode chars for common symbols
 // Excludes operator named chars (\[Element], \[NotElement], \[ReverseElement], \[DirectedEdge], \[UndirectedEdge])
 // which must be parsed as infix operators, not as identifiers in implicit multiplication.
-NamedCharBase = _{ !("\\[Sqrt]" | "\\[CubeRoot]" | "\\[Element]" | "\\[NotElement]" | "\\[ReverseElement]" | "\\[DirectedEdge]" | "\\[UndirectedEdge]" | "\\[Distributed]" | "\\[Conditioned]" | "\\[Function]" | "\\[Transpose]" | "\\[ConjugateTranspose]" | "\\[Cross]" | "\\[TensorProduct]" | "\\[CircleTimes]" | "\\[CirclePlus]" | "\\[CenterDot]" | "\\[Times]" | "\\[Divide]" | "\\[CircleMinus]" | "\\[Star]" | "\\[Diamond]" | "\\[Backslash]" | "\\[CircleDot]" | "\\[SmallCircle]" | "\\[Wedge]" | "\\[Vee]" | "\\[Cap]" | "\\[Cup]" | "\\[DoubleRightTee]" | "\\[RightTee]" | "\\[DoubleLeftTee]" | "\\[LeftTee]" | "\\[And]" | "\\[Or]" | "\\[Not]" | "\\[Xor]" | "\\[Nand]" | "\\[Nor]" | "\\[Implies]" | "\\[Equivalent]") ~ "\\[" ~ ASCII_ALPHA+ ~ "]" | "\u{20AC}" | "\u{03F5}" | "\u{03C0}" | "\u{212F}" | "\u{2147}" | "\u{00B0}" | "\u{221E}" | "\u{2148}" | "\u{F74D}" | "\u{F74E}" | "\u{F74F}" }
+NamedCharBase = _{ !("\\[DifferentialD]" | "\\[Sqrt]" | "\\[CubeRoot]" | "\\[Element]" | "\\[NotElement]" | "\\[ReverseElement]" | "\\[DirectedEdge]" | "\\[UndirectedEdge]" | "\\[Distributed]" | "\\[Conditioned]" | "\\[Function]" | "\\[Transpose]" | "\\[ConjugateTranspose]" | "\\[Cross]" | "\\[TensorProduct]" | "\\[CircleTimes]" | "\\[CirclePlus]" | "\\[CenterDot]" | "\\[Times]" | "\\[Divide]" | "\\[CircleMinus]" | "\\[Star]" | "\\[Diamond]" | "\\[Backslash]" | "\\[CircleDot]" | "\\[SmallCircle]" | "\\[Wedge]" | "\\[Vee]" | "\\[Cap]" | "\\[Cup]" | "\\[DoubleRightTee]" | "\\[RightTee]" | "\\[DoubleLeftTee]" | "\\[LeftTee]" | "\\[And]" | "\\[Or]" | "\\[Not]" | "\\[Xor]" | "\\[Nand]" | "\\[Nor]" | "\\[Implies]" | "\\[Equivalent]") ~ "\\[" ~ ASCII_ALPHA+ ~ "]" | "\u{20AC}" | "\u{03F5}" | "\u{03C0}" | "\u{212F}" | "\u{2147}" | "\u{00B0}" | "\u{221E}" | "\u{2148}" | "\u{F74D}" | "\u{F74E}" | "\u{F74F}" }
 // Adjacent `\[Name]` segments (or named char + identifier chars)
 // concatenate into a single identifier — `\[CapitalGamma]\[Beta]` → `Γβ`,
 // `\[Angle]XYZ` → `∠XYZ`, `i\[Ellipsis]j` (when `i` then `\[Ellipsis]j`
@@ -528,6 +528,7 @@ Term = _{
   | SlotCall
   | ImplicitTimes
   | RadicalPrefix
+  | DifferentialPrefix
   | Unset
   | ApplyToOp
   | AddTo
@@ -569,6 +570,13 @@ Term = _{
 // `\[Sqrt]x y` is `Sqrt[x] y` but `\[Sqrt]x^2` is `Sqrt[x^2]`.
 RadicalOp = { "\\[Sqrt]" | "\u{221A}" | "\\[CubeRoot]" | "\u{221B}" }
 RadicalPrefix = { RadicalOp ~ SimpleTerm ~ PartIndexSuffix? ~ ImplicitPowerSuffix? ~ FactorialSuffix? }
+// `\[DifferentialD]x` is the differential the calculus notation `ⅆarea == 2 π r ⅆr`
+// is written with: a prefix operator binding to the next factor, so `2 π r ⅆr`
+// is `2 π r DifferentialD[r]`. The FrontEnd stores the character in the private
+// use area (U+F74C); the public code point (U+2146) is a Unicode *letter*, so
+// the prefix has to be tried before `Identifier` or `ⅆarea` reads as one name.
+DifferentialOp = { "\\[DifferentialD]" | "\u{2146}" | "\u{F74C}" }
+DifferentialPrefix = { DifferentialOp ~ SimpleTerm ~ PartIndexSuffix? ~ ImplicitPowerSuffix? }
 PrefixApplySimple = { (FunctionCall | Identifier) ~ "@" ~ SimpleTerm }
 SimpleTerm = _{
   // Increment/Decrement come first so a postfix `++` binds to its operand
@@ -577,6 +585,7 @@ SimpleTerm = _{
     Increment
   | Decrement
   | RadicalPrefix
+  | DifferentialPrefix
   | UnsignedNumericValue
   | PrefixApplySimple
   | FunctionCall
@@ -880,7 +889,13 @@ TopLevelSpan = { &HasSpanSep ~ SpanExpr ~ ("//" ~ PostfixFunction)* }
 // Atomic so the `!";"` lookahead checks the *immediate* next character.
 // Without atomic mode, pest skips WHITESPACE before evaluating `!";"`, which
 // would (wrongly) reject `; ;;3` because the next non-whitespace char is `;`.
-StatementSeparator = @{ (";" ~ !";")? }
+//
+// Several semicolons in a row with only space or a comment between them
+// (`c = 4; (* c = 6 *); c`) separate the same two statements: what stands
+// between them is the empty statement `Null`, which has no value and no
+// effect. They are taken together here rather than left to produce a
+// statement that is not there. `;;` stays untouched — that is a `Span`.
+StatementSeparator = @{ (";" ~ !";" ~ ((WHITESPACE | COMMENT)+ ~ ";" ~ !";")*)? }
 
 // TrailingSemicolon marks that the last statement ends with ; (suppresses output)
 TrailingSemicolon = @{ ";" ~ !";" }

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -12215,6 +12215,22 @@ mod difference_delta {
   }
 
   #[test]
+  fn cos_function() {
+    // Δ Cos[x] = Cos[1 + x] - Cos[x] = -2 Sin[1/2] Sin[1/2 + x]. The sine of
+    // the mean takes no phase shift — adding one (as the Sin case needs to
+    // turn its cosine into a sine) gave back the *sine's* difference instead.
+    assert_eq!(
+      interpret("DifferenceDelta[Cos[x], x]").unwrap(),
+      "-2*Sin[1/2]*Sin[1/2 + x]"
+    );
+    // The derivative it defines has to come out as the cosine's own.
+    assert_eq!(
+      interpret("Limit[DifferenceQuotient[Cos[x], {x, h}], h -> 0]").unwrap(),
+      "-Sin[x]"
+    );
+  }
+
+  #[test]
   fn second_order() {
     // Second-order difference of x^2 is 2
     assert_eq!(interpret("DifferenceDelta[x^2, {x, 2}]").unwrap(), "2");
@@ -16669,5 +16685,39 @@ mod unevaluated_limit_echoes_the_original {
     // result still echoes what was asked.
     let out = interpret("Limit[h[x], x -> Infinity]").unwrap();
     assert_eq!(out, "Limit[h[x], x -> Infinity]");
+  }
+}
+
+mod differential_notation {
+  use super::*;
+
+  /// `ⅆx` is the differential of `x`, the notation the "Linear
+  /// Approximations" chapter states its error estimates in. It has no value
+  /// of its own, so an equation between differentials stays symbolic and a
+  /// rule can replace a whole differential.
+  #[test]
+  fn a_differential_is_a_symbolic_factor() {
+    assert_eq!(
+      interpret(r"\[DifferentialD]area == 2 \[Pi] r \[DifferentialD]r")
+        .unwrap(),
+      "DifferentialD[area] == 2*Pi*r*DifferentialD[r]"
+    );
+    assert_eq!(
+      interpret(
+        r"sol = \[DifferentialD]area == 2 \[Pi] r \[DifferentialD]r; \
+          sol /. {r -> 50, \[DifferentialD]r -> 0.1}"
+      )
+      .unwrap(),
+      "DifferentialD[area] == 31.41592653589793"
+    );
+  }
+
+  /// The bare character a notebook stores it as parses the same way, even
+  /// though Unicode files it under *letters* — `ⅆarea` is a differential,
+  /// not a symbol named "ⅆarea".
+  #[test]
+  fn the_differential_character_is_not_part_of_the_name() {
+    assert_eq!(interpret("\u{2146}area").unwrap(), "DifferentialD[area]");
+    assert_eq!(interpret("\u{F74C}x").unwrap(), "DifferentialD[x]");
   }
 }

--- a/tests/interpreter_tests/patterns.rs
+++ b/tests/interpreter_tests/patterns.rs
@@ -4658,3 +4658,31 @@ mod call_patterns_nested_in_a_list_pattern {
     }
   }
 }
+
+mod literal_left_hand_side {
+  use super::*;
+
+  /// A rule whose left side is a literal call rather than a pattern
+  /// rewrites every subexpression equal to it, brackets and all. The
+  /// "Related Rates" chapter of *Introduction to Calculus* substitutes the
+  /// radius of a cone by half its height; the squared radius used to lose
+  /// its square, so the volume came out one power of `h` short.
+  #[test]
+  fn a_compound_replacement_keeps_its_brackets() {
+    assert_eq!(
+      interpret("v[t] == (Pi r[t]^2 h[t])/3 /. r[t] -> h[t]/2").unwrap(),
+      "v[t] == (Pi*h[t]^3)/12"
+    );
+    assert_eq!(
+      interpret("r[t]^2 /. r[t] -> q[t] + 1").unwrap(),
+      "(1 + q[t])^2"
+    );
+    assert_eq!(interpret("r[t]^2 /. r[t] -> 2 q[t]").unwrap(), "4*q[t]^2");
+  }
+
+  /// Only the subexpressions that really are the left side are rewritten.
+  #[test]
+  fn other_calls_are_left_alone() {
+    assert_eq!(interpret("f[x] + f[y] /. f[x] -> 1").unwrap(), "1 + f[y]");
+  }
+}

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -10436,3 +10436,27 @@ mod precision_mark_with_exponent {
     );
   }
 }
+
+mod empty_statements {
+  use super::*;
+
+  /// A notebook writes a commented-out line as a comment standing alone
+  /// between two `;` — "Calculus and Programming" shows `c = 4;
+  /// (* c = 6 *); c` to explain that a comment is not evaluated. What
+  /// stands between the two separators is the empty statement `Null`.
+  #[test]
+  fn a_comment_between_two_semicolons_is_an_empty_statement() {
+    assert_eq!(interpret("c = 4; (* c = 6 *); c").unwrap(), "4");
+  }
+
+  #[test]
+  fn a_bare_empty_statement_evaluates_to_the_next_one() {
+    assert_eq!(interpret("c = 4; ; c + 1").unwrap(), "5");
+  }
+
+  /// `;;` is still a `Span`, not two separators.
+  #[test]
+  fn a_double_semicolon_stays_a_span() {
+    assert_eq!(interpret("1 ;; 4").unwrap(), "Span[1, 4]");
+  }
+}

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -3128,6 +3128,37 @@ mod tests {
       assert!(!boxes.contains("Derivative"), "head hidden: {boxes}");
     }
 
+    /// StandardForm — what an evaluated cell shows in Woxi Studio — hides
+    /// the `Derivative` head too. Every derivative of an undefined function
+    /// in *Introduction to Calculus* (`D[f[g[x]], x]` → `f′[g[x]] g′[x]`)
+    /// used to read as `Derivative[1][f][g[x]]` there.
+    #[test]
+    fn standard_form_derivative_sets_as_prime_marks() {
+      let boxes = |code: &str| {
+        format!(
+          "{:?}",
+          woxi::evaluator::dispatch::complex_and_special::expr_to_box_form(
+            &woxi::interpret_to_expr(code).expect("eval")
+          )
+        )
+      };
+      let one = boxes("D[f[x], x]");
+      assert!(one.contains('\u{2032}'), "one prime mark: {one}");
+      assert!(one.contains("\"[\""), "square brackets: {one}");
+      assert!(!one.contains("Derivative"), "head hidden: {one}");
+
+      let two = boxes("f''[x]");
+      assert!(two.contains("\u{2032}\u{2032}"), "two prime marks: {two}");
+
+      // Past three the order is spelled out, as is the multivariate order.
+      let fourth = boxes("Derivative[4][f][x]");
+      assert!(fourth.contains("\"4\""), "order shown: {fourth}");
+      assert!(!fourth.contains('\u{2032}'), "no prime marks: {fourth}");
+      let partial = boxes("D[f[x, y], x]");
+      assert!(!partial.contains("Derivative"), "head hidden: {partial}");
+      assert!(partial.contains("\"0\""), "each order shown: {partial}");
+    }
+
     #[test]
     fn high_order_derivative_uses_a_parenthesised_order() {
       // Past three, the marks stop being countable and Wolfram spells the


### PR DESCRIPTION
Opening Wolfram's *Introduction to Calculus* ebook (41 notebooks) in Woxi
Studio and evaluating every Input cell in order found 29 cells across six
notebooks that could not be read or run at all, and one wrong answer. All
of them are fixed; every cell of all 41 notebooks now evaluates.

- `∫ f ⅆx` and `∫_a^b f ⅆx` come back as `Integrate[f, x]` and
  `Integrate[f, {x, a, b}]`. The integral sign takes the rest of its row
  as the body, the way `∑`/`∏` already did, and the `ⅆx` closing that
  body names the variable. The "Separable Differential Equations",
  "Indefinite Integrals" and "Average Value of a Function" chapters are
  written this way throughout.
- `ⅆx` on its own is `DifferentialD[x]`, so the differentials the
  "Linear Approximations" chapter states its error estimates in stay
  symbolic and can be replaced by a rule. The character is a Unicode
  letter, so `ⅆarea` used to read as a single symbol name.
- A typeset `Piecewise` comes back as a `Piecewise[…]` call rather than
  the nested list its `GridBox` looks like, so `RevolutionPlot3D` of one
  has a function to sample.
- A quote inside a cell's string literal stays escaped, so a `Plot`
  legend written as an inline cell stays one string.
- `c = 4; (* c = 6 *); c` evaluates: several `;` with only space or a
  comment between them separate the same two statements. `;;` still
  parses as `Span`.
- `DifferenceDelta[Cos[f], …]`, and so the derivative of the cosine
  defined as a limit of difference quotients, is the cosine's own. The
  sine of the mean was given the half-turn phase shift only the `Sin`
  case needs, which turned the result back into the sine's difference —
  `Limit[DifferenceQuotient[Cos[x], {x, h}], h -> 0]` came out as
  `Cos[x]`, and the quotient itself was numerically wrong.
- Woxi Studio: a derivative sets as prime marks (`f′[x]`, `f″[x]`,
  `f⁽⁴⁾[x]`) in an evaluated cell. `TraditionalForm` already hid the
  `Derivative` head; StandardForm, which a cell's result is typeset
  with, did not.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GYzL51naR1Dc3UCLFZ1nCG