### PR TITLE
Support legacy HypothesisTesting`MeanTest compatibility package

### DIFF
--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -660,6 +660,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "HilbertMatrix" => Some((1, 1)),
     "HistogramDistribution" => Some((1, 2)),
     "HistogramList" => Some((1, 2)),
+    "HypothesisTesting`MeanTest" => Some((1, usize::MAX)),
     "HoldForm" => Some((1, 1)),
     "Hyperfactorial" => Some((1, 1)),
     "BinormalDistribution" => Some((1, 3)),

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -842,6 +842,11 @@ pub fn dispatch_math_functions(
     "LocationTest" if !args.is_empty() && args.len() <= 3 => {
       return Some(crate::functions::math_ast::location_test_ast(args));
     }
+    "HypothesisTesting`MeanTest" if !args.is_empty() => {
+      return Some(
+        crate::functions::math_ast::hypothesis_testing_mean_test_ast(args),
+      );
+    }
     "PearsonChiSquareTest" if !args.is_empty() && args.len() <= 3 => {
       return Some(crate::functions::math_ast::pearson_chi_square_test_ast(
         args,

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -4794,6 +4794,85 @@ fn format_location_test_result(
   }
 }
 
+/// `HypothesisTesting`MeanTest[data, mu0, opts]` - the legacy
+/// `Statistics`HypothesisTests`` / `HypothesisTesting`` compatibility-package
+/// one- or two-sample mean test. Unlike the modern `LocationTest`, which
+/// returns a single requested property, the legacy function reports a list
+/// of context-qualified rules (`HypothesisTesting`TwoSidedPValue`, etc.) so
+/// that callers extract results with `property /. MeanTest[...]`. The
+/// underlying t-statistic and degrees of freedom are computed by the same
+/// helpers `LocationTest` uses, so the two never drift apart.
+pub fn hypothesis_testing_mean_test_ast(
+  args: &[Expr],
+) -> Result<Expr, InterpreterError> {
+  if args.is_empty() {
+    return Err(InterpreterError::EvaluationError(
+      "MeanTest expects at least 1 argument".into(),
+    ));
+  }
+
+  let mu0 = if args.len() >= 2 {
+    match &args[1] {
+      Expr::Identifier(s) if s == "Automatic" => 0.0,
+      other => match try_eval_to_f64(other) {
+        Some(v) => v,
+        None => {
+          return Ok(unevaluated("HypothesisTesting`MeanTest", args));
+        }
+      },
+    }
+  } else {
+    0.0
+  };
+
+  let (t_stat, df) = match &args[0] {
+    Expr::List(items) if !items.is_empty() => {
+      if items.len() == 2
+        && matches!(&items[0], Expr::List(_))
+        && matches!(&items[1], Expr::List(_))
+      {
+        let vals1 = extract_numeric_list(&items[0])?;
+        let vals2 = extract_numeric_list(&items[1])?;
+        if vals1.len() < 2 || vals2.len() < 2 {
+          return Err(InterpreterError::EvaluationError(
+            "MeanTest: each sample needs at least 2 elements".into(),
+          ));
+        }
+        two_sample_t_test(&vals1, &vals2, mu0)
+      } else {
+        let vals = extract_numeric_list_flat(items)?;
+        if vals.len() < 2 {
+          return Err(InterpreterError::EvaluationError(
+            "MeanTest: need at least 2 elements".into(),
+          ));
+        }
+        one_sample_t_test(&vals, mu0)
+      }
+    }
+    _ => return Ok(unevaluated("HypothesisTesting`MeanTest", args)),
+  };
+
+  let two_sided_p = t_test_p_value(t_stat, df);
+  let one_sided_p = two_sided_p / 2.0;
+
+  let rule = |head: &str, value: Expr| -> Expr {
+    Expr::Rule {
+      pattern: Box::new(Expr::Identifier(head.to_string())),
+      replacement: Box::new(value),
+    }
+  };
+
+  Ok(Expr::List(
+    vec![
+      rule("HypothesisTesting`TestStatistic", num_to_expr(t_stat)),
+      rule("HypothesisTesting`DegreesOfFreedom", num_to_expr(df)),
+      rule("HypothesisTesting`OneSidedPValue", num_to_expr(one_sided_p)),
+      rule("HypothesisTesting`TwoSidedPValue", num_to_expr(two_sided_p)),
+    ]
+    .into(),
+  ))
+}
+
 fn t_test_p_value(t_stat: f64, df: f64) -> f64 {
   // Two-tailed p-value: p = I(df/(df+t^2), df/2, 1/2)
   if t_stat.is_infinite() {

--- a/tests/interpreter_tests/statistics.rs
+++ b/tests/interpreter_tests/statistics.rs
@@ -4918,6 +4918,157 @@ mod location_test {
   }
 }
 
+mod hypothesis_testing_mean_test {
+  use super::*;
+
+  // `HypothesisTesting`MeanTest` is the legacy `Statistics`HypothesisTests``
+  // / `HypothesisTesting`` compatibility-package mean test, loaded via
+  // `Get["HypothesisTesting`"]` (or `Needs["HypothesisTesting`"]`) in older
+  // notebooks. Unlike `LocationTest`, it reports a list of context-qualified
+  // rules so callers pull out a property with
+  // `property /. MeanTest[data, mu0, opts]`. It shares its t-statistic and
+  // degrees-of-freedom computation with `LocationTest`, so the numbers below
+  // match that suite's `location_test` module exactly.
+
+  #[test]
+  fn get_hypothesis_testing_context_is_a_noop() {
+    clear_state();
+    assert_eq!(interpret("Get[\"HypothesisTesting`\"]").unwrap(), "\0");
+  }
+
+  #[test]
+  fn one_sample_rule_list_shape() {
+    clear_state();
+    let result = interpret(
+      "HypothesisTesting`MeanTest[{1.2, 0.5, 1.9, 2.1, 0.8, 1.5}, 0]",
+    )
+    .unwrap();
+    assert!(
+      result.contains("HypothesisTesting`TestStatistic ->"),
+      "got: {result}"
+    );
+    assert!(
+      result.contains("HypothesisTesting`DegreesOfFreedom ->"),
+      "got: {result}"
+    );
+    assert!(
+      result.contains("HypothesisTesting`OneSidedPValue ->"),
+      "got: {result}"
+    );
+    assert!(
+      result.contains("HypothesisTesting`TwoSidedPValue ->"),
+      "got: {result}"
+    );
+  }
+
+  #[test]
+  fn two_sided_p_value_matches_location_test() {
+    clear_state();
+    let result = interpret(
+      "HypothesisTesting`TwoSidedPValue /. HypothesisTesting`MeanTest[\
+       {1.2, 0.5, 1.9, 2.1, 0.8, 1.5}, 0, HypothesisTesting`TwoSided -> True]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().unwrap();
+    assert!(
+      (val - 0.0033200264871519245).abs() < 1e-8,
+      "Expected ~0.00332 (LocationTest's PValue), got {val}"
+    );
+  }
+
+  #[test]
+  fn one_sided_p_value_is_half_two_sided() {
+    clear_state();
+    let two_sided: f64 = interpret(
+      "HypothesisTesting`TwoSidedPValue /. HypothesisTesting`MeanTest[{1.2, 0.5, 1.9, 2.1, 0.8, 1.5}, 0]",
+    )
+    .unwrap()
+    .parse()
+    .unwrap();
+    let one_sided: f64 = interpret(
+      "HypothesisTesting`OneSidedPValue /. HypothesisTesting`MeanTest[{1.2, 0.5, 1.9, 2.1, 0.8, 1.5}, 0]",
+    )
+    .unwrap()
+    .parse()
+    .unwrap();
+    assert!(
+      (one_sided - two_sided / 2.0).abs() < 1e-12,
+      "OneSidedPValue ({one_sided}) should be half of TwoSidedPValue ({two_sided})"
+    );
+  }
+
+  #[test]
+  fn test_statistic_matches_location_test() {
+    clear_state();
+    let result = interpret(
+      "HypothesisTesting`TestStatistic /. HypothesisTesting`MeanTest[{1.2, 0.5, 1.9, 2.1, 0.8, 1.5}, 0]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().unwrap();
+    assert!(
+      (val - 5.252257314388901).abs() < 1e-10,
+      "Expected ~5.2523 (LocationTest's TestStatistic), got {val}"
+    );
+  }
+
+  #[test]
+  fn nonzero_mu0() {
+    clear_state();
+    let result = interpret(
+      "HypothesisTesting`TwoSidedPValue /. HypothesisTesting`MeanTest[{1.2, 0.5, 1.9, 2.1, 0.8, 1.5}, 1]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().unwrap();
+    assert!(
+      (val - 0.2461912778840749).abs() < 1e-8,
+      "Expected ~0.2462 (LocationTest's PValue at mu0=1), got {val}"
+    );
+  }
+
+  #[test]
+  fn automatic_mu0_defaults_to_zero() {
+    clear_state();
+    let result = interpret(
+      "HypothesisTesting`TwoSidedPValue /. HypothesisTesting`MeanTest[{1.2, 0.5, 1.9, 2.1, 0.8, 1.5}, Automatic]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().unwrap();
+    assert!(
+      (val - 0.0033200264871519245).abs() < 1e-8,
+      "Expected ~0.00332, got {val}"
+    );
+  }
+
+  #[test]
+  fn two_sample_test() {
+    clear_state();
+    let result = interpret(
+      "HypothesisTesting`TwoSidedPValue /. HypothesisTesting`MeanTest[{{1.2, 0.5, 1.9}, {2.1, 0.8, 1.5}}, 0]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().unwrap();
+    assert!(
+      (val - 0.6541475396789262).abs() < 1e-3,
+      "Expected ~0.654 (LocationTest's two-sample PValue), got {val}"
+    );
+  }
+
+  #[test]
+  fn extraction_pattern_used_in_demonstrations() {
+    // The exact idiom Wolfram Demonstrations Project notebooks use after
+    // `Needs["HypothesisTesting`"]`: extract a single named property from
+    // the returned rule list.
+    clear_state();
+    let result = interpret(
+      "x = RandomReal[NormalDistribution[0, 1], 30]; \
+       p = HypothesisTesting`TwoSidedPValue /. HypothesisTesting`MeanTest[x, 0, HypothesisTesting`TwoSided -> True]; \
+       0 <= p <= 1",
+    )
+    .unwrap();
+    assert_eq!(result, "True");
+  }
+}
+
 mod discrete_asymptotic {
   use super::*;
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -7316,6 +7316,56 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`glyph$$ = \"pick a letter\"}, \"…
     }
   }
 
+  /// A Demonstration whose `Initialization :> (Get["HypothesisTesting`"];)`
+  /// loads the legacy `Statistics`HypothesisTests`` compatibility package
+  /// and whose body extracts a named property with
+  /// `TwoSidedPValue /. MeanTest[data, mu, TwoSided -> True]` must open
+  /// live: the context-qualified `HypothesisTesting`MeanTest` call has to
+  /// evaluate to a proper rule list (not merely echo unevaluated) so the
+  /// `ReplaceAll` actually extracts a p-value for the plot.
+  #[test]
+  fn demonstration_with_legacy_hypothesis_testing_mean_test_opens_live() {
+    let nb_src = r#"Notebook[{
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[
+ Module[{p, x, repCount},
+  SeedRandom[seed];
+  repCount = {50, 100}[[reps]];
+  p = Quiet@Table[
+    x = RandomReal[NormalDistribution[0, 1], n];
+    HypothesisTesting`TwoSidedPValue /. HypothesisTesting`MeanTest[x, 0, HypothesisTesting`TwoSided -> True],
+    {repCount}];
+  If[graph == 1, Histogram[p, 10, \"Probability\"], ListPlot[Sort[p]]]],
+ {{n, 20, \"sample size\"}, 10, 50, 10, Appearance -> \"Labeled\"},
+ {{seed, 1, \"seed\"}, 1, 100, 1, Appearance -> \"Labeled\"},
+ {{reps, 1, \"reps\"}, {1 -> \"50\", 2 -> \"100\"}},
+ {{graph, 1, \"graph\"}, {1 -> \"histogram\", 2 -> \"scatter\"}},
+ TrackedSymbols :> {n, seed, reps, graph},
+ SynchronousUpdating -> False,
+ Initialization :> (Get[\"HypothesisTesting`\"];)]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 20}, \"…\"]"], "Output"]
+}, Open]]
+}]"#;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .iter()
+      .find_map(|e| e.manipulate_state.as_ref())
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some() && widget.text_output.is_none(),
+      "the histogram of extracted p-values must draw, not echo the \
+       unevaluated MeanTest/ReplaceAll: {:?}",
+      widget.text_output
+    );
+    assert_eq!(widget.controls.len(), 4);
+  }
+
   /// A stored Manipulate whose body calls helpers from earlier Input
   /// cells (the Demonstrations "Initialization Code" section) must open
   /// live: `editors_from_notebook` replays the preceding inputs before


### PR DESCRIPTION
## Summary

Part of a routine that samples a random notebook from the Wolfram Demonstrations Project and checks whether Woxi Studio fully supports it (without referencing or copying the notebook itself, per repo policy).

This run's notebook uses the legacy pre-9 `Statistics\`HypothesisTests\`` compatibility package (loaded via `Get["HypothesisTesting`"]`) inside a `Manipulate`, and extracts a named property from its result with the idiom:

```
TwoSidedPValue /. MeanTest[data, mu0, TwoSided -> True]
```

Two things were missing:

- `HypothesisTesting\`MeanTest` wasn't recognized at all, so the call stayed unevaluated.
- The rule list I first built used a generic `Rule[...]` function call instead of the interpreter's dedicated `Expr::Rule` AST node, so even once `MeanTest` returned a rule list, `ReplaceAll` couldn't match against it.

## Changes

- `src/functions/math_ast/statistics.rs`: new `hypothesis_testing_mean_test_ast`, delegating to the same one-/two-sample t-test helpers `LocationTest` already uses (no duplicate implementation). Returns a list of context-qualified rules — `HypothesisTesting\`TestStatistic`, `DegreesOfFreedom`, `OneSidedPValue`, `TwoSidedPValue` — matching the legacy package's report shape.
- `src/evaluator/dispatch/math_functions.rs`, `arg_count.rs`: dispatch registration for `HypothesisTesting\`MeanTest`.
- `tests/interpreter_tests/statistics.rs`: unit tests covering the rule-list shape, one-/two-sample cases, `Automatic` mu0, and cross-checking against `LocationTest`'s already-tested values.
- `woxi-studio/src/main.rs`: a regression test (`demonstration_with_legacy_hypothesis_testing_mean_test_opens_live`) with a from-scratch rewritten Manipulate in the same shape as the sampled Demonstration (popup-menu controls, `TrackedSymbols`, `SynchronousUpdating`, `Initialization :> Get[...]`), asserting the widget opens live and draws its histogram instead of echoing the unevaluated `MeanTest`/`ReplaceAll`.

Note: `functions.csv` intentionally isn't updated — it documents `System\`` symbols (see `is_builtin_symbol`'s doc comment), and this is a legacy, explicitly context-qualified compatibility-package function rather than a `System\`` symbol.

## Test plan

- [x] `make test` (26988 tests passed)
- [x] `make test-studio` (122 tests passed, including the new regression test)
- [x] `make format`
- [x] Manual `woxi eval` checks that `HypothesisTesting\`TwoSidedPValue /. HypothesisTesting\`MeanTest[...]` now matches `LocationTest`'s p-value for the same data, for both one- and two-sample inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF5oM64m7cVUqKAE2DGzHi

---
_Generated by [Claude Code](https://claude.ai/code/session_01WF5oM64m7cVUqKAE2DGzHi)_