### PR TITLE
Add support for external command pipes in I/O functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,8 +39,24 @@
     script's own input. `ReadLine` pulls one line at a time, so a `While` loop
     over a live pipe advances as its command produces output rather than
     waiting for the command to exit, and `Close` stops a command that is still
-    running. `ReadLine["!cmd"]`, `ReadString["!cmd"]` and `ReadList["!cmd"]`
-    take the same specification without an explicit stream.
+    running.
+    - `OpenWrite["!cmd"]` and `OpenAppend["!cmd"]` open the other end: what
+        `Write`, `WriteString` and `BinaryWrite` send to the stream becomes
+        the command's standard input, and `Close` is what tells the command
+        its input has ended — so a filter that only answers at end-of-input,
+        like `"!sort"`, gets there.
+    - Every function that takes a file name takes a command instead:
+        `ReadLine`, `ReadString`, `ReadList`, `BinaryReadList`, `Find`,
+        `FindList`, `FilePrint` and `Import` read what the command writes,
+        `Get["!cmd"]` (and `<< "!cmd"`) evaluates it as Wolfram code, and
+        `Put`/`PutAppend` feed the command their expressions.
+- `Import[file, "FMT"]` where `"FMT"` is the file's own format imports it
+    the way the format-less call does, instead of failing: naming a format
+    selects no element, so `Import["data.csv", "CSV"]` is `Import["data.csv"]`
+    and `Import["data.csv", {"CSV", "ColumnLabels"}]` is
+    `Import["data.csv", "ColumnLabels"]`. The format name used to travel on
+    as an element name, which no importer recognized, and the call returned
+    `$Failed[]`.
 - `PacletDirectoryLoad` and `PacletDirectoryUnload` register the directories
     the paclet manager searches. A registered directory may be a paclet
     itself — a directory with a `PacletInfo.wl` — or a directory collecting

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,16 @@
     - `Information[sym, "Property"]` returns that one field (`Missing[
         "UnknownProperty", …]` for an unknown one), and a package symbol's
         `FullName` names its own context.
+- A file name starting with `!` names an external command, as in the Wolfram
+    Language: `OpenRead["!cat"]` runs the command through the shell and reads
+    its standard output instead of reporting `OpenRead::noopen` and returning
+    `$Failed`. The command's standard input and standard error stay connected
+    to the interpreter's, so filters like `"!cat"` or `"!grep foo"` read the
+    script's own input. `ReadLine` pulls one line at a time, so a `While` loop
+    over a live pipe advances as its command produces output rather than
+    waiting for the command to exit, and `Close` stops a command that is still
+    running. `ReadLine["!cmd"]`, `ReadString["!cmd"]` and `ReadList["!cmd"]`
+    take the same specification without an explicit stream.
 - `PacletDirectoryLoad` and `PacletDirectoryUnload` register the directories
     the paclet manager searches. A registered directory may be a paclet
     itself — a directory with a `PacletInfo.wl` — or a directory collecting

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -10887,7 +10887,19 @@ fn evaluate_function_call_ast_inner(
     && args.len() == 1
     && let Expr::String(path) = &args[0]
   {
-    if let Ok(contents) = std::fs::read_to_string(path) {
+    // A `"!command"` name prints the command's output rather than a file.
+    #[cfg(not(target_arch = "wasm32"))]
+    let read =
+      match crate::evaluator::dispatch::io_functions::command_file_spec(path) {
+        Some(command) => {
+          crate::evaluator::dispatch::io_functions::run_command_capture(command)
+            .ok_or(())
+        }
+        None => std::fs::read_to_string(path).map_err(|_| ()),
+      };
+    #[cfg(target_arch = "wasm32")]
+    let read = std::fs::read_to_string(path).map_err(|_| ());
+    if let Ok(contents) = read {
       if !crate::is_quiet_print() {
         print!("{contents}");
       }

--- a/src/evaluator/dispatch/image_functions.rs
+++ b/src/evaluator/dispatch/image_functions.rs
@@ -203,6 +203,54 @@ fn import_extension(path: &str) -> String {
   cleaned.rsplit('.').next().unwrap_or("").to_lowercase()
 }
 
+/// The file extension a Wolfram import *format* name stands for, or `None`
+/// when the name is an element (`"Data"`, `"Elements"`, …) instead.
+fn import_format_name(name: &str) -> Option<&'static str> {
+  Some(match name {
+    "CSV" => "csv",
+    "TSV" => "tsv",
+    "JSON" | "RawJSON" => "json",
+    "SVG" => "svg",
+    "XLSX" => "xlsx",
+    "XLS" => "xls",
+    "ODS" => "ods",
+    "ROOT" => "root",
+    "PNG" => "png",
+    "JPEG" => "jpg",
+    "GIF" => "gif",
+    "BMP" => "bmp",
+    "TIFF" => "tiff",
+    "PPM" => "ppm",
+    "PGM" => "pgm",
+    "PBM" => "pbm",
+    "PNM" => "pnm",
+    "Text" => "txt",
+    _ => return None,
+  })
+}
+
+/// The format an `Import` spec names, for the `"FMT"` and `{"FMT", elem…}`
+/// shapes alike.
+fn import_spec_format(spec: &Expr) -> Option<&'static str> {
+  match spec {
+    Expr::String(fmt) => import_format_name(fmt),
+    Expr::List(items) => match items.first() {
+      Some(Expr::String(fmt)) => import_format_name(fmt),
+      _ => None,
+    },
+    _ => None,
+  }
+}
+
+/// The file extension standing in for an explicit `Import` format, so a
+/// command's output is dispatched the way the same bytes in a file would
+/// be. Text is the fallback: it is what a pipe carries unless the caller
+/// says otherwise.
+#[cfg(not(target_arch = "wasm32"))]
+fn import_format_extension(format: Option<&Expr>) -> &'static str {
+  format.and_then(import_spec_format).unwrap_or("txt")
+}
+
 /// Resolve `Import`'s first argument to a path string: a plain string or a
 /// `URL["…"]` wrapper (which wolframscript accepts interchangeably).
 fn import_path_spec(expr: &Expr) -> Option<String> {
@@ -982,6 +1030,42 @@ pub fn dispatch_image_functions(
     "Rasterize" if !args.is_empty() => {
       return Some(crate::functions::image_ast::rasterize_ast(args));
     }
+    // Import["!command"] / Import["!command", format] — run the command and
+    // import what it writes to standard output. Its bytes are materialized
+    // in a temporary file so every format below reads them exactly as it
+    // reads a real file; the file carries the extension that stands for the
+    // requested format (text when none is given).
+    #[cfg(not(target_arch = "wasm32"))]
+    "Import"
+      if (1..=2).contains(&args.len())
+        && import_path_spec(&args[0]).is_some_and(|p| p.starts_with('!')) =>
+    {
+      use crate::evaluator::dispatch::io_functions::{
+        command_file_spec, run_command_capture_bytes,
+      };
+      let path = import_path_spec(&args[0]).unwrap_or_default();
+      let command = command_file_spec(&path).unwrap_or_default();
+      let failed = || {
+        crate::emit_message(&format!("Import::nffil: Cannot open {path}."));
+        Some(Ok(Expr::Identifier("$Failed".to_string())))
+      };
+      let Some(bytes) = run_command_capture_bytes(command) else {
+        return failed();
+      };
+      let ext = import_format_extension(args.get(1));
+      let Ok(temp) = crate::utils::create_temp_file(ext) else {
+        return failed();
+      };
+      if std::fs::write(&temp, &bytes).is_err() {
+        let _ = std::fs::remove_file(&temp);
+        return failed();
+      }
+      let mut piped = args.to_vec();
+      piped[0] = Expr::String(temp.to_string_lossy().into_owned());
+      let result = dispatch_image_functions("Import", &piped);
+      let _ = std::fs::remove_file(&temp);
+      return result;
+    }
     "Import" if args.len() == 1 => {
       let Some(path) = import_path_spec(&args[0]) else {
         return Some(Ok(unevaluated("Import", args)));
@@ -1301,6 +1385,29 @@ pub fn dispatch_image_functions(
             )));
           }
         }
+      }
+
+      // Formats with handling of their own have claimed the call by now.
+      // What is left is a second argument that names a format, an element,
+      // or both — and naming the format the file already has says nothing
+      // about *what* to extract, so `Import[f, "CSV"]` is `Import[f]` and
+      // `Import[f, {"CSV", elem}]` is `Import[f, elem]`. Without this the
+      // format name would travel on as an element name that no importer
+      // recognizes.
+      if import_spec_format(&args[1]) == Some(ext.as_str()) {
+        let reduced: Vec<Expr> = match &args[1] {
+          Expr::List(items) if items.len() > 1 => {
+            let mut rest: Vec<Expr> = items.iter().skip(1).cloned().collect();
+            let elem = if rest.len() == 1 {
+              rest.remove(0)
+            } else {
+              Expr::List(rest.into())
+            };
+            vec![args[0].clone(), elem]
+          }
+          _ => vec![args[0].clone()],
+        };
+        return dispatch_image_functions("Import", &reduced);
       }
 
       if ext == "csv" {

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -6,11 +6,131 @@ use std::collections::HashMap;
 // Stream registry for open streams (InputStream/OutputStream)
 #[derive(Clone, Debug)]
 enum StreamKind {
-  StringStream(String), // content of the string
+  Text(String), // content of the string
   // Only the native build opens files: `OpenRead`/`OpenWrite`/`OpenAppend`
   // are compiled out on wasm, where there is no local filesystem.
   #[cfg(not(target_arch = "wasm32"))]
-  FileStream(String), // file path
+  File(String), // file path
+  // A file specification starting with `!` names an external command
+  // instead of a file; the command runs through the shell and its
+  // standard output is what the stream reads.
+  #[cfg(not(target_arch = "wasm32"))]
+  Command(std::rc::Rc<RefCell<CommandStreamState>>),
+}
+
+/// State of a `"!command"` stream: the running child process plus the part
+/// of its standard output consumed so far. Output already handed out has to
+/// stay addressable because streams are position-indexed, so it is kept in
+/// `buffer` rather than discarded.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug)]
+struct CommandStreamState {
+  child: Option<std::process::Child>,
+  reader: Option<std::io::BufReader<std::process::ChildStdout>>,
+  buffer: String,
+  eof: bool,
+}
+
+/// Start `command` through the shell, with its standard output piped back
+/// to us. Standard input and standard error are inherited so that filters
+/// like `"!cat"` or `"!grep foo"` read the script's own input and report
+/// their errors on the terminal, as they do in wolframscript.
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_command_stream(command: &str) -> std::io::Result<CommandStreamState> {
+  use std::process::{Command, Stdio};
+  let mut cmd = if cfg!(target_os = "windows") {
+    let mut c = Command::new("cmd");
+    c.arg("/C").arg(command);
+    c
+  } else {
+    let mut c = Command::new("sh");
+    c.arg("-c").arg(command);
+    c
+  };
+  cmd
+    .stdin(Stdio::inherit())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::inherit());
+  let mut child = cmd.spawn()?;
+  let reader = child.stdout.take().map(std::io::BufReader::new);
+  Ok(CommandStreamState {
+    child: Some(child),
+    reader,
+    buffer: String::new(),
+    eof: false,
+  })
+}
+
+/// Release the pipe and reap the child once its output is exhausted.
+#[cfg(not(target_arch = "wasm32"))]
+fn command_stream_finish(state: &mut CommandStreamState) {
+  state.eof = true;
+  state.reader = None;
+  if let Some(mut child) = state.child.take() {
+    let _ = child.wait();
+  }
+}
+
+/// Pull one more line of the child's output into the buffer.
+/// Returns `false` once the command's output is exhausted.
+#[cfg(not(target_arch = "wasm32"))]
+fn command_stream_read_line(state: &mut CommandStreamState) -> bool {
+  use std::io::BufRead;
+  if state.eof {
+    return false;
+  }
+  let Some(reader) = state.reader.as_mut() else {
+    command_stream_finish(state);
+    return false;
+  };
+  let mut chunk: Vec<u8> = Vec::new();
+  match reader.read_until(b'\n', &mut chunk) {
+    Ok(0) | Err(_) => {
+      command_stream_finish(state);
+      false
+    }
+    Ok(_) => {
+      state.buffer.push_str(&String::from_utf8_lossy(&chunk));
+      true
+    }
+  }
+}
+
+/// Pull the rest of the child's output into the buffer.
+#[cfg(not(target_arch = "wasm32"))]
+fn command_stream_read_all(state: &mut CommandStreamState) {
+  while command_stream_read_line(state) {}
+}
+
+/// Stop a command stream that is closed before its output ran out, so a
+/// still-running command (`"!yes"`, an interactive filter) does not keep
+/// the interpreter waiting.
+#[cfg(not(target_arch = "wasm32"))]
+fn command_stream_close(state: &RefCell<CommandStreamState>) {
+  let mut state = state.borrow_mut();
+  state.reader = None;
+  if let Some(mut child) = state.child.take() {
+    let _ = child.kill();
+    let _ = child.wait();
+  }
+  state.eof = true;
+}
+
+/// Run `command` through the shell and return everything it writes to
+/// standard output. `None` if the shell could not be started at all.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn run_command_capture(command: &str) -> Option<String> {
+  let mut state = spawn_command_stream(command).ok()?;
+  command_stream_read_all(&mut state);
+  Some(state.buffer)
+}
+
+/// Split a Wolfram file specification into the external command it names.
+/// `"!sort -u"` runs `sort -u`; anything without the leading `!` is a
+/// plain file path.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn command_file_spec(spec: &str) -> Option<&str> {
+  spec.strip_prefix('!')
 }
 
 #[derive(Clone, Debug)]
@@ -58,21 +178,47 @@ fn is_stream_open(id: usize) -> bool {
   STREAM_REGISTRY.with(|reg| reg.borrow().contains_key(&id))
 }
 
+/// Look up a stream's kind and current read position.
+/// The kind is cloned so the registry is not kept borrowed across a read,
+/// which for a command stream can block on the child process.
+fn get_stream_kind(id: usize) -> Option<(StreamKind, usize)> {
+  STREAM_REGISTRY
+    .with(|reg| reg.borrow().get(&id).map(|s| (s.kind.clone(), s.position)))
+}
+
 /// Get the remaining content of a stream (for reading)
 fn get_stream_content(id: usize) -> Option<(String, usize)> {
-  STREAM_REGISTRY.with(|reg| {
-    let registry = reg.borrow();
-    registry.get(&id).map(|s| {
-      let content = match &s.kind {
-        StreamKind::StringStream(text) => text.clone(),
-        #[cfg(not(target_arch = "wasm32"))]
-        StreamKind::FileStream(path) => {
-          std::fs::read_to_string(path).unwrap_or_default()
-        }
-      };
-      (content, s.position)
-    })
-  })
+  let (kind, position) = get_stream_kind(id)?;
+  let content = match &kind {
+    StreamKind::Text(text) => text.clone(),
+    #[cfg(not(target_arch = "wasm32"))]
+    StreamKind::File(path) => std::fs::read_to_string(path).unwrap_or_default(),
+    // Whole-stream reads have to wait for the command to finish.
+    #[cfg(not(target_arch = "wasm32"))]
+    StreamKind::Command(state) => {
+      let mut state = state.borrow_mut();
+      command_stream_read_all(&mut state);
+      state.buffer.clone()
+    }
+  };
+  Some((content, position))
+}
+
+/// Content for a line-oriented read. A command stream only pulls as much of
+/// its child's output as the next line needs, so `ReadLine` keeps working
+/// line by line on a live pipe instead of blocking until the command exits.
+#[cfg(not(target_arch = "wasm32"))]
+fn get_stream_line_content(id: usize) -> Option<(String, usize)> {
+  if let Some((StreamKind::Command(state), position)) = get_stream_kind(id) {
+    let mut state = state.borrow_mut();
+    while !state.eof
+      && !state.buffer[position.min(state.buffer.len())..].contains('\n')
+    {
+      command_stream_read_line(&mut state);
+    }
+    return Some((state.buffer.clone(), position));
+  }
+  get_stream_content(id)
 }
 
 /// Get the current read position of a stream
@@ -476,7 +622,11 @@ pub fn dispatch_io_functions(
 
       let (content, position, stream_id) = match &args[0] {
         Expr::String(path) => {
-          if let Ok(c) = std::fs::read_to_string(path) {
+          let content = match command_file_spec(path) {
+            Some(command) => run_command_capture(command),
+            None => std::fs::read_to_string(path).ok(),
+          };
+          if let Some(c) = content {
             (c, 0usize, None)
           } else {
             crate::emit_message(&format!(
@@ -1850,16 +2000,27 @@ pub fn dispatch_io_functions(
           return Some(Ok(unevaluated("OpenRead", args)));
         }
       };
-      if !std::path::Path::new(&filename).exists() {
-        crate::emit_message_to_stdout(&format!(
-          "OpenRead::noopen: Cannot open {filename}."
-        ));
-        return Some(Ok(Expr::Identifier("$Failed".to_string())));
-      }
-      let id = register_stream(
-        filename.clone(),
-        StreamKind::FileStream(filename.clone()),
-      );
+      // `"!command"` opens a pipe from an external command instead of a
+      // file: the command runs through the shell and the stream reads its
+      // standard output.
+      let kind = if let Some(command) = command_file_spec(&filename) {
+        let Ok(state) = spawn_command_stream(command) else {
+          crate::emit_message_to_stdout(&format!(
+            "OpenRead::noopen: Cannot open {filename}."
+          ));
+          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        };
+        StreamKind::Command(std::rc::Rc::new(RefCell::new(state)))
+      } else {
+        if !std::path::Path::new(&filename).exists() {
+          crate::emit_message_to_stdout(&format!(
+            "OpenRead::noopen: Cannot open {filename}."
+          ));
+          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        }
+        StreamKind::File(filename.clone())
+      };
+      let id = register_stream(filename.clone(), kind);
       return Some(Ok(Expr::FunctionCall {
         name: "InputStream".to_string(),
         args: vec![Expr::String(filename), Expr::Integer(id as i128)].into(),
@@ -1896,10 +2057,8 @@ pub fn dispatch_io_functions(
       }) {
         return Some(Err(e));
       }
-      let id = register_stream(
-        filename.clone(),
-        StreamKind::FileStream(filename.clone()),
-      );
+      let id =
+        register_stream(filename.clone(), StreamKind::File(filename.clone()));
       return Some(Ok(Expr::FunctionCall {
         name: "OutputStream".to_string(),
         args: vec![Expr::String(filename), Expr::Integer(id as i128)].into(),
@@ -2186,10 +2345,8 @@ pub fn dispatch_io_functions(
       {
         return Some(Err(e));
       }
-      let id = register_stream(
-        filename.clone(),
-        StreamKind::FileStream(filename.clone()),
-      );
+      let id =
+        register_stream(filename.clone(), StreamKind::File(filename.clone()));
       return Some(Ok(Expr::FunctionCall {
         name: "OutputStream".to_string(),
         args: vec![Expr::String(filename), Expr::Integer(id as i128)].into(),
@@ -2206,8 +2363,7 @@ pub fn dispatch_io_functions(
           ))));
         }
       };
-      let id =
-        register_stream("String".to_string(), StreamKind::StringStream(text));
+      let id = register_stream("String".to_string(), StreamKind::Text(text));
       // Use Symbol `String` (not the string literal "String") so the
       // formatted form matches wolframscript: `InputStream[String, id]`.
       return Some(Ok(Expr::FunctionCall {
@@ -2239,11 +2395,18 @@ pub fn dispatch_io_functions(
           match close_stream(id) {
             // Close[FileStream] returns the file path as a String;
             // Close[StringToStream[…]] returns the symbol `String`.
-            Some((_, StreamKind::StringStream(_))) => {
+            Some((_, StreamKind::Text(_))) => {
               return Some(Ok(Expr::Identifier("String".to_string())));
             }
             #[cfg(not(target_arch = "wasm32"))]
-            Some((name, StreamKind::FileStream(_))) => {
+            Some((name, StreamKind::File(_))) => {
+              return Some(Ok(Expr::String(name)));
+            }
+            // Close[OpenRead["!cmd"]] returns the `"!cmd"` spec, and stops
+            // the command if it is still producing output.
+            #[cfg(not(target_arch = "wasm32"))]
+            Some((name, StreamKind::Command(state))) => {
+              command_stream_close(&state);
               return Some(Ok(Expr::String(name)));
             }
             None => {
@@ -2365,9 +2528,14 @@ pub fn dispatch_io_functions(
     #[cfg(not(target_arch = "wasm32"))]
     "ReadLine" if args.len() == 1 => {
       let (content, position, stream_id) = match &args[0] {
+        // ReadLine["file"] — read the first line from a file directly;
+        // ReadLine["!cmd"] — the first line of the command's output.
         Expr::String(path) => {
-          // ReadLine["file"] - read first line from file directly
-          if let Ok(content) = std::fs::read_to_string(path) {
+          let content = match command_file_spec(path) {
+            Some(command) => run_command_capture(command),
+            None => std::fs::read_to_string(path).ok(),
+          };
+          if let Some(content) = content {
             (content, 0usize, None)
           } else {
             crate::emit_message(&format!(
@@ -2382,7 +2550,7 @@ pub fn dispatch_io_functions(
         } if stream_head == "InputStream" && stream_args.len() == 2 => {
           if let Expr::Integer(id) = &stream_args[1] {
             let id = *id as usize;
-            match get_stream_content(id) {
+            match get_stream_line_content(id) {
               Some((content, pos)) => (content, pos, Some(id)),
               None => {
                 return Some(Ok(Expr::Identifier("EndOfFile".to_string())));
@@ -2546,8 +2714,9 @@ pub fn dispatch_io_functions(
             STREAM_REGISTRY.with(|reg| {
               let registry = reg.borrow();
               registry.get(&stream_id).and_then(|s| match &s.kind {
-                StreamKind::FileStream(path) => Some(path.clone()),
-                StreamKind::StringStream(_) => None,
+                StreamKind::File(path) => Some(path.clone()),
+                // Neither a string nor a command stream is writable.
+                StreamKind::Text(_) | StreamKind::Command(_) => None,
               })
             })
           } else {
@@ -2637,8 +2806,9 @@ pub fn dispatch_io_functions(
             STREAM_REGISTRY.with(|reg| {
               let registry = reg.borrow();
               registry.get(&stream_id).and_then(|s| match &s.kind {
-                StreamKind::FileStream(path) => Some(path.clone()),
-                StreamKind::StringStream(_) => None,
+                StreamKind::File(path) => Some(path.clone()),
+                // Neither a string nor a command stream is writable.
+                StreamKind::Text(_) | StreamKind::Command(_) => None,
               })
             })
           } else {
@@ -5214,14 +5384,22 @@ pub(crate) fn readlist_inputstream(
       let registry = reg.borrow();
       if let Some(stream) = registry.get(&stream_id) {
         match &stream.kind {
-          StreamKind::StringStream(text) => Ok(text.clone()),
+          StreamKind::Text(text) => Ok(text.clone()),
           #[cfg(not(target_arch = "wasm32"))]
-          StreamKind::FileStream(path) => std::fs::read_to_string(path)
-            .map_err(|_| {
+          StreamKind::File(path) => {
+            std::fs::read_to_string(path).map_err(|_| {
               InterpreterError::EvaluationError(format!(
                 "ReadList::noopen: Cannot open {path}."
               ))
-            }),
+            })
+          }
+          // ReadList consumes the whole stream, so wait for the command.
+          #[cfg(not(target_arch = "wasm32"))]
+          StreamKind::Command(state) => {
+            let mut state = state.borrow_mut();
+            command_stream_read_all(&mut state);
+            Ok(state.buffer.clone())
+          }
         }
       } else {
         Err(InterpreterError::EvaluationError(

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -16,19 +16,54 @@ enum StreamKind {
   // standard output is what the stream reads.
   #[cfg(not(target_arch = "wasm32"))]
   Command(std::rc::Rc<RefCell<CommandStreamState>>),
+  // The write end of the same convention: `OpenWrite["!command"]` feeds
+  // what is written to it into the command's standard input.
+  #[cfg(not(target_arch = "wasm32"))]
+  CommandSink(std::rc::Rc<RefCell<CommandSinkState>>),
 }
 
 /// State of a `"!command"` stream: the running child process plus the part
 /// of its standard output consumed so far. Output already handed out has to
 /// stay addressable because streams are position-indexed, so it is kept in
 /// `buffer` rather than discarded.
+///
+/// The buffer holds raw bytes so `BinaryRead` sees the command's output
+/// unaltered; text reads decode it lossily, which leaves byte offsets and
+/// string offsets in step for the valid UTF-8 that text reads assume.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug)]
 struct CommandStreamState {
   child: Option<std::process::Child>,
   reader: Option<std::io::BufReader<std::process::ChildStdout>>,
-  buffer: String,
+  buffer: Vec<u8>,
   eof: bool,
+}
+
+/// State of a `"!command"` output stream: the running child process and the
+/// handle on its standard input. Closing the stream drops the handle, which
+/// is the command's end-of-input, and then waits for it to finish.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug)]
+struct CommandSinkState {
+  child: Option<std::process::Child>,
+  stdin: Option<std::process::ChildStdin>,
+}
+
+/// Build the shell invocation that runs `command`.
+#[cfg(not(target_arch = "wasm32"))]
+fn shell_command(command: &str) -> std::process::Command {
+  let mut cmd = if cfg!(target_os = "windows") {
+    std::process::Command::new("cmd")
+  } else {
+    std::process::Command::new("sh")
+  };
+  cmd.arg(if cfg!(target_os = "windows") {
+    "/C"
+  } else {
+    "-c"
+  });
+  cmd.arg(command);
+  cmd
 }
 
 /// Start `command` through the shell, with its standard output piped back
@@ -37,28 +72,72 @@ struct CommandStreamState {
 /// their errors on the terminal, as they do in wolframscript.
 #[cfg(not(target_arch = "wasm32"))]
 fn spawn_command_stream(command: &str) -> std::io::Result<CommandStreamState> {
-  use std::process::{Command, Stdio};
-  let mut cmd = if cfg!(target_os = "windows") {
-    let mut c = Command::new("cmd");
-    c.arg("/C").arg(command);
-    c
-  } else {
-    let mut c = Command::new("sh");
-    c.arg("-c").arg(command);
-    c
-  };
-  cmd
+  use std::process::Stdio;
+  let mut child = shell_command(command)
     .stdin(Stdio::inherit())
     .stdout(Stdio::piped())
-    .stderr(Stdio::inherit());
-  let mut child = cmd.spawn()?;
+    .stderr(Stdio::inherit())
+    .spawn()?;
   let reader = child.stdout.take().map(std::io::BufReader::new);
   Ok(CommandStreamState {
     child: Some(child),
     reader,
-    buffer: String::new(),
+    buffer: Vec::new(),
     eof: false,
   })
+}
+
+/// Start `command` through the shell with its standard input piped from us.
+/// Its output streams straight to the terminal, as it does in wolframscript.
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_command_sink(command: &str) -> std::io::Result<CommandSinkState> {
+  use std::process::Stdio;
+  let mut child = shell_command(command)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::inherit())
+    .stderr(Stdio::inherit())
+    .spawn()?;
+  let stdin = child.stdin.take();
+  Ok(CommandSinkState {
+    child: Some(child),
+    stdin,
+  })
+}
+
+/// Feed `bytes` to an open command sink. `false` if the command is gone —
+/// it exited early, or the stream has already been closed.
+#[cfg(not(target_arch = "wasm32"))]
+fn command_sink_write(state: &RefCell<CommandSinkState>, bytes: &[u8]) -> bool {
+  use std::io::Write;
+  let mut state = state.borrow_mut();
+  let Some(stdin) = state.stdin.as_mut() else {
+    return false;
+  };
+  stdin.write_all(bytes).is_ok() && stdin.flush().is_ok()
+}
+
+/// Close a command sink: drop the pipe so the command sees end-of-input,
+/// then wait for it to finish so its output lands before evaluation goes on.
+#[cfg(not(target_arch = "wasm32"))]
+fn command_sink_close(state: &RefCell<CommandSinkState>) {
+  let mut state = state.borrow_mut();
+  drop(state.stdin.take());
+  if let Some(mut child) = state.child.take() {
+    let _ = child.wait();
+  }
+}
+
+/// Run `command` through the shell, feed it `input`, and wait for it.
+/// `false` if the shell could not be started at all.
+#[cfg(not(target_arch = "wasm32"))]
+fn run_command_with_input(command: &str, input: &[u8]) -> bool {
+  let Ok(state) = spawn_command_sink(command) else {
+    return false;
+  };
+  let state = RefCell::new(state);
+  command_sink_write(&state, input);
+  command_sink_close(&state);
+  true
 }
 
 /// Release the pipe and reap the child once its output is exhausted.
@@ -90,7 +169,7 @@ fn command_stream_read_line(state: &mut CommandStreamState) -> bool {
       false
     }
     Ok(_) => {
-      state.buffer.push_str(&String::from_utf8_lossy(&chunk));
+      state.buffer.extend_from_slice(&chunk);
       true
     }
   }
@@ -116,13 +195,21 @@ fn command_stream_close(state: &RefCell<CommandStreamState>) {
   state.eof = true;
 }
 
-/// Run `command` through the shell and return everything it writes to
+/// Run `command` through the shell and return the bytes it writes to
 /// standard output. `None` if the shell could not be started at all.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn run_command_capture(command: &str) -> Option<String> {
+pub(crate) fn run_command_capture_bytes(command: &str) -> Option<Vec<u8>> {
   let mut state = spawn_command_stream(command).ok()?;
   command_stream_read_all(&mut state);
   Some(state.buffer)
+}
+
+/// Run `command` through the shell and return everything it writes to
+/// standard output as text. `None` if the shell could not be started at all.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn run_command_capture(command: &str) -> Option<String> {
+  run_command_capture_bytes(command)
+    .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
 }
 
 /// Split a Wolfram file specification into the external command it names.
@@ -131,6 +218,117 @@ pub(crate) fn run_command_capture(command: &str) -> Option<String> {
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn command_file_spec(spec: &str) -> Option<&str> {
   spec.strip_prefix('!')
+}
+
+/// The registry id of an `InputStream[name, id]` / `OutputStream[name, id]`.
+fn io_stream_id(expr: &Expr) -> Option<usize> {
+  let Expr::FunctionCall { name, args } = expr else {
+    return None;
+  };
+  if (name != "InputStream" && name != "OutputStream") || args.len() != 2 {
+    return None;
+  }
+  match &args[1] {
+    Expr::Integer(id) => Some(*id as usize),
+    _ => None,
+  }
+}
+
+/// Bytes for a binary read. An open stream is served from the registry, so
+/// a `"!command"` pipe reads the command's output; `path` (the stream's
+/// name) is the fallback for a stream that is no longer open.
+#[cfg(not(target_arch = "wasm32"))]
+fn io_binary_bytes(expr: &Expr, path: &str) -> std::io::Result<Vec<u8>> {
+  if let Some(id) = io_stream_id(expr)
+    && let Some(bytes) = get_stream_bytes(id)
+  {
+    return Ok(bytes);
+  }
+  match command_file_spec(path) {
+    Some(command) => run_command_capture_bytes(command)
+      .ok_or_else(|| std::io::Error::other("cannot start the shell")),
+    None => std::fs::read(path),
+  }
+}
+
+/// Where a write function sends its bytes.
+#[cfg(not(target_arch = "wasm32"))]
+enum WriteTarget {
+  /// Append to a file.
+  File(String),
+  /// The standard input of an open `OpenWrite["!command"]` stream.
+  Sink(std::rc::Rc<RefCell<CommandSinkState>>),
+  /// A `"!command"` named directly instead of through an open stream: the
+  /// command runs for this one write and is fed exactly its bytes.
+  Command(String),
+}
+
+/// Resolve the first argument of `Write`/`WriteString`/`BinaryWrite` to the
+/// thing that receives the bytes. `None` for anything unwritable, which
+/// leaves the call unevaluated.
+#[cfg(not(target_arch = "wasm32"))]
+fn io_write_target(expr: &Expr) -> Option<WriteTarget> {
+  match expr {
+    Expr::String(spec) => Some(match command_file_spec(spec) {
+      Some(command) => WriteTarget::Command(command.to_string()),
+      None => WriteTarget::File(spec.clone()),
+    }),
+    Expr::FunctionCall { name, args }
+      if (name == "OutputStream" || name == "InputStream")
+        && args.len() == 2 =>
+    {
+      let Expr::Integer(id) = &args[1] else {
+        return None;
+      };
+      match get_stream_kind(*id as usize)?.0 {
+        StreamKind::File(path) => Some(WriteTarget::File(path)),
+        StreamKind::CommandSink(state) => Some(WriteTarget::Sink(state)),
+        // Neither a string stream nor the read end of a pipe is writable.
+        StreamKind::Text(_) | StreamKind::Command(_) => None,
+      }
+    }
+    _ => None,
+  }
+}
+
+/// Send `bytes` to a write target, appending for files. `caller` only names
+/// the function in the error message.
+#[cfg(not(target_arch = "wasm32"))]
+fn write_target_bytes(
+  target: &WriteTarget,
+  bytes: &[u8],
+  caller: &str,
+) -> Result<(), InterpreterError> {
+  match target {
+    WriteTarget::File(path) => {
+      use std::io::Write;
+      let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| {
+          InterpreterError::EvaluationError(format!(
+            "{caller}: cannot open {path}: {e}"
+          ))
+        })?;
+      file.write_all(bytes).map_err(|e| {
+        InterpreterError::EvaluationError(format!("{caller}: write error: {e}"))
+      })
+    }
+    WriteTarget::Sink(state) => {
+      command_sink_write(state, bytes);
+      Ok(())
+    }
+    WriteTarget::Command(command) => {
+      if run_command_with_input(command, bytes) {
+        Ok(())
+      } else {
+        Err(InterpreterError::EvaluationError(format!(
+          "{caller}: cannot open !{command}."
+        )))
+      }
+    }
+  }
 }
 
 #[derive(Clone, Debug)]
@@ -198,10 +396,29 @@ fn get_stream_content(id: usize) -> Option<(String, usize)> {
     StreamKind::Command(state) => {
       let mut state = state.borrow_mut();
       command_stream_read_all(&mut state);
-      state.buffer.clone()
+      String::from_utf8_lossy(&state.buffer).into_owned()
     }
+    // Nothing was ever read into a command sink.
+    #[cfg(not(target_arch = "wasm32"))]
+    StreamKind::CommandSink(_) => String::new(),
   };
   Some((content, position))
+}
+
+/// The raw bytes behind a stream, for `BinaryRead`. Command streams are
+/// drained to the end, like any other whole-stream read.
+#[cfg(not(target_arch = "wasm32"))]
+fn get_stream_bytes(id: usize) -> Option<Vec<u8>> {
+  match get_stream_kind(id)?.0 {
+    StreamKind::Text(text) => Some(text.into_bytes()),
+    StreamKind::File(path) => std::fs::read(path).ok(),
+    StreamKind::Command(state) => {
+      let mut state = state.borrow_mut();
+      command_stream_read_all(&mut state);
+      Some(state.buffer.clone())
+    }
+    StreamKind::CommandSink(_) => Some(Vec::new()),
+  }
 }
 
 /// Content for a line-oriented read. A command stream only pulls as much of
@@ -212,11 +429,14 @@ fn get_stream_line_content(id: usize) -> Option<(String, usize)> {
   if let Some((StreamKind::Command(state), position)) = get_stream_kind(id) {
     let mut state = state.borrow_mut();
     while !state.eof
-      && !state.buffer[position.min(state.buffer.len())..].contains('\n')
+      && !state.buffer[position.min(state.buffer.len())..].contains(&b'\n')
     {
       command_stream_read_line(&mut state);
     }
-    return Some((state.buffer.clone(), position));
+    return Some((
+      String::from_utf8_lossy(&state.buffer).into_owned(),
+      position,
+    ));
   }
   get_stream_content(id)
 }
@@ -301,20 +521,25 @@ pub(crate) fn evaluate_file(
   // The read file is the input file for the duration of the read, so
   // `$InputFileName` must point at it and not at the enclosing script.
   let _input_file_name = InputFileNameGuard::install(path);
-  // Use interpret to evaluate the file content (handles all node types
+  Some(evaluate_source(&content))
+}
+
+/// Evaluate Wolfram source, returning its last result — what `Get` yields
+/// for whatever it read, be that a file or a command's output.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn evaluate_source(content: &str) -> Result<Expr, InterpreterError> {
+  // Use interpret to evaluate the content (handles all node types
   // including FunctionDefinition, Expression, etc.)
-  let result_str = match crate::interpret(&content) {
-    Ok(v) => v,
-    Err(e) => return Some(Err(e)),
-  };
+  let result_str = crate::interpret(content)?;
   // `interpret` reports a `Null` result as the "\0" display-suppression
   // sentinel; as the value of `Get` it is the symbol `Null` again.
   if result_str == "\0" {
-    return Some(Ok(Expr::Identifier("Null".to_string())));
+    return Ok(Expr::Identifier("Null".to_string()));
   }
-  let result = crate::syntax::string_to_expr(&result_str)
-    .unwrap_or(Expr::Identifier(result_str));
-  Some(Ok(result))
+  Ok(
+    crate::syntax::string_to_expr(&result_str)
+      .unwrap_or(Expr::Identifier(result_str)),
+  )
 }
 
 /// Scopes `$InputFileName` to the file a `Get` is currently reading.
@@ -776,6 +1001,17 @@ pub fn dispatch_io_functions(
       if crate::utils::is_standard_distribution_context(&filename) {
         return Some(Ok(Expr::Identifier("Null".to_string())));
       }
+      // `"!command"` evaluates the code the command writes to its standard
+      // output, the read counterpart of `Put["!command"]`.
+      if let Some(command) = command_file_spec(&filename) {
+        let Some(content) = run_command_capture(command) else {
+          crate::emit_message_to_stdout(&format!(
+            "Get::noopen: Cannot open {filename}."
+          ));
+          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        };
+        return Some(evaluate_source(&content));
+      }
       let resolved = resolve_get_target(&filename);
       let loaded = resolved.as_deref().and_then(evaluate_file);
       let Some(result) = loaded else {
@@ -852,6 +1088,14 @@ pub fn dispatch_io_functions(
       } else {
         format!("{content}\n")
       };
+      // `"!command"` feeds the expressions to a command instead of a file.
+      if let Some(command) = command_file_spec(&filename) {
+        if run_command_with_input(command, to_write.as_bytes()) {
+          return Some(Ok(Expr::Identifier("Null".to_string())));
+        }
+        crate::emit_message(&format!("Put::noopen: Cannot open {filename}."));
+        return Some(Ok(Expr::Identifier("$Failed".to_string())));
+      }
       match std::fs::write(&filename, to_write) {
         Ok(()) => return Some(Ok(Expr::Identifier("Null".to_string()))),
         Err(_e) => {
@@ -878,6 +1122,16 @@ pub fn dispatch_io_functions(
       if !exprs.is_empty() {
         use std::io::Write;
         let to_write = format!("{content}\n");
+        // A pipe has nothing to append to, so `"!command"` just runs.
+        if let Some(command) = command_file_spec(&filename) {
+          if run_command_with_input(command, to_write.as_bytes()) {
+            return Some(Ok(Expr::Identifier("Null".to_string())));
+          }
+          crate::emit_message(&format!(
+            "PutAppend::noopen: Cannot open {filename}."
+          ));
+          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        }
         if let Ok(mut file) = std::fs::OpenOptions::new()
           .create(true)
           .append(true)
@@ -1473,16 +1727,22 @@ pub fn dispatch_io_functions(
 
       // (content, start_pos, optional stream id for position advance)
       let (content, start_pos, stream_id) = match &args[0] {
+        // A `"!command"` name searches the command's output.
         Expr::String(path) => {
-          let body = match std::fs::read_to_string(path) {
-            Ok(c) => c,
-            Err(e) => {
-              return Some(Err(InterpreterError::EvaluationError(format!(
-                "Find: {e}"
-              ))));
-            }
+          let body = match command_file_spec(path) {
+            Some(command) => run_command_capture(command).ok_or_else(|| {
+              InterpreterError::EvaluationError(format!(
+                "Find: cannot run {command}"
+              ))
+            }),
+            None => std::fs::read_to_string(path).map_err(|e| {
+              InterpreterError::EvaluationError(format!("Find: {e}"))
+            }),
           };
-          (body, 0usize, None)
+          match body {
+            Ok(c) => (c, 0usize, None),
+            Err(e) => return Some(Err(e)),
+          }
         }
         Expr::FunctionCall {
           name: stream_head,
@@ -1627,8 +1887,13 @@ pub fn dispatch_io_functions(
           out.push(Expr::Identifier("$Failed".to_string()));
           continue;
         };
-        match std::fs::read_to_string(path) {
-          Err(_) => {
+        // A `"!command"` entry searches that command's output.
+        let read = match command_file_spec(path) {
+          Some(command) => run_command_capture(command).ok_or(()),
+          None => std::fs::read_to_string(path).map_err(|_| ()),
+        };
+        match read {
+          Err(()) => {
             crate::emit_message(&format!(
               "FindList::noopen: Cannot open {path}."
             ));
@@ -2049,16 +2314,28 @@ pub fn dispatch_io_functions(
           path.to_string_lossy().into_owned()
         }
       };
-      // Create or truncate the file
-      if let Err(e) = std::fs::File::create(&filename).map_err(|e| {
-        InterpreterError::EvaluationError(format!(
-          "OpenWrite: cannot open {filename}: {e}"
-        ))
-      }) {
-        return Some(Err(e));
-      }
-      let id =
-        register_stream(filename.clone(), StreamKind::File(filename.clone()));
+      // `"!command"` opens a pipe *into* an external command: whatever is
+      // written to the stream becomes the command's standard input.
+      let kind = if let Some(command) = command_file_spec(&filename) {
+        let Ok(state) = spawn_command_sink(command) else {
+          crate::emit_message_to_stdout(&format!(
+            "OpenWrite::noopen: Cannot open {filename}."
+          ));
+          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        };
+        StreamKind::CommandSink(std::rc::Rc::new(RefCell::new(state)))
+      } else {
+        // Create or truncate the file
+        if let Err(e) = std::fs::File::create(&filename).map_err(|e| {
+          InterpreterError::EvaluationError(format!(
+            "OpenWrite: cannot open {filename}: {e}"
+          ))
+        }) {
+          return Some(Err(e));
+        }
+        StreamKind::File(filename.clone())
+      };
+      let id = register_stream(filename.clone(), kind);
       return Some(Ok(Expr::FunctionCall {
         name: "OutputStream".to_string(),
         args: vec![Expr::String(filename), Expr::Integer(id as i128)].into(),
@@ -2073,7 +2350,7 @@ pub fn dispatch_io_functions(
     // infers the type from the value (Integer → Byte, String → Character8).
     #[cfg(not(target_arch = "wasm32"))]
     "BinaryWrite" if (2..=3).contains(&args.len()) => {
-      let Some(path) = io_stream_path(&args[0]) else {
+      let Some(target) = io_write_target(&args[0]) else {
         return Some(Ok(unevaluated("BinaryWrite", args)));
       };
       // Render a single value at the given type into the byte buffer.
@@ -2144,23 +2421,8 @@ pub fn dispatch_io_functions(
           _ => return Some(Ok(unevaluated())),
         }
       };
-      use std::io::Write;
-      let mut f = match std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-      {
-        Ok(f) => f,
-        Err(e) => {
-          return Some(Err(InterpreterError::EvaluationError(format!(
-            "BinaryWrite: cannot open {path}: {e}"
-          ))));
-        }
-      };
-      if let Err(e) = f.write_all(&bytes) {
-        return Some(Err(InterpreterError::EvaluationError(format!(
-          "BinaryWrite: write failed on {path}: {e}"
-        ))));
+      if let Err(e) = write_target_bytes(&target, &bytes, "BinaryWrite") {
+        return Some(Err(e));
       }
       return Some(Ok(args[0].clone()));
     }
@@ -2178,22 +2440,10 @@ pub fn dispatch_io_functions(
       let Some(path) = io_stream_path(&args[0]) else {
         return Some(Ok(unevaluated("BinaryRead", args)));
       };
-      // Extract stream id (second arg of InputStream[path, id]) so we can
-      // track and advance the read position. Falls back to id-less reads
-      // (always from offset 0) when the structure doesn't match.
-      let stream_id = if let Expr::FunctionCall {
-        name: sname,
-        args: sargs,
-      } = &args[0]
-        && (sname == "InputStream" || sname == "OutputStream")
-        && sargs.len() == 2
-        && let Expr::Integer(id) = &sargs[1]
-      {
-        Some(*id as usize)
-      } else {
-        None
-      };
-      let bytes = match std::fs::read(&path) {
+      // The stream id lets consecutive reads advance the position; an
+      // id-less stream always reads from offset 0.
+      let stream_id = io_stream_id(&args[0]);
+      let bytes = match io_binary_bytes(&args[0], &path) {
         Ok(b) => b,
         Err(e) => {
           return Some(Err(InterpreterError::EvaluationError(format!(
@@ -2296,7 +2546,7 @@ pub fn dispatch_io_functions(
           return Some(Ok(unevaluated("BinaryReadList", args)));
         }
       }
-      let bytes = match std::fs::read(&path) {
+      let bytes = match io_binary_bytes(&args[0], &path) {
         Ok(b) => b,
         Err(e) => {
           return Some(Err(InterpreterError::EvaluationError(format!(
@@ -2332,21 +2582,33 @@ pub fn dispatch_io_functions(
           }
         }
       };
-      // Open for appending (create if not exists)
-      if let Err(e) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&filename)
-        .map_err(|e| {
-          InterpreterError::EvaluationError(format!(
-            "OpenAppend: cannot open {filename}: {e}"
-          ))
-        })
-      {
-        return Some(Err(e));
-      }
-      let id =
-        register_stream(filename.clone(), StreamKind::File(filename.clone()));
+      // A pipe has no contents to append to, so `"!command"` opens the same
+      // stream `OpenWrite` would.
+      let kind = if let Some(command) = command_file_spec(&filename) {
+        let Ok(state) = spawn_command_sink(command) else {
+          crate::emit_message_to_stdout(&format!(
+            "OpenAppend::noopen: Cannot open {filename}."
+          ));
+          return Some(Ok(Expr::Identifier("$Failed".to_string())));
+        };
+        StreamKind::CommandSink(std::rc::Rc::new(RefCell::new(state)))
+      } else {
+        // Open for appending (create if not exists)
+        if let Err(e) = std::fs::OpenOptions::new()
+          .create(true)
+          .append(true)
+          .open(&filename)
+          .map_err(|e| {
+            InterpreterError::EvaluationError(format!(
+              "OpenAppend: cannot open {filename}: {e}"
+            ))
+          })
+        {
+          return Some(Err(e));
+        }
+        StreamKind::File(filename.clone())
+      };
+      let id = register_stream(filename.clone(), kind);
       return Some(Ok(Expr::FunctionCall {
         name: "OutputStream".to_string(),
         args: vec![Expr::String(filename), Expr::Integer(id as i128)].into(),
@@ -2407,6 +2669,13 @@ pub fn dispatch_io_functions(
             #[cfg(not(target_arch = "wasm32"))]
             Some((name, StreamKind::Command(state))) => {
               command_stream_close(&state);
+              return Some(Ok(Expr::String(name)));
+            }
+            // Closing the write end is what tells the command its input has
+            // ended, so it runs to completion here.
+            #[cfg(not(target_arch = "wasm32"))]
+            Some((name, StreamKind::CommandSink(state))) => {
+              command_sink_close(&state);
               return Some(Ok(Expr::String(name)));
             }
             None => {
@@ -2700,61 +2969,18 @@ pub fn dispatch_io_functions(
     // Write[stream, expr1, expr2, ...] — write expressions to a stream in OutputForm
     #[cfg(not(target_arch = "wasm32"))]
     "Write" if args.len() >= 2 => {
-      let stream = &args[0];
-      let file_path = match stream {
-        Expr::FunctionCall {
-          name: stream_head,
-          args: stream_args,
-        } if (stream_head == "OutputStream"
-          || stream_head == "InputStream")
-          && stream_args.len() == 2 =>
-        {
-          if let Expr::Integer(id) = &stream_args[1] {
-            let stream_id = *id as usize;
-            STREAM_REGISTRY.with(|reg| {
-              let registry = reg.borrow();
-              registry.get(&stream_id).and_then(|s| match &s.kind {
-                StreamKind::File(path) => Some(path.clone()),
-                // Neither a string nor a command stream is writable.
-                StreamKind::Text(_) | StreamKind::Command(_) => None,
-              })
-            })
-          } else {
-            None
-          }
-        }
-        Expr::String(path) => Some(path.clone()),
-        _ => None,
+      let Some(target) = io_write_target(&args[0]) else {
+        return Some(Ok(unevaluated("Write", args)));
       };
-
-      if let Some(path) = file_path {
-        use std::io::Write;
-        let mut file = match std::fs::OpenOptions::new()
-          .create(true)
-          .append(true)
-          .open(&path)
-          .map_err(|e| {
-            InterpreterError::EvaluationError(format!(
-              "Write: cannot open {path}: {e}"
-            ))
-          }) {
-          Ok(v) => v,
-          Err(e) => return Some(Err(e)),
-        };
-        let mut content = String::new();
-        for arg in &args[1..] {
-          content.push_str(&crate::syntax::expr_to_string(arg));
-        }
-        content.push('\n');
-        if let Err(e) = file.write_all(content.as_bytes()).map_err(|e| {
-          InterpreterError::EvaluationError(format!("Write: write error: {e}"))
-        }) {
-          return Some(Err(e));
-        }
-        return Some(Ok(Expr::Identifier("Null".to_string())));
+      let mut content = String::new();
+      for arg in &args[1..] {
+        content.push_str(&crate::syntax::expr_to_string(arg));
       }
-
-      return Some(Ok(unevaluated("Write", args)));
+      content.push('\n');
+      if let Err(e) = write_target_bytes(&target, content.as_bytes(), "Write") {
+        return Some(Err(e));
+      }
+      return Some(Ok(Expr::Identifier("Null".to_string())));
     }
     // WriteString[stream, "text1", "text2", ...] — write strings to a stream
     #[cfg(not(target_arch = "wasm32"))]
@@ -2792,64 +3018,24 @@ pub fn dispatch_io_functions(
         }
         return Some(Ok(Expr::Identifier("Null".to_string())));
       }
-      // Extract stream info
-      let file_path = match stream {
-        Expr::FunctionCall {
-          name: stream_head,
-          args: stream_args,
-        } if (stream_head == "OutputStream"
-          || stream_head == "InputStream")
-          && stream_args.len() == 2 =>
-        {
-          if let Expr::Integer(id) = &stream_args[1] {
-            let stream_id = *id as usize;
-            STREAM_REGISTRY.with(|reg| {
-              let registry = reg.borrow();
-              registry.get(&stream_id).and_then(|s| match &s.kind {
-                StreamKind::File(path) => Some(path.clone()),
-                // Neither a string nor a command stream is writable.
-                StreamKind::Text(_) | StreamKind::Command(_) => None,
-              })
-            })
-          } else {
-            None
-          }
-        }
-        Expr::String(path) => Some(path.clone()),
-        _ => None,
+      let Some(target) = io_write_target(stream) else {
+        return Some(Ok(unevaluated("WriteString", args)));
       };
-
-      if let Some(path) = file_path {
-        use std::io::Write;
-        let mut file = match std::fs::OpenOptions::new()
-          .create(true)
-          .append(true)
-          .open(&path)
-          .map_err(|e| {
-            InterpreterError::EvaluationError(format!(
-              "WriteString: cannot open {path}: {e}"
-            ))
-          }) {
-          Ok(v) => v,
-          Err(e) => return Some(Err(e)),
-        };
-        for arg in &args[1..] {
-          let text = match arg {
-            Expr::String(s) => s.clone(),
-            other => crate::syntax::expr_to_string(other),
-          };
-          if let Err(e) = file.write_all(text.as_bytes()).map_err(|e| {
-            InterpreterError::EvaluationError(format!(
-              "WriteString: write error: {e}"
-            ))
-          }) {
-            return Some(Err(e));
-          }
+      // A `"!command"` named directly runs once per call, so the whole
+      // argument list has to reach it in a single write.
+      let mut text = String::new();
+      for arg in &args[1..] {
+        match arg {
+          Expr::String(s) => text.push_str(s),
+          other => text.push_str(&crate::syntax::expr_to_string(other)),
         }
-        return Some(Ok(Expr::Identifier("Null".to_string())));
       }
-
-      return Some(Ok(unevaluated("WriteString", args)));
+      if let Err(e) =
+        write_target_bytes(&target, text.as_bytes(), "WriteString")
+      {
+        return Some(Err(e));
+      }
+      return Some(Ok(Expr::Identifier("Null".to_string())));
     }
     // Save["filename", symbol] or Save["filename", {sym1, sym2, ...}]
     // Saves symbol definitions (OwnValues, DownValues, Attributes, Options) to a file
@@ -5378,38 +5564,27 @@ fn read_string_chunk(
 pub(crate) fn readlist_inputstream(
   args: &[Expr],
 ) -> Result<String, InterpreterError> {
-  if let Expr::Integer(id) = &args[1] {
-    let stream_id = *id as usize;
-    STREAM_REGISTRY.with(|reg| {
-      let registry = reg.borrow();
-      if let Some(stream) = registry.get(&stream_id) {
-        match &stream.kind {
-          StreamKind::Text(text) => Ok(text.clone()),
-          #[cfg(not(target_arch = "wasm32"))]
-          StreamKind::File(path) => {
-            std::fs::read_to_string(path).map_err(|_| {
-              InterpreterError::EvaluationError(format!(
-                "ReadList::noopen: Cannot open {path}."
-              ))
-            })
-          }
-          // ReadList consumes the whole stream, so wait for the command.
-          #[cfg(not(target_arch = "wasm32"))]
-          StreamKind::Command(state) => {
-            let mut state = state.borrow_mut();
-            command_stream_read_all(&mut state);
-            Ok(state.buffer.clone())
-          }
-        }
-      } else {
-        Err(InterpreterError::EvaluationError(
-          "ReadList: stream is not open".into(),
-        ))
-      }
-    })
-  } else {
-    Err(InterpreterError::EvaluationError(
+  let Expr::Integer(id) = &args[1] else {
+    return Err(InterpreterError::EvaluationError(
       "ReadList: invalid stream object".into(),
-    ))
+    ));
+  };
+  let stream_id = *id as usize;
+  let Some((kind, _)) = get_stream_kind(stream_id) else {
+    return Err(InterpreterError::EvaluationError(
+      "ReadList: stream is not open".into(),
+    ));
+  };
+  // A file that cannot be read is the one case with its own message; every
+  // other kind (including a command's output) is drained by
+  // `get_stream_content`, which reads it whole.
+  #[cfg(not(target_arch = "wasm32"))]
+  if let StreamKind::File(path) = &kind
+    && !std::path::Path::new(path).is_file()
+  {
+    return Err(InterpreterError::EvaluationError(format!(
+      "ReadList::noopen: Cannot open {path}."
+    )));
   }
+  Ok(get_stream_content(stream_id).map_or_else(String::new, |(c, _)| c))
 }

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -11971,12 +11971,26 @@ fn readlist_get_text(source: &Expr) -> Result<String, InterpreterError> {
         path
       ))),
     },
+    // A `"!command"` spec reads the output of an external command instead
+    // of a file.
     #[cfg(not(target_arch = "wasm32"))]
-    Expr::String(path) => std::fs::read_to_string(path).map_err(|_| {
-      InterpreterError::EvaluationError(format!(
-        "ReadList::noopen: Cannot open {path}."
-      ))
-    }),
+    Expr::String(path) => {
+      let content =
+        match crate::evaluator::dispatch::io_functions::command_file_spec(path)
+        {
+          Some(command) => {
+            crate::evaluator::dispatch::io_functions::run_command_capture(
+              command,
+            )
+          }
+          None => std::fs::read_to_string(path).ok(),
+        };
+      content.ok_or_else(|| {
+        InterpreterError::EvaluationError(format!(
+          "ReadList::noopen: Cannot open {path}."
+        ))
+      })
+    }
     _ => Err(InterpreterError::EvaluationError(
       "ReadList expects a filename string or StringToStream[\"text\"]".into(),
     )),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,12 +24,31 @@ pub fn create_file(
     None => std::env::temp_dir().join(rand_str(16)),
   };
 
+  create_new_file(file_path)
+}
+
+/// Create a uniquely named empty file in the system temp directory carrying
+/// `extension`, for callers that need the name to say what the bytes are.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn create_temp_file(
+  extension: &str,
+) -> Result<std::path::PathBuf, std::io::Error> {
+  create_new_file(
+    std::env::temp_dir().join(format!("{}.{extension}", rand_str(16))),
+  )
+}
+
+/// Create `path`, failing if something is already there.
+#[cfg(not(target_arch = "wasm32"))]
+fn create_new_file(
+  path: std::path::PathBuf,
+) -> Result<std::path::PathBuf, std::io::Error> {
   std::fs::OpenOptions::new()
     .create_new(true)
     .write(true)
     .truncate(true)
-    .open(&file_path)
-    .map(|_| file_path)
+    .open(&path)
+    .map(|_| path)
 }
 
 /// Join `sub` onto `base` with the platform's path separator.

--- a/tests/cli/file_system/Get.md
+++ b/tests/cli/file_system/Get.md
@@ -1,3 +1,18 @@
 # `Get`
 
 Reads and evaluates a file returning the last result.
+
+A file name starting with `!` evaluates the code an external command writes
+to its standard output:
+
+```scrut
+$ wo 'Get["!echo 1 + 2"]'
+3
+```
+
+`<<` is the same function in operator form:
+
+```scrut
+$ wo '<< "!echo 6*7"'
+42
+```

--- a/tests/cli/file_system/OpenRead.md
+++ b/tests/cli/file_system/OpenRead.md
@@ -1,3 +1,18 @@
 # `OpenRead`
 
 Opens a file for reading.
+
+A file name starting with `!` names an external command instead of a file:
+the command is run through the shell and the stream reads its standard output.
+
+```scrut
+$ wo 'stream = OpenRead["!echo woxi"]; line = ReadLine[stream]; Close[stream]; line'
+woxi
+```
+
+Reading past the command's output yields `EndOfFile`:
+
+```scrut
+$ wo 'stream = OpenRead["!echo woxi"]; ReadLine[stream]; rest = ReadLine[stream]; Close[stream]; rest'
+EndOfFile
+```

--- a/tests/cli/file_system/OpenWrite.md
+++ b/tests/cli/file_system/OpenWrite.md
@@ -6,3 +6,13 @@ Opens a file for writing.
 $ wo 'Head[OpenWrite[]]'
 OutputStream
 ```
+
+A file name starting with `!` opens a pipe into an external command instead:
+what is written to the stream becomes the command's standard input, and
+closing the stream is what tells the command its input has ended.
+
+```scrut
+$ wo 'stream = OpenWrite["!tr a-z A-Z"]; WriteString[stream, "hello pipe\n"]; Close[stream];'
+HELLO PIPE
+Null
+```

--- a/tests/cli/undocumented.md
+++ b/tests/cli/undocumented.md
@@ -1,6 +1,6 @@
 # Dispatched functions still without scrut-tested docs
 
-Generated from `src/evaluator/dispatch/`. Total: **286**.
+Generated from `src/evaluator/dispatch/`. Total: **285**.
 
 These are functions that are reachable in Woxi's evaluator but don't yet have a `## \`Fn\``
 section with a working scrut example in `tests/cli/`. Most fall into categories that resist
@@ -56,7 +56,7 @@ syntactic forms (`UpSet`, `Span`), and special functions that stay symbolic for 
 - `TimeRemaining` — Returns the time remaining in a TimeConstrained evaluation
 - `Trace` — Returns a minimal evaluation trace as a two-element list
 
-## I/O & Streams (33)
+## I/O & Streams (32)
 
 - `AbsoluteFileName`
 - `AnimationRate`
@@ -72,7 +72,6 @@ syntactic forms (`UpSet`, `Span`), and special functions that stay symbolic for 
 - `FileHash`
 - `Find` — Finds a file on the search path
 - `FindFile` — Find file
-- `Get` — Reads and evaluates a file returning the last result
 - `GetEnvironment` — Returns rule(s) mapping env variable names to their values
 - `ImageResolution` — Option for image resolution in DPI
 - `Message` — Issues a message (no-op in Woxi)

--- a/tests/cli/undocumented.md
+++ b/tests/cli/undocumented.md
@@ -1,6 +1,6 @@
 # Dispatched functions still without scrut-tested docs
 
-Generated from `src/evaluator/dispatch/`. Total: **288**.
+Generated from `src/evaluator/dispatch/`. Total: **286**.
 
 These are functions that are reachable in Woxi's evaluator but don't yet have a `## \`Fn\``
 section with a working scrut example in `tests/cli/`. Most fall into categories that resist
@@ -56,7 +56,7 @@ syntactic forms (`UpSet`, `Span`), and special functions that stay symbolic for 
 - `TimeRemaining` — Returns the time remaining in a TimeConstrained evaluation
 - `Trace` — Returns a minimal evaluation trace as a two-element list
 
-## I/O & Streams (34)
+## I/O & Streams (33)
 
 - `AbsoluteFileName`
 - `AnimationRate`
@@ -76,7 +76,6 @@ syntactic forms (`UpSet`, `Span`), and special functions that stay symbolic for 
 - `GetEnvironment` — Returns rule(s) mapping env variable names to their values
 - `ImageResolution` — Option for image resolution in DPI
 - `Message` — Issues a message (no-op in Woxi)
-- `OpenRead` — Opens a file for reading
 - `PNG`
 - `ParentDirectory` — Parent directory path
 - `PutAppend` — Append expressions to a file
@@ -143,7 +142,7 @@ syntactic forms (`UpSet`, `Span`), and special functions that stay symbolic for 
 - `TensorWedge` — Exterior (wedge) product of vectors/tensors
 - `YuleDissimilarity` — Yule dissimilarity between binary vectors
 
-## Lists (4)
+## Lists (3)
 
 - `List` — Represents a list of elements
 - `Nearest` — Find the nearest elements in a list to a given value

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -205,6 +205,23 @@ mod find {
     std::fs::remove_file(path).ok();
   }
 
+  // A `"!command"` name searches the command's output.
+  #[test]
+  #[cfg(unix)]
+  fn find_command_spec() {
+    let result =
+      interpret(r#"Find["!printf 'alpha\nbeta\ngamma\n'", "bet"]"#).unwrap();
+    assert_eq!(result, "beta");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn find_command_spec_no_match() {
+    let result =
+      interpret(r#"Find["!printf 'alpha\nbeta\n'", "zeta"]"#).unwrap();
+    assert_eq!(result, "EndOfFile");
+  }
+
   #[test]
   fn find_string_stream_with_list_of_terms() {
     // Find on a StringToStream-backed stream, with a list of search
@@ -233,6 +250,31 @@ mod find {
 mod get {
   use super::*;
   use std::io::Write;
+
+  // `"!command"` evaluates the code the command writes to standard output.
+  #[test]
+  #[cfg(unix)]
+  fn get_command_spec() {
+    clear_state();
+    assert_eq!(interpret(r#"Get["!echo 1+2"]"#).unwrap(), "3");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn get_command_spec_shorthand() {
+    clear_state();
+    assert_eq!(interpret(r#"<< "!echo 6*7""#).unwrap(), "42");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn get_command_spec_defines_symbols() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Get["!printf 'sq[x_] := x^2;\nsq[5]\n'"]"#).unwrap(),
+      "25"
+    );
+  }
 
   fn write_temp(name: &str, content: &str) -> String {
     let path = temp_file(&format!("woxi_test_{name}.txt"));
@@ -591,6 +633,147 @@ mod streams {
       interpret(r#"ReadList["!printf '1\n2\n3\n'", Number]"#).unwrap(),
       "{1, 2, 3}"
     );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn binary_read_list_command_spec() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"BinaryReadList["!printf 'AB'"]"#).unwrap(),
+      "{65, 66}"
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn binary_read_command_stream() {
+    clear_state();
+    let result = interpret(
+      r#"s = OpenRead["!printf 'AB'", BinaryFormat -> True]; r = {BinaryRead[s], BinaryRead[s], BinaryRead[s]}; Close[s]; r"#,
+    )
+    .unwrap();
+    assert_eq!(result, "{65, 66, EndOfFile}");
+  }
+
+  // The write end of the same convention: OpenWrite["!cmd"] feeds what is
+  // written to it into the command's standard input. The command inherits
+  // the real stdout rather than Woxi's capture buffer, so these tests have
+  // the shell redirect its output into a file and read that back.
+  #[test]
+  #[cfg(unix)]
+  fn open_write_command_returns_output_stream() {
+    clear_state();
+    let result =
+      interpret(r#"s = OpenWrite["!cat"]; r = ToString[s]; Close[s]; r"#)
+        .unwrap();
+    assert!(
+      result.starts_with("OutputStream[!cat, "),
+      "expected a command output stream, got {result}"
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn write_string_to_command_stream() {
+    clear_state();
+    let path = temp_file("woxi_pipe_write_string.txt");
+    let result = interpret(&format!(
+      r#"s = OpenWrite["!tr a-z A-Z > {path}"]; WriteString[s, "hello ", "pipe\n"]; c = Close[s]; {{c, ReadString["{path}"]}}"#
+    ))
+    .unwrap();
+    assert_eq!(
+      result,
+      "{!tr a-z A-Z > ".to_owned() + &path + ", HELLO PIPE\n}"
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn write_to_command_stream() {
+    clear_state();
+    let path = temp_file("woxi_pipe_write.txt");
+    let result = interpret(&format!(
+      r#"s = OpenWrite["!cat > {path}"]; Write[s, 1 + 1]; Close[s]; ReadString["{path}"]"#
+    ))
+    .unwrap();
+    assert_eq!(result, "2\n");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn binary_write_to_command_stream() {
+    clear_state();
+    let path = temp_file("woxi_pipe_binary_write.txt");
+    let result = interpret(&format!(
+      r#"s = OpenWrite["!cat > {path}"]; BinaryWrite[s, {{104, 105}}]; Close[s]; ReadString["{path}"]"#
+    ))
+    .unwrap();
+    assert_eq!(result, "hi");
+  }
+
+  // A command named directly rather than through an open stream runs once
+  // for that call, so every argument has to reach it in one write.
+  #[test]
+  #[cfg(unix)]
+  fn write_string_to_command_spec() {
+    clear_state();
+    let path = temp_file("woxi_pipe_write_string_spec.txt");
+    let result = interpret(&format!(
+      r#"WriteString["!tr a-z A-Z > {path}", "a", "b"]; ReadString["{path}"]"#
+    ))
+    .unwrap();
+    assert_eq!(result, "AB");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn open_append_command_writes_like_open_write() {
+    clear_state();
+    let path = temp_file("woxi_pipe_append.txt");
+    let result = interpret(&format!(
+      r#"s = OpenAppend["!cat > {path}"]; WriteString[s, "appended"]; Close[s]; ReadString["{path}"]"#
+    ))
+    .unwrap();
+    assert_eq!(result, "appended");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn put_to_command_spec() {
+    clear_state();
+    let path = temp_file("woxi_pipe_put.txt");
+    let result = interpret(&format!(
+      r#"Put[1 + 1, "!cat > {path}"]; ReadString["{path}"]"#
+    ))
+    .unwrap();
+    assert_eq!(result, "2\n");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn put_append_to_command_spec() {
+    clear_state();
+    let path = temp_file("woxi_pipe_put_append.txt");
+    let result = interpret(&format!(
+      r#"PutAppend[3 + 4, "!cat > {path}"]; ReadString["{path}"]"#
+    ))
+    .unwrap();
+    assert_eq!(result, "7\n");
+  }
+
+  // Closing the write end is what tells the command its input has ended,
+  // so a filter that only produces output at EOF still gets there.
+  #[test]
+  #[cfg(unix)]
+  fn close_command_sink_ends_the_commands_input() {
+    clear_state();
+    let path = temp_file("woxi_pipe_sort.txt");
+    let result = interpret(&format!(
+      r#"s = OpenWrite["!sort > {path}"]; WriteString[s, "b\na\n"]; c = Close[s]; {{c, ReadList["{path}", String]}}"#
+    ))
+    .unwrap();
+    assert_eq!(result, "{!sort > ".to_owned() + &path + ", {a, b}}");
   }
 
   #[test]
@@ -7680,6 +7863,16 @@ mod find_list_tests {
     }
   }
 
+  // A `"!command"` entry searches that command's output.
+  #[test]
+  #[cfg(unix)]
+  fn command_spec_lines() {
+    assert_eq!(
+      interpret(r#"FindList["!printf 'a1\nb2\na3\n'", "a"]"#).unwrap(),
+      "{a1, a3}"
+    );
+  }
+
   // Missing files emit `noopen` and yield $Failed — as the whole result
   // for a single file, as one element inside a file-list result.
   #[test]
@@ -9411,5 +9604,108 @@ mod paclet {
     // Replacing the whole mapping drops the alias with it.
     interpret("$ContextAliases = <||>").unwrap();
     assert_eq!(interpret("a`foo").unwrap(), "a`foo");
+  }
+}
+
+// A file name starting with `!` names an external command in the Wolfram
+// Language. These cover the functions that take a file name without going
+// through an open stream.
+mod command_file_specs {
+  use super::*;
+
+  #[test]
+  #[cfg(unix)]
+  fn file_print_command_spec() {
+    clear_state();
+    let result =
+      interpret_with_stdout(r#"FilePrint["!printf 'one\ntwo\n'"]"#).unwrap();
+    assert_eq!(result.stdout, "one\ntwo\n");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn file_print_command_spec_with_no_output() {
+    clear_state();
+    let result = interpret_with_stdout(r#"FilePrint["!true"]"#).unwrap();
+    assert_eq!(result.stdout, "\n");
+  }
+
+  // Import defaults a command's output to text, the format a pipe carries
+  // unless the caller names another one.
+  #[test]
+  #[cfg(unix)]
+  fn import_command_spec_defaults_to_text() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Import["!printf 'plain text\n'"]"#).unwrap(),
+      "plain text"
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn import_command_spec_text() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Import["!printf 'plain text\n'", "Text"]"#).unwrap(),
+      "plain text"
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn import_command_spec_csv() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Import["!printf 'a,b\n1,2\n'", "CSV"]"#).unwrap(),
+      "{{a, b}, {1, 2}}"
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn import_command_spec_csv_element() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Import["!printf 'a,b\n1,2\n'", {"CSV", "ColumnLabels"}]"#)
+        .unwrap(),
+      "{a, b}"
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn import_command_spec_json() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"Import["!printf '{\"k\": 5}'", "JSON"]"#).unwrap(),
+      "{k -> 5}"
+    );
+  }
+
+  // Naming a file's own format selects no element, so it imports exactly
+  // as the format-less call does. This used to yield `$Failed[]` because
+  // the format name travelled on as an element name.
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn import_format_name_is_not_an_element() {
+    clear_state();
+    let path = temp_file("woxi_import_format_name.csv");
+    std::fs::write(&path, "a,b\n1,2\n").unwrap();
+    assert_eq!(
+      interpret(&format!(r#"Import["{path}", "CSV"]"#)).unwrap(),
+      "{{a, b}, {1, 2}}"
+    );
+    assert_eq!(
+      interpret(&format!(r#"Import["{path}", {{"CSV", "ColumnLabels"}}]"#))
+        .unwrap(),
+      "{a, b}"
+    );
+    // An element name still selects an element.
+    assert_eq!(
+      interpret(&format!(r#"Import["{path}", "ColumnLabels"]"#)).unwrap(),
+      "{a, b}"
+    );
+    std::fs::remove_file(path).ok();
   }
 }

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -463,6 +463,136 @@ mod streams {
     assert_eq!(result, "$Failed");
   }
 
+  // A file specification starting with `!` names an external command whose
+  // standard output is what the stream reads.
+  #[test]
+  #[cfg(unix)]
+  fn open_read_command_returns_input_stream() {
+    clear_state();
+    let result = interpret(r#"OpenRead["!echo hi"]"#).unwrap();
+    assert!(
+      result.starts_with("InputStream[!echo hi, "),
+      "expected a command input stream, got {result}"
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn open_read_command_read_lines() {
+    clear_state();
+    let result = interpret(
+      r#"s = OpenRead["!printf 'a\nb\nc\n'"]; l = {ReadLine[s], ReadLine[s], ReadLine[s], ReadLine[s]}; Close[s]; l"#,
+    )
+    .unwrap();
+    assert_eq!(result, "{a, b, c, EndOfFile}");
+  }
+
+  // Regression test for the reported issue: reading a command stream in a
+  // While loop used to spin forever because OpenRead["!cat"] returned
+  // $Failed and ReadLine[$Failed] never reached EndOfFile.
+  #[test]
+  #[cfg(unix)]
+  fn open_read_command_while_loop_terminates() {
+    clear_state();
+    let result = interpret(
+      r#"s = OpenRead["!printf 'one\ntwo\n' | cat"]; n = 0; While[True, line = ReadLine[s]; If[line === EndOfFile, Break[]]; n = n + 1]; Close[s]; n"#,
+    )
+    .unwrap();
+    assert_eq!(result, "2");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn open_read_command_read_string() {
+    clear_state();
+    let result = interpret(
+      r#"s = OpenRead["!printf 'x y'"]; r = ReadString[s]; Close[s]; r"#,
+    )
+    .unwrap();
+    assert_eq!(result, "x y");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn open_read_command_read_number() {
+    clear_state();
+    let result = interpret(
+      r#"s = OpenRead["!printf '11 22\n'"]; r = {Read[s, Number], Read[s, Number], Read[s, Number]}; Close[s]; r"#,
+    )
+    .unwrap();
+    assert_eq!(result, "{11, 22, EndOfFile}");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn open_read_command_read_list() {
+    clear_state();
+    let result = interpret(
+      r#"s = OpenRead["!printf '1\n2\n3\n'"]; r = ReadList[s, Number]; Close[s]; r"#,
+    )
+    .unwrap();
+    assert_eq!(result, "{1, 2, 3}");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn close_command_stream_returns_spec() {
+    clear_state();
+    let result = interpret(r#"s = OpenRead["!echo hi"]; Close[s]"#).unwrap();
+    assert_eq!(result, "!echo hi");
+  }
+
+  // Closing while the command still has output pending must not hang.
+  #[test]
+  #[cfg(unix)]
+  fn close_command_stream_before_end_of_output() {
+    clear_state();
+    let result =
+      interpret(r#"s = OpenRead["!yes woxi"]; l = ReadLine[s]; Close[s]; l"#)
+        .unwrap();
+    assert_eq!(result, "woxi");
+  }
+
+  // A command that cannot be run still opens: the shell reports the error
+  // and the stream is simply empty.
+  #[test]
+  #[cfg(unix)]
+  fn open_read_command_not_found_is_empty() {
+    clear_state();
+    let result = interpret(
+      r#"s = OpenRead["!woxi-no-such-command 2>/dev/null"]; r = ReadLine[s]; Close[s]; r"#,
+    )
+    .unwrap();
+    assert_eq!(result, "EndOfFile");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn read_line_command_spec() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"ReadLine["!printf 'first\nsecond\n'"]"#).unwrap(),
+      "first"
+    );
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn read_string_command_spec() {
+    clear_state();
+    assert_eq!(interpret(r#"ReadString["!printf 'abc'"]"#).unwrap(), "abc");
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn read_list_command_spec() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"ReadList["!printf '1\n2\n3\n'", Number]"#).unwrap(),
+      "{1, 2, 3}"
+    );
+  }
+
   #[test]
   #[cfg(not(target_arch = "wasm32"))]
   fn open_write_and_close() {

--- a/tests/script_snapshot_tests.rs
+++ b/tests/script_snapshot_tests.rs
@@ -1536,6 +1536,7 @@ script_test!(
 );
 script_test!(script_input_loop, "input_loop.wls");
 script_test!(script_read_from_command, "read_from_command.wls");
+script_test!(script_write_to_command, "write_to_command.wls");
 script_test!(script_a_b, "a_b.wls");
 script_test!(script_dynamic_variable_names, "dynamic_variable_names.wls");
 script_test!(script_mad_libs, "mad_libs.wls");

--- a/tests/script_snapshot_tests.rs
+++ b/tests/script_snapshot_tests.rs
@@ -1535,6 +1535,7 @@ script_test!(
   "read_a_specific_line_from_a_file.wls"
 );
 script_test!(script_input_loop, "input_loop.wls");
+script_test!(script_read_from_command, "read_from_command.wls");
 script_test!(script_a_b, "a_b.wls");
 script_test!(script_dynamic_variable_names, "dynamic_variable_names.wls");
 script_test!(script_mad_libs, "mad_libs.wls");

--- a/tests/scripts/read_from_command.wls
+++ b/tests/scripts/read_from_command.wls
@@ -1,0 +1,7 @@
+stream = OpenRead["!printf 'alpha\\nbeta\\ngamma\\n'"];
+While[True,
+  line = ReadLine[stream];
+  If[line === EndOfFile, Break[]];
+  Print["Processed line: ", line];
+];
+Close[stream];

--- a/tests/scripts/write_to_command.wls
+++ b/tests/scripts/write_to_command.wls
@@ -1,0 +1,15 @@
+(* A file name starting with `!` names an external command.
+   The command's own output goes to the terminal, so these examples
+   redirect it into a file and read that back. *)
+
+stream = OpenWrite["!sort > sorted.txt"];
+WriteString[stream, "gamma\nalpha\nbeta\n"];
+Close[stream];
+Print[ReadList["sorted.txt", String]];
+
+Put[2 + 3, "!cat > put.txt"];
+Print[ReadString["put.txt"]];
+
+Print[Import["!printf 'a,b\\n1,2\\n'", "CSV"]];
+Print[Get["!echo 6*7"]];
+Print[Find["!printf 'alpha\\nbeta\\n'", "bet"]];

--- a/tests/snapshots/script_snapshot_tests__read_from_command.wls.snap
+++ b/tests/snapshots/script_snapshot_tests__read_from_command.wls.snap
@@ -1,0 +1,7 @@
+---
+source: tests/script_snapshot_tests.rs
+expression: stdout
+---
+Processed line: alpha
+Processed line: beta
+Processed line: gamma

--- a/tests/snapshots/script_snapshot_tests__write_to_command.wls.snap
+++ b/tests/snapshots/script_snapshot_tests__write_to_command.wls.snap
@@ -1,0 +1,10 @@
+---
+source: tests/script_snapshot_tests.rs
+expression: stdout
+---
+{alpha, beta, gamma}
+5
+
+{{a, b}, {1, 2}}
+42
+beta


### PR DESCRIPTION
## Summary

Implement support for file specifications starting with `!` to name external commands instead of files, following Wolfram Language conventions. Commands are executed through the shell and their standard output/input are piped to/from Woxi's I/O functions.

## Key Changes

- **New stream types**: Added `Command` and `CommandSink` variants to `StreamKind` enum to represent pipes from/to external commands, replacing `StringStream`/`FileStream` with `Text`/`File` for clarity
- **Command execution infrastructure**: Implemented helper functions for spawning and managing child processes:
  - `spawn_command_stream()` / `spawn_command_sink()` - start commands with piped I/O
  - `command_stream_read_line()` / `command_stream_read_all()` - read from command output with buffering
  - `command_sink_write()` / `command_sink_close()` - write to command input
  - `run_command_capture()` / `run_command_capture_bytes()` - execute commands and capture output
  - `command_file_spec()` - parse `!command` syntax from file specifications

- **I/O function updates**: Extended all relevant I/O functions to support command pipes:
  - `OpenRead["!command"]` - opens a pipe from a command's stdout
  - `OpenWrite["!command"]` - opens a pipe to a command's stdin
  - `ReadLine`, `ReadString`, `Read`, `ReadList`, `BinaryRead` - read from command streams
  - `Write`, `WriteString`, `BinaryWrite` - write to command streams
  - `Get["!command"]` - evaluate code from command output
  - `Put["!command"]`, `PutAppend["!command"]` - write expressions to command input
  - `Find`, `FindList`, `FilePrint`, `Import` - support command specs

- **Stream management**: Refactored stream registry to properly handle command lifecycle:
  - Commands inherit stdin/stderr from interpreter for filter-like behavior
  - Line-oriented reads (`ReadLine`) pull incrementally to avoid blocking on live pipes
  - Closing a command stream kills the process to prevent hanging on infinite output
  - Closing a command sink drops the pipe to signal EOF to the command

- **Comprehensive test coverage**: Added 30+ tests covering:
  - Basic command stream operations (read/write/close)
  - Line-by-line reading from live pipes
  - Integration with loops and control flow
  - Binary I/O with commands
  - Command execution through various I/O functions
  - Error handling for missing commands

## Notable Implementation Details

- Command output is buffered in memory to maintain position-indexed stream semantics
- Binary reads see raw bytes; text reads decode lossily to keep byte/string offsets aligned
- Commands run through `sh -c` on Unix and `cmd /C` on Windows
- Temporary files are used for `Import["!command", format]` to leverage existing format handlers
- The implementation is gated behind `#[cfg(not(target_arch = "wasm32"))]` as file I/O is unavailable on WASM

https://claude.ai/code/session_011axAYoGbA55ZVYWZ3okvno