### PR TITLE
Fix Sequence splicing into Unevaluated during pure-function slot substitution

### DIFF
--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -1421,14 +1421,11 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
   }
 }
 
-pub fn flatten_sequences<'a>(
-  name: &str,
-  args: &'a [Expr],
-) -> std::borrow::Cow<'a, [Expr]> {
-  // Check for SequenceHold attribute. HoldAllComplete implicitly carries
-  // SequenceHold semantics (Wolfram Language: HoldAllComplete = HoldAll
-  // + SequenceHold + ... ).
-  let has_sequence_hold = matches!(
+/// Check for SequenceHold attribute. HoldAllComplete implicitly carries
+/// SequenceHold semantics (Wolfram Language: HoldAllComplete = HoldAll
+/// + SequenceHold + ... ).
+pub(crate) fn has_sequence_hold(name: &str) -> bool {
+  matches!(
     name,
     "Set"
       | "SetDelayed"
@@ -1441,11 +1438,15 @@ pub fn flatten_sequences<'a>(
       attrs.contains(&"SequenceHold".to_string())
         || attrs.contains(&"HoldAllComplete".to_string())
     })
-  })
-    || crate::evaluator::attributes::get_builtin_attributes(name)
-      .contains(&"HoldAllComplete");
+  }) || crate::evaluator::attributes::get_builtin_attributes(name)
+    .contains(&"HoldAllComplete")
+}
 
-  if has_sequence_hold {
+pub fn flatten_sequences<'a>(
+  name: &str,
+  args: &'a [Expr],
+) -> std::borrow::Cow<'a, [Expr]> {
+  if has_sequence_hold(name) {
     return std::borrow::Cow::Borrowed(args);
   }
 

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -15,7 +15,7 @@ mod core_eval;
 pub mod dispatch;
 pub(crate) mod function_application;
 pub mod functions;
-mod listable;
+pub(crate) mod listable;
 pub(crate) mod part_extraction;
 mod pattern_functions;
 pub(crate) mod pattern_matching;

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -13435,6 +13435,27 @@ fn substitute_slots_impl(expr: &Expr, values: &[Expr]) -> Expr {
         expr.clone()
       }
     }
+    // `Unevaluated`, `Hold`, `HoldComplete` and other SequenceHold /
+    // HoldAllComplete heads must keep a `Sequence[...]` produced by slot
+    // substitution as a single argument rather than splicing it into their
+    // own argument list — splicing is an evaluation-time rule that doesn't
+    // apply to their (permanently unevaluated) contents. This matters for
+    // the common Demonstrations idiom
+    // `(If[cond, Unevaluated[Sequence[a, b]], {}]) & [x]`, where splicing
+    // here would turn `Unevaluated[Sequence[a, b]]` into the wrong
+    // `Unevaluated[a, b]`.
+    Expr::FunctionCall { name, args }
+      if crate::evaluator::listable::has_sequence_hold(name) =>
+    {
+      Expr::FunctionCall {
+        name: name.clone(),
+        args: args
+          .iter()
+          .map(|a| substitute_slots(a, values))
+          .collect::<Vec<_>>()
+          .into(),
+      }
+    }
     Expr::FunctionCall { name, args } => Expr::FunctionCall {
       name: name.clone(),
       args: substitute_slots_expand(args, values).into(),

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -6682,6 +6682,63 @@ mod unevaluated {
       "{HoldAllComplete, Protected}"
     );
   }
+
+  // Regression: a pure function whose body wraps a Sequence in Unevaluated
+  // (the standard Demonstrations idiom for conditionally splicing several
+  // items into a list) must substitute its Slot without prematurely
+  // splicing the Sequence into Unevaluated's own argument list — that would
+  // turn `Unevaluated[Sequence[3, 9]]` into the wrong `Unevaluated[3, 9]`.
+  #[test]
+  fn pure_function_keeps_sequence_as_single_argument() {
+    assert_eq!(
+      interpret("(Unevaluated[Sequence[#, #^2]]) & [3]").unwrap(),
+      "Unevaluated[Sequence[3, 3^2]]"
+    );
+  }
+
+  #[test]
+  fn pure_function_splices_into_enclosing_list() {
+    assert_eq!(
+      interpret("{0, (Unevaluated[Sequence[#, #^2]]) & [3], 9}").unwrap(),
+      "{0, 3, 9, 9}"
+    );
+  }
+
+  #[test]
+  fn pure_function_conditional_splice_via_if() {
+    assert_eq!(
+      interpret("{0, (If[# > 0, Unevaluated[Sequence[#, #^2]], {}]) & [3], 9}")
+        .unwrap(),
+      "{0, 3, 9, 9}"
+    );
+    assert_eq!(
+      interpret(
+        "{0, (If[# > 0, Unevaluated[Sequence[#, #^2]], {}]) & [-3], 9}"
+      )
+      .unwrap(),
+      "{0, {}, 9}"
+    );
+  }
+
+  // A literal `Unevaluated[...]` written directly as a list element keeps
+  // its wrapper (Wolfram only strips/splices the wrapper when it is
+  // produced by evaluation, not when written as-is).
+  #[test]
+  fn literal_in_list_keeps_wrapper() {
+    assert_eq!(
+      interpret("{0, Unevaluated[1 + 1], 9}").unwrap(),
+      "{0, Unevaluated[1 + 1], 9}"
+    );
+  }
+
+  #[test]
+  fn if_producing_unevaluated_still_splices() {
+    assert_eq!(
+      interpret("{0, If[True, Unevaluated[Sequence[1, 2 + 3]], {}], 9}")
+        .unwrap(),
+      "{0, 1, 5, 9}"
+    );
+  }
 }
 
 mod v2_option_symbols {


### PR DESCRIPTION
## Summary

- Found via the scheduled Woxi Studio Demonstrations-compatibility check: a random Wolfram Demonstrations Project notebook ("Hoehn's Theorem") failed to fully render in Woxi Studio. Its `Manipulate` conditionally splices extra `Graphics` primitives using the standard idiom `(If[cond, Unevaluated[Sequence[a, b]], {}]) & [x]`, and Woxi rendered a `"Coordinate ... should be a pair of numbers"` error instead of the primitives.
- Root cause: `substitute_slots_impl`'s generic `FunctionCall` case in `src/syntax.rs` unconditionally flattened a `Sequence[...]` produced by `Slot` substitution into the surrounding argument list — even when that list belonged to a `SequenceHold`/`HoldAllComplete` head like `Unevaluated`. That turned `Unevaluated[Sequence[3, 9]]` into the wrong `Unevaluated[3, 9]`, which then failed to splice correctly once it reached the enclosing list.
- Fix: extracted the existing `SequenceHold`/`HoldAllComplete` check out of `flatten_sequences` (`src/evaluator/listable.rs`) into a shared `has_sequence_hold` helper, and used it in `substitute_slots_impl` to skip Sequence-flattening when substituting slots into such a head's own arguments.
- Verified the fix directly against the downloaded Demonstrations notebook using `woxi-studio`'s `dump_manipulate` diagnostic: the inner pentagon (points + connecting lines computed via this exact `Unevaluated[Sequence[...]]` pattern) now renders correctly, and the embedded coordinate error is gone.

## Test plan

- [x] Added regression unit tests in `tests/interpreter_tests/syntax.rs` (`mod unevaluated`) covering: a pure function substituting a Slot into `Unevaluated[Sequence[...]]` (keeps `Sequence` as one argument), splicing that result into an enclosing list, the `If`-conditional variant, and that a *literal* `Unevaluated[...]` written directly in a list still keeps its wrapper (unaffected, existing behavior).
- [x] `make test` — all 27,222 unit tests pass.
- [x] `make format`.
- [x] Re-ran `cargo run --example dump_manipulate` in `woxi-studio` against the notebook and confirmed the rendered SVG now includes the previously-missing inner-pentagon points/lines with no embedded coordinate error.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FqBGaT9YeyCpe9CNXMq4Uk)_