### PR TITLE
Fix two multivariate solver bugs found auditing Woxi Studio notebook support

### DIFF
--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -5536,6 +5536,27 @@ pub fn find_root_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     return find_root_multivariate(&args[0], specs);
   }
 
+  // Multivariate form: FindRoot[{eqns}, {x, x0}, {y, y0}, ...] — the
+  // documented form (used throughout Wolfram's own examples) where each
+  // variable spec is its own trailing argument instead of being wrapped in
+  // one outer list. Collect every leading trailing argument that looks like
+  // a {var, start} pair; two or more means this is the multivariate form
+  // rather than the single-variable {var, x0} / {var, x0, x1} form handled
+  // below.
+  if args.len() >= 3 {
+    let candidate_specs: Vec<Expr> = args[1..]
+      .iter()
+      .take_while(|s| {
+        matches!(s, Expr::List(p)
+        if p.len() == 2 && matches!(&p[0], Expr::Identifier(_)))
+      })
+      .cloned()
+      .collect();
+    if candidate_specs.len() >= 2 {
+      return find_root_multivariate(&args[0], &candidate_specs);
+    }
+  }
+
   // Parse the options we honour: Method -> "Secant" picks the secant iteration,
   // and MaxIterations caps the number of steps. The rest are accepted and
   // ignored (see the note on AccuracyGoal/PrecisionGoal below).
@@ -10071,6 +10092,19 @@ fn solve_linear_symbolic(eqs: &[Expr], var_names: &[String]) -> Option<Expr> {
       let mut valid = true;
       for (j, var) in var_names.iter().enumerate() {
         let (power, coeff) = term_var_power_and_coeff(term, var);
+        // A factor this function cannot decompose (e.g. the `1/(1+z)` inside
+        // `z/(1+z)`) reports itself back as a "coefficient" that still
+        // contains `var` — its (-1)-power sentinel, meant to signal
+        // "unrecognised structure", is indistinguishable from a genuine
+        // negative power once it has combined multiplicatively with a real
+        // `var^1` factor elsewhere in the same term (1 + -1 = 0, disguising a
+        // rational term as a constant one). Requiring the reported
+        // coefficient to actually be free of `var` catches that collision
+        // for both the constant (power 0) and linear (power 1) cases.
+        if (power == 0 || power == 1) && !is_constant_wrt(&coeff, var) {
+          valid = false;
+          break;
+        }
         if power == 1 {
           if found_var.is_some() {
             valid = false; // product of two variables → nonlinear

--- a/tests/interpreter_tests/algebra.rs
+++ b/tests/interpreter_tests/algebra.rs
@@ -7483,6 +7483,35 @@ mod nsolve {
     );
   }
 
+  // A rational equation (one side divided by an expression that contains
+  // the variable) inside a multi-variable system must not be mistaken for
+  // a constant. The variable-power/coefficient extractor reports a factor
+  // it cannot decompose, like `(1 + z)^-1`, with a sentinel power of -1;
+  // multiplying that by a genuine `z^1` factor elsewhere in the same term
+  // summed the powers to 0 (1 + -1) and disguised the still-z-dependent
+  // `(1 + z)^-1` as a constant coefficient. The symbolic linear solver then
+  // built a bogus augmented matrix and reported the (solvable) system as
+  // inconsistent instead of falling back to the general solver.
+  #[test]
+  fn solve_system_with_rational_equation() {
+    assert_eq!(
+      interpret("Solve[{z/(1 + z) == 1/2, y == 3}, {z, y}]").unwrap(),
+      "{{z -> 1, y -> 3}}"
+    );
+    assert_eq!(
+      interpret("NSolve[{z/(1 + z) == 0.5, y == 3}, {z, y}]").unwrap(),
+      "{{z -> 1., y -> 3.}}"
+    );
+    // The same collision can chain across more than two variables.
+    assert_eq!(
+      interpret(
+        "NSolve[{z/(1 + z) == 0.5, y == z + 1, w == y + 1}, {z, y, w}]"
+      )
+      .unwrap(),
+      "{{z -> 1., y -> 2., w -> 3.}}"
+    );
+  }
+
   // A polynomial with no radical solution falls back to numeric roots, which
   // previously arrived unfiltered — the Reals domain must still drop the
   // complex roots. Verified against wolframscript.
@@ -8065,6 +8094,27 @@ mod find_root {
       )
       .unwrap(),
       "{s -> 1.618033988749895, t -> 0.6180339887498949}"
+    );
+  }
+
+  // Regression: the documented multivariate calling convention —
+  // `FindRoot[{eqns}, {x, x0}, {y, y0}, ...]`, each variable spec its own
+  // trailing argument — was not recognised as multivariate at all. Only the
+  // single-list form `{{x, x0}, {y, y0}}` was detected, so this call fell
+  // through to the single-variable path, which built a "function" out of
+  // the whole two-equation list and failed with FindRoot::nlnum ("not a
+  // number") on evaluating it.
+  #[test]
+  fn multivariate_separate_trailing_specs() {
+    assert_eq!(
+      interpret("FindRoot[{x + y == 3, x - y == 1}, {x, 0}, {y, 0}]").unwrap(),
+      "{x -> 2., y -> 1.}"
+    );
+    // Must agree with the equivalent single-list form.
+    assert_eq!(
+      interpret("FindRoot[{x + y == 3, x - y == 1}, {x, 0}, {y, 0}]").unwrap(),
+      interpret("FindRoot[{x + y == 3, x - y == 1}, {{x, 0}, {y, 0}}]")
+        .unwrap()
     );
   }
 


### PR DESCRIPTION
## Summary

While auditing whether Woxi Studio fully supports a randomly selected Wolfram Demonstrations notebook, its `Manipulate` body's downstream computation (unit conversion via a coupled nonlinear system, then a nested `FindRoot`) failed with cascading errors. Root-caused to two independent bugs in the multivariate numeric solvers:

- **`Solve`/`NSolve`**: a rational equation (one side divided by an expression containing the variable) inside a multi-variable system was mistaken for a constant. `term_var_power_and_coeff`'s "can't decompose this" sentinel (power `-1`) is indistinguishable from a genuine negative power once it combines multiplicatively with a real `var^1` factor elsewhere in the same term (`1 + -1 == 0`), disguising a still-variable-dependent factor as a constant coefficient. `solve_linear_symbolic` then built a bogus augmented matrix and reported perfectly solvable systems as inconsistent (`{}`).
- **`FindRoot`**: the documented multivariate calling convention `FindRoot[{eqns}, {x, x0}, {y, y0}, ...]` (each variable spec its own trailing argument, as used throughout Wolfram's own examples) was never recognised as multivariate — only the single `{{x, x0}, {y, y0}}` list form was. Calls using the standard form silently fell through to the single-variable path and failed with `FindRoot::nlnum`.

Both bugs are fixed with minimal, targeted checks (no new abstractions), and neither construct is implemented twice elsewhere. Woxi Studio now evaluates the notebook's interactive widget without any error messages.

## Test plan

- [x] Added regression tests for both fixes in `tests/interpreter_tests/algebra.rs` (`solve_system_with_rational_equation`, `multivariate_separate_trailing_specs`)
- [x] Full unit suite (`cargo nextest run`, 27082 tests) passes
- [x] `make format`
- [x] Manually re-verified against the triggering Demonstration notebook via Woxi Studio's `dump_manipulate` diagnostic — no more error messages, widget builds and renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQF9dbt1EfM6Arxs9BTmCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQF9dbt1EfM6Arxs9BTmCV)_