### PR TITLE
Add regression test for 2D-slider + Initialization Manipulate widgets

### DIFF
--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6530,6 +6530,53 @@ mod tests {
   use super::*;
 
   #[test]
+  fn probe_catastrophe_demo() {
+    let code = r#"Manipulate[
+      Show[
+        ss[-phi[[2]], phi[[1]]],
+        sing[-phi[[2]], phi[[1]]],
+        pl,
+        ssing[-phi[[2]], phi[[1]]],
+        PlotRange -> {{-1, 1}, {-1, 1}, {-2, 1}},
+        BoxRatios -> {1, 1, 2},
+        ImageSize -> {400, 400}
+      ],
+      {{phi, {4.5, 0}, ""}, {1, -Pi/3}, {8, Pi/3}},
+      Initialization :> (
+        pl = Plot3D[-2, {x, -1, 1}, {y, -1, 1}, Mesh -> False];
+        s[x_, u_, th_, ph_] := {
+          u Cos[ph] - 2 x (u - 2 x^2) Sin[ph],
+          -x Sin[th] + Cos[th] (2 x (u - 2 x^2) Cos[ph] + u Sin[ph]),
+          x Cos[th] + Sin[th] (2 x (u - 2 x^2) Cos[ph] + u Sin[ph])
+        };
+        ss[th_, ph_] := ParametricPlot3D[s[x, u, th, ph], {u, -1.2, 1.2}, {x, -1.2, 1.2}, Boxed -> False, Axes -> False, Mesh -> False, PlotStyle -> Opacity[0.5]];
+        sing[th_, ph_] := ParametricPlot3D[s[x, (1/2) Cos[ph] Tan[th] + x (6 x - Sin[ph] Tan[th]), th, ph], {x, -1, 1}, Boxed -> False, Axes -> False, PlotStyle -> Blue];
+        ssing[th_, ph_] := ParametricPlot3D[{
+          (1/2) Cos[ph]^2 Tan[th] + 2 x Cos[ph] (3 x - Sin[ph] Tan[th]) + 2 x^2 Sin[ph] (-4 x + Sin[ph] Tan[th]),
+          2 x^2 Cos[th] (4 x Cos[ph] + 3 Sin[ph]) + (1/2) Sin[th] Sin[ph] (Cos[ph] - 4 x^2 Cos[ph] - 4 x Sin[ph]),
+          -2
+        }, {x, -1, 1}, Boxed -> False, Axes -> False, PlotStyle -> Hue[0]]
+      )
+    ]"#;
+    let expr = woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr);
+    match &state {
+      Some(s) => {
+        eprintln!(
+          "controls: {:?}",
+          s.controls.iter().map(|c| c.name()).collect::<Vec<_>>()
+        );
+        eprintln!("error: {:?}", s.error);
+        eprintln!("graphics_handle is_some: {}", s.graphics_handle.is_some());
+        eprintln!("text_output: {:?}", s.text_output);
+      }
+      None => eprintln!("from_expr returned None"),
+    }
+    assert!(state.is_some());
+    assert!(state.unwrap().error.is_none());
+  }
+
+  #[test]
   fn collapsed_chapter_hides_following_until_next_chapter() {
     let states = &[
       (CellStyle::Chapter, true), // collapsed

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6529,51 +6529,45 @@ fn strip_svg_wrapper(svg: &str) -> &str {
 mod tests {
   use super::*;
 
+  /// A single 2D-slider control (`{{var, {x0, y0}, label}, {xmin, ymin},
+  /// {xmax, ymax}}`) driving a Greek-lettered rotation/tilt pair, whose
+  /// components are split apart with `Part` and fed into several
+  /// `Initialization`-defined helper surfaces that a `Show` combines. This
+  /// mirrors the general construct category used by many rotating-3D-surface
+  /// Wolfram Demonstrations Project notebooks (independently written, not
+  /// copied from any specific one).
   #[test]
-  fn probe_catastrophe_demo() {
+  fn manipulate_2d_angle_slider_combines_initialization_surfaces() {
     let code = r#"Manipulate[
       Show[
-        ss[-phi[[2]], phi[[1]]],
-        sing[-phi[[2]], phi[[1]]],
-        pl,
-        ssing[-phi[[2]], phi[[1]]],
-        PlotRange -> {{-1, 1}, {-1, 1}, {-2, 1}},
-        BoxRatios -> {1, 1, 2},
-        ImageSize -> {400, 400}
+        base,
+        ribbon[θ[[1]], θ[[2]]],
+        PlotRange -> {{-2, 2}, {-2, 2}, {-2, 2}},
+        BoxRatios -> {1, 1, 1}
       ],
-      {{phi, {4.5, 0}, ""}, {1, -Pi/3}, {8, Pi/3}},
+      {{θ, {1, 0.5}, "tilt"}, {0, -Pi}, {2 Pi, Pi}},
       Initialization :> (
-        pl = Plot3D[-2, {x, -1, 1}, {y, -1, 1}, Mesh -> False];
-        s[x_, u_, th_, ph_] := {
-          u Cos[ph] - 2 x (u - 2 x^2) Sin[ph],
-          -x Sin[th] + Cos[th] (2 x (u - 2 x^2) Cos[ph] + u Sin[ph]),
-          x Cos[th] + Sin[th] (2 x (u - 2 x^2) Cos[ph] + u Sin[ph])
-        };
-        ss[th_, ph_] := ParametricPlot3D[s[x, u, th, ph], {u, -1.2, 1.2}, {x, -1.2, 1.2}, Boxed -> False, Axes -> False, Mesh -> False, PlotStyle -> Opacity[0.5]];
-        sing[th_, ph_] := ParametricPlot3D[s[x, (1/2) Cos[ph] Tan[th] + x (6 x - Sin[ph] Tan[th]), th, ph], {x, -1, 1}, Boxed -> False, Axes -> False, PlotStyle -> Blue];
-        ssing[th_, ph_] := ParametricPlot3D[{
-          (1/2) Cos[ph]^2 Tan[th] + 2 x Cos[ph] (3 x - Sin[ph] Tan[th]) + 2 x^2 Sin[ph] (-4 x + Sin[ph] Tan[th]),
-          2 x^2 Cos[th] (4 x Cos[ph] + 3 Sin[ph]) + (1/2) Sin[th] Sin[ph] (Cos[ph] - 4 x^2 Cos[ph] - 4 x Sin[ph]),
-          -2
-        }, {x, -1, 1}, Boxed -> False, Axes -> False, PlotStyle -> Hue[0]]
+        base = Plot3D[0, {x, -2, 2}, {y, -2, 2}, Mesh -> False];
+        ribbon[spin_, tilt_] := ParametricPlot3D[
+          {Cos[u] Cos[spin] - tilt Sin[u], Cos[u] Sin[spin] + tilt Cos[u], Sin[u]},
+          {u, 0, 2 Pi}, Boxed -> False, Axes -> False, PlotStyle -> Hue[0.6]
+        ];
       )
     ]"#;
     let expr = woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
-    let state = manipulate::ManipulateState::from_expr(&expr);
-    match &state {
-      Some(s) => {
-        eprintln!(
-          "controls: {:?}",
-          s.controls.iter().map(|c| c.name()).collect::<Vec<_>>()
-        );
-        eprintln!("error: {:?}", s.error);
-        eprintln!("graphics_handle is_some: {}", s.graphics_handle.is_some());
-        eprintln!("text_output: {:?}", s.text_output);
-      }
-      None => eprintln!("from_expr returned None"),
-    }
-    assert!(state.is_some());
-    assert!(state.unwrap().error.is_none());
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a single 2D-slider control should build a ManipulateState");
+
+    assert_eq!(state.controls.len(), 1, "exactly one control row");
+    assert!(
+      matches!(state.controls[0], manipulate::ControlState::Slider2D { .. }),
+      "the {{var, {{x, y}}, label}} spec builds a 2D slider, not a plain slider"
+    );
+    assert!(state.error.is_none(), "body should evaluate cleanly: {:?}", state.error);
+    assert!(
+      state.graphics_handle.is_some(),
+      "Show of ParametricPlot3D + Plot3D should render a graphic"
+    );
   }
 
   #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6554,7 +6554,8 @@ mod tests {
         ];
       )
     ]"#;
-    let expr = woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
     let state = manipulate::ManipulateState::from_expr(&expr)
       .expect("a single 2D-slider control should build a ManipulateState");
 
@@ -6563,7 +6564,11 @@ mod tests {
       matches!(state.controls[0], manipulate::ControlState::Slider2D { .. }),
       "the {{var, {{x, y}}, label}} spec builds a 2D slider, not a plain slider"
     );
-    assert!(state.error.is_none(), "body should evaluate cleanly: {:?}", state.error);
+    assert!(
+      state.error.is_none(),
+      "body should evaluate cleanly: {:?}",
+      state.error
+    );
     assert!(
       state.graphics_handle.is_some(),
       "Show of ParametricPlot3D + Plot3D should render a graphic"


### PR DESCRIPTION
## Summary

- Sampled a random notebook from the Wolfram Demonstrations Project (via the resource system's `RandomResourcePage` API) to check whether Woxi Studio fully supports it.
- The sampled notebook's interactive content is a `Manipulate` with a single 2D-slider control (`{{var, {x0, y0}, label}, {xmin, ymin}, {xmax, ymax}}`) driving a Greek-lettered angle pair, split apart with `Part`, and fed into several helper 3D surfaces defined in an `Initialization :>` block and combined with `Show`.
- Verified end to end that Woxi already supports this construct category correctly:
  - the notebook's actual box-form cell source parses through `woxi::notebook::box_source_to_expression` into a valid `Manipulate` expression,
  - `ManipulateState::from_expr` builds the widget with the expected 2D-slider control, and
  - the body evaluates without error and renders a graphic.
- No fixes were needed. Added a regression test (independently written, not copied from the sampled notebook) that locks in this behavior so a future change can't silently regress it.

## Test plan

- [x] `make test` (27,037 tests passed)
- [x] `make test-studio` (128 tests passed, including the new test)
- [x] `make format`

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5AM8ARSYkpFXLQ1wnKX8x)_