### PR TITLE
Add PolyhedronData["RhombicHexecontahedron"]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+- `PolyhedronData["RhombicHexecontahedron", …]` supports the nonconvex
+    stellation of the rhombic triacontahedron: 62 vertices, 120 edges, and 60
+    golden-rhombus faces, plus its exact `Volume`, `SurfaceArea`, `Inradius`,
+    `VertexCoordinates`, `FaceIndices`, and `Classes`.
 - `HoldCompleteForm[expr]` keeps `expr` completely unevaluated for display:
     `HoldCompleteForm[2 + 3]` stays `HoldCompleteForm[2 + 3]` and
     `Attributes[HoldCompleteForm]` is `{HoldAllComplete, Protected}`. It is the

--- a/functions.csv
+++ b/functions.csv
@@ -637,7 +637,7 @@ PlotLabels,Option for labeling plot curves,✅,none,10.4,597
 Scale,Scales a graphics object,✅,pure,6.0,597
 Log10,Returns the base-10 logarithm of a number,✅,pure,7.0,598
 EndPackage,Ends a package and puts its context on $ContextPath so its exports become visible,✅,effectful,1.0,599
-PolyhedronData,Properties of named polyhedra (Platonic solids plus the icosahedral and cubic Archimedean solids and their duals),🚧,pure,6.0,601
+PolyhedronData,Properties of named polyhedra (Platonic solids; the icosahedral and cubic Archimedean solids and their duals; and the rhombic hexecontahedron stellation),🚧,pure,6.0,601
 PolyhedronOperations`Truncate,Corner-cuts each Polygon face of a graphics expression to a ratio (default 3/10) of its edge length; resolves Rotate/Translate-wrapped faces first,✅,pure,3.0,
 PolyhedronOperations`Stellate,Replaces each Polygon face of a graphics expression with a pyramid to a ratio (default 2) of the face's centroid distance; resolves Rotate/Translate-wrapped faces first,✅,pure,3.0,
 Nearest,Find the nearest elements in a list to a given value (numbers/vectors by Euclidean distance; strings by edit distance) — DistanceFunction supplies another metric; empty or non-list data reports ::near1,✅,pure,6.0,602

--- a/src/functions/polyhedron_data.rs
+++ b/src/functions/polyhedron_data.rs
@@ -1219,6 +1219,93 @@ static POLYHEDRA: &[PolyhedronInfo] = &[
       \"Convex\", \"Equilateral\", \"Isohedron\", \"Rigid\", \
       \"Rupert\", \"Simple\", \"UniformDual\", \"Zonohedron\"}",
   },
+  PolyhedronInfo {
+    name: "RhombicHexecontahedron",
+    vertex_count: 62,
+    edge_count: 120,
+    face_count: 60,
+    volume: "4*Sqrt[2*(5 + Sqrt[5])]",
+    surface_area: "24*Sqrt[5]",
+    circumradius: "Missing[\"NotApplicable\"]",
+    inradius: "Sqrt[(5 + Sqrt[5])/10]",
+    // A nonconvex stellation of the rhombic triacontahedron: take a unit
+    // dodecahedron and move its 20 vertices, 12 face centers, and 30 edge
+    // midpoints radially to circumradius*(GoldenRatio+1)/2, inradius*
+    // (3-GoldenRatio)/2, and midradius (unchanged) respectively, then join
+    // each face center to its face's vertices and edge midpoints. Every
+    // face is then a planar golden rhombus (diagonal ratio GoldenRatio).
+    // Scaled here to unit edge length and cross-checked (Volume,
+    // SurfaceArea, and the three vertex radii) against dmccooey.com's
+    // independent exact-form polyhedron data.
+    vertices_src: "\
+      {{(-5 - 3*Sqrt[5])/5, 0, Sqrt[5]/5}, {(5 + 3*Sqrt[5])/5, 0, \
+      -Sqrt[5]/5}, {(-5 - Sqrt[5])/10, -Sqrt[(25 + 11*Sqrt[5])/10], \
+      Sqrt[5]/5}, {(-5 - Sqrt[5])/10, Sqrt[(25 + 11*Sqrt[5])/10], Sqrt[5]/5}, \
+      {(5 + 2*Sqrt[5])/5, -Sqrt[(5 + 2*Sqrt[5])/5], Sqrt[5]/5}, {(5 + \
+      2*Sqrt[5])/5, Sqrt[(5 + 2*Sqrt[5])/5], Sqrt[5]/5}, {-Sqrt[5]/5, \
+      -Sqrt[(5 + 2*Sqrt[5])/5], (5 + 2*Sqrt[5])/5}, {-Sqrt[5]/5, Sqrt[(5 + \
+      2*Sqrt[5])/5], (5 + 2*Sqrt[5])/5}, {(-5 - 3*Sqrt[5])/10, -Sqrt[(5 + \
+      Sqrt[5])/10], (-5 - 2*Sqrt[5])/5}, {(-5 - 3*Sqrt[5])/10, Sqrt[(5 + \
+      Sqrt[5])/10], (-5 - 2*Sqrt[5])/5}, {(5 + 3*Sqrt[5])/10, -Sqrt[(5 + \
+      Sqrt[5])/10], (5 + 2*Sqrt[5])/5}, {(5 + 3*Sqrt[5])/10, Sqrt[(5 + \
+      Sqrt[5])/10], (5 + 2*Sqrt[5])/5}, {(5 + Sqrt[5])/5, 0, (-5 - \
+      2*Sqrt[5])/5}, {(-5 - 2*Sqrt[5])/5, -Sqrt[(5 + 2*Sqrt[5])/5], \
+      -Sqrt[5]/5}, {(-5 - 2*Sqrt[5])/5, Sqrt[(5 + 2*Sqrt[5])/5], -Sqrt[5]/5}, \
+      {(-5 - Sqrt[5])/5, 0, (5 + 2*Sqrt[5])/5}, {Sqrt[5]/5, -Sqrt[(5 + \
+      2*Sqrt[5])/5], (-5 - 2*Sqrt[5])/5}, {Sqrt[5]/5, Sqrt[(5 + \
+      2*Sqrt[5])/5], (-5 - 2*Sqrt[5])/5}, {(5 + Sqrt[5])/10, -Sqrt[(25 + \
+      11*Sqrt[5])/10], -Sqrt[5]/5}, {(5 + Sqrt[5])/10, Sqrt[(25 + \
+      11*Sqrt[5])/10], -Sqrt[5]/5}, {-2*Sqrt[5]/5, 0, -Sqrt[5]/5}, \
+      {2*Sqrt[5]/5, 0, Sqrt[5]/5}, {(5 - Sqrt[5])/10, -Sqrt[(5 + \
+      Sqrt[5])/10], Sqrt[5]/5}, {0, 0, 1}, {(5 - Sqrt[5])/10, Sqrt[(5 + \
+      Sqrt[5])/10], Sqrt[5]/5}, {(5 + Sqrt[5])/10, Sqrt[(5 - Sqrt[5])/10], \
+      -Sqrt[5]/5}, {(5 + Sqrt[5])/10, -Sqrt[(5 - Sqrt[5])/10], -Sqrt[5]/5}, \
+      {(-5 + Sqrt[5])/10, Sqrt[(5 + Sqrt[5])/10], -Sqrt[5]/5}, {0, 0, -1}, \
+      {(-5 + Sqrt[5])/10, -Sqrt[(5 + Sqrt[5])/10], -Sqrt[5]/5}, {(-5 - \
+      Sqrt[5])/10, -Sqrt[(5 - Sqrt[5])/10], Sqrt[5]/5}, {(-5 - Sqrt[5])/10, \
+      Sqrt[(5 - Sqrt[5])/10], Sqrt[5]/5}, {(-1 - Sqrt[5])/2, -Sqrt[(5 - \
+      Sqrt[5])/10], 0}, {(-1 - Sqrt[5])/2, Sqrt[(5 - Sqrt[5])/10], 0}, {(-5 - \
+      Sqrt[5])/5, 0, 2*Sqrt[5]/5}, {(1 + Sqrt[5])/2, -Sqrt[(5 - Sqrt[5])/10], \
+      0}, {(1 + Sqrt[5])/2, Sqrt[(5 - Sqrt[5])/10], 0}, {(5 + Sqrt[5])/5, 0, \
+      -2*Sqrt[5]/5}, {-Sqrt[5]/5, -Sqrt[(5 + 2*Sqrt[5])/5], 2*Sqrt[5]/5}, \
+      {-1, -Sqrt[(5 + 2*Sqrt[5])/5], 0}, {0, -Sqrt[(10 + 2*Sqrt[5])/5], 0}, \
+      {-Sqrt[5]/5, Sqrt[(5 + 2*Sqrt[5])/5], 2*Sqrt[5]/5}, {-1, Sqrt[(5 + \
+      2*Sqrt[5])/5], 0}, {0, Sqrt[(10 + 2*Sqrt[5])/5], 0}, {(5 + \
+      3*Sqrt[5])/10, -Sqrt[(5 + Sqrt[5])/10], 2*Sqrt[5]/5}, {1, -Sqrt[(5 + \
+      2*Sqrt[5])/5], 0}, {(5 + 3*Sqrt[5])/10, Sqrt[(5 + Sqrt[5])/10], \
+      2*Sqrt[5]/5}, {1, Sqrt[(5 + 2*Sqrt[5])/5], 0}, {(5 - Sqrt[5])/10, \
+      -Sqrt[(5 + Sqrt[5])/10], (5 + Sqrt[5])/5}, {(-5 - Sqrt[5])/10, -Sqrt[(5 \
+      - Sqrt[5])/10], (5 + Sqrt[5])/5}, {(5 - Sqrt[5])/10, Sqrt[(5 + \
+      Sqrt[5])/10], (5 + Sqrt[5])/5}, {(-5 - Sqrt[5])/10, Sqrt[(5 - \
+      Sqrt[5])/10], (5 + Sqrt[5])/5}, {-2*Sqrt[5]/5, 0, (-5 - Sqrt[5])/5}, \
+      {(-5 - 3*Sqrt[5])/10, -Sqrt[(5 + Sqrt[5])/10], -2*Sqrt[5]/5}, {(-5 + \
+      Sqrt[5])/10, -Sqrt[(5 + Sqrt[5])/10], (-5 - Sqrt[5])/5}, {(-5 - \
+      3*Sqrt[5])/10, Sqrt[(5 + Sqrt[5])/10], -2*Sqrt[5]/5}, {(-5 + \
+      Sqrt[5])/10, Sqrt[(5 + Sqrt[5])/10], (-5 - Sqrt[5])/5}, {2*Sqrt[5]/5, \
+      0, (5 + Sqrt[5])/5}, {(5 + Sqrt[5])/10, -Sqrt[(5 - Sqrt[5])/10], (-5 - \
+      Sqrt[5])/5}, {(5 + Sqrt[5])/10, Sqrt[(5 - Sqrt[5])/10], (-5 - \
+      Sqrt[5])/5}, {Sqrt[5]/5, -Sqrt[(5 + 2*Sqrt[5])/5], -2*Sqrt[5]/5}, \
+      {Sqrt[5]/5, Sqrt[(5 + 2*Sqrt[5])/5], -2*Sqrt[5]/5}}",
+    faces_src: "\
+      {{21, 34, 15, 56}, {21, 56, 10, 53}, {21, 53, 9, 54}, {21, 54, 14, 33}, \
+      {21, 33, 1, 34}, {22, 36, 2, 37}, {22, 37, 6, 47}, {22, 47, 12, 58}, \
+      {22, 58, 11, 45}, {22, 45, 5, 36}, {23, 46, 5, 45}, {23, 45, 11, 49}, \
+      {23, 49, 7, 39}, {23, 39, 3, 41}, {23, 41, 19, 46}, {24, 49, 11, 58}, \
+      {24, 58, 12, 51}, {24, 51, 8, 52}, {24, 52, 16, 50}, {24, 50, 7, 49}, \
+      {25, 51, 12, 47}, {25, 47, 6, 48}, {25, 48, 20, 44}, {25, 44, 4, 42}, \
+      {25, 42, 8, 51}, {26, 48, 6, 37}, {26, 37, 2, 38}, {26, 38, 13, 60}, \
+      {26, 60, 18, 62}, {26, 62, 20, 48}, {27, 38, 2, 36}, {27, 36, 5, 46}, \
+      {27, 46, 19, 61}, {27, 61, 17, 59}, {27, 59, 13, 38}, {28, 43, 4, 44}, \
+      {28, 44, 20, 62}, {28, 62, 18, 57}, {28, 57, 10, 56}, {28, 56, 15, 43}, \
+      {29, 57, 18, 60}, {29, 60, 13, 59}, {29, 59, 17, 55}, {29, 55, 9, 53}, \
+      {29, 53, 10, 57}, {30, 55, 17, 61}, {30, 61, 19, 41}, {30, 41, 3, 40}, \
+      {30, 40, 14, 54}, {30, 54, 9, 55}, {31, 40, 3, 39}, {31, 39, 7, 50}, \
+      {31, 50, 16, 35}, {31, 35, 1, 33}, {31, 33, 14, 40}, {32, 35, 16, 52}, \
+      {32, 52, 8, 42}, {32, 42, 4, 43}, {32, 43, 15, 34}, {32, 34, 1, 35}}",
+    classes_src: "\
+      {\"Amphichiral\", \"Equilateral\", \"Isohedron\", \
+      \"Zonohedron\"}",
+  },
 ];
 
 fn find_polyhedron(name: &str) -> Option<&'static PolyhedronInfo> {

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -20066,9 +20066,10 @@ mod manipulate {
     match &spec.controls[0] {
       ManipulateControl::Discrete { name, values, .. } => {
         assert_eq!(name, "g");
-        // The five Platonic solids, plus the Archimedean solids (and
-        // their duals) with icosahedral or cubic symmetry.
-        assert_eq!(values.len(), 18, "every known solid");
+        // The five Platonic solids, the Archimedean solids (and their
+        // duals) with icosahedral or cubic symmetry, and the rhombic
+        // hexecontahedron stellation.
+        assert_eq!(values.len(), 19, "every known solid");
         assert!(values.contains(&"\"Cube\"".to_string()));
         assert!(values.contains(&"\"TruncatedIcosahedron\"".to_string()));
       }

--- a/tests/interpreter_tests/polyhedron_data.rs
+++ b/tests/interpreter_tests/polyhedron_data.rs
@@ -377,10 +377,10 @@ mod polyhedron_data_tests {
       "{Cube, DeltoidalHexecontahedron, DisdyakisTriacontahedron, \
        Dodecahedron, GreatRhombicosidodecahedron, Icosahedron, \
        Icosidodecahedron, Octahedron, PentakisDodecahedron, \
-       RhombicDodecahedron, RhombicTriacontahedron, \
-       SmallRhombicosidodecahedron, SmallRhombicuboctahedron, \
-       Tetrahedron, TruncatedDodecahedron, TruncatedIcosahedron, \
-       TruncatedOctahedron, TruncatedTetrahedron}"
+       RhombicDodecahedron, RhombicHexecontahedron, \
+       RhombicTriacontahedron, SmallRhombicosidodecahedron, \
+       SmallRhombicuboctahedron, Tetrahedron, TruncatedDodecahedron, \
+       TruncatedIcosahedron, TruncatedOctahedron, TruncatedTetrahedron}"
     );
   }
 
@@ -470,6 +470,91 @@ mod polyhedron_data_tests {
     // Every solid still draws.
     assert_eq!(
       interpret(r#"PolyhedronData["GreatRhombicosidodecahedron"]"#).unwrap(),
+      "-Graphics3D-"
+    );
+  }
+
+  // The rhombic hexecontahedron: a nonconvex stellation of the rhombic
+  // triacontahedron with 60 congruent golden-rhombus faces. Its exact
+  // metrics were cross-checked against dmccooey.com/polyhedra's
+  // independent data (Volume, SurfaceArea, and the three vertex radii),
+  // since it is nonconvex and not one of the classic Platonic/Archimedean/
+  // Catalan families.
+  #[test]
+  fn polyhedron_data_rhombic_hexecontahedron() {
+    assert_eq!(
+      interpret(
+        r#"{PolyhedronData["RhombicHexecontahedron", "VertexCount"],
+            PolyhedronData["RhombicHexecontahedron", "EdgeCount"],
+            PolyhedronData["RhombicHexecontahedron", "FaceCount"]}"#
+      )
+      .unwrap(),
+      "{62, 120, 60}"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["RhombicHexecontahedron", "SurfaceArea"]"#)
+        .unwrap(),
+      "24*Sqrt[5]"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["RhombicHexecontahedron", "Volume"]"#)
+        .unwrap(),
+      "4*Sqrt[2*(5 + Sqrt[5])]"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["RhombicHexecontahedron", "Circumradius"]"#)
+        .unwrap(),
+      "Missing[NotApplicable]"
+    );
+    // Three vertex "shells": the 12 pulled-in dodecahedron face centers, the
+    // 30 unmoved dodecahedron edge midpoints, and the 20 pulled-out
+    // dodecahedron vertices — a nonconvex solid has no single circumradius.
+    assert_eq!(
+      interpret(
+        r#"With[{v = N[PolyhedronData["RhombicHexecontahedron",
+               "VertexCoordinates"]]},
+             {Length[v], Length[Union[Round[10^6 * Norm /@ v]]]}]"#
+      )
+      .unwrap(),
+      "{62, 3}"
+    );
+    // Every face is a golden rhombus: all 4 sides equal, and the ratio of
+    // the diagonals is the golden ratio.
+    assert_eq!(
+      interpret(
+        r#"With[{v = N[PolyhedronData["RhombicHexecontahedron",
+               "VertexCoordinates"]],
+              faces = PolyhedronData["RhombicHexecontahedron",
+                "FaceIndices"]},
+             Union @ Flatten @ Table[
+               With[{q = v[[f]]},
+                 Round[10^6 * {
+                   Norm[q[[1]] - q[[2]]], Norm[q[[2]] - q[[3]]],
+                   Norm[q[[3]] - q[[4]]], Norm[q[[4]] - q[[1]]],
+                   Norm[q[[1]] - q[[3]]] / Norm[q[[2]] - q[[4]]]}]],
+               {f, faces}]]"#
+      )
+      .unwrap(),
+      "{1000000, 1618034}"
+    );
+    // Nonconvex, but still isohedral: every face plane sits at the same
+    // distance from the center, so a well-defined insphere exists even
+    // though the solid is not convex.
+    assert_eq!(
+      interpret(r#"PolyhedronData["RhombicHexecontahedron", "Inradius"]"#)
+        .unwrap(),
+      "Sqrt[(5 + Sqrt[5])/10]"
+    );
+    assert_eq!(
+      interpret(
+        r#"MemberQ[PolyhedronData["RhombicHexecontahedron", "Classes"],
+             "Convex"]"#
+      )
+      .unwrap(),
+      "False"
+    );
+    assert_eq!(
+      interpret(r#"PolyhedronData["RhombicHexecontahedron"]"#).unwrap(),
       "-Graphics3D-"
     );
   }


### PR DESCRIPTION
## Summary

As part of the recurring task of testing Woxi Studio against random Wolfram Demonstrations, this run's notebook built a cluster of stellated polyhedra using `Manipulate` and `PolyhedronData["RhombicHexecontahedron", ...]`. That entity wasn't in Woxi's `PolyhedronData` table, so the call stayed unevaluated, `GraphicsComplex` never got real coordinates, and nothing rendered.

- Added `PolyhedronData["RhombicHexecontahedron"]`: a nonconvex stellation of the rhombic triacontahedron (62 vertices, 120 edges, 60 golden-rhombus faces), with exact `VertexCoordinates`, `FaceIndices`, `Volume`, `SurfaceArea`, `Inradius`, `Circumradius`, and `Classes`.
- The vertex/face data was derived from Wikipedia's documented "scale a dodecahedron's vertices, face centers, and edge midpoints" construction, then cross-checked against dmccooey.com/polyhedra's independent exact-form reference data — `Volume`, `SurfaceArea`, and all three distinct vertex radii match to machine precision.
- No code from the source notebook is reproduced; only the target entity name and the underlying (independently documented, uncopyrighted) geometric construction were used.

## Test plan

- [x] `cargo test` (full suite) — all green, including a new `polyhedron_data_rhombic_hexecontahedron` test (vertex/edge/face counts, `Volume`, `SurfaceArea`, `Inradius`, `Circumradius`, golden-rhombus face shape, non-convexity, and that it renders).
- [x] Updated `PolyhedronData[All]` and the discrete-Manipulate-spec test to include the new entity.
- [x] `make format` (cargo fmt + clippy --fix) — clean.
- [x] `functions.csv` updated to describe the new coverage.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01VaB7jnK9dLKNda5114mRm7)_