### PR TITLE
Support anonymous head-constrained patterns in function definitions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -414,6 +414,10 @@
         printing their source next to a slash. Operands with nothing to
         typeset stay on the OutputForm path, which already knows this
         arithmetic's precedence and sign conventions.
+- A head-restricted blank without a name — `f[_String] := …` — defines a
+    function instead of panicking the interpreter. The name in `name_Head` is
+    optional, and the anonymous form dispatches on the head just like the
+    named one, so `f[_String]` and `f[_Integer]` are two overloads of `f`.
 
 # 2026-08-06 - 0.3.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5339,15 +5339,22 @@ fn store_function_definition(
       }
       Rule::PatternWithHead => {
         // Extract parameter name and head (e.g., "x_List" -> name="x", head="List")
+        // The name is optional (`PatternName? ~ PatternBlanks ~ Identifier`),
+        // so an anonymous `_String` yields the head as the only child.
         let full = item.as_str();
-        let mut pat_inner = item.into_inner();
-        let pat_name_str = pat_inner.next().unwrap().as_str();
-        let blank_count = full[pat_name_str.len()..]
+        let children: Vec<_> = item.into_inner().collect();
+        let (param_name, head_name) = match children.as_slice() {
+          [name, head, ..] => {
+            (name.as_str().to_owned(), head.as_str().to_owned())
+          }
+          [head] => (String::new(), head.as_str().to_owned()),
+          [] => (String::new(), String::new()),
+        };
+        let blank_count = full[param_name.len()..]
+          .trim_start()
           .chars()
           .take_while(|&c| c == '_')
           .count();
-        let param_name = pat_name_str.to_owned();
-        let head_name = pat_inner.next().unwrap().as_str().to_owned();
         params.push(param_name);
         conditions.push(None);
         defaults.push(None);

--- a/tests/cli/syntax.md
+++ b/tests/cli/syntax.md
@@ -221,6 +221,27 @@ $ wo '(# + 1 &) /@ {10, 20, 30}'
 ```
 
 
+## Head-Constrained Patterns (`_Head`)
+
+A blank can be restricted to a head, with or without a name. Each head is a
+separate definition, so the argument's head selects which one fires.
+
+```scrut
+$ wo 'f[_String] := "a string"; f[_Integer] := "an integer"; f[1]'
+an integer
+```
+
+```scrut
+$ wo 'f[_String] := "a string"; f[_Integer] := "an integer"; {f[2], f["a"]}'
+{an integer, a string}
+```
+
+```scrut
+$ wo 'g[x_Integer] := x^2; g[_] := "other"; {g[3], g[a]}'
+{9, other}
+```
+
+
 ## Alternatives (`|`)
 
 The `|` operator represents alternatives in pattern matching.

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -4266,3 +4266,90 @@ mod repeated_pattern_variables {
     );
   }
 }
+
+/// Anonymous head-constrained patterns — `f[_String] := …`. The name in
+/// `PatternName? ~ PatternBlanks ~ Identifier` is optional, so the head is
+/// the only child of the parse node and the definition must not assume a
+/// name is present (issue #459: the missing child panicked the interpreter).
+/// All expectations match wolframscript.
+mod anonymous_head_patterns {
+  use super::*;
+
+  #[test]
+  fn anonymous_head_pattern_dispatches_by_head() {
+    clear_state();
+    let (out, res) = {
+      let r = interpret_with_stdout(
+        "f[_String] := Echo[\"It is a string\"]\n\
+         f[_Integer] := Echo[\"It is an integer\"]\n\
+         f[1]",
+      )
+      .unwrap();
+      (r.stdout, r.result)
+    };
+    assert_eq!(out, ">> It is an integer\n");
+    assert_eq!(res, "It is an integer");
+    clear_state();
+  }
+
+  #[test]
+  fn anonymous_head_patterns_are_separate_downvalues() {
+    clear_state();
+    assert_eq!(
+      interpret(
+        "f[_String] := \"s\"; f[_Integer] := \"i\"; {f[1], f[\"a\"], f[1.5]}"
+      )
+      .unwrap(),
+      "{i, s, f[1.5]}"
+    );
+    clear_state();
+  }
+
+  #[test]
+  fn anonymous_head_pattern_downvalues() {
+    clear_state();
+    assert_eq!(
+      interpret("f[_String] := \"s\"; f[_Integer] := \"i\"; DownValues[f]")
+        .unwrap(),
+      "{HoldPattern[f[_String]] :> s, HoldPattern[f[_Integer]] :> i}"
+    );
+    clear_state();
+  }
+
+  #[test]
+  fn anonymous_head_sequence_patterns() {
+    clear_state();
+    assert_eq!(
+      interpret("q[__Integer] := \"one or more\"; {q[1], q[1, 2, 3], q[]}")
+        .unwrap(),
+      "{one or more, one or more, q[]}"
+    );
+    clear_state();
+    assert_eq!(
+      interpret("z[___Integer] := \"any number\"; {z[], z[1, 2], z[a]}")
+        .unwrap(),
+      "{any number, any number, z[a]}"
+    );
+    clear_state();
+  }
+
+  #[test]
+  fn anonymous_head_pattern_mixed_with_named_parameters() {
+    clear_state();
+    assert_eq!(
+      interpret("m[_Integer, y_] := y * 2; {m[1, 5], m[\"a\", 5]}").unwrap(),
+      "{10, m[a, 5]}"
+    );
+    clear_state();
+  }
+
+  #[test]
+  fn anonymous_head_pattern_with_pattern_test() {
+    clear_state();
+    assert_eq!(
+      interpret("k[_Integer?Positive] := \"pos\"; {k[3], k[-3]}").unwrap(),
+      "{pos, k[-3]}"
+    );
+    clear_state();
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds support for anonymous head-constrained patterns in function definitions, such as `f[_String] := …`. Previously, the interpreter would panic when encountering a pattern without an explicit name. Now these patterns are properly handled and dispatch on the head just like named patterns.

## Changes

- **Parser handling**: Updated `PatternWithHead` parsing to handle optional pattern names. The grammar allows `PatternName? ~ PatternBlanks ~ Identifier`, so the head can be the only child of the parse node.

- **Interpreter fix**: Modified `store_function_definition()` in `src/lib.rs` to correctly extract both named and anonymous patterns by checking the number of children in the parse tree:
  - Two or more children: `name_Head` (named pattern)
  - One child: `_Head` (anonymous pattern)
  - Empty: fallback case

- **Test coverage**: Added comprehensive test suite in `tests/interpreter_tests/function_definitions.rs` covering:
  - Basic dispatch by head with anonymous patterns
  - Multiple overloads with different heads
  - DownValues inspection
  - Sequence patterns (`__Integer`, `___Integer`)
  - Mixed named and anonymous parameters
  - Pattern tests with anonymous patterns

- **Documentation**: Added new section "Head-Constrained Patterns (`_Head`)" to `tests/cli/syntax.md` with illustrative examples showing both named and anonymous patterns.

- **Changelog**: Documented the fix for issue #459 where anonymous head-constrained patterns would panic the interpreter.

## Implementation Details

The key insight is that the parse tree structure differs based on whether a name is present:
- `f[x_String]` produces children: `[name, head]`
- `f[_String]` produces children: `[head]`

The fix uses pattern matching on the children slice to handle both cases, with the anonymous form using an empty string for the parameter name while still properly registering the head constraint for dispatch.

https://claude.ai/code/session_01P5vRwbRdEKZC32v7xCGcwM