### PR TITLE
Implement DateListLogPlot

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -2272,7 +2272,7 @@ SystemsModelLabels,Control systems,🚫,None,8.0,2289
 JoinAcross,Joins lists of associations on a common key,✅,None,10.0,2292
 MeshCellMeasure,mesh computation option,🚫,None,10.0,2292
 AlignmentPoint,typesetting option,🚫,None,6.0,2294
-DateListLogPlot,date visualization,🚫,None,7.0,2294
+DateListLogPlot,Plots date-valued data with a logarithmic y-axis,✅,pure,7.0,2294
 AbsoluteCurrentValue,dynamic content,🚫,None,6.0,2299
 BatchSize,machine learning option,🚫,None,11.0,2299
 DaubechiesWavelet,Daubechies wavelet family of order n,✅,pure,8.0,2299

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -532,6 +532,9 @@ pub fn dispatch_plotting(
     "DateListPlot" if !args.is_empty() => {
       Some(crate::functions::chart::date_list_plot_ast(args))
     }
+    "DateListLogPlot" if !args.is_empty() => {
+      Some(crate::functions::chart::date_list_log_plot_ast(args))
+    }
     "NumberLinePlot" if !args.is_empty() => Some(
       crate::functions::number_line_plot::number_line_plot_ast(args),
     ),

--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -3421,6 +3421,20 @@ fn date_expr_to_absolute_time(expr: &Expr) -> Option<f64> {
 /// Dates can be date lists ({y,m,d}), DateObject[{...}], or AbsoluteTime values.
 /// Multiple datasets are supported: DateListPlot[{data1, data2, ...}].
 pub fn date_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  date_list_plot_ast_impl(args, false)
+}
+
+/// DateListLogPlot[{{date, y}, ...}] - like [`date_list_plot_ast`] but with
+/// a logarithmic y-axis, matching how `ListLogPlot` relates to `ListPlot`.
+/// Non-positive y values are dropped since they have no log-space position.
+pub fn date_list_log_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  date_list_plot_ast_impl(args, true)
+}
+
+fn date_list_plot_ast_impl(
+  args: &[Expr],
+  log_y: bool,
+) -> Result<Expr, InterpreterError> {
   let data = evaluate_expr_to_expr(&args[0])?;
   // A TimeSeries plots as its {date, value} path.
   let data = match crate::functions::timeseries_ast::time_series_pairs(&data) {
@@ -3433,9 +3447,14 @@ pub fn date_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     None => data,
   };
   let Expr::List(items) = &data else {
-    return Err(InterpreterError::EvaluationError(
-      "DateListPlot: first argument must be a list".into(),
-    ));
+    return Err(InterpreterError::EvaluationError(format!(
+      "{}: first argument must be a list",
+      if log_y {
+        "DateListLogPlot"
+      } else {
+        "DateListPlot"
+      }
+    )));
   };
 
   // `DateListPlot[{y1, y2, …}, datespec]` — plain values plus a starting
@@ -3471,7 +3490,7 @@ pub fn date_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       .collect();
     let mut new_args = vec![Expr::List(pair_items.into())];
     new_args.extend(args[2..].iter().cloned());
-    return date_list_plot_ast(&new_args);
+    return date_list_plot_ast_impl(&new_args, log_y);
   }
 
   // Detect whether this is multiple datasets or a single dataset.
@@ -3517,7 +3536,9 @@ pub fn date_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         let y = try_eval_to_f64(
           &evaluate_expr_to_expr(&pair[1]).unwrap_or(pair[1].clone()),
         );
-        if let (Some(x), Some(y)) = (x, y) {
+        if let (Some(x), Some(y)) = (x, y)
+          && (!log_y || y > 0.0)
+        {
           points.push((x, y));
         }
       }
@@ -3529,7 +3550,14 @@ pub fn date_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   if all_series.is_empty() {
     // Return unevaluated (like Wolfram does for invalid data)
-    return Ok(unevaluated("DateListPlot", args));
+    return Ok(unevaluated(
+      if log_y {
+        "DateListLogPlot"
+      } else {
+        "DateListPlot"
+      },
+      args,
+    ));
   }
 
   let chart_opts = parse_chart_options(args);
@@ -3547,14 +3575,28 @@ pub fn date_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       y_max = y_max.max(y);
     }
   }
-  let yp = (y_max - y_min) * 0.04;
-  let yp = if yp.abs() < f64::EPSILON { 1.0 } else { yp };
 
   // Compute x range with padding
   let xp = (x_max - x_min) * 0.04;
   let xp = if xp.abs() < f64::EPSILON { 86400.0 } else { xp };
   let x_range_min = x_min - xp;
   let x_range_max = x_max + xp;
+
+  // Compute y range with padding: multiplicatively in log space for
+  // DateListLogPlot (matching ListLogPlot), additively otherwise.
+  let (y_range_min, y_range_max) = if log_y {
+    let log_range = (y_max / y_min).ln();
+    let factor = if log_range.abs() < f64::EPSILON {
+      std::f64::consts::E
+    } else {
+      (log_range * 0.04).exp()
+    };
+    (y_min / factor, y_max * factor)
+  } else {
+    let yp = (y_max - y_min) * 0.04;
+    let yp = if yp.abs() < f64::EPSILON { 1.0 } else { yp };
+    (y_min - yp, y_max + yp)
+  };
 
   // Compute nice date tick positions
   let date_ticks =
@@ -3567,13 +3609,14 @@ pub fn date_list_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     svg_height: chart_opts.svg_height,
     full_width: chart_opts.full_width,
     date_axis: true,
+    log_y,
     ..Default::default()
   };
 
   let svg = crate::functions::plot::generate_svg_with_filling(
     &all_series,
     (x_range_min, x_range_max),
-    (y_min - yp, y_max + yp),
+    (y_range_min, y_range_max),
     &plot_opts,
   )?;
 

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -9066,6 +9066,50 @@ ParametricPlot[f[t], {t, 0, 1}]]",
     }
 
     #[test]
+    fn date_list_log_plot_date_list() {
+      insta::assert_snapshot!(export_svg(
+        "DateListLogPlot[{{{2000, 1, 1}, 1}, {{2005, 6, 15}, 100}, {{2010, 12, 31}, 10}}]"
+      ));
+    }
+
+    #[test]
+    fn date_list_log_plot_multiple_series() {
+      insta::assert_snapshot!(export_svg(
+        "DateListLogPlot[{{{{2000, 1, 1}, 1}, {{2010, 1, 1}, 1000}}, {{{2000, 1, 1}, 500}, {{2010, 1, 1}, 5}}}]"
+      ));
+    }
+
+    #[test]
+    fn date_list_log_plot_drops_non_positive_values() {
+      // Non-positive y values have no log-space position, so they are
+      // dropped and the plot renders from the remaining positive points.
+      assert_eq!(
+        interpret(
+          "Head[DateListLogPlot[{{{2000, 1, 1}, 1}, {{2005, 1, 1}, -3}, {{2010, 1, 1}, 2}}]]"
+        )
+        .unwrap(),
+        "Graphics"
+      );
+    }
+
+    #[test]
+    fn date_list_log_plot_invalid_returns_unevaluated() {
+      assert_eq!(
+        interpret("DateListLogPlot[{1, 3, 2, 5, 4}]").unwrap(),
+        "DateListLogPlot[{1, 3, 2, 5, 4}]"
+      );
+    }
+
+    #[test]
+    fn date_list_log_plot_values_with_start_date() {
+      assert_eq!(
+        interpret("Head[DateListLogPlot[{1, 10, 100, 1000}, {2000, 8}]]")
+          .unwrap(),
+        "Graphics"
+      );
+    }
+
+    #[test]
     fn bar_chart_chart_labels() {
       insta::assert_snapshot!(export_svg(
         r#"BarChart[{5, 9, 24}, ChartLabels -> {"Anna", "Ben", "Carl"}]"#

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__charts__date_list_log_plot_date_list.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__charts__date_list_log_plot_date_list.snap
@@ -1,0 +1,26 @@
+---
+source: tests/interpreter_tests/graphics.rs
+assertion_line: 9070
+expression: "export_svg(\"DateListLogPlot[{{{2000, 1, 1}, 1}, {{2005, 6, 15}, 100}, {{2010, 12, 31}, 10}}]\")"
+---
+<svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1688" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1688 749,1688 "/>
+<text x="670" y="925" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,925 749,925 "/>
+<text x="670" y="162" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,162 749,162 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1688 2114,162 3397,925 "/>
+<text x="670.2" y="1688.9" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145" fill="#666">1</text>
+<text x="670.2" y="925.0" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145" fill="#666">10</text>
+<text x="670.2" y="161.1" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">2</tspan></text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="852,1750 852,1790"/><text x="852" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2000</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1315,1750 1315,1790"/><text x="1315" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2002</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1778,1750 1778,1790"/><text x="1778" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2004</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2241,1750 2241,1790"/><text x="2241" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2006</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2704,1750 2704,1790"/><text x="2704" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2008</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3167,1750 3167,1790"/><text x="3167" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2010</text></svg>

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__charts__date_list_log_plot_multiple_series.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__charts__date_list_log_plot_multiple_series.snap
@@ -1,0 +1,32 @@
+---
+source: tests/interpreter_tests/graphics.rs
+assertion_line: 9077
+expression: "export_svg(\"DateListLogPlot[{{{{2000, 1, 1}, 1}, {{2010, 1, 1}, 1000}}, {{{2000, 1, 1}, 500}, {{2010, 1, 1}, 5}}}]\")"
+---
+<svg width="360" height="225" viewBox="0 0 3600 2250" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="2250" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,1749 "/>
+<text x="670" y="1688" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1688 749,1688 "/>
+<text x="670" y="1179" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1179 749,1179 "/>
+<text x="670" y="671" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,671 749,671 "/>
+<text x="670" y="162" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="104.83870967741936" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,162 749,162 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,1750 3499,1750 "/>
+<polyline fill="none" opacity="1" stroke="#5E81B5" stroke-width="15" points="851,1688 3397,162 "/>
+<polyline fill="none" opacity="1" stroke="#E0932C" stroke-width="15" points="851,315 3397,1333 "/>
+<text x="670.2" y="1688.9" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145" fill="#666">1</text>
+<text x="670.2" y="1179.6" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145" fill="#666">10</text>
+<text x="670.2" y="670.4" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">2</tspan></text>
+<text x="670.2" y="161.1" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145" fill="#666">10<tspan baseline-shift="super" font-size="102">3</tspan></text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="852,1750 852,1790"/><text x="852" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2000</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1361,1750 1361,1790"/><text x="1361" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2002</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1870,1750 1870,1790"/><text x="1870" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2004</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2380,1750 2380,1790"/><text x="2380" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2006</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2889,1750 2889,1790"/><text x="2889" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2008</text><polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3398,1750 3398,1790"/><text x="3398" y="1792" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="180" opacity="1" fill="#666666">2010</text></svg>


### PR DESCRIPTION
## Summary

While checking a randomly sampled Wolfram Demonstration notebook against Woxi Studio's notebook support, its `Manipulate` body selected between `DateListPlot` and `DateListLogPlot` for a "log scale" toggle on a date-axis chart. `DateListPlot` and `ListLogPlot` were both already supported, but `DateListLogPlot` — the function combining a date-valued x-axis with a logarithmic y-axis — was marked unimplemented (🚫) in `functions.csv`.

- Refactored `date_list_plot_ast` into a shared `date_list_plot_ast_impl(args, log_y)` so `DateListLogPlot` reuses all the date-axis plotting logic instead of duplicating it (per repo convention of never implementing a construct twice).
- Non-positive y-values are dropped (they have no log-space position), matching `ListLogPlot`'s handling of non-positive data.
- y-axis range padding is computed multiplicatively in log space (matching `ListLogPlot`/`LogPlot`) instead of additively.
- Wired up dispatch in `plotting.rs` and marked the function ✅ in `functions.csv`.

The rest of the notebook's constructs (its `Manipulate` controls — `Setter`, `TogglerBar`, `CheckboxBar` — and general notebook parsing) were already supported by Woxi Studio.

## Test plan

- [x] Added unit tests in `tests/interpreter_tests/graphics.rs` covering: single/multiple date series, non-positive value filtering, invalid-input fallback to unevaluated, and the values+start-date form.
- [x] `make test` — all 27,085 tests pass.
- [x] `make test-studio` — all 133 tests pass (verified in isolation after two unrelated tests timed out only under heavy parallel sandbox contention, not from this change).
- [x] `make format`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BUbGWH8RuDNaeNuPejpGVF)_