### PR TITLE
Resolve symbolic bounds in Manipulate leading assignments and Slider2D

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1439,6 +1439,19 @@ fn typeset_constant_glyph(name: &str) -> Option<&'static str> {
   })
 }
 
+/// Whether an expression is a plain-assignment target: a bare symbol, or a
+/// (possibly nested) list of them — `{{xmin, xmax}, {ymin, ymax}}` is the
+/// left side of the list-destructuring form `{{xmin, xmax}, {ymin, ymax}} =
+/// {{-2, 2}, {-2, 2}}`, which `Set` threads element-wise the same way it
+/// does a plain `{a, b} = {1, 2}`.
+fn is_assignment_target(expr: &Expr) -> bool {
+  match expr {
+    Expr::Identifier(_) => true,
+    Expr::List(items) => items.iter().all(is_assignment_target),
+    _ => false,
+  }
+}
+
 /// The run of plain assignments a Manipulate body opens with. A body that
 /// sets up its own bounds does so first (`tmin = 0; tmax = 2 Pi; …`), and
 /// stopping at the first statement that is not a `Set` keeps this to
@@ -1453,7 +1466,7 @@ fn leading_assignments(body: &Expr) -> Vec<&Expr> {
     .take_while(|stmt| {
       matches!(stmt, Expr::FunctionCall { name, args }
         if name == "Set" && args.len() == 2
-          && matches!(&args[0], Expr::Identifier(_)))
+          && is_assignment_target(&args[0]))
     })
     .collect()
 }
@@ -18495,11 +18508,19 @@ fn manipulate_value_to_input_form(expr: &Expr) -> String {
 /// Interpret an expression as a 2-element numeric list `{a, b}`, evaluating
 /// each element to an `f64`. Returns `None` for anything that isn't a
 /// 2-vector of numbers.
+///
+/// A corner point may name a symbol a leading body assignment sets rather
+/// than carry a literal number — `{{u, {1, 1}, ""}, {xmin, ymin}, {xmax,
+/// ymax}, ControlType -> Slider2D}` bounds a 2D control by the same `xmin`
+/// leading assignments resolve for a 1D slider (`eval_manipulate_bound`
+/// falls back to a full evaluation for exactly this reason). Each element
+/// gets the same fallback here so a `Slider2D` corner point resolves a
+/// symbolic bound the way a plain slider's `min`/`max` already does.
 fn list2_f64(e: &Expr) -> Option<(f64, f64)> {
   match e {
     Expr::List(l) if l.len() == 2 => {
-      let a = crate::functions::math_ast::try_eval_to_f64(&l[0])?;
-      let b = crate::functions::math_ast::try_eval_to_f64(&l[1])?;
+      let a = eval_manipulate_bound(&l[0])?.0;
+      let b = eval_manipulate_bound(&l[1])?.0;
       Some((a, b))
     }
     _ => None,

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -17481,6 +17481,71 @@ mod manipulate {
     assert_eq!(woxi::interpret("Length[Flatten[tree]]").unwrap(), "7");
   }
 
+  /// A leading assignment may destructure a nested list in one `Set` —
+  /// `{{xmin, xmax}, {ymin, ymax}} = {{-2, 2}, {-2, 2}}` threads element-wise
+  /// the same way a plain `{a, b} = {1, 2}` does. `leading_assignments` only
+  /// recognized a single bare symbol on the left, so a body opening with a
+  /// destructuring bound-setup line was cut from the leading run entirely —
+  /// every name it introduces stayed unresolved for the rest of the body.
+  #[test]
+  fn spec_leading_assignments_include_list_destructuring() {
+    let expr = interpret_to_expr(
+      "Manipulate[{{xmin, xmax}, {ymin, ymax}} = {{-2, 2}, {-3, 3}}; g[x, y], \
+       {{pt, {1, 1}, \"\"}, {xmin, ymin}, {xmax, ymax}, ControlType -> Slider2D}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    match &spec.controls[0] {
+      ManipulateControl::Slider2D {
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        ..
+      } => {
+        assert_eq!(*x_min, -2.0);
+        assert_eq!(*x_max, 2.0);
+        assert_eq!(*y_min, -3.0);
+        assert_eq!(*y_max, 3.0);
+      }
+      other => panic!("expected a Slider2D control, got {other:?}"),
+    }
+  }
+
+  /// `Slider2D`'s corner-point bounds (`{xmin, ymin}, {xmax, ymax}`) may name
+  /// symbols a leading body assignment sets, exactly as a plain slider's
+  /// scalar `min`/`max` already could (see the test above this one).
+  /// `list2_f64`, which reads each corner point, only accepted literal
+  /// numbers — a symbolic corner point made the control panel fail
+  /// structurally rather than just widen: `is_2d_range` came back false, and
+  /// the scalar-bounds fallback then tried to evaluate a whole `{xmin,
+  /// ymin}` list as one bound and gave up on the entire Manipulate.
+  #[test]
+  fn spec_slider2d_corner_bounds_see_leading_assignments() {
+    let expr = interpret_to_expr(
+      "Manipulate[umin = -5; umax = 5; g[x, y], \
+       {{pt, {0, 0}, \"\"}, {umin, umin}, {umax, umax}, \
+        ControlType -> Slider2D}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    match &spec.controls[0] {
+      ManipulateControl::Slider2D {
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        ..
+      } => {
+        assert_eq!(*x_min, -5.0);
+        assert_eq!(*x_max, 5.0);
+        assert_eq!(*y_min, -5.0);
+        assert_eq!(*y_max, 5.0);
+      }
+      other => panic!("expected a Slider2D control, got {other:?}"),
+    }
+  }
+
   /// `ControlType -> Slider` over a *choice list* keeps the choices but
   /// asks for a slider that steps through them by index — how Wolfram
   /// draws a twenty-entry colour-scheme picker. Without the flag the


### PR DESCRIPTION
## Summary

- `Manipulate`'s leading run of plain body assignments (the setup lines a body runs before its controls, e.g. `xmin = 0; xmax = 1; …`) only recognized a single bare symbol as the assignment target. A body opening with a list-destructuring assignment such as `{{xmin, xmax}, {ymin, ymax}} = {{-2, 2}, {-2, 2}}` was excluded from that leading run entirely, leaving every name it introduces unresolved for the rest of the body — an interpreter/Manipulate-extraction gap unrelated to any specific script.
- Separately, a `Slider2D` control's corner-point bounds (`{xmin, ymin}, {xmax, ymax}`) only accepted literal numbers. A plain slider's scalar `min`/`max` already falls back to evaluating against the interpreter's live globals when it isn't a literal, but the 2D corner-point reader didn't have the same fallback — so a symbolic corner point broke control-panel extraction structurally (the whole `Manipulate` failed to build a widget) instead of just widening.
- Found by checking Woxi Studio's compatibility with a randomly selected Wolfram Demonstration notebook (as part of a recurring compatibility check) that combines both patterns; the notebook itself isn't included here, and the fixes and tests are written as general, original examples.

## Changes

- `src/functions/graphics.rs`: `leading_assignments` now accepts a `Set` whose left side is a bare symbol *or* a (possibly nested) list of them, matching Wolfram's element-wise list-assignment semantics. `list2_f64` (used to read a `Slider2D` corner point) now goes through the same `eval_manipulate_bound` fallback the 1D case already uses, so a symbolic bound resolves the same way.
- `tests/interpreter_tests/graphics.rs`: two new regression tests — one for the list-destructuring leading assignment, one for a `Slider2D` control whose corner bounds are symbols set by a leading assignment.

## Test plan

- [x] `make format`
- [x] `make test` (27,039 tests, all passing)
- [x] Manually verified via the `dump_manipulate` diagnostic example that a `Manipulate` combining both patterns now builds an interactive widget and renders graphics successfully (previously it failed to build a widget at all)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PSfkaDtcBd2VJdL7hpuP6z)_