### PR TITLE
Implement GeometricScene point substitution and Graphics extraction

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1732,7 +1732,7 @@ FindFormula,Find formula fitting data,,unevaluated,10.2,1740
 Graph3D,3D graph visualization,,unevaluated,10.0,1740
 NotebookDelete,Delete notebook cells,,unevaluated,3.0,1740
 WhittakerW,Whittaker W function E^(-z/2) z^(m+1/2) HypergeometricU[m-k+1/2 2m+1 z],✅,pure,6.0,1741
-GeometricScene,Geometric scene,,unevaluated,12.0,1743
+GeometricScene,Geometric scene,✅,pure,12.0,1743
 MaxDetect,Gives a 0/1 mask marking the regional maxima of a numeric list or matrix,✅,pure,8.0,1743
 FactorList,List irreducible factors of a polynomial with exponents,✅,pure,1.0,1745
 Parallelize,Evaluates an expression and returns the same result as the sequential evaluation (single Woxi kernel),✅,pure,7.0,1745

--- a/src/evaluator/attributes.rs
+++ b/src/evaluator/attributes.rs
@@ -583,6 +583,10 @@ pub fn get_builtin_attributes(name: &str) -> Vec<&'static str> {
     // its argument via the explicit name-match in core_eval.rs rather than a
     // HoldAll attribute.
     "Control" => vec!["Protected"],
+    // GeometricScene: Protected + ReadProtected (matches wolframscript). Like
+    // Manipulate it holds its arguments via the explicit name-match in
+    // core_eval.rs rather than a HoldAll attribute.
+    "GeometricScene" => vec!["Protected", "ReadProtected"],
     // PfaffianDet: Protected + ReadProtected (matches wolframscript).
     "PfaffianDet" => vec!["Protected", "ReadProtected"],
     // Parallel* combinators: Protected + ReadProtected. This matches a COLD

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -2286,6 +2286,10 @@ pub fn evaluate_expr_to_expr_inner(
         // un-applied function until fed a click position.
         || name == "LocatorPane"
         || name == "ClickPane"
+        // GeometricScene holds its point-definition rules and primitives:
+        // the primitives reference point *symbols*, not values, and must
+        // stay symbolic until a `["Graphics"]` property substitutes them in.
+        || name == "GeometricScene"
         {
           // Show/GraphicsRow/GraphicsColumn/GraphicsGrid/PlotGrid/
           // BooleanTable aren't actually HoldAll in Wolfram Language, so a

--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -612,6 +612,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "GeneratingFunction" => Some((3, 3)),
     "GeometricDistribution" => Some((1, 1)),
     "GeometricMean" => Some((1, 1)),
+    "GeometricScene" => Some((2, 3)),
     "GeometricTest" => Some((2, usize::MAX)),
     "Get" => Some((1, 1)),
     "Needs" => Some((1, 2)),

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -123,6 +123,13 @@ pub fn dispatch_plotting(
     // with the variable spec's bounds evaluated. Playground / Studio detect
     // the held Control[…] and render an interactive control widget.
     "Control" => Some(crate::functions::graphics::control_ast(args)),
+    // GeometricScene holds its arguments (see core_eval.rs) and evaluates
+    // the point-definition rules in order, leaving the primitives symbolic
+    // until a `["Graphics"]` property call resolves them (see
+    // apply_curried_call in function_application.rs).
+    "GeometricScene" if args.len() == 2 || args.len() == 3 => {
+      Some(crate::functions::graphics::geometric_scene_ast(args))
+    }
     "Plot3D" if args.len() >= 3 => {
       Some(quiet_plot(|| crate::functions::plot3d::plot3d_ast(args)))
     }

--- a/src/evaluator/function_application.rs
+++ b/src/evaluator/function_application.rs
@@ -1101,6 +1101,34 @@ pub fn apply_curried_call(
       // Entity["type", "name"]["property"] — property access on entities
       crate::functions::entity_ast::entity_property_access(func_args, args)
     }
+    // GeometricScene[{sym -> value, ...}, {primitives...}]["Graphics"] —
+    // substitute point symbols into the primitives and return an ordinary
+    // Graphics[{...}] expression. ["Elements"] returns the resolved point
+    // definitions. Unknown properties keep the curried form unevaluated.
+    Expr::FunctionCall {
+      name,
+      args: func_args,
+    } if name == "GeometricScene"
+      && (func_args.len() == 2 || func_args.len() == 3)
+      && args.len() == 1
+      && matches!(&args[0], Expr::String(_)) =>
+    {
+      let Expr::String(prop) = &args[0] else {
+        unreachable!();
+      };
+      match prop.as_str() {
+        "Graphics" => {
+          crate::functions::graphics::geometric_scene_graphics(func_args)
+        }
+        "Elements" => {
+          crate::functions::graphics::geometric_scene_elements(func_args)
+        }
+        _ => Ok(Expr::CurriedCall {
+          func: Box::new(func.clone()),
+          args: args.to_vec(),
+        }),
+      }
+    }
     // Around[x, δ]["Value"] / ["Uncertainty"] — property extraction on an
     // uncertain value. Unknown properties keep the curried form unevaluated.
     Expr::FunctionCall {

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16221,6 +16221,140 @@ pub fn control_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 // ─────────────────────────────────────────────────────────────────
+// GeometricScene
+// ─────────────────────────────────────────────────────────────────
+
+/// Pull the bound symbol name out of a point-definition rule's
+/// left-hand side (`sym -> value`); anything else isn't a point rule.
+fn geometric_scene_point_name(pattern: &Expr) -> Option<String> {
+  match pattern {
+    Expr::Identifier(name) => Some(name.clone()),
+    _ => None,
+  }
+}
+
+/// Held evaluation of `GeometricScene[{sym -> value, ...}, {primitives...}]`
+/// (an optional third constraints-list argument is accepted and, like the
+/// primitives, held for later use). The point-definition rules are
+/// evaluated in order, left to right, with every earlier point symbol
+/// substituted into later right-hand sides first — so a later point may be
+/// derived from earlier ones, e.g. `centroid -> TriangleCenter[{a, b, c},
+/// "Centroid"]`. The primitives (and constraints) stay symbolic, still
+/// referencing the point *names*, until `["Graphics"]` resolves them.
+pub fn geometric_scene_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  let mut out_args: Vec<Expr> = Vec::with_capacity(args.len());
+
+  let mut bindings: Vec<(String, Expr)> = Vec::new();
+  match args.first() {
+    Some(Expr::List(items)) => {
+      let mut evaluated_rules: Vec<Expr> = Vec::with_capacity(items.len());
+      for item in items {
+        let rule_parts = match item {
+          Expr::Rule {
+            pattern,
+            replacement,
+          }
+          | Expr::RuleDelayed {
+            pattern,
+            replacement,
+          } => Some((pattern.as_ref(), replacement.as_ref())),
+          Expr::FunctionCall { name, args: rargs }
+            if (name == "Rule" || name == "RuleDelayed")
+              && rargs.len() == 2 =>
+          {
+            Some((&rargs[0], &rargs[1]))
+          }
+          _ => None,
+        };
+        if let Some((name, replacement)) =
+          rule_parts.and_then(|(pattern, replacement)| {
+            geometric_scene_point_name(pattern).map(|name| (name, replacement))
+          })
+        {
+          let binding_refs: Vec<(&str, &Expr)> =
+            bindings.iter().map(|(n, v)| (n.as_str(), v)).collect();
+          let substituted =
+            crate::syntax::substitute_variables(replacement, &binding_refs);
+          let value = evaluate_expr_to_expr(&substituted)?;
+          evaluated_rules.push(Expr::Rule {
+            pattern: Box::new(Expr::Identifier(name.clone())),
+            replacement: Box::new(value.clone()),
+          });
+          bindings.push((name, value));
+        } else {
+          // Not a recognizable `symbol -> value` point rule; evaluate it
+          // on its own (with points bound so far in scope) and keep it as-is.
+          let binding_refs: Vec<(&str, &Expr)> =
+            bindings.iter().map(|(n, v)| (n.as_str(), v)).collect();
+          let substituted =
+            crate::syntax::substitute_variables(item, &binding_refs);
+          evaluated_rules.push(evaluate_expr_to_expr(&substituted)?);
+        }
+      }
+      out_args.push(Expr::List(evaluated_rules.into()));
+    }
+    Some(other) => out_args.push(other.clone()),
+    None => {}
+  }
+
+  // Primitives (args[1]) and any optional constraints (args[2]) reference
+  // the point symbols by name rather than by value, so they stay held
+  // until a `["Graphics"]` (or similar) property substitutes them in.
+  for extra in args.iter().skip(1) {
+    out_args.push(extra.clone());
+  }
+
+  Ok(call("GeometricScene", out_args))
+}
+
+/// `GeometricScene[{sym -> value, ...}, {primitives...}][ "Graphics" ]` —
+/// substitute every point symbol occurring anywhere in the primitives
+/// (including inside wrappers like `Style[...]`/`Directive[...]`) with its
+/// bound coordinate value, then evaluate the result as an ordinary
+/// `Graphics[{...}]` expression.
+pub fn geometric_scene_graphics(
+  func_args: &[Expr],
+) -> Result<Expr, InterpreterError> {
+  let bindings: Vec<(String, Expr)> = match func_args.first() {
+    Some(Expr::List(items)) => items
+      .iter()
+      .filter_map(|item| match item {
+        Expr::Rule {
+          pattern,
+          replacement,
+        } => geometric_scene_point_name(pattern)
+          .map(|name| (name, replacement.as_ref().clone())),
+        _ => None,
+      })
+      .collect(),
+    _ => Vec::new(),
+  };
+  let binding_refs: Vec<(&str, &Expr)> =
+    bindings.iter().map(|(n, v)| (n.as_str(), v)).collect();
+
+  let primitives = func_args
+    .get(1)
+    .cloned()
+    .unwrap_or(Expr::List(Vec::new().into()));
+  let substituted =
+    crate::syntax::substitute_variables(&primitives, &binding_refs);
+  evaluate_expr_to_expr(&call("Graphics", vec![substituted]))
+}
+
+/// `GeometricScene[{sym -> value, ...}, ...][ "Elements" ]` — the resolved
+/// list of `sym -> value` point definitions, i.e. `args[0]` as-is.
+pub fn geometric_scene_elements(
+  func_args: &[Expr],
+) -> Result<Expr, InterpreterError> {
+  Ok(
+    func_args
+      .first()
+      .cloned()
+      .unwrap_or(Expr::List(Vec::new().into())),
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────
 // Interactive Manipulate support (for Woxi Playground / Woxi Studio)
 // ─────────────────────────────────────────────────────────────────
 

--- a/tests/interpreter_tests/geometry.rs
+++ b/tests/interpreter_tests/geometry.rs
@@ -1623,6 +1623,143 @@ mod triangle_center {
   }
 }
 
+mod geometric_scene {
+  use super::*;
+  use woxi::interpret_to_expr;
+  use woxi::syntax::expr_to_input_form;
+
+  /// A basic point substitution: the symbol in a single primitive is
+  /// replaced by its bound coordinate value, and the result is an ordinary
+  /// `Graphics[{...}]` expression.
+  #[test]
+  fn substitutes_point_symbol_in_primitive() {
+    let expr = interpret_to_expr(
+      "GeometricScene[{p -> {2, 3}}, {Point[p]}][\"Graphics\"]",
+    )
+    .unwrap();
+    assert_eq!(expr_to_input_form(&expr), "Graphics[{Point[{2, 3}]}]");
+  }
+
+  /// The general shape of the returned expression is `Graphics[{...}]`
+  /// (a `FunctionCall` headed by `Graphics`, wrapping a `List`).
+  #[test]
+  fn graphics_property_returns_graphics_head() {
+    let expr = interpret_to_expr(
+      "GeometricScene[{p -> {0, 0}, q -> {1, 1}}, {Line[{p, q}]}][\"Graphics\"]",
+    )
+    .unwrap();
+    match &expr {
+      woxi::syntax::Expr::FunctionCall { name, args } => {
+        assert_eq!(name, "Graphics");
+        assert_eq!(args.len(), 1);
+        assert!(matches!(&args[0], woxi::syntax::Expr::List(_)));
+      }
+      other => panic!("expected Graphics[...], got {other:?}"),
+    }
+  }
+
+  /// A later point may be derived from earlier ones — the right-hand side
+  /// of a later rule can reference symbols bound by earlier rules, and
+  /// those references are substituted with the already-evaluated values
+  /// before the later rule's own right-hand side is evaluated.
+  #[test]
+  fn later_point_can_depend_on_earlier_points() {
+    let held = interpret(
+      "GeometricScene[{p -> {1, 1}, q -> {5, 3}, m -> Mean[{p, q}]}, \
+       {Point[m]}]",
+    )
+    .unwrap();
+    // The dependent rule resolves to a concrete value, not a symbolic
+    // Mean[{p, q}] — proof that p and q were substituted in before Mean
+    // was evaluated.
+    assert!(
+      held.contains("m -> {3, 2}"),
+      "expected m to resolve to {{3, 2}}, got {held}"
+    );
+
+    let graphics = interpret_to_expr(
+      "GeometricScene[{p -> {1, 1}, q -> {5, 3}, m -> Mean[{p, q}]}, \
+       {Point[m]}][\"Graphics\"]",
+    )
+    .unwrap();
+    assert_eq!(expr_to_input_form(&graphics), "Graphics[{Point[{3, 2}]}]");
+  }
+
+  /// A primitive wrapped in styling (`Style[..., Dashed]`) still has its
+  /// point symbols substituted, wherever in the wrapper they occur.
+  #[test]
+  fn substitutes_inside_style_wrapper() {
+    let expr = interpret_to_expr(
+      "GeometricScene[{p -> {0, 0}, q -> {2, 2}}, \
+       {Style[Line[{p, q}], Dashed]}][\"Graphics\"]",
+    )
+    .unwrap();
+    let code = expr_to_input_form(&expr);
+    assert!(
+      code.contains("Line[{{0, 0}, {2, 2}}]"),
+      "expected substituted coordinates, got {code}"
+    );
+    assert!(
+      !code.contains("Line[{p, q}]"),
+      "point symbols should have been substituted, got {code}"
+    );
+  }
+
+  /// Regression test resembling the shape that originally motivated this
+  /// feature: three named vertex points plus a fourth point computed from
+  /// them via a function call (here `TriangleCenter`), referenced by
+  /// several primitives including a styled one.
+  #[test]
+  fn triangle_scene_with_derived_center_point() {
+    let expr = interpret_to_expr(
+      "GeometricScene[{v1 -> {0, 0}, v2 -> {6, 0}, v3 -> {0, 4}, \
+       ctr -> TriangleCenter[{v1, v2, v3}, \"Centroid\"]}, \
+       {Triangle[{v1, v2, v3}], Style[Line[{v1, ctr}], Dashed], \
+       Style[Line[{v2, ctr}], Dashed], Style[Line[{v3, ctr}], Dashed], \
+       Point[ctr]}][\"Graphics\"]",
+    )
+    .unwrap();
+    let code = expr_to_input_form(&expr);
+    assert!(code.starts_with("Graphics[{"), "got {code}");
+    // TriangleCenter[{{0,0},{6,0},{0,4}}, "Centroid"] is the mean of the
+    // three vertices: {2, 4/3}.
+    assert!(
+      code.contains("Point[{2, 4/3}]"),
+      "expected the derived centroid point substituted in, got {code}"
+    );
+    assert!(
+      code.contains("Triangle[{{0, 0}, {6, 0}, {0, 4}}]"),
+      "expected the vertex points substituted into Triangle, got {code}"
+    );
+    assert!(
+      code.contains("Line[{{0, 0}, {2, 4/3}}]"),
+      "expected a dashed line from v1 to the centroid, got {code}"
+    );
+  }
+
+  /// A malformed / missing property call keeps the curried form
+  /// unevaluated, matching the idiom used by other constructor objects
+  /// (`Entity[...]["prop"]`, `Around[...]["prop"]`).
+  #[test]
+  fn unknown_property_stays_unevaluated() {
+    assert_eq!(
+      interpret("GeometricScene[{p -> {1, 1}}, {Point[p]}][\"Bogus\"]")
+        .unwrap(),
+      "GeometricScene[{p -> {1, 1}}, {Point[p]}][Bogus]"
+    );
+  }
+
+  /// The resolved point definitions are available via `["Elements"]`.
+  #[test]
+  fn elements_property_returns_resolved_points() {
+    assert_eq!(
+      interpret("GeometricScene[{p -> {1, 1}}, {Point[p]}][\"Elements\"]")
+        .unwrap(),
+      "{p -> {1, 1}}"
+    );
+  }
+}
+
 mod circle_points {
   use super::*;
 


### PR DESCRIPTION
## Summary

Implements `GeometricScene[{sym -> value, ...}, {primitives...}]`:

- The point-definition rules are evaluated left to right, substituting every earlier point symbol into later right-hand sides before evaluating them — so a later point can be derived from earlier ones (e.g. `centroid -> TriangleCenter[{a, b, c}, "Centroid"]`). This works for an arbitrary number of points, not just a fixed count.
- The result stays a held/symbolic `GeometricScene[...]` object — the primitives keep referencing the point *symbols*, not their coordinate values — until a property is requested.
- `GeometricScene[...]["Graphics"]` substitutes every point symbol occurring anywhere in the primitives (including inside wrappers like `Style[...]`/`Directive[...]`) with its resolved value, and returns an ordinary `Graphics[{...}]` expression. This follows the existing `CurriedCall` idiom already used by `Entity[...]["property"]` and `Around[...]["property"]`.
- `GeometricScene[...]["Elements"]` returns the resolved point definitions. Any other property keeps the curried call unevaluated.
- Arity is `2` or `3` arguments (an optional third constraints-list argument is accepted and held for later use, though no property currently consumes it).
- `functions.csv`: `GeometricScene` is now marked `✅` implemented, `effect_level` `pure`.

All symbol substitution reuses the existing generic `substitute_variables` tree-walker (already used for e.g. `Function`/`NamedFunction` parameter substitution) rather than adding a new bespoke tree-walker.

## Test plan

- [x] `tests/interpreter_tests/geometry.rs` — new `geometric_scene` module covering:
  - Basic point substitution into a simple primitive (`Point[p]`).
  - The general shape of the `["Graphics"]` result (`Graphics[{...}]`).
  - A later point defined in terms of earlier ones (dependency ordering), verified both on the held object and on the extracted `Graphics[...]`.
  - A primitive wrapped in `Style[..., Dashed]` still gets its symbols substituted.
  - A multi-point scene (3 named vertices + 1 point derived from them via a function call) resembling the pattern this unlocks.
  - Unknown property calls stay unevaluated.
  - The `["Elements"]` property.
- [x] `make test` — all 26986 tests pass.
- [x] `make format` — clean.
- [x] `cargo build -p woxi-studio` — builds cleanly; verified via `cargo run -- eval` that a `Manipulate` whose body is `GeometricScene[...]["Graphics"]` (a `CurriedCall`) correctly echoes back held, and correctly re-evaluates to `Graphics[{...}]` inside a `Block[{vars...}, body]` — the same mechanism Woxi Studio's redraw path uses — so no Woxi Studio code changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjGKJxBk34NLcquLtQAwZr


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjGKJxBk34NLcquLtQAwZr)_