### PR TITLE
Add legacy Combinatorica`/GraphUtilities` graph function compatibility

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -6300,3 +6300,4 @@ SetProperty,Graph with an annotation set for one of its vertices or edges,✅,pu
 Evaluated,Option for whether to evaluate a plot's function once symbolically,✅,pure,6.0,
 ParallelSelect,Parallel version of Select (evaluated sequentially),✅,pure,14.2,
 ParallelCases,Parallel version of Cases (evaluated sequentially),✅,pure,14.2,
+GraphPath,Shortest path between two vertices — legacy GraphUtilities package name for FindShortestPath,✅,pure,8.0,

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -4466,6 +4466,15 @@ fn evaluate_function_call_ast_inner(
     return Ok(graph);
   }
 
+  // Combinatorica`FromUnorderedPairs[pairs] — the legacy Combinatorica
+  // package's graph constructor; builds a Graph[...] on vertices
+  // 1 .. Max[Flatten[pairs]] from a list of unordered vertex-index pairs.
+  if name == "Combinatorica`FromUnorderedPairs" {
+    return crate::functions::graph::combinatorica_from_unordered_pairs_ast(
+      args,
+    );
+  }
+
   // Graph[{rule1, rule2, ...}] or Graph[{edge1, edge2, ...}]
   // → Graph[{sorted vertices}, {DirectedEdge/UndirectedEdge[...], ...}]
   if name == "Graph" {
@@ -4703,6 +4712,14 @@ fn evaluate_function_call_ast_inner(
   // shortest weighted path (Dijkstra).
   if name == "FindShortestPath" && args.len() >= 3 {
     return crate::functions::graph::find_shortest_path_ast(args);
+  }
+
+  // GraphPath[graph, src, dst] — the legacy GraphUtilities package's name
+  // for a shortest path between two vertices; same graph, same result as
+  // FindShortestPath. (GraphUtilities predates Wolfram Language's built-in
+  // Graph type and was absorbed into the language core in Version 8.)
+  if name == "GraphPath" && args.len() == 3 {
+    return evaluate_function_call_ast_inner("FindShortestPath", args);
   }
 
   // EdgeList[Graph[vertices, edges]] → edges list
@@ -5911,6 +5928,12 @@ fn evaluate_function_call_ast_inner(
       return Ok(Expr::List(dist.into_iter().map(dist_to_expr).collect()));
     }
     // Fall through to unevaluated when a vertex argument is invalid.
+  }
+
+  // GraphUtilities`GraphDistanceMatrix[g] — the legacy GraphUtilities
+  // package's name for GraphDistanceMatrix; same graph, same result.
+  if name == "GraphUtilities`GraphDistanceMatrix" && args.len() == 1 {
+    return evaluate_function_call_ast_inner("GraphDistanceMatrix", args);
   }
 
   // GraphDistanceMatrix[g] — matrix whose (i, j) entry is the shortest-path
@@ -7434,6 +7457,12 @@ fn evaluate_function_call_ast_inner(
       }
     }
     return Ok(bool_expr(false));
+  }
+
+  // Combinatorica`ConnectedComponents[g] — the legacy Combinatorica
+  // package's name for ConnectedComponents; same graph, same result.
+  if name == "Combinatorica`ConnectedComponents" && args.len() == 1 {
+    return evaluate_function_call_ast_inner("ConnectedComponents", args);
   }
 
   // ConnectedComponents[Graph[{vertices}, {edges}]]

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -2889,6 +2889,11 @@ pub fn dispatch_list_operations(
         args,
       ));
     }
+    "Combinatorica`RandomPermutation" if args.len() == 1 => {
+      return Some(list_helpers_ast::combinatorica_random_permutation_ast(
+        args,
+      ));
+    }
     "Signature" if args.len() == 1 => {
       use crate::functions::list_helpers_ast::sorting::canonical_cmp;
       // Signature operates on any non-atomic expression: it treats the

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -203,9 +203,8 @@ pub fn combinatorica_from_unordered_pairs_ast(
   if args.len() != 1 {
     return Ok(original());
   }
-  let pairs = match &args[0] {
-    Expr::List(items) => items,
-    _ => return Ok(original()),
+  let Expr::List(pairs) = &args[0] else {
+    return Ok(original());
   };
 
   let mut max_vertex: i128 = 0;

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -188,6 +188,58 @@ fn build_render_graph(
   (graph, index_map)
 }
 
+/// `Combinatorica\`FromUnorderedPairs[pairs]` — the legacy Combinatorica
+/// package's graph constructor: builds an undirected graph on vertices
+/// `1 .. Max[Flatten[pairs]]` (including any vertex that never appears in an
+/// edge) from a list of unordered vertex-index pairs `{v1, v2}`, returned in
+/// the canonical `Graph[{vertices}, {edges}]` form so it feeds directly into
+/// `ConnectedComponents`, `GraphDistanceMatrix`, `FindShortestPath`, etc.
+/// Anything that is not a list of two-element positive-integer pairs is left
+/// symbolic.
+pub fn combinatorica_from_unordered_pairs_ast(
+  args: &[Expr],
+) -> Result<Expr, InterpreterError> {
+  let original = || unevaluated("Combinatorica`FromUnorderedPairs", args);
+  if args.len() != 1 {
+    return Ok(original());
+  }
+  let pairs = match &args[0] {
+    Expr::List(items) => items,
+    _ => return Ok(original()),
+  };
+
+  let mut max_vertex: i128 = 0;
+  let mut edges = Vec::with_capacity(pairs.len());
+  for p in pairs {
+    let Expr::List(pair) = p else {
+      return Ok(original());
+    };
+    if pair.len() != 2 {
+      return Ok(original());
+    }
+    let (Expr::Integer(a), Expr::Integer(b)) = (&pair[0], &pair[1]) else {
+      return Ok(original());
+    };
+    if *a < 1 || *b < 1 {
+      return Ok(original());
+    }
+    max_vertex = max_vertex.max(*a).max(*b);
+    edges.push(call(
+      "UndirectedEdge",
+      vec![Expr::Integer(*a), Expr::Integer(*b)],
+    ));
+  }
+  if max_vertex == 0 {
+    return Ok(original());
+  }
+
+  let vertices: Vec<Expr> = (1..=max_vertex).map(Expr::Integer).collect();
+  Ok(call(
+    "Graph",
+    vec![Expr::List(vertices.into()), Expr::List(edges.into())],
+  ))
+}
+
 /// Render a Graph[{vertices}, {edges}, options...] expression to SVG
 /// via the Graphics pipeline, using petgraph as the underlying data structure.
 pub fn graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/list_helpers_ast/combinatorics.rs
+++ b/src/functions/list_helpers_ast/combinatorics.rs
@@ -190,6 +190,31 @@ pub fn combinatorica_unrank_permutation_ast(
   Ok(Expr::List(result.into()))
 }
 
+/// `Combinatorica\`RandomPermutation[n]` / `Combinatorica\`RandomPermutation[l]`
+/// — the legacy Combinatorica package's permutation generator, distinct from
+/// the modern `RandomPermutation[n]` (which returns a `Cycles[...]` object
+/// representing the permutation): `RandomPermutation[n_Integer]` returns a
+/// uniformly random permutation of `Range[n]` as a plain list, and
+/// `RandomPermutation[l_List]` returns a uniformly random shuffle of `l`
+/// itself, elements unchanged. Anything else is left symbolic.
+pub fn combinatorica_random_permutation_ast(
+  args: &[Expr],
+) -> Result<Expr, InterpreterError> {
+  use rand::seq::SliceRandom;
+
+  let original = || unevaluated("Combinatorica`RandomPermutation", args);
+  if args.len() != 1 {
+    return Ok(original());
+  }
+  let mut items: Vec<Expr> = match &args[0] {
+    Expr::Integer(n) if *n >= 0 => (1..=*n).map(Expr::Integer).collect(),
+    Expr::List(items) => items.to_vec(),
+    _ => return Ok(original()),
+  };
+  crate::with_rng(|rng| items.shuffle(rng));
+  Ok(Expr::List(items.into()))
+}
+
 /// Helper to generate k-permutations.
 ///
 /// When the input contains duplicate elements, only distinct permutations

--- a/src/functions/ode_ast.rs
+++ b/src/functions/ode_ast.rs
@@ -347,7 +347,7 @@ fn parse_pde_domain(expr: &Expr) -> Option<PdeDomain> {
   };
   let min = nval_to_f64(&items[1])?;
   let max = nval_to_f64(&items[2])?;
-  if !(max > min) {
+  if !matches!(max.partial_cmp(&min), Some(std::cmp::Ordering::Greater)) {
     return None;
   }
   Some(PdeDomain {
@@ -643,8 +643,7 @@ fn ndsolve_pde(args: &[Expr]) -> Result<Option<Expr>, InterpreterError> {
   // boundary needs to be resolved.
   const MIN_STEPS: usize = 200;
   let n_steps = (((t_dom.max - t_dom.min) / dt_stable).ceil() as usize)
-    .max(MIN_STEPS)
-    .min(20_000);
+    .clamp(MIN_STEPS, 20_000);
   let dt = (t_dom.max - t_dom.min) / n_steps as f64;
 
   let derivative =

--- a/tests/interpreter_tests/graph_theory.rs
+++ b/tests/interpreter_tests/graph_theory.rs
@@ -2392,6 +2392,98 @@ mod find_shortest_path {
   }
 }
 
+mod combinatorica_legacy_graph_functions {
+  use super::*;
+
+  // Combinatorica`FromUnorderedPairs / Combinatorica`ConnectedComponents /
+  // GraphUtilities`GraphPath (bare, from that package's context) / bare
+  // GraphPath: the pre-Version-8 Combinatorica and GraphUtilities packages'
+  // graph API, superseded by the built-in Graph type but still used by
+  // notebooks written against them. They delegate to the modern
+  // FromUnorderedPairs-built Graph, ConnectedComponents, GraphDistanceMatrix
+  // and FindShortestPath so there is exactly one implementation of each
+  // algorithm.
+
+  #[test]
+  fn from_unordered_pairs_builds_a_graph() {
+    assert_eq!(
+      interpret("Combinatorica`FromUnorderedPairs[{{1, 2}, {2, 3}, {3, 1}}]")
+        .unwrap(),
+      interpret("Graph[{1, 2, 3}, {1 <-> 2, 2 <-> 3, 3 <-> 1}]").unwrap()
+    );
+  }
+
+  #[test]
+  fn from_unordered_pairs_includes_isolated_vertices() {
+    // Vertex 4 never appears as an edge endpoint but is still within
+    // 1 .. Max[Flatten[pairs]], so it must be included as an isolated vertex.
+    assert_eq!(
+      interpret(
+        "VertexList[Combinatorica`FromUnorderedPairs[{{1, 2}, {2, 4}}]]"
+      )
+      .unwrap(),
+      "{1, 2, 3, 4}"
+    );
+  }
+
+  #[test]
+  fn from_unordered_pairs_invalid_args_stay_symbolic() {
+    assert_eq!(
+      interpret("Combinatorica`FromUnorderedPairs[{{1, 2, 3}}]").unwrap(),
+      "Combinatorica`FromUnorderedPairs[{{1, 2, 3}}]"
+    );
+    assert_eq!(
+      interpret("Combinatorica`FromUnorderedPairs[{}]").unwrap(),
+      "Combinatorica`FromUnorderedPairs[{}]"
+    );
+  }
+
+  #[test]
+  fn combinatorica_connected_components_matches_modern() {
+    assert_eq!(
+      interpret(
+        "Combinatorica`ConnectedComponents[\
+         Combinatorica`FromUnorderedPairs[{{1, 2}, {2, 3}, {4, 5}}]]"
+      )
+      .unwrap(),
+      "{{1, 2, 3}, {4, 5}}"
+    );
+  }
+
+  #[test]
+  fn graph_utilities_graph_distance_matrix_matches_modern() {
+    assert_eq!(
+      interpret(
+        "GraphUtilities`GraphDistanceMatrix[\
+         Combinatorica`FromUnorderedPairs[{{1, 2}, {2, 3}, {3, 4}}]]"
+      )
+      .unwrap(),
+      interpret(
+        "GraphDistanceMatrix[Graph[{1, 2, 3, 4}, \
+         {1 <-> 2, 2 <-> 3, 3 <-> 4}]]"
+      )
+      .unwrap()
+    );
+  }
+
+  #[test]
+  fn bare_graph_path_matches_find_shortest_path() {
+    assert_eq!(
+      interpret(
+        "GraphPath[Combinatorica`FromUnorderedPairs[\
+         {{1, 2}, {2, 3}, {3, 4}}], 1, 4]"
+      )
+      .unwrap(),
+      "{1, 2, 3, 4}"
+    );
+    assert_eq!(
+      interpret("GraphPath[Combinatorica`FromUnorderedPairs[{{1, 2}}], 1, 3]")
+        .unwrap(),
+      "{}"
+    );
+  }
+}
+
 mod transitive_closure_graph {
   use super::*;
 

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -10014,6 +10014,56 @@ mod join_non_list {
   }
 
   #[test]
+  fn combinatorica_random_permutation_of_integer_is_permutation_of_range() {
+    // Combinatorica`RandomPermutation[n] differs from the modern
+    // RandomPermutation[n] (which returns a Cycles[...] object): it returns
+    // a plain list that is some permutation of Range[n].
+    for n in [0, 1, 5, 20] {
+      assert_eq!(
+        interpret(&format!("Sort[Combinatorica`RandomPermutation[{n}]]"))
+          .unwrap(),
+        interpret(&format!("Range[{n}]")).unwrap()
+      );
+    }
+  }
+
+  #[test]
+  fn combinatorica_random_permutation_of_list_is_permutation_of_list() {
+    // Combinatorica`RandomPermutation[list] shuffles the list itself
+    // (used in the wild on arbitrary lists, not just Range[n]).
+    assert_eq!(
+      interpret(
+        "Sort[Combinatorica`RandomPermutation[{\"a\", \"b\", \"c\", \"d\"}]]"
+      )
+      .unwrap(),
+      "{a, b, c, d}"
+    );
+    assert_eq!(
+      interpret(
+        "Sort[Combinatorica`RandomPermutation[{{1, 2}, {3, 4}, {5, 6}}]]"
+      )
+      .unwrap(),
+      "{{1, 2}, {3, 4}, {5, 6}}"
+    );
+  }
+
+  #[test]
+  fn combinatorica_random_permutation_invalid_args_stay_symbolic() {
+    assert_eq!(
+      interpret("Combinatorica`RandomPermutation[-1]").unwrap(),
+      "Combinatorica`RandomPermutation[-1]"
+    );
+    assert_eq!(
+      interpret("Combinatorica`RandomPermutation[\"x\"]").unwrap(),
+      "Combinatorica`RandomPermutation[x]"
+    );
+    assert_eq!(
+      interpret("Combinatorica`RandomPermutation[1, 2]").unwrap(),
+      "Combinatorica`RandomPermutation[1, 2]"
+    );
+  }
+
+  #[test]
   fn permutations_with_duplicates() {
     // Permutations of a multiset should return only distinct permutations.
     // Wolfram: Permutations[{1, 1, 2}] -> {{1, 1, 2}, {1, 2, 1}, {2, 1, 1}}


### PR DESCRIPTION
## Summary

This is the output of the scheduled "check a random Wolfram Demonstration notebook against Woxi Studio" routine.

The notebook picked this run was ["Covering Maze"](https://demonstrations.wolfram.com/CoveringMaze/) by Ed Pegg Jr. Its single `Manipulate[...]` cell relies on the pre-Version-8 `Combinatorica`` and `GraphUtilities`` packages.

Woxi does have a package system — `BeginPackage`/`Begin`/`End`/`EndPackage`, `$Context`/`$ContextPath`/`Context[]`, and `Get`/`Needs` resolving real files off `$Path` and paclet directories. What it does not have is the *sources* of the packages that ship inside a Mathematica installation: there is no `Combinatorica.m` for `Get` to read. So those context names are special-cased to a `Null` no-op (`is_standard_distribution_context`, `io_functions.rs`), and every symbol such a package would have defined has to exist as a Woxi built-in under its context-qualified name — which is how `Combinatorica`UnrankPermutation` was already implemented before this PR. The symbols this notebook needs were missing, so they stayed unevaluated.

This PR adds those symbols, each delegating to its already-implemented modern equivalent rather than reimplementing graph algorithms (per the "never implement a construct twice" rule):

- `Combinatorica`RandomPermutation[n|list]` — unlike the modern `RandomPermutation[n]` (which returns a `Cycles[...]` object), this returns a plain shuffled list: a permutation of `Range[n]` for an integer, or a shuffle of the list itself for a list argument (the notebook calls it both ways).
- `Combinatorica`FromUnorderedPairs[pairs]` — builds a `Graph[...]` on vertices `1 .. Max[Flatten[pairs]]` (including any vertex that never appears in an edge) from a list of unordered vertex-index pairs.
- `Combinatorica`ConnectedComponents[g]`, `GraphUtilities`GraphDistanceMatrix[g]`, and bare `GraphPath[g, u, v]` delegate straight to the modern `ConnectedComponents`, `GraphDistanceMatrix`, and `FindShortestPath`.

### Note on approach

Adding legacy package symbols as Rust built-ins is per-symbol whack-a-mole and does not scale — Combinatorica alone is 450+ functions. The alternative worth considering is shipping a clean-room `Combinatorica.wl` (written in Wolfram Language, in terms of Woxi's existing built-ins) as a bundled resource, and having `Needs["Combinatorica`"]` load it through the package machinery that already exists instead of no-op'ing. That would scale a whole package at a time, be written in WL rather than Rust, and exercise Woxi's own package system. It is out of scope here but is the better long-term direction.

### Verification caveats

This sandbox has neither `wolframscript` nor a working GUI display (missing `libxkbcommon-x11.so` blocks launching Woxi Studio under Xvfb, and no screenshot tooling is installed), so I could not visually confirm the notebook's `Manipulate` renders in Woxi Studio, nor run the usual wolframscript 100%-match check. The semantics of `RandomPermutation[list_List]` are inferred: only `RandomPermutation[n]` is documented, but the notebook calls it on both `Range[20]` and an arbitrary edge-pair list, which implies a list-shuffle overload. Everything else delegates to Woxi's existing, tested implementations.

## Test plan

- [x] Added unit tests in `tests/interpreter_tests/list.rs` (`Combinatorica`RandomPermutation`) and `tests/interpreter_tests/graph_theory.rs` (`Combinatorica`FromUnorderedPairs`, `Combinatorica`ConnectedComponents`, `GraphUtilities`GraphDistanceMatrix`, bare `GraphPath`)
- [x] `make test` — 27283 tests pass (after merging current `main`)
- [x] `make format`; `cargo clippy --all-targets -- -D warnings` clean on the CI toolchain (1.97.1)
- [ ] Could not verify against `wolframscript` (not installed in this sandbox) or visually in Woxi Studio's GUI (missing X11 libs in this sandbox) — worth a manual check before merging