### PR TITLE
Support brace level specifications in FileNames (#499)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,11 @@
     specification now leaves the call unevaluated. Recursing below `"."` also
     keeps each hit's path relative to the current directory rather than
     collapsing it to a bare file name.
+- `FileNames[form, dirs, levelspec]` accepts a level specification in braces:
+    `{n}` searches only the `n`-th directory level, and `{n1, n2}` the levels
+    from `n1` to `n2`, with `Infinity` allowed as the upper end. So
+    `FileNames["f.txt", dir, {2}]` reports the matches in `dir`'s
+    subdirectories without the ones in `dir` itself.
 - `InputString[]` and `Input[]` actually read from standard input when `woxi`
     owns it — `woxi run script.wls`, a shebang script, and `woxi eval` — so a
     script that prompts for a value now waits for one instead of running

--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -3239,6 +3239,8 @@ pub fn dispatch_io_functions(
     // FileNames[{p1, p2}] / FileNames[p1 | p2] — any of several patterns
     // FileNames["pattern", "dir"] — list files in dir matching pattern
     // FileNames["pattern", "dir", n] — descend n directory levels
+    // FileNames["pattern", "dir", {n}] — only the n-th level
+    // FileNames["pattern", "dir", {n1, n2}] — levels n1 through n2
     // FileNames["pattern", "dir", Infinity] — recursive search
     #[cfg(not(target_arch = "wasm32"))]
     "FileNames" if args.len() <= 3 => {
@@ -3250,16 +3252,17 @@ pub fn dispatch_io_functions(
         collected
       };
 
-      // Third argument: how many directory levels to include. `1` (the
+      // Third argument: which directory levels to include. `1` (the
       // default) searches only the given directories, `2` also their
       // immediate subdirectories, and `Infinity` descends without limit.
+      // A list restricts the search to a range of levels instead.
       let levels = if args.len() >= 3 {
         match file_names_levels(&args[2]) {
-          Some(n) => n,
+          Some(range) => range,
           None => return Some(Ok(unevaluated("FileNames", args))),
         }
       } else {
-        1
+        FileNameLevels { min: 1, max: 1 }
       };
 
       let dir = if args.len() >= 2 {
@@ -4235,23 +4238,42 @@ fn file_name_matches(patterns: &[Expr], file_name: &str) -> bool {
 fn collect_file_names(
   patterns: &[Expr],
   dir: &str,
-  levels: usize,
+  levels: FileNameLevels,
 ) -> Vec<String> {
   let root = crate::vfs::resolve(dir);
-  if levels == 0 || !root.is_dir() {
+  if levels.is_empty() || !root.is_dir() {
     return Vec::new();
   }
 
   let mut results = Vec::new();
-  collect_files_recursive(&root, &root, dir, patterns, levels, &mut results);
+  collect_files_recursive(&root, &root, dir, patterns, levels, 1, &mut results);
   results
 }
 
-/// Number of directory levels the third `FileNames` argument asks for.
-/// `Infinity` means "no limit"; a non-positive count matches nothing.
-/// Returns `None` for arguments that aren't a level specification.
+/// The range of directory levels a `FileNames` search reports, with level
+/// `1` standing for the searched directories themselves. An empty range —
+/// one whose `min` exceeds its `max` — matches nothing.
 #[cfg(not(target_arch = "wasm32"))]
-fn file_names_levels(spec: &Expr) -> Option<usize> {
+#[derive(Clone, Copy)]
+struct FileNameLevels {
+  min: usize,
+  max: usize,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl FileNameLevels {
+  /// Whether the range cannot contain any level at all.
+  fn is_empty(self) -> bool {
+    self.min > self.max || self.max == 0
+  }
+}
+
+/// A single level number in a `FileNames` level specification.
+/// `Infinity` stands for "no limit"; a non-positive count is clamped to
+/// zero, which is a level no file ever sits on.
+/// Returns `None` for expressions that aren't a level number.
+#[cfg(not(target_arch = "wasm32"))]
+fn file_names_level_number(spec: &Expr) -> Option<usize> {
   match spec {
     Expr::Identifier(s) if s == "Infinity" => Some(usize::MAX),
     Expr::Integer(n) => Some(usize::try_from(*n).unwrap_or(0)),
@@ -4262,9 +4284,36 @@ fn file_names_levels(spec: &Expr) -> Option<usize> {
   }
 }
 
+/// The directory levels the third `FileNames` argument asks for, following
+/// the usual level specifications: `n` searches levels `1` through `n`,
+/// `{n}` only level `n`, and `{n1, n2}` the levels from `n1` to `n2`.
+/// `Infinity` stands for "no limit" wherever a level number is allowed.
+/// Returns `None` for arguments that aren't a level specification.
+#[cfg(not(target_arch = "wasm32"))]
+fn file_names_levels(spec: &Expr) -> Option<FileNameLevels> {
+  match spec {
+    Expr::List(items) => match items.as_slice() {
+      [only] => {
+        let n = file_names_level_number(only)?;
+        Some(FileNameLevels { min: n, max: n })
+      }
+      [from, to] => Some(FileNameLevels {
+        min: file_names_level_number(from)?,
+        max: file_names_level_number(to)?,
+      }),
+      _ => None,
+    },
+    other => Some(FileNameLevels {
+      min: 1,
+      max: file_names_level_number(other)?,
+    }),
+  }
+}
+
 /// Walk `path`, collecting entries whose name matches any of `patterns`.
-/// `levels` counts the directory levels still to visit, so `1` stops at
-/// `path` itself and `usize::MAX` stands in for `Infinity`.
+/// `depth` is the level the entries of `path` sit on, counting the searched
+/// directory itself as level `1`; only entries within `levels` are reported
+/// and the walk stops once `levels.max` is reached.
 ///
 /// Every match is reported as `base_dir` spells it: entries are named
 /// relative to `root` (the resolved `base_dir`) and prefixed with
@@ -4277,7 +4326,8 @@ fn collect_files_recursive(
   root: &std::path::Path,
   base_dir: &str,
   patterns: &[Expr],
-  levels: usize,
+  levels: FileNameLevels,
+  depth: usize,
   results: &mut Vec<String>,
 ) {
   let Ok(entries) = std::fs::read_dir(path) else {
@@ -4290,7 +4340,7 @@ fn collect_files_recursive(
     let file_type = entry.file_type();
 
     if let Ok(ft) = file_type {
-      if file_name_matches(patterns, &file_name) {
+      if depth >= levels.min && file_name_matches(patterns, &file_name) {
         let relative = entry_path.strip_prefix(root).unwrap_or(&entry_path);
         let named = if base_dir == "." {
           relative.to_path_buf()
@@ -4299,13 +4349,14 @@ fn collect_files_recursive(
         };
         results.push(named.to_string_lossy().into_owned());
       }
-      if ft.is_dir() && levels > 1 {
+      if ft.is_dir() && depth < levels.max {
         collect_files_recursive(
           &entry_path,
           root,
           base_dir,
           patterns,
-          levels - 1,
+          levels,
+          depth + 1,
           results,
         );
       }

--- a/tests/cli/file_system/FileNames.md
+++ b/tests/cli/file_system/FileNames.md
@@ -60,6 +60,27 @@ $ wo 'FileNames["report.txt", "docs", Infinity]'
 {docs/inner/deeper/report.txt, docs/inner/report.txt, docs/report.txt}
 ```
 
+A level in braces restricts the search to exactly that level:
+
+```scrut
+$ wo 'FileNames["report.txt", "docs", {2}]'
+{docs/inner/report.txt}
+```
+
+Two levels in braces give the range of levels to search:
+
+```scrut
+$ wo 'FileNames["report.txt", "docs", {2, 3}]'
+{docs/inner/deeper/report.txt, docs/inner/report.txt}
+```
+
+`Infinity` works as the upper end of the range as well:
+
+```scrut
+$ wo 'FileNames["report.txt", "docs", {2, Infinity}]'
+{docs/inner/deeper/report.txt, docs/inner/report.txt}
+```
+
 The current directory is the one `SetDirectory` last set,
 not the one the script was started from.
 

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -5987,6 +5987,71 @@ mod file_names {
     std::fs::remove_dir_all(&root).ok();
   }
 
+  // Regression test for #499: a level specification in braces asks for
+  // exactly that level, instead of leaving the call unevaluated.
+  #[test]
+  fn brace_level_reports_only_that_level() {
+    let root = nested_tree("exact_level");
+    assert_eq!(relative_hits(&root, "{1}"), "target.txt");
+    assert_eq!(relative_hits(&root, "{2}"), "sub/target.txt");
+    assert_eq!(relative_hits(&root, "{3}"), "sub/sub/target.txt");
+    assert_eq!(relative_hits(&root, "{4}"), "sub/sub/sub/target.txt");
+    // No directory sits that deep, and level zero holds no files at all.
+    assert_eq!(relative_hits(&root, "{5}"), "");
+    assert_eq!(relative_hits(&root, "{0}"), "");
+    std::fs::remove_dir_all(&root).ok();
+  }
+
+  // A two-element level specification reports the levels in between,
+  // with `Infinity` as an open upper end.
+  #[test]
+  fn level_range_reports_the_levels_in_between() {
+    let root = nested_tree("level_range");
+    assert_eq!(
+      relative_hits(&root, "{2, 3}"),
+      "sub/sub/target.txt|sub/target.txt"
+    );
+    assert_eq!(relative_hits(&root, "{1, 4}"), relative_hits(&root, "4"));
+    assert_eq!(
+      relative_hits(&root, "{2, Infinity}"),
+      "sub/sub/sub/target.txt|sub/sub/target.txt|sub/target.txt"
+    );
+    // A range whose start is past its end matches nothing.
+    assert_eq!(relative_hits(&root, "{3, 2}"), "");
+    std::fs::remove_dir_all(&root).ok();
+  }
+
+  // A level specification applies to a list of directories as well —
+  // the shape the issue report used.
+  #[test]
+  fn brace_level_applies_to_a_list_of_directories() {
+    let root = nested_tree("exact_level_list");
+    let names = interpret(&format!(
+      r#"FileNames["target.txt", {{"{root}"}}, {{2}}] === {{FileNameJoin[{{"{root}", "sub", "target.txt"}}]}}"#
+    ))
+    .unwrap();
+    assert_eq!(names, "True");
+    std::fs::remove_dir_all(&root).ok();
+  }
+
+  // A list that is not a level specification leaves the call unevaluated,
+  // just like any other non-level third argument.
+  #[test]
+  fn non_level_list_stays_unevaluated() {
+    assert_eq!(
+      interpret(r#"FileNames["*.rs", "src", {1, 2, 3}]"#).unwrap(),
+      "FileNames[*.rs, src, {1, 2, 3}]"
+    );
+    assert_eq!(
+      interpret(r#"FileNames["*.rs", "src", {foo}]"#).unwrap(),
+      "FileNames[*.rs, src, {foo}]"
+    );
+    assert_eq!(
+      interpret(r#"FileNames["*.rs", "src", {}]"#).unwrap(),
+      "FileNames[*.rs, src, {}]"
+    );
+  }
+
   // Recursing below "." keeps the path relative to the current directory
   // instead of collapsing every hit to its bare file name.
   #[test]


### PR DESCRIPTION
FileNames only accepted a plain level count as its third argument, so
FileNames["f.txt", dirs, {2}] left the call unevaluated instead of
searching. Parse the usual level specifications into a level range:
`n` covers levels 1 through n, `{n}` exactly level n, and `{n1, n2}`
the levels in between, with `Infinity` allowed as an endpoint.

The directory walk now tracks the level its entries sit on, reporting
only the ones inside the requested range and descending until the
upper end is reached.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X6qXszSYFc9nC6i9H56zxX