### PR TITLE
Support Appearance -&gt; "Vertical" for Manipulate button bars

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16478,6 +16478,11 @@ pub enum ManipulateControl {
     /// choices by index, the way Wolfram draws a slider over a discrete
     /// domain. Without it a twenty-entry list would become a dropdown.
     slider: bool,
+    /// `Appearance -> "Vertical"` (or the bare symbol `Vertical`): stack the
+    /// choice row in a column instead of Wolfram's default horizontal bar.
+    /// Only affects the SetterBar/RadioButtonBar bar layout; a dropdown or
+    /// index slider ignores it.
+    vertical: bool,
   },
   /// A 2D control (`ControlType -> Slider2D`, or a 2D range spec
   /// `{u, {xmin, ymin}, {xmax, ymax}}`). Binds its variable to a 2-vector
@@ -19823,6 +19828,26 @@ fn parse_manipulate_control(
     })
     .collect();
 
+  // `Appearance -> "Vertical"` (or the bare symbol `Vertical`) stacks a
+  // SetterBar/RadioButtonBar/CheckboxBar in a column instead of Wolfram's
+  // default horizontal bar.
+  let appearance_vertical = items.iter().any(|it| {
+    let (Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    }) = it
+    else {
+      return false;
+    };
+    matches!(pattern.as_ref(), Expr::Identifier(s) if s == "Appearance")
+      && (matches!(replacement.as_ref(), Expr::Identifier(s) if s == "Vertical")
+        || matches!(replacement.as_ref(), Expr::String(s) if s == "Vertical"))
+  });
+
   // A `ControlType -> Trigger` (or bare `Trigger` marker) becomes a
   // dedicated play/pause control sweeping its variable from `min` towards
   // `max` — whether that end is infinite (`{time, 0, Infinity, 1, …}`, the
@@ -20003,10 +20028,17 @@ fn parse_manipulate_control(
       Some(init) => manipulate_value_to_input_form(init),
       None => "{}".to_string(),
     };
-    let display = format!(
-      "TogglerBar[Dynamic[{name}], {}]",
-      crate::syntax::expr_to_input_form(&choices)
-    );
+    let display = if appearance_vertical {
+      format!(
+        "TogglerBar[Dynamic[{name}], {}, Appearance -> \"Vertical\"]",
+        crate::syntax::expr_to_input_form(&choices)
+      )
+    } else {
+      format!(
+        "TogglerBar[Dynamic[{name}], {}]",
+        crate::syntax::expr_to_input_form(&choices)
+      )
+    };
     return Some(ParsedControl::StateWithDisplay {
       name,
       value,
@@ -20083,6 +20115,7 @@ fn parse_manipulate_control(
             control_type.as_deref(),
             Some("Slider" | "VerticalSlider" | "Manipulator")
           ),
+          vertical: appearance_vertical,
         },
         enabled,
         min_code: None,
@@ -20937,6 +20970,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
         popup,
         setter_bar,
         slider,
+        vertical,
       } => {
         let value_parts: Vec<String> = values
           .iter()
@@ -20953,6 +20987,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           ""
         };
         let slider_json = if *slider { r#","slider":true"# } else { "" };
+        let vertical_json = if *vertical { r#","vertical":true"# } else { "" };
         // Icon labels (rule right sides that are graphics) ride along as
         // rendered SVG, parallel to `values`; omitted when all-text.
         let svg_json = if value_label_svgs.iter().any(Option::is_some) {
@@ -20970,7 +21005,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           String::new()
         };
         ctrl_parts.push(format!(
-          r#"{{"kind":"discrete","name":"{}","label":"{}","labelRuns":{},"values":[{}],"valueLabels":[{}],"initialIndex":{}{}{}{}{}}}"#,
+          r#"{{"kind":"discrete","name":"{}","label":"{}","labelRuns":{},"values":[{}],"valueLabels":[{}],"initialIndex":{}{}{}{}{}{}}}"#,
           json_escape_manipulate(name),
           json_escape_manipulate(label),
           label_runs_to_json(label_runs),
@@ -20980,6 +21015,7 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
           popup_json,
           setter_bar_json,
           slider_json,
+          vertical_json,
           svg_json,
         ));
       }
@@ -21605,7 +21641,30 @@ fn togglerbar_node(
       selected,
     });
   }
-  Some(DisplayNode::Row(buttons))
+  // A trailing `Appearance -> "Vertical"` (added by the CheckboxBar/TogglerBar
+  // branch of `parse_manipulate_control`) stacks the toggles in a column
+  // instead of Wolfram's default horizontal bar.
+  let vertical = args[2..].iter().any(|it| {
+    let (Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    }) = it
+    else {
+      return false;
+    };
+    matches!(pattern.as_ref(), Expr::Identifier(s) if s == "Appearance")
+      && (matches!(replacement.as_ref(), Expr::Identifier(s) if s == "Vertical")
+        || matches!(replacement.as_ref(), Expr::String(s) if s == "Vertical"))
+  });
+  Some(if vertical {
+    DisplayNode::Column(buttons)
+  } else {
+    DisplayNode::Row(buttons)
+  })
 }
 
 /// Fill in each checkbox's `checked` flag from the batched probe results, in

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -17803,6 +17803,39 @@ mod manipulate {
     assert!(json.contains("MemberQ[picks, psin]"), "{json}");
   }
 
+  /// `Appearance -> "Vertical"` on a `CheckboxBar` stacks its toggle buttons
+  /// in a column instead of Wolfram's default horizontal bar: the generated
+  /// `TogglerBar[…]` display carries the option through, and
+  /// `build_manipulate_display` renders a `DisplayNode::Column` rather than
+  /// a `DisplayNode::Row` for it.
+  #[test]
+  fn spec_checkbox_bar_appearance_vertical_stacks_the_toggles() {
+    let expr = interpret_to_expr(
+      "Manipulate[picks, \
+       {{picks, {pcos}, \"\"}, {psin -> \" sine\", pcos -> \" cosine\"}, \
+        ControlType -> CheckboxBar, Appearance -> Vertical}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("checkbox bar");
+    assert_eq!(spec.displays.len(), 1);
+    assert!(
+      spec.displays[0].contains("Appearance -> \"Vertical\""),
+      "{}",
+      spec.displays[0]
+    );
+    let bindings = manipulate_initial_bindings(&spec);
+    let node = woxi::with_scoped_globals(&bindings, || {
+      woxi::functions::graphics::build_manipulate_display(
+        &spec.displays[0],
+        &[],
+      )
+    });
+    assert!(
+      matches!(node, woxi::functions::graphics::DisplayNode::Column(_)),
+      "{node:?}"
+    );
+  }
+
   /// A bare `None` in the control-type slot after the bounds says the
   /// variable has no widget — how a puzzle Demonstration declares the state
   /// its buttons drive. It used to be read as a bound, so the variable

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -3905,6 +3905,7 @@ fn render_manipulate_widget<'a>(
         popup,
         setter_bar: force_setter_bar,
         slider: as_slider,
+        vertical: is_vertical,
       } => {
         let label_widget =
           manipulate_label_widget(label_runs, label, label_col_width, enabled);
@@ -3981,7 +3982,8 @@ fn render_manipulate_widget<'a>(
         let control: Element<Message> = if *force_setter_bar
           || (renders_as_setter_bar(value_labels, value_label_svgs) && !*popup)
         {
-          let mut bar = Row::new().spacing(0).align_y(Center);
+          let is_vertical = *is_vertical;
+          let mut buttons = Vec::with_capacity(value_labels.len());
           for (i, choice_label) in value_labels.iter().enumerate() {
             let is_selected = i == *current_index;
             let choice = choice_label.clone();
@@ -4004,6 +4006,7 @@ fn render_manipulate_widget<'a>(
                   i,
                   count,
                   enabled,
+                  is_vertical,
                 )
               },
             );
@@ -4012,9 +4015,18 @@ fn render_manipulate_widget<'a>(
                 cell_idx, ctrl_idx, choice,
               ));
             }
-            bar = bar.push(btn);
+            buttons.push(btn.into());
           }
-          bar.into()
+          // `Appearance -> "Vertical"` stacks the segments in a column
+          // instead of Wolfram's default horizontal bar.
+          if is_vertical {
+            Column::with_children(buttons).spacing(0).into()
+          } else {
+            Row::with_children(buttons)
+              .spacing(0)
+              .align_y(Center)
+              .into()
+          }
         } else {
           let selected = value_labels.get(*current_index).cloned();
           let on_select = move |choice: String| {
@@ -5261,6 +5273,7 @@ fn setter_button_style(
   index: usize,
   count: usize,
   enabled: bool,
+  vertical: bool,
 ) -> button::Style {
   use iced::border::Radius;
   let is_dark = !matches!(theme, Theme::Light);
@@ -5273,15 +5286,26 @@ fn setter_button_style(
   };
   let accent_hover = Color::from_rgb(0.30, 0.56, 0.98);
 
-  // Round only the outer corners of the first and last segment.
+  // Round only the outer corners of the first and last segment — the left
+  // pair/right pair for a horizontal bar, the top pair/bottom pair for a
+  // `Appearance -> "Vertical"` column of segments.
   let r = 6.0;
   let first = index == 0;
   let last = index + 1 == count;
-  let radius = Radius {
-    top_left: if first { r } else { 0.0 },
-    bottom_left: if first { r } else { 0.0 },
-    top_right: if last { r } else { 0.0 },
-    bottom_right: if last { r } else { 0.0 },
+  let radius = if vertical {
+    Radius {
+      top_left: if first { r } else { 0.0 },
+      top_right: if first { r } else { 0.0 },
+      bottom_left: if last { r } else { 0.0 },
+      bottom_right: if last { r } else { 0.0 },
+    }
+  } else {
+    Radius {
+      top_left: if first { r } else { 0.0 },
+      bottom_left: if first { r } else { 0.0 },
+      top_right: if last { r } else { 0.0 },
+      bottom_right: if last { r } else { 0.0 },
+    }
   };
 
   let (idle_bg, idle_text, border_color) = if is_dark {
@@ -14408,6 +14432,51 @@ Cell[BoxData["Manipulate[Module[{s = 2. r/n, pts}, pts = Table[{{x, y}, {y, -x}}
           *setter_bar && !*popup,
           "ControlType -> RadioButtonBar must force the bar layout"
         );
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+  }
+
+  /// `Appearance -> "Vertical"` on a `RadioButtonBar`/`SetterBar` stacks its
+  /// segments in a column instead of Wolfram's default horizontal bar. The
+  /// spec's option threads through as `ControlState::Discrete::vertical`,
+  /// which the render loop reads to swap the `Row` for a `Column`.
+  #[test]
+  fn appearance_vertical_marks_the_bar_a_column() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[level, {{level, \"low\"}, {\"low\", \"medium\", \"high\"}, \
+       ControlType -> SetterBar, Appearance -> \"Vertical\"}]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Discrete {
+          setter_bar,
+          vertical,
+          ..
+        },
+      ] => {
+        assert!(*setter_bar);
+        assert!(*vertical, "Appearance -> \"Vertical\" must set vertical");
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+  }
+
+  /// Without `Appearance -> "Vertical"` the bar stays the default horizontal
+  /// row — the flag must not default to `true`.
+  #[test]
+  fn horizontal_bar_stays_the_default_without_appearance_vertical() {
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[level, {{level, \"low\"}, {\"low\", \"medium\", \"high\"}, \
+       ControlType -> SetterBar}]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr).unwrap();
+    match &state.controls[..] {
+      [manipulate::ControlState::Discrete { vertical, .. }] => {
+        assert!(!*vertical);
       }
       other => panic!("unexpected controls: {other:?}"),
     }

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -62,6 +62,10 @@ pub enum ControlState {
     /// `ControlType -> Slider`: render a slider stepping through the
     /// choices by index rather than a setter bar or dropdown.
     slider: bool,
+    /// `Appearance -> "Vertical"`: stack the SetterBar/RadioButtonBar
+    /// choices in a column instead of a row. Ignored by the dropdown and
+    /// index-slider layouts.
+    vertical: bool,
   },
   /// A 2D slider binding its variable to a `{x, y}` pair.
   Slider2D {
@@ -982,6 +986,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         popup,
         setter_bar,
         slider,
+        vertical,
       } => ControlState::Discrete {
         name: name.clone(),
         label: label.clone(),
@@ -999,6 +1004,7 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         popup: *popup,
         setter_bar: *setter_bar,
         slider: *slider,
+        vertical: *vertical,
       },
       ManipulateControl::Slider2D {
         name,


### PR DESCRIPTION
## Summary

While checking Woxi Studio's `Manipulate` support against a real Wolfram Demonstration notebook, I found that `RadioButtonBar`/`SetterBar` and `CheckboxBar`/`TogglerBar` controls always render their choices as a horizontal row, silently ignoring an explicit `Appearance -> "Vertical"` (or the bare symbol `Vertical`) option. Wolfram's FrontEnd stacks these bars in a column when that option is given.

- `ManipulateControl::Discrete` (core) gains a `vertical: bool` field, set from a new `Appearance -> "Vertical"` extraction in `parse_manipulate_control`.
- The `CheckboxBar`/`TogglerBar` branch threads the option through the generated `TogglerBar[Dynamic[…], …]` display string; `togglerbar_node` now returns `DisplayNode::Column` instead of `DisplayNode::Row` when it's present.
- `manipulate_spec_to_json` (used by the Playground) exposes the flag as `"vertical":true` for forward compatibility.
- Woxi Studio's `ControlState::Discrete` carries the same `vertical` flag; the SetterBar/RadioButtonBar render loop builds an iced `Column` instead of `Row` when set, and `setter_button_style` rounds the top/bottom corners of the first/last segment instead of the left/right corners.

## Test plan
- [x] Added a core regression test (`spec_checkbox_bar_appearance_vertical_stacks_the_toggles`) asserting the generated display carries the option and renders as `DisplayNode::Column`.
- [x] Added two Woxi Studio regression tests confirming `ControlState::Discrete::vertical` is set from `Appearance -> "Vertical"` and stays `false` by default.
- [x] `make test` — 27081 tests passed.
- [x] `make test-studio` — 135 tests passed.
- [x] `make format` / `make format-check` clean.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DDaw88QYDZkd5LKcDenftL)_