### PR TITLE
Unixify $InputFileName to fix scripts/build_summary.wls on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,28 @@ use std::path::PathBuf;
 use woxi::notebook::{CellStyle, parse_notebook};
 use woxi::{interpret, set_script_command_line, without_shebang};
 
+fn run_script(file: &PathBuf, args: Vec<String>) {
+  let absolute_path = if file.is_absolute() {
+    file.clone()
+  } else {
+    env::current_dir()
+      .unwrap_or_else(|_| PathBuf::from("."))
+      .join(file)
+  };
+
+  // Set $InputFileName and $ScriptCommandLine
+  let abs_str = absolute_path
+    .to_string_lossy()
+    .to_string()
+    .replace('\\', "/");
+  woxi::set_system_variable("$InputFileName", &format!("\"{abs_str}\""));
+  let mut cmd_line = vec![abs_str];
+  cmd_line.extend(args);
+  set_script_command_line(&cmd_line);
+
+  run_script_file(&absolute_path);
+}
+
 /// Execute a script file referenced by `absolute_path`.
 ///
 /// `.nb` notebook files are parsed and their Input/Code cells are
@@ -261,22 +283,7 @@ fn run(cli: Cli) {
       // A script owns stdin, so `Input[]` / `InputString[]` read from it.
       woxi::set_stdin_input(true);
 
-      let absolute_path = if file.is_absolute() {
-        file.clone()
-      } else {
-        env::current_dir()
-          .unwrap_or_else(|_| PathBuf::from("."))
-          .join(&file)
-      };
-
-      // Set $InputFileName and $ScriptCommandLine
-      let abs_str = absolute_path.to_string_lossy().to_string();
-      woxi::set_system_variable("$InputFileName", &format!("\"{abs_str}\""));
-      let mut cmd_line = vec![abs_str];
-      cmd_line.extend(args);
-      set_script_command_line(&cmd_line);
-
-      run_script_file(&absolute_path);
+      run_script(&file, args);
     }
     Commands::Jupyter { connection_file } => {
       if let Err(e) = jupyter::run(connection_file.as_deref()) {
@@ -301,22 +308,7 @@ fn run(cli: Cli) {
         return;
       }
       let file = PathBuf::from(&args[0]);
-      let absolute_path = if file.is_absolute() {
-        file.clone()
-      } else {
-        env::current_dir()
-          .unwrap_or_else(|_| PathBuf::from("."))
-          .join(&file)
-      };
-
-      // Set $InputFileName and $ScriptCommandLine
-      let abs_str = absolute_path.to_string_lossy().to_string();
-      woxi::set_system_variable("$InputFileName", &format!("\"{abs_str}\""));
-      let mut cmd_line = vec![abs_str];
-      cmd_line.extend(args.into_iter().skip(1));
-      set_script_command_line(&cmd_line);
-
-      run_script_file(&absolute_path);
+      run_script(&file, args.into_iter().skip(1).collect());
     }
   }
 }


### PR DESCRIPTION
build_summary.wls fails to run on Windows because $InputFileName is set to C:\...\Woxi\scripts/. Since DirectoryName does not handle backslashes, scriptDir ends up being empty. Even if DirectoryName handled backslashes correctly, the path could end up with \n, \r, \t and Woxi would convert those to escape sequences and the file i/o would fail.

The hacky fix for now is to unixify $InputFileName, like is done for paths in much of the test suite.  Even if this isn't the long term fix, most of the patch is actually just unifying two common code branches which should be a desired change.