### PR TITLE
Add regression test for Manipulate function-list picker + mesh-plane pattern

### DIFF
--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -20480,6 +20480,84 @@ mod manipulate {
       &svg[..svg.len().min(400)]
     );
   }
+
+  // The "level curves of a surface" Demonstration pattern: a prior cell
+  // defines a list of `Function[{x, y}, …]` surfaces, and the Manipulate
+  // body picks one by `Part` indexing (`surfaces[[choice]]`) into a local
+  // variable before plotting it, with three `Appearance -> "Labeled"`
+  // sliders driving `MeshFunctions`/`Mesh` cutting planes on the surface and
+  // a fourth control switching which surface is shown via a pick list whose
+  // choices are `TraditionalForm[Row[{…}]]`-labelled formulas.
+  #[test]
+  fn spec_surface_mesh_planes_with_function_list_picker() {
+    let expr = interpret_to_expr(
+      "surfaces = {Function[{u, v}, Sin[u^2 + v^2]], \
+       Function[{u, v}, u^2 - v^2], \
+       Function[{u, v}, Exp[-u^2 - v^2]]}; \
+       Manipulate[\
+       g = surfaces[[choice]]; \
+       With[{px = px0, py = py0, pz = pz0}, \
+       Plot3D[g[u, v], {u, -2, 2}, {v, -2, 2}, \
+       MeshFunctions -> {#1 & , #2 & , #3 & }, \
+       Mesh -> {{px}, {py}, {pz}}, \
+       MeshStyle -> {{Red, Thickness[0.006]}, {Blue, Thickness[0.006]}, \
+       {Darker[Green], Thickness[0.006]}}, \
+       AxesLabel -> {Style[\"u\", Italic], Style[\"v\", Italic], \
+       Style[\"g\", Italic]}, ImageSize -> {300, 300}]], \
+       {px0, -3, 3, Appearance -> \"Labeled\"}, \
+       {py0, -3, 3, Appearance -> \"Labeled\"}, \
+       {pz0, -3, 3, Appearance -> \"Labeled\"}, \
+       {{choice, 1, \"surface\"}, \
+       {1 -> TraditionalForm[Row[{Sin[U^2 + V^2]}]], \
+       2 -> TraditionalForm[Row[{U^2 - V^2}]], \
+       3 -> TraditionalForm[Row[{Exp[-U^2 - V^2]}]]}, \
+       FieldSize -> {10, 1.8}, ControlPlacement -> Left}, \
+       SaveDefinitions -> True, TrackedSymbols -> True]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+
+    // Three plain continuous sliders, then the discrete surface picker.
+    assert_eq!(spec.controls.len(), 4);
+    for c in &spec.controls[..3] {
+      assert!(
+        matches!(c, ManipulateControl::Continuous { .. }),
+        "expected a continuous slider, got {c:?}"
+      );
+    }
+    match &spec.controls[3] {
+      ManipulateControl::Discrete {
+        name,
+        values,
+        value_labels,
+        ..
+      } => {
+        assert_eq!(name, "choice");
+        assert_eq!(
+          values,
+          &vec!["1".to_string(), "2".to_string(), "3".to_string()]
+        );
+        // `Row[{…}]` around a single element collapses to that element, so
+        // the TraditionalForm label renders the bare formula.
+        assert_eq!(value_labels.len(), 3);
+        for label in value_labels {
+          assert!(!label.is_empty(), "surface picker label must not be empty");
+        }
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+
+    // The initial bindings (px0=py0=pz0=-3, choice=1) render a surface —
+    // the `funcs[[choice]]` indirection inside the body must resolve.
+    let bindings = manipulate_initial_bindings(&spec);
+    let code = manipulate_block_code(&spec.body_code, &bindings);
+    let result = woxi::interpret_with_stdout(&code).unwrap();
+    assert!(
+      result.graphics.is_some(),
+      "Plot3D through a Part-indexed function list must still render: {:?}",
+      result.result
+    );
+  }
 }
 
 // ----- Callout tests -----


### PR DESCRIPTION
## Summary
- As part of the recurring "check a random Wolfram Demonstration against Woxi Studio" routine, this run's notebook was a 3D level-curves visualizer: a `Manipulate` whose body picks a function out of a pre-defined list via `Part` (`funcs[[choice]]`), assigns it locally, then feeds it to `Plot3D` with three `Appearance -> "Labeled"` sliders driving `MeshFunctions`/`Mesh` cutting planes, plus a discrete picker whose choices are `TraditionalForm[Row[{…}]]`-labelled formulas.
- Running the actual downloaded `.nb` file through `woxi` (`cargo run -- file.nb`, the same notebook parser/interpreter Woxi Studio uses) evaluated every cell cleanly with no errors or warnings, and `extract_manipulate_spec`/`controls_from_spec` already build the right widgets (3 continuous sliders + 1 discrete picker) and render the initial surface — so no interpreter or Studio fix was needed.
- Added a regression test capturing this pattern with an equivalent, non-verbatim example (different function set/names) so future changes don't silently break it: `spec_surface_mesh_planes_with_function_list_picker` in `tests/interpreter_tests/graphics.rs`.

## Test plan
- [x] `cargo run -- <the demonstration's .nb file>` evaluates every cell with exit code 0 and no stderr output (verified locally against the downloaded notebook, not committed since it's copyrighted).
- [x] New test `spec_surface_mesh_planes_with_function_list_picker` passes.
- [x] `make test` — full suite: 26,980 tests passed, 0 failed.
- [x] `make format` — no additional changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_016trdk9a81tebvZmSmmDon9

---
_Generated by [Claude Code](https://claude.ai/code/session_016trdk9a81tebvZmSmmDon9)_