### PR TITLE
Mark ButtonBar implemented and fix Root/Part[[UpTo]] precision gaps

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -2537,7 +2537,7 @@ DeleteContents,option for DeleteDirectory,✅,Symbolic,2.0,2565
 PaletteNotebook,,🚫,,6.0,2565
 ValueDimensions,Option symbol specifying the number of value dimensions in temporal data,✅,pure,10.0,2565
 AdjustmentBox,,🚫,,3.0,2570
-ButtonBar,,🚫,,7.0,2570
+ButtonBar,Row of buttons with held actions (stays symbolic in script mode),✅,unevaluated,7.0,2570
 ColumnSpacings,option for column spacing in grids,✅,Symbolic,3.0,2570
 DiagonalizableMatrixQ,Test whether a matrix is diagonalizable,✅,none,10.0,2570
 StreamPosition,Returns the current position in an open stream,✅,io,2.0,2570

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -3561,13 +3561,14 @@ pub fn evaluate_expr_to_expr_inner(
 
       // Check if any index needs the recursive apply_part_indices path:
       // - `All` always needs it (even alone, to return the expression itself)
-      // - `List` / `Span` in non-last position need it (to map remaining
-      //   indices over each extracted element rather than extract sequentially)
+      // - `List` / `Span` / `UpTo` in non-last position need it (to map
+      //   remaining indices over each extracted element rather than extract
+      //   sequentially)
       let needs_mapping = indices.iter().enumerate().any(|(i, idx)| {
         matches!(idx, Expr::Identifier(s) if s == "All")
           || (i + 1 < indices.len()
             && (matches!(idx, Expr::List(_))
-              || matches!(idx, Expr::FunctionCall { name, .. } if name == "Span")))
+              || matches!(idx, Expr::FunctionCall { name, .. } if name == "Span" || name == "UpTo")))
       });
 
       // Fast path for a chain of integer positions into a variable's stored

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -10929,6 +10929,7 @@ fn evaluate_function_call_ast_inner(
         | "ControllerManipulate"
         | "Trigger"
         | "SetterBar"
+        | "ButtonBar"
         | "CheckboxBar"
         | "TogglerBar"
         | "RadioButton"

--- a/src/evaluator/part_extraction.rs
+++ b/src/evaluator/part_extraction.rs
@@ -223,11 +223,12 @@ pub fn apply_part_indices(
     }
     Ok(Expr::List(results.into()))
   } else if let Expr::FunctionCall { name, .. } = idx
-    && name == "Span"
+    && (name == "Span" || name == "UpTo")
     && !rest.is_empty()
   {
-    // Part[expr, Span[...], rest...] → map remaining indices over each
-    // element of the span-extracted sub-list.
+    // Part[expr, Span[...] | UpTo[...], rest...] → map remaining indices
+    // over each element of the extracted sub-list, the same way a bare
+    // list-of-positions index does.
     let extracted = extract_part_ast(expr, idx)?;
     match &extracted {
       Expr::List(items) => {
@@ -455,6 +456,40 @@ fn extract_part_ast_rest(
     crate::functions::linear_algebra_ast::structured_matrix_to_dense(expr)
   {
     return extract_part_ast(&dense, index);
+  }
+
+  // UpTo[n]: the first Min[n, len] parts, matching Take[expr, UpTo[n]] —
+  // "give me up to n parts" for a mediant-style approximation loop that
+  // wants a bounded prefix without knowing exactly how long the list is.
+  // Reduces to the equivalent {1, 2, ..., k} list-of-positions spec so the
+  // existing per-head list-index logic (List, Association, FunctionCall,
+  // Rule/RuleDelayed, …) does the actual extraction — no separate UpTo path
+  // to keep in sync with it.
+  if let Expr::FunctionCall { name, args } = index
+    && name == "UpTo"
+    && args.len() == 1
+  {
+    let len = match expr {
+      Expr::List(items) => Some(items.len() as i128),
+      Expr::Association(items) => Some(items.len() as i128),
+      Expr::Rule { .. } | Expr::RuleDelayed { .. } => Some(2),
+      Expr::FunctionCall { name: h, args } if h != "ByteArray" => {
+        Some(args.len() as i128)
+      }
+      _ => None,
+    };
+    if let (Some(len), Some(n)) =
+      (len, crate::functions::list_helpers_ast::upto_count(index))
+    {
+      let k = n.min(len);
+      let positions: Vec<Expr> = (1..=k).map(Expr::Integer).collect();
+      return extract_part_ast(expr, &Expr::List(positions.into()));
+    }
+    crate::emit_message_to_stdout(&format!(
+      "Part::pkspec1: The expression {} cannot be used as a part specification.",
+      crate::syntax::format_expr(index, crate::syntax::ExprForm::Output)
+    ));
+    return Ok(part_take_unevaluated(expr, index));
   }
 
   // For associations, handle key-based lookup and integer position indexing

--- a/src/functions/list_helpers_ast/element_access.rs
+++ b/src/functions/list_helpers_ast/element_access.rs
@@ -501,7 +501,7 @@ fn take_drop_message(fname: &str, from: i128, to: i128, list: &Expr) {
 /// The (from, to) display range of a Take/Drop spec, for messages.
 /// The count carried by a valid `UpTo[n]` wrapper: a non-negative
 /// integer, or effectively unbounded for `UpTo[Infinity]`.
-fn upto_count(e: &Expr) -> Option<i128> {
+pub(crate) fn upto_count(e: &Expr) -> Option<i128> {
   if let Expr::FunctionCall { name, args } = e
     && name == "UpTo"
     && args.len() == 1

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -1537,6 +1537,16 @@ pub fn expr_to_bigfloat(
           let d = expr_to_bigfloat(&args[1], bits, rm, cc)?;
           Ok(n.div(&d, bits, rm))
         }
+        // Root[f, k] / Root[f, k, 0] — Newton-refine the (real) k-th root
+        // to `bits` of precision, e.g. `N[Root[#^3 - # - 1 &, 1], 30]` (the
+        // plastic constant).
+        "Root" if args.len() == 2 || args.len() == 3 => {
+          root_n_eval_arbitrary(&args[0], &args[1], bits, rm).ok_or_else(|| {
+            InterpreterError::EvaluationError(
+              "N: cannot evaluate Root[…] to arbitrary precision".into(),
+            )
+          })
+        }
         "Sqrt" if args.len() == 1 => {
           let v = expr_to_bigfloat(&args[0], bits, rm, cc)?;
           Ok(v.sqrt(bits, rm))
@@ -6453,12 +6463,20 @@ fn root_sum_n_eval(poly_arg: &Expr, fn_arg: &Expr) -> Option<Expr> {
   }
 }
 
-/// `N[Root[poly &, k]]`: the k-th root of the polynomial `poly`, ordered as
-/// wolframscript does — real roots first in increasing order, then the
-/// non-real roots by increasing real part and then increasing imaginary part.
-/// Returns the root as a `Real` (or `Plus[Real, Times[Real, I]]` for complex
-/// roots), or `None` when the shape doesn't fit.
-pub(crate) fn root_n_eval(poly_arg: &Expr, k_arg: &Expr) -> Option<Expr> {
+/// Shared by the machine- and arbitrary-precision `Root[f, k]` evaluators:
+/// extracts the integer coefficients of the polynomial `f` (in whichever
+/// single variable it names — a Slot-bodied pure function or a named
+/// symbol), finds every root at machine precision, sorts them the way
+/// `Root`'s index `k` expects (real roots first in ascending order, then
+/// complex roots ordered by real then imaginary part), and returns the
+/// `k`-th one as a machine-precision seed for whichever precision the
+/// caller ultimately wants. Both evaluators therefore agree on which root
+/// `k` names — refining the same seed to more digits, not risking a
+/// different root at high precision.
+fn root_coeffs_and_seed(
+  poly_arg: &Expr,
+  k_arg: &Expr,
+) -> Option<(Vec<i128>, bool, f64, f64)> {
   use crate::functions::polynomial_ast::extract_poly_coeffs;
   let k = expr_to_i128(k_arg)?;
   if k < 1 {
@@ -6512,7 +6530,17 @@ pub(crate) fn root_n_eval(poly_arg: &Expr, k_arg: &Expr) -> Option<Expr> {
     }
   });
   let (re, im) = roots[(k - 1) as usize];
-  if is_real(re, im) {
+  Some((coeffs_i, is_real(re, im), re, im))
+}
+
+/// `N[Root[poly &, k]]`: the k-th root of the polynomial `poly`, ordered as
+/// wolframscript does — real roots first in increasing order, then the
+/// non-real roots by increasing real part and then increasing imaginary part.
+/// Returns the root as a `Real` (or `Plus[Real, Times[Real, I]]` for complex
+/// roots), or `None` when the shape doesn't fit.
+pub(crate) fn root_n_eval(poly_arg: &Expr, k_arg: &Expr) -> Option<Expr> {
+  let (_, is_real, re, im) = root_coeffs_and_seed(poly_arg, k_arg)?;
+  if is_real {
     Some(Expr::Real(re))
   } else {
     Some(Expr::FunctionCall {
@@ -6527,6 +6555,61 @@ pub(crate) fn root_n_eval(poly_arg: &Expr, k_arg: &Expr) -> Option<Expr> {
       .into(),
     })
   }
+}
+
+/// Arbitrary-precision `Root[f, k]` — Newton-refines the machine-precision
+/// seed from `root_coeffs_and_seed` to `bits` of working precision using
+/// `astro_float::BigFloat` arithmetic. Real roots only (a complex result
+/// falls back to `expr_to_complex_bigfloat`'s caller, same as any other
+/// expression it doesn't special-case); `N[Root[#^3 - # - 1 &, 1], 30]`
+/// (the plastic constant) is the motivating case.
+pub(crate) fn root_n_eval_arbitrary(
+  poly_arg: &Expr,
+  k_arg: &Expr,
+  bits: usize,
+  rm: astro_float::RoundingMode,
+) -> Option<astro_float::BigFloat> {
+  use astro_float::BigFloat;
+  let (coeffs_i, is_real, re0, _im0) = root_coeffs_and_seed(poly_arg, k_arg)?;
+  if !is_real {
+    return None;
+  }
+  // A couple of guard words above the target precision so the Newton
+  // iterates (and the Horner evaluation of p/p' at each step) don't lose
+  // the last few bits to rounding before the final result is rounded down
+  // to `bits`.
+  let wbits = bits + 64;
+  let coeffs_bf: Vec<BigFloat> = coeffs_i
+    .iter()
+    .map(|&c| BigFloat::from_i128(c, wbits))
+    .collect();
+  let n = coeffs_bf.len() - 1;
+  let eval = |x: &BigFloat| -> (BigFloat, BigFloat) {
+    // Horner's method for p(x) and, alongside it, p'(x) via the standard
+    // simultaneous evaluation (b_n = a_n, b_{k} = a_k + x*b_{k+1}; p' is
+    // built from the b's excluding the constant term).
+    let mut p = coeffs_bf[n].clone();
+    let mut dp = BigFloat::from_i32(0, wbits);
+    for k in (0..n).rev() {
+      dp = dp.mul(x, wbits, rm).add(&p, wbits, rm);
+      p = p.mul(x, wbits, rm).add(&coeffs_bf[k], wbits, rm);
+    }
+    (p, dp)
+  };
+  let mut x = BigFloat::from_f64(re0, wbits);
+  // Newton's method roughly doubles the number of correct digits per step;
+  // starting from a machine-precision (~53-bit) seed, enough steps to
+  // double past `wbits` covers any working precision this function is
+  // called with.
+  let iterations = (wbits as f64 / 40.0).log2().ceil().max(1.0) as usize + 4;
+  for _ in 0..iterations {
+    let (p, dp) = eval(&x);
+    if dp.is_zero() {
+      break;
+    }
+    x = x.sub(&p.div(&dp, wbits, rm), wbits, rm);
+  }
+  Some(x)
 }
 
 /// Collect the free symbol names in `expr` (skipping the boolean/null

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -11463,6 +11463,50 @@ mod root {
   fn out_of_range_error() {
     assert!(interpret("Root[#^2 - 1 &, 3]").is_err());
   }
+
+  // `N[Root[…], prec]` — arbitrary-precision evaluation of a root with no
+  // closed radical form (the "casus irreducibilis" cubic case). Digits
+  // beyond machine precision must be correct, not garbage padding: this is
+  // the plastic constant, the real root of x^3 - x - 1.
+  #[test]
+  fn arbitrary_precision_casus_irreducibilis() {
+    assert_eq!(
+      interpret("N[Root[#^3 - # - 1 &, 1], 10]").unwrap(),
+      "1.32471795724474602596090885447809734073`10."
+    );
+    assert_eq!(
+      interpret("N[Root[#^3 - # - 1 &, 1], 30]").unwrap(),
+      "1.324717957244746025960908854478097340734404056901733364534`30."
+    );
+  }
+
+  // A higher precision request keeps agreeing with the machine-precision
+  // value on their shared leading digits.
+  #[test]
+  fn arbitrary_precision_matches_machine_precision_prefix() {
+    let machine = interpret("N[Root[#^3 - # - 1 &, 1]]").unwrap();
+    let arbitrary = interpret("N[Root[#^3 - # - 1 &, 1], 12]").unwrap();
+    let arbitrary_digits = arbitrary.split('`').next().unwrap();
+    assert!(
+      arbitrary_digits.starts_with(&machine[..machine.len() - 3]),
+      "machine={machine} arbitrary={arbitrary}"
+    );
+  }
+
+  // Arbitrary precision agrees with the closed radical form for a
+  // quadratic root, and with the machine-precision digits for a quartic
+  // with an irrational real root.
+  #[test]
+  fn arbitrary_precision_quadratic_and_quartic() {
+    assert_eq!(
+      interpret("N[Root[#^2 - 2 &, 1], 15]").unwrap(),
+      "-1.41421356237309504880168872420969807857`15."
+    );
+    assert_eq!(
+      interpret("N[Root[#^4 - # - 1 &, 1], 15]").unwrap(),
+      "-0.72449195900051561158837228218703656579`15."
+    );
+  }
 }
 
 mod root_sum {

--- a/tests/interpreter_tests/functions.rs
+++ b/tests/interpreter_tests/functions.rs
@@ -3538,6 +3538,41 @@ mod radio_button_bar {
   }
 }
 
+mod button_bar {
+  use super::*;
+
+  // `ButtonBar[…]` has no interactive frontend in script mode, so — like
+  // `Button`, `SetterBar` and `RadioButtonBar` — it stays symbolic rather
+  // than firing any of its held actions, and is not "unimplemented" for
+  // returning that canonical unevaluated form.
+  #[test]
+  fn unevaluated() {
+    assert_eq!(
+      interpret(r#"ButtonBar[{"A" :> Print["a"], "B" :> Print["b"]}]"#)
+        .unwrap(),
+      r#"ButtonBar[{A :> Print[a], B :> Print[b]}]"#
+    );
+  }
+
+  #[test]
+  fn head() {
+    assert_eq!(interpret("Head[ButtonBar]").unwrap(), "Symbol");
+  }
+
+  // A bare ButtonBar call must not be reported as an unimplemented
+  // built-in — it is a recognized (if inert, in script mode) control head.
+  #[test]
+  fn not_reported_unimplemented() {
+    let r =
+      interpret_with_stdout(r#"ButtonBar[{"A" :> 1, "B" :> 2}]"#).unwrap();
+    assert!(
+      !r.warnings.iter().any(|w| w.contains("not yet implemented")),
+      "warnings={:?}",
+      r.warnings
+    );
+  }
+}
+
 mod step_monitor {
   use super::*;
 

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -16847,6 +16847,58 @@ mod manipulate {
     );
   }
 
+  // A Demonstration-style control panel combining a `RadioButtonBar`
+  // (picking a target constant) with a `ButtonBar` (a row of held-action
+  // buttons, e.g. incrementing a counter) side by side: both control kinds
+  // extract cleanly and the panel renders without erroring.
+  #[test]
+  fn spec_radio_button_bar_and_button_bar_together() {
+    let expr = interpret_to_expr(
+      "Manipulate[{c, n}, \
+       {{c, Pi}, {Pi, E, GoldenRatio}, ControlType -> RadioButtonBar}, \
+       ButtonBar[{\"Increment\" :> (n = n + 1), \"Reset\" :> (n = 0)}], \
+       {{n, 0}, ControlType -> None}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed Manipulate");
+    let has_radio_button_bar = spec.controls.iter().any(|c| {
+      matches!(
+        c,
+        ManipulateControl::Discrete {
+          setter_bar: true,
+          ..
+        }
+      )
+    });
+    assert!(
+      has_radio_button_bar,
+      "expected a setter-bar-style discrete control, got {:?}",
+      spec.controls
+    );
+    let buttons: Vec<&str> = spec
+      .controls
+      .iter()
+      .filter_map(|c| match c {
+        ManipulateControl::Button { label, .. } => Some(label.as_str()),
+        _ => None,
+      })
+      .collect();
+    assert_eq!(buttons, vec!["Increment", "Reset"]);
+  }
+
+  // The same combined panel renders to a complete SVG document, matching
+  // how every other control kind is confirmed to render.
+  #[test]
+  fn export_string_svg_radio_button_bar_and_button_bar_together() {
+    let svg = export_svg(
+      "Manipulate[{c, n}, \
+       {{c, Pi}, {Pi, E, GoldenRatio}, ControlType -> RadioButtonBar}, \
+       ButtonBar[{\"Increment\" :> (n = n + 1), \"Reset\" :> (n = 0)}], \
+       {{n, 0}, ControlType -> None}]",
+    );
+    assert!(svg.contains("Increment") && svg.contains("Reset"));
+  }
+
   #[test]
   fn spec_locator_pane_binds_point_over_graphic() {
     // LocatorPane[Dynamic[p], body] is a draggable 2D point driving `body`.

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -4639,6 +4639,86 @@ mod part_noninteger_spec {
   }
 }
 
+mod part_upto {
+  use super::*;
+  use woxi::interpret_with_stdout;
+
+  // `Part[expr, UpTo[n]]` (the `[[UpTo[n]]]` sugar included) takes the
+  // first Min[n, Length[expr]] parts, matching `Take[expr, UpTo[n]]` —
+  // used to grab a bounded-length prefix without knowing exactly how long
+  // the underlying list is.
+  #[test]
+  fn list_within_bound() {
+    assert_eq!(
+      interpret("{1, 2, 3, 4, 5}[[UpTo[3]]]").unwrap(),
+      "{1, 2, 3}"
+    );
+  }
+
+  #[test]
+  fn list_clamps_past_length() {
+    assert_eq!(
+      interpret("{1, 2, 3, 4, 5}[[UpTo[10]]]").unwrap(),
+      "{1, 2, 3, 4, 5}"
+    );
+  }
+
+  #[test]
+  fn zero_takes_nothing() {
+    assert_eq!(interpret("{1, 2, 3}[[UpTo[0]]]").unwrap(), "{}");
+  }
+
+  #[test]
+  fn function_call_keeps_head() {
+    assert_eq!(interpret("f[a, b, c][[UpTo[2]]]").unwrap(), "f[a, b]");
+  }
+
+  #[test]
+  fn association_within_bound() {
+    assert_eq!(
+      interpret(r#"<|"a" -> 1, "b" -> 2, "c" -> 3|>[[UpTo[2]]]"#).unwrap(),
+      "<|a -> 1, b -> 2|>"
+    );
+  }
+
+  #[test]
+  fn rule_within_bound() {
+    assert_eq!(interpret("(a -> b)[[UpTo[1]]]").unwrap(), "{a}");
+  }
+
+  #[test]
+  fn infinity_takes_everything() {
+    assert_eq!(
+      interpret("{1, 2, 3}[[UpTo[Infinity]]]").unwrap(),
+      "{1, 2, 3}"
+    );
+  }
+
+  #[test]
+  fn maps_remaining_index_over_selection() {
+    // Part[expr, UpTo[n], rest…] maps the remaining indices over each of
+    // the selected elements, the same way a bare list-of-positions or a
+    // Span index does.
+    assert_eq!(
+      interpret("{{1, 2}, {3, 4}, {5, 6}}[[UpTo[2], 1]]").unwrap(),
+      "{1, 3}"
+    );
+  }
+
+  #[test]
+  fn negative_count_errors() {
+    let r = interpret_with_stdout("{1, 2, 3}[[UpTo[-1]]]").unwrap();
+    assert_eq!(r.result, "{1, 2, 3}[[UpTo[-1]]]");
+    assert!(
+      r.warnings.iter().any(|w| w.contains(
+        "Part::pkspec1: The expression UpTo[-1] cannot be used as a part specification."
+      )),
+      "warnings={:?}",
+      r.warnings
+    );
+  }
+}
+
 mod take_out_of_bounds {
   use super::*;
 


### PR DESCRIPTION
## Summary

Verified Woxi's support for continued-fraction/mediant-style number-theory constructs and `Manipulate`'s `RadioButtonBar`/`ButtonBar` controls, of the kind used by a sampled Wolfram Demonstrations Project notebook (not part of this repo). Found and fixed three related gaps:

- **`ButtonBar`**: `functions.csv` marked it 🚫 (not implemented), but `src/functions/graphics.rs` already had full extraction/rendering support for `ButtonBar[...]` inside `Manipulate`, shared with Woxi Studio's control-panel rendering. The real bug was narrower: a bare top-level `ButtonBar[{"A" :> ..., "B" :> ...}]` call was wrongly flagged as an unimplemented built-in, instead of staying symbolic the way `Button`/`SetterBar`/`RadioButtonBar` already do in script mode (no interactive frontend). Added `ButtonBar` to that unevaluated-heads list and flipped its `functions.csv` row to ✅ (`unevaluated` effect level, matching `Button`/`SetterBar`).
- **`N[Root[...], precision]`**: arbitrary-precision evaluation only worked for roots expressible via radicals (degree ≤ 2). A higher-degree root with no closed form — e.g. the real root of `x^3 - x - 1` (the "plastic constant", an example algebraic constant this kind of demonstration approximates) — left the call unevaluated with a garbled precision-tagged second argument instead of Newton-refining to the requested precision. Added arbitrary-precision Newton refinement (seeded from the existing machine-precision root finder, so both agree on which root index `k` names).
- **`Part[[UpTo[n]]]`**: not recognized as a part specification at all (including the chained form `expr[[UpTo[n], j]]`), so it stayed unevaluated. Now takes the first `Min[n, Length[expr]]` parts, matching `Take[expr, UpTo[n]]`, for `List`, `Association`, general `FunctionCall` heads, and `Rule`/`RuleDelayed`.

## What was tested and confirmed already correct (no changes needed)

`Module`/`Block`/`While`/`Table`/`Map`/`Select`/`Sort`/`Union`/`Intersection`/`Complement`/`Transpose`, `Part`/`Span`, `If`/`Switch`/`Break`, `AppendTo`/`Append`/`Prepend`/`Join`/`Drop`/`First`/`Last`/`Length`, `Ceiling`/`Round`/`Min`/`Max`/`Abs`, `Numerator`/`Denominator`/`Rational`, pattern matching (`Blank`/`Pattern`/`PatternTest`/`Alternatives`), `ReplaceAll`, `Apply`, `MessageName`, `TagSet`, `ContinuedFraction`, `Convergents`, `Root` (machine precision), `NumberLinePlot`/`Arrow`/`Arrowheads`/`PointSize`/`Directive`/`Darker`, `Grid`/`Column`/`Row`/`Style`/`TraditionalForm`/`Spacer`/`Pane`/`Panel`, and a combined `Manipulate[...]` using both `RadioButtonBar` and `ButtonBar` together (parses, evaluates, and renders to SVG cleanly).

Woxi Studio (the `iced`-based `.nb` editor) consumes the same `ManipulateSpec`/`ManipulateControl` extraction as the CLI — no separate/divergent implementation — so it automatically picks up the `ButtonBar` fix. Its own test suite (`cargo test -p woxi-studio`, 127 tests, including existing `ButtonBar`/`RadioButtonBar` end-to-end regressions) passes.

## Test plan

- [x] `make test` — 27054 tests passed, 0 failed
- [x] `cargo test -p woxi-studio` — 127 tests passed, 0 failed
- [x] `cargo build -p woxi-studio` succeeds
- [x] `make format`
- [x] New unit tests added for each fix (`tests/interpreter_tests/functions.rs`, `tests/interpreter_tests/list.rs`, `tests/interpreter_tests/algebra.rs`, `tests/interpreter_tests/graphics.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhdrbjmMCQLvvyUakGj69i

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhdrbjmMCQLvvyUakGj69i)_