### PR TITLE
Subdivide long Tube/Cylinder sides so the painter's algorithm sorts correctly

### DIFF
--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -347,7 +347,7 @@ fn parse_pde_domain(expr: &Expr) -> Option<PdeDomain> {
   };
   let min = nval_to_f64(&items[1])?;
   let max = nval_to_f64(&items[2])?;
-  if !(max > min) {
+  if max.partial_cmp(&min) != Some(std::cmp::Ordering::Greater) {
     return None;
   }
   Some(PdeDomain {
@@ -643,8 +643,7 @@ fn ndsolve_pde(args: &[Expr]) -> Result<Option<Expr>, InterpreterError> {
   // boundary needs to be resolved.
   const MIN_STEPS: usize = 200;
   let n_steps = (((t_dom.max - t_dom.min) / dt_stable).ceil() as usize)
-    .max(MIN_STEPS)
-    .min(20_000);
+    .clamp(MIN_STEPS, 20_000);
   let dt = (t_dom.max - t_dom.min) / n_steps as f64;
 
   let derivative =

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -4181,7 +4181,31 @@ fn box_edge_flags(tri: &(Point3D, Point3D, Point3D)) -> [bool; 3] {
   ]
 }
 
+/// Bounds how elongated a single tessellated side face can be. Without
+/// this, a long cylinder or tube tessellates its side into quads that span
+/// its whole length in one piece, and the painter's algorithm sorts each
+/// quad by its centroid depth — averaging a face's near and far ends
+/// together lets a smaller object poking through only the far half of the
+/// face sort as if it were in front of the whole thing. Subdividing the
+/// length so each face stays roughly as long as it is wide keeps every
+/// face's centroid a good local depth estimate.
+const MAX_SIDE_FACE_ASPECT: f64 = 1.0;
+const MAX_SIDE_SUBDIVISIONS: usize = 200;
+
+/// How many rings to place along a side of the given length and radius so
+/// that no single tessellated face is more elongated than
+/// `MAX_SIDE_FACE_ASPECT` times as long as it is wide, given `sides`
+/// facets around the circumference.
+fn side_subdivision_steps(len: f64, radius: f64, sides: usize) -> usize {
+  let facet_width =
+    2.0 * std::f64::consts::PI * radius.abs().max(1e-9) / sides as f64;
+  ((len / facet_width) / MAX_SIDE_FACE_ASPECT)
+    .ceil()
+    .clamp(1.0, MAX_SIDE_SUBDIVISIONS as f64) as usize
+}
+
 /// Tessellate a cylinder along its axis.
+
 fn tessellate_cylinder(
   p1: &Point3D,
   p2: &Point3D,
@@ -4228,49 +4252,40 @@ fn tessellate_cylinder(
   let biny = az * perpx - ax * perpz;
   let binz = ax * perpy - ay * perpx;
 
+  let steps = side_subdivision_steps(len, radius, n);
+  let ring_at = |t: f64| -> Vec<Point3D> {
+    let center = Point3D {
+      x: p1.x + dx * t,
+      y: p1.y + dy * t,
+      z: p1.z + dz * t,
+    };
+    (0..n)
+      .map(|i| {
+        let a = 2.0 * pi * i as f64 / n as f64;
+        let (c, s) = (a.cos(), a.sin());
+        Point3D {
+          x: center.x + radius * (c * perpx + s * binx),
+          y: center.y + radius * (c * perpy + s * biny),
+          z: center.z + radius * (c * perpz + s * binz),
+        }
+      })
+      .collect()
+  };
+  let rings: Vec<Vec<Point3D>> = (0..=steps)
+    .map(|s| ring_at(s as f64 / steps as f64))
+    .collect();
+
   let mut tris = Vec::new();
-  for i in 0..n {
-    let a1 = 2.0 * pi * i as f64 / n as f64;
-    let a2 = 2.0 * pi * (i + 1) as f64 / n as f64;
-    let c1 = a1.cos();
-    let s1 = a1.sin();
-    let c2 = a2.cos();
-    let s2 = a2.sin();
-
-    let offset1 = (
-      radius * (c1 * perpx + s1 * binx),
-      radius * (c1 * perpy + s1 * biny),
-      radius * (c1 * perpz + s1 * binz),
-    );
-    let offset2 = (
-      radius * (c2 * perpx + s2 * binx),
-      radius * (c2 * perpy + s2 * biny),
-      radius * (c2 * perpz + s2 * binz),
-    );
-
-    let a = Point3D {
-      x: p1.x + offset1.0,
-      y: p1.y + offset1.1,
-      z: p1.z + offset1.2,
-    };
-    let b = Point3D {
-      x: p2.x + offset1.0,
-      y: p2.y + offset1.1,
-      z: p2.z + offset1.2,
-    };
-    let c = Point3D {
-      x: p2.x + offset2.0,
-      y: p2.y + offset2.1,
-      z: p2.z + offset2.2,
-    };
-    let d = Point3D {
-      x: p1.x + offset2.0,
-      y: p1.y + offset2.1,
-      z: p1.z + offset2.2,
-    };
-
-    tris.push((a, b, c));
-    tris.push((a, c, d));
+  for ring_pair in rings.windows(2) {
+    let (ring1, ring2) = (&ring_pair[0], &ring_pair[1]);
+    for i in 0..n {
+      let i2 = (i + 1) % n;
+      // Same vertex order as the un-subdivided quad (a, b, c) / (a, c, d)
+      // with a = ring1[i], b = ring2[i], c = ring2[i2], d = ring1[i2], so
+      // the winding — and therefore the face normal direction — matches.
+      tris.push((ring1[i], ring2[i], ring2[i2]));
+      tris.push((ring1[i], ring2[i2], ring1[i2]));
+    }
   }
   tris
 }
@@ -4348,6 +4363,24 @@ fn tessellate_tube(
   };
   let mut normal = unit(cross(t0, seed)).unwrap_or((1.0, 0.0, 0.0));
 
+  let ring_at = |center: Point3D,
+                 radius: f64,
+                 normal: (f64, f64, f64),
+                 binormal: (f64, f64, f64)|
+   -> Vec<Point3D> {
+    (0..TUBE_SIDES)
+      .map(|k| {
+        let a = 2.0 * std::f64::consts::PI * k as f64 / TUBE_SIDES as f64;
+        let (c, s) = (a.cos() * radius, a.sin() * radius);
+        Point3D {
+          x: center.x + c * normal.0 + s * binormal.0,
+          y: center.y + c * normal.1 + s * binormal.1,
+          z: center.z + c * normal.2 + s * binormal.2,
+        }
+      })
+      .collect()
+  };
+
   let mut rings: Vec<Vec<Point3D>> = Vec::with_capacity(keep.len());
   for (i, &idx) in keep.iter().enumerate() {
     let t = tangents[i];
@@ -4369,19 +4402,29 @@ fn tessellate_tube(
       let d = dirs[i - 1].0 * t.0 + dirs[i - 1].1 * t.1 + dirs[i - 1].2 * t.2;
       if d.abs() < 1e-6 { 1.0 } else { 1.0 / d }
     };
-    rings.push(
-      (0..TUBE_SIDES)
-        .map(|k| {
-          let a = 2.0 * std::f64::consts::PI * k as f64 / TUBE_SIDES as f64;
-          let (c, s) = (a.cos() * r * widen, a.sin() * r * widen);
-          Point3D {
-            x: points[idx].x + c * normal.0 + s * binormal.0,
-            y: points[idx].y + c * normal.1 + s * binormal.1,
-            z: points[idx].z + c * normal.2 + s * binormal.2,
-          }
-        })
-        .collect(),
-    );
+    rings.push(ring_at(points[idx], r * widen, normal, binormal));
+
+    // Subdivide the straight run to the next vertex so no single
+    // tessellated face spans an outsized fraction of the tube's length
+    // (see `side_subdivision_steps`). The normal/binormal frame doesn't
+    // need to change along a straight run, so the interpolated rings just
+    // reuse this vertex's frame; only the centre and radius move.
+    if i + 1 < keep.len() {
+      let idx_next = keep[i + 1];
+      let seg_len = norm(sub(&points[idx_next], &points[idx]));
+      let r_next = radii.get(idx_next).copied().unwrap_or(0.0);
+      let steps = side_subdivision_steps(seg_len, r.max(r_next), TUBE_SIDES);
+      for s in 1..steps {
+        let frac = s as f64 / steps as f64;
+        let center = Point3D {
+          x: points[idx].x + (points[idx_next].x - points[idx].x) * frac,
+          y: points[idx].y + (points[idx_next].y - points[idx].y) * frac,
+          z: points[idx].z + (points[idx_next].z - points[idx].z) * frac,
+        };
+        let rr = r + (r_next - r) * frac;
+        rings.push(ring_at(center, rr, normal, binormal));
+      }
+    }
   }
 
   let mut tris = Vec::new();

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -4205,7 +4205,6 @@ fn side_subdivision_steps(len: f64, radius: f64, sides: usize) -> usize {
 }
 
 /// Tessellate a cylinder along its axis.
-
 fn tessellate_cylinder(
   p1: &Point3D,
   p2: &Point3D,

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -24460,6 +24460,72 @@ mod tube_and_cap_form {
   }
 }
 
+mod graphics3d_painters_algorithm_face_subdivision {
+  use super::*;
+
+  /// The painter's algorithm sorts every tessellated triangle by its own
+  /// centroid depth. A straight `Tube`/`Cylinder` side used to tessellate
+  /// into one quad strip spanning its *whole* length, so a face's centroid
+  /// averaged its near and far ends together — a smaller object poking
+  /// through only the far half of such a face could then sort as if it
+  /// were in front of the whole face. Regression, found by a Demonstration
+  /// that put several `Cylinder` fan blades inside a wide `Tube` housing:
+  /// pieces of the blades showed through the housing's wall. The fix
+  /// subdivides a straight run so no face is more elongated than it is
+  /// wide, which only matters once a run is many facet-widths long.
+  #[test]
+  fn long_tube_segment_subdivides_its_length() {
+    clear_state();
+    let short = export_svg("Graphics3D[{Tube[{{0, 0, 0}, {0, 0, 1}}, 1]}]");
+    let long = export_svg("Graphics3D[{Tube[{{0, 0, 0}, {0, 0, 40}}, 1]}]");
+    let count = |svg: &str| svg.matches("<polygon").count();
+    assert!(
+      count(&long) > count(&short) * 4,
+      "a straight tube 40x longer than its radius must tessellate into \
+       many more, smaller faces along its length: short={} long={}",
+      count(&short),
+      count(&long)
+    );
+  }
+
+  /// Same fix, for `Cylinder`.
+  #[test]
+  fn long_cylinder_segment_subdivides_its_length() {
+    clear_state();
+    let short = export_svg("Graphics3D[{Cylinder[{{0, 0, 0}, {0, 0, 1}}, 1]}]");
+    let long = export_svg("Graphics3D[{Cylinder[{{0, 0, 0}, {0, 0, 40}}, 1]}]");
+    let count = |svg: &str| svg.matches("<polygon").count();
+    assert!(
+      count(&long) > count(&short) * 4,
+      "a straight cylinder 40x longer than its radius must tessellate \
+       into many more, smaller faces along its length: short={} long={}",
+      count(&short),
+      count(&long)
+    );
+  }
+
+  /// End-to-end regression for the fan-housing shape above: several
+  /// `Cylinder` blades sit well inside a wide, open-ended `Tube`, close
+  /// enough to its inner wall that the wall's un-subdivided facet used to
+  /// sort behind a blade it should have occluded. A finely subdivided
+  /// housing wall renders far more polygons for the same scene.
+  #[test]
+  fn blades_inside_a_wide_tube_get_a_finely_subdivided_housing() {
+    clear_state();
+    let svg = export_svg(
+      "Graphics3D[{Green, CapForm[None], Tube[{{0, 0, -5}, {0, 0, 1}}, \
+       5.5], Blue, Table[Rotate[Cylinder[{{0, 1.2, 0}, {0, 5, 0}}], \
+       i*Pi/2, {0, 0, 1}], {i, 4}]}]",
+    );
+    assert!(
+      svg.matches("<polygon").count() > 1000,
+      "the tube housing must be subdivided along its length, not one \
+       quad strip per side: {} polygons",
+      svg.matches("<polygon").count()
+    );
+  }
+}
+
 mod revolution_plot3d_part_extraction {
   use super::*;
 

--- a/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cylinder.snap
+++ b/tests/interpreter_tests/snapshots/interpreter_tests__interpreter_tests__graphics__plot3d__graphics3d_primitives__graphics3d_cylinder.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/interpreter_tests/graphics.rs
+assertion_line: 11395
 expression: "export_svg(\"Graphics3D[Cylinder[{{0,0,0},{0,0,1}}, 0.5]]\")"
 ---
 <svg width="360" height="360" viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
@@ -54,194 +55,530 @@ expression: "export_svg(\"Graphics3D[Cylinder[{{0,0,0},{0,0,1}}, 0.5]]\")"
 <line x1="152.1" y1="146.5" x2="152.1" y2="135.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="262.0" y1="291.8" x2="265.4" y2="288.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="101.4" y1="292.0" x2="104.8" y2="288.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="195.1,195.1 178.5,181.1 178.5,194.0" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="178.5,194.0 162.0,182.6 162.0,195.5" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="275.5" y1="254.5" x2="275.5" y2="243.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="210.7,198.6 195.1,182.2 195.1,195.1" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="258.6" y1="295.4" x2="262.0" y2="291.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="98.0" y1="295.6" x2="101.4" y2="292.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="178.5,194.0 178.5,181.1 162.0,182.6" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="195.1,195.1 195.1,182.2 178.5,181.1" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
 <line x1="152.1" y1="135.1" x2="152.1" y2="123.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="162.0,195.5 146.8,186.6 146.8,199.5" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="162.0,195.5 162.0,182.6 146.8,186.6" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="210.7,198.6 210.7,185.7 195.1,182.2" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="255.2" y1="299.1" x2="258.6" y2="295.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="94.6" y1="299.3" x2="98.0" y2="295.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="224.2,204.4 210.7,185.7 210.7,198.6" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
 <line x1="275.5" y1="243.1" x2="275.5" y2="231.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="195.1,182.2 178.5,168.2 178.5,181.1" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="178.5,181.1 162.0,169.7 162.0,182.6" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="210.7,185.7 195.1,169.2 195.1,182.2" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="146.8,199.5 133.7,192.7 133.7,205.7" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
 <line x1="251.9" y1="302.7" x2="255.2" y2="299.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="152.1" y1="123.7" x2="152.1" y2="112.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="178.5,181.1 178.5,168.2 162.0,169.7" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="91.2" y1="302.9" x2="94.6" y2="299.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="146.8,199.5 146.8,186.6 133.7,192.7" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="195.1,182.2 195.1,169.2 178.5,168.2" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="224.2,204.4 224.2,191.5 210.7,185.7" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="162.0,182.6 146.8,173.6 146.8,186.6" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="162.0,182.6 162.0,169.7 146.8,173.6" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="210.7,185.7 210.7,172.8 195.1,169.2" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="234.7,212.1 224.2,191.5 224.2,204.4" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
 <line x1="275.5" y1="231.8" x2="275.5" y2="220.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="248.5" y1="306.4" x2="251.9" y2="302.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="87.9" y1="306.6" x2="91.2" y2="302.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="224.2,191.5 210.7,172.8 210.7,185.7" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="195.1,169.2 178.5,155.2 178.5,168.2" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="178.5,168.2 162.0,156.7 162.0,169.7" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="152.1" y1="112.4" x2="152.1" y2="101.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="195.1,195.1 178.5,90.6 178.5,194.0" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="210.7,172.8 195.1,156.3 195.1,169.2" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="146.8,186.6 133.7,179.8 133.7,192.7" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="178.5,168.2 178.5,155.2 162.0,156.7" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="133.7,205.7 133.7,192.7 123.9,200.7" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="146.8,186.6 146.8,173.6 133.7,179.8" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="195.1,169.2 195.1,156.3 178.5,155.2" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
 <line x1="245.1" y1="310.0" x2="248.5" y2="306.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="178.5,194.0 162.0,92.1 162.0,195.5" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="133.7,205.7 123.9,200.7 123.9,213.6" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="84.5" y1="310.2" x2="87.9" y2="306.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="210.7,198.6 195.1,91.7 195.1,195.1" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="224.2,191.5 224.2,178.6 210.7,172.8" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="234.7,212.1 234.7,199.2 224.2,191.5" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="162.0,169.7 146.8,160.7 146.8,173.6" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="162.0,169.7 162.0,156.7 146.8,160.7" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
 <line x1="275.5" y1="220.4" x2="275.5" y2="209.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="210.7,172.8 210.7,159.9 195.1,156.3" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="234.7,199.2 224.2,178.6 224.2,191.5" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
 <line x1="84.5" y1="310.2" x2="90.7" y2="312.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="162.0,195.5 146.8,96.1 146.8,199.5" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="224.2,178.6 210.7,159.9 210.7,172.8" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
 <line x1="241.7" y1="313.6" x2="245.1" y2="310.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="195.1,156.3 178.5,142.3 178.5,155.2" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="241.4,221.1 234.7,199.2 234.7,212.1" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="178.5,155.2 162.0,143.8 162.0,156.7" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="152.1" y1="101.0" x2="152.1" y2="89.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="90.7" y1="312.2" x2="96.8" y2="314.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="310.2" x2="84.5" y2="298.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="224.2,204.4 210.7,95.2 210.7,198.6" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="210.7,159.9 195.1,143.4 195.1,156.3" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="146.8,173.6 133.7,166.9 133.7,179.8" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="178.5,155.2 178.5,142.3 162.0,143.8" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="133.7,192.7 133.7,179.8 123.9,187.8" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="146.8,173.6 146.8,160.7 133.7,166.9" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="195.1,156.3 195.1,143.4 178.5,142.3" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="133.7,192.7 123.9,187.8 123.9,200.7" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="96.8" y1="314.2" x2="103.0" y2="316.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="238.4" y1="317.3" x2="241.7" y2="313.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="224.2,178.6 224.2,165.7 210.7,159.9" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="234.7,199.2 234.7,186.3 224.2,178.6" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="162.0,156.7 146.8,147.8 146.8,160.7" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="123.9,213.6 123.9,200.7 117.8,209.8" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
 <line x1="275.5" y1="209.0" x2="275.5" y2="197.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="146.8,199.5 133.7,102.3 133.7,205.7" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="123.9,213.6 117.8,209.8 117.8,222.8" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="162.0,156.7 162.0,143.8 146.8,147.8" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
 <line x1="103.0" y1="316.2" x2="109.2" y2="318.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="210.7,159.9 210.7,146.9 195.1,143.4" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="241.4,221.1 241.4,208.2 234.7,199.2" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="234.7,186.3 224.2,165.7 224.2,178.6" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="224.2,165.7 210.7,146.9 210.7,159.9" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
 <line x1="152.1" y1="89.6" x2="152.1" y2="78.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="235.0" y1="320.9" x2="238.4" y2="317.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="109.2" y1="318.2" x2="115.3" y2="320.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="195.1,143.4 178.5,129.4 178.5,142.3" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
 <line x1="84.5" y1="298.8" x2="84.5" y2="287.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="234.7,212.1 224.2,101.1 224.2,204.4" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="241.4,208.2 234.7,186.3 234.7,199.2" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="178.5,142.3 162.0,130.9 162.0,143.8" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="210.7,146.9 195.1,130.5 195.1,143.4" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="115.3" y1="320.1" x2="121.5" y2="322.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="146.8,160.7 133.7,154.0 133.7,166.9" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="178.5,142.3 178.5,129.4 162.0,130.9" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="133.7,179.8 133.7,166.9 123.9,174.8" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="244.0,230.8 241.4,208.2 241.4,221.1" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="146.8,160.7 146.8,147.8 133.7,154.0" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="195.1,143.4 195.1,130.5 178.5,129.4" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="133.7,179.8 123.9,174.8 123.9,187.8" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="275.5" y1="197.7" x2="275.5" y2="186.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="224.2,165.7 224.2,152.7 210.7,146.9" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
 <line x1="231.6" y1="324.5" x2="235.0" y2="320.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="234.7,186.3 234.7,173.3 224.2,165.7" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="162.0,143.8 146.8,134.9 146.8,147.8" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="123.9,200.7 123.9,187.8 117.8,196.9" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
 <line x1="121.5" y1="322.1" x2="127.7" y2="324.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="133.7,205.7 123.9,110.2 123.9,213.6" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="123.9,200.7 117.8,196.9 117.8,209.8" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="162.0,143.8 162.0,130.9 146.8,134.9" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="210.7,146.9 210.7,134.0 195.1,130.5" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="241.4,208.2 241.4,195.3 234.7,186.3" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="234.7,173.3 224.2,152.7 224.2,165.7" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
 <line x1="152.1" y1="78.2" x2="152.1" y2="66.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="127.7" y1="324.1" x2="133.9" y2="326.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="287.4" x2="84.5" y2="276.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="178.5,194.0 178.5,90.6 162.0,92.1" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="224.2,152.7 210.7,134.0 210.7,146.9" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="117.8,222.8 117.8,209.8 116.0,219.6" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="195.1,130.5 178.5,116.5 178.5,129.4" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="241.4,195.3 234.7,173.3 234.7,186.3" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
 <line x1="228.2" y1="328.2" x2="231.6" y2="324.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="195.1,195.1 195.1,91.7 178.5,90.6" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="117.8,222.8 116.0,219.6 116.0,232.6" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="178.5,129.4 162.0,118.0 162.0,130.9" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="133.9" y1="326.1" x2="140.0" y2="328.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="241.4,221.1 234.7,108.7 234.7,212.1" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
-<polygon points="162.0,195.5 162.0,92.1 146.8,96.1" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="244.0,230.8 244.0,217.9 241.4,208.2" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="210.7,134.0 195.1,117.5 195.1,130.5" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="146.8,147.8 133.7,141.0 133.7,154.0" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="178.5,129.4 178.5,116.5 162.0,118.0" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="133.7,166.9 133.7,154.0 123.9,161.9" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="244.0,217.9 241.4,195.3 241.4,208.2" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="146.8,147.8 146.8,134.9 133.7,141.0" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
 <line x1="275.5" y1="186.3" x2="275.5" y2="174.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="210.7,198.6 210.7,95.2 195.1,91.7" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="195.1,130.5 195.1,117.5 178.5,116.5" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="133.7,166.9 123.9,161.9 123.9,174.8" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="140.0" y1="328.1" x2="146.2" y2="330.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="224.2,152.7 224.2,139.8 210.7,134.0" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="234.7,173.3 234.7,160.4 224.2,152.7" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="162.0,130.9 146.8,122.0 146.8,134.9" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="123.9,187.8 123.9,174.8 117.8,184.0" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
 <line x1="224.8" y1="331.8" x2="228.2" y2="328.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="123.9,187.8 117.8,184.0 117.8,196.9" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="162.0,130.9 162.0,118.0 146.8,122.0" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
 <line x1="146.2" y1="330.1" x2="152.4" y2="332.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="152.1" y1="66.9" x2="152.1" y2="55.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="276.1" x2="84.5" y2="264.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="123.9,213.6 117.8,119.4 117.8,222.8" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="210.7,134.0 210.7,121.1 195.1,117.5" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="242.2,240.6 244.0,217.9 244.0,230.8" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="241.4,195.3 241.4,182.3 234.7,173.3" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="234.7,160.4 224.2,139.8 224.2,152.7" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="224.2,139.8 210.7,121.1 210.7,134.0" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="117.8,209.8 117.8,196.9 116.0,206.7" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="195.1,117.5 178.5,103.5 178.5,116.5" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="241.4,182.3 234.7,160.4 234.7,173.3" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
 <line x1="152.4" y1="332.1" x2="158.6" y2="334.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="146.8,199.5 146.8,96.1 133.7,102.3" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="117.8,209.8 116.0,206.7 116.0,219.6" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="178.5,116.5 162.0,105.1 162.0,118.0" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="221.5" y1="335.5" x2="224.8" y2="331.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="224.2,204.4 224.2,101.1 210.7,95.2" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="244.0,217.9 244.0,205.0 241.4,195.3" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
 <line x1="275.5" y1="174.9" x2="275.5" y2="163.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="210.7,121.1 195.1,104.6 195.1,117.5" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="158.6" y1="334.1" x2="164.7" y2="336.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="146.8,134.9 133.7,128.1 133.7,141.0" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="178.5,116.5 178.5,103.5 162.0,105.1" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="133.7,154.0 133.7,141.0 123.9,149.0" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,232.6 116.0,219.6 118.6,229.4" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="244.0,205.0 241.4,182.3 241.4,195.3" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="146.8,134.9 146.8,122.0 133.7,128.1" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="195.1,117.5 195.1,104.6 178.5,103.5" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="133.7,154.0 123.9,149.0 123.9,161.9" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,232.6 118.6,229.4 118.6,242.3" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="224.2,139.8 224.2,126.9 210.7,121.1" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="234.7,160.4 234.7,147.5 224.2,139.8" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="162.0,118.0 146.8,109.0 146.8,122.0" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="123.9,174.8 123.9,161.9 117.8,171.1" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="242.2,240.6 242.2,227.7 244.0,217.9" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
 <line x1="164.7" y1="336.1" x2="170.9" y2="338.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="152.1" y1="55.5" x2="152.1" y2="44.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="218.1" y1="339.1" x2="221.5" y2="335.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="264.7" x2="84.5" y2="253.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="244.0,230.8 241.4,117.7 241.4,221.1" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="123.9,174.8 117.8,171.1 117.8,184.0" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="162.0,118.0 162.0,105.1 146.8,109.0" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="210.7,121.1 210.7,108.2 195.1,104.6" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="242.2,227.7 244.0,205.0 244.0,217.9" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="241.4,182.3 241.4,169.4 234.7,160.4" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="234.7,147.5 224.2,126.9 224.2,139.8" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
 <line x1="170.9" y1="338.1" x2="177.1" y2="340.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="133.7,205.7 133.7,102.3 123.9,110.2" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="224.2,126.9 210.7,108.2 210.7,121.1" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="117.8,196.9 117.8,184.0 116.0,193.8" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="195.1,104.6 178.5,90.6 178.5,103.5" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="241.4,169.4 234.7,147.5 234.7,160.4" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="117.8,196.9 116.0,193.8 116.0,206.7" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="178.5,103.5 162.0,92.1 162.0,105.1" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="275.5" y1="163.5" x2="275.5" y2="152.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="214.7" y1="342.7" x2="218.1" y2="339.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="244.0,205.0 244.0,192.1 241.4,182.3" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="236.1,249.8 242.2,227.7 242.2,240.6" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
 <line x1="177.1" y1="340.0" x2="183.3" y2="342.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="234.7,212.1 234.7,108.7 224.2,101.1" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
-<polygon points="117.8,222.8 116.0,129.2 116.0,232.6" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="210.7,108.2 195.1,91.7 195.1,104.6" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="146.8,122.0 133.7,115.2 133.7,128.1" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="178.5,103.5 178.5,90.6 162.0,92.1" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="133.7,141.0 133.7,128.1 123.9,136.1" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,219.6 116.0,206.7 118.6,216.4" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="244.0,192.1 241.4,169.4 241.4,182.3" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="146.8,122.0 146.8,109.0 133.7,115.2" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="195.1,104.6 195.1,91.7 178.5,90.6" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="133.7,141.0 123.9,136.1 123.9,149.0" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="183.3" y1="342.0" x2="189.4" y2="344.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="116.0,219.6 118.6,216.4 118.6,229.4" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
 <line x1="152.1" y1="44.1" x2="152.1" y2="32.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="224.2,126.9 224.2,114.0 210.7,108.2" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
 <line x1="84.5" y1="253.3" x2="84.5" y2="242.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="234.7,147.5 234.7,134.6 224.2,126.9" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="162.0,105.1 146.8,96.1 146.8,109.0" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="123.9,161.9 123.9,149.0 117.8,158.2" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="242.2,227.7 242.2,214.8 244.0,205.0" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="123.9,161.9 117.8,158.2 117.8,171.1" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="162.0,105.1 162.0,92.1 146.8,96.1" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
 <line x1="211.3" y1="346.4" x2="214.7" y2="342.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="118.6,242.3 118.6,229.4 125.3,238.4" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
 <line x1="189.4" y1="344.0" x2="195.6" y2="346.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="210.7,108.2 210.7,95.2 195.1,91.7" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="242.2,214.8 244.0,192.1 244.0,205.0" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="241.4,169.4 241.4,156.5 234.7,147.5" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="234.7,134.6 224.2,114.0 224.2,126.9" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="118.6,242.3 125.3,238.4 125.3,251.3" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="224.2,114.0 210.7,95.2 210.7,108.2" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="117.8,184.0 117.8,171.1 116.0,180.9" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="236.1,249.8 236.1,236.9 242.2,227.7" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="241.4,156.5 234.7,134.6 234.7,147.5" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
 <line x1="275.5" y1="152.2" x2="275.5" y2="140.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="195.6" y1="346.0" x2="201.8" y2="348.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="242.2,240.6 244.0,127.4 244.0,230.8" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="117.8,184.0 116.0,180.9 116.0,193.8" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="244.0,192.1 244.0,179.1 241.4,169.4" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="236.1,236.9 242.2,214.8 242.2,227.7" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
 <line x1="207.9" y1="350.0" x2="211.3" y2="346.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="123.9,213.6 123.9,110.2 117.8,119.4" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="146.8,109.0 133.7,102.3 133.7,115.2" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
 <line x1="201.8" y1="348.0" x2="207.9" y2="350.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="133.7,128.1 133.7,115.2 123.9,123.1" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,206.7 116.0,193.8 118.6,203.5" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="244.0,179.1 241.4,156.5 241.4,169.4" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="146.8,109.0 146.8,96.1 133.7,102.3" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
 <line x1="152.1" y1="32.7" x2="152.1" y2="21.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="133.7,128.1 123.9,123.1 123.9,136.1" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="84.5" y1="242.0" x2="84.5" y2="230.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="241.4,221.1 241.4,117.7 234.7,108.7" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
-<polygon points="116.0,232.6 118.6,138.9 118.6,242.3" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="226.3,257.7 236.1,236.9 236.1,249.8" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,206.7 118.6,203.5 118.6,216.4" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="224.2,114.0 224.2,101.1 210.7,95.2" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="234.7,134.6 234.7,121.6 224.2,114.0" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="123.9,149.0 123.9,136.1 117.8,145.2" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="242.2,214.8 242.2,201.8 244.0,192.1" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="123.9,149.0 117.8,145.2 117.8,158.2" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="118.6,229.4 118.6,216.4 125.3,225.4" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="242.2,201.8 244.0,179.1 244.0,192.1" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="241.4,156.5 241.4,143.6 234.7,134.6" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="234.7,121.6 224.2,101.1 224.2,114.0" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="118.6,229.4 125.3,225.4 125.3,238.4" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
 <line x1="275.5" y1="140.8" x2="275.5" y2="129.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="207.9" y1="350.0" x2="207.9" y2="338.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="117.8,171.1 117.8,158.2 116.0,167.9" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="236.1,236.9 236.1,223.9 242.2,214.8" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="125.3,251.3 125.3,238.4 135.8,246.0" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="241.4,143.6 234.7,121.6 234.7,134.6" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="125.3,251.3 135.8,246.0 135.8,258.9" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="117.8,171.1 116.0,167.9 116.0,180.9" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="244.0,179.1 244.0,166.2 241.4,156.5" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="226.3,257.7 226.3,244.8 236.1,236.9" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="236.1,223.9 242.2,201.8 242.2,214.8" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
 <line x1="152.1" y1="21.4" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="230.6" x2="84.5" y2="219.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="236.1,249.8 242.2,137.2 242.2,240.6" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
-<polygon points="117.8,222.8 117.8,119.4 116.0,129.2" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="133.7,115.2 133.7,102.3 123.9,110.2" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,193.8 116.0,180.9 118.6,190.6" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="244.0,166.2 241.4,143.6 241.4,156.5" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="133.7,115.2 123.9,110.2 123.9,123.1" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="226.3,244.8 236.1,223.9 236.1,236.9" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,193.8 118.6,190.6 118.6,203.5" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="213.2,263.9 226.3,244.8 226.3,257.7" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="234.7,121.6 234.7,108.7 224.2,101.1" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="123.9,136.1 123.9,123.1 117.8,132.3" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="242.2,201.8 242.2,188.9 244.0,179.1" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="123.9,136.1 117.8,132.3 117.8,145.2" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="118.6,216.4 118.6,203.5 125.3,212.5" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="242.2,188.9 244.0,166.2 244.0,179.1" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
 <line x1="275.5" y1="129.4" x2="275.5" y2="118.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="241.4,143.6 241.4,130.6 234.7,121.6" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
 <line x1="207.9" y1="338.6" x2="207.9" y2="327.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="244.0,230.8 244.0,127.4 241.4,117.7" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="118.6,216.4 125.3,212.5 125.3,225.4" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
 <line x1="152.1" y1="10.0" x2="158.2" y2="12.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="117.8,158.2 117.8,145.2 116.0,155.0" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="236.1,223.9 236.1,211.0 242.2,201.8" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="135.8,258.9 149.3,251.8 149.3,264.8" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
 <line x1="148.7" y1="13.6" x2="152.1" y2="10.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="125.3,238.4 125.3,225.4 135.8,233.1" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="135.8,258.9 135.8,246.0 149.3,251.8" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="241.4,130.6 234.7,108.7 234.7,121.6" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="125.3,238.4 135.8,233.1 135.8,246.0" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="117.8,158.2 116.0,155.0 116.0,167.9" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
 <line x1="158.2" y1="12.0" x2="164.4" y2="14.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="213.2,263.9 213.2,251.0 226.3,244.8" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="244.0,166.2 244.0,153.3 241.4,143.6" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="226.3,244.8 226.3,231.9 236.1,223.9" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="84.5" y1="219.2" x2="84.5" y2="207.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="118.6,242.3 125.3,147.9 125.3,251.3" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="236.1,211.0 242.2,188.9 242.2,201.8" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="198.0,267.9 213.2,251.0 213.2,263.9" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="116.0,180.9 116.0,167.9 118.6,177.7" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="244.0,153.3 241.4,130.6 241.4,143.6" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
 <line x1="164.4" y1="14.0" x2="170.6" y2="16.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="226.3,231.9 236.1,211.0 236.1,223.9" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,180.9 118.6,177.7 118.6,190.6" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
 <line x1="145.3" y1="17.3" x2="148.7" y2="13.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="213.2,251.0 226.3,231.9 226.3,244.8" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="123.9,123.1 123.9,110.2 117.8,119.4" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="242.2,188.9 242.2,176.0 244.0,166.2" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="149.3,264.8 164.9,255.4 164.9,268.3" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="275.5" y1="118.0" x2="275.5" y2="106.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="123.9,123.1 117.8,119.4 117.8,132.3" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
 <line x1="207.9" y1="327.3" x2="207.9" y2="315.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="170.6" y1="16.0" x2="176.7" y2="18.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="226.3,257.7 236.1,146.4 236.1,249.8" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="118.6,203.5 118.6,190.6 125.3,199.6" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="149.3,264.8 149.3,251.8 164.9,255.4" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="181.5,269.4 198.0,254.9 198.0,267.9" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="242.2,176.0 244.0,153.3 244.0,166.2" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="241.4,130.6 241.4,117.7 234.7,108.7" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="198.0,267.9 198.0,254.9 213.2,251.0" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="118.6,203.5 125.3,199.6 125.3,212.5" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="164.9,268.3 181.5,256.5 181.5,269.4" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="117.8,145.2 117.8,132.3 116.0,142.1" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="236.1,211.0 236.1,198.1 242.2,188.9" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="135.8,246.0 149.3,238.9 149.3,251.8" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,225.4 125.3,212.5 135.8,220.2" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
 <line x1="176.7" y1="18.0" x2="182.9" y2="20.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="116.0,232.6 116.0,129.2 118.6,138.9" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="135.8,246.0 135.8,233.1 149.3,238.9" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,225.4 135.8,220.2 135.8,233.1" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
 <line x1="141.9" y1="20.9" x2="145.3" y2="17.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="207.8" x2="84.5" y2="196.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="242.2,240.6 242.2,137.2 244.0,127.4" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="117.8,145.2 116.0,142.1 116.0,155.0" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="164.9,268.3 164.9,255.4 181.5,256.5" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="213.2,251.0 213.2,238.0 226.3,231.9" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="244.0,153.3 244.0,140.4 241.4,130.6" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="226.3,231.9 226.3,219.0 236.1,211.0" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="236.1,198.1 242.2,176.0 242.2,188.9" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="181.5,269.4 181.5,256.5 198.0,254.9" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="182.9" y1="20.0" x2="189.1" y2="21.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="125.3,251.3 135.8,155.6 135.8,258.9" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="198.0,254.9 213.2,238.0 213.2,251.0" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="116.0,167.9 116.0,155.0 118.6,164.7" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="244.0,140.4 241.4,117.7 241.4,130.6" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="226.3,219.0 236.1,198.1 236.1,211.0" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,167.9 118.6,164.7 118.6,177.7" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="213.2,238.0 226.3,219.0 226.3,231.9" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
 <line x1="275.5" y1="106.7" x2="275.5" y2="95.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="138.5" y1="24.5" x2="141.9" y2="20.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="207.9" y1="315.9" x2="207.9" y2="304.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="242.2,176.0 242.2,163.1 244.0,153.3" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="149.3,251.8 164.9,242.5 164.9,255.4" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="189.1" y1="21.9" x2="195.3" y2="23.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="213.2,263.9 226.3,154.3 226.3,257.7" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="118.6,190.6 118.6,177.7 125.3,186.7" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="149.3,251.8 149.3,238.9 164.9,242.5" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="181.5,256.5 198.0,242.0 198.0,254.9" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="242.2,163.1 244.0,140.4 244.0,153.3" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="198.0,254.9 198.0,242.0 213.2,238.0" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="118.6,190.6 125.3,186.7 125.3,199.6" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="164.9,255.4 181.5,243.5 181.5,256.5" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
 <line x1="195.3" y1="23.9" x2="201.4" y2="25.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="196.5" x2="84.5" y2="185.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="117.8,132.3 117.8,119.4 116.0,129.2" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="236.1,198.1 236.1,185.2 242.2,176.0" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="135.8,233.1 149.3,226.0 149.3,238.9" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,212.5 125.3,199.6 135.8,207.3" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="135.8,233.1 135.8,220.2 149.3,226.0" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,212.5 135.8,207.3 135.8,220.2" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="117.8,132.3 116.0,129.2 116.0,142.1" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
 <line x1="135.2" y1="28.2" x2="138.5" y2="24.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="164.9,255.4 164.9,242.5 181.5,243.5" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="213.2,238.0 213.2,225.1 226.3,219.0" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="244.0,140.4 244.0,127.4 241.4,117.7" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="226.3,219.0 226.3,206.0 236.1,198.1" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="201.4" y1="25.9" x2="207.6" y2="27.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="135.8,258.9 149.3,161.4 149.3,264.8" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
-<polygon points="118.6,242.3 118.6,138.9 125.3,147.9" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="236.1,185.2 242.2,163.1 242.2,176.0" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="181.5,256.5 181.5,243.5 198.0,242.0" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="198.0,242.0 213.2,225.1 213.2,238.0" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="116.0,155.0 116.0,142.1 118.6,151.8" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
 <line x1="275.5" y1="95.3" x2="275.5" y2="83.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="207.9" y1="304.5" x2="207.9" y2="293.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="226.3,206.0 236.1,185.2 236.1,198.1" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="207.6" y1="27.9" x2="213.8" y2="29.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="116.0,155.0 118.6,151.8 118.6,164.7" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="213.2,225.1 226.3,206.0 226.3,219.0" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="242.2,163.1 242.2,150.2 244.0,140.4" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="149.3,238.9 164.9,229.5 164.9,242.5" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="131.8" y1="31.8" x2="135.2" y2="28.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="236.1,249.8 236.1,146.4 242.2,137.2" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
-<polygon points="198.0,267.9 213.2,160.5 213.2,263.9" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="118.6,177.7 118.6,164.7 125.3,173.7" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
 <line x1="213.8" y1="29.9" x2="220.0" y2="31.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="149.3,238.9 149.3,226.0 164.9,229.5" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="181.5,243.5 198.0,229.1 198.0,242.0" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="242.2,150.2 244.0,127.4 244.0,140.4" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
 <line x1="84.5" y1="185.1" x2="84.5" y2="173.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="149.3,264.8 164.9,164.9 164.9,268.3" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="198.0,242.0 198.0,229.1 213.2,225.1" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="118.6,177.7 125.3,173.7 125.3,186.7" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="164.9,242.5 181.5,230.6 181.5,243.5" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="236.1,185.2 236.1,172.2 242.2,163.1" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="135.8,220.2 149.3,213.1 149.3,226.0" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,199.6 125.3,186.7 135.8,194.3" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="135.8,220.2 135.8,207.3 149.3,213.1" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,199.6 135.8,194.3 135.8,207.3" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
 <line x1="220.0" y1="31.9" x2="226.1" y2="33.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="181.5,269.4 198.0,164.5 198.0,267.9" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="164.9,242.5 164.9,229.5 181.5,230.6" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
 <line x1="128.4" y1="35.5" x2="131.8" y2="31.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="164.9,268.3 181.5,166.0 181.5,269.4" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="213.2,225.1 213.2,212.2 226.3,206.0" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="226.3,206.0 226.3,193.1 236.1,185.2" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="236.1,172.2 242.2,150.2 242.2,163.1" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="181.5,243.5 181.5,230.6 198.0,229.1" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="275.5" y1="83.9" x2="275.5" y2="72.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="198.0,229.1 213.2,212.2 213.2,225.1" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
 <line x1="226.1" y1="33.9" x2="232.3" y2="35.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="207.9" y1="293.1" x2="207.9" y2="281.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="116.0,142.1 116.0,129.2 118.6,138.9" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="226.3,193.1 236.1,172.2 236.1,185.2" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="116.0,142.1 118.6,138.9 118.6,151.8" fill="rgb(34,46,65)" stroke="rgb(34,46,65)" stroke-width="0.5"/>
+<polygon points="213.2,212.2 226.3,193.1 226.3,206.0" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="242.2,150.2 242.2,137.2 244.0,127.4" fill="rgb(44,60,84)" stroke="rgb(44,60,84)" stroke-width="0.5"/>
+<polygon points="149.3,226.0 164.9,216.6 164.9,229.5" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="232.3" y1="35.9" x2="238.5" y2="37.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="125.3,251.3 125.3,147.9 135.8,155.6" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
 <line x1="125.0" y1="39.1" x2="128.4" y2="35.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="173.7" x2="84.5" y2="162.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="226.3,257.7 226.3,154.3 236.1,146.4" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="118.6,164.7 118.6,151.8 125.3,160.8" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="149.3,226.0 149.3,213.1 164.9,216.6" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="181.5,230.6 198.0,216.2 198.0,229.1" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="198.0,229.1 198.0,216.2 213.2,212.2" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="118.6,164.7 125.3,160.8 125.3,173.7" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="164.9,229.5 181.5,217.7 181.5,230.6" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
 <line x1="238.5" y1="37.9" x2="244.7" y2="39.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="236.1,172.2 236.1,159.3 242.2,150.2" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="135.8,207.3 149.3,200.1 149.3,213.1" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,186.7 125.3,173.7 135.8,181.4" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="135.8,207.3 135.8,194.3 149.3,200.1" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,186.7 135.8,181.4 135.8,194.3" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="164.9,229.5 164.9,216.6 181.5,217.7" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="213.2,212.2 213.2,199.3 226.3,193.1" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="226.3,193.1 226.3,180.2 236.1,172.2" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="236.1,159.3 242.2,137.2 242.2,150.2" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="181.5,230.6 181.5,217.7 198.0,216.2" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="275.5" y1="72.6" x2="275.5" y2="61.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="244.7" y1="39.9" x2="250.8" y2="41.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="121.6" y1="42.7" x2="125.0" y2="39.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="207.9" y1="281.8" x2="207.9" y2="270.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="198.0,216.2 213.2,199.3 213.2,212.2" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="226.3,180.2 236.1,159.3 236.1,172.2" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="250.8" y1="41.8" x2="257.0" y2="43.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="213.2,199.3 226.3,180.2 226.3,193.1" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
 <line x1="84.5" y1="162.3" x2="84.5" y2="151.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="135.8,258.9 135.8,155.6 149.3,161.4" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="149.3,213.1 164.9,203.7 164.9,216.6" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="118.3" y1="46.4" x2="121.6" y2="42.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="118.6,151.8 118.6,138.9 125.3,147.9" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="149.3,213.1 149.3,200.1 164.9,203.7" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="181.5,217.7 198.0,203.3 198.0,216.2" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="257.0" y1="43.8" x2="263.2" y2="45.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="213.2,263.9 213.2,160.5 226.3,154.3" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="198.0,216.2 198.0,203.3 213.2,199.3" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="118.6,151.8 125.3,147.9 125.3,160.8" fill="rgb(42,58,81)" stroke="rgb(42,58,81)" stroke-width="0.5"/>
+<polygon points="164.9,216.6 181.5,204.8 181.5,217.7" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="236.1,159.3 236.1,146.4 242.2,137.2" fill="rgb(53,73,103)" stroke="rgb(53,73,103)" stroke-width="0.5"/>
+<polygon points="135.8,194.3 149.3,187.2 149.3,200.1" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,173.7 125.3,160.8 135.8,168.5" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="135.8,194.3 135.8,181.4 149.3,187.2" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,173.7 135.8,168.5 135.8,181.4" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
 <line x1="275.5" y1="61.2" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="263.2" y1="45.8" x2="269.3" y2="47.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="207.9" y1="270.4" x2="207.9" y2="259.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="164.9,216.6 164.9,203.7 181.5,204.8" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="213.2,199.3 213.2,186.4 226.3,180.2" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="226.3,180.2 226.3,167.3 236.1,159.3" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="181.5,217.7 181.5,204.8 198.0,203.3" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="114.9" y1="50.0" x2="118.3" y2="46.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="198.0,203.3 213.2,186.4 213.2,199.3" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
 <line x1="269.3" y1="47.8" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="149.3,264.8 149.3,161.4 164.9,164.9" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="226.3,167.3 236.1,146.4 236.1,159.3" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
 <line x1="84.5" y1="151.0" x2="84.5" y2="139.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="198.0,267.9 198.0,164.5 213.2,160.5" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="213.2,186.4 226.3,167.3 226.3,180.2" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="149.3,200.1 164.9,190.8 164.9,203.7" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="149.3,200.1 149.3,187.2 164.9,190.8" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="272.1" y1="53.4" x2="275.5" y2="49.8" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="181.5,204.8 198.0,190.3 198.0,203.3" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="111.5" y1="53.6" x2="114.9" y2="50.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
-<polygon points="164.9,268.3 164.9,164.9 181.5,166.0" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
-<polygon points="181.5,269.4 181.5,166.0 198.0,164.5" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="198.0,203.3 198.0,190.3 213.2,186.4" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="164.9,203.7 181.5,191.8 181.5,204.8" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="135.8,181.4 149.3,174.3 149.3,187.2" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
 <line x1="207.9" y1="259.0" x2="207.9" y2="247.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="125.3,160.8 125.3,147.9 135.8,155.6" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="135.8,181.4 135.8,168.5 149.3,174.3" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="125.3,160.8 135.8,155.6 135.8,168.5" fill="rgb(52,71,100)" stroke="rgb(52,71,100)" stroke-width="0.5"/>
+<polygon points="164.9,203.7 164.9,190.8 181.5,191.8" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="213.2,186.4 213.2,173.4 226.3,167.3" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="226.3,167.3 226.3,154.3 236.1,146.4" fill="rgb(61,84,118)" stroke="rgb(61,84,118)" stroke-width="0.5"/>
+<polygon points="181.5,204.8 181.5,191.8 198.0,190.3" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="268.8" y1="57.1" x2="272.1" y2="53.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="198.0,190.3 213.2,173.4 213.2,186.4" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
 <line x1="108.1" y1="57.3" x2="111.5" y2="53.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="139.6" x2="84.5" y2="128.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="213.2,173.4 226.3,154.3 226.3,167.3" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="149.3,187.2 164.9,177.8 164.9,190.8" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="149.3,187.2 149.3,174.3 164.9,177.8" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="181.5,191.8 198.0,177.4 198.0,190.3" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="265.4" y1="60.7" x2="268.8" y2="57.1" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="198.0,190.3 198.0,177.4 213.2,173.4" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
 <line x1="207.9" y1="247.6" x2="207.9" y2="236.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="104.8" y1="60.9" x2="108.1" y2="57.3" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="164.9,190.8 181.5,178.9 181.5,191.8" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="135.8,168.5 149.3,161.4 149.3,174.3" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="135.8,168.5 135.8,155.6 149.3,161.4" fill="rgb(60,83,116)" stroke="rgb(60,83,116)" stroke-width="0.5"/>
+<polygon points="164.9,190.8 164.9,177.8 181.5,178.9" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="213.2,173.4 213.2,160.5 226.3,154.3" fill="rgb(67,92,130)" stroke="rgb(67,92,130)" stroke-width="0.5"/>
+<polygon points="181.5,191.8 181.5,178.9 198.0,177.4" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="84.5" y1="128.2" x2="84.5" y2="116.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="198.0,177.4 213.2,160.5 213.2,173.4" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
 <line x1="262.0" y1="64.4" x2="265.4" y2="60.7" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="101.4" y1="64.6" x2="104.8" y2="60.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="149.3,174.3 164.9,164.9 164.9,177.8" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
 <line x1="207.9" y1="236.3" x2="207.9" y2="224.9" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="149.3,174.3 149.3,161.4 164.9,164.9" fill="rgb(67,91,128)" stroke="rgb(67,91,128)" stroke-width="0.5"/>
+<polygon points="181.5,178.9 198.0,164.5 198.0,177.4" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
+<polygon points="198.0,177.4 198.0,164.5 213.2,160.5" fill="rgb(71,98,137)" stroke="rgb(71,98,137)" stroke-width="0.5"/>
+<polygon points="164.9,177.8 181.5,166.0 181.5,178.9" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
 <line x1="258.6" y1="68.0" x2="262.0" y2="64.4" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="98.0" y1="68.2" x2="101.4" y2="64.6" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="84.5" y1="116.9" x2="84.5" y2="105.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
+<polygon points="164.9,177.8 164.9,164.9 181.5,166.0" fill="rgb(71,97,136)" stroke="rgb(71,97,136)" stroke-width="0.5"/>
+<polygon points="181.5,178.9 181.5,166.0 198.0,164.5" fill="rgb(72,99,139)" stroke="rgb(72,99,139)" stroke-width="0.5"/>
 <line x1="255.2" y1="71.6" x2="258.6" y2="68.0" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="94.6" y1="71.8" x2="98.0" y2="68.2" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>
 <line x1="207.9" y1="224.9" x2="207.9" y2="213.5" stroke="rgb(102,102,102)" stroke-width="0.5" stroke-linecap="round" opacity="0.4"/>


### PR DESCRIPTION
## Summary

- Found via the recurring "check a random Demonstration in Woxi Studio" task: a Demonstration puts several `Cylinder` fan blades inside a wide, open-ended `Tube` housing, and pieces of the blades showed through the housing wall.
- Root cause: `tessellate_tube`/`tessellate_cylinder` tessellated a straight run into one quad strip spanning its whole length, so the painter's algorithm's per-triangle centroid depth averaged a face's near and far ends together. A smaller object poking through only the far half of such a face could then sort as if it were in front of the whole face.
- Fix: subdivide a straight `Tube`/`Cylinder` run lengthwise so no single tessellated face is more elongated than it is wide (`side_subdivision_steps`), which only kicks in once a run is many facet-widths long. This is a general improvement to the `Graphics3D` renderer, not specific to one scene.
- One pre-existing snapshot (`graphics3d_cylinder`) changed because the default test cylinder now tessellates into more (still smooth, visually identical) faces; reviewed and accepted.

## Test plan

- [x] Added `graphics3d_painters_algorithm_face_subdivision` module in `tests/interpreter_tests/graphics.rs` with:
  - `long_tube_segment_subdivides_its_length` / `long_cylinder_segment_subdivides_its_length`: a long straight run must tessellate into many more faces than a short one.
  - `blades_inside_a_wide_tube_get_a_finely_subdivided_housing`: end-to-end regression reproducing the bug shape (rewritten from scratch, not copied from the Demonstration, per repo policy).
- [x] Verified visually (rendered SVG → PNG) that the artifact is present on the pre-fix code and gone after the fix, both on the original downloaded Demonstration notebook and on the minimal synthetic repro.
- [x] `make test` — 27260 passed, 0 failed.
- [x] `make test-studio` — 163 passed, 0 failed.
- [x] `make format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015zppQff2NLZUG24Phkor4e)_