### PR TITLE
Support GreaterSlantEqual/LessSlantEqual and embed rasterized images via Inset/Text

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -5218,7 +5218,7 @@ FindMaximumCut,,,,12.1,5486
 GeneratedDocumentBinding,,🚫,,10.0,5486
 GeoBoundary,,🚫,,12.2,5486
 GeoResolution,,🚫,,12.0,5486
-GreaterSlantEqual,,,,3.0,5486
+GreaterSlantEqual,Checks if one value is greater than or equal to another (slanted-equal glyph variant of GreaterEqual),✅,pure,3.0,5486
 HeatOutflowValue,,,,12.2,5486
 HeatSymmetryValue,,,,12.2,5486
 HelmholtzPDEComponent,,,,12.2,5486
@@ -5230,7 +5230,7 @@ IncludeQuantities,,,,10.0,5486
 IncludeWindowTimes,,,,10.0,5486
 InflationMethod,,🚫,,10.0,5486
 KeyComplement,Returns the first association restricted to keys absent from the rest,✅,pure,10.1,5486
-LessSlantEqual,,,,3.0,5486
+LessSlantEqual,Checks if one value is less than or equal to another (slanted-equal glyph variant of LessEqual),✅,pure,3.0,5486
 LibraryFunctionInformation,,,,8.0,5486
 LinearFractionalOptimization,,,,12.0,5486
 MarcumQ,Generalized Marcum Q function (symbolic rules and numeric series),✅,pure,8.0,5486

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -1732,7 +1732,19 @@ fn collect_primitives(
           }
         }
         "Text" if !args.is_empty() => {
-          parse_text(args, style, prims);
+          // `Text[picture, pos]` embeds an already-rendered `Graphics` or
+          // `Image` the same way `Inset` does — either primitive can hold a
+          // picture, not just a string label — instead of printing the
+          // object's `-Graphics-`/`-Image-` short form as literal text.
+          match peel_style_wrapper(&args[0]) {
+            Expr::Graphics { .. } | Expr::Image { .. } => {
+              match inset_primitives(args, errors) {
+                Some(inner) => prims.extend(inner),
+                None => parse_text(args, style, prims),
+              }
+            }
+            _ => parse_text(args, style, prims),
+          }
         }
         "BezierCurve" if !args.is_empty() => {
           let before = prims.len();
@@ -2819,6 +2831,23 @@ fn button_plate_svg(label: &str) -> String {
   )
 }
 
+/// Peel a top-level `Style[content, dirs…]`/`StyleForm[…]` wrapper so
+/// callers can pattern-match the payload underneath — e.g. `Inset[Style[img,
+/// Magnification -> .2], pos]` still embeds `img` as a picture rather than
+/// falling through to the plain-text path just because it is styled. The
+/// style directives themselves (font, magnification, …) are not applied;
+/// getting the picture on screen at all matters more than honoring them.
+fn peel_style_wrapper(expr: &Expr) -> &Expr {
+  match expr {
+    Expr::FunctionCall { name, args }
+      if is_style_wrapper(name) && !args.is_empty() =>
+    {
+      peel_style_wrapper(&args[0])
+    }
+    other => other,
+  }
+}
+
 fn inset_primitives(
   args: &[Expr],
   errors: &mut Vec<String>,
@@ -2836,7 +2865,8 @@ fn inset_primitives(
   // from falling through to the text path and printing `-Graphics3D-`.
   let anchor = args.get(1).and_then(expr_to_anchor);
   let rendered;
-  let embedded = match &args[0] {
+  let image_svg;
+  let embedded = match peel_style_wrapper(&args[0]) {
     Expr::Graphics {
       svg,
       structure: None,
@@ -2845,6 +2875,21 @@ fn inset_primitives(
     Expr::Graphics {
       svg, is_3d: true, ..
     } => Some(svg),
+    // A rasterized picture (e.g. from `Rasterize[…]` or `Import`) draws at
+    // its own pixel size, the same as a rendered `Graphics` above — there is
+    // no symbolic content to fold into this picture's coordinate system.
+    Expr::Image {
+      width,
+      height,
+      channels,
+      data,
+      ..
+    } => {
+      image_svg = crate::functions::image_ast::image_to_html_img(
+        *width, *height, *channels, data,
+      );
+      Some(&image_svg)
+    }
     // A picture given symbolically normally has its primitives folded into
     // this one (below), which is what lets it share the coordinate system.
     // That cannot be done from a `Scaled` anchor — the range it names is

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -4831,9 +4831,11 @@ fn parse_expression_inner(
           | "<"
           | "<="
           | "\u{2264}"
+          | "\u{2A7D}"
           | ">"
           | ">="
           | "\u{2265}"
+          | "\u{2A7E}"
           | "==="
           | "=!="
       )
@@ -4847,9 +4849,9 @@ fn parse_expression_inner(
           "==" | "\u{2A75}" => ComparisonOp::Equal,
           "!=" | "\u{2260}" => ComparisonOp::NotEqual,
           "<" => ComparisonOp::Less,
-          "<=" | "\u{2264}" => ComparisonOp::LessEqual,
+          "<=" | "\u{2264}" | "\u{2A7D}" => ComparisonOp::LessEqual,
           ">" => ComparisonOp::Greater,
-          ">=" | "\u{2265}" => ComparisonOp::GreaterEqual,
+          ">=" | "\u{2265}" | "\u{2A7E}" => ComparisonOp::GreaterEqual,
           "===" => ComparisonOp::SameQ,
           "=!=" => ComparisonOp::UnsameQ,
           _ => ComparisonOp::Equal,
@@ -5666,8 +5668,8 @@ fn operator_precedence(op: &str) -> u8 {
     // the right operand absorbs y, y = 1, y /; z, y -> 1. Place at TagSet
     // level so its rhs stays maximally permissive.
     "\\[Function]" | "\u{F4A1}" | "|->" => 3,
-    "==" | "!=" | "\u{2260}" | "<" | "<=" | "\u{2264}" | ">" | ">="
-    | "\u{2265}" | "===" | "=!=" => 21, // Comparisons
+    "==" | "!=" | "\u{2260}" | "<" | "<=" | "\u{2264}" | "\u{2A7D}" | ">"
+    | ">=" | "\u{2265}" | "\u{2A7E}" | "===" | "=!=" => 21, // Comparisons
     "~~" => 24,      // StringExpression (lower than Alternatives)
     "|" => 27, // Alternatives (higher than StringExpression, Or, And, Rule)
     "+" | "-" => 30, // Plus/Minus
@@ -6299,15 +6301,15 @@ fn make_binary_op(left: &Expr, op_str: &str, right: &Expr) -> Expr {
         }
       }
     }
-    "==" | "\u{2A75}" | "!=" | "\u{2260}" | "<" | "<=" | "\u{2264}" | ">"
-    | ">=" | "\u{2265}" | "===" | "=!=" => {
+    "==" | "\u{2A75}" | "!=" | "\u{2260}" | "<" | "<=" | "\u{2264}"
+    | "\u{2A7D}" | ">" | ">=" | "\u{2265}" | "\u{2A7E}" | "===" | "=!=" => {
       let comp_op = match op_str {
         "==" | "\u{2A75}" => ComparisonOp::Equal,
         "!=" | "\u{2260}" => ComparisonOp::NotEqual,
         "<" => ComparisonOp::Less,
-        "<=" | "\u{2264}" => ComparisonOp::LessEqual,
+        "<=" | "\u{2264}" | "\u{2A7D}" => ComparisonOp::LessEqual,
         ">" => ComparisonOp::Greater,
-        ">=" | "\u{2265}" => ComparisonOp::GreaterEqual,
+        ">=" | "\u{2265}" | "\u{2A7E}" => ComparisonOp::GreaterEqual,
         "===" => ComparisonOp::SameQ,
         "=!=" => ComparisonOp::UnsameQ,
         _ => ComparisonOp::Equal,

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -257,7 +257,7 @@ Operator = @{
   | "||"     // Or operator (must be before single |)
   | "|"      // Alternatives operator
   | "===" | "=!=" | "==" | "\u{2A75}" | "!=" | "\u{2260}"  // SameQ, UnsameQ (must be before == and !=), Equal, ⩵, Unequal, ≠
-  | "<=" | ">=" | "\u{2264}" | "\u{2265}"  // LessEqual, GreaterEqual, ≤, ≥
+  | "<=" | ">=" | "\u{2264}" | "\u{2265}" | "\u{2A7D}" | "\u{2A7E}"  // LessEqual, GreaterEqual, ≤, ≥, ⩽, ⩾
   | ">>>" ~ !(">" | "=")   // PutAppend operator (must be before >> and >)
   | ">>" ~ !(">" | "=")    // Put operator (must be before > and >=)
   | "/*" ~ !(")")  // RightComposition operator (must be before / ; avoid matching /* in comments)
@@ -715,7 +715,7 @@ ConditionOp = @{
   | "===" | "=!=" | "==" | "\u{2A75}" | "!=" | "\u{2260}"  // Comparison, ⩵, ≠
   | "<->"                         // TwoWayRule (must be before <>, <=, <)
   | "<>"                          // StringJoin (must be before < to avoid partial match)
-  | "<=" | ">=" | "\u{2264}" | "\u{2265}" | "<" | ">"       // Order comparison, ≤, ≥
+  | "<=" | ">=" | "\u{2264}" | "\u{2265}" | "\u{2A7D}" | "\u{2A7E}" | "<" | ">"       // Order comparison, ≤, ≥, ⩽, ⩾
   | "/@"                          // Map (must be before the bare "/" of Arithmetic)
   | "@@@"                         // MapApply (must be before @@)
   | "@@"                          // Apply (must be before @)

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1439,6 +1439,90 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_greater_less_slant_equal_operators() {
+    // `\[GreaterSlantEqual]` (⩾, U+2A7E) and `\[LessSlantEqual]` (⩽,
+    // U+2A7D) are glyph variants of GreaterEqual/LessEqual that a
+    // Demonstration's box notation resolves to literal Unicode characters
+    // once extracted from a notebook cell. Regression: the parser only
+    // recognized the plain ≥/≤ (U+2265/U+2264) forms as comparison
+    // operators, so `q⩾q1` failed to parse at all.
+    clear_state();
+    assert_eq!(interpret("3\u{2A7E}2").unwrap(), "True");
+    assert_eq!(interpret("2\u{2A7E}3").unwrap(), "False");
+    assert_eq!(interpret("2\u{2A7E}2").unwrap(), "True");
+    clear_state();
+    assert_eq!(interpret("2\u{2A7D}3").unwrap(), "True");
+    assert_eq!(interpret("3\u{2A7D}2").unwrap(), "False");
+    assert_eq!(interpret("2\u{2A7D}2").unwrap(), "True");
+    // The chained/mixed form parses as a Comparison, same as `<=`/`>=`.
+    clear_state();
+    assert_eq!(interpret("1\u{2A7D}2\u{2A7D}3").unwrap(), "True");
+    clear_state();
+    assert_eq!(interpret("If[3\u{2A7E}2, \"yes\", \"no\"]").unwrap(), "yes");
+  }
+
+  #[test]
+  fn test_inset_and_text_embed_rasterized_image() {
+    // `Inset[img, pos]` and `Text[img, pos]` with `img` an already-rasterized
+    // `Image[…]` (e.g. from `Rasterize[Graphics[…]]`) must draw the picture
+    // itself, the way a Demonstration composites a small rendered icon into
+    // a larger scene. Regression: both fell through to the plain-text path
+    // and printed the object's `-Image-` short form as literal text instead.
+    clear_state();
+    let inset_svg = interpret(
+      "h = Rasterize[Graphics[Disk[]]]; ExportString[Graphics[{Inset[h, {0, 0}]}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      inset_svg.contains("data:image/png;base64,"),
+      "Inset of a rasterized image did not embed a PNG: {inset_svg}"
+    );
+    assert!(
+      !inset_svg.contains("-Image-"),
+      "Inset fell back to the -Image- text placeholder: {inset_svg}"
+    );
+
+    clear_state();
+    let text_svg = interpret(
+      "h = Rasterize[Graphics[Disk[]]]; ExportString[Graphics[{Text[h, {0, 0}]}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      text_svg.contains("data:image/png;base64,"),
+      "Text of a rasterized image did not embed a PNG: {text_svg}"
+    );
+    assert!(
+      !text_svg.contains("-Image-"),
+      "Text fell back to the -Image- text placeholder: {text_svg}"
+    );
+
+    // A `Style[…]`-wrapped image (as a Demonstration writes to scale an
+    // icon down with `Magnification`) still embeds instead of falling
+    // through just because it is styled.
+    clear_state();
+    let styled_svg = interpret(
+      "h = Rasterize[Graphics[Disk[]]]; ExportString[Graphics[{Inset[Style[h, Magnification -> .5], {0, 0}]}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      styled_svg.contains("data:image/png;base64,"),
+      "Style-wrapped Inset did not embed a PNG: {styled_svg}"
+    );
+
+    // Plain text content is unaffected — still drawn as a label, not
+    // mistaken for a picture.
+    clear_state();
+    let plain_svg =
+      interpret("ExportString[Graphics[{Text[\"hello\", {0, 0}]}], \"SVG\"]")
+        .unwrap();
+    assert!(
+      plain_svg.contains("hello"),
+      "plain text label lost: {plain_svg}"
+    );
+    assert!(!plain_svg.contains("data:image/png;base64,"));
+  }
+
+  #[test]
   fn test_plot_aspect_ratio_sizes_frame_not_canvas() {
     // AspectRatio sets the height/width ratio of the plotting *area* (the data
     // frame), not the whole image. A short ratio must therefore NOT squash the


### PR DESCRIPTION
## Summary

A random Wolfram Demonstrations Project notebook exercised against Woxi Studio surfaced two gaps in language/graphics support:

- **Parser**: only the plain `≥`/`≤` (U+2265/U+2264) comparison glyphs were recognized as comparison operators. A notebook using the slanted variants `⩾`/`⩽` (U+2A7E/U+2A7D — what `\[GreaterSlantEqual]`/`\[LessSlantEqual]` resolve to) failed to parse entirely.
- **Graphics**: `Inset[img, pos]` and `Text[img, pos]` fell through to the plain-text path and printed an already-rasterized `Image`'s `-Image-`/`-Graphics-` short form as literal text instead of embedding the picture — including when the image was wrapped in `Style[...]` (e.g. for `Magnification`).

Both are general parser/graphics gaps, not specific to any one notebook's content.

## Changes

- `src/wolfram.pest`, `src/syntax.rs`: recognize `⩾`/`⩽` (U+2A7E/U+2A7D) as `GreaterEqual`/`LessEqual` operators everywhere the plain `≥`/`≤` forms already are.
- `src/functions/graphics.rs`:
  - `Inset[image, pos]` now embeds a rasterized `Image` at its own pixel size, the same way an already-rendered `Graphics` object is embedded.
  - `Text[picture, pos]` now embeds a `Graphics`/`Image` payload instead of always treating its first argument as a text label.
  - A `Style[...]` wrapper around the picture (e.g. `Inset[Style[img, Magnification -> .5], pos]`) is peeled off before the type check, so a styled image still embeds.
- `functions.csv`: mark `GreaterSlantEqual`/`LessSlantEqual` as implemented.
- `tests/interpreter_tests.rs`: regression tests for both fixes.

## Test plan

- [x] `make test` (27082 tests, all passing)
- [x] `make format`
- [x] Verified against the target notebook: the `Manipulate` now builds and renders (`graphics=true`, `error=None`) via `cargo run -p woxi-studio --example dump_manipulate`, where it previously failed to parse at all.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WAzXRJ3LP8a8FhSF5vHJ8D)_