### PR TITLE
Draw graph vertices with VertexRenderingFunction

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -988,7 +988,7 @@ ArrayReshape,Reshapes a list into specified dimensions,✅,pure,9.0,965
 Key,Operator form for extracting values from associations by key,✅,none,10.0,966
 ProbabilityDistribution,Defines a custom probability distribution,✅,1,8.0,967
 MeshCells,Cells of a mesh region of a given dimension as index primitives,✅,pure,10.0,968
-VertexStyle,,🚫,,8.0,969
+VertexStyle,Option for styling vertices in graphs,✅,none,8.0,969
 OverHat,Display form with a hat accent,✅,none,6.0,970
 ListLogLogPlot,Plots data with logarithmic x and y axes,✅,pure,6.0,971
 SetAccuracy,Set every numeric leaf of an expression to a fixed accuracy (precision = accuracy + Log10[|x|] per leaf),✅,pure,2.0,972
@@ -1002,7 +1002,7 @@ GammaDistribution,Gamma probability distribution,✅,pure,6.0,981
 FrontEndExecute,Requires external services or GUI infrastructure,🚫,io,3.0,982
 ScientificForm,Displays number in scientific notation,✅,pure,1.0,983
 LocatorPane,Draggable locator over a graphic; renders as an interactive 2D pane,✅,unevaluated,6.0,984
-DirectedEdges,,🚫,,6.0,986
+DirectedEdges,Option saying whether graph edges are drawn as arrows,✅,none,6.0,986
 ViewVertical,,🚫,,2.0,986
 StyleDefinitions,,🚫,,3.0,987
 RoundingRadius,,🚫,,7.0,988
@@ -1186,10 +1186,11 @@ DistanceFunction,Option naming the metric a nearest-neighbour or clustering func
 IgnoreCase,,🚫,,2.0,1172
 GaussianFilter,Gaussian filter for images and arrays,✅,pure,7.0,1173
 FixedPointList,Returns the list of results from applying a function repeatedly until fixed point,✅,pure,2.0,1174
-EdgeShapeFunction,,🚫,,8.0,1175
+EdgeShapeFunction,Option giving the function that draws each edge of a graph plot,✅,none,8.0,1175
 BSplineFunction,Evaluate B-spline curves and surfaces from control points using de Boor algorithm,✅,pure,7.0,1176
-VertexShapeFunction,,🚫,,8.0,1177
+VertexShapeFunction,Option naming the shape each vertex of a graph is drawn as,✅,none,8.0,1177
 CosIntegral,Cosine integral Ci(z),✅,pure,2.0,1178
+VertexRenderingFunction,Option giving the function that draws each vertex of a graph plot,✅,none,6.0,1179
 GeoListPlot,,🚫,,10.0,1180
 Volume,Volume (3-dimensional measure) of a solid region,✅,pure,2.0,1180
 TimeConstrained,Runs computation with time limit (no-op in Woxi),✅,effectful,1.0,1182

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -230,6 +230,9 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let mut edge_shape_rules: Vec<(Expr, EdgeShape)> = Vec::new();
   let mut vertex_labels = false;
   let mut vertex_shape: Option<String> = None;
+  // `VertexRenderingFunction -> f` hands the drawing of each vertex to
+  // `f`, applied as `f[{x, y}, name]`.
+  let mut vertex_render: Option<VertexRender> = None;
   let mut vertex_size_scale: f64 = 1.0;
   let mut plot_label: Option<Expr> = None;
   let mut layered: Option<LayerDirection> = None;
@@ -272,6 +275,12 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           if let Expr::String(s) = replacement.as_ref() {
             vertex_shape = Some(s.clone());
           }
+        }
+        "VertexRenderingFunction" => {
+          vertex_render = Some(match replacement.as_ref() {
+            Expr::Identifier(s) if s == "None" => VertexRender::Hidden,
+            other => VertexRender::Func(other.clone()),
+          });
         }
         "VertexSize" => {
           // Named sizes use progressively larger gaps so a Table over
@@ -679,6 +688,27 @@ pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     let i = node_idx.index();
     let (x, y) = positions[i];
 
+    // `VertexRenderingFunction` replaces the shape, the fill colour and
+    // the label alike: whatever it returns is the whole vertex.
+    match &vertex_render {
+      Some(VertexRender::Hidden) => continue,
+      Some(VertexRender::Func(f)) => {
+        let point = Expr::List(vec![Expr::Real(x), Expr::Real(y)].into());
+        let name = unwrap_vertex_style(&vertices[i]).0.clone();
+        if let Ok(drawn) =
+          crate::functions::list_helpers_ast::apply_func_to_two_args(
+            f, &point, &name,
+          )
+        {
+          // Wrapped in a list so any directives it sets stay scoped to
+          // this vertex.
+          primitives.push(Expr::List(vec![drawn].into()));
+          continue;
+        }
+      }
+      None => {}
+    }
+
     // Emit this vertex's fill color: per-vertex Style[] override wins over
     // the VertexStyle option, which itself wins over the Wolfram default.
     let fill_for_v: &Color = vertex_colors[i]
@@ -926,6 +956,16 @@ enum EdgeShape {
   Named(String),
   /// A function applied as `f[{pt, …}, edge]` whose result is used as
   /// the graphics for that edge.
+  Func(Expr),
+}
+
+/// How a vertex is drawn, as `VertexRenderingFunction -> …` asks for it.
+#[derive(Clone, Debug)]
+enum VertexRender {
+  /// `VertexRenderingFunction -> None` — the vertex is not drawn.
+  Hidden,
+  /// A function applied as `f[{x, y}, name]` whose result is used as the
+  /// graphics for that vertex.
   Func(Expr),
 }
 

--- a/tests/cli/plotting/GraphPlot.md
+++ b/tests/cli/plotting/GraphPlot.md
@@ -48,3 +48,24 @@ Graphics
 $ wo 'Head[GraphPlot[{1 -> 2, 2 -> 3}, EdgeShapeFunction -> {DirectedEdge[1, 2] -> ({Red, Line[#1]} &)}]]'
 Graphics
 ```
+
+`VertexRenderingFunction -> f` draws each vertex with `f[{x, y}, name]`
+instead of the built-in disk. The first argument is the vertex's
+coordinate, the second its name:
+
+```scrut
+$ wo 'Head[GraphPlot[{1 -> 2, 2 -> 3}, VertexRenderingFunction -> (Point[#] &)]]'
+Graphics
+```
+
+```scrut
+$ wo 'Head[GraphPlot[{1 -> 2, 2 -> 3}, VertexRenderingFunction -> (Text[#2, #] &)]]'
+Graphics
+```
+
+`VertexRenderingFunction -> None` leaves the vertices undrawn:
+
+```scrut
+$ wo 'Head[GraphPlot[{1 -> 2, 2 -> 3}, VertexRenderingFunction -> None]]'
+Graphics
+```

--- a/tests/miscellaneous_tests/svg_rendering.rs
+++ b/tests/miscellaneous_tests/svg_rendering.rs
@@ -3807,6 +3807,94 @@ mod tests {
       );
     }
 
+    /// `VertexRenderingFunction -> f` draws every vertex with
+    /// `f[{x, y}, name]` instead of the built-in disk. A Demonstration
+    /// uses this to swap the plain node for a coloured point.
+    #[test]
+    fn vertex_rendering_function_replaces_the_drawn_vertex() {
+      let svg = svg_of(
+        r#"GraphPlot[{1 -> 2, 2 -> 3},
+           VertexRenderingFunction -> ({Red, Rectangle[# - 0.05, # + 0.05]} &)]"#,
+      );
+      assert!(
+        circle_centres(&svg).is_empty(),
+        "the default disks are gone once the shape is ours: {svg}"
+      );
+      assert_eq!(
+        svg.matches("<rect").count(),
+        3,
+        "each of the three vertices is drawn by the function: {svg}"
+      );
+      assert_eq!(
+        svg.matches(r#"fill="rgb(255,0,0)""#).count(),
+        3,
+        "and each takes the colour the function set: {svg}"
+      );
+    }
+
+    /// The first argument is the vertex's own coordinate, so the drawn
+    /// shapes land where the default disks would have.
+    #[test]
+    fn vertex_rendering_function_is_given_the_vertex_coordinate() {
+      let plain = svg_of(r#"GraphPlot[{1 -> 2, 2 -> 3}]"#);
+      let drawn = svg_of(
+        r#"GraphPlot[{1 -> 2, 2 -> 3},
+           VertexRenderingFunction -> (Disk[#, 0.05] &)]"#,
+      );
+      let defaults = circle_centres(&plain);
+      let points = circle_centres(&drawn);
+      assert_eq!(points.len(), defaults.len(), "{drawn}");
+      for (p, d) in points.iter().zip(&defaults) {
+        assert!(
+          (p.0 - d.0).abs() < 3.0 && (p.1 - d.1).abs() < 3.0,
+          "the function draws at the vertex's own position: {points:?} vs {defaults:?}"
+        );
+      }
+    }
+
+    /// The second argument is the vertex name, which is what a
+    /// Demonstration labels its nodes with.
+    #[test]
+    fn vertex_rendering_function_is_given_the_vertex_name() {
+      let svg = svg_of(
+        r#"GraphPlot[{1 -> 2, 2 -> 3},
+           VertexRenderingFunction -> (Text[#2, #] &)]"#,
+      );
+      for name in ["1", "2", "3"] {
+        assert!(
+          svg.contains(&format!(">{name}<")),
+          "every vertex is labelled with its own name: {svg}"
+        );
+      }
+    }
+
+    /// Directives the rendering function sets are scoped to its own
+    /// vertex and do not bleed into the next one.
+    #[test]
+    fn vertex_rendering_function_directives_do_not_bleed_between_vertices() {
+      let svg = svg_of(
+        r#"GraphPlot[{1 -> 2, 2 -> 3},
+           VertexRenderingFunction -> (If[#2 === 1,
+             {Red, Disk[#, 0.05]}, Disk[#, 0.05]] &)]"#,
+      );
+      assert_eq!(
+        svg.matches(r#"fill="rgb(255,0,0)""#).count(),
+        1,
+        "only the vertex that asked for it is red: {svg}"
+      );
+    }
+
+    /// `VertexRenderingFunction -> None` leaves the edges without any
+    /// vertices drawn on their ends.
+    #[test]
+    fn vertex_rendering_function_none_draws_no_vertices() {
+      let svg = svg_of(
+        r#"GraphPlot[{1 -> 2, 2 -> 3}, VertexRenderingFunction -> None]"#,
+      );
+      assert!(circle_centres(&svg).is_empty(), "no vertex is drawn: {svg}");
+      assert!(svg.contains("<polyline"), "the edges stay: {svg}");
+    }
+
     /// A graph plot is sized by its `ImageSize`, so a Demonstration can ask
     /// for a wide, short strip.
     #[test]

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -14364,6 +14364,118 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`fam$$ = 1}, \"\\[Ellipsis]\"]"], "O
     assert_ne!(net, render(1, 1), "the view control must matter");
   }
 
+  /// End-to-end regression for the shape a "state transition diagram for
+  /// modular multiplication" Demonstration has: a `Manipulate` whose body
+  /// is a `GraphPlot` over `Table[i -> Mod[a i, m], {i, 0, m - 1}]`, with
+  /// two `Appearance -> "Labeled"` sliders for the modulus and the
+  /// multiplier, a `Delimiter`, and a Boolean picklist that switches the
+  /// nodes between labelled `Text` and plain `Tooltip`-ed `Point`s through
+  /// `VertexRenderingFunction`.
+  ///
+  /// The Manipulate is written here rather than lifted from the published
+  /// notebook. The modulus range is kept small so the test draws a graph
+  /// it can count the parts of.
+  #[test]
+  fn modular_multiplication_diagram_notebook_builds_its_widget() {
+    let nb_src = r##"Notebook[{
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[\nGraphPlot[Table[i -> Mod[a i, m], {i, 0, m - 1}],\n  ImageSize -> {500, 375},\n  PlotLabel -> Style[Row[{n -> a n, \" mod \", m}], 14],\n  VertexRenderingFunction -> If[label,\n    (Text[#2, #, Background -> White] &),\n    (Tooltip[{Darker[Blue, .7], Point[#]}, #2] &)],\n  DirectedEdges -> True],\n{{m, 8, \"modulus\"}, 2, 20, 1, Appearance -> \"Labeled\"},\n{{a, 3, \"multiplier\"}, 2, 20, 1, Appearance -> \"Labeled\"},\nDelimiter,\n{{label, False, \"label nodes\"}, {True, False}},\nAutorunSequencing -> {1, 2}]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`m$$ = 8}, \"\\[Ellipsis]\"]"], "Output"]
+}, Open]]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .iter()
+      .find_map(|e| e.manipulate_state.as_ref())
+      .expect("the Manipulate cell must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "the diagram must evaluate: {:?}",
+      widget.error
+    );
+    assert!(widget.graphics_handle.is_some(), "the diagram must draw");
+
+    // Two labelled sliders, the `Delimiter` separator row, then the
+    // Boolean picklist.
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name: m_name,
+          label: m_label,
+          current: m_current,
+          min: m_min,
+          max: m_max,
+          ..
+        },
+        manipulate::ControlState::Continuous {
+          name: a_name,
+          label: a_label,
+          current: a_current,
+          ..
+        },
+        manipulate::ControlState::Divider,
+        manipulate::ControlState::Discrete {
+          name: l_name,
+          label: l_label,
+          values,
+          current_index,
+          ..
+        },
+      ] => {
+        assert_eq!((m_name.as_str(), m_label.as_str()), ("m", "modulus"));
+        assert_eq!((*m_current, *m_min, *m_max), (8.0, 2.0, 20.0));
+        assert_eq!((a_name.as_str(), a_label.as_str()), ("a", "multiplier"));
+        assert_eq!(*a_current, 3.0);
+        assert_eq!(
+          (l_name.as_str(), l_label.as_str()),
+          ("label", "label nodes")
+        );
+        assert_eq!(values, &["True", "False"]);
+        assert_eq!(*current_index, 1, "the published default is False");
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    let render = |m: u32, a: u32, label: &str| {
+      woxi::interpret_with_stdout(&format!(
+        "m = {m}; a = {a}; label = {label};\n{}",
+        widget.body
+      ))
+      .expect("the body must render")
+      .graphics
+      .expect("the body must produce a graphic")
+    };
+
+    // Unlabelled, every one of the `m` residues is drawn as a point in
+    // the function's own dark blue — not as the default vertex disk.
+    let points = render(8, 3, "False");
+    assert_eq!(
+      points.matches(r#"fill="rgb(0,0,77)""#).count(),
+      8,
+      "each residue is a Darker[Blue, .7] point: {points}"
+    );
+    // Labelled, each node is its own residue's numeral instead.
+    let labelled = render(8, 3, "True");
+    for residue in 0..8 {
+      assert!(
+        labelled.contains(&format!(">{residue}<")),
+        "residue {residue} is labelled: {labelled}"
+      );
+    }
+    // Both controls reach the graph: a different modulus draws a
+    // different number of nodes, a different multiplier a different
+    // shape.
+    assert_eq!(
+      render(12, 3, "False")
+        .matches(r#"fill="rgb(0,0,77)""#)
+        .count(),
+      12,
+      "the modulus control must matter"
+    );
+    assert_ne!(points, render(8, 5, "False"), "the multiplier must matter");
+  }
+
   /// End-to-end regression for the "Chaos and Order in the Damped Forced
   /// Pendulum in a Plane" Demonstration: it integrates the damped driven
   /// pendulum `θ'' == -(g/l) Sin[θ] - γ θ' + a Cos[ω t]` from a grid of


### PR DESCRIPTION
Found by auditing a random Wolfram Demonstration against Woxi Studio: [State Transition Diagrams for Modular Multiplication](https://demonstrations.wolfram.com/StateTransitionDiagramsForModularMultiplication/) (Stephen Wolfram, 2007).

## The gap

Its `Manipulate` body draws a `GraphPlot` over `Table[i -> Mod[a i, m], {i, 0, m - 1}]` and renders the nodes itself:

```wolfram
VertexRenderingFunction -> If[label,
  (Text[#2, #, Background -> White] &),
  (Tooltip[{Darker[Blue, .7], Point[#]}, #2] &)]
```

`VertexRenderingFunction` had no implementation anywhere in Woxi — the option was parsed as an option and then silently dropped. Every node drew as the default blue disk regardless, so the Demonstration's "label nodes" control changed nothing on screen.

Everything else the notebook needs already worked: the `Appearance -> "Labeled"` sliders, the `Delimiter` row, `AutorunSequencing`, `DirectedEdges`, and the `PlotLabel -> Style[Row[…], 14]` title.

## The fix

`src/functions/graph.rs` reads the option into a `VertexRender` enum, mirroring how `EdgeShapeFunction` is read into an `EdgeShape`, and applies it per vertex as `f[{x, y}, name]` through the existing `apply_func_to_two_args`. Whatever the function returns is the whole vertex — shape, fill and label alike — wrapped in a list so its directives stay scoped to that vertex. `VertexRenderingFunction -> None` leaves the vertices undrawn.

## Tests

- **Unit** (`tests/miscellaneous_tests/svg_rendering.rs`, 5 tests): the function replaces the default disk; it is handed the vertex coordinate and the vertex name; its directives do not bleed between vertices; `-> None` draws no vertices but keeps the edges.
- **Regression** (`woxi-studio/src/main.rs`): an end-to-end notebook test for the Demonstration's shape — the widget instantiates with two labelled sliders, the `Delimiter` divider and the Boolean picklist, draws one dark-blue point per residue unlabelled, each residue's numeral labelled, and both sliders reach the graph. The `Manipulate` is written for the test rather than lifted from the published notebook.
- **Docs** (`tests/cli/plotting/GraphPlot.md`): three cases alongside the existing `EdgeShapeFunction` ones.

## functions.csv

Adds the `VertexRenderingFunction` row. Also corrects four sibling graph options — `VertexStyle`, `DirectedEdges`, `EdgeShapeFunction`, `VertexShapeFunction` — which this same code path already honours but which were still marked `🚫` with no description, unlike `VertexLabels`, `VertexSize` and `EdgeStyle` next to them.

`make test` is green (all suites, 0 failures) and `cargo fmt --all --check` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017BGp6WZVFyG3BNobq3yVci)_