### PR TITLE
Fix clippy lints from the PDE NDSolve branch (#567 follow-up)

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -347,7 +347,9 @@ fn parse_pde_domain(expr: &Expr) -> Option<PdeDomain> {
   };
   let min = nval_to_f64(&items[1])?;
   let max = nval_to_f64(&items[2])?;
-  if !(max > min) {
+  // NaN bounds must bail out too, so compare via `partial_cmp` rather than
+  // a negated float comparison.
+  if max.partial_cmp(&min) != Some(std::cmp::Ordering::Greater) {
     return None;
   }
   Some(PdeDomain {
@@ -643,8 +645,7 @@ fn ndsolve_pde(args: &[Expr]) -> Result<Option<Expr>, InterpreterError> {
   // boundary needs to be resolved.
   const MIN_STEPS: usize = 200;
   let n_steps = (((t_dom.max - t_dom.min) / dt_stable).ceil() as usize)
-    .max(MIN_STEPS)
-    .min(20_000);
+    .clamp(MIN_STEPS, 20_000);
   let dt = (t_dom.max - t_dom.min) / n_steps as f64;
 
   let derivative =


### PR DESCRIPTION
## Summary

#567 (the PDE `NDSolve` support for Permafrost-style Demonstrations) was merged before its `lint` CI job — `cargo clippy --all-targets -- -D warnings` — finished. It failed on two lints that my local `make format` pass (`clippy --fix`, which only auto-fixes a subset of lints) didn't catch:

- `neg_cmp_op_on_partial_ord`: `if !(max > min)` in `parse_pde_domain` → rewritten as `max.partial_cmp(&min) != Some(Ordering::Greater)`, matching the identical NaN-safe idiom already used elsewhere in the same file for the same reason.
- `manual_clamp`: `.max(MIN_STEPS).min(20_000)` → `.clamp(MIN_STEPS, 20_000)`.

No behavior change — both are equivalent to the code they replace (verified NaN handling is preserved for the first one, since clippy's suggested `<=` rewrite would have silently changed that).

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `make test` — 27,257 unit tests pass
- [x] `make format`

https://claude.ai/code/session_018THTtxX66DrkPe731LHcbG


---
_Generated by [Claude Code](https://claude.ai/code/session_018THTtxX66DrkPe731LHcbG)_