### PR TITLE
Add Combinatorica`UnrankPermutation

### DIFF
--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -1072,6 +1072,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "PermutationPower" => Some((2, 2)),
     "Permutations" => Some((1, 2)),
     "PermutationSupport" => Some((1, 1)),
+    "Combinatorica`UnrankPermutation" => Some((2, 2)),
     "PerpendicularBisector" => Some((1, 2)),
     "PerfectNumber" => Some((1, 1)),
     "RamanujanTau" => Some((1, 1)),

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -2872,6 +2872,11 @@ pub fn dispatch_list_operations(
     "Permutations" if !args.is_empty() && args.len() <= 2 => {
       return Some(list_helpers_ast::permutations_ast(args));
     }
+    "Combinatorica`UnrankPermutation" if args.len() == 2 => {
+      return Some(list_helpers_ast::combinatorica_unrank_permutation_ast(
+        args,
+      ));
+    }
     "Signature" if args.len() == 1 => {
       use crate::functions::list_helpers_ast::sorting::canonical_cmp;
       // Signature operates on any non-atomic expression: it treats the

--- a/src/functions/list_helpers_ast/combinatorics.rs
+++ b/src/functions/list_helpers_ast/combinatorics.rs
@@ -132,6 +132,64 @@ pub fn permutations_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(Expr::List(result.into()))
 }
 
+/// `Combinatorica\`UnrankPermutation[r, l]` / `Combinatorica\`UnrankPermutation[r, n]`
+/// — the legacy Combinatorica package's permutation unranking: the `r`-th
+/// permutation of `l` (or of `Range[n]`) in lexicographic order, where `r`
+/// runs from 1 (the list itself) to `Length[l]!` (its reverse) and each
+/// factorial-number-system digit of `r - 1` selects how many of the
+/// still-unused elements, taken in `l`'s own order, to skip before picking
+/// the next one. A non-list/non-integer second argument or an `r` outside
+/// `1..Length[l]!` is left symbolic, matching that Combinatorica itself only
+/// defines the function on that domain.
+pub fn combinatorica_unrank_permutation_ast(
+  args: &[Expr],
+) -> Result<Expr, InterpreterError> {
+  use num_bigint::{BigInt, Sign};
+  use num_traits::ToPrimitive;
+
+  let original = || unevaluated("Combinatorica`UnrankPermutation", args);
+  if args.len() != 2 {
+    return Ok(original());
+  }
+
+  let rank = match &args[0] {
+    Expr::Integer(r) if *r >= 1 => BigInt::from(*r),
+    Expr::BigInteger(r) if r.sign() == Sign::Plus => r.clone(),
+    _ => return Ok(original()),
+  };
+
+  let items: Vec<Expr> = match &args[1] {
+    Expr::List(items) => items.to_vec(),
+    Expr::Integer(n) if *n >= 0 => (1..=*n).map(Expr::Integer).collect(),
+    _ => return Ok(original()),
+  };
+
+  let n = items.len();
+  let mut n_factorial = BigInt::from(1u32);
+  for k in 2..=n {
+    n_factorial *= k as u64;
+  }
+  if rank > n_factorial {
+    return Ok(original());
+  }
+
+  let mut remaining = items;
+  let mut result = Vec::with_capacity(n);
+  let mut rem_rank = rank - 1;
+  for i in 0..n {
+    let remaining_len = n - i;
+    let mut weight = BigInt::from(1u32);
+    for k in 2..remaining_len {
+      weight *= k as u64;
+    }
+    let quotient: BigInt = &rem_rank / &weight;
+    let idx: usize = quotient.to_usize().unwrap_or(0);
+    rem_rank -= &weight * BigInt::from(idx);
+    result.push(remaining.remove(idx));
+  }
+  Ok(Expr::List(result.into()))
+}
+
 /// Helper to generate k-permutations.
 ///
 /// When the input contains duplicate elements, only distinct permutations

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -9931,6 +9931,89 @@ mod join_non_list {
   }
 
   #[test]
+  fn combinatorica_unrank_permutation_matches_lexicographic_order() {
+    // Combinatorica`UnrankPermutation[r, l] gives the r-th permutation of
+    // `l` in lexicographic order, 1-indexed (r runs from 1 through
+    // Length[l]!, so the sequence below must line up with what
+    // `Permutations` itself already produces in lexicographic order).
+    assert_eq!(
+      interpret(
+        "Table[Combinatorica`UnrankPermutation[r, {1, 2, 3}], {r, 1, 6}]"
+      )
+      .unwrap(),
+      interpret("Permutations[{1, 2, 3}]").unwrap()
+    );
+  }
+
+  #[test]
+  fn combinatorica_unrank_permutation_boundaries() {
+    assert_eq!(
+      interpret("Combinatorica`UnrankPermutation[1, {1, 2, 3}]").unwrap(),
+      "{1, 2, 3}"
+    );
+    assert_eq!(
+      interpret("Combinatorica`UnrankPermutation[6, {1, 2, 3}]").unwrap(),
+      "{3, 2, 1}"
+    );
+    // Out of the valid 1..Length[l]! range, the call stays symbolic rather
+    // than silently wrapping or erroring.
+    assert_eq!(
+      interpret("Combinatorica`UnrankPermutation[0, {1, 2, 3}]").unwrap(),
+      "Combinatorica`UnrankPermutation[0, {1, 2, 3}]"
+    );
+    assert_eq!(
+      interpret("Combinatorica`UnrankPermutation[7, {1, 2, 3}]").unwrap(),
+      "Combinatorica`UnrankPermutation[7, {1, 2, 3}]"
+    );
+  }
+
+  #[test]
+  fn combinatorica_unrank_permutation_integer_second_arg() {
+    // UnrankPermutation[r, n] for an integer n is UnrankPermutation[r, Range[n]].
+    assert_eq!(
+      interpret("Combinatorica`UnrankPermutation[1, 4]").unwrap(),
+      "{1, 2, 3, 4}"
+    );
+    assert_eq!(
+      interpret("Combinatorica`UnrankPermutation[24, 4]").unwrap(),
+      "{4, 3, 2, 1}"
+    );
+  }
+
+  #[test]
+  fn combinatorica_unrank_permutation_is_a_bijection() {
+    // Every rank from 1 to n! must produce a distinct permutation.
+    assert_eq!(
+      interpret(
+        "Length[Union[Table[Combinatorica`UnrankPermutation[r, {1, 2, 3, 4, \
+         5}], {r, 1, 120}]]]"
+      )
+      .unwrap(),
+      "120"
+    );
+  }
+
+  #[test]
+  fn combinatorica_unrank_permutation_handles_large_factorial_rank() {
+    // The rank can exceed machine-integer range (12! = 479001600) — the
+    // last permutation at exactly n! must still resolve, and one past it
+    // must stay symbolic rather than silently wrapping.
+    assert_eq!(
+      interpret("Combinatorica`UnrankPermutation[12!, Range[12]]").unwrap(),
+      "{12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}"
+    );
+    assert_eq!(
+      interpret("Combinatorica`UnrankPermutation[1, Range[12]]").unwrap(),
+      "{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}"
+    );
+    assert_eq!(
+      interpret("Combinatorica`UnrankPermutation[12! + 1, Range[12]]").unwrap(),
+      "Combinatorica`UnrankPermutation[479001601, {1, 2, 3, 4, 5, 6, 7, 8, 9, \
+       10, 11, 12}]"
+    );
+  }
+
+  #[test]
   fn permutations_with_duplicates() {
     // Permutations of a multiset should return only distinct permutations.
     // Wolfram: Permutations[{1, 1, 2}] -> {{1, 1, 2}, {1, 2, 1}, {2, 1, 1}}


### PR DESCRIPTION
## Summary

- Spot-checked a random Wolfram Demonstrations notebook against Woxi Studio (per the routine that periodically does this). The notebook's `Manipulate` picks a permutation by rank via the legacy Combinatorica package function `UnrankPermutation`, which Woxi didn't implement — the body stayed fully symbolic and nothing rendered.
- Everything else in that notebook parsed and evaluated exactly as expected (cell structure, `With`, `ReplaceAll`, `Append`, `First`, `MapIndexed`, `ColorFunction`, `Epilog`, `ListLinePlot` options, the `Manipulate` slider with a `12!`-sized range and `Bookmarks` option all behaved correctly on the held expression), so this was the one real gap.
- Implements `Combinatorica\`UnrankPermutation[r, l]` / `UnrankPermutation[r, n]`: the `r`-th permutation of `l` (or `Range[n]`) in lexicographic order, 1-indexed from `1` through `Length[l]!` (matching the official documentation's "r-th permutation" phrasing and the natural boundary at exactly `n!`). Uses `BigInt` throughout so ranks past machine-integer factorials (e.g. `12! = 479001600`) stay exact.
- Out-of-range or malformed input (rank `< 1` or `> n!`, non-list/non-integer second argument) is left symbolic, consistent with how other legacy-package functions are handled in this codebase (e.g. `HypothesisTesting\`MeanTest`).
- Does not reference or embed any content from the source Demonstration notebook — the implementation is derived from the public Combinatorica documentation and verified independently by hand-enumerating small cases (e.g. `n = 3`) against the documented lexicographic ordering.

## Test plan

- [x] Added unit tests in `tests/interpreter_tests/list.rs`: lexicographic order matches `Permutations`, boundary values (`1`, `n!`, and one past each end), the integer-second-argument form, a bijection check across all `5!` ranks, and the large-factorial-rank case at `12!`.
- [x] `cargo test` (full suite) — all tests pass.
- [x] `cargo fmt --check` — clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HWLjekrqePE83iCNhTcV9y

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWLjekrqePE83iCNhTcV9y)_