### PR TITLE
Parse a pattern test whose left side is not a blank (#550)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@
 
 # Unreleased
 
+- The left side of a pattern test may now be any self-delimiting expression,
+    not just a blank: `Except[0]?NumericQ`, `{_, _}?VectorQ`, `"a"?StringQ`
+    and `1?NumericQ` parse as `PatternTest[…]` the way `x_?NumericQ` always
+    did, so `f[x : Except[0]?NumericQ] := 1/x` and
+    `Cases[list, x : Except[7]?Positive]` no longer fail with a parse error.
+- `Except[c]` is recognized as a pattern in replacement rules and in
+    `MemberQ`, which compared it literally before: `1 /. Except[3] -> x` is
+    `x`, and `MemberQ[{1, 2, 3}, Except[2]]` is `True`.
+- `MemberQ` finds a string element again: `MemberQ[{"x", "y"}, "y"]` compared
+    the element's source text against the evaluated target and returned
+    `False`.
+
 - An implicit product whose left factor is a function call now yields to a
     tighter operator the same way `2 Times @@ {3, 4}` already did:
     `Sum[…] Times @@ dp` is `Sum[…] (Times @@ dp)`. It used to parse as

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -241,6 +241,10 @@ pub fn contains_pattern(expr: &Expr) -> bool {
     // variable number of args without themselves being Expr::Pattern.
     // OptionsPattern[…] is also a sequence pattern (matches zero or more
     // Rule/RuleDelayed args).
+    // Except[c] and PatternTest[p, f] constrain what matches without
+    // necessarily holding a blank themselves — `Except[3]` and
+    // `Except[0]?NumericQ` are patterns even though every argument is a
+    // literal, so the head has to be recognized on its own.
     Expr::FunctionCall { name, .. }
       if matches!(
         name.as_str(),
@@ -249,6 +253,8 @@ pub fn contains_pattern(expr: &Expr) -> bool {
           | "BlankSequence"
           | "BlankNullSequence"
           | "OptionsPattern"
+          | "Except"
+          | "PatternTest"
       ) =>
     {
       true
@@ -3904,6 +3910,20 @@ fn match_pattern_impl(
         return None;
       }
       match_args_with_sequences(&expr_args, pat_args)
+    }
+    // PatternTest[p, f] — the general `p?f` form, where `p` is any pattern
+    // rather than a blank (`Except[0]?NumericQ`, `Alternatives[1, 2]?IntegerQ`).
+    // Blank forms are `Expr::PatternTest` and handled above.
+    Expr::FunctionCall {
+      name: pat_name,
+      args: pat_args,
+    } if pat_name == "PatternTest" && pat_args.len() == 2 => {
+      let bindings = match_pattern(expr, &pat_args[0])?;
+      if apply_pattern_test(&pat_args[1], expr) {
+        Some(bindings)
+      } else {
+        None
+      }
     }
     // Except[c] - matches anything that doesn't match c
     // Except[c, pattern] - matches pattern but not c

--- a/src/functions/list_helpers_ast/filtering.rs
+++ b/src/functions/list_helpers_ast/filtering.rs
@@ -674,7 +674,12 @@ pub fn matches_pattern_ast(expr: &Expr, pattern: &Expr) -> bool {
       name: pat_name,
       args: pat_args,
     } => {
-      if pat_name == "Except" || pat_name == "PatternTest" {
+      if pat_name == "PatternTest" && pat_args.len() == 2 {
+        // `Except[0]?NumericQ` and friends — any pattern constrained by a
+        // test. Delegate rather than re-deriving the rules here.
+        crate::evaluator::pattern_matching::match_pattern(expr, pattern)
+          .is_some()
+      } else if pat_name == "Except" || pat_name == "PatternTest" {
         // Already handled above or not a structural match
         let pattern_str = crate::syntax::expr_to_string(pattern);
         let expr_str = crate::syntax::expr_to_string(expr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4992,6 +4992,15 @@ fn try_fast_function_call(
       let Ok(target) = interpret(elem_expr) else {
         return None;
       };
+      // A pattern needs real matching, not the literal comparison below.
+      // The textual check above misses the heads that constrain a match
+      // without spelling a blank (`Except[2]`, `Except[0]?NumericQ`), so
+      // ask the canonical predicate once the element has been parsed.
+      if syntax::string_to_expr(&target)
+        .is_ok_and(|e| evaluator::pattern_matching::contains_pattern(&e))
+      {
+        return None;
+      }
 
       // Parse the list
       if !list_str.starts_with('{') || !list_str.ends_with('}') {
@@ -5004,14 +5013,13 @@ fn try_fast_function_call(
       // Check if target is in the list
       for elem in list_elems {
         let elem = elem.trim();
-        // Try to evaluate the list element if needed
-        let elem_val = if elem.contains('[') {
-          match interpret(elem) {
-            Ok(v) => v,
-            Err(_) => elem.to_string(),
-          }
-        } else {
-          elem.to_string()
+        // Evaluate the list element so it is compared in the same form the
+        // target is: `interpret` renders a string literal without its
+        // quotes, so comparing the raw source text made
+        // `MemberQ[{"x"}, "x"]` False.
+        let elem_val = match interpret(elem) {
+          Ok(v) => v,
+          Err(_) => elem.to_string(),
         };
         if elem_val == target {
           return Some(Ok(bool_fast_path_result(true)));

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -3119,6 +3119,15 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
       let mut inner = pair.into_inner();
       let name = inner.next().unwrap().as_str().to_string();
       let mut body = pair_to_expr(inner.next().unwrap());
+      let mut rest = inner.peekable();
+      if rest
+        .peek()
+        .is_some_and(|p| p.as_rule() == Rule::PatternTestSuffix)
+      {
+        let suffix = rest.next().unwrap();
+        body = build_pattern_test(body, suffix.into_inner());
+      }
+      let mut inner = rest;
       // Optional trailing `..` / `...` postfix: wrap body in
       // Repeated[…] / RepeatedNull[…] before the Pattern so e.g.
       // `s:0..` parses as `Pattern[s, Repeated[0]]` (Wolfram's binding)
@@ -3255,39 +3264,8 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
         Some(Rule::PatternTestLhsBare)
       ) {
         let mut iter = inner_pairs.into_iter();
-        let lhs_pair = iter.next().unwrap();
-        let lhs = Expr::Identifier(lhs_pair.as_str().to_string());
-        let rhs = pair_to_expr(iter.next().unwrap());
-        let bracket_sequences: Vec<Vec<Expr>> = iter
-          .filter(|p| matches!(p.as_rule(), Rule::BracketArgs))
-          .map(|bracket| {
-            bracket
-              .into_inner()
-              .filter(|p| {
-                p.as_str() != "[" && p.as_str() != "]" && p.as_str() != ","
-              })
-              .map(pair_to_expr)
-              .collect()
-          })
-          .collect();
-        let pt = Expr::FunctionCall {
-          name: "PatternTest".to_string(),
-          args: vec![lhs, rhs].into(),
-        };
-        if bracket_sequences.is_empty() {
-          return pt;
-        }
-        let mut result = Expr::CurriedCall {
-          func: Box::new(pt),
-          args: bracket_sequences[0].clone(),
-        };
-        for args in bracket_sequences.into_iter().skip(1) {
-          result = Expr::CurriedCall {
-            func: Box::new(result),
-            args,
-          };
-        }
-        return result;
+        let lhs = Expr::Identifier(iter.next().unwrap().as_str().to_string());
+        return build_pattern_test(lhs, iter);
       }
       // Pattern form (existing): optional PatternName, optional PatternTestHead, then test
       let mut inner = inner_pairs.into_iter();
@@ -4726,6 +4704,18 @@ fn parse_expression_inner(
             name: "Transpose".to_string(),
             args: vec![last].into(),
           });
+          term_was_implicit_times.push(false);
+        }
+      }
+      Rule::PatternTestSuffix => {
+        // expr?test → PatternTest[expr, test]. The left side is whatever
+        // term precedes the `?` — a function call (`Except[0]?NumericQ`), a
+        // list, a literal or a bracketed expression. Blank patterns
+        // (`x_?test`) and the bare-infix form (`a?b`) never get here: their
+        // own `PatternTest` rule consumes the `?` first.
+        if let Some(last) = terms.pop() {
+          term_was_implicit_times.pop();
+          terms.push(build_pattern_test(last, item.into_inner()));
           term_was_implicit_times.push(false);
         }
       }
@@ -8635,11 +8625,15 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
         let pat = fmt(&args[0]);
         let test = fmt(&args[1]);
         // Bare blanks `_`/`__`/`___` and simple Identifiers like `A`
-        // print without parens, matching wolframscript.
+        // print without parens, matching wolframscript. Everything else is
+        // parenthesized unless it is self-delimiting (`Except[0]`, `{1, 2}`,
+        // `"s"`), because `?` binds tighter than any infix operator: `x_`
+        // prints as `(x_)?IntegerQ` but `Except[0]` needs no brackets.
         let pat_atomic = pat == "_"
           || pat == "__"
           || pat == "___"
-          || matches!(&args[0], Expr::Identifier(_));
+          || matches!(&args[0], Expr::Identifier(_))
+          || is_self_delimiting_form(&pat);
         if pat_atomic {
           return format!("{pat}?{test}");
         }
@@ -16096,4 +16090,74 @@ pub fn unevaluated(name: &str, args: &[Expr]) -> Expr {
     name: name.to_string(),
     args: args.to_vec().into(),
   }
+}
+
+/// True when an already-formatted expression carries no operator at bracket
+/// depth 0, i.e. it reads back as one unit no matter how tightly the
+/// surrounding operator binds. `Except[0]`, `{1, 2}` and `"s"` qualify; `x_`,
+/// `-1` and `a + b` do not.
+fn is_self_delimiting_form(s: &str) -> bool {
+  let mut depth: i32 = 0;
+  let mut chars = s.chars().peekable();
+  while let Some(c) = chars.next() {
+    match c {
+      '"' => {
+        // Skip the whole string literal, escapes included.
+        loop {
+          match chars.next() {
+            Some('\\') => {
+              chars.next();
+            }
+            Some('"') | None => break,
+            Some(_) => {}
+          }
+        }
+      }
+      '<' if chars.peek() == Some(&'|') => {
+        chars.next();
+        depth += 1;
+      }
+      '|' if chars.peek() == Some(&'>') => {
+        chars.next();
+        depth -= 1;
+      }
+      '[' | '{' | '(' | '\u{27E6}' | '\u{301A}' => depth += 1,
+      ']' | '}' | ')' | '\u{27E7}' | '\u{301B}' => depth -= 1,
+      _ if depth == 0 && !(c.is_alphanumeric() || c == '$' || c == '`') => {
+        return false;
+      }
+      _ => {}
+    }
+    if depth < 0 {
+      return false;
+    }
+  }
+  depth == 0 && !s.is_empty()
+}
+
+/// Build `PatternTest[lhs, test]` from the pairs following an infix `?`:
+/// the test function, then any trailing `[args]` groups. `?` binds before
+/// those brackets, so `a?b[c]` is `PatternTest[a, b][c]`, not
+/// `PatternTest[a, b[c]]`.
+fn build_pattern_test<'i>(
+  lhs: Expr,
+  mut rest: impl Iterator<Item = pest::iterators::Pair<'i, Rule>>,
+) -> Expr {
+  let test = pair_to_expr(rest.next().expect("pattern test function"));
+  let mut result = Expr::FunctionCall {
+    name: "PatternTest".to_string(),
+    args: vec![lhs, test].into(),
+  };
+  for bracket in rest.filter(|p| p.as_rule() == Rule::BracketArgs) {
+    let args = bracket
+      .into_inner()
+      .filter(|p| p.as_str() != "[" && p.as_str() != "]" && p.as_str() != ",")
+      .map(pair_to_expr)
+      .collect();
+    result = Expr::CurriedCall {
+      func: Box::new(result),
+      args,
+    };
+  }
+  result
 }

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -439,7 +439,7 @@ ConjugateTransposeSuffix = @{ "\\[ConjugateTranspose]" | "\u{F3C6}" | "\u{F3C8}"
 // TermSuffix: postfix suffix tokens that can follow a Term (after
 // FactorialSuffix). Silent choice rule — the underlying named rules
 // are the ones that appear in the parse tree.
-TermSuffix = _{ TransposeSuffix | ConjugateTransposeSuffix }
+TermSuffix = _{ TransposeSuffix | ConjugateTransposeSuffix | PatternTestSuffix }
 Expression = {
     (LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingPlus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?) ~ (UnsetSuffix | (Operator | TildeInfix) ~ (LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingPlus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?))*
     ~ (ReplaceRepeatedSuffix | ReplaceAllSuffix)*
@@ -683,11 +683,19 @@ PatternTest = {
   | PatternTestLhsParen ~ "?" ~ !"?" ~ PatternTestFunc ~ BracketArgs*
   | PatternTestLhsBare ~ "?" ~ !"?" ~ PatternTestFunc ~ BracketArgs*
 }
+// Every other left side — a function call (`Except[0]?NumericQ`), a list
+// (`{_, _}?VectorQ`), a literal (`"a"?StringQ`) or a bracketed expression
+// (`(1 | 2)?EvenQ`) — is picked up as a suffix on the term that precedes it,
+// so `?` needs no left-side rule of its own and an ordinary term is never
+// parsed twice looking for one. The `BracketArgs*` keeps `?` binding before a
+// trailing `[…]`, exactly as in the bare-infix branch above.
+PatternTestSuffix = { "?" ~ !"?" ~ PatternTestFunc ~ BracketArgs* }
 // A parenthesized left side — `(r_)?Positive` is the same pattern as
 // `r_?Positive`, and a Demonstration writes its argument tests that way.
 // Only a *pattern* may be bracketed here: letting it be any expression
 // makes every parenthesized group try this branch, and a deeply nested one
-// then runs the parser out of its call budget.
+// then runs the parser out of its call budget. `(1 | 2)?EvenQ` and friends
+// go through `PatternTestSuffix` instead.
 PatternTestLhsParen = { "(" ~ (PatternWithHead | PatternSimple) ~ ")" }
 // LHS for the bare-infix form: an Identifier that does NOT end with an
 // underscore — `!"_"` after Identifier ensures the pattern branch above
@@ -754,7 +762,7 @@ PatternSimple = { PatternName? ~ PatternBlanks ~ !("_" | "?" | ".") }
 // where the body is any expression the pattern should match. Distinct
 // from `name_:default` (Optional with default) and `name::tag`
 // (MessageName); the negative lookaheads keep those forms intact.
-PatternNamed = { PatternName ~ ":" ~ !("=" | ">" | ":") ~ Term ~ (RepeatedNullSuffix | RepeatedSuffix)? }
+PatternNamed = { PatternName ~ ":" ~ !("=" | ">" | ":") ~ Term ~ PatternTestSuffix? ~ (RepeatedNullSuffix | RepeatedSuffix)? }
 Pattern = { PatternCondition | PatternTest | PatternOptionalNamedBlank | PatternOptionalWithHead | PatternOptionalSimple | PatternOptionalAnonBlank | PatternOptionalDefaultSimple | PatternWithHead | PatternSimple }
 
 // Replacement rule: pattern -> replacement or pattern :> replacement (RuleDelayed)

--- a/tests/cli/boolean/predicates/PatternTest.md
+++ b/tests/cli/boolean/predicates/PatternTest.md
@@ -6,3 +6,16 @@ Tests whether a pattern matches using a predicate function (pattern?test).
 $ wo 'PatternTest[x_, IntegerQ]'
 (x_)?IntegerQ
 ```
+
+The left side of `?` may be any self-delimiting expression,
+not just a blank pattern:
+
+```scrut
+$ wo 'Cases[{-3, 0, 5, 7, 12, "text", 7.5}, x : Except[7]?Positive]'
+{5, 12, 7.5}
+```
+
+```scrut
+$ wo 'f[x : Except[0]?NumericQ] := 1/x; f[4]'
+1/4
+```

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -14827,6 +14827,24 @@ mod cases {
   fn member_q_power_head_pattern_level() {
     assert_case(r#"MemberQ[{x^2, y^3}, _Power, {1}]"#, r#"True"#);
   }
+  // A string element has to be compared in the same form as the target:
+  // the fast path compared the raw source text of the element (`"y"`)
+  // against the evaluated target (`y`), so this was False.
+  #[test]
+  fn member_q_string_element() {
+    assert_case(r#"MemberQ[{"x", "y"}, "y"]"#, r#"True"#);
+    assert_case(r#"MemberQ[{"x", "y"}, "z"]"#, r#"False"#);
+  }
+  // `Except[c]` and `p?test` constrain a match without spelling a blank,
+  // so the fast path has to recognize them as patterns rather than as
+  // literal elements to compare against.
+  #[test]
+  fn member_q_except_and_pattern_test() {
+    assert_case(r#"MemberQ[{1, 2, 3}, Except[2]]"#, r#"True"#);
+    assert_case(r#"MemberQ[{2}, Except[2]]"#, r#"False"#);
+    assert_case(r#"MemberQ[{1, 2, 3}, Except[2]?OddQ]"#, r#"True"#);
+    assert_case(r#"MemberQ[{2, 4}, Except[2]?OddQ]"#, r#"False"#);
+  }
   #[test]
   fn subset_q_1() {
     assert_case(r#"SubsetQ[{1, 2, 3}, {3, 1}]"#, r#"True"#);

--- a/tests/interpreter_tests/patterns.rs
+++ b/tests/interpreter_tests/patterns.rs
@@ -610,6 +610,96 @@ mod pattern_matching {
       assert_eq!(interpret("(((((((((1)))))))))").unwrap(), "1");
     }
 
+    /// The left side of `?` may be any self-delimiting expression, not just a
+    /// blank: `Except[0]?NumericQ` is `PatternTest[Except[0], NumericQ]`,
+    /// because `?` binds tighter than every infix operator. Both forms below
+    /// used to fail to parse at all (issue #550).
+    #[test]
+    fn pattern_test_on_function_call_lhs() {
+      assert_eq!(
+        interpret("f[x : Except[0]?NumericQ] := 1/x; {f[4], f[0], f[a]}")
+          .unwrap(),
+        "{1/4, f[0], f[a]}"
+      );
+      assert_eq!(
+        interpret(
+          "list = {-3, 0, 5, 7, 12, \"text\", 7.5}; \
+           Cases[list, x : Except[7]?Positive]"
+        )
+        .unwrap(),
+        "{5, 12, 7.5}"
+      );
+      // Same pattern without the `x :` name binding.
+      assert_eq!(
+        interpret(
+          "Cases[{-3, 0, 5, 7, 12, \"text\", 7.5}, Except[7]?Positive]"
+        )
+        .unwrap(),
+        "{5, 12, 7.5}"
+      );
+      assert_eq!(interpret("MatchQ[3, Except[0]?NumericQ]").unwrap(), "True");
+      assert_eq!(interpret("MatchQ[0, Except[0]?NumericQ]").unwrap(), "False");
+      assert_eq!(
+        interpret("MatchQ[\"a\", Except[0]?NumericQ]").unwrap(),
+        "False"
+      );
+      // The `PatternTest[…]` spelling of the same pattern.
+      assert_eq!(
+        interpret("MatchQ[3, PatternTest[Except[0], NumericQ]]").unwrap(),
+        "True"
+      );
+      // Any head works, not just Except.
+      assert_eq!(
+        interpret("Cases[{1, 2, 3, 4}, Alternatives[2, 3, 4]?EvenQ]").unwrap(),
+        "{2, 4}"
+      );
+      // A function call left side needs no brackets when printed back.
+      assert_eq!(
+        interpret("Hold[Except[0]?NumericQ]").unwrap(),
+        "Hold[Except[0]?NumericQ]"
+      );
+    }
+
+    /// Lists, literals and bracketed expressions are equally valid left sides.
+    #[test]
+    fn pattern_test_on_other_self_delimiting_lhs() {
+      assert_eq!(
+        interpret("Cases[{1, 2, 3, 4}, (2 | 3 | 4)?EvenQ]").unwrap(),
+        "{2, 4}"
+      );
+      assert_eq!(
+        interpret("Cases[{{1, 2}, {1, 2, 3}, 3}, {_, _}?VectorQ]").unwrap(),
+        "{{1, 2}}"
+      );
+      assert_eq!(interpret("MatchQ[3, (1 + 2)?IntegerQ]").unwrap(), "True");
+      assert_eq!(interpret("MatchQ[3, (1 + 2)?StringQ]").unwrap(), "False");
+      assert_eq!(interpret("MatchQ[\"ab\", \"ab\"?StringQ]").unwrap(), "True");
+      assert_eq!(interpret("MatchQ[1, 1?IntegerQ]").unwrap(), "True");
+      assert_eq!(interpret("MatchQ[2, 1?IntegerQ]").unwrap(), "False");
+      assert_eq!(interpret("Hold[{1, 2}?f]").unwrap(), "Hold[{1, 2}?f]");
+      assert_eq!(interpret("Hold[(1 | 2)?f]").unwrap(), "Hold[(1 | 2)?f]");
+      // `?` still binds before a trailing `[…]`: `a?b[c]` is `(a?b)[c]`.
+      assert_eq!(interpret("Hold[a?b[c]]").unwrap(), "Hold[a?b[c]]");
+    }
+
+    /// `Except[c]` is a pattern even though none of its arguments is a
+    /// blank, so a replacement rule using one has to go through the AST
+    /// matcher instead of falling through to literal text replacement.
+    #[test]
+    fn replace_all_with_except_pattern() {
+      assert_eq!(interpret("1 /. Except[3] -> x").unwrap(), "x");
+      assert_eq!(interpret("3 /. Except[3] -> x").unwrap(), "3");
+      assert_eq!(
+        interpret("{1, 2, 3, 4} /. Except[3]?OddQ -> x").unwrap(),
+        "{x, 2, 3, 4}"
+      );
+      assert_eq!(
+        interpret("ReplaceAll[{1, 2, 3}, x : Except[2]?IntegerQ :> x^2]")
+          .unwrap(),
+        "{1, 2, 9}"
+      );
+    }
+
     #[test]
     fn pattern_test_matches() {
       assert_eq!(interpret("4 /. x_?EvenQ :> \"even\"").unwrap(), "even");


### PR DESCRIPTION
`f[x : Except[0]?NumericQ] := 1/x` and `Cases[list, x : Except[7]?Positive]`
failed with a parse error: `?` only accepted a blank pattern, a bare
identifier or a bracketed pattern on its left.

Make `?` a real infix suffix on any term, so a function call, a list, a
literal or a bracketed expression can be its left operand. The suffix is
folded through one shared builder with the existing bare-infix branch, so
`?` keeps binding before a trailing `[…]` (`a?b[c]` is `(a?b)[c]`), and the
named-pattern rule takes the suffix itself so `x : Except[7]?Positive` is
`Pattern[x, PatternTest[Except[7], Positive]]`.

Matching a general `PatternTest[p, f]` is new too, and printing one no
longer brackets a self-delimiting left side: `Except[0]?NumericQ`, while
`(x_)?IntegerQ` keeps its brackets.

Two pre-existing gaps surfaced on the way and are fixed here:

- `Except[c]` constrains a match without spelling a blank, so
  `contains_pattern` did not see it as a pattern and replacement rules fell
  through to literal text replacement: `1 /. Except[3] -> x` is now `x`.
- `MemberQ`'s fast path compared a list element's source text against the
  evaluated target, so `MemberQ[{"x", "y"}, "y"]` was `False`, and it
  treated `Except[2]` as a literal element rather than a pattern.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XYruzwNCgnRDQcHPN9doRz