### PR TITLE
Fix `woxi install-kernel` crashing outside a source checkout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,10 @@ repository = "https://github.com/ad-si/Woxi"
 default-run = "woxi"
 # Keep packages built from this crate (crates.io and the PyPI sdist,
 # which vendors this crate via maturin) down to what's needed to
-# compile it. tests/SUMMARY.md, functions.csv, and resources/ are
-# embedded via include_str!/include_bytes! and must stay, as must
-# benches/interpreter.rs (an explicitly declared [[bench]] target).
+# compile it. tests/SUMMARY.md, functions.csv, resources/ and
+# kernelspec/ are embedded via include_str!/include_bytes! and must
+# stay, as must benches/interpreter.rs (an explicitly declared
+# [[bench]] target).
 exclude = [
   "/tests/*/",
   "/tests/woxi",
@@ -39,7 +40,6 @@ exclude = [
   "/examples",
   "/entity_types",
   "/jupyterlite-woxi-kernel",
-  "/kernelspec",
   "/scripts",
   "/woxi-studio",
   "/woxi-py",

--- a/readme.md
+++ b/readme.md
@@ -150,22 +150,18 @@ woxi repl
 
 ### Jupyter Notebook
 
-You can also use Woxi in Jupyter notebooks. In this case you must clone this repository,
-as installing Woxi using `cargo install woxi` won't copy the necessary files to your
-computer.
-
-Clone the repository and move into the `Woxi` directory with:
-
-```sh
-git clone https://github.com/ad-si/Woxi
-cd Woxi
-```
-
-Be sure to have Jupyter already installed, and install the kernel with:
+You can also use Woxi in Jupyter notebooks.
+Install the kernel with:
 
 ```sh
 woxi install-kernel
 ```
+
+The kernelspec is embedded in the `woxi` binary,
+so this works from any directory and with any installation method.
+It is registered with `jupyter kernelspec install` when the `jupyter` command
+is available, and written to Jupyter's kernels directory directly otherwise.
+Use `--system` to install it for all users instead of only the current one.
 
 Then start the Jupyter server:
 

--- a/src/kernelspec.rs
+++ b/src/kernelspec.rs
@@ -1,0 +1,212 @@
+//! Installation of the Woxi Jupyter kernelspec (`woxi install-kernel`).
+//!
+//! The kernelspec files are embedded in the binary, so the command works from
+//! any working directory and from a binary installed via `cargo install` /
+//! a release archive, which has no `kernelspec/` directory next to it.
+//! They are materialised into a temporary staging directory and handed to
+//! `jupyter kernelspec install`; when the `jupyter` CLI is not on `PATH` the
+//! spec is written into Jupyter's kernels directory directly.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+/// Name of the kernel in Jupyter, i.e. the kernelspec directory name.
+const KERNEL_NAME: &str = "woxi";
+
+/// The repository's `kernelspec/woxi` is the single source of truth for the
+/// kernel's metadata and icons; it is compiled into the binary verbatim.
+const KERNEL_JSON: &str = include_str!("../kernelspec/woxi/kernel.json");
+const LOGO_32: &[u8] = include_bytes!("../kernelspec/woxi/logo-32x32.png");
+const LOGO_64: &[u8] = include_bytes!("../kernelspec/woxi/logo-64x64.png");
+
+/// Where the kernelspec is installed to.
+#[derive(Clone, Copy)]
+enum Scope {
+  /// The current user's Jupyter data directory.
+  User,
+  /// The machine-wide Jupyter data directory.
+  System,
+}
+
+/// Install Woxi as a Jupyter kernel.
+///
+/// `user` takes precedence over `system`, and a user installation is the
+/// default when neither flag is given.
+pub(crate) fn install(user: bool, system: bool) -> io::Result<()> {
+  let scope = if system && !user {
+    Scope::System
+  } else {
+    Scope::User
+  };
+
+  // Stage the spec in a temporary directory. `jupyter kernelspec install`
+  // derives the kernel name from the directory name, hence the `woxi`
+  // subdirectory.
+  let staging_root =
+    env::temp_dir().join(format!("woxi-kernelspec-{}", std::process::id()));
+  let staging = staging_root.join(KERNEL_NAME);
+  let _ = fs::remove_dir_all(&staging_root);
+  let result =
+    write_spec(&staging).and_then(|()| install_spec(&staging, scope));
+  let _ = fs::remove_dir_all(&staging_root);
+  result
+}
+
+/// Write `kernel.json` and both logos into `dir`, creating it if needed.
+fn write_spec(dir: &Path) -> io::Result<()> {
+  fs::create_dir_all(dir)?;
+  fs::write(dir.join("kernel.json"), kernel_json())?;
+  fs::write(dir.join("logo-32x32.png"), LOGO_32)?;
+  fs::write(dir.join("logo-64x64.png"), LOGO_64)?;
+  Ok(())
+}
+
+/// The `kernel.json` to install.
+///
+/// `argv[0]` is rewritten to the absolute path of the running executable so
+/// the kernel also starts when the Jupyter server runs with a `PATH` that
+/// does not contain `woxi` (a virtualenv, a systemd unit, JupyterHub …).
+/// The embedded `woxi` is kept when the path cannot be determined.
+fn kernel_json() -> String {
+  let Some(exe) = current_exe() else {
+    return KERNEL_JSON.to_string();
+  };
+  let Ok(mut spec) = serde_json::from_str::<serde_json::Value>(KERNEL_JSON)
+  else {
+    return KERNEL_JSON.to_string();
+  };
+  if let Some(argv0) = spec
+    .get_mut("argv")
+    .and_then(|argv| argv.as_array_mut())
+    .and_then(|argv| argv.first_mut())
+  {
+    *argv0 = serde_json::Value::String(exe);
+  }
+  format!(
+    "{}\n",
+    serde_json::to_string_pretty(&spec).unwrap_or_default()
+  )
+}
+
+/// The absolute path of the running `woxi` binary, if it is representable as
+/// UTF-8 (`kernel.json` is JSON, so non-UTF-8 paths cannot be stored).
+fn current_exe() -> Option<String> {
+  let exe = env::current_exe().ok()?;
+  // Resolves `./woxi` and symlinks; the un-canonicalised path is still
+  // absolute and usable, so a failure here is not fatal.
+  let exe = fs::canonicalize(&exe).unwrap_or(exe);
+  exe.to_str().map(ToString::to_string)
+}
+
+/// Hand `spec_dir` to `jupyter kernelspec install`, falling back to a direct
+/// copy into Jupyter's kernels directory when the `jupyter` CLI is missing.
+fn install_spec(spec_dir: &Path, scope: Scope) -> io::Result<()> {
+  let scope_flag = match scope {
+    Scope::User => "--user",
+    Scope::System => "--system",
+  };
+  let status = std::process::Command::new("jupyter")
+    .args([
+      "kernelspec",
+      "install",
+      "--replace",
+      "--name",
+      KERNEL_NAME,
+      scope_flag,
+    ])
+    .arg(spec_dir)
+    .status();
+
+  match status {
+    Ok(status) if status.success() => {
+      report_success(None);
+      Ok(())
+    }
+    Ok(status) => Err(io::Error::other(format!(
+      "Failed to install kernel. Exit code: {status}"
+    ))),
+    Err(err) if err.kind() == io::ErrorKind::NotFound => {
+      // No Jupyter CLI on `PATH` — install the spec ourselves rather than
+      // failing, so the kernel is ready for whichever Jupyter the user runs.
+      let destination = kernels_dir(scope)?.join(KERNEL_NAME);
+      copy_spec(spec_dir, &destination)?;
+      report_success(Some(&destination));
+      Ok(())
+    }
+    Err(err) => Err(err),
+  }
+}
+
+/// Replace `destination` with the staged kernelspec.
+fn copy_spec(spec_dir: &Path, destination: &Path) -> io::Result<()> {
+  if destination.exists() {
+    fs::remove_dir_all(destination)?;
+  }
+  fs::create_dir_all(destination)?;
+  for entry in fs::read_dir(spec_dir)? {
+    let entry = entry?;
+    fs::copy(entry.path(), destination.join(entry.file_name()))?;
+  }
+  Ok(())
+}
+
+fn report_success(destination: Option<&Path>) {
+  match destination {
+    Some(path) => {
+      println!("Woxi kernel installed successfully in {}", path.display());
+    }
+    None => println!("Woxi kernel installed successfully!"),
+  }
+  println!(
+    "You can now use it in Jupyter Lab or Notebook by selecting 'Woxi' from the kernel list."
+  );
+}
+
+/// Jupyter's kernels directory for `scope`, mirroring the locations
+/// `jupyter_core` uses.
+fn kernels_dir(scope: Scope) -> io::Result<PathBuf> {
+  Ok(jupyter_data_dir(scope)?.join("kernels"))
+}
+
+fn jupyter_data_dir(scope: Scope) -> io::Result<PathBuf> {
+  if let Scope::System = scope {
+    return Ok(if cfg!(windows) {
+      PathBuf::from(non_empty_var("PROGRAMDATA").ok_or_else(|| {
+        io::Error::other("Cannot locate %PROGRAMDATA%: set JUPYTER_DATA_DIR")
+      })?)
+      .join("jupyter")
+    } else {
+      PathBuf::from("/usr/local/share/jupyter")
+    });
+  }
+
+  // An explicit data directory wins over the platform default.
+  if let Some(dir) = non_empty_var("JUPYTER_DATA_DIR") {
+    return Ok(PathBuf::from(dir));
+  }
+
+  if cfg!(windows) {
+    return Ok(
+      PathBuf::from(non_empty_var("APPDATA").ok_or_else(|| {
+        io::Error::other("Cannot locate %APPDATA%: set JUPYTER_DATA_DIR")
+      })?)
+      .join("jupyter"),
+    );
+  }
+
+  let home = dirs::home_dir().ok_or_else(|| {
+    io::Error::other("Cannot locate the home directory: set JUPYTER_DATA_DIR")
+  })?;
+  if cfg!(target_os = "macos") {
+    return Ok(home.join("Library").join("Jupyter"));
+  }
+  let data_home = non_empty_var("XDG_DATA_HOME")
+    .map_or_else(|| home.join(".local").join("share"), PathBuf::from);
+  Ok(data_home.join("jupyter"))
+}
+
+/// `env::var` treating an empty value as unset, like `jupyter_core` does.
+fn non_empty_var(name: &str) -> Option<String> {
+  env::var(name).ok().filter(|value| !value.is_empty())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 mod jupyter;
+mod kernelspec;
 mod repl;
 use std::env;
 use std::fs;
@@ -161,42 +162,6 @@ enum Commands {
   Script(Vec<String>), // invoked by a shebang:  woxi <file> [...]
 }
 
-fn install_kernel(user: bool, system: bool) -> std::io::Result<()> {
-  let user_flag = if user {
-    "--user"
-  } else if system {
-    "--system"
-  } else {
-    "--user"
-  };
-
-  // Get the path to the kernelspec directory
-  let kernelspec_dir = env::current_dir()?.join("kernelspec/woxi");
-
-  // Use jupyter kernelspec to install the kernel
-  let status = std::process::Command::new("jupyter")
-    .args([
-      "kernelspec",
-      "install",
-      "--replace",
-      user_flag,
-      kernelspec_dir.to_str().unwrap(),
-    ])
-    .status()?;
-
-  if status.success() {
-    println!("Woxi kernel installed successfully!");
-    println!(
-      "You can now use it in Jupyter Lab or Notebook by selecting 'Woxi' from the kernel list."
-    );
-    Ok(())
-  } else {
-    Err(std::io::Error::other(format!(
-      "Failed to install kernel. Exit code: {status}"
-    )))
-  }
-}
-
 fn main() {
   let cli = Cli::parse();
   // Run all work on a worker thread with a large stack. The interpreter and
@@ -291,8 +256,9 @@ fn run(cli: Cli) {
       }
     }
     Commands::InstallKernel { user, system } => {
-      if let Err(e) = install_kernel(user, system) {
+      if let Err(e) = kernelspec::install(user, system) {
         eprintln!("Error installing kernel: {e}");
+        std::process::exit(1);
       }
     }
     //  shebang / direct script execution  ---------------------------------

--- a/tests/cli/jupyter.md
+++ b/tests/cli/jupyter.md
@@ -11,6 +11,12 @@ Install the kernel with:
 woxi install-kernel
 ```
 
+The kernelspec is embedded in the `woxi` binary,
+so this works from any directory and with any installation method.
+It is registered with `jupyter kernelspec install` when the `jupyter` command
+is available, and written to Jupyter's kernels directory directly otherwise.
+Use `--system` to install it for all users instead of only the current one.
+
 Then start JupyterLab:
 
 ```sh

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -5,7 +5,7 @@
 //! command-line argument handling (e.g. `woxi eval -12` should accept a
 //! leading-hyphen value rather than treating it as a flag).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn woxi_bin() -> PathBuf {
@@ -776,4 +776,255 @@ fn paclets_keep_their_private_helpers_to_themselves() {
      {Pac1`, Global`}\n\
      {\"helper\", \"Pac1`Private`helper\", \"Pac2`Private`helper\"}\n"
   );
+}
+
+// --- `woxi install-kernel` ------------------------------------------------
+
+/// Scratch directory for an `install-kernel` test, laid out as
+/// `bin/` (the process `PATH`), `data/` (`JUPYTER_DATA_DIR`) and `tmp/`.
+fn kernel_test_dir(name: &str) -> PathBuf {
+  let dir = std::env::temp_dir().join(format!("woxi_cli_{name}"));
+  std::fs::remove_dir_all(&dir).ok();
+  for sub in ["bin", "tmp"] {
+    std::fs::create_dir_all(dir.join(sub)).expect("create test dir");
+  }
+  dir
+}
+
+/// Run `woxi install-kernel` with a `PATH` holding only `dir/bin`, a private
+/// Jupyter data directory and a working directory without a `kernelspec/`
+/// subdirectory — i.e. every invocation outside a source checkout.
+fn run_install_kernel(
+  dir: &Path,
+  extra_args: &[&str],
+) -> (String, String, bool) {
+  let output = Command::new(woxi_bin())
+    .arg("install-kernel")
+    .args(extra_args)
+    .current_dir(dir)
+    .env("PATH", dir.join("bin"))
+    .env("JUPYTER_DATA_DIR", dir.join("data"))
+    .env("TMPDIR", dir.join("tmp"))
+    .output()
+    .expect("failed to spawn woxi");
+  (
+    String::from_utf8_lossy(&output.stdout).into_owned(),
+    String::from_utf8_lossy(&output.stderr).into_owned(),
+    output.status.success(),
+  )
+}
+
+/// Regression test for issue #547: the kernelspec used to be read from
+/// `./kernelspec/woxi`, so installing from anywhere but a source checkout
+/// crashed with `No such file or directory`.
+#[test]
+fn install_kernel_works_outside_a_source_checkout() {
+  let dir = kernel_test_dir("install_kernel_no_checkout");
+  let (stdout, stderr, ok) = run_install_kernel(&dir, &[]);
+  assert!(ok, "woxi install-kernel failed: stderr={stderr}");
+  assert!(
+    !stderr.contains("No such file or directory"),
+    "install-kernel read the kernelspec from disk: stderr={stderr}"
+  );
+
+  let installed = dir.join("data").join("kernels").join("woxi");
+  let spec = std::fs::read_to_string(installed.join("kernel.json"))
+    .expect("kernel.json installed");
+  assert!(
+    installed.join("logo-32x32.png").is_file(),
+    "32px logo missing"
+  );
+  assert!(
+    installed.join("logo-64x64.png").is_file(),
+    "64px logo missing"
+  );
+  assert!(
+    stdout.contains(&installed.display().to_string()),
+    "install location not reported: stdout={stdout}"
+  );
+
+  // `argv[0]` must be an absolute path to the running binary so the kernel
+  // also starts when the Jupyter server's PATH has no `woxi` in it.
+  let argv0 = spec
+    .lines()
+    .find(|line| line.contains("woxi"))
+    .and_then(|line| line.split('"').nth(1).map(ToString::to_string))
+    .expect("argv[0] in kernel.json");
+  assert!(
+    Path::new(&argv0).is_absolute() && Path::new(&argv0).is_file(),
+    "argv[0] is not an existing absolute path: {argv0}"
+  );
+  assert!(spec.contains("\"jupyter\""), "kernel.json: {spec}");
+  assert!(
+    spec.contains("\"{connection_file}\""),
+    "kernel.json: {spec}"
+  );
+  assert!(
+    spec.contains("Woxi (Wolfram Language)"),
+    "kernel.json: {spec}"
+  );
+  assert!(
+    spec.contains("\"language\": \"wolfram\""),
+    "kernel.json: {spec}"
+  );
+
+  // The staged copy is a temporary and must not be left behind.
+  let leftovers: Vec<_> = std::fs::read_dir(dir.join("tmp"))
+    .map(|entries| entries.filter_map(Result::ok).map(|e| e.path()).collect())
+    .unwrap_or_default();
+  assert!(
+    leftovers.is_empty(),
+    "staging directories left behind: {leftovers:?}"
+  );
+
+  std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A second run replaces the previously installed spec instead of failing.
+#[test]
+fn install_kernel_replaces_an_existing_installation() {
+  let dir = kernel_test_dir("install_kernel_replace");
+  let installed = dir.join("data").join("kernels").join("woxi");
+  std::fs::create_dir_all(&installed).expect("create stale spec");
+  std::fs::write(installed.join("stale.json"), "{}").expect("write stale file");
+
+  let (_stdout, stderr, ok) = run_install_kernel(&dir, &[]);
+  assert!(ok, "woxi install-kernel failed: stderr={stderr}");
+  assert!(
+    installed.join("kernel.json").is_file(),
+    "kernel.json missing"
+  );
+  assert!(
+    !installed.join("stale.json").exists(),
+    "stale file survived the reinstall"
+  );
+
+  std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Write an executable `jupyter` stub into `dir/bin` that logs its arguments
+/// to `dir/args.txt`, copies the kernelspec it was pointed at to `dir/staged`
+/// and exits with `exit_code`.
+#[cfg(unix)]
+fn write_jupyter_stub(dir: &Path, exit_code: i32) {
+  use std::os::unix::fs::PermissionsExt;
+  let stub = dir.join("bin").join("jupyter");
+  // `woxi` is run with a PATH that only contains the stub, so the stub
+  // restores the test process' PATH to reach `cp`.
+  let path = std::env::var("PATH").unwrap_or_default();
+  std::fs::write(
+    &stub,
+    format!(
+      "#!/bin/sh\n\
+       PATH='{path}'\n\
+       for arg in \"$@\"; do\n\
+       printf '%s\\n' \"$arg\" >> '{dir}/args.txt'\n\
+       last=\"$arg\"\n\
+       done\n\
+       cp -r \"$last\" '{dir}/staged'\n\
+       exit {exit_code}\n",
+      dir = dir.display()
+    ),
+  )
+  .expect("write jupyter stub");
+  std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+    .expect("chmod jupyter stub");
+}
+
+/// When the `jupyter` CLI is available it performs the installation, and it
+/// is handed a complete kernelspec directory.
+#[cfg(unix)]
+#[test]
+fn install_kernel_hands_a_complete_spec_to_jupyter() {
+  let dir = kernel_test_dir("install_kernel_via_jupyter");
+  write_jupyter_stub(&dir, 0);
+
+  let (stdout, stderr, ok) = run_install_kernel(&dir, &[]);
+  assert!(ok, "woxi install-kernel failed: stderr={stderr}");
+  assert!(
+    stdout.contains("installed successfully"),
+    "stdout={stdout} stderr={stderr}"
+  );
+
+  let logged = std::fs::read_to_string(dir.join("args.txt")).expect("ran");
+  let args: Vec<&str> = logged.lines().collect();
+  assert_eq!(
+    args[..args.len() - 1],
+    [
+      "kernelspec",
+      "install",
+      "--replace",
+      "--name",
+      "woxi",
+      "--user"
+    ]
+  );
+  let source_dir = Path::new(args.last().expect("source directory argument"));
+  assert_eq!(
+    source_dir.file_name().and_then(|name| name.to_str()),
+    Some("woxi"),
+    "jupyter derives the kernel name from the directory name: {source_dir:?}"
+  );
+
+  // The staged directory jupyter was pointed at held the whole spec.
+  let staged = dir.join("staged");
+  assert!(
+    staged.join("kernel.json").is_file(),
+    "staged kernel.json missing"
+  );
+  assert!(
+    staged.join("logo-32x32.png").is_file(),
+    "staged 32px logo missing"
+  );
+  assert!(
+    staged.join("logo-64x64.png").is_file(),
+    "staged 64px logo missing"
+  );
+
+  // Nothing is written directly when jupyter handles the installation.
+  assert!(
+    !dir.join("data").exists(),
+    "the spec was also installed directly"
+  );
+
+  std::fs::remove_dir_all(&dir).ok();
+}
+
+/// `--system` is forwarded to `jupyter kernelspec install`.
+#[cfg(unix)]
+#[test]
+fn install_kernel_forwards_the_system_scope() {
+  let dir = kernel_test_dir("install_kernel_system_scope");
+  write_jupyter_stub(&dir, 0);
+
+  let (_stdout, stderr, ok) = run_install_kernel(&dir, &["--system"]);
+  assert!(ok, "woxi install-kernel --system failed: stderr={stderr}");
+  let logged = std::fs::read_to_string(dir.join("args.txt")).expect("ran");
+  assert!(
+    logged.lines().any(|arg| arg == "--system"),
+    "--system not forwarded: {logged}"
+  );
+  assert!(
+    !logged.lines().any(|arg| arg == "--user"),
+    "--user forwarded alongside --system: {logged}"
+  );
+
+  std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A failing `jupyter kernelspec install` is reported and exits non-zero.
+#[cfg(unix)]
+#[test]
+fn install_kernel_fails_when_jupyter_fails() {
+  let dir = kernel_test_dir("install_kernel_jupyter_error");
+  write_jupyter_stub(&dir, 1);
+
+  let (stdout, stderr, ok) = run_install_kernel(&dir, &[]);
+  assert!(!ok, "expected a non-zero exit: stdout={stdout}");
+  assert!(
+    stderr.contains("Error installing kernel"),
+    "stderr={stderr}"
+  );
+
+  std::fs::remove_dir_all(&dir).ok();
 }


### PR DESCRIPTION
`install_kernel` resolved the kernelspec as `./kernelspec/woxi`, relative
to the current working directory, so the command only worked when run
from a clone of this repository. Anywhere else `jupyter kernelspec
install` aborted with `FileNotFoundError: No such file or directory`
(#547), and `/kernelspec` was excluded from the packaged crate, so a
`cargo install woxi` binary could never find it.

The kernelspec (`kernel.json` and both logos) is now embedded in the
binary and materialised into a temporary staging directory at install
time, which is handed to `jupyter kernelspec install --name woxi`.
Alongside that:

- `argv[0]` in the installed `kernel.json` is rewritten to the absolute
  path of the running executable, so the kernel also starts when the
  Jupyter server's `PATH` does not contain `woxi`.
- When the `jupyter` CLI is not on `PATH`, the spec is written into
  Jupyter's kernels directory directly (honouring `JUPYTER_DATA_DIR`,
  `XDG_DATA_HOME` and the platform defaults) and the location is printed.
- A failed installation now exits non-zero instead of reporting the
  error and returning success.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016ogxF49Xi8qT2xSn78XYdu