### PR TITLE
Live-update Manipulate control-panel rows that embed Dynamic[…]

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -10957,6 +10957,24 @@ pub(crate) fn is_manipulate_annotation_head(name: &str) -> bool {
   is_style_wrapper(name) || matches!(name, "Text" | "Row" | "Column")
 }
 
+/// Whether an annotation row (`Style[…]`, `Row[{…}]`, `Column[{…}]`, …) has a
+/// `Dynamic[…]` anywhere inside it — a Demonstration's live step counter is
+/// often written `Row[{Style["moves: "], Dynamic[moves]}]` right in the
+/// control-panel argument list. Such a row is not "plain text layout" (see
+/// [`is_manipulate_annotation_head`]): the `Dynamic` part must track its
+/// variable and update every frame, so it needs the same live "display"
+/// treatment as a bare `Dynamic[…]` argument rather than being frozen into a
+/// static `Heading` at parse time.
+fn annotation_contains_dynamic(expr: &Expr) -> bool {
+  match expr {
+    Expr::FunctionCall { name, args } => {
+      name == "Dynamic" || args.iter().any(annotation_contains_dynamic)
+    }
+    Expr::List(items) => items.iter().any(annotation_contains_dynamic),
+    _ => false,
+  }
+}
+
 /// Peel a display-only `Invisible[expr]` wrapper, returning the content it
 /// hides. `Invisible` keeps exactly the space `expr` would take but paints
 /// nothing — Demonstrations use it to hold a layout's shape steady while an
@@ -16965,13 +16983,27 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         continue;
       }
       Expr::FunctionCall { name, .. }
-        if is_manipulate_annotation_head(name) =>
+        if is_manipulate_annotation_head(name)
+          && !annotation_contains_dynamic(spec) =>
       {
         let label_runs = manipulate_label_runs(spec, false);
         controls.push(ManipulateControl::Heading {
           label: flatten_label_runs(&label_runs),
           label_runs,
         });
+        continue;
+      }
+      // A `Row`/`Column`/`Style`/`Text` annotation with a `Dynamic[…]`
+      // somewhere inside (a live step counter, e.g.
+      // `Row[{Style["moves: "], Dynamic[moves]}]`) is not static text: fall
+      // through to the generic "extra display element" handling below so it
+      // re-renders from the live bindings every frame instead of being
+      // frozen into a `Heading` with the `Dynamic` wrapper's bare source.
+      Expr::FunctionCall { name, .. }
+        if is_manipulate_annotation_head(name)
+          && annotation_contains_dynamic(spec) =>
+      {
+        displays.push(crate::syntax::expr_to_input_form(spec));
         continue;
       }
       // `Button[label, action, opts…]`: a pressable control row whose

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -9298,6 +9298,82 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
   }
 
   #[test]
+  fn manipulate_row_with_dynamic_shows_live_value_not_frozen_text() {
+    // Regression for "Water Colors Puzzle": a Demonstration's live move
+    // counter is often written directly among the control-panel arguments as
+    // `Row[{Style["moves: "], Dynamic[moves]}]`. `Row`/`Column`/`Style` are
+    // normally treated as a static caption row (Wolfram's
+    // `ThisIsNotAControl`), but one that embeds a `Dynamic[…]` must track
+    // that variable's live value every frame instead of freezing into a
+    // `Heading` that echoes the bare `Dynamic[moves]` source as literal text.
+    let code = "Manipulate[\n\
+      moves = moves + go;\n\
+      go,\n\
+      {{go, 0}, ControlType -> None},\n\
+      Row[{Style[\"moves: \"], Dynamic[moves]}],\n\
+      {{moves, 0}, ControlType -> None}\n\
+      ]";
+    let mut state =
+      instantiate_stored_manipulate(code, "").expect("must build a widget");
+    assert!(state.error.is_none(), "body must evaluate cleanly");
+
+    // The Dynamic row must not show up as a frozen `Heading` echoing the
+    // `Dynamic[moves]` source.
+    assert!(
+      !state
+        .controls
+        .iter()
+        .any(|c| matches!(c, manipulate::ControlState::Heading { .. })),
+      "the Row[{{…, Dynamic[moves]}}] must not freeze into a Heading, got {:?}",
+      state.controls
+    );
+
+    // It renders live instead, starting at `moves`'s initial value (0).
+    fn row_text(node: &woxi::functions::graphics::DisplayNode) -> String {
+      use woxi::functions::graphics::DisplayNode;
+      match node {
+        DisplayNode::Row(children) | DisplayNode::Column(children) => {
+          children.iter().map(row_text).collect()
+        }
+        DisplayNode::Text { runs } => {
+          runs.iter().map(|r| r.text.as_str()).collect()
+        }
+        DisplayNode::Static { text, .. } => text.clone(),
+        _ => String::new(),
+      }
+    }
+    let moves_row = state
+      .display_trees
+      .iter()
+      .find(|t| row_text(t).contains("moves:"))
+      .unwrap_or_else(|| {
+        panic!(
+          "no display tree has the moves row: {:?}",
+          state.display_trees
+        )
+      });
+    assert_eq!(row_text(moves_row), "moves: 0");
+
+    // Bumping `go` and re-rendering must move the live counter, not the
+    // frozen text a `Heading` would have kept forever.
+    if let Some(slot) = state.state.iter_mut().find(|(n, _)| n == "go") {
+      slot.1 = "1".to_string();
+    }
+    state.reevaluate();
+    let moves_row = state
+      .display_trees
+      .iter()
+      .find(|t| row_text(t).contains("moves:"))
+      .unwrap_or_else(|| {
+        panic!(
+          "no display tree has the moves row: {:?}",
+          state.display_trees
+        )
+      });
+    assert_eq!(row_text(moves_row), "moves: 1");
+  }
+
+  #[test]
   fn solar_panel_manipulate_folds_its_array() {
     // End-to-end regression for "Solar Panel of NASA's Phoenix Mars
     // Lander": two sliders fold a fan of triangular panels around a shaft.


### PR DESCRIPTION
## Summary

- Checked Woxi Studio against a random Wolfram Demonstrations Project notebook ("Water Colors Puzzle"). Its board, gates, and target-pattern graphics all rendered correctly, but its move counter — written directly among the `Manipulate` control-panel arguments as `Row[{Style["moves: "], Dynamic[moves]}]` — never advanced past its frozen initial label.
- `Row`/`Column`/`Style`/`Text` arguments in a `Manipulate` control list are normally treated as static caption rows (`is_manipulate_annotation_head`, added in #473). That's correct for plain captions, but a row with a `Dynamic[…]` nested inside it needs the same live "display" treatment a bare `Dynamic[…]` argument already gets — otherwise it's typeset once from the `Dynamic[…]` wrapper's literal source (e.g. showing the word `moves` instead of its current value) and never updates again.
- Added `annotation_contains_dynamic` to detect this case and route such rows into the existing live-display pipeline (the same one that already re-renders `Dynamic[Style[tx, Red, 25, Bold]]`-style captions every frame) instead of freezing them into a `Heading`.

## Test plan

- [x] Added `manipulate_row_with_dynamic_shows_live_value_not_frozen_text` in `woxi-studio/src/main.rs`, asserting the row does not freeze into a `Heading` and that its rendered text tracks a live variable across a `reevaluate()`.
- [x] `make test` — 27037 tests passed.
- [x] `make test-studio` — 128 tests passed.
- [x] `make format`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyHp2dcoXRBmJ1hcK8oyKd)_