### PR TITLE
Keep Manipulate sliders real-valued when their spec is inexact

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16397,6 +16397,15 @@ pub enum ManipulateControl {
     label: String,
     /// The label split into styled runs for rich-text rendering.
     label_runs: Vec<LabelRun>,
+    /// Whether the control's variable is machine-real by construction — any
+    /// of its `min`/`max`/step/initial was written as an inexact number
+    /// (e.g. `{{rq, 0, "RQ"}, 0, 1, 0.01}`). Wolfram keeps such a variable
+    /// real-valued even while the slider sits at a "round" value (`0.`, not
+    /// `0`), which matters once a caption formats it with `NumberForm[…, {n,
+    /// f}]` — that wrapper pads a real's fraction but leaves an exact
+    /// integer unchanged. A control whose whole spec is exact integers
+    /// (`{{n, 5, "n"}, 1, 10, 1}`) keeps binding exact integers throughout.
+    is_real: bool,
   },
   Discrete {
     name: String,
@@ -17967,6 +17976,28 @@ fn eval_manipulate_bound(expr: &Expr) -> Option<(f64, bool)> {
     .map(|v| (v, true))
 }
 
+/// Whether a Manipulate bound expression (a `min`/`max`/step/initial-value
+/// term) is an inexact (machine-real) number rather than an exact integer or
+/// rational — `0.01` or `N[Pi]`, not `1` or `1/2`. Mirrors
+/// [`eval_manipulate_bound`]'s own resolution (static first, then against
+/// the live environment) so a bound naming another control's variable
+/// (`{{t, 0, …}, 0, P, .01}`) sees the same value. Used to decide whether a
+/// continuous control's variable stays real-valued even at a "round" slider
+/// position (see [`ManipulateControl::Continuous::is_real`]).
+fn manipulate_bound_is_inexact(expr: &Expr) -> bool {
+  let (expr, _) = manipulate_bound_expr(expr);
+  // Fast path for a literal: no need to round-trip through the evaluator.
+  match expr {
+    Expr::Real(_) | Expr::BigFloat(_, _) => return true,
+    Expr::Integer(_) | Expr::BigInteger(_) => return false,
+    _ => {}
+  }
+  matches!(
+    crate::evaluator::evaluate_expr_to_expr(expr),
+    Ok(Expr::Real(_) | Expr::BigFloat(_, _))
+  )
+}
+
 /// Re-resolve a dynamic bound's code fragment against the interpreter's
 /// current globals (the caller installs the live bindings via
 /// `with_scoped_globals`). Returns `None` when the code doesn't evaluate to
@@ -18197,6 +18228,7 @@ pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       italic: false,
       ..Default::default()
     }],
+    is_real: false,
   };
   Some(ManipulateSpec {
     body_code,
@@ -18241,7 +18273,7 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
     var.clone_from(s);
     idx = 1;
   }
-  let (min, max, step, initial) = match args.get(idx) {
+  let (min, max, step, initial, is_real) = match args.get(idx) {
     Some(Expr::List(items)) if !items.is_empty() => {
       let min = crate::functions::math_ast::try_eval_to_f64(&items[0])?;
       let max = items
@@ -18251,15 +18283,18 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
       let step = items
         .get(2)
         .and_then(crate::functions::math_ast::try_eval_to_f64);
-      (min, max, step, min)
+      let is_real = manipulate_bound_is_inexact(&items[0])
+        || items.get(1).is_some_and(manipulate_bound_is_inexact)
+        || items.get(2).is_some_and(manipulate_bound_is_inexact);
+      (min, max, step, min, is_real)
     }
     // A single number is the initial value over the default 0..1 range.
     Some(other) if idx == 0 => {
       let init = crate::functions::math_ast::try_eval_to_f64(other)?;
-      (0.0, 1.0, None, init)
+      (0.0, 1.0, None, init, manipulate_bound_is_inexact(other))
     }
     // `Animator[]` / `Animator[Dynamic[v]]`: default 0..1 range.
-    None => (0.0, 1.0, None, 0.0),
+    None => (0.0, 1.0, None, 0.0, false),
     _ => return None,
   };
   let control = ManipulateControl::Continuous {
@@ -18274,6 +18309,7 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
       italic: false,
       ..Default::default()
     }],
+    is_real,
   };
   Some(ManipulateSpec {
     body_code: var,
@@ -19986,6 +20022,18 @@ fn parse_manipulate_control(
     Some(init) => eval_manipulate_bound(init).map_or(min, |(v, _)| v),
     None => min,
   };
+  // The variable stays machine-real for the widget's whole lifetime once any
+  // of its spec terms was inexact — even a slider that happens to sit at a
+  // "round" position (e.g. `rq = 0` on a `0, 1, 0.01` range) binds `0.`, not
+  // the exact integer `0`.
+  let is_real = manipulate_bound_is_inexact(bounds[0])
+    || manipulate_bound_is_inexact(bounds[1])
+    || bounds
+      .get(2)
+      .is_some_and(|e| manipulate_bound_is_inexact(e))
+    || explicit_initial
+      .as_ref()
+      .is_some_and(manipulate_bound_is_inexact);
 
   // A `Trigger`/`Animator` control is a play button sweeping its variable
   // over the range: the widget animates that variable (a Trigger starts
@@ -20005,6 +20053,7 @@ fn parse_manipulate_control(
       initial,
       label,
       label_runs,
+      is_real,
     },
     enabled,
     min_code,
@@ -20177,8 +20226,20 @@ pub fn manipulate_initial_bindings(
       ManipulateControl::Heading { .. }
       | ManipulateControl::Divider
       | ManipulateControl::Button { .. } => None,
-      ManipulateControl::Continuous { name, initial, .. }
-      | ManipulateControl::Trigger { name, initial, .. } => {
+      ManipulateControl::Continuous {
+        name,
+        initial,
+        is_real,
+        ..
+      } => Some((
+        name.clone(),
+        if *is_real {
+          format_f64_real(*initial)
+        } else {
+          format_f64_input(*initial)
+        },
+      )),
+      ManipulateControl::Trigger { name, initial, .. } => {
         Some((name.clone(), format_f64_input(*initial)))
       }
       ManipulateControl::Discrete {
@@ -20664,6 +20725,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
         initial,
         label,
         label_runs,
+        ..
       } => {
         let step_json = match step {
           Some(s) => format!(r#","step":{s}"#),

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -17907,6 +17907,7 @@ mod manipulate {
         initial,
         label,
         label_runs,
+        is_real,
       } => {
         assert_eq!(name, "x");
         assert_eq!(*min, 0.0);
@@ -17918,9 +17919,67 @@ mod manipulate {
         assert_eq!(label_runs.len(), 1);
         assert_eq!(label_runs[0].text, "x");
         assert!(!label_runs[0].italic);
+        // {x, 0, 10} is all exact integers, so x stays exact throughout.
+        assert!(!is_real);
       }
       _ => panic!("expected continuous control"),
     }
+  }
+
+  // Wolfram keeps a Manipulate slider's variable machine-real for its whole
+  // lifetime once any of `{min, max, step, initial}` was written as an
+  // inexact number — even while the slider sits at a "round" position, so
+  // `rq = 0.` (Real), never the exact integer `0`. That distinction matters
+  // once a caption formats the value with `NumberForm[…, {n, f}]`, which
+  // pads a real's fraction but leaves an exact integer unchanged. Regression
+  // for a Reaction-Engineering-style Demonstration whose title row showed a
+  // real-valued parameter with two forced decimal places even when it
+  // dragged to exactly zero.
+  #[test]
+  fn spec_continuous_is_real_tracks_inexact_bounds() {
+    let is_real_of = |code: &str| {
+      let expr = interpret_to_expr(code).unwrap();
+      let spec =
+        extract_manipulate_spec(&expr).expect("well-formed manipulate");
+      match &spec.controls[0] {
+        ManipulateControl::Continuous { is_real, .. } => *is_real,
+        other => panic!("expected continuous control, got {other:?}"),
+      }
+    };
+    // An inexact step makes the variable real-valued even though every
+    // other term (min, max, and the default initial = min) is an integer.
+    assert!(is_real_of("Manipulate[rq, {{rq, 0, \"RQ\"}, 0, 1, 0.01}]"));
+    // Likewise for an inexact min or max alone.
+    assert!(is_real_of("Manipulate[u, {u, 0., 1}]"));
+    assert!(is_real_of("Manipulate[u, {u, 0, 1.}]"));
+    // Or an inexact explicit initial value.
+    assert!(is_real_of("Manipulate[u, {{u, 0.5, \"u\"}, 0, 1}]"));
+    // All-exact-integer specs (the common integer-slider idiom) stay exact.
+    assert!(!is_real_of(
+      "Manipulate[u, {{alpha, 20, \"\\[Alpha]\"}, 1, 50, 1}]"
+    ));
+    // An exact rational bound/initial is still exact, not inexact.
+    assert!(!is_real_of("Manipulate[u, {{u, 1/2, \"u\"}, 0, 1}]"));
+  }
+
+  // End-to-end: a caption built from `NumberForm[…, {n, f}]` on a real-
+  // valued slider must show the padded fraction even when the slider is at
+  // its exact-integer-looking initial position, matching the real Wolfram
+  // Demonstrations Project rendering this was checked against.
+  #[test]
+  fn manipulate_real_slider_number_form_caption_at_zero() {
+    let expr = interpret_to_expr(
+      "Manipulate[ToString[Row[{\"rq = \", NumberForm[rq, {3, 2}]}]], \
+       {{rq, 0, \"RQ\"}, 0, 1, 0.01}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
+    let bindings = manipulate_initial_bindings(&spec);
+    // The slider starts at its min (0), the "round" value the bug hid.
+    assert_eq!(bindings, vec![("rq".to_string(), "0.".to_string())]);
+    let code = manipulate_block_code(&spec.body_code, &bindings);
+    let result = interpret_with_stdout(&code).unwrap();
+    assert_eq!(result.result, "rq = 0.00");
   }
 
   #[test]
@@ -18433,6 +18492,7 @@ mod manipulate {
           initial: got_initial,
           label,
           label_runs,
+          ..
         } => {
           assert_eq!(got, name);
           assert_eq!((*min, *max), (-10.0, 10.0));

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -3862,6 +3862,7 @@ fn render_manipulate_widget<'a>(
         max,
         step,
         current,
+        ..
       } => {
         let label_widget =
           manipulate_label_widget(label_runs, label, label_col_width, enabled);
@@ -10675,6 +10676,7 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
       max: 1.0,
       step: 0.1,
       current: 0.0,
+      is_real: false,
     };
     let empty = manipulate::ControlState::Continuous {
       name: "theta".to_string(),
@@ -10684,6 +10686,7 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
       max: 1.0,
       step: 0.1,
       current: 0.0,
+      is_real: false,
     };
     assert_eq!(manipulate_label_char_count(&m1), 2);
     assert_eq!(manipulate_label_char_count(&empty), 0);

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -30,6 +30,12 @@ pub enum ControlState {
     /// we pick `(max - min) / 100`.
     step: f64,
     current: f64,
+    /// Whether the variable is machine-real by construction (see
+    /// `woxi::functions::graphics::ManipulateControl::Continuous::is_real`).
+    /// A round current value (`0`, `20`) still substitutes as the real `0.`
+    /// rather than the exact integer, matching Wolfram — which matters for
+    /// a caption that formats it with `NumberForm[…, {n, f}]`.
+    is_real: bool,
   },
   Discrete {
     name: String,
@@ -155,8 +161,16 @@ impl ControlState {
   /// `Block[{name = <value>}, …]` binding.
   pub fn current_code(&self) -> String {
     match self {
-      ControlState::Continuous { current, .. }
-      | ControlState::Trigger { current, .. } => format_f64(*current),
+      ControlState::Continuous {
+        current, is_real, ..
+      } => {
+        if *is_real {
+          format_f64_real(*current)
+        } else {
+          format_f64(*current)
+        }
+      }
+      ControlState::Trigger { current, .. } => format_f64(*current),
       ControlState::Discrete {
         values,
         current_index,
@@ -899,6 +913,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         max,
         step,
         initial,
+        is_real,
       } => {
         let step = step.unwrap_or_else(|| {
           let span = (*max - *min).abs();
@@ -912,6 +927,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
           max: *max,
           step,
           current: *initial,
+          is_real: *is_real,
         }
       }
       ManipulateControl::Discrete {
@@ -1051,5 +1067,20 @@ fn format_f64(v: f64) -> String {
     format!("{}", v as i64)
   } else {
     format!("{}", v)
+  }
+}
+
+/// Format a f64 as a Wolfram machine-real InputForm literal: a whole number
+/// keeps a trailing dot (`0.`, `20.`) so it substitutes as Real rather than
+/// Integer. Used for a continuous control whose spec was written with an
+/// inexact bound/step — Wolfram keeps such a variable real-valued even while
+/// the slider sits at a "round" position, which a caption formatting it with
+/// `NumberForm[…, {n, f}]` depends on (that wrapper pads a real's fraction
+/// but leaves an exact integer unchanged).
+fn format_f64_real(v: f64) -> String {
+  if v.is_finite() && v.fract() == 0.0 && v.abs() < 1e15 {
+    format!("{}.", v as i64)
+  } else {
+    format!("{v}")
   }
 }


### PR DESCRIPTION
## Summary

I audited Woxi Studio against a randomly-selected Wolfram Demonstration (a chemical-engineering `Manipulate` plotting a reaction "enhancement factor" against the Hatta number, with three sliders and a dynamic title caption showing the current parameter values). Comparing my reconstruction of its interaction pattern against the Demonstration's own published snapshot image turned up a real formatting bug in Woxi Studio's `Manipulate` support:

A continuous slider control whose `min`/`max`/`step`/initial value contains an inexact (real) number — e.g. `{{rq, 0, "RQ"}, 0, 1, 0.01}` — stays bound to a machine real for its whole lifetime in real Wolfram, even while the slider sits at a "round" value: `rq` starts at `0.` (Real), not the exact integer `0`. Woxi Studio (and the WASM Playground) instead always substituted a whole-number current value as a bare integer. This silently dropped `NumberForm[…, {n, f}]`'s decimal-place padding in any caption built from such a slider — a common Demonstrations idiom for showing live parameter values in a title/annotation. The Demonstration's actual published snapshot shows `rq = 0.00`; Woxi produced `rq = 0`.

## Changes

- Added an `is_real` field to `ManipulateControl::Continuous` (`src/functions/graphics.rs`), set when any of the control's `min`/`max`/`step`/initial-value terms was written as an inexact number (checked against the evaluated expression, so a bound naming another control still resolves correctly; an exact rational like `1/2` is correctly *not* treated as inexact).
- Threaded `is_real` through to Woxi Studio's `ControlState::Continuous` (`woxi-studio/src/manipulate.rs`) and format the substituted current value with a trailing decimal point when set.
- Applied the same fix to `manipulate_initial_bindings`, which backs the WASM Playground/JupyterLite initial render.
- Added regression tests in `tests/interpreter_tests/graphics.rs` covering `is_real` detection (inexact min/max/step/initial, exact-integer specs, and exact rationals) and an end-to-end caption-formatting check.

No new Wolfram Language function is introduced, so `functions.csv` is unchanged.

I didn't reference or include the source Demonstration notebook itself in this repo (it isn't part of Woxi, and its content is copyrighted); my synthetic test cases use an original placeholder formula rather than the Demonstration's actual code.

## Test plan

- [x] `cargo test --lib` (193 passed)
- [x] `cargo test --test interpreter_tests` — full suite (24,981 passed)
- [x] `cargo test` in `woxi-studio` — full suite, including ~130 real-Demonstration regression tests (127 passed)
- [x] `cargo check --workspace --all-targets` (includes `woxi-py`)
- [x] Manually verified via `dump_manipulate` that a reconstructed slider matching the audited Demonstration's pattern now renders `α = 20   rq = 0.00   β = 0.00`, matching the Demonstration's published snapshot exactly
- [x] `make format`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XU9wtjgGHYkB6am2LFq9Q1)_