### PR TITLE
Render a bare Dynamic[GraphicsRow[...]] Manipulate display directly

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -21002,6 +21002,18 @@ fn display_expr_to_node(
     }
     // Literal prose in a caption row.
     Expr::String(_) => styled_text_node(expr, bindings),
+    // Releasing a `Dynamic[…]` hold (above) can fully evaluate its content
+    // into an already-rendered graphic rather than a layout container (e.g.
+    // `Dynamic[GraphicsRow[…]]` used directly as a Specifications entry, a
+    // common Demonstrations idiom for a live preview beside the sliders).
+    // Route the SVG straight through instead of falling into the generic
+    // leaf path below, which round-trips through `InputForm` text — and
+    // `Expr::Graphics` has no source form, only the `-Graphics-` /
+    // `-Graphics3D-` display placeholder, which does not re-parse.
+    Expr::Graphics { svg, .. } => DisplayNode::Static {
+      svg: Some(svg.clone()),
+      text: String::new(),
+    },
     _ => static_leaf_node(expr, bindings),
   }
 }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -19640,6 +19640,32 @@ mod manipulate {
     );
   }
 
+  #[test]
+  fn display_bare_dynamic_graphics_row_renders_svg() {
+    // A Demonstrations idiom: a live preview placed directly among the
+    // Specifications (not wrapped in Panel/Grid/…), e.g. a small
+    // `Dynamic[GraphicsRow[{…}]]` shown beside the sliders. Releasing the
+    // `Dynamic` hold fully evaluates the `GraphicsRow` into an
+    // already-rendered graphic rather than a layout container; that must
+    // still surface as SVG, not silently blank out.
+    use woxi::functions::graphics::build_manipulate_display;
+    let code = "Manipulate[r, {r, 0, 1}, \
+      Dynamic[GraphicsRow[{Graphics[Circle[{0, 0}, r]], \
+      Graphics[Disk[{0, 0}, r]]}]]]";
+    let expr = interpret_to_expr(code).unwrap();
+    let spec = extract_manipulate_spec(&expr).unwrap();
+    assert_eq!(spec.displays.len(), 1, "one trailing display element");
+    let bindings = manipulate_initial_bindings(&spec);
+    let tree = build_manipulate_display(&spec.displays[0], &bindings);
+    let DisplayNode::Static { svg, text } = tree else {
+      panic!("expected a Static leaf, got {tree:?}");
+    };
+    assert!(
+      svg.as_deref().is_some_and(|s| s.contains("<svg")),
+      "GraphicsRow display should render SVG, got svg={svg:?} text={text:?}"
+    );
+  }
+
   // ── Buttons, spacers and styled prose in a Dynamic caption ──
 
   /// A Demonstration-style caption: two stepping buttons, spacers and a


### PR DESCRIPTION
## Summary

- Fixes a rendering bug found while checking Woxi Studio's compatibility against a randomly-sampled Wolfram Demonstration ("Visualizing the Poisson Kernel"): a `Manipulate` display item that is a bare graphics expression — not wrapped in `Panel`/`Grid`/`Column`/… — e.g. `Dynamic[GraphicsRow[{...}]]` used directly as a `Specifications` entry, a common Demonstrations idiom for a small live preview shown beside the sliders, rendered as a blank panel instead of the graphic.
- Root cause: releasing the `Dynamic` hold fully evaluates such content into an already-rendered `Expr::Graphics` rather than a layout container. That fell through to the generic leaf handler, which round-trips the expression through `InputForm` text to re-evaluate it — but `Expr::Graphics` has no source form, only the `-Graphics-` / `-Graphics3D-` display placeholder, so the re-parse failed and the display silently blanked out.
- Fix: handle `Expr::Graphics` directly in `display_expr_to_node`, using its already-rendered SVG instead of round-tripping through text.
- This is a general fix (not specific to any one Demonstration) — any Manipulate with a bare graphics `Dynamic[...]` display item is affected.

## Test plan

- [x] Added a regression unit test (`display_bare_dynamic_graphics_row_renders_svg` in `tests/interpreter_tests/graphics.rs`) reproducing the bug with a minimal `Dynamic[GraphicsRow[{...}]]` display.
- [x] Verified against the downloaded Demonstration notebook via `woxi-studio`'s `dump_manipulate` example: the preview display now renders real SVG instead of an empty `Static` node.
- [x] `make test` — all 26,833 tests pass.
- [x] `make test-studio` — all 115 woxi-studio tests pass.
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01QKxyDZk3pDyPjbGXKzsn23

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKxyDZk3pDyPjbGXKzsn23)_