### PR TITLE
Honor PlotLabel in PieChart

### DIFF
--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -6,7 +6,7 @@ use crate::functions::math_ast::try_eval_to_f64;
 use crate::functions::plot::{
   BinSpec, DEFAULT_HEIGHT, DEFAULT_WIDTH, HistogramHeight, MarginOverrides,
   PLOT_COLORS, RESOLUTION_SCALE, generate_bar_svg, generate_histogram_svg,
-  html_escape, parse_image_size, svg_header,
+  html_escape, parse_image_size, plot_label_extra_lines, svg_header,
 };
 
 /// Extract grouped values from the first argument.
@@ -1678,13 +1678,25 @@ pub fn pie_chart_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if !explicit_dims {
     opts.svg_height = opts.svg_width;
   }
-  let (svg_width, svg_height, full_width) =
-    (opts.svg_width, opts.svg_height, opts.full_width);
+  // A `PlotLabel` sits above the pie in extra headroom, matching wolframscript:
+  // the pie itself keeps its size, and the frame grows taller to fit the title.
+  let has_plot_label = opts
+    .plot_label
+    .as_ref()
+    .is_some_and(|sl| !sl.text.is_empty());
+  let title_font_size = 16.0;
+  let top_margin: f64 = if has_plot_label {
+    30.0 + plot_label_extra_lines(opts.plot_label.as_ref()) as f64 * 20.0
+  } else {
+    0.0
+  };
+  let (svg_width, full_width) = (opts.svg_width, opts.full_width);
+  let svg_height = opts.svg_height + top_margin.round() as u32;
 
   let w = svg_width as f64;
-  let h = svg_height as f64;
+  let h = opts.svg_height as f64;
   let cx = w / 2.0;
-  let cy = h / 2.0;
+  let cy = top_margin + h / 2.0;
 
   // `LabelingFunction -> f` labels every slice with `f[value]`. The result
   // may be wrapped in `Placed[…, position]`, which decides how far out along
@@ -1832,6 +1844,31 @@ pub fn pie_chart_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
       start_angle = end_angle;
     }
+  }
+
+  // PlotLabel: centered above the pie, in the headroom reserved above.
+  if let Some(sl) = &opts.plot_label
+    && !sl.text.is_empty()
+  {
+    let ty = top_margin - title_font_size * 0.5;
+    let fs = sl.font_size.unwrap_or(title_font_size);
+    let fill = sl
+      .color
+      .as_ref()
+      .map_or_else(|| "black".to_string(), |c| c.to_svg_rgb());
+    let mut style_attrs = String::new();
+    if sl.bold {
+      style_attrs.push_str(" font-weight=\"bold\"");
+    }
+    if sl.italic {
+      style_attrs.push_str(" font-style=\"italic\"");
+    }
+    labels_svg.push_str(&format!(
+      "<text x=\"{cx:.1}\" y=\"{ty:.1}\" text-anchor=\"middle\" \
+       font-family=\"sans-serif\" font-size=\"{fs:.0}\" \
+       fill=\"{fill}\"{style_attrs}>{}</text>\n",
+      sl.svg_scaled_stacked(1.0, cx, fs * 1.2)
+    ));
   }
 
   svg.push_str(&labels_svg);

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -13,7 +13,7 @@ use crate::syntax::PlotMarker;
 /// How many lines below the first a stacked `PlotLabel` (a `Grid`/`Column`
 /// title) occupies — the extra top margin every renderer has to reserve for
 /// it. Zero for the ordinary single-line title and for no title at all.
-fn plot_label_extra_lines(label: Option<&StyledLabel>) -> usize {
+pub(crate) fn plot_label_extra_lines(label: Option<&StyledLabel>) -> usize {
   label
     .filter(|sl| !sl.text.is_empty())
     .map_or(0, StyledLabel::extra_line_count)

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -855,6 +855,60 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_piechart_plotlabel_string() {
+    // Regression: PieChart silently ignored PlotLabel (unlike Plot/BarChart).
+    clear_state();
+    let with_label =
+      interpret_with_stdout("PieChart[{1, 2, 3}, PlotLabel -> \"Split\"]")
+        .unwrap()
+        .graphics
+        .expect("PieChart should produce a graphics SVG");
+    assert!(
+      with_label.contains(">Split</text>"),
+      "PieChart SVG missing PlotLabel text:\n{with_label}"
+    );
+
+    // The frame grows taller to fit the label, while an unlabeled chart
+    // keeps its default square size.
+    clear_state();
+    let without_label = interpret_with_stdout("PieChart[{1, 2, 3}]")
+      .unwrap()
+      .graphics
+      .expect("PieChart should produce a graphics SVG");
+    let height_of = |svg: &str| -> u32 {
+      let start = svg.find("height=\"").unwrap() + "height=\"".len();
+      let rest = &svg[start..];
+      rest[..rest.find('"').unwrap()].parse().unwrap()
+    };
+    assert!(
+      height_of(&with_label) > height_of(&without_label),
+      "PieChart with a PlotLabel must reserve extra headroom:\nlabeled: {with_label}\nunlabeled: {without_label}"
+    );
+  }
+
+  #[test]
+  fn test_piechart_plotlabel_grid_stacks_lines() {
+    // Regression: a Grid/Column PlotLabel (as Demonstrations commonly build,
+    // e.g. a two-row table of names and computed values) stacks its rows as
+    // separate lines above the pie, matching Plot/BarChart.
+    clear_state();
+    let svg = interpret_with_stdout(
+      "PieChart[{1, 2}, PlotLabel -> Grid[{{\"A\", \"B\"}, {1, 2}}]]",
+    )
+    .unwrap()
+    .graphics
+    .expect("PieChart should produce a graphics SVG");
+    assert!(
+      svg.contains(">A B<"),
+      "PieChart SVG missing first PlotLabel line:\n{svg}"
+    );
+    assert!(
+      svg.contains("<tspan") && svg.contains(">1 2</tspan>"),
+      "PieChart SVG missing stacked second PlotLabel line:\n{svg}"
+    );
+  }
+
+  #[test]
   fn test_column_with_nested_tableform_renders_as_graphics() {
     // In visual mode (playground / woxi-studio), a Column containing a
     // TableForm must pre-render the table as a sub-SVG instead of falling


### PR DESCRIPTION
## Summary

- `PieChart` parsed the `PlotLabel` option but never rendered it — `Plot` and `BarChart` already reserved headroom and drew it centered above the chart, but `PieChart` silently dropped it.
- `PieChart[..., PlotLabel -> "text"]` now grows the frame to fit the title and draws it centered above the pie, matching the existing `Plot`/`BarChart` behavior.
- A `Grid`/`Column` title (e.g. a small two-row table of computed values, a pattern real Demonstrations use for a dynamic caption) now stacks its rows as separate lines, reusing the same helper (`plot_label_extra_lines`, now `pub(crate)`) the other chart renderers already share.

This was found while checking whether Woxi Studio fully supports a real Wolfram Demonstrations Project notebook (a financial calculator built around `Manipulate` with four labeled sliders driving a `PieChart`). The interactive `Manipulate` widget itself already rendered correctly end-to-end (confirmed via `woxi-studio`'s `dump_manipulate` example — all 9 Input cells evaluated with zero errors), but the chart's `PlotLabel -> Grid[...]` summary table was being silently dropped.

## Changes

- `src/functions/chart.rs`: `pie_chart_ast` now reserves top headroom for a `PlotLabel` and renders it (single-line and stacked `Grid`/`Column` forms).
- `src/functions/plot.rs`: made `plot_label_extra_lines` `pub(crate)` so `chart.rs` can reuse it instead of duplicating the stacking-line-count logic.
- `tests/interpreter_tests.rs`: added regression tests covering a plain string `PlotLabel` (text present, frame grows taller than an unlabeled chart) and a `Grid` `PlotLabel` (both rows render, stacked via `<tspan>`).

## Test plan

- [x] `cargo test` — new tests `test_piechart_plotlabel_string` and `test_piechart_plotlabel_grid_stacks_lines` pass
- [x] `make format`
- [x] `make test` (full suite via `cargo nextest`) — 27,039 tests passed, 0 failed


---
_Generated by [Claude Code](https://claude.ai/code/session_01RKnXypoJGz1zY99B53uBkM)_