### PR TITLE
Add HoldCompleteForm function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 # Unreleased
 
+- `HoldCompleteForm[expr]` keeps `expr` completely unevaluated for display:
+    `HoldCompleteForm[2 + 3]` stays `HoldCompleteForm[2 + 3]` and
+    `Attributes[HoldCompleteForm]` is `{HoldAllComplete, Protected}`. It is the
+    `HoldAllComplete` sibling of `HoldForm`, so an inner `Evaluate` does not
+    break through the hold and a `Sequence` argument keeps its wrapper. This is
+    the head `TracePrint` already used for its output.
+- `Manipulate` colour controls compile again — the two-swatch `ColorSetter`
+    control was built without the `Appearance -> "Vertical"` field added
+    alongside it, which broke the build. The swatch row now honours
+    `Appearance -> "Vertical"` like every other button bar.
 - `TracePrint[expr]` prints every sub-expression used while evaluating `expr`,
     wrapped in `HoldCompleteForm` and indented by one space per level of the
     evaluation, and returns the result.

--- a/functions.csv
+++ b/functions.csv
@@ -135,6 +135,7 @@ Entity,Symbolic representation of a real-world entity,✅,pure,10.0,76
 Sum,Computes a sum over one or more ranges — accepts trailing options and gives a divergent sum a value under Regularization -> Dirichlet or Abel,✅,pure,1.0,77
 Product,Computes the product of an expression over one or more ranges — accepts trailing options,✅,pure,1.0,376
 HoldComplete,Holds arguments completely unevaluated,✅,pure,3.0,78
+HoldCompleteForm,Holds an expression completely unevaluated for display,✅,pure,3.0,
 Word,Symbol representing a word in string patterns,✅,none,2.0,79
 First,Returns the first element of a list or the given default which is only evaluated when used,✅,pure,1.0,80
 Last,Returns the last element of a list or the given default which is only evaluated when used,✅,pure,1.0,140

--- a/src/evaluator/attributes.rs
+++ b/src/evaluator/attributes.rs
@@ -547,7 +547,7 @@ pub fn get_builtin_attributes(name: &str) -> Vec<&'static str> {
     }
 
     // HoldAllComplete + Protected
-    "HoldComplete" | "Unevaluated" => {
+    "HoldComplete" | "HoldCompleteForm" | "Unevaluated" => {
       vec!["HoldAllComplete", "Protected"]
     }
     // MakeBoxes: HoldAllComplete only (matches wolframscript)

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -5074,8 +5074,9 @@ fn tf_call(name: &str, args: &[Expr]) -> Expr {
     // Wrappers that only hold or re-label their content: typeset what is
     // inside them. `Style` keeps its directives outside the box tree — the
     // enclosing cell/label already carries size and colour.
-    "HoldForm" | "HoldComplete" | "Defer" | "Identity" | "TraditionalForm"
-    | "StandardForm" | "DisplayForm" | "OutputForm" | "Text"
+    "HoldForm" | "HoldComplete" | "HoldCompleteForm" | "Defer" | "Identity"
+    | "TraditionalForm" | "StandardForm" | "DisplayForm" | "OutputForm"
+    | "Text"
       if args.len() == 1 =>
     {
       tf(&args[0])

--- a/src/evaluator/dispatch/evaluation_control.rs
+++ b/src/evaluator/dispatch/evaluation_control.rs
@@ -15,6 +15,14 @@ pub fn dispatch_evaluation_control(
     "HoldComplete" if !args.is_empty() => {
       return Some(Ok(unevaluated("HoldComplete", args)));
     }
+    // `HoldCompleteForm` is `HoldForm`'s HoldAllComplete sibling: it keeps its
+    // argument unevaluated for display (`HoldCompleteForm[2 + 3]` prints as
+    // `HoldCompleteForm[2 + 3]`) and, unlike `HoldForm`, does not honour a
+    // wrapping `Evaluate` — see the HoldAllComplete attribute in
+    // `attributes.rs`, which is what suppresses argument evaluation.
+    "HoldCompleteForm" if !args.is_empty() => {
+      return Some(Ok(unevaluated("HoldCompleteForm", args)));
+    }
     "Unevaluated" if !args.is_empty() => {
       return Some(Ok(unevaluated("Unevaluated", args)));
     }

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -8068,7 +8068,12 @@ fn normal_with_heads(expr: &Expr, heads: &[String]) -> Expr {
   let is_hold = |name: &str| {
     matches!(
       name,
-      "Hold" | "HoldForm" | "HoldComplete" | "HoldPattern" | "HoldAllComplete"
+      "Hold"
+        | "HoldForm"
+        | "HoldComplete"
+        | "HoldCompleteForm"
+        | "HoldPattern"
+        | "HoldAllComplete"
     )
   };
   match expr {

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -4576,7 +4576,10 @@ fn apply_replace_all_multi_ast(
 }
 
 fn is_hold_head(name: &str) -> bool {
-  matches!(name, "Hold" | "HoldComplete" | "HoldForm" | "HoldPattern")
+  matches!(
+    name,
+    "Hold" | "HoldComplete" | "HoldCompleteForm" | "HoldForm" | "HoldPattern"
+  )
 }
 
 /// Internal: `held` is true when we are recursing inside a Hold/HoldComplete/

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -20371,6 +20371,9 @@ fn parse_manipulate_control(
           // never a dropdown.
           setter_bar: true,
           slider: false,
+          // The swatches are a setter bar, so `Appearance -> "Vertical"`
+          // stacks them the same way it stacks any other button bar.
+          vertical: appearance_vertical,
         },
         enabled,
         min_code: None,

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -15793,7 +15793,8 @@ pub fn top_level_output(expr: &Expr) -> String {
               // postfix-operator InputForm inside the FullForm wrapper.
               | "Factorial"
               | "Factorial2"
-              // `Hold`/`HoldForm`/`HoldComplete`/`HoldPattern`/`Defer`
+              // `Hold`/`HoldForm`/`HoldComplete`/`HoldCompleteForm`/
+              // `HoldPattern`/`Defer`
               // preserve the FullForm wrapper and render their argument
               // in InputForm — wolframscript prints `FullForm[Hold[1+2]]`
               // as `FullForm[Hold[1 + 2]]`, not the bare
@@ -15802,6 +15803,7 @@ pub fn top_level_output(expr: &Expr) -> String {
               | "Hold"
               | "HoldForm"
               | "HoldComplete"
+              | "HoldCompleteForm"
               | "HoldPattern"
               | "Defer"
           )

--- a/tests/SUMMARY.md
+++ b/tests/SUMMARY.md
@@ -1077,6 +1077,7 @@
     - [`HalfNormalDistribution`](functions/HalfNormalDistribution.md)
     - [`CensoredDistribution`](functions/CensoredDistribution.md)
     - [`TruncatedDistribution`](functions/TruncatedDistribution.md)
+    - [`HoldCompleteForm`](functions/HoldCompleteForm.md)
     - [`HoldForm`](functions/HoldForm.md)
     - [`If`](functions/If.md)
     - [`Increment`](functions/Increment.md)

--- a/tests/cli/functions.md
+++ b/tests/cli/functions.md
@@ -41,6 +41,7 @@ icon: lucide/square-function
 - [`HalfNormalDistribution`](functions/HalfNormalDistribution.md)
 - [`CensoredDistribution`](functions/CensoredDistribution.md)
 - [`TruncatedDistribution`](functions/TruncatedDistribution.md)
+- [`HoldCompleteForm`](functions/HoldCompleteForm.md)
 - [`HoldForm`](functions/HoldForm.md)
 - [`If`](functions/If.md)
 - [`Increment`](functions/Increment.md)

--- a/tests/cli/functions/HoldCompleteForm.md
+++ b/tests/cli/functions/HoldCompleteForm.md
@@ -1,0 +1,20 @@
+# `HoldCompleteForm`
+
+Holds an expression completely unevaluated for display.
+
+```scrut
+$ wo 'Attributes[HoldCompleteForm]'
+{HoldAllComplete, Protected}
+```
+
+```scrut
+$ wo 'HoldCompleteForm[2 + 3]'
+HoldCompleteForm[2 + 3]
+```
+
+Unlike `HoldForm`, an inner `Evaluate` does not break through the hold:
+
+```scrut
+$ wo 'HoldCompleteForm[Evaluate[1 + 2]]'
+HoldCompleteForm[Evaluate[1 + 2]]
+```

--- a/tests/interpreter_tests/attributes.rs
+++ b/tests/interpreter_tests/attributes.rs
@@ -1364,6 +1364,13 @@ mod cases {
     );
   }
   #[test]
+  fn attributes_hold_complete_form() {
+    assert_case(
+      r#"Attributes[HoldCompleteForm]"#,
+      r#"{HoldAllComplete, Protected}"#,
+    );
+  }
+  #[test]
   fn f_14() {
     assert_case(r#"SetAttributes[f, HoldAll]; f[1 + 2]"#, r#"f[1 + 2]"#);
   }
@@ -1386,6 +1393,41 @@ mod cases {
     assert_case(
       r#"SetAttributes[f, HoldAll]; f[1 + 2]; f[Evaluate[1 + 2]]; Hold[Evaluate[1 + 2]]; HoldComplete[Evaluate[1 + 2]]"#,
       r#"HoldComplete[Evaluate[1 + 2]]"#,
+    );
+  }
+  #[test]
+  fn hold_complete_form() {
+    // HoldCompleteForm is HoldForm's HoldAllComplete sibling: it keeps its
+    // argument unevaluated for display, and — unlike HoldForm — an inner
+    // `Evaluate` does not break through the hold.
+    assert_case(r#"HoldCompleteForm[2 + 3]"#, r#"HoldCompleteForm[2 + 3]"#);
+    assert_case(
+      r#"HoldCompleteForm[Evaluate[1 + 2]]"#,
+      r#"HoldCompleteForm[Evaluate[1 + 2]]"#,
+    );
+    assert_case(r#"HoldForm[Evaluate[1 + 2]]"#, r#"HoldForm[3]"#);
+    // HoldAllComplete also carries SequenceHold, so a `Sequence` argument
+    // keeps its wrapper instead of splicing.
+    assert_case(
+      r#"HoldCompleteForm[Sequence[1, 2]]"#,
+      r#"HoldCompleteForm[Sequence[1, 2]]"#,
+    );
+    // …and `Unevaluated` is not stripped inside it.
+    assert_case(
+      r#"HoldCompleteForm[Unevaluated[1 + 1]]"#,
+      r#"HoldCompleteForm[Unevaluated[1 + 1]]"#,
+    );
+    // An assigned symbol keeps its name inside the wrapper.
+    assert_case(r#"x = 2; HoldCompleteForm[x]"#, r#"HoldCompleteForm[x]"#);
+    // Nested and wrapped forms keep the wrapper in the output, like
+    // `Hold[HoldForm[…]]` does.
+    assert_case(
+      r#"Hold[HoldCompleteForm[1 + 2]]"#,
+      r#"Hold[HoldCompleteForm[1 + 2]]"#,
+    );
+    assert_case(
+      r#"FullForm[HoldCompleteForm[1 + 2]]"#,
+      r#"FullForm[HoldCompleteForm[1 + 2]]"#,
     );
   }
   #[test]

--- a/tests/zensical.toml
+++ b/tests/zensical.toml
@@ -1161,6 +1161,7 @@ nav = [
       { "HalfNormalDistribution" = "functions/HalfNormalDistribution.md" },
       { "CensoredDistribution" = "functions/CensoredDistribution.md" },
       { "TruncatedDistribution" = "functions/TruncatedDistribution.md" },
+      { "HoldCompleteForm" = "functions/HoldCompleteForm.md" },
       { "HoldForm" = "functions/HoldForm.md" },
       { "If" = "functions/If.md" },
       { "Increment" = "functions/Increment.md" },


### PR DESCRIPTION
Implements `HoldCompleteForm`, a new function that keeps its argument completely unevaluated for display. It is the `HoldAllComplete` sibling of `HoldForm`, meaning that unlike `HoldForm`, an inner `Evaluate` does not break through the hold.

## Key Changes

- **Core implementation**: Added `HoldCompleteForm` dispatch in `evaluation_control.rs` that returns its argument unevaluated, with detailed comments explaining its relationship to `HoldForm`
- **Attributes**: Assigned `HoldCompleteForm` the attributes `{HoldAllComplete, Protected}` in `attributes.rs`
- **Pattern matching**: Updated `is_hold_head()` in `pattern_matching.rs` to recognize `HoldCompleteForm` as a hold-type head
- **Output formatting**: Added `HoldCompleteForm` to the list of hold-type wrappers in `syntax.rs` that preserve their wrapper in `FullForm` output
- **Typesetting**: Updated `tf_call()` in `complex_and_special.rs` to typeset the contents of `HoldCompleteForm` like other hold wrappers
- **Normalization**: Added `HoldCompleteForm` to the `is_hold()` predicate in `list_operations.rs` for proper expression normalization
- **Documentation**: Added comprehensive test cases covering behavior with `Evaluate`, `Sequence`, `Unevaluated`, nested holds, and `FullForm`
- **CLI documentation**: Created `HoldCompleteForm.md` with usage examples
- **Changelog**: Updated with feature description
- **Function registry**: Added to `functions.csv`

## Implementation Details

`HoldCompleteForm` works by returning its argument wrapped in the same head without evaluation, leveraging the `HoldAllComplete` attribute to prevent argument evaluation. This is the same head already used by `TracePrint` for its output formatting.

A bonus fix was included: the `ColorSetter` control in `Manipulate` now properly honors the `Appearance -> "Vertical"` field for vertical stacking of color swatches.

https://claude.ai/code/session_01MWVb8teo5WqPXJAukqL5H4