### PR TITLE
Fix parsing of bare Slot pure functions on the right of //

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3861,7 +3861,14 @@ fn parse_postfix_function(pair: Pair<Rule>) -> Expr {
   let has_ampersand = pair.as_str().trim_end().ends_with('&');
   // The inner children are the same (BaseFunctionCall or Identifier);
   // the "&" is an anonymous literal in the grammar and doesn't appear as a child.
-  let func = pair_to_expr(pair.into_inner().next().unwrap());
+  let inner = pair.into_inner().next().unwrap();
+  // SimpleAnonymousFunction (`#&`, `#+1&`) already parses itself into a
+  // Function{body} and consumes its own trailing "&" — wrapping it again
+  // would nest a second Slot scope and break `#` binding.
+  if matches!(inner.as_rule(), Rule::SimpleAnonymousFunction) {
+    return pair_to_expr(inner);
+  }
+  let func = pair_to_expr(inner);
   if has_ampersand {
     Expr::Function {
       body: Box::new(func),

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -280,9 +280,13 @@ Operator = @{
 // Optional trailing & allows "x // f &" to parse as x // (f &), matching Wolfram precedence.
 // Parenthesised expressions and List literals can also serve as the postfix
 // operator, supporting `expr // (#1+1&)` and `expr // {#1, Precision[#1]}&`.
+// A bare Slot-based body (`expr // #&`, `expr // #+1&`) is its own
+// alternative: SimpleAnonymousFunction already parses `# op term &` and
+// unlike the other branches doesn't start with `(`, a list, or an
+// identifier, so it needs an explicit path here.
 PostfixFunction = {
-    ("(" ~ Expression ~ ")" | List | BaseFunctionCall | Identifier)
-  ~ ("&" ~ !"&")?
+    SimpleAnonymousFunction
+  | ("(" ~ Expression ~ ")" | List | BaseFunctionCall | Identifier) ~ ("&" ~ !"&")?
 }
 
 // Increment/Decrement: x++ or x-- (postfix operators)

--- a/tests/interpreter_tests/function_application.rs
+++ b/tests/interpreter_tests/function_application.rs
@@ -2834,6 +2834,22 @@ mod arithmetic_head_application {
     assert_eq!(interpret("x // (f + g)").unwrap(), "(f + g)[x]");
   }
 
+  // A bare Slot-based pure function as the right operand of `//` — no
+  // enclosing parens — must parse the same as the parenthesized form.
+  #[test]
+  fn postfix_slashslash_bare_slot_function() {
+    assert_eq!(interpret("5 // #&").unwrap(), "5");
+    assert_eq!(interpret("5 // #+1&").unwrap(), "6");
+    assert_eq!(interpret("{1, 2} // #&").unwrap(), "{1, 2}");
+    // Must match the already-supported parenthesized form exactly — if the
+    // bare form were double-wrapped in an extra Function, {3, 4} would bind
+    // to an unused outer slot and #1/#2 would stay unevaluated inside it.
+    assert_eq!(
+      interpret("{3, 4} // #1+#2&").unwrap(),
+      interpret("{3, 4} // (#1+#2)&").unwrap()
+    );
+  }
+
   #[test]
   fn map_and_apply() {
     assert_eq!(


### PR DESCRIPTION
## Summary

- Fixes a parser bug: `expr // #&` and `expr // #+1&` (a bare `Slot`-based pure function immediately to the right of `//`, without enclosing parens) failed with `Parse error: expected SpanSep or ScanComment`. Only the parenthesized form (`expr // (#&)`) worked before this fix.
- `PostfixFunction` in `src/wolfram.pest` only accepted an `Identifier`, `List`, `BaseFunctionCall`, or parenthesized `Expression` as the right operand of `//`. A bare `#` (`Slot`) isn't any of those, so it fell through to a parse error. Added `SimpleAnonymousFunction` (the existing rule that already parses `# op term &`) as an alternative.
- `parse_postfix_function` in `src/syntax.rs` is updated to avoid double-wrapping: `SimpleAnonymousFunction` already parses itself into `Function{body}` and consumes its own trailing `&`, so wrapping it a second time would nest an extra `Slot` scope and break `#` binding. Verified with a regression test that a bare two-slot form (`{3, 4} // #1+#2&`) matches its already-supported parenthesized equivalent exactly.

This surfaced while checking whether Woxi Studio can open a random Wolfram Demonstrations Project notebook — its `Manipulate` cell used this exact `... //#&` idiom in its body, which previously made the whole cell fail to parse. With this fix the notebook's `Manipulate` cell (and all its other input cells) evaluate cleanly through the interpreter.

## Test plan
- [x] Added a regression test (`postfix_slashslash_bare_slot_function`) in `tests/interpreter_tests/function_application.rs` covering `5 // #&`, `5 // #+1&`, `{1, 2} // #&`, and the double-wrap differentiator case.
- [x] `make test` (27,038 tests) — all passed.
- [x] `make test-studio` (127 tests) — all passed.
- [x] `make format` — no changes needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H2gsoxnAJkKMYBhLLPCuNB)_