### PR TITLE
Fix PlotStyle in 3D surface rendering and named-character comparison/rule operators

### DIFF
--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -393,6 +393,7 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut mesh_mode = MeshMode::Default;
   let mut show_axes = true;
   let mut z_clip: Option<(f64, f64)> = None;
+  let mut plot_style_expr: Option<&Expr> = None;
 
   for opt in &args[3..] {
     if let Expr::Rule {
@@ -401,6 +402,9 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } = opt
     {
       match pattern.as_ref() {
+        Expr::Identifier(name) if name == "PlotStyle" => {
+          plot_style_expr = Some(replacement.as_ref());
+        }
         Expr::Identifier(name) if name == "ImageSize" => {
           if let Some((w, h, fw)) =
             parse_image_size(replacement, DEFAULT_SIZE, DEFAULT_SIZE)
@@ -463,7 +467,20 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     _ => vec![body],
   };
 
+  // `PlotStyle`, one style per surface (cycling); empty means it was not
+  // given, so the height-based rainbow default is used unchanged.
+  let plot_styles: Vec<StyleState3D> = plot_style_expr
+    .map(|e| parse_plot_style_3d(e, bodies.len()))
+    .unwrap_or_default();
+
   let camera = Camera::default();
+  // Direction from the scene towards the viewer, used to place a
+  // `Specularity` highlight from `PlotStyle`.
+  let view_dir = {
+    let (sa, ca) = camera.azimuth.sin_cos();
+    let (se, ce) = camera.elevation.sin_cos();
+    [ce * ca, ce * sa, se]
+  };
   let x_step = (x_max - x_min) / GRID_N as f64;
   let y_step = (y_max - y_min) / GRID_N as f64;
 
@@ -718,10 +735,12 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             + (cz10 - z_lo) / z_range
             + (cz01 - z_lo) / z_range)
             / 3.0;
-          let base_color =
+          let default_color =
             surface_height_color(avg_z_norm, surface_idx, num_surfaces);
           let normal = triangle_normal(v0, v1, v2);
-          let color = apply_lighting(base_color, normal);
+          let style = plot_style_for_surface(&plot_styles, surface_idx);
+          let (color, opacity) =
+            shade_facet(default_color, style, normal, view_dir);
 
           let p0 = project(v0, &camera);
           let p1 = project(v1, &camera);
@@ -738,7 +757,7 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             projected: [p0, p1, p2],
             depth: depth(center, &camera),
             color,
-            opacity: 1.0,
+            opacity,
           });
         }
 
@@ -768,10 +787,12 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             + (cz01 - z_lo) / z_range
             + (cz10 - z_lo) / z_range)
             / 3.0;
-          let base_color =
+          let default_color =
             surface_height_color(avg_z_norm, surface_idx, num_surfaces);
           let normal = triangle_normal(v0, v1, v2);
-          let color = apply_lighting(base_color, normal);
+          let style = plot_style_for_surface(&plot_styles, surface_idx);
+          let (color, opacity) =
+            shade_facet(default_color, style, normal, view_dir);
 
           let p0 = project(v0, &camera);
           let p1 = project(v1, &camera);
@@ -788,7 +809,7 @@ pub fn plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             projected: [p0, p1, p2],
             depth: depth(center, &camera),
             color,
-            opacity: 1.0,
+            opacity,
           });
         }
       }
@@ -1004,13 +1025,18 @@ fn generate_svg(
       let (x1, y1) = to_svg(tri.projected[1].0, tri.projected[1].1);
       let (x2, y2) = to_svg(tri.projected[2].0, tri.projected[2].1);
       let (r, g, b) = tri.color;
+      let opacity_attr = if tri.opacity < 1.0 {
+        format!(" opacity=\"{}\"", tri.opacity)
+      } else {
+        String::new()
+      };
       if mesh_mode == MeshMode::All {
         svg.push_str(&format!(
-          "<polygon points=\"{x0:.1},{y0:.1} {x1:.1},{y1:.1} {x2:.1},{y2:.1}\" fill=\"rgb({r},{g},{b})\" stroke=\"#00000060\" stroke-width=\"0.5\"/>\n"
+          "<polygon points=\"{x0:.1},{y0:.1} {x1:.1},{y1:.1} {x2:.1},{y2:.1}\" fill=\"rgb({r},{g},{b})\" stroke=\"#00000060\" stroke-width=\"0.5\"{opacity_attr}/>\n"
         ));
       } else {
         svg.push_str(&format!(
-          "<polygon points=\"{x0:.1},{y0:.1} {x1:.1},{y1:.1} {x2:.1},{y2:.1}\" fill=\"rgb({r},{g},{b})\" stroke=\"rgb({r},{g},{b})\" stroke-width=\"0.5\"/>\n"
+          "<polygon points=\"{x0:.1},{y0:.1} {x1:.1},{y1:.1} {x2:.1},{y2:.1}\" fill=\"rgb({r},{g},{b})\" stroke=\"rgb({r},{g},{b})\" stroke-width=\"0.5\"{opacity_attr}/>\n"
         ));
       }
     }
@@ -2518,6 +2544,92 @@ fn parse_specularity(args: &[Expr]) -> Option<((u8, u8, u8), f64)> {
     .filter(|n| *n > 0.0)
     .unwrap_or(1.0);
   Some((rgb, exponent))
+}
+
+/// Resolve which entry of a `PlotStyle` style list a surface uses, cycling
+/// through fewer styles than surfaces (`PlotStyle -> {Red, Blue}` on three
+/// surfaces gives Red, Blue, Red). `None` — an absent or empty list — means
+/// `PlotStyle` was not given, so callers keep their default colouring.
+fn plot_style_for_surface(
+  styles: &[StyleState3D],
+  surface_idx: usize,
+) -> Option<&StyleState3D> {
+  if styles.is_empty() {
+    None
+  } else {
+    Some(&styles[surface_idx % styles.len()])
+  }
+}
+
+/// Parse a `PlotStyle` option value into one style per surface, mirroring
+/// [`crate::functions::plot::parse_plot_style`]'s disambiguation for 2D
+/// `Plot`: with more than one surface, a flat list of colours/directives is
+/// read as one style per surface (`PlotStyle -> {Red, Blue}`), cycling when
+/// there are fewer styles than surfaces; a single style — one bare
+/// directive, or a list that mixes directives for a single style, like
+/// `{RGBColor[...], Opacity[.5]}` — applies to every surface alike. An
+/// empty result means `PlotStyle` was not given (or produced nothing
+/// applicable), so callers keep drawing the height-based rainbow default.
+fn parse_plot_style_3d(
+  replacement: &Expr,
+  num_surfaces: usize,
+) -> Vec<StyleState3D> {
+  use crate::functions::graphics::parse_color;
+
+  let val =
+    evaluate_expr_to_expr(replacement).unwrap_or_else(|_| replacement.clone());
+  let items: Vec<Expr> = match &val {
+    Expr::List(list_items) if num_surfaces > 1 => {
+      let per_surface = list_items.iter().any(|item| {
+        matches!(item, Expr::FunctionCall { name, .. } if name == "Directive")
+          || matches!(item, Expr::List(_))
+          || parse_color(item).is_some()
+      });
+      if per_surface {
+        list_items.to_vec()
+      } else {
+        vec![val.clone()]
+      }
+    }
+    _ => vec![val.clone()],
+  };
+
+  items
+    .into_iter()
+    .map(|item| {
+      let mut style = StyleState3D::default();
+      apply_3d_directive(&item, &mut style);
+      style
+    })
+    .collect()
+}
+
+/// Shade one triangle facet, folding in a `PlotStyle` override:
+/// `default_color` is the plot's ordinary colour for this facet (height-
+/// based, as today) and is used unchanged — through the same diffuse +
+/// ambient lighting as before — when `style` is `None`, so a plot without
+/// `PlotStyle` renders byte-identically to before this existed. When a
+/// style is given, its own colour (falling back to `default_color` if the
+/// style set no colour of its own, e.g. `PlotStyle -> Opacity[.5]`) is
+/// shaded instead, with any `Specularity` the style carries layered on top,
+/// and the style's opacity is returned alongside the colour for the
+/// triangle to draw translucently.
+fn shade_facet(
+  default_color: (u8, u8, u8),
+  style: Option<&StyleState3D>,
+  normal: [f64; 3],
+  view_dir: [f64; 3],
+) -> ((u8, u8, u8), f64) {
+  match style {
+    Some(s) => {
+      let base = s.color.unwrap_or(default_color);
+      (
+        apply_lighting_specular(base, normal, s.specular, view_dir),
+        s.opacity,
+      )
+    }
+    None => (apply_lighting(default_color, normal), 1.0),
+  }
 }
 
 /// The linear part of a rotation by `angle` around the axis direction `w`
@@ -6460,6 +6572,21 @@ pub fn revolution_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     global_r_max
   };
 
+  // `RevolutionPlot3D` draws a single surface, so `PlotStyle` is one style
+  // rather than a per-surface list.
+  let render_style: Option<StyleState3D> = plot_style.as_ref().map(|ps| {
+    let mut style = StyleState3D::default();
+    apply_3d_directive(ps, &mut style);
+    style
+  });
+  // Direction from the scene towards the viewer, used to place a
+  // `Specularity` highlight from `PlotStyle`.
+  let view_dir = {
+    let (sa, ca) = camera.azimuth.sin_cos();
+    let (se, ce) = camera.elevation.sin_cos();
+    [ce * ca, ce * sa, se]
+  };
+
   let nz = |z: f64| -> f64 {
     let cz = z.clamp(z_lo, z_hi);
     ((cz - z_lo) / z_range) * 2.0 * Z_SCALE - Z_SCALE
@@ -6495,9 +6622,10 @@ pub fn revolution_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
         let avg_z_norm =
           (z_norm_of(pp00) + z_norm_of(pp10) + z_norm_of(pp01)) / 3.0;
-        let base_color = height_color(avg_z_norm);
+        let default_color = height_color(avg_z_norm);
         let normal = triangle_normal(v0, v1, v2);
-        let color = apply_lighting(base_color, normal);
+        let (color, opacity) =
+          shade_facet(default_color, render_style.as_ref(), normal, view_dir);
 
         let proj0 = project(v0, &camera);
         let proj1 = project(v1, &camera);
@@ -6514,7 +6642,7 @@ pub fn revolution_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           projected: [proj0, proj1, proj2],
           depth: depth(center, &camera),
           color,
-          opacity: 1.0,
+          opacity,
         });
       }
 
@@ -6526,9 +6654,10 @@ pub fn revolution_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
         let avg_z_norm =
           (z_norm_of(pp11) + z_norm_of(pp01) + z_norm_of(pp10)) / 3.0;
-        let base_color = height_color(avg_z_norm);
+        let default_color = height_color(avg_z_norm);
         let normal = triangle_normal(v0, v1, v2);
-        let color = apply_lighting(base_color, normal);
+        let (color, opacity) =
+          shade_facet(default_color, render_style.as_ref(), normal, view_dir);
 
         let proj0 = project(v0, &camera);
         let proj1 = project(v1, &camera);
@@ -6545,7 +6674,7 @@ pub fn revolution_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           projected: [proj0, proj1, proj2],
           depth: depth(center, &camera),
           color,
-          opacity: 1.0,
+          opacity,
         });
       }
     }
@@ -8808,6 +8937,7 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut full_width = false;
   let mut mesh_mode = MeshMode::Default;
   let mut show_axes = true;
+  let mut plot_style_expr: Option<&Expr> = None;
 
   for opt in &args[3..] {
     if let Expr::Rule {
@@ -8816,6 +8946,9 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     } = opt
     {
       match pattern.as_ref() {
+        Expr::Identifier(name) if name == "PlotStyle" => {
+          plot_style_expr = Some(replacement.as_ref());
+        }
         Expr::Identifier(name) if name == "ImageSize" => {
           if let Some((w, h, fw)) =
             parse_image_size(replacement, DEFAULT_SIZE, DEFAULT_SIZE)
@@ -8892,7 +9025,20 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   };
 
+  // `PlotStyle`, one style per surface (cycling); empty means it was not
+  // given, so the height-based rainbow default is used unchanged.
+  let plot_styles: Vec<StyleState3D> = plot_style_expr
+    .map(|e| parse_plot_style_3d(e, surfaces.len()))
+    .unwrap_or_default();
+
   let camera = Camera::default();
+  // Direction from the scene towards the viewer, used to place a
+  // `Specularity` highlight from `PlotStyle`.
+  let view_dir = {
+    let (sa, ca) = camera.azimuth.sin_cos();
+    let (se, ce) = camera.elevation.sin_cos();
+    [ce * ca, ce * sa, se]
+  };
   let u_step = (u_max - u_min) / GRID_N as f64;
   let v_step = (v_max - v_min) / GRID_N as f64;
 
@@ -8953,7 +9099,8 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Phase 2: Build triangles
   let mut all_triangles: Vec<Triangle> = Vec::new();
 
-  for sg in &all_surface_points {
+  for (surface_idx, sg) in all_surface_points.iter().enumerate() {
+    let style = plot_style_for_surface(&plot_styles, surface_idx);
     for i in 0..GRID_N {
       for j in 0..GRID_N {
         let p00 = sg[i][j];
@@ -8977,9 +9124,10 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           let v1 = normalize(b);
           let v2 = normalize(c);
           let avg_z_norm = (z_norm(a.2) + z_norm(b.2) + z_norm(c.2)) / 3.0;
-          let base_color = height_color(avg_z_norm);
+          let default_color = height_color(avg_z_norm);
           let normal = triangle_normal(v0, v1, v2);
-          let color = apply_lighting(base_color, normal);
+          let (color, opacity) =
+            shade_facet(default_color, style, normal, view_dir);
           let center = Point3D {
             x: (v0.x + v1.x + v2.x) / 3.0,
             y: (v0.y + v1.y + v2.y) / 3.0,
@@ -8995,7 +9143,7 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             ],
             depth: depth(center, &camera),
             color,
-            opacity: 1.0,
+            opacity,
           });
         }
 
@@ -9005,9 +9153,10 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           let v1 = normalize(b);
           let v2 = normalize(c);
           let avg_z_norm = (z_norm(a.2) + z_norm(b.2) + z_norm(c.2)) / 3.0;
-          let base_color = height_color(avg_z_norm);
+          let default_color = height_color(avg_z_norm);
           let normal = triangle_normal(v0, v1, v2);
-          let color = apply_lighting(base_color, normal);
+          let (color, opacity) =
+            shade_facet(default_color, style, normal, view_dir);
           let center = Point3D {
             x: (v0.x + v1.x + v2.x) / 3.0,
             y: (v0.y + v1.y + v2.y) / 3.0,
@@ -9023,7 +9172,7 @@ pub fn parametric_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
             ],
             depth: depth(center, &camera),
             color,
-            opacity: 1.0,
+            opacity,
           });
         }
       }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -4826,16 +4826,21 @@ fn parse_expression_inner(
         op.as_str(),
         "=="
           | "\u{2A75}"
+          | "\\[Equal]"
+          | "\u{F431}"
           | "!="
           | "\u{2260}"
+          | "\\[NotEqual]"
           | "<"
           | "<="
           | "\u{2264}"
           | "\u{2A7D}"
+          | "\\[LessEqual]"
           | ">"
           | ">="
           | "\u{2265}"
           | "\u{2A7E}"
+          | "\\[GreaterEqual]"
           | "==="
           | "=!="
       )
@@ -4846,12 +4851,16 @@ fn parse_expression_inner(
       let comp_ops: Vec<ComparisonOp> = operators
         .iter()
         .map(|op| match op.as_str() {
-          "==" | "\u{2A75}" => ComparisonOp::Equal,
-          "!=" | "\u{2260}" => ComparisonOp::NotEqual,
+          "==" | "\u{2A75}" | "\\[Equal]" | "\u{F431}" => ComparisonOp::Equal,
+          "!=" | "\u{2260}" | "\\[NotEqual]" => ComparisonOp::NotEqual,
           "<" => ComparisonOp::Less,
-          "<=" | "\u{2264}" | "\u{2A7D}" => ComparisonOp::LessEqual,
+          "<=" | "\u{2264}" | "\u{2A7D}" | "\\[LessEqual]" => {
+            ComparisonOp::LessEqual
+          }
           ">" => ComparisonOp::Greater,
-          ">=" | "\u{2265}" | "\u{2A7E}" => ComparisonOp::GreaterEqual,
+          ">=" | "\u{2265}" | "\u{2A7E}" | "\\[GreaterEqual]" => {
+            ComparisonOp::GreaterEqual
+          }
           "===" => ComparisonOp::SameQ,
           "=!=" => ComparisonOp::UnsameQ,
           _ => ComparisonOp::Equal,
@@ -5612,6 +5621,15 @@ pub const CONTINUING_NAMED_OPERATORS: &[&str] = &[
   "\u{221A}",
   "\\[CubeRoot]",
   "\u{221B}",
+  "\\[Rule]",
+  "\u{F522}",
+  "\\[RuleDelayed]",
+  "\u{F51F}",
+  "\\[Equal]",
+  "\u{F431}",
+  "\\[NotEqual]",
+  "\\[LessEqual]",
+  "\\[GreaterEqual]",
 ];
 
 /// Does this line's code (whitespace already squeezed out) end with a named
@@ -5636,15 +5654,16 @@ fn operator_precedence(op: &str) -> u8 {
     // so `lhs /; test :> rhs` is `RuleDelayed[Condition[lhs, test], rhs]` and
     // `lhs :> rhs /; test` is `RuleDelayed[lhs, Condition[rhs, test]]`.
     "/;" => 12,
-    "->" | "\u{2192}" | ":>" => 11, // Rule/RuleDelayed (lower than boolean operators)
-    "||" => 15,                     // Or
-    "&&" => 18,                     // And
-    "\\[And]" | "\u{2227}" => 18,   // \[And] (same as &&)
-    "\\[Nand]" | "\u{22BC}" => 18,  // \[Nand] (And level)
-    "\\[Xor]" | "\u{22BB}" => 16,   // \[Xor] (between Or and And)
-    "\\[Or]" | "\u{2228}" => 15,    // \[Or] (same as ||)
-    "\\[Nor]" | "\u{22BD}" => 15,   // \[Nor] (Or level)
-    "\\[Equivalent]" | "\u{29E6}" => 14, // \[Equivalent] (below Or)
+    "->" | "\u{2192}" | "\\[Rule]" | "\u{F522}" | ":>" | "\\[RuleDelayed]"
+    | "\u{F51F}" => 11, // Rule/RuleDelayed (lower than boolean operators)
+    "||" => 15,                              // Or
+    "&&" => 18,                              // And
+    "\\[And]" | "\u{2227}" => 18,            // \[And] (same as &&)
+    "\\[Nand]" | "\u{22BC}" => 18,           // \[Nand] (And level)
+    "\\[Xor]" | "\u{22BB}" => 16,            // \[Xor] (between Or and And)
+    "\\[Or]" | "\u{2228}" => 15,             // \[Or] (same as ||)
+    "\\[Nor]" | "\u{22BD}" => 15,            // \[Nor] (Or level)
+    "\\[Equivalent]" | "\u{29E6}" => 14,     // \[Equivalent] (below Or)
     "\\[Implies]" | "\u{F523}" => 13, // \[Implies] (lowest logical, right-assoc)
     "\\[NotElement]" | "\u{2209}" => 21, // NotElement (same level as comparisons)
     "\\[ReverseElement]" | "\u{220B}" => 21, // ReverseElement (same level as comparisons)
@@ -5668,8 +5687,10 @@ fn operator_precedence(op: &str) -> u8 {
     // the right operand absorbs y, y = 1, y /; z, y -> 1. Place at TagSet
     // level so its rhs stays maximally permissive.
     "\\[Function]" | "\u{F4A1}" | "|->" => 3,
-    "==" | "!=" | "\u{2260}" | "<" | "<=" | "\u{2264}" | "\u{2A7D}" | ">"
-    | ">=" | "\u{2265}" | "\u{2A7E}" | "===" | "=!=" => 21, // Comparisons
+    "==" | "\u{2A75}" | "\\[Equal]" | "\u{F431}" | "!=" | "\u{2260}"
+    | "\\[NotEqual]" | "<" | "<=" | "\u{2264}" | "\u{2A7D}"
+    | "\\[LessEqual]" | ">" | ">=" | "\u{2265}" | "\u{2A7E}"
+    | "\\[GreaterEqual]" | "===" | "=!=" => 21, // Comparisons
     "~~" => 24,      // StringExpression (lower than Alternatives)
     "|" => 27, // Alternatives (higher than StringExpression, Or, And, Rule)
     "+" | "-" => 30, // Plus/Minus
@@ -5761,7 +5782,11 @@ fn build_expr_with_precedence(
       || op_str == "/*"
       || op_str == "->"
       || op_str == "\u{2192}"
+      || op_str == "\\[Rule]"
+      || op_str == "\u{F522}"
       || op_str == ":>"
+      || op_str == "\\[RuleDelayed]"
+      || op_str == "\u{F51F}"
       || op_str == "\\[RightTee]"
       || op_str == "\u{22A2}"
       || op_str == "\\[Implies]"
@@ -6214,11 +6239,11 @@ fn make_binary_op(left: &Expr, op_str: &str, right: &Expr) -> Expr {
       name: "Dot".to_string(),
       args: vec![left.clone(), right.clone()].into(),
     },
-    "->" | "\u{2192}" => Expr::Rule {
+    "->" | "\u{2192}" | "\\[Rule]" | "\u{F522}" => Expr::Rule {
       pattern: Box::new(left.clone()),
       replacement: Box::new(right.clone()),
     },
-    ":>" => Expr::RuleDelayed {
+    ":>" | "\\[RuleDelayed]" | "\u{F51F}" => Expr::RuleDelayed {
       pattern: Box::new(left.clone()),
       replacement: Box::new(right.clone()),
     },
@@ -6301,15 +6326,21 @@ fn make_binary_op(left: &Expr, op_str: &str, right: &Expr) -> Expr {
         }
       }
     }
-    "==" | "\u{2A75}" | "!=" | "\u{2260}" | "<" | "<=" | "\u{2264}"
-    | "\u{2A7D}" | ">" | ">=" | "\u{2265}" | "\u{2A7E}" | "===" | "=!=" => {
+    "==" | "\u{2A75}" | "\\[Equal]" | "\u{F431}" | "!=" | "\u{2260}"
+    | "\\[NotEqual]" | "<" | "<=" | "\u{2264}" | "\u{2A7D}"
+    | "\\[LessEqual]" | ">" | ">=" | "\u{2265}" | "\u{2A7E}"
+    | "\\[GreaterEqual]" | "===" | "=!=" => {
       let comp_op = match op_str {
-        "==" | "\u{2A75}" => ComparisonOp::Equal,
-        "!=" | "\u{2260}" => ComparisonOp::NotEqual,
+        "==" | "\u{2A75}" | "\\[Equal]" | "\u{F431}" => ComparisonOp::Equal,
+        "!=" | "\u{2260}" | "\\[NotEqual]" => ComparisonOp::NotEqual,
         "<" => ComparisonOp::Less,
-        "<=" | "\u{2264}" | "\u{2A7D}" => ComparisonOp::LessEqual,
+        "<=" | "\u{2264}" | "\u{2A7D}" | "\\[LessEqual]" => {
+          ComparisonOp::LessEqual
+        }
         ">" => ComparisonOp::Greater,
-        ">=" | "\u{2265}" | "\u{2A7E}" => ComparisonOp::GreaterEqual,
+        ">=" | "\u{2265}" | "\u{2A7E}" | "\\[GreaterEqual]" => {
+          ComparisonOp::GreaterEqual
+        }
         "===" => ComparisonOp::SameQ,
         "=!=" => ComparisonOp::UnsameQ,
         _ => ComparisonOp::Equal,

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -126,9 +126,10 @@ PrivateUseLetter = _{ '\u{F6B2}'..'\u{F6CB}' | '\u{F770}'..'\u{F789}' }
 PatternName = @{ (ASCII_ALPHA | LETTER | PrivateUseLetter) ~ (ASCII_ALPHANUMERIC | LETTER | PrivateUseLetter)* }
 // NamedCharIdentifier: named character sequences like \[Phi], \[Alpha], etc.
 // Matches \[Name] syntax or direct Unicode chars for common symbols
-// Excludes operator named chars (\[Element], \[NotElement], \[ReverseElement], \[DirectedEdge], \[UndirectedEdge])
+// Excludes operator named chars (\[Element], \[NotElement], \[ReverseElement], \[DirectedEdge], \[UndirectedEdge],
+// \[Rule], \[RuleDelayed], \[Equal], \[NotEqual], \[LessEqual], \[GreaterEqual], …)
 // which must be parsed as infix operators, not as identifiers in implicit multiplication.
-NamedCharBase = _{ !("\\[DifferentialD]" | "\\[Sqrt]" | "\\[CubeRoot]" | "\\[Element]" | "\\[NotElement]" | "\\[ReverseElement]" | "\\[DirectedEdge]" | "\\[UndirectedEdge]" | "\\[Distributed]" | "\\[Conditioned]" | "\\[Function]" | "\\[Transpose]" | "\\[ConjugateTranspose]" | "\\[Cross]" | "\\[TensorProduct]" | "\\[CircleTimes]" | "\\[CirclePlus]" | "\\[CenterDot]" | "\\[Times]" | "\\[Divide]" | "\\[CircleMinus]" | "\\[Star]" | "\\[Diamond]" | "\\[Backslash]" | "\\[CircleDot]" | "\\[SmallCircle]" | "\\[Wedge]" | "\\[Vee]" | "\\[Cap]" | "\\[Cup]" | "\\[DoubleRightTee]" | "\\[RightTee]" | "\\[DoubleLeftTee]" | "\\[LeftTee]" | "\\[And]" | "\\[Or]" | "\\[Not]" | "\\[Xor]" | "\\[Nand]" | "\\[Nor]" | "\\[Implies]" | "\\[Equivalent]") ~ "\\[" ~ ASCII_ALPHA+ ~ "]" | "\u{20AC}" | "\u{03F5}" | "\u{03C0}" | "\u{212F}" | "\u{2147}" | "\u{00B0}" | "\u{221E}" | "\u{2148}" | "\u{F74D}" | "\u{F74E}" | "\u{F74F}" }
+NamedCharBase = _{ !("\\[DifferentialD]" | "\\[Sqrt]" | "\\[CubeRoot]" | "\\[Element]" | "\\[NotElement]" | "\\[ReverseElement]" | "\\[DirectedEdge]" | "\\[UndirectedEdge]" | "\\[Distributed]" | "\\[Conditioned]" | "\\[Function]" | "\\[Transpose]" | "\\[ConjugateTranspose]" | "\\[Cross]" | "\\[TensorProduct]" | "\\[CircleTimes]" | "\\[CirclePlus]" | "\\[CenterDot]" | "\\[Times]" | "\\[Divide]" | "\\[CircleMinus]" | "\\[Star]" | "\\[Diamond]" | "\\[Backslash]" | "\\[CircleDot]" | "\\[SmallCircle]" | "\\[Wedge]" | "\\[Vee]" | "\\[Cap]" | "\\[Cup]" | "\\[DoubleRightTee]" | "\\[RightTee]" | "\\[DoubleLeftTee]" | "\\[LeftTee]" | "\\[And]" | "\\[Or]" | "\\[Not]" | "\\[Xor]" | "\\[Nand]" | "\\[Nor]" | "\\[Implies]" | "\\[Equivalent]" | "\\[Rule]" | "\\[RuleDelayed]" | "\\[Equal]" | "\\[NotEqual]" | "\\[LessEqual]" | "\\[GreaterEqual]") ~ "\\[" ~ ASCII_ALPHA+ ~ "]" | "\u{20AC}" | "\u{03F5}" | "\u{03C0}" | "\u{212F}" | "\u{2147}" | "\u{00B0}" | "\u{221E}" | "\u{2148}" | "\u{F74D}" | "\u{F74E}" | "\u{F74F}" }
 // Adjacent `\[Name]` segments (or named char + identifier chars)
 // concatenate into a single identifier — `\[CapitalGamma]\[Beta]` → `Γβ`,
 // `\[Angle]XYZ` → `∠XYZ`, `i\[Ellipsis]j` (when `i` then `\[Ellipsis]j`
@@ -256,17 +257,17 @@ Operator = @{
   | "&&"     // And operator (must be before single &)
   | "||"     // Or operator (must be before single |)
   | "|"      // Alternatives operator
-  | "===" | "=!=" | "==" | "\u{2A75}" | "!=" | "\u{2260}"  // SameQ, UnsameQ (must be before == and !=), Equal, ⩵, Unequal, ≠
-  | "<=" | ">=" | "\u{2264}" | "\u{2265}" | "\u{2A7D}" | "\u{2A7E}"  // LessEqual, GreaterEqual, ≤, ≥, ⩽, ⩾
+  | "===" | "=!=" | "==" | "\u{2A75}" | "\\[Equal]" | "\u{F431}" | "!=" | "\u{2260}" | "\\[NotEqual]"  // SameQ, UnsameQ (must be before == and !=), Equal, ⩵, Unequal, ≠
+  | "<=" | "\u{2264}" | "\u{2A7D}" | "\\[LessEqual]" | ">=" | "\u{2265}" | "\u{2A7E}" | "\\[GreaterEqual]"  // LessEqual, ≤, ⩽, GreaterEqual, ≥, ⩾
   | ">>>" ~ !(">" | "=")   // PutAppend operator (must be before >> and >)
   | ">>" ~ !(">" | "=")    // Put operator (must be before > and >=)
   | "/*" ~ !(")")  // RightComposition operator (must be before / ; avoid matching /* in comments)
   | "/;" ~ !("/")  // Condition operator (must be before / and ;)
   | "/:" ~ !("/")  // TagSet/TagSetDelayed operator (must be before / and :)
   | "::" ~ !":"   // MessageName (a::b → MessageName[a, "b"]). Must precede :> and :=.
-  | ":>"     // RuleDelayed (must be before := and >)
+  | "\\[RuleDelayed]" | "\u{F51F}" | ":>"     // RuleDelayed (must be before := and >)
   | ":="
-  | "->" | "\u{2192}"     // Rule (must be before - and >), →
+  | "\\[Rule]" | "\u{F522}" | "->" | "\u{2192}"     // Rule (must be before - and >), →
   | "^:="    // UpSetDelayed (must be before ^= and :=)
   | "^="     // UpSet (must be before ^ and =)
   | "+" | "-" | "*" | "/" | "^"
@@ -712,10 +713,10 @@ ConditionOp = @{
   | "\\[RightTee]" | "\u{22A2}"   // RightTee (⊢)
   | "\\[DoubleLeftTee]" | "\u{2AE4}" // DoubleLeftTee (⫤)
   | "\\[LeftTee]" | "\u{22A3}"    // LeftTee (⊣)
-  | "===" | "=!=" | "==" | "\u{2A75}" | "!=" | "\u{2260}"  // Comparison, ⩵, ≠
+  | "===" | "=!=" | "==" | "\u{2A75}" | "\\[Equal]" | "\u{F431}" | "!=" | "\u{2260}" | "\\[NotEqual]"  // Comparison, ⩵, ≠
   | "<->"                         // TwoWayRule (must be before <>, <=, <)
   | "<>"                          // StringJoin (must be before < to avoid partial match)
-  | "<=" | ">=" | "\u{2264}" | "\u{2265}" | "\u{2A7D}" | "\u{2A7E}" | "<" | ">"       // Order comparison, ≤, ≥, ⩽, ⩾
+  | "<=" | "\u{2264}" | "\u{2A7D}" | "\\[LessEqual]" | ">=" | "\u{2265}" | "\u{2A7E}" | "\\[GreaterEqual]" | "<" | ">"       // Order comparison, ≤, ≥, ⩽, ⩾
   | "/@"                          // Map (must be before the bare "/" of Arithmetic)
   | "@@@"                         // MapApply (must be before @@)
   | "@@"                          // Apply (must be before @)

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -1874,6 +1874,147 @@ mod plot3d {
         "the box must stop at the range asked for, not at the domain: {svg}"
       );
     }
+
+    /// Every `<polygon>` fill colour appearing in the SVG, as `(r, g, b)`
+    /// triples — parsed straight out of the `fill="rgb(r,g,b)"` attribute so
+    /// a test can check the lit colours a surface actually rendered with.
+    fn fill_colors(svg: &str) -> Vec<(u32, u32, u32)> {
+      svg
+        .split("<polygon ")
+        .skip(1)
+        .filter_map(|tag| {
+          let tag = tag.split('>').next()?;
+          let inner = tag.split("fill=\"rgb(").nth(1)?.split(')').next()?;
+          let mut parts =
+            inner.split(',').filter_map(|n| n.trim().parse().ok());
+          Some((parts.next()?, parts.next()?, parts.next()?))
+        })
+        .collect()
+    }
+
+    /// Without `PlotStyle`, `Plot3D` colours a surface by height (a rainbow
+    /// gradient); this must stay the *only* thing that produces colour, so
+    /// this baseline call is the regression guard the `PlotStyle` tests
+    /// below diff against — any accidental change to the no-`PlotStyle`
+    /// path would also show up in the `paraboloid`/`trig_function` snapshots
+    /// above.
+    fn no_plotstyle_svg() -> String {
+      export_svg("Plot3D[Sin[x*y], {x, 0, 3}, {y, 0, 3}]")
+    }
+
+    /// `PlotStyle -> RGBColor[...]` used to be silently ignored by the
+    /// rendered surface (only the symbolic `GraphicsComplex` structure used
+    /// it): the picture stayed the default height-based rainbow no matter
+    /// what colour was asked for. The rendered fills must now be shaded
+    /// versions of the requested colour instead.
+    #[test]
+    fn plotstyle_color_changes_rendered_fill() {
+      let styled = export_svg(
+        "Plot3D[Sin[x*y], {x, 0, 3}, {y, 0, 3}, \
+         PlotStyle -> RGBColor[0.6, 0.73, 0.36]]",
+      );
+      assert_ne!(
+        no_plotstyle_svg(),
+        styled,
+        "PlotStyle must change the rendered SVG"
+      );
+      // Diffuse+ambient lighting attenuates the requested colour but keeps
+      // its channel ordering (green brightest, blue darkest), so check the
+      // ratio rather than an exact unlit RGBColor[0.6, 0.73, 0.36] byte match.
+      let colors = fill_colors(&styled);
+      assert!(!colors.is_empty(), "expected shaded fills: {styled}");
+      assert!(
+        colors.iter().all(|&(r, g, b)| g >= r && r >= b && g > 0),
+        "expected every fill tinted toward the requested green, got {colors:?}"
+      );
+    }
+
+    /// `PlotStyle -> {c1, c2}` on a multi-surface `Plot3D[{f1, f2}, ...]`
+    /// gives each surface its own colour, cycling through the list.
+    #[test]
+    fn plotstyle_list_gives_each_surface_its_own_color() {
+      let svg = export_svg(
+        "Plot3D[{Sin[x*y], Cos[x*y]}, {x, 0, 3}, {y, 0, 3}, \
+         PlotStyle -> {Red, Blue}]",
+      );
+      let colors = fill_colors(&svg);
+      assert!(
+        colors.iter().any(|&(r, g, b)| r > g && r > b),
+        "expected a red-tinted surface, got {colors:?}"
+      );
+      assert!(
+        colors.iter().any(|&(r, g, b)| b > r && b > g),
+        "expected a blue-tinted surface, got {colors:?}"
+      );
+    }
+
+    /// `Opacity[...]` inside `PlotStyle` must flow through to the rendered
+    /// triangles' fill opacity.
+    #[test]
+    fn plotstyle_opacity_sets_fill_opacity() {
+      let svg = export_svg(
+        "Plot3D[Sin[x*y], {x, 0, 3}, {y, 0, 3}, PlotStyle -> Opacity[0.4]]",
+      );
+      assert!(
+        svg.contains("opacity=\"0.4\""),
+        "expected PlotStyle -> Opacity[0.4] to set fill opacity: {svg}"
+      );
+    }
+
+    /// A `Specularity` directive mixed into `PlotStyle` adds a highlight on
+    /// top of the requested colour rather than repainting the surface with
+    /// the highlight's own colour (mirrors the `Graphics3D` behaviour). A
+    /// rippled surface's facet normals rarely line up with the exact
+    /// light/view bisector the way a full sphere's do, so this checks for a
+    /// clear brightening rather than the near-white peak the `Graphics3D`
+    /// sphere test can rely on.
+    #[test]
+    fn plotstyle_directive_adds_specular_highlight() {
+      let plain = export_svg(
+        "Plot3D[Sin[x*y], {x, 0, 3}, {y, 0, 3}, PlotStyle -> GrayLevel[.25]]",
+      );
+      let shiny = export_svg(
+        "Plot3D[Sin[x*y], {x, 0, 3}, {y, 0, 3}, \
+         PlotStyle -> Directive[GrayLevel[.25], Specularity[White, 20]]]",
+      );
+      let brightest = |svg: &str| {
+        fill_colors(svg).into_iter().map(|c| c.0).max().unwrap_or(0)
+      };
+      let plain_max = brightest(&plain);
+      let shiny_max = brightest(&shiny);
+      assert!(
+        plain_max < 128,
+        "matte GrayLevel[.25] surface should stay dark, got {plain_max}"
+      );
+      assert!(
+        shiny_max > plain_max + 30,
+        "Specularity[White, …] should brighten some facet well past the \
+         matte surface's own colour, got {plain_max} -> {shiny_max}"
+      );
+    }
+
+    /// No `PlotStyle` must render byte-identically to before it was
+    /// supported at all — the height-based rainbow default is load-bearing
+    /// for every other Plot3D snapshot test. (The axis grid legitimately
+    /// draws its lines at `opacity="0.4"`, so only the surface's own
+    /// `<polygon>` fills are checked here.)
+    #[test]
+    fn no_plotstyle_is_unchanged() {
+      let a = no_plotstyle_svg();
+      let b = no_plotstyle_svg();
+      assert_eq!(a, b);
+      assert!(
+        a.split("<polygon ").skip(1).all(|tag| {
+          !tag
+            .split('>')
+            .next()
+            .unwrap_or_default()
+            .contains("opacity=")
+        }),
+        "the default render's surface fills must not carry a translucency \
+         attribute: {a}"
+      );
+    }
   }
 
   mod errors {
@@ -2228,6 +2369,55 @@ mod plot3d {
         insta::assert_snapshot!(export_svg(
           "RevolutionPlot3D[{t^2, t}, {t, 0, 2}, PlotRange -> {0, 1.5}]"
         ));
+      }
+
+      /// Every `<polygon>` fill colour in the SVG, as `(r, g, b)` triples —
+      /// see the identical helper documented in `plot3d::options`.
+      fn fill_colors(svg: &str) -> Vec<(u32, u32, u32)> {
+        svg
+          .split("<polygon ")
+          .skip(1)
+          .filter_map(|tag| {
+            let tag = tag.split('>').next()?;
+            let inner = tag.split("fill=\"rgb(").nth(1)?.split(')').next()?;
+            let mut parts =
+              inner.split(',').filter_map(|n| n.trim().parse().ok());
+            Some((parts.next()?, parts.next()?, parts.next()?))
+          })
+          .collect()
+      }
+
+      /// `PlotStyle -> RGBColor[...]` used to be silently ignored by the
+      /// rendered surface: only `First[RevolutionPlot3D[...]]`'s symbolic
+      /// `GraphicsComplex` respected it, so the picture stayed the default
+      /// height-based rainbow no matter what colour was requested.
+      #[test]
+      fn plotstyle_color_changes_rendered_fill() {
+        let baseline = export_svg("RevolutionPlot3D[{t^2, t}, {t, 0, 2}]");
+        let styled = export_svg(
+          "RevolutionPlot3D[{t^2, t}, {t, 0, 2}, \
+           PlotStyle -> RGBColor[0.9, 0.1, 0.1]]",
+        );
+        assert_ne!(baseline, styled, "PlotStyle must change the rendered SVG");
+        let colors = fill_colors(&styled);
+        assert!(!colors.is_empty(), "expected shaded fills: {styled}");
+        assert!(
+          colors.iter().all(|&(r, g, b)| r >= g && r >= b && r > 0),
+          "expected every fill tinted toward the requested red, got {colors:?}"
+        );
+      }
+
+      /// `Opacity[...]` inside `PlotStyle` must flow through to the
+      /// rendered triangles' fill opacity.
+      #[test]
+      fn plotstyle_opacity_sets_fill_opacity() {
+        let svg = export_svg(
+          "RevolutionPlot3D[{t^2, t}, {t, 0, 2}, PlotStyle -> Opacity[0.4]]",
+        );
+        assert!(
+          svg.contains("opacity=\"0.4\""),
+          "expected PlotStyle -> Opacity[0.4] to set fill opacity: {svg}"
+        );
       }
     }
 
@@ -15857,6 +16047,77 @@ mod parametric_plot3d {
       interpret("Head[ParametricPlot3D[{u, v, u + v}, {u, 0, 1}, {v, 0, 1}]]")
         .unwrap();
     assert_eq!(result, "Graphics3D");
+  }
+
+  /// Every `<polygon>` fill colour in the SVG, as `(r, g, b)` triples — see
+  /// the identical helper documented in `plot3d::options`.
+  fn fill_colors(svg: &str) -> Vec<(u32, u32, u32)> {
+    svg
+      .split("<polygon ")
+      .skip(1)
+      .filter_map(|tag| {
+        let tag = tag.split('>').next()?;
+        let inner = tag.split("fill=\"rgb(").nth(1)?.split(')').next()?;
+        let mut parts = inner.split(',').filter_map(|n| n.trim().parse().ok());
+        Some((parts.next()?, parts.next()?, parts.next()?))
+      })
+      .collect()
+  }
+
+  /// `PlotStyle -> RGBColor[...]` used to be silently ignored by the
+  /// rendered surface (the 2-iterator form): the picture stayed the default
+  /// height-based rainbow no matter what colour was requested.
+  #[test]
+  fn plotstyle_color_changes_rendered_fill() {
+    let baseline = export_svg(
+      "ParametricPlot3D[{Cos[u], Sin[u] + Cos[v], Sin[v]}, {u, 0, 2 Pi}, \
+       {v, -Pi, Pi}]",
+    );
+    let styled = export_svg(
+      "ParametricPlot3D[{Cos[u], Sin[u] + Cos[v], Sin[v]}, {u, 0, 2 Pi}, \
+       {v, -Pi, Pi}, PlotStyle -> RGBColor[0.1, 0.2, 0.9]]",
+    );
+    assert_ne!(baseline, styled, "PlotStyle must change the rendered SVG");
+    let colors = fill_colors(&styled);
+    assert!(!colors.is_empty(), "expected shaded fills: {styled}");
+    assert!(
+      colors.iter().all(|&(r, g, b)| b >= g && b >= r && b > 0),
+      "expected every fill tinted toward the requested blue, got {colors:?}"
+    );
+  }
+
+  /// `PlotStyle -> {c1, c2}` on `ParametricPlot3D[{{...}, {...}}, ...]`
+  /// (multiple surfaces) gives each surface its own colour, cycling
+  /// through the list.
+  #[test]
+  fn plotstyle_list_gives_each_surface_its_own_color() {
+    let svg = export_svg(
+      "ParametricPlot3D[{{Cos[u], Sin[u], v}, {Cos[u] + 3, Sin[u], v}}, \
+       {u, 0, 2 Pi}, {v, 0, 1}, PlotStyle -> {Red, Blue}]",
+    );
+    let colors = fill_colors(&svg);
+    assert!(
+      colors.iter().any(|&(r, g, b)| r > g && r > b),
+      "expected a red-tinted surface, got {colors:?}"
+    );
+    assert!(
+      colors.iter().any(|&(r, g, b)| b > r && b > g),
+      "expected a blue-tinted surface, got {colors:?}"
+    );
+  }
+
+  /// `Opacity[...]` inside `PlotStyle` must flow through to the rendered
+  /// triangles' fill opacity.
+  #[test]
+  fn plotstyle_opacity_sets_fill_opacity() {
+    let svg = export_svg(
+      "ParametricPlot3D[{Cos[u], Sin[u], v}, {u, 0, 2 Pi}, {v, 0, 1}, \
+       PlotStyle -> Opacity[0.4]]",
+    );
+    assert!(
+      svg.contains("opacity=\"0.4\""),
+      "expected PlotStyle -> Opacity[0.4] to set fill opacity: {svg}"
+    );
   }
 }
 

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -7104,6 +7104,124 @@ mod line_continuation {
   }
 }
 
+/// `\[Rule]`, `\[RuleDelayed]`, `\[Equal]`, `\[NotEqual]`, `\[LessEqual]`,
+/// and `\[GreaterEqual]` are legitimate ASCII spellings of the same
+/// operators as `->`, `:>`, `==`, `!=`, `<=`, `>=`: Wolfram-authored source
+/// (`.wl`/`.wls` files, `ToExpression["..."]`, literal REPL input) may use
+/// either. Previously only some named-character operators (`\[Element]`,
+/// `\[And]`, …) were recognised by the grammar; this comparison/rule family
+/// fell through to `NamedCharIdentifier`, so `Mesh \[Rule] None` parsed as
+/// implicit multiplication `Mesh * None * Rule` instead of `Rule[Mesh,
+/// None]`. (Note this never affected `.nb` notebook loading, which
+/// flattens box-form names to ASCII operators before the code reaches the
+/// parser.)
+mod comparison_and_rule_named_char_operators {
+  use super::*;
+
+  #[test]
+  fn rule_escape_matches_ascii_infix() {
+    assert_eq!(
+      interpret("Mesh \\[Rule] None").unwrap(),
+      interpret("Mesh -> None").unwrap()
+    );
+  }
+
+  #[test]
+  fn rule_escape_matches_ascii_prefix() {
+    assert_eq!(
+      interpret("a \\[Rule] b").unwrap(),
+      interpret("Rule[a, b]").unwrap()
+    );
+  }
+
+  #[test]
+  fn rule_delayed_escape_matches_ascii_infix() {
+    assert_eq!(
+      interpret("Head[a \\[RuleDelayed] b]").unwrap(),
+      interpret("Head[a :> b]").unwrap()
+    );
+    assert_eq!(
+      interpret("Head[a \\[RuleDelayed] b]").unwrap(),
+      "RuleDelayed"
+    );
+  }
+
+  #[test]
+  fn rule_delayed_escape_matches_ascii_prefix() {
+    assert_eq!(
+      interpret("a \\[RuleDelayed] b").unwrap(),
+      interpret("RuleDelayed[a, b]").unwrap()
+    );
+  }
+
+  #[test]
+  fn equal_escape_matches_ascii_infix() {
+    assert_eq!(interpret("3 \\[Equal] 3").unwrap(), "True");
+    assert_eq!(
+      interpret("3 \\[Equal] 3").unwrap(),
+      interpret("3 == 3").unwrap()
+    );
+    assert_eq!(interpret("3 \\[Equal] 4").unwrap(), "False");
+  }
+
+  #[test]
+  fn equal_escape_matches_ascii_prefix() {
+    assert_eq!(
+      interpret("a \\[Equal] b").unwrap(),
+      interpret("Equal[a, b]").unwrap()
+    );
+  }
+
+  #[test]
+  fn not_equal_escape_matches_ascii_infix() {
+    assert_eq!(interpret("3 \\[NotEqual] 4").unwrap(), "True");
+    assert_eq!(
+      interpret("3 \\[NotEqual] 4").unwrap(),
+      interpret("3 != 4").unwrap()
+    );
+    assert_eq!(interpret("3 \\[NotEqual] 3").unwrap(), "False");
+  }
+
+  #[test]
+  fn less_equal_escape_matches_ascii_infix() {
+    assert_eq!(interpret("3 \\[LessEqual] 4").unwrap(), "True");
+    assert_eq!(
+      interpret("3 \\[LessEqual] 4").unwrap(),
+      interpret("3 <= 4").unwrap()
+    );
+    assert_eq!(interpret("4 \\[LessEqual] 3").unwrap(), "False");
+  }
+
+  #[test]
+  fn greater_equal_escape_matches_ascii_infix() {
+    assert_eq!(interpret("4 \\[GreaterEqual] 3").unwrap(), "True");
+    assert_eq!(
+      interpret("4 \\[GreaterEqual] 3").unwrap(),
+      interpret("4 >= 3").unwrap()
+    );
+    assert_eq!(interpret("3 \\[GreaterEqual] 4").unwrap(), "False");
+  }
+
+  /// A chained comparison spelled with the escape form must build the same
+  /// flat `Comparison` chain as the ASCII spelling, not a nested one.
+  #[test]
+  fn chained_comparison_escape_matches_ascii() {
+    assert_eq!(
+      interpret("1 \\[LessEqual] x \\[LessEqual] 10 /. x -> 5").unwrap(),
+      interpret("1 <= x <= 10 /. x -> 5").unwrap()
+    );
+  }
+
+  /// `\[Rule]`/`\[RuleDelayed]` must not be swallowed as bare identifiers
+  /// named `Rule`/`RuleDelayed` — the regression this whole family guards
+  /// against (`Mesh \[Rule] None` used to become `Mesh*None*Rule`).
+  #[test]
+  fn escape_forms_are_not_parsed_as_identifiers() {
+    assert_eq!(interpret("Head[Mesh \\[Rule] None]").unwrap(), "Rule");
+    assert_eq!(interpret("Head[3 \\[Equal] 3]").unwrap(), "Symbol");
+  }
+}
+
 mod structural_pattern_consistency {
   use super::*;
 


### PR DESCRIPTION
## Summary

Two independent correctness fixes found while checking Woxi Studio's support for interactive `Manipulate`/3D-graphics notebooks:

- **`PlotStyle` was silently ignored by the rendered output of `Plot3D`, `ParametricPlot3D` (surface form), and `RevolutionPlot3D`.** All three rasterize their surface by an automatic height-based color unconditionally, never consulting `PlotStyle`. `RevolutionPlot3D` was the sneakiest case: it *did* thread `PlotStyle` into the symbolic `GraphicsComplex` structure returned for `First[...]` composability, but the picture it actually draws never looked at it. Fixed by resolving `PlotStyle` (a single style, or a list cycling one style per surface for multi-surface plots) through the existing `StyleState3D`/`apply_3d_directive` machinery already used by `Graphics3D` primitives, and using it — still passed through the same per-facet diffuse/ambient/specular lighting — as the triangle base color and opacity instead of the automatic rainbow gradient. When `PlotStyle` is absent, output is unchanged (verified byte-identical).
- **`\[Rule]`, `\[RuleDelayed]`, `\[Equal]`, `\[NotEqual]`, `\[LessEqual]`, `\[GreaterEqual]` named-character escapes weren't recognized as infix operators** in plain WL source text (`Mesh \[Rule] None` parsed as `Mesh*None*Rule` instead of `Mesh -> None`). The grammar already special-cased escape *and* Unicode-codepoint spellings for several other named operators (`\[Element]`, `\[And]`, …); this family was simply missing from that list, so the ASCII-escape form fell through to implicit multiplication with a bare symbol. Added the missing escapes (using their existing canonical codepoints from `named_char_to_unicode`) to the grammar and to precedence/associativity handling so they build identical ASTs to their ASCII-operator spellings. Notebook (`.nb`) loading is unaffected, since `notebook.rs` already flattens box-form option arrows/comparisons before parsing.

## Test plan

- [x] New unit tests for `PlotStyle` on `Plot3D`/`ParametricPlot3D`/`RevolutionPlot3D` (`tests/interpreter_tests/graphics.rs`): single style, per-surface style list, `Opacity[...]`, and a no-`PlotStyle` regression guard.
- [x] New unit tests for named-character comparison/rule operators (`tests/interpreter_tests/syntax.rs`): each escape form evaluates identically to its ASCII spelling.
- [x] `make test` — 27181/27181 passing.
- [x] `make format` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7GbDqrkmeTvYS4S5JRPKf)_