### PR TITLE
Add $StandardOutputStream and $StandardErrorStream variables

### DIFF
--- a/src/evaluator/dispatch/io_functions.rs
+++ b/src/evaluator/dispatch/io_functions.rs
@@ -220,6 +220,60 @@ pub(crate) fn command_file_spec(spec: &str) -> Option<&str> {
   spec.strip_prefix('!')
 }
 
+/// The two standard output streams, as `(name, id)`. Both are open for the
+/// whole session and keep these fixed ids, which is why `register_stream`
+/// hands out ids starting after them.
+pub(crate) const STANDARD_STREAMS: [(&str, i128); 2] =
+  [("stdout", 1), ("stderr", 2)];
+
+/// The `OutputStream[name, id]` expression for a standard stream:
+/// `OutputStream["stdout", 1]` for stdout, `OutputStream["stderr", 2]` for
+/// stderr. This is what `$StandardOutputStream`, `$StandardErrorStream` and
+/// `Streams[]` all hand out.
+pub(crate) fn standard_stream_expr(is_stdout: bool) -> Expr {
+  let (name, id) = STANDARD_STREAMS[usize::from(!is_stdout)];
+  call(
+    "OutputStream",
+    vec![Expr::String(name.to_string()), Expr::Integer(id)],
+  )
+}
+
+/// Recognize a channel that names one of the process's standard streams:
+/// `Some(true)` for stdout, `Some(false)` for stderr. Covers the stream
+/// names, the `$Output`/`$Messages` symbols and the `OutputStream[…]`
+/// expressions `$StandardOutputStream` / `Streams[]` return.
+///
+/// Only the write functions ask, and those are native-only — the browser
+/// has no process streams to write to.
+#[cfg(not(target_arch = "wasm32"))]
+fn standard_stream_channel(expr: &Expr) -> Option<bool> {
+  let is_stdout = |name: &str| match name {
+    "stdout" | "$Output" => Some(true),
+    "stderr" | "$Messages" => Some(false),
+    _ => None,
+  };
+  match expr {
+    Expr::String(name) => is_stdout(name),
+    Expr::Identifier(name) => is_stdout(name),
+    // Only the standard streams' own ids count: a file stream that
+    // happens to be named "stdout" is still a file.
+    Expr::FunctionCall { name, args }
+      if name == "OutputStream" && args.len() == 2 =>
+    {
+      let (Expr::String(stream_name), Expr::Integer(id)) = (&args[0], &args[1])
+      else {
+        return None;
+      };
+      STANDARD_STREAMS
+        .iter()
+        .any(|(n, i)| n == stream_name && i == id)
+        .then(|| is_stdout(stream_name))
+        .flatten()
+    }
+    _ => None,
+  }
+}
+
 /// The registry id of an `InputStream[name, id]` / `OutputStream[name, id]`.
 fn io_stream_id(expr: &Expr) -> Option<usize> {
   let Expr::FunctionCall { name, args } = expr else {
@@ -264,6 +318,9 @@ fn io_binary_bytes(expr: &Expr, path: &str) -> std::io::Result<Vec<u8>> {
 /// Where a write function sends its bytes.
 #[cfg(not(target_arch = "wasm32"))]
 enum WriteTarget {
+  /// One of the process's standard streams: `true` for stdout, `false`
+  /// for stderr.
+  Standard(bool),
   /// Append to a file.
   File(String),
   /// The standard input of an open `OpenWrite["!command"]` stream.
@@ -278,6 +335,11 @@ enum WriteTarget {
 /// leaves the call unevaluated.
 #[cfg(not(target_arch = "wasm32"))]
 fn io_write_target(expr: &Expr) -> Option<WriteTarget> {
+  // `"stdout"`, `$Output`, `OutputStream["stdout", 1]` and their stderr
+  // counterparts name the process's own streams, never a file of that name.
+  if let Some(is_stdout) = standard_stream_channel(expr) {
+    return Some(WriteTarget::Standard(is_stdout));
+  }
   match expr {
     Expr::String(spec) => Some(match command_file_spec(spec) {
       Some(command) => WriteTarget::Command(command.to_string()),
@@ -301,6 +363,31 @@ fn io_write_target(expr: &Expr) -> Option<WriteTarget> {
   }
 }
 
+/// The targets a channel argument names. A list of channels — what
+/// `Streams["stderr"]` and `$Output` style variables hand over — writes to
+/// every one of them, as in wolframscript. `None` if any element is not
+/// writable, which leaves the whole call unevaluated.
+#[cfg(not(target_arch = "wasm32"))]
+fn io_write_targets(expr: &Expr) -> Option<Vec<WriteTarget>> {
+  match expr {
+    Expr::List(items) => items.iter().map(io_write_target).collect(),
+    _ => io_write_target(expr).map(|target| vec![target]),
+  }
+}
+
+/// Send `bytes` to every target of a channel, in order.
+#[cfg(not(target_arch = "wasm32"))]
+fn write_targets_bytes(
+  targets: &[WriteTarget],
+  bytes: &[u8],
+  caller: &str,
+) -> Result<(), InterpreterError> {
+  for target in targets {
+    write_target_bytes(target, bytes, caller)?;
+  }
+  Ok(())
+}
+
 /// Shared body of `WriteString` and `WriteLine`. `args[0]` is the channel and
 /// `args[1..]` the things to write; they are concatenated, `terminator` is
 /// appended, and the result goes out in a single write. `WriteLine` is just
@@ -322,37 +409,10 @@ fn write_string_to_channel(
   }
   text.push_str(terminator);
 
-  // Special-case the standard streams so `WriteString["stdout", …]` and
-  // `WriteString[$Output, …]` write to the process's stdout, matching
-  // wolframscript. `$Output`/`"stdout"` map to stdout, `$Messages`/
-  // `"stderr"` to stderr. Stdout writes also go through the captured
-  // buffer (like Print) so they appear in `interpret_with_stdout`.
-  let std_target = match &args[0] {
-    Expr::String(name) if name == "stdout" => Some(true),
-    Expr::String(name) if name == "stderr" => Some(false),
-    Expr::Identifier(name) if name == "$Output" => Some(true),
-    Expr::Identifier(name) if name == "$Messages" => Some(false),
-    _ => None,
-  };
-  if let Some(is_stdout) = std_target {
-    use std::io::Write;
-    if is_stdout {
-      if !crate::is_quiet_print() {
-        print!("{text}");
-        let _ = std::io::stdout().flush();
-      }
-      crate::capture_stdout_raw(&text);
-    } else {
-      eprint!("{text}");
-      let _ = std::io::stderr().flush();
-    }
-    return Ok(Expr::Identifier("Null".to_string()));
-  }
-
-  let Some(target) = io_write_target(&args[0]) else {
+  let Some(targets) = io_write_targets(&args[0]) else {
     return Ok(unevaluated(caller, args));
   };
-  write_target_bytes(&target, text.as_bytes(), caller)?;
+  write_targets_bytes(&targets, text.as_bytes(), caller)?;
   Ok(Expr::Identifier("Null".to_string()))
 }
 
@@ -365,6 +425,27 @@ fn write_target_bytes(
   caller: &str,
 ) -> Result<(), InterpreterError> {
   match target {
+    // Stdout writes also go through the captured buffer (like Print) so
+    // they appear in `interpret_with_stdout`.
+    WriteTarget::Standard(is_stdout) => {
+      use std::io::Write;
+      // The bytes go out unaltered — `BinaryWrite` may hand over data that
+      // is not valid UTF-8 — while the capture buffer, being text, gets a
+      // lossy decoding of the same bytes.
+      if *is_stdout {
+        if !crate::is_quiet_print() {
+          let mut stdout = std::io::stdout();
+          let _ = stdout.write_all(bytes);
+          let _ = stdout.flush();
+        }
+        crate::capture_stdout_raw(&String::from_utf8_lossy(bytes));
+      } else {
+        let mut stderr = std::io::stderr();
+        let _ = stderr.write_all(bytes);
+        let _ = stderr.flush();
+      }
+      Ok(())
+    }
     WriteTarget::File(path) => {
       use std::io::Write;
       let mut file = std::fs::OpenOptions::new()
@@ -407,7 +488,10 @@ struct OpenStream {
 
 thread_local! {
     static STREAM_REGISTRY: RefCell<HashMap<usize, OpenStream>> = RefCell::new(HashMap::new());
-    static STREAM_COUNTER: RefCell<usize> = const { RefCell::new(1) };
+    // The standard streams already occupy ids 1 and 2, so — as in
+    // wolframscript — the first stream a script opens gets id 3.
+    static STREAM_COUNTER: RefCell<usize> =
+      const { RefCell::new(STANDARD_STREAMS.len() + 1) };
 }
 
 /// Register a new open stream and return its ID
@@ -803,32 +887,16 @@ pub fn dispatch_io_functions(
     // Streams[] — return list of open streams (stdout and stderr)
     "Streams" if args.is_empty() => {
       return Some(Ok(Expr::List(
-        vec![
-          call(
-            "OutputStream",
-            vec![Expr::String("stdout".to_string()), Expr::Integer(1)],
-          ),
-          call(
-            "OutputStream",
-            vec![Expr::String("stderr".to_string()), Expr::Integer(2)],
-          ),
-        ]
-        .into(),
+        vec![standard_stream_expr(true), standard_stream_expr(false)].into(),
       )));
     }
     // Streams["name"] — filter streams by name
     "Streams" if args.len() == 1 => {
       if let Expr::String(name_filter) = &args[0] {
-        let all_streams = [("stdout", 1), ("stderr", 2)];
-        let matching: Vec<Expr> = all_streams
+        let matching: Vec<Expr> = STANDARD_STREAMS
           .iter()
           .filter(|(n, _)| *n == name_filter.as_str())
-          .map(|(n, id)| {
-            call(
-              "OutputStream",
-              vec![Expr::String(n.to_string()), Expr::Integer(*id)],
-            )
-          })
+          .map(|(n, _)| standard_stream_expr(*n == "stdout"))
           .collect();
         return Some(Ok(Expr::List(matching.into())));
       }
@@ -2390,7 +2458,7 @@ pub fn dispatch_io_functions(
     // infers the type from the value (Integer → Byte, String → Character8).
     #[cfg(not(target_arch = "wasm32"))]
     "BinaryWrite" if (2..=3).contains(&args.len()) => {
-      let Some(target) = io_write_target(&args[0]) else {
+      let Some(targets) = io_write_targets(&args[0]) else {
         return Some(Ok(unevaluated("BinaryWrite", args)));
       };
       // Render a single value at the given type into the byte buffer.
@@ -2461,7 +2529,7 @@ pub fn dispatch_io_functions(
           _ => return Some(Ok(unevaluated())),
         }
       };
-      if let Err(e) = write_target_bytes(&target, &bytes, "BinaryWrite") {
+      if let Err(e) = write_targets_bytes(&targets, &bytes, "BinaryWrite") {
         return Some(Err(e));
       }
       return Some(Ok(args[0].clone()));
@@ -3006,7 +3074,7 @@ pub fn dispatch_io_functions(
     // Write[stream, expr1, expr2, ...] — write expressions to a stream in OutputForm
     #[cfg(not(target_arch = "wasm32"))]
     "Write" if args.len() >= 2 => {
-      let Some(target) = io_write_target(&args[0]) else {
+      let Some(targets) = io_write_targets(&args[0]) else {
         return Some(Ok(unevaluated("Write", args)));
       };
       let mut content = String::new();
@@ -3014,7 +3082,8 @@ pub fn dispatch_io_functions(
         content.push_str(&crate::syntax::expr_to_string(arg));
       }
       content.push('\n');
-      if let Err(e) = write_target_bytes(&target, content.as_bytes(), "Write") {
+      if let Err(e) = write_targets_bytes(&targets, content.as_bytes(), "Write")
+      {
         return Some(Err(e));
       }
       return Some(Ok(Expr::Identifier("Null".to_string())));

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -385,6 +385,16 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
     "$GeoLocation" => {
       Some(call1("Missing", Expr::String("NotAvailable".to_string())))
     }
+    // The process's standard streams, always open and always carrying the
+    // ids `Streams[]` reports: `OutputStream[stdout, 1]` and
+    // `OutputStream[stderr, 2]`. Writing to them — `WriteString[
+    // $StandardOutputStream, "hi"]` — goes to the process's stdout/stderr.
+    "$StandardOutputStream" => {
+      Some(crate::evaluator::dispatch::io_functions::standard_stream_expr(true))
+    }
+    "$StandardErrorStream" => Some(
+      crate::evaluator::dispatch::io_functions::standard_stream_expr(false),
+    ),
     "$MachineEpsilon" => Some(Expr::Real(2.220446049250313e-16)),
     "$MaxMachineNumber" => Some(Expr::Real(f64::MAX)),
     // Wolfram's $MinMachineNumber is the smallest normalized double

--- a/tests/cli/file_system/Streams.md
+++ b/tests/cli/file_system/Streams.md
@@ -10,3 +10,21 @@ trailing streams.
 $ wo 'Streams[]'
 \{OutputStream\[stdout, 1\], OutputStream\[stderr, 2\].*\} (regex)
 ```
+
+The two always-open ones are also available as `$StandardOutputStream` and
+`$StandardErrorStream`:
+
+```scrut
+$ wo '$StandardOutputStream'
+OutputStream[stdout, 1]
+```
+
+```scrut
+$ wo '$StandardErrorStream'
+OutputStream[stderr, 2]
+```
+
+```scrut
+$ wo '{$StandardOutputStream, $StandardErrorStream} === Take[Streams[], 2]'
+True
+```

--- a/tests/cli/file_system/WriteString.md
+++ b/tests/cli/file_system/WriteString.md
@@ -1,3 +1,34 @@
 # `WriteString`
 
 Write a string to an output stream.
+
+The stream can be named directly, or given as the `OutputStream[…]`
+expression that `$StandardOutputStream` stands for. Both write to the
+process's standard output, and neither appends a newline of its own.
+
+```scrut
+$ wo 'WriteString["stdout", "hello world\n"]'
+hello world
+Null
+```
+
+```scrut
+$ wo 'WriteString[$StandardOutputStream, "hello world\n"]'
+hello world
+Null
+```
+
+`$StandardErrorStream` writes to standard error instead:
+
+```scrut
+$ wo 'WriteString[$StandardErrorStream, "oh no\n"]' 2> /dev/null
+Null
+```
+
+All arguments after the stream are written in one go, without separators:
+
+```scrut
+$ wo 'WriteString[$StandardOutputStream, "a", "b", "c\n"]'
+abc
+Null
+```

--- a/tests/interpreter_tests/io.rs
+++ b/tests/interpreter_tests/io.rs
@@ -870,6 +870,136 @@ mod streams {
         .unwrap();
     assert_eq!(result.stdout, "Goodbye, World!");
   }
+
+  // Regression test for issue #530: the stream `$StandardOutputStream`
+  // stands for is writable, just like the `"stdout"` name.
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn write_string_standard_output_stream() {
+    clear_state();
+    let result = interpret_with_stdout(
+      r#"WriteString[$StandardOutputStream, "hello world\n"]"#,
+    )
+    .unwrap();
+    assert_eq!(result.stdout, "hello world\n");
+  }
+
+  // The `OutputStream[…]` expression itself is what carries the stream,
+  // so writing to a literal one works the same way.
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn write_string_stdout_output_stream_expression() {
+    clear_state();
+    let result =
+      interpret_with_stdout(r#"WriteString[OutputStream["stdout", 1], "hi"]"#)
+        .unwrap();
+    assert_eq!(result.stdout, "hi");
+  }
+
+  // An `OutputStream` named "stdout" but carrying another id is some other
+  // stream — a file of that name — and must not reach the process's stdout.
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn write_string_stdout_name_with_foreign_id_is_a_file() {
+    clear_state();
+    let path = temp_file("woxi_stdout_named_file");
+    let _ = std::fs::remove_file(&path);
+    let result = interpret_with_stdout(&format!(
+      r#"s = OpenWrite["{path}"]; WriteString[OutputStream["stdout", Last[s]], "to the file"]; Close[s]; ReadString["{path}"]"#
+    ))
+    .unwrap();
+    assert_eq!(result.stdout, "");
+    assert_eq!(result.result, "to the file");
+    let _ = std::fs::remove_file(&path);
+  }
+}
+
+mod standard_streams {
+  use super::*;
+
+  // A channel can be a list of streams — `Streams["stdout"]` is one — and
+  // the text then goes to each of them.
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn write_string_to_a_list_of_channels() {
+    clear_state();
+    let result = interpret_with_stdout(
+      r#"WriteString[Streams["stdout"], "once "]; WriteString[{$StandardOutputStream, "stdout"}, "twice"]"#,
+    )
+    .unwrap();
+    assert_eq!(result.stdout, "once twicetwice");
+  }
+
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn write_to_a_list_of_channels() {
+    clear_state();
+    let result =
+      interpret_with_stdout(r#"Write[Streams["stdout"], 1 + 1]"#).unwrap();
+    assert_eq!(result.stdout, "2\n");
+  }
+
+  // An unwritable element leaves the whole call unevaluated rather than
+  // writing to the writable ones.
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn write_string_to_a_list_with_an_unwritable_channel() {
+    clear_state();
+    let result =
+      interpret_with_stdout(r#"WriteString[{$StandardOutputStream, 5}, "x"]"#)
+        .unwrap();
+    assert_eq!(result.stdout, "");
+    assert_eq!(
+      result.result,
+      "WriteString[{OutputStream[stdout, 1], 5}, x]"
+    );
+  }
+
+  // Issue #530: the standard streams are ordinary `OutputStream[…]`
+  // expressions with the fixed ids `Streams[]` reports.
+  #[test]
+  fn standard_output_stream() {
+    assert_eq!(
+      interpret("$StandardOutputStream").unwrap(),
+      "OutputStream[stdout, 1]"
+    );
+  }
+
+  #[test]
+  fn standard_error_stream() {
+    assert_eq!(
+      interpret("$StandardErrorStream").unwrap(),
+      "OutputStream[stderr, 2]"
+    );
+  }
+
+  #[test]
+  fn standard_output_stream_is_the_first_open_stream() {
+    assert_eq!(
+      interpret("$StandardOutputStream === First[Streams[]]").unwrap(),
+      "True"
+    );
+  }
+
+  #[test]
+  fn head_is_output_stream() {
+    assert_eq!(
+      interpret("Head[$StandardOutputStream]").unwrap(),
+      "OutputStream"
+    );
+  }
+
+  // Ids 1 and 2 belong to the standard streams, so a newly opened stream
+  // starts at 3 — as it does in wolframscript.
+  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
+  fn opened_streams_do_not_reuse_standard_ids() {
+    clear_state();
+    assert_eq!(
+      interpret(r#"StringToStream["abc"]"#).unwrap(),
+      "InputStream[String, 3]"
+    );
+  }
 }
 
 mod find_file {
@@ -2667,7 +2797,7 @@ mod read_string {
   fn a_non_string_terminator_reports_iterm() {
     assert_eq!(
       interpret(r#"ReadString[StringToStream["abc"], 2]"#).unwrap(),
-      "ReadString[InputStream[String, 1], 2]"
+      "ReadString[InputStream[String, 3], 2]"
     );
     let msgs = woxi::get_captured_messages_raw();
     assert!(
@@ -3244,7 +3374,7 @@ mod read {
         .unwrap();
     assert_eq!(
       result,
-      "ReadList[InputStream[String, 1], {Word, Number}, -1]"
+      "ReadList[InputStream[String, 3], {Word, Number}, -1]"
     );
   }
 }

--- a/tests/script_snapshot_tests.rs
+++ b/tests/script_snapshot_tests.rs
@@ -1299,6 +1299,11 @@ script_test!(
   script_hello_world_newline_omission,
   "hello_world_newline_omission.wls"
 );
+// === Unlocked by $StandardOutputStream naming the process's stdout ===
+script_test!(
+  script_hello_world_standard_output_stream,
+  "hello_world_standard_output_stream.wls"
+);
 // === Unlocked by the DayRange weekday filter + DatePlus multi-unit fix
 //     (uses a warm-up shim to swallow wolframscript's CalendarData init Print) ===
 script_test!(

--- a/tests/scripts/hello_world_standard_output_stream.wls
+++ b/tests/scripts/hello_world_standard_output_stream.wls
@@ -1,0 +1,1 @@
+WriteString[$StandardOutputStream, "Goodbye, World!"]

--- a/tests/snapshots/script_snapshot_tests__hello_world_standard_output_stream.wls.snap
+++ b/tests/snapshots/script_snapshot_tests__hello_world_standard_output_stream.wls.snap
@@ -1,0 +1,5 @@
+---
+source: tests/script_snapshot_tests.rs
+expression: stdout
+---
+Goodbye, World!


### PR DESCRIPTION
## Summary

Implement `$StandardOutputStream` and `$StandardErrorStream` system variables that represent the process's standard output and error streams as `OutputStream[…]` expressions. These variables enable writing to standard streams using the same `OutputStream` mechanism as file streams, improving consistency with wolframscript.

## Key Changes

- **New system variables**: Added `$StandardOutputStream` (maps to `OutputStream["stdout", 1]`) and `$StandardErrorStream` (maps to `OutputStream["stderr", 2]`)
- **Stream infrastructure**: 
  - Defined `STANDARD_STREAMS` constant with fixed ids (1 for stdout, 2 for stderr)
  - Created `standard_stream_expr()` helper to generate `OutputStream[…]` expressions
  - Implemented `standard_stream_channel()` to recognize standard stream references in multiple forms (string names, identifiers, and `OutputStream[…]` expressions)
- **Write target refactoring**:
  - Added `WriteTarget::Standard` variant to distinguish process streams from file streams
  - Implemented `io_write_targets()` to support writing to lists of channels (e.g., `Streams["stdout"]`)
  - Created `write_targets_bytes()` to write to multiple targets in sequence
  - Updated `write_target_bytes()` to handle standard streams with proper stdout capture for `interpret_with_stdout`
- **Stream registry**: Updated `STREAM_COUNTER` to start at 3 instead of 1, ensuring newly opened streams don't reuse the standard stream ids (matching wolframscript behavior)
- **Function updates**: Modified `WriteString`, `Write`, and `BinaryWrite` to use the new multi-target infrastructure
- **Tests**: Added comprehensive tests covering:
  - Writing to `$StandardOutputStream` and `$StandardErrorStream`
  - Writing to `OutputStream[…]` expressions directly
  - Distinguishing between standard streams and files with the same name
  - Writing to lists of channels
  - Verifying standard stream ids and behavior
- **Documentation**: Updated CLI documentation with examples of writing to standard streams

## Implementation Details

The key insight is that `$StandardOutputStream` and `$StandardErrorStream` are not special cases but rather ordinary `OutputStream[…]` expressions with fixed ids. This allows the write functions to treat them uniformly with file streams while still recognizing them as process streams. The `standard_stream_channel()` function handles multiple representations (string names like `"stdout"`, identifiers like `$Output`, and full `OutputStream[…]` expressions) to maintain backward compatibility while supporting the new variables.

https://claude.ai/code/session_013F9NzULVXJ75jrDyTx9GwN