### PR TITLE
Fix FaceForm recoloring Text/Line/Point in Graphics

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -245,6 +245,11 @@ pub(crate) fn named_color(name: &str) -> Option<Color> {
 #[derive(Debug, Clone)]
 struct StyleState {
   color: Color,
+  /// `FaceForm[…]` sets only this — the fill color of area primitives
+  /// (Disk, Polygon, Rectangle, …) — leaving `color` (which Text, Line,
+  /// Point and everything else read) untouched. `None` means those
+  /// primitives fall back to `color` too, matching a bare color directive.
+  face_color: Option<Color>,
   opacity: f64,
   thickness: f64, // fraction of plot width; negative = absolute pixels
   point_size: f64, // fraction of plot width, default ~0.012
@@ -424,6 +429,7 @@ impl Default for StyleState {
   fn default() -> Self {
     Self {
       color: BLACK,
+      face_color: None,
       opacity: 1.0,
       // Wolfram strokes an undirected primitive 1 pixel wide whatever the
       // image size — measured from wolframscript at four sizes — so the
@@ -522,6 +528,14 @@ fn parse_arrowheads(spec: &Expr) -> Option<Vec<ArrowHead>> {
 impl StyleState {
   fn effective_color(&self) -> Color {
     self.color.with_alpha(self.color.a * self.opacity)
+  }
+
+  /// The fill color for area primitives (Disk, Polygon, Rectangle, …):
+  /// `FaceForm`'s color when one was set, otherwise the general color —
+  /// the same fallback a bare color directive gives every primitive.
+  fn effective_face_color(&self) -> Color {
+    let c = self.face_color.unwrap_or(self.color);
+    c.with_alpha(c.a * self.opacity)
   }
 }
 
@@ -1297,9 +1311,11 @@ fn apply_directive(expr: &Expr, style: &mut StyleState) -> bool {
         true
       }
       "FaceForm" if !args.is_empty() => {
-        // FaceForm[color] sets fill color
+        // FaceForm[color] sets the fill color of area primitives only —
+        // unlike a bare color directive, it must not recolor Text, Line
+        // or Point primitives that follow it.
         if let Some(c) = parse_color(&args[0]) {
-          style.color = c;
+          style.face_color = Some(c);
         }
         true
       }
@@ -5578,7 +5594,7 @@ fn render_primitive(
       let scy = coord_y(*cy, bb, svg_h);
       let srx = *rx / bb.width() * svg_w;
       let sry = *ry / bb.height() * svg_h;
-      let color = style.effective_color();
+      let color = style.effective_face_color();
       // Edge form for stroke
       let (stroke_color, stroke_width) =
         match edge_stroke(style.edge_form.as_ref(), bb, svg_w) {
@@ -5637,7 +5653,7 @@ fn render_primitive(
       // need sweep-flag=0 (counter-clockwise in SVG y-down) to trace the
       // correct half of the ellipse.
       let sweep_flag = 0;
-      let color = style.effective_color();
+      let color = style.effective_face_color();
       let fill_opacity = if color.a < 1.0 {
         format!(" fill-opacity=\"{}\"", color.a)
       } else {
@@ -5677,7 +5693,7 @@ fn render_primitive(
       let sy = coord_y(*y_max, bb, svg_h); // y_max maps to top (lower SVG y)
       let sw = (*x_max - *x_min) / bb.width() * svg_w;
       let sh = (*y_max - *y_min) / bb.height() * svg_h;
-      let color = style.effective_color();
+      let color = style.effective_face_color();
       // Edge form
       let (stroke_color, stroke_width) =
         match edge_stroke(style.edge_form.as_ref(), bb, svg_w) {
@@ -5714,7 +5730,7 @@ fn render_primitive(
       holes,
       style,
     } => {
-      let color = style.effective_color();
+      let color = style.effective_face_color();
       let pts: Vec<String> = points
         .iter()
         .map(|&(x, y)| {

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -884,6 +884,80 @@ mod graphics {
       insta::assert_snapshot!(export_svg("Graphics[{EdgeForm[Red], Disk[]}]"));
     }
 
+    /// `FaceForm` sets only the fill of area primitives (Disk, Polygon,
+    /// Rectangle); unlike a bare colour directive, it must not recolour a
+    /// `Text` that follows it. A random Wolfram Demonstration notebook
+    /// (Stapler Puzzle) hit this: `{FaceForm[Yellow], Disk[...],
+    /// Text[Style[1, Bold], ...]}` rendered the digit in the disk's own
+    /// fill colour, making it invisible against the disk.
+    #[test]
+    fn face_form_does_not_recolor_text() {
+      let svg = export_svg(
+        "Graphics[{FaceForm[Yellow], Disk[{0, 0}], Text[Style[1, Bold], {0, 0}]}]",
+      );
+      let disk = svg
+        .lines()
+        .find(|l| l.starts_with("<ellipse"))
+        .expect("a disk");
+      assert!(
+        disk.contains("fill=\"rgb(255,255,0)\""),
+        "Disk should still take FaceForm's fill: {disk}"
+      );
+      let text = svg
+        .lines()
+        .find(|l| l.starts_with("<text"))
+        .expect("a text label");
+      assert!(
+        text.contains("fill=\"rgb(0,0,0)\""),
+        "Text after FaceForm should keep the default black, not the disk's fill: {text}"
+      );
+    }
+
+    /// A bare colour directive (not wrapped in `FaceForm`) is the general
+    /// "current colour" and does recolour the `Text` that follows it,
+    /// unlike `FaceForm`.
+    #[test]
+    fn bare_color_directive_does_recolor_text() {
+      let svg = export_svg(
+        "Graphics[{Blue, Disk[{0, 0}], Text[Style[1, Bold], {0, 0}]}]",
+      );
+      let text = svg
+        .lines()
+        .find(|l| l.starts_with("<text"))
+        .expect("a text label");
+      assert!(
+        text.contains("fill=\"rgb(0,0,255)\""),
+        "Text after a bare colour directive should take that colour: {text}"
+      );
+    }
+
+    /// `FaceForm` also governs `Polygon` and `Rectangle` fills, not just
+    /// `Disk`.
+    #[test]
+    fn face_form_fills_polygon_and_rectangle() {
+      let poly_svg =
+        export_svg("Graphics[{FaceForm[Green], Polygon[{{0,0},{1,0},{0,1}}]}]");
+      let poly = poly_svg
+        .lines()
+        .find(|l| l.starts_with("<polygon"))
+        .expect("a polygon");
+      assert!(
+        poly.contains("fill=\"rgb(0,255,0)\""),
+        "Polygon should take FaceForm's fill: {poly}"
+      );
+
+      let rect_svg =
+        export_svg("Graphics[{FaceForm[Orange], Rectangle[{0,0},{1,1}]}]");
+      let rect = rect_svg
+        .lines()
+        .find(|l| l.starts_with("<rect"))
+        .expect("a rectangle");
+      assert!(
+        rect.contains("fill=\"rgb(255,128,0)\""),
+        "Rectangle should take FaceForm's fill: {rect}"
+      );
+    }
+
     /// What an `EdgeForm` leaves unsaid comes from Wolfram's defaults: a
     /// width alone strokes black, a colour alone strokes at width 1, and
     /// an `EdgeForm` that names neither draws no edge at all — which is


### PR DESCRIPTION
## Summary

A randomly sampled Wolfram Demonstrations Project notebook (**Stapler Puzzle**, by Karl Scherer) failed to render correctly in Woxi Studio: each game piece is drawn as `{FaceForm[color], Disk[...], Text[Style[n, Bold], ...]}`, and the digit label came out in the *same color* as the disk's fill, making it invisible against it.

`FaceForm` is documented to set only the fill color of area primitives (`Disk`, `Polygon`, `Rectangle`, …) — unlike a bare color directive (`RGBColor[...]`, `Red`, …), it must not recolor `Text`, `Line`, or `Point` primitives that follow it. `StyleState` folded `FaceForm`'s color into the same `color` field everything else read, so it leaked into every subsequent primitive.

- Added a dedicated `face_color: Option<Color>` field to `StyleState`, set only by `FaceForm`.
- Added `effective_face_color()`, which falls back to the general `color` when no `FaceForm` was given (matching a bare color directive's behavior).
- Switched `Disk`, `DiskSector`, `RectPrim`, and `PolygonPrim` fill rendering to use `effective_face_color()`; `Text`, `Line`, `Point`, and other primitives are unaffected and keep reading the general `color`.

## Test plan

- [x] Added `face_form_does_not_recolor_text` — `Text` after `FaceForm[Yellow]` stays black.
- [x] Added `bare_color_directive_does_recolor_text` — a bare `Blue` directive *does* recolor a following `Text`, confirming the distinction is intentional.
- [x] Added `face_form_fills_polygon_and_rectangle` — `FaceForm` still governs `Polygon`/`Rectangle` fills.
- [x] `make test` — all 27244 tests pass.
- [x] `make format`.
- [x] Manually verified against the Stapler Puzzle notebook's `Manipulate` widget via `woxi-studio`'s `dump_manipulate`/`rasterize_svg` examples: the "1" labels on the yellow game pieces now render in black instead of disappearing into the disk fill.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra9fAB5uxuSrwC65hYomQb)_