### PR TITLE
Split an implicit product headed by a function call

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -50,6 +50,14 @@ slow-timeout = { period = "90s", terminate-after = 1 }
 filter = 'test(two_species_competition_manipulate_builds_widget)'
 slow-timeout = { period = "120s", terminate-after = 1 }
 
+# `rolling_polygon_on_catenary_notebook_rolls_its_polygon` re-solves the
+# rolling polygon's contact geometry and rasterizes the traced curve for every
+# animation step: ~12s standalone in debug builds, which the 20s default does
+# not survive under parallel load. Give it a wider window.
+[[profile.default.overrides]]
+filter = 'test(rolling_polygon_on_catenary_notebook_rolls_its_polygon)'
+slow-timeout = { period = "120s", terminate-after = 1 }
+
 # The remaining (non-`#[ignore]`d) RosettaCode script snapshots run a few
 # seconds in debug builds; under full parallel load they can brush past the
 # default 20s timeout. Give them a safety ceiling. The genuinely heavy

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 # Unreleased
 
+- An implicit product whose left factor is a function call now yields to a
+    tighter operator the same way `2 Times @@ {3, 4}` already did:
+    `Sum[…] Times @@ dp` is `Sum[…] (Times @@ dp)`. It used to parse as
+    `(Sum[…] Times) @@ dp`, which applies a list as a head — the reason the
+    spherical `orthocenter` branch of the "Non-Euclidean Triangle Continuum"
+    Wolfram Demonstration drew no center point.
 - `PolyhedronData["RhombicHexecontahedron", …]` supports the nonconvex
     stellation of the rhombic triacontahedron: 62 vertices, 120 edges, and 60
     golden-rhombus faces, plus its exact `Volume`, `SurfaceArea`, `Inradius`,

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -4757,12 +4757,23 @@ fn parse_expression_inner(
           }
           leading_minus = false;
         }
-        // When an `ImplicitTimes` follows a Divide operator (`/`), splice
-        // its factors into the running term/operator vectors so that the
-        // implicit factors stay at multiplicative precedence — `a/b c`
-        // must parse as `(a*c)/b`, not `a/(b*c)`. Without this, the whole
-        // ImplicitTimes is consumed as a single divisor.
-        let is_implicit_times = matches!(item.as_rule(), Rule::ImplicitTimes);
+        // `f[x] y` is an implicit product as much as `x y` is; the grammar
+        // just reaches it through `FunctionCallExtended`'s implicit suffix
+        // instead of `ImplicitTimes`. Both have to be spliceable, or a
+        // neighbouring tighter operator takes the whole product as one
+        // operand — `f[x] Times @@ list` would read as
+        // `Apply[f[x] Times, list]`.
+        let is_implicit_times = matches!(item.as_rule(), Rule::ImplicitTimes)
+          || (matches!(item.as_rule(), Rule::FunctionCallExtended)
+            && item
+              .clone()
+              .into_inner()
+              .any(|p| p.as_rule() == Rule::FunctionCallImplicitSuffix));
+        // When such a product follows a Divide operator (`/`), splice its
+        // factors into the running term/operator vectors so that they stay
+        // at multiplicative precedence — `a/b c` must parse as `(a*c)/b`,
+        // not `a/(b*c)`. Without this, the whole product is consumed as a
+        // single divisor.
         let split_implicit =
           is_implicit_times && operators.last().is_some_and(|o| o == "/");
         let expr = pair_to_expr(item);

--- a/tests/cli/syntax.md
+++ b/tests/cli/syntax.md
@@ -79,6 +79,28 @@ False
 ```
 
 
+## Apply (`@@`) and Map (`/@`) inside an implicit product
+
+`@@`, `@@@` and `/@` bind tighter than multiplication, so in `a b @@ c` the
+operator reaches only the factor next to it — whether the leading factor is a
+number or a function call:
+
+```scrut
+$ wo '2 Times @@ {3, 4}'
+24
+```
+
+```scrut
+$ wo 'Sum[i, {i, 0, 2}] Times @@ {3, 4}'
+36
+```
+
+```scrut
+$ wo 'Length[{a, b}] f /@ {x, y}'
+{2*f[x], 2*f[y]}
+```
+
+
 ## Rule (`->`) and RuleDelayed (`:>`) as general operators
 
 `->` creates a rule, and `:>` creates a delayed rule.

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -521,6 +521,41 @@ mod operator_shorthand_parens {
     assert_eq!(interpret("-2 x /. x -> 3").unwrap(), "-6");
   }
 
+  // The left factor of an implicit product may itself be a function call
+  // (`Sum[…] Times @@ dp`), which the grammar reaches through
+  // `FunctionCallExtended`'s implicit suffix rather than `ImplicitTimes`.
+  // Regression: that path did not split, so the tighter operator swallowed
+  // the whole product — `Sum[i, {i, 0, 2}] Times @@ {3, 4}` parsed as
+  // `(3 Times) @@ {3, 4}`, applying a list as a head instead of scaling the
+  // product.
+  #[test]
+  fn function_call_implicit_product_yields_to_tighter_operators() {
+    assert_eq!(
+      interpret("Sum[i, {i, 0, 2}] Times @@ {3, 4}").unwrap(),
+      "36"
+    );
+    assert_eq!(interpret("Length[{a, b}] Plus @@ {3, 4}").unwrap(), "14");
+    assert_eq!(
+      interpret("Hold[f[1] Times @@ {3, 4}]").unwrap(),
+      "Hold[f[1]*Times @@ {3, 4}]"
+    );
+    assert_eq!(
+      interpret("Length[{a}] f /@ {x, y}").unwrap(),
+      "{f[x], f[y]}"
+    );
+    assert_eq!(interpret("Length[{a, b}] List @@@ {{1}}").unwrap(), "{{2}}");
+    // Dot and Power reach the adjacent factor through a call head too.
+    assert_eq!(interpret("Length[{a, b}] {1, 2} . {3, 4}").unwrap(), "22");
+    assert_eq!(interpret("Length[{a, b}] x^3 /. x -> 2").unwrap(), "16");
+    // A power on the call itself still belongs to the call, not the product.
+    assert_eq!(
+      interpret("f[2]^2 Times @@ {3, 4} /. f -> Identity").unwrap(),
+      "48"
+    );
+    // Without a tighter neighbour the product is unchanged.
+    assert_eq!(interpret("Length[{a, b}] x /. x -> 5").unwrap(), "10");
+  }
+
   #[test]
   fn held_subtraction_keeps_additive_operand_parens() {
     // Subtraction is left-associative, so a parenthesized additive right

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -17672,4 +17672,158 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 1}, DynamicBox[\[Ellipsis]]]"
       "raising the boom and extending its reach must move the hook and change the render"
     );
   }
+
+  /// End-to-end regression for the shape of the "Non-Euclidean Triangle
+  /// Continuum" Demonstration: a `Module` that clamps its triangle's vertices
+  /// with `Table[If[…, v[[i]] = …]]`, derives per-edge weights with
+  /// `Dot @@ Drop[…]`, picks a triangle center with `Switch`, and draws the
+  /// result over a `LightBlue` `Disk` — driven by `Row`-grouped `Control`
+  /// rows (a `Column`-labeled `Appearance -> "Labeled"` slider, checkbox
+  /// pairs, and a rule-labeled `PopupMenu`) plus three `Locator` controls
+  /// with `Appearance -> None`, under `SaveDefinitions`,
+  /// `AutorunSequencing`, and `SynchronousInitialization`.
+  ///
+  /// The weighted-hub branch is the reason this notebook used to fail: its
+  /// scale factor is written as `Sum[…] Times @@ weights`, an implicit
+  /// product whose left factor is a function call.
+  #[test]
+  fn demonstration_non_euclidean_triangle_manipulate_switches_centers() {
+    let code = "Manipulate[\
+      Module[{tri = {p1, p2, p3}, weights, hub}, \
+        Table[If[Norm[tri[[i]]] >= 1, tri[[i]] = Normalize[tri[[i]]]], {i, 1, 3}]; \
+        weights = Table[Dot @@ Drop[tri, {i}], {i, 1, 3}]; \
+        hub = Switch[center, \
+          1, Plus @@ tri/3, \
+          2, Sum[tri[[1 + Mod[i, 3]]]/weights[[i]], {i, 1, 3}] Times @@ weights, \
+          _, {0, 0}]; \
+        Graphics[{\
+          {LightBlue, Disk[{0, 0}, 1]}, \
+          {Blue, Dashed, Circle[{0, 0}, 1/Sqrt[Abs[k]]]}, \
+          {Red, PointSize[0.02], Point[hub]}, \
+          {PointSize[0.015], Point[tri]}, \
+          Table[Line[Drop[tri, {i}]], {i, 1, 3}], \
+          If[showdata, Text[NumberForm[Total[weights], 4], {-1.2, 1.05}, {-1, 0}], {}]}, \
+          PlotRange -> {{-1.5, 1.5}, {-1.1, 1.1}}, \
+          AspectRatio -> Automatic, ImageSize -> 320]], \
+      Row[{\
+        Control[{{k, 1, Column[{\"Gaussian\", \"curvature\"}]}, -1, 1, 0.0001, \
+          Appearance -> \"Labeled\", ImageSize -> Large}], \
+        Spacer[10], \
+        Control[{{showdata, True, Column[{\"show\", \"data\"}]}, {False, True}}]}], \
+      Row[{Control[{{center, 1, \"center\"}, \
+        {0 -> \"none\", 1 -> \"centroid\", 2 -> \"weighted hub\"}, \
+        ControlType -> PopupMenu}]}], \
+      {{p1, {0.5, 0.2}}, {-1, -1}, {1, 1}, Locator, Appearance -> None}, \
+      {{p2, {-0.2, 0.7}}, {-1, -1}, {1, 1}, Locator, Appearance -> None}, \
+      {{p3, {-0.3, -0.4}}, {-1, -1}, {1, 1}, Locator, Appearance -> None}, \
+      SaveDefinitions -> True, AutorunSequencing -> {1}, \
+      SynchronousInitialization -> False\
+    ]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the triangle-continuum Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the disk, triangle, and centroid must render"
+    );
+
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name: k_name,
+          label: k_label,
+          min: k_min,
+          max: k_max,
+          step: k_step,
+          ..
+        },
+        manipulate::ControlState::Discrete {
+          name: data_name,
+          values: data_values,
+          ..
+        },
+        manipulate::ControlState::Discrete {
+          name: center_name,
+          value_labels: center_labels,
+          popup: center_popup,
+          ..
+        },
+        manipulate::ControlState::Slider2D { name: p1_name, .. },
+        manipulate::ControlState::Slider2D { name: p2_name, .. },
+        manipulate::ControlState::Slider2D { name: p3_name, .. },
+      ] => {
+        assert_eq!(k_name.as_str(), "k");
+        assert_eq!(k_label.as_str(), "Gaussian\ncurvature");
+        assert_eq!(*k_min, -1.0);
+        assert_eq!(*k_max, 1.0);
+        assert_eq!(*k_step, 0.0001);
+        assert_eq!(data_name.as_str(), "showdata");
+        assert_eq!(data_values, &["False", "True"]);
+        assert_eq!(center_name.as_str(), "center");
+        assert!(*center_popup, "the center picker is a PopupMenu");
+        assert_eq!(
+          center_labels,
+          &["none", "centroid", "weighted hub"],
+          "rule-labeled popup values keep their labels"
+        );
+        assert_eq!(p1_name.as_str(), "p1");
+        assert_eq!(p2_name.as_str(), "p2");
+        assert_eq!(p3_name.as_str(), "p3");
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the triangle and its center must render")
+    };
+    let centroid = render(&state);
+
+    // Switching to the weighted hub takes the `Sum[…] Times @@ weights`
+    // branch. Its center has to be drawn like the centroid was — a scale
+    // factor that parses as `(Sum[…] Times) @@ weights` leaves `hub`
+    // unevaluated and silently drops the point.
+    for control in &mut state.controls {
+      if let manipulate::ControlState::Discrete {
+        name,
+        current_index,
+        ..
+      } = control
+        && name == "center"
+      {
+        *current_index = 2;
+      }
+    }
+    state.reevaluate();
+    assert!(
+      state.error.is_none(),
+      "the weighted-hub branch must evaluate: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some());
+    let hub = render(&state);
+    assert_eq!(
+      hub.matches("<circle").count(),
+      centroid.matches("<circle").count(),
+      "the weighted hub must be plotted like the centroid was"
+    );
+    assert_ne!(
+      centroid, hub,
+      "the weighted hub sits elsewhere than the centroid"
+    );
+  }
 }


### PR DESCRIPTION
As part of the recurring "verify Woxi Studio against a random Wolfram Demonstration" check, this run sampled the Non-Euclidean Triangle Continuum Demonstration (fetched via `RandomResourcePage`, not committed to the repo per policy).

## What the notebook needed

The notebook parses cleanly (162 cells, all styles recognized) and all 61 initialization cells evaluate without error. Its `Manipulate` builds a full widget — a `Column`-labeled curvature slider, checkbox pairs, a rule-labeled `PopupMenu`, and three `Appearance -> None` locators — and renders geometry matching the published snapshot, numbers included.

One branch failed, though: the spherical case of its `orthocenter` construction. That branch scales a `Sum[…]` of vectors by `Times @@ dp`, and Woxi read the juxtaposition as `(Sum[…] Times) @@ dp` — applying a list as a head, so the center point was never drawn and `Det::matsq` was reported instead.

## The fix

`@@`, `@@@` and `/@` bind tighter than `Times`, and `split_implicit_products` already reaches into an adjacent implicit product for exactly this reason. It only recognised products the grammar produced through `ImplicitTimes`, though; `f[x] y` reaches the tree builder through `FunctionCallExtended`'s implicit suffix instead, and so was handed over whole.

Flagging that shape as an implicit product too fixes the whole family:

```
Sum[i, {i, 0, 2}] Times @@ {3, 4}   36   (was (3 Times)[3, 4])
Length[{a, b}] f /@ {x, y}          {2 f[x], 2 f[y]}
Length[{a, b}] {1, 2} . {3, 4}      22
```

It also makes `x / f[y] z` parse as `(x z) / f[y]`, matching what the `ImplicitTimes` path already did.

With the fix, all 56 combinations of the notebook's curvature slider (positive, zero, and negative) and center picker render without errors, and the default widget's output is byte-identical to before.

## Tests

- `function_call_implicit_product_yields_to_tighter_operators` — interpreter coverage for `@@`, `@@@`, `/@`, `.` and `^` reaching through a call head, plus the cases that must stay unchanged.
- Three `scrut` cases in `tests/cli/syntax.md` documenting the precedence.
- `demonstration_non_euclidean_triangle_manipulate_switches_centers` — a non-verbatim Woxi Studio end-to-end test for the notebook's shape, asserting the weighted-center branch still plots its point. Both new tests fail without the fix.

`make test` (27170 tests), `make test-studio` (150 tests) and the `syntax.md` documentation tests all pass.

## Unrelated flake

Gives `rolling_polygon_on_catenary_notebook_rolls_its_polygon` a wider `slow-timeout`. It is ~12s standalone in debug builds and was timing out against the 20s default under the parallel load of a full studio run — pre-existing and unrelated to this change, fixed the same way as the other known-slow studio tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX1BTXMAX8z4B1hb7HU9HR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX1BTXMAX8z4B1hb7HU9HR)_