### PR TITLE
Render Manipulate two-swatch colour controls as real ColorSetter widgets

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16169,6 +16169,50 @@ pub fn manipulate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(call("Manipulate", out_args))
 }
 
+/// Whether `expr` still mentions a free symbol after evaluation — i.e. it
+/// did not reduce to a concrete value. A control bound evaluated on its own
+/// (outside the Manipulate's own variable scope) stays symbolic when it
+/// depends on another control's variable (`Range[y]`); a call like
+/// `RGBColor[0.49, 0, 0]` that evaluates to itself has no such dependency.
+/// Named mathematical constants don't count as free — they're already
+/// concrete values in disguise.
+fn expr_is_symbolic(expr: &Expr) -> bool {
+  match expr {
+    Expr::Identifier(name) => !matches!(
+      name.as_str(),
+      "Pi"
+        | "E"
+        | "Degree"
+        | "I"
+        | "Infinity"
+        | "ComplexInfinity"
+        | "True"
+        | "False"
+        | "None"
+        | "Automatic"
+        | "All"
+        | "Null"
+        | "GoldenRatio"
+        | "EulerGamma"
+        | "Catalan"
+    ),
+    Expr::FunctionCall { args, .. } => args.iter().any(expr_is_symbolic),
+    Expr::List(items) => items.iter().any(expr_is_symbolic),
+    Expr::Association(pairs) => pairs
+      .iter()
+      .any(|(k, v)| expr_is_symbolic(k) || expr_is_symbolic(v)),
+    Expr::Rule {
+      pattern,
+      replacement,
+    }
+    | Expr::RuleDelayed {
+      pattern,
+      replacement,
+    } => expr_is_symbolic(pattern) || expr_is_symbolic(replacement),
+    _ => false,
+  }
+}
+
 /// Process a single Manipulate/Control variable specification list,
 /// evaluating trailing bounds/step/discrete values while keeping the head
 /// (variable symbol or `{u, uinit, ulbl}`) intact. A 2-item spec
@@ -16201,6 +16245,12 @@ fn process_manipulate_var_spec(items: &[Expr]) -> Expr {
     && let needs_dynamic = match &new_items[1] {
       Expr::Integer(_) | Expr::Real(_) | Expr::List(_) => false,
       Expr::FunctionCall { name, .. } if name == "Dynamic" => false,
+      // Any other call (e.g. `RGBColor[0.49, 0, 0]`) only needs wrapping
+      // when it stayed symbolic after evaluation — i.e. it still mentions a
+      // free symbol such as another control's variable. A call that
+      // evaluated down to a concrete value is already stable and needs no
+      // live re-resolution.
+      Expr::FunctionCall { args, .. } => args.iter().any(expr_is_symbolic),
       // A trailing control option such as `ControlType -> None` is not a
       // range, so it must not be wrapped in Dynamic[…].
       Expr::Rule { .. } | Expr::RuleDelayed { .. } => false,
@@ -18191,6 +18241,12 @@ fn discrete_choice_columns(
         discrete_choice_label(label)
       });
       svgs.push(svg);
+    } else if let Some(color) = crate::functions::graphics::parse_color(item) {
+      // A plain colour choice (no Rule label) renders as a swatch icon —
+      // the ColorSetter idiom — rather than its `RGBColor[…]` InputForm.
+      values.push(crate::syntax::expr_to_input_form(item));
+      labels.push(discrete_choice_label(item));
+      svgs.push(Some(color_swatch_svg(&color)));
     } else {
       values.push(crate::syntax::expr_to_input_form(item));
       labels.push(discrete_choice_label(item));
@@ -20143,21 +20199,48 @@ fn parse_manipulate_control(
     });
   }
 
-  // Colour form: `{{u, uinit, ulbl}, colour}` — a single colour where the
-  // bounds go. wolframscript renders a `ColorSlider`; Woxi has no colour
-  // widget yet, so the variable is bound to its initial colour and the
-  // other controls stay live. Without this the whole Manipulate failed to
-  // build, taking every control with it.
+  // Colour form: `{{u, uinit, ulbl}, colour}` — wolframscript renders a
+  // ColorSetter whose swatches are the initial colour and the listed
+  // alternate(s), matching the Demonstrations idiom of toggling between a
+  // couple of fixed colours. With an explicit initial colour that differs
+  // from `colour`, the two form a real 2-swatch choice; without one there is
+  // only a single possible value, so the variable stays fixed at it (there
+  // is nothing to pick between).
   if bounds.len() == 1
     && crate::functions::graphics::parse_color(bounds[0]).is_some()
   {
-    let value = explicit_initial
-      .as_ref()
-      .filter(|init| parse_color(init).is_some())
-      .map_or_else(
-        || crate::syntax::expr_to_input_form(bounds[0]),
-        crate::syntax::expr_to_input_form,
-      );
+    let alt_code = crate::syntax::expr_to_input_form(bounds[0]);
+    if let Some(init) = explicit_initial.as_ref().filter(|init| {
+      parse_color(init).is_some()
+        && crate::syntax::expr_to_input_form(init) != alt_code
+    }) {
+      let value_items = vec![init.clone(), bounds[0].clone()];
+      let (values, value_labels, value_label_svgs) =
+        discrete_choice_columns(&value_items);
+      return Some(ParsedControl::Visible {
+        control: ManipulateControl::Discrete {
+          name,
+          values,
+          value_labels,
+          value_label_svgs,
+          initial_index: 0,
+          label,
+          label_runs,
+          popup: false,
+          // A ColorSetter always shows its swatches as a row of buttons,
+          // never a dropdown.
+          setter_bar: true,
+          slider: false,
+        },
+        enabled,
+        min_code: None,
+        max_code: None,
+        values_code: None,
+        animate: None,
+        tracking: tracking.clone(),
+      });
+    }
+    let value = crate::syntax::expr_to_input_form(bounds[0]);
     return Some(ParsedControl::Fixed { name, value });
   }
 

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -17209,6 +17209,63 @@ mod manipulate {
     }
   }
 
+  /// `{{u, uinit}, colour}` — the Demonstrations idiom for a two-swatch
+  /// colour toggle (`ColorSetter`) — becomes a real discrete control whose
+  /// two choices are the initial colour and the listed one, each rendered
+  /// as a colour swatch icon rather than its `RGBColor[…]` InputForm.
+  #[test]
+  fn spec_two_color_swatch_form_becomes_a_discrete_control() {
+    let expr = interpret_to_expr(
+      "Manipulate[ringColor, \
+       {{ringColor, RGBColor[0.88, 0.63, 0.23]}, RGBColor[0.49, 0, 0]}]",
+    )
+    .unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed Manipulate");
+    match &spec.controls[0] {
+      ManipulateControl::Discrete {
+        name,
+        values,
+        initial_index,
+        value_label_svgs,
+        setter_bar,
+        ..
+      } => {
+        assert_eq!(name, "ringColor");
+        assert_eq!(
+          values,
+          &["RGBColor[0.88, 0.63, 0.23]", "RGBColor[0.49, 0, 0]"]
+        );
+        assert_eq!(*initial_index, 0);
+        assert!(
+          value_label_svgs.iter().all(Option::is_some),
+          "both swatches should render as colour icons: {value_label_svgs:?}"
+        );
+        assert!(*setter_bar, "a colour toggle always shows its swatches");
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
+  /// `{u, colour}` with no explicit initial has only one possible value —
+  /// the variable is baked into the body as a fixed binding rather than
+  /// building a one-swatch control with nothing to pick between.
+  #[test]
+  fn spec_single_color_form_without_explicit_initial_stays_fixed() {
+    let expr =
+      interpret_to_expr("Manipulate[c, {c, RGBColor[0.49, 0, 0]}]").unwrap();
+    let spec = extract_manipulate_spec(&expr).expect("well-formed Manipulate");
+    assert!(
+      spec.controls.is_empty(),
+      "a single fixed colour is baked into the body, not a visible control: {:?}",
+      spec.controls
+    );
+    assert!(
+      spec.body_code.contains("0.49"),
+      "the fixed colour should be baked into the body: {}",
+      spec.body_code
+    );
+  }
+
   /// A control panel laid out as a `Grid` marks its stretched cells with
   /// `SpanFromLeft` / `SpanFromAbove`. Once the grid is flattened into
   /// control rows those markers name nothing, so they are dropped — they


### PR DESCRIPTION
## Summary

While testing Woxi Studio against a random Wolfram Demonstration, I found that `Manipulate` variable specs of the form `{{u, uinit}, colour}` — the Demonstrations idiom for a two-swatch colour toggle (`ColorSetter`) — silently dropped their interactivity: the variable was bound to its initial colour and no widget was rendered at all.

- `{{u, uinit}, colour}` now becomes a real `Discrete` control whose two choices (the initial colour and the listed alternate) render as colour-swatch icons, matching Wolfram's `ColorSetter`. A degenerate spec where both colours are the same still binds a fixed value, since there's nothing to pick between.
- `discrete_choice_columns` now renders a swatch icon for any plain (non-`Rule`-labelled) colour choice, so the existing `{u, {color1, color2, ...}}` list form benefits too.
- Fixed a related bug in the held `Manipulate`'s echoed form: a 2-item spec whose second element was a concrete `FunctionCall` (e.g. `RGBColor[0.49, 0, 0]`) was unconditionally wrapped in `Dynamic[…]`, even when it doesn't reference another control's variable. This actually broke the colour-control fix above until corrected, since the wrapped `Dynamic[RGBColor[…]]` no longer parsed as a colour. The `Dynamic` wrapping now depends on whether the evaluated value still contains a free symbol.

## Test plan

- [x] Added `spec_two_color_swatch_form_becomes_a_discrete_control` and `spec_single_color_form_without_explicit_initial_stays_fixed` unit tests
- [x] `cargo test --test interpreter_tests` — 25021 passed, 0 failed
- [x] `cargo test -p woxi-studio` — 133 passed, 0 failed
- [x] `cargo build -p woxi-studio` compiles cleanly
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013iwFvfMpwHvVJ47nVXMygT)_