### PR TITLE
Implement NCache

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -4234,7 +4234,7 @@ KnownUnitQ,Tests whether an expression is a recognised unit specification,✅,pu
 LeftVector,,,,3.0,4356
 LinearSolveFunction,,,,5.0,4356
 LossFunction,,,,11.3,4356
-NCache,,,,6.0,4356
+NCache,Represents an expression tagged with a numeric approximation and evaluates to the expression,✅,pure,6.0,4356
 NearestTo,Operator form of Nearest that finds the elements nearest to a value,✅,pure,11.3,4356
 NumberFieldIntegralBasis,,,,6.0,4356
 ParentCell,,🚫,,10.0,4356

--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -675,6 +675,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "WhittakerW" => Some((3, 3)),
     "Identity" => Some((1, 1)),
     "Once" => Some((1, 2)),
+    "NCache" => Some((2, 2)),
     "CompanionMatrix" => Some((1, 3)),
     "IdentityMatrix" => Some((1, 2)),
     "PermutationMatrix" => Some((1, 1)),

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -5213,6 +5213,13 @@ pub fn dispatch_list_operations(
     "Once" if args.len() == 1 || args.len() == 2 => {
       return Some(Ok(args[0].clone()));
     }
+    // NCache[expr, value] tags `expr` with a precomputed numeric
+    // approximation `value` (the front end uses this to redisplay sliders
+    // etc. without renumericizing). It evaluates to the exact expression;
+    // the cached approximation is discarded.
+    "NCache" if args.len() == 2 => {
+      return Some(Ok(args[0].clone()));
+    }
     // Composition[] -> Identity
     "Composition" if args.is_empty() => {
       return Some(Ok(Expr::Identifier("Identity".to_string())));

--- a/tests/interpreter_tests/function_application.rs
+++ b/tests/interpreter_tests/function_application.rs
@@ -2867,6 +2867,37 @@ mod once_wrapper {
   }
 }
 
+// NCache[expr, value] tags expr with a numeric approximation and evaluates
+// to expr, discarding the cached value.
+mod ncache_wrapper {
+  use super::*;
+
+  #[test]
+  fn evaluates_to_first_argument() {
+    assert_eq!(interpret("NCache[1/3, 0.3333333333333333]").unwrap(), "1/3");
+    assert_eq!(
+      interpret("NCache[Pi/4, 0.7853981633974483]").unwrap(),
+      "Pi/4"
+    );
+  }
+
+  #[test]
+  fn preserves_exact_head() {
+    assert_eq!(
+      interpret("Head[NCache[1/3, 0.3333333333333333]]").unwrap(),
+      "Rational"
+    );
+  }
+
+  #[test]
+  fn works_inside_a_list_of_slider_bounds() {
+    assert_eq!(
+      interpret("{0, NCache[2/45, 0.044444], 1}").unwrap(),
+      "{0, 2/45, 1}"
+    );
+  }
+}
+
 // ApplyTo[x, f] / x //= f: applies f to the held variable's value,
 // reassigns, and returns the new value. Verified against wolframscript.
 mod apply_to {


### PR DESCRIPTION
## Summary

While checking whether Woxi Studio fully supports a random Wolfram Demonstration notebook (fetched via the Demonstrations random-resource API, not committed to this repo), one gap surfaced: `NCache` was recognized as a symbol but had no evaluation rule, so it fell through to Woxi's "not yet implemented" warning path.

`NCache[expr, value]` is the internal wrapper Wolfram's front end uses to tag an exact expression with a precomputed numeric approximation — commonly seen in `Manipulate` control specs (e.g. slider bounds like `NCache[2/45, 0.044444]`) so the value doesn't need renumericizing on redisplay. The kernel evaluates it to the exact expression, discarding the cached approximation.

## Changes

- `NCache[expr, value]` now evaluates to `expr` (2-argument form only, matching real usage).
- Registered its arg-count range (`2, 2`).
- Filled in its `functions.csv` row (description, `✅` status, `pure` effect level).
- Added unit tests covering the basic identity behavior, that the exact head is preserved (not coerced to a float), and usage nested inside a list of slider-style bounds.

## Test plan

- [x] `make test` (27,040 tests passed)
- [x] `make format`
- [x] Re-ran the notebook's `Manipulate` through Woxi Studio's `dump_manipulate` diagnostic — the widget now builds without the `NCache` warning


---
_Generated by [Claude Code](https://claude.ai/code/session_0178bLQdJtkkiEaTyP2w8Tji)_