### PR TITLE
Support Manipulate's TrackingFunction option in Woxi Studio

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -2113,7 +2113,7 @@ PercentForm,Formats a non-negative real number as a percentage,✅,pure,12.0,212
 GroupOrder,Order of a group,✅,pure,8.0,2129
 QueueingProcess,Queueing theory process,🚫,,9.0,2129
 RegionProduct,Cartesian product of regions — named as a box cylinder prism or parallelotope where one exists,✅,pure,10.0,2129
-TrackingFunction,Tracking callback option,🚫,,10.0,2129
+TrackingFunction,Tracking callback option,✅,none,10.0,2129
 MathieuCharacteristicB,Mathieu characteristic value,🚫,,3.0,2131
 PowerRange,List of values from xmin by successive multiplication while their magnitude stays within xmax,✅,pure,10.0,2131
 ParentDirectory,Parent directory path,✅,none,2.0,2132

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16612,6 +16612,14 @@ pub struct ManipulateSpec {
   /// means every variable is tracked, which is Wolfram's default and also
   /// what `TrackedSymbols -> All` / `-> Manipulate` ask for.
   pub tracked_symbols: Option<Vec<String>>,
+  /// Per-control `TrackingFunction -> f` callbacks, as `(control name,
+  /// function code)`. Whenever the named control's value changes, `f` runs
+  /// with the new value as `#` — typically to reset a *different* control
+  /// (an Electrophilic Aromatic Substitution demonstration resets its time
+  /// slider to `0` whenever the reaction step picker changes: `{{a, 1, ""},
+  /// choices, TrackingFunction -> (a = #; t = 0; &)}`). Controls with no
+  /// `TrackingFunction` option do not appear here.
+  pub tracking: Vec<(String, String)>,
 }
 
 /// Result of parsing a single list-shaped Manipulate argument.
@@ -16633,6 +16641,9 @@ enum ParsedControl {
     /// (re-resolved live by the frontend, like `min_code`/`max_code`).
     values_code: Option<String>,
     animate: Option<bool>,
+    /// `TrackingFunction -> f` (InputForm code), run with the control's new
+    /// value whenever it changes.
+    tracking: Option<String>,
   },
   /// A `Locator` control with no widget. It contributes a fixed `name =
   /// value` binding that is baked directly into the body so the variable is
@@ -16714,6 +16725,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     mut dynamic_bounds,
     mut dynamic_values,
     mut animation_var,
+    mut tracking,
   ) = if let Some(inner) = inner {
     animated = true;
     animation_running = inner.animation_running;
@@ -16728,6 +16740,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       inner.dynamic_bounds,
       inner.dynamic_values,
       inner.animation_var,
+      inner.tracking,
     )
   } else {
     // `TogglerBar[Dynamic[var], …]` inside the body moves into the
@@ -16752,6 +16765,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       Vec::new(),
       Vec::new(),
       None,
+      Vec::new(),
     )
   };
   // `Locator[Dynamic[var, cb], …]` markers inside the body drive their
@@ -17083,6 +17097,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         max_code,
         values_code,
         animate,
+        tracking: tracking_fn,
       } => {
         if let Some((orig, orig_form, synth)) = &rename {
           patch_default_label(&mut c, orig, synth);
@@ -17107,6 +17122,9 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         }
         if let Some(cond) = enabled {
           control_enabled.push((c.name().to_string(), cond));
+        }
+        if let Some(code) = tracking_fn {
+          tracking.push((c.name().to_string(), code));
         }
         if min_code.is_some() || max_code.is_some() {
           dynamic_bounds.push((c.name().to_string(), min_code, max_code));
@@ -17316,6 +17334,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animation_running,
     appearance_none,
     tracked_symbols,
+    tracking,
   })
 }
 
@@ -18213,6 +18232,7 @@ pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animation_running: true,
     appearance_none: false,
     tracked_symbols: None,
+    tracking: Vec::new(),
   })
 }
 
@@ -18290,6 +18310,7 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animation_running: true,
     appearance_none: false,
     tracked_symbols: None,
+    tracking: Vec::new(),
   })
 }
 
@@ -18365,6 +18386,7 @@ pub fn extract_locator_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animation_running: true,
     appearance_none: false,
     tracked_symbols: None,
+    tracking: Vec::new(),
   })
 }
 
@@ -18416,6 +18438,7 @@ pub fn extract_click_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animation_running: true,
     appearance_none: false,
     tracked_symbols: None,
+    tracking: Vec::new(),
   })
 }
 
@@ -18478,6 +18501,7 @@ pub fn extract_control_spec(expr: &Expr) -> Option<ManipulateSpec> {
     animation_running: animate.unwrap_or(true),
     appearance_none: false,
     tracked_symbols: None,
+    tracking: Vec::new(),
   })
 }
 
@@ -19421,6 +19445,24 @@ fn parse_manipulate_control(
     _ => None,
   });
 
+  // `TrackingFunction -> f` / `:> f` runs `f[newValue]` whenever this
+  // control's value changes, so a Demonstration can reset a companion
+  // control (e.g. rewinding a time slider when the reaction step changes).
+  let tracking: Option<String> = items.iter().find_map(|it| match it {
+    Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    } if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "TrackingFunction") =>
+    {
+      Some(crate::syntax::expr_to_input_form(replacement))
+    }
+    _ => None,
+  });
+
   // `Locator` controls (`{{p, init}, pmin, pmax, Locator}`, as a bare
   // marker or `ControlType -> Locator`) and hidden `ControlType -> None`
   // variables (`{{v, init}, ControlType -> None}`).
@@ -19546,6 +19588,7 @@ fn parse_manipulate_control(
         max_code: None,
         values_code: None,
         animate: None,
+        tracking: tracking.clone(),
       });
     }
     if let Some(points) = point_list_f64(&evaluated) {
@@ -19566,6 +19609,7 @@ fn parse_manipulate_control(
         max_code: None,
         values_code: None,
         animate: None,
+        tracking: tracking.clone(),
       });
     }
     let value = manipulate_value_to_input_form(&value_expr);
@@ -19666,6 +19710,7 @@ fn parse_manipulate_control(
       max_code: None,
       values_code: None,
       animate: Some(running),
+      tracking: tracking.clone(),
     });
   }
 
@@ -19710,6 +19755,7 @@ fn parse_manipulate_control(
       max_code: None,
       values_code: None,
       animate: None,
+      tracking: tracking.clone(),
     });
   }
 
@@ -19745,6 +19791,7 @@ fn parse_manipulate_control(
       max_code: None,
       values_code: None,
       animate: None,
+      tracking: tracking.clone(),
     });
   }
 
@@ -19871,6 +19918,7 @@ fn parse_manipulate_control(
         max_code: None,
         values_code,
         animate: None,
+        tracking: tracking.clone(),
       });
     }
   }
@@ -20011,6 +20059,7 @@ fn parse_manipulate_control(
     max_code,
     values_code: None,
     animate,
+    tracking,
   })
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -5186,7 +5186,22 @@ fn parse_compound_expression(pair: &Pair<Rule>) -> Expr {
   // by scanning the source string for top-level `;`s between children.
   let src = pair.as_str();
   let src_start = pair.as_span().start();
-  let children: Vec<_> = pair.clone().into_inner().collect();
+  let mut children: Vec<_> = pair.clone().into_inner().collect();
+  // A trailing `&` with no statement between it and the last `;` (the
+  // `(a = #; t = 0; &)` idiom — see the grammar comment on
+  // `CompoundExpression`) turns the whole sequence into a pure function
+  // body. It rides along as a final `AnonymousFunctionSuffix` child; pull
+  // it out before the statement loop below so it isn't mistaken for one.
+  let anon_func_suffix = children
+    .last()
+    .is_some_and(|p| p.as_rule() == Rule::AnonymousFunctionSuffix)
+    .then(|| children.pop().unwrap());
+  // Stop the trailing-`;` scan at the suffix (if any) rather than the end
+  // of the whole match, so its `&`/`[…]` text is never mistaken for
+  // statement content.
+  let stmts_end = anon_func_suffix
+    .as_ref()
+    .map_or(src_start + src.len(), |s| s.as_span().start());
   let mut exprs: Vec<Expr> = Vec::new();
   // Count the number of top-level `;` separators between `lo` and `hi`
   // (absolute offsets into the original input). `;;` is treated as a
@@ -5243,16 +5258,33 @@ fn parse_compound_expression(pair: &Pair<Rule>) -> Expr {
     prev_end = span.end();
   }
   // Trailing separators after the last child → each is a Null.
-  let end_offset = src_start + src.len();
-  let trailing = count_separators(prev_end, end_offset);
+  let trailing = count_separators(prev_end, stmts_end);
   for _ in 0..trailing {
     exprs.push(Expr::Identifier("Null".to_string()));
   }
-  if exprs.len() == 1 {
+  let mut result = if exprs.len() == 1 {
     exprs.into_iter().next().unwrap()
   } else {
     Expr::CompoundExpr(exprs)
+  };
+  // Wrap in a pure function and apply any immediately-chained call
+  // (`(a = #; t = 0; &)[2]`), mirroring how a bare `expr &` is handled in
+  // `parse_expression`.
+  if let Some(suffix) = anon_func_suffix {
+    result = Expr::Function {
+      body: Box::new(result),
+    };
+    for bracket in suffix
+      .into_inner()
+      .filter(|p| matches!(p.as_rule(), Rule::BracketArgs))
+    {
+      result = Expr::CurriedCall {
+        func: Box::new(result),
+        args: bracket.into_inner().map(pair_to_expr).collect(),
+      };
+    }
   }
+  result
 }
 
 fn parse_association_extended(pair: Pair<Rule>) -> Expr {

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -457,7 +457,13 @@ PostfixApplication = { PostfixBase ~ ("//" ~ PostfixFunction)+ }
 // free to follow a separator (`... ; ;;`). parse_compound_expression counts the
 // `;` separators from the source to reinsert omitted (Null) statements.
 CompoundStatement = _{ TopLevelSpan | Expression }
-CompoundExpression = { CompoundStatement ~ (";" ~ CompoundStatement?)+ }
+// An optional trailing `&` (no expression between it and the last `;`) turns
+// the whole statement sequence into a pure function body — the idiom
+// `(a = #; t = 0; &)` Options like `TrackingFunction` commonly use for a
+// multi-statement callback. Without a statement between the final `;` and
+// `&`, `&` cannot attach to a `CompoundStatement` (there isn't one), so it
+// must be consumed here instead, at the CompoundExpression level.
+CompoundExpression = { CompoundStatement ~ (";" ~ CompoundStatement?)+ ~ AnonymousFunctionSuffix? }
 
 // DerivativeNumeric: numeric literal followed by '...' (e.g. 1', (-1.4)', I via Constant)
 DerivativeNumeric = { (PrecisionReal | Real | IntegerScientific | Integer | Constant) ~ DerivativePrime }

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -18792,6 +18792,68 @@ mod manipulate {
   }
 
   #[test]
+  fn spec_tracking_function_captured() {
+    // A popup-menu control's `TrackingFunction -> f` runs `f[newValue]`
+    // whenever the picker changes — Demonstrations commonly use this to
+    // reset a companion slider (e.g. rewinding a step counter whenever the
+    // selected mode changes).
+    let expr = interpret_to_expr(
+      "Manipulate[If[mode == 1, step^2, step + 1], \
+       {{mode, 1, \"\"}, {1 -> \"square\", 2 -> \"increment\"}, \
+        TrackingFunction -> (mode = #; step = 0; &)}, \
+       {{step, 0, \"step\"}, 0, 5, 1}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    assert_eq!(
+      spec.tracking,
+      vec![(
+        "mode".to_string(),
+        "(mode = #1; step = 0; Null) & ".to_string()
+      )]
+    );
+    // The `step` control carries no `TrackingFunction` of its own.
+    assert!(spec.tracking.iter().all(|(n, _)| n != "step"));
+  }
+
+  /// End to end: the tracking function captured above actually resets the
+  /// companion control when run against the live bindings — the same
+  /// runtime path (`apply_manipulate_button_action`) the frontends use to
+  /// fold a control's `TrackingFunction` writes back into the widget state.
+  #[test]
+  fn tracking_function_resets_companion_control() {
+    use woxi::functions::graphics::apply_manipulate_button_action;
+    let expr = interpret_to_expr(
+      "Manipulate[If[mode == 1, step^2, step + 1], \
+       {{mode, 1, \"\"}, {1 -> \"square\", 2 -> \"increment\"}, \
+        TrackingFunction -> (mode = #; step = 0; &)}, \
+       {{step, 0, \"step\"}, 0, 5, 1}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    let (_, tracking_code) = spec
+      .tracking
+      .iter()
+      .find(|(n, _)| n == "mode")
+      .expect("mode has a TrackingFunction");
+    // Bindings as they stand right after the user picks "increment" (2),
+    // with the step slider still wherever it was left.
+    let bindings = vec![
+      ("mode".to_string(), "2".to_string()),
+      ("step".to_string(), "4".to_string()),
+    ];
+    let action = format!("({tracking_code})[2]");
+    let updated = apply_manipulate_button_action(&bindings, &action);
+    assert_eq!(
+      updated,
+      vec![
+        ("mode".to_string(), "2".to_string()),
+        ("step".to_string(), "0".to_string()),
+      ]
+    );
+  }
+
+  #[test]
   fn spec_json_includes_enabled_when() {
     let expr = interpret_to_expr(
       "Manipulate[a, {{a, 0.5}, 0.1, 0.9, Enabled -> Dynamic[Not[b]]}, {b, {1, 2}}]",

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -8517,6 +8517,27 @@ mod anonymous_function_precedence {
       "{11, 13, 17, 19}"
     );
   }
+
+  #[test]
+  fn amp_after_trailing_semicolon_wraps_whole_compound_expression() {
+    // A trailing `;` with no statement between it and `&` wraps the whole
+    // preceding statement sequence in a Function — the idiom
+    // `TrackingFunction -> (a = #; b = 0; &)` needs for a multi-statement
+    // callback (used by Manipulate's `TrackingFunction` option to reset a
+    // companion control). Without a statement following the last `;`, `&`
+    // cannot bind to it the way `a; b &` binds to just `b`, so it must
+    // instead close out the whole `CompoundExpression` built so far.
+    assert_eq!(
+      interpret("FullForm[Hold[(a = #; b = 0; &)]]").unwrap(),
+      "FullForm[Hold[(a = #1; b = 0; Null) & ]]"
+    );
+    // The trailing `;` before `&` also appends an implicit `Null` as the
+    // function's own last statement (same as any other trailing `;`), so
+    // calling it returns `Null` — what matters is that both assignments
+    // ran, in order, as side effects.
+    let _ = interpret("(trackPrecA = #; trackPrecB = 0; &)[5]").unwrap();
+    assert_eq!(interpret("{trackPrecA, trackPrecB}").unwrap(), "{5, 0}");
+  }
 }
 
 mod out_shortcut {

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -1677,6 +1677,7 @@ impl WoxiStudio {
           && let manipulate::ControlState::Continuous { current, .. } = control
         {
           *current = value;
+          state.apply_tracking(ctrl_idx);
           if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
@@ -1696,6 +1697,7 @@ impl WoxiStudio {
           && let Some(idx) = value_labels.iter().position(|v| *v == choice)
         {
           *current_index = idx;
+          state.apply_tracking(ctrl_idx);
           if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
@@ -1710,6 +1712,7 @@ impl WoxiStudio {
           // Routes through the control's write-back callback (if any), so
           // e.g. Locator-promoted controls round/validate the candidate.
           state.slider2d_change(ctrl_idx, axis, value);
+          state.apply_tracking(ctrl_idx);
           if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
@@ -1736,6 +1739,7 @@ impl WoxiStudio {
           } else {
             *high = value.max(*low);
           }
+          state.apply_tracking(ctrl_idx);
           if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
@@ -1761,6 +1765,7 @@ impl WoxiStudio {
           } else {
             point.1 = value;
           }
+          state.apply_tracking(ctrl_idx);
           if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
@@ -1783,6 +1788,7 @@ impl WoxiStudio {
         {
           // New points appear at the range centre, ready to drag.
           points.push(((*x_min + *x_max) / 2.0, (*y_min + *y_max) / 2.0));
+          state.apply_tracking(ctrl_idx);
           if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
@@ -1798,6 +1804,7 @@ impl WoxiStudio {
           && point_idx < points.len()
         {
           points.remove(point_idx);
+          state.apply_tracking(ctrl_idx);
           if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
           }
@@ -6633,6 +6640,54 @@ mod tests {
     state.run_scheduled_reeval();
     state.run_scheduled_reeval();
     assert!(state.request_reeval(0), "flag must clear on an empty fire");
+  }
+
+  /// A discrete control's `TrackingFunction -> f` resets a companion
+  /// control when the picker changes — the Demonstrations idiom of
+  /// rewinding a step/time slider whenever the selected mode changes.
+  /// Independently written, not copied from any specific Demonstration.
+  #[test]
+  fn manipulate_tracking_function_resets_companion_control() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[If[mode == 1, step^2, step + 1], \
+       {{mode, 1, \"\"}, {1 -> \"square\", 2 -> \"increment\"}, \
+        TrackingFunction -> (mode = #; step = 0; &)}, \
+       {{step, 3, \"step\"}, 0, 5, 1}]",
+    )
+    .unwrap();
+    let mut state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    let mode_idx = state
+      .controls
+      .iter()
+      .position(|c| c.name() == "mode")
+      .unwrap();
+    let step_idx = state
+      .controls
+      .iter()
+      .position(|c| c.name() == "step")
+      .unwrap();
+
+    // Move `step` away from its initial value so the reset is observable.
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[step_idx]
+    {
+      *current = 4.0;
+    }
+
+    // Pick the other choice in the `mode` popup.
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[mode_idx]
+    {
+      *current_index = 1;
+    }
+    state.apply_tracking(mode_idx);
+
+    let manipulate::ControlState::Continuous { current, .. } =
+      &state.controls[step_idx]
+    else {
+      panic!("expected step to remain a continuous slider");
+    };
+    assert_eq!(*current, 0.0, "TrackingFunction should reset step to 0");
   }
 
   /// A control panel written as a `Grid` — the Demonstrations layout for a

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -297,6 +297,13 @@ pub struct ManipulateState {
   /// `advance_animation` targets this control instead of defaulting to the
   /// first continuous one.
   animation_var: Option<String>,
+  /// Per-control `TrackingFunction -> f` callback (InputForm code), as
+  /// `(control name, function code)`. Run against the control's new value
+  /// whenever the user moves it (see [`apply_tracking`]), so a Demonstration
+  /// can reset a companion control the way Wolfram does.
+  ///
+  /// [`apply_tracking`]: Self::apply_tracking
+  tracking: Vec<(String, String)>,
   /// Continuous-control bounds that reference other control variables, as
   /// `(control name, min code, max code)`. Re-resolved against the live
   /// bindings on every re-evaluation so a slider range can follow another
@@ -392,6 +399,7 @@ impl ManipulateState {
       appearance_none: spec.appearance_none,
       tracked_symbols: spec.tracked_symbols,
       animation_var: spec.animation_var,
+      tracking: spec.tracking,
       dynamic_bounds: spec.dynamic_bounds,
       dynamic_values: spec.dynamic_values,
       control_enabled,
@@ -444,6 +452,39 @@ impl ManipulateState {
       }
     }
     self.reevaluate();
+  }
+
+  /// Run the control at `ctrl_idx`'s `TrackingFunction -> f` (if it has
+  /// one) against its *new* current value, folding back whatever `f`
+  /// assigns (e.g. a companion control it resets) into state/controls.
+  /// Called right after a control's value is updated, before the caller
+  /// requests a re-evaluation, so the tracking function's writes are
+  /// already part of the binding set the re-render uses.
+  pub fn apply_tracking(&mut self, ctrl_idx: usize) {
+    let Some(control) = self.controls.get(ctrl_idx) else {
+      return;
+    };
+    let Some((_, code)) =
+      self.tracking.iter().find(|(n, _)| n == control.name())
+    else {
+      return;
+    };
+    let action = format!("({code})[{}]", control.current_code());
+    let updated = woxi::functions::graphics::apply_manipulate_button_action(
+      &self.bindings(),
+      &action,
+    );
+    for (name, value) in updated {
+      if let Some(slot) = self.state.iter_mut().find(|(n, _)| *n == name) {
+        slot.1 = value;
+        continue;
+      }
+      for ctrl in &mut self.controls {
+        if ctrl.name() == name {
+          ctrl.set_current_from_code(&value);
+        }
+      }
+    }
   }
 
   /// The full binding set (visible controls + mutable state) used to


### PR DESCRIPTION
## Summary

Sampled a random Wolfram Demonstration notebook ("Electrophilic Aromatic Substitution Reactions of Benzene") and checked whether Woxi Studio fully supports it. Its `Manipulate` uses `TrackingFunction`, an option Woxi didn't implement, to reset a time slider whenever the reaction-step picker changes.

- `TrackingFunction -> f` runs `f[newValue]` whenever a control changes, letting a Demonstration reset a companion control. Wired the callback through `extract_manipulate_spec`/`parse_manipulate_control` in `src/functions/graphics.rs`, Woxi Studio's `ManipulateState` (`woxi-studio/src/manipulate.rs`), and its control-change message handlers (`woxi-studio/src/main.rs`). Marked `TrackingFunction` as supported (`✅`) in `functions.csv`.
- Writing `TrackingFunction`'s real-world idiom — a multi-statement pure function with a trailing `;` immediately before `&` (e.g. `(a = #; b = 0; &)`) — surfaced a parser bug: `&` with no statement following the last `;` failed to parse at all (`AnonymousFunctionSuffix` had nowhere to attach within `CompoundExpression`). Fixed the grammar (`src/wolfram.pest`) and the AST builder (`src/syntax.rs`) so `CompoundExpression` accepts a trailing `&` directly, matching Wolfram's own precedence (`->` binds tighter than `&`, so this inner-paren placement is required for a Rule's value to become a `Function`).

No code was copied from the sampled notebook (only used to identify which constructs it exercises); all test cases are independently written.

## Test plan
- [x] `cargo test` (full unit + integration suite, 24982 interpreter tests) — all pass
- [x] `cargo test -p woxi-studio` (`make test-studio`) — all 128 pass, including new `manipulate_tracking_function_resets_companion_control`
- [x] New regression tests: `spec_tracking_function_captured`, `tracking_function_resets_companion_control` (graphics.rs), `amp_after_trailing_semicolon_wraps_whole_compound_expression` (syntax.rs)
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fryoo1Fmkh85vm9bfh5Wyi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fryoo1Fmkh85vm9bfh5Wyi)_