### PR TITLE
Typeset inline OverscriptBox/UnderscriptBox labels in Manipulate controls

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -19166,6 +19166,16 @@ fn manipulate_label_runs_inner(expr: &Expr, italic: bool) -> Vec<LabelRun> {
       },
       "Subscript" => script_runs(args, italic, false),
       "Superscript" => script_runs(args, italic, true),
+      // `Underscript[base, mark]` — the limit written under a base, e.g. a
+      // sum's index. No diacritic reads as an under-mark in practice, so
+      // the mark simply sits in subscript position like `Subscript` does.
+      "Underscript" if args.len() == 2 => script_runs(args, italic, false),
+      // `Overscript[base, mark]`, the evaluable form `OverscriptBox` reads
+      // as. A diacritic mark (a hat, bar, tilde, dot, …) draws directly on
+      // the base's last glyph — `Overscript[u, "_"]` is the antiquark ū in
+      // a Demonstration's quark-content picker; anything else (a rate
+      // constant over a reaction arrow) hangs above the base instead.
+      "Overscript" if args.len() == 2 => overscript_runs(args, italic),
       // `Power[b, e]`, which is what a label's typeset `SuperscriptBox`
       // reads as: a Demonstration writes its gravity slider's unit as
       // `m/\!\(\*SuperscriptBox[\(s\), \(2\)]\)`, and it must show as
@@ -19511,6 +19521,40 @@ fn script_runs(
       italic: false,
       ..Default::default()
     });
+  }
+  runs
+}
+
+/// Build the runs for an `Overscript[base, mark]`. A diacritic mark
+/// (recognized by [`crate::notebook::combining_accent`]) is appended as a
+/// Unicode combining character onto the base's last run, so `Overscript[u,
+/// "_"]` reads as `ū` rather than `u_`. Anything else is a script the base
+/// carries above it — a rate constant over a reaction arrow — which has no
+/// combining form, so it is written out in parentheses instead.
+fn overscript_runs(args: &[Expr], italic: bool) -> Vec<LabelRun> {
+  let mut runs = args
+    .first()
+    .map(|a| manipulate_label_runs(a, italic))
+    .unwrap_or_default();
+  let Some(mark_arg) = args.get(1) else {
+    return runs;
+  };
+  let mark = flatten_label_runs(&manipulate_label_runs(mark_arg, false));
+  match crate::notebook::combining_accent(&mark) {
+    Some(combining) => match runs.last_mut() {
+      Some(last) => last.text.push_str(combining),
+      None => runs.push(LabelRun {
+        text: combining.to_string(),
+        italic,
+        ..Default::default()
+      }),
+    },
+    None if !mark.is_empty() => runs.push(LabelRun {
+      text: format!("^({mark})"),
+      italic: false,
+      ..Default::default()
+    }),
+    None => {}
   }
   runs
 }
@@ -20548,11 +20592,18 @@ fn discrete_choice_rule(item: &Expr) -> Option<(&Expr, &Expr)> {
 /// anything that renders empty falls back to its InputForm.
 fn discrete_choice_label(expr: &Expr) -> String {
   match expr {
-    // The label is drawn, so it shows glyphs rather than the private-use
-    // code points the string itself keeps.
-    Expr::String(s) => {
-      crate::syntax::substitute_private_use_glyphs(s).into_owned()
-    }
+    // A string may carry inline typeset boxes the FrontEnd wrote as
+    // `\!\(\*…\)` — an antiquark's `\!\(\*OverscriptBox[\(u\), \(_\)]\)`
+    // reads as `ū`, not the private-use box markers it's stored with.
+    // A plain string just needs its remaining private-use code points
+    // (e.g. `\[WarningSign]`) swapped for real glyphs.
+    Expr::String(s) => match inline_box_label_runs(s, false) {
+      Some(runs) => crate::syntax::substitute_private_use_glyphs(
+        &flatten_label_runs(&runs),
+      )
+      .into_owned(),
+      None => crate::syntax::substitute_private_use_glyphs(s).into_owned(),
+    },
     other => {
       let flat = flatten_label_runs(&manipulate_label_runs(other, false));
       // A structural head (Grid/Row/Column/…) can legitimately typeset to

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -20598,10 +20598,10 @@ fn discrete_choice_label(expr: &Expr) -> String {
     // A plain string just needs its remaining private-use code points
     // (e.g. `\[WarningSign]`) swapped for real glyphs.
     Expr::String(s) => match inline_box_label_runs(s, false) {
-      Some(runs) => crate::syntax::substitute_private_use_glyphs(
-        &flatten_label_runs(&runs),
-      )
-      .into_owned(),
+      Some(runs) => {
+        crate::syntax::substitute_private_use_glyphs(&flatten_label_runs(&runs))
+          .into_owned()
+      }
       None => crate::syntax::substitute_private_use_glyphs(s).into_owned(),
     },
     other => {

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -690,6 +690,8 @@ fn extract_typeset_box(s: &str) -> Option<String> {
     "SuperscriptBox",
     "SubscriptBox",
     "SubsuperscriptBox",
+    "OverscriptBox",
+    "UnderscriptBox",
     "SqrtBox",
     "RadicalBox",
     "TagBox",
@@ -773,6 +775,27 @@ fn extract_typeset_box(s: &str) -> Option<String> {
           conv(&args[0]),
           conv(&args[1]),
           conv(&args[2])
+        )
+      }
+      // `OverscriptBox[a, b]` / `UnderscriptBox[a, b]` → `Overscript[a, "b"]`
+      // / `Underscript[a, "b"]` (Wolfram's evaluable forms, which — like
+      // `Subscript` — stay symbolic rather than evaluating away). The mark
+      // is a display annotation (a hat, bar, tilde, or a rate constant over
+      // a reaction arrow), not code, so it is quoted as a string literal
+      // rather than left bare: an unquoted `_` would otherwise parse as the
+      // `Blank[]` pattern instead of the macron mark it typesets.
+      "OverscriptBox" if args.len() == 2 => {
+        format!(
+          "Overscript[{}, \"{}\"]",
+          conv(&args[0]),
+          escape_string(&conv(&args[1]))
+        )
+      }
+      "UnderscriptBox" if args.len() == 2 => {
+        format!(
+          "Underscript[{}, \"{}\"]",
+          conv(&args[0]),
+          escape_string(&conv(&args[1]))
         )
       }
       // `SqrtBox[a]` → `Sqrt[a]`.
@@ -1552,7 +1575,7 @@ fn render_boxes_text(s: &str) -> String {
 /// `OverscriptBox` — `OverHat[x]`, `OverBar[x]`, `OverVector[x]` and friends
 /// all typeset that way. `None` for anything that reads as a script rather
 /// than a diacritic (a rate constant over a reaction arrow, say).
-fn combining_accent(over: &str) -> Option<&'static str> {
+pub(crate) fn combining_accent(over: &str) -> Option<&'static str> {
   match over.trim() {
     "^" | "\\[Hat]" | "\u{F759}" => Some("\u{0302}"),
     "~" | "\\[Tilde]" | "\u{223C}" => Some("\u{0303}"),
@@ -3479,6 +3502,23 @@ Cell["Chapter 2", "Chapter"]
     // An ordinary subscript is still `Subscript`.
     let s = r#"BoxData[SubscriptBox["c", "1"]]"#;
     assert_eq!(extract_cell_content(s), "Subscript[c, 1]");
+  }
+
+  /// `OverscriptBox`/`UnderscriptBox` become the evaluable `Overscript`/
+  /// `Underscript` forms — Wolfram's own typesetting heads, which (like
+  /// `Subscript`) stay symbolic rather than evaluating away. Regression: an
+  /// antiquark label (`OverscriptBox["u", "_"]`, from a physics
+  /// Demonstration's quark-content picker) came back with its mark left
+  /// bare, which parses as the `Blank[]` pattern rather than the macron
+  /// mark it typesets.
+  #[test]
+  fn test_overscript_box_becomes_evaluable_overscript() {
+    let s = r#"BoxData[OverscriptBox["u", "_"]]"#;
+    assert_eq!(extract_cell_content(s), "Overscript[u, \"_\"]");
+    let s = r#"BoxData[OverscriptBox["x", "^"]]"#;
+    assert_eq!(extract_cell_content(s), "Overscript[x, \"^\"]");
+    let s = r#"BoxData[UnderscriptBox["x", "k"]]"#;
+    assert_eq!(extract_cell_content(s), "Underscript[x, \"k\"]");
   }
 
   /// `SubscriptBox["\\[PartialD]", vars]` is the typeset partial-derivative

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -9333,6 +9333,42 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
   }
 
   #[test]
+  fn popup_menu_choice_labels_typeset_inline_overscript_boxes() {
+    // Regression: a PopupMenu whose per-choice labels carry an inline
+    // `\!\(\*OverscriptBox[…]\)` — as a particle/antiparticle picker marks
+    // the antiparticle with an overbar — came back showing the box's raw
+    // private-use markers instead of the accent it typesets. A diacritic
+    // mark (`_`, `^`) becomes a combining accent on the base glyph; any
+    // other mark is not a diacritic and hangs above the base as a plain
+    // superscript instead.
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[x, \
+       {{x, 1, \"particle\"}, \
+        {1 -> \"\\!\\(\\*OverscriptBox[\\(x\\), \\(_\\)]\\)\", \
+         2 -> \"\\!\\(\\*OverscriptBox[\\(x\\), \\(^\\)]\\)\", \
+         3 -> \"\\!\\(\\*OverscriptBox[\\(x\\), \\(k\\)]\\)\"}, \
+        ControlType -> PopupMenu}]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("the overscript-labelled Manipulate must build a widget");
+    assert!(state.error.is_none(), "body must evaluate cleanly: {:?}", state.error);
+    match &state.controls[0] {
+      manipulate::ControlState::Discrete { value_labels, .. } => {
+        assert_eq!(
+          value_labels,
+          &[
+            "x\u{0304}".to_string(), // macron -> combining accent: x̄
+            "x\u{0302}".to_string(), // hat -> combining accent: x̂
+            "x^(k)".to_string(),     // not a diacritic -> a plain superscript
+          ]
+        );
+      }
+      other => panic!("expected a discrete control, got {other:?}"),
+    }
+  }
+
+  #[test]
   fn parametric_curves_manipulate_lays_out_its_plots() {
     // End-to-end regression for "Parametric Curves in 2D": four plots are
     // `Inset` into one picture, and the `t` slider is bounded by symbols

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -9352,7 +9352,11 @@ p \\[LessEqual] \\!\\(\\*SubscriptBox[\\(p\\), \\(0\\)]\\)\"}]}, \
     .unwrap();
     let state = manipulate::ManipulateState::from_expr(&expr)
       .expect("the overscript-labelled Manipulate must build a widget");
-    assert!(state.error.is_none(), "body must evaluate cleanly: {:?}", state.error);
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
     match &state.controls[0] {
       manipulate::ControlState::Discrete { value_labels, .. } => {
         assert_eq!(


### PR DESCRIPTION
## Summary

Following this session's routine (pull a random Wolfram Demonstration notebook and check whether Woxi Studio fully supports it), the ["The OZI Rule in Meson Decay"](https://demonstrations.wolfram.com/TheOZIRuleInMesonDecay/) Demonstration exposed a labeling bug: its quark-content picker's `PopupMenu` choices carry inline typeset labels like `\!\(\*OverscriptBox[\(u\), \(_\)]\)` (the antiquark's overbar, ū). Woxi Studio showed the raw private-use box markers instead of the accent.

## Root cause

- `extract_typeset_box` (in `notebook.rs`), which turns a typeset box's source into an evaluable expression, had no case for `OverscriptBox`/`UnderscriptBox` — only `SuperscriptBox`/`SubscriptBox`/etc.
- `discrete_choice_label`'s `Expr::String` branch (in `graphics.rs`) never even attempted inline-box parsing for a rule's label string — it only ran a private-use-glyph substitution, unlike the general label-run renderer other label text goes through.

## Fix

- Convert `OverscriptBox[a, b]` / `UnderscriptBox[a, b]` box source to the evaluable `Overscript[a, "b"]` / `Underscript[a, "b"]` forms (Wolfram's own typesetting heads, which — like `Subscript` — stay symbolic). The mark is quoted as a string literal since it's a display annotation, not code: leaving it bare would let a macron mark (`_`) parse as the `Blank[]` pattern instead.
- Render `Overscript[base, mark]` as a Unicode combining accent on the base's last glyph when the mark is a known diacritic (reusing the existing `combining_accent` helper), falling back to a plain superscript-style rendering otherwise (e.g. a rate constant over a reaction arrow). `Underscript` renders like `Subscript`, since no diacritic reads as an under-mark in practice.
- Route `discrete_choice_label`'s string case through the same inline-box-label machinery slider captions already use, so a rule-labeled choice picks up inline typesetting too.

## Testing

- Added a core-crate unit test (`notebook.rs`) covering the box→evaluable-expression conversion for both `OverscriptBox` and `UnderscriptBox`.
- Added a Woxi Studio regression test (`main.rs`) with an original PopupMenu example (not copied from the Demonstration) covering a diacritic mark, a hat mark, and a non-diacritic mark, verifying the value labels typeset correctly.
- Verified end-to-end against the downloaded Demonstration notebook via the `dump_manipulate` diagnostic example: labels now read `u\u{304}`/`d\u{304}`/`s\u{304}`/`c\u{304}` (ū, d̄, s̄, c̄) instead of garbled private-use characters, and the diagram graphics render correctly for the initial control state.
- `make test`: 27199/27199 passed.
- `make format` applied.

https://claude.ai/code/session_01GTQi8H3GWXHQ8bom4ERomF


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTQi8H3GWXHQ8bom4ERomF)_