### PR TITLE
Keep multiple SetterBar/control rows bound to one Manipulate variable in sync

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16862,6 +16862,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   }
   let arg_items: Vec<Expr> =
     arg_items.into_iter().map(unwrap_control_wrapper).collect();
+  let pane_governed_names = pane_or_tab_governed_names(&args[1..]);
   // A `ControlType -> …` given to the Manipulate itself sets the type of every
   // control that does not choose one; push it into the specs now that they are
   // flattened, so they parse through the single per-spec path below.
@@ -17160,11 +17161,22 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
           animation_running = running;
           animation_var = Some(c.name().to_string());
         }
-        // A second spec for an already-bound variable (Kepler pairs a time
-        // slider with a `Trigger` on the same `t`) must not bind twice —
-        // the first spec keeps the widget row, later duplicates only
-        // contribute their animation/enabled semantics above.
-        if !c.name().is_empty()
+        // A second spec for an already-bound variable merges into the
+        // earlier row — contributing only the animation/enabled semantics
+        // captured above — in the two cases Wolfram itself collapses: a
+        // `Trigger` pairing with an existing slider (Kepler's time slider
+        // plus a `Trigger` on the same `t`), and a variable declared inside
+        // a `PaneSelector`/`TabView` pane (only one pane is ever on screen,
+        // so a shared widget — or a per-pane variant of one, with its own
+        // bounds or choice list — still gets a single row; see
+        // `pane_or_tab_governed_names`). Two *different* ordinary specs
+        // sharing a variable outside any pane (e.g. a coarse and a fine
+        // SetterBar preset row for the same count, as in "Polypath
+        // Iterations") are a real Wolfram pattern instead: both stay
+        // visible, independently interactive, and read/write the same
+        // binding, so those get their own rows.
+        if (animate.is_some() || pane_governed_names.contains(c.name()))
+          && !c.name().is_empty()
           && controls.iter().any(|prev| prev.name() == c.name())
         {
           continue;
@@ -17972,6 +17984,54 @@ fn collect_pane_visibility(spec: &Expr, out: &mut Vec<(String, String)>) {
       }
     }
   }
+}
+
+/// The Manipulate variable names declared inside a `PaneSelector`/`TabView`
+/// pane or tab, anywhere among `args` (a Manipulate's control-spec
+/// arguments). Only one pane/tab is ever on screen at a time, so a
+/// duplicate spec for one of these names — the same widget shared across
+/// panes, or a per-pane variant of it (different bounds, different choice
+/// list) — must still collapse to a single row; see the merge check where
+/// this is used, alongside `collect_pane_visibility` which computes the
+/// same panes' *display* condition for the row that does get built.
+fn pane_or_tab_governed_names(
+  args: &[Expr],
+) -> std::collections::HashSet<String> {
+  fn walk(e: &Expr, out: &mut std::collections::HashSet<String>) {
+    match e {
+      Expr::FunctionCall { name, args } => {
+        if (name == "PaneSelector" || name == "TabView")
+          && let Some(Expr::List(panes)) = args.first()
+        {
+          for pane in panes {
+            if let Expr::Rule { replacement, .. }
+            | Expr::RuleDelayed { replacement, .. } = pane
+            {
+              out.extend(pane_control_variables(replacement));
+            }
+          }
+        }
+        for a in args {
+          walk(a, out);
+        }
+      }
+      // A `PaneSelector`/`TabView` may sit inside a `Row[{…}]`/`Column[{…}]`
+      // layout, whose single argument is itself a list of the grouped
+      // items — walk has to descend into that list too, not just a
+      // function call's own arguments, or a pane nested that way is missed.
+      Expr::List(items) => {
+        for it in items {
+          walk(it, out);
+        }
+      }
+      _ => {}
+    }
+  }
+  let mut out = std::collections::HashSet::new();
+  for a in args {
+    walk(a, &mut out);
+  }
+  out
 }
 
 /// The control variables a `PaneSelector` pane declares: the variable of

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -9757,6 +9757,138 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
   }
 
   #[test]
+  fn polypath_iterations_manipulate_folds_its_quadrilateral() {
+    // End-to-end regression for "Polypath Iterations": two draggable
+    // vertices seed a quadrilateral that gets iteratively reflected via
+    // complex-number `Conjugate`, `NestList` builds the fold history, and
+    // `Partition[…, 2, 1, {1, 1}]` turns each fold into a cyclic chain of
+    // segments colored by `ColorData`. The fold count is exposed through
+    // *two* SetterBars bound to the same variable — a coarse and a fine
+    // preset row sharing one `reps$$` — plus a `Button` that reassigns
+    // both locator-bound variables at once via list-destructuring.
+    let code = "Manipulate[\
+      Graphics[{\
+        MapIndexed[{ColorData[\"Rainbow\"][(#2[[1]] - 1)/(reps + \
+            $MachineEpsilon)], AbsoluteThickness[1.5], Line[#]} &, \
+          Partition[\
+            Map[{Re[#], Im[#]} &, \
+              NestList[{#[[2]], #[[3]], #[[4]], \
+                  Conjugate[(#[[1]] - #[[2]])/(#[[4]] - #[[2]])] (#[[4]] - \
+                      #[[2]]) + #[[2]]} &, \
+                {u1[[1]] + I u1[[2]], u2[[1]] + I u2[[2]], -u2[[1]] - \
+                    I u2[[2]], -u1[[1]] - I u1[[2]]}, reps]], \
+            2, 1, {1, 1}]], \
+        Directive[Opacity[If[showPts == 1, 1, 0], White]], \
+        AbsolutePointSize[6], \
+        Point[{u1, u2}]}, \
+        Background -> Black, ImagePadding -> 4, ImageSize -> {380, 380}, \
+        PlotRange -> range], \
+      {{showPts, 1, \"\"}, {0 -> \"hide\", 1 -> \"show\"}, \
+        ControlType -> SetterBar}, \
+      Button[\"randomize\", \
+        {u1, u2} = Table[{RandomReal[{-1, 1}], RandomReal[{-1, 1}]}, {2}]], \
+      Delimiter, \
+      {{u1, {-0.3, 0.9}}, {-1, -1}, {1, 1}, ControlType -> Locator}, \
+      {{u2, {0.6, 1}}, {-1, -1}, {1, 1}, ControlType -> Locator}, \
+      Style[\"fold count\", Bold], \
+      {{reps, 40, \"\"}, {0, 1, 2, 5, 10}, ControlType -> SetterBar}, \
+      {{reps, 40, \"\"}, {20, 40, 80}, ControlType -> SetterBar}, \
+      Delimiter, \
+      Style[\"plot range\", Bold], \
+      {{range, All, \"\"}, {All, 1, 5, 10}, ControlType -> SetterBar}\
+      ]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the polypath-iterations Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the initial render must draw the folded quadrilateral"
+    );
+
+    // Two locators, plus two independent SetterBar rows both bound to
+    // `reps` (a coarse preset row and a fine preset row sharing one
+    // variable) — dragging or clicking either must move the other.
+    let reps_rows: Vec<usize> = state
+      .controls
+      .iter()
+      .enumerate()
+      .filter(|(_, c)| c.name() == "reps")
+      .map(|(i, _)| i)
+      .collect();
+    assert_eq!(
+      reps_rows.len(),
+      2,
+      "expected two SetterBar rows sharing the `reps` variable, got {:?}",
+      state.controls
+    );
+
+    let locators: Vec<&str> = state
+      .controls
+      .iter()
+      .filter_map(|c| match c {
+        manipulate::ControlState::Slider2D { name, .. } => Some(name.as_str()),
+        _ => None,
+      })
+      .collect();
+    assert_eq!(locators, vec!["u1", "u2"]);
+
+    // Clicking a preset in the fine SetterBar must move the coarse one too.
+    let fine_idx = reps_rows[1];
+    if let manipulate::ControlState::Discrete { current_index, .. } =
+      &mut state.controls[fine_idx]
+    {
+      *current_index = 1; // picks "40"
+    }
+    state.apply_tracking(fine_idx);
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "re-render after picking a fold-count preset failed: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some());
+
+    // Dragging a locator re-folds the quadrilateral from its new corner.
+    let u1_idx = state
+      .controls
+      .iter()
+      .position(|c| c.name() == "u1")
+      .expect("a locator for u1");
+    if let manipulate::ControlState::Slider2D { x, y, .. } =
+      &mut state.controls[u1_idx]
+    {
+      *x = -0.7;
+      *y = 0.4;
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+
+    // The randomize Button reassigns both locator variables at once via
+    // list-destructuring; both must move together and the widget must
+    // still render afterwards.
+    let randomize = state
+      .controls
+      .iter()
+      .find_map(|c| match c {
+        manipulate::ControlState::Button { action, .. } => Some(action.clone()),
+        _ => None,
+      })
+      .expect("a randomize button");
+    state.apply_button_action(&randomize);
+    assert!(
+      state.error.is_none(),
+      "randomize button failed: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some());
+  }
+
+  #[test]
   fn constraint_tiling_manipulate_switches_net_and_solid() {
     // End-to-end regression for "Constraint Tiling on a Truncated
     // Icosahedron": a setter bar picks one of six constraint sets and a

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -468,13 +468,39 @@ impl ManipulateState {
     self.reevaluate();
   }
 
+  /// Copy the control at `ctrl_idx`'s just-changed value into every other
+  /// control sharing its variable name. Wolfram lets more than one widget
+  /// row bind the same Manipulate variable — e.g. a coarse and a fine
+  /// `SetterBar` preset row for one count, as in "Polypath Iterations" —
+  /// and moving either must move the other, since both are just different
+  /// views onto the same underlying value.
+  fn sync_named_siblings(&mut self, ctrl_idx: usize) {
+    let Some(control) = self.controls.get(ctrl_idx) else {
+      return;
+    };
+    let name = control.name().to_string();
+    if name.is_empty() {
+      return;
+    }
+    let code = control.current_code();
+    for (i, ctrl) in self.controls.iter_mut().enumerate() {
+      if i != ctrl_idx && ctrl.name() == name {
+        ctrl.set_current_from_code(&code);
+      }
+    }
+  }
+
   /// Run the control at `ctrl_idx`'s `TrackingFunction -> f` (if it has
   /// one) against its *new* current value, folding back whatever `f`
   /// assigns (e.g. a companion control it resets) into state/controls.
   /// Called right after a control's value is updated, before the caller
   /// requests a re-evaluation, so the tracking function's writes are
-  /// already part of the binding set the re-render uses.
+  /// already part of the binding set the re-render uses. Also keeps any
+  /// sibling row bound to the same variable in sync (see
+  /// `sync_named_siblings`), regardless of whether a tracking function
+  /// is present.
   pub fn apply_tracking(&mut self, ctrl_idx: usize) {
+    self.sync_named_siblings(ctrl_idx);
     let Some(control) = self.controls.get(ctrl_idx) else {
       return;
     };
@@ -797,10 +823,12 @@ impl ManipulateState {
         slot.1 = value;
         continue;
       }
+      // Every row bound to this name (a body may reassign a variable that
+      // has more than one widget row, e.g. a shared SetterBar pair) moves
+      // together — not just the first.
       for ctrl in &mut self.controls {
         if ctrl.name() == name {
           ctrl.set_current_from_code(&value);
-          break;
         }
       }
     }


### PR DESCRIPTION
## Summary

While checking Woxi Studio's support for a real Wolfram Demonstration ("Polypath Iterations" — an interactive folded-quadrilateral geometry demo built on `Manipulate`), I found that a common Wolfram Demonstrations idiom wasn't fully supported: offering **two separate control rows bound to the same Manipulate variable**, e.g. a coarse and a fine `SetterBar` preset row for one fold-count variable.

Woxi Studio's `extract_manipulate_spec` collapsed *any* second control spec for an already-bound variable name into the first — silently dropping the second row. That collapsing behavior was only actually correct for two specific Wolfram-defined cases:
- A `Trigger` pairing with an existing slider on the same variable (the Kepler's-second-law pattern), where the Trigger only borrows the existing row's animation.
- A variable declared inside more than one `PaneSelector`/`TabView` pane (only one pane is ever shown at a time, so a shared widget — or a per-pane variant of it — collapses to one row).

Two *different*, ordinary control specs sharing a variable **outside** any pane (like Polypath's two SetterBars) are a real Wolfram pattern too, and Wolfram keeps both as independent, interactive, synced rows.

## Changes

- `src/functions/graphics.rs`: only merge a duplicate-name spec into the earlier row when it's a `Trigger` animation pairing or when the variable is `pane_or_tab_governed` (declared inside a `PaneSelector`/`TabView` pane); otherwise both specs get their own control row.
- `woxi-studio/src/manipulate.rs`:
  - Added `sync_named_siblings`, called on every interactive control change, so moving one row bound to a shared variable immediately moves any sibling row bound to the same variable.
  - Fixed a body-write-back loop that stopped syncing at the *first* control row matching a name (dropped a stray `break`), so a body-driven reassignment of a shared variable now updates every row bound to it, not just one.
- Added a regression test (`polypath_iterations_manipulate_folds_its_quadrilateral`) exercising a from-scratch, non-verbatim reimplementation of the Demonstration's control pattern: two Locators, a `Button` doing a list-destructuring reassignment of both locator variables, and two SetterBars sharing one fold-count variable.
- Fixed a `PaneSelector` nested inside a `Row[...]`/`Column[...]` layout not being detected by the new pane-membership check (the walk didn't recurse into `Expr::List`), which the existing `spec_pane_selector_grouped_controls_flatten` test caught.

## Test plan

- [x] `cargo test --workspace` — all 25,000+ interpreter tests and all 134 `woxi-studio` tests pass (including the new regression test and all pre-existing `PaneSelector`/`Trigger` dedup tests).
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012e3QTFKMaRuzXuJ9tYEo8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_012e3QTFKMaRuzXuJ9tYEo8Y)_