### PR TITLE
Fix Solve/NSolve for multi-equation systems combined with an inequality

### DIFF
--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2119,6 +2119,66 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
+  // Handle a system of equations combined with inequality constraints when
+  // solving for a list of variables: Solve[eq1 && eq2 && ... && ineq, {v1,
+  // v2, ...}]. The pre-pass above only flattens an And into a List of
+  // equations when every conjunct is an equality, so a mixed system with two
+  // or more equalities plus an inequality is still a single And expression
+  // here, and would otherwise be treated as one non-list "equation" by the
+  // block below. Split it into its equalities and inequalities, solve the
+  // equalities as a system, then discard any solution an inequality rules
+  // out.
+  if let Expr::List(var_items) = &args[1]
+    && !var_items.is_empty()
+  {
+    let mut constraints = Vec::new();
+    collect_and_constraints(&args[0], &mut constraints);
+    let is_equality = |e: &Expr| -> bool {
+      matches!(e, Expr::Comparison { operators, .. }
+          if operators.len() == 1 && operators[0] == ComparisonOp::Equal)
+        || matches!(e, Expr::FunctionCall { name, args } if name == "Equal" && args.len() == 2)
+    };
+    let (eqs, ineqs): (Vec<Expr>, Vec<Expr>) =
+      constraints.into_iter().partition(|e| is_equality(e));
+    if eqs.len() >= 2 && !ineqs.is_empty() {
+      let eq_solutions = solve_ast(&[Expr::List(eqs.into()), args[1].clone()])?;
+      return Ok(match &eq_solutions {
+        Expr::List(solutions) => Expr::List(
+          solutions
+            .iter()
+            .filter(|sol| {
+              let Expr::List(rules) = sol else {
+                return true;
+              };
+              !ineqs.iter().any(|ineq| {
+                let substituted =
+                  rules.iter().fold(ineq.clone(), |acc, rule| {
+                    let Expr::Rule {
+                      pattern,
+                      replacement,
+                    } = rule
+                    else {
+                      return acc;
+                    };
+                    let Expr::Identifier(name) = pattern.as_ref() else {
+                      return acc;
+                    };
+                    crate::syntax::substitute_variable(&acc, name, replacement)
+                  });
+                matches!(
+                  crate::evaluator::evaluate_expr_to_expr(&substituted),
+                  Ok(Expr::Identifier(ref s)) if s == "False"
+                )
+              })
+            })
+            .cloned()
+            .collect(),
+        ),
+        _ => eq_solutions,
+      });
+    }
+  }
+
   // Handle single equation with list of variables: Solve[eq, {var1, var2, ...}]
   if let Expr::List(vars_exprs) = &args[1] {
     if vars_exprs.len() == 1 {

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -4809,6 +4809,24 @@ mod solve {
     );
   }
 
+  // Regression: a multi-equation system combined with an inequality (as an
+  // And expression, not a list) used to fall through to Solve's
+  // non-identifier-target branch and return unevaluated, because only the
+  // single-variable path recognized "equation && inequality". The equality
+  // system is solved first and the inequality then filters the result.
+  #[test]
+  fn system_with_trailing_inequality() {
+    assert_eq!(
+      interpret("Solve[x + y == 3 && x - y == 1 && x > 0, {x, y}]").unwrap(),
+      "{{x -> 2, y -> 1}}"
+    );
+    // The inequality rules out every solution of the equality system.
+    assert_eq!(
+      interpret("Solve[x + y == 3 && x - y == 1 && x > 5, {x, y}]").unwrap(),
+      "{}"
+    );
+  }
+
   #[test]
   fn linear_system_with_and_in_list() {
     // Solve[{eq1 && eq2}, {x, y}] should behave like
@@ -7315,6 +7333,32 @@ mod nsolve {
       .unwrap(),
       "{{x -> 1.7055408794701485, y -> -0.8090169943749475}, \
        {x -> -0.16669911088252198, y -> -0.8090169943749475}}"
+    );
+  }
+
+  // Regression: solving a parametrized-line/plane intersection for a system
+  // of coordinate equations plus a bound on the line parameter (a common
+  // pattern for clipping a segment to a face) used to return unevaluated
+  // rather than the numeric rules, because the multi-equation-plus-
+  // inequality path only existed for a single variable.
+  #[test]
+  fn system_with_parameter_bound() {
+    assert_eq!(
+      interpret(
+        "NSolve[z == -1. + 2.*t && x == -1. && y == -1. && z == 0. && \
+         0. < t < 1., {t, x, y, z}]"
+      )
+      .unwrap(),
+      "{{t -> 0.5, x -> -1., y -> -1., z -> 0.}}"
+    );
+    // Out of bounds for t: no solution survives the filter.
+    assert_eq!(
+      interpret(
+        "NSolve[z == -1. + 2.*t && x == -1. && y == -1. && z == 5. && \
+         0. < t < 1., {t, x, y, z}]"
+      )
+      .unwrap(),
+      "{}"
     );
   }
 


### PR DESCRIPTION
## Summary

- `Solve`/`NSolve` on a system of two or more equations combined with an inequality constraint (e.g. `Solve[eq1 && eq2 && ineq, {v1, v2, ...}]`) fell through to an unrelated non-identifier-target branch and returned unevaluated, because the pre-pass that flattens an `And` of equations into a list only fires when every conjunct is an equality, and the only existing "equation + inequality" handling required a single-`Identifier` solve target.
- Added a branch that splits such a mixed system into its equalities and inequalities, solves the equality system for the given variable list, and filters out any solution an inequality rules out.
- This surfaced while checking Woxi Studio's compatibility with a Wolfram Demonstrations-style notebook that computes a parametric line/plane intersection bounded to a segment (`0 < t < 1`) alongside several coordinate equations — a common pattern in 3D-geometry Demonstrations (clipping a point to the interior of an edge/segment). With the fix, Woxi Studio's `Manipulate` pipeline for that notebook evaluates and renders without error.

## Test plan

- [x] Added regression tests in `tests/interpreter_tests/algebra.rs` (`solve::system_with_trailing_inequality`, `nsolve::system_with_parameter_bound`) covering both the solvable and no-solution-survives-the-inequality cases for `Solve` and `NSolve`.
- [x] `make test` — all 27,039 unit tests pass.
- [x] `make format`.
- [x] Manually verified via `woxi-studio`'s `dump_manipulate` example that the previously-failing Demonstration-style notebook now evaluates and renders its `Manipulate` widget correctly (no more `ReplaceAll::reps` error).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm7rSnwU1Q1Mrnr9WaffyG)_