### PR TITLE
Parse a default value written on any pattern (#551)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,17 @@
 
 # Unreleased
 
+- A default value can be written on any pattern, not just a named blank:
+    `f[x_?NumericQ : 2]`, `f[x : _Symbol | _Integer : 2]` and
+    `f[x : x_?NumericQ : 2]` now parse as `Optional[…]` patterns instead of
+    failing with a parse error at the second colon. `|` (Alternatives) binds
+    tighter than `:`, so the default attaches to the whole alternation.
+- `f[x : _ : 2] := …` and `f[_ : 2] := …` keep their parameter — the
+    definition-storing path used to drop the whole slot, filing them as
+    `f[] := …`.
+- Two anonymous blanks in one pattern no longer collapse onto each other, so
+    `f[_Symbol | _Integer] := …` is stored (and matches) as written rather than
+    as `f[_Symbol | _Symbol]`.
 - An implicit product whose left factor is a function call now yields to a
     tighter operator the same way `2 Times @@ {3, 4}` already did:
     `Sum[…] Times @@ dp` is `Sum[…] (Times @@ dp)`. It used to parse as

--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -577,11 +577,30 @@ pub fn constrain_repeated_params(
   }
 }
 
-/// Collect all pattern variable names from an expression.
-/// Returns tuples of (name, head, is_optional) for each Pattern/PatternOptional node found.
+/// The key a pattern node is tracked under while it stands in for a
+/// placeholder identifier. A named pattern keys on its name, so every
+/// occurrence of `x_` collapses onto one variable. An anonymous blank has no
+/// name to key on, and keying them all on the empty string made distinct
+/// blanks collide — `_Symbol | _Integer` was stored as `_Symbol | _Symbol` —
+/// so an anonymous one keys on its own written shape instead, which is
+/// exactly what tells two of them apart.
+fn pattern_var_key(name: &str, expr: &Expr) -> String {
+  if !name.is_empty() {
+    return name.to_string();
+  }
+  let shape: String = crate::syntax::expr_to_string(expr)
+    .chars()
+    .map(|c| if c.is_ascii_alphanumeric() { c } else { 'x' })
+    .collect();
+  format!("anon{shape}")
+}
+
+/// Collect all pattern variables from an expression.
+/// Returns tuples of (key, name, head, is_optional, blank_type) for each
+/// Pattern/PatternOptional node found.
 fn collect_pattern_vars(
   expr: &Expr,
-) -> Vec<(String, Option<String>, bool, u8)> {
+) -> Vec<(String, String, Option<String>, bool, u8)> {
   let mut vars = Vec::new();
   collect_pattern_vars_inner(expr, &mut vars);
   vars
@@ -589,23 +608,33 @@ fn collect_pattern_vars(
 
 fn collect_pattern_vars_inner(
   expr: &Expr,
-  vars: &mut Vec<(String, Option<String>, bool, u8)>,
+  vars: &mut Vec<(String, String, Option<String>, bool, u8)>,
 ) {
   match expr {
     Expr::Pattern {
       name,
       head,
       blank_type,
-    } if !vars.iter().any(|(n, _, _, _)| n == name) => {
-      vars.push((name.clone(), head.clone(), false, *blank_type));
+    } if !vars
+      .iter()
+      .any(|(k, _, _, _, _)| *k == pattern_var_key(name, expr)) =>
+    {
+      vars.push((
+        pattern_var_key(name, expr),
+        name.clone(),
+        head.clone(),
+        false,
+        *blank_type,
+      ));
     }
     Expr::PatternOptional {
       name,
       head,
       default,
     } => {
-      if !vars.iter().any(|(n, _, _, _)| n == name) {
-        vars.push((name.clone(), head.clone(), true, 1));
+      let key = pattern_var_key(name, expr);
+      if !vars.iter().any(|(k, _, _, _, _)| *k == key) {
+        vars.push((key, name.clone(), head.clone(), true, 1));
       }
       if let Some(d) = default {
         collect_pattern_vars_inner(d, vars);
@@ -617,8 +646,9 @@ fn collect_pattern_vars_inner(
       blank_type,
       ..
     } => {
-      if !vars.iter().any(|(n, _, _, _)| n == name) {
-        vars.push((name.clone(), None, false, *blank_type));
+      let key = pattern_var_key(name, expr);
+      if !vars.iter().any(|(k, _, _, _, _)| *k == key) {
+        vars.push((key, name.clone(), None, false, *blank_type));
       }
       collect_pattern_vars_inner(test, vars);
     }
@@ -647,19 +677,15 @@ fn collect_pattern_vars_inner(
 /// Returns the substituted expression.
 fn replace_patterns_with_placeholders(
   expr: &Expr,
-  vars: &[(String, Option<String>, bool, u8)],
+  vars: &[(String, String, Option<String>, bool, u8)],
 ) -> Expr {
   match expr {
-    Expr::Pattern { name, .. } | Expr::PatternOptional { name, .. } => {
-      if vars.iter().any(|(n, _, _, _)| n == name) {
-        Expr::Identifier(format!("__patvar{name}__"))
-      } else {
-        expr.clone()
-      }
-    }
-    Expr::PatternTest { name, .. } => {
-      if vars.iter().any(|(n, _, _, _)| n == name) {
-        Expr::Identifier(format!("__patvar{name}__"))
+    Expr::Pattern { name, .. }
+    | Expr::PatternOptional { name, .. }
+    | Expr::PatternTest { name, .. } => {
+      let key = pattern_var_key(name, expr);
+      if vars.iter().any(|(k, _, _, _, _)| *k == key) {
+        Expr::Identifier(format!("__patvar{key}__"))
       } else {
         expr.clone()
       }
@@ -693,15 +719,15 @@ fn replace_patterns_with_placeholders(
 /// Replace placeholder identifiers back with Pattern or PatternOptional nodes.
 fn replace_placeholders_with_patterns(
   expr: &Expr,
-  vars: &[(String, Option<String>, bool, u8)],
+  vars: &[(String, String, Option<String>, bool, u8)],
 ) -> Expr {
   match expr {
     Expr::Identifier(name) => {
       if let Some(stripped) = name
         .strip_prefix("__patvar")
         .and_then(|s| s.strip_suffix("__"))
-        && let Some((pat_name, head, is_optional, blank_type)) =
-          vars.iter().find(|(n, _, _, _)| n == stripped)
+        && let Some((_, pat_name, head, is_optional, blank_type)) =
+          vars.iter().find(|(k, _, _, _, _)| k == stripped)
       {
         if *is_optional {
           return Expr::PatternOptional {
@@ -2305,6 +2331,19 @@ pub fn set_delayed_ast(
 
     for (i, arg) in lhs_args.iter().enumerate() {
       let arg = unwrap_longest_shortest(arg);
+      // `Optional[p, d]` in call form — the shape a default written on
+      // anything richer than a named blank parses to (`x_?NumericQ : 2`,
+      // `x : _Symbol | _Integer : 2`, …). The slot itself is described by
+      // `p`, so describe that and attach the default afterwards; the
+      // `PatternOptional` node (`x_ : 2`) keeps its own handling below.
+      let (arg, optional_default) =
+        match crate::evaluator::pattern_matching::optional_call_parts(arg) {
+          Some((inner, default)) => {
+            (unwrap_longest_shortest(inner), default.cloned())
+          }
+          None => (arg, None),
+        };
+      let slot_start = params.len();
       match arg {
         // OptionsPattern[] or OptionsPattern[{defaults...}] — matches zero or more Rule arguments
         Expr::FunctionCall {
@@ -2543,6 +2582,11 @@ pub fn set_delayed_ast(
           };
           defaults.push(default_for_slot);
           heads.push(head);
+        }
+      }
+      if let Some(d) = optional_default {
+        for slot in defaults.iter_mut().skip(slot_start) {
+          *slot = Some(d.clone());
         }
       }
     }

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -1666,8 +1666,87 @@ pub fn permutations(items: &[Expr]) -> Vec<Vec<Expr>> {
   result
 }
 
-/// Check if a pattern tree contains any PatternOptional nodes.
+/// The inner pattern and default of a general `Optional[p]` / `Optional[p, d]`
+/// call. `canonicalize_pattern` lowers `Optional[x_, d]` to `PatternOptional`,
+/// but anything richer than a named blank (`_?NumericQ : 2`,
+/// `x : _Symbol | _Integer : 2`, …) stays in call form, so every place that
+/// reasons about optional argument slots has to see both shapes.
+pub fn optional_call_parts(pat: &Expr) -> Option<(&Expr, Option<&Expr>)> {
+  match pat {
+    Expr::FunctionCall { name, args }
+      if name == "Optional" && (args.len() == 1 || args.len() == 2) =>
+    {
+      Some((&args[0], args.get(1)))
+    }
+    _ => None,
+  }
+}
+
+/// Is `pat` an argument slot that may be omitted (either representation)?
+pub fn is_optional_slot(pat: &Expr) -> bool {
+  matches!(pat, Expr::PatternOptional { .. })
+    || optional_call_parts(pat).is_some()
+}
+
+/// Every pattern variable bound inside `pat`, in first-seen order.
+///
+/// Used when an `Optional[…]` slot is omitted: Wolfram binds the names in the
+/// skipped pattern to the default value without re-testing the pattern, so
+/// `f[x : _?NumericQ : 2] := x^2` gives `f[] == 4` even though the default
+/// never runs through `NumericQ`.
+fn pattern_binding_names(pat: &Expr, out: &mut Vec<String>) {
+  let push = |name: &String, out: &mut Vec<String>| {
+    if !name.is_empty() && !out.contains(name) {
+      out.push(name.clone());
+    }
+  };
+  match pat {
+    Expr::Pattern { name, .. }
+    | Expr::PatternOptional { name, .. }
+    | Expr::PatternTest { name, .. } => push(name, out),
+    Expr::FunctionCall { name, args }
+      if name == "Pattern" && args.len() == 2 =>
+    {
+      if let Expr::Identifier(n) = &args[0] {
+        push(n, out);
+      }
+      pattern_binding_names(&args[1], out);
+    }
+    Expr::FunctionCall { args, .. } => {
+      for a in args {
+        pattern_binding_names(a, out);
+      }
+    }
+    Expr::List(items) => {
+      for a in items {
+        pattern_binding_names(a, out);
+      }
+    }
+    Expr::BinaryOp { left, right, .. } => {
+      pattern_binding_names(left, out);
+      pattern_binding_names(right, out);
+    }
+    Expr::UnaryOp { operand, .. } => pattern_binding_names(operand, out),
+    _ => {}
+  }
+}
+
+/// Bindings produced when an optional slot is omitted: every pattern variable
+/// inside it takes the default value.
+fn bindings_for_omitted_optional(
+  inner: &Expr,
+  default: &Expr,
+) -> Vec<(String, Expr)> {
+  let mut names = Vec::new();
+  pattern_binding_names(inner, &mut names);
+  names.into_iter().map(|n| (n, default.clone())).collect()
+}
+
+/// Check if a pattern tree contains any optional argument slots.
 fn pattern_contains_optional(pat: &Expr) -> bool {
+  if optional_call_parts(pat).is_some() {
+    return true;
+  }
   match pat {
     Expr::PatternOptional { .. } => true,
     Expr::FunctionCall { args, .. } => {
@@ -3518,6 +3597,15 @@ fn try_skip_optional_subsets(
     let mut expr_iter = expr_args.iter();
     for (i, p) in pat_args.iter().enumerate() {
       if skip.contains(&i) {
+        // General `Optional[p, d]` slot: bind every name inside `p` to the
+        // default. Without an explicit default the slot cannot fire (there
+        // is no `Default[f]` fallback for these richer forms in Wolfram
+        // either), so the partial fill fails.
+        if let Some((inner, default)) = optional_call_parts(p) {
+          let d = default?;
+          bindings.extend(bindings_for_omitted_optional(inner, d));
+          continue;
+        }
         if let Expr::PatternOptional { name, default, .. } = p {
           let def = match default {
             Some(d) => Some(*d.clone()),
@@ -3657,6 +3745,14 @@ fn match_pattern_impl(
         }
       }
       Some(vec![(name.clone(), expr.clone())])
+    }
+    // `Optional[p]` / `Optional[p, d]` in call form (the shapes
+    // `canonicalize_pattern` leaves alone, e.g. `_?NumericQ : 2`). When a
+    // value is present the default is irrelevant — match the inner pattern.
+    Expr::FunctionCall { name, args }
+      if name == "Optional" && (args.len() == 1 || args.len() == 2) =>
+    {
+      match_pattern_impl(expr, &args[0])
     }
     Expr::PatternOptional { name, head, .. } => {
       // When a value is present, PatternOptional matches like a regular Pattern
@@ -4079,7 +4175,7 @@ fn match_pattern_impl(
               let opt_positions: Vec<usize> = pat_args
                 .iter()
                 .enumerate()
-                .filter(|(_, p)| matches!(p, Expr::PatternOptional { .. }))
+                .filter(|(_, p)| is_optional_slot(p))
                 .map(|(i, _)| i)
                 .collect();
               if opt_positions.len() >= missing {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -5748,7 +5748,11 @@ fn operator_precedence(op: &str) -> u8 {
     | "\\[NotEqual]" | "<" | "<=" | "\u{2264}" | "\u{2A7D}"
     | "\\[LessEqual]" | ">" | ">=" | "\u{2265}" | "\u{2A7E}"
     | "\\[GreaterEqual]" | "===" | "=!=" => 21, // Comparisons
-    "~~" => 24,      // StringExpression (lower than Alternatives)
+    "~~" => 24, // StringExpression (lower than Alternatives)
+    // Pattern/Optional `:` sits between StringExpression and Alternatives,
+    // as in Wolfram (135 < 150 < 160): `x : a | b : v` is
+    // `Optional[Pattern[x, Alternatives[a, b]], v]`.
+    ":" => 26,
     "|" => 27, // Alternatives (higher than StringExpression, Or, And, Rule)
     "+" | "-" => 30, // Plus/Minus
     "*" | "/" => 33, // Times/Divide
@@ -6012,6 +6016,25 @@ fn make_binary_op(left: &Expr, op_str: &str, right: &Expr) -> Expr {
       left: Box::new(left.clone()),
       right: Box::new(right.clone()),
     },
+    ":" => {
+      // Bare `:` reaching the operator level means the left side is a
+      // complete pattern rather than a bare name — `x_?NumericQ : 2`,
+      // `_Integer | _Symbol : 2`, or the trailing default of
+      // `x : pat : 2` (whose `x : pat` half `Term` already consumed).
+      // Wolfram reads `sym : p` as `Pattern[sym, p]` and `p : v` for any
+      // other left side as `Optional[p, v]`.
+      if let Expr::Identifier(name) = left {
+        Expr::FunctionCall {
+          name: "Pattern".to_string(),
+          args: vec![Expr::Identifier(name.clone()), right.clone()].into(),
+        }
+      } else {
+        Expr::FunctionCall {
+          name: "Optional".to_string(),
+          args: vec![left.clone(), right.clone()].into(),
+        }
+      }
+    }
     "|" => {
       // `:` (Pattern) binds looser than `|` (Alternatives) in Wolfram, so
       // `x : a | b` is `Pattern[x, Alternatives[a, b]]`. Woxi's parser

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -274,6 +274,13 @@ Operator = @{
   | "." ~ !ASCII_DIGIT ~ !"."  // Dot operator (not decimal point, not .. or ...)
   | "<" | ">"
   | "=" | "@"
+  // Bare ":" — Pattern / Optional. Must come after "::", ":>", ":=" and
+  // "/:" so those keep ownership of their spellings. `Term` already takes
+  // the pattern forms that start with a name (`x_:v`, `x:body`), so this
+  // only fires for a `:` that follows a complete term — the trailing
+  // default in `x : pat : v`, or `pat : v` where `pat` is not a bare name
+  // (`x_?NumericQ : 2`, `_Integer | _Symbol : 2`).
+  | ":" ~ !("=" | ">" | ":")
 }
 
 // PostfixFunction: function used in postfix application (x // f or x // Map[f])
@@ -909,7 +916,13 @@ BracketArgs = { "[" ~ (FunctionArgOrOmitted ~ ("," ~ FunctionArgOrOmittedLast)*)
 FunctionCall = { (Identifier | NamedCharIdentifier | SimpleAnonymousFunction) ~ DerivativePrime? ~ BracketArgs+ ~ DerivativePrime? }
 
 // FunctionDefinition supports multiple pattern arguments: f[a_, b_] := ...
-FunctionDefinitionPattern = _{ PatternCondition | PatternTest | PatternOptionalNamedBlank | PatternOptionalWithHead | PatternOptionalSimple | PatternOptionalAnonBlank | PatternOptionalDefaultSimple | PatternWithHead | PatternSimple }
+// `PatternOptionalNamedBlank` (`x:_:v`) and `PatternOptionalAnonBlank`
+// (`_:v`) are deliberately absent: `store_function_definition` has no
+// reader for them, so listing them here let the parameter be swallowed
+// (`f[x:_:2] := x^2` filed as `f[] := x^2`). Leaving them out makes the
+// definition fall through to the general `Expression` path, which builds
+// the same `Optional[…]` pattern the `Hold`ed form does.
+FunctionDefinitionPattern = _{ PatternCondition | PatternTest | PatternOptionalWithHead | PatternOptionalSimple | PatternOptionalDefaultSimple | PatternWithHead | PatternSimple }
 // Body is a simple ExpressionNoImplicit (we removed CompoundExpression option to prevent
 // greedy parsing of subsequent statements as part of the function body)
 // Compound expressions in function bodies should use explicit parentheses: f[x_] := (a; b)

--- a/tests/cli/syntax.md
+++ b/tests/cli/syntax.md
@@ -296,6 +296,38 @@ $ wo 'Cases[{1, 2, 3, 4, 5}, Except[2 | 4]]'
 ```
 
 
+## Optional Pattern Defaults (`:`)
+
+Writing `pattern : value` gives an argument a default, so the argument may
+be left out. The short form names a blank (`x_ : 2`):
+
+```scrut
+$ wo 'f[x_ : 2] := x^2; {f[3], f[]}'
+{9, 4}
+```
+
+The default may be written on any pattern, not just a named blank — on a
+pattern test, or on a whole alternation (`|` binds tighter than `:`):
+
+```scrut
+$ wo 'f[x_?NumericQ : 2] := x^2; {f[3], f[], f[a]}'
+{9, 4, f[a]}
+```
+
+```scrut
+$ wo 'f[x : _Symbol | _Integer : 2] := x^2; {f[3], f[a], f[]}'
+{9, a^2, 4}
+```
+
+The default value is taken as written — it is not checked against the
+pattern it stands in for:
+
+```scrut
+$ wo 'f[x : x_?NumericQ : 2] := x^2; {f[3], f[]}'
+{9, 4}
+```
+
+
 ## Comments (`(* … *)`)
 
 A comment is skipped wherever whitespace is, and what it holds is never

--- a/tests/interpreter_tests/patterns.rs
+++ b/tests/interpreter_tests/patterns.rs
@@ -2267,6 +2267,121 @@ mod optional_pattern_without_default {
     assert_eq!(interpret("f[] /. f[a:_:b] -> {a, b}").unwrap(), "{b, b}");
   }
 
+  // A default can be written on any pattern, not just a named blank:
+  // `p : v` is `Optional[p, v]` whenever `p` is not a bare symbol. The
+  // parse used to stop at the second colon (issue #551).
+  #[test]
+  fn optional_default_on_pattern_test() {
+    clear_state();
+    interpret("opt1[x : x_?NumericQ : 2] := x^2").unwrap();
+    assert_eq!(interpret("opt1[3]").unwrap(), "9");
+    assert_eq!(interpret("opt1[]").unwrap(), "4");
+    // The default is used as-is — it is never run through the test.
+    assert_eq!(interpret("opt1[a]").unwrap(), "opt1[a]");
+    clear_state();
+  }
+
+  #[test]
+  fn optional_default_on_alternatives() {
+    clear_state();
+    interpret("opt2[x : _Symbol | _Integer : 2] := x^2").unwrap();
+    assert_eq!(interpret("opt2[3]").unwrap(), "9");
+    assert_eq!(interpret("opt2[a]").unwrap(), "a^2");
+    assert_eq!(interpret("opt2[]").unwrap(), "4");
+    assert_eq!(interpret("opt2[1.5]").unwrap(), "opt2[1.5]");
+    clear_state();
+  }
+
+  // `|` (Alternatives) binds tighter than `:` (Pattern/Optional), so the
+  // default attaches to the whole alternation and the name covers it too.
+  #[test]
+  fn optional_default_on_alternatives_structure() {
+    assert_eq!(
+      interpret("Hold[x : _Symbol | _Integer : 2][[1, 0]]").unwrap(),
+      "Optional"
+    );
+    assert_eq!(
+      interpret("Hold[x : _Symbol | _Integer : 2][[1, 1, 0]]").unwrap(),
+      "Pattern"
+    );
+    assert_eq!(
+      interpret("Hold[x : _Symbol | _Integer : 2][[1, 1, 2, 0]]").unwrap(),
+      "Alternatives"
+    );
+    assert_eq!(
+      interpret("Hold[x : _Symbol | _Integer : 2][[1, 2]]").unwrap(),
+      "2"
+    );
+  }
+
+  // Without a leading name the same forms are a bare `Optional[p, v]`.
+  #[test]
+  fn optional_default_on_unnamed_pattern_test() {
+    assert_eq!(interpret("MatchQ[3, _?NumericQ : 2]").unwrap(), "True");
+    assert_eq!(interpret("MatchQ[a, _?NumericQ : 2]").unwrap(), "False");
+    clear_state();
+    interpret("opt3[x_?NumericQ : 2] := x^2").unwrap();
+    assert_eq!(interpret("opt3[3]").unwrap(), "9");
+    assert_eq!(interpret("opt3[]").unwrap(), "4");
+    assert_eq!(interpret("opt3[a]").unwrap(), "opt3[a]");
+    clear_state();
+  }
+
+  // Anonymous blanks inside one pattern used to collapse onto a single
+  // placeholder variable while the definition was normalised, so
+  // `f[_Symbol | _Integer]` was stored (and matched) as
+  // `f[_Symbol | _Symbol]`.
+  #[test]
+  fn unnamed_alternatives_keep_each_head() {
+    clear_state();
+    interpret("alt1[_Symbol | _Integer] := 7").unwrap();
+    assert_eq!(interpret("alt1[3]").unwrap(), "7");
+    assert_eq!(interpret("alt1[a]").unwrap(), "7");
+    assert_eq!(interpret("alt1[1.5]").unwrap(), "alt1[1.5]");
+    clear_state();
+  }
+
+  #[test]
+  fn optional_default_on_alternatives_unnamed() {
+    clear_state();
+    interpret("opt4[_Symbol | _Integer : 2] := 7").unwrap();
+    assert_eq!(interpret("opt4[3]").unwrap(), "7");
+    assert_eq!(interpret("opt4[]").unwrap(), "7");
+    assert_eq!(interpret("opt4[1.5]").unwrap(), "opt4[1.5]");
+    clear_state();
+  }
+
+  // `x:_:v` and `_:v` as parameters of a `f[…] := …` definition used to be
+  // dropped by the definition-storing path, filing `f[x:_:2] := x^2` as
+  // `f[] := x^2`.
+  #[test]
+  fn optional_named_blank_colon_syntax_in_definition() {
+    clear_state();
+    interpret("opt5[x : _ : 2] := x^2").unwrap();
+    assert_eq!(interpret("opt5[3]").unwrap(), "9");
+    assert_eq!(interpret("opt5[]").unwrap(), "4");
+    clear_state();
+    interpret("opt6[x : _Integer : 2] := x^2").unwrap();
+    assert_eq!(interpret("opt6[3]").unwrap(), "9");
+    assert_eq!(interpret("opt6[]").unwrap(), "4");
+    assert_eq!(interpret("opt6[a]").unwrap(), "opt6[a]");
+    clear_state();
+    interpret("opt7[_ : 2] := 5").unwrap();
+    assert_eq!(interpret("opt7[]").unwrap(), "5");
+    assert_eq!(interpret("opt7[7]").unwrap(), "5");
+    clear_state();
+  }
+
+  // A defaulted slot mixed with a required one still fills from the left.
+  #[test]
+  fn optional_default_on_pattern_after_required_arg() {
+    clear_state();
+    interpret("opt8[a_, x : _Integer : 5] := {a, x}").unwrap();
+    assert_eq!(interpret("opt8[1]").unwrap(), "{1, 5}");
+    assert_eq!(interpret("opt8[1, 2]").unwrap(), "{1, 2}");
+    clear_state();
+  }
+
   // `Optional[X]` only collapses to the `X.` shorthand when X is a
   // single untyped Blank (`_` or `x_`). BlankSequence (`__`),
   // BlankNullSequence (`___`), and typed Blanks (`_Integer`,


### PR DESCRIPTION
`pattern : value` is `Optional[pattern, value]` whenever the left side is
not a bare symbol, but the parser only knew the forms that start with a
name (`x_:v`, `x:_Head:v`). `f[x : x_?NumericQ : 2] := x^2` and
`f[x : _Symbol | _Integer : 2] := x^2` both stopped at the second colon
with a parse error.

Add a bare `:` to the infix operators, at Wolfram's precedence — looser
than `|` (Alternatives) and tighter than `~~` (StringExpression) — so the
default attaches to the whole alternation. `Term` still takes the
name-led forms first, so chained `a:b:c` keeps its existing right-nested
reading; the operator only fires for a colon that follows a complete
term.

The matcher and the definition-storing path both keyed optional argument
slots on the lowered `PatternOptional` node, which cannot express a
pattern test or an alternation. Teach them the general `Optional[p, d]`
call form as well: when a value is present the inner pattern matches;
when the slot is omitted, every pattern variable inside it takes the
default (Wolfram does not run the default through the pattern).

Two pre-existing bugs turned up alongside:

- `f[x : _ : 2] := x^2` and `f[_ : 2] := 5` were filed as `f[] := …`.
  `FunctionDefinitionPattern` listed `PatternOptionalNamedBlank` and
  `PatternOptionalAnonBlank`, but `store_function_definition` has no
  reader for either, so the parameter was silently dropped. Remove them
  from that rule and let the general `Expression` path build the same
  `Optional[…]` the `Hold`ed form does.
- `f[_Symbol | _Integer] := 7` was stored as `f[_Symbol | _Symbol]`.
  While a structural pattern is normalised its variables are keyed by
  name, and every anonymous blank has the empty name, so they collapsed
  onto whichever came first. Key anonymous ones on their written shape.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0143zyb9y9yJ2thgg7ayY1Rg