### PR TITLE
Apply LabelStyle to Plot/Show frame, axes, and title text

### DIFF
--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -208,6 +208,46 @@ fn text_wrapper_content(expr: &Expr) -> Option<&Expr> {
   }
 }
 
+/// Extract the bold/italic flags, color, and font size from a list of style
+/// directives — `Style[…]`'s trailing arguments, `Directive[…]`'s arguments,
+/// or a bare `LabelStyle -> {…}` list, all of which share this shape.
+pub(crate) fn parse_style_directive_args(
+  args: &[Expr],
+) -> (bool, bool, Option<Color>, Option<f64>) {
+  let mut bold = false;
+  let mut italic = false;
+  let mut color = None;
+  let mut font_size = None;
+  for arg in args {
+    match arg {
+      Expr::Identifier(s) if s == "Bold" => bold = true,
+      Expr::Identifier(s) if s == "Italic" => italic = true,
+      _ => {
+        if let Some(c) = parse_color(arg) {
+          color = Some(c);
+        } else if let Some(f) = try_eval_to_f64(arg) {
+          font_size = Some(f);
+        }
+      }
+    }
+  }
+  (bold, italic, color, font_size)
+}
+
+/// Parse a `LabelStyle -> …` option value into a text color and font size.
+/// Accepts a single style item (`Black`, `17`, `Directive[…]`) or a list of
+/// them (`{17, Black}`) — the same shapes `Style[…]`'s trailing arguments
+/// take.
+pub(crate) fn parse_label_style(expr: &Expr) -> (Option<Color>, Option<f64>) {
+  let items: Vec<Expr> = match expr {
+    Expr::List(items) => items.to_vec(),
+    Expr::FunctionCall { name, args } if name == "Directive" => args.to_vec(),
+    other => vec![other.clone()],
+  };
+  let (_, _, color, font_size) = parse_style_directive_args(&items);
+  (color, font_size)
+}
+
 /// Parse a plain string or `Style["text", Bold, Italic, color, size]` into a `StyledLabel`.
 pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
   // `Text[…]` sets its content in the graphic's own text style, so the font
@@ -290,23 +330,8 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
           (svg_markup_visible_text(&markup), Some(markup))
         }
       };
-      let mut bold = false;
-      let mut italic = false;
-      let mut color = None;
-      let mut font_size = None;
-      for arg in &args[1..] {
-        match arg {
-          Expr::Identifier(s) if s == "Bold" => bold = true,
-          Expr::Identifier(s) if s == "Italic" => italic = true,
-          _ => {
-            if let Some(c) = parse_color(arg) {
-              color = Some(c);
-            } else if let Some(f) = try_eval_to_f64(arg) {
-              font_size = Some(f);
-            }
-          }
-        }
-      }
+      let (bold, italic, color, font_size) =
+        parse_style_directive_args(&args[1..]);
       Some(StyledLabel {
         text,
         markup,

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -4,7 +4,7 @@ use plotters::prelude::{Color, *};
 use super::*;
 use crate::evaluator::evaluate_expr_to_expr;
 use crate::functions::chart::{
-  ChartLabel, ChartOptions, LabelPosition, StyledLabel,
+  ChartLabel, ChartOptions, LabelPosition, StyledLabel, parse_label_style,
 };
 use crate::functions::graphics::{Color as WoxiColor, parse_color};
 use crate::functions::math_ast::try_eval_to_f64;
@@ -1866,6 +1866,17 @@ pub(crate) struct PlotOptions {
   /// `PlotMarkers -> …`: the glyph each series' points are drawn with,
   /// cycled over the series. Empty = plain round points.
   pub plot_markers: Vec<Option<PlotMarker>>,
+  /// `LabelStyle -> …`: font size / color applied to the `FrameLabel`,
+  /// `AxesLabel`, and `PlotLabel` text. `None` keeps the theme default.
+  pub label_style: Option<LabelStyleSpec>,
+}
+
+/// Font size / color parsed from a `LabelStyle -> …` option. Either field
+/// may be absent — an unset one keeps the theme default for that property.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct LabelStyleSpec {
+  pub color: Option<WoxiColor>,
+  pub font_size: Option<f64>,
 }
 
 impl Default for PlotOptions {
@@ -1914,6 +1925,7 @@ impl Default for PlotOptions {
       image_padding: None,
       aspect_ratio: None,
       plot_markers: Vec::new(),
+      label_style: None,
     }
   }
 }
@@ -2330,8 +2342,21 @@ pub(crate) fn plot_labels_svg(
   title_default_fill: &str,
 ) -> String {
   let axis_y = margin_top + plot_h;
-  let font_size = sf * 14.0;
-  let title_font_size = sf * 17.0;
+  // `LabelStyle` overrides the frame/axes/title text's default size and
+  // color; either half may be absent, in which case that property keeps
+  // the theme default.
+  let label_style_font_size = opts.label_style.and_then(|s| s.font_size);
+  let label_style_color = opts.label_style.and_then(|s| s.color);
+  let font_size = label_style_font_size.map_or(sf * 14.0, |pt| sf * pt);
+  let title_font_size = label_style_font_size.map_or(sf * 17.0, |pt| sf * pt);
+  let label_fill_owned =
+    label_style_color.map(super::graphics::Color::to_svg_rgb);
+  let label_fill = label_fill_owned.as_deref().unwrap_or(label_fill);
+  let title_default_fill_owned =
+    label_style_color.map(super::graphics::Color::to_svg_rgb);
+  let title_default_fill = title_default_fill_owned
+    .as_deref()
+    .unwrap_or(title_default_fill);
   let has_top_label =
     opts.frame_label_top.as_ref().is_some_and(|t| !t.is_empty());
   let axes_label_y = opts
@@ -8208,6 +8233,14 @@ pub(crate) fn apply_common_plot_option(
       plot_opts.image_padding = parse_image_padding(replacement);
     }
     "FrameLabel" => apply_frame_label_option(replacement, plot_opts),
+    "LabelStyle" => {
+      let val = evaluate_expr_to_expr(replacement)
+        .unwrap_or_else(|_| replacement.clone());
+      let (color, font_size) = parse_label_style(&val);
+      if color.is_some() || font_size.is_some() {
+        plot_opts.label_style = Some(LabelStyleSpec { color, font_size });
+      }
+    }
     "Ticks" => match replacement {
       Expr::Identifier(s) if s == "None" => plot_opts.ticks = false,
       Expr::Identifier(s) if s == "Automatic" || s == "All" => {

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1404,6 +1404,54 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_plot_label_style_sets_frame_label_size_and_color() {
+    // LabelStyle -> {size, color} must restyle the FrameLabel/AxesLabel/
+    // PlotLabel text; it used to be accepted and silently dropped, so a
+    // Demonstration asking for large, high-contrast labels rendered them at
+    // the default small gray size instead.
+    clear_state();
+    let plain = interpret(
+      "ExportString[Plot[Sin[x], {x, 0, 2 Pi}, \
+         FrameLabel -> {\"t\", \"y\"}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      !plain.contains("fill=\"rgb(255,0,0)\""),
+      "an unstyled frame label must not already be red"
+    );
+
+    clear_state();
+    let styled = interpret(
+      "ExportString[Plot[Sin[x], {x, 0, 2 Pi}, \
+         FrameLabel -> {\"t\", \"y\"}, LabelStyle -> {20, Red}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      styled.contains("font-size=\"200\""),
+      "LabelStyle size 20 must scale to font-size 200 at the default 10x \
+       render scale: {styled}"
+    );
+    assert!(
+      styled.contains("fill=\"rgb(255,0,0)\""),
+      "LabelStyle color Red must reach the frame label: {styled}"
+    );
+
+    // The same option reaches a Plot wrapped in Show, the way a
+    // Demonstration typically applies it to a Which-selected sub-plot.
+    clear_state();
+    let via_show = interpret(
+      "ExportString[Show[Plot[Sin[x], {x, 0, 2 Pi}, \
+         FrameLabel -> {\"t\", \"y\"}], LabelStyle -> {20, Red}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      via_show.contains("font-size=\"200\"")
+        && via_show.contains("fill=\"rgb(255,0,0)\""),
+      "LabelStyle applied via Show must still restyle the frame label: {via_show}"
+    );
+  }
+
+  #[test]
   fn test_audio_missing_file_still_renders_player_chrome() {
     // A file-backed Audio whose file cannot be read (missing here; any local
     // path in the browser playground) still renders the player chrome: the

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -14826,4 +14826,114 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`ctrl1$$ = 1}, \"\\[Ellipsis]\"]"], 
       other => panic!("expected waveT0 as a Continuous control: {other:?}"),
     }
   }
+
+  /// Checked a randomly-sampled Wolfram Demonstrations Project notebook (a
+  /// diffusion-driven release-profile visualizer) against Woxi Studio's
+  /// Manipulate pipeline. Its shape: a `Setter` swaps between two `Plot`s
+  /// selected by `Which`, a `RadioButtonBar` picks a discrete rate
+  /// multiplier consumed by another `Which`, a `PaneSelector` shows a
+  /// labeled `Slider` only on one of the two panes, an `Animator` drives
+  /// elapsed time, and the body's helper functions lean on `Quiet[Sum[...
+  /// Exp[...]]]` truncated-series formulas feeding `Plot`s styled with
+  /// `PlotTheme`, dashed `PlotStyle`, `LabelStyle`, `FrameLabel`, `Filling`/
+  /// `FillingStyle`, wrapped in a `Show` with `Frame`, `LabelStyle`,
+  /// `ImageSize`, and `AspectRatio -> Full`.
+  ///
+  /// This is a self-authored, construct-equivalent example (a made-up
+  /// "signal attenuation" scenario) — not the notebook's own code, data, or
+  /// wording, which is copyrighted. It doubles as a regression test for the
+  /// `LabelStyle` option, which used to be silently dropped by `Plot`.
+  #[test]
+  fn attenuation_manipulate_switches_panes_and_honors_label_style() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[ \
+         Module[{rateB, envFn, spatialFn, curve1, curve2}, \
+           rateB = Which[bankPick == 1, 0.5, bankPick == 2, 1, bankPick == 3, 2]; \
+           envFn[r_, k_, t_] := Quiet[100 Exp[-t (k Pi/r)^2]]; \
+           spatialFn[r_, x_, t_] := Quiet[If[t < 0.01, 100, \
+             100 (2/Pi) Sum[((-1)^(m + 1)/m) Sin[m Pi x/r] Exp[-t (m Pi/r)^2], {m, 40}]]]; \
+           curve1 = Plot[{envFn[lenA, 4, elapsed], envFn[lenA, rateB, elapsed]}, \
+             {elapsed, 0, 30}, PlotTheme -> \"Detailed\", \
+             PlotStyle -> {{Gray, Thick}, {Orange, Thick, Dashed}}, \
+             LabelStyle -> {17, Black}, PlotLegends -> False, \
+             FrameLabel -> {\"elapsed (s)\", \"signal (%)\"}]; \
+           curve2 = Plot[spatialFn[lenA, xPos, 0.05], {xPos, 0, lenA}, \
+             PlotTheme -> \"Detailed\", PlotStyle -> {Gray, Thick}, \
+             Filling -> Axis, FillingStyle -> Directive[Opacity[0.25]], \
+             FrameLabel -> {\"position\", \"signal (%)\"}]; \
+           Show[Which[viewPick == 1, curve1, viewPick == 2, curve2], \
+             Frame -> True, LabelStyle -> {17, Black}, \
+             ImageSize -> {600, 360}, AspectRatio -> Full] \
+         ], \
+         Control[{{viewPick, 1}, {1 -> \"vs time\", 2 -> \"vs position\"}, Setter}], \
+         {{bankPick, 2}, {1 -> \"low\", 2 -> \"mid\", 3 -> \"high\"}, \
+          ControlType -> RadioButtonBar}, \
+         {{elapsed, 0, \"elapsed (s)\"}, 0, 30, 0.5, \
+          ControlType -> Animator, AnimationRunning -> False}, \
+         PaneSelector[{1 -> Control[{{lenA, 5, \"length A\"}, 1, 10, 0.5, \
+           ControlType -> Slider, Appearance -> \"Labeled\"}], 2 -> \" \"}, \
+           viewPick]]",
+    )
+    .expect("the Manipulate source must parse and evaluate");
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("the Manipulate must build a widget");
+
+    assert!(
+      state.error.is_none(),
+      "initial body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the initial Which branch (curve1) must render a graphic"
+    );
+    let names: Vec<&str> = state.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, vec!["viewPick", "bankPick", "elapsed", "lenA"]);
+
+    // viewPick starts at 1 ("vs time"): the PaneSelector shows lenA's row;
+    // the always-visible bankPick/elapsed rows show regardless.
+    assert_eq!(
+      state.control_is_visible,
+      vec![true, true, true, true],
+      "pane 1 must show the length slider too"
+    );
+
+    // Switching the Setter to "vs position" swaps both the selected curve
+    // and the PaneSelector's visible row.
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[0]
+    {
+      *current_index = 1;
+    }
+    state.reevaluate();
+    assert_eq!(
+      state.control_is_visible,
+      vec![true, true, true, false],
+      "pane 2 must hide the length slider"
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the second Which branch (curve2) must also render"
+    );
+
+    // The body's own text — not just Woxi Studio's live widget — must
+    // reflect the LabelStyle fix: FrameLabel text drawn at the requested
+    // size/color rather than silently defaulting to the theme's small gray.
+    let render_code = format!(
+      "viewPick = 1; bankPick = 2; elapsed = 12; lenA = 5;\n{}",
+      state.body
+    );
+    let render = woxi::interpret_with_stdout(&render_code)
+      .expect("the extracted body must re-render standalone");
+    let svg = render.graphics.expect("Show[...] must produce a graphic");
+    assert!(
+      svg.contains("font-size=\"170\""),
+      "LabelStyle size 17 must scale to font-size 170 at the default 10x \
+       render scale: {svg}"
+    );
+    assert!(
+      svg.contains("fill=\"rgb(0,0,0)\""),
+      "LabelStyle color Black must reach the frame label: {svg}"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Checked a randomly-sampled Wolfram Demonstrations Project notebook (a diffusion-driven release-profile visualizer) against Woxi Studio's Manipulate pipeline.

Its `Plot` calls set `LabelStyle -> {17, Black}` for legible frame labels, but the option was silently dropped: `FrameLabel`/`AxesLabel`/`PlotLabel` text always rendered at the theme's small gray default regardless of the requested size or color — whether `LabelStyle` was passed directly to `Plot` or via `Show` wrapping a `Plot` result.

- Factored the color/font-size extraction already used by `Style["text", ...]` into a shared `parse_style_directive_args` helper (avoids a second implementation) and reused it for `LabelStyle -> ...` via a new `parse_label_style`.
- Applied the parsed size/color in `plot_labels_svg`, the shared label renderer for the line/scatter plot family, so `FrameLabel`, `AxesLabel`, and `PlotLabel` text all honor it.
- Everything else checked against this notebook — `Manipulate` with `Setter`/`RadioButtonBar`/labeled `Slider`/`Animator` controls, `PaneSelector` pane switching, `DynamicModule`/`Module`, `Sum`/`Exp`/`Sin`/`Which`/`Quiet`, `PlotTheme`, dashed `PlotStyle`, `Filling`/`FillingStyle`, and `AspectRatio -> Full` applied via `Show` — already worked correctly.

## Test plan

- [x] Added `test_plot_label_style_sets_frame_label_size_and_color` (`tests/interpreter_tests.rs`): verifies `LabelStyle -> {size, color}` restyles the frame label both applied directly to `Plot` and via `Show[Plot[...], LabelStyle -> ...]`.
- [x] Added a self-authored, construct-equivalent regression test `attenuation_manipulate_switches_panes_and_honors_label_style` (`woxi-studio/src/main.rs`) — a made-up "signal attenuation" scenario, not the source notebook's own code or wording, which is copyrighted. It exercises a `Setter` swapping between two `Which`-selected `Plot`s, a `RadioButtonBar` picking a discrete rate multiplier, a `PaneSelector` showing a labeled `Slider` on only one of two panes, an `Animator` driving elapsed time, and `Quiet[Sum[...Exp[...]]]` helpers feeding `Plot`s styled with `PlotTheme`/dashed `PlotStyle`/`LabelStyle`/`FrameLabel`/`Filling`, wrapped in a `Show` with `Frame`/`LabelStyle`/`ImageSize`/`AspectRatio -> Full`.
- [x] `make test` — 26,891 tests passed, 0 failed.
- [x] `make format`.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01HZgp9aCWN3iqgQwEvWomiK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZgp9aCWN3iqgQwEvWomiK)_