### PR TITLE
Fix FileNames to honor level count for recursive directory search

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 # Unreleased
 
+- `FileNames[form, dirs, n]` honours the level count instead of only
+    searching `dirs` themselves: `n` includes files up to `n` directory levels
+    down, so `FileNames["f.txt", dir, 2]` also reports the matches in `dir`'s
+    immediate subdirectories. `Infinity` keeps descending without a limit,
+    and `n <= 0` matches nothing. A third argument that is not a level
+    specification now leaves the call unevaluated. Recursing below `"."` also
+    keeps each hit's path relative to the current directory rather than
+    collapsing it to a bare file name.
 - `InputString[]` and `Input[]` actually read from standard input when `woxi`
     owns it — `woxi run script.wls`, a shebang script, and `woxi eval` — so a
     script that prompts for a value now waits for one instead of running

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -3236,6 +3236,7 @@ pub fn dispatch_io_functions(
     // FileNames[] — list all files in current directory
     // FileNames["pattern"] — list files matching pattern
     // FileNames["pattern", "dir"] — list files in dir matching pattern
+    // FileNames["pattern", "dir", n] — descend n directory levels
     // FileNames["pattern", "dir", Infinity] — recursive search
     #[cfg(not(target_arch = "wasm32"))]
     "FileNames" if args.len() <= 3 => {
@@ -3250,18 +3251,27 @@ pub fn dispatch_io_functions(
         }
       };
 
+      // Third argument: how many directory levels to include. `1` (the
+      // default) searches only the given directories, `2` also their
+      // immediate subdirectories, and `Infinity` descends without limit.
+      let levels = if args.len() >= 3 {
+        match file_names_levels(&args[2]) {
+          Some(n) => n,
+          None => return Some(Ok(unevaluated("FileNames", args))),
+        }
+      } else {
+        1
+      };
+
       let dir = if args.len() >= 2 {
         match &args[1] {
           Expr::String(s) => s.clone(),
           Expr::List(dirs) => {
             // FileNames["pat", {"dir1", "dir2"}] — search multiple dirs
             let mut all_files = Vec::new();
-            let recursive = args.len() >= 3
-              && matches!(&args[2], Expr::Identifier(s) if s == "Infinity");
             for d in dirs {
               if let Expr::String(dir_str) = d {
-                let mut files =
-                  collect_file_names(&pattern, dir_str, recursive);
+                let mut files = collect_file_names(&pattern, dir_str, levels);
                 all_files.append(&mut files);
               }
             }
@@ -3276,10 +3286,7 @@ pub fn dispatch_io_functions(
         ".".to_string()
       };
 
-      let recursive = args.len() >= 3
-        && matches!(&args[2], Expr::Identifier(s) if s == "Infinity");
-
-      let mut files = collect_file_names(&pattern, &dir, recursive);
+      let mut files = collect_file_names(&pattern, &dir, levels);
       files.sort();
       return Some(Ok(Expr::List(
         files.into_iter().map(Expr::String).collect(),
@@ -4188,29 +4195,43 @@ fn export_string_csv(
 
 /// Collect file names matching a glob pattern in a directory.
 #[cfg(not(target_arch = "wasm32"))]
-fn collect_file_names(
-  pattern: &str,
-  dir: &str,
-  recursive: bool,
-) -> Vec<String> {
+fn collect_file_names(pattern: &str, dir: &str, levels: usize) -> Vec<String> {
   use std::path::Path;
 
   let dir_path = Path::new(dir);
-  if !dir_path.is_dir() {
+  if levels == 0 || !dir_path.is_dir() {
     return Vec::new();
   }
 
   let mut results = Vec::new();
-  collect_files_recursive(dir_path, dir, pattern, recursive, &mut results);
+  collect_files_recursive(dir_path, dir, pattern, levels, &mut results);
   results
 }
 
+/// Number of directory levels the third `FileNames` argument asks for.
+/// `Infinity` means "no limit"; a non-positive count matches nothing.
+/// Returns `None` for arguments that aren't a level specification.
+#[cfg(not(target_arch = "wasm32"))]
+fn file_names_levels(spec: &Expr) -> Option<usize> {
+  match spec {
+    Expr::Identifier(s) if s == "Infinity" => Some(usize::MAX),
+    Expr::Integer(n) => Some(usize::try_from(*n).unwrap_or(0)),
+    Expr::Real(r) if r.fract() == 0.0 => {
+      Some(if *r <= 0.0 { 0 } else { *r as usize })
+    }
+    _ => None,
+  }
+}
+
+/// Walk `path`, collecting entries whose name matches `pattern`. `levels`
+/// counts the directory levels still to visit, so `1` stops at `path`
+/// itself and `usize::MAX` stands in for `Infinity`.
 #[cfg(not(target_arch = "wasm32"))]
 fn collect_files_recursive(
   path: &std::path::Path,
   base_dir: &str,
   pattern: &str,
-  recursive: bool,
+  levels: usize,
   results: &mut Vec<String>,
 ) {
   let Ok(entries) = std::fs::read_dir(path) else {
@@ -4223,25 +4244,36 @@ fn collect_files_recursive(
 
     if let Ok(ft) = file_type {
       if glob_match(pattern, &file_name) {
-        if base_dir == "." {
-          results.push(file_name.clone());
+        let rel_str = entry.path().to_string_lossy().to_string();
+        // A "." base is spelled implicitly, matching `FileNames["pat"]`,
+        // so drop the leading "./" that joining the base introduces.
+        results.push(if base_dir == "." {
+          strip_dot_prefix(&rel_str).to_string()
         } else {
-          let rel = entry.path();
-          let rel_str = rel.to_string_lossy().to_string();
-          results.push(rel_str);
-        }
+          rel_str
+        });
       }
-      if ft.is_dir() && recursive {
+      if ft.is_dir() && levels > 1 {
         collect_files_recursive(
           &entry.path(),
           base_dir,
           pattern,
-          true,
+          levels - 1,
           results,
         );
       }
     }
   }
+}
+
+/// Strip the leading `./` (or `.\` on Windows) from a path built by
+/// joining onto the "." base directory.
+#[cfg(not(target_arch = "wasm32"))]
+fn strip_dot_prefix(path: &str) -> &str {
+  path
+    .strip_prefix('.')
+    .and_then(|rest| rest.strip_prefix(['/', '\\']))
+    .unwrap_or(path)
 }
 
 /// Simple glob pattern matching supporting * and ?

--- a/tests/cli/file_system/FileNames.md
+++ b/tests/cli/file_system/FileNames.md
@@ -6,3 +6,33 @@ Returns a list of file names matching a pattern in the current directory.
 $ wo 'ListQ[FileNames["*"]]'
 True
 ```
+
+A third argument sets how many directory levels to include.
+Set up a `docs` directory with a `report.txt` on three levels:
+
+```scrut
+$ wo 'CreateDirectory["docs/inner/deeper"]; CreateFile["docs/report.txt"]; CreateFile["docs/inner/report.txt"]; CreateFile["docs/inner/deeper/report.txt"]; FileNames["*", "docs"]'
+{docs/inner, docs/report.txt}
+```
+
+The default, `1`, only looks at `docs` itself,
+so the copies further down are not reported:
+
+```scrut
+$ wo 'FileNames["report.txt", "docs"]'
+{docs/report.txt}
+```
+
+With `2`, the immediate subdirectories are searched as well:
+
+```scrut
+$ wo 'FileNames["report.txt", "docs", 2]'
+{docs/inner/report.txt, docs/report.txt}
+```
+
+`Infinity` descends without a limit:
+
+```scrut
+$ wo 'FileNames["report.txt", "docs", Infinity]'
+{docs/inner/deeper/report.txt, docs/inner/report.txt, docs/report.txt}
+```

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -5647,6 +5647,109 @@ mod file_names {
     let result = interpret(r#"MemberQ[FileNames[], "src"]"#).unwrap();
     assert_eq!(result, "True");
   }
+
+  /// Build `<temp>/<name>/sub/sub/sub` with a `target.txt` on every level
+  /// and return the unix-style path of the tree's root directory.
+  fn nested_tree(name: &str) -> String {
+    let root = std::env::temp_dir().join(format!("woxi_file_names_{name}"));
+    std::fs::remove_dir_all(&root).ok();
+    let mut dir = root.clone();
+    loop {
+      std::fs::create_dir_all(&dir).unwrap();
+      std::fs::write(dir.join("target.txt"), "x").unwrap();
+      match dir.strip_prefix(&root).unwrap().components().count() {
+        3 => break,
+        _ => dir = dir.join("sub"),
+      }
+    }
+    unixify(&root.display().to_string())
+  }
+
+  /// The reported names, relative to the tree root, joined with `|`.
+  fn relative_hits(root: &str, levels: &str) -> String {
+    let names = interpret(&format!(
+      r#"StringRiffle[
+        StringDrop[FileNames["target.txt", "{root}", {levels}], {}],
+        "|"
+      ]"#,
+      root.chars().count() + 1
+    ))
+    .unwrap();
+    names.replace('\\', "/")
+  }
+
+  // The default depth of one level only reports the directory itself.
+  #[test]
+  fn default_depth_stays_in_the_given_directory() {
+    let root = nested_tree("default_depth");
+    let names = interpret(&format!(
+      r#"FileNames["target.txt", "{root}"] === {{FileNameJoin[{{"{root}", "target.txt"}}]}}"#
+    ))
+    .unwrap();
+    assert_eq!(names, "True");
+    std::fs::remove_dir_all(&root).ok();
+  }
+
+  // Regression test for #479: an explicit level count has to descend into
+  // subdirectories instead of being ignored.
+  #[test]
+  fn level_count_descends_that_many_directories() {
+    let root = nested_tree("level_count");
+    assert_eq!(relative_hits(&root, "1"), "target.txt");
+    assert_eq!(relative_hits(&root, "2"), "sub/target.txt|target.txt");
+    assert_eq!(
+      relative_hits(&root, "3"),
+      "sub/sub/target.txt|sub/target.txt|target.txt"
+    );
+    assert_eq!(
+      relative_hits(&root, "4"),
+      "sub/sub/sub/target.txt|sub/sub/target.txt|sub/target.txt|target.txt"
+    );
+    std::fs::remove_dir_all(&root).ok();
+  }
+
+  // A level count past the deepest directory behaves like Infinity, and
+  // level zero matches nothing at all.
+  #[test]
+  fn level_count_saturates_and_zero_matches_nothing() {
+    let root = nested_tree("level_bounds");
+    assert_eq!(relative_hits(&root, "99"), relative_hits(&root, "Infinity"));
+    assert_eq!(relative_hits(&root, "0"), "");
+    std::fs::remove_dir_all(&root).ok();
+  }
+
+  // A list of directories honours the level count as well.
+  #[test]
+  fn level_count_applies_to_a_list_of_directories() {
+    let root = nested_tree("level_list");
+    let count = interpret(&format!(
+      r#"Length[FileNames["target.txt", {{"{root}", FileNameJoin[{{"{root}", "sub"}}]}}, 2]]"#
+    ))
+    .unwrap();
+    // Two levels below the root plus two below "sub", with
+    // "sub/target.txt" reported once per directory spec it came through.
+    assert_eq!(count, "4");
+    std::fs::remove_dir_all(&root).ok();
+  }
+
+  // Recursing below "." keeps the path relative to the current directory
+  // instead of collapsing every hit to its bare file name.
+  #[test]
+  fn dot_directory_keeps_relative_paths() {
+    let result = interpret(
+      r#"MemberQ[FileNames["lib.rs", ".", Infinity], "src/lib.rs" | "src\\lib.rs"]"#,
+    )
+    .unwrap();
+    assert_eq!(result, "True");
+  }
+
+  // A third argument that is not a level specification leaves the call
+  // unevaluated rather than silently searching a single level.
+  #[test]
+  fn non_level_third_argument_stays_unevaluated() {
+    let result = interpret(r#"FileNames["*.rs", "src", foo]"#).unwrap();
+    assert_eq!(result, "FileNames[*.rs, src, foo]");
+  }
 }
 
 mod set_directory {


### PR DESCRIPTION
## Summary

Fixed `FileNames` to properly honor the third argument specifying how many directory levels to search, instead of ignoring it and only searching the given directories themselves. This resolves issue #479.

## Key Changes

- **Level count parameter**: The third argument to `FileNames` now controls directory recursion depth:
  - `1` (default): searches only the specified directories
  - `2`: includes immediate subdirectories
  - `n`: descends up to `n` directory levels
  - `Infinity`: descends without limit
  - `0` or negative: matches nothing

- **Validation**: Non-level-specification third arguments now leave the call unevaluated instead of being silently ignored

- **Relative path handling**: When recursing below `"."`, paths are now kept relative to the current directory instead of being collapsed to bare file names

- **Implementation refactoring**:
  - Replaced boolean `recursive` parameter with `levels: usize` in `collect_file_names` and `collect_files_recursive`
  - Added `file_names_levels()` function to parse and validate level specifications
  - Added `strip_dot_prefix()` helper to handle relative path formatting for `"."` base directory

## Testing

Added comprehensive test coverage including:
- Default depth behavior (single level only)
- Level count descent verification (1, 2, 3, 4 levels)
- Level saturation and zero-level edge cases
- Level count application to directory lists
- Relative path preservation for `"."` directory
- Invalid third argument handling

Updated CLI documentation with examples demonstrating the level count feature.

https://claude.ai/code/session_01HjFbvfzu6ouAQzisb8ZEYC