### PR TITLE
Fix crash and image-input gaps found by a random Demonstration notebook

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -1172,6 +1172,24 @@ fn is_downvalue_head_protected(name: &str) -> bool {
     })
 }
 
+/// Flatten a left-associative chain of `BinaryOp { op: Times, .. }` into
+/// its factors, in left-to-right source order. A non-`Times` expression
+/// flattens to the single-element list `[expr]`.
+fn flatten_times_chain(expr: &Expr) -> Vec<Expr> {
+  match expr {
+    Expr::BinaryOp {
+      op: BinaryOperator::Times,
+      left,
+      right,
+    } => {
+      let mut factors = flatten_times_chain(left);
+      factors.push((**right).clone());
+      factors
+    }
+    other => vec![other.clone()],
+  }
+}
+
 pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
   let lhs = &normalize_symbol_lhs(lhs);
   // Unwrap Condition on LHS: f[x_] /; test = body is parsed as
@@ -1983,6 +2001,72 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
         }
         _ => break,
       }
+    }
+  }
+
+  // A `Times` chain on the LHS most often isn't an attempt at real
+  // algebra — it's two statements a missing `;` glued together (e.g.
+  // `While[…]\nvecLEN = Length[vecBASIS];` parses as
+  // `Times[While[…], vecLEN] = Length[vecBASIS]` since `=` binds looser
+  // than implicit multiplication). wolframscript evaluates every factor
+  // left to right (for side effects, e.g. running that `While`) and, when
+  // all but one factor comes back `Null`, assigns the right-hand side to
+  // the remaining factor directly — treating the `Null`s as contributing
+  // no coefficient rather than as an error. Only a bare identifier
+  // qualifies as that remaining factor; anything else (a number, a Part
+  // extract, …) falls through to the generic Protected-tag rejection
+  // below.
+  if let Expr::BinaryOp {
+    op: BinaryOperator::Times,
+    ..
+  } = lhs
+  {
+    let factors = flatten_times_chain(lhs);
+    let mut target: Option<&str> = None;
+    let mut ambiguous = false;
+    for factor in &factors {
+      let value = evaluate_expr_to_expr(factor)?;
+      let is_null = matches!(&value, Expr::Identifier(s) if s == "Null");
+      if !is_null {
+        match factor {
+          Expr::Identifier(name) if target.is_none() => target = Some(name),
+          _ => ambiguous = true,
+        }
+      }
+    }
+    if !ambiguous && let Some(name) = target {
+      return set_ast(&Expr::Identifier(name.to_string()), rhs);
+    }
+  }
+
+  // A LHS built from an operator like `+`, `*`, `^` (e.g. `2 x = 5`,
+  // written without a separating `;` after a prior statement so the
+  // parser reads it as `Times[prior, x] = 5`) attempts to install a
+  // DownValue on the corresponding built-in (`Plus`, `Times`, `Power`,
+  // …), which is Protected. wolframscript doesn't abort the
+  // calculation for this — it emits `Set::write` (naming the tag and
+  // the whole left-hand side) and returns the right-hand side, leaving
+  // the assignment un-done. Mirror `set_delayed_ast`'s handling of the
+  // same shape for `:=` so a stray missing semicolon doesn't take down
+  // everything after it.
+  if let Expr::BinaryOp { op, .. } = lhs {
+    use BinaryOperator as B;
+    let tag = match op {
+      B::Plus | B::Minus => Some("Plus"),
+      B::Times | B::Divide => Some("Times"),
+      B::Power => Some("Power"),
+      _ => None,
+    };
+    if let Some(t) = tag
+      && crate::evaluator::get_builtin_attributes(t).contains(&"Protected")
+    {
+      let rhs_value = evaluate_expr_to_expr(rhs)?;
+      crate::emit_message(&format!(
+        "Set::write: Tag {} in {} is Protected.",
+        t,
+        expr_to_string(lhs)
+      ));
+      return Ok(rhs_value);
     }
   }
 

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -735,6 +735,17 @@ pub fn image_data_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "ImageData expects 1 or 2 arguments".into(),
     ));
   }
+  let coerced;
+  let args: &[Expr] = if !matches!(&args[0], Expr::Image { .. })
+    && let Some(img) = coerce_graphics_to_image(&args[0])
+  {
+    let mut v = args.to_vec();
+    v[0] = img;
+    coerced = v;
+    &coerced
+  } else {
+    args
+  };
   let requested_type: Option<&str> = if args.len() == 2 {
     match &args[1] {
       Expr::String(s) => Some(s.as_str()),
@@ -1491,6 +1502,17 @@ pub fn image_adjust_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       "ImageAdjust expects 1 or 2 arguments".into(),
     ));
   }
+  let coerced;
+  let args: &[Expr] = if !matches!(&args[0], Expr::Image { .. })
+    && let Some(img) = coerce_graphics_to_image(&args[0])
+  {
+    let mut v = args.to_vec();
+    v[0] = img;
+    coerced = v;
+    &coerced
+  } else {
+    args
+  };
 
   let Expr::Image {
     color_space: _,
@@ -1522,6 +1544,11 @@ pub fn image_adjust_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     && items.len() == 2
   {
     Adjust::BrightnessContrast(expr_to_f64(&items[0])?, expr_to_f64(&items[1])?)
+  } else if let Expr::List(_) = &args[1] {
+    // A list shape other than the {c, b} pair (e.g. a gamma-correction
+    // {c, b, γ} triple) isn't implemented — leave the call unevaluated
+    // rather than crashing on the failed numeric conversion below.
+    return Ok(unevaluated("ImageAdjust", args));
   } else {
     Adjust::Contrast(expr_to_f64(&args[1])?)
   };
@@ -1924,6 +1951,18 @@ pub fn image_rotate_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// ImageResize[img, {w, h}] or ImageResize[img, w] - Resize to target dimensions
 pub fn image_resize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  let coerced;
+  let args: &[Expr] = if !matches!(&args[0], Expr::Image { .. })
+    && let Some(img) = coerce_graphics_to_image(&args[0])
+  {
+    let mut v = args.to_vec();
+    v[0] = img;
+    coerced = v;
+    &coerced
+  } else {
+    args
+  };
+
   if !matches!(&args[0], Expr::Image { .. }) {
     crate::emit_message(&format!(
       "ImageResize::imginv: Expecting an image or graphics instead of {}.",
@@ -7940,6 +7979,43 @@ fn load_embedded_fonts(fontdb: &mut resvg::usvg::fontdb::Database) {
   fontdb.set_fantasy_family("Atkinson Hyperlegible Next");
 }
 
+/// Extract an SVG rendering of `expr` when it is a `Graphics`/`Graphics3D`
+/// expression, evaluated or still a bare `FunctionCall`. Returns `None`
+/// for anything else.
+fn graphics_svg(expr: &Expr) -> Option<String> {
+  match expr {
+    Expr::Graphics { svg, .. } => Some(svg.clone()),
+    Expr::FunctionCall { name, args }
+      if name == "Graphics" || name == "Graphics3D" =>
+    {
+      match crate::functions::graphics::graphics_ast(args) {
+        Ok(Expr::Graphics { ref svg, .. }) => Some(svg.clone()),
+        _ => None,
+      }
+    }
+    _ => None,
+  }
+}
+
+/// Coerce a `Graphics`/`Graphics3D` expression into an `Image` by
+/// rasterizing it, matching wolframscript's image-processing functions
+/// (`ImageResize`, `ImageData`, `ImageAdjust`, ...), which transparently
+/// accept graphics wherever an image is expected. Returns `None` for
+/// anything that isn't a renderable graphics expression, or on the
+/// wasm32 target where the SVG rasterizer is unavailable — callers fall
+/// back to their existing `imginv` handling in that case.
+fn coerce_graphics_to_image(expr: &Expr) -> Option<Expr> {
+  #[cfg(target_arch = "wasm32")]
+  {
+    let _ = expr;
+    None
+  }
+  #[cfg(not(target_arch = "wasm32"))]
+  {
+    rasterize_svg(&graphics_svg(expr)?, 96.0).ok()
+  }
+}
+
 /// Rasterize[expr] or Rasterize[expr, ImageResolution -> n]
 /// Converts a Graphics, Grid, or other visual expression to a raster image.
 #[cfg(not(target_arch = "wasm32"))]
@@ -7968,35 +8044,25 @@ pub fn rasterize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   }
 
   // Get SVG string from the expression
-  let svg_str = match &args[0] {
-    Expr::Graphics { svg, .. } => svg.clone(),
-    Expr::FunctionCall { name, args: fargs }
-      if name == "Graphics" || name == "Graphics3D" =>
-    {
-      if let Ok(Expr::Graphics { ref svg, .. }) =
-        crate::functions::graphics::graphics_ast(fargs)
-      {
-        svg.clone()
-      } else {
+  let svg_str = if let Some(svg) = graphics_svg(&args[0]) {
+    svg
+  } else {
+    match &args[0] {
+      Expr::FunctionCall { name, args: fargs } if name == "Grid" => {
+        crate::functions::graphics::grid_svg_with_gaps(fargs, &[])?
+      }
+      Expr::FunctionCall { name, args: fargs } if name == "Column" => {
+        crate::functions::graphics::column_to_svg(fargs).ok_or_else(|| {
+          InterpreterError::EvaluationError(
+            "Rasterize: failed to render Column".into(),
+          )
+        })?
+      }
+      _ => {
         return Err(InterpreterError::EvaluationError(
-          "Rasterize: failed to render Graphics".into(),
+          "Rasterize: unsupported expression type".into(),
         ));
       }
-    }
-    Expr::FunctionCall { name, args: fargs } if name == "Grid" => {
-      crate::functions::graphics::grid_svg_with_gaps(fargs, &[])?
-    }
-    Expr::FunctionCall { name, args: fargs } if name == "Column" => {
-      crate::functions::graphics::column_to_svg(fargs).ok_or_else(|| {
-        InterpreterError::EvaluationError(
-          "Rasterize: failed to render Column".into(),
-        )
-      })?
-    }
-    _ => {
-      return Err(InterpreterError::EvaluationError(
-        "Rasterize: unsupported expression type".into(),
-      ));
     }
   };
 

--- a/tests/interpreter_tests/attributes.rs
+++ b/tests/interpreter_tests/attributes.rs
@@ -530,6 +530,61 @@ mod protect_unprotect {
   }
 
   #[test]
+  fn set_on_times_lhs_is_rejected_not_fatal() {
+    // `2 x = 5` parses as `Set[Times[2, x], 5]` since `=` binds looser than
+    // implicit multiplication. wolframscript rejects this with a message
+    // (not a fatal error) and returns the right-hand side, leaving `x`
+    // unassigned. Regression for a Times/Plus/Power-headed Set target
+    // aborting the whole interpretation instead of just failing softly.
+    clear_state();
+    let result = interpret_with_stdout("2 x = 5").unwrap();
+    assert_eq!(result.result, "5");
+    assert!(
+      result.warnings[0].contains("Set::write: Tag Times in 2*x is Protected."),
+      "unexpected warnings: {:?}",
+      result.warnings
+    );
+    assert_eq!(interpret("x").unwrap(), "x");
+  }
+
+  #[test]
+  fn set_after_null_statement_without_semicolon_assigns_target() {
+    // A `While`/`For`/etc. statement followed by another statement with no
+    // separating `;` parses as implicit multiplication: `While[...] y = v`
+    // becomes `Set[Times[While[...], y], v]`. wolframscript still runs the
+    // `While` for its side effects and, since it evaluates to `Null`
+    // (contributing no coefficient), assigns `v` to `y` directly rather
+    // than rejecting the Times-headed target. This is the exact shape a
+    // missing `;` between two Module statements produces.
+    clear_state();
+    assert_eq!(
+      interpret(
+        "Module[{n = 0, total}, While[n < 3, n = n + 1] total = n * 10; total]"
+      )
+      .unwrap(),
+      "30"
+    );
+  }
+
+  #[test]
+  fn set_after_null_statement_runs_side_effects_of_both_factors() {
+    // Same shape as above, but confirms the `While` loop's side effects
+    // (not just the final assignment) actually ran — a naive fix that
+    // only patched the error message without evaluating the held Times
+    // factors would leave `acc` empty.
+    clear_state();
+    assert_eq!(
+      interpret(concat!(
+        "Module[{acc = {}, i = 1, len},",
+        "  While[i <= 3, acc = Append[acc, i]; i++] len = Length[acc];",
+        "  {acc, len}]"
+      ))
+      .unwrap(),
+      "{{1, 2, 3}, 3}"
+    );
+  }
+
+  #[test]
   fn clear_protected_symbol_keeps_definitions() {
     clear_state();
     let result =

--- a/tests/interpreter_tests/image.rs
+++ b/tests/interpreter_tests/image.rs
@@ -931,6 +931,68 @@ mod image_processing {
     );
   }
 
+  // A gamma-correction triple {c, b, γ} isn't implemented; the call must
+  // stay unevaluated rather than crash trying to read the list as a
+  // single number. Regression for ImageAdjust aborting the whole
+  // interpretation on this shape instead of failing softly.
+  #[test]
+  fn image_adjust_gamma_triple_stays_unevaluated() {
+    clear_state();
+    assert_eq!(
+      interpret("Head[ImageAdjust[Image[{{0.1, 0.5, 0.9}}], {0, 0, 10}]]")
+        .unwrap(),
+      "ImageAdjust"
+    );
+  }
+
+  // ImageResize/ImageData/ImageAdjust transparently accept a `Graphics`
+  // expression wherever an image is expected, rasterizing it first —
+  // matching wolframscript. Regression for these functions emitting
+  // `imginv` and refusing any Graphics input outright.
+  #[test]
+  fn image_resize_accepts_graphics() {
+    clear_state();
+    assert_eq!(
+      interpret("ImageDimensions[ImageResize[Graphics[Disk[]], {5, 5}]]")
+        .unwrap(),
+      "{5, 5}"
+    );
+  }
+
+  #[test]
+  fn image_data_accepts_graphics() {
+    clear_state();
+    let result = interpret_with_stdout("ImageData[Graphics[Disk[]]]").unwrap();
+    assert!(result.warnings.is_empty(), "{:?}", result.warnings);
+    assert!(result.result.starts_with("{{"), "got {}", result.result);
+  }
+
+  #[test]
+  fn image_adjust_accepts_graphics() {
+    clear_state();
+    assert_eq!(
+      interpret("ImageQ[ImageAdjust[Graphics[Disk[]]]]").unwrap(),
+      "True"
+    );
+  }
+
+  // Genuinely invalid input (neither an image nor graphics) is still
+  // rejected with `imginv`, matching the pre-existing behavior.
+  #[test]
+  fn image_resize_still_rejects_non_image_non_graphics() {
+    clear_state();
+    let result =
+      interpret_with_stdout(r#"ImageResize["hello", {10, 10}]"#).unwrap();
+    assert!(
+      result.warnings[0].contains(
+        r#"ImageResize::imginv: Expecting an image or graphics instead of "hello"."#
+      ),
+      "unexpected warnings: {:?}",
+      result.warnings
+    );
+    assert_eq!(result.result, "ImageResize[hello, {10, 10}]");
+  }
+
   #[test]
   fn image_reflect_horizontal() {
     clear_state();


### PR DESCRIPTION
## Summary

Per the scheduled "test Woxi Studio against a random Wolfram Demonstration" task, I downloaded a randomly sampled notebook from the Wolfram Demonstrations Project (a color visual-cryptography scheme) and checked whether Woxi Studio fully supports it. It didn't — evaluating the notebook's `Manipulate` crashed the whole interpretation. This PR fixes the underlying gaps:

- `ImageResize`/`ImageData`/`ImageAdjust` rejected `Graphics` input outright with `imginv`, even though wolframscript transparently rasterizes graphics wherever an image is expected. They now coerce `Graphics`/`Graphics3D` to an `Image` first (falling back to the existing `imginv` rejection for anything that still isn't image-like).
- A `Set` whose left-hand side is a `Times` chain (typically two statements separated only by a missing `;`, which implicit multiplication glues into one `Times[...] = rhs` since `=` binds looser than `*`) aborted the *entire* interpretation with a fatal error instead of evaluating every factor for its side effects the way wolframscript does. It now evaluates each factor in order and, when all but one factor comes back `Null`, assigns the right-hand side to the remaining identifier directly (the "statement glued to the next by a missing semicolon" idiom); otherwise it falls back to a non-fatal `Set::write` message, mirroring the existing `SetDelayed::write` handling for the same shape.
- `ImageAdjust`'s unrecognized list-shaped second argument (e.g. a `{contrast, brightness, gamma}` triple, which isn't implemented) crashed on a failed numeric conversion instead of returning unevaluated.

No code from the downloaded notebook is reproduced here — the regression tests use independently written, structurally analogous snippets.

## Test plan
- [x] `make test` — all 27,233 tests pass
- [x] `make format`
- [x] New regression tests in `tests/interpreter_tests/attributes.rs` and `tests/interpreter_tests/image.rs`
- [x] Verified against the downloaded Demonstration notebook via `woxi-studio`'s `dump_manipulate` example: the widget now evaluates and renders (`graphics=true`, no error) instead of crashing


---
_Generated by [Claude Code](https://claude.ai/code/session_01Syv4goDyjDZ3bpKFWJuBKd)_