### PR TITLE
Install a genuine SubValue when Set targets a curried call

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -1967,22 +1967,48 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
     return Ok(rhs_value);
   }
 
-  // SubValue form: `f[a][b] = rhs` (also deeper nestings). Mathematica
-  // stores these under SubValues[f]; Woxi's `set_delayed_ast` already
-  // accepts `:=` here and returns Null without actually installing a
-  // subvalue rule. Mirror that for `=` so `f[a][b] = 3` doesn't error
-  // out — matching wolframscript's surface behaviour.
-  if let Expr::CurriedCall { func, .. } = lhs {
-    let mut inner = func.as_ref();
-    loop {
-      match inner {
-        Expr::CurriedCall { func: f2, .. } => inner = f2.as_ref(),
-        Expr::FunctionCall { .. } => {
-          let rhs_value = evaluate_expr_to_expr(rhs)?;
-          return Ok(rhs_value);
+  // SubValue form: `f[a][b] = rhs` (also deeper nestings like `f[a][b][c]`).
+  // Mathematica stores these under SubValues[f] and they fire when exactly
+  // `f[a][b]` is evaluated. `set_delayed_ast` already installs a genuine
+  // subvalue rule for `:=`; mirror that here for `=`, evaluating the
+  // right-hand side immediately (as any other `Set` does) rather than
+  // storing it as a held body — this is what lets curried DownValue-style
+  // definitions like `f[1][{x_,y_}] = {x-y,x+y}/2.` (the Demonstrations
+  // idiom for a family of point-transform functions) actually fire on
+  // later calls instead of leaving them unevaluated.
+  if let Expr::CurriedCall { .. } = lhs {
+    let evaluated_lhs = evaluate_curried_lhs_non_pattern_parts(lhs)?;
+    let outer_head = if let Expr::CurriedCall { func, .. } = &evaluated_lhs {
+      let mut inner = func.as_ref();
+      loop {
+        match inner {
+          Expr::CurriedCall { func: f2, .. } => inner = f2.as_ref(),
+          Expr::FunctionCall { name, .. } => break Some(name.clone()),
+          _ => break None,
         }
-        _ => break,
       }
+    } else {
+      None
+    };
+    if let Some(head) = outer_head {
+      let rhs_value = evaluate_expr_to_expr(rhs)?;
+      SUB_VALUES.with(|m| {
+        let mut m = m.borrow_mut();
+        let rules = m.entry(head).or_default();
+        // Redefining the same pattern replaces the old rule in place,
+        // matching `DownValues` and how a Demonstration's Manipulate body
+        // re-evaluates (and thus re-defines) its SubValues on every control
+        // change.
+        let lhs_str = crate::syntax::expr_to_string(&evaluated_lhs);
+        match rules
+          .iter()
+          .position(|(l, _)| crate::syntax::expr_to_string(l) == lhs_str)
+        {
+          Some(idx) => rules[idx] = (evaluated_lhs, rhs_value.clone()),
+          None => rules.push((evaluated_lhs, rhs_value.clone())),
+        }
+      });
+      return Ok(rhs_value);
     }
   }
 

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -1253,7 +1253,10 @@ pub fn evaluate_expr_to_expr_inner(
             return Ok(Expr::Identifier("Null".to_string()));
           }
           // SubValues[sym] =. and DownValues[sym] =. clear the corresponding
-          // function definitions for sym.
+          // function definitions for sym. A SubValue rule (from `f[a][b] =
+          // …`/`f[a][b] := …`) lives in SUB_VALUES rather than FUNC_DEFS, so
+          // both maps need clearing for `SubValues[sym] =.` to actually undo
+          // a curried definition.
           if let Expr::FunctionCall {
             name: head,
             args: lhs_args,
@@ -1265,6 +1268,11 @@ pub fn evaluate_expr_to_expr_inner(
             crate::FUNC_DEFS.with(|m| {
               m.borrow_mut().remove(sym_name);
             });
+            if head == "SubValues" {
+              crate::evaluator::assignment::SUB_VALUES.with(|m| {
+                m.borrow_mut().remove(sym_name);
+              });
+            }
             return Ok(Expr::Identifier("Null".to_string()));
           }
           // UpValues[sym] =. removes every upvalue rule attached to

--- a/tests/interpreter_tests/function_definitions.rs
+++ b/tests/interpreter_tests/function_definitions.rs
@@ -1252,10 +1252,37 @@ mod set_curried_and_upvalues_unset {
   #[test]
   fn set_on_curried_call_returns_rhs() {
     clear_state();
-    // Same shape as `f[a][b] := rhs` but with `=`. Doesn't actually
-    // install a SubValue (Woxi doesn't model SubValues yet) — just
-    // returns the RHS instead of erroring.
+    // Same shape as `f[a][b] := rhs` but with `=`. Returns the RHS, and
+    // (like `:=`) installs a genuine SubValue that fires on later calls —
+    // see `set_on_curried_call_installs_subvalue` below.
     assert_eq!(interpret("f[a][b] = 3").unwrap(), "3");
+  }
+
+  #[test]
+  fn set_on_curried_call_installs_subvalue() {
+    clear_state();
+    // Regression: `f[a][b] = rhs` used to be a pure no-op beyond returning
+    // the RHS — the rule was never stored, so a later `f[a][b]` stayed
+    // unevaluated. A Wolfram Demonstrations Project fractal-tiling
+    // notebook defines its family of point-transform functions this way
+    // (`someFunc[1][{x_,y_}] = …`), which left the fractal's coordinates
+    // entirely symbolic instead of numeric.
+    assert_eq!(interpret("f[1][x_] = x + 1; f[1][10]").unwrap(), "11");
+    clear_state();
+    assert_eq!(
+      interpret("f[1][{x_, y_}] = {2 x + y, x - 3 y}; f[1][{10, 3}]").unwrap(),
+      "{23, 1}"
+    );
+    clear_state();
+    // A literal (non-pattern) curried key also installs and fires.
+    assert_eq!(interpret("f[1][2] = 99; f[1][2]").unwrap(), "99");
+    clear_state();
+    // Two distinct keys on the same curried head coexist independently.
+    assert_eq!(
+      interpret("f[1][x_] = x + 1; f[2][x_] = x ^ 2; {f[1][10], f[2][10]}")
+        .unwrap(),
+      "{11, 100}"
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- Sourced a random Wolfram Demonstrations Project notebook ("Tiling Dragons and Rep-tiles of Order Two") via the resource-system API and checked whether Woxi Studio fully supports it.
- The notebook's `Manipulate` widget built correctly (all 5 controls extracted right), but the rendered graphic was full of unevaluated expressions like `fLevy[1][fLevy[1][...[{0., 0.}]]]` instead of numeric fractal coordinates.
- Root cause: `f[a][b] = rhs` (curried `Set`, as opposed to `:=`) evaluated and returned the RHS but never actually installed a SubValue rule, so later calls to `f[a][b]` stayed completely unevaluated. `set_delayed_ast` (`:=`) already did this correctly for the curried case — `set_ast` (`=`) had a stale no-op fallback with a comment claiming "Woxi doesn't model SubValues yet", which was no longer true.
- Fixed `set_ast` to mirror `set_delayed_ast`'s SubValues installation, evaluating the right-hand side immediately (as any other `Set` does).
- Also fixed `SubValues[sym] =.`, which only cleared `FUNC_DEFS` and left the SubValue rule (now actually stored in `SUB_VALUES`) still firing afterward.
- After the fix, the notebook's `Manipulate` renders the correct Lévy-dragon fractal tiling graphic.

## Test plan

- [x] Added regression tests in `tests/interpreter_tests/function_definitions.rs::set_curried_and_upvalues_unset` covering pattern-based, literal, and multi-key curried `Set` definitions, and updated the stale test/comment that previously documented the no-op behavior.
- [x] `make test` — all 27,234 tests pass.
- [x] `make format`.
- [x] Manually verified via `cargo run --example dump_manipulate -p woxi-studio` against the downloaded notebook that the `Manipulate` widget now renders numeric polygon coordinates (a proper fractal tiling) instead of the "should be a pair of numbers" error overlay.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NxY6LjGMm17W8PQUgcXD2Y)_