### PR TITLE
Support Dynamic-wrapped PopupMenu choices and rule-pure-function operator chains

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -19747,6 +19747,25 @@ fn unicode_script_char(c: char, superscript: bool) -> Option<char> {
   Some(mapped)
 }
 
+/// A discrete control's choice list may be written `Dynamic[expr, opts…]`
+/// (e.g. `Dynamic[# -> data[[#]] & /@ Range[Length[data]], SynchronousUpdating -> False]`)
+/// so the front end refreshes it as other state changes. The trailing
+/// options only govern *when* Wolfram redraws the popup, not what the list
+/// contains, so unwrapping to `expr` and evaluating it once already matches
+/// what Wolfram renders. `Dynamic` is `HoldFirst` and has no evaluation rule
+/// of its own, so without this the wrapped expression is never reached and
+/// the control fails to parse.
+fn unwrap_dynamic_choices(expr: &Expr) -> &Expr {
+  match expr {
+    Expr::FunctionCall { name, args }
+      if name == "Dynamic" && !args.is_empty() =>
+    {
+      &args[0]
+    }
+    _ => expr,
+  }
+}
+
 /// Parse a single variable-spec list into a `ParsedControl`. `siblings`
 /// names the Manipulate's other control variables, so a choice list built
 /// from one of them can be marked for live re-resolution; pass an empty
@@ -20215,7 +20234,7 @@ fn parse_manipulate_control(
   // multiple-choice bar rather than a one-of picker.
   if matches!(control_type.as_deref(), Some("CheckboxBar" | "TogglerBar"))
     && bounds.len() == 1
-    && let Some(choices) = match bounds[0] {
+    && let Some(choices) = match unwrap_dynamic_choices(bounds[0]) {
       l @ Expr::List(_) => Some(l.clone()),
       other => crate::evaluator::evaluate_expr_to_expr(other).ok(),
     }
@@ -20244,7 +20263,7 @@ fn parse_manipulate_control(
   }
   {
     let value_items: Option<Vec<Expr>> = if bounds.len() == 1 {
-      match bounds[0] {
+      match unwrap_dynamic_choices(bounds[0]) {
         Expr::List(vs) => Some(vs.iter().cloned().collect()),
         other => match crate::evaluator::evaluate_expr_to_expr(other) {
           Ok(Expr::List(ref vs)) => Some(vs.iter().cloned().collect()),
@@ -20285,10 +20304,13 @@ fn parse_manipulate_control(
       // A choice list built from another control's variable (`Range[1,
       // If[flat, 3, 6], 1]`) only holds for that variable's current value;
       // keep its code so the frontend can rebuild the choices whenever the
-      // other control moves.
+      // other control moves. A `Dynamic[…]` wrapper is stripped first (see
+      // `unwrap_dynamic_choices`) so the kept code re-evaluates cleanly too.
       let values_code = (bounds.len() == 1
-        && expr_references_any(bounds[0], siblings))
-      .then(|| crate::syntax::expr_to_input_form(bounds[0]));
+        && expr_references_any(unwrap_dynamic_choices(bounds[0]), siblings))
+      .then(|| {
+        crate::syntax::expr_to_input_form(unwrap_dynamic_choices(bounds[0]))
+      });
       return Some(ParsedControl::Visible {
         control: ManipulateControl::Discrete {
           name,
@@ -22549,6 +22571,43 @@ mod manipulate_dynamic_control_list_tests {
        Sequence@@If[mode == 1, {Control[{{y, 0}, -1, 1}]}, {}]}]]",
     );
     assert_eq!(names(&s), vec!["mode"]);
+  }
+
+  /// A discrete control's own *choice list* (not the whole control-spec
+  /// list) can be written `Dynamic[expr, opts…]` — the shape a PopupMenu
+  /// built from a lookup table uses so the front end can refresh it as
+  /// other state changes (e.g. `Dynamic[# -> data[[#, 2]] & /@
+  /// Range[Length[data]], SynchronousUpdating -> False]`). `Dynamic` is
+  /// `HoldFirst` with no evaluation rule of its own, so the wrapper must be
+  /// stripped before the wrapped expression is evaluated to a list of
+  /// choices; previously the control silently failed to parse at all.
+  #[test]
+  fn dynamic_wrapped_choice_list_still_offers_its_options() {
+    let _ = crate::interpret_with_stdout(
+      "presetTable = {{1, \"a\"}, {2, \"b\"}, {3, \"c\"}};",
+    );
+    let s = spec(
+      "Manipulate[pick, {{pick, 2, \"preset\"}, \
+       Dynamic[#\
+        -> presetTable[[#, 2]] & /@ Range[Length[presetTable]], \
+        SynchronousUpdating -> False], ControlType -> PopupMenu}]",
+    );
+    assert_eq!(names(&s), vec!["pick"]);
+    match &s.controls[0] {
+      ManipulateControl::Discrete {
+        values,
+        value_labels,
+        initial_index,
+        popup,
+        ..
+      } => {
+        assert_eq!(values, &["1", "2", "3"]);
+        assert_eq!(value_labels, &["a", "b", "c"]);
+        assert_eq!(*initial_index, 1);
+        assert!(popup, "ControlType -> PopupMenu must render as a dropdown");
+      }
+      other => panic!("expected a Discrete control, got {other:?}"),
+    }
   }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3400,45 +3400,54 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
       // Combined ReplacementRule + optional anonymous function suffix (&),
       // then any postfix applications: `f[a -> 5 // Head]` hands the whole
       // rule to Head, because `//` binds looser than `->`.
-      let inner_pairs: Vec<_> = pair.into_inner().collect();
-      let rule_expr = pair_to_expr(inner_pairs[0].clone());
-      let has_anon = inner_pairs
+      let mut inner_pairs: Vec<_> = pair.into_inner().collect();
+      let rule_expr = pair_to_expr(inner_pairs.remove(0));
+      let anon_idx = inner_pairs
         .iter()
-        .any(|p| matches!(p.as_rule(), Rule::RuleAnonSuffix));
-      let mut result = if has_anon {
-        Expr::Function {
+        .position(|p| matches!(p.as_rule(), Rule::RuleAnonSuffix));
+      if let Some(idx) = anon_idx {
+        // Everything after the `&` is a continuation on the pure function
+        // it just produced — operator/tilde-infix chains (`pat -> repl &
+        // /@ list`, the idiom for building a PopupMenu's choices from a
+        // lookup table), `/.`/`//.`, and trailing `//` — shared with a
+        // plain Expression's own post-& handling.
+        let post_pairs: Vec<_> = inner_pairs.split_off(idx + 1);
+        let func = Expr::Function {
           body: Box::new(rule_expr),
-        }
+        };
+        apply_anon_continuation(func, post_pairs)
       } else {
-        rule_expr
-      };
-      for p in &inner_pairs {
-        match p.as_rule() {
-          Rule::RuleReplaceSuffix => {
-            let repeated = p.as_str().trim_start().starts_with("//.");
-            let rules = pair_to_expr(p.clone().into_inner().next().unwrap());
-            result = if repeated {
-              Expr::ReplaceRepeated {
+        // No `&`: only `/.`/`//.` (RuleReplaceSuffix) and trailing `//`
+        // can follow the bare rule.
+        let mut result = rule_expr;
+        for p in inner_pairs {
+          match p.as_rule() {
+            Rule::RuleReplaceSuffix => {
+              let repeated = p.as_str().trim_start().starts_with("//.");
+              let rules = pair_to_expr(p.into_inner().next().unwrap());
+              result = if repeated {
+                Expr::ReplaceRepeated {
+                  expr: Box::new(result),
+                  rules: Box::new(rules),
+                }
+              } else {
+                Expr::ReplaceAll {
+                  expr: Box::new(result),
+                  rules: Box::new(rules),
+                }
+              };
+            }
+            Rule::PostfixFunction => {
+              result = Expr::Postfix {
                 expr: Box::new(result),
-                rules: Box::new(rules),
-              }
-            } else {
-              Expr::ReplaceAll {
-                expr: Box::new(result),
-                rules: Box::new(rules),
-              }
-            };
+                func: Box::new(parse_postfix_function(p)),
+              };
+            }
+            _ => {}
           }
-          Rule::PostfixFunction => {
-            result = Expr::Postfix {
-              expr: Box::new(result),
-              func: Box::new(parse_postfix_function(p.clone())),
-            };
-          }
-          _ => {}
         }
+        result
       }
-      result
     }
     Rule::PartExtract => {
       let mut inner = pair.into_inner();
@@ -5038,20 +5047,6 @@ fn parse_expression_inner(
 
     // Apply continuation operators after & (e.g., #^2& @ 3)
     if !post_anon_pairs.is_empty() {
-      let mut post_terms: Vec<Expr> = Vec::new();
-      let mut post_ops: Vec<String> = Vec::new();
-      let mut post_postfix: Vec<Pair<Rule>> = Vec::new();
-
-      // Collect postfix functions from the end of post-& pairs
-      let mut post_pairs = post_anon_pairs;
-      while post_pairs
-        .last()
-        .is_some_and(|p| p.as_rule() == Rule::PostfixFunction)
-      {
-        post_postfix.push(post_pairs.pop().unwrap());
-      }
-      post_postfix.reverse();
-
       // If the pre-& result is an assignment (`a = body &`), the post-&
       // continuation operators (e.g. `/@ newlist`) almost always bind
       // tighter than `=`, so they should be applied to the RHS only.
@@ -5079,138 +5074,7 @@ fn parse_expression_inner(
         result
       };
 
-      // Parse continuation as operator-term pairs
-      post_terms.push(starting_term);
-      // Each `&` chain may be followed by `/.` / `//.` suffixes, which
-      // apply to the *result* of the application: `f & [x] /. rules`.
-      #[allow(clippy::type_complexity)]
-      let mut pending_anon_chains: Vec<(
-        Vec<Vec<Expr>>,
-        Vec<(Expr, bool)>,
-      )> = Vec::new();
-      let mut leading_replaces: Vec<(Expr, bool)> = Vec::new();
-      let mut iter = post_pairs.into_iter();
-      while let Some(op_pair) = iter.next() {
-        if op_pair.as_rule() == Rule::Operator {
-          post_ops.push(op_pair.as_str().to_string());
-          // Check for LeadingMinus after operator
-          if let Some(next_pair) = iter.next() {
-            if next_pair.as_rule() == Rule::LeadingMinus {
-              // Use `^_NEG` for `^-` (see comment in main expression branch).
-              if post_ops.last().is_some_and(|o| o == "^") {
-                post_ops.pop();
-                post_ops.push("^_NEG".to_string());
-              } else {
-                post_terms.push(Expr::Integer(0));
-                post_ops.push("NEGATE".to_string());
-              }
-              if let Some(term_pair) = iter.next() {
-                post_terms.push(pair_to_expr(term_pair));
-              }
-            } else {
-              post_terms.push(pair_to_expr(next_pair));
-            }
-          }
-        } else if op_pair.as_rule() == Rule::TildeInfix {
-          let inner = op_pair.into_inner().next().unwrap();
-          let func_expr = pair_to_expr(inner);
-          let func_str = match &func_expr {
-            Expr::Identifier(name) => format!("~{name}~"),
-            _ => format!("~{}~", expr_to_string(&func_expr)),
-          };
-          post_ops.push(func_str);
-          if let Some(next_pair) = iter.next() {
-            if next_pair.as_rule() == Rule::LeadingMinus {
-              post_terms.push(Expr::Integer(0));
-              post_ops.push("NEGATE".to_string());
-              if let Some(term_pair) = iter.next() {
-                post_terms.push(pair_to_expr(term_pair));
-              }
-            } else {
-              post_terms.push(pair_to_expr(next_pair));
-            }
-          }
-        } else if op_pair.as_rule() == Rule::AnonymousFunctionSuffix {
-          // (TildeInfix doesn't need `^_NEG` handling — Power is never the
-          // operator immediately preceding a tilde infix.)
-          // A second `&` after the first: wrap the accumulated infix chain
-          // built so far (including any infix continuation) in a Function
-          // and apply its BracketArgs. Matches Wolfram's `f & [x] & [y]`
-          // ≡ `((f &)[x] &)[y]`.
-          let bracket_args: Vec<Vec<Expr>> = op_pair
-            .into_inner()
-            .filter(|p| matches!(p.as_rule(), Rule::BracketArgs))
-            .map(|bracket| bracket.into_inner().map(pair_to_expr).collect())
-            .collect();
-          pending_anon_chains.push((bracket_args, Vec::new()));
-        } else if matches!(
-          op_pair.as_rule(),
-          Rule::ReplaceAllSuffix | Rule::ReplaceRepeatedSuffix
-        ) {
-          // `f & [x] /. rules` replaces in the *result* of the
-          // application. Before any further `&`, that result is the term
-          // chain built so far; after one, it is that chain's own result.
-          let repeated = op_pair.as_rule() == Rule::ReplaceRepeatedSuffix;
-          let rules = pair_to_expr(op_pair.into_inner().next().unwrap());
-          match pending_anon_chains.last_mut() {
-            Some((_, replaces)) => replaces.push((rules, repeated)),
-            None => leading_replaces.push((rules, repeated)),
-          }
-        }
-      }
-
-      // Build expression tree with precedence
-      result = build_binary_tree(post_terms, &post_ops);
-
-      // A `/.` between the first `&` application and any further one.
-      for (rules, repeated) in leading_replaces {
-        result = if repeated {
-          Expr::ReplaceRepeated {
-            expr: Box::new(result),
-            rules: Box::new(rules),
-          }
-        } else {
-          Expr::ReplaceAll {
-            expr: Box::new(result),
-            rules: Box::new(rules),
-          }
-        };
-      }
-
-      // Apply any additional `& [...]` chains that followed the first one.
-      for (bracket_args, replaces) in pending_anon_chains {
-        result = Expr::Function {
-          body: Box::new(result),
-        };
-        for args in bracket_args {
-          result = Expr::CurriedCall {
-            func: Box::new(result),
-            args,
-          };
-        }
-        for (rules, repeated) in replaces {
-          result = if repeated {
-            Expr::ReplaceRepeated {
-              expr: Box::new(result),
-              rules: Box::new(rules),
-            }
-          } else {
-            Expr::ReplaceAll {
-              expr: Box::new(result),
-              rules: Box::new(rules),
-            }
-          };
-        }
-      }
-
-      // Apply post-& postfix functions
-      for func_pair in post_postfix {
-        let func = parse_postfix_function(func_pair);
-        result = Expr::Postfix {
-          expr: Box::new(result),
-          func: Box::new(func),
-        };
-      }
+      result = apply_anon_continuation(starting_term, post_anon_pairs);
 
       // Re-wrap the assignment around the now-extended RHS.
       if let Some((name, lhs)) = assignment_lhs {
@@ -5220,6 +5084,170 @@ fn parse_expression_inner(
         };
       }
     }
+  }
+
+  result
+}
+
+/// Apply the continuation that can follow a `&`-terminated pure function:
+/// operator/tilde-infix chains (`f & /@ list`), a further `&[args]`
+/// application chained after (`f & [x] & [y]`), `/.`/`//.` replacements,
+/// and trailing `// g` postfix, interleaved in any order. `starting_term`
+/// is the pure function itself (already `Expr::Function`-wrapped);
+/// `post_pairs` is everything the grammar captured after the `&`.
+///
+/// Shared by `Expression`'s own post-& handling and by
+/// `ListItemRule`/`FunctionArgRule`, whose `pattern -> replacement &` is
+/// exactly such a pure function and can take the same continuation —
+/// `pattern -> replacement & /@ list` is the idiom for building a
+/// `PopupMenu`'s choices from a lookup table.
+fn apply_anon_continuation(
+  starting_term: Expr,
+  post_pairs: Vec<Pair<Rule>>,
+) -> Expr {
+  let mut post_terms: Vec<Expr> = Vec::new();
+  let mut post_ops: Vec<String> = Vec::new();
+  let mut post_postfix: Vec<Pair<Rule>> = Vec::new();
+
+  // Collect postfix functions from the end of post-& pairs
+  let mut post_pairs = post_pairs;
+  while post_pairs
+    .last()
+    .is_some_and(|p| p.as_rule() == Rule::PostfixFunction)
+  {
+    post_postfix.push(post_pairs.pop().unwrap());
+  }
+  post_postfix.reverse();
+
+  // Parse continuation as operator-term pairs
+  post_terms.push(starting_term);
+  // Each `&` chain may be followed by `/.` / `//.` suffixes, which
+  // apply to the *result* of the application: `f & [x] /. rules`.
+  #[allow(clippy::type_complexity)]
+  let mut pending_anon_chains: Vec<(Vec<Vec<Expr>>, Vec<(Expr, bool)>)> =
+    Vec::new();
+  let mut leading_replaces: Vec<(Expr, bool)> = Vec::new();
+  let mut iter = post_pairs.into_iter();
+  while let Some(op_pair) = iter.next() {
+    if op_pair.as_rule() == Rule::Operator {
+      post_ops.push(op_pair.as_str().to_string());
+      // Check for LeadingMinus after operator
+      if let Some(next_pair) = iter.next() {
+        if next_pair.as_rule() == Rule::LeadingMinus {
+          // Use `^_NEG` for `^-` (see comment in main expression branch).
+          if post_ops.last().is_some_and(|o| o == "^") {
+            post_ops.pop();
+            post_ops.push("^_NEG".to_string());
+          } else {
+            post_terms.push(Expr::Integer(0));
+            post_ops.push("NEGATE".to_string());
+          }
+          if let Some(term_pair) = iter.next() {
+            post_terms.push(pair_to_expr(term_pair));
+          }
+        } else {
+          post_terms.push(pair_to_expr(next_pair));
+        }
+      }
+    } else if op_pair.as_rule() == Rule::TildeInfix {
+      let inner = op_pair.into_inner().next().unwrap();
+      let func_expr = pair_to_expr(inner);
+      let func_str = match &func_expr {
+        Expr::Identifier(name) => format!("~{name}~"),
+        _ => format!("~{}~", expr_to_string(&func_expr)),
+      };
+      post_ops.push(func_str);
+      if let Some(next_pair) = iter.next() {
+        if next_pair.as_rule() == Rule::LeadingMinus {
+          post_terms.push(Expr::Integer(0));
+          post_ops.push("NEGATE".to_string());
+          if let Some(term_pair) = iter.next() {
+            post_terms.push(pair_to_expr(term_pair));
+          }
+        } else {
+          post_terms.push(pair_to_expr(next_pair));
+        }
+      }
+    } else if op_pair.as_rule() == Rule::AnonymousFunctionSuffix {
+      // (TildeInfix doesn't need `^_NEG` handling — Power is never the
+      // operator immediately preceding a tilde infix.)
+      // A second `&` after the first: wrap the accumulated infix chain
+      // built so far (including any infix continuation) in a Function
+      // and apply its BracketArgs. Matches Wolfram's `f & [x] & [y]`
+      // ≡ `((f &)[x] &)[y]`.
+      let bracket_args: Vec<Vec<Expr>> = op_pair
+        .into_inner()
+        .filter(|p| matches!(p.as_rule(), Rule::BracketArgs))
+        .map(|bracket| bracket.into_inner().map(pair_to_expr).collect())
+        .collect();
+      pending_anon_chains.push((bracket_args, Vec::new()));
+    } else if matches!(
+      op_pair.as_rule(),
+      Rule::ReplaceAllSuffix | Rule::ReplaceRepeatedSuffix
+    ) {
+      // `f & [x] /. rules` replaces in the *result* of the
+      // application. Before any further `&`, that result is the term
+      // chain built so far; after one, it is that chain's own result.
+      let repeated = op_pair.as_rule() == Rule::ReplaceRepeatedSuffix;
+      let rules = pair_to_expr(op_pair.into_inner().next().unwrap());
+      match pending_anon_chains.last_mut() {
+        Some((_, replaces)) => replaces.push((rules, repeated)),
+        None => leading_replaces.push((rules, repeated)),
+      }
+    }
+  }
+
+  // Build expression tree with precedence
+  let mut result = build_binary_tree(post_terms, &post_ops);
+
+  // A `/.` between the first `&` application and any further one.
+  for (rules, repeated) in leading_replaces {
+    result = if repeated {
+      Expr::ReplaceRepeated {
+        expr: Box::new(result),
+        rules: Box::new(rules),
+      }
+    } else {
+      Expr::ReplaceAll {
+        expr: Box::new(result),
+        rules: Box::new(rules),
+      }
+    };
+  }
+
+  // Apply any additional `& [...]` chains that followed the first one.
+  for (bracket_args, replaces) in pending_anon_chains {
+    result = Expr::Function {
+      body: Box::new(result),
+    };
+    for args in bracket_args {
+      result = Expr::CurriedCall {
+        func: Box::new(result),
+        args,
+      };
+    }
+    for (rules, repeated) in replaces {
+      result = if repeated {
+        Expr::ReplaceRepeated {
+          expr: Box::new(result),
+          rules: Box::new(rules),
+        }
+      } else {
+        Expr::ReplaceAll {
+          expr: Box::new(result),
+          rules: Box::new(rules),
+        }
+      };
+    }
+  }
+
+  // Apply post-& postfix functions
+  for func_pair in post_postfix {
+    let func = parse_postfix_function(func_pair);
+    result = Expr::Postfix {
+      expr: Box::new(result),
+      func: Box::new(func),
+    };
   }
 
   result

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -788,7 +788,12 @@ List = { "{" ~ (ListItemOrOmitted ~ ("," ~ ListItemOrOmittedLast)*)? ~ "}" }
 // nesting depth. This avoids exponential backtracking for deeply nested lists by
 // skipping the ReplacementRule attempt when no rule operator exists.
 RuleAnonSuffix = { "&" ~ !"&" }
-ListItemRule = { ReplacementRule ~ RuleAnonSuffix? ~ RuleReplaceSuffix* ~ ("//" ~ PostfixFunction)* }
+// After a trailing `&` turns the rule into a pure function, that function
+// can itself take a further operator — `pat -> repl & /@ list` (Map over
+// the rule-producing function) is the common idiom for building PopupMenu
+// choices from a lookup table. Without RuleAnonSuffix nothing changes:
+// `RuleReplaceSuffix*` alone still lets `/.`/`//.` apply to the bare rule.
+ListItemRule = { ReplacementRule ~ (RuleAnonSuffix ~ ((ReplaceRepeatedSuffix | ReplaceAllSuffix) | (Operator | TildeInfix) ~ RuleOperatorTerm)* | RuleReplaceSuffix*) ~ ("//" ~ PostfixFunction)* }
 // `/.` and `//.` bind looser than `->`, so a rule written as an argument may
 // itself be replaced in: `f[a -> 5 /. 5 -> 6]` is `f[(a -> 5) /. (5 -> 6)]`.
 RuleReplaceSuffix = { ("//." | "/.") ~ (&HasRuleOperator ~ ReplacementRule | List | ConditionExpr) }
@@ -799,6 +804,17 @@ RuleReplaceSuffix = { ("//." | "/.") ~ (&HasRuleOperator ~ ReplacementRule | Lis
 // scan and make the whole expression unparseable.  Listed first in every
 // alternation so `(*` is never mistaken for a parenthesis group.
 ScanComment = @{ "(*" ~ (ScanComment | (!"(*" ~ !"*)" ~ ANY))* ~ "*)" }
+// The Term chain used after an infix Operator: an optional leading sign,
+// a Term, then the usual postfix suffixes. Shared by ListItemRule and
+// FunctionArgRule below so `(pattern -> replacement) &` can chain a
+// further operator (`/@`, `@@`, …), matching how a plain Expression
+// continues after its own trailing `&`.
+RuleOperatorTerm = _{
+    LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?
+  | LeadingPlus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?
+  | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?
+  | Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?
+}
 // Scan forward looking for -> or :> at the current nesting depth
 NestedContent = _{ (
     ScanComment
@@ -882,7 +898,9 @@ AssociationExtended = {
 // Uses HasRuleOperator lookahead to skip rule parsing when no rule operator exists.
 // A rule may be handed to a postfix function: `f[a -> 5 // Head]` is
 // `f[Head[a -> 5]]`, since `//` binds looser than `->`.
-FunctionArgRule = { ReplacementRule ~ RuleAnonSuffix? ~ RuleReplaceSuffix* ~ ("//" ~ PostfixFunction)* }
+// See ListItemRule's comment: RuleAnonSuffix gates the extra Operator
+// continuation so `pat -> repl & /@ list` parses as an argument too.
+FunctionArgRule = { ReplacementRule ~ (RuleAnonSuffix ~ ((ReplaceRepeatedSuffix | ReplaceAllSuffix) | (Operator | TildeInfix) ~ RuleOperatorTerm)* | RuleReplaceSuffix*) ~ ("//" ~ PostfixFunction)* }
 FunctionArg = _{ &HasRuleOperator ~ FunctionArgRule | &HasSemicolon ~ CompoundExpression | &HasSpanSep ~ SpanExpr | Expression }
 // BracketArgs groups arguments within a single bracket pair, allowing proper chained call parsing
 FunctionArgOrOmitted = _{ FunctionArg | OmittedArg }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -18574,4 +18574,93 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 3, $CellContext`spread$$ = 0,
       "the weighted hub sits elsewhere than the centroid"
     );
   }
+
+  /// Regression for a Manipulate whose selector's *choice list itself* is
+  /// wrapped in `Dynamic[…]` — the shape a Demonstration built from a preset
+  /// table uses so a `PopupMenu` can be assembled from data instead of
+  /// literal choices (`Dynamic[# -> presetNames[[#]] & /@
+  /// Range[Length[presetShapes]], SynchronousUpdating -> False]`). `Dynamic`
+  /// is `HoldFirst` with no evaluation rule of its own, so the wrapper used
+  /// to reach the control-spec parser unevaluated and the whole choice list
+  /// (and with it, the whole widget) failed to build.
+  #[test]
+  fn demonstration_preset_popup_choices_wrapped_in_dynamic_still_builds() {
+    let _ = woxi::interpret_with_stdout(
+      "presetShapes = {{{1, 0}, {0, 1}, {-1, 0}, {0, -1}}, \
+       {{1, 1}, {-1, 1}, {-1, -1}, {1, -1}}, \
+       {{2, 0}, {0, 1}, {-2, 0}, {0, -1}}}; \
+       presetNames = {\"diamond\", \"square\", \"kite\"};",
+    );
+    let code = "Manipulate[\
+      Module[{corners}, \
+        corners = presetShapes[[shapeIndex]]; \
+        Graphics[{Blue, Line[Append[corners, First[corners]]]}, \
+          PlotRange -> 3, ImageSize -> 250]], \
+      {{shapeIndex, 1, \"shape\"}, \
+        Dynamic[#\
+         -> presetNames[[#]] & /@ Range[Length[presetShapes]], \
+         SynchronousUpdating -> False], ControlType -> PopupMenu}\
+    ]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the Dynamic-wrapped popup choices must still build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the selected preset's outline must render"
+    );
+
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Discrete {
+          name,
+          values,
+          value_labels,
+          current_index,
+          popup,
+          ..
+        },
+      ] => {
+        assert_eq!(name.as_str(), "shapeIndex");
+        assert_eq!(values, &["1", "2", "3"]);
+        assert_eq!(value_labels, &["diamond", "square", "kite"]);
+        assert_eq!(*current_index, 0);
+        assert!(*popup, "ControlType -> PopupMenu must render as a dropdown");
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the outline must render")
+    };
+    let diamond = render(&state);
+
+    match &mut state.controls[..] {
+      [manipulate::ControlState::Discrete { current_index, .. }] => {
+        *current_index = 2;
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    let kite = render(&state);
+    assert_ne!(
+      diamond, kite,
+      "picking a different preset must change the outline drawn"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

As part of the recurring "verify Woxi Studio against a random Wolfram Demonstration" check, this run sampled the *Deterministic Context Free (DOL) Systems* Demonstration (fetched via `RandomResourcePage`, not committed to the repo per policy). Its Manipulate builds a `PopupMenu` whose choices are computed from a lookup table via `Dynamic[# -> table[[#, 2]] & /@ Range[Length[table]], SynchronousUpdating -> False]`.

Two separate bugs blocked this shape:

- **Parser bug (general, not Manipulate-specific):** the `ListItemRule`/`FunctionArgRule` fast path for `pattern -> replacement` list/function-call items only allowed a bare trailing `&` (plus `/.`/`//.` and `//`), not a further operator applied to the resulting pure function. `f[# -> #+1 & /@ Range[3], 5]` failed to parse at all, even outside any Manipulate context, while the equivalent bare expression `# -> #+1 & /@ Range[3]` parsed fine at top level. Fixed by extending the grammar to allow the same operator/tilde-infix continuation a plain `Expression` already supports after its own `&`, and extracting the continuation-building logic (previously inlined only in `Expression`'s post-`&` handling) into a shared `apply_anon_continuation` helper so both paths stay in sync instead of drifting apart.
- **Woxi Studio bug:** once that parsed, the Manipulate control-spec parser still didn't resolve a discrete control's choice list when it was wrapped in `Dynamic[expr, opts]` — `Dynamic` is `HoldFirst` with no evaluation rule of its own, so the wrapped expression was never reached. Fixed by unwrapping `Dynamic[...]` before resolving a control's choices in `extract_manipulate_spec`.

## Test plan
- [x] Added a regression test for the parser fix in `src/functions/graphics.rs` (`dynamic_wrapped_choice_list_still_offers_its_options`)
- [x] Added a regression test for the Manipulate widget build in `woxi-studio/src/main.rs` (`demonstration_preset_popup_choices_wrapped_in_dynamic_still_builds`), using an equivalent but non-verbatim reimplementation of the Demonstration's control shape
- [x] `make test` passes (27,199 tests, full workspace green)
- [x] `make test-studio` passes (157 tests)
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp7QXEaNEPBv2cSyz53h26

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tp7QXEaNEPBv2cSyz53h26)_