### PR TITLE
Support body-embedded Buttons and persistent DynamicModule state in Manipulate

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16944,21 +16944,29 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
       inner.tracking,
     )
   } else {
-    // `TogglerBar[Dynamic[var], …]` inside the body moves into the
-    // display list (replaced by `Nothing` in the body): a front-end
-    // renders displays as live widgets, whereas inside the rendered
-    // output it would only be a static picture.
+    // `DynamicModule[{locals…}, …]` wrapping the body: unlike `Module`, a
+    // DynamicModule's locals live for the widget's whole lifetime, so a
+    // `Button` inside it that writes one (a Demonstration's "throw"/"step"
+    // action) must have that write survive the next re-render. Hoist them
+    // into the widget's hidden state — the same mechanism a Manipulate's
+    // own `ControlType -> None` variables use — and drop the wrapper, so
+    // `reevaluate` installs them as ordinary globals instead of Module
+    // re-creating fresh ones every frame.
+    let mut dynamic_module_state = Vec::new();
+    let unwrapped =
+      unwrap_dynamic_module_locals(&args[0], &mut dynamic_module_state);
+    // `TogglerBar[Dynamic[var], …]` and a bare `Button[label, action]`
+    // inside the body move into the display list (replaced by `Nothing` in
+    // the body): a front-end renders displays as live widgets, whereas
+    // inside the rendered output they would only be an inert picture.
     let mut body_displays = Vec::new();
-    let body_expr = extract_body_togglerbars(
-      unwrap_dynamic_body(&args[0]),
-      &mut body_displays,
-    );
+    let body_expr = extract_body_togglerbars(&unwrapped, &mut body_displays);
     let body_code = crate::syntax::expr_to_input_form(&body_expr);
     body_expr_kept = Some(body_expr);
     (
       body_code,
       Vec::with_capacity(args.len() - 1),
-      Vec::new(),
+      dynamic_module_state,
       body_displays,
       None,
       Vec::new(),
@@ -17842,6 +17850,18 @@ fn extract_body_togglerbars(expr: &Expr, displays: &mut Vec<String>) -> Expr {
       displays.push(crate::syntax::expr_to_input_form(expr));
       Expr::Identifier("Nothing".to_string())
     }
+    // A bare `Button[label, action, opts…]` drawn directly by the body (a
+    // Demonstration's "throw"/"step" action mixed into a `Column` of
+    // graphics and captions), distinct from a `Button` given as its own
+    // Manipulate control-spec argument (handled in `manipulate_controls`).
+    // Moves into the display list, replaced by `Nothing`, so it renders as
+    // a live, clickable element instead of an inert picture.
+    Expr::FunctionCall { name, args }
+      if name == "Button" && args.len() >= 2 =>
+    {
+      displays.push(crate::syntax::expr_to_input_form(expr));
+      Expr::Identifier("Nothing".to_string())
+    }
     Expr::FunctionCall { name, args } => Expr::FunctionCall {
       name: name.clone(),
       args: args
@@ -17904,6 +17924,91 @@ fn unwrap_dynamic_body(body: &Expr) -> &Expr {
       &args[0]
     }
     other => other,
+  }
+}
+
+/// Peel `Dynamic[…]` wrappers and any top-level `DynamicModule[{locals…},
+/// …]` off a Manipulate body, pushing each local's `(name, initial value)`
+/// onto `state`. A `DynamicModule` local without an initializer (`{tf,
+/// soln}`, computed fresh each frame) is seeded as `Null`.
+///
+/// Wolfram keeps a `DynamicModule`'s locals alive for the widget's whole
+/// lifetime — that is the entire point of `DynamicModule` over `Module` —
+/// so a `Button` inside it that writes one (a Demonstration's "throw" or
+/// "step" action) must have that write survive the next re-render. Hoisting
+/// the locals into the widget's hidden state, the same mechanism a
+/// Manipulate's own `ControlType -> None` variables use, gets that for
+/// free: `reevaluate` installs `state` as scoped globals before every
+/// render, and writes the body (or a button action) makes to any of those
+/// names get read back afterwards.
+fn unwrap_dynamic_module_locals(
+  body: &Expr,
+  state: &mut Vec<(String, String)>,
+) -> Expr {
+  let mut cur = body;
+  loop {
+    match cur {
+      Expr::FunctionCall { name, args }
+        if name == "Dynamic" && !args.is_empty() =>
+      {
+        cur = &args[0];
+      }
+      // Only a `DynamicModule` whose own body is *itself* an explicit
+      // `Dynamic[…]` gets its locals hoisted: that inner `Dynamic` is the
+      // author's own re-render boundary, marking everything outside it —
+      // the locals — as evaluated once and persisted, exactly what
+      // `DynamicModule` (vs. `Module`) is for. A `DynamicModule` whose body
+      // is plain code (`DynamicModule[{p = a x^2+b x+c}, RegionPlot[…]]`,
+      // no inner `Dynamic`) has no such boundary: Manipulate's own
+      // (implicit, outer) dynamic wrapping re-evaluates the whole
+      // `DynamicModule` — including the local's initializer — on every
+      // control change, so `p` must keep tracking `a`/`b`/`c` fresh each
+      // frame rather than freezing at its first value.
+      Expr::FunctionCall { name, args }
+        if name == "DynamicModule"
+          && args.len() >= 2
+          && matches!(
+            &args[1],
+            Expr::FunctionCall { name: inner, args: iargs }
+              if inner == "Dynamic" && !iargs.is_empty()
+          ) =>
+      {
+        if let Expr::List(locals) = &args[0] {
+          for local in locals {
+            match local {
+              Expr::FunctionCall {
+                name: set_name,
+                args: set_args,
+              } if set_name == "Set" && set_args.len() == 2 => {
+                if let Expr::Identifier(var_name) = &set_args[0] {
+                  state.push((
+                    var_name.clone(),
+                    crate::syntax::expr_to_input_form(&set_args[1]),
+                  ));
+                }
+              }
+              Expr::Rule {
+                pattern,
+                replacement,
+              } => {
+                if let Expr::Identifier(var_name) = pattern.as_ref() {
+                  state.push((
+                    var_name.clone(),
+                    crate::syntax::expr_to_input_form(replacement),
+                  ));
+                }
+              }
+              Expr::Identifier(var_name) => {
+                state.push((var_name.clone(), "Null".to_string()));
+              }
+              _ => {}
+            }
+          }
+        }
+        cur = &args[1];
+      }
+      _ => return cur.clone(),
+    }
   }
 }
 

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -347,7 +347,7 @@ fn parse_pde_domain(expr: &Expr) -> Option<PdeDomain> {
   };
   let min = nval_to_f64(&items[1])?;
   let max = nval_to_f64(&items[2])?;
-  if !(max > min) {
+  if max.partial_cmp(&min) != Some(std::cmp::Ordering::Greater) {
     return None;
   }
   Some(PdeDomain {
@@ -643,8 +643,7 @@ fn ndsolve_pde(args: &[Expr]) -> Result<Option<Expr>, InterpreterError> {
   // boundary needs to be resolved.
   const MIN_STEPS: usize = 200;
   let n_steps = (((t_dom.max - t_dom.min) / dt_stable).ceil() as usize)
-    .max(MIN_STEPS)
-    .min(20_000);
+    .clamp(MIN_STEPS, 20_000);
   let dt = (t_dom.max - t_dom.min) / n_steps as f64;
 
   let derivative =

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -19164,4 +19164,79 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`nmax$$ = 10}, DynamicBox[\[Ellipsis
     );
     assert!(state.graphics_handle.is_some());
   }
+
+  /// A synthetic "throw a dart at a target" Manipulate in the shape the
+  /// "Dart Practice" Demonstration uses: the interactive picture lives in a
+  /// `DynamicModule` wrapping the Manipulate body, and a `Button` embedded
+  /// directly in that body's `Column` (not given as its own Manipulate
+  /// control-spec argument) flips a DynamicModule-local variable on every
+  /// press. Two things must both work for the widget to be usable: the
+  /// body-drawn `Button` must render as a live, clickable element (not get
+  /// baked into the static picture), and its write to the DynamicModule
+  /// local must survive the next re-render — `DynamicModule` locals persist
+  /// for the widget's life, unlike `Module`'s fresh scope every call.
+  #[test]
+  fn body_button_flips_a_dynamic_module_local_and_it_sticks() {
+    let code = r#"Manipulate[
+      DynamicModule[{hit = "miss"},
+        Dynamic[Column[{
+          Graphics[{}, ImageSize -> 10],
+          hit,
+          Button["throw", hit = If[hit == "miss", "hit", "miss"]]
+        }]]
+      ],
+      {n, 1, 5}
+    ]"#;
+    let expr = woxi::interpret_to_expr(code).expect("should parse");
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("should build a widget");
+    assert!(state.error.is_none(), "body failed: {:?}", state.error);
+    let hit = |state: &manipulate::ManipulateState| -> String {
+      state
+        .state
+        .iter()
+        .find(|(n, _)| n == "hit")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default()
+    };
+    assert_eq!(
+      hit(&state),
+      "\"miss\"",
+      "the DynamicModule local's initial value should be hoisted into state"
+    );
+
+    // The body-drawn Button must render as a live display element, not
+    // disappear into the static picture.
+    let buttons = collect_display_buttons(&state.display_trees);
+    let (action, label) = buttons
+      .into_iter()
+      .find(|(_, label)| label == "throw")
+      .expect("the body's Button should render as a clickable display");
+    assert_eq!(label, "throw");
+
+    // Pressing it moves the DynamicModule local, and that write survives
+    // this re-render — it must not snap back to "miss".
+    state.apply_button_action(&action);
+    assert!(state.error.is_none(), "button failed: {:?}", state.error);
+    assert_eq!(
+      hit(&state),
+      "\"hit\"",
+      "the button's write to the DynamicModule local should stick"
+    );
+
+    // An unrelated control changing and re-rendering again must not reset
+    // it either — a fresh `Module` scope would silently revert to "miss".
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[0]
+    {
+      *current = 3.0;
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert_eq!(
+      hit(&state),
+      "\"hit\"",
+      "the DynamicModule local must stay put across an unrelated re-render"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

The weekly random-Demonstration check picked ["Dart Practice"](https://demonstrations.wolfram.com/DartPractice/), whose `Manipulate` wraps its interactive picture in a `DynamicModule` and draws a "throw" `Button` directly inside the body's `Column` (not as its own Manipulate control-spec argument). Two things were broken:

- The Button never rendered as a clickable element. Only a bare `TogglerBar` embedded in the body was pulled out into the widget's display list; any other body-embedded `Button` baked into the static picture instead, inert.
- Even once clickable, the Button's action mutated `DynamicModule` locals (`col`, `epil`) that never stuck: `DynamicModule` was evaluated exactly like `Module`, so every re-render created fresh locals from their initializers and silently discarded whatever the previous click had written.

## Fixes

Both in `extract_manipulate_spec` (`src/functions/graphics.rs`):

- `extract_body_togglerbars` now also extracts a bare `Button[label, action]` found anywhere in the body, replacing it with `Nothing` and pushing its InputForm onto the display list — the same treatment `TogglerBar` already got. `DisplayNode::Button` and the click-to-action wiring already existed for this list; the body-embedded case just never fed it.
- `unwrap_dynamic_module_locals` hoists a `DynamicModule`'s locals into the widget's hidden Manipulate state (the same mechanism a `ControlType -> None` variable uses), so `reevaluate` installs them as ordinary globals and writes to them survive across re-renders. This only fires when the `DynamicModule`'s own body is itself an explicit `Dynamic[…]` — that inner `Dynamic` is the author's own persistence boundary, marking the locals as evaluated once and kept, which is the entire point of `DynamicModule` over `Module`.

  A first, unconditional version of this hoist regressed `quadratic_inequality_notebook_shades_its_region`: its `DynamicModule[{p = a x^2+b x+c}, RegionPlot[…]]` has no inner `Dynamic`, and Manipulate's own implicit dynamic wrapping reconstructs the whole `DynamicModule` (recomputing `p` from live `a`/`b`/`c`) on every control change, so `p` must never freeze at its initial value. Scoping the hoist to bodies with an explicit inner `Dynamic` keeps both notebooks correct.

Adds `body_button_flips_a_dynamic_module_local_and_it_sticks`, a synthetic "throw at a target" Manipulate in the Dart Practice shape (`DynamicModule` + body-drawn `Button` + a hoisted local), verifying the button renders as a live display element and its write survives both the click's own re-render and a later, unrelated control change. No code from the Demonstration notebook itself is included — the test is an independently authored synthetic reproduction.

## Test plan

- [x] `make test-studio` — 164 tests pass (cargo-nextest substituted with plain `cargo test`, since nextest isn't installed in this sandbox)
- [x] `make test` — 27,257 core `woxi` crate tests pass
- [x] `make format`
- [x] Manually verified against the actual downloaded "Dart Practice" notebook with `cargo run --example dump_manipulate` (woxi-studio): the throw button now appears in the widget's display list and its state persists across renders

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013CmNer8RAu7st9s9r11YPV

---
_Generated by [Claude Code](https://claude.ai/code/session_013CmNer8RAu7st9s9r11YPV)_