### PR TITLE
Fix reversed-range Manipulate sliders clamping to the wrong bound

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -20551,6 +20551,16 @@ fn parse_manipulate_control(
     _ => None,
   };
 
+  // `{u, umin, umax}` with umin > umax is a documented reversed-direction
+  // slider (e.g. an angle control counting down from a positive start to a
+  // negative end). `initial` above is already resolved against the original
+  // umin/umax order, so it is safe to sort the pair now — every downstream
+  // consumer (the slider widget, dynamic-bounds re-resolution) expects
+  // `min <= max`.
+  if min > max {
+    std::mem::swap(&mut min, &mut max);
+  }
+
   Some(ParsedControl::Visible {
     control: ManipulateControl::Continuous {
       name,
@@ -22715,5 +22725,50 @@ mod manipulate_display_pane_selector_tests {
       DisplayNode::Column(children) => assert!(children.is_empty()),
       other => panic!("expected an empty column, got {other:?}"),
     }
+  }
+}
+
+#[cfg(test)]
+mod manipulate_reversed_range_tests {
+  use super::*;
+
+  fn first_continuous(code: &str) -> (f64, f64, f64) {
+    let expr = crate::parse_to_expr(code).expect("parse");
+    let spec = extract_manipulate_spec(&expr).expect("extract spec");
+    match spec.controls.first() {
+      Some(ManipulateControl::Continuous {
+        min, max, initial, ..
+      }) => (*min, *max, *initial),
+      other => panic!("expected a continuous control, got {other:?}"),
+    }
+  }
+
+  /// `{u, umin, umax}` with `umin > umax` is a documented reversed-direction
+  /// slider (Wolfram draws it counting down from left to right). The parsed
+  /// `min`/`max` fields must still satisfy `min <= max` — every downstream
+  /// consumer (the slider widget's `RangeInclusive`, dynamic-bounds
+  /// re-resolution) assumes that order, and an unsorted pair makes the
+  /// iced slider clamp the initial value to the wrong end of the range.
+  #[test]
+  fn reversed_bounds_are_sorted_for_the_control() {
+    let (min, max, initial) = first_continuous(
+      r#"Manipulate[u, {{u, -1.57, "angle"}, 0.01, -3.14, 0.01}]"#,
+    );
+    assert!(min <= max, "min ({min}) must not exceed max ({max})");
+    assert_eq!(min, -3.14);
+    assert_eq!(max, 0.01);
+    // The initial value is still the one written in the spec, not clamped
+    // to either sorted bound.
+    assert_eq!(initial, -1.57);
+  }
+
+  /// The ordinary (already increasing) case is unaffected by the sort.
+  #[test]
+  fn forward_bounds_are_unchanged() {
+    let (min, max, initial) =
+      first_continuous(r#"Manipulate[u, {{u, 1.3, "radius"}, 0.01, 2}]"#);
+    assert_eq!(min, 0.01);
+    assert_eq!(max, 2.0);
+    assert_eq!(initial, 1.3);
   }
 }

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -22752,14 +22752,14 @@ mod manipulate_reversed_range_tests {
   #[test]
   fn reversed_bounds_are_sorted_for_the_control() {
     let (min, max, initial) = first_continuous(
-      r#"Manipulate[u, {{u, -1.57, "angle"}, 0.01, -3.14, 0.01}]"#,
+      r#"Manipulate[u, {{u, -1.2, "angle"}, 0.02, -2.5, 0.02}]"#,
     );
     assert!(min <= max, "min ({min}) must not exceed max ({max})");
-    assert_eq!(min, -3.14);
-    assert_eq!(max, 0.01);
+    assert_eq!(min, -2.5);
+    assert_eq!(max, 0.02);
     // The initial value is still the one written in the spec, not clamped
     // to either sorted bound.
-    assert_eq!(initial, -1.57);
+    assert_eq!(initial, -1.2);
   }
 
   /// The ordinary (already increasing) case is unaffected by the sort.

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -7881,9 +7881,9 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`base$$ = 1000, $CellContext`pct$$ =
 Cell[CellGroupData[{
 Cell[BoxData["Manipulate[
  Graphics[{Circle[{0, 0}, 1], PointSize[Large], Point[{Cos[angle], Sin[angle]}]}],
- {{angle, -1.57, \"angle\"}, 0.01, -3.14, 0.01, Appearance -> \"Labeled\"},
+ {{angle, -1.2, \"angle\"}, 0.02, -2.5, 0.02, Appearance -> \"Labeled\"},
  SaveDefinitions -> True]"], "Input"],
-Cell[BoxData["DynamicModuleBox[{$CellContext`angle$$ = -1.57}, \"…\"]"], "Output"]
+Cell[BoxData["DynamicModuleBox[{$CellContext`angle$$ = -1.2}, \"…\"]"], "Output"]
 }, Open]]
 }]"##;
     let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
@@ -7913,8 +7913,8 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`angle$$ = -1.57}, \"…\"]"], "Outp
       ] => {
         assert_eq!(name, "angle");
         assert!(min <= max, "min ({min}) must not exceed max ({max})");
-        assert_eq!((*min, *max), (-3.14, 0.01));
-        assert_eq!(*current, -1.57, "initial value must not be clamped");
+        assert_eq!((*min, *max), (-2.5, 0.02));
+        assert_eq!(*current, -1.2, "initial value must not be clamped");
       }
       other => panic!("unexpected controls: {other:?}"),
     }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -7867,6 +7867,59 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`base$$ = 1000, $CellContext`pct$$ =
     }
   }
 
+  /// A stored Manipulate with a reversed-direction slider — `{u, umin,
+  /// umax}` written with `umin > umax`, the way a Demonstrations angle
+  /// control counts down from a positive start to a negative end — must
+  /// still open with its initial value intact rather than snapped to one
+  /// end of the range. `ManipulateState` is built from a `min <= max`
+  /// pair (see `parse_manipulate_control`'s sort), so the slider widget's
+  /// `RangeInclusive` never sees the reversed order that broke the initial
+  /// clamp.
+  #[test]
+  fn demonstration_reversed_range_slider_keeps_its_initial_value() {
+    let nb_src = r##"Notebook[{
+Cell[CellGroupData[{
+Cell[BoxData["Manipulate[
+ Graphics[{Circle[{0, 0}, 1], PointSize[Large], Point[{Cos[angle], Sin[angle]}]}],
+ {{angle, -1.57, \"angle\"}, 0.01, -3.14, 0.01, Appearance -> \"Labeled\"},
+ SaveDefinitions -> True]"], "Input"],
+Cell[BoxData["DynamicModuleBox[{$CellContext`angle$$ = -1.57}, \"…\"]"], "Output"]
+}, Open]]
+}]"##;
+    let nb = woxi::notebook::parse_notebook(nb_src).unwrap();
+    let editors = WoxiStudio::editors_from_notebook(&nb);
+    let widget = editors
+      .iter()
+      .find_map(|e| e.manipulate_state.as_ref())
+      .expect("the stored Manipulate must instantiate on load");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+    assert!(
+      widget.graphics_handle.is_some(),
+      "the point-on-circle graphic must draw"
+    );
+    match &widget.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name,
+          min,
+          max,
+          current,
+          ..
+        },
+      ] => {
+        assert_eq!(name, "angle");
+        assert!(min <= max, "min ({min}) must not exceed max ({max})");
+        assert_eq!((*min, *max), (-3.14, 0.01));
+        assert_eq!(*current, -1.57, "initial value must not be clamped");
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+  }
+
   #[test]
   fn demonstration_compatibility_checkboxes_render_as_a_card() {
     // The metadata cells at the end of every Demonstration submission
@@ -16996,8 +17049,8 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`terms$$ = 24, $CellContext`\[Beta]$
   /// driven by a second slider), and combining the colored pieces in a
   /// `Graphics3D` with `ViewPoint`/`ViewAngle`/`SphericalRegion`/`Boxed`/
   /// `PlotRange` options. Driven by two continuous sliders with text
-  /// labels, one ascending and one descending (`max` to `min`), plus a
-  /// `TrackedSymbols` option.
+  /// labels, one written ascending and one written descending (`max` to
+  /// `min` — a reversed-direction slider), plus a `TrackedSymbols` option.
   #[test]
   fn demonstration_polyhedron_compound_manipulate_rotates_and_scales() {
     let nb_src = r##"Notebook[{
@@ -17048,10 +17101,14 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`grow$$ = 1.5, $CellContext`spin$$ =
         assert_eq!(*grow_now, 1.5);
         assert_eq!(spin_name.as_str(), "spin");
         assert_eq!(spin_label.as_str(), "rotate tetrahedron");
-        // The spin slider's spec range descends (max to min), matching
-        // the source demonstration's rotation control.
-        assert!((*spin_min - std::f64::consts::FRAC_PI_2).abs() < 1e-9);
-        assert_eq!(*spin_max, 0.0);
+        // The spin slider's spec is written descending (`Pi/2` down to
+        // `0`, matching the source demonstration's rotation control), but
+        // the parsed control sorts `min <= max` — the slider widget's
+        // `RangeInclusive` cannot represent a reversed pair, and an
+        // unsorted one clamps the initial value to the wrong end. The
+        // initial value itself is unaffected by the sort.
+        assert_eq!(*spin_min, 0.0);
+        assert!((*spin_max - std::f64::consts::FRAC_PI_2).abs() < 1e-9);
         assert!((*spin_now - std::f64::consts::FRAC_PI_2).abs() < 1e-9);
       }
       other => panic!("unexpected controls: {other:?}"),


### PR DESCRIPTION
## Summary

- Downloaded a random Wolfram Demonstration via the resource-system random-page API (`ComptonScatteringAngle`, "Compton Scattering Angle") and checked whether Woxi Studio fully supports it, per the routine's standing task.
- Its `Manipulate` uses a reversed-direction slider for the source angle — `{{θbron, -3.14/2, "source angle"}, 0.01, -3.14, 0.01, ...}`, i.e. `umin (0.01) > umax (-3.14)`, a documented Wolfram feature. Woxi Studio stored `min`/`max` exactly as parsed without sorting them, so the slider widget's `RangeInclusive` saw an inverted range; iced's `Slider::new` clamp logic (`value >= start` then `value <= end`) snapped the initial value to the wrong end of the range instead of leaving it where the spec put it.
- Fixed in `parse_manipulate_control` (`src/functions/graphics.rs`) by sorting `min`/`max` after the initial value is resolved against the original (unsorted) order — mirroring the swap `apply_dynamic_bounds` already performs when a slider's bounds are re-resolved dynamically.
- Updated the one existing test (`demonstration_polyhedron_compound_manipulate_rotates_and_scales`) that had locked in the old, unsorted (and therefore broken) `min`/`max` values for its own reversed-range slider.
- Added regression tests: a parser-level test in `graphics.rs` and an end-to-end widget test in `woxi-studio/src/main.rs`, using a synthetic minimal reproduction (not the copyrighted Demonstration's own code).

No verbatim code from the downloaded Demonstration notebook is included anywhere in this diff — only a generic reproduction of the reversed-range-slider pattern.

## Test plan

- [x] `cargo test` (root `woxi` crate): 576 passed, 0 failed
- [x] `cargo test` (`woxi-studio`): 158 passed, 0 failed among tests related to this change
- [x] `cargo fmt --all`
- [x] Verified via `woxi-studio/examples/dump_manipulate` that the downloaded notebook's `Manipulate` now builds its widget with `min <= max` and the correct initial value for every control, and renders graphics with no error

## Note

One pre-existing, unrelated test failure (`popup_menu_choice_labels_typeset_inline_overscript_boxes`, about `PopupMenu` choice labels containing inline `OverscriptBox`) was already failing on `main` before this change (verified via `git stash`) and is out of scope for this fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NxEj4sEgqtVdMWgzWBWFJZ)_