### PR TITLE
Implement interactive stdin for Input[] and InputString[]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 # Unreleased
 
+- `InputString[]` and `Input[]` actually read from standard input when `woxi`
+    owns it — `woxi run script.wls`, a shebang script, and `woxi eval` — so a
+    script that prompts for a value now waits for one instead of running
+    straight through. `InputString` returns the line as a string,
+    `Input` parses and evaluates it, and both return `EndOfFile` once input is
+    exhausted. Embedders that don't own stdin (the wasm playground, the
+    Jupyter kernel, `woxi eval -`, which reads its expression from stdin) keep
+    the previous `EndOfFile` behaviour.
 - Contexts are real: a symbol's name is resolved when its input is *read*,
     against `$Context` and `$ContextPath`, and the symbol is stored under its
     full name. A package's `Begin["`Private`"]` helpers are therefore private

--- a/functions.csv
+++ b/functions.csv
@@ -675,7 +675,7 @@ FourierTransform,Computes the symbolic Fourier transform of an expression,✅,pu
 InverseFourierTransform,Computes the symbolic inverse Fourier transform of an expression,✅,pure,4.0,1124
 PowerExpand,Expands powers and logarithms assuming positive reals,✅,pure,2.0,640
 Fit,Performs a least-squares fit of data to a linear combination of basis functions — a design matrix without full column rank gives the minimum-norm solution,✅,pure,1.0,641
-Input,Reads user input (inert in Woxi),✅,effectful,1.0,642
+Input,Reads and evaluates a line of user input,✅,effectful,1.0,642
 UnitConvert,Converts a quantity to a different unit; with one argument converts to SI base units,✅,pure,9.0,643
 BoundaryStyle,Option for boundary styling in plots,✅,none,6.0,644
 StandardDeviation,Returns the standard deviation of a list or an association's values — exact unless a machine number is among them,✅,pure,5.0,645
@@ -2037,7 +2037,7 @@ Wednesday,Day of the week symbol,✅,unevaluated,9.0,2045
 PieChart3D,3D pie chart,✅,pure,7.0,2048
 Tuesday,Day of the week symbol,✅,unevaluated,9.0,2048
 WindowElements,Window UI elements option,🚫,,3.0,2048
-InputString,Symbol specifying input string type for Input,✅,pure,1.0,2051
+InputString,Reads a line of user input as a string,✅,effectful,1.0,2051
 LinkRead,Read from WSTP link,🚫,,3.0,2051
 SelectionEvaluate,Evaluate selected notebook content,🚫,,3.0,2051
 Annulus,Symbolic annular region; stays unevaluated and is consumed by region functions (RegionDimension/RegionMeasure/…),✅,unevaluated,10.2,2054

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -3327,9 +3327,13 @@ pub fn dispatch_io_functions(
       return Some(Ok(unevaluated("FileNameTake", args)));
     }
     // Input[] / Input[prompt] / InputString[] / InputString[prompt] —
-    // wolframscript in script mode prints the prompt to stdout (no trailing
-    // newline) and returns `EndOfFile` since interactive stdin isn't
-    // available. Match that so non-interactive scripts behave identically.
+    // wolframscript prints the prompt to stdout (no trailing newline) and
+    // then reads one line from stdin, returning `EndOfFile` once stdin is
+    // exhausted. `InputString` yields the raw line; `Input` parses and
+    // evaluates it as a Wolfram expression (blank line → Null, syntax error
+    // → $Failed with the usual message), exactly like ToExpression.
+    // Embedders that don't own stdin never get a line, so they keep the
+    // non-interactive `EndOfFile` result.
     "Input" | "InputString" if args.len() <= 1 => {
       if let Some(arg) = args.first() {
         let prompt = match arg {
@@ -3343,7 +3347,16 @@ pub fn dispatch_io_functions(
         }
         crate::capture_stdout_raw(&prompt);
       }
-      return Some(Ok(Expr::Identifier("EndOfFile".to_string())));
+      let Some(line) = crate::read_stdin_line() else {
+        return Some(Ok(Expr::Identifier("EndOfFile".to_string())));
+      };
+      if name == "InputString" {
+        return Some(Ok(Expr::String(line)));
+      }
+      return Some(crate::functions::string_ast::to_expression_ast_as(
+        &[Expr::String(line)],
+        "Syntax",
+      ));
     }
     _ => {}
   }

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -8482,6 +8482,16 @@ pub fn apply_string_template(
 ///   is accepted but the parser is the same regardless.
 /// - With `h`, apply `h` to the evaluated expression before returning.
 pub fn to_expression_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  to_expression_ast_as(args, "ToExpression")
+}
+
+/// `to_expression_ast` with the symbol that owns the `sntxi` / `sntx` syntax
+/// messages made explicit. `Input[]` reuses the whole parse-and-evaluate
+/// path but reports syntax problems as `Syntax::…`, the way the reader does.
+pub fn to_expression_ast_as(
+  args: &[Expr],
+  message_symbol: &str,
+) -> Result<Expr, InterpreterError> {
   if args.is_empty() || args.len() > 3 {
     return Err(InterpreterError::EvaluationError(
       "ToExpression expects 1 to 3 arguments".into(),
@@ -8514,7 +8524,7 @@ pub fn to_expression_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
   // Syntactically invalid input yields $Failed with a Wolfram syntax message
   // (sntxi/sntx), rather than leaking the internal parser error.
-  if let Some(msg) = to_expression_syntax_error(&s) {
+  if let Some(msg) = to_expression_syntax_error(&s, message_symbol) {
     crate::emit_message(&msg);
     return Ok(Expr::Identifier("$Failed".to_string()));
   }
@@ -8575,7 +8585,7 @@ pub(crate) fn parse_program_to_expr(
 /// parse failed at end of input) or `sntx` for invalid syntax elsewhere.
 /// Returns `None` when the input parses — it may still fail at evaluation
 /// time, which is handled by the normal evaluation path.
-fn to_expression_syntax_error(src: &str) -> Option<String> {
+fn to_expression_syntax_error(src: &str, symbol: &str) -> Option<String> {
   use crate::Rule;
   let normalized = if src.contains('\r') {
     src.replace("\r\n", "\n").replace('\r', "\n")
@@ -8605,14 +8615,13 @@ fn to_expression_syntax_error(src: &str) -> Option<String> {
     Ok(_) => return None,
   };
   if offset >= preprocessed.trim_end().len() {
-    Some(
-      "ToExpression::sntxi: Incomplete expression; more input is needed."
-        .to_string(),
-    )
+    Some(format!(
+      "{symbol}::sntxi: Incomplete expression; more input is needed."
+    ))
   } else {
     let snippet = preprocessed[offset..].trim();
     Some(format!(
-      "ToExpression::sntx: Invalid syntax in or before \"{snippet}\"."
+      "{symbol}::sntx: Invalid syntax in or before \"{snippet}\"."
     ))
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,50 @@ pub fn is_quiet_print() -> bool {
   QUIET_PRINT.with(|q| *q.borrow())
 }
 
+// Interactive-stdin mode — lets `Input[]` / `InputString[]` consume the
+// process's standard input, the way `wolframscript -file` does. Off by
+// default so embedders that don't own stdin (the wasm playground, the
+// Jupyter kernel, the Python bindings, unit tests) keep the
+// non-interactive `EndOfFile` behaviour instead of blocking on a stream
+// that will never deliver a line.
+thread_local! {
+    static STDIN_INPUT: RefCell<bool> = const { RefCell::new(false) };
+}
+
+/// Enable/disable reading `Input[]` / `InputString[]` from standard input.
+pub fn set_stdin_input(enabled: bool) {
+  STDIN_INPUT.with(|s| *s.borrow_mut() = enabled);
+}
+
+/// Check whether `Input[]` / `InputString[]` may read from standard input.
+pub fn is_stdin_input() -> bool {
+  STDIN_INPUT.with(|s| *s.borrow())
+}
+
+/// Read one line from standard input for `Input[]` / `InputString[]`,
+/// with the trailing newline stripped. Returns `None` at end of input, or
+/// when interactive stdin is disabled — both of which the callers turn
+/// into `EndOfFile`.
+pub fn read_stdin_line() -> Option<String> {
+  if !is_stdin_input() {
+    return None;
+  }
+  use std::io::BufRead as _;
+  let mut line = String::new();
+  match std::io::stdin().lock().read_line(&mut line) {
+    Ok(0) | Err(_) => None,
+    Ok(_) => {
+      if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+          line.pop();
+        }
+      }
+      Some(line)
+    }
+  }
+}
+
 // Visual display mode flag — set by interpret_with_stdout to enable
 // rendering of display wrappers like TableForm as SVG grids
 thread_local! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,6 +218,9 @@ fn run(cli: Cli) {
         }
         buf
       } else {
+        // Only when the expression didn't come from stdin is stdin still
+        // free for `Input[]` / `InputString[]` to read from.
+        woxi::set_stdin_input(true);
         expression
       };
       match interpret(&expression) {
@@ -255,6 +258,8 @@ fn run(cli: Cli) {
       // `wolframscript -file` writes messages (e.g. `Get::noopen`,
       // `Power::infy`) to stdout, so match it: route diagnostics there too.
       woxi::set_messages_to_stdout(true);
+      // A script owns stdin, so `Input[]` / `InputString[]` read from it.
+      woxi::set_stdin_input(true);
 
       let absolute_path = if file.is_absolute() {
         file.clone()
@@ -288,6 +293,8 @@ fn run(cli: Cli) {
       // Shebang scripts run like `wolframscript -file`; send messages to
       // stdout to match it (see the `Run` arm above).
       woxi::set_messages_to_stdout(true);
+      // A script owns stdin, so `Input[]` / `InputString[]` read from it.
+      woxi::set_stdin_input(true);
 
       if args.is_empty() {
         eprintln!("Error: no script file supplied");

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -117,6 +117,171 @@ fn eval_stdin_handles_large_image_input() {
   assert_eq!(stdout.trim(), "Image");
 }
 
+/// Run `woxi eval <expression>` with `input` piped to stdin, so `Input[]` and
+/// `InputString[]` have something to read.
+fn run_eval_with_input(
+  expression: &str,
+  input: &str,
+) -> (String, String, bool) {
+  use std::io::Write;
+  use std::process::Stdio;
+  let mut child = Command::new(woxi_bin())
+    .arg("eval")
+    .arg(expression)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .expect("failed to spawn woxi");
+  child
+    .stdin
+    .as_mut()
+    .expect("no stdin")
+    .write_all(input.as_bytes())
+    .expect("failed to write stdin");
+  let output = child.wait_with_output().expect("failed to wait");
+  (
+    String::from_utf8_lossy(&output.stdout).into_owned(),
+    String::from_utf8_lossy(&output.stderr).into_owned(),
+    output.status.success(),
+  )
+}
+
+#[test]
+fn input_string_reads_a_line_from_stdin() {
+  // Regression for #462: `InputString[prompt]` must consume a line of stdin
+  // instead of immediately returning `EndOfFile`, so scripts that prompt for
+  // a value actually get one.
+  let (stdout, stderr, ok) =
+    run_eval_with_input(r#"InputString["Please enter your name:"]"#, "Alice\n");
+  assert!(ok, "woxi eval failed: stderr={stderr}");
+  assert_eq!(stdout, "Please enter your name:Alice\n");
+}
+
+#[test]
+fn input_string_reads_successive_lines() {
+  // Each call advances through stdin rather than re-reading the first line.
+  let (stdout, stderr, ok) =
+    run_eval_with_input("Table[InputString[], {3}]", "a\nb\nc\n");
+  assert!(ok, "woxi eval failed: stderr={stderr}");
+  assert_eq!(stdout.trim(), "{a, b, c}");
+}
+
+#[test]
+fn input_string_returns_end_of_file_when_stdin_is_exhausted() {
+  // Past the last line — and with a closed stdin — the result is `EndOfFile`,
+  // the behaviour wolframscript shows when there is nothing left to read.
+  let (stdout, stderr, ok) =
+    run_eval_with_input("{InputString[], InputString[]}", "only\n");
+  assert!(ok, "woxi eval failed: stderr={stderr}");
+  assert_eq!(stdout.trim(), "{only, EndOfFile}");
+}
+
+#[test]
+fn input_string_keeps_a_blank_line_as_empty_string() {
+  // A bare newline is an empty string, not `EndOfFile`.
+  let (stdout, stderr, ok) =
+    run_eval_with_input("StringLength[InputString[]]", "\n");
+  assert!(ok, "woxi eval failed: stderr={stderr}");
+  assert_eq!(stdout.trim(), "0");
+}
+
+#[test]
+fn input_parses_the_line_as_an_expression() {
+  // `Input[]` evaluates what it reads, unlike `InputString[]`.
+  let (stdout, stderr, ok) = run_eval_with_input(r#"Input["n: "]"#, "2 + 3\n");
+  assert!(ok, "woxi eval failed: stderr={stderr}");
+  assert_eq!(stdout, "n: 5\n");
+}
+
+#[test]
+fn input_reports_syntax_errors_as_failed() {
+  // An unparsable line yields `$Failed` with a Syntax message — the message
+  // is owned by `Syntax`, not by the shared `ToExpression` implementation.
+  let (stdout, stderr, ok) = run_eval_with_input("Input[]", "1 +\n");
+  assert!(ok, "woxi eval failed: stderr={stderr}");
+  assert!(
+    stdout.contains("Syntax::sntxi:"),
+    "expected a Syntax message, got: {stdout}"
+  );
+  assert!(
+    !stdout.contains("ToExpression::"),
+    "message should not leak ToExpression: {stdout}"
+  );
+  assert_eq!(stdout.trim_end().lines().last().unwrap(), "$Failed");
+}
+
+#[test]
+fn input_returns_null_for_a_blank_line() {
+  let (stdout, stderr, ok) = run_eval_with_input("Input[]", "\n");
+  assert!(ok, "woxi eval failed: stderr={stderr}");
+  assert_eq!(stdout.trim(), "Null");
+}
+
+#[test]
+fn eval_from_stdin_still_returns_end_of_file_for_input() {
+  // `woxi eval -` consumes stdin for the expression itself, so there is
+  // nothing left for `InputString[]` to read.
+  let (stdout, stderr, ok) = run_eval_stdin("InputString[]");
+  assert!(ok, "woxi eval - failed: stderr={stderr}");
+  assert_eq!(stdout.trim(), "EndOfFile");
+}
+
+/// Run `woxi run <file>` with `input` piped to stdin.
+fn run_file_with_input(
+  path: &std::path::Path,
+  input: &str,
+) -> (String, String, bool) {
+  use std::io::Write;
+  use std::process::Stdio;
+  let mut child = Command::new(woxi_bin())
+    .arg("run")
+    .arg(path)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .expect("failed to spawn woxi");
+  child
+    .stdin
+    .as_mut()
+    .expect("no stdin")
+    .write_all(input.as_bytes())
+    .expect("failed to write stdin");
+  let output = child.wait_with_output().expect("failed to wait");
+  (
+    String::from_utf8_lossy(&output.stdout).into_owned(),
+    String::from_utf8_lossy(&output.stderr).into_owned(),
+    output.status.success(),
+  )
+}
+
+#[test]
+fn run_script_prompts_and_reads_stdin() {
+  // The exact script from #462: it must greet the name it was given.
+  let script = "userName = InputString[\"Please enter your name:\"];\n\
+                Echo[StringJoin[\"Hello \", userName]];\n";
+  let path = std::env::temp_dir().join("woxi_cli_input_string.wls");
+  std::fs::write(&path, script).expect("write script");
+  let (stdout, stderr, ok) = run_file_with_input(&path, "Alice\n");
+  let _ = std::fs::remove_file(&path);
+  assert!(ok, "woxi run failed: stderr={stderr}");
+  assert_eq!(stdout, "Please enter your name:>> Hello Alice\n");
+}
+
+#[test]
+fn run_script_falls_back_to_end_of_file_without_stdin() {
+  // With stdin closed immediately the script still terminates rather than
+  // hanging, and `InputString[]` reports `EndOfFile`.
+  let script = "Print[InputString[]];\n";
+  let path = std::env::temp_dir().join("woxi_cli_input_string_eof.wls");
+  std::fs::write(&path, script).expect("write script");
+  let (stdout, stderr, ok) = run_file_with_input(&path, "");
+  let _ = std::fs::remove_file(&path);
+  assert!(ok, "woxi run failed: stderr={stderr}");
+  assert_eq!(stdout, "EndOfFile\n");
+}
+
 /// Run `woxi run <file>` and return (stdout, stderr, success).
 fn run_file(path: &std::path::Path) -> (String, String, bool) {
   let output = Command::new(woxi_bin())

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -5506,8 +5506,11 @@ mod directory_stack {
 mod input_function {
   use super::*;
 
-  // In script mode (non-interactive), Input/InputString return EndOfFile
-  // — matching wolframscript's behaviour when stdin is closed.
+  // Embedders of the library (this harness, the wasm playground, the Jupyter
+  // kernel) don't hand stdin to the interpreter, so Input/InputString return
+  // EndOfFile — matching wolframscript's behaviour when stdin is closed. The
+  // CLI does enable stdin reading; that path is covered by the
+  // `input_string_*` / `run_script_prompts_*` tests in tests/cli_tests.rs.
 
   #[test]
   fn input_no_args_returns_end_of_file() {


### PR DESCRIPTION
## Summary

Enable `Input[]` and `InputString[]` to read from standard input when the interpreter owns it, matching `wolframscript`'s behavior. Previously these functions always returned `EndOfFile` in non-interactive mode.

## Key Changes

- **Added stdin reading infrastructure** (`src/lib.rs`):
  - New thread-local flag `STDIN_INPUT` to control whether stdin reading is enabled
  - `set_stdin_input()` / `is_stdin_input()` to manage the flag
  - `read_stdin_line()` to read one line from stdin with newline stripped

- **Updated `Input[]` and `InputString[]` implementation** (`src/evaluator/dispatch/io_functions.rs`):
  - `InputString[]` now reads a line from stdin and returns it as a string
  - `Input[]` reads a line, parses it as a Wolfram expression, and evaluates it
  - Both return `EndOfFile` when stdin is exhausted or reading is disabled
  - `Input[]` reports syntax errors as `Syntax::sntxi` / `Syntax::sntx` messages (not `ToExpression::`)

- **Enhanced expression parsing** (`src/functions/string_ast.rs`):
  - Refactored `to_expression_ast()` to `to_expression_ast_as()` with explicit message symbol parameter
  - Allows `Input[]` to report syntax errors under the `Syntax` symbol instead of `ToExpression`

- **Enabled stdin in CLI** (`src/main.rs`):
  - `woxi eval <expr>`: Enable stdin only when expression is not from stdin (preserves `woxi eval -` behavior)
  - `woxi run <file>`: Enable stdin for script execution
  - Shebang scripts: Enable stdin to match `wolframscript -file` behavior

- **Comprehensive test coverage** (`tests/cli_tests.rs`):
  - Added `run_eval_with_input()` helper for testing `woxi eval` with stdin
  - Added `run_file_with_input()` helper for testing `woxi run` with stdin
  - Tests for `InputString[]`: reading lines, successive reads, EOF handling, blank lines
  - Tests for `Input[]`: expression parsing, syntax error reporting, blank line handling
  - Tests for edge cases: `woxi eval -` with `InputString[]`, scripts without stdin

- **Updated documentation** (`functions.csv`):
  - Changed `Input` description from "Reads user input (inert in Woxi)" to "Reads and evaluates a line of user input"

## Implementation Details

- Stdin reading is **disabled by default** to preserve non-interactive behavior for embedders (wasm playground, Jupyter kernel, Python bindings, unit tests) that don't own stdin
- Blank lines are handled correctly: `InputString[]` returns empty string, `Input[]` returns `Null`
- Syntax errors in `Input[]` yield `$Failed` with appropriate `Syntax::` messages
- The implementation respects the exact behavior of `wolframscript`, including prompt output format and EOF handling

https://claude.ai/code/session_01AD96j3NbM1AHZbZusPpCaA