### PR TITLE
Support Prolog in Plot, and per-rule Filling styles

### DIFF
--- a/src/evaluator/part_extraction.rs
+++ b/src/evaluator/part_extraction.rs
@@ -394,7 +394,7 @@ pub fn graphics_symbolic_form(expr: &Expr) -> Option<Expr> {
     let series: Vec<Expr> = source
       .series
       .iter()
-      .map(|s| {
+      .flat_map(|s| {
         let points = Expr::List(
           s.points
             .iter()
@@ -404,13 +404,12 @@ pub fn graphics_symbolic_form(expr: &Expr) -> Option<Expr> {
             })
             .collect(),
         );
-        let (r, g, b) = s.color;
-        let color = Expr::FunctionCall {
+        let rgb_expr = |(r, g, b): (u8, u8, u8)| Expr::FunctionCall {
           name: "RGBColor".to_string(),
           args: vec![
-            Expr::Real(r as f64 / 255.0),
-            Expr::Real(g as f64 / 255.0),
-            Expr::Real(b as f64 / 255.0),
+            Expr::Real(f64::from(r) / 255.0),
+            Expr::Real(f64::from(g) / 255.0),
+            Expr::Real(f64::from(b) / 255.0),
           ]
           .into(),
         };
@@ -418,12 +417,77 @@ pub fn graphics_symbolic_form(expr: &Expr) -> Option<Expr> {
           name: if s.is_scatter { "Point" } else { "Line" }.to_string(),
           args: vec![points].into(),
         };
-        Expr::List(vec![color, draw].into())
+        let mut prims = vec![Expr::List(vec![rgb_expr(s.color), draw].into())];
+        // `Filling` draws a shaded region under the curve — bake it in as
+        // an explicit `Polygon` primitive alongside the `Line`, the way
+        // Wolfram does. Without this, a Demonstration's `region =
+        // First[Plot[…, Filling -> …]]` (extracting the drawing to
+        // transform and redraw elsewhere, e.g. with
+        // `GeometricTransformation`) silently loses the shading.
+        if let Some(polygon_points) = series_fill_polygon(s) {
+          let fill_color = s.fill_color.unwrap_or(s.color);
+          let opacity = s.fill_opacity.unwrap_or(0.2);
+          let styled_fill = Expr::FunctionCall {
+            name: "Opacity".to_string(),
+            args: vec![Expr::Real(opacity), rgb_expr(fill_color)].into(),
+          };
+          let polygon = Expr::FunctionCall {
+            name: "Polygon".to_string(),
+            args: vec![Expr::List(
+              polygon_points
+                .into_iter()
+                .map(|(x, y)| {
+                  Expr::List(vec![Expr::Real(x), Expr::Real(y)].into())
+                })
+                .collect(),
+            )]
+            .into(),
+          };
+          prims.push(Expr::List(vec![styled_fill, polygon].into()));
+        }
+        prims
       })
       .collect();
     return Some(call1("Graphics", Expr::List(series.into())));
   }
   None
+}
+
+/// The polygon points for a `PlotSeriesData`'s `Filling` level: the curve's
+/// points followed by the same x-values back along the reference level, so
+/// the closed loop matches what `AreaSeries` draws when rendering the SVG.
+/// `None` for unfilled or scatter series (a scatter plot's `Filling` draws
+/// per-point stems, not a shaded area, so it has no single polygon).
+fn series_fill_polygon(
+  s: &crate::syntax::PlotSeriesData,
+) -> Option<Vec<(f64, f64)>> {
+  if s.is_scatter {
+    return None;
+  }
+  let finite: Vec<(f64, f64)> = s
+    .points
+    .iter()
+    .copied()
+    .filter(|(x, y)| x.is_finite() && y.is_finite())
+    .collect();
+  if finite.len() < 2 {
+    return None;
+  }
+  let (y_min, y_max) = finite
+    .iter()
+    .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), &(_, y)| {
+      (lo.min(y), hi.max(y))
+    });
+  let ref_y = match s.filling {
+    crate::syntax::SeriesFilling::None => return None,
+    crate::syntax::SeriesFilling::Axis => 0.0,
+    crate::syntax::SeriesFilling::Bottom => y_min,
+    crate::syntax::SeriesFilling::Top => y_max,
+    crate::syntax::SeriesFilling::Value(v) => v,
+  };
+  let mut polygon = finite.clone();
+  polygon.extend(finite.iter().rev().map(|&(x, _)| (x, ref_y)));
+  Some(polygon)
 }
 
 /// The rest of `extract_part_ast`, after the graphics and Tree atoms have

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -3736,7 +3736,9 @@ fn rotate_point(
 /// homogeneous `TransformationFunction[…]` itself, and a list of any of
 /// those — a list draws one transformed copy per entry. Empty when nothing
 /// numeric can be read out.
-fn parse_affine_transforms(expr: &Expr) -> Vec<([[f64; 2]; 2], (f64, f64))> {
+pub(crate) fn parse_affine_transforms(
+  expr: &Expr,
+) -> Vec<([[f64; 2]; 2], (f64, f64))> {
   // {{a, b}, {c, d}} — a 2×2 linear map.
   fn matrix2(expr: &Expr) -> Option<[[f64; 2]; 2]> {
     let Expr::List(rows) = expr else { return None };

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -1472,8 +1472,18 @@ pub(crate) enum FillTarget {
 }
 
 /// Parse the rule-list form `Filling -> {i -> spec, …}`, where `spec` is
-/// `{j}` (fill between series i and j), `{{j}, style}` (the style is not
-/// rendered yet), or a constant level (`Axis`, `Bottom`, `Top`, a number).
+/// `{j}` (fill between series i and j), `{{j}, style}` (a series target with
+/// a style), a constant level (`Axis`, `Bottom`, `Top`, a number), or
+/// `{level, style}` (a level with a style, e.g. `{0, Opacity[.4, Red]}` to
+/// fill down to the x-axis in translucent red). A series target is only a
+/// bare integer when it is the sole element of its list (`{j}`) or nested
+/// one level deeper alongside a style (`{{j}, style}`); a two-or-more-element
+/// list whose first element is a plain number is a level, not a series
+/// index, so `{0, style}` doesn't get mistaken for "fill to series 0"
+/// (which isn't even a valid 1-based series index) and silently drop the
+/// whole option. Each rule's style, when given, is returned alongside its
+/// target — the caller stores it by series index for `series_filling_style`
+/// to pick up.
 /// Returns `None` when `replacement` is not a list of rules keyed by
 /// 1-based series indices, so the caller can fall back to `parse_filling`.
 ///
@@ -1482,7 +1492,9 @@ pub(crate) enum FillTarget {
 /// first. Only the list scaffolding around the rules is flattened; a rule's
 /// own right-hand side (`{j}`, the brace form that names a target series)
 /// stays as written.
-fn parse_filling_rules(replacement: &Expr) -> Option<Vec<(usize, FillTarget)>> {
+fn parse_filling_rules(
+  replacement: &Expr,
+) -> Option<Vec<(usize, FillTarget, Option<FillStyle>)>> {
   fn flatten_rules<'a>(e: &'a Expr, out: &mut Vec<&'a Expr>) {
     match e {
       Expr::List(items) => items.iter().for_each(|i| flatten_rules(i, out)),
@@ -1511,29 +1523,43 @@ fn parse_filling_rules(replacement: &Expr) -> Option<Vec<(usize, FillTarget)>> {
       Expr::Integer(n) if *n >= 1 => *n as usize - 1,
       _ => return None,
     };
-    let target = match rhs {
-      // Braces mark a series target: `{j}` or `{{j}, style}`.
+    let (target, style) = match rhs {
+      // A lone `{j}` is a bare series target, with no style.
+      Expr::List(spec) if spec.len() == 1 => (
+        match &spec[0] {
+          Expr::Integer(j) if *j >= 1 => FillTarget::Series(*j as usize - 1),
+          other => FillTarget::Level(parse_filling(other)),
+        },
+        None,
+      ),
+      // `{target, style, …}`: a series target is nested one level deeper
+      // (`{{j}, style}`) so it isn't confused with a level that happens to
+      // be a positive integer (`{2, style}` fills to level 2, not series 2).
       Expr::List(spec) => {
-        let target_idx = match spec.first()? {
-          Expr::Integer(j) if *j >= 1 => *j as usize - 1,
-          Expr::List(inner) => match inner.first()? {
-            Expr::Integer(j) if *j >= 1 => *j as usize - 1,
-            _ => return None,
-          },
-          _ => return None,
+        let target = match spec.first()? {
+          Expr::List(inner) => {
+            let target_idx = match inner.first()? {
+              Expr::Integer(j) if *j >= 1 => *j as usize - 1,
+              _ => return None,
+            };
+            FillTarget::Series(target_idx)
+          }
+          level => FillTarget::Level(parse_filling(level)),
         };
-        FillTarget::Series(target_idx)
+        let style = spec.get(1).and_then(parse_filling_style);
+        (target, style)
       }
-      other => FillTarget::Level(parse_filling(other)),
+      other => (FillTarget::Level(parse_filling(other)), None),
     };
-    rules.push((series_idx, target));
+    rules.push((series_idx, target, style));
   }
   Some(rules)
 }
 
 /// Apply a `Filling` option value to `opts`: either the per-series rule
-/// list `{i -> spec, …}` (stored in `filling_rules`) or a global mode
-/// (stored in `filling`).
+/// list `{i -> spec, …}` (stored in `filling_rules`, with any per-rule
+/// style stored in the corresponding slot of `filling_styles`) or a global
+/// mode (stored in `filling`).
 pub(crate) fn apply_filling_option(replacement: &Expr, opts: &mut PlotOptions) {
   // The value may be computed rather than named — a Demonstration switches
   // its shading with `Filling -> If[b === Axis, Axis, None]` — so read it
@@ -1542,7 +1568,19 @@ pub(crate) fn apply_filling_option(replacement: &Expr, opts: &mut PlotOptions) {
   let value =
     evaluate_expr_to_expr(replacement).unwrap_or_else(|_| replacement.clone());
   if let Some(rules) = parse_filling_rules(&value) {
-    opts.filling_rules = rules;
+    if let Some(max_idx) = rules.iter().map(|(i, ..)| *i).max() {
+      let mut styles = vec![None; max_idx + 1];
+      for (i, _, style) in &rules {
+        if style.is_some() {
+          styles[*i] = *style;
+        }
+      }
+      opts.filling_styles = styles;
+    }
+    opts.filling_rules = rules
+      .into_iter()
+      .map(|(i, target, _)| (i, target))
+      .collect();
   } else {
     opts.filling = parse_filling(&value);
   }
@@ -1856,6 +1894,10 @@ pub(crate) struct PlotOptions {
   /// `Epilog -> {…}` graphics primitives (already evaluated), drawn on top
   /// of the plotted data in data coordinates.
   pub epilog: Vec<Expr>,
+  /// `Prolog -> {…}` graphics primitives (already evaluated), drawn
+  /// underneath the plotted data in data coordinates — the mirror of
+  /// `epilog`, painted first instead of last.
+  pub prolog: Vec<Expr>,
   /// Per-series error bars from `Around` data values, parallel to the
   /// series' points: each entry is ((dx_minus, dx_plus), (dy_minus,
   /// dy_plus)) in data units. Empty when the data has no uncertainties.
@@ -1937,6 +1979,7 @@ impl Default for PlotOptions {
       log_y: false,
       stacked: false,
       epilog: Vec::new(),
+      prolog: Vec::new(),
       error_bars: Vec::new(),
       interval_markers: IntervalMarkers::default(),
       data_points: Vec::new(),
@@ -2526,6 +2569,43 @@ fn inject_epilog(
     crate::functions::plot_epilog::render_epilog_svg(&opts.epilog, &area);
   if let Some(pos) = buf.rfind("</svg>") {
     buf.insert_str(pos, &epilog_svg);
+  }
+}
+
+/// Draw a `Prolog`'s primitives under a finished plot — the mirror of
+/// [`inject_epilog`]: same primitive-to-SVG rendering and the same `area`/
+/// `ranges`/`scale` meaning, but spliced in right after the opening `<svg
+/// …>` tag instead of before `</svg>`, so later-painted content (axes, the
+/// curve itself, any epilog) draws on top of it rather than the reverse.
+fn inject_prolog(
+  buf: &mut String,
+  opts: &PlotOptions,
+  area: (f64, f64, f64, f64),
+  ranges: (f64, f64, f64, f64),
+  scale: f64,
+) {
+  if opts.prolog.is_empty() {
+    return;
+  }
+  let (x0, y0, w, h) = area;
+  let (x_min, x_max, y_min, y_max) = ranges;
+  let area = crate::functions::plot_epilog::PlotArea {
+    x0,
+    y0,
+    w,
+    h,
+    x_min,
+    x_max,
+    y_min,
+    y_max,
+    scale,
+  };
+  let prolog_svg =
+    crate::functions::plot_epilog::render_epilog_svg(&opts.prolog, &area);
+  if let Some(tag_start) = buf.find("<svg")
+    && let Some(tag_end) = buf[tag_start..].find('>')
+  {
+    buf.insert_str(tag_start + tag_end + 1, &prolog_svg);
   }
 }
 
@@ -3285,26 +3365,23 @@ fn generate_svg_with_options(
     }
   }
 
-  // Draw Epilog primitives over the plotted data, using the same
-  // data→pixel transform as the dash overlays above.
-  inject_epilog(
-    &mut buf,
-    opts,
-    (
-      margin_left as f64 + y_label_area as f64,
-      top_margin as f64,
-      render_width as f64
-        - margin_left as f64
-        - margin_right as f64
-        - y_label_area as f64,
-      render_height as f64
-        - top_margin as f64
-        - margin_bottom as f64
-        - x_label_area as f64,
-    ),
-    (x_min, x_max, y_min, y_max),
-    sf,
+  // Draw Prolog primitives under the plotted data, and Epilog primitives
+  // over it, using the same data→pixel transform as the dash overlays
+  // above.
+  let plot_area = (
+    margin_left as f64 + y_label_area as f64,
+    top_margin as f64,
+    render_width as f64
+      - margin_left as f64
+      - margin_right as f64
+      - y_label_area as f64,
+    render_height as f64
+      - top_margin as f64
+      - margin_bottom as f64
+      - x_label_area as f64,
   );
+  inject_prolog(&mut buf, opts, plot_area, (x_min, x_max, y_min, y_max), sf);
+  inject_epilog(&mut buf, opts, plot_area, (x_min, x_max, y_min, y_max), sf);
 
   // Extend labeled (major) ticks so they appear slightly longer than the
   // unlabeled minor ticks drawn by plotters. Only applies when ticks are
@@ -4230,7 +4307,15 @@ pub(crate) fn generate_scatter_svg_with_options(
     buf.insert_str(pos, &overlay_svg);
   }
 
-  // Epilog primitives sit over the points, as in the line renderer.
+  // Prolog primitives sit under the points and Epilog primitives over them,
+  // as in the line renderer.
+  inject_prolog(
+    &mut buf,
+    opts,
+    (plot_x0, plot_y0, plot_w, plot_h),
+    (x_min, x_max, y_min, y_max),
+    sf,
+  );
   inject_epilog(
     &mut buf,
     opts,
@@ -8276,6 +8361,16 @@ pub(crate) fn apply_common_plot_option(
         other => vec![other],
       };
     }
+    "Prolog" => {
+      // Same evaluate-now treatment as `Epilog` — see above.
+      let val = evaluate_expr_to_expr(replacement)
+        .unwrap_or_else(|_| replacement.clone());
+      plot_opts.prolog = match val {
+        Expr::List(ref items) => items.to_vec(),
+        Expr::Identifier(ref s) if s == "None" => Vec::new(),
+        other => vec![other],
+      };
+    }
     _ => return false,
   }
   true
@@ -8759,7 +8854,7 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   crate::capture_graphicsbox(&graphicsbox);
 
   // Build source data for Show merging
-  let source = build_plot_source(
+  let mut source = build_plot_source(
     &all_points,
     &plot_opts.plot_style,
     (x_display_min, x_display_max),
@@ -8770,6 +8865,25 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     plot_opts.filling_style,
     crate::functions::plot::explicit_options(args),
   );
+  // `build_plot_source` only knows the single global `Filling` mode; a
+  // per-series `Filling -> {i -> spec, …}` rule list is resolved here
+  // instead, so `source.series[i].filling` (which `Part`/`First` reads to
+  // reconstitute the plot's primitives, and which `Show` reads to re-render
+  // it) reflects each series' own target rather than staying unfilled.
+  // A curve-to-curve target (`{i -> {j}}`) isn't representable as a single
+  // series' fill level, so it's left unfilled here — the SVG rendering
+  // above still draws it directly from `plot_opts.filling_rules`.
+  if !plot_opts.filling_rules.is_empty() {
+    for (i, s) in source.series.iter_mut().enumerate() {
+      if let FillTarget::Level(level) = series_fill_target(&plot_opts, i) {
+        s.filling = level.to_series_filling();
+        if let Some(style) = series_filling_style(&plot_opts, i) {
+          s.fill_color = style.color;
+          s.fill_opacity = style.opacity;
+        }
+      }
+    }
+  }
 
   // Return -Graphics- as the text representation
   Ok(crate::graphics_result_with_source(svg, source))

--- a/src/functions/plot_epilog.rs
+++ b/src/functions/plot_epilog.rs
@@ -259,6 +259,14 @@ fn apply_directive(expr: &Expr, style: &mut EpilogStyle) -> bool {
         if let Some(o) = try_eval_to_f64(&args[0]) {
           style.opacity = o.clamp(0.0, 1.0);
         }
+        // `Opacity[a, color]` also sets the fill/stroke color, not just
+        // the alpha — the same two-argument form `FillingStyle` and a
+        // plain `Opacity[a, color]` graphics directive both accept.
+        if args.len() >= 2
+          && let Some(c) = parse_color(&args[1])
+        {
+          style.color = c;
+        }
       }
       "Thickness" if args.len() == 1 => match &args[0] {
         Expr::Identifier(s) => match s.as_str() {
@@ -311,6 +319,44 @@ fn apply_directive(expr: &Expr, style: &mut EpilogStyle) -> bool {
     _ => return false,
   }
   true
+}
+
+/// Map every data-space point in a primitive expression through an affine
+/// transform `p -> m.p + v`, leaving everything else (heads, strings,
+/// directives, non-point numeric args) untouched. A "point" is any 2-element
+/// list of two numbers, which is how a point shows up wherever a primitive
+/// takes one — `Line[{pt, pt, …}]`, `Polygon[{pt, …}]`, `Point[pt]`,
+/// `Text[label, pt]`, `Rectangle[pt, pt]` — so this single recursive walk
+/// covers every primitive `render_item` knows about without special-casing
+/// each one's argument shape.
+fn affine_map_points(expr: &Expr, m: [[f64; 2]; 2], v: (f64, f64)) -> Expr {
+  if let Expr::List(items) = expr
+    && items.len() == 2
+    && let (Some(x), Some(y)) =
+      (try_eval_to_f64(&items[0]), try_eval_to_f64(&items[1]))
+  {
+    return Expr::List(
+      vec![
+        Expr::Real(m[0][0] * x + m[0][1] * y + v.0),
+        Expr::Real(m[1][0] * x + m[1][1] * y + v.1),
+      ]
+      .into(),
+    );
+  }
+  match expr {
+    Expr::List(items) => {
+      Expr::List(items.iter().map(|it| affine_map_points(it, m, v)).collect())
+    }
+    Expr::FunctionCall { name, args } => Expr::FunctionCall {
+      name: name.clone(),
+      args: args
+        .iter()
+        .map(|a| affine_map_points(a, m, v))
+        .collect::<Vec<_>>()
+        .into(),
+    },
+    other => other.clone(),
+  }
 }
 
 /// Render one Epilog item (directive, primitive, or nested scoped list).
@@ -409,6 +455,23 @@ fn render_item(
             style.fill_attrs(),
             polyline_points(&pts, area),
           ));
+        }
+      }
+      // `GeometricTransformation[content, transform]` maps `content`
+      // through an affine transform before drawing it — a Demonstration
+      // reuses a plot's own curve or filled region this way (extracted via
+      // `First[Plot[…]]`) as a shape to shift, scale or reflect inside its
+      // own Prolog/Epilog. A list of transforms draws one mapped copy per
+      // entry, matching `Graphics[GeometricTransformation[…]]`.
+      "GeometricTransformation" if args.len() == 2 => {
+        let transforms =
+          crate::functions::graphics::parse_affine_transforms(&args[1]);
+        if transforms.is_empty() {
+          render_item(&args[0], style, area, out);
+        } else {
+          for (m, v) in transforms {
+            render_item(&affine_map_points(&args[0], m, v), style, area, out);
+          }
         }
       }
       "Text" if args.len() >= 2 => {

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -6810,8 +6810,9 @@ mod plot3d {
       ));
     }
 
-    // The `{i -> {{j}, style}}` form parses; the style itself is not
-    // rendered yet, but the between-series fill must still be drawn.
+    // The `{i -> {{j}, style}}` form parses, and the between-series fill
+    // is drawn in the given style (`Directive[Orange]`), not the series'
+    // own color.
     #[test]
     fn list_plot_filling_between_series_styled() {
       insta::assert_snapshot!(export_svg(
@@ -24432,5 +24433,102 @@ fn the_default_stroke_is_one_pixel_at_every_size() {
   assert!(
     relative.contains("stroke-width=\"10.00\""),
     "Thickness is a fraction of the width: {relative}"
+  );
+}
+
+/// Regression coverage for the combination of constructs a Wolfram
+/// Demonstrations "region transform" widget uses together: a `Manipulate`
+/// whose body is a `Module`/`Which` that picks an `AffineTransform` from the
+/// slider position, draws the transformed copy via `GeometricTransformation`
+/// inside `Prolog`, toggles an `Epilog` label from a `Checkbox`, and titles
+/// the plot with a `Row` mixing `Style` and a held `TraditionalForm`
+/// integral. Each piece has its own tests elsewhere; this locks in that they
+/// still cooperate when nested exactly this way.
+#[test]
+fn manipulate_module_which_affine_prolog_checkbox_and_traditional_plot_label() {
+  let body = "Module[{t, u, pause = 0.3, base, shifted}, \
+     Which[w <= 1, t = w; u = 0, w <= 1 + pause, t = 1; u = 0, True, t = 1; u = 1]; \
+     base = First[Plot[x^2, {x, 0, 1}, Filling -> {1 -> {0, Opacity[0.4, Red]}}]]; \
+     shifted = GeometricTransformation[base, \
+       AffineTransform[{{{1, 0}, {-u, 1}}, {-(u/2), u^2/4}}]]; \
+     Plot[x^2, {x, -1, 1}, \
+       Prolog -> {shifted}, \
+       Epilog -> If[labels, {Text[\"A\", {0.8, 0.3}]}, {}], \
+       PlotLabel -> Row[{Style[\"A\", Italic], \" = \", \
+         TraditionalForm[HoldForm[Integrate[x^2, {x, 0, 1}]]]}]]]";
+
+  // The Manipulate spec exposes exactly the slider and the checkbox, under
+  // their own variable names — `AutorunSequencing` is a display-only hint
+  // and must not be mistaken for a third control.
+  let manipulate_src = format!(
+    "Manipulate[{body}, {{{{w, 0, \"shift\"}}, 1.5, 0}}, \
+     {{{{labels, True, \"show labels\"}}, {{True, False}}, Checkbox}}, \
+     AutorunSequencing -> {{{{1, 5}}, {{2, 2}}}}]"
+  );
+  let expr = woxi::interpret_to_expr(&manipulate_src).unwrap();
+  let spec = woxi::functions::graphics::extract_manipulate_spec(&expr)
+    .expect("well-formed manipulate");
+  assert_eq!(spec.controls.len(), 2);
+  match &spec.controls[0] {
+    woxi::functions::graphics::ManipulateControl::Continuous {
+      name, ..
+    } => {
+      assert_eq!(name, "w");
+    }
+    other => panic!("expected a continuous control for w, got {other:?}"),
+  }
+  match &spec.controls[1] {
+    woxi::functions::graphics::ManipulateControl::Discrete {
+      name,
+      values,
+      ..
+    } => {
+      assert_eq!(name, "labels");
+      assert_eq!(values, &["True".to_string(), "False".to_string()]);
+    }
+    other => {
+      panic!("expected a discrete checkbox control for labels, got {other:?}")
+    }
+  }
+
+  // Re-evaluating the body under bound control values (what the frontend
+  // does on every slider/checkbox change) must still render a complete
+  // picture: the affine-shifted red-filled region, the toggled Epilog
+  // label, and the held integral in the plot title.
+  let render = |w: &str, labels: &str| {
+    let code = format!(
+      "Block[{{w = {w}, labels = {labels}}}, ExportString[{body}, \"SVG\"]]"
+    );
+    let svg = interpret(&code).unwrap();
+    assert!(
+      svg.starts_with("<svg"),
+      "expected SVG for w={w}, labels={labels}: {svg}"
+    );
+    svg
+  };
+
+  let with_label = render("1.2", "True");
+  assert!(
+    with_label.contains("fill=\"rgb(255,0,0)\""),
+    "the Filling->Opacity[.., Red] region should still tint red: {with_label}"
+  );
+  assert!(
+    // The Epilog's plain `Text["A", …]` draws as a bare `<text>A</text>`
+    // (unlike the italic "A" in `PlotLabel`, which is a `<tspan>` inside a
+    // larger `<text>` element) — check for that specific shape so this
+    // doesn't also match the "A" in "A = ∫…" up top.
+    with_label.contains(">A</text>"),
+    "Epilog should draw the \"A\" label when labels is True: {with_label}"
+  );
+  assert!(
+    with_label.contains("\u{222b}") && with_label.contains("\u{2146}"),
+    "PlotLabel should typeset the held integral (\u{222b} \u{2026} \u{2146}x), not raw \
+     TraditionalForm/HoldForm source: {with_label}"
+  );
+
+  let without_label = render("1.2", "False");
+  assert!(
+    !without_label.contains(">A</text>"),
+    "Epilog's \"A\" label must not draw when labels is False: {without_label}"
   );
 }

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_plot_filling_between_series_styled.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__list_plot__list_plot_filling_between_series_styled.snap
@@ -146,10 +146,10 @@ expression: "export_svg(\"ListPlot[{{1, 2, 3, 4}, {2, 3, 4, 5}}, Filling -> {1 -
 
 </text>
 <polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3227,1750 3227,1790 "/>
-<polyline fill="none" opacity="0.2" stroke="#5E81B5" stroke-width="10" points="851,1688 851,1307 "/>
-<polyline fill="none" opacity="0.2" stroke="#5E81B5" stroke-width="10" points="1700,1307 1700,925 "/>
-<polyline fill="none" opacity="0.2" stroke="#5E81B5" stroke-width="10" points="2548,925 2548,543 "/>
-<polyline fill="none" opacity="0.2" stroke="#5E81B5" stroke-width="10" points="3397,543 3397,162 "/>
+<polyline fill="none" opacity="0.2" stroke="#FF8000" stroke-width="10" points="851,1688 851,1307 "/>
+<polyline fill="none" opacity="0.2" stroke="#FF8000" stroke-width="10" points="1700,1307 1700,925 "/>
+<polyline fill="none" opacity="0.2" stroke="#FF8000" stroke-width="10" points="2548,925 2548,543 "/>
+<polyline fill="none" opacity="0.2" stroke="#FF8000" stroke-width="10" points="3397,543 3397,162 "/>
 <circle cx="851" cy="1688" r="30" opacity="1" fill="#5E81B5" stroke="none" stroke-width="1"/>
 <circle cx="1700" cy="1307" r="30" opacity="1" fill="#5E81B5" stroke="none" stroke-width="1"/>
 <circle cx="2548" cy="925" r="30" opacity="1" fill="#5E81B5" stroke="none" stroke-width="1"/>


### PR DESCRIPTION
## Summary

As part of a routine check of a random Wolfram Demonstration ("Area under a Parabola by Symmetries") against Woxi Studio, I found several related gaps in a common Demonstrations idiom: extracting a filled plot region via `First[Plot[...]]`, transforming it with `GeometricTransformation`, and drawing it in another plot's `Prolog`.

- `Plot[...]` silently ignored the `Prolog` option entirely — only `Epilog` was implemented. `Prolog` now draws under the curve the same way `Epilog` draws over it.
- `Filling -> {i -> spec, ...}` rules with a two-element spec whose first element was a plain integer (e.g. `{0, style}` or `{2, style}`) were misparsed as a curve-to-curve target instead of a level target. `{0, style}` in particular silently dropped the whole `Filling` option (0 isn't a valid 1-based series index).
- A rule's trailing style (e.g. `{0, Opacity[.4, Red]}` or `{{2}, Directive[Orange]}`) was parsed but discarded; it's now applied to the fill.
- `First[Plot[..., Filling -> ...]]` dropped the filled region entirely, since only the curve's `Line` primitive was reconstructed from the plot's stored source data. The fill is now baked in as an explicit `Polygon` primitive, matching Wolfram.
- `Opacity[a, color]` inside a plot's `Prolog`/`Epilog` only applied the alpha, ignoring the color argument.
- `GeometricTransformation` wasn't supported inside `Prolog`/`Epilog` at all.

Added a regression test covering the combination (`Manipulate` + `Module` + `Which` + Block-scoped controls, `Filling`, `AffineTransform` + `GeometricTransformation` in `Prolog`, a `Checkbox`-toggled `Epilog` label, and a `Row`/`Style`/`TraditionalForm`/`HoldForm` plot title) that this class of Demonstration exercises together. Also updated an existing snapshot (`list_plot_filling_between_series_styled`) whose fill color previously silently ignored its `Directive[Orange]` style.

## Test plan

- [x] `cargo test` — all 4 test binaries pass (27,842 tests total: 39 CLI doc tests, 24,984 unit tests, 1,251 misc tests, 575 script snapshot tests)
- [x] `make format`
- [x] Manually verified against the downloaded (not committed) Demonstration notebook via `woxi run` and `ExportString[..., "SVG"]`


---
_Generated by [Claude Code](https://claude.ai/code/session_016kt4WLhNE9GJzaYY2nPnER)_