### PR TITLE
Fix upvalues on Plus/Times/Power to fire for arithmetic shorthands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 # Unreleased
 
+- Upvalues on `Plus`, `Times` and `Power` also fire for the arithmetic
+    shorthands that expand to those heads. `-a` is `Times[-1, a]`, `a - b` is
+    `Plus[a, Times[-1, b]]` and `a / b` is `Times[a, Power[b, -1]]`, so with
+    `mytag /: mytag[a_] + mytag[b_] := mytag[a + b]` and
+    `mytag /: i_Integer mytag[a_] := mytag[a i]` the expression
+    `mytag[3] - mytag[3]` is `mytag[0]` instead of collapsing numerically to
+    `0`. This applies to the `Minus`, `Subtract` and `Divide` heads as well,
+    and makes the modular-arithmetic example from the `TagSetDelayed`
+    documentation work.
 - `FileNames` takes a string pattern, not just a literal wildcard string:
     `FileNames["*.md" | "*.txt"]` and `FileNames[{"*.md", "*.txt"}]` list the
     files matching any of the given patterns (nested arbitrarily), and pattern

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -89,6 +89,102 @@ fn needs_reevaluation(expr: &Expr, self_name: &str) -> bool {
   }
 }
 
+/// Check whether user-defined rules (DownValues, or upvalues installed via
+/// TagSetDelayed) are attached to the given head.
+fn has_user_rules(name: &str) -> bool {
+  crate::FUNC_DEFS.with(|m| m.borrow().contains_key(name))
+}
+
+/// Whether user-defined rules attached to `head` could apply to `args`.
+///
+/// An upvalue only fires when the symbol it is tagged on appears among the
+/// operands, so unrelated upvalues must not divert an operation from its
+/// built-in path (`Divide[37, 1.8]` stays a single IEEE division even while
+/// some `mytag` carries upvalues on Times). A plain DownValue on the head
+/// itself (`Unprotect[Times]; Times[x_, y_] := …`) has no such restriction and
+/// always counts.
+fn arith_rules_may_apply(head: &str, args: &[Expr]) -> bool {
+  let rule_count =
+    crate::FUNC_DEFS.with(|m| m.borrow().get(head).map_or(0, Vec::len));
+  if rule_count == 0 {
+    return false;
+  }
+  let tags_with_upvalues: Vec<String> = crate::UPVALUES.with(|m| {
+    m.borrow()
+      .iter()
+      .filter(|(_, entries)| entries.iter().any(|e| e.0 == head))
+      .map(|(tag, _)| tag.clone())
+      .collect()
+  });
+  let upvalue_count = crate::UPVALUES.with(|m| {
+    m.borrow()
+      .values()
+      .flatten()
+      .filter(|entry| entry.0 == head)
+      .count()
+  });
+  // More rules than accounted-for upvalues means at least one is a DownValue
+  // on the head; those can match anything.
+  if rule_count > upvalue_count {
+    return true;
+  }
+  args.iter().any(|arg| {
+    let arg_head = match arg {
+      Expr::FunctionCall { name, .. } => name.as_str(),
+      Expr::Identifier(s) => s.as_str(),
+      _ => return false,
+    };
+    tags_with_upvalues.iter().any(|tag| tag == arg_head)
+  })
+}
+
+/// `-a`, `a - b` and `a / b` are shorthand for `Times[-1, a]`,
+/// `Plus[a, Times[-1, b]]` and `Times[a, Power[b, -1]]`. When any head such a
+/// shorthand expands to carries user-defined rules (typically upvalues
+/// installed with TagSetDelayed), the expanded form has to be evaluated
+/// through the rule-aware function-call path so those rules get a chance to
+/// fire. Without it `mytag[3] - mytag[3]` collapses numerically to `0` instead
+/// of reaching the `mytag` upvalues via `mytag[3] + mytag[-3]` and producing
+/// `mytag[0]`.
+///
+/// Returns `None` when no such rule could apply (see `arith_rules_may_apply`),
+/// leaving the built-in arithmetic path in charge. `head` is `"Minus"`,
+/// `"Subtract"` or `"Divide"` with the matching arity; anything else is `None`.
+pub fn expand_arith_shorthand(
+  head: &str,
+  args: &[Expr],
+) -> Option<Result<Expr, InterpreterError>> {
+  // The inner call wraps the last operand; the outer one combines the result
+  // with the remaining operand (absent for the unary `Minus`).
+  let (inner_head, outer_head) = match (head, args.len()) {
+    ("Minus", 1) => ("Times", None),
+    ("Subtract", 2) => ("Times", Some("Plus")),
+    ("Divide", 2) => ("Power", Some("Times")),
+    _ => return None,
+  };
+  if !arith_rules_may_apply(inner_head, args)
+    && !outer_head.is_some_and(|h| arith_rules_may_apply(h, args))
+  {
+    return None;
+  }
+  let last = args[args.len() - 1].clone();
+  let inner_args = if inner_head == "Power" {
+    [last, Expr::Integer(-1)]
+  } else {
+    [Expr::Integer(-1), last]
+  };
+  Some(
+    evaluate_function_call_ast(inner_head, &inner_args).and_then(|inner| {
+      match outer_head {
+        Some(outer) => {
+          evaluate_function_call_ast(outer, &[args[0].clone(), inner])
+        }
+        None => Ok(inner),
+      }
+    }),
+  )
+}
+
 /// Check if a function has a specific Hold attribute (built-in or user-defined).
 fn has_hold_attribute(name: &str, attr: &str) -> bool {
   get_builtin_attributes(name).contains(&attr)
@@ -2538,9 +2634,7 @@ pub fn evaluate_expr_to_expr_inner(
         _ => None,
       };
       if let Some(name) = func_name {
-        let has_user_rules =
-          crate::FUNC_DEFS.with(|m| m.borrow().contains_key(name));
-        if has_user_rules {
+        if has_user_rules(name) {
           return evaluate_function_call_ast(name, &[left_val, right_val]);
         }
         // If the head symbol has an OwnValue (e.g. `Unprotect[Plus]; Plus=Q`),
@@ -2566,6 +2660,20 @@ pub fn evaluate_expr_to_expr_inner(
         {
           return evaluate_function_call_ast(&new_head, &[left_val, right_val]);
         }
+      }
+
+      // `a - b` / `a / b` expand to Plus/Times/Power; let user-defined rules
+      // on those heads apply before the built-in arithmetic below.
+      let shorthand_head = match op {
+        BinaryOperator::Minus => Some("Subtract"),
+        BinaryOperator::Divide => Some("Divide"),
+        _ => None,
+      };
+      if let Some(head) = shorthand_head
+        && let Some(result) =
+          expand_arith_shorthand(head, &[left_val.clone(), right_val.clone()])
+      {
+        return result;
       }
 
       // Check for list threading (arithmetic operations thread over lists)
@@ -2689,6 +2797,13 @@ pub fn evaluate_expr_to_expr_inner(
       let val = evaluate_expr_to_expr(operand)?;
       match op {
         UnaryOperator::Minus => {
+          // `-x` is `Times[-1, x]`; let user-defined rules on Times apply
+          // before the built-in path.
+          if let Some(result) =
+            expand_arith_shorthand("Minus", std::slice::from_ref(&val))
+          {
+            return result;
+          }
           // Use times_ast for proper distribution: -(a+b) → -a - b
           crate::functions::math_ast::times_ast(&[Expr::Integer(-1), val])
         }

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -8379,6 +8379,12 @@ pub fn times_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// (use Subtract for that)
 pub fn minus_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() == 1 {
+    // Minus[a] = -1 * a; user-defined rules on Times apply first.
+    if let Some(result) =
+      crate::evaluator::expand_arith_shorthand("Minus", args)
+    {
+      return result;
+    }
     // Use times_ast for proper distribution: -(a+b) → -a - b
     times_ast(&[Expr::Integer(-1), args[0].clone()])
   } else {
@@ -8393,6 +8399,13 @@ pub fn divide_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Err(InterpreterError::EvaluationError(
       "Divide expects exactly 2 arguments".into(),
     ));
+  }
+
+  // Divide[a, b] = a * b^-1; user-defined rules on Times/Power win over the
+  // built-in quotient handling.
+  if let Some(result) = crate::evaluator::expand_arith_shorthand("Divide", args)
+  {
+    return result;
   }
 
   // Check for list threading
@@ -8467,6 +8480,14 @@ pub fn divide_head_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // constants like Pi still evaluate through the reciprocal, and lists
   // thread element-wise with the same head semantics.
   if args.len() == 2 {
+    // Divide[a, b] = a * b^-1: user-defined rules on Times/Power apply before
+    // the built-in quotient handling (but after the `Divide::infy` /
+    // `Divide::indet` messages above, which are specific to this head).
+    if let Some(result) =
+      crate::evaluator::expand_arith_shorthand("Divide", args)
+    {
+      return result;
+    }
     if args.iter().any(|a| matches!(a, Expr::List(_))) {
       return thread_binary_over_lists(args, divide_two_head);
     }
@@ -11917,6 +11938,11 @@ pub fn subtract_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return Ok(unevaluated("Subtract", args));
   }
   // Subtract[a, b] = a + (-1 * b)
+  if let Some(result) =
+    crate::evaluator::expand_arith_shorthand("Subtract", args)
+  {
+    return result;
+  }
   let negated_b = times_ast(&[Expr::Integer(-1), args[1].clone()])?;
   plus_ast(&[args[0].clone(), negated_b])
 }

--- a/tests/SUMMARY.md
+++ b/tests/SUMMARY.md
@@ -1253,6 +1253,7 @@
     - [`TableForm`](expressions/TableForm.md)
     - [`TagBox`](expressions/TagBox.md)
     - [`TagSet`](expressions/TagSet.md)
+    - [`TagSetDelayed`](expressions/TagSetDelayed.md)
     - [`TensorDimensions`](expressions/TensorDimensions.md)
     - [`Trace`](expressions/Trace.md)
     - [`Undefined`](expressions/Undefined.md)

--- a/tests/cli/expressions.md
+++ b/tests/cli/expressions.md
@@ -79,6 +79,7 @@ Output is always in [FullForm].
 - [`SystemColor`](expressions/SystemColor.md)
 - [`TableForm`](expressions/TableForm.md)
 - [`TagSet`](expressions/TagSet.md)
+- [`TagSetDelayed`](expressions/TagSetDelayed.md)
 - [`TensorDimensions`](expressions/TensorDimensions.md)
 - [`ThemeColor`](expressions/ThemeColor.md)
 - [`Unevaluated`](expressions/Unevaluated.md)

--- a/tests/cli/expressions/TagSetDelayed.md
+++ b/tests/cli/expressions/TagSetDelayed.md
@@ -1,0 +1,36 @@
+# `TagSetDelayed`
+
+Defines a delayed upvalue assignment associated with a tag symbol. The
+`tag /: lhs := rhs` shorthand is the usual way to write it.
+
+```scrut
+$ wo 'TagSetDelayed[g, f[g[x_]], 1 + 2]; f[g[5]]'
+3
+```
+
+Upvalues attached to `Plus`, `Times` and `Power` also apply to the arithmetic
+shorthands that expand to those heads: `a - b` is `Plus[a, Times[-1, b]]`,
+`a / b` is `Times[a, Power[b, -1]]` and `-a` is `Times[-1, a]`.
+
+```scrut
+$ wo 'mytag /: mytag[a_] + mytag[b_] := mytag[a + b]; mytag /: i_Integer mytag[a_] := mytag[a i]; mytag[3] - mytag[3]'
+mytag[0]
+```
+
+```scrut
+$ wo 'mytag /: i_Integer mytag[a_] := mytag[a i]; -mytag[3]'
+mytag[-3]
+```
+
+```scrut
+$ wo 'q /: q[a_] q[b_] := q[a b]; q /: q[a_]^n_Integer := q[a^n]; q[6] / q[3]'
+q[2]
+```
+
+Together they implement modular arithmetic, where `m[a, n]` stands for
+`a` modulo `n`:
+
+```scrut
+$ wo 'm /: m[a_, n_] + m[b_, n_] := m[Mod[a + b, n], n]; m /: c_Integer m[a_, n_] := m[Mod[c a, n], n]; m[3, 7] - m[6, 7]'
+m[4, 7]
+```

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -4353,3 +4353,113 @@ mod anonymous_head_patterns {
     clear_state();
   }
 }
+
+/// Upvalues on Plus/Times/Power have to fire for the arithmetic shorthands
+/// too: `a - b` is `Plus[a, Times[-1, b]]`, `a / b` is `Times[a, Power[b, -1]]`
+/// and `-a` is `Times[-1, a]`. Woxi used to evaluate those numerically before
+/// consulting the upvalues, so `mytag[3] - mytag[3]` collapsed to `0` instead
+/// of `mytag[0]` (issue #505). All expectations match wolframscript.
+mod upvalues_for_arithmetic_shorthands {
+  use super::*;
+
+  const MYTAG: &str = "mytag /: mytag[a_] + mytag[b_] := mytag[a + b]\n\
+                       mytag /: i_Integer mytag[a_] := mytag[a i]\n";
+
+  #[test]
+  fn subtraction_reaches_plus_and_times_upvalues() {
+    clear_state();
+    assert_eq!(
+      interpret(&format!("{MYTAG}mytag[3] - mytag[3]")).unwrap(),
+      "mytag[0]"
+    );
+    clear_state();
+    assert_eq!(
+      interpret(&format!("{MYTAG}mytag[8] - mytag[3]")).unwrap(),
+      "mytag[5]"
+    );
+    clear_state();
+    // The explicit head behaves the same as the `-` shorthand
+    assert_eq!(
+      interpret(&format!("{MYTAG}Subtract[mytag[3], mytag[3]]")).unwrap(),
+      "mytag[0]"
+    );
+    clear_state();
+  }
+
+  #[test]
+  fn unary_minus_reaches_times_upvalues() {
+    clear_state();
+    assert_eq!(
+      interpret(&format!("{MYTAG}-mytag[3]")).unwrap(),
+      "mytag[-3]"
+    );
+    clear_state();
+    assert_eq!(
+      interpret(&format!("{MYTAG}Minus[mytag[3]]")).unwrap(),
+      "mytag[-3]"
+    );
+    clear_state();
+  }
+
+  #[test]
+  fn division_reaches_times_and_power_upvalues() {
+    clear_state();
+    let q = "q /: q[a_] q[b_] := q[a b]\n\
+             q /: q[a_]^n_Integer := q[a^n]\n";
+    assert_eq!(interpret(&format!("{q}q[6] / q[3]")).unwrap(), "q[2]");
+    clear_state();
+    assert_eq!(
+      interpret(&format!("{q}Divide[q[6], q[3]]")).unwrap(),
+      "q[2]"
+    );
+    clear_state();
+  }
+
+  /// The "Implement modular arithmetic" example from the TagSetDelayed
+  /// reference page, which is what surfaced the bug.
+  #[test]
+  fn modular_arithmetic_example() {
+    clear_state();
+    let m = "m /: m[a_, n_] + m[b_, n_] := m[Mod[a + b, n], n]\n\
+             m /: m[a_, n_] m[b_, n_] := m[Mod[a b, n], n]\n\
+             m /: c_Integer m[a_, n_] := m[Mod[c a, n], n]\n";
+    assert_eq!(
+      interpret(&format!("{m}m[3, 7] + m[6, 7]")).unwrap(),
+      "m[2, 7]"
+    );
+    clear_state();
+    assert_eq!(
+      interpret(&format!("{m}m[3, 7] - m[6, 7]")).unwrap(),
+      "m[4, 7]"
+    );
+    clear_state();
+    assert_eq!(interpret(&format!("{m}-m[3, 7]")).unwrap(), "m[4, 7]");
+    clear_state();
+  }
+
+  /// Unrelated upvalues on Plus/Times must not change ordinary arithmetic.
+  #[test]
+  fn plain_arithmetic_is_unaffected_by_unrelated_upvalues() {
+    clear_state();
+    assert_eq!(
+      interpret(&format!(
+        "{MYTAG}{{1.5 - 0.5, 3 - 5, 2/4, 6/3, x - x, {{1, 2, 3}} - 1}}"
+      ))
+      .unwrap(),
+      "{1., -2, 1/2, 2, 0, {0, 1, 2}}"
+    );
+    clear_state();
+    // Upvalues only fire for the symbol they are tagged on, so operands
+    // unrelated to `mytag` keep the head-specific built-in behaviour: the
+    // explicit `Divide` head is one IEEE division while `/` multiplies by
+    // the rounded reciprocal, and complex quotients stay exact.
+    let quotients =
+      "{Divide[37, 1.8], 37/1.8, (2 + 3 I)/(1 - I), Divide[3. + 4. I, 5.]}";
+    let expected =
+      "{20.555555555555554, 20.555555555555557, -1/2 + (5*I)/2, 0.6 + 0.8*I}";
+    assert_eq!(interpret(quotients).unwrap(), expected);
+    clear_state();
+    assert_eq!(interpret(&format!("{MYTAG}{quotients}")).unwrap(), expected);
+    clear_state();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes issue #505 where upvalues on `Plus`, `Times`, and `Power` were not being applied to arithmetic shorthand operators (`-`, `/`) and unary minus. This caused expressions like `mytag[3] - mytag[3]` to collapse numerically to `0` instead of reaching the upvalues and producing `mytag[0]`.

## Key Changes

- Added `expand_arith_shorthand()` function to expand arithmetic shorthands to their full forms before evaluation, allowing user-defined rules to apply:
  - `-a` expands to `Times[-1, a]`
  - `a - b` expands to `Plus[a, Times[-1, b]]`
  - `a / b` expands to `Times[a, Power[b, -1]]`

- Added `arith_rules_may_apply()` helper to determine if user-defined rules on a head could match the given arguments, distinguishing between:
  - DownValues on the head itself (always apply)
  - Upvalues on operands (only apply if the tagged symbol appears in the arguments)

- Integrated `expand_arith_shorthand()` calls in:
  - Binary operator evaluation (`Minus`, `Subtract`, `Divide`)
  - Unary operator evaluation (unary `Minus`)
  - Built-in arithmetic functions (`minus_ast`, `subtract_ast`, `divide_ast`, `divide_head_ast`)

- Added comprehensive test suite covering:
  - Subtraction with upvalues on `Plus` and `Times`
  - Unary minus with upvalues on `Times`
  - Division with upvalues on `Times` and `Power`
  - Modular arithmetic example from TagSetDelayed documentation
  - Verification that unrelated upvalues don't affect plain arithmetic

- Added documentation test for `TagSetDelayed` with examples of arithmetic shorthand behavior

## Implementation Details

The solution respects the distinction between DownValues and upvalues: plain DownValues on arithmetic heads (e.g., `Unprotect[Times]; Times[x_, y_] := …`) always apply, while upvalues only fire when their tagged symbol appears among the operands. This ensures that unrelated upvalues don't divert operations from their built-in paths (e.g., `Divide[37, 1.8]` remains a single IEEE division even with unrelated upvalues on other symbols).

https://claude.ai/code/session_01CcEeyNBuMwWZcb1B6FANFV