### PR TITLE
Fix NDSolve's {t, tmax} shorthand and a huge-coefficient Jacobian bug

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -628,27 +628,38 @@ fn ndsolve_system(
   args: &[Expr],
   event: Option<&EventSpec>,
 ) -> Result<Option<Expr>, InterpreterError> {
-  // Domain {x, xmin, xmax}.
+  // Domain {x, xmin, xmax}, or the shorthand {x, xmax} that integrates
+  // from the initial conditions' x-value out to xmax — the x_min side is
+  // resolved below, once x0 is known from the equations.
   let Expr::List(domain_items) = &args[2] else {
     return Ok(None);
   };
-  if domain_items.len() != 3 {
-    return Ok(None);
-  }
   let Expr::Identifier(x_name) = &domain_items[0] else {
     return Ok(None);
   };
-  let Some(x_min) = nval_to_f64(&domain_items[1]) else {
-    return Ok(None);
+  let (x_min_given, x_max): (Option<f64>, f64) = match domain_items.len() {
+    3 => {
+      let Some(min) = nval_to_f64(&domain_items[1]) else {
+        return Ok(None);
+      };
+      let Some(max) = nval_to_f64(&domain_items[2]) else {
+        return Ok(None);
+      };
+      // NaN bounds must bail out too, so compare via partial_cmp rather
+      // than a negated float comparison.
+      if max.partial_cmp(&min) != Some(std::cmp::Ordering::Greater) {
+        return Ok(None);
+      }
+      (Some(min), max)
+    }
+    2 => {
+      let Some(target) = nval_to_f64(&domain_items[1]) else {
+        return Ok(None);
+      };
+      (None, target)
+    }
+    _ => return Ok(None),
   };
-  let Some(x_max) = nval_to_f64(&domain_items[2]) else {
-    return Ok(None);
-  };
-  // NaN bounds must bail out too, so compare via partial_cmp rather
-  // than a negated float comparison.
-  if x_max.partial_cmp(&x_min) != Some(std::cmp::Ordering::Greater) {
-    return Ok(None);
-  }
 
   // Dependent functions: `{θ, ϕ, ψ}`, a single symbol, or `f[x]` forms.
   let dep_items: Vec<&Expr> = match &args[1] {
@@ -753,6 +764,21 @@ fn ndsolve_system(
     return Ok(None);
   }
   let Some(x0) = x0 else { return Ok(None) };
+  let (x_min, x_max) = match x_min_given {
+    Some(min) => (min, x_max),
+    // {x, xmax} shorthand: integrate from x0 to xmax, in whichever
+    // direction that is — x0 always lands on one edge of the range. An
+    // absolute epsilon here would wrongly reject ranges that are tiny by
+    // scale (e.g. femtosecond time constants) rather than degenerate, so
+    // only bit-identical endpoints count as degenerate.
+    None => {
+      let target = x_max;
+      if target == x0 {
+        return Ok(None);
+      }
+      (x0.min(target), x0.max(target))
+    }
+  };
   if x0 < x_min - 1e-12 || x0 > x_max + 1e-12 {
     return Ok(None);
   }
@@ -1299,9 +1325,19 @@ fn solve_highest_derivatives(
     }
     c[i] = v;
   }
+  // Each column is recovered from r(delta·e_j) − r(0) = M·(delta·e_j), a
+  // finite difference that is *exact* since the residuals are affine in
+  // the highest-derivative vector. A unit-sized `delta` is lost entirely to
+  // rounding when the other terms in the residual dwarf it — e.g. a
+  // coefficient of 1e16 (from squaring a large angular frequency) makes
+  // `c[i] + 1.0` round straight back down to `c[i]` in `f64`, which reads
+  // as an exactly-zero, falsely singular column. Scaling `delta` up to the
+  // residuals' own magnitude keeps the perturbation's contribution above
+  // the rounding floor at that scale, so it survives the subtraction.
+  let delta = c.iter().fold(1.0_f64, |acc, v| acc.max(v.abs()));
   let mut m = vec![vec![0.0; n]; n];
   for j in 0..n {
-    vars[1 + state.len() + j] = 1.0;
+    vars[1 + state.len() + j] = delta;
     for (i, r) in residuals.iter().enumerate() {
       let Ok(v) = r.eval(&vars) else {
         return None;
@@ -1309,7 +1345,7 @@ fn solve_highest_derivatives(
       if !v.is_finite() {
         return None;
       }
-      m[i][j] = v - c[i];
+      m[i][j] = (v - c[i]) / delta;
     }
     vars[1 + state.len() + j] = 0.0;
   }

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -764,20 +764,19 @@ fn ndsolve_system(
     return Ok(None);
   }
   let Some(x0) = x0 else { return Ok(None) };
-  let (x_min, x_max) = match x_min_given {
-    Some(min) => (min, x_max),
+  let (x_min, x_max) = if let Some(min) = x_min_given {
+    (min, x_max)
+  } else {
     // {x, xmax} shorthand: integrate from x0 to xmax, in whichever
     // direction that is — x0 always lands on one edge of the range. An
     // absolute epsilon here would wrongly reject ranges that are tiny by
     // scale (e.g. femtosecond time constants) rather than degenerate, so
     // only bit-identical endpoints count as degenerate.
-    None => {
-      let target = x_max;
-      if target == x0 {
-        return Ok(None);
-      }
-      (x0.min(target), x0.max(target))
+    let target = x_max;
+    if target == x0 {
+      return Ok(None);
     }
+    (x0.min(target), x0.max(target))
   };
   if x0 < x_min - 1e-12 || x0 > x_max + 1e-12 {
     return Ok(None);

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -8705,15 +8705,29 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   // `Plot[Table[f[i, x], {i, …}], …]` names its curves only after the
   // generator runs; expand it so each element becomes its own curve
-  // instead of being sampled as one expression yielding a list.
-  let generated_storage;
-  let body: &Expr = match expand_generated_bodies(body, &var_name) {
-    Some(expanded) => {
-      generated_storage = expanded;
-      &generated_storage
+  // instead of being sampled as one expression yielding a list. This has
+  // to recurse into an explicit `{f, g, …}` list too — `NDSolve` returns a
+  // list of solution sets even when there is only one, so an element like
+  // `y[t] /. sol` (or `Evaluate[y[t] /. sol]`, the same thing one Hold
+  // level up) evaluates to a one-element list, not a bare number, exactly
+  // like the bare `Table[…]` case below. Resolving it here — before the
+  // list is split into per-curve bodies — turns that one element into its
+  // own singleton list, which the flattening step below unwraps same as
+  // any other nested list; left unresolved, every sample point comes back
+  // as an unconvertible list and the curve silently plots as nothing.
+  fn resolve_generated_bodies_deep(body: &Expr, var: &str) -> Expr {
+    match body {
+      Expr::List(items) => Expr::List(
+        items
+          .iter()
+          .map(|it| resolve_generated_bodies_deep(it, var))
+          .collect(),
+      ),
+      _ => expand_generated_bodies(body, var).unwrap_or_else(|| body.clone()),
     }
-    None => body,
-  };
+  }
+  let generated_storage = resolve_generated_bodies_deep(body, &var_name);
+  let body: &Expr = &generated_storage;
 
   // Collect function bodies: a single function or a (possibly nested) list of
   // functions. Wolfram flattens nested lists into individual curves, so

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2571,12 +2571,3 @@ mod interpreter_tests {
   mod wavelets;
   mod wxf;
 }
-
-#[cfg(test)]
-mod tmp_dbg4 {
-  #[test]
-  fn t() {
-    woxi::clear_state();
-    let _ = woxi::interpret_with_stdout("{1, 2, 3}");
-  }
-}

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7743,6 +7743,61 @@ mod ndsolve {
       );
     }
   }
+
+  /// `{t, tmax}` (no explicit `tmin`) integrates from the initial
+  /// conditions' t-value out to `tmax` — the shorthand used throughout the
+  /// Wolfram Demonstrations Project for time-only integration. It must
+  /// match the explicit three-argument form exactly, and it must also work
+  /// backward when `tmax` is on the other side of the initial point.
+  #[test]
+  fn two_argument_domain_matches_explicit_bounds() {
+    let explicit =
+      interpret("s = NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 2}]; (y /. s[[1]])[2]")
+        .unwrap();
+    let shorthand = interpret(
+      "s = NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 2}]; (y /. s[[1]])[2]",
+    )
+    .unwrap();
+    assert_eq!(explicit, shorthand);
+
+    // Backward: tmax below the initial point integrates the other way.
+    let backward = interpret(
+      "s = NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, -2}]; (y /. s[[1]])[-2]",
+    )
+    .unwrap();
+    let val: f64 = backward.parse().expect("should be a number");
+    let expected = 2.0_f64.exp();
+    assert!(
+      (val - expected).abs() < 1e-3,
+      "y(-2) should be about {expected}, got {val}"
+    );
+  }
+
+  /// A coupled linear system whose coefficients are astronomically larger
+  /// than the state (an oscillator with a huge angular frequency, as in
+  /// models working in natural units far from 1) used to come back
+  /// unevaluated: the Jacobian used to advance each step was recovered by
+  /// perturbing the highest-derivative slot by a fixed `1.0` and
+  /// subtracting the unperturbed residual, and when that residual is
+  /// already of order `1e16` the `+1.0` rounds away in `f64`, so every
+  /// entry of that column reads as exactly zero — a falsely singular
+  /// pivot. Scaling the perturbation to the residual's own magnitude fixes
+  /// it. `x'' = -omega^2 x` with `omega = 10^9` has the closed form
+  /// `x(t) = A Cos[omega t]`.
+  #[test]
+  fn coupled_system_survives_a_huge_coefficient() {
+    let result = interpret(
+      "s = NDSolve[{x'[t] == v[t], v'[t] == -(10^9)^2 x[t], \
+       x[0] == 1, v[0] == 0}, {x, v}, {t, 10^-9}]; (x /. s[[1]])[10^-9]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    let expected = 1.0_f64.cos(); // Cos[omega * t] at t = 1/omega.
+    assert!(
+      (val - expected).abs() < 1e-3,
+      "x(1/omega) should be about {expected}, got {val}"
+    );
+  }
 }
 
 mod sinh_cosh {

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -18614,4 +18614,103 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 3, $CellContext`spread$$ = 0,
       "the weighted hub sits elsewhere than the centroid"
     );
   }
+
+  /// A `Module`-local pair of `NDSolve` calls compared against each other
+  /// and plotted through a `Which`-branched view picker — the shape of a
+  /// physical-model-vs-reference-model Demonstration (independently
+  /// written, not copied from any specific one). One system's restoring
+  /// coefficient is squared from a large stiffness constant, and the time
+  /// domain is given as `{t, span}` (no explicit start), the shorthand
+  /// that integrates from the initial conditions out to `span`.
+  ///
+  /// Regression coverage for two bugs this run found in `NDSolve`:
+  /// the two-argument domain form came back entirely unevaluated (only
+  /// `{t, tmin, tmax}` was accepted), and even with an explicit domain a
+  /// large coefficient (here `stiffness^2 = 10^18`) made the per-step
+  /// Jacobian probe — which perturbed the highest-derivative slot by a
+  /// fixed `1.0` and subtracted the unperturbed residual — round away to
+  /// exactly zero in `f64`, reading as a falsely singular system.
+  #[test]
+  fn stiff_vs_soft_spring_picker_solves_with_large_coefficient() {
+    let code = "Manipulate[\
+      Module[{stiff, soft}, \
+        stiff = NDSolve[{p'[t] == q[t], q'[t] == -stiffness^2 p[t], \
+          p[0] == amp, q[0] == 0}, {p, q}, {t, span}]; \
+        soft = NDSolve[{p'[t] == q[t], q'[t] == -p[t], \
+          p[0] == amp, q[0] == 0}, {p, q}, {t, span}]; \
+        Which[\
+          view == \"position\", Plot[{Evaluate[p[t] /. stiff], \
+            Evaluate[p[t] /. soft]}, {t, 0, span}, PlotRange -> All], \
+          view == \"velocity\", Plot[{Evaluate[q[t] /. stiff], \
+            Evaluate[q[t] /. soft]}, {t, 0, span}, PlotRange -> All]\
+        ]\
+      ], \
+      {{view, \"position\", \"quantity\"}, {\"position\", \"velocity\"}}, \
+      {{stiffness, 10^9, \"stiffness\"}, 10^8, 10^10}, \
+      {{amp, 1, \"amplitude\"}, 0.5, 2}, \
+      {{span, 10^-9, \"duration\"}, 10^-10, 10^-8}\
+    ]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the stiff/soft spring picker Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the default position view must render"
+    );
+    assert_eq!(state.controls.len(), 4, "picker plus three sliders");
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("both curves must render")
+    };
+    let position_view = render(&state);
+
+    // Switching the picker to the velocity view must re-evaluate cleanly
+    // (both NDSolve calls still solved, in particular the large-stiffness
+    // one) and change the picture.
+    match &mut state.controls[0] {
+      manipulate::ControlState::Discrete { current_index, .. } => {
+        *current_index = 1;
+      }
+      other => panic!("expected view as a Discrete control, got {other:?}"),
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert!(state.graphics_handle.is_some());
+    let velocity_view = render(&state);
+    assert_ne!(
+      position_view, velocity_view,
+      "switching the picker must change the rendered curves"
+    );
+
+    // Pulling the stiffness slider further changes the stiff spring's
+    // curve, so the picture changes again.
+    match &mut state.controls[1] {
+      manipulate::ControlState::Continuous { current, .. } => *current = 5e9,
+      other => {
+        panic!("expected stiffness as a Continuous control, got {other:?}")
+      }
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    let restiffened_view = render(&state);
+    assert_ne!(
+      velocity_view, restiffened_view,
+      "raising the stiffness must change the stiff spring's curve"
+    );
+  }
 }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -18704,7 +18704,6 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 3, $CellContext`spread$$ = 0,
     );
   }
 
-
   /// A `Module`-local pair of `NDSolve` calls compared against each other
   /// and plotted through a `Which`-branched view picker — the shape of a
   /// physical-model-vs-reference-model Demonstration (independently


### PR DESCRIPTION
## Summary

As part of the recurring "verify Woxi Studio against a random Wolfram Demonstration" check, this run sampled **"The Harmonic Oscillator in Extended Relativistic Dynamics"** (fetched via `RandomResourcePage`, not committed to the repo per policy) — a `Manipulate` comparing an extended-relativistic oscillator against the classical one via two `NDSolve` calls and a `Which`-branched `Plot`.

Found three real bugs, all in `NDSolve`/`Plot`, not specific to this notebook's physics:

1. **`NDSolve`'s domain only accepted the explicit `{t, tmin, tmax}` form.** The two-argument shorthand `{t, tmax}` — integrate from the initial conditions' t-value out to `tmax`, used throughout the Wolfram Demonstrations Project for time-only integration — came back entirely unevaluated.

2. **Even with an explicit domain, a system whose coefficients are astronomically larger than its state** (an oscillator with a large angular frequency) failed to solve. The per-step Jacobian was recovered by perturbing the highest-derivative slot by a fixed `1.0` and subtracting the unperturbed residual; when that residual is already of order `1e16`, `c[i] + 1.0` rounds straight back down to `c[i]` in `f64`, so the column reads as exactly zero — a falsely singular pivot. Scaling the perturbation to the residual's own magnitude fixes it.

3. **`Plot[{Evaluate[e1], Evaluate[e2]}, ...]`** — exactly the notebook's own two-curve pattern — silently rendered nothing. `NDSolve` returns a list of solution sets even when there is only one, so an element like `y[t] /. sol` evaluates to a one-element list, not a bare number. The "does this body evaluate to a list of curves" resolution already existed for a bare `Table[...]` body, but explicitly skipped whenever the top-level body was already a list, so it never ran on the individual elements of an explicit `{f, g}` list. Every sample point then came back as an unconvertible list, plotting as nothing.

Also removes a leftover debug test module (`mod tmp_dbg4`) that had been accidentally committed in an earlier run.

## Test plan

- [x] Independently written (non-verbatim) regression tests locking in all three fixes:
  - `two_argument_domain_matches_explicit_bounds` and `coupled_system_survives_a_huge_coefficient` in `tests/interpreter_tests/calculus.rs`
  - `stiff_vs_soft_spring_picker_solves_with_large_coefficient` in `woxi-studio/src/main.rs`, a `Manipulate` widget test comparing a stiff vs. soft spring through a `Module`-local pair of `NDSolve` calls and a `Which`-branched view picker, matching this run's notebook shape without copying its code
- [x] `cargo test` (full workspace) passes
- [x] `cargo test -p woxi-studio` passes
- [x] `make format`
- [x] Manually verified the downloaded notebook's actual `Manipulate` body (adapted, not committed) now solves and renders both curves end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XwbtczjYcGvm2fUNYLcoJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwbtczjYcGvm2fUNYLcoJB)_