### PR TITLE
Implement ListVectorPlot and the legacy VectorFieldPlots` alias

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -2015,7 +2015,7 @@ RandomWord,Generate random words (requires dictionary),🚫,,10.3,2018
 NMaxValue,Numerical maximum value optimization (numerical optimization),✅,,7.0,2020
 UnitSimplify,Simplify physical units (unit system),🚫,,9.0,2020
 AirTemperatureData,,🚫,,10.0,2024
-ListVectorPlot,Vector field plot from list data (plotting),🚫,,7.0,2024
+ListVectorPlot,Creates a vector field plot from a list of {position vector} pairs,✅,pure,7.0,2024
 OrderDistribution,Order statistics distribution (complex statistics),🚫,,8.0,2024
 TracePrint,Print all sub-expressions used during an evaluation indented by depth,✅,effectful,2.0,2025
 Circumsphere,Circumsphere of a simplex (computational geometry),✅,pure,10.0,2026

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -484,6 +484,16 @@ fn evaluate_function_call_ast_inner(
 ) -> Result<Expr, InterpreterError> {
   use crate::functions::list_helpers_ast;
 
+  // Legacy standard-distribution package functions whose modern built-in
+  // equivalent lives under a different name. Woxi keeps every built-in in
+  // one flat namespace (see `is_standard_distribution_context`), so a
+  // qualified call to one of these is normalized to its modern name before
+  // dispatch rather than reimplementing the legacy function separately.
+  let name = match name {
+    "VectorFieldPlots`ListVectorFieldPlot" => "ListVectorPlot",
+    other => other,
+  };
+
   // Thread Listable functions over list arguments
   let is_listable = is_builtin_listable(name)
     || crate::FUNC_ATTRS.with(|m| {

--- a/src/evaluator/dispatch/plotting.rs
+++ b/src/evaluator/dispatch/plotting.rs
@@ -481,6 +481,9 @@ pub fn dispatch_plotting(
     "VectorPlot" if args.len() >= 3 => Some(quiet_plot(|| {
       crate::functions::field_plot::vector_plot_ast(args)
     })),
+    "ListVectorPlot" if !args.is_empty() => Some(quiet_plot(|| {
+      crate::functions::field_plot::list_vector_plot_ast(args)
+    })),
     "VectorPlot3D" if args.len() >= 4 => Some(quiet_plot(|| {
       crate::functions::plot3d::vector_plot3d_ast(args)
     })),

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -1748,6 +1748,109 @@ pub fn region_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   Ok(crate::graphics_result(svg))
 }
 
+/// Draws arrows for a set of `(x, y, vx, vy, magnitude)` vectors onto `svg`,
+/// scaled so the largest arrow spans about `cell_size * 0.4` pixels, and
+/// returns the `{color, Arrow[...]}` primitives drawn (so callers can hand
+/// them back as `Graphics[{…}]`, e.g. for `VectorPlot[…][[1]]`).
+///
+/// Shared by `VectorPlot` (vectors sampled from a symbolic field over a
+/// regular grid) and `ListVectorPlot` (vectors supplied as literal data), so
+/// both draw identically instead of maintaining two arrow renderers.
+fn render_vector_arrows(
+  vectors: &[(f64, f64, f64, f64, f64)],
+  max_mag: f64,
+  cell_size: f64,
+  area: &crate::functions::plot::PlotArea,
+  svg: &mut String,
+) -> Vec<Expr> {
+  let mut primitives: Vec<Expr> = Vec::new();
+  if max_mag <= 0.0 {
+    return primitives;
+  }
+
+  let to_px = |x: f64, y: f64| -> (f64, f64) {
+    let sx =
+      area.plot_x0 + (x - area.x_min) / (area.x_max - area.x_min) * area.plot_w;
+    let sy =
+      area.plot_y0 + (area.y_max - y) / (area.y_max - area.y_min) * area.plot_h;
+    (sx, sy)
+  };
+
+  let arrow_scale = cell_size * 0.4 / max_mag;
+  let stroke_w = area.render_width as f64 / 1000.0 * 1.5;
+  // The pixel-space arrow length maps back to a data-space length so the
+  // symbolic arrows have the same footprint as the drawn ones.
+  let data_scale_x = arrow_scale * (area.x_max - area.x_min) / area.plot_w;
+  let data_scale_y = arrow_scale * (area.y_max - area.y_min) / area.plot_h;
+  for &(x, y, vx, vy, mag) in vectors {
+    if mag < 1e-15 {
+      continue;
+    }
+
+    let (sx, sy) = to_px(x, y);
+    let dx = vx * arrow_scale;
+    let dy = -vy * arrow_scale; // SVG y is flipped
+
+    let ex = sx + dx;
+    let ey = sy + dy;
+
+    // Color based on magnitude
+    let t = (mag / max_mag).clamp(0.0, 1.0);
+    let r = (t * 200.0) as u8 + 50;
+    let g = ((1.0 - t) * 150.0) as u8 + 50;
+    let b = 100_u8;
+
+    primitives.push(Expr::List(
+      vec![
+        rgb_color((r, g, b)),
+        Expr::FunctionCall {
+          name: "Arrow".to_string(),
+          args: vec![Expr::List(
+            vec![
+              Expr::List(vec![Expr::Real(x), Expr::Real(y)].into()),
+              Expr::List(
+                vec![
+                  Expr::Real(x + vx * data_scale_x),
+                  Expr::Real(y + vy * data_scale_y),
+                ]
+                .into(),
+              ),
+            ]
+            .into(),
+          )]
+          .into(),
+        },
+      ]
+      .into(),
+    ));
+
+    // Arrow shaft
+    svg.push_str(&format!(
+      "<line x1=\"{sx:.1}\" y1=\"{sy:.1}\" x2=\"{ex:.1}\" y2=\"{ey:.1}\" stroke=\"rgb({r},{g},{b})\" stroke-width=\"{stroke_w:.1}\"/>\n"
+    ));
+
+    // Arrowhead
+    let len = (dx * dx + dy * dy).sqrt();
+    if len > 2.0 {
+      let ux = dx / len;
+      let uy = dy / len;
+      let head_len = len * 0.3;
+      let head_w = head_len * 0.4;
+      let px = -uy;
+      let py = ux;
+      let bx1 = ex - ux * head_len + px * head_w;
+      let by1 = ey - uy * head_len + py * head_w;
+      let bx2 = ex - ux * head_len - px * head_w;
+      let by2 = ey - uy * head_len - py * head_w;
+      svg.push_str(&format!(
+        "<polygon points=\"{ex:.1},{ey:.1} {bx1:.1},{by1:.1} {bx2:.1},{by2:.1}\" fill=\"rgb({r},{g},{b})\"/>\n"
+      ));
+    }
+  }
+
+  primitives
+}
+
 /// VectorPlot[{vx, vy}, {x, xmin, xmax}, {y, ymin, ymax}]
 pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   let (xvar, x_min, x_max) = parse_iterator(&args[1], "VectorPlot")?;
@@ -1781,7 +1884,7 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Use plotters for axes
-  let area = generate_axes_only(
+  let mut area = generate_axes_only(
     (x_min, x_max),
     (y_min, y_max),
     svg_width,
@@ -1789,107 +1892,119 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     full_width,
   )?;
 
-  // Extract coordinate transform fields before moving svg
-  let plot_x0 = area.plot_x0;
-  let plot_y0 = area.plot_y0;
-  let plot_w = area.plot_w;
-  let plot_h = area.plot_h;
-  let render_w = area.render_width;
-  let ax_min = area.x_min;
-  let ax_max = area.x_max;
-  let ay_min = area.y_min;
-  let ay_max = area.y_max;
-
-  let mut svg = area.svg;
+  let mut svg = std::mem::take(&mut area.svg);
   if let Some(pos) = svg.rfind("</svg>") {
     svg.truncate(pos);
   }
 
-  let to_px = |x: f64, y: f64| -> (f64, f64) {
-    let sx = plot_x0 + (x - ax_min) / (ax_max - ax_min) * plot_w;
-    let sy = plot_y0 + (ay_max - y) / (ay_max - ay_min) * plot_h;
-    (sx, sy)
-  };
-
   let cell_size =
-    (plot_w / VECTOR_GRID as f64).min(plot_h / VECTOR_GRID as f64);
+    (area.plot_w / VECTOR_GRID as f64).min(area.plot_h / VECTOR_GRID as f64);
 
   // Arrows in data coordinates, kept so `VectorPlot[…][[1]]` yields the
   // primitives a surrounding `Graphics[{…}]` can redraw.
-  let mut primitives: Vec<Expr> = Vec::new();
-  if max_mag > 0.0 {
-    let arrow_scale = cell_size * 0.4 / max_mag;
-    let stroke_w = render_w as f64 / 1000.0 * 1.5;
-    // The pixel-space arrow length maps back to a data-space length so the
-    // symbolic arrows have the same footprint as the drawn ones.
-    let data_scale_x = arrow_scale * (ax_max - ax_min) / plot_w;
-    let data_scale_y = arrow_scale * (ay_max - ay_min) / plot_h;
-    for &(x, y, vx, vy, mag) in &vectors {
-      if mag < 1e-15 {
-        continue;
-      }
+  let primitives =
+    render_vector_arrows(&vectors, max_mag, cell_size, &area, &mut svg);
 
-      let (sx, sy) = to_px(x, y);
-      let dx = vx * arrow_scale;
-      let dy = -vy * arrow_scale; // SVG y is flipped
+  svg.push_str("</svg>");
+  Ok(crate::graphics_result_with_structure(
+    svg,
+    call1("Graphics", Expr::List(primitives.into())),
+  ))
+}
 
-      let ex = sx + dx;
-      let ey = sy + dy;
-
-      // Color based on magnitude
-      let t = (mag / max_mag).clamp(0.0, 1.0);
-      let r = (t * 200.0) as u8 + 50;
-      let g = ((1.0 - t) * 150.0) as u8 + 50;
-      let b = 100_u8;
-
-      primitives.push(Expr::List(
-        vec![
-          rgb_color((r, g, b)),
-          Expr::FunctionCall {
-            name: "Arrow".to_string(),
-            args: vec![Expr::List(
-              vec![
-                Expr::List(vec![Expr::Real(x), Expr::Real(y)].into()),
-                Expr::List(
-                  vec![
-                    Expr::Real(x + vx * data_scale_x),
-                    Expr::Real(y + vy * data_scale_y),
-                  ]
-                  .into(),
-                ),
-              ]
-              .into(),
-            )]
-            .into(),
-          },
-        ]
-        .into(),
-      ));
-
-      // Arrow shaft
-      svg.push_str(&format!(
-        "<line x1=\"{sx:.1}\" y1=\"{sy:.1}\" x2=\"{ex:.1}\" y2=\"{ey:.1}\" stroke=\"rgb({r},{g},{b})\" stroke-width=\"{stroke_w:.1}\"/>\n"
-      ));
-
-      // Arrowhead
-      let len = (dx * dx + dy * dy).sqrt();
-      if len > 2.0 {
-        let ux = dx / len;
-        let uy = dy / len;
-        let head_len = len * 0.3;
-        let head_w = head_len * 0.4;
-        let px = -uy;
-        let py = ux;
-        let bx1 = ex - ux * head_len + px * head_w;
-        let by1 = ey - uy * head_len + py * head_w;
-        let bx2 = ex - ux * head_len - px * head_w;
-        let by2 = ey - uy * head_len - py * head_w;
-        svg.push_str(&format!(
-          "<polygon points=\"{ex:.1},{ey:.1} {bx1:.1},{by1:.1} {bx2:.1},{by2:.1}\" fill=\"rgb({r},{g},{b})\"/>\n"
-        ));
-      }
-    }
+/// Reads a literal `{x, y}` point/vector pair, evaluating each coordinate.
+fn as_xy_pair(expr: &Expr) -> Option<(f64, f64)> {
+  let Expr::List(items) = expr else {
+    return None;
+  };
+  if items.len() != 2 {
+    return None;
   }
+  let x = try_eval_to_f64(&items[0])?;
+  let y = try_eval_to_f64(&items[1])?;
+  Some((x, y))
+}
+
+/// ListVectorPlot[{{{x1, y1}, {vx1, vy1}}, {{x2, y2}, {vx2, vy2}}, ...}]
+///
+/// Draws arrows from literal `{position, vector}` data, rather than sampling
+/// a symbolic field over a grid the way `VectorPlot` does. This is also the
+/// modern name for the legacy `VectorFieldPlots\`ListVectorFieldPlot`, whose
+/// calls are normalized to `ListVectorPlot` before dispatch (see
+/// `evaluate_function_call_ast`) since the two take identical data.
+pub fn list_vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  let data = evaluate_expr_to_expr(&args[0])?;
+  let Expr::List(rows) = &data else {
+    return Err(InterpreterError::EvaluationError(
+      "ListVectorPlot: first argument must be a list of {position, vector} pairs"
+        .into(),
+    ));
+  };
+
+  let mut vectors = Vec::new();
+  let mut max_mag = 0.0_f64;
+  let (mut x_min, mut x_max, mut y_min, mut y_max) = (
+    f64::INFINITY,
+    f64::NEG_INFINITY,
+    f64::INFINITY,
+    f64::NEG_INFINITY,
+  );
+  for row in rows {
+    let Expr::List(pair) = row else { continue };
+    if pair.len() != 2 {
+      continue;
+    }
+    let Some((x, y)) = as_xy_pair(&pair[0]) else {
+      continue;
+    };
+    let Some((vx, vy)) = as_xy_pair(&pair[1]) else {
+      continue;
+    };
+    x_min = x_min.min(x);
+    x_max = x_max.max(x);
+    y_min = y_min.min(y);
+    y_max = y_max.max(y);
+    let mag = (vx * vx + vy * vy).sqrt();
+    max_mag = max_mag.max(mag);
+    vectors.push((x, y, vx, vy, mag));
+  }
+
+  if vectors.is_empty() || !x_min.is_finite() || !y_min.is_finite() {
+    return Ok(crate::graphics_result(
+      "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>".to_string(),
+    ));
+  }
+  // A single row/column of data (or all-equal coordinates) has zero span;
+  // pad it so the axes aren't degenerate.
+  if (x_max - x_min).abs() < 1e-12 {
+    x_min -= 1.0;
+    x_max += 1.0;
+  }
+  if (y_max - y_min).abs() < 1e-12 {
+    y_min -= 1.0;
+    y_max += 1.0;
+  }
+
+  let (svg_width, svg_height, full_width) = parse_field_options(args, 1);
+  let mut area = generate_axes_only(
+    (x_min, x_max),
+    (y_min, y_max),
+    svg_width,
+    svg_height,
+    full_width,
+  )?;
+  let mut svg = std::mem::take(&mut area.svg);
+  if let Some(pos) = svg.rfind("</svg>") {
+    svg.truncate(pos);
+  }
+
+  // Data points aren't laid out on a regular grid, so the arrow scale is
+  // based on the average spacing implied by the plot area and point count
+  // instead of `VectorPlot`'s fixed sampling grid.
+  let cell_size =
+    (area.plot_w * area.plot_h / vectors.len().max(1) as f64).sqrt();
+  let primitives =
+    render_vector_arrows(&vectors, max_mag, cell_size, &area, &mut svg);
 
   svg.push_str("</svg>");
   Ok(crate::graphics_result_with_structure(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -230,6 +230,7 @@ const STANDARD_DISTRIBUTION_CONTEXTS: &[&str] = &[
   "Units",
   "VariationalMethods",
   "VectorAnalysis",
+  "VectorFieldPlots",
   "WaveletScalogram",
 ];
 

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -9851,6 +9851,46 @@ ParametricPlot[f[t], {t, 0, 1}]]",
     }
 
     #[test]
+    fn list_vector_plot_basic() {
+      insta::assert_snapshot!(export_svg(
+        "ListVectorPlot[{{{0, 0}, {1, 0}}, {{1, 1}, {0, 1}}, {{-1, 1}, {-1, 0}}}]"
+      ));
+    }
+
+    #[test]
+    fn list_vector_plot_part_one_yields_drawable_primitives() {
+      assert_eq!(
+        interpret(
+          "Head[ListVectorPlot[{{{0, 0}, {1, 0}}, {{1, 1}, {0, 1}}}][[1]]]"
+        )
+        .unwrap(),
+        "List"
+      );
+      assert_eq!(
+        interpret(
+          "Length[Cases[ListVectorPlot[{{{0, 0}, {1, 0}}, {{1, 1}, {0, 1}}}][[1]], \
+             _Line | _Arrow, Infinity]] > 0"
+        )
+        .unwrap(),
+        "True"
+      );
+    }
+
+    // Demonstrations from before `ListVectorPlot` existed (Wolfram Language
+    // 9) load `VectorFieldPlots`` and call its qualified
+    // `ListVectorFieldPlot` — same data shape, so it draws the same picture
+    // as the modern name instead of being silently dropped by `Show`.
+    #[test]
+    fn legacy_list_vector_field_plot_matches_list_vector_plot() {
+      assert_eq!(
+        export_svg(
+          "VectorFieldPlots`ListVectorFieldPlot[{{{0, 0}, {1, 0}}, {{1, 1}, {0, 1}}}]"
+        ),
+        export_svg("ListVectorPlot[{{{0, 0}, {1, 0}}, {{1, 1}, {0, 1}}}]")
+      );
+    }
+
+    #[test]
     fn stream_plot_basic() {
       insta::assert_snapshot!(export_svg(
         "StreamPlot[{-y, x}, {x, -2, 2}, {y, -2, 2}]"

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__field_plots__list_vector_plot_basic.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__field_plots__list_vector_plot_basic.snap
@@ -1,0 +1,191 @@
+---
+source: tests/interpreter_tests/graphics.rs
+expression: "export_svg(\"ListVectorPlot[{{{0, 0}, {1, 0}}, {{1, 1}, {0, 1}}, {{-1, 1}, {-1, 0}}}]\")"
+---
+<svg width="360" height="360" viewBox="0 0 3600 3600" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="3600" height="3600" opacity="1" fill="#FFFFFF" stroke="none"/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="749,100 749,3099 "/>
+<text x="670" y="3099" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+0.0
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,3099 749,3099 "/>
+<text x="670" y="2950" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,2950 749,2950 "/>
+<text x="670" y="2800" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,2800 749,2800 "/>
+<text x="670" y="2650" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,2650 749,2650 "/>
+<text x="670" y="2500" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+0.2
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,2500 749,2500 "/>
+<text x="670" y="2350" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,2350 749,2350 "/>
+<text x="670" y="2200" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,2200 749,2200 "/>
+<text x="670" y="2050" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,2050 749,2050 "/>
+<text x="670" y="1900" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+0.4
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1900 749,1900 "/>
+<text x="670" y="1750" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1750 749,1750 "/>
+<text x="670" y="1600" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1600 749,1600 "/>
+<text x="670" y="1450" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1450 749,1450 "/>
+<text x="670" y="1300" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+0.6
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1300 749,1300 "/>
+<text x="670" y="1150" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1150 749,1150 "/>
+<text x="670" y="1000" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,1000 749,1000 "/>
+<text x="670" y="850" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,850 749,850 "/>
+<text x="670" y="700" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+0.8
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,700 749,700 "/>
+<text x="670" y="550" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,550 749,550 "/>
+<text x="670" y="400" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,400 749,400 "/>
+<text x="670" y="250" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,250 749,250 "/>
+<text x="670" y="100" dy="0.5ex" text-anchor="end" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+1.0
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="709,100 749,100 "/>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,3100 3499,3100 "/>
+<text x="750" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+-1.0
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="750,3100 750,3140 "/>
+<text x="887" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="887,3100 887,3140 "/>
+<text x="1024" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1024,3100 1024,3140 "/>
+<text x="1162" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1162,3100 1162,3140 "/>
+<text x="1299" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1299,3100 1299,3140 "/>
+<text x="1437" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+-0.5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1437,3100 1437,3140 "/>
+<text x="1574" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1574,3100 1574,3140 "/>
+<text x="1712" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1712,3100 1712,3140 "/>
+<text x="1849" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1849,3100 1849,3140 "/>
+<text x="1987" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="1987,3100 1987,3140 "/>
+<text x="2124" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+0.0
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2124,3100 2124,3140 "/>
+<text x="2261" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2261,3100 2261,3140 "/>
+<text x="2399" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2399,3100 2399,3140 "/>
+<text x="2536" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2536,3100 2536,3140 "/>
+<text x="2674" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2674,3100 2674,3140 "/>
+<text x="2811" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+0.5
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2811,3100 2811,3140 "/>
+<text x="2949" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="2949,3100 2949,3140 "/>
+<text x="3086" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3086,3100 3086,3140 "/>
+<text x="3224" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3224,3100 3224,3140 "/>
+<text x="3361" y="3180" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">
+
+</text>
+<polyline fill="none" opacity="1" stroke="#666666" stroke-width="10" points="3361,3100 3361,3140 "/>
+<line x1="750.0" y1="3140.0" x2="750.0" y2="3170.0" stroke="#666" stroke-width="10"/>
+<line x1="1437.5" y1="3140.0" x2="1437.5" y2="3170.0" stroke="#666" stroke-width="10"/>
+<line x1="2125.0" y1="3140.0" x2="2125.0" y2="3170.0" stroke="#666" stroke-width="10"/>
+<line x1="2812.5" y1="3140.0" x2="2812.5" y2="3170.0" stroke="#666" stroke-width="10"/>
+<line x1="3500.0" y1="3140.0" x2="3500.0" y2="3170.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="3100.0" x2="680.0" y2="3100.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="2500.0" x2="680.0" y2="2500.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1900.0" x2="680.0" y2="1900.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="1300.0" x2="680.0" y2="1300.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="700.0" x2="680.0" y2="700.0" stroke="#666" stroke-width="10"/>
+<line x1="710.0" y1="100.0" x2="680.0" y2="100.0" stroke="#666" stroke-width="10"/>
+<text x="3500.0" y="3180.0" dy="0.76em" text-anchor="middle" font-family="Atkinson Hyperlegible Next, sans-serif" font-size="145.16129032258064" opacity="1" fill="#666666">1.0</text>
+<line x1="2125.0" y1="3100.0" x2="2788.3" y2="3100.0" stroke="rgb(250,50,100)" stroke-width="5.4"/>
+<polygon points="2788.3,3100.0 2589.3,3179.6 2589.3,3020.4" fill="rgb(250,50,100)"/>
+<line x1="3500.0" y1="100.0" x2="3500.0" y2="-563.3" stroke="rgb(250,50,100)" stroke-width="5.4"/>
+<polygon points="3500.0,-563.3 3579.6,-364.3 3420.4,-364.3" fill="rgb(250,50,100)"/>
+<line x1="750.0" y1="100.0" x2="86.7" y2="100.0" stroke="rgb(250,50,100)" stroke-width="5.4"/>
+<polygon points="86.7,100.0 285.7,20.4 285.7,179.6" fill="rgb(250,50,100)"/>
+</svg>

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -4361,6 +4361,9 @@ mod needs_function {
     );
     assert_eq!(interpret("Needs[\"Combinatorica`\"]").unwrap(), "\0");
     assert_eq!(interpret("Get[\"Units`\"]").unwrap(), "\0");
+    // `VectorFieldPlots` is the legacy package Demonstrations load via
+    // `Get["VectorFieldPlots`"]` before calling `ListVectorFieldPlot`.
+    assert_eq!(interpret("Get[\"VectorFieldPlots`\"]").unwrap(), "\0");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

While checking a random Wolfram Demonstration ("Pólya Vector Fields and Complex Integration along Closed Curves") against Woxi Studio, I found it didn't render its vector field: the notebook's `Manipulate` calls `Get["VectorFieldPlots\`"]` in its `Initialization`, then draws with `VectorFieldPlots\`ListVectorFieldPlot[...]`. Neither was recognized — `Get` reported `Get::noopen`, and the qualified function call fell through unevaluated, so `Show` silently dropped the vector field and only the integration curve rendered.

- Add `VectorFieldPlots` to the standard-distribution package contexts, so `Get`/`Needs` loads it as a no-op like the other legacy plotting packages already there (`BarCharts`, `PieCharts`, `StatisticalPlots`, ...).
- Implement the modern `ListVectorPlot[{{pos, vec}, ...}]`, drawing arrows from literal `{position, vector}` data. It shares its arrow-rendering code with `VectorPlot` (extracted into `render_vector_arrows`) rather than duplicating it.
- Normalize the legacy qualified call `VectorFieldPlots\`ListVectorFieldPlot` to `ListVectorPlot` before dispatch, since both take identical data — one implementation, not two.
- Mark `ListVectorPlot` as implemented in `functions.csv`.

## Test plan

- [x] Added unit tests for `ListVectorPlot` (basic rendering, `[[1]]` drawable primitives) and for the legacy `VectorFieldPlots\`ListVectorFieldPlot` alias matching `ListVectorPlot` output.
- [x] Extended the existing `standard_distribution_packages_load_as_no_ops` test to cover `Get["VectorFieldPlots\`"]`.
- [x] `make test` — all 27,172 tests pass.
- [x] `make format`.
- [x] Manually verified against the downloaded Demonstration notebook via `woxi-studio`'s `dump_manipulate` example: the vector field now renders (previously only the bare integration curve showed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kb9K4N6b7P8MUgRFReo7CT)_