### PR TITLE
Support cubic+ denominators in InverseLaplaceTransform via partial fractions

### DIFF
--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -1946,7 +1946,163 @@ fn inverse_laplace_inner(expr: &Expr, s: &str, t: &str) -> Option<Expr> {
     }
   }
 
+  // Last resort: a general partial-fraction inversion for a proper
+  // rational function with purely numeric coefficients, e.g. a
+  // Demonstrations transfer function whose denominator is a cubic or
+  // higher — past what the specific pole shapes above cover.
+  if let Some(result) = inverse_laplace_partial_fractions(expr, s, t) {
+    return Some(result);
+  }
+
   None
+}
+
+/// General numeric partial-fraction inversion for a proper rational
+/// function `P(s)/Q(s)` with purely numeric coefficients — the case that
+/// remains once a Manipulate control's numeric value has been substituted
+/// into a transfer function, so none of `s`, `s^2 + a^2`, etc. patterns
+/// above match a plain `1/(s+1)` or `1/(s^2+a^2)` shape.
+///
+/// Finds `Q`'s roots numerically (the same Durand-Kerner solver behind
+/// `Roots`/`NRoots`) and sums simple-pole residues: a real root `r`
+/// contributes `Residue * E^(r t)`, and each complex-conjugate pair
+/// `a ± b i` contributes `E^(a t) (2 Re[Residue] Cos[b t] - 2
+/// Im[Residue] Sin[b t])` (the residues of a conjugate pair are
+/// themselves conjugates, so summing `Residue * E^((a+bi) t)` with its
+/// conjugate term collapses to that real oscillation).
+///
+/// Returns `None` — leaving the call unevaluated, as before — whenever the
+/// assumption doesn't hold: a coefficient isn't a plain number, the
+/// fraction is improper, or `Q` has a repeated (or near-repeated) root,
+/// which needs the different `t^k E^(r t)` term this simple-pole formula
+/// doesn't produce.
+fn inverse_laplace_partial_fractions(
+  expr: &Expr,
+  s: &str,
+  t: &str,
+) -> Option<Expr> {
+  let combined = crate::functions::together_ast(&[expr.clone()]).ok()?;
+  let num_expr = crate::functions::numerator_ast(&[combined.clone()]).ok()?;
+  let den_expr = crate::functions::denominator_ast(&[combined]).ok()?;
+  if !depends_on(&den_expr, s) {
+    return None;
+  }
+
+  let s_id = Expr::Identifier(s.to_string());
+  let num_coeffs = polynomial_f64_coeffs(&num_expr, &s_id)?;
+  let den_coeffs = polynomial_f64_coeffs(&den_expr, &s_id)?;
+  let den_degree = den_coeffs.len().checked_sub(1)?;
+  if den_degree < 1 || num_coeffs.len() > den_coeffs.len() {
+    // A constant "denominator" (not actually rational in s) or an
+    // improper fraction (needing polynomial division first) — leave
+    // unevaluated rather than guess.
+    return None;
+  }
+
+  let roots =
+    crate::functions::polynomial_ast::solve::durand_kerner_roots(&den_coeffs);
+  let scale = roots
+    .iter()
+    .fold(1.0_f64, |m, &(re, im)| m.max(re.hypot(im)));
+  for i in 0..roots.len() {
+    for j in (i + 1)..roots.len() {
+      let (ar, ai) = roots[i];
+      let (br, bi) = roots[j];
+      if (ar - br).hypot(ai - bi) < 1e-6 * scale {
+        return None;
+      }
+    }
+  }
+
+  let deriv_coeffs: Vec<f64> = (1..den_coeffs.len())
+    .map(|k| den_coeffs[k] * k as f64)
+    .collect();
+
+  let e_const = || Expr::Constant("E".to_string());
+  let t_id = || Expr::Identifier(t.to_string());
+
+  let mut terms: Vec<Expr> = Vec::new();
+  let mut consumed = vec![false; roots.len()];
+  for i in 0..roots.len() {
+    if consumed[i] {
+      continue;
+    }
+    let (re, im) = roots[i];
+    let (pr, pi) = eval_poly_complex(&num_coeffs, re, im);
+    let (qr, qi) = eval_poly_complex(&deriv_coeffs, re, im);
+    if qr == 0.0 && qi == 0.0 {
+      return None;
+    }
+    let (rr, ri) = complex_div(pr, pi, qr, qi);
+    let exp_part = call(
+      "Power",
+      vec![e_const(), call("Times", vec![Expr::Real(re), t_id()])],
+    );
+    if im.abs() < 1e-9 * scale.max(1.0) {
+      terms.push(call("Times", vec![Expr::Real(rr), exp_part]));
+      continue;
+    }
+    let j = ((i + 1)..roots.len()).find(|&j| {
+      let (br, bi) = roots[j];
+      !consumed[j]
+        && (br - re).abs() < 1e-6 * scale
+        && (bi + im).abs() < 1e-6 * scale
+    })?;
+    consumed[j] = true;
+    let cos_part =
+      call("Cos", vec![call("Times", vec![Expr::Real(im), t_id()])]);
+    let sin_part =
+      call("Sin", vec![call("Times", vec![Expr::Real(im), t_id()])]);
+    let oscillation = call(
+      "Plus",
+      vec![
+        call("Times", vec![Expr::Real(2.0 * rr), cos_part]),
+        call("Times", vec![Expr::Real(-2.0 * ri), sin_part]),
+      ],
+    );
+    terms.push(call("Times", vec![exp_part, oscillation]));
+  }
+
+  Some(call("Plus", terms))
+}
+
+/// `CoefficientList[poly, var]`, converted to `f64`s from lowest to highest
+/// degree. `None` if any coefficient isn't a plain number once evaluated,
+/// which routes the caller back to leaving the call unevaluated.
+fn polynomial_f64_coeffs(poly: &Expr, var: &Expr) -> Option<Vec<f64>> {
+  let list =
+    crate::functions::coefficient_list_ast(&[poly.clone(), var.clone()])
+      .ok()?;
+  let Expr::List(ref items) = list else {
+    return None;
+  };
+  items
+    .iter()
+    .map(|item| {
+      let evaluated = crate::evaluator::evaluate_expr_to_expr(item).ok()?;
+      expr_to_f64(&evaluated)
+    })
+    .collect()
+}
+
+/// Evaluate a real-coefficient polynomial (lowest-degree-first, as from
+/// `CoefficientList`) at a complex point via Horner's method.
+fn eval_poly_complex(coeffs: &[f64], zr: f64, zi: f64) -> (f64, f64) {
+  let mut re = 0.0;
+  let mut im = 0.0;
+  for &c in coeffs.iter().rev() {
+    let nr = re * zr - im * zi + c;
+    let ni = re * zi + im * zr;
+    re = nr;
+    im = ni;
+  }
+  (re, im)
+}
+
+/// Complex division `(ar + ai i) / (br + bi i)`.
+fn complex_div(ar: f64, ai: f64, br: f64, bi: f64) -> (f64, f64) {
+  let denom = br * br + bi * bi;
+  ((ar * br + ai * bi) / denom, (ai * br - ar * bi) / denom)
 }
 
 /// If `c` is a negative constant (a negative number, `Times[-1, X]`, or a

--- a/src/evaluator/dispatch/calculus_functions.rs
+++ b/src/evaluator/dispatch/calculus_functions.rs
@@ -1981,8 +1981,10 @@ fn inverse_laplace_partial_fractions(
   s: &str,
   t: &str,
 ) -> Option<Expr> {
-  let combined = crate::functions::together_ast(&[expr.clone()]).ok()?;
-  let num_expr = crate::functions::numerator_ast(&[combined.clone()]).ok()?;
+  let combined =
+    crate::functions::together_ast(std::slice::from_ref(expr)).ok()?;
+  let num_expr =
+    crate::functions::numerator_ast(std::slice::from_ref(&combined)).ok()?;
   let den_expr = crate::functions::denominator_ast(&[combined]).ok()?;
   if !depends_on(&den_expr, s) {
     return None;

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -347,7 +347,7 @@ fn parse_pde_domain(expr: &Expr) -> Option<PdeDomain> {
   };
   let min = nval_to_f64(&items[1])?;
   let max = nval_to_f64(&items[2])?;
-  if !(max > min) {
+  if max.partial_cmp(&min) != Some(std::cmp::Ordering::Greater) {
     return None;
   }
   Some(PdeDomain {
@@ -643,8 +643,7 @@ fn ndsolve_pde(args: &[Expr]) -> Result<Option<Expr>, InterpreterError> {
   // boundary needs to be resolved.
   const MIN_STEPS: usize = 200;
   let n_steps = (((t_dom.max - t_dom.min) / dt_stable).ceil() as usize)
-    .max(MIN_STEPS)
-    .min(20_000);
+    .clamp(MIN_STEPS, 20_000);
   let dt = (t_dom.max - t_dom.min) / n_steps as f64;
 
   let derivative =

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -820,7 +820,7 @@ pub fn nroots_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 /// Find all roots of polynomial (coeffs[i] is coefficient of x^i) using
 /// the Durand-Kerner (Weierstrass) method on complex doubles.
-fn durand_kerner_roots(coeffs: &[f64]) -> Vec<(f64, f64)> {
+pub(crate) fn durand_kerner_roots(coeffs: &[f64]) -> Vec<(f64, f64)> {
   let n = coeffs.len() - 1;
   if n == 0 {
     return vec![];

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -9341,6 +9341,59 @@ mod inverse_laplace_transform {
     );
   }
 
+  // ─── Partial-fraction fallback (numeric-coefficient rational functions
+  // past a quadratic denominator, e.g. a control-system transfer function
+  // with a Manipulate slider's value substituted in) ───────────────────
+
+  // Three distinct real poles: the textbook partial-fraction expansion of
+  // 1/((s+1)(s+2)(s+3)) is (1/2)E^-t - E^-2t + (1/2)E^-3t.
+  #[test]
+  fn partial_fractions_three_real_poles() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/((s + 1)(s + 2)(s + 3)), s, t]")
+        .unwrap(),
+      "0.5/E^(3.*t) - 1./E^(2.*t) + 0.5/E^(1.*t)"
+    );
+  }
+
+  // A real pole at s = 0 plus a complex-conjugate pair (-1 ± 2 I) from
+  // s^2 + 2 s + 5: the real pole contributes a constant, the pair an
+  // exponentially damped oscillation.
+  #[test]
+  fn partial_fractions_real_and_complex_poles() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/(s^3 + 2 s^2 + 5 s), s, t]")
+        .unwrap(),
+      "0.2 + (-0.2*Cos[2.*t] - 0.1*Sin[2.*t])/E^(1.*t)"
+    );
+  }
+
+  // A repeated pole needs `t^k E^(r t)` terms the simple-pole residue sum
+  // doesn't produce — it must stay unevaluated rather than silently return
+  // a wrong answer.
+  #[test]
+  fn partial_fractions_repeated_pole_stays_unevaluated() {
+    assert_eq!(
+      interpret("InverseLaplaceTransform[1/(s + 1)^3, s, t]").unwrap(),
+      "InverseLaplaceTransform[(1 + s)^(-3), s, t]"
+    );
+  }
+
+  // At t = 0 the three-real-pole case above must reproduce the exact
+  // partial-fraction coefficients (1/2 - 1 + 1/2 = 0), a quick numeric
+  // sanity check independent of the exact printed form.
+  #[test]
+  fn partial_fractions_value_at_zero() {
+    assert_eq!(
+      interpret(
+        "Chop[InverseLaplaceTransform[1/((s + 1)(s + 2)(s + 3)), s, t] \
+         /. t -> 0]"
+      )
+      .unwrap(),
+      "0"
+    );
+  }
+
   // ─── Two-variable InverseLaplaceTransform ───────────────────────────
   // wolframscript:
   //   InverseLaplaceTransform[1/(p*q), {p, q}, {x, y}]      -> 1


### PR DESCRIPTION
## Summary

While testing Woxi Studio against a randomly picked Wolfram Demonstration ("Integral Error Criteria for Controller Tuning"), I found that its `Manipulate` never rendered a live plot: the demonstration defines a step-response function `b[q_?NumericQ] := ... InverseLaplaceTransform[<rational function of s>, s, t]`, and once `q` is substituted with a slider's numeric value, the resulting Laplace-domain expression has a denominator of degree 4 — past what `InverseLaplaceTransform` could handle. It stayed unevaluated, so the dependent `Plot`/`NIntegrate` calls in the demonstration had nothing numeric to work with.

- `InverseLaplaceTransform` previously only pattern-matched a fixed library of shapes (`1/s^n`, `1/(s^2+a^2)`, `1/(s±a)`, exponential shifts, …), which only covers denominators up to degree 2.
- Added a general fallback for a proper rational function `P(s)/Q(s)` with purely numeric coefficients: combine to a single fraction (`Together`/`Numerator`/`Denominator`), find `Q`'s roots numerically via the existing Durand-Kerner solver (the same one behind `Roots`/`NRoots`), and sum simple-pole residues — a real root contributes `Residue * E^(r t)`, and each complex-conjugate pair contributes a damped `Cos`/`Sin` oscillation.
- Bails safely (leaving the call unevaluated, as before) on a non-numeric coefficient, an improper fraction, or a repeated/near-repeated root, rather than guessing.
- Verified against the demonstration itself: the fixed function's plot renders, and its numerically-integrated `f1[1.25]` value (5.0595) matches the demonstration's own published table entry (5.05889).

No code from the (copyrighted) Demonstration notebook is included — the new tests use independently written rational functions.

## Test plan
- [x] `cargo test --test interpreter_tests inverse_laplace` — 41 passed (4 new, 37 existing unchanged)
- [x] `cargo test` (full unit + script suite) — 25182 + 576 passed, 0 failed
- [x] `cargo test -p woxi-studio` — 163 passed, 0 failed
- [x] Manual check: `Plot[{1, b[1.25]}, ...]` with the demonstration's exact styling options now renders a real SVG instead of leaving the curve symbolic
- [x] `make format`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lh4geqZxvhu8YDwAqgC4Lt)_