### PR TITLE
Support fit[{prop1, prop2, ...}] on FittedModel results

### DIFF
--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -7483,6 +7483,31 @@ fn solve_linear_system(a: &[Vec<f64>], b: &[f64]) -> Option<Vec<f64>> {
   Some(x)
 }
 
+/// Look up a single named property on a `FittedModel` association.
+fn lookup_fitted_model_property(
+  assoc: &[(Expr, Expr)],
+  prop: &str,
+) -> Result<Expr, InterpreterError> {
+  // `"BestFit"` is wolframscript's name for the fitted expression itself
+  // (mathematically: the polynomial of the basis terms with their best
+  // coefficients). Internally we store that under `"FittedExpression"`.
+  let lookup_key = if prop == "BestFit" {
+    "FittedExpression"
+  } else {
+    prop
+  };
+  for (key, val) in assoc {
+    if let Expr::String(k) = key
+      && k == lookup_key
+    {
+      return Ok(val.clone());
+    }
+  }
+  Err(InterpreterError::EvaluationError(format!(
+    "FittedModel: unknown property \"{prop}\""
+  )))
+}
+
 /// Evaluate a FittedModel at a point or query a property.
 /// Called when FittedModel[assoc][arg] is encountered.
 pub fn evaluate_fitted_model(
@@ -7503,25 +7528,23 @@ pub fn evaluate_fitted_model(
 
   // Check if the argument is a string (property query)
   if let Expr::String(prop) = &call_args[0] {
-    // `"BestFit"` is wolframscript's name for the fitted expression itself
-    // (mathematically: the polynomial of the basis terms with their best
-    // coefficients). Internally we store that under `"FittedExpression"`.
-    let lookup_key = if prop == "BestFit" {
-      "FittedExpression"
-    } else {
-      prop.as_str()
-    };
-    // Look up the property in the association
-    for (key, val) in assoc {
-      if let Expr::String(k) = key
-        && k == lookup_key
-      {
-        return Ok(val.clone());
-      }
+    return lookup_fitted_model_property(assoc, prop);
+  }
+
+  // `fit[{prop1, prop2, ...}]` looks up each property and returns the list
+  // of results, mirroring how a single string is handled above.
+  if let Expr::List(props) = &call_args[0]
+    && !props.is_empty()
+    && props.iter().all(|p| matches!(p, Expr::String(_)))
+  {
+    let mut results = Vec::with_capacity(props.len());
+    for p in props {
+      let Expr::String(prop) = p else {
+        unreachable!()
+      };
+      results.push(lookup_fitted_model_property(assoc, prop)?);
     }
-    return Err(InterpreterError::EvaluationError(format!(
-      "FittedModel: unknown property \"{prop}\""
-    )));
+    return Ok(Expr::List(results.into()));
   }
 
   // Otherwise, evaluate the model at the given point

--- a/tests/interpreter_tests/linear_algebra.rs
+++ b/tests/interpreter_tests/linear_algebra.rs
@@ -3785,6 +3785,30 @@ mod linear_model_fit {
     assert!((val - 0.814043583535109).abs() < 1e-10);
   }
 
+  // `fit[{prop1, prop2, ...}]` looks up several properties at once and
+  // returns them as a list, the same as querying each one individually.
+  #[test]
+  fn multiple_properties_at_once() {
+    let result = interpret(
+      "lm = LinearModelFit[{{0, 1}, {1, 0}, {3, 2}, {5, 4}}, x, x]; \
+       lm[{\"RSquared\", \"AdjustedRSquared\"}]",
+    )
+    .unwrap();
+    let parts: Vec<f64> = result
+      .trim_start_matches('{')
+      .trim_end_matches('}')
+      .split(',')
+      .map(|s| s.trim().parse().unwrap())
+      .collect();
+    assert_eq!(parts.len(), 2);
+    assert!((parts[0] - 0.814043583535109).abs() < 1e-10);
+    let adjusted =
+      interpret("lm = LinearModelFit[{{0, 1}, {1, 0}, {3, 2}, {5, 4}}, x, x]; lm[\"AdjustedRSquared\"]")
+        .unwrap();
+    let adjusted: f64 = adjusted.parse().unwrap();
+    assert!((parts[1] - adjusted).abs() < 1e-10);
+  }
+
   #[test]
   fn with_basis_list() {
     // LinearModelFit with explicit basis {1, x, x^2}


### PR DESCRIPTION
## Summary

This is the output of the scheduled "check a random Wolfram Demonstration against Woxi Studio" routine. This run fetched **"Probit and Logit Models with Normal Errors"** by Seth J. Chandler from the Wolfram Demonstrations Project.

- `FittedModel[...][prop]` only handled a single property-name string. `FittedModel[...][{prop1, prop2, ...}]` — a common, documented way to query several `LinearModelFit`/`NonlinearModelFit` properties at once — fell through to the "evaluate the model at a point" branch and silently substituted the *list itself* as the independent variable's value, instead of returning the requested properties (or erroring cleanly).
- Extracted the single-property lookup into `lookup_fitted_model_property` and reused it for both the single-string and list-of-strings call forms.
- Added a regression test (`multiple_properties_at_once`) exercising `lm[{"RSquared", "AdjustedRSquared"}]` against `LinearModelFit`.

## Notebook conformance status

The Demonstration's `Manipulate` calls `NonlinearModelFit[...][reportItems]`, where `reportItems` is a list including `"ANOVATable"`, `"ParameterTable"`, `"ParameterCITable"`, and `"ParameterConfidenceRegion"`. After this fix, the list-lookup itself works correctly, but the widget still cannot fully render because those four specific properties are not implemented for `NonlinearModelFit`/`LinearModelFit` in Woxi (only `BestFit`, `BestFitParameters`, `FitResiduals`, `RSquared`, `AdjustedRSquared`, etc. are). Implementing them correctly requires:

- A full statistical report (standard errors, t-statistics, p-values, ANOVA sum-of-squares decomposition) formatted to match Mathematica's exact `Grid` layout.
- Replicating the private, undocumented `` FittedModels`ParameterEllipsoid `` object `ParameterConfidenceRegion` returns.

Neither of these can be verified for an exact match against `wolframscript` in this environment (no Wolfram Engine available here), so rather than guess at unverifiable formatting/internals, I'm leaving them as a known gap for a follow-up with `wolframscript` access, and shipping the concrete, verified bug fix found along the way.

## Test plan

- [x] `make test` — 27203 tests passed
- [x] `make format`
- [x] New regression test `multiple_properties_at_once` passes
- [x] Verified via `woxi-studio`'s `dump_manipulate`/`test_notebook` diagnostic examples against the downloaded notebook (no verbatim notebook content committed, per repo policy on copyrighted material)


---
_Generated by [Claude Code](https://claude.ai/code/session_014K8zoSSx7ApeDqHatYCre1)_