### PR TITLE
Add TracePrint function and fix Hold attribute handling in tracing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,8 @@
 # Unreleased
 
 - `TracePrint[expr]` prints every sub-expression used while evaluating `expr`,
-    indented by one space per level of the evaluation, and returns the result.
+    wrapped in `HoldCompleteForm` and indented by one space per level of the
+    evaluation, and returns the result.
     `TracePrint[expr, form]` restricts the printing to sub-expressions matching
     `form`. Tracing now also respects `Hold` attributes, so
     `TracePrint[x = x + 1]` no longer evaluates the assignment target —

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@
 
 # Unreleased
 
+- `TracePrint[expr]` prints every sub-expression used while evaluating `expr`,
+    indented by one space per level of the evaluation, and returns the result.
+    `TracePrint[expr, form]` restricts the printing to sub-expressions matching
+    `form`. Tracing now also respects `Hold` attributes, so
+    `TracePrint[x = x + 1]` no longer evaluates the assignment target —
+    the same fix applies to `TraceScan`, which additionally used to print the
+    rebuilt step of a list in `List[…]` instead of `{…}` form.
 - Upvalues on `Plus`, `Times` and `Power` also fire for the arithmetic
     shorthands that expand to those heads. `-a` is `Times[-1, a]`, `a - b` is
     `Plus[a, Times[-1, b]]` and `a / b` is `Times[a, Power[b, -1]]`, so with

--- a/functions.csv
+++ b/functions.csv
@@ -2014,7 +2014,7 @@ UnitSimplify,Simplify physical units (unit system),🚫,,9.0,2020
 AirTemperatureData,,🚫,,10.0,2024
 ListVectorPlot,Vector field plot from list data (plotting),🚫,,7.0,2024
 OrderDistribution,Order statistics distribution (complex statistics),🚫,,8.0,2024
-TracePrint,Print evaluation trace (debugging/tracing),🚫,,2.0,2025
+TracePrint,Print all sub-expressions used during an evaluation indented by depth,✅,effectful,2.0,2025
 Circumsphere,Circumsphere of a simplex (computational geometry),✅,pure,10.0,2026
 AnyTrue,Checks if any element in a list is true,✅,pure,10.0,2031
 Convergents,List of convergents of a continued fraction representation,✅,none,6.0,2031

--- a/src/evaluator/attributes.rs
+++ b/src/evaluator/attributes.rs
@@ -556,7 +556,7 @@ pub fn get_builtin_attributes(name: &str) -> Vec<&'static str> {
     // HoldAll + Protected
     "Hold" | "HoldForm" | "HoldPattern" | "Table" | "Do" | "While" | "For"
     | "Module" | "DynamicModule" | "Block" | "With" | "Assuming" | "Trace"
-    | "TraceScan"
+    | "TraceScan" | "TracePrint"
     | "Defer" | "Compile" | "CompiledFunction" | "Which"
     | "Clear" | "ClearAll" | "Condition" | "Off" | "On"
     | "TimeConstrained" | "MemoryConstrained" | "TagUnset" | "NProduct"

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -207,6 +207,23 @@ pub(crate) fn head_holds_arguments(expr: &Expr) -> bool {
     .any(|attr| has_hold_attribute(name, attr))
 }
 
+/// Whether `name` holds the argument at the 0-based position `index`.
+/// Mirrors the Hold-attribute logic of `evaluate_args_with_hold`, including
+/// its `Association` exception, for callers that walk arguments themselves
+/// (the tracing functions).
+pub(crate) fn holds_argument_at(name: &str, index: usize) -> bool {
+  if has_hold_attribute(name, "HoldAll")
+    || (name != "Association" && has_hold_attribute(name, "HoldAllComplete"))
+  {
+    return true;
+  }
+  if index == 0 {
+    has_hold_attribute(name, "HoldFirst")
+  } else {
+    has_hold_attribute(name, "HoldRest")
+  }
+}
+
 /// Evaluate function arguments respecting Hold attributes.
 /// Returns the evaluated (or held) arguments based on the function's attributes.
 /// Held arguments still honour `Evaluate[expr]`: it forces evaluation of the
@@ -2326,6 +2343,10 @@ pub fn evaluate_expr_to_expr_inner(
         // Special handling for TraceScan - traces evaluation of sub-expressions
         if name == "TraceScan" && args.len() >= 2 && args.len() <= 3 {
           return crate::functions::control_flow_ast::trace_scan_ast(args);
+        }
+        // Special handling for TracePrint - prints the evaluation trace
+        if name == "TracePrint" && !args.is_empty() && args.len() <= 2 {
+          return crate::functions::control_flow_ast::trace_print_ast(args);
         }
         // Special handling for Table, Do, With - don't evaluate args (body needs iteration/bindings)
         // These functions take unevaluated expressions as first argument

--- a/src/functions/control_flow_ast.rs
+++ b/src/functions/control_flow_ast.rs
@@ -382,8 +382,8 @@ fn hold_form(expr: &Expr) -> Expr {
 enum TraceSink<'a> {
   /// TraceScan[f, …] — apply `f` to the HoldForm-wrapped sub-expression.
   Apply(&'a Expr),
-  /// TracePrint[…] — print the sub-expression, indented by its depth in the
-  /// evaluation, matching the nesting `Trace` would produce.
+  /// TracePrint[…] — print the sub-expression wrapped in HoldCompleteForm,
+  /// indented by its depth in the evaluation (the nesting `Trace` produces).
   Print,
 }
 
@@ -401,10 +401,13 @@ fn do_trace(
       apply_function_to_arg(f, &wrapped)?;
     }
     TraceSink::Print => {
+      // Each step is printed wrapped in HoldCompleteForm, the same way
+      // TraceScan's steps reach the scanning function wrapped in HoldForm.
+      let wrapped = call1("HoldCompleteForm", expr.clone());
       let line = format!(
         "{}{}",
         " ".repeat(depth),
-        crate::syntax::expr_to_output(expr)
+        crate::syntax::expr_to_output(&wrapped)
       );
       if !crate::is_quiet_print() {
         println!("{line}");

--- a/src/functions/control_flow_ast.rs
+++ b/src/functions/control_flow_ast.rs
@@ -378,62 +378,107 @@ fn hold_form(expr: &Expr) -> Expr {
   call1("HoldForm", expr.clone())
 }
 
-/// Call the trace function on an expression, unconditionally.
-fn do_trace(expr: &Expr, f: &Expr) -> Result<(), InterpreterError> {
-  let wrapped = hold_form(expr);
-  apply_function_to_arg(f, &wrapped)?;
+/// What to do with each sub-expression a trace visits.
+enum TraceSink<'a> {
+  /// TraceScan[f, …] — apply `f` to the HoldForm-wrapped sub-expression.
+  Apply(&'a Expr),
+  /// TracePrint[…] — print the sub-expression, indented by its depth in the
+  /// evaluation, matching the nesting `Trace` would produce.
+  Print,
+}
+
+/// Deliver an expression to the trace sink, unconditionally.
+/// `depth` is the expression's nesting level in the evaluation (1 for the
+/// traced expression itself) and is only used for TracePrint's indentation.
+fn do_trace(
+  expr: &Expr,
+  sink: &TraceSink,
+  depth: usize,
+) -> Result<(), InterpreterError> {
+  match sink {
+    TraceSink::Apply(f) => {
+      let wrapped = hold_form(expr);
+      apply_function_to_arg(f, &wrapped)?;
+    }
+    TraceSink::Print => {
+      let line = format!(
+        "{}{}",
+        " ".repeat(depth),
+        crate::syntax::expr_to_output(expr)
+      );
+      if !crate::is_quiet_print() {
+        println!("{line}");
+      }
+      crate::capture_stdout(&line);
+    }
+  }
   Ok(())
 }
 
-/// Call the trace function on an expression if it matches the form filter.
+/// Deliver an expression to the trace sink if it matches the form filter.
 /// Returns true if the expression was traced.
 fn maybe_trace(
   expr: &Expr,
-  f: &Expr,
+  sink: &TraceSink,
   form: Option<&Expr>,
+  depth: usize,
 ) -> Result<bool, InterpreterError> {
   if let Some(form_pat) = form
     && crate::evaluator::match_pattern(expr, form_pat).is_none()
   {
     return Ok(false);
   }
-  do_trace(expr, f)?;
+  do_trace(expr, sink, depth)?;
   Ok(true)
 }
 
-/// Rebuild an expression from a head name and children as a FunctionCall.
+/// Rebuild an expression from a head name and its evaluated children.
+/// Uses the canonical `Expr` variant for the head so the rebuilt step prints
+/// like the original (`{2, 4}`, not `List[2, 4]`).
 fn rebuild_from_head(head: &str, children: &[Expr]) -> Expr {
-  unevaluated(head, children)
+  crate::functions::expr_form::compose_expr(head, children)
 }
 
-/// Recursively trace-evaluate an expression, calling f on each sub-expression.
+/// Recursively trace-evaluate an expression, handing every sub-expression to
+/// `sink`. `depth` is the nesting level of `expr` in the evaluation; the head
+/// and the arguments sit one level deeper, while the rebuilt expression and
+/// the result stay at the same level (mirroring the list nesting of `Trace`).
 fn trace_eval(
   expr: &Expr,
-  f: &Expr,
+  sink: &TraceSink,
   form: Option<&Expr>,
+  depth: usize,
 ) -> Result<Expr, InterpreterError> {
   // Trace the input expression
-  maybe_trace(expr, f, form)?;
+  maybe_trace(expr, sink, form, depth)?;
 
   match decompose_expr(expr) {
     ExprForm::Atom(_) => {
       // Atoms evaluate to themselves (or to their value)
       let result = evaluate_expr_to_expr(expr)?;
       if expr_to_string(&result) != expr_to_string(expr) {
-        maybe_trace(&result, f, form)?;
+        maybe_trace(&result, sink, form, depth)?;
       }
       Ok(result)
     }
     ExprForm::Composite { head, children } => {
       // Trace the head; remember if it matched the form
       let head_expr = Expr::Identifier(head.clone());
-      let head_matched = maybe_trace(&head_expr, f, form)?;
+      let head_matched = maybe_trace(&head_expr, sink, form, depth + 1)?;
 
-      // Recursively trace-evaluate each child
+      // Recursively trace-evaluate each child. Arguments the head holds are
+      // reported but left untouched — evaluating them here would defeat the
+      // Hold attribute (`TracePrint[x = x + 1]` must not turn the assignment
+      // target into `0 = 1`).
       let mut evaluated_children = Vec::new();
       let mut children_changed = false;
-      for child in &children {
-        let eval_child = trace_eval(child, f, form)?;
+      for (index, child) in children.iter().enumerate() {
+        let eval_child = if crate::evaluator::holds_argument_at(&head, index) {
+          maybe_trace(child, sink, form, depth + 1)?;
+          child.clone()
+        } else {
+          trace_eval(child, sink, form, depth + 1)?
+        };
         if expr_to_string(&eval_child) != expr_to_string(child) {
           children_changed = true;
         }
@@ -445,9 +490,9 @@ fn trace_eval(
       if children_changed {
         // When head matched, always trace rebuilt; otherwise check form
         if head_matched {
-          do_trace(&rebuilt, f)?;
+          do_trace(&rebuilt, sink, depth)?;
         } else {
-          maybe_trace(&rebuilt, f, form)?;
+          maybe_trace(&rebuilt, sink, form, depth)?;
         }
       }
 
@@ -458,9 +503,9 @@ fn trace_eval(
       if result_str != rebuilt_str {
         // When head matched, always trace result; otherwise check form
         if head_matched {
-          do_trace(&result, f)?;
+          do_trace(&result, sink, depth)?;
         } else {
-          maybe_trace(&result, f, form)?;
+          maybe_trace(&result, sink, form, depth)?;
         }
       }
 
@@ -482,5 +527,16 @@ pub fn trace_scan_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     None
   };
 
-  trace_eval(expr, &f, form)
+  trace_eval(expr, &TraceSink::Apply(&f), form, 1)
+}
+
+/// TracePrint[expr] — print every sub-expression used while evaluating expr,
+/// indented by one space per level of the evaluation.
+/// TracePrint[expr, form] — print only sub-expressions matching form.
+/// Returns the evaluated result of expr.
+pub fn trace_print_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  let expr = &args[0];
+  let form = args.get(1);
+
+  trace_eval(expr, &TraceSink::Print, form, 1)
 }

--- a/src/functions/expr_form.rs
+++ b/src/functions/expr_form.rs
@@ -414,6 +414,73 @@ pub fn decompose_expr(expr: &Expr) -> ExprForm {
   }
 }
 
+/// Rebuild an expression from the `head` / `children` pair that
+/// `decompose_expr` produces, restoring the dedicated `Expr` variant whenever
+/// one exists.
+///
+/// `Expr::FunctionCall` is the generic fallback, but it is not always
+/// interchangeable with the dedicated variant: `FunctionCall { name: "List" }`
+/// renders as `List[1, 2]` while `Expr::List` renders as `{1, 2}`. Rebuilding
+/// through this function keeps a recomposed expression printing exactly like
+/// the original one.
+///
+/// Associative arithmetic (`Plus`, `Times`, `Power`, …) is deliberately left
+/// as a `FunctionCall`: `decompose_expr` flattens those, so there is no unique
+/// binary tree to restore, and the flat form already renders in operator
+/// notation (`Plus[8, 5]` → `8 + 5`).
+pub fn compose_expr(head: &str, children: &[Expr]) -> Expr {
+  let two = |f: fn(Box<Expr>, Box<Expr>) -> Expr| {
+    f(Box::new(children[0].clone()), Box::new(children[1].clone()))
+  };
+  let comparison = |op: ComparisonOp| Expr::Comparison {
+    operands: children.to_vec(),
+    operators: vec![op; children.len() - 1],
+  };
+
+  match (head, children.len()) {
+    ("List", _) => Expr::List(children.to_vec().into()),
+    ("CompoundExpression", _) => Expr::CompoundExpr(children.to_vec()),
+    ("Rule", 2) => two(|pattern, replacement| Expr::Rule {
+      pattern,
+      replacement,
+    }),
+    ("RuleDelayed", 2) => two(|pattern, replacement| Expr::RuleDelayed {
+      pattern,
+      replacement,
+    }),
+    ("ReplaceAll", 2) => two(|expr, rules| Expr::ReplaceAll { expr, rules }),
+    ("ReplaceRepeated", 2) => {
+      two(|expr, rules| Expr::ReplaceRepeated { expr, rules })
+    }
+    ("Map", 2) => two(|func, list| Expr::Map { func, list }),
+    ("Apply", 2) => two(|func, list| Expr::Apply { func, list }),
+    ("MapApply", 2) => two(|func, list| Expr::MapApply { func, list }),
+    ("Not", 1) => Expr::UnaryOp {
+      op: UnaryOperator::Not,
+      operand: Box::new(children[0].clone()),
+    },
+    // Part[expr, i, j, …] re-nests into expr[[i]][[j]]…, the shape
+    // `flatten_part` collapsed.
+    ("Part", n) if n >= 2 => {
+      children[1..]
+        .iter()
+        .fold(children[0].clone(), |base, index| Expr::Part {
+          expr: Box::new(base),
+          index: Box::new(index.clone()),
+        })
+    }
+    ("Equal", n) if n >= 2 => comparison(ComparisonOp::Equal),
+    ("Unequal", n) if n >= 2 => comparison(ComparisonOp::NotEqual),
+    ("Less", n) if n >= 2 => comparison(ComparisonOp::Less),
+    ("LessEqual", n) if n >= 2 => comparison(ComparisonOp::LessEqual),
+    ("Greater", n) if n >= 2 => comparison(ComparisonOp::Greater),
+    ("GreaterEqual", n) if n >= 2 => comparison(ComparisonOp::GreaterEqual),
+    ("SameQ", n) if n >= 2 => comparison(ComparisonOp::SameQ),
+    ("UnsameQ", n) if n >= 2 => comparison(ComparisonOp::UnsameQ),
+    _ => unevaluated(head, children),
+  }
+}
+
 /// Helper: render a rational (num, denom) pair in FullForm notation.
 fn render_rational_full_form(numer: i128, denom: i128) -> String {
   // Reduce to lowest terms

--- a/tests/SUMMARY.md
+++ b/tests/SUMMARY.md
@@ -1256,6 +1256,7 @@
     - [`TagSetDelayed`](expressions/TagSetDelayed.md)
     - [`TensorDimensions`](expressions/TensorDimensions.md)
     - [`Trace`](expressions/Trace.md)
+    - [`TracePrint`](expressions/TracePrint.md)
     - [`Undefined`](expressions/Undefined.md)
     - [`UnderoverscriptBox`](expressions/UnderoverscriptBox.md)
     - [`UnderscriptBox`](expressions/UnderscriptBox.md)

--- a/tests/cli/expressions.md
+++ b/tests/cli/expressions.md
@@ -124,6 +124,7 @@ Output is always in [FullForm].
 - [`SuperscriptBox`](expressions/SuperscriptBox.md)
 - [`TagBox`](expressions/TagBox.md)
 - [`Trace`](expressions/Trace.md)
+- [`TracePrint`](expressions/TracePrint.md)
 - [`Undefined`](expressions/Undefined.md)
 - [`UnderoverscriptBox`](expressions/UnderoverscriptBox.md)
 - [`UnderscriptBox`](expressions/UnderscriptBox.md)

--- a/tests/cli/expressions/TracePrint.md
+++ b/tests/cli/expressions/TracePrint.md
@@ -1,0 +1,44 @@
+# `TracePrint`
+
+Print every sub-expression used while evaluating an expression and
+return the result of the evaluation.
+Each line is indented by one space per level of the evaluation,
+so nested computations are visibly deeper than their enclosing ones.
+
+```scrut
+$ wo 'TracePrint[2 + 3]'
+ 2 + 3
+  Plus
+  2
+  3
+ 5
+5
+```
+
+```scrut
+$ wo 'TracePrint[2^3 + 5]'
+ 2^3 + 5
+  Plus
+  2^3
+   Power
+   2
+   3
+  8
+  5
+ 8 + 5
+ 13
+13
+```
+
+A second argument restricts the printing to sub-expressions
+matching the given pattern:
+
+```scrut
+$ wo 'TracePrint[2^3 + 5, _Integer]'
+   2
+   3
+  8
+  5
+ 13
+13
+```

--- a/tests/cli/expressions/TracePrint.md
+++ b/tests/cli/expressions/TracePrint.md
@@ -2,31 +2,32 @@
 
 Print every sub-expression used while evaluating an expression and
 return the result of the evaluation.
-Each line is indented by one space per level of the evaluation,
+Each step is wrapped in `HoldCompleteForm` and indented
+by one space per level of the evaluation,
 so nested computations are visibly deeper than their enclosing ones.
 
 ```scrut
 $ wo 'TracePrint[2 + 3]'
- 2 + 3
-  Plus
-  2
-  3
- 5
+ HoldCompleteForm[2 + 3]
+  HoldCompleteForm[Plus]
+  HoldCompleteForm[2]
+  HoldCompleteForm[3]
+ HoldCompleteForm[5]
 5
 ```
 
 ```scrut
 $ wo 'TracePrint[2^3 + 5]'
- 2^3 + 5
-  Plus
-  2^3
-   Power
-   2
-   3
-  8
-  5
- 8 + 5
- 13
+ HoldCompleteForm[2^3 + 5]
+  HoldCompleteForm[Plus]
+  HoldCompleteForm[2^3]
+   HoldCompleteForm[Power]
+   HoldCompleteForm[2]
+   HoldCompleteForm[3]
+  HoldCompleteForm[8]
+  HoldCompleteForm[5]
+ HoldCompleteForm[8 + 5]
+ HoldCompleteForm[13]
 13
 ```
 
@@ -35,10 +36,10 @@ matching the given pattern:
 
 ```scrut
 $ wo 'TracePrint[2^3 + 5, _Integer]'
-   2
-   3
-  8
-  5
- 13
+   HoldCompleteForm[2]
+   HoldCompleteForm[3]
+  HoldCompleteForm[8]
+  HoldCompleteForm[5]
+ HoldCompleteForm[13]
 13
 ```

--- a/tests/interpreter_tests/control_flow.rs
+++ b/tests/interpreter_tests/control_flow.rs
@@ -2480,9 +2480,15 @@ mod trace_print {
     clear_state();
     let result = woxi::interpret_with_stdout("TracePrint[2 + 3]").unwrap();
     assert_eq!(result.result, "5");
-    // Every sub-expression is printed, indented by one space per level of
-    // the evaluation, matching `wolframscript -code 'TracePrint[2 + 3]'`.
-    assert_eq!(result.stdout, " 2 + 3\n  Plus\n  2\n  3\n 5\n");
+    // Every sub-expression is printed wrapped in HoldCompleteForm and
+    // indented by one space per level of the evaluation, matching
+    // `wolframscript -code 'TracePrint[2 + 3]'`.
+    assert_eq!(
+      result.stdout,
+      " HoldCompleteForm[2 + 3]\n  HoldCompleteForm[Plus]\n  \
+       HoldCompleteForm[2]\n  HoldCompleteForm[3]\n \
+       HoldCompleteForm[5]\n"
+    );
   }
 
   #[test]
@@ -2493,7 +2499,11 @@ mod trace_print {
     assert_eq!(result.result, "13");
     assert_eq!(
       result.stdout,
-      " 2^3 + 5\n  Plus\n  2^3\n   Power\n   2\n   3\n  8\n  5\n 8 + 5\n 13\n"
+      " HoldCompleteForm[2^3 + 5]\n  HoldCompleteForm[Plus]\n  \
+       HoldCompleteForm[2^3]\n   HoldCompleteForm[Power]\n   \
+       HoldCompleteForm[2]\n   HoldCompleteForm[3]\n  \
+       HoldCompleteForm[8]\n  HoldCompleteForm[5]\n \
+       HoldCompleteForm[8 + 5]\n HoldCompleteForm[13]\n"
     );
   }
 
@@ -2502,7 +2512,7 @@ mod trace_print {
     clear_state();
     let result = woxi::interpret_with_stdout("TracePrint[3]").unwrap();
     assert_eq!(result.result, "3");
-    assert_eq!(result.stdout, " 3\n");
+    assert_eq!(result.stdout, " HoldCompleteForm[3]\n");
   }
 
   #[test]
@@ -2510,7 +2520,11 @@ mod trace_print {
     clear_state();
     let result = woxi::interpret_with_stdout("TracePrint[f[1, 2]]").unwrap();
     assert_eq!(result.result, "f[1, 2]");
-    assert_eq!(result.stdout, " f[1, 2]\n  f\n  1\n  2\n");
+    assert_eq!(
+      result.stdout,
+      " HoldCompleteForm[f[1, 2]]\n  HoldCompleteForm[f]\n  \
+       HoldCompleteForm[1]\n  HoldCompleteForm[2]\n"
+    );
   }
 
   #[test]
@@ -2522,8 +2536,13 @@ mod trace_print {
     assert_eq!(result.result, "{2, 4}");
     assert_eq!(
       result.stdout,
-      " {1 + 1, 2 + 2}\n  List\n  1 + 1\n   Plus\n   1\n   1\n  2\n  \
-       2 + 2\n   Plus\n   2\n   2\n  4\n {2, 4}\n"
+      " HoldCompleteForm[{1 + 1, 2 + 2}]\n  HoldCompleteForm[List]\n  \
+       HoldCompleteForm[1 + 1]\n   HoldCompleteForm[Plus]\n   \
+       HoldCompleteForm[1]\n   HoldCompleteForm[1]\n  \
+       HoldCompleteForm[2]\n  HoldCompleteForm[2 + 2]\n   \
+       HoldCompleteForm[Plus]\n   HoldCompleteForm[2]\n   \
+       HoldCompleteForm[2]\n  HoldCompleteForm[4]\n \
+       HoldCompleteForm[{2, 4}]\n"
     );
   }
 
@@ -2535,7 +2554,12 @@ mod trace_print {
     let result =
       woxi::interpret_with_stdout("TracePrint[2^3 + 5, _Integer]").unwrap();
     assert_eq!(result.result, "13");
-    assert_eq!(result.stdout, "   2\n   3\n  8\n  5\n 13\n");
+    assert_eq!(
+      result.stdout,
+      "   HoldCompleteForm[2]\n   HoldCompleteForm[3]\n  \
+       HoldCompleteForm[8]\n  HoldCompleteForm[5]\n \
+       HoldCompleteForm[13]\n"
+    );
   }
 
   #[test]

--- a/tests/interpreter_tests/control_flow.rs
+++ b/tests/interpreter_tests/control_flow.rs
@@ -2452,6 +2452,125 @@ mod trace_scan {
     assert_eq!(result.result, "3");
     assert_eq!(result.stdout.trim(), "");
   }
+
+  #[test]
+  fn trace_scan_rebuilds_list_canonically() {
+    clear_state();
+    // The rebuilt step is a list, so it must print as `{2, 4}` and not as
+    // `List[2, 4]` — and must therefore coincide with the result, which is
+    // printed only once.
+    let result =
+      woxi::interpret_with_stdout("TraceScan[Print, {1 + 1, 2 + 2}]").unwrap();
+    assert_eq!(result.result, "{2, 4}");
+    assert_eq!(
+      result.stdout.trim(),
+      "HoldForm[{1 + 1, 2 + 2}]\nHoldForm[List]\n\
+       HoldForm[1 + 1]\nHoldForm[Plus]\nHoldForm[1]\nHoldForm[1]\n\
+       HoldForm[2]\nHoldForm[2 + 2]\nHoldForm[Plus]\nHoldForm[2]\n\
+       HoldForm[2]\nHoldForm[4]\nHoldForm[{2, 4}]"
+    );
+  }
+}
+
+mod trace_print {
+  use super::*;
+
+  #[test]
+  fn basic_trace_print_addition() {
+    clear_state();
+    let result = woxi::interpret_with_stdout("TracePrint[2 + 3]").unwrap();
+    assert_eq!(result.result, "5");
+    // Every sub-expression is printed, indented by one space per level of
+    // the evaluation, matching `wolframscript -code 'TracePrint[2 + 3]'`.
+    assert_eq!(result.stdout, " 2 + 3\n  Plus\n  2\n  3\n 5\n");
+  }
+
+  #[test]
+  fn trace_print_nested_indentation() {
+    clear_state();
+    // The nested Power is one level deeper than the enclosing Plus.
+    let result = woxi::interpret_with_stdout("TracePrint[2^3 + 5]").unwrap();
+    assert_eq!(result.result, "13");
+    assert_eq!(
+      result.stdout,
+      " 2^3 + 5\n  Plus\n  2^3\n   Power\n   2\n   3\n  8\n  5\n 8 + 5\n 13\n"
+    );
+  }
+
+  #[test]
+  fn trace_print_atom() {
+    clear_state();
+    let result = woxi::interpret_with_stdout("TracePrint[3]").unwrap();
+    assert_eq!(result.result, "3");
+    assert_eq!(result.stdout, " 3\n");
+  }
+
+  #[test]
+  fn trace_print_undefined_function() {
+    clear_state();
+    let result = woxi::interpret_with_stdout("TracePrint[f[1, 2]]").unwrap();
+    assert_eq!(result.result, "f[1, 2]");
+    assert_eq!(result.stdout, " f[1, 2]\n  f\n  1\n  2\n");
+  }
+
+  #[test]
+  fn trace_print_list() {
+    clear_state();
+    // The rebuilt list prints as `{2, 4}`, not `List[2, 4]`.
+    let result =
+      woxi::interpret_with_stdout("TracePrint[{1 + 1, 2 + 2}]").unwrap();
+    assert_eq!(result.result, "{2, 4}");
+    assert_eq!(
+      result.stdout,
+      " {1 + 1, 2 + 2}\n  List\n  1 + 1\n   Plus\n   1\n   1\n  2\n  \
+       2 + 2\n   Plus\n   2\n   2\n  4\n {2, 4}\n"
+    );
+  }
+
+  #[test]
+  fn trace_print_with_form() {
+    clear_state();
+    // Only sub-expressions matching the form are printed, but each keeps
+    // the indentation of its actual evaluation level.
+    let result =
+      woxi::interpret_with_stdout("TracePrint[2^3 + 5, _Integer]").unwrap();
+    assert_eq!(result.result, "13");
+    assert_eq!(result.stdout, "   2\n   3\n  8\n  5\n 13\n");
+  }
+
+  #[test]
+  fn trace_print_non_matching_form() {
+    clear_state();
+    let result =
+      woxi::interpret_with_stdout("TracePrint[1 + 2, _String]").unwrap();
+    assert_eq!(result.result, "3");
+    assert_eq!(result.stdout, "");
+  }
+
+  #[test]
+  fn trace_print_returns_evaluated_result() {
+    clear_state();
+    assert_eq!(interpret("TracePrint[2 + 3]").unwrap(), "5");
+  }
+
+  #[test]
+  fn trace_print_holds_its_argument() {
+    clear_state();
+    // HoldAll is what lets TracePrint see the unevaluated input.
+    assert_eq!(
+      interpret("Attributes[TracePrint]").unwrap(),
+      "{HoldAll, Protected}"
+    );
+  }
+
+  #[test]
+  fn trace_print_side_effects_run_once() {
+    clear_state();
+    // A traced side effect must not be evaluated twice.
+    let result =
+      woxi::interpret_with_stdout("x = 0; TracePrint[x = x + 1]; x").unwrap();
+    assert_eq!(result.result, "1");
+  }
 }
 
 mod piecewise {

--- a/tests/zensical.toml
+++ b/tests/zensical.toml
@@ -1343,6 +1343,7 @@ nav = [
       { "TagSet" = "expressions/TagSet.md" },
       { "TensorDimensions" = "expressions/TensorDimensions.md" },
       { "Trace" = "expressions/Trace.md" },
+      { "TracePrint" = "expressions/TracePrint.md" },
       { "Undefined" = "expressions/Undefined.md" },
       { "UnderoverscriptBox" = "expressions/UnderoverscriptBox.md" },
       { "UnderscriptBox" = "expressions/UnderscriptBox.md" },


### PR DESCRIPTION
## Summary

Implements `TracePrint[expr]` to print every sub-expression used during evaluation, indented by nesting level, and fixes tracing to properly respect `Hold` attributes so held arguments aren't evaluated.

## Key Changes

- **New `TracePrint` function**: Prints each sub-expression wrapped in `HoldCompleteForm`, indented by one space per evaluation depth level. Supports optional form filtering with `TracePrint[expr, form]`.

- **Refactored tracing infrastructure**: Extracted common trace evaluation logic into a `TraceSink` enum that supports both `TraceScan` (apply function) and `TracePrint` (print with indentation) modes, eliminating code duplication.

- **Fixed Hold attribute handling**: Tracing now respects `Hold` attributes (HoldAll, HoldFirst, HoldRest, HoldAllComplete) so held arguments are reported but not evaluated. This fixes `TracePrint[x = x + 1]` to not evaluate the assignment target.

- **Fixed list rebuilding**: `TraceScan` now rebuilds lists using the canonical `Expr::List` variant via new `compose_expr` function, so rebuilt steps print as `{2, 4}` instead of `List[2, 4]`.

- **Added `holds_argument_at` helper**: New evaluator function mirrors Hold-attribute logic for callers that walk arguments themselves.

- **New `compose_expr` function**: Rebuilds expressions from head/children pairs while restoring dedicated `Expr` variants (List, Rule, Part, etc.) for correct canonical printing.

## Implementation Details

- Depth tracking added to trace evaluation to support `TracePrint`'s indentation (1 for the traced expression, incrementing for nested sub-expressions).
- `TracePrint` captures output via existing `capture_stdout` mechanism, respecting quiet mode.
- Comprehensive test coverage added including edge cases: nested expressions, form filtering, undefined functions, lists, and side effects.
- Documentation added via new `TracePrint.md` CLI test file.

https://claude.ai/code/session_01SNpQK8pLxXnWuNV8a47UHx