### PR TITLE
Implement PolyhedronOperations`Truncate and `Stellate

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -637,6 +637,8 @@ Scale,Scales a graphics object,✅,pure,6.0,597
 Log10,Returns the base-10 logarithm of a number,✅,pure,7.0,598
 EndPackage,Ends a package and puts its context on $ContextPath so its exports become visible,✅,effectful,1.0,599
 PolyhedronData,Properties of named polyhedra (Platonic solids plus the icosahedral and cubic Archimedean solids and their duals),🚧,pure,6.0,601
+PolyhedronOperations`Truncate,Corner-cuts each Polygon face of a graphics expression to a ratio (default 3/10) of its edge length; resolves Rotate/Translate-wrapped faces first,✅,pure,3.0,
+PolyhedronOperations`Stellate,Replaces each Polygon face of a graphics expression with a pyramid to a ratio (default 2) of the face's centroid distance; resolves Rotate/Translate-wrapped faces first,✅,pure,3.0,
 Nearest,Find the nearest elements in a list to a given value (numbers/vectors by Euclidean distance; strings by edit distance) — DistanceFunction supplies another metric; empty or non-list data reports ::near1,✅,pure,6.0,602
 RegionPlot3D,plots the 3D region where a condition is true,✅,pure,6.0,603
 IntervalMemberQ,Tests if a point or sub-interval is contained in an interval,✅,pure,3.0,605

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -1577,6 +1577,43 @@ fn evaluate_function_call_ast_inner(
     return crate::functions::polyhedron_data::polyhedron_data_ast(args);
   }
 
+  // The legacy `PolyhedronOperations` package: Truncate/Stellate a
+  // graphics expression's Polygon faces, corner-cutting or pyramiding
+  // each one to a ratio (`Needs["PolyhedronOperations`"]` has nothing to
+  // load — see `evaluator::contexts` — so the fully-qualified names work
+  // unconditionally, as they do for every context Woxi recognizes).
+  if name == "PolyhedronOperations`Truncate"
+    && (args.len() == 1 || args.len() == 2)
+  {
+    let ratio = match args.get(1) {
+      Some(r) => match crate::functions::math_ast::try_eval_to_f64(r) {
+        Some(v) => v,
+        None => return Ok(unevaluated(name, args)),
+      },
+      None => crate::functions::polyhedron_operations::DEFAULT_TRUNCATE_RATIO,
+    };
+    if !(ratio > 0.0 && ratio < 0.5) {
+      return Ok(unevaluated(name, args));
+    }
+    return Ok(crate::functions::polyhedron_operations::truncate(
+      &args[0], ratio,
+    ));
+  }
+  if name == "PolyhedronOperations`Stellate"
+    && (args.len() == 1 || args.len() == 2)
+  {
+    let ratio = match args.get(1) {
+      Some(r) => match crate::functions::math_ast::try_eval_to_f64(r) {
+        Some(v) => v,
+        None => return Ok(unevaluated(name, args)),
+      },
+      None => crate::functions::polyhedron_operations::DEFAULT_STELLATE_RATIO,
+    };
+    return Ok(crate::functions::polyhedron_operations::stellate(
+      &args[0], ratio,
+    ));
+  }
+
   // Chemistry: molecules and their properties
   match name {
     "Molecule" => {

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -70,6 +70,7 @@ pub mod plot3d;
 pub mod plot_epilog;
 pub mod polygon_holes;
 pub mod polyhedron_data;
+pub mod polyhedron_operations;
 pub mod polynomial_ast;
 pub mod predicate_ast;
 pub mod quantity_ast;

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -2520,6 +2520,40 @@ fn parse_specularity(args: &[Expr]) -> Option<((u8, u8, u8), f64)> {
   Some((rgb, exponent))
 }
 
+/// The linear part of a rotation by `angle` around the axis direction `w`
+/// (Rodrigues' formula), `None` for a degenerate (zero-length) axis. Shared
+/// with [`crate::functions::polyhedron_operations`], which rotates raw
+/// points the same way `Rotate` rotates rendered primitives.
+pub(crate) fn rotation_matrix(
+  angle: f64,
+  w: [f64; 3],
+) -> Option<[[f64; 3]; 3]> {
+  let len = (w[0] * w[0] + w[1] * w[1] + w[2] * w[2]).sqrt();
+  if !len.is_finite() || len < 1e-12 {
+    return None;
+  }
+  let (ux, uy, uz) = (w[0] / len, w[1] / len, w[2] / len);
+  let (s, c) = angle.sin_cos();
+  let ic = 1.0 - c;
+  Some([
+    [
+      c + ux * ux * ic,
+      ux * uy * ic - uz * s,
+      ux * uz * ic + uy * s,
+    ],
+    [
+      uy * ux * ic + uz * s,
+      c + uy * uy * ic,
+      uy * uz * ic - ux * s,
+    ],
+    [
+      uz * ux * ic - uy * s,
+      uz * uy * ic + ux * s,
+      c + uz * uz * ic,
+    ],
+  ])
+}
+
 /// Collect 3D primitives from an expression.
 /// An affine 3D transform (`p ↦ m·p + t`) built from `Translate`, `Rotate`,
 /// or `Scale` wrappers and applied to already-collected primitives.
@@ -2592,30 +2626,7 @@ impl Affine3 {
   /// Rotation by `angle` around the axis direction `w` through `anchor`
   /// (Rodrigues' formula).
   fn rotation(angle: f64, w: [f64; 3], anchor: [f64; 3]) -> Option<Self> {
-    let len = (w[0] * w[0] + w[1] * w[1] + w[2] * w[2]).sqrt();
-    if !len.is_finite() || len < 1e-12 {
-      return None;
-    }
-    let (ux, uy, uz) = (w[0] / len, w[1] / len, w[2] / len);
-    let (s, c) = angle.sin_cos();
-    let ic = 1.0 - c;
-    let m = [
-      [
-        c + ux * ux * ic,
-        ux * uy * ic - uz * s,
-        ux * uz * ic + uy * s,
-      ],
-      [
-        uy * ux * ic + uz * s,
-        c + uy * uy * ic,
-        uy * uz * ic - ux * s,
-      ],
-      [
-        uz * ux * ic - uy * s,
-        uz * uy * ic + ux * s,
-        c + uz * uz * ic,
-      ],
-    ];
+    let m = rotation_matrix(angle, w)?;
     // Conjugate with the anchor so the axis passes through it:
     // p ↦ m·(p - anchor) + anchor.
     let t = [

--- a/src/functions/polyhedron_operations.rs
+++ b/src/functions/polyhedron_operations.rs
@@ -1,0 +1,269 @@
+//! The legacy `PolyhedronOperations` package: ``Truncate`` and ``Stellate``.
+//!
+//! Woxi has no package system (see [`crate::evaluator::contexts`]), so these
+//! two functions are implemented directly under their fully-qualified names
+//! — the way code that has run `Needs["PolyhedronOperations`"]` calls them.
+//!
+//! Both operate on a "graphics expression": an arbitrarily nested `List` of
+//! `Polygon[…]` primitives, possibly wrapped in `Rotate`/`Translate` — a
+//! `Rotate[g, θ, axis]` outside an actual graphic stays a symbolic wrapper
+//! around `g` rather than eagerly recomputing `g`'s coordinates (see the
+//! `Rotate` reference page's "outside a graphic" details; `Normal[expr]`
+//! is the documented way to resolve such a wrapper to concrete
+//! coordinates). [`resolve_transforms`] does the equivalent resolution so
+//! the truncation/stellation itself can run per `Polygon` face.
+
+use crate::functions::math_ast::try_eval_to_f64;
+use crate::functions::plot3d::rotation_matrix;
+use crate::helpers::call1;
+use crate::syntax::Expr;
+
+/// `Truncate[expr]` truncates to this fraction of each edge's length.
+pub(crate) const DEFAULT_TRUNCATE_RATIO: f64 = 0.3;
+/// `Stellate[expr]` raises each face's pyramid to this ratio.
+pub(crate) const DEFAULT_STELLATE_RATIO: f64 = 2.0;
+
+type Vec3 = [f64; 3];
+
+fn add(a: Vec3, b: Vec3) -> Vec3 {
+  [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+
+fn sub(a: Vec3, b: Vec3) -> Vec3 {
+  [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+fn scale(a: Vec3, s: f64) -> Vec3 {
+  [a[0] * s, a[1] * s, a[2] * s]
+}
+
+fn lerp(a: Vec3, b: Vec3, t: f64) -> Vec3 {
+  add(a, scale(sub(b, a), t))
+}
+
+fn apply_matrix(m: &[[f64; 3]; 3], p: Vec3) -> Vec3 {
+  [
+    m[0][0] * p[0] + m[0][1] * p[1] + m[0][2] * p[2],
+    m[1][0] * p[0] + m[1][1] * p[1] + m[1][2] * p[2],
+    m[2][0] * p[0] + m[2][1] * p[1] + m[2][2] * p[2],
+  ]
+}
+
+fn vec3_to_expr(v: Vec3) -> Expr {
+  Expr::List(vec![Expr::Real(v[0]), Expr::Real(v[1]), Expr::Real(v[2])].into())
+}
+
+/// `expr` as a point — a `List` of exactly three numeric entries.
+fn as_point(expr: &Expr) -> Option<Vec3> {
+  let Expr::List(items) = expr else {
+    return None;
+  };
+  if items.len() != 3 {
+    return None;
+  }
+  Some([
+    try_eval_to_f64(&items[0])?,
+    try_eval_to_f64(&items[1])?,
+    try_eval_to_f64(&items[2])?,
+  ])
+}
+
+/// Apply `f` to every point (three-element numeric `List`) found anywhere
+/// inside `expr`, leaving everything else — heads, non-point lists, style
+/// directives — structurally unchanged.
+fn map_points(expr: &Expr, f: &dyn Fn(Vec3) -> Vec3) -> Expr {
+  if let Some(p) = as_point(expr) {
+    return vec3_to_expr(f(p));
+  }
+  match expr {
+    Expr::List(items) => Expr::List(
+      items
+        .iter()
+        .map(|e| map_points(e, f))
+        .collect::<Vec<_>>()
+        .into(),
+    ),
+    Expr::FunctionCall { name, args } => Expr::FunctionCall {
+      name: name.clone(),
+      args: args
+        .iter()
+        .map(|e| map_points(e, f))
+        .collect::<Vec<_>>()
+        .into(),
+    },
+    Expr::Rule {
+      pattern,
+      replacement,
+    } => Expr::Rule {
+      pattern: Box::new(map_points(pattern, f)),
+      replacement: Box::new(map_points(replacement, f)),
+    },
+    other => other.clone(),
+  }
+}
+
+/// The transform a `Rotate[g, θ, …]` or `Translate[g, offset]` wrapper
+/// applies to its content's points, built from the wrapper's arguments
+/// (everything after `g`). `None` when the arguments don't describe a
+/// transform Woxi can resolve (e.g. `Translate` with a list of several
+/// offset vectors, which produces multiple copies rather than one).
+fn wrapper_transform(
+  name: &str,
+  rest: &[Expr],
+) -> Option<Box<dyn Fn(Vec3) -> Vec3>> {
+  match name {
+    "Translate" if rest.len() == 1 => {
+      let offset = as_point(&rest[0])?;
+      Some(Box::new(move |p| add(p, offset)))
+    }
+    "Rotate" if rest.len() == 2 => {
+      let angle = try_eval_to_f64(&rest[0])?;
+      // `Rotate[g, θ, w]`: axis direction `w` through the origin.
+      if let Some(w) = as_point(&rest[1]) {
+        let m = rotation_matrix(angle, w)?;
+        return Some(Box::new(move |p| apply_matrix(&m, p)));
+      }
+      // `Rotate[g, θ, {p1, p2}]`: axis through the points `p1` and `p2`.
+      if let Expr::List(pts) = &rest[1]
+        && pts.len() == 2
+        && let (Some(p1), Some(p2)) = (as_point(&pts[0]), as_point(&pts[1]))
+      {
+        let w = sub(p2, p1);
+        let m = rotation_matrix(angle, w)?;
+        return Some(Box::new(move |p| add(apply_matrix(&m, sub(p, p1)), p1)));
+      }
+      None
+    }
+    "Rotate" if rest.len() == 3 => {
+      let angle = try_eval_to_f64(&rest[0])?;
+      let w = as_point(&rest[1])?;
+      let anchor = as_point(&rest[2])?;
+      let m = rotation_matrix(angle, w)?;
+      Some(Box::new(move |p| {
+        add(apply_matrix(&m, sub(p, anchor)), anchor)
+      }))
+    }
+    _ => None,
+  }
+}
+
+/// Resolve every `Rotate`/`Translate` wrapper in `expr` to concrete
+/// coordinates — needed because those wrappers stay symbolic (see the
+/// `Rotate` reference page) until something asks for the transformed
+/// points explicitly, the way `Normal` would for a rendered graphic.
+pub(crate) fn resolve_transforms(expr: &Expr) -> Expr {
+  match expr {
+    Expr::List(items) => Expr::List(
+      items
+        .iter()
+        .map(resolve_transforms)
+        .collect::<Vec<_>>()
+        .into(),
+    ),
+    Expr::FunctionCall { name, args }
+      if (name == "Rotate" || name == "Translate") && !args.is_empty() =>
+    {
+      let inner = resolve_transforms(&args[0]);
+      match wrapper_transform(name, &args[1..]) {
+        Some(f) => map_points(&inner, f.as_ref()),
+        None => Expr::FunctionCall {
+          name: name.clone(),
+          args: std::iter::once(inner)
+            .chain(args[1..].iter().cloned())
+            .collect::<Vec<_>>()
+            .into(),
+        },
+      }
+    }
+    other => other.clone(),
+  }
+}
+
+/// The points of a `Polygon[…]` face, `None` if `expr` isn't a `List` of
+/// points (e.g. the `Polygon[points -> holes]` form, left untouched).
+fn face_points(expr: &Expr) -> Option<Vec<Vec3>> {
+  let Expr::List(items) = expr else {
+    return None;
+  };
+  items.iter().map(as_point).collect()
+}
+
+fn polygon_expr(points: &[Vec3]) -> Expr {
+  call1(
+    "Polygon",
+    Expr::List(
+      points
+        .iter()
+        .copied()
+        .map(vec3_to_expr)
+        .collect::<Vec<_>>()
+        .into(),
+    ),
+  )
+}
+
+/// Replace every `Polygon[…]` face found anywhere inside `expr` — already
+/// resolved to concrete points via [`resolve_transforms`] — with `f`
+/// applied to its points, leaving everything else unchanged.
+fn map_faces(expr: &Expr, f: &dyn Fn(&[Vec3]) -> Expr) -> Expr {
+  match expr {
+    Expr::List(items) => Expr::List(
+      items
+        .iter()
+        .map(|e| map_faces(e, f))
+        .collect::<Vec<_>>()
+        .into(),
+    ),
+    Expr::FunctionCall { name, args }
+      if name == "Polygon" && args.len() == 1 =>
+    {
+      match face_points(&args[0]) {
+        Some(pts) if pts.len() >= 3 => f(&pts),
+        _ => expr.clone(),
+      }
+    }
+    other => other.clone(),
+  }
+}
+
+/// Corner-cut each face's polygon to `ratio` of its edge length: every
+/// vertex is replaced by the two points that `ratio` of the way along its
+/// adjoining edges, turning an *n*-gon face into a 2*n*-gon face.
+fn truncate_face(pts: &[Vec3], ratio: f64) -> Expr {
+  let n = pts.len();
+  let mut cut = Vec::with_capacity(2 * n);
+  for i in 0..n {
+    let prev = pts[(i + n - 1) % n];
+    let cur = pts[i];
+    let next = pts[(i + 1) % n];
+    cut.push(lerp(cur, prev, ratio));
+    cut.push(lerp(cur, next, ratio));
+  }
+  polygon_expr(&cut)
+}
+
+/// Replace each face's polygon by a pyramid with the polygon as its base:
+/// the apex sits at `ratio` times the face's centroid (so `ratio = 1`
+/// degenerates to the face itself, and `ratio < 1` pulls the apex toward —
+/// or past — the solid's center, the "concave" stellation the reference
+/// documents).
+fn stellate_face(pts: &[Vec3], ratio: f64) -> Expr {
+  let n = pts.len();
+  let sum = pts.iter().fold([0.0; 3], |acc, &p| add(acc, p));
+  let centroid = scale(sum, 1.0 / n as f64);
+  let apex = scale(centroid, ratio);
+  let triangles: Vec<Expr> = (0..n)
+    .map(|i| polygon_expr(&[pts[i], pts[(i + 1) % n], apex]))
+    .collect();
+  Expr::List(triangles.into())
+}
+
+/// `` PolyhedronOperations`Truncate[expr, ratio] ``.
+pub(crate) fn truncate(expr: &Expr, ratio: f64) -> Expr {
+  map_faces(&resolve_transforms(expr), &|pts| truncate_face(pts, ratio))
+}
+
+/// `` PolyhedronOperations`Stellate[expr, ratio] ``.
+pub(crate) fn stellate(expr: &Expr, ratio: f64) -> Expr {
+  map_faces(&resolve_transforms(expr), &|pts| stellate_face(pts, ratio))
+}

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2471,6 +2471,7 @@ mod interpreter_tests {
   mod music;
   mod patterns;
   mod polyhedron_data;
+  mod polyhedron_operations;
   mod property;
   mod quantity;
   mod rosetta_script_fixes;

--- a/tests/interpreter_tests/polyhedron_operations.rs
+++ b/tests/interpreter_tests/polyhedron_operations.rs
@@ -1,0 +1,175 @@
+use super::*;
+
+/// The legacy `PolyhedronOperations` package's `Truncate` and `Stellate`,
+/// implemented under their fully-qualified names since Woxi has no package
+/// system for `Needs["PolyhedronOperations`"]` to load into.
+mod polyhedron_operations_tests {
+  use super::*;
+
+  #[test]
+  fn truncate_corner_cuts_a_square() {
+    assert_eq!(
+      interpret(
+        "PolyhedronOperations`Truncate[Polygon[{{0,0,0},{2,0,0},{2,2,0},{0,2,0}}], 1/4]"
+      )
+      .unwrap(),
+      "Polygon[{{0., 0.5, 0.}, {0.5, 0., 0.}, {1.5, 0., 0.}, {2., 0.5, 0.}, \
+       {2., 1.5, 0.}, {1.5, 2., 0.}, {0.5, 2., 0.}, {0., 1.5, 0.}}]"
+    );
+  }
+
+  #[test]
+  fn truncate_default_ratio_is_three_tenths() {
+    assert_eq!(
+      interpret(
+        "PolyhedronOperations`Truncate[Polygon[{{0,0,0},{2,0,0},{2,2,0},{0,2,0}}]]"
+      )
+      .unwrap(),
+      "Polygon[{{0., 0.6, 0.}, {0.6, 0., 0.}, {1.4, 0., 0.}, {2., 0.6, 0.}, \
+       {2., 1.4, 0.}, {1.4, 2., 0.}, {0.6, 2., 0.}, {0., 1.4, 0.}}]"
+    );
+  }
+
+  #[test]
+  fn truncate_ratio_outside_zero_to_half_stays_unevaluated() {
+    assert_eq!(
+      interpret(
+        "PolyhedronOperations`Truncate[Polygon[{{0,0,0},{1,0,0},{1,1,0}}], 0.6]"
+      )
+      .unwrap(),
+      "PolyhedronOperations`Truncate[Polygon[{{0, 0, 0}, {1, 0, 0}, {1, 1, 0}}], 0.6]"
+    );
+  }
+
+  #[test]
+  fn truncate_symbolic_ratio_stays_unevaluated() {
+    assert_eq!(
+      interpret(
+        "PolyhedronOperations`Truncate[Polygon[{{0,0,0},{1,0,0},{1,1,0}}], x]"
+      )
+      .unwrap(),
+      "PolyhedronOperations`Truncate[Polygon[{{0, 0, 0}, {1, 0, 0}, {1, 1, 0}}], x]"
+    );
+  }
+
+  #[test]
+  fn truncate_recurses_into_a_list_of_faces() {
+    assert_eq!(
+      interpret(
+        "PolyhedronOperations`Truncate[{Polygon[{{0,0,0},{2,0,0},{2,2,0},{0,2,0}}]}, 1/4]"
+      )
+      .unwrap(),
+      "{Polygon[{{0., 0.5, 0.}, {0.5, 0., 0.}, {1.5, 0., 0.}, {2., 0.5, 0.}, \
+       {2., 1.5, 0.}, {1.5, 2., 0.}, {0.5, 2., 0.}, {0., 1.5, 0.}}]}"
+    );
+  }
+
+  #[test]
+  fn stellate_replaces_a_triangle_with_three_pyramid_faces() {
+    assert_eq!(
+      interpret(
+        "PolyhedronOperations`Stellate[Polygon[{{1,0,0},{0,1,0},{0,0,1}}], 2]"
+      )
+      .unwrap(),
+      "{Polygon[{{1., 0., 0.}, {0., 1., 0.}, \
+       {0.6666666666666666, 0.6666666666666666, 0.6666666666666666}}], \
+       Polygon[{{0., 1., 0.}, {0., 0., 1.}, \
+       {0.6666666666666666, 0.6666666666666666, 0.6666666666666666}}], \
+       Polygon[{{0., 0., 1.}, {1., 0., 0.}, \
+       {0.6666666666666666, 0.6666666666666666, 0.6666666666666666}}]}"
+    );
+  }
+
+  #[test]
+  fn stellate_default_ratio_is_two() {
+    assert_eq!(
+      interpret(
+        "PolyhedronOperations`Stellate[Polygon[{{1,0,0},{0,1,0},{0,0,1}}]]"
+      )
+      .unwrap(),
+      interpret(
+        "PolyhedronOperations`Stellate[Polygon[{{1,0,0},{0,1,0},{0,0,1}}], 2]"
+      )
+      .unwrap()
+    );
+  }
+
+  /// A stellation ratio of 1 puts the apex exactly at the face centroid —
+  /// the pyramid degenerates to a flat fan of triangles at the original
+  /// face's own distance from the origin, as documented ("ratios less
+  /// than 1 give concave figures", implying ratio 1 is the flat boundary).
+  #[test]
+  fn stellate_ratio_one_places_apex_at_centroid() {
+    assert_eq!(
+      interpret(
+        "PolyhedronOperations`Stellate[Polygon[{{1,0,0},{0,1,0},{0,0,1}}], 1]"
+      )
+      .unwrap(),
+      "{Polygon[{{1., 0., 0.}, {0., 1., 0.}, \
+       {0.3333333333333333, 0.3333333333333333, 0.3333333333333333}}], \
+       Polygon[{{0., 1., 0.}, {0., 0., 1.}, \
+       {0.3333333333333333, 0.3333333333333333, 0.3333333333333333}}], \
+       Polygon[{{0., 0., 1.}, {1., 0., 0.}, \
+       {0.3333333333333333, 0.3333333333333333, 0.3333333333333333}}]}"
+    );
+  }
+
+  /// `Rotate[g, θ, axis]` stays a symbolic wrapper around `g` outside a
+  /// rendered graphic, so `Truncate`/`Stellate` must resolve it to
+  /// concrete coordinates before finding the `Polygon` faces inside —
+  /// otherwise a rotated face would pass through untouched.
+  #[test]
+  fn truncate_resolves_a_rotate_wrapped_face() {
+    // Compare the two point sets by their (chopped) difference rather than
+    // as strings: `Sin[Pi/2]`/`Cos[Pi/2]` carry ~1 ulp of floating-point
+    // rotation error, which `Chop` only clears from a value near zero, not
+    // from a coordinate near -1 that is a few ulps off exact — but the
+    // *difference* between the two computations is near zero regardless.
+    let code = "\
+      direct = PolyhedronOperations`Truncate[ \
+        Polygon[{{0,1,0},{0,2,0},{-1,2,0},{-1,1,0}}], 1/4][[1]]; \
+      rotated = PolyhedronOperations`Truncate[Rotate[ \
+        Polygon[{{1,0,0},{2,0,0},{2,1,0},{1,1,0}}], Pi/2, {0,0,1}], 1/4][[1]]; \
+      Union[Flatten[Chop[direct - rotated]]]";
+    assert_eq!(interpret(code).unwrap(), "{0}");
+  }
+
+  /// `Needs["PolyhedronOperations`"]` has nothing to load (Woxi has no
+  /// package system, see `evaluator::contexts`) but must not error, and
+  /// the fully-qualified functions must keep working after it runs.
+  #[test]
+  fn needs_polyhedron_operations_is_a_harmless_no_op() {
+    assert_eq!(
+      interpret(
+        r#"Needs["PolyhedronOperations`"]; PolyhedronOperations`Truncate[Polygon[{{0,0,0},{2,0,0},{2,2,0},{0,2,0}}]]"#
+      )
+      .unwrap(),
+      "Polygon[{{0., 0.6, 0.}, {0.6, 0., 0.}, {1.4, 0., 0.}, {2., 0.6, 0.}, \
+       {2., 1.4, 0.}, {1.4, 2., 0.}, {0.6, 2., 0.}, {0., 1.4, 0.}}]"
+    );
+  }
+
+  /// End-to-end: a ring of bands (its own construction, not derived from
+  /// any Demonstration) truncated then stellated, wrapped in `Graphics3D`
+  /// and exported — every face must still be a Polygon and the export
+  /// must produce non-empty SVG.
+  #[test]
+  fn truncate_then_stellate_renders_as_graphics3d() {
+    let code = "\
+      n = 8; m = 6; \
+      band = Table[Polygon[{ \
+          {Cos[t], Sin[t], -0.5}, \
+          {Cos[t + 2 Pi/n], Sin[t + 2 Pi/n], -0.5}, \
+          {Cos[t + 2 Pi/n], Sin[t + 2 Pi/n], 0.5}, \
+          {Cos[t], Sin[t], 0.5} \
+        }], {t, 0, 2 Pi - 2 Pi/n, 2 Pi/n}]; \
+      ring = Table[Rotate[band, i (2 Pi/m), {0, 1, 0}], {i, m}]; \
+      stellated = PolyhedronOperations`Stellate[ \
+        PolyhedronOperations`Truncate[ring, 0.3], 1.7]; \
+      svg = ExportString[Graphics3D[{Yellow, stellated}, Boxed -> False], \"SVG\"]; \
+      {Length[Flatten[{stellated}]], StringLength[svg] > 0}";
+    // n faces × m copies, each an 8-gon after truncation (n=8) → n triangles
+    // per stellated face: n * m * n = 8*6*8 = 384.
+    assert_eq!(interpret(code).unwrap(), "{384, True}");
+  }
+}


### PR DESCRIPTION
## Summary

- As part of routinely checking Woxi Studio against a randomly selected Wolfram Demonstration, I found that a Manipulate-driven `Graphics3D` scene using `` Needs["PolyhedronOperations`"] `` followed by `` PolyhedronOperations`Truncate ``/`` PolyhedronOperations`Stellate `` on a `Rotate`-wrapped `Polygon` mesh did not work — Woxi has no package system (so `Needs` is correctly a no-op) but never defined these two legacy functions, so calls to them just returned unevaluated.
- Everything else the scene used (`Manipulate` with numeric sliders, `Table`/`Partition`/`Transpose`/`Map` with a pattern-defined function, `Polygon`/`Cylinder`/`Sphere`, `Rotate`, `Graphics3D` with `ViewAngle`/`PlotRange`/`Boxed`/`SphericalRegion`/`ViewPoint`, and `ExportString[…, "SVG"]` for 3D — including Woxi Studio's interactive slider rendering) already worked correctly.
- Implements `` PolyhedronOperations`Truncate[expr, ratio] `` (corner-cuts each `Polygon` face to `ratio` of its edge length, default `3/10`) and `` PolyhedronOperations`Stellate[expr, ratio] `` (replaces each face with a pyramid whose apex sits at `ratio` times the face's centroid, default `2`), matching the documented semantics of the legacy package.
- Both resolve any `Rotate`/`Translate` wrapper around a face to concrete coordinates first, since such a wrapper stays a symbolic graphics directive (matching `Rotate`'s documented "outside a graphic" behavior) rather than eagerly recomputing coordinates — reusing the same rotation-matrix math `Graphics3D` already uses to render its own `Rotate` primitive (factored out of `plot3d.rs` into a shared `rotation_matrix` helper).

## Test plan

- [x] Added 11 new unit tests in `tests/interpreter_tests/polyhedron_operations.rs` covering: corner-cut truncation math, default ratios for both functions, out-of-range/symbolic ratios staying unevaluated, recursion into nested lists, stellation pyramid geometry (including the degenerate ratio-1 case), resolving a `Rotate`-wrapped face, `Needs` as a harmless no-op, and an end-to-end scene truncated + stellated + rendered through `Graphics3D`/`ExportString`.
- [x] `make test` — all 27,091 tests pass, no regressions.
- [x] `make format`

Note: this legacy package's exact geometric conventions aren't fully pinned down in the public Wolfram reference docs (no worked numeric example), and I didn't have `wolframscript` access in this environment to verify bit-for-bit parity — the implementation follows the documented ratio semantics (edge-length fraction for `Truncate`, centroid-distance multiplier for `Stellate`) as closely as possible. Structural correctness (face counts, degenerate cases, wrapper resolution) is unit-tested.


---
_Generated by [Claude Code](https://claude.ai/code/session_018N6CSYkWzn9uKzMBZT9na4)_