### PR TITLE
Let Point accept trailing options like Line and Polygon

### DIFF
--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -1083,7 +1083,14 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "PolygonCoordinates" => Some((1, 1)),
     "Plot" => Some((2, usize::MAX)),
     "Pochhammer" => Some((2, 2)),
-    "Point" => Some((1, 1)),
+    // Unrestricted, like the other graphics primitive heads (`Line`,
+    // `Polygon`, `Arrow`, …) that also carry no entry here: a Demonstrations
+    // idiom applies a control-variable head directly to a point list plus a
+    // trailing option, e.g. `renderMode[pts, VertexNormals -> Automatic]`
+    // where `renderMode` may be bound to `Point`. Graphics/Graphics3D parsing
+    // already reads only the first argument and ignores the rest, so `Point`
+    // must accept them the same way instead of raising a spurious argx
+    // message and staying unevaluated.
     "PoissonDistribution" => Some((1, 1)),
     "PoissonProcess" => Some((1, 1)),
     "PolarPlot" => Some((2, usize::MAX)),

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -2624,6 +2624,80 @@ mod plot3d {
       ));
     }
 
+    /// `Point`, like the other graphics-primitive heads (`Line`, `Polygon`,
+    /// `Arrow`, …), carries no built-in downvalue restricting its arity, so
+    /// a trailing option such as `VertexNormals -> Automatic` (harmless —
+    /// only `Polygon`/`Line` meshes actually use it) must pass straight
+    /// through instead of tripping a spurious `Point::argx` message and
+    /// leaving the call unevaluated. Regression for a bug found while
+    /// checking a `Manipulate` control variable that binds `Point` and
+    /// applies it as `renderMode[pts, VertexNormals -> Automatic]`.
+    #[test]
+    fn point_accepts_trailing_options_like_line_and_polygon() {
+      assert_eq!(
+        interpret("Point[{1, 2, 3}, VertexNormals -> Automatic]").unwrap(),
+        "Point[{1, 2, 3}, VertexNormals -> Automatic]"
+      );
+      // The plain single-argument form still works unchanged.
+      assert_eq!(interpret("Point[{1, 2, 3}]").unwrap(), "Point[{1, 2, 3}]");
+    }
+
+    /// A `Manipulate`/`Control` variable can be bound to a graphics-primitive
+    /// head symbol (`Line`, `Point`, or `Polygon`) and applied directly as a
+    /// function head — the pattern the Demonstrations site uses to let one
+    /// popup menu switch how a mesh renders: `Polygon[pts_] :> If[render ===
+    /// Point, Point[Apply[Join, pts], …], render[pts, …]]`. Covers `/.`
+    /// dispatching to a dynamically bound head for all three choices.
+    #[test]
+    fn replace_all_applies_dynamically_bound_head_symbol() {
+      let rule = "Polygon[pts_] :> If[render === Point, \
+        Point[Apply[Join, pts], VertexNormals -> Automatic], \
+        render[pts, VertexNormals -> Automatic]]";
+      let poly = "Polygon[{{1, 2}, {3, 4}}]";
+
+      assert_eq!(
+        interpret(&format!(
+          "Block[{{render = Line}}, ReplaceAll[{poly}, {rule}]]"
+        ))
+        .unwrap(),
+        "Line[{{1, 2}, {3, 4}}, VertexNormals -> Automatic]"
+      );
+      assert_eq!(
+        interpret(&format!(
+          "Block[{{render = Polygon}}, ReplaceAll[{poly}, {rule}]]"
+        ))
+        .unwrap(),
+        "Polygon[{{1, 2}, {3, 4}}, VertexNormals -> Automatic]"
+      );
+      // The `render === Point` branch additionally flattens the point-lists
+      // with `Apply[Join, pts]` before handing them to `Point`.
+      assert_eq!(
+        interpret(&format!(
+          "Block[{{render = Point}}, ReplaceAll[{poly}, {rule}]]"
+        ))
+        .unwrap(),
+        "Point[{1, 2, 3, 4}, VertexNormals -> Automatic]"
+      );
+    }
+
+    /// End-to-end regression for the same idiom rendered through
+    /// `Graphics3D`/`Show`/`SphericalRegion`: a small hand-built polygon
+    /// mesh redirected to `Point` rendering must still produce real SVG
+    /// point markers, not an empty picture.
+    #[test]
+    fn manipulate_style_polygon_to_point_redirect_renders_svg() {
+      let svg = export_svg(
+        "Show[Graphics3D[Polygon[{{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}}, \
+         {{0, 0, 0}, {1, 0, 0}, {0, 0, 1}}}]] /. \
+         Polygon[pts_] :> Point[Apply[Join, pts], VertexNormals -> Automatic], \
+         SphericalRegion -> True]",
+      );
+      assert!(
+        svg.contains("<circle"),
+        "expected rendered point markers: {svg}"
+      );
+    }
+
     /// The unbounded primitives — `InfiniteLine`, `HalfLine`,
     /// `InfinitePlane`, `HalfPlane` — show the part of themselves that
     /// falls inside the picture's box. They used to draw nothing at all in


### PR DESCRIPTION
## Summary

Found and fixed while validating Woxi Studio's `Manipulate` support against a Wolfram Demonstrations Project notebook (not included in this repo). The demonstration's core construct is a control variable that holds one of the graphics-primitive head symbols `Line`, `Point`, or `Polygon`, applied directly as a dynamic function head over a point list plus a trailing option:

```
renderMode[pts, VertexNormals -> Automatic]
```

- `Point` was the only graphics-primitive head with an arity of exactly 1 enforced in the evaluator's argument-count table (`get_arg_count_range`). `Line`, `Polygon`, `Arrow`, etc. carry no such entry and already accept (and ignore) trailing option arguments, since `Graphics`/`Graphics3D` primitive parsing only ever reads the first argument.
- When the control variable was bound to `Point`, Woxi raised a spurious `Point::argx` message and left the call unevaluated instead of passing the option through like its sibling primitives — so `Point`-mode rendering came out blank instead of drawing the mesh's vertices.

## Fix

- Removed the `(1, 1)` restriction on `"Point"` in `src/evaluator/dispatch/arg_count.rs`, making it unrestricted like `Line`/`Polygon`/`Arrow` (no entry in the table at all — the single canonical arity-checking path).
- Added regression tests in `tests/interpreter_tests/graphics.rs`:
  - `point_accepts_trailing_options_like_line_and_polygon` — the bare bug repro.
  - `replace_all_applies_dynamically_bound_head_symbol` — the `ReplaceAll`-with-dynamically-bound-head idiom for all three choices (`Line`/`Point`/`Polygon`).
  - `manipulate_style_polygon_to_point_redirect_renders_svg` — end-to-end `Graphics3D`/`Show`/`SphericalRegion` render, asserting real `<circle>` markers are drawn.

Verified manually (with small original synthetic test snippets, no verbatim code from the source notebook) that the rest of the notebook's constructs — dynamic-head dispatch via `Block`, `Apply[Join, pts]`, `VertexNormals -> Automatic` as an inert option, `SphericalRegion -> True`, `Manipulate` discrete controls whose choices are bare graphics-primitive symbols, and the Woxi Studio `dump_manipulate` → SVG render pipeline (via `woxi-studio/examples/dump_manipulate.rs`) — were already working correctly before this fix; this was the one genuine gap found.

## Test plan

- [x] `make test` — 26835 tests passed, 0 failed
- [x] `make format` — no additional changes
- [x] Manually verified via `cargo run -- eval` and `woxi-studio`'s `dump_manipulate` example against small hand-built synthetic notebooks/snippets exercising the same constructs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT7d8NvMPCZ5mjGHdFA9Z6


---
_Generated by [Claude Code](https://claude.ai/code/session_01CT7d8NvMPCZ5mjGHdFA9Z6)_