### PR TITLE
Add Text[] fourth direction argument and phase-diagram Manipulate regression

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,6 +14,16 @@ slow-timeout = { period = "20s", terminate-after = 1 }
 filter = 'test(high_order_derivative_of_x_x_does_not_panic)'
 slow-timeout = { period = "60s", terminate-after = 1 }
 
+# `demonstration_three_phase_field_manipulate_opens_with_its_widget` builds
+# its widget from a stored `SaveDefinitions -> True` Manipulate and renders
+# a `ParametricPlot`/`Show`/`GraphicsRow` twice (initial render plus one
+# after moving a slider): ~13s standalone in debug builds, close enough to
+# the default 20s timeout to time out under full parallel load. Give it a
+# wider window.
+[[profile.default.overrides]]
+filter = 'test(demonstration_three_phase_field_manipulate_opens_with_its_widget)'
+slow-timeout = { period = "60s", terminate-after = 1 }
+
 # `axial_dispersion_manipulate_builds_widget` integrates a ten-equation
 # finite-difference system twice (once to build the widget, once after moving
 # the slider), and the tracer pulse in its forcing term makes NDSolve bisect

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -672,6 +672,12 @@ enum Primitive {
     /// `x`/`y` are `Scaled[…]` fractions of the plot range, resolved when
     /// the range is known — see [`resolve_anchor`].
     scaled: bool,
+    /// `Text[expr, pos, offset, direction]`'s fourth argument: a data-space
+    /// vector the label's baseline is rotated to run parallel to (e.g. the
+    /// local tangent of a curve it annotates). `None` for the unrotated
+    /// (horizontal) default — including when the argument is omitted or
+    /// written `Automatic`.
+    direction: Option<(f64, f64)>,
     style: StyleState,
   },
   BezierCurvePrim {
@@ -3070,6 +3076,10 @@ fn parse_text(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
     (0.0, 0.0, false)
   };
   let offset = args.get(2).and_then(text_offset).unwrap_or((0.0, 0.0));
+  // `Text[expr, pos, offset, direction]`: rotate the label so its baseline
+  // runs parallel to `direction`, a vector in the same data coordinates as
+  // `pos`. Left `None` for the common `Automatic`/omitted case.
+  let direction = args.get(3).and_then(text_direction);
   // `Background -> colour`, written either as a trailing option of the
   // `Text` or as a directive of the `Style` it wraps.
   fn option_value<'a>(opts: &'a [Expr], key: &str) -> Option<&'a Expr> {
@@ -3120,8 +3130,21 @@ fn parse_text(args: &[Expr], style: &StyleState, prims: &mut Vec<Primitive>) {
     background,
     frame,
     scaled,
+    direction,
     style: local_style,
   });
+}
+
+/// The rotation direction of `Text[expr, pos, offset, direction]`: a plain
+/// `{dx, dy}` vector, or `None` for `Automatic` (no rotation) or anything
+/// else that isn't a 2-vector.
+fn text_direction(spec: &Expr) -> Option<(f64, f64)> {
+  match spec {
+    Expr::List(items) if items.len() == 2 => {
+      Some((expr_to_f64(&items[0])?, expr_to_f64(&items[1])?))
+    }
+    _ => None,
+  }
 }
 
 /// The alignment offset of `Text[expr, pos, offset]` / `Inset[…]`: a pair
@@ -3961,6 +3984,7 @@ fn rotate_primitive(
       background,
       frame,
       scaled,
+      direction,
       style,
     } => {
       let (nx, ny) = if *scaled { (*x, *y) } else { rp(*x, *y) };
@@ -3972,6 +3996,7 @@ fn rotate_primitive(
         background: *background,
         frame: *frame,
         scaled: *scaled,
+        direction: direction.map(|(dx, dy)| rv(dx, dy)),
         style: style.clone(),
       }
     }
@@ -4145,6 +4170,7 @@ fn translate_primitive(prim: &Primitive, dx: f64, dy: f64) -> Primitive {
       background,
       frame,
       scaled,
+      direction,
       style,
     } => Primitive::TextPrim {
       text: text.clone(),
@@ -4154,6 +4180,7 @@ fn translate_primitive(prim: &Primitive, dx: f64, dy: f64) -> Primitive {
       background: *background,
       frame: *frame,
       scaled: *scaled,
+      direction: *direction,
       style: style.clone(),
     },
     Primitive::RasterPrim {
@@ -4372,6 +4399,7 @@ fn scale_primitive(
       background,
       frame,
       scaled,
+      direction,
       style,
     } => {
       let (nx, ny) = if *scaled { (*x, *y) } else { sp(*x, *y) };
@@ -4383,6 +4411,7 @@ fn scale_primitive(
         background: *background,
         frame: *frame,
         scaled: *scaled,
+        direction: direction.map(|(dx, dy)| (dx * sx, dy * sy)),
         style: style.clone(),
       }
     }
@@ -5884,6 +5913,7 @@ fn render_primitive(
       background,
       frame,
       scaled,
+      direction,
       style,
     } => {
       let color = style.effective_color();
@@ -5903,6 +5933,22 @@ fn render_primitive(
       let (ax, ay) = resolve_anchor(*x, *y, *scaled, bb);
       let sx = coord_x(ax, bb, svg_w) - offset.0 * text_w / 2.0;
       let sy = coord_y(ay, bb, svg_h) + offset.1 * text_h / 2.0;
+      // A fourth `direction` argument tilts the label's baseline to match
+      // that vector — carried in data coordinates, so it has to go through
+      // the same x/y pixel-per-unit scaling `coord_x`/`coord_y` apply (and
+      // the same y-flip) before it becomes a screen-space angle for SVG's
+      // `rotate()`.
+      let rotate_attr = match direction {
+        Some((dx, dy)) if *dx != 0.0 || *dy != 0.0 => {
+          let px = dx * svg_w / bb.width();
+          let py = -dy * svg_h / bb.height();
+          format!(
+            " transform=\"rotate({:.3} {sx:.2} {sy:.2})\"",
+            py.atan2(px).to_degrees()
+          )
+        }
+        _ => String::new(),
+      };
       // `Background -> colour` paints a panel behind the label, which is
       // what keeps a value readable over whatever it is placed on; a
       // `Framed` label additionally gets the border drawn around it.
@@ -5931,7 +5977,7 @@ fn render_primitive(
         // Multi-line text with tspan
         let lines: Vec<&str> = text.split('\n').collect();
         out.push_str(&format!(
-          "<text x=\"{sx:.2}\" y=\"{sy:.2}\" fill=\"{}\" font-size=\"{fs}\" font-weight=\"{}\" font-style=\"{}\"{ff_attr} text-anchor=\"middle\" dominant-baseline=\"central\"{}>",
+          "<text x=\"{sx:.2}\" y=\"{sy:.2}\" fill=\"{}\" font-size=\"{fs}\" font-weight=\"{}\" font-style=\"{}\"{ff_attr} text-anchor=\"middle\" dominant-baseline=\"central\"{}{rotate_attr}>",
           color.to_svg_rgb(),
           style.font_weight,
           style.font_style,
@@ -5953,7 +5999,7 @@ fn render_primitive(
         out.push_str("</text>\n");
       } else {
         out.push_str(&format!(
-          "<text x=\"{sx:.2}\" y=\"{sy:.2}\" fill=\"{}\" font-size=\"{fs}\" font-weight=\"{}\" font-style=\"{}\"{ff_attr} text-anchor=\"middle\" dominant-baseline=\"central\"{}>{}</text>\n",
+          "<text x=\"{sx:.2}\" y=\"{sy:.2}\" fill=\"{}\" font-size=\"{fs}\" font-weight=\"{}\" font-style=\"{}\"{ff_attr} text-anchor=\"middle\" dominant-baseline=\"central\"{}{rotate_attr}>{}</text>\n",
           color.to_svg_rgb(),
           style.font_weight,
           style.font_style,

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1051,6 +1051,57 @@ mod graphics {
       assert!(svg.contains("rgb(255,0,0)"), "the disk stays red:\n{svg}");
     }
 
+    /// `Text[expr, pos, offset, direction]`'s fourth argument tilts the
+    /// label's baseline to run parallel to `direction`. Regression: it used
+    /// to be silently dropped, so the label always came out horizontal.
+    #[test]
+    fn text_with_direction_rotates_the_label() {
+      let svg = export_svg(
+        "Graphics[{Text[\"diag\", {0.5, 0.5}, Automatic, {1, 1}]}, \
+          PlotRange -> {{0, 1}, {0, 1}}]",
+      );
+      let line = svg
+        .lines()
+        .find(|l| l.starts_with("<text"))
+        .unwrap_or_else(|| panic!("no text element in {svg}"));
+      // A square plot range makes data space and pixel space agree up to
+      // the y-flip, so a 45-degree data-space direction is a -45-degree
+      // (clockwise-negative, i.e. counterclockwise) screen rotation.
+      assert!(
+        line.contains("rotate(-45"),
+        "a {{1, 1}} direction rotates the label -45 degrees: {line}"
+      );
+    }
+
+    /// `Automatic` (or an omitted) direction leaves the label unrotated,
+    /// and a `{1, 0}` (purely horizontal) direction is a no-op rotation.
+    #[test]
+    fn text_without_direction_is_not_rotated() {
+      let automatic = export_svg(
+        "Graphics[{Text[\"flat\", {0.5, 0.5}, Automatic, Automatic]}]",
+      );
+      let omitted = export_svg("Graphics[{Text[\"flat\", {0.5, 0.5}]}]");
+      for svg in [&automatic, &omitted] {
+        let line = svg
+          .lines()
+          .find(|l| l.starts_with("<text"))
+          .unwrap_or_else(|| panic!("no text element in {svg}"));
+        assert!(!line.contains("rotate("), "must stay unrotated: {line}");
+      }
+      // A horizontal direction is a legal rotation request too — just one
+      // whose angle happens to be (approximately) zero.
+      let horizontal =
+        export_svg("Graphics[{Text[\"flat\", {0.5, 0.5}, Automatic, {1, 0}]}]");
+      let line = horizontal
+        .lines()
+        .find(|l| l.starts_with("<text"))
+        .unwrap_or_else(|| panic!("no text element in {horizontal}"));
+      assert!(
+        line.contains("rotate(-0.000") || line.contains("rotate(0.000"),
+        "a horizontal direction is a ~0-degree rotation: {line}"
+      );
+    }
+
     /// `Inset[graphic, pos, opos, size]` draws the picture inside this
     /// one — scaled into its box and moved to `pos` — instead of writing
     /// the object's text form. `{Automatic, dir}` turns it to face `dir`.

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -15094,6 +15094,177 @@ $CellContext`phase3[$CellContext`t]; Null))]"], "Output"]
   }
 
   /// Checked a randomly-sampled Wolfram Demonstrations Project notebook (a
+  /// binary-mixture phase-equilibrium diagram visualizer) against Woxi
+  /// Studio's Manipulate pipeline. Its shape: a `Module` body defines a
+  /// couple of `Exp[…]`-based activity-style helper functions of one
+  /// variable, then a `While[i < n, {…, i++}]` loop whose body is a
+  /// comma-separated *list* (not a `CompoundExpression`) repeatedly calls
+  /// `FindRoot` to solve a nonlinear equation and stores the results into
+  /// indexed assignments (`arr[i] = …`); the resulting tables feed
+  /// `Interpolation[…, InterpolationOrder -> 1]` to build a few
+  /// `InterpolatingFunction`s; a `Switch` on an integer control then picks
+  /// between two rendered views — a `Show` of a `Plot` of one interpolated
+  /// curve overlaid with a `Graphics` of `Table`-generated tie-line
+  /// `Line`s and `Style[Text[Row[{ToString[NumberForm[…]], "…"}], pos,
+  /// Automatic, direction], size]` labels tilted to follow each tie line,
+  /// versus a `Plot` of another interpolated curve with an `Epilog` marking
+  /// a reference point — driven by a rule-list discrete control (`{{ctrl,
+  /// 1, ""}, {1 -> "…", 2 -> "…"}}`) and a labeled slider, tracked via
+  /// `TrackedSymbols`.
+  ///
+  /// This is a self-authored, construct-equivalent example (a made-up
+  /// binary system with invented coefficients) — not the notebook's own
+  /// code, data, or wording, which is copyrighted. It doubles as a
+  /// regression test for `Text`'s fourth (`direction`) argument, which
+  /// used to be silently dropped instead of tilting the label.
+  #[test]
+  fn demonstration_phase_diagram_manipulate_solves_and_interpolates_tables() {
+    let nb_src = r##"Notebook[{
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[
+ Module[{i, x, xL, pL, yV, fL, fV, fEQ, tblL, tblV, tblEQ, sol, p, kA, kB, mm, psA, psB, px, py},
+  kA = 1.8; kB = 1.3; mm = 0.15;
+  psA = 0.82 P; psB = 0.64 P;
+  gA[u_] := Exp[kA (1 - u)^2 (1 + mm u)];
+  gB[u_] := Exp[kB u^2 (1 - mm (1 - u))];
+  i = 0;
+  While[i < 21, {x = i*0.05, xL[i] = x, sol = FindRoot[gA[x] x psA + gB[x] (1 - x) psB == p, {p, 500}], pL[i] = (p /. sol), yV[i] = gA[x] psA x/pL[i], i++}];
+  tblL = Table[{xL[i], pL[i]}, {i, 0, 20}];
+  tblV = Table[{yV[i], pL[i]}, {i, 0, 20}];
+  tblEQ = Table[{xL[i], yV[i]}, {i, 0, 20}];
+  fL = Interpolation[tblL, InterpolationOrder -> 1];
+  fV = Interpolation[tblV, InterpolationOrder -> 1];
+  fEQ = Interpolation[tblEQ, InterpolationOrder -> 1];
+  px = 0.5; py = fEQ[px];
+  Switch[ctrl,
+   1,
+    Show[
+     Plot[fL[xv], {xv, 0, 1}, Frame -> True, FrameLabel -> {Style[\"liquid mole fraction\", 14], Style[\"pressure (mmHg)\", 14]}, GridLines -> Automatic, ImageSize -> {600, 350}, PlotStyle -> Thick, PlotRange -> {{0, 1}, {0, 700}}],
+     Graphics[{Thick, Green, Table[Line[{{a, fL[a]}, {fEQ[a], fV[fEQ[a]]}}], {a, 0.1, 0.9, 0.1}], Red, Table[Style[Text[Row[{ToString[NumberForm[fL[a], {4, 2}]], \" mmHg\"}], {(a + fEQ[a])/2, fL[a]}, Automatic, {1000, (fV[fEQ[a]] - fL[a])}], 10], {a, 0.1, 0.9, 0.1}]}]
+    ],
+   2,
+    Plot[fEQ[t], {t, 0, 1}, Epilog -> {Green, Line[{{0, 0}, {1, 1}}], Red, PointSize[0.025], Point[{px, py}]}, ImageSize -> {600, 350}, Frame -> True, GridLines -> Automatic, PlotStyle -> Thick, FrameLabel -> {Style[\"liquid mole fraction\", 14], Style[\"vapor mole fraction\", 14]}]
+  ]
+ ],
+ Control[{{ctrl, 1, \"\"}, {1 -> \"Pressure Curve\", 2 -> \"Equilibrium Curve\"}}],
+ {{P, 760, \"system pressure (mmHg)\"}, 50, 1200, 10, Appearance -> \"Labeled\"},
+ TrackedSymbols :> {P, ctrl}]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`ctrl$$ = 1, $CellContext`P$$ = 760}, DynamicBox[\[Ellipsis]]]"], "Output"]
+}, Open]]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let mut widget = editors
+      .into_iter()
+      .find_map(|e| e.manipulate_state)
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "the Switch's first branch (Show of Plot + Graphics overlay) must draw"
+    );
+
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Discrete {
+          name: ctrl_name,
+          values: ctrl_values,
+          value_labels: ctrl_labels,
+          current_index: ctrl_idx,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: p_name,
+          label: p_label,
+          min: p_min,
+          max: p_max,
+          step: p_step,
+          current: p_now,
+          ..
+        },
+      ] => {
+        assert_eq!(ctrl_name.as_str(), "ctrl");
+        assert_eq!(ctrl_values.as_slice(), ["1", "2"]);
+        assert_eq!(
+          ctrl_labels.as_slice(),
+          ["Pressure Curve", "Equilibrium Curve"]
+        );
+        assert_eq!(*ctrl_idx, 0, "ctrl starts at its initial value 1");
+
+        assert_eq!(p_name.as_str(), "P");
+        assert_eq!(p_label.as_str(), "system pressure (mmHg)");
+        assert_eq!(*p_min, 50.0);
+        assert_eq!(*p_max, 1200.0);
+        assert_eq!(*p_step, 10.0);
+        assert_eq!(*p_now, 760.0);
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    // Re-render the extracted body directly to inspect the two Switch
+    // branches and the tilted tie-line labels the fourth Text argument
+    // draws — the same technique the other demonstration regressions use.
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the pieces must render")
+    };
+    let pressure_view = render(&widget);
+    assert!(
+      pressure_view.contains("rotate("),
+      "the tie-line labels' direction vector must tilt the text: \
+       {pressure_view}"
+    );
+
+    // Moving the pressure slider re-solves the `FindRoot`/`Interpolation`
+    // table and must change the rendered pressure curve.
+    match &mut widget.controls[1] {
+      manipulate::ControlState::Continuous { current, .. } => {
+        *current = 1100.0;
+      }
+      other => panic!("expected P as a Continuous control, got {other:?}"),
+    }
+    widget.reevaluate();
+    assert!(widget.error.is_none());
+    assert!(widget.graphics_handle.is_some());
+    assert_ne!(
+      pressure_view,
+      render(&widget),
+      "raising the system pressure must change the re-solved curve"
+    );
+
+    // Switching `ctrl` to the second rule-list choice must render the
+    // other Switch branch (the Plot with an Epilog point) instead.
+    match &mut widget.controls[0] {
+      manipulate::ControlState::Discrete { current_index, .. } => {
+        *current_index = 1;
+      }
+      other => panic!("expected ctrl as a Discrete control, got {other:?}"),
+    }
+    widget.reevaluate();
+    assert!(widget.error.is_none());
+    assert!(widget.graphics_handle.is_some());
+    assert_ne!(
+      pressure_view,
+      render(&widget),
+      "the Switch must render a different picture for the other choice"
+    );
+  }
+
+  /// Checked a randomly-sampled Wolfram Demonstrations Project notebook (a
   /// diffusion-driven release-profile visualizer) against Woxi Studio's
   /// Manipulate pipeline. Its shape: a `Setter` swaps between two `Plot`s
   /// selected by `Which`, a `RadioButtonBar` picks a discrete rate


### PR DESCRIPTION
`Text[expr, pos, offset, direction]`'s fourth argument (a data-space vector to tilt the label's baseline toward, e.g. a curve's local tangent) was silently dropped, so labels always rendered horizontal. It now rotates the SVG `<text>` element to match, carried through the same rotate/translate/scale primitive transforms as the other `Text` fields.

Adds a construct-equivalent Woxi Studio regression test modeled on a binary-mixture phase-equilibrium Demonstration: a `Module` with a `While` loop driving `FindRoot` into per-index tables, `Interpolation` building `InterpolatingFunction`s from them, and a `Switch` between a `Show` of `Plot`+`Graphics` (tilted tie-line labels via `Text`'s direction argument) and a `Plot` with an `Epilog` point, controlled by a rule-list `Setter` and a labeled slider. This is a self-authored, construct-equivalent example, not the notebook's own code, data, or wording.

Also widens the nextest timeout for the existing `demonstration_three_phase_field_manipulate_opens_with_its_widget` test-studio test, which was intermittently timing out at the default 20s window under full parallel load.

## Test plan
- [x] `make test` — 26912 tests passed, 0 skipped
- [x] `make test-studio` — 121 tests passed, 0 skipped
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCsGPPiyBaaJqKkM6gpLoR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCsGPPiyBaaJqKkM6gpLoR)_