### PR TITLE
Give `;;` a slot in the operator precedence table (#564)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,17 @@
 
 # Unreleased
 
+- `;;` no longer swallows the operators that bind looser than it. `Span` has
+    Wolfram precedence 305, so `=`, `:=`, `==`, `&&`, `||`, `|`, `~~` and
+    `/;` are the *outer* expression: `x = 1 ;; 3` stores `Span[1, 3]` in `x`
+    (it used to store `1`, the assignment happening inside the span), and
+    `a == 1 ;; 3` is `Equal[a, Span[1, 3]]` rather than `Span[a == 1, 3]`.
+    Operators above `;;` are unchanged — `1 ;; 2 + 3` is still `Span[1, 5]`.
+- An omitted span operand is allowed on the right of an operator:
+    `x = ;; 3` is `Set[x, Span[1, 3]]`, which used to be a parse error.
+- A line ending in `;;` is a statement of its own. The statement splitter read
+    any trailing `;` as a separator that was already there, so `x = 3;;`
+    ran into the next line and swallowed it as the span's end.
 - `;;` binds tighter than `->` and `:>`, so a `Span` can stand on either side
     of a rule: `StringExtract["a--bbb--ccc", "--" -> 3 ;;]` and
     `1 ;; 2 -> b` used to fail with a parse error or, where they did parse,

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -8675,7 +8675,7 @@ fn to_expression_syntax_error(src: &str, symbol: &str) -> Option<String> {
 }
 
 /// Parse `src` as a Wolfram program and evaluate every top-level
-/// Expression/TopLevelSpan statement in order, returning the last result.
+/// Expression statement in order, returning the last result.
 /// Falls back to `string_to_expr` + evaluate for inputs the parser treats as
 /// a single expression.
 fn parse_and_evaluate_program(src: &str) -> Result<Expr, InterpreterError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2053,7 +2053,7 @@ pub fn interpret(input: &str) -> Result<String, InterpreterError> {
   for node in program.into_inner() {
     let line = node.as_span().start_pos().line_col().0;
     match node.as_rule() {
-      Rule::Expression | Rule::TopLevelSpan => {
+      Rule::Expression => {
         let expr = syntax::pair_to_expr(node);
         expr_asts.push(expr.clone());
         stmts.push(ProgramStmt::Expr(expr));
@@ -4475,6 +4475,15 @@ fn expand_char_escapes(input: &str) -> String {
   result
 }
 
+/// Does the code on this line end in a `;;` (a complete `Span`) rather than
+/// in a statement separator? Both are spelled with `;`, so the trailing run
+/// decides: an even run is `;;` (or `;;;;`) and the line still needs a
+/// separator after it, an odd one ends in a `;` that already separates.
+fn ends_with_span_separator(code_tail: &str) -> bool {
+  let semicolons = code_tail.chars().rev().take_while(|c| *c == ';').count();
+  semicolons > 0 && semicolons % 2 == 0
+}
+
 /// Append a code character to a line's rolling tail, keeping the tail bounded.
 /// Whitespace is skipped, so `f[x] \[Star]` ends in `\[Star]` either way.
 fn push_code_tail(tail: &mut String, ch: char) {
@@ -4658,7 +4667,8 @@ pub fn insert_statement_separators(input: &str) -> String {
           )
         );
       let needs_semi = line_has_code
-        && last_code_char != Some(';')
+        && (last_code_char != Some(';')
+          || ends_with_span_separator(&code_tail))
         && !ends_with_set_delayed
         && !ends_with_tag_set
         && !ends_with_operator
@@ -5085,7 +5095,6 @@ pub(crate) fn is_statement_rule(rule: Rule) -> bool {
   matches!(
     rule,
     Rule::Expression
-      | Rule::TopLevelSpan
       | Rule::FunctionDefinition
       | Rule::TagSetDelayed
       | Rule::TagSet

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2943,53 +2943,6 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
       // But if encountered standalone, treat as a sentinel
       Expr::Integer(0) // Should not be reached
     }
-    Rule::SpanExpr => {
-      // SpanExpr: Expression? ~ SpanSep ~ Expression? ~ (SpanSep ~ Expression?)?
-      // SpanSep tokens act as position markers to distinguish ;;b from b;;
-      // Produces Span[start, end] or Span[start, end, step]
-      // Defaults: start=1, end=All
-      let one = Expr::Integer(1);
-      let all = Expr::Identifier("All".to_string());
-
-      // Collect children as slots separated by SpanSep markers
-      // slots[0] = before first ;;, slots[1] = between ;; and ;;, slots[2] = after second ;;
-      let mut slots: Vec<Option<Expr>> = vec![None];
-      for child in pair.into_inner() {
-        if child.as_rule() == Rule::SpanSep {
-          slots.push(None);
-        } else {
-          let last = slots.last_mut().unwrap();
-          *last = Some(pair_to_expr(child));
-        }
-      }
-
-      let start = slots
-        .first()
-        .and_then(std::clone::Clone::clone)
-        .unwrap_or(one);
-      let end = slots
-        .get(1)
-        .and_then(std::clone::Clone::clone)
-        .unwrap_or(all);
-
-      if slots.len() >= 3 {
-        // 3-part Span: a;;b;;c
-        let step = slots
-          .get(2)
-          .and_then(std::clone::Clone::clone)
-          .unwrap_or_else(|| Expr::Integer(1));
-        Expr::FunctionCall {
-          name: "Span".to_string(),
-          args: vec![start, end, step].into(),
-        }
-      } else {
-        // 2-part Span: a;;b
-        Expr::FunctionCall {
-          name: "Span".to_string(),
-          args: vec![start, end].into(),
-        }
-      }
-    }
     Rule::CompoundExpression => parse_compound_expression(&pair),
     Rule::AssociationExtended => parse_association_extended(pair),
     Rule::Association => parse_association(pair),
@@ -3773,30 +3726,6 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
       }
       result
     }
-    Rule::TopLevelSpan => {
-      // Wrap the inner SpanExpr, then apply any trailing `// f` postfix
-      // applications left-to-right using the same Expr::Postfix node the
-      // main PostfixApplication rule produces.
-      //
-      // The inner SpanExpr's trailing Expression may itself have consumed
-      // `// f` applications — e.g. `a;;b;;c // f` parses as
-      // `Span[a, b, c // f]` because Expression's `//` postfix is greedy.
-      // Wolfram semantics bind `//` looser than `;;`, so hoist any
-      // postfix chain on the last Span arg up to the outer level.
-      let mut inner = pair.into_inner();
-      let mut expr = pair_to_expr(inner.next().unwrap());
-      expr = hoist_last_arg_postfix(expr);
-      for child in inner {
-        if child.as_rule() == Rule::PostfixFunction {
-          let func = parse_postfix_function(child);
-          expr = Expr::Postfix {
-            expr: Box::new(expr),
-            func: Box::new(func),
-          };
-        }
-      }
-      expr
-    }
     Rule::PostfixBase => {
       let inner = pair.into_inner().next().unwrap();
       pair_to_expr(inner)
@@ -3828,36 +3757,6 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
       Expr::Raw(pair.as_str().to_string())
     }
   }
-}
-
-/// For a `Span[args…]` whose last arg is `Expr::Postfix { expr, func }`,
-/// walk the trailing Postfix chain outward: the Span keeps only the base
-/// expression, and each Postfix wraps the whole Span.
-/// This makes `a;;b // f` parse as `f[Span[a, b]]`, matching wolframscript's
-/// precedence where `//` binds looser than `;;`.
-fn hoist_last_arg_postfix(expr: Expr) -> Expr {
-  let (name, args) = match &expr {
-    Expr::FunctionCall { name, args } if name == "Span" && !args.is_empty() => {
-      (name.clone(), args.clone())
-    }
-    _ => return expr,
-  };
-  let mut args = args;
-  let mut postfix_chain: Vec<Expr> = Vec::new();
-  let last_idx = args.len() - 1;
-  while let Expr::Postfix { expr: inner, func } = &args[last_idx] {
-    postfix_chain.push((**func).clone());
-    let new_last = (**inner).clone();
-    args[last_idx] = new_last;
-  }
-  let mut result = Expr::FunctionCall { name, args };
-  for func in postfix_chain.into_iter().rev() {
-    result = Expr::Postfix {
-      expr: Box::new(result),
-      func: Box::new(func),
-    };
-  }
-  result
 }
 
 /// Parse a PostfixFunction pair into an Expr, wrapping in Function if & is present.
@@ -4504,8 +4403,13 @@ fn parse_expression(pair: Pair<Rule>) -> Expr {
   // Popped from the end, so restore left-to-right application order.
   replace_rules.reverse();
 
-  // Single term case (no operators, no replace, no post-& continuation)
-  if inner.len() == 1 && replace_rules.is_empty() && post_anon_pairs.is_empty()
+  // Single term case (no operators, no replace, no post-& continuation).
+  // A lone `;;` is not a term — it is `Span[1, All]`, built from the two
+  // omitted operands by `parse_expression_inner`.
+  if inner.len() == 1
+    && inner[0].as_rule() != Rule::SpanNoOperandSep
+    && replace_rules.is_empty()
+    && post_anon_pairs.is_empty()
   {
     let mut result = pair_to_expr(inner.remove(0));
     for func_pair in postfix_funcs {
@@ -4623,6 +4527,33 @@ fn parse_expression_inner(
         );
         operators.push("=.".to_string());
         terms.push(Expr::Identifier("Null".to_string())); // dummy right operand
+        term_was_implicit_times.push(false);
+      }
+      Rule::SpanNoOperandSep => {
+        // `;;` on its own (`f[;;]`, `;; ;; 2`) — neither operand written.
+        terms.push(Expr::Identifier(SPAN_OMITTED.to_string()));
+        term_was_implicit_times.push(false);
+        operators.push(";;".to_string());
+        terms.push(Expr::Identifier(SPAN_OMITTED.to_string()));
+        term_was_implicit_times.push(false);
+      }
+      Rule::SpanNoLhsSep => {
+        // `;; 3` — a `;;` the chain has no left operand for. Stand the
+        // omitted one in explicitly; `build_span` turns it into the `1`
+        // default.
+        terms.push(Expr::Identifier(SPAN_OMITTED.to_string()));
+        term_was_implicit_times.push(false);
+        operators.push(";;".to_string());
+      }
+      Rule::SpanNoRhsSep => {
+        // `3 ;;`, and the gap in `1 ;;;; 3` — a `;;` with no right operand.
+        flush_pending_not(
+          &mut pending_not_on_last,
+          &mut terms,
+          &mut term_was_implicit_times,
+        );
+        operators.push(";;".to_string());
+        terms.push(Expr::Identifier(SPAN_OMITTED.to_string()));
         term_was_implicit_times.push(false);
       }
       Rule::TildeInfix => {
@@ -5738,6 +5669,11 @@ fn operator_precedence(op: &str) -> u8 {
     | "\\[NotEqual]" | "<" | "<=" | "\u{2264}" | "\u{2A7D}"
     | "\\[LessEqual]" | ">" | ">=" | "\u{2265}" | "\u{2A7E}"
     | "\\[GreaterEqual]" | "===" | "=!=" => 21, // Comparisons
+    // `;;` (Span, Wolfram precedence 305) sits just below `+` (310) and
+    // above every operator Wolfram places under it — `|` (160), `~~` (135),
+    // the comparisons, `&&`, `||`, `->`, `/;` and the assignments. Without a
+    // slot here those operators end up *inside* the Span (issue #564).
+    ";;" => 29,
     "~~" => 24, // StringExpression (lower than Alternatives)
     // Pattern/Optional `:` sits between StringExpression and Alternatives,
     // as in Wolfram (135 < 150 < 160): `x : a | b : v` is
@@ -5780,6 +5716,55 @@ fn operator_precedence(op: &str) -> u8 {
   }
 }
 
+/// Placeholder term for a `Span` operand the source left out — the `1` of
+/// `1 ;; 3` when it is written `;; 3`, or the `3` when it is written `1 ;;`.
+/// Which value fills the gap depends on the slot it sits in, so the omission
+/// has to survive precedence climbing and is resolved by [`build_span`]. The
+/// leading control character keeps the marker distinct from every symbol a
+/// program could spell.
+const SPAN_OMITTED: &str = "\u{1}SpanOmitted";
+
+/// Is this term an omitted `Span` operand?
+fn is_span_omitted(expr: &Expr) -> bool {
+  matches!(expr, Expr::Identifier(name) if name == SPAN_OMITTED)
+}
+
+/// The stand-in for an omitted `Span` operand that never reached
+/// [`build_span`]; see the `;;` arm of [`make_binary_op`].
+fn span_omitted_fallback(expr: &Expr) -> Expr {
+  if is_span_omitted(expr) {
+    Expr::Integer(1)
+  } else {
+    expr.clone()
+  }
+}
+
+/// Assemble `Span[…]` from the operands of one `;;` chain, filling in the
+/// default for every operand the source left out: `1` for the start, `All`
+/// for the end and `1` for the step — `;;3` is `Span[1, 3]`, `3;;` is
+/// `Span[3, All]` and `1;;;;3` is `Span[1, All, 3]`.
+fn build_span(parts: Vec<Expr>) -> Expr {
+  let args: Vec<Expr> = parts
+    .into_iter()
+    .enumerate()
+    .map(|(slot, part)| {
+      if is_span_omitted(&part) {
+        if slot == 1 {
+          Expr::Identifier("All".to_string())
+        } else {
+          Expr::Integer(1)
+        }
+      } else {
+        part
+      }
+    })
+    .collect();
+  Expr::FunctionCall {
+    name: "Span".to_string(),
+    args: args.into(),
+  }
+}
+
 /// Build a binary operation tree from terms and operators with correct precedence
 fn build_binary_tree(terms: Vec<Expr>, operators: &[String]) -> Expr {
   if terms.len() == 1 {
@@ -5817,6 +5802,40 @@ fn build_expr_with_precedence(
 
     if prec < min_prec {
       break;
+    }
+
+    // `;;` groups n-ary: `1 ;; 2 ;; 3` is one `Span[1, 2, 3]`, never
+    // `Span[Span[1, 2], 3]`. The whole run of `;;` operators at this level is
+    // taken at once, which keeps a Span that came from parentheses nested —
+    // `(1 ;; 2) ;; 3` has only one `;;` here, the other one is inside a term.
+    if op_str == ";;" {
+      // Left-associative, like every other operator without its own case.
+      let next_min_prec = prec + 1;
+      let mut parts = vec![result];
+      loop {
+        parts.push(build_expr_with_precedence(
+          terms,
+          operators,
+          op_idx + 1,
+          next_min_prec,
+        ));
+        // Skip past the terms the right operand consumed, as below.
+        let mut right_terms = 1;
+        let mut i = op_idx + 1;
+        while i < operators.len()
+          && operator_precedence(&operators[i]) >= next_min_prec
+        {
+          right_terms += 1;
+          i += 1;
+        }
+        op_idx += right_terms;
+        if operators.get(op_idx).map(String::as_str) != Some(";;") {
+          break;
+        }
+      }
+      result = build_span(parts);
+      in_cross_chain = false;
+      continue;
     }
 
     // For right-associative operators, use prec, otherwise use prec + 1
@@ -5909,6 +5928,18 @@ fn build_flat_op(head: &str, left: &Expr, right: &Expr) -> Expr {
 
 fn make_binary_op(left: &Expr, op_str: &str, right: &Expr) -> Expr {
   match op_str {
+    // A two-operand Span. Chains (`a ;; b ;; c`) are collected into a single
+    // n-ary `Span` by `build_expr_with_precedence` before they get here.
+    ";;" => build_span(vec![left.clone(), right.clone()]),
+    // An omitted `;;` operand that an operator binding tighter than `;;`
+    // claimed first — `a + ;; 3`, where `+` (310) takes the operand `;;`
+    // (305) left out. Only `build_span` can fill such a gap in properly, so
+    // read the omission as the `1` a written-out `Span[1, …]` would have.
+    _ if is_span_omitted(left) || is_span_omitted(right) => make_binary_op(
+      &span_omitted_fallback(left),
+      op_str,
+      &span_omitted_fallback(right),
+    ),
     "=." => {
       // Unset (postfix): f[x] =. → Unset[f[x]], right operand is a dummy
       Expr::FunctionCall {

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -10,24 +10,27 @@ COMMENT = _{ "(*" ~ (COMMENT | (!"(*" ~ !"*)" ~ ANY))* ~ "*)" }
 
 // Span expression: a;;b or a;;b;;c (with optional operands: ;;b, a;;, ;;;;c)
 // Produces Span[a, b] or Span[a, b, c] with defaults (1 for start, All for end)
-// SpanSep is a visible token so the parser can count separators and determine positions.
-// Atomic (`@`) so whitespace is not skipped between `;;` and any trailing check.
-SpanSep = @{ ";;" }
-SpanExpr = { SpanOperand? ~ SpanSep ~ SpanOperand? ~ (SpanSep ~ SpanOperand?)? }
-// A Span operand. `;;` binds tighter than `->` and `:>` in Wolfram
-// (precedence 305 vs 120), so `1 ;; 2 -> b` is Rule[Span[1, 2], b] and not
-// Span[1, Rule[2, b]] — an operand must stop at a rule operator. Only when
-// one actually follows at this depth is the operand narrowed to a
-// ConditionExpr (an Expression that stops before `->` and `:>`); otherwise
-// the full Expression stays available, so `a ;; b // f` is unaffected.
-SpanOperand = _{ !HasRuleOperator ~ Expression | ConditionExpr }
-// A `;;` expression that may itself be one side of a rule: with `;;`
-// binding tighter, the rule is the outer expression (`1 ;; 2 -> b`), so it
-// has to be tried before the bare Span. Used wherever a Span is reached
-// without a rule alternative already having been attempted.
-SpanOrRule = _{ &HasRuleOperator ~ ReplacementRule | SpanExpr }
-// PartIndex: an index inside [[ ]] — can be a SpanExpr or a plain Expression
-PartIndex = _{ &HasSpanSep ~ SpanOrRule | Expression }
+//
+// `;;` is an ordinary infix operator of the expression chain (see `Operator`),
+// so the precedence climbing in the AST builder places it against every other
+// operator at once: it binds looser than `+`, `*`, `^` and `.` but tighter
+// than `=`, `:=`, `==`, `&&`, `||`, `|`, `~~`, `/;` and `->` — Wolfram's
+// precedence 305. Building it as a rule of its own could not do that: its
+// operands were whole `Expression`s, so every operator below `;;` ended up
+// *inside* the Span instead of around it.
+//
+// Wolfram lets either operand be left out, and a chain needs an operand for
+// every operator, so each spelling that leaves one out gets a `;;` token of
+// its own — the AST builder reads the token to know which operand is missing.
+// They are ordinary (non-empty) rules: a zero-width operand would let
+// `Expression` match nothing at all.
+// Atomic (`@`) so the two characters are one token.
+SpanNoLhsSep     = @{ ";;" }   // nothing before the `;;`: `;;3`
+SpanNoRhsSep     = @{ ";;" }   // nothing after it: `3;;`, the gap in `1;;;;3`
+SpanNoOperandSep = @{ ";;" }   // nothing on either side: `;;`, `;; ;; 2`
+// PartIndex: an index inside [[ ]] — an ordinary Expression, which covers
+// `m[[2 ;; 5]]` because `;;` is one of its operators.
+PartIndex = _{ Expression }
 
 // Part bracket openers/closers: both ASCII "[[" / "]]" and the Unicode
 // double-struck brackets. We accept the MATHEMATICAL LEFT/RIGHT WHITE
@@ -210,7 +213,7 @@ ListExtended = {
 ParenCallSuffix = { BracketArgs+ }
 ParenExtended = {
     &("(" ~ NestedContent ~ ")" ~ (DerivativePrime | PartOpen | "["))
-    ~ "(" ~ (&HasSemicolon ~ CompoundExpression | &HasSpanSep ~ SpanOrRule | Expression) ~ ")"
+    ~ "(" ~ (&HasSemicolon ~ CompoundExpression | Expression) ~ ")"
     ~ (DerivativePrime ~ ParenCallSuffix? | PartIndexSuffix | ParenCallSuffix)
 }
 // RuleAnonymousFunction handles ReplacementRule& - for expressions like {#, First@#2} -> "Q" &
@@ -260,6 +263,7 @@ Operator = @{
   | "\\[And]" | "\u{2227}" // And operator (named form of &&)
   | "\\[Or]" | "\u{2228}" // Or operator (named form of ||)
   | "/@"     // keep first
+  | ";;"     // Span (Wolfram precedence 305: tighter than =, ==, &&, |, ~~ and ->, looser than + and *)
   | "@@@"    // MapApply operator (must be before @@)
   | "@@"     // Apply operator (must be before single @)
   | "@*"     // Composition operator (must be before single @)
@@ -459,11 +463,23 @@ ConjugateTransposeSuffix = @{ "\\[ConjugateTranspose]" | "\u{F3C6}" | "\u{F3C8}"
 // FactorialSuffix). Silent choice rule — the underlying named rules
 // are the ones that appear in the parse tree.
 TermSuffix = _{ TransposeSuffix | ConjugateTransposeSuffix | PatternTestSuffix }
+// One operand of an expression chain: an optional prefix operator, a Term and
+// the suffixes that bind to it. Spelled out as one alternative per prefix
+// rather than `(LeadingNot | LeadingPlus | LeadingMinus)? ~ Term ~ …` because
+// a PEG never backtracks into a `?` it has already matched.
+ExprOperand = _{ LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingPlus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? }
+// The same operand with `;;`'s omitted left one allowed in front of it, so
+// `x = ;; 3` reads as `Set[x, Span[1, 3]]`.
+SpanOrExprOperand = _{ SpanNoLhsSep ~ ExprOperand | SpanNoOperandSep | ExprOperand }
+// `ExpressionNoImplicit`'s operand: as above, over `TermNoImplicit`.
+ExprOperandNoImplicit = _{ LeadingNot ~ TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? }
+SpanOrExprOperandNoImplicit = _{ SpanNoLhsSep ~ ExprOperandNoImplicit | SpanNoOperandSep | ExprOperandNoImplicit }
+
 Expression = {
-    (LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingPlus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?) ~ (UnsetSuffix | (Operator | TildeInfix) ~ (LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingPlus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?))*
+    SpanOrExprOperand ~ (UnsetSuffix | (Operator | TildeInfix) ~ SpanOrExprOperand | SpanNoRhsSep)*
     ~ (ReplaceRepeatedSuffix | ReplaceAllSuffix)*
     ~ ("//" ~ PostfixFunction)*               // Postfix application (lowest precedence): x // f
-    ~ (AnonymousFunctionSuffix ~ ((ReplaceRepeatedSuffix | ReplaceAllSuffix) | (Operator | TildeInfix) ~ (LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingPlus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | Term ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?))*  ~ ("//" ~ PostfixFunction)*)*  // Function: expr & (lowest precedence), then optional continuation (Operator/ReplaceAll/ReplaceRepeated may interleave in any order, e.g. `f & /@ list /. rules`) — repeated for chains like `f & [x] & [y]`
+    ~ (AnonymousFunctionSuffix ~ ((ReplaceRepeatedSuffix | ReplaceAllSuffix) | (Operator | TildeInfix) ~ SpanOrExprOperand)*  ~ ("//" ~ PostfixFunction)*)*  // Function: expr & (lowest precedence), then optional continuation (Operator/ReplaceAll/ReplaceRepeated may interleave in any order, e.g. `f & /@ list /. rules`) — repeated for chains like `f & [x] & [y]`
 }
 
 // Legacy rules kept for backward compatibility in evaluation code
@@ -475,12 +491,12 @@ PostfixApplication = { PostfixBase ~ ("//" ~ PostfixFunction)+ }
 // A trailing ; means the result is Null (e.g. "a;" is CompoundExpression[a, Null])
 // Allows consecutive `;` separators with empty expressions between them,
 // matching Wolfram's `a ; ; c` → `CompoundExpression[a, Null, c]`.
-// Each statement may itself be a Span (`5 ;; 2; 1 ;; 10 ;; 2`): a Span operand
+// Each statement may itself be a Span (`5 ;; 2; 1 ;; 10 ;; 2`): an Expression
 // greedily consumes its own `;;`, so every remaining top-level `;` is a genuine
 // CompoundExpression separator — no `;;` guard is needed and a `;;` statement is
 // free to follow a separator (`... ; ;;`). parse_compound_expression counts the
 // `;` separators from the source to reinsert omitted (Null) statements.
-CompoundStatement = _{ TopLevelSpan | Expression }
+CompoundStatement = _{ Expression }
 // An optional trailing `&` (no expression between it and the last `;`) turns
 // the whole statement sequence into a pure function body — the idiom
 // `(a = #; t = 0; &)` Options like `TrackingFunction` commonly use for a
@@ -602,7 +618,7 @@ Term = _{
   | AssociationExtended
   | Association
   | ParenExtended
-  | "(" ~ (&HasSemicolon ~ CompoundExpression | &HasSpanSep ~ SpanOrRule | Expression) ~ ")"
+  | "(" ~ (&HasSemicolon ~ CompoundExpression | Expression) ~ ")"
 }
 
 // SimpleTerm is used for implicit multiplication - doesn't include ImplicitTimes to avoid recursion
@@ -643,7 +659,7 @@ SimpleTerm = _{
   | List
   | StringCall
   | String
-  | "(" ~ (&HasSpanSep ~ SpanOrRule | Expression) ~ ")"
+  | "(" ~ Expression ~ ")"
 }
 
 // TermNoImplicit is like Term but without ImplicitTimes - used for function bodies
@@ -684,10 +700,10 @@ TermNoImplicit = _{
 
 // ExpressionNoImplicit is like Expression but uses TermNoImplicit
 ExpressionNoImplicit = {
-    (LeadingNot ~ TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?) ~ (UnsetSuffix | (Operator | TildeInfix) ~ (LeadingNot ~ TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?))*
+    SpanOrExprOperandNoImplicit ~ (UnsetSuffix | (Operator | TildeInfix) ~ SpanOrExprOperandNoImplicit | SpanNoRhsSep)*
     ~ (ReplaceRepeatedSuffix | ReplaceAllSuffix)*
     ~ ("//" ~ PostfixFunction)*
-    ~ (AnonymousFunctionSuffix ~ (ReplaceRepeatedSuffix | ReplaceAllSuffix)* ~ ((Operator | TildeInfix) ~ (LeadingNot ~ TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | LeadingMinus ~ TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)? | TermNoImplicit ~ FactorialSuffix? ~ TermSuffix* ~ (RepeatedNullSuffix | RepeatedSuffix)?))*  ~ ("//" ~ PostfixFunction)*)?
+    ~ (AnonymousFunctionSuffix ~ (ReplaceRepeatedSuffix | ReplaceAllSuffix)* ~ ((Operator | TildeInfix) ~ SpanOrExprOperandNoImplicit)*  ~ ("//" ~ PostfixFunction)*)?
 }
 
 // Pattern: x_ or x_Head or x_?test or x_ /; condition or x_:default or x_Head:default
@@ -723,8 +739,11 @@ PatternTestLhsBare = @{ Identifier ~ !"_" }
 PatternTestHead = { !("_") ~ Identifier }
 // ConditionExpr is like Expression but stops before -> and :> (rule operators)
 // This prevents the condition from consuming the replacement part of a rule
+// `ConditionExpr`'s operand: as `ExprOperand`, without the `..`/`...` suffixes.
+CondOperand = _{ LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* | Term ~ FactorialSuffix? ~ TermSuffix* }
+SpanOrCondOperand = _{ SpanNoLhsSep ~ CondOperand | SpanNoOperandSep | CondOperand }
 ConditionExpr = {
-    (LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* | Term ~ FactorialSuffix? ~ TermSuffix*) ~ ((ConditionOp | TildeInfix) ~ (LeadingNot ~ Term ~ FactorialSuffix? ~ TermSuffix* | LeadingMinus ~ Term ~ FactorialSuffix? ~ TermSuffix* | Term ~ FactorialSuffix? ~ TermSuffix*))*
+    SpanOrCondOperand ~ ((ConditionOp | TildeInfix) ~ SpanOrCondOperand | SpanNoRhsSep)*
 }
 // Operators allowed in conditions - excludes -> and :> which mark rule boundaries
 // Atomic so that WHITESPACE/COMMENT tokens are not consumed within the operator span.
@@ -744,6 +763,7 @@ ConditionOp = @{
   | "<->"                         // TwoWayRule (must be before <>, <=, <)
   | "<>"                          // StringJoin (must be before < to avoid partial match)
   | "<=" | "\u{2264}" | "\u{2A7D}" | "\\[LessEqual]" | ">=" | "\u{2265}" | "\u{2A7E}" | "\\[GreaterEqual]" | "<" | ">"       // Order comparison, ≤, ≥, ⩽, ⩾
+  | ";;"                          // Span
   | "/@"                          // Map (must be before the bare "/" of Arithmetic)
   | "@@@"                         // MapApply (must be before @@)
   | "@@"                          // Apply (must be before @)
@@ -789,9 +809,10 @@ Pattern = { PatternCondition | PatternTest | PatternOptionalNamedBlank | Pattern
 // Patterns (x_, x_Head, etc.) can appear as terms within the LHS expression.
 // The replacement side recurses so rule chains parse right-associatively:
 // a -> b -> c is Rule[a, Rule[b, c]] (matching wolframscript).
-// Either side may be a Span (`"--" -> 3 ;;` is Rule["--", Span[3, All]]),
-// which binds tighter than the rule operator.
-RuleOperand = _{ &HasSpanSep ~ SpanExpr | ConditionExpr }
+// Either side may be a Span (`"--" -> 3 ;;` is Rule["--", Span[3, All]]):
+// `;;` is one of `ConditionExpr`'s own operators and binds tighter than the
+// rule operator.
+RuleOperand = _{ ConditionExpr }
 ReplacementRule = { RuleOperand ~ ("/;" ~ ConditionExpr)? ~ ("->" | "\u{2192}" | ":>") ~ (ReplacementRule | RuleOperand) }
 
 // Replacement expressions: expr /. rule or expr //. rule
@@ -871,23 +892,6 @@ HasRuleOperator = _{ (
   | "<->"                       // skip TwoWayRule (don't match its "->" substring as a rule operator)
   | !("->" | "\u{2192}" | ":>" | "<|" | "|>" | "}" | "," | "]" | ")" | "\u{27E7}" | "\u{301B}" | "\"") ~ ANY
 )* ~ ("->" | "\u{2192}" | ":>") }
-// Scan forward looking for ;; (span separator) at the current nesting depth.
-// Used as a zero-width lookahead to avoid expensive SpanExpr backtracking.
-// Ends with an atomic check so that `;; ;;` (second ;; separated by whitespace)
-// is correctly detected — otherwise the non-atomic trailing `~` would skip the
-// whitespace and the `!(";"|"=")` lookahead would falsely reject the next `;`.
-HasSpanSep = _{ (
-    ScanComment
-  | "<|" ~ NestedContent ~ "|>"
-  | "{" ~ NestedContent ~ "}"
-  | "[" ~ NestedContent ~ "]"
-  | "(" ~ NestedContent ~ ")"
-  | "\u{27E6}" ~ NestedContent ~ "\u{27E7}"
-  | "\u{301A}" ~ NestedContent ~ "\u{301B}"
-  | "\"" ~ (!("\"") ~ ANY)* ~ "\""
-  | ";" ~ !";"                  // skip lone semicolons (not ;;)
-  | !(";" | "<|" | "|>" | "}" | "," | "]" | ")" | "\u{27E7}" | "\u{301B}" | "\"") ~ ANY
-)* ~ SpanSep }
 // Scan forward looking for ; (compound separator, not ;;) at the current nesting depth.
 // Used as a zero-width lookahead to avoid expensive CompoundExpression backtracking.
 HasSemicolon = @{ (
@@ -902,7 +906,7 @@ HasSemicolon = @{ (
   | "\"" ~ (!("\"") ~ ANY)* ~ "\""
   | !(";" | "<|" | "|>" | "}" | "," | "]" | ")" | "\u{27E7}" | "\u{301B}" | "\"") ~ ANY
 )* ~ ";" ~ !";" }
-ListItem = _{ &HasRuleOperator ~ ListItemRule | &HasSemicolon ~ CompoundExpression | &HasSpanSep ~ SpanExpr | Expression }
+ListItem = _{ &HasRuleOperator ~ ListItemRule | &HasSemicolon ~ CompoundExpression | Expression }
 
 AssociationItem = { RuleOperand ~ ("->" | "\u{2192}" | ":>") ~ RuleOperand }
 // Non-rule items inside <|...|> are rare but legal — Wolfram parses <|a, b|>
@@ -931,7 +935,7 @@ AssociationExtended = {
 // See ListItemRule's comment: RuleAnonSuffix gates the extra Operator
 // continuation so `pat -> repl & /@ list` parses as an argument too.
 FunctionArgRule = { ReplacementRule ~ (RuleAnonSuffix ~ ((ReplaceRepeatedSuffix | ReplaceAllSuffix) | (Operator | TildeInfix) ~ RuleOperatorTerm)* | RuleReplaceSuffix*) ~ ("//" ~ PostfixFunction)* }
-FunctionArg = _{ &HasRuleOperator ~ FunctionArgRule | &HasSemicolon ~ CompoundExpression | &HasSpanSep ~ SpanExpr | Expression }
+FunctionArg = _{ &HasRuleOperator ~ FunctionArgRule | &HasSemicolon ~ CompoundExpression | Expression }
 // BracketArgs groups arguments within a single bracket pair, allowing proper chained call parsing
 FunctionArgOrOmitted = _{ FunctionArg | OmittedArg }
 FunctionArgOrOmittedLast = _{ FunctionArg | OmittedArg | OmittedTrailingArg }
@@ -958,10 +962,10 @@ TagSetDelayed = { Identifier ~ "/:" ~ BaseFunctionCall ~ ":=" ~ ExpressionNoImpl
 TagSet = { Identifier ~ "/:" ~ BaseFunctionCall ~ "=" ~ !("." | "=" | "!") ~ ExpressionNoImplicit }
 TagUnset = { Identifier ~ "/:" ~ BaseFunctionCall ~ "=." }
 
-Statement = _{ TagSetDelayed | TagUnset | TagSet | FunctionDefinition | TopLevelSpan | Expression }
-// Top-level Span: allows bare `;;` / `a;;b` / `;;4` / `a;;b;;c` as a
-// statement, with optional postfix applications (e.g. `1;;4 // FullForm`).
-TopLevelSpan = { &HasSpanSep ~ SpanOrRule ~ ("//" ~ PostfixFunction)* }
+// A bare `;;` / `a;;b` / `;;4` / `a;;b;;c` statement needs no rule of its
+// own: `;;` is an operator of `Expression`, and `//` sits at the end of that
+// rule, so `1;;4 // FullForm` is `FullForm[Span[1, 4]]` without any hoisting.
+Statement = _{ TagSetDelayed | TagUnset | TagSet | FunctionDefinition | Expression }
 
 // StatementSeparator can be a semicolon (traditional) or empty (relying on whitespace/newlines)
 // Atomic so the `!";"` lookahead checks the *immediate* next character.

--- a/tests/cli/expressions/Span.md
+++ b/tests/cli/expressions/Span.md
@@ -28,3 +28,29 @@ $ wo 'StringExtract["a--bbb--ccc--dddd", "--" -> 3 ;;]'
 $ wo 'Head[1 ;; 2 -> b]'
 Rule
 ```
+
+Every operator Wolfram places below `;;` — assignment, comparison, the
+logical operators, `|`, `~~` and `->` — keeps the whole span as its operand,
+so a symbol set to a span holds the span itself:
+
+```scrut
+$ wo 'x = 2 ;; 4; Range[6][[x]]'
+{2, 3, 4}
+```
+
+```scrut
+$ wo 'a == 1 ;; 3'
+a == Span[1, 3]
+```
+
+```scrut
+$ wo 'a && 1 ;; 3'
+a && Span[1, 3]
+```
+
+The arithmetic operators bind tighter and stay inside the span's operands:
+
+```scrut
+$ wo '1 ;; 2 + 3'
+Span[1, 5]
+```

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7684,7 +7684,7 @@ mod ndsolve {
   fn derivative_of_a_part_extracted_solution() {
     // `solutions[[i]][[2]]'[t]` — the prime differentiates the
     // InterpolatingFunction the rule was carrying. It used to be a parse
-    // error ("expected SpanSep").
+    // error (the parser demanded a `;;` after the part index).
     let result = interpret(
       "s = Flatten[NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 5}]]; \
        s[[1]][[2]]'[2.0]",

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -7175,6 +7175,22 @@ mod line_continuation {
   }
 
   #[test]
+  fn a_line_ending_in_a_span_separator_is_its_own_statement() {
+    // Regression: `;;` and `;` are both spelled with `;`, and the statement
+    // splitter took any trailing `;` for a separator that was already
+    // there — so `x = 3;;` ran into the next line and the following
+    // statement became the Span's end operand.
+    assert_eq!(interpret("x = 3;;\nRange[6][[x]]").unwrap(), "{3, 4, 5, 6}");
+    assert_eq!(interpret("1 ;;\n2 ;;").unwrap(), "Span[2, All]");
+    // An odd run of `;` still ends with a genuine separator.
+    assert_eq!(
+      interpret("x = 3;;;\nRange[6][[x]]").unwrap(),
+      "{3, 4, 5, 6}"
+    );
+    assert_eq!(interpret("x = 3;\nRange[6][[x ;; 4]]").unwrap(), "{3, 4}");
+  }
+
+  #[test]
   fn replace_all_across_newline() {
     // Regression: `/.` (ReplaceAll) at end of line must continue on the
     // next line. Previously insert_statement_separators didn't recognise
@@ -11022,5 +11038,115 @@ mod span_as_a_rule_operand {
   fn a_parenthesized_span_takes_a_part_index() {
     assert_eq!(interpret("(1 ;; 3)[[1]]").unwrap(), "1");
     assert_eq!(interpret("(a ;; b)[[2]]").unwrap(), "b");
+  }
+}
+
+/// `;;` is Wolfram's precedence 305: every operator below it — `=`, `:=`,
+/// `==`, `&&`, `||`, `|`, `~~`, `/;`, `->` — is the *outer* expression, and
+/// every operator above it (`+`, `*`, `^`, `.`, `@`) is part of an operand.
+/// https://github.com/ad-si/Woxi/issues/564
+mod span_precedence {
+  use super::*;
+
+  /// The reported case: the assignment is the outer expression, so the
+  /// symbol holds the whole Span and not just its first operand.
+  #[test]
+  fn an_assignment_stores_the_whole_span() {
+    assert_eq!(interpret("x = 1 ;; 3; Head[x]").unwrap(), "Span");
+    assert_eq!(interpret("x = 1 ;; 3; x").unwrap(), "Span[1, 3]");
+    assert_eq!(interpret("y := 1 ;; 3; y").unwrap(), "Span[1, 3]");
+    assert_eq!(interpret("x = 1 ;; 6 ;; 2; x").unwrap(), "Span[1, 6, 2]");
+    // A stored Span is a Part specification like any other.
+    assert_eq!(
+      interpret("s = 2 ;; ; Range[5][[s]]").unwrap(),
+      "{2, 3, 4, 5}"
+    );
+    assert_eq!(interpret("s = ;; 3; Range[5][[s]]").unwrap(), "{1, 2, 3}");
+  }
+
+  #[test]
+  fn a_comparison_holds_the_span() {
+    assert_eq!(interpret("a == 1 ;; 3").unwrap(), "a == Span[1, 3]");
+    assert_eq!(interpret("Head[a == 1 ;; 3]").unwrap(), "Equal");
+    assert_eq!(interpret("a != 1 ;; 3").unwrap(), "a != Span[1, 3]");
+    assert_eq!(interpret("1 ;; 3 == a").unwrap(), "Span[1, 3] == a");
+  }
+
+  #[test]
+  fn the_logical_operators_hold_the_span() {
+    assert_eq!(interpret("a && 1 ;; 3").unwrap(), "a && Span[1, 3]");
+    assert_eq!(interpret("Head[a && 1 ;; 3]").unwrap(), "And");
+    assert_eq!(interpret("a || 1 ;; 3").unwrap(), "a || Span[1, 3]");
+  }
+
+  #[test]
+  fn alternatives_and_string_expression_hold_the_span() {
+    assert_eq!(interpret("a | 1 ;; 3").unwrap(), "a | Span[1, 3]");
+    assert_eq!(interpret("Head[a | 1 ;; 3]").unwrap(), "Alternatives");
+    assert_eq!(
+      interpret("a ~~ 1 ;; 3").unwrap(),
+      "StringExpression[a, Span[1, 3]]"
+    );
+    assert_eq!(interpret("Head[a ~~ 1 ;; 3]").unwrap(), "StringExpression");
+  }
+
+  #[test]
+  fn a_condition_holds_the_span() {
+    assert_eq!(interpret("x /; y ;; 3").unwrap(), "x /; Span[y, 3]");
+    assert_eq!(interpret("Head[x /; y ;; 3]").unwrap(), "Condition");
+  }
+
+  /// `//` and `&` bind looser still, so they wrap the finished Span.
+  #[test]
+  fn postfix_application_and_a_pure_function_wrap_the_span() {
+    assert_eq!(interpret("1 ;; 4 // Head").unwrap(), "Span");
+    assert_eq!(interpret("a ;; b // f").unwrap(), "f[Span[a, b]]");
+    assert_eq!(interpret("(1 ;; 3 &)[]").unwrap(), "Span[1, 3]");
+  }
+
+  /// Operators *above* `;;` stay inside its operands.
+  #[test]
+  fn the_tighter_operators_stay_inside_the_span() {
+    assert_eq!(interpret("1 ;; 2 + 3").unwrap(), "Span[1, 5]");
+    assert_eq!(interpret("2 ;; 3 * 4").unwrap(), "Span[2, 12]");
+    assert_eq!(interpret("1 ;; 2 ^ 3").unwrap(), "Span[1, 8]");
+    assert_eq!(interpret("1 + 1 ;; 3").unwrap(), "Span[2, 3]");
+    assert_eq!(
+      interpret("Range[10][[2 ;; 3 + 4]]").unwrap(),
+      "{2, 3, 4, 5, 6, 7}"
+    );
+  }
+
+  /// Every spelling with an omitted operand keeps its default — `1` for the
+  /// start, `All` for the end — wherever the Span stands.
+  #[test]
+  fn an_omitted_operand_keeps_its_default() {
+    assert_eq!(interpret(";; 3").unwrap(), "Span[1, 3]");
+    assert_eq!(interpret("3 ;;").unwrap(), "Span[3, All]");
+    assert_eq!(interpret(";;").unwrap(), "Span[1, All]");
+    assert_eq!(interpret("1 ;;;; 3").unwrap(), "Span[1, All, 3]");
+    assert_eq!(interpret("a == ;; 3").unwrap(), "a == Span[1, 3]");
+    assert_eq!(interpret("a == 3 ;;").unwrap(), "a == Span[3, All]");
+    assert_eq!(
+      interpret("{;;, 2 ;;}").unwrap(),
+      "{Span[1, All], Span[2, All]}"
+    );
+    assert_eq!(interpret("f[;;]").unwrap(), "f[Span[1, All]]");
+    assert_eq!(interpret("Range[5][[;;]]").unwrap(), "{1, 2, 3, 4, 5}");
+    assert_eq!(interpret("Range[5][[;; 3]]").unwrap(), "{1, 2, 3}");
+    assert_eq!(interpret("Range[5][[3 ;;]]").unwrap(), "{3, 4, 5}");
+    assert_eq!(interpret("Range[6][[;; ;; 2]]").unwrap(), "{1, 3, 5}");
+  }
+
+  /// A `;;` chain is one n-ary Span; parentheses still nest it.
+  #[test]
+  fn a_chain_of_separators_is_a_single_span() {
+    assert_eq!(interpret("1 ;; 6 ;; 2").unwrap(), "Span[1, 6, 2]");
+    assert_eq!(interpret("(1 ;; 2) ;; 3").unwrap(), "Span[Span[1, 2], 3]");
+    assert_eq!(interpret("1 ;; (2 ;; 3)").unwrap(), "Span[1, Span[2, 3]]");
+    assert_eq!(
+      interpret("Range[10][[1 ;; 10 ;; 3]]").unwrap(),
+      "{1, 4, 7, 10}"
+    );
   }
 }


### PR DESCRIPTION
`;;` has Wolfram precedence 305, so every operator below it — `=`, `:=`, `==`,
`&&`, `||`, `|`, `~~`, `/;`, `->` — has to be the *outer* expression. `Span`
was built from a grammar rule of its own whose operands were whole
`Expression`s, and those happily consumed the looser operators:
`x = 1 ;; 3` parsed as `Span[Set[x, 1], 3]`, so `x` ended up `1` instead of
`Span[1, 3]`, and `a == 1 ;; 3` read as `Span[a == 1, 3]` rather than
`Equal[a, Span[1, 3]]`. #563 had patched this for `->` and `:>` alone; that
per-operator workaround could not generalize, and rebalancing the tree
afterwards cannot work either — `1 ;; Equal[a, b]` and `1 ;; a == b` build the
same one.

`;;` is now an entry in `Operator` (and `ConditionOp`) with a precedence slot
between `+` and the comparisons, so the precedence climbing in
`build_expr_with_precedence` places it against every operator at once. The
chain is collected n-ary, which keeps `1 ;; 2 ;; 3` a single `Span[1, 2, 3]`
while `(1 ;; 2) ;; 3` stays nested. Operators above `;;` are untouched:
`1 ;; 2 + 3` is still `Span[1, 5]`.

`SpanExpr`, `SpanOperand`, `SpanOrRule`, `TopLevelSpan` and the `HasSpanSep`
lookahead are gone with it, as is the postfix hoisting `TopLevelSpan` needed:
`//` sits at the end of `Expression`, so `1 ;; 4 // f` is `f[Span[1, 4]]` by
construction. `Expression`'s operand alternation, which the rule spelled out
four times, is now the silent `ExprOperand` — same parse tree, one definition.

A chain needs an operand for every operator, so each spelling that leaves one
out gets a `;;` token of its own (`SpanNoLhsSep`, `SpanNoRhsSep`,
`SpanNoOperandSep`) and the AST builder stands in a marker that the `Span`
builder resolves to the slot's default. An omitted left operand now also
parses after an operator: `x = ;; 3` is `Set[x, Span[1, 3]]`, which used to be
a parse error.

Fixing this surfaced a statement-splitter bug: it read any trailing `;` as a
separator that was already there, so a line ending in `;;` ran into the next
one and swallowed it as the span's end — `x = 3;;` followed by
`Range[6][[x]]` gave `Set[x, Span[3, Range[6][[x]]]]`. It now looks at the
whole trailing run of `;`: an even run ends in a `;;` and still needs a
separator.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BQBDKCXRVWGubVewN4oJxJ