### PR TITLE
Render inline box notation in graphics Text labels

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -2621,6 +2621,15 @@ fn point_along_path(pts: &[(f64, f64)], t: f64) -> (f64, f64) {
 /// else falls back to `ToString`'s default form.
 fn graphics_text_content(expr: &Expr) -> String {
   match expr {
+    // A string carrying inline `\!\(\*…\)` box notation — the front end's
+    // linear-syntax form for a typeset sub-expression, e.g. the label a
+    // Demonstration writes as `Text["\!\(\*SubscriptBox[\(X\), \(3\)]\)",
+    // pos]` for "X₃". Fold each box segment into the Unicode glyphs it
+    // typesets to, the same as `Subscript`/`Superscript` below, instead of
+    // drawing the private-use markers and box source literally.
+    Expr::String(s) if s.contains(crate::functions::string_ast::BOX_START) => {
+      inline_box_label_runs(s, false).map_or_else(|| s.clone(), |runs| flatten_label_runs(&runs))
+    }
     Expr::String(s) => s.clone(),
     // Text inside a picture is typeset, not printed: a mathematical
     // constant shows as its glyph there, the way it does in a notebook.

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1344,6 +1344,47 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_graphics_text_renders_inline_box_notation() {
+    // A notebook `Text[…]` label can carry its typeset content as inline
+    // `\!\(\*…\)` box notation — the front end's linear-syntax form for a
+    // sub/superscript, e.g. `Text["\!\(\*SubscriptBox[\(X\), \(3\)]\)",
+    // pos]` for "X₃". Regression: this used to draw the private-use box
+    // markers and box source literally instead of the Unicode glyph.
+    clear_state();
+    let svg = interpret(
+      "ExportString[Graphics[Text[\"\\!\\(\\*SubscriptBox[\\(X\\), \\(3\\)]\\)\", {0, 0}]], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(svg.contains(">X₃<"), "expected X₃ in SVG, got: {svg}");
+    assert!(
+      !svg.contains("SubscriptBox"),
+      "raw box source leaked into SVG: {svg}"
+    );
+
+    clear_state();
+    let svg_super = interpret(
+      "ExportString[Graphics[Text[\"\\!\\(\\*SuperscriptBox[\\(x\\), \\(2\\)]\\)\", {0, 0}]], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      svg_super.contains(">x²<"),
+      "expected x² in SVG, got: {svg_super}"
+    );
+
+    // The same escape nested inside a `Row` label (how a Demonstration
+    // typically mixes plain text with a typeset sub-expression).
+    clear_state();
+    let svg_row = interpret(
+      "ExportString[Graphics[Text[Row[{\"d\", \"\\!\\(\\*SubscriptBox[\\(X\\), \\(6\\)]\\)\"}], {0, 0}]], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      svg_row.contains(">dX₆<"),
+      "expected dX₆ in SVG, got: {svg_row}"
+    );
+  }
+
+  #[test]
   fn test_plot_aspect_ratio_sizes_frame_not_canvas() {
     // AspectRatio sets the height/width ratio of the plotting *area* (the data
     // frame), not the whole image. A short ratio must therefore NOT squash the


### PR DESCRIPTION
## Summary

- `Text[…]` labels inside `Graphics` whose string content carries inline `\!\(\*…\)` box notation (the front end's linear-syntax form for a typeset sub-expression, e.g. a point label written as `Text["\!\(\*SubscriptBox[\(X\), \(3\)]\)", pos]` for "X₃") were drawn with the raw private-use box markers and box source literally instead of the Unicode glyphs they typeset to.
- `graphics_text_content` now detects such strings and folds each box segment into Unicode through the same conversion already used for Manipulate widget labels, matching the output of the equivalent `Text[Subscript["X", 3], pos]` form.

Found while checking whether Woxi Studio fully supports a random Wolfram Demonstrations Project notebook (triangle-geometry Demonstration with a `Manipulate` whose graphics labels several triangle centers this way). The notebook itself isn't part of this repo and no code from it was copied — the fix and its regression test use independent minimal examples.

## Test plan
- [x] Added `test_graphics_text_renders_inline_box_notation` covering `SubscriptBox`, `SuperscriptBox`, and the same escape nested inside a `Row` label
- [x] `make test` — all 27038 unit tests pass
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lv8da1X9zhyAqZCcp64sQB)_