### PR TITLE
Add LeftBracketingBar/RightBracketingBar named characters

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -498,6 +498,13 @@ pub fn named_char_to_unicode(name: &str) -> Option<&'static str> {
     "RightFloor" => Some("\u{230B}"),
     "LeftDoubleBracket" => Some("\u{301A}"),
     "RightDoubleBracket" => Some("\u{301B}"),
+    // Abs/Norm bars. Wolfram has no public Unicode code point for these
+    // (unlike the ASCII `|` they visually resemble), so like `Rule` and
+    // `Equal` above they live in the private use area.
+    "LeftBracketingBar" => Some("\u{F603}"),
+    "RightBracketingBar" => Some("\u{F604}"),
+    "LeftDoubleBracketingBar" => Some("\u{F605}"),
+    "RightDoubleBracketingBar" => Some("\u{F606}"),
     // Whitespace control characters (Wolfram treats these as the raw chars).
     // `\[IndentingNewLine]` is the FrontEnd's own newline, so it carries a
     // private-use code point instead of U+000A.
@@ -671,6 +678,8 @@ fn private_use_glyph(c: char) -> Option<&'static str> {
     '\u{F725}' => "\u{26A0}",              // WarningSign: ⚠
     '\u{F3DF}' => "\u{2641}",              // Earth: ♁
     '\u{F431}' => "=",                     // Equal
+    '\u{F603}' | '\u{F604}' => "|",        // Left/RightBracketingBar: |
+    '\u{F605}' | '\u{F606}' => "\u{2016}", // Left/RightDoubleBracketingBar: ‖
     '\u{F74B}' => "\u{2145}",              // CapitalDifferentialD: ⅅ
     '\u{F74C}' => "\u{2146}",              // DifferentialD: ⅆ
     '\u{F74D}' => "\u{212F}",              // ExponentialE: ℯ

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -4724,6 +4724,40 @@ mod plot3d {
       );
     }
 
+    /// The `Abs`/`Norm` bar characters are private use too, and were
+    /// missing from the substitution table entirely (not just drawing the
+    /// wrong glyph): a caption written with them drew the literal
+    /// `\[LeftBracketingBar]`/`\[RightBracketingBar]` escape text.
+    #[test]
+    fn bracketing_bar_glyphs_are_drawn_as_standard_characters() {
+      let svg = export_svg(
+        r#"Graphics[{Text["\[LeftBracketingBar]x\[RightBracketingBar]", {0, 0}],
+           Text["\[LeftDoubleBracketingBar]x\[RightDoubleBracketingBar]", {0, 1}]},
+           PlotRange -> {{-1, 1}, {-1, 2}}]"#,
+      );
+      assert!(svg.contains(">|x|</text>"), "bars not drawn: {svg}");
+      assert!(
+        svg.contains(">\u{2016}x\u{2016}</text>"),
+        "double bars not drawn: {svg}"
+      );
+      assert!(
+        !svg.contains('\u{F603}')
+          && !svg.contains('\u{F604}')
+          && !svg.contains('\u{F605}')
+          && !svg.contains('\u{F606}'),
+        "private-use code point drawn: {svg}"
+      );
+      assert!(
+        !svg.contains("LeftBracketingBar"),
+        "literal escape text drawn: {svg}"
+      );
+      // The strings themselves are unchanged.
+      assert_eq!(
+        woxi::interpret(r#"ToCharacterCode["\[LeftBracketingBar]"]"#).unwrap(),
+        "{62979}"
+      );
+    }
+
     /// A constant inside a larger label is typeset too: `Text[50 Degree]`
     /// reads "50 °", the way Wolfram draws it, not "50 Degree".
     #[test]

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -5304,6 +5304,30 @@ mod unknown_function_no_args {
     assert_eq!(interpret("\\[ImaginaryI]").unwrap(), "I");
   }
 
+  /// `\[LeftBracketingBar]`/`\[RightBracketingBar]` (the bars `Abs`/`Norm`
+  /// typeset with) and their double-bar counterparts have no public
+  /// Unicode code point, so like `\[Rule]` they live in Wolfram's private
+  /// use area. Regression: they were missing from the parse table
+  /// entirely, so a string built with them kept the literal `\[...]`
+  /// escape text instead of resolving to a private-use code point.
+  #[test]
+  fn bracketing_bar_named_chars_parse_to_private_use_code_points() {
+    assert_eq!(
+      interpret(
+        "ToCharacterCode[\"\\[LeftBracketingBar]a\\[RightBracketingBar]\"]"
+      )
+      .unwrap(),
+      "{62979, 97, 62980}"
+    );
+    assert_eq!(
+      interpret(
+        "ToCharacterCode[\"\\[LeftDoubleBracketingBar]a\\[RightDoubleBracketingBar]\"]"
+      )
+      .unwrap(),
+      "{62981, 97, 62982}"
+    );
+  }
+
   /// A named character that is a letter spells a symbol with that letter,
   /// not with its own name: `\[AAcute]` is `á`, and `\[ScriptX]` is the
   /// letter of Wolfram's private-use script alphabet (U+F6C9). Regression:

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -17672,4 +17672,106 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 1}, DynamicBox[\[Ellipsis]]]"
       "raising the boom and extending its reach must move the hook and change the render"
     );
   }
+
+  /// Regression for the shape of the "Equality of a Segment and an Arc in
+  /// Archimedes's Spiral" Demonstration: a `Module` that derives a point
+  /// from a slider parameter and reports its distance from the origin in a
+  /// `Text[Style[Row[{...}], ...]]` caption written with the
+  /// `\[LeftBracketingBar]`/`\[RightBracketingBar]` bar characters (the
+  /// notation `Abs`/`Norm` are typeset with). Those two named characters
+  /// were missing from both the parse table and the private-use-glyph
+  /// substitution table, so the caption drew the literal escape text
+  /// (`\[LeftBracketingBar]d\[RightBracketingBar] = ...`) instead of
+  /// `|d| = ...`.
+  #[test]
+  fn demonstration_spiral_gap_manipulate_draws_bracketing_bars() {
+    let code = "Manipulate[\
+      Module[{origin, tip, gap}, \
+        origin = {0, 0}; \
+        tip = {r Cos[r], r Sin[r]}; \
+        gap = Norm[tip - origin]; \
+        Column[{\
+          Graphics[{Blue, Line[{origin, tip}], Red, PointSize[0.02], \
+            Point[{origin, tip}]}, \
+            PlotRange -> {{-3, 3}, {-3, 3}}, Axes -> True], \
+          Text[Style[Row[{\"\\[LeftBracketingBar]d\\[RightBracketingBar] = \", \
+            NumberForm[gap, {4, 3}]}], 14]]\
+        }]\
+      ], \
+      {{r, 1.5, \"reach\"}, 0.5, 3, Appearance -> \"Labeled\"}\
+    ]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the spiral-gap Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the segment and its caption must render"
+    );
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the segment and caption must render")
+    };
+    let initial = render(&state);
+    assert!(
+      initial.contains("|d| = "),
+      "caption must draw the bars as `|d| = ...`, not the raw escape: {initial}"
+    );
+    assert!(
+      !initial.contains("LeftBracketingBar")
+        && !initial.contains("RightBracketingBar"),
+      "caption must not draw the literal named-character escape: {initial}"
+    );
+    assert!(
+      !initial.contains('\u{F603}') && !initial.contains('\u{F604}'),
+      "caption must not draw the raw private-use code points: {initial}"
+    );
+
+    match &mut state.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name,
+          label,
+          min,
+          max,
+          current,
+          ..
+        },
+      ] => {
+        assert_eq!(name.as_str(), "r");
+        assert_eq!(label.as_str(), "reach");
+        assert_eq!(*min, 0.5);
+        assert_eq!(*max, 3.0);
+        assert_eq!(*current, 1.5);
+        *current = 2.5;
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    let moved = render(&state);
+    assert_ne!(
+      initial, moved,
+      "moving the reach slider must change the point and the reported gap"
+    );
+    assert!(
+      moved.contains("|d| = "),
+      "caption must keep drawing the bars after re-render: {moved}"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

As part of the recurring "verify Woxi Studio against a random Wolfram Demonstration" check, this run sampled the [Equality of a Segment and an Arc in Archimedes's Spiral](https://demonstrations.wolfram.com/EqualityOfASegmentAndAnArcInArchimedessSpiral/) Demonstration (fetched via `RandomResourcePage`, not committed to the repo per policy).

Its Manipulate captions a distance with `` \[LeftBracketingBar]d\[RightBracketingBar] = ... ``, the notation `Abs`/`Norm` are typeset with. Those two named characters (and their double-bar counterparts) were missing from both:
- the parse table (`named_char_to_unicode`), so the string kept the literal `\[LeftBracketingBar]` escape text instead of resolving to a code point, and
- the private-use-glyph display substitution (`private_use_glyph`), so even once parsed correctly the caption would draw nothing rather than `|`.

The combined effect: Woxi Studio drew the literal escape text `\[LeftBracketingBar]OT\[RightBracketingBar] = 8.0747` instead of `|OT| = 8.0747` in the rendered graphics.

- Adds the four private-use code points (U+F603–U+F606, confirmed against `reference.wolfram.com/language/ref/character/...`) to `named_char_to_unicode`.
- Adds their `|` / `‖` display substitutes to `private_use_glyph`.
- Unit tests for both the parse path (`ToCharacterCode` round trip) and the drawing path (SVG text content).
- A non-verbatim Woxi Studio regression test (`demonstration_spiral_gap_manipulate_draws_bracketing_bars`) that builds an analogous Manipulate (different geometry, no code copied from the notebook) and asserts the caption renders the bars correctly end to end, including after moving the slider.

## Test plan

- [x] `make format`
- [x] `make test` — 27,162 tests passed
- [x] `make test-studio` — 150 tests passed (includes the new regression test)
- [x] Manually verified the fix by downloading the actual Demonstration notebook, running it through `woxi-studio`'s `dump_manipulate`/`rasterize_svg` example harness before and after the fix, and visually confirming the caption changed from the raw escape text to `|OT| = 8.0747`

---
_Generated by [Claude Code](https://claude.ai/code/session_014T2gsUCNkoyhqgZpzjfT24)_