### PR TITLE
Fix slow InterpolatingFunction derivatives in NDSolve-driven phase portraits

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -4196,11 +4196,25 @@ pub fn evaluate_interpolating_function(
   let (start, end) = lagrange_window(n, idx, eff_order);
 
   // `f'` differentiates the local polynomial piece, so the derivative is
-  // exact wherever the interpolation itself is.
+  // exact wherever the interpolation itself is. Exact data and an exact
+  // query point take the symbolic route to preserve exactness; anything
+  // else (machine-precision NDSolve output, the common case) takes the
+  // fast numeric route so sampling a phase portrait's velocity stays cheap.
   if derivative_order > 0 {
-    return interpolating_derivative_value(
+    if is_exact_number(&x_val_expr)
+      && let Some(exact) = interpolating_derivative_value_exact(
+        data_points,
+        &x_val_expr,
+        start,
+        end,
+        derivative_order,
+      )?
+    {
+      return Ok(exact);
+    }
+    return interpolating_derivative_value_numeric(
       data_points,
-      &x_val_expr,
+      x_val,
       start,
       end,
       derivative_order,
@@ -4512,20 +4526,20 @@ fn lagrange_interpolate_exact(
 }
 
 /// The `derivative_order`-th derivative of the local polynomial piece,
-/// evaluated at `x`. Exact data and an exact point give an exact derivative.
-fn interpolating_derivative_value(
+/// evaluated at `x`, carried out in exact arithmetic. Returns `None` when a
+/// coordinate in the stencil (or `x` itself) is not an exact number, leaving
+/// [`interpolating_derivative_value_numeric`] to handle it.
+fn interpolating_derivative_value_exact(
   data_points: &[Expr],
   x: &Expr,
   start: usize,
   end: usize,
   derivative_order: usize,
-) -> Result<Expr, InterpreterError> {
+) -> Result<Option<Expr>, InterpreterError> {
   let var = Expr::Identifier("\u{2620}ifderiv\u{2620}".to_string());
-  let Some(poly) = lagrange_polynomial(data_points, &var, start, end, false)
+  let Some(poly) = lagrange_polynomial(data_points, &var, start, end, true)
   else {
-    return Err(InterpreterError::EvaluationError(
-      "InterpolatingFunction: invalid data point format".into(),
-    ));
+    return Ok(None);
   };
   let mut expr = crate::evaluator::evaluate_expr_to_expr(&poly)?;
   for _ in 0..derivative_order {
@@ -4536,7 +4550,77 @@ fn interpolating_derivative_value(
   }
   let substituted =
     crate::syntax::substitute_variable(&expr, "\u{2620}ifderiv\u{2620}", x);
-  crate::evaluator::evaluate_expr_to_expr(&substituted)
+  Ok(Some(crate::evaluator::evaluate_expr_to_expr(&substituted)?))
+}
+
+/// The `derivative_order`-th derivative of the local polynomial piece,
+/// evaluated at `x_val`, computed directly in machine arithmetic (Newton
+/// divided differences expanded to monomial coefficients, then
+/// differentiated and evaluated by Horner's method).
+///
+/// This is the hot path for `f'[t]`/`f''[t]` on an `NDSolve`-produced
+/// `InterpolatingFunction` — e.g. sampling a phase portrait's velocity
+/// alongside its position. Building and simplifying a symbolic Lagrange
+/// polynomial through the general evaluator for every sample point (the
+/// exact-arithmetic path above) is thousands of times slower and turns a
+/// `Manipulate` slider drag into a multi-second stall, so machine-precision
+/// data — the overwhelmingly common case — never takes that path.
+fn interpolating_derivative_value_numeric(
+  data_points: &[Expr],
+  x_val: f64,
+  start: usize,
+  end: usize,
+  derivative_order: usize,
+) -> Result<Expr, InterpreterError> {
+  let mut xs = Vec::with_capacity(end - start);
+  let mut coeffs = Vec::with_capacity(end - start);
+  for pt in &data_points[start..end] {
+    let (x, y) = extract_point(pt)?;
+    xs.push(x);
+    coeffs.push(y);
+  }
+  let m = xs.len();
+
+  // Newton divided differences: coeffs[k] becomes f[x_0, ..., x_k].
+  for j in 1..m {
+    for i in (j..m).rev() {
+      coeffs[i] = (coeffs[i] - coeffs[i - 1]) / (xs[i] - xs[i - j]);
+    }
+  }
+
+  // Expand the nested Newton form
+  // c[0] + (x-x0)(c[1] + (x-x1)(c[2] + ...))
+  // into ascending-power monomial coefficients, via repeated polynomial
+  // multiplication by (x - x_k) — cheap since m is a handful of points.
+  let mut monomial = vec![coeffs[m - 1]];
+  for k in (0..m - 1).rev() {
+    // monomial *= (x - xs[k])
+    let mut shifted = vec![0.0; monomial.len() + 1];
+    for (i, c) in monomial.iter().enumerate() {
+      shifted[i + 1] += c;
+      shifted[i] -= c * xs[k];
+    }
+    monomial = shifted;
+    // monomial += coeffs[k] (constant term)
+    monomial[0] += coeffs[k];
+  }
+
+  if derivative_order >= monomial.len() {
+    return Ok(Expr::Real(0.0));
+  }
+  // Differentiate `derivative_order` times: term c*x^p -> c*p*x^(p-1).
+  for _ in 0..derivative_order {
+    monomial = monomial
+      .iter()
+      .enumerate()
+      .skip(1)
+      .map(|(p, c)| c * p as f64)
+      .collect();
+  }
+
+  // Horner evaluation of the (now differentiated) monomial polynomial.
+  let value = monomial.iter().rev().fold(0.0, |acc, c| acc * x_val + c);
+  Ok(Expr::Real(value))
 }
 
 /// Lagrange polynomial interpolation using (order+1) nearest points.

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7366,6 +7366,64 @@ mod ndsolve {
     );
   }
 
+  /// `f'`/`f''` on machine-precision interpolation data takes a fast
+  /// numeric path (Newton divided differences expanded to monomial
+  /// coefficients) rather than building and simplifying a symbolic
+  /// Lagrange polynomial through the general evaluator — the latter turned
+  /// every sample in an adaptively-plotted phase portrait into a
+  /// multi-millisecond symbolic evaluation. The data here is exactly `x^2`
+  /// (`f = x^2`, `f' = 2x`, `f'' = 2`), including a query exactly at a grid
+  /// node — the classic singularity for a naive log-derivative Lagrange
+  /// formula — to guard the replacement algorithm's correctness there too.
+  #[test]
+  fn interpolation_derivative_numeric_path_matches_analytic_derivative() {
+    let result = interpret(
+      "f = Interpolation[{{0., 0.}, {1., 1.}, {2., 4.}, {3., 9.}}]; \
+       {f[1.5], f'[1.5], f''[1.5], f[1.0], f'[1.0], f''[1.0]}",
+    )
+    .unwrap();
+    let nums: Vec<f64> = result
+      .trim_matches(['{', '}'])
+      .split(", ")
+      .map(|s| s.parse().expect("all entries are numbers"))
+      .collect();
+    let expected = [2.25, 3.0, 2.0, 1.0, 2.0, 2.0];
+    for (got, want) in nums.iter().zip(expected.iter()) {
+      assert!(
+        (got - want).abs() < 1e-9,
+        "expected {expected:?}, got {result}"
+      );
+    }
+  }
+
+  /// A derivative order at or beyond the local interpolating polynomial's
+  /// degree is exactly zero, not a numerical artifact from over-differentiating
+  /// the expanded monomial coefficients.
+  #[test]
+  fn interpolation_derivative_beyond_polynomial_degree_is_zero() {
+    assert_eq!(
+      interpret(
+        "f = Interpolation[{{0., 0.}, {1., 1.}, {2., 4.}, {3., 9.}}]; \
+         Derivative[3][f][1.5]"
+      )
+      .unwrap(),
+      "0."
+    );
+  }
+
+  /// The derivative path shares the value path's extrapolation window, so a
+  /// query outside the data range still differentiates the boundary piece
+  /// instead of panicking or returning nonsense.
+  #[test]
+  fn interpolation_derivative_extrapolates_past_data_range() {
+    let result = interpret(
+      "f = Interpolation[{{0., 0.}, {1., 1.}, {2., 4.}, {3., 9.}}]; f'[5.0]",
+    )
+    .unwrap();
+    let value: f64 = result.parse().expect("a number");
+    assert!((value - 10.0).abs() < 1e-9, "expected 10., got {result}");
+  }
+
   #[test]
   fn exponential_growth() {
     // NDSolve y'=y, y(0)=1, check y(0.5) ≈ E^0.5

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -7059,6 +7059,80 @@ mod tests {
     assert!(!state.playing);
   }
 
+  /// A phase-portrait Demonstration — sliders for a nonlinear oscillator's
+  /// parameters driving a `Module` that solves several initial conditions
+  /// with `NDSolve`, then overlays the vector field (`StreamPlot`) with the
+  /// solution trajectories (a multi-curve `ParametricPlot[Evaluate[Table[…
+  /// /. sol]]]`, each curve pairing a position with its `InterpolatingFunction`
+  /// derivative). This pattern used to make every slider drag stall for
+  /// seconds: `f'[t]` on an `NDSolve`-produced `InterpolatingFunction` built
+  /// and simplified a symbolic Lagrange polynomial through the general
+  /// evaluator on every sampled point instead of computing the local
+  /// derivative directly in machine arithmetic. Regression coverage for
+  /// that fix lives with `InterpolatingFunction` in
+  /// `tests/interpreter_tests/calculus.rs`; this test guards the widget
+  /// built from it keeps working end to end, including after a slider
+  /// changes and the body re-runs.
+  #[test]
+  fn phase_portrait_manipulate_builds_and_redraws() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[\
+        Module[{esol}, \
+          esol = Table[NDSolve[{x''[t] + delta x'[t] + alpha x[t] + beta x[t]^3 == 0, x[0] == x0, x'[0] == 0}, x, {t, 0, tmax}][[1]], {x0, -2, 2, 1}]; \
+          Show[ \
+            StreamPlot[{y, -delta y - alpha x - beta x^3}, {x, -2.5, 2.5}, {y, -2.5, 2.5}], \
+            ParametricPlot[Evaluate[Table[{x[t], x'[t]} /. esol[[i]], {i, Length[esol]}]], {t, 0, tmax}] \
+          ] \
+        ], \
+        {{delta, 0.2, \"damping\"}, 0, 1}, \
+        {{alpha, 1, \"stiffness\"}, -2, 2}, \
+        {{beta, 0.5, \"nonlinearity\"}, -2, 2}, \
+        {{tmax, 20, \"time\"}, 5, 60} \
+      ]",
+    )
+    .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("Manipulate builds a widget");
+    assert_eq!(
+      state.controls.iter().map(|c| c.name()).collect::<Vec<_>>(),
+      vec!["delta", "alpha", "beta", "tmax"]
+    );
+    assert!(
+      state.error.is_none(),
+      "manipulate body errored: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "expected a rendered graphic, got text_output={:?}",
+      state.text_output
+    );
+
+    // Dragging the `alpha` slider (stiffness) must re-solve and re-render
+    // without error, matching a user interacting with the widget.
+    let alpha_idx = state
+      .controls
+      .iter()
+      .position(|c| c.name() == "alpha")
+      .unwrap();
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[alpha_idx]
+    {
+      *current = -1.5;
+    }
+    state.request_reeval(alpha_idx);
+    state.run_scheduled_reeval();
+    assert!(
+      state.error.is_none(),
+      "manipulate body errored after slider drag: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "expected a rendered graphic after slider drag"
+    );
+  }
+
   #[test]
   fn dynamic_box_dump_is_recognized() {
     // The saved box form of a live Manipulate (what Mathematica writes


### PR DESCRIPTION
## Summary

- Checked whether Woxi Studio fully supports a Wolfram Demonstrations-style notebook built around an unforced nonlinear oscillator's phase-plane trajectories: a `Manipulate` whose sliders drive a `Module` that solves several initial conditions with `NDSolve`, then overlays the vector field (`StreamPlot`) with the solution trajectories via a multi-curve `ParametricPlot[Evaluate[Table[{x[t], x'[t]} /. sol[[i]], …]]]`.
- Found that sampling `f'[t]` on an `NDSolve`-produced `InterpolatingFunction` built and simplified a full symbolic Lagrange polynomial through the general evaluator on *every* sampled point, even for ordinary machine-precision data. For this widget, that turned a single slider drag into an 8+ second stall (11s in a debug build) — Woxi Studio's re-evaluation would visibly hang on every interaction.
- Machine-precision data (the overwhelmingly common case — any `NDSolve` output) now differentiates via Newton divided differences expanded to monomial coefficients and evaluated with Horner's method, entirely in `f64` — no symbolic AST construction or evaluator round-trips per sample. Exact data with an exact query point still takes the symbolic path, preserving exactness (`Interpolation[{{0,0},{1,1},{2,4}}]; f'[1]` still returns exact `2`, not `2.`).
- Net effect: the phase-portrait widget's slider-drag re-render dropped from ~11s to a fraction of a second in a debug build (the woxi-studio test suite, which now includes an end-to-end regression test for this exact widget shape, runs its full 117 tests in 15.5s).

## Test plan

- [x] `cargo nextest run` (full interpreter suite, 26,893 tests) — all passing, including new correctness regression tests for the derivative fast path (exact analytic match, exact-grid-node singularity guard, derivative-order-beyond-degree, and extrapolation).
- [x] `cargo nextest run -p woxi-studio` (117 tests) — all passing, including a new end-to-end test that builds the phase-portrait `Manipulate` widget, checks it renders, then drags a slider and checks it re-renders without error.
- [x] `make format`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMyt54ZUrjeYMK6eCqxiyP)_