### PR TITLE
Fix DiscretePlot multi-function/Joined support and a Manipulate label capture bug

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -19487,8 +19487,13 @@ fn inline_box_label_runs(s: &str, italic: bool) -> Option<Vec<LabelRun>> {
       });
       continue;
     }
+    // Parsed, not evaluated: a box like `OverscriptBox[x, "_"]` is a frozen
+    // typesetting form, and `x` here names the base glyph to draw, not a
+    // reference to whatever a same-named Manipulate control is currently
+    // bound to. Evaluating it would substitute that control's live value
+    // (e.g. `x -> 1`) into every choice label that happens to mention `x`.
     let rendered = crate::notebook::box_source_to_expression(&seg.text)
-      .and_then(|code| crate::interpret_to_expr(&code).ok())
+      .and_then(|code| crate::parse_to_expr(&code).ok())
       .map(|expr| manipulate_label_runs(&expr, italic));
     match rendered {
       // An unrecognised box head keeps its source text rather than

--- a/src/functions/list_plot.rs
+++ b/src/functions/list_plot.rs
@@ -1731,38 +1731,51 @@ pub fn discrete_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     ));
   }
 
-  // Generate data points by evaluating expr at each discrete value
-  let mut points: Vec<(f64, f64)> = Vec::new();
-  let mut n = n_min;
+  // A single function or a (possibly nested) list of functions: Wolfram
+  // flattens `DiscretePlot[{f, g}, …]` into two separately-colored series,
+  // just like `Plot`.
+  let mut bodies: Vec<&Expr> = Vec::new();
+  crate::functions::plot::flatten_plot_bodies(expr, &mut bodies);
+
+  // Generate data points by evaluating each body at each discrete value.
   let max_points = 10000;
-  while n <= n_max + step * 0.5e-10 && points.len() < max_points {
-    let n_expr = if n == n.floor() && n.abs() < 1e15 {
-      Expr::Integer(n as i128)
-    } else {
-      Expr::Real(n)
-    };
-    let substituted = substitute_var(expr, &var_name, &n_expr);
-    if let Ok(result) = evaluate_expr_to_expr(&substituted)
-      && let Some(y) = try_eval_to_f64(&result)
-      && y.is_finite()
-    {
-      points.push((n, y));
+  let mut all_series: Vec<Vec<(f64, f64)>> = Vec::with_capacity(bodies.len());
+  for body in &bodies {
+    let mut points: Vec<(f64, f64)> = Vec::new();
+    let mut n = n_min;
+    while n <= n_max + step * 0.5e-10 && points.len() < max_points {
+      let n_expr = if n == n.floor() && n.abs() < 1e15 {
+        Expr::Integer(n as i128)
+      } else {
+        Expr::Real(n)
+      };
+      let substituted = substitute_var(body, &var_name, &n_expr);
+      if let Ok(result) = evaluate_expr_to_expr(&substituted)
+        && let Some(y) = try_eval_to_f64(&result)
+        && y.is_finite()
+      {
+        points.push((n, y));
+      }
+      n += step;
     }
-    n += step;
+    all_series.push(points);
   }
 
-  let all_series = vec![points];
   let parsed = parse_plot_options(args);
   let (x_range, y_range) = compute_ranges(&all_series);
   let y_range = adjust_y_range_for_filling_opts(&parsed.opts, y_range);
   let (x_range, y_range) = apply_plot_range_override(&parsed, x_range, y_range);
 
-  let svg = generate_scatter_svg_with_options(
-    &all_series,
-    x_range,
-    y_range,
-    &parsed.opts,
-  )?;
+  let svg = if parsed.joined {
+    generate_svg_with_filling(&all_series, x_range, y_range, &parsed.opts)?
+  } else {
+    generate_scatter_svg_with_options(
+      &all_series,
+      x_range,
+      y_range,
+      &parsed.opts,
+    )?
+  };
   Ok(crate::graphics_result(svg))
 }
 

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -8532,6 +8532,22 @@ pub(crate) fn resolve_indirect_plot_body(
   (mentioned(&evaluated) > before).then_some(evaluated)
 }
 
+/// Flatten a single function or a (possibly nested) list of functions into
+/// individual curve bodies. Wolfram flattens nested lists into individual
+/// curves, so `Plot[{{f}, {g}}, …]` draws two curves. Nesting arises
+/// naturally from idioms like `expr /. C[1] -> Range[…]`, where threading a
+/// replacement over several expressions yields a list of lists.
+pub(crate) fn flatten_plot_bodies<'a>(e: &'a Expr, out: &mut Vec<&'a Expr>) {
+  match e {
+    Expr::List(items) => {
+      for it in items {
+        flatten_plot_bodies(it, out);
+      }
+    }
+    _ => out.push(e),
+  }
+}
+
 /// Implementation of Plot[f, {x, xmin, xmax}]
 pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   if args.len() < 2 {
@@ -8720,16 +8736,6 @@ pub fn plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // `Plot[{{f}, {g}}, …]` draws two curves. Nesting arises naturally from
   // idioms like `expr /. C[1] -> Range[…]`, where threading a replacement over
   // several expressions yields a list of lists.
-  fn flatten_plot_bodies<'a>(e: &'a Expr, out: &mut Vec<&'a Expr>) {
-    match e {
-      Expr::List(items) => {
-        for it in items {
-          flatten_plot_bodies(it, out);
-        }
-      }
-      _ => out.push(e),
-    }
-  }
   let mut raw_bodies: Vec<&Expr> = Vec::new();
   flatten_plot_bodies(body, &mut raw_bodies);
 

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -15335,6 +15335,60 @@ mod discrete_plot {
     let result = interpret("DiscretePlot[2.5 Sqrt[k], {k, 100}]").unwrap();
     assert_eq!(result, "-Graphics-");
   }
+
+  // Regression: `DiscretePlot[{f, g}, {n, min, max}]` used to substitute `n`
+  // into the whole `{f, g}` list and try to convert that *list* result to a
+  // single f64, which always fails — so every point was silently dropped and
+  // the plot came out empty. Each function must now get its own series, one
+  // circle per sampled point per series, matching `Plot`'s handling of a
+  // list of functions.
+  #[test]
+  fn multiple_functions() {
+    let svg = export_svg(
+      "DiscretePlot[{n^2, 2*n}, {n, 1, 5}, PlotStyle -> {Red, Blue}]",
+    );
+    assert_eq!(
+      svg.matches("fill=\"#FF0000\"").count(),
+      5,
+      "series 1 should draw one circle per sampled point: {svg}"
+    );
+    assert_eq!(
+      svg.matches("fill=\"#0000FF\"").count(),
+      5,
+      "series 2 should draw one circle per sampled point: {svg}"
+    );
+  }
+
+  // Regression: `Joined -> True` was accepted as an option but never read,
+  // so `DiscretePlot` always rendered scatter points regardless. Each
+  // series must now render as a single connected polyline instead of one
+  // circle per point.
+  #[test]
+  fn joined_option() {
+    let svg = export_svg("DiscretePlot[n^2, {n, 1, 5}, Joined -> True]");
+    assert!(!svg.contains("<circle"), "should not scatter-plot: {svg}");
+    assert!(svg.contains("<polyline"), "should draw a curve: {svg}");
+  }
+
+  // The combination the two bugs above were found in together: several
+  // joined series sharing one plot, as in `Plot[{f, g}, …, Joined -> True]`.
+  #[test]
+  fn joined_multiple_functions() {
+    let svg = export_svg(
+      "DiscretePlot[{n^2, 2*n}, {n, 1, 5}, Joined -> True, PlotStyle -> {Red, Blue}]",
+    );
+    assert!(!svg.contains("<circle"), "should not scatter-plot: {svg}");
+    assert_eq!(
+      svg.matches("stroke=\"#FF0000\"").count(),
+      1,
+      "series 1 should draw as one connected curve: {svg}"
+    );
+    assert_eq!(
+      svg.matches("stroke=\"#0000FF\"").count(),
+      1,
+      "series 2 should draw as one connected curve: {svg}"
+    );
+  }
 }
 
 mod log_log_plot {

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -18703,4 +18703,105 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`n$$ = 3, $CellContext`spread$$ = 0,
       "picking a different preset must change the outline drawn"
     );
   }
+
+  // Checked a randomly-sampled Wolfram Demonstrations Project notebook
+  // (an asymptotic-formula-vs-exact-sequence explorer) against Woxi
+  // Studio's Manipulate pipeline. Self-authored, construct-equivalent
+  // body — Fibonacci numbers against Binet's closed form, not the
+  // notebook's own sequence or wording, which is copyrighted —
+  // exercising the general shape: a single `Manipulate` wrapping a
+  // `DiscretePlot` of *two* series (`Joined -> True`, distinct
+  // `PlotStyle` colors), driven by one `Appearance -> "Labeled"`
+  // integer slider that controls the upper end of the sampled range.
+  //
+  // `DiscretePlot[{f, g}, {n, min, max}]` used to substitute `n` into
+  // the whole `{f, g}` list and try to convert that *list* result to a
+  // single number, which always failed silently — so every point was
+  // dropped and the Demonstration rendered an empty plot. `Joined` was
+  // also accepted but never read, so even a single-series `DiscretePlot`
+  // always scattered points instead of connecting them.
+  #[test]
+  fn demonstration_fibonacci_binet_discrete_plot_renders_two_joined_series() {
+    let nb_src = r##"Notebook[{
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[
+ DiscretePlot[{
+ Fibonacci[n],
+ GoldenRatio^n/Sqrt[5]
+ },{n,1,nmax,1},Joined->True,PlotStyle->{Red,Blue}],
+ {{nmax,10,\"n max\"},5,30,1,Appearance->\"Labeled\"}
+ ]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`nmax$$ = 10}, DynamicBox[\[Ellipsis]]]"], "Output"]
+}, Open]]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let mut widget = editors
+      .into_iter()
+      .find_map(|e| e.manipulate_state)
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "the two-series DiscretePlot must draw"
+    );
+
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name,
+          label,
+          min,
+          max,
+          current,
+          ..
+        },
+      ] => {
+        assert_eq!(name.as_str(), "nmax");
+        assert_eq!(label.as_str(), "n max");
+        assert_eq!(*min, 5.0);
+        assert_eq!(*max, 30.0);
+        assert_eq!(*current, 10.0);
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the two-series plot must render")
+    };
+    let short_range = render(&widget);
+    // Both series must actually have been sampled: the exact Fibonacci
+    // series (red) and Binet's approximation (blue) each draw their own
+    // connected curve, not a single merged (and previously empty) one.
+    assert_eq!(short_range.matches("stroke=\"#FF0000\"").count(), 1);
+    assert_eq!(short_range.matches("stroke=\"#0000FF\"").count(), 1);
+    assert!(!short_range.contains("<circle"), "Joined must not scatter");
+
+    match &mut widget.controls[..] {
+      [manipulate::ControlState::Continuous { current, .. }] => *current = 25.0,
+      other => panic!("expected nmax as a Continuous control, got {other:?}"),
+    }
+    widget.reevaluate();
+    assert!(widget.error.is_none());
+    let wide_range = render(&widget);
+    assert_ne!(
+      short_range, wide_range,
+      "moving the n-max slider must change the rendered picture"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

As part of the recurring "verify Woxi Studio against a random Wolfram Demonstration" check, this run sampled the "Hardy and Ramanujan's Asymptotic Formula for the Partition Numbers" Demonstration (fetched via `RandomResourcePage`, not committed to the repo per policy). Its `Manipulate` wraps `DiscretePlot[{PartitionsP[n], asymptoticFormula}, {n, 1, nmax, 1}, Joined -> True, PlotStyle -> {Red, Blue}]`, and it rendered as a completely empty plot in Woxi Studio.

Two bugs in `DiscretePlot`:
- `DiscretePlot[{f, g}, ...]` substituted `n` into the whole `{f, g}` list and tried to convert that *list* result to a single `f64`, which always failed — so every point was silently dropped. Now it flattens the body into one series per function (reusing `Plot`'s existing `flatten_plot_bodies` helper), matching how `Plot[{f, g}, ...]` already works.
- `Joined -> True` was parsed into `ParsedOptions` but never read, so even a single-function `DiscretePlot` always scattered points instead of connecting them. Now it dispatches between `generate_svg_with_filling`/`generate_scatter_svg_with_options` the same way `ListPlot` does.

While verifying the fix, `make test-studio` turned up a second, unrelated **pre-existing** failure: a `PopupMenu` choice label built from an inline `` \!\(\*OverscriptBox[...]\) `` box evaluated its box source through the live interpreter, so a base symbol matching a currently-bound Manipulate variable (e.g. `x`) got replaced by that variable's *current value* instead of staying a symbol (`x̄` rendered as `1̄`). Box labels are frozen typesetting forms, not code to run, so this now parses the box source without evaluating it.

## Test plan

- [x] `make test` — 27,212 tests pass
- [x] `make test-studio` — 159 tests pass (including the new regression test, and the previously-failing `popup_menu_choice_labels_typeset_inline_overscript_boxes`)
- [x] `make format`
- [x] Added unit tests for both `DiscretePlot` bugs (`multiple_functions`, `joined_option`, `joined_multiple_functions`)
- [x] Added a non-verbatim Woxi Studio end-to-end regression test (own Fibonacci/Binet's-formula body, not the Demonstration's own sequence or wording, which is copyrighted) locking in the fixed rendering
- [x] Visually verified the rendered SVG for the original Demonstration's construct shape before/after the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01VghXkkqQ8pnQbzDw9UNZse)_