### PR TITLE
Add regression test for sphere-peeled-into-torus-segments Manipulate demonstration

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -41,6 +41,26 @@ slow-timeout = { period = "120s", terminate-after = 1 }
 filter = 'test(fourier_matrix_boundary_materializes)'
 slow-timeout = { period = "90s", terminate-after = 1 }
 
+# `two_species_competition_manipulate_builds_widget` solves for equilibria
+# with `Solve`, classifies their stability, and integrates a phase portrait
+# of streamlines with `NDSolve` to build its widget: ~38s standalone in
+# debug builds on this machine, already past the default 20s timeout with
+# no contention at all (a pre-existing gap — this test had no override).
+# Give it a wider window.
+[[profile.default.overrides]]
+filter = 'test(two_species_competition_manipulate_builds_widget)'
+slow-timeout = { period = "90s", terminate-after = 1 }
+
+# `demonstration_sphere_torus_segments_manipulate_reshapes_and_spreads`
+# renders a `Table` of `ParametricPlot3D` lune surfaces three times (initial
+# render, after toggling full-torus, after moving the spread slider), each
+# doubled by a direct re-evaluation to compare pictures: ~14s standalone in
+# debug builds, close enough to the default 20s timeout to time out under
+# full parallel load. Give it a wider window.
+[[profile.default.overrides]]
+filter = 'test(demonstration_sphere_torus_segments_manipulate_reshapes_and_spreads)'
+slow-timeout = { period = "60s", terminate-after = 1 }
+
 # The remaining (non-`#[ignore]`d) RosettaCode script snapshots run a few
 # seconds in debug builds; under full parallel load they can brush past the
 # default 20s timeout. Give them a safety ceiling. The genuinely heavy

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -17560,4 +17560,169 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 1}, DynamicBox[\[Ellipsis]]]"
     );
     assert!(state.graphics_handle.is_some());
   }
+
+  /// End-to-end regression for the shape of a "sphere peeled into lune
+  /// segments that spread into a torus" Demonstration: an
+  /// `InitializationCell` defines a `Module`-based helper mapping a
+  /// segment index and two surface parameters onto either a sphere lune or
+  /// a torus-tube lune (picked with `If`) and displaces it outward along
+  /// its own segment direction, and a stored `Manipulate` assembles the
+  /// scene from a `Table` of `ParametricPlot3D` surfaces combined with
+  /// `Show`, driven by a `SetterBar`-shaped segment-count control, two
+  /// continuous sliders (spread offset, segment width), a torus/sphere
+  /// checkbox, and a torus-diameter slider. Self-authored, construct-
+  /// equivalent body — not the sampled notebook's own code or wording,
+  /// which is copyrighted.
+  #[test]
+  fn demonstration_sphere_torus_segments_manipulate_reshapes_and_spreads() {
+    let nb_src = r##"Notebook[{
+Cell[BoxData["segmentPoint[k_, u_, v_, n_, spread_, width_, torusQ_, torusDiam_] := Module[{theta, phi, dir, base}, theta = 2 Pi k/n; phi = theta + width (v - 1/2) (2 Pi/n); dir = {Cos[theta], Sin[theta], 0}; base = If[torusQ, {(torusDiam + Cos[2 u]) Cos[phi], (torusDiam + Cos[2 u]) Sin[phi], Sin[2 u]}, {Sin[u] Cos[phi], Sin[u] Sin[phi], Cos[u]}]; base + spread dir]"], "Input",
+ InitializationCell->True],
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[
+ Show[
+  Table[
+   ParametricPlot3D[segmentPoint[k, u, v, n, spread, width, fullTorus, torusDiam],
+    {u, 0, Pi}, {v, 0, 1},
+    PlotStyle -> ColorData[\"Rainbow\"][k/(n - 1)], Mesh -> None],
+   {k, 0, n - 1}],
+  Boxed -> False, Axes -> False, PlotRange -> {{-6, 6}, {-6, 6}, {-6, 6}}, ImageSize -> 350],
+ {{n, 3, \"n\"}, {3, 4, 5, 6, 7, 8, 9, 10}},
+ {{spread, 0, \"move in direction x\"}, 0, 3},
+ {{width, 0.8, \"segment width\"}, 0.3, 1},
+ {{fullTorus, False, \"full torus\"}, {True, False}},
+ {{torusDiam, 3, \"torus diameter\"}, 1.5, 6}]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 3, $CellContext`spread$$ = 0, $CellContext`width$$ = 0.8, $CellContext`fullTorus$$ = False, $CellContext`torusDiam$$ = 3}, DynamicBox[\[Ellipsis]]]"], "Output"]
+}, Open]]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let mut widget = editors
+      .into_iter()
+      .find_map(|e| e.manipulate_state)
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "the sphere-mode Table of ParametricPlot3D lunes must draw"
+    );
+
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Discrete {
+          name: n_name,
+          values: n_values,
+          current_index: n_idx,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: spread_name,
+          label: spread_label,
+          min: spread_min,
+          max: spread_max,
+          current: spread_now,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: width_name,
+          min: width_min,
+          max: width_max,
+          current: width_now,
+          ..
+        },
+        manipulate::ControlState::Discrete {
+          name: torus_name,
+          values: torus_values,
+          current_index: torus_idx,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: diam_name,
+          min: diam_min,
+          max: diam_max,
+          current: diam_now,
+          ..
+        },
+      ] => {
+        assert_eq!(n_name.as_str(), "n");
+        assert_eq!(
+          n_values.as_slice(),
+          ["3", "4", "5", "6", "7", "8", "9", "10"]
+        );
+        assert_eq!(*n_idx, 0, "default n = 3 is the first choice");
+        assert_eq!(spread_name.as_str(), "spread");
+        assert_eq!(spread_label.as_str(), "move in direction x");
+        assert_eq!(*spread_min, 0.0);
+        assert_eq!(*spread_max, 3.0);
+        assert_eq!(*spread_now, 0.0);
+        assert_eq!(width_name.as_str(), "width");
+        assert_eq!(*width_min, 0.3);
+        assert_eq!(*width_max, 1.0);
+        assert_eq!(*width_now, 0.8);
+        assert_eq!(torus_name.as_str(), "fullTorus");
+        assert_eq!(torus_values.as_slice(), ["True", "False"]);
+        assert_eq!(
+          *torus_idx, 1,
+          "default fullTorus = False is the second choice"
+        );
+        assert_eq!(diam_name.as_str(), "torusDiam");
+        assert_eq!(*diam_min, 1.5);
+        assert_eq!(*diam_max, 6.0);
+        assert_eq!(*diam_now, 3.0);
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the lune segments must render")
+    };
+    let sphere_view = render(&widget);
+
+    // Checking "full torus" must switch every segment from a sphere lune to
+    // a torus-tube lune, changing the picture.
+    match &mut widget.controls[3] {
+      manipulate::ControlState::Discrete { current_index, .. } => {
+        *current_index = 0
+      }
+      other => {
+        panic!("expected fullTorus as a Discrete control, got {other:?}")
+      }
+    }
+    widget.reevaluate();
+    assert!(widget.error.is_none());
+    let torus_view = render(&widget);
+    assert_ne!(
+      sphere_view, torus_view,
+      "toggling full torus must change the rendered scene"
+    );
+
+    // Pulling the "move in direction x" slider must spread the torus
+    // segments apart, changing the picture again.
+    match &mut widget.controls[1] {
+      manipulate::ControlState::Continuous { current, .. } => *current = 1.5,
+      other => panic!("expected spread as a Continuous control, got {other:?}"),
+    }
+    widget.reevaluate();
+    assert!(widget.error.is_none());
+    let spread_view = render(&widget);
+    assert_ne!(
+      torus_view, spread_view,
+      "spreading the segments apart must change the rendered scene"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- Verified against a randomly sampled Wolfram Demonstration ("Sphere and Torus Made of Segments"): a sphere shown peeled into `n` lune-shaped segments (picked via a `SetterBar`) that can be pulled apart and reshaped into a torus made of the same segments, driven by sliders for spread offset, segment width, and torus diameter plus a full-torus checkbox.
- Added an original, construct-equivalent regression test (`demonstration_sphere_torus_segments_manipulate_reshapes_and_spreads` in `woxi-studio/src/main.rs`) exercising the same category of Wolfram Language constructs — an `InitializationCell`-defined `Module` helper, `Manipulate` driving a `Table` of `ParametricPlot3D` surfaces combined via `Show`, a `SetterBar` segment-count control, continuous sliders, and a checkbox — without copying the sampled notebook's own code or wording (which is copyrighted).
- Woxi Studio already handled this shape correctly; the test locks in that coverage.
- Also fixed a pre-existing gap in `.config/nextest.toml`: both the new test and the unrelated `two_species_competition_manipulate_builds_widget` test exceed the default 20s nextest timeout standalone on this machine (confirmed reproducible on a clean checkout of `main`) and had no override, so `make test-studio` failed even without any of these changes. Added `slow-timeout` overrides for both, following the file's existing convention.

## Test plan

- [x] `make test-unit` — 27160 tests passed
- [x] `make test-studio` — 149 tests passed
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hf3coknUN5EwmHXWrP1RXV)_