### PR TITLE
Woxi Studio: render finite Trigger controls as a play/pause row

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1019,7 +1019,7 @@ SphericalBesselJ,Spherical Bessel function of the first kind,✅,pure,6.0,1001
 BoxWhiskerChart,Creates a box-and-whisker chart from data,✅,pure,8.0,1002
 GridGraph,Constructs an m by n grid graph,✅,pure,8.0,1005
 ToUpperCase,Converts a string to uppercase,✅,pure,2.0,1005
-ViewAngle,,🚫,,6.0,1005
+ViewAngle,Option specifying the camera field of view for 3D graphics,✅,pure,6.0,1005
 ChartLegends,Specifies legend labels for chart elements,✅,pure,7.0,1006
 SystemOpen,Requires external services or GUI infrastructure,🚫,io,7.0,1007
 TemporalData,Represents temporal data and builds a time series from values and a date specification,✅,pure,9.0,1008

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -19469,63 +19469,65 @@ fn parse_manipulate_control(
     })
     .collect();
 
-  // A `ControlType -> Trigger` (or bare `Trigger` marker) with an
-  // *infinite* sweep end (`{time, 0, Infinity, 1, …}` — the Demonstrations
-  // "run/stop simulation" control) cannot drive a finite slider; it becomes
-  // a dedicated play/pause control that never wraps. A finite Trigger falls
-  // through to the continuous path below (Kepler pairs one with a plain
-  // slider on the same variable).
+  // A `ControlType -> Trigger` (or bare `Trigger` marker) becomes a
+  // dedicated play/pause control sweeping its variable from `min` towards
+  // `max` — whether that end is infinite (`{time, 0, Infinity, 1, …}`, the
+  // Demonstrations "run/stop simulation" control) or finite (`{{t, 0, ""},
+  // 0, tmax, .01, Trigger, DefaultDuration -> tmax}`, the "play once over a
+  // fixed duration" pattern). When this variable already has a visible row
+  // from an earlier spec (Kepler pairs a `Trigger` with a plain slider on
+  // the same `t`), the row built here is dropped by the caller's dedup
+  // check and only this control's `animate` field takes effect, so building
+  // the dedicated widget here is safe either way.
   if control_type.as_deref() == Some("Trigger") {
+    let min = bounds
+      .first()
+      .and_then(|e| {
+        crate::functions::math_ast::try_eval_to_f64_with_infinity(e)
+      })
+      .unwrap_or(0.0);
     let max = bounds
       .get(1)
       .and_then(|e| {
         crate::functions::math_ast::try_eval_to_f64_with_infinity(e)
       })
       .unwrap_or(f64::INFINITY);
-    if !max.is_finite() {
-      let min = bounds
-        .first()
-        .and_then(|e| {
-          crate::functions::math_ast::try_eval_to_f64_with_infinity(e)
-        })
-        .unwrap_or(0.0);
-      let step = bounds
-        .get(2)
-        .and_then(|e| crate::functions::math_ast::try_eval_to_f64(e))
-        .unwrap_or(1.0);
-      let initial = explicit_initial
-        .as_ref()
-        .and_then(crate::functions::math_ast::try_eval_to_f64)
-        .unwrap_or(min);
-      // Wolfram's Trigger sits paused until pressed; only an explicit
-      // `AnimationRunning -> True` starts it sweeping immediately.
-      let running = items.iter().any(|it| {
-        matches!(
-          it,
-          Expr::Rule { pattern, replacement }
-          | Expr::RuleDelayed { pattern, replacement }
-            if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "AnimationRunning")
-              && matches!(replacement.as_ref(), Expr::Identifier(s) if s == "True")
-        )
-      });
-      return Some(ParsedControl::Visible {
-        control: ManipulateControl::Trigger {
-          name,
-          min,
-          max,
-          step,
-          initial,
-          running,
-          label,
-          label_runs,
-        },
-        enabled,
-        min_code: None,
-        max_code: None,
-        values_code: None,
-        animate: Some(running),
-      });
-    }
+    let step = bounds
+      .get(2)
+      .and_then(|e| crate::functions::math_ast::try_eval_to_f64(e))
+      .unwrap_or(1.0);
+    let initial = explicit_initial
+      .as_ref()
+      .and_then(crate::functions::math_ast::try_eval_to_f64)
+      .unwrap_or(min);
+    // Wolfram's Trigger sits paused until pressed; only an explicit
+    // `AnimationRunning -> True` starts it sweeping immediately.
+    let running = items.iter().any(|it| {
+      matches!(
+        it,
+        Expr::Rule { pattern, replacement }
+        | Expr::RuleDelayed { pattern, replacement }
+          if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "AnimationRunning")
+            && matches!(replacement.as_ref(), Expr::Identifier(s) if s == "True")
+      )
+    });
+    return Some(ParsedControl::Visible {
+      control: ManipulateControl::Trigger {
+        name,
+        min,
+        max,
+        step,
+        initial,
+        running,
+        label,
+        label_runs,
+      },
+      enabled,
+      min_code: None,
+      max_code: None,
+      values_code: None,
+      animate: Some(running),
+    });
   }
 
   // 2D control: either an explicit `ControlType -> Slider2D`, or a range

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -20242,20 +20242,22 @@ mod manipulate {
   }
 
   #[test]
-  fn spec_standalone_trigger_keeps_its_slider() {
-    // A Trigger that is its variable's only control still binds it (and
-    // shows a slider row the user can also drag directly).
+  fn spec_standalone_trigger_builds_a_trigger_row() {
+    // A Trigger that is its variable's only control still binds it, as a
+    // dedicated Trigger (play/pause) row rather than an ordinary slider —
+    // Wolfram draws player buttons for `ControlType -> Trigger` regardless
+    // of whether the sweep end is finite or infinite.
     let expr =
       interpret_to_expr("Manipulate[u^2, {u, 0, 1, ControlType -> Trigger}]")
         .unwrap();
     let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
     assert_eq!(spec.controls.len(), 1);
     match &spec.controls[0] {
-      ManipulateControl::Continuous { name, min, max, .. } => {
+      ManipulateControl::Trigger { name, min, max, .. } => {
         assert_eq!(name, "u");
         assert_eq!((*min, *max), (0.0, 1.0));
       }
-      other => panic!("expected continuous control, got {other:?}"),
+      other => panic!("expected a Trigger control, got {other:?}"),
     }
     assert!(spec.animated && !spec.animation_running);
     assert_eq!(spec.animation_var.as_deref(), Some("u"));

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6938,6 +6938,67 @@ mod tests {
   }
 
   #[test]
+  fn sole_finite_trigger_builds_a_dedicated_trigger_row() {
+    // A Demonstrations "play once over a fixed duration" control: unlike
+    // Kepler's Trigger (a *second* spec for a variable that already has a
+    // plain slider, so it only steals the animation without a row of its
+    // own), this Trigger is the *only* spec for its variable and its sweep
+    // end is finite — `AppearanceElements` even asks for player buttons
+    // instead of a thumb. That must still build a dedicated `Trigger` row
+    // (play/pause + step buttons), not fall back to an ordinary slider.
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[Rotate[Square[], angle Degree], \
+       {{angle, 0, \"spin\"}, 0, 360, 1, Trigger, \
+       AppearanceElements -> {\"PlayPauseButton\", \"ResetButton\"}}]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    assert!(
+      state.animated,
+      "a Trigger control makes the widget animatable"
+    );
+    assert!(!state.playing, "a Trigger sits paused until pressed");
+    assert_eq!(state.controls.len(), 1);
+    match &state.controls[0] {
+      manipulate::ControlState::Trigger {
+        name,
+        min,
+        max,
+        step,
+        current,
+        ..
+      } => {
+        assert_eq!(name, "angle");
+        assert_eq!(*min, 0.0);
+        assert_eq!(*max, 360.0);
+        assert_eq!(*step, 1.0);
+        assert_eq!(*current, 0.0);
+      }
+      other => panic!("expected a dedicated Trigger row, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn sole_finite_trigger_animation_wraps_at_its_end() {
+    // The dedicated Trigger row must still wrap back to its start once the
+    // sweep passes `max`, exactly like a plain finite slider would — a
+    // finite Trigger is a bounded loop, not an indefinite run.
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[disk = Disk[{0, 0}, r], \
+       {{r, 3, \"grow\"}, 1, 3, 1, Trigger}]",
+    )
+    .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    let current = |s: &manipulate::ManipulateState| match &s.controls[0] {
+      manipulate::ControlState::Trigger { current, .. } => *current,
+      other => panic!("expected a Trigger control, got {other:?}"),
+    };
+    assert_eq!(current(&state), 3.0, "starts at its explicit initial value");
+    state.advance_animation();
+    assert_eq!(current(&state), 1.0, "steps past max wrap back to min");
+  }
+
+  #[test]
   fn locator_manipulate_builds_a_draggable_widget() {
     // The "Center of Mass of a Polygon" Demonstration pattern: a Locator
     // bound to a point list drives the polygon, with icon-labelled

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -580,8 +580,8 @@ impl ManipulateState {
   /// once it passes the end, then re-render. Called from the app's
   /// animation-tick subscription while `playing` is set. The target is the
   /// `ControlType -> Trigger`/`Animator` variable when the spec named one
-  /// (a slider row for a finite sweep, a dedicated `Trigger` row for an
-  /// infinite one — which never wraps), else the first continuous control.
+  /// (always a dedicated `Trigger` row, which wraps for a finite sweep and
+  /// runs forever for an infinite one), else the first continuous control.
   pub fn advance_animation(&mut self) {
     let target = self.animation_var.clone();
     let ctrl = self.controls.iter_mut().find(|c| match &target {


### PR DESCRIPTION
## Summary

Found while checking Woxi Studio's support for a random Wolfram Demonstrations Project notebook (an interactive 3D animation controlled by a `Manipulate` with a `ControlType -> Trigger` time control).

- `Manipulate`'s `ControlType -> Trigger` (or a bare `Trigger` marker) only built a dedicated play/pause widget when the control's sweep had an *infinite* upper bound. A `Trigger` whose sole spec has a *finite* bound — the common Demonstrations "play once over a fixed duration" idiom, often paired with `AppearanceElements` restricting the row to player buttons — silently fell back to rendering as an ordinary draggable slider, even though the interpreter still correctly marked the widget as animated.
- Fixed `parse_manipulate_control` in `src/functions/graphics.rs` to always build the dedicated `ManipulateControl::Trigger` widget for a `Trigger`-typed control spec, regardless of whether the bound is finite or infinite. The existing dedup step that lets a second `Trigger` spec animate an already-visible variable without adding a second row (the Kepler's-second-law pattern) is unaffected, since it only keys off the control's name, not its variant.
- Updated a stale comment in `woxi-studio/src/manipulate.rs::advance_animation` that described the old (now incorrect) behavior.
- Updated the existing `spec_standalone_trigger_keeps_its_slider` test (renamed to `spec_standalone_trigger_builds_a_trigger_row`) to assert the corrected behavior.
- Added two new regression tests in `woxi-studio/src/main.rs` using freshly written examples (not copied from the source notebook) covering: a sole finite `Trigger` building a dedicated row, and that row's animation wrapping correctly at its bound.
- Also corrected a stale `functions.csv` entry: `ViewAngle` was marked unimplemented (🚫) even though it has been implemented (and covered by tests) for a while; verified it changes rendered 3D output before flipping it to ✅.

## Test plan

- [x] `cargo test --test '*'` (full core integration suite) — all green
- [x] `cargo test -p woxi-studio` (includes `kepler_trigger_and_period_bounded_sliders` and the two new tests) — all green
- [x] `cargo test --lib --bins` — all green
- [x] `make format`


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgTw2UXLJp9c6r6cxkLTsR)_