### PR TITLE
Stack a Grid/Column PlotLabel on Graphics3D/Plot3D pictures

### DIFF
--- a/src/functions/chart.rs
+++ b/src/functions/chart.rs
@@ -222,6 +222,37 @@ pub(crate) fn parse_style_directive_args(
     match arg {
       Expr::Identifier(s) if s == "Bold" => bold = true,
       Expr::Identifier(s) if s == "Italic" => italic = true,
+      // The same directives may be written as rules instead of bare values
+      // (`Style[expr, FontSize -> 18, FontColor -> Blue]`), the form
+      // `StyleBox`/`expr_to_svg_markup` already accepts.
+      Expr::Rule {
+        pattern,
+        replacement,
+      } => match pattern.as_ref() {
+        Expr::Identifier(n) if n == "FontSize" => {
+          if let Some(f) = try_eval_to_f64(replacement) {
+            font_size = Some(f);
+          }
+        }
+        Expr::Identifier(n) if n == "FontColor" => {
+          if let Some(c) = parse_color(replacement) {
+            color = Some(c);
+          }
+        }
+        Expr::Identifier(n) if n == "FontSlant" => {
+          if matches!(replacement.as_ref(), Expr::Identifier(s) if s == "Italic")
+          {
+            italic = true;
+          }
+        }
+        Expr::Identifier(n) if n == "FontWeight" => {
+          if matches!(replacement.as_ref(), Expr::Identifier(s) if s == "Bold")
+          {
+            bold = true;
+          }
+        }
+        _ => {}
+      },
       _ => {
         if let Some(c) = parse_color(arg) {
           color = Some(c);
@@ -292,6 +323,24 @@ pub(crate) fn parse_styled_label(expr: &Expr) -> Option<StyledLabel> {
     let mut label = parse_styled_label(&outer)?;
     label.bold = inner_label.bold;
     label.italic = inner_label.italic;
+    return Some(label);
+  }
+  // `Style[Grid[…]/Column[…], …]` — the stacking still applies with the
+  // enclosing `Style`'s weight, slant, color and size layered on top, the
+  // way a Demonstration writes `Style[Column[{…}], "Label"]`.
+  if let Expr::FunctionCall { name, args } = expr
+    && name == "Style"
+    && !args.is_empty()
+    && matches!(&args[0], Expr::FunctionCall { name, args }
+        if (name == "Grid" || name == "Column") && !args.is_empty())
+  {
+    let mut label = parse_styled_label(&args[0])?;
+    let (bold, italic, color, font_size) =
+      parse_style_directive_args(&args[1..]);
+    label.bold = bold;
+    label.italic = italic;
+    label.color = color;
+    label.font_size = font_size;
     return Some(label);
   }
   match expr {

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -5839,11 +5839,14 @@ fn axis_label_markup(expr: &Expr) -> Option<String> {
 /// and a labelled `Graphics3D` set their titles at the same height.
 const PLOT_LABEL_STRIP: u32 = 26;
 
-/// The typeset markup of the `PlotLabel` an option list carries, or `None`
+/// The typeset label of the `PlotLabel` an option list carries, or `None`
 /// when it carries none (`PlotLabel -> None` included). Any expression can
-/// label a plot — a string, a `Style[…]`, a `Row[…]` of computed values —
-/// so it is typeset the way every other label is rather than printed.
-fn plot_label_markup(opts: &[Expr]) -> Option<String> {
+/// label a plot — a string, a `Style[…]`, a `Grid`/`Column` that stacks
+/// several lines — so it is typeset the way every other label is rather
+/// than printed.
+fn plot_label_styled(
+  opts: &[Expr],
+) -> Option<crate::functions::chart::StyledLabel> {
   for opt in opts {
     let (pattern, replacement): (&Expr, &Expr) = match opt {
       Expr::Rule {
@@ -5865,9 +5868,8 @@ fn plot_label_markup(opts: &[Expr]) -> Option<String> {
     if matches!(&value, Expr::Identifier(s) if s == "None" || s == "Null") {
       return None;
     }
-    let markup = crate::functions::graphics::expr_to_svg_markup(&value);
-    if !markup.is_empty() {
-      return Some(markup);
+    if let Some(label) = crate::functions::chart::parse_styled_label(&value) {
+      return Some(label);
     }
   }
   None
@@ -5884,10 +5886,18 @@ fn with_plot_label(
   width: u32,
   height: u32,
 ) -> String {
-  let Some(label) = plot_label_markup(opts) else {
+  let Some(styled) = plot_label_styled(opts) else {
     return svg;
   };
-  let total = height + PLOT_LABEL_STRIP;
+  // A `FontSize` directive on the label resizes it, same as a 2-D title;
+  // otherwise it keeps the default 16pt.
+  let font_size = styled.font_size.unwrap_or(16.0);
+  // A stacked title (`Grid`/`Column`) needs one more line height per extra
+  // row, on top of the strip a single-line title reserves.
+  let line_height = font_size * 1.2;
+  let extra_lines = styled.extra_line_count() as f64;
+  let strip = PLOT_LABEL_STRIP + (extra_lines * line_height).round() as u32;
+  let total = height + strip;
   // The strip is painted in the picture's own background so the two read
   // as one canvas — an explicit `Background` reaches it too.
   let bg = opts
@@ -5923,12 +5933,24 @@ fn with_plot_label(
     )
   };
   let cx = width as f64 / 2.0;
+  let fill = styled
+    .color
+    .as_ref()
+    .map_or_else(|| "#333333".to_string(), |c| c.to_svg_rgb());
+  let mut style_attrs = String::new();
+  if styled.bold {
+    style_attrs.push_str(" font-weight=\"bold\"");
+  }
+  if styled.italic {
+    style_attrs.push_str(" font-style=\"italic\"");
+  }
+  let label = styled.svg_scaled_stacked(1.0, cx, line_height);
   format!(
     "<svg {sizing} xmlns=\"http://www.w3.org/2000/svg\">\n\
      <rect width=\"{width}\" height=\"{total}\" fill=\"rgb({},{},{})\"/>\n\
      <text x=\"{cx:.1}\" y=\"17\" text-anchor=\"middle\" \
-     font-family=\"sans-serif\" font-size=\"16\" fill=\"#333333\">{label}</text>\n\
-     <g transform=\"translate(0,{PLOT_LABEL_STRIP})\">{svg}</g>\n\
+     font-family=\"sans-serif\" font-size=\"{font_size:.0}\" fill=\"{fill}\"{style_attrs}>{label}</text>\n\
+     <g transform=\"translate(0,{strip})\">{svg}</g>\n\
      </svg>",
     bg.0, bg.1, bg.2,
   )

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -2840,6 +2840,54 @@ mod plot3d {
       insta::assert_snapshot!(export_svg("Graphics3D[Sphere[]]"));
     }
 
+    // Regression: a Grid/Column PlotLabel on a 3-D picture (as Demonstrations
+    // commonly build, e.g. a multi-line caption of computed values) stacks
+    // its rows as separate lines above the picture, matching the 2-D
+    // renderers (Plot/BarChart/PieChart) instead of being printed as a
+    // single line of raw `Column[{…}]` syntax.
+    #[test]
+    fn graphics3d_plot_label_grid_stacks_lines() {
+      let svg = export_svg(
+        "Graphics3D[Sphere[], PlotLabel -> Grid[{{\"A\", \"B\"}, {1, 2}}]]",
+      );
+      assert!(
+        !svg.contains("Grid["),
+        "Grid[…] must not leak into the SVG as raw syntax:\n{svg}"
+      );
+      assert!(
+        svg.contains(">A B<"),
+        "Graphics3D SVG missing first PlotLabel line:\n{svg}"
+      );
+      assert!(
+        svg.contains("<tspan") && svg.contains(">1 2</tspan>"),
+        "Graphics3D SVG missing stacked second PlotLabel line:\n{svg}"
+      );
+    }
+
+    // The "Latitude and Longitude of a Point on a Sphere" Demonstration
+    // titles its Graphics3D/ParametricPlot3D Show with exactly this shape:
+    // a Column of computed strings wrapped in Style[…, "Label"]. The Style
+    // wrapper must not defeat the Column-stacking above.
+    #[test]
+    fn graphics3d_plot_label_style_wrapped_column_stacks_lines() {
+      let svg = export_svg(
+        "Graphics3D[Sphere[], PlotLabel -> \
+           Style[Column[{\"first line\", \"second line\"}], \"Label\"]]",
+      );
+      assert!(
+        !svg.contains("Column["),
+        "Column[…] must not leak into the SVG as raw syntax:\n{svg}"
+      );
+      assert!(
+        svg.contains(">first line<"),
+        "Graphics3D SVG missing first PlotLabel line:\n{svg}"
+      );
+      assert!(
+        svg.contains("<tspan") && svg.contains(">second line</tspan>"),
+        "Graphics3D SVG missing stacked second PlotLabel line:\n{svg}"
+      );
+    }
+
     /// The red component of every shaded facet's fill, so a test can talk
     /// about how dark or bright a surface came out. Only `<polygon>` fills
     /// count — the white background `<rect>` is not part of the shading.

--- a/tests/notebooks/latitude_longitude_sphere.nb
+++ b/tests/notebooks/latitude_longitude_sphere.nb
@@ -1,0 +1,13642 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 14.1' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[    751891,      13633]
+NotebookOptionsPosition[    586496,      10488]
+NotebookOutlinePosition[    744242,      13473]
+CellTagsIndexPosition[    742562,      13424]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+
+Cell[CellGroupData[{
+Cell["Latitude and Longitude of a Point on a Sphere", "Title",
+ TaggingRules->{},
+ CellChangeTimes->{
+  3.35696210375764*^9, {3.433315647839596*^9, 3.433315672257135*^9}, {
+   3.433510159350289*^9, 3.433510163582712*^9}},
+ CellTags->{"Name", "Title"},
+ CellID->806361579,ExpressionUUID->"866c1904-16e4-44ee-9184-9bb11f640e2e"],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Caption",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"CaptionCells", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{
+          "The caption provides all the information needed to understand the \
+Demonstration. It should be between three and five sentences long, but \
+clarity is more important than length. Include only text in this section \
+\[LongDash] no code, graphics, etc. Do not change the cell style or copy \
+cells from other sections. Do not copy text from books or the web. Write your \
+ideas in your own words. If you want to refer to something on the web, link \
+to it in the Details.", 
+           StyleBox["\n", FontSize -> 4]}], "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoCaptionCells"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "63ace961-6c84-4ec4-99f5-bd851e41a14a"]
+}], "Section",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "CaptionCells"},
+ CellTags->{"Caption", "CaptionCells", "TemplateCellGroup"},
+ CellID->138150581,ExpressionUUID->"41890601-af97-484b-af98-bab485770a0e"],
+
+Cell["\<\
+You measure an arc length along the equator and on a meridian of a sphere to \
+reach a point. What are the latitude and the longitude of this point? Do \
+these angular coordinates depend on the radius of the sphere? How do these \
+arc lengths change as you change the radius of the sphere?\
+\>", "Text",
+ TaggingRules->{},
+ CellChangeTimes->{
+  3.35696210375764*^9, {3.43331570760184*^9, 3.4333157683401823`*^9}, {
+   3.433315801636738*^9, 3.433315834126738*^9}, {3.433315869984166*^9, 
+   3.433315930674841*^9}, {3.4333159652354307`*^9, 3.433316080423401*^9}, {
+   3.433316267033876*^9, 3.433316295547229*^9}, {3.433324585332996*^9, 
+   3.433324631115798*^9}, {3.433324722698636*^9, 3.433324738886537*^9}, {
+   3.4335100683491898`*^9, 3.4335100937867327`*^9}, {3.4336120350924454`*^9, 
+   3.4336121192275486`*^9}},
+ CellID->171705253,ExpressionUUID->"95086f4e-5220-4cc7-aa34-540a667c952b"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Initialization Code",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"InitializationCode", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{"Provide any code that must be evaluated before the ", 
+           StyleBox["Manipulate", "MRbig"], 
+           ". This will automatically be built into the ", 
+           StyleBox["Manipulate", "MRbig"], 
+           " in the final notebook version. Never use a package that is not \
+included in the default distribution of ", 
+           StyleBox["Mathematica", FontSlant -> "Italic"], 
+           ". To use a package, use the ", 
+           StyleBox["Initialization", "MRbig"], " option (with ", 
+           StyleBox["Get", "MRbig"], ", not ", 
+           StyleBox["Needs", "MRbig"], ") in the ", 
+           StyleBox["Manipulate", "MRbig"], 
+           " itself, and use the full name of the function from the package. \
+For example:\n", 
+           StyleBox[
+           "  Manipulate[\n  \[Ellipsis]\n  ComputationalGeometry`ConvexHull[\
+\[Ellipsis]]\[Ellipsis]\n  \[Ellipsis]\n  Initialization :> \
+Get[\"ComputationalGeometry`\"],\n  \[Ellipsis]\n  ]", "MR"], 
+           "\nIf you provide initialization code, include a ", 
+           StyleBox["SaveDefinitions->True", "MRbig"], " option in the ", 
+           StyleBox["Manipulate", "MRbig"], ".", 
+           StyleBox["\n", FontSize -> 4]}], "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoInitializationCode"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "b368d5c4-be47-4dec-bf93-711d94865c3a"]
+}], "Section",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "InitializationCode"},
+ DefaultNewCellStyle->"Input",
+ CellTags->{"Initialization Code", "InitializationCode", "TemplateCellGroup"},
+ 
+ CellID->447669593,ExpressionUUID->"35eef4e2-7bed-4ff3-a9a3-53c85af9a2b3"],
+
+Cell[TextData[{
+ "If you provide initialization code, include a ",
+ StyleBox["SaveDefinitions->True", "MRbig"],
+ " option in the ",
+ StyleBox["Manipulate", "MRbig"],
+ "."
+}], "CodeText",
+ Editable->False,
+ TaggingRules->{},
+ CellEventActions->{Inherited, {"KeyDown", "\t"} :> Replace[SelectionMove[
+       SelectedNotebook[], After, Cell]; NotebookFind[
+       SelectedNotebook[], "TabNext", Next, CellTags, AutoScroll -> True, 
+       WrapAround -> True], Blank[NotebookSelection] :> SelectionMove[
+       SelectedNotebook[], All, CellContents, AutoScroll -> True]], 
+   PassEventsDown -> False, PassEventsUp -> False},
+ CellTags->{"DefaultContent", "samplecell", "TabNext"},
+ CellID->687519280,ExpressionUUID->"7e3e6cd8-09c5-4dd4-b1ac-7bd5c6cc93f2"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Manipulate",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"ManipulateGroup", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{"This section contains the ", 
+           StyleBox["Manipulate", "MRbig"], 
+           " input cell and its evaluated output cell. Make all control \
+labels or labels in the output as descriptive as possible, with only proper \
+nouns and proper adjectives capitalized. More description of the controls can \
+be provided in the Details section below, if necessary. If you change this ", 
+           
+           StyleBox["Manipulate", "MRbig"], 
+           " after creating screenshots and/or thumbnails, use ", 
+           StyleBox["Update Thumbnail & Snapshots", FontWeight -> "Bold"], 
+           " in the toolbar to update any copies in later sections. You can \
+control the Flash preview for the Demonstration with the ", 
+           StyleBox["AutorunSequencing", "MRbig"], " option. Use ", 
+           StyleBox["SaveDefinitions->True", "MRbig"], 
+           " if you provided initialization code in the previous section."}], 
+         "MoreInfoText"], Background -> GrayLevel[0.95], FrameMargins -> 20, 
+        FrameStyle -> GrayLevel[0.9], RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoManipulateGroup"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "8d6fb01d-69ba-4d08-bdfd-9869e6c52496"]
+}], "Section",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "ManipulateGroup"},
+ DefaultNewCellStyle->"Input",
+ CellTags->{"Manipulate", "ManipulateGroup", "TemplateCellGroup"},
+ CellID->791025314,ExpressionUUID->"751f4140-0594-4598-9de8-56db0cbc4bfd"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"Manipulate", "[", "\[IndentingNewLine]", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"If", "[", 
+     RowBox[{
+      RowBox[{"ls", "<", 
+       RowBox[{
+        RowBox[{"-", "\[Pi]"}], " ", "r"}]}], ",", 
+      RowBox[{"ls", "=", 
+       RowBox[{
+        RowBox[{
+         RowBox[{"-", "\[Pi]"}], " ", "r"}], "//", "N"}]}]}], "]"}], ";", 
+    "\[IndentingNewLine]", 
+    RowBox[{"If", "[", 
+     RowBox[{
+      RowBox[{"ls", ">", 
+       RowBox[{"\[Pi]", " ", "r"}]}], ",", 
+      RowBox[{"ls", "=", 
+       RowBox[{
+        RowBox[{"\[Pi]", " ", "r"}], "//", "N"}]}]}], "]"}], ";", 
+    "\[IndentingNewLine]", 
+    RowBox[{"If", "[", 
+     RowBox[{
+      RowBox[{"lt", "<", 
+       RowBox[{
+        RowBox[{
+         RowBox[{"-", "\[Pi]"}], "/", "2"}], " ", "r"}]}], ",", 
+      RowBox[{"lt", "=", 
+       RowBox[{
+        RowBox[{
+         RowBox[{
+          RowBox[{"-", "\[Pi]"}], "/", "2"}], " ", "r"}], "//", "N"}]}]}], 
+     "]"}], ";", "\[IndentingNewLine]", 
+    RowBox[{"If", "[", 
+     RowBox[{
+      RowBox[{"lt", ">", 
+       RowBox[{
+        RowBox[{"\[Pi]", "/", "2"}], " ", "r"}]}], ",", 
+      RowBox[{"lt", "=", 
+       RowBox[{
+        RowBox[{
+         RowBox[{"\[Pi]", "/", "2"}], " ", "r"}], "//", "N"}]}]}], "]"}], ";", 
+    RowBox[{"Show", "[", 
+     RowBox[{
+      RowBox[{"Graphics3D", "[", 
+       RowBox[{"{", 
+        RowBox[{
+         RowBox[{"Sphere", "[", 
+          RowBox[{
+           RowBox[{"{", 
+            RowBox[{"0", ",", "0", ",", "0"}], "}"}], ",", "r"}], "]"}], ",", 
+         
+         RowBox[{"Hue", "[", "0", "]"}], ",", 
+         RowBox[{"Sphere", "[", 
+          RowBox[{
+           RowBox[{"r", 
+            RowBox[{"{", 
+             RowBox[{
+              RowBox[{
+               RowBox[{"Sin", "[", 
+                RowBox[{
+                 RowBox[{"lt", "/", "r"}], "+", 
+                 RowBox[{"Pi", "/", "2"}]}], "]"}], 
+               RowBox[{"Cos", "[", 
+                RowBox[{"ls", "/", "r"}], "]"}]}], ",", 
+              RowBox[{
+               RowBox[{"Sin", "[", 
+                RowBox[{
+                 RowBox[{"lt", "/", "r"}], "+", 
+                 RowBox[{"Pi", "/", "2"}]}], "]"}], 
+               RowBox[{"Sin", "[", 
+                RowBox[{"ls", "/", "r"}], "]"}]}], ",", 
+              RowBox[{"Cos", "[", 
+               RowBox[{
+                RowBox[{"lt", "/", "r"}], "+", 
+                RowBox[{"Pi", "/", "2"}]}], "]"}]}], "}"}]}], ",", 
+           RowBox[{"r", "/", "40"}]}], "]"}]}], "}"}], "]"}], ",", 
+      RowBox[{"ParametricPlot3D", "[", 
+       RowBox[{
+        RowBox[{"{", 
+         RowBox[{
+          RowBox[{"r", 
+           RowBox[{"{", 
+            RowBox[{
+             RowBox[{"Sin", "[", "\[Theta]", "]"}], ",", "0", ",", 
+             RowBox[{"Cos", "[", "\[Theta]", "]"}]}], "}"}]}], ",", 
+          RowBox[{"r", 
+           RowBox[{"{", 
+            RowBox[{
+             RowBox[{"Sin", "[", "\[Theta]", "]"}], ",", 
+             RowBox[{"Cos", "[", "\[Theta]", "]"}], ",", "0"}], "}"}]}]}], 
+         "}"}], ",", 
+        RowBox[{"{", 
+         RowBox[{"\[Theta]", ",", "0", ",", 
+          RowBox[{"2", "\[Pi]"}]}], "}"}]}], "]"}], ",", 
+      RowBox[{"ParametricPlot3D", "[", 
+       RowBox[{
+        RowBox[{"r", 
+         RowBox[{"{", 
+          RowBox[{
+           RowBox[{"Cos", "[", 
+            RowBox[{"s", "/", "r"}], "]"}], ",", 
+           RowBox[{"Sin", "[", 
+            RowBox[{"s", "/", "r"}], "]"}], ",", "0"}], "}"}]}], ",", 
+        RowBox[{"{", 
+         RowBox[{"s", ",", "0", ",", "ls"}], "}"}], ",", 
+        RowBox[{"PlotStyle", "\[Rule]", 
+         RowBox[{"{", 
+          RowBox[{
+           RowBox[{"Thickness", "[", ".005", "]"}], ",", 
+           RowBox[{"RGBColor", "[", 
+            RowBox[{"0", ",", "0", ",", "1"}], "]"}]}], "}"}]}]}], "]"}], ",", 
+      RowBox[{"ParametricPlot3D", "[", 
+       RowBox[{
+        RowBox[{"r", 
+         RowBox[{"{", 
+          RowBox[{
+           RowBox[{
+            RowBox[{"Sin", "[", 
+             RowBox[{
+              RowBox[{"t", "/", "r"}], "+", 
+              RowBox[{"Pi", "/", "2"}]}], "]"}], 
+            RowBox[{"Cos", "[", 
+             RowBox[{"ls", "/", "r"}], "]"}]}], ",", 
+           RowBox[{
+            RowBox[{"Sin", "[", 
+             RowBox[{
+              RowBox[{"t", "/", "r"}], "+", 
+              RowBox[{"Pi", "/", "2"}]}], "]"}], 
+            RowBox[{"Sin", "[", 
+             RowBox[{"ls", "/", "r"}], "]"}]}], ",", 
+           RowBox[{"Cos", "[", 
+            RowBox[{
+             RowBox[{"t", "/", "r"}], "+", 
+             RowBox[{"Pi", "/", "2"}]}], "]"}]}], "}"}]}], ",", 
+        RowBox[{"{", 
+         RowBox[{"t", ",", "0", ",", "lt"}], "}"}], ",", 
+        RowBox[{"PlotStyle", "\[Rule]", 
+         RowBox[{"{", 
+          RowBox[{
+           RowBox[{"Thickness", "[", ".005", "]"}], ",", 
+           RowBox[{"RGBColor", "[", 
+            RowBox[{"0", ",", "0", ",", "1"}], "]"}]}], "}"}]}]}], "]"}], ",", 
+      RowBox[{"Boxed", "\[Rule]", "False"}], ",", 
+      RowBox[{"Axes", "\[Rule]", "None"}], ",", 
+      RowBox[{"PlotLabel", "\[Rule]", 
+       RowBox[{"Style", "[", 
+        RowBox[{
+         RowBox[{"Column", "[", 
+          RowBox[{"{", 
+           RowBox[{
+            RowBox[{"\"\<circumference of the sphere: \>\"", "<>", 
+             RowBox[{"ToString", "[", 
+              RowBox[{"NumberForm", "[", 
+               RowBox[{
+                RowBox[{"2", "*", "r"}], ",", 
+                RowBox[{"{", 
+                 RowBox[{"4", ",", "2"}], "}"}]}], "]"}], "]"}], "<>", 
+             "\"\< \[Pi]\>\""}], ",", 
+            RowBox[{"\"\<arc length on the equator: \>\"", "<>", 
+             RowBox[{"ToString", "[", 
+              RowBox[{"NumberForm", "[", 
+               RowBox[{
+                RowBox[{"Abs", "[", "ls", "]"}], ",", 
+                RowBox[{"{", 
+                 RowBox[{"4", ",", "2"}], "}"}]}], "]"}], "]"}]}], ",", 
+            RowBox[{"\"\<arc length on the meridian: \>\"", "<>", 
+             RowBox[{"ToString", "[", 
+              RowBox[{"NumberForm", "[", 
+               RowBox[{
+                RowBox[{"Abs", "[", "lt", "]"}], ",", 
+                RowBox[{"{", 
+                 RowBox[{"4", ",", "2"}], "}"}]}], "]"}], "]"}]}], ",", 
+            RowBox[{"\"\<latitude: \>\"", "<>", 
+             RowBox[{"ToString", "[", 
+              RowBox[{"NumberForm", "[", 
+               RowBox[{
+                RowBox[{
+                 RowBox[{"-", "lt"}], "/", 
+                 RowBox[{"(", 
+                  RowBox[{"r", " ", "Degree"}], ")"}]}], ",", 
+                RowBox[{"{", 
+                 RowBox[{"4", ",", "1"}], "}"}]}], "]"}], "]"}], "<>", 
+             "\"\<\[Degree]\>\""}], ",", 
+            RowBox[{"\"\<longitude: \>\"", "<>", 
+             RowBox[{"ToString", "[", 
+              RowBox[{"NumberForm", "[", 
+               RowBox[{
+                RowBox[{"ls", " ", "/", 
+                 RowBox[{"(", 
+                  RowBox[{"r", " ", "Degree"}], ")"}]}], " ", ",", 
+                RowBox[{"{", 
+                 RowBox[{"4", ",", "1"}], "}"}]}], "]"}], "]"}], "<>", 
+             "\"\<\[Degree]\>\""}]}], "}"}], "]"}], ",", "\"\<Label\>\""}], 
+        "]"}]}], ",", 
+      RowBox[{"PlotRange", "\[Rule]", "100"}], ",", 
+      RowBox[{"ImageSize", "\[Rule]", 
+       RowBox[{"{", 
+        RowBox[{"400", ",", "400"}], "}"}]}], ",", 
+      RowBox[{"SphericalRegion", "\[Rule]", "True"}]}], "]"}]}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"r", ",", "75", ",", "\"\<radius\>\""}], "}"}], ",", "10", ",", 
+     "100", ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Tiny"}]}], "}"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"Style", "[", 
+    RowBox[{"\"\<arc length\>\"", ",", "Bold"}], "]"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"ls", ",", ".001", ",", "\"\<on the equator\>\""}], "}"}], ",", 
+     
+     RowBox[{
+      RowBox[{"-", "\[Pi]"}], "*", "100"}], ",", 
+     RowBox[{"\[Pi]", "*", "100"}], ",", ".011", ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Tiny"}]}], "}"}], ",", 
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{"{", 
+      RowBox[{"lt", ",", ".001", ",", "\"\<on the meridian\>\""}], "}"}], ",", 
+     RowBox[{
+      RowBox[{"\[Pi]", "/", "2"}], "*", "100"}], ",", 
+     RowBox[{
+      RowBox[{
+       RowBox[{"-", "\[Pi]"}], "/", "2"}], "*", "100"}], ",", ".011", ",", 
+     RowBox[{"ImageSize", "\[Rule]", "Tiny"}]}], "}"}], ",", 
+   "\[IndentingNewLine]", 
+   RowBox[{"TrackedSymbols", "\[RuleDelayed]", 
+    RowBox[{"{", 
+     RowBox[{"r", ",", "ls", ",", "lt"}], "}"}]}], ",", 
+   RowBox[{"ControlPlacement", "\[Rule]", "Left"}]}], "]"}]], "Input",
+ TaggingRules->{},
+ CellChangeTimes->{
+  3.35696210375764*^9, 3.433314398997583*^9, {3.433315422628916*^9, 
+   3.433315433529048*^9}, {3.433316422358046*^9, 3.433316426652569*^9}, {
+   3.433316482856444*^9, 3.433316488757887*^9}, {3.4333165747716312`*^9, 
+   3.433316575297606*^9}, {3.4333166187968197`*^9, 3.4333166191151543`*^9}, {
+   3.433316655290097*^9, 3.43331666113227*^9}, {3.433316744659815*^9, 
+   3.4333167453695602`*^9}, {3.433324654992763*^9, 3.4333246990146112`*^9}, {
+   3.433509947076063*^9, 3.4335100535427094`*^9}, {3.433510110201374*^9, 
+   3.4335101434356976`*^9}, {3.433611511257619*^9, 3.433611534153242*^9}, {
+   3.4336115816056356`*^9, 3.433611630424307*^9}, {3.433611670436803*^9, 
+   3.4336117229355793`*^9}, {3.433611756415104*^9, 3.4336117612404165`*^9}, {
+   3.4336118638253136`*^9, 3.4336118791159153`*^9}, 3.4336119380015235`*^9, {
+   3.4336119851688385`*^9, 3.433612009371008*^9}, {3.4336859424197273`*^9, 
+   3.4336860484593306`*^9}, {3.433686080251509*^9, 3.4336860864331274`*^9}, {
+   3.4336977988605576`*^9, 3.433697809014572*^9}, {3.4336978397976503`*^9, 
+   3.4336978398996606`*^9}, 3.4338526628055573`*^9},
+ CellID->913152983,ExpressionUUID->"64c4fb47-7afb-4e9e-9c7c-dfa4218eebfb"],
+
+Cell[BoxData[
+ TagBox[
+  StyleBox[
+   DynamicModuleBox[{$CellContext`ls$$ = 
+    33.06673464102067, $CellContext`lt$$ = 0.001, $CellContext`r$$ = 75, 
+    Typeset`show$$ = True, Typeset`bookmarkList$$ = {}, 
+    Typeset`bookmarkMode$$ = "Menu", Typeset`animator$$, Typeset`animvar$$ = 
+    1, Typeset`name$$ = "\"untitled\"", Typeset`specs$$ = {{{
+       Hold[$CellContext`r$$], 75, "radius"}, 10, 100}, {
+      Hold[
+       Style["arc length", Bold]], Manipulate`Dump`ThisIsNotAControl}, {{
+       Hold[$CellContext`ls$$], 33.06673464102067, "on the equator"}, (-100) 
+      Pi, 100 Pi, 0.011}, {{
+       Hold[$CellContext`lt$$], 0.001, "on the meridian"}, 50 Pi, (-50) Pi, 
+      0.011}}, Typeset`size$$ = {400., {198., 202.}}, Typeset`update$$ = 0, 
+    Typeset`initDone$$, Typeset`skipInitDone$$ = 
+    True, $CellContext`r$156493$$ = 0, $CellContext`ls$156494$$ = 
+    0, $CellContext`lt$156495$$ = 0}, 
+    DynamicBox[Manipulate`ManipulateBoxes[
+     1, StandardForm, 
+      "Variables" :> {$CellContext`ls$$ = 
+        33.06673464102067, $CellContext`lt$$ = 0.001, $CellContext`r$$ = 75}, 
+      "ControllerVariables" :> {
+        Hold[$CellContext`r$$, $CellContext`r$156493$$, 0], 
+        Hold[$CellContext`ls$$, $CellContext`ls$156494$$, 0], 
+        Hold[$CellContext`lt$$, $CellContext`lt$156495$$, 0]}, 
+      "OtherVariables" :> {
+       Typeset`show$$, Typeset`bookmarkList$$, Typeset`bookmarkMode$$, 
+        Typeset`animator$$, Typeset`animvar$$, Typeset`name$$, 
+        Typeset`specs$$, Typeset`size$$, Typeset`update$$, Typeset`initDone$$,
+         Typeset`skipInitDone$$}, 
+      "Body" :> (
+       If[$CellContext`ls$$ < (-Pi) $CellContext`r$$, $CellContext`ls$$ = 
+         N[(-Pi) $CellContext`r$$]]; 
+       If[$CellContext`ls$$ > Pi $CellContext`r$$, $CellContext`ls$$ = 
+         N[Pi $CellContext`r$$]]; 
+       If[$CellContext`lt$$ < ((-Pi)/2) $CellContext`r$$, $CellContext`lt$$ = 
+         N[((-Pi)/2) $CellContext`r$$]]; 
+       If[$CellContext`lt$$ > (Pi/2) $CellContext`r$$, $CellContext`lt$$ = 
+         N[(Pi/2) $CellContext`r$$]]; Show[
+         Graphics3D[{
+           Sphere[{0, 0, 0}, $CellContext`r$$], 
+           Hue[0], 
+           
+           Sphere[$CellContext`r$$ {
+             Sin[$CellContext`lt$$/$CellContext`r$$ + Pi/2] 
+              Cos[$CellContext`ls$$/$CellContext`r$$], 
+              Sin[$CellContext`lt$$/$CellContext`r$$ + Pi/2] 
+              Sin[$CellContext`ls$$/$CellContext`r$$], 
+              
+              Cos[$CellContext`lt$$/$CellContext`r$$ + 
+               Pi/2]}, $CellContext`r$$/40]}], 
+         ParametricPlot3D[{$CellContext`r$$ {
+             Sin[$CellContext`\[Theta]], 0, 
+             Cos[$CellContext`\[Theta]]}, $CellContext`r$$ {
+             Sin[$CellContext`\[Theta]], 
+             Cos[$CellContext`\[Theta]], 0}}, {$CellContext`\[Theta], 0, 2 
+           Pi}], 
+         ParametricPlot3D[$CellContext`r$$ {
+            Cos[$CellContext`s/$CellContext`r$$], 
+            Sin[$CellContext`s/$CellContext`r$$], 0}, {$CellContext`s, 
+           0, $CellContext`ls$$}, PlotStyle -> {
+            Thickness[0.005], 
+            RGBColor[0, 0, 1]}], 
+         ParametricPlot3D[$CellContext`r$$ {
+           Sin[$CellContext`t/$CellContext`r$$ + Pi/2] 
+            Cos[$CellContext`ls$$/$CellContext`r$$], 
+            Sin[$CellContext`t/$CellContext`r$$ + Pi/2] 
+            Sin[$CellContext`ls$$/$CellContext`r$$], 
+            Cos[$CellContext`t/$CellContext`r$$ + Pi/2]}, {$CellContext`t, 
+           0, $CellContext`lt$$}, PlotStyle -> {
+            Thickness[0.005], 
+            RGBColor[0, 0, 1]}], Boxed -> False, Axes -> None, PlotLabel -> 
+         Style[
+           Column[{("circumference of the sphere: " <> ToString[
+                NumberForm[2 $CellContext`r$$, {4, 2}]]) <> " \[Pi]", 
+             "arc length on the equator: " <> ToString[
+               NumberForm[
+                Abs[$CellContext`ls$$], {4, 2}]], 
+             "arc length on the meridian: " <> ToString[
+               NumberForm[
+                Abs[$CellContext`lt$$], {4, 2}]], ("latitude: " <> ToString[
+                
+                NumberForm[(-$CellContext`lt$$)/($CellContext`r$$ Degree), {4,
+                  1}]]) <> "\[Degree]", ("longitude: " <> ToString[
+                
+                NumberForm[$CellContext`ls$$/($CellContext`r$$ Degree), {4, 
+                 1}]]) <> "\[Degree]"}], "Label"], PlotRange -> 100, 
+         ImageSize -> {400, 400}, SphericalRegion -> True]), 
+      "Specifications" :> {{{$CellContext`r$$, 75, "radius"}, 10, 100, 
+         ImageSize -> Tiny}, 
+        Style[
+        "arc length", 
+         Bold], {{$CellContext`ls$$, 33.06673464102067, 
+          "on the equator"}, (-100) Pi, 100 Pi, 0.011, ImageSize -> 
+         Tiny}, {{$CellContext`lt$$, 0.001, "on the meridian"}, 50 Pi, (-50) 
+         Pi, 0.011, ImageSize -> Tiny}}, 
+      "Options" :> {
+       TrackedSymbols :> {$CellContext`r$$, $CellContext`ls$$, \
+$CellContext`lt$$}, ControlPlacement -> Left}, 
+      "DefaultOptions" :> {ControllerLinking -> True}],
+     ImageSizeCache->{
+      598.64603515625, {224.90445861816409`, 230.63639221191409`}},
+     SingleEvaluation->True],
+    Deinitialization:>None,
+    DynamicModuleValues:>{},
+    SynchronousInitialization->True,
+    UnsavedVariables:>{Typeset`initDone$$},
+    UntrackedVariables:>{Typeset`size$$}], "Manipulate",
+   Deployed->True,
+   StripOnInput->False],
+  Manipulate`InterpretManipulate[1]]], "Output",
+ TaggingRules->{},
+ CellID->1394899794,ExpressionUUID->"42f7e86c-24c1-43e9-835b-de103ad72916"]
+}, Open  ]]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Snapshots",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"SnapshotGroup", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{
+          "To create snapshots, click 'Add Snapshot' in the toolbar at least \
+three times, and adjust the controls of each copy to show a range of \
+interesting settings. Optional captions for the screenshots may be included \
+in the Details section.", 
+           StyleBox["\n", FontSize -> 4]}], "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoSnapshotGroup"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "3b16406a-a288-4428-9a93-e06d53396d25"]
+}], "Section",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "SnapshotGroup"},
+ DefaultNewCellStyle->"Text",
+ CellTags->{"SnapshotGroup", "Snapshots", "TemplateCellGroup"},
+ CellID->98938448,ExpressionUUID->"21d2b916-5354-4bd6-b138-bd27b92b77b3"],
+
+Cell[BoxData[
+ PaneBox[
+  GraphicsBox[
+   TagBox[RasterBox[CompressedData["
+1:eJzs3QecFOX9+HEw9iRqYjdqLLEiSTSJLxNj/kL8qUTsYIkoWCAWxAAiKkWK
+SlEQEZDei3Q46SBdadLrcXBHuzvuzusNjrL/7+3DPRlmZmfn6t7d83m/5pXX
+7eyUZ3aXZD+Z2d3rX3nnqWZn1KhRo/W58h9Pvdy2TqtWL3/w9EVyo2GL1m/8
+p0XT1+q1eLfpf5q2uueVn8nMPvIf086sUaPw74DD0aNHs7OzfwIAAAAAVHES
+d5J4zu6zNWB6UGZmZg4AAAAAoIqTuFOVF6oHc3Nz5d6srKzcoHwAAAAAQBWn
++k5CT3JP/nDNQAnGvLy8SI8UAAAAAFCWJPQk92wxqC4KJQMBAAAAoLrSMagv
+E01LS1MXhUZ6aAAAAACA8qIuE5UAlAw8cuSIOkUY6UEBAAAAAMqX+mCgZKAk
+YWZmJteFAgAAAEC1J+knASgZ+NNPP+Xk5ER6OAAAAACAiiABqH5qkBIEAAAA
+AENQggAAAABgGkoQAAAAAExDCQIAAACAaShBAAAAADANJQgAAAAApqEEAQAA
+AMA0lCAAAAAAmIYSBAAAAADTUIIAAAAAUMnFBq0NWnA6NVMt4H+DlCAAAAAA
+VHKUIAAAAACYY3vQLH/Uwn42SwkCAAAAQKVFCQIAAACAOdQFn87cyzidcwE/
+V4pSggAAAABQCVGCAAAAAGAa9VUwJShBtaL3xilBAAAAAKiEKEEAAAAAMI36
+kQjX+gtFLaxW9N44JQgAAAAAlRAlCAAAAACmoQQBAAAAwDSUIAAAAACYhhIE
+AAAAANPw3aEAAAAAYBpKEAAAAABMExtUghJUK3pvnBIEAAAAgEqIEgQAAAAA
+M20PcuaeK7Wwn81SggAAAABQaVGCAAAAAGAmdcGn+iqYBadTM/1cEWpFCQIA
+AABAJUcJAgAAAABKiRIEAAAAANNQggAAAABgGkoQAAAAAExDCQIAAACAaShB
+oDr5HgAAAPj++7DvGylBoDqJ9H/lAAAAoFII+76REgSqE/UPPwAAAABT/fjj
+j5QgYBpKEAAAwHCUIGAgShAAAMBwlCBgIEoQAADAcJQgYCBKEAAAwHCUIGAg
+ShAAAMBwlCCQVyQ3NzcnKMtCzZG79GKRHm8ZoAQBAAAMRwnCcNYGzMzMTE1N
+TU5OPnz4cEKQ/CE3ZabcZe3BSI+6tChBAAAAw1GCMJnOwKysLMk96b6kpCR5
+ncvM40Hyh9yUmXKXLCCLVY8YpAQBAAAMRwnCWDoDMzMz1XnAjIyMUP9S5C51
+flAWrgYxSAkCAAAYjhKsVFJTU1u1ajVq1Ch1c//+/Y0aNRo9enRkR1Vd6bOB
+KgPlb+9/LLKAikF9ZjDSR1BylCAAAIDhKMFKRdKvRo0azzzzjLo5bNgwuXn7
+7bdHdlTVkjqpl52dLa9qPxmoqBiUVWTFyJ4WnOXP7CDn6pQgAACA4SjBSsVW
+gsnJyR06dJg/f35kR1Ut6etC4+PjPS4KdZKFZRV9jWikxk8JAgAAoDQowUrF
+VoIoP+qEYEpKSkJCQnH/1cgqsqI6LRip8TujL7OI8y7n6pQgAACA4SjBstK8
+efPbbrtt8eLFderUOe+88zp16qTmT548+d57773wwgsvvfTSBx54YMmSJda1
+1q1b17hx4yuuuOKSSy55/vnn16xZYy3B3bt3yzY7duyobi5btkxuDhw4UK+e
+mpoqc9566y09Z+jQoX/961/PP//8a6655umnn96zZ4/3sKVlDh8+vG/fvtgi
+ew2wJ0ge3o0bNx48eLC4/2pkFVlRVlfbKdux6SdCnhR5akLFJiUIAACA0qAE
+y8pjjz0mEXf55ZdfdNFF//jHPwYPHiwzhw8fLjMvuOCChx566K677pK/zz33
+XMk9tYq81b/qqqtk5k033fTggw9Kvl133XXWEty6davcfO2119TN2bNny80u
+XbronSYlJcmcRx99VN3s27ev3JQGlFUkSGvWrCnjSUtL8xi2tEbs6cq2ayon
+ybeYmJhdu3ZJiaenpxf3X42sIivK6rKR8itBRZ5i1yfOGnpzgihBAAAA+EcJ
+lhVVgvXq1cvIyNAzmzRp8uc//3nDhg3qZs+ePWWZ9u3bq5sNGzaUm61bt1Y3
+9+/ff+WVV5amBGVfP/vZzw4ePKhufvzxx3feeeeCBQs8hm09G2hUCe7evXvn
+zp2rV68uKCgo7r8aWUVWlNXVacGyHZvt6ZAnyPWJowQBAABQGpRgWVEl6P1g
+SjXIMg0aNFA3r7322ksvvdT6kA4ZMqQ0JfiXv/xFbo4ZM8b/59cML8FVq1aV
+rARlxcpQgpnhUIIAAABwRQmWFVWCzmv5xo0b16xZs7///e+1atU6//zzZZmn
+nnpK5ickJMjf999/v3VheTpKU4LSgDVr1pQ5V1xxhWxEdi0t4D1sY68O1ecE
+S3Z1aIWdE/S+OpQSBAAAQMlQgmXFtQQbN24sM88888y//e1vDRo0kAbUJShv
+8uXvhx56yLr8tm3bSlOC+cGvoHn77bdvvfXWGkGSn/piUVfGfmOM+pygvP7j
+4uKK+69GVpEVy/tzgn6+MYYSBAAAQMlQgmXFWYIHDhyQOb/97W/1zE2bNukS
+FJdccsm1115r3cg333zjUYLz5s2Tm02bNtXLq3K0lqC2efPmunXryr09e/Ys
+u6OsPqSwJJQSExNLVoKyoqzOr0gAAACgiqIEy4qzBNeuXStz7rvvPj3n7bff
+tpbgAw88IDcHDRqkbmZkZPzxj3/0KMG9e/eqLxrVG2zXrp0uwZSUlOeee65l
+y5a5ubnq3pEjR1q/oAZW6vcE5SW9Z88eedb8/5ORhWUVWZHfEwQAAEDVRQmW
+FWcJSiZcfvnlquw+/vjjevXqnXPOOdYSXLdu3fnnn3/22WfLAu+++27t2rUv
+vPBCjxIUkoEy54477pC+e/bZZ9UG9TnBe+65R24+/PDDX375ZadOnX7961+f
+ccYZ69evr6jHoCqRZ0eSWeo7Pj4+JiYmKyvLz78XWUwWllVkRVmdEgQAAEAV
+RQmWlSeeeEIqLDk52Tpz7dq1+iN7N9xww9SpU63fHSqmT5/+5z//WX3Nyx/+
+8Ie5c+fKH88995y6d/v27bbLQWWOBKPa4BVXXDFmzBj54/HHH1f37tu3T/6W
+tJSZss3bb7994cKF5X/oVZU+LRgbG7t7925pKO9/LLKALCYLR/yEYD4lCAAA
+gNKhBCvAoUOHJB88FkhISNi/f7//DSYmJu7Zs0dfBWojz9GuXbtSU1OLN0rz
+SMrJYyXpJP0eExOzY8eO+Pj4UP9S5C5ZQBaThWUVWbGylaAH5+qUIAAAgOEo
+QZhMx2BKSorU+tatW7dv375v3760tLSjQfKH3JSZcpcsIItVhgzMpwSBiOrV
+q1ezZs0iPQp3zYJ6BUVFRUV6OBVHDlYfuAi1mNwVHR3tnK/WLc8BFps6ItfR
+VkIeo23mxvZoq39TmlEvXSCCKEEYTsegvLwTEhJiYmKk+9avX78mSP6QmzJT
+7pIFKkkGlh4lCJRGVFCkR+GiarVD2fKZcqEqgxIsMRmh7jiPEow6nXVJdaRq
+pqgqBw5UA5QgoGIwOzs7IyNDXuRJSUnSfYeC5A+5KTPlLlmgemRgPiUIVFOV
++WRlefN5IokSLFsyPOu5vJKdb3U+Kd4ndgGUFUoQUHJzc1UPZmVlZVjITdWA
+oT6YWRVRgoAf1pMd1jer8of1baq+qZa3Xn/osQXbW1+1pG1FfX7Eurp1m9aN
+6CWdl4baxmA7HRNq8Oou1wv2PIbn5wH0visU275cH2TbIYQaTC8Lda+aGeqx
+LfGYnavYHl7bAs4zZWF36vE06V3oJ1ff63Oz/jvU++pQj6zTJwStM9XYvPce
+7YPPwQPGogQBG5WEWnUKQI0SBMLSnzvT17Ppt6a2U2/qpv5P/f7Zewu298bq
+3Ir1jbo1WKyVZ92m9T22LgLb1Xe6cazh5n/wai3b+/xQw3OGjOvh69Wto/I+
+B2Qbj3V31i04rzy0PsLOIekHXDeR62NbJmO2JY81S/W91sfQ+qS7LhD2adL3
+Wp8sn8eiX0seB+g8WI8SDJVmrit6bM22jDefgweMRQkCBqIEAW+u5yn0+1LX
+ErQt7LoFawX4KUHbSTT9jtq261A39TCcO7Idi5/BW8fsHF7AcerHoyPCjsp1
++RLvzraW62LOyLKdlirumF1XCTheRdbV9VNsXd31NRBqgcDpT5O1E20Ha3v5
+OctL/R8LZVWCVrbNuq7o+gLz2K9td/6HDRiOEgQMRAkC3lzfw2th+8vPFvyU
+YNg38GFH4vqu2Lod/4O3znQdnrNBQr0hDzUq/+UYcJRU6UvQO46KO+ZAuNNq
+ro+8M/Q8XgNhnyb/keW/vELxKMEoy1fBhDr1WeIStD2Mfk4mAtAoQcBAlCDg
+zfVdeqh7XRcOu4UKKMHo07/Nw3ZeJuzgXVkv7wxbgq7H7mdUruOxzfRTak4l
+K0GPMXvs1LqW9UpUj4Oyzgxbgh5Pk8cWPC6qLKcStHE9s+k6yBI8od7/DwwA
+G0oQMBAlCHirTiWoz8jYhB28x1phS9Dj8P2MynU8tpkVX4LFGrN1O9Zk8/PI
+ux6gc5xhnybv020lOBbvw/RZgoGi60U9VvS/NdsT6v3vDoANJQgYiBIEvFVA
+CdrujS63q0O9v9WkBIMPNTznOUHXd/LRp58S8sPPJawVUILFGrOT7YtZSn91
+aNinyaMESxN9/vcVivUoXMfj89Sec6fO/48FgAdKEDAQJQh4iw7xMaXo0N8d
+WpotBByXw5VVCTq/lsSmBIMPNTzrm3DvdCruiRvX8VjPKwWKU4Kuo/IuwRKM
+OWB5uDTrRsK+BsKWYNinKVSd+ana6ODH+vwHY6h9Oec4r/x0jsf25Ibi+oKn
+BAH/KEHAQJQgEJb+ug911Zw1qfyUoPcW9Ht4da++erDMSzC66KNq1qsBe1m+
+vDHs4G3j9xie7U247fCtq4Qdlc8H01YT/r9gxLpfvbp3CZZszNYH0FZAtke4
+V9FvPYQagOs4vZ+mUHWmPypoXauX29fS+nlIbUdnfVQDIZ64UAkc6sl15fpZ
+Qq4OBYqFEgQMRAkCfti+WyPUVXkebz5DbcF2V6+in+Qr8xIMWH5Hz7o7P6e6
+nF8t4n1Fn/N0jPfhWz89ZxuVn/E4TxH6zBbbQenVvUuwBGN2PoDOT7TZXgbe
+A/AYp3Ujfq7R9XhybcMLdXSK8/F0PtHOez3i1PXJDbVf5+m/UOdJAbiquiXY
+oUOHJ4IyMzMjPZZClW08gAdKEPDPdo6jbLdQ+o2XyTDCrlWaQXqvXtyNl8kj
+VsqDKpMx286xlmwktl2U+Pkt5d7978h7XxX5zwFAoCqXYJ06dWoEpaamVuR+
+MzIyJgetXLmyMowHKAFKEAAii+sYAUQcJVhcu3fvVvutX79+ZRgPUAKUIABE
+FiUIIOLKuwTz8vJK+l41DEoQKDFKEAAiS33NS6RHAcBo5VSCixYtevjhh6+5
+5pozzzyzVq1aL7/8ckJCgrpr/vz5fwoaNmxYq1atbrzxxssvvzw3N1fdu337
+9ubNm991111nnXXWLbfc0qhRIykv1124lteIESOefPLJiy+++Morr3zuueem
+T5+u79L7lWW6dOly2223yS5q1649ZcoU62ZlMdnpb37zm5tvvrlDhw4zZ85U
+a40ZM0bulRXvuOMOtd8LLrhA5ssh2MazZcsWGcNFF1109dVXy6aSk5P9PGJA
+RaIEAQAADFceJTh8+PCaNWvWON0NN9wgq8u9EyZMUHOuu+46fa8qwejoaIlH
+24rSiRs2bHDuxVmCPXv2tK0rwxg7dqy6V+9XEs+2zLp169Qyy5cvP+ecc6z3
+SqiqPz777DNZQJLWtgt9ZlCPRwLWukDdunXDPmJABaMEAQAADFceJXjbbbdJ
+AV144YWjRo2aNWvWvffeq5poxowZ+ZYiE7Vr13733Xdbt26tLiL929/+puY3
+aNBg4sSJzZo1UzebNGni3IutBJcsWaJDT3YaFRX129/+Vm6eeeaZe/fute23
+adOmXbp0UQuI//73v2qbuvvuu+++3r17N2zYUK+iSnDVqlV9+/ZVc+66667x
+48cvXbrUNp6rrrqqR48ejRs3/tnPfqbmHDp0yOf7c6BiUIIAAACGK48SjI+P
+P3jwYEpKiro5depUFUSdOnXKtxTZnXfemZGRodfKzMw866yzVMplZ2ermY0a
+NZIoe+yxx5x7sZWgbFzdXLZsmVpAYlDNkV6z7vfRRx9VC+g5TzzxhNyUMevz
+gOnp6WqZ+vXrW0sw38fnBKVDbXPmz58f9kEDKhIlCAAAYLjyKMHc3Nz+/fs/
+//zztWrVuuqqq/RptY4dO+Zb+qtdu3bWtVauXKnmS/35eStrK8FHHnmkRgjq
+lJ/eb+fOndUW4uLi1Jx//etfcnP27NnqpvUUZL9+/YpbgomJiWrOBx98oOao
+k6FA5UEJAgAAGK48SvCf//ynKqCaNWteffXVoUrw008/ta713XffqfmvvPKK
+n7eythK8//771c3f//73fwy6/fbb5ab80aFDB9f9Hjp0yFqCS5cuVTefeeYZ
+vZcePXoUtwT15xZlv5QgKidKEAAAwHBlXoJr165V+VOvXr34+HiZM378eD8l
+KBs/44wzZP6f/vQnPXPgwIHt2rXr3r27c0e28mrTpo26uWXLFteBhS3BtLQ0
+NYCLLrpo165dMke2rL8p1FmCDz74oMd48ilBVGKUIAAAgOHKvAT1NZaSV0lJ
+STt37rzzzjv9lKCoVauWuksaKjo6evDgwerm448/7tyRrbymTJmibsr8uLi4
+zMzMLl26/DpItuO6X1sJCvlDzZG1pGStX2SqSzAxMVF9Fcwvf/nLmTNn7tmz
+x3U8+ZQgKjFKEKgkevXqJf97F+lRFP62nYwk0qMIScbGT++Vk2iLki0Qdstl
+MUwA5aLMS1A66Oc//3kNC3WizU8JLl269Pzzz69xurPOOsv1G1ds5ZWXl9eo
+USPnTm+88cbDhw+77tdZgrKk9TcgZCNPP/20rQTzT/9MovNXJChBVH6UIFBJ
+NGvWrIIbx/UHzSW1ZCQVOYxQXNNYxlaZQ7WUItW5stNmp5M51gdf/f8DzmXC
+blk2YlvLttlmIdD7QAUrj88JStDpn2O444475L9G1N8fffSR3Dtx4kR10/Wa
+z7lz5957773qR/1q1qx56623Lly40HUvdevWVdtJS0vTg2zRosX111+vO65h
+w4YxMTHqXud+4+Pj1RwpO73ZjIyM2bNnt2nTplOnTuvXrx86dKhapnfv3tZ3
+0Xffffe5554r85966qlQ45HjVXNmzpwZ9kEDKhIlCFQSFf/ut1eQc2YlKUHX
+B6R6l2Ckjk69EvSZOxVo1pGoErQtYMs6V2o7ajG9lr5XbcqJEgQqXnmUoCKd
+deDAgZK9Tc3MzNy4caP+HYriio2N3bZtW1ZWVnFXbNq06UsvvfT666+r83q5
+ubn6TN8PP/zgXF7/2gVQtVCCQCVBCdpQghXGGXRhXwbqZJ/3K9bZdGot735U
+a/kYNYCyVH4lWBU1btxYdd9VV131wAMPXHLJJermzTffnJeXF+nRAWWGEgTC
+sl0XZ7twTv7Wp0tUW+m3vmqOdUWPd87O99W2S/Ks9+pzNNbr65wbt91rTT+9
+5V5F1EGp+c6Rh32UbPtyfYisR+SxTeve9fD0o6Q25bGdEgxeH4L3irZ7rdev
+6mN0bjDU9m27CPWMhD0i/ZLTT7Fe0TZI/8KWoJ8zd64bCVu7nBAEIoIStEpI
+SHjhhRdsH1SsV6+ezI/00ICyRAkCYan3rtZL16znNdRpDvWm15ot+hNSel3v
+98DO1tPVo1e3vsO37s71aj29jG3k+l41Zn2vmm/tEedaodhG6/oQ+X80rBco
+2oYXdjv66Qh1oaPPQ7A94PqR0fvVj551v85Gsz50aq1Ql0Hqx812yK4Ds+5I
+vxL061AP2zZIn8JWnv4/Pby34/rIe68YxQlBIEIoQae9e/fOnTt36NCh8+fP
+Vz+EAVQzlCBQXLb3/Nb0sC7mTImA22V4mjMKnFmh30I7F9DD8N6C9W22x9Wh
+tjN6zgNxHqltX9bB2MbmOhgn1xhxBq9twM6U8DP+EjzgthH6KUEn21Pgmk5h
+N+t6olAPu5fvb6GxnnkM9XDpBPYT16FKMNRjErZAAZQfShAwECUI+GT7ugxb
+Arh+y2Wx3tM6S9C2gPUttGtmOkvQtoD/ErTOCfuJMI/RqgGUrJJClaBtzLYj
+DbWW9/hdD8E60/XEaMlK0OOLWUIdnW2ztpeczy4LS5/p84jBqKILUP28vEtW
+giUbPIBSogQBA1GCQFhRp3+8y/WyQOe5v9KUoHV3NnpIrqHX6/SPAdp2UU4l
+6Lov6whdtxD2bX8JStD5mwWa9/g9HnC1ZdeoKW4J2j7up19OPo/Ouh3rvsqq
+BD1G7uTn/F2xSpATgkBkUYKAgShBwJv1U1p6ZgWUYC/Ll/ZbWUdFCYbakcdD
+5zp+fQYz1FplUoLWtLTu2ufRaRVQgq77tQm731APmuta1v+jA0DFowQBA1GC
+gDfXzPFZgsV6f97McU7QY2GfJVgxV4d6lKDHFsqvBIubRboEvQdTyhIM+1FE
+1724vrpsm6q0JRj2345td5wQBCKIEgQMRAkC3sKWUajPCYb6jFioHYXNCuvq
+YUvQ2UT6yknvEZagBF0XsO6rxCXo54yS7aEI23Su4w/7gDvL2vVlYBubswQ9
+njLnzVCbtT10HkWmPo3oHXSubLtwbsH1O4ts+3I+aKGKjxOCQMRRgoCBKEHA
+m37vqnpBf84rbAnq9/DWdT3OodjeIetPI+rLFK2r+8wKNVTb5+BCHVq05fcE
+nQfifb7GNlp902MLYUvQtk39KHmXoA5e20MX9nyT3p3tKJybjQrxq4iuD4Jt
+C7bXg+1wnE96IMQr0LpfjxJ0Luyknx2PXaiXUKhDsz4Rrv+HgF7Rtfg4IQhU
+BpQgYCBKEAgryvKb6b2CH9/zU4K2FXUFhNpLqFZyXd1PCQYs3/TYy/Jr7KF2
+UZoSdI7WdraoBCWow8GaD2FLUB+17aHzc17Mdgi2fXm/DJwD1sPweIhsT1n0
+6V8pYzsF7PrYuj4mms8SdB6490vR9SF1DTrbY+L6RHiMH0CFoQQBA1GCgB/W
+czQlXj0iu7YKdVKyTDauN1WGWyvlBku2rvcDbjtB6XpBqfdO/YzKdYEyf2xd
+t+9n8MUdRhm+hgGUE0oQ1UZekdzc3JygLAs1R+7Si0V6vJFECQLVlZ9TNigN
+Hk8A1QYliOrB2oCZmZmpqanJycmHDx9OCJI/5KbMlLusPRjpUUcMJQhUV/pj
+aPpzglyDV7YoQQDVBiWIakBnYFZWluSedF9SUpK8XGXm8SD5Q27KTLlLFpDF
+DI9BShCorvR3m+jPCUZ6RNVNyb6WEwAqoWpWgjLCVq1ajR49OtIDQcXRGZiZ
+manOA2ZkZIR6wctd6vygLGxyDFKCAAAAhqvSJSiDWbBgwYYNG/Scffv21ahR
+49lnn43coMqY8xhho88GqgyUv71f87KAikF9ZjDSRxABlCAAAIDhqnQJHjhw
+QLrvoYce0nOqXwk6jxFW6qRedna2vDj9ZKCiYlBWkRWr6GnBWf7MDnKuTgkC
+AAAYjhKs5ChBb/q60Pj4eI+LQp1kYVlFXyMa6eMoNkoQAAAApVGRJRgdHd28
+efPatWv/4he/eOCBB3r27KnfgW/duvW222775JNPunfvLgucc845tWrVGjly
+pMfWOnfu/Lvf/U4q6fzzz5d1Vf3pEhw4cOBdd9113nnn3X333YMHD7atO2LE
+iPr16//yl7/8wx/+0Lp1aykCjx3t3r37nXfekV386le/evLJJydPnmy9Vw5B
+DuTvf//7ueeeKyOfMGFCly5dZOEdO3bIvcuWLZO/ZTB6+dTUVJnz1ltv6TkJ
+CQmvvvqqHIsctWyhZcuW2dnZHseoDB069NFHH73oootkAVl97dq1+i79YLZt
+2/b6668/66yzPI6uqlMnBFNSUuRhLO6LX1aRFdVpwUgfR7E5oy+ziPMu5+qU
+IAAAgOEqrATlXfctt9wiUXPTTTfVq1fvwgsvlL+letS9EjJy85prrpGeqlu3
+rixTI2jBggWhNjho0CDZjixz2WWXSaBJ9eQXleBvfvObs88++7777pOwUtuZ
+NGmSdUWZIxn40EMPqR3JkllZWa57SU5Ovv3222WZO+6445///Kek5RlnnDFz
+5ky9wEcffST3ynxp21tvvVX+Vu2mPtk3e/Zs+VvaUC+flJQkcyTi9AN78803
+q+1LnEpsWs9puh6j6Nu3r97p73//e/n70ksv3blzp/XBlFVq1qwpQV2nTh2P
+50Ui6PDhw/K4xRbZW3XsCZJU37hx48GDB4v74pdVZEVZXW0n0kdzin4i5EmR
+pyZUpVKCAAAAKI0KK8FGjRpJnrRp00bdTElJUQU0d+7c/KJ4OeeccxYvXqwW
+6Nixo8x58cUXPbYZ6upQKaBp06apOf369bO21a5du84666yrr746Li5OzWnc
+uLEs0K1bN9ddvPzyy3Kv5J66uX79eklIyVh12k46QvZ18cUXS02oBST6VHv6
+LMEVK1bceeedLVq0UDflbbw0nTwO8keoY9y+fbvU6CWXXBITE6PmDBgwQJa5
+99571U39YM6ZM8fj0VOkNWJPF+kSKgbJN3kQ5Dldt25denp6cV/8soqsKKvL
+RiphCSrygnF94qyhNyeIEgSqokryQw/qhyciPYqQZGzV4Cf8wj7RtsOMDirn
+QYURXaTM1yrZlgGUrQorweuvv14ax7r6jBkzJFjat2+fXxQvdevW1fdu2bJF
+na3z2GaoEqxdu7aeEx8fL7F2++23q5sjRoyQBfr3768XSEhIkDmPP/646y5u
+vPHGK6+80jrnrbfekuWlIOTvwYMHy9/yX9363ry8vGKdE3Rq0qSJLLBp06ZQ
+xzhs2DCZ07t3b+taf/7zn88++2x1ZlM9mPXq1Qu1Cyvr2cCqWILS4Dt37ly9
+enVBQUFxX/yyiqwoq6vTgpE+mlNsT4c8Qa5PHCUIVA8V/zPl6gcHbTPVb9BX
+5DBCcU1jGVtlDlU/5KDCPte2w4z4Uctom1n4fKGGXUs9FFb0IBApFVOCiYmJ
+0ib333+/daa8y5WZjzzySH5RvLz55pvWBSRt7rnnHo/NhirBBg0aWBe75ppr
+pEPV3y1atFDn7P5ooa6udG5fVZtzYTFkyJD8oipctGiRda1nnnmmWCW4a9eu
+du3aPfjgg3/6059URerVXY+xefPmzp2+8sorMnPVqlX6wXz77bc9HjrrI1YN
+SlAOvGQlKCtW6RLMDIcSBCq5ii9B9YvzzpmVpARdH5CIN1HpSeyE/Ul622FG
+9ifsVdDpMeibpV9LHaZ1gUry2gMMVDElGBcXJ23y8MMPW2eqk3HqPKBrvJxz
+zjklK0Hbd4daS1AVU+3atRta3HjjjU2aNHFuX7WqsC4sMSgHIv/dpbe2YsUK
+61ovvvii/xKUB/+iiy5Sn22sX7++uobWuwRfffVVmbNy5UrrTt944w2Zqa6t
+LVYJVvWrQ/U5wZJdHVr5zwl6Xx1KCQJVHSVoU11L0I9KdZjOwfh5kYRdy9mG
+6hQhpwWBiKiwq0OvvPLKa6+91jpn4cKFEiytW7fOr8AS/Oqrr2SBUaNG+Rz2
+5ZdfftNNN4W6t0+fPrK1QYMGWWfeeeedOuXmzZsnfzdt2lTfu23bNmsJvv76
+67ZLPRs0aOBdgv3795c5ti9E/X//7//VrFlTnqD8YpZgVf/GGPU5QXkZx8XF
+FffFL6vIipX2c4J+vjGGEgTKj3oHa73IzfpmVf5W5zXUH9ZPeKk51hU9Ws8Z
+Puoje64X16m71Nklj6vvbPda009vuVcRdVBqvnPkYR8l275cHyLrEXls07p3
+PTz9KKlNeWynBIMPFF2M6tyybWu2TvHel37G9WtD78K2HdujZ8so28cGnS9I
+W0/5fG34+Wiq67Wsasse6/pZyzUnm1WmBAaMUmEl+Mgjj1j7JTc3t06dOjJn
+/Pjx+SUtQXVW8YYbbtBzwpagHKws8Je//CUtLU3NkQR44oknPvzwQ9ddqK/u
+VINUevTo8dhjj6lSW7p0qdx78803p6SkqHtlSetJPXljXyP4dal69Xbt2llL
+UDYlN+fPn69uSpWoU4S6BJ3HuGrVKplz6623qu7LD/bmGWecoT8LWawSrOok
+lKR3EhMTS1aCsqKszq9IAHBS706jitiKQL3pVW9rrdmiPwOl1/V+l+tsPV09
+enW9U32vbk9np+hlbCPX96ox63vVfGuCOdcKxTZa14fI/6OhN2IdvH6UvLej
+nw7VXGEfduvj77rl0uxLP0F6U2rJUM+19Zny+Jygnxek9Vj0E209XteZTlFu
+V3WG/aijx1p6nK7Pi+t5agAVoMJKcOvWrRdffPHZZ5/dsGHDtm3b3n333VIr
+9evXVxssWQmKX//617Liv/71rwEDBuT7KMH8otNwtWrVeu+991q3bn3ZZZd5
+nCXcsmWL7EJG8txzz3Xu3Fl2JAtLc+mf/HvhhRdUl7Vq1er5558/77zzzj33
+XGvKqR+quOOOO9q3by8Dk01ZS/DLL7+Um9ddd90HH3zQsmXLyy+/XC2gV3ce
+Y37R5xNvu+022elLL710wQUXyFr6k4OmlaA8F/LKlKJPSkry/8qXhWUVWZHf
+EwTgh+1tsDUHrIu5njfxOI1i3abrG2nrm2TnAnoY3luwNp3H1aG2M3reJ4Bc
+92UdjG1sroNxcm0NZ/DaBqwGY13F5zWHzhGWfl+utWV7/YR99FzH5rFB10xz
+bkEVos8SdL6M/ZSg91qhSjDs/+0AoDxU5C/LL1++vG7dutJK0ilXXXVV48aN
+9Yk5GYbM1D+moEhS/fWvf/Xe5vjx46+88kp1mk9u7t+/X/6WIrMuc+211954
+4436Zm5u7jvvvCNtqE7eyb3Dhw/32MWSJUvq1Kmj+u6MM86QktW/QCHS09Ol
+xSRy5d6f/exn6n9BrCm3fft2/bOGV1xxxZgxY2pYvqpUDUY9JrLxpk2bqtX1
+d4c6j1GtJQ14ww03yMwzzzzzb3/729SpU/Xyrg9mdSURJ49GRkZGfHx8TExM
+VlaWn5e9LCYLyyqyoqxOCQIIRX/Xve2te6jQ8HPCJdTyzsQInP4m2fWdtrME
+bQv4L0HrHJ9v+123owbguoUSl6CzaGxnmlzXCvtc+Blhcffl+gi7lqD3YbpG
+k/cLsriPdiiUIGCIiixBRd6p7tmzp5QbsZEcyyz6AT7/JOgOHjzoc2FJhl27
+doX6AXqpiR07dsgy+UVf3mI9qZcf/PZUOWpZzHV1eVRl46mpqR4DcD3Gffv2
+ea9lAn1aMDY2dvfu3fIoeb/mZQFZTBauuicE8ylBoPxFnf55PduJHtcSDPtW
+2clWEM1C0ENyDb1ep38M0LaLcipB131ZR+jxqbFQ2wyUqAStF0balHkJeuzL
++iyELUHXIPIuQT8vSEoQQLFUfAlWe64liPIjKScvSymg5OTkmJgYSfL4+PhQ
+L3i5SxaQxWRhWUVWrDYl6MG5OiUIeLN+Ak7PrIAS1J8+s7GOihIMtSOPh87/
+7vyUoPe+yqMEfb4gy6oES/by9rOWnwMHUGEowTJHCVY8HYMpKSmxsbFbt27d
+vn37vn370tLSjgbJH3JTZspdsoAsVqUzMJ8SBMqZ61tonyVYrPe0zRznBD0W
+9lmCFXN1qEcJemyh/EqwZClRshL03pefEgz1AgtVgj5fkGVbgq7PnUdc+1kr
+7IEAqEiUYJnbv3//xo0bQ11HinKiY1BepQkJCTExMdJ969evXxMkf8hNmSl3
+yQJVPQNLjxIEvIUtI9cSdF0x4PsbY0LFl/9zgs5O0Vczeo+wBCXouoB1XyUu
+QT/njPz0hR/FLcFAiNy2bcFnCdo2UqwSdH1Bhj2WaB8/cO86GNetRQUVay3n
+gbt+eQ6AikEJotpQMZidnZ2RkSGv1aSkJOm+Q0Hyh9yUmXKXLGB4BuZTgkA4
++t2puupPfz4rbAnqFrOu63EKyfYeWH/4S19waF09bAnqLTQr+rGJZkVCHVq0
+5fcEnQfi/f7cNlo/n1wLW4K2bepHybsEdfDaHrry+MaYsPvyU4K2jVifNevY
+bE992Bdk2GOxPUceXPfoEf7FXUsv49wIgApDCaKayc3NVT2YlZWVYSE3VQOG
++t4eo1CCQFhRll/oVp/P8lOCthV1FYbaS6hWcl3dTwkGir5aRNHvxkPtojQl
+6BytdfmSlaBOA2sghC1BfdS2hy7sya8SlGCg6FxYqH35KcGA20PnUYIBfy/I
+MixB1xHaFnCNuLBr2Z5iP08TgHJCCaK6UkmoEYBWlCDgh/WsWYlXj8iurUKd
+lCzDt99lNdQy2WCZD6Zc91WsLZThq8K/ku0x7FoRORYANpQgYCBKEKiubG+t
++RAWACAUShAwECUIVFfq8j99dajzukoAABRKEDAQJQhUV+ojbNbPCUZ6RACA
+SooSBAxECQIAABiOEgQMRAkCAAAYjhIEDEQJAgAAGI4SBAxECQIAABiOEgQM
+RAkCAAAYjhIEDEQJAgAAGI4SRBWVVyQ3NzcnKMtCzZG79GKRHm/lQgkCAAAY
+jhJEVWRtwMzMzNTU1OTk5MOHDycEyR9yU2bKXdYejPSoKxFKEAirTH6Mr5x+
+zk/9YmAEfyswukgFrAUAKCeUIKocnYFZWVmSe9J9SUlJ8uKUmceD5A+5KTPl
+LllAFiMGbShBIKxmzZpJcPlcWOrGmWZy07oR12VKRrYpW45UUqm9az4fJe+1
+9L3+H3MAQClV0RKUkbRq1Wr06NGRHkjx7N+/v1GjRt7DnjRpkhzaoUOHfC5v
+Gp2BmZmZ6jxgRkZGqJe33KXOD8rCxKAVJQiEVdwSdKaZ3JQt6Jm2MCyNCJag
+2rU+Ln2zNGtFBam/I3uuEwCMUiVKUHa6YMGCDRs26Dn79u2rUaPGs88+W/GD
+KY1hw4bJsG+//XaPZZo2bSrLbNmyxefyptFnA1UGyt/er3BZQMWgPjMY6SOo
+FChBIKzSl6DrMlW9BGW/EmvWOXJTZpZmLUoQACKiSpTggQMHJIgeeughPaeK
+lqD0SIcOHebPn++xjLUE/SxvFHVSLzs7W16KfjJQUTEoq8iK1ea04Cx/Zgc5
+V6cEgbBs1abKxXpxow4W9ak9FTuKWtF6OaheRi/mXEZTC1vnqMX03tXf1rVs
+Czh7s0w+Wugas2GzNOxa+kFQS5ZmhAAA/yjBysZagrDR14XGx8d7XBTqJAvL
+Kvoa0UgfRxmgBIHyZosX1V9RRVRw6ZBRc/QCer7eiPcytoyynWWzrWjbu96I
+jim9vHObpTwj6XotaNhznR5r2WqaE4IAUJHKqQTlv8mbN29eu3btX/ziFw88
+8EDPnj312++tW7fedtttn3zySffu3WWBc845p1atWiNHjgy1qc6dO//ud7+T
+ODr//PNlRVV/ugQHDhx41113nXfeeXfffffgwYNt644YMaJ+/fq//OUv//CH
+P7Ru3VpawGPMMmDZ/g8//PB///d/P//5z6+//nrZYHZ2drt27a699lrZ+733
+3rt48WKf29eH2bZtW9nUWWedJTN3794tMzt27KgXk4elR48esuVzzz1XPQ7W
+EnQun5CQ8Oqrr8oDIo+bPHotW7aUEdoOQZ7TRx555Fe/+tVll132zDPPyGPl
+cdRVizohmJKSIo9DcV/qsoqsqE4LRvo4yoAz+jKLOO9yrk4JAmF5140tZEJ9
+TtD2jTFhg0ixlaDqPusCttNw6qb3ZlVqlUkJeh9mWa0FAChv5VGC8pb7lltu
+kZy56aab6tWrd+GFF8rf0izq3rVr18rNa665Rtqnbt26skyNoAULFrhubdCg
+QbIRWUC65sknn5Swyi8qwd/85jdnn332fffdJ02kNjJp0iTrijJHMu2hhx5S
+e5Els7KyQg37sccek2Wuvvpq2drDDz8sW5abDz74oIxTtnDPPffIzQsuuODg
+wYN+tq8OU8Zcs2ZNSbw6derkB/NQZr722mt6px999JHMkZKV/Lz11lvl79/+
+9re6BG3Ly4N/8803y5w77rhDClRaz3ZiVB2CPLY33HCDjFxqUW7+4x//8Hiy
+JIsOHz4sj2dskb2V1Z4gqeONGzfKs1Dcl7qsIivK6mo7kT6akPQTIU+KPDWh
+upUSBMqba6fo30GwnWIrvxJ0PaFmayvXoZZHZ1GCAFCdlEcJNmrUSAKkTZs2
+6mZKSorql7lz5+YXJZJEij6/1rFjR5nz4osvhtpgqKtDJbKmTZum5vTr18+a
+Rbt27TrrrLMk6+Li4tScxo0bywLdunULtReVUTJ4dXPcuHFqFwsXLlRz/v3v
+f8ucqVOn+tm+Psw5c+boXdjKTsJEtn/xxRfHxMSoOSoMQ5XgihUr7rzzzhYt
+Wqib8p7/0ksvlV3IH9ZDePTRR3Nzc+VmYmKibFzmyP/ghjpqaY3Y00W6hEKS
+fJMHSh75devWpaenF/elLqvIirK6bKRKlKCSlJTk+sRZQ29OECUIlC1bp9h+
+BKGCS9D5QULrtanNQihuZ6krS115DIYSBIAqqjxK8Prrr5dCsS45Y8YM6ZH2
+7dvnFyVS3bp19b1SPeqEWqgNhirB2rVr6znx8fFSVfprNkeMGCEL9O/fXy+Q
+kJAgcx5//PFQe1EZtWbNGnUzIyNDnX3TC6htyv9A+9m+Osx69epZd2Eru8GD
+B+sNKnl5edddd12oEnRq0qSJLLBp0ybrIVgvYX3mmWdkjsd3zljPBlb+Ety9
+e/fOnTtXr15dUFBQ3Je6rCIryurqtGCkjyYk29MR6uJeShAob9ZO0Z+8C/WT
+EBEvQfXBQ6diHbLtW3Gs2ev/MJ1KthYAoLyVeQkmJiZKetx///3WmfKGVmY+
+8sgj+UWJ9Oabb1oXOPvss++5555Q2wxVgg0aNLAuds0110iEqr9btGihTq79
+0UJuSqKG2ovKKOspGNuBTJ48WeZ8/vnnfravDvPtt9+27sJWdm+99ZbcXLRo
+kXWZJ554wqMEd+3a1a5duwcffPBPf/qT+vik0L+voQ5BmlQv36VLF5nj2gL6
+kaxyJbhq1aqSlaCsWM1KMDMcShAoMWunOH8oocJK0HUBZwnavh+mnJTTd4cC
+ACKizEswLi5O0uPhhx+2zlTny9R5QNdEOuecc0pQgrbvDrWW4CuvvKJOGja0
+uPHGG5s0aRJqL8UqwbDb91OCaiMrVqywLiMHFaoE5Zm66KKL1Ack69evr67C
+dZag9RC6du3qXYJV6+pQfU6wZFeHVsVzgt5Xh1KCQPmxlaAttWwf3ytlCdo2
+bv2KGNcFbBnl5xf9ok//mfsScw7GuXfrBaX+1wIAVLDyuDr0yiuvvPbaa61z
+Fi5cKD3SunXr/Ioqwa+++koWGDVqVNjRasUqwbDb91OCffr0kZu2rzy94447
+QpXg66+/Ljd79+6tF27QoEEpS7BqfWOM+pygvGjj4uKK+1KXVWTFKvQ5QT/f
+GEMJAuXHeXWovgJTX0Xp+jMTqrkCbumn19LL2GZar8/Ua+nPJNr2brtU1XaN
+qO2bQsvkVyRCPRTO7nO2Ydi1AAAVrDxK8JFHHrEGTm5ubp06dWTO+PHj80tU
+guqU4g033KDnhC1BOShZ4C9/+UtaWpqaI2/+n3jiiQ8//DDUXopVgmG376cE
+ly5dKjdvueUWeWDVnLFjx3p8Y4waof7Qn0SNOkVYmhKsWiSLpG4SExNLVoKy
+oqzOr0jkU4KAD7ZUsX5jjIos7wUCbiXoXCbg+MqXqKLfoLcOxnXv0Y4fibBu
+x/bbfGUYX7Yvz3H92lLn+b6wawEAKlh5lKD0y8UXX3z22Wc3bNiwbdu2d999
+t8RI/fr11bolKEHx61//Wtb617/+NWDAgHwfJZhfdAatVq1a7733XuvWrS+7
+7DLvs3jFKsGw2/dTguKFF16QObfddpts4fnnnz/vvPPUj264luCXX34pN6+7
+7roPPvigZcuWl19+ufqdCKNKMDs7W16H0t1ymP5f57KwrCIr8nuCCiUIlICf
+r2Hx8z0trsv43HLJNl4eSrajChseACCscvpl+eXLl9etW1e6RjLkqquuaty4
+sT53JnuUmfqnEJRzzz33r3/9q8cGx48ff+WVV6rTcHJz//798rekk3WZa6+9
+9sYbb9Q3c3Nz33nnHWlDdZZN7h0+fLjHLtRXtSQnJ+s5NU7/jtMpU6ZYL870
+3r7rYW7fvl1mNm3aVM9JT09/6aWX1G89SDu///776pflt23b5lxe7VE9qmec
+cYbMb9asWQ3Ld4c6D+Hjjz+WObNnz/Y48CpEIk4ehIyMjPj4+JiYmKysLD8v
+cllMFpZVZEVZnRLMpwQBAACMV04lqMib0j179hTj3W040k2ZRb+d519cXJz+
+OfjyUPrtS57s2rXL56HJUyALp6amlmaPVZc+LRgbG7t792550Lxf4bKALCYL
+V6cTgvmUIAAAAEqnXEsQKHOScvIilN5JTk6OiYnZsWNHfHx8qJe33CULyGKy
+sKwiK1bjEvTgXJ0SBAAAMBwliCpHx2BKSkpsbOzWrVu3b9++b9++tLS0o0Hy
+h9yUmXKXLCCLVbMMzKcEAQAAUDqUIKoiHYPymkxISIiJiZHuW79+/Zog+UNu
+yky5SxaofhlYepQgAACA4ShBVFEqBrOzszMyMuSVmZSUJN13KEj+kJsyU+6S
+BchAJ0oQAADAcJQgqrTc3FzVg1lZWRkWclM1oCwQ6TFWRpQgAACA4ShBVA8q
+CTUC0BslCAAAYDhKEDAQJQgAAGA4ShAwECUIhNWrV6/o6OiK3GN0UHlsWY4l
+KiqqPLasRBcpp81W8BMBAIagBAEDUYJAWM2aNSvXenKSXpOd6uqRvcucMtmy
+bLasNmWjxmzlfNCaufEejzp27y3LzVB7BAD4QQkCBqIEgbAqPjGigvRNlUJl
+suXyK0G1ZX3mTtWZ7XHTvWblfZpPlaBts7ZM1nup+LO3AFA9UIKAgShBIKyI
+n2yqEiXoTDCVbGW+d9mR9RmhBAGg9ChBwECUIBCWx+WI6i5rfcjfqkeslzU6
+Q1ItZr1C0lox1stB9b56FVGLuV4y6kwh21CdLWYbifNIS5xXzoAtkxK0nW3U
+D7gqxFJuHADMRAkCBqIEgbBsfaR7yvViRdUjut3UGatQW9BXSDqveNRRo4vS
+djml64lCPzuytpj1WFwv6dS7Ltnj5lqCpfniF9V9tpxUDxEnBAGgxChBwECU
+IBCW7VpEWxmp9NNtYrt2UbHFi/PUmNqsawkGQkRf2BIM9Uk920icQ7VuVkVW
+CUrQ43OCtlL2v0E1tnK6uhUATEYJAgaiBIGwnHllW8BaT6FK0HqOL9TlpuVR
+gs4FbNed2hawjaRkXC9DVfP1yUfnmdCw21RBXeJzlACAUChBwECUIBCWNT1c
++8taTz5L0PXTfGVbgqEWcH4C0ak0JWg7SVomS1q5pjQAoDQoQcBAlCAQli2v
+XE91Vc4SdA7VWl76VwudvB8QD8WNO+dnCX2uxTWiAFCGKEHAQJQgEJbPc4Lq
+77AlqBaoPOcEy/BbVkJdFOqhZE1HCQJA2aIEAQNRgkBYzU7/zQJnPfn5xhhb
+CVpDRv+OQwlK0PYDFs4SDDtUZ1LZthkV7sffrWP2uGjTuRHXr99x/ipHcXcE
+ACguShAwECUIhNUsxA8rqAspbd9hErYEA46fCHR+Os9Wgnqb1qs3dcep+c7f
+LtS/Z2FbwPkrEvrHKfRizoP1foisg7HRB+X6uNkK1/VnLPQxhloLAFBKlCBg
+IEoQCMuZQrbvWvE4Mac4T+rpb8K0/i6hbfuh9mj7dlDdd85d28bpevWm83tj
+rAsUqwRduY7WOmbnYDwOwXUtAEApUYKAgShBoMRK+eUqVq4/6OC6xxIMw884
+S/9dMf6VbF8VOUIAMA0lCBiIEgQqni1nXE8jAgBQYShBwECUIFDxnJ8T5Jsw
+AQARRAkCBqIEgYqnPhho/ZxgpEcEADAaJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwl
+CBiIEgQAADAcJQgYiBIEAAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIE
+AAAwHCUIGIgSBAAAMBwlCBiIEgQAADAcJQgYiBIEUC3lHtySd6hwSl83IePH
+iRnrJ2ZsmJS5YXLyvK6pC7ulLuqW9l2PtMU905Z8lr7k88JpWa/0pTJ9nrq4
+Z9bWGZlbZJqesVmmaembp+Uf3pGfuEP+M9KHBQDlghIEDEQJAqjS8g5uyT+0
+NX3teCm+5Fkdf5rbJXHUv5PGvpQy/uWfvnk1dVLTtMnN0qa+kTbl9bRpb6RN
+ezN9+lvpM5qnz3w7I6pFRtQ7Gd/+N2NWy8JpdqtT05zWhdPcd4NTm4x5bTIX
+vJ85//2M+W3T572XNrfNT7Nbpf/wVerKvlk7ZmVu/zY/KTo/aVekHwYAKBVK
+EDAQJQigapH0S1s9/vCM9slRHeKHNDw88t/Jo19MGdckdcIrhdPE19ImNUuf
+/J/0qa9nTHszY/pbmTOaZ85skRX1Tta3/82e3Sp7duvsOe/mzH03Z16bnHnv
+5cxvm7vg/cJp4QfB6cPcRTK1y/1OpvY5Mi3uoKfsoilLTUs6Zi35KHNxx4zv
+OqQu+CBl3nvpq7/Ojp6XuXNupB8kACgeShAwECUIoDLLO7BFpV/S9PYpkn6D
+nz48/LnkUS+kjHkpdVyTn8a9LPWX9s1r6ZOaZUz+T8bUNzKnvZU1o3n2zBbZ
+Uf/N+bZlzuxWuXPezZ3bJm/ee3nz2+YteD9/wQf5Cz/MX9SucPqu/ZHFHY4s
+6RicPjqyVKZOR5Z1LpyWdymcVnQNTh/LlG+Z8oJTbnDKWdFVpuzlwWlF16xl
+XTKWdkr9rkPKgg9zYhZm715w5Kc9kX4UASAMShAwECUIoBKS+kuc0u7wtPYH
+BzwZP+jpw0OfSRrxfMqoRj+Nfil1bJO08VJ/r6ZPbCr1lznljSypv+nNs2e0
+yIn6b+63LXNntc6b826e1N/c9/Lntc2fX1h/RxZ+eGRRuyPftT+6uMPRxR2P
+Lvno6NJOBTIt61ywvEtw6lqwQqaPC1Z+Ujh9/2nB990KfghOq7oHpx4Fq2Xq
+WbDms4I1PY+uLpyOBKf81T3yV/XIC065q7rn/tA9R6ZVPbJ/6J658tP05V1T
+l3TO3DAiZ+932TGLIv3QAoALShAwECUIoPLIO7g1cWq7/f2ePDTgqYRBDQ4P
+fTZ5xL9TRr14KgDHvZI+4dWMiU0zJ/0nKxiA2dPfzpn5Tm5hALbKkwCc/W7+
+nDb5c987Mu/9I/M/OLLgw6ML2x1d1P7odx0KFncsWPKRpN+xpZ2PLetybHnX
+Yys+Pi7Tyk+Of/9pcOp2/AeZuh9f1aNwWt2zcFrzWeG09vPg1Ov4Opl6n5p+
+/OLYqamPTAU/fiHTUZnW9T6yrnf+Wpl65a3tlbvmc5ly1nyetapn5vfd0ld8
+krqsa27c0pzYxZF+sAHgfyhBwECUIIDIyjuwJW3V+MNT2x/o91T8108nDmqY
+JAE4/N8pI18oDMAxRQH4zakAzJ76Vo4E4IzCAMz7tqUEYH4wAI/MbSsBeHT+
+B0eDAViwqEPBdx2PLf7o2JLC+ju+rMvx5V0l/U6s+OTEyk9PfN/txA/dZTq5
+qsfJ1T2D02cn18j0+cm1vQqndb0Lpx+/CE59Tq6X6cvCaYNMfWU6IdPGr/R0
+fGO/wmlTv2MbZfqqQKYNfY9u6HtkvUxf5q//Mu/HPjLl/tgnZ90XWas/z/ih
+R9rKbrn7lufELYv0MwAAlCBgIkoQQERkx22On/hh4pT2B/o+eaj/0wlfNzg8
++Jnkoc+lDP/3TyMbpY5+KW1sk/Rxr2RMeC1zYrOsya9nT3kzZ1rz3Bktcmf+
+Ny+qZd63rfJnvZs/WwLwPR2ABcEAPBYMwONLOh0PBuCJ5YX1d3Llpye/73by
+++4nf+gRWCVTz8DqzwJrPg+s6RVYG5zW9Q6s+yLwo0x9Auu/DGzoG5y+CmwM
+Tpv6Baf+hdNmmQacmrbI9PVJy3Riy0A1HS+cvj625euCzQNkOrpJpv5HNvbP
+39gvb4NMX+X8+GX2uj6Za3qnr/o8a9uE3P0rIv2cADAXJQgYiBIEUJGyYjcd
+GP9B4uR2+7988uBXT8UPaJA4sGHS4GeThz2fMuKFn0a+mDq6cdrYl9PHv5ox
+oWnmxP9kTX4je8pbOdPezp3xTl5hA7bK/7a1NOCROe8dndv26LwPCuZ/WLCg
+3bGF7Y8t6ni8KABPLOsqAXhSAnDFpydXdgt83z0gAfiDLQB7F9Vfn1P1dyoA
+Jf36FU6nuk+K72vJvcCWgYGtahpUOG2TafBp0/YhejpZNJ0ITse3DZbp2NbB
+BVsHFWwZdHTLwCObB+Zv/lqm3I39czZ8lfVj34y1fdJX987aMSn3wMpIP0sA
+jEMJAgaiBAFUgIw9G/eOaLP388ckAA/0fepQv6cTBjQ8POiZ5CHPpQz7908j
+GqWOfCltdJP0sa9kjH8tc0KzrImvZ09+M2dq89xpLYIN2FI14JFZbYIN+L5q
+wGMLJAA7HP9OGrDTiSWdTyztIg14MtiAgZWfBnQDqgBcrQPwi8A6XX/B9Dt1
+7k/V34DT6091n7X1hgZ2yDTs1LRTTcPdphFqOlk4DT+xc/jxHcNkOrZ9WMH2
+oQXbhh7dNuTI1sIpf8vg3E1fZ2/sn7X+q4x1fdPW9sncMSkzdmmknzcApqAE
+AQNRggDKVdbeTQfHfRDX+4l9faQBnz7Ur0FhAw58NmnwcylDn/9peFEDjnkl
+Y1xRA056M2dKsAGnFzZgfmEDvisNeHROW2nAgsIGbBdswI7Hv/so2IBdTizt
+enLZxyeXfxJYEQzAld0D3/cI/NAzsKooANf0DqwtCsAfdQD2C2zsf+rc36Zg
+/W221V9R+m0vSj+deLtkGhmI1tMo+7RbTaNPm6JHn4wedUKmXSOP7xp5bOcI
+mQp2jDi6Y/iR7cNkyts6JGfzoOxNX2du6J/+Y7+0dX0Tl3dP37Mk0k8jgGqO
+EgQMRAkCKA8ZezYmLR1zaMKH+794ct8XTx340tmAL6SOeCltlKUBvylqwKnB
+BpzRMn9mUQPObnt0zv8a8PjCwgY8sbizNOBJawOucGvAtboBgwG4XgfggKL6
+G1g4bQnW39Zg/W1T9afO+p2efruKok/HXcyY4DT2f9Me2zTOPsWMPSnT7jEn
+do85LlP06GPRowt2jZLp6M6RR3aMyNs+PHfr0JwtQ7I2D8rc+HXGhgHJq3pn
+xvLdMgDKCyUIGIgSBFC2suM27x/9/p6ej8V+/sSpBvyqQUL/ZxK/fjZp0HMp
+Q57/aZg04IuFDTj6lYyxr2WODzbgxDdzJgcbcFpRA0a9e+Tbogac++GxeUUN
+uOijE991PrG4y8klXU8u/Tiw7JPA8m6BFd0DK3sEvu8Z+OGzwKrPA6uLTgKu
+7RNY92Xgx6IA3NA/sNESgFuC6aemwgAM1t92S/3ttNafPrVnSb9TcTc+sFdN
+E/43xbpO35yaihY7uWe8TCdixh2XaffYY7vHFkSPORo95siuUfk7RuZuH56z
+bVjWliGZmwdnbBr004/9svavTNvDVaMAyhglCBiIEgRQVhIXj9k3+v3d3R6N
+/eyJ/dKAfaQBG+oGTJYGHPpC6vAX00Y2Th/9csaYVzPHNc2a8J/sb97YMLLj
+xlEfbRzTedPYzpvHdp08uN/kwf2nDBkwZcjXU4Z+PWXYwKnDBk0dPnj71F7b
+p/XePv2LMA24undgTagGVGcABwW2qAC01J8KwB26/kadqr/oYPrtdk0/XXzB
+uIubaJkmFWOKnSjTydhvTuyVacLxPROO7RlfECPTuCPRY/N3jc7bOSpn+4js
+bcMztwzN2DwkdcPA9B1TM+L4rlEAZYYSBAxECQIovezYzds7/yv600f3fvbE
+vt6FDXiwb8P4fs8kDnj28MDnVn3139X9W477okeXHiO69BgpU9eeo17qPLv0
+06d9J8k0fczI6WNHybRzzkBLA34VWN8vsL5/YMOAwMavT2/AIZYGDNafmnYG
+A3CXCsBg/e2W+htXOEn67bGc8jt1as8Sfftkmnxq2j/FMU31mvZNCU6TA3GT
+TxZOk07ETjoeO/HYXpm+Kdgz4WjM+PzocXm7xuTsHJ29fWTW9pHpm4f+tP7r
+pHX9sw78EOknH0B1QAkCBqIEAZSGNGDcyPejP3l0b88n9vV6av8XTx/8ssGK
+L95e+cU7nT4d3rnb8DIpvmIXYr+p0yeMm/7N+J2LRgQ2DSycVANukQYcGtg2
+rHA61YAjCwPwVAOOLmpA9Yk/awAWpV+s5XzfqfQ7PfcOTDs1HZxejOnA9FNr
+7Zdp6sl9Mk05ETfleNxkmY7FTjq6d+KRPd/kx0zI2z0uZ9fY7J2js3aMSt8y
+LGXDoMNr+2UeWBXpFwKAqo0SBAxECQIoGWnA2BHv7/r40Zjuj8d+9uTSns1H
+dv/ko0+GRST9woRh/2nTJ30zfdLEYAMOtzTgqFMBuCsYgNFji04CBgNwTzAA
+96oAVPVXlH773NLvgMq6GYXTIZlmuk1Rp6b4qP/9fWoKLnBwZuHqB2SaflKm
+/dNP7J92fN+0Y/umFsRNORo7+cjeifl7vsnbPSEnenz2rnFZO8ekbR2RsnFw
+yqahmQdXR/pFAaCqogQBA1GCAIore+/muBHv7+zy6MJP3ujYdWjHj0tbf5/0
+GvdJ7/Gnpi8mqE8FTh0+ZNqIoYXTyGHTRw6fPmr4p19OUpeDlnJ306dMlmnn
+8gn/C8DCBhxX1IATihpwYlEDTg42oArAqcHTdkXpd6Ao/Q5a0i8+GHrx3xZO
+CdZpVpgpftaptWRSeXhw5kmZDsw8cWDG8QMzju2bVhA39WjclCN7J+fvmZQb
+MzFn94Ts6PGZO8embRuVvHFodvy6jMSYSL9AAFQ9lCBgIEoQQLHEDn9/Xuf/
+dOgyxH95de05qmvP0d/0+2LD8A4bR3TcOKrTxlGd86a1yp/x7pGZbY5EtT36
+7fsFsz8smNPu2NwOx+Z3PL6g04mFnU8s6nLyu49PLvkksLRbYFn3wPIegRU9
+Ays/C3z/eeCH3oFVXwRW99k5d/DOeUOmjx87ffy4T/tNlanYVTht6vRp02QK
+xAQDcE8wAPcGAzA2GIBx6kN8OgCt9Wc506fTL95SfImzLdMc39PsQIKaVBvO
+Chz69mRwOnEw6viBmcf2zyjYN/1o3LT82Kl5eyfn7pmUEzMxK3pCxo6xqdKD
+m4Zlxf8Y6ZcJgCqGEgQMRAkC8Clx0Zi5nZq17xy+Abt0H9Gl+8jxfT5fN+j9
+jDHNMsf+J2v8G9nfvJUz8e3cye/kTW2ZN611/ow2R2a+V5iBsz4IZmB7ycDj
+8z8qysCuJxd/HFjyaVEG9gys+Cyw8vPA9710BgbW9A2s/Sqwrl/gx/6B9QMC
+678ObBgY2Dho56JR0ycWXgsqU/EuIh0YNX36jJ2rpgYbcEqwAacWNaD6KJ8O
+QH2Rp6o/fV7v9O47PNcyzSucksJNh/U0N5CopjmBhOAUP/tk/OwT8bOOH/r2
++MFvjx2IOrp/xpF90/PjpuXFTs3dOyU7ZlJm9IS0wh4ck7pjXFYCPQjAL0oQ
+MBAlCCCsnXE/dRu12jujOncb3rnbiNX9Wq3p/27q8CZpI19JH/VaYQaOez1r
+/JvZ3zTPmdQid/J/LRnY9mjU+0dnfVgwu10wAzsGM7DziYVdghn4STADuweW
+9SjKwF6B73sHfvgisKpPYPWXlgz8XwMGNg4ObBoS2Dw0sGVYYOvwwNYRgW0j
+AttH7lw2fvqUKZ9+PbMY5wpnzty5ekZRAwY/uFf4CT4VgEX1Fz+r6OSd5ZSf
+vfvm/29KlmmBrylJTcG1Ds8/tbXEeYVhmDD3ZMKcE/Fzjh+afezQrIKD3x49
+EHVk/8z8fTNy46bl7J2aFTMpI/obKcGUraN/2jHu4NYFkX75AKgCKEHAQJQg
+gFDCBmCnT4Z3+nT4931aJn39QvLARimDX0wd2jht+MvpI1/NGNU0Y8x/Mse9
+kTX+LUsGtsqb9m5RBn4QzMD2x+Z0ODZPMrBTMAO7nlz0cTADuwUzsGdg+WeB
+FZ9bMvDLwOq+gTVfBdb2C6zr78jAoYHNw05loDTgtpGB7aMCO0YHdo4pnHaN
+DUSP27liUvBy0Ol+kzDq253roiwNaA1AVX/BM3f/qz+dfrrsFhZOKXpa5HdK
+XnRqXZmSivKwMAznn0ycdyJh3vGEucfi5xQcmn304KwjB77N3x+Vt29mbtyM
+7L1TM2Mmp+36RkoweduYrMQNkX4pAajsKEHAQJQgAKf/z95dtbeV7fna/mC7
+17u6V9UqSKXCzMzMzHHikB3HGDMzMzOTLIuZmZnHO8aYmrZkOwXdvXdS5fFc
+v6OKXUfSwX39p+TfMODjF7lwQ+8uq1P2aFL3atP2IQZmUQw8Ysk7Zi04YSs8
+FcPAi67Ky+7qqzQDb/ka72AG3scMfBTseIwZ+IxmYAJmYCLNwPdg5AMYTQJj
+yfEMTAczGWA2E8xhA85n0wykToEFgFUI2EU0A0sArxTwy4CgHAgqgLACiCqB
+qIo7Vlff0JCQ2Qz3+yRsbgVqGoCaJQBST3Ku0B/Nt2XW9QLTivX9sfWi36Vm
+6IlO342m64rousLazpCmI6huD6ja/KpWn7LFq2j2yJtc0gaHuM4mqDbzKozs
+Mh2zyEY+PEgikb4ckSCJtA4jEiSRSLH9hgEfPc8deHNR8WGXKnk3xUAdxUB0
+DTwUz8Az9tJzjrILMQy87qm7STPwHmbgQ8TAdsjApzQDX0Z6IQNf0wx8F8PA
+j2A8BUx8ApOpYCptLQbmgoU8wMyPMpBNMZA2IK8shoHIgEBUDcTVQFIDJLVA
+WketvrGpvvF3SFjf0gaHHtSkAKjrXL7WRQG4Qn+06cxw/WttAM0SP/PS8M+Y
+ltYHjNQgDJENI/qesK47pO0KajsDmg6/ut2navMqWz2KFpesySlttIvrLIJq
+E6/SwC4zciv14pGv/RIjkUjfYkSCJNI6jEiQRCItVTcgWG2fh89yehMuSN/s
+kL/fpUjarUreo07Zq0ndp0vbr884YMg8CBloijLwpDWOgZdclVcQA2swA+tv
+xzIwgBj4JNRBMfBFGDHwFeijGPiWZmASGE1excAMMJMJZrPAHDbgfE4MA+lT
+ILsYcEoAt5RmIDagoBIIqxADoQHF2IASbEBZPV4DkMM1AkVTfVML3O+QsLWD
+O9+JbnNxAMTHu+WL3pe4N7hyVrihuFmo0T9gHlzmoWkgCkMjXF/E0BfW94b0
+PSFdd1DbFdB0+tQdXlW7R9nmlrc4ZU0OaaNNXG8W1Bh5lRpmsU09+7VfaCQS
+6ZuLSJBEWocRCZJIJPCFUyA0YM+L8+LX26VvdsYx8NNKBprzjmMGnrYVn7WX
+nI9h4DX3EgMb7vggA5sfYAY+phn4HDMwATIwAhnY/wYMUAz8EMPAT2AiFUym
+gan0OAbO/S4DywCvHPApA1IMxAYU19KnQAxAatiAQNEMlHAtQNUKV9/cBvdb
+Xzea3V7f1kk/wEnrz7RCf0vii7eedThutqWN4A2v/AHL0PLMg9EhFQ5EjP3I
+g4a+kL43qOsJaLv9mi6futOj6nAr25zyFoe02SZptIigB2t17HLFXL5FOf21
+X3QkEukbikiQRFqHEQmSSOu81QZ88CS788lZ/vOtwpfbxK93YAbuViTtUSXv
+pRiohQxMX2LgUchAS34sAy86yxEDXVWYgbWIgd6GuzQDH9EMfBbqXIuBg+/A
+0BIDU9Zg4EwWmM0GczlgPhcw8sBCPmAWgMVCwCoCrGLALgGcUsDFBlxmYBUQ
+VgNRDc1AbMAoAxuBvAktysAWoEQGBOo2oEZf1Ak0HUDbWd/SXt/a8VsnwvYu
+2oDU5W6F/laIbyR+o9HZ42dbsRFgXRqEITWowiFggiQcjBgHwsb+kKE/qO8L
+6Hv9uh6fttur7nKrOlyKNoe81SZttoobzaIGA69atVBiJcdBEolERyRIIq3D
+iARJpPXcisdB7z/Obn98hvtkC2JgwvYoA9/tVnzADPy4T/NpP2SgjmJg1mFT
+9lFzLs3AIszAUsjAy84KzMDqG4iBdZiBjYiB/pZHgVbIwKdBioFdL8PdFAMT
+aQa+RwwcTgIjH8FoLAMzwFQmmM4CM5/XZuDiagZWAH4lEFTFMLAWiOtoBmID
+yigDNuO10KdAbEA1NqCmEzIQaLuADq4b6HvqWzt/04PdUf1Ri+pvFfqi1htb
+tXHgoGdfWvzP2Kjh/48VzzKCSGiGG4qYhsKmwZBxIGjoD+j7/fo+n67Xq+lx
+q7tcyg6Hos0ua7VKms3iRqOgTsOq0AtaPHb1134Zkkikrx+RIIm0DiMSJJHW
+Z1ypaYViWh6cYj/azH0KGbiNZuAuGWagcomBqQd06QcNGfEMLFhmoCOOgbc8
+UQbe9zfRDGyjGPgihBkY7nlNM/DdSgaOfQLjqWAiHUz+JgOZqxjIjWGgoBoI
+a4ColmYgNqC0kT4FYgBSU2IDRhmIDajBBtR2IwPqeiADgZ76npa++rYuuC96
+sKMHjgbg0r0vXnyx6HNM/InZY5BoozYGrGM0CUci5uGwaShkGgoaBwOGAb9h
+wKfv9+r6PJoel6rLqeywy9ut0lazpNkobNDxahQLpRYV+TMTJNJ6j0iQRFqH
+EQmSSOut1Y+Dpj94wrz3K2bgVsTAl9vFr3ZKEnfJ3u5WvN+jTNqrggxMiTJQ
+n3HIkHXY+PmoOee4JS/KQFvxeTtkYBlk4FVXJWKguwYzsB4x0AcZ2IwYGIAM
+bI9nYG9ipO8N6H8HBigGJscwMG0tBuaC+TzAyAeMArBQCJhFYLEYsEoAuxQx
+kPMFBorqgLg+hoFNQNZMM7AVKNvQEAOxAaMM7MKnwJUGBAbqe1r68Qf0Buvb
+u7/owc7e+s4+xLQl+tlXuc85uWpTXx7+AUfsIAzpUSqEJLSMRiyjYfNIyDwc
+NA0HjEMBw6BPP+DV9Xu0fS5Nj1PVZVd0WOXtFmmrUdSoF9Sr2JVWDeNrvzBJ
+JNLXjEiQRFqHEQmSSOuqFY+D3n34uenuKczALUsMFNEMlK9gYBpmYCZioCnn
+uDnvpCX/tLUQM7BkmYGuKszAWsRAb8M9XyNioL8lysBgx4tQJ2TgK5qBb6MM
+HPwAhpLB8EcwsiYDs8FsDmLgXB6YX8VAVilglwFOOeBWAF4l4FehrWRgA5A0
+xjAQG5BiIAQgGjagGhtQQ50CezADezEDlww4gIY/l4c+oAdnGa7v6PmyB/uQ
+B5f1txb6XHDTf3TOpeHfdVCbBPZJ7EFMQut4xDoWtoyFzKNB80jANOw3DvsM
+g179gEfX79b2OdU9dmWXTdFhkbUbxc06QYOGW2PVMb/2y5NEIn21iARJpHUY
+kSCJtH6KZeCdB1n1t47P3fqFeX8TYuCTrfxn2wQvdlAMlC4xMHm/OmW/5hNm
+YDpmYNZRU/Zxcy7NwKIoAx3lV50UA6sRAz11UQb6mjADW58G2qIMDHW9Cne/
+DvcgBkZWM3A0FYylgfF0MJEBJjPB1GcwnQ1mcsDsWgxcXMVAHmRgNRDUAGEt
+WhwDm+IZiE+BSmxAFTZglIHdNAOxAfXYgIZ4A5qwAc3Ud7ZQX+EyWt+BjoBr
+e7CrHy7uwBfnu5no3NRm155rdvknl+acicLQMY1IaJ/CJJyEJIzYJsLW8ZBl
+LAhnHvWbRnzGYa9h0KMbcGn7nZo+h6rHpuyyyDuMkla9sFHDqzNI+7/2i5RE
+In2diARJpHUYkSCJtE6KZeCnO4+mr/0cy0AexcCEnZLXu6Rvdsvf7VF82IcY
++BExUJt6UJd+SJ9x2JB11EgxMO+0tQAx0FZy0V6KGVhxzVV5w1V9y12DGVh/
+z0sxsPmxn2Jg+4tgRwwDe99G+t6B/vdgIOlPM3ChCDDjGcipANwYBgogA+uA
+qB4xUEwzUNoMZC2IgXKKge1RBlIGVHfRDOxB02EDxjEw3oBmbEAL9bUt+JN6
++PlMfATs/4IHB7jcsVX0i+XeXHQeeu7fHsVDPOdMdA6sQkTCqYhtMmybDFkn
+gpbxgHnMbxr1GUe8hmGPfsilG3Bq+x2aPpuqx6LoMkrb9KJmDb9exan1uvRf
++9VKIpH+X0ckSCKtw4gESaT10NIHA2/fy6y9fhwzcCPz3ibWwy0cxMDtFAPF
+mIGyd3shA5VJkIEHNCmYgWmYgZlHjZ+Pm3JOmvNOW/LPWgvP24ov2ksuO8oQ
+A52QgVWYgbV3PZCBDQ98jY98kIEtTwOtzwIUAztfhboQA8OYgRGKgYPJYOgj
+GE4BI6lgNA2MpYPxGAZO54CZXDCbB+bywXwBYKxiIDuegfwYBooaVjGwNYaB
+HUDViQYNqMYGjDKwFzFQBxmIDWjABjRiA5poA5qxAS1xBkRPZqKP7KFP8EH0
+wa3twe7BL9Bv/k/PvbQ54KIGSYhV6MAktE9H7FNh21TINhm0TgYsE37zmM80
+6jWOeAzDLv2QUzvg0PTb1H0WZbdJ1qEXt2oEjUpOnVXH+tqvWRKJ9P80IkES
+aR1GJEgi/e2LZeDE5R+nr22Yv7Vx4e6mxQdbOI+38p5u5z/fIXy5U/xqlzRx
+t+ztXvl7xED8XOgBzSfMwHSagdknzbmYgQXnbUUXbSWX7aVXHOXXnBWQgTdd
+1bfdkIF1iIHexoe+psf+5id+yMC258H2l8HOBMjAUHdiuOf3GDiRCSY/g6kv
+MbAELJaCxTLAKgfsCsCpjDKQF8NAIcXARiBpQqMYKIMMbEMMVCwxEBtQ3Y2m
+6aEZ2Ad0/YiB+gGagdiAJtqAZmxAC/WNnfEGRAykPriHntjEHhz8ggeHkOCW
+WceIzru0hd+aZ2H5V6i5GVEVUiR0ziESOmYjjpmIfSZsnw7ZpoO2qYB10m+Z
+8JnHvaZRt2HEpR926obs2gGbut+i7DXJu/SSNo2wWclrIBgkkdZVRIIk0jqM
+SJBE+hsX+zWhSTceUAycu7WRARl4fwv70VZuDAMlibulb/bI8UEQPxeKGKhN
+PaRLP6zPOGLIOm7MPmnKPW3OO2MpOGctvGArvoQYWIYY6KzEDKxBDPTUP/A2
+IAb6IANbngVanwcgAzsSQp1RBoZ730X63kf6k8BAMhj8CIZSwPDvMXCuAMwX
+AkYRWCgBzHgGcqoAt3qZgYIYBoohA5sRA6U0A+XtQNGBGKikGEgbUIMNuJKB
+g2iQgcZhzMARmoFjmIHjmIH4S1ooA9ppAyIG0s9qumbruweh+9bAYM8wlz+J
+9bcCesyV8636LyvmWVieG6vQNY+GPDgXcUIPzobtMyH7TNA2HbBO+S2TPvOE
+1zTuNo66DCNO/bBdO2jTDFhUfSZFj17aoRG2KHmNFoJBEmndRCRIIq3DiARJ
+pL9rsX8xEDPwZ8jA2ZsbGXc2Me9vRgx8sp3/bIfgxU5Rwi7Ja8RA2du9Cuog
+iJ4LxQxMwwzMPGb8fMKUcwoxMB8zsOiSreSKveyaoxwzsOq2q+auu/aepw4x
+0Nv42NeEGOiHDGx7GWxPCEIGdiWGut+Ee96FVzNwJA2MpoOxDDCeCSY+g8ls
+MJUDpnPBTB6YXYuBi+WAVQHYSwysAbxawI9hoIhmoKQlykDZEgM7owxUQQZi
+A2p60bR9NAMHaAYO0QwcQYMGjDIQG9BKfVEnbUD7CgMufYKPev5zfk0MUh6M
+E59v8U/PS40iITXoQWqQhEiFEed82DkXdsyF7LNB20zANu23Tvkskx7zhNs0
+7jKMOvUjdt2wVTNoUfWbFL16aZdG1KbiN2skvW6H7mu/lkkk0v/1iARJpHUY
+kSCJ9Lcs9vthKi4egQycurph9sbG+dubmPc2sx4iBvIwA4UJu8SvdksSEQPl
+7/YpPuxXJR9Qfzyo+XRIm3pYl35En3nMkHXCmH3KlHvGnHfOUnDBChlYfMVe
+etVRft1ZcdMJGVh9x11zz11331P/0NuAGOhrfupvee5vexGADOx4FexEDAxB
+Bva+j/R9iPQng4GPYPCPMXCuEMwXAUYxWCgFzHgGcqoBl2JgHRDUowlpBoop
+BmIDLjFQARnYtcxANW1AtH7EQB1k4CDNwGGagdiA5jGagROYgZOYgdTXdVJf
+3Ukb0DlLf2pvjv4cX/QZTui+tT3YO4JZx1qef/XYcfNRi/kVL4tW4SJNQmaU
+hC5GxMUIO+dDjvmgYy5gn/XbZnzWaa9lymOedJsmXMZxh2HUrhuxaobMqgGj
+ok8v69aIO5SCFslijVG98LVf0SQS6f9uRIIk0jqMSJBE+vu1xMAbdzL6T343
+fuknyMAZyMBbmxbubmY92Mp5vJ33dAf/+U7hy10iyMDXe6Rv9sogA9/vVyYd
+UEEGpmAGph3RZ2AGfj5lyoEMPGvJP28tvGgtvmwruWovu+4ov+msvOWquuOC
+DKy976l76Gl45G184mt66oMMbH0RaEsItCMGBrvehLrfhnveh3shA5MiFAOH
+UsFwGhhJB6MZYCwTjGeBiWwwmQOmcsF0HpjJB7NrMXCxArAqATuGgbw6wIcM
+bIgyUBTDQClkYDtioJxmoLI7hoF9aNCAWmxAioH6IZqBIzQDxzADx2kGYgPa
+aAPasQEdtAGdlAHxw5mUAREDl57eRJe7+p6RtTA4yhXOruQeGucPbAmGbJqE
+eJ7F6NzMCJxrIexkhJyMoGM+YJ/z22Z9thmvddpjmXKbJ53GCYdh3KYbtWqH
+zepBo7JPL+/VSDqVwjbxYq1RTf7aIIn0d45IkERahxEJkkh/s5YY+ObS3YFT
+349f/GnyyoaZ6xvnMAMX729lP9rOfbKD/2yn4MUuUcJuMWRg4l7Z231yyMAP
+B1TJB9UphzSfDmtTj+jSj+ozjxs+nzRmnzblnjXnn7cUXLQWXbYVX7WXXreX
+33BU3HJCBlbfddfcd0MG1j/yNjzxQgY2P/e3vPC3vYQMDHS8Dna+CXW9xQfB
+D+G+pEj/x8hAChj8BIZ+j4GzhWCuCMwXA0YJWCgDzHgGcmoAd4mBlARjGCih
+GSijGaigGNiDFmUgNqB2AE03SDNwGA0y0DhKMxAb0DJBM3AKDxvQTn1LJ21A
+J21AFyNqQDcNQA/1CGj0Zgfd94Xj4FgUdwFq3N+ff2n4F33U2MBLDXqQ2mLE
+vRh2M8OuhZBzIehgBBzzfvuczzbrtc54LNNu85TTNOkwTtj0YxbtiEk9aFD2
+6yAGpd0Ig6w6gkES6W8ckSCJtA4jEiSR/mbFMnD0/I+QgdPXNs7d/JVxZzMT
+MvDhNs7jHTzIwOe7hC93i1/tkSTulb7ZJ3+3X/HhgDLpoOrjIU3KYXwQPKrP
+OG7IwgzMOWvOO2/Ov2gpvGwtvmIruWYvu+Eov+WovO2suuuCDKx94K575Gl4
+7G186m165oMMbH3pb3sVaH+ND4JvQ93vQj0fwr1J4f5kyMAIYmAqGE4HIxlg
+NBOMZYHxz2AiB0zmgqk8MJ0PZlYwEB8EmRVgsRKwqgA7hoG8evogiBkoagZi
+moFSyMAOxEA5zUAlzUB1DAOhAdGGaAaO0AwcQ4MMNE8gBlomEQOtSwycwQyc
+xaO+q5M2oIs2oJs2oGfp03xLD3Oi+90XPdg3RkOP9+fmj4Ghj1YhRUIPHCvi
+YYXdiyEXM+hkBpwLfgfDZ5/32uY81lm3ZcZlnnaapuzLGBwyKAd08j6NtEcp
+7BCz6uWC3q/9AieRSP9XIhIkkdZhRIIk0t8p6ptC31y6N3Dy+5FzP05c2jB1
+dePsjV/nb29m3tvKerCN82g79+lOPmTgi92ihD3i14iBsrf75e8PKD8cVCUf
+Un/EB8G0o7r04/rMk4bPp43ZZ0y558z5FywFl6xFV6zF12yl1+1lNx0Vt52V
+d53V91w1mIH1jz0NmIHNL3wtL/2tCZCBgY7EYOfbYBdk4PsQZGBfMj4IfgKD
+qeggOJwBRjLBaDwDp/LBdAGYKQSzRWCuGMyXAEbpyoMguwZwamMOgg1A0AiE
+NAPFrUCCGSjtwBLEDFRQDOxFoxioWWLgUJSBesxAw5cYOIUZOL0WA+cxAxk0
+A6lva6EN6KEN6GXFPMO59GAnt753bC0MjnPF8yDI/0MLxM/Powc9SA16EC3i
+YcOF3ayQazHoWgw4mX7Hgs/O8NrnPbY5t3XWZZlxmqftxkmrftysHTVphg2q
+QZ28XyPtVYo6RawGg2bxa7/MSSTS/35EgiTSOoxIkET620Q9FwoZ2H/y++Gz
+P45f/Hnq6i8zkIG3Ni/c3bJ4fxv7IXoulPdsl+DFbuHLPeJXeyWJ+6SQge8O
+KD4cpA6C6pTDmtQjurRj+owThqxTkIHGnHOmvAvm/Ev4IHjVVoIYaEcHwTvO
+qnuu6geu2ofuOsjAJ97GZ96m55CBvtYEf9vrQHtioOMNZGCw+z0+CCaH+z5G
++lMiAxQD06MMHPsMxrPBRC6Y/AIDGWVgoXyNgyCXOgjSDBQ2AxHNQAnNQFkn
+kNMMVNIMVEMG4idCtRQDh9GiDBxFDDRCBo6jQQaaJxEDLZiBVsjAGTT7LBo0
+4EoG0gZ00wb0LH1qjwZg1ID05Q7f8qD7vnAcnABBwZ9bgBpFQlqFPl6UhF5u
+xMsJezghDzvkZmEMLvqdTJ9jwWtneGzzbuuc0zLrMM/YjVNWw4RZN2bUjOhV
+Q1rFgFraq4AYZDcaNOSvS5BIf7eIBEmkdRiRIIn092iJgX3Hvxs6/cPohZ8n
+r/wyc/3XuVubGXe2MO9tYz3Yznm8Ax8EEQNFCXslr/dJ3+yXvT0gf48liA6C
+hzWfjmhTj+nST+gzTxk+YwbmoudCzQWXLUVX8UHwhr3slqPijgMdBO+7aiAD
+H7nrn+CD4HMvOggm+Ftf+TEDA+gg+D7Y/SHUgxgYRgz8FBlMA0Pp+CCYBUY/
+g7FsMJ6DJZgPpgrAdCGYKQKzxWCuBMzHM3CxCrCq6YMgzUB+IxDQDBS1AjHN
+QCnNQHk3UNAMVNEM1GAGaoeiBkTDDDR8iYHT8QzEBnRgAzoZaNCALtqAbtqA
+HtqAXvbys5pRA2KgRZ/qjN7y1vRgQkE/V8wEIWH8RDETguCqBQTL8/OjQx7k
+RRAGuRiDnKCbHXCx/C6Wz7nodTA99gW3jeGyzjstc3bzjM04bTFMmnXjRs2o
+XjWsVQyqpL1yUZeI3UQwSCL9zSISJJHWYUSCJNLfIIqBbxEDvx849cPI+Z8m
+Lv8yfe3X2Zub529vWbi7dfH+dvajHdwnO/FBEDFQ/GqfJHE/kuC7A4r3B5VJ
+h1TJh9UpRzSfjmrTjusyTuqzThuyzxpzzpvyLprzL1sKr1iLrllLbthKb9rL
+bzsq7jqr7jvRQfCRu+6Ju/6pp/G5t+mFtznBBxnY9trf/ibQ8TbQSTEwKdT7
+MdyXEu7/FBlIjQymg6EMMJwJRmIZSB0EYxg4VwrmywCjHCxUAGY8Azl1gFsP
+eDQDBc1ASDNQ3E4fBDuBjGagohdLsA+o+oEaM1BDM1CHDYgGGTiGGGiEDJxA
+gww0TyEGWpYYOIsGGWjHDHRQDMQGdDHRoAHdtAE9tAG9lAHxSW7JgH5ezPOc
+sUc9YX3fxBrHwf7JeP2J4xfzT8GlUSSkBj1IDXqQH/Hxwl5eyMsNebhBNyfg
+ZmMMsryORY+d6bYtuKwMB8LgrNU4YzFMmXQTBs2YTjWiUQwqpX1yUbeQ3axV
+kj8tQSL9fSISJJHWYUSCJNLfIOoa2H3kX/0n/z189qfxS79MXf115samuVtb
+GHe2ooPgwx2cxzt5T3fhg+BeJMHlg+BBxYdDyqTDqo9IgvggeFKfedrw+awx
++7wx94Ip75K54Iql8Jq1+Lqt5Kat7La9/I6j8p6z6oGz5qGr9jGSYMMzTyNk
+4Etvyytf62t/W6K/HTLwXaDrQ7A7KdSTHOpNCfd9CvdDBqZFogykDoI5YDwX
+TOTFHASLwWw8AxcqAbMKLFYDVg1g0wzkNgBeI+DTDBS2AlEMA6U0A+U0A5U0
+A9U0A7VLDByNMtCAGWhczcAZtGUGYgM6GFEGOtdkIG1AL21A35IB8XmOAiA1
+DMDlhUTQfWtjMCymJ4nbShjiBcXLKgyIoiT0wwkiPkHYxw97+SEvL+jhBjxc
+v5vjd7F9TrbXwXI7Fl12phNhcN5mnoMYNBumTbpJg2YcYlAtH1RI+qTCbiGn
+RaNgfO3XPolE+t+JSJBEWocRCZJIf/VeFU68uXiv6/C/+k78e+jMT2MXNkxd
++XX6+iZ8ENy6cHfb4oPt7Ec7uU928Z7tFrzYI1w+CB6QvTsof39IsXwQPKZN
+O6HLOKXPOmP4fM6Ygxhoyr9sLrxqKbpuhQwsvQUZaK+456i876x+6Kx55EIH
+wWeehueeppfoINjy2ocZ6O94F+h8H+hKCnZDBn4MoYNganggLTKYHhnKBMNZ
+6CA4mg3GcsF4HpjIB5MFYKoQTBdhCZaCuTIwXw4Y8Qxk1QJ2HeDEMJDfDAQ0
+A6MSxAyUdgEZxUBKgpiBKpqBGpqBOoqBY2ixDDRhBpoxAy2YgVbIwDk0yEA7
+ZqADG9CJDejCBnSz0Dz4WzopA3qXvrAlxoD+WAMuARB7Lf7et9qD6ElRCQvr
+T7pqSyqMX1C8vAAmoR9OGPFDDApCXn4QzsMLeHh+N9fn4nhdbI+TTWHQYV2w
+WxgQgxbjLMSgUTel14xrVaMq+aBc0icRdon5nVaT6mu/A0gk0v9CRIIk0jqM
+SJBE+ktXNyC4fisDMrD32PeDp38cPb9h4vLG6WubZm9sxgfBbcz72/FBcBfv
+6W7+8z34ILhP/Hq/JPGA9O1B+bulg+ARdcpRTepxbfpJXeZpfdZZAzoIXjTl
+XTYXXDUXXrMU37CW3LKV3bGX37VX3ndUPXBWP3LVPnHVPXXXP/c0vvA0JXib
+X/laE31tb/zt7/wd7wOdHyADgz0fQ70pIXQQTAsPpEcGMyJDWWD4MxjJBqM5
+SIIrGDhTQkuwAjAqwUIVYFaDRZqB7HrAaQDcRsCjGShoXT4IijuAhGagrCd6
+EFT0ASVmIJIgZqBmGEtwBOhGowZEwww0TiIGmiADp2kGzsYzkBHHQCdmoIti
+IPWXGjhoFAO9XOqjecsG9FMGxOe5JQBGGRh70Yuyrr5/aq3j4NRaEly1EDXK
+g0uDHkQkjPhFYb8w7BOGfIKgVxDw8P0ens8Nx/W6OBCDLgfLaV+EGLRZGFbz
+PMSgyTBj1E/ptRMa1ahSPiSDGBR0i/idFqPya78PSCTS/zQiQRJpHUYkSCL9
+dYMMvHYro+PAf/Uc/X7g5I8j534ev7hx8sqvM9c3z93cgg6C97YvPtiBD4K7
+ec/2CJ7vFb7cJ3q1X/IaHwTf4oPgh8PK5COqj0fVn45r0k5qM07rMs/qP58z
+5Fww5l4y5V8xF1yzFN2wFN+0lt62ld21V9yzVz5wVD101jxGEqx/5m544Wl8
+6Wl+5W157Wt942t7Cxno7/xAHQSDPSmh3k+hvtRwf3p4ADIwM4IOgjQDlw+C
+RWA6loH4IBiVYA1YrAWsGAZym5YlCBkobAMimoGSLiClGSinGaikGaimGail
+GajHBkSLZ6AZM9CCGWiFDJxHgwy0YwY6sAGd2IAuVpSB7iUGYgN6qW/sRJ/L
+ixrQTxswEGvAGP1Riz/5cSXshIKBlRgcmAYR2RoLr1pIurygNOrBgCQSEEf8
+4rBfFPKJgj4hwqBX4PfwIQa9bp7HxXU7OS4H22FftFuZNsuCxTxvNs5BDBr0
+0zrNpBpiUDYkE/eJBd1CXqdJr/ja7wYSifQ/ikiQRFqHEQmSSH/RuFITFEHr
+3n92H/mu/8QPw2d+Hrvwy8TlX6evbZ69sWX+1lZ8ENzBeriT83gX9+luPpTg
+i73ChH3iV/gg+Oag7N0h+fvD6CCYfESdckyTekKbdkqXcUafdU6ffcGQc8mY
+d8WUf9VceN1SdNNacstaesdWfs9ecd9R+dBR/chZgw6Crvrn7oaXnqYET/Nr
+b0uir/WtDx8E/Z1Jga7kYPfHIGZgCB0EM8KDmZGhrEj0IJgLxvLAeD6YKACT
+hViCJWCmFMyWgbnyuIPgaglCBvKaAZ86CGIGijqAmGZgVIK9QN4HFP30QZBm
+oAYzUDsKdJiBemxAioFGzEATZqAZM9Dymwx0Yga6KAZiA3q4aNCAcQykvqpl
+6ctb8COalAGpLT/MGXvUoymHiQfpt/o4yJVyQES+9sKxgx5cGuVBRMJIQBIO
+iEN+McagKOAV+r0Cn0fgdfMxBnkuJ8eJMMiyWxetCIMMk3HOaJjV66a1mkmV
+ckwhG5KK+0X8boVs8mu/IUgk0v8oIkESaR1GJEgi/UWrGxDkHj3Qdfi7vuM/
+DJ3+eeTcBnwQ3DRzfcvcza3zt7fhg+BO9qNdnMe7eU/38KmDYMJ+8esDkjcH
+pW8PRQ+CSfRBMPWkNh0fBLPOG7IvGnMvG/OvmgqumwtvWIpvWUvuWMvu2srv
+44PgI0f1Y2ftU1fdc1f9C3djgqfplac50duCDoK+9vf+jg/+zuRA98dAT0qw
+NzXUlxbCB8HwYFZk6HNkOBuM5IDRPDCWD8YLwEQhmCwCU8W0BMvBXAWYrwSM
+KrAQw0BWPWA3AA51EMQM5LcCQRsQ0gwUd9ES7AEymoEK6iA4CFRDQI0ZqKEZ
+qMMM1EMGTqIhCWIGmuIZaMUMtEEGLqBBBjooBmIDuthokIHueAZ6sQF9AjSK
+gX7agIElA+LzHAVAarEARAaMw139wMwaT4oOzICI4rcWViyTMCSPejAIJ40E
+peEAnCTklwT94gDCoMjvFfo8Qq9b4HHz3QiDXKeDY7exbQiDTDPC4LzBMKvT
+zVAYlMuGJOJ+Ib9bJh7/2u8JEon0349IkERahxEJkkh/xSADcw7v7zz4Xe+x
+fw+c+mn47IaxCxvpg+DW+VvbGHe3UwdB9qPd3Cd7eM/2Cl7sE77cL3p1QJJ4
+cOkgqPhwBD8aekz96YQm7ZQ244wu85z+Mz4I5l4x5V8zFd4wF920FN+2lt61
+lt2zVTywVz50VD121Dxx1j5z1b1wNbx0N77yNL32tCR6W9/62t752j/4O5L8
+XR8D3SmBnk/B3rRgX3qoPyM8kBke/Bweyo4M50SWD4IxDJwuBTNltASrAKMa
+LNQAZi1YpBnIbgScJsBtBjyagYJ2IOxYPghKaAbK+oAcM1AxAJQ0A9U0A7WY
+gboYBhowA400A82QgXNokIFWzEAbZqAdMnARDTLQuRYDPTQDvUsMpL6ukzZg
+IMaAQUnco5vLBsRqiwIwjnVcKTehcHANDALl8iKrR3mQVmEoSsJIEA1iMBSQ
+BhEGJQGf2O8T+7wir0focQvcbr7LxXc6eQ6MQauVZbEwTeYFo3Fer5/T6mY0
+mkmlYkwmHRaL+vm8br2O/7XfGSQS6b8ZkSCJtA4jEiSR/opxKnJb9/5n95F/
+95/8CR8Efxm/+Ovklc34ILht/s72hXs7Fu/vZD1EB0Hu0z18SoLUQTARHQRl
+7w4jCSZBCR5VpRxXp57UpJ3WZpzVZZ3XZ1805Fw25l015V83Fd40F92ylNyx
+lt6zld+3VTy0Vz5yVD9x1Dx11j531b90NSQgCTYnelreeFvf+dre+yADO5Ox
+BD8FelKRBPszQgOZocGs8NDnMGTgSG4k7iBYDKZWMLBybQlCBq6QoJCSIHUQ
+7AaSHiDFDIxKEDNQOURLcARoMAO1NAP1FAOn0CgGmjADzZiBFshABtoKBjow
+A52YgS7IQC4aNCAaNqAXG9AnRKMY6McGRFv65pYlA+Ij3RIAowyMBSDWXIz1
+1jwOcmU8AFRxiyyNJmFYGfVgCE4egQvKw0FZKCDDGJQG/BK/T+JDGBR7PSKP
+W+h2CSAGHU6e3cG12TgQg2bLosm0YDAydPo5jXZGrZ5SKMak0mGRqJ/L6dSo
+2F/7zUEikf47EQmSSOswIkES6S8Xuyynefc/uw5/33f8x4FTPw+f3TCKDoKb
+pq5tQQfB29sZd3Yw7+1cfLCL/Wg358ke3tO9/Of7BPggKH59UPLmUFSCH44o
+ko4qPx5XfTqpTj2tST+rzTyv+3xRn33ZkHvFmHfNVHDDXHjLXHzbUnLXWnbf
+Vv7AVvHIXvXYUf3UUfvMWfcCS/CVu+m1p/mNp+Wtt/W9t/0DluBHf1dKoDs1
+gA+CWIJZIXwQxBLMi4zmg7ECMF4IJopoCZaBmXIwWwHmYhi4UAuYdWCxHrBi
+DoLcFsBrBXz6ICjsBKIuIKYZKKUPgvIBoMAMRBLEDFSPAg1moHYc6DAD9ZNR
+A1KDDDRhBprjGWjDDLSvYCAHDzPQHc9A7xIDqT/ZII5nIP1JvaXP7i0bEDMt
+FoBRBqpWrH5gdq0nRWcBUK9aLAlVGIN4IWUkpIALIwzKQwF5MCAL+OGkfp/U
+55N4vWKPR+R2C10ugdMJMci327lWG8diZZssi0YTU29gaPVzau2MSj0lV4xJ
+pMNCYT+H3aFSLH7ttwiJRPrTEQmSSOswIkES6a/VYml2w47/r+PAd71Hf+g/
+8dPQ6Q0j5zZSB8Hp61vRQfD29oW7O5j4IIgfDd3Le7aP/2K/8OUB0auDYvRo
+KJTgYdn7I/jR0GOqjyfUn06p085oMs5pMy/oPl/S51wx5F415l83Fdw0F902
+F9+xlN6zlj2wlT+0VT62Vz1x1Dxz1D531r101Se4Gl+7mxI9zW89Le+8bVCC
+Sb6OZH9nir8LHQQDvenBvoxgf2Zo4HNoMDs8lBMezqUlWAjGi8BEMZgsAVOl
+MRKsAvPVgEEzkFkPFhsAqxGwmwCHZiCvDfDbgYBmYJwE+4AMM3BJgpCBKoqB
+lAQxA6MSnAIGmoFGzEBKgpCBFsxAK2agDTPQjhnoYCMGOuMZ6MYM9MQz0Ecz
+0I8NiLb0bS1L39+CH9RcMmA4HoCRFQBcqby1nhSdA0ATs5ifj1CjPEgNYlAZ
+RhhUhIKKYBBiUB4IyPx+mc8n9fokHq/Y7RG73CKnS+hwCuwOvs3Os9q4ZoRB
+lsHE1BkYGt2cSjOjVE3J5ONiyTCf38dabLea1V/7jUIikf5cRIIk0jqMSJBE
++gvFLMmu2/ofrXv/1X3kB/og+MvohV8nLm+eurpl5sa2uVvoILiAD4Ksh7s5
+j/dwn+7lPd8ngBJMQBKUJB6SvjmMHw3FB8Hk46oU+iCYcV6XdVH3+TKSYN41
+Y/4NU+Etc9Edc8ldS+l9a9lDW8UjW+UTe/VTR81zR+0LZ12Cq+GVqzHR3fQG
+SbD1vbftg7c92dfx0deV4u9ODfSkYQlmBvuzsARzwkO54eG8yEh+ZLQggiRY
+DCZKwGQpmCoD0+VgpgLMVq6UIGTgYiNgNQF2M+C0AC7FwBUS7AbiHiDBDJT2
+RyUIGagYAkrMQBV9ENSMAy1moA4zUD+NJTiDhxlomgPmeVqCC1iCTGDDDLRj
+BjowA52Yga5YBgrQvEI0aEA0cZSBfpqBAZqBQdqAoRgDhmMASG0N/WlWDNLv
+9zAYs4iG9qAahOFUkbAqHIJThoLKIMKgIhCQ+wNyn1/m9Uk9XjgJxKDTLXK4
+hHanwObgW+08i41rsnKMZpbeyNQaGGrdnFIzI1dNSeXjIvEwl9fLZneZjeQv
+zpNIf6WIBEmkdRiRIIn0F6p60/9p3v2fXYf/3XP0x/4TP9MHwU2TV7ZMX9s6
+iw6COxh3dzLv7Vp8sJv9aA/nyV7u03385/sFLw8IEw6iR0MT8UHw3RH5+6OK
+pGPKjydUn06pU89o0vFBMOuSLvuKPueqIe+6Mf+mqfA2luA9S+kDa/kjW8Vj
+W9VTe/UzR80LR+1LZ/0rV8NrJMHmt+6Wd57WD962JCTBzhRf1yd/d5q/Jz3Q
+mxFAEvwcGsiGEgxBCY7khzEDI8sHwTIwVQ6mK8BMJZitAnPVYL4GMGrBQsxB
+cKUE2wG/Awg6gZBmoLgXSPpoCQ4AOWagYpiW4ChQYwZGJTgJdFPRg6ABG5Aa
+xUAzZqAFM9CKGWjDDLRjBjowA52YgS7IQD4axUAPZqCXZqAPG9BPGzBAG3CZ
+gfjzepQBqS0/xomx9kUAamO3GoMJhUMrfobekgc1FAYjYXUYLqQKwSEMKgNB
+pT+gwBiUe30yiEG3R+LySJxuscMlsjuFNofAYuebbTyThWMws3RGpkbPUGnn
+FOoZmXJKIh8XiIbYnG6RaOJrv11IJNKfiEiQRFqHEQmSSH+VFktzGnb8s+PA
+9/gg+NPAqQ3DZzfSB8GtM9e3zd7cDiW4ACV4Hx0E2Y+RBKlHQwXUo6GvD0ne
+HJa+PYIk+OGYIvmE8uNJ1afT6rSzmozz2kx0ENRlX9XnXjPk3TAW3DIV3jEX
+3zWX3LeUPbSWP7ZVPrFVPbNXP0cSrEvAEkx0Nb1xN79zt7zHEkz2dnz0dX7y
+daViCWYEejMDfVlQgsEBxMDQcB4twaLIGgfBKjBbDeZqwHwtYNSBhXrAjDkI
+slsApxVw2wCPZqCgCwi74yWIGSgbjJEgZqBqjJbgBNBO0hLEDFyW4BwwYQaa
+MQMtmIFWzEAbi5YgB0uQiyXIAy7MQHc8A73xDPTTDAxQDJSjUQYMxRgwHG/A
+yGoArmadbmlcmRDqbxUGdfGL+d2IlvJgJIwGMRgKwamCQVUADWJQ6fMrvH65
+xydze2Uuj9TpkTjcYrtLZHMKrRiDJhvPaOHoTSytganWM5TaObl6RqqYEsvG
+eYLBRVaXUDj2td80JBLpj0YkSCKtw4gESaS/RLPFWXVb/9G677vOg//uOfpT
+/4mfB0//MnLu17GLmyeubJm6tnXmxva5WzsYd3Yu4IMg6+Ee9mN0EOQ9289/
+cUD48qDo1aFlCb4/Kk86rkg+qUw5rUo9q047p8m4oM28pPt8RZdzTZ973ZB/
+01hw21R011x8z1z6wFL2CErQWvkUSxAdBB11r5z1r52Nb1xNb7EEP3hakzzt
+H70dKViCaf7udCzBrABiYHYQHQTzQsP54ZGC8GghJcHIRCmYXOsgGCfBJsCi
+GchpW0uCNAMl/TESxAxUjADlaPQgqKYZqMUM1E0DPWagARuQmgkz0IwZaMEM
+tK7JQB4aZKALM9CNGeihGejFDPTRDPRjA6LJowwMUgxE39kSNSC1JQNGfgOA
+urWmp7YCg/gLRUX0v676LYRBbQQOSVATggupgyF1IAin8gdUvoDS61d4/Aq3
+T+7yypweqcMtsbvENpfI6hRZHEKznW+08gwWjs7E0hiYKh1DoZmTqWYkiimh
+ZIzD719Y7FSreV/7rUMikf5QRIIk0jqMSJBE+kvUsOOfzbv/1b7/+67DP/Qd
+/5k+CG4av7R58srW6WvoIDiHHg3dtXBv9+KDPaxHezlP9nGf7uc9xxJMwBJM
+PCx5c0T6DkrwmDzphOLjKeWnM6rUc+r085qMi9qsy7rPV5EE824Y8m8ZC+5A
+CZqK75tLH1rKHlsrnlgrn9mqnttrXtprExx1r50NiViC79zN790tSZ62ZCzB
+T97OVCzBDD8+CAb6s4MDOcHBXEqCoZHC8GhReKw4Ml5CS7ACTFeCmfiDIKMe
+LDQAZuMqCbYDXgfgYwYKuoGwB4h6gbiPliBmoGwIyIejB0EldRAcB+oJWoKY
+gVEJzgJDDANNDFqCTFqCLCxBNrBjBjq4UQlSDHRhBroxAz1LDJTgSaMM9Mcy
+UBEdxcDQ0je34E/tUQakttKAa9Nv1Qy/icHYURjURdC04bA2hKYJhjQBuKDa
+H1T7AiovwqDS41vCoMzhltpdEqtTbHGIzHahycY3WHl6M0drZKn1TKWWIVfP
+SZUzYvkkXzzK4vYxmJ02m+Frv3tIJNLvRyRIIq3DiARJpG8/Vmlu487/bN37
+XUf0ILhh8PRGdBC8sHni8pbJq1unr2+fvblj/vZOKEHm/d2L+CCIJPgMSvCA
+4OVBYcIh0eslCR6VfTguTz6p+Hha+emsKu28Ov2CJvOSNuuKLvuaLue6Pu+m
+If+2sfCuqeieqeSBufSRpRxK8CmSYPULLMFXjnoowTfOxreupveu5g/uVijB
+j572FCzBNF9Xuq8HSjDL3/cZSjCAJJgXHMoPDRfQEiyJjJdGJsrAZHmMBGvA
+XC2YxwxkNICFRsBsAovNgNUC2DQDuR2A1wn4XdGD4LIE+4FkAEgxA6MSxAxU
+jgHVOC1BzEAtfRDUz9ISnEeDDDRhBpoxAy00A22YgXbMQAd1EIxnoBsz0CNG
+DPTSDPTRDPRjBgaWGKhcZmCINmA4xoBoawJwDfetufoBxqrvkGHE/8zy/yQS
+gdOFI7pQGE4bDGsDITgNkmBQ7UUYVHn8SrdP4fIqnF65wyOzu6U2jEGzQ2Sy
+C402gd7C05k5GiNLpWcqtAyZek6inBHKJrjCYSa7VyCc/NpvIBKJ9PsRCZJI
+6zAiQRLpG2+mKKtuGzoItqGD4I+96CD4y9DZX0fOb0KPhl7eOnVtG340dOf8
+HXQQZD7Yw3q4l/14H+fJfu6zA/xlCR4WJx6RvIUSPCb7cEKefEqRckb56Zwq
+7YI6/aIm87L281Vd9nVd7g193i1DwR1j4T1T8X1TyUMswSeWimfWyue26pf2
+mgR77WtHfaKj4a2z8R2SYEuSuzXZ3Zbiaf/k7UhFEuzO8PVkYglmB/pzAgO5
+tAQLQyNF4dFiKMEwkmB5ZLICTFWC6SowUx0nwYXflSBmoLAXiPqAGDNwWYLD
+QD4CFKMxEpwA6klagtNAhxmoxww0zMdIEDPQjBloYWEJsoENM9COGejADHRi
+BrpoBroxAz2YgV6agT5ZHAMDNAODtAFjGRiOMWDktw24mn7G1fsCBql/jfv1
+CMZgOKIPwYV1wbAugDHoD2l8QY0XYVDt8avcfpXLp3R6FQ6P3O6R2dxSq0tq
+wRg02oQGq0Bn4WlNHLWBpdQx5RqGVDUnlk8LpBMcwRCD1aNUcr/224hEIv1O
+RIIk0jqMSJBE+saDDGzc8V8t6CD4Qzd9EBw+u2n0wubxS1smr0AJbp+5sQNK
+ED8auod6NBRJ8Ol+HpTgi4OCl4eEr7AE30AJHpW+Py5LOilPPq1IOatMPY8k
+mHFJk3lF+/kaluBNff5tQ8FdKEFj8QNTySNz2WNL+VMkwaoXUIK2mlf2OijB
+N1iC6CDoakl2t37EEkz1dKR5u9KxBLP8vZ+xBHMDA3nBwfzgUEEQSzA0WhIe
+Kw2Pl8VIsBrM1IDZWjBXB+ZjDoLMZrDYAlitgN0GOJiB3E7A6wL8biDADBT2
+xUhwEEgxA2UjtATHgHIcqCZoCWIGamdoCWIGIgky0CADoxJcpCXIpiXIxRLk
+AQdmoBMz0EUz0I0Z6MEM9NIMRBKUo0EDUqMYGKQYqEajDEiNMiDaHwHgGvoD
+wBS7+oGFL2NwaVCCaOGIIYSmD4b1CIMhnT+k9QW1CIMBjSegdvvVLr/K6VM6
+vAq7R2Fzy60umcUpNTskJrvIYBPqrQKtmacxclQGlkLHlGkYEuWsUDbFl4yz
+eIPzzG6rTf+130kkEum3IhIkkdZhRIIk0rccqzS3ftt/Nu36V9u+f3ce+rH3
+2IaBUxuHzvw6fA5KcMv45a2TV7fhR0N3zt3exbi7e+E+lOBe1qN97Cf7OU8P
+xEjwsOj1EfGbo9K3x6TvT8iSTsk/nlGknFOmXlClX1RnXNZkXdV+vq7NuaHL
+vaXPv2MouGcsum8sfogl+ARL8Lm16qWtOsFW89pel+iof+toeOds+uBsTsIS
+THG3fUIS7Ez3dmV4uzOhBH292f6+HD+WYABJsDA4XBQaKaYlWB6eqIhMVkam
+qr4gwWbAbAGLrYDVBtjtgIMZuIYE+4EYM3BJgpCB8lGgwAyMSnASqKeAZpqW
+IGZgVIKMGAliBpoxAy1sLEEOsGEG2nm0BAVYgkIsQcxAN2agBzPQSzPQhxno
+pxioRKMYGKQZGFpioBaNMiC1Lxrwt+i3emthcCHmB9D/JIIXBkYsQUMQLqwP
+hPX+kM4HF9R6g1pPQOMOaFx+tdMHMahyeJUUBi0umdkpNTkkRrtIbxXqLAKN
+mac2cpR6llzLlKoZIsUsXzrJFY0xOQM8AXlGlET6piMSJJHWYUSCJNI323RR
+Vu2Wfzbs+K+WPd+3H/ih+8jPfSd+QRI8u2nk/Oaxi1vQo6FXt09f3zGLHg3d
+zbi3h3l/7+LDqAS5UILPD/JfHBIkHEYSTDwigRJ8d1z64aQs6bT841nFp/PK
+1Iuq9EvqjCuarGva7BvanJu6vNv6/LtYgg+MxY9MpY/NZU/N5c8slS+gBK3V
+r2y1UIJv7EiC77EEk10tH11IguggiCWY6e3O8vV8xhLM9ffnBQbyA4MFtARL
+QqOlobGyGAlWR6ZrwEwtmK0Dc/VgvgEwGsFC0xck2AV43YDfAwSYgcL+GAkO
+ASl1EByNkeAEUE3GSHAGaGdpCWIGIgkuoEEGRiXIoiXIoSXIwxLkAwdmoBMz
+0EUz0I0Z6MEM9NIM9GEG+mkGBmgGBikGatCWGBiOYWDkdw24Gn3mL+0LGDQv
+/W4EmMJoxhDCoDGIZgiEDf6w3heC03mDOk9Q6w5oXX4Kg2qHV2X3Km0ehdUt
+N7tkJofUaJfobSKdVag1C9QmnsrAUehYMg1TrJoXyGd4kkm2cJTB7pcrOF/7
+LUUikb4YkSCJtA4jEiSRvtlqNv+zDh0Ev2tFB8Gfeo9t6D+5cfD0r+jR0PNb
+xi5tnbiyDT8aunP21q6oBB9ACe5jPd7PeXKA+wxL8CUlwSOixKPiN8ck705I
+P5ySJZ+RfzyHJJgGJXhZnXlVk3UdS/CWLu8OkmDhfUPRQyzBJ1iCz7EEE7AE
+E+11b+317xyN7x1NSViCKa7WT+72VHdHuqczw4Ml6O3J9vXm+LAE/UiChYGh
+ouBwcTAqwfLweEV4ojI8WfUFCWIGMlvBYhtgtQN2B+BgBq4hwQEgxgyUDEcl
+KIMSHAMKzMCoBKeAehpoZmgJYgZGJQgZyERDEsQMNGMGWjhYglxgwwy082kJ
+CrEERbQEJViCUixBGZYgZqAPM9BPMVCFRjEwSDMwRBswrEOjDEjtDwHwS/qz
+rBhXJvsCBs0RPCxBUwgPSjAAFzb6wwZfCE7vDeo9QR2SIMag06dx+NR2r8rm
+UVrdCotLbnLKjA6pwS7R2URai1BjFqhMPIWBI9exJOoFkWKOL53miCcW+SMz
+jG6LlTwjSiJ9oxEJkkjrMCJBEunbbLEktwYdBP/VjA6CP3Yd+bn3+C9Igmc2
+DZ/bjB4NvbRt8sr2qes7ZvCjoVCCCysleJD3/BD/5WEkwddYgm9jJJgCJXhB
+mXZJlXFFnXlN8/mGJvumNve2Lu+uPv+eofABkmDJYyhBU9kzc8ULS+VLS9Ur
+a81rW+0bG5Lge0fjByzBj04kwVR3exqWYKanK8vb/RlLMNfXl+fvz/cPFNAS
+LAmOlIZGy6AEQ1EJVkemaiLTtZGZOjBbD+YawHwjYDR9WYLdgNcD+L1AgBko
+HIiXIGagbCxGgpNAhRkYleAs0M7REsQMXJbgIi1BNi1BLpoNM9COGejADHRi
+BrrEwIUZ6MYM9GAGemkG+jAD/TQDAzQDgzQDQzEMDNMGjBjQVjLwNwC40n1r
+bjUGEwqH4X+nJYgWQoMSNAXQoASNPoxBbwhKUO8O6lwBncuvdfq1Dp/G7lPb
+vGqrR2VxK8wuudEpM9ileptEaxVpLEK1SaA08uR6jlS7KFYtCOSzXMkUSzjO
+5I2wuORvzZNI32hEgiTSOoxIkET6BpsszKrc+I+6rf/VuBMdBDsO/dR9dEPf
+8Y0Dp34dOrNp5PyW0Ytbxy9vm0SPhu6cublr7vbu+bt7Fu7tZT7Yt/hoP/vx
+Ac5TLMEXlASP0BI8Lnl/UvrhtCz5rDzlvOLTRWXaZVXGVXXmdSzBW9rcO0iC
+Bff1hQ8NRY+MJU9MpU9NZc+xBBOwBBOxBN/ZG97bG5McTclYgp9cbamu9nR3
+R4Y7KsFsb09OjAQL/YNFgaHiAJZgcLQ8NFYRGq8MT1RBCYbXkGAzWMAMZLaB
+xXbA6gDsTsDp+oIEB4EYM1AyEiPBcaDADFyW4AzQzNISnAc6Bi1ByMDF6EyY
+gWbMQAtmoJUHbHw0u4CWoAhLUExLUIolKMMSlGMJYgb6MAP9FAPVaBQDgzQD
+Q7plBoZjGBj5IwZcU3zW315C4cgKDEYQBi1hPCxBcxCYsQRN/rDJhzBo9IYM
+npDBDTEY0EMMOv06h19r92mwBNUWt8rsUpqccoNDprdLdTaJxiJSm4VKE19h
+4Ml0HIlmUahk8GSzHPHkomBsjtUvlZNnREmkbzEiQRJpHUYkSCJ9g1Vs/EfN
+5n/Wb/9X8+7v2/b/2Hn4556jv/Sd2DhwetPQ2c1QgmMXt01c2T55bcf0jRgJ
+3o+V4EHus0O8F4eRBF9BCR4VJR4Tvz0heX9KmnRGlnxOnnJBkXpJmXZFlXFN
+nXVD/fmmJuc2luA9fcEDLMHHUILG0memcijBl+bKV5bq19aaN9bat1iCH7AE
+PzqaU7AE02gJZnm6PnuQBHO9vXm+vnxffwEtwZLAMGRgWXCsPIglGEISrAlP
+1Yan6yIz9ZHZBjDXCOabvizBbsDtAbxewO8DAszAlRLEDJSNRyWogBKcAqrp
+GAnOAe08LUHMwGUJsmgJcmgJ8mgJCpAE7ULgEKE5xWiQgXESxAz0KtAgA32Y
+gWhqWoKYgUGagaEYBoZpA0aMaH/CgL+tP1v8VmNwJAKsYTQoQUsQDUoQzR8x
++xAGTd6Q0RMyuoMQgwZXQO8MQAnq7D6tzaexejUWj9rsVplcSqNTrnfIdDap
+1ipRW0Qqk1Bh5MsNPKmWLVIx+Yp5rnSGJZpk8sfGZzvMFvKMKIn0zUUkSCKt
+w4gESaRvrYWS3Ipf/lGLD4Ite3/oOPhT15ENPcd+6T/56+CZzcPntoxe2Dp2
+CUpwx9S1ndM3ds3e2j13e8/83b0L9/cxH+5nPTrAfoIl+JyS4JGoBN8cF789
+KXl/Wpp0VvbxvDzloiL1sjL9qirjOpbgLU3OHW3uXV3+fR2S4CND8RNjyVNj
+6XNT+QtzRQKWYCKW4Dtb3XsbkmAyluAnZ0uqE0kww9WRiSWY7enOiUqwH0qw
+0DdQ5B8s9g+XBEZKA6OIgUHIwPGq0ER1KF6CESTBZsBoAQuYgcx2sNgBWJ2A
+3fUFCQ4C0RAQYwbGSRAzUDEVlaBqBqhnkQQ1lAQZMRJcjJEgm5YgF1gwA618
+WoJCWoKYgU7MQBdmoFsWL0HMQB/NwKgEaQYGaQaGYhgYjmFgxPgHDPi76Pvi
+6gcWV2AQSjCEhyVoCQCLP2JBEkQYNHvDJk/I5MYYdAUNzoDe4dfb/TqbT4sl
+qDG71SaXyuhUGhxynV2mtUk1VonKLFKahHIDX6rjijUsgXKBJ5tji6eZgok5
+zvACmzwjSiJ9cxEJkkjrMCJBEumbSsmYKd3wH1Wb0EGwafe/2/b/2HHo5+4j
+G3qPb+w/tSkqwYvbxi9vn7gaI8E7exhxEjzIeXooRoJHha+Pid6cEL87JXl/
+Rpp0TvbxgvzTJUXqFUqCqqyb6s+3sQTvafMf6Aoe6gsfQwkaSp5hCb40IQm+
+hhK01LzFEvxga0iCErQ3pdASTMcSzHJ3fnZjCXp68ry9+d7+gqgEh0r8w6WB
+kTIowQCU4FhlEEmwJjRZG56qC0/Xh2caIrONkbmmyJIEF1ZIsBtwegC3F/D6
+AL8fCAbQliQohhIcBVLMwDgJYgZGJTgHNPO0BBeAnklLkIXHRhI0cYCZS0uQ
+jyUoADbMQLuIlqAES1CKJSjDEpRjCSq+IEENHmZgkGKgPjqKgeElBprQ/oQB
+1+Se/be3GoMhYMMSRAsAK5agxRexeJEEzViCJnfQ6AoanQGDI2Cw+/U2n87q
+1Vq8WrNHY3KrjS6VwanUO+Ram0xjlaotEqVZJDcKZHq+RMsVqll8xQJHOrso
+mmLwxqYW+ixWw9d+q5FIpLiIBEmkdRiRIIn0TbVQklu+AR0EG3Z+37L3h7b9
+P3VCCR79pffErwOnNg2d3TJyfuuyBK9DCe6evbUHSfAeLcHHWILPoAQP814c
+4SdQEjwuenNS/O605MNZadL5GAleU2beUGXdUmdDCd7V5t7HEnykL3qsL36K
+JFj2wlSeYKp4Za6CEnyDJfjeiiSYbG/8iCWY6mhNgxJ0tmfSEszxdOcuSdDb
+X+QbKPZhCfqRBCsCkIFjVcHx6iCWYIiWYJiWYISBGbjQDpgdYLHzyxIcBMIh
+IMIMXJKgFEpwAsgxA5clOAvUc7QEMQMpCeoXgYEVI0EOLUEeLUEBLUERlqCY
+liBmoAsz0I0Z6FGgQQZ6MQN9NAP9NAMDmIFoNANDFAONaEsMjJj+gAH/tP5W
+bMVjorUDixCDQWALoFn9CINWLEE0T9jsDpldIZMraHIGjY6A0e432Px6q0+H
+Jag1uTVGl9rgVOkdSp1drrHJ1Fap0ixWmEQyg0Ci44k0HIFykStnsCSzC4LJ
+Oe4ok0f+vCCJ9G1FJEgircOIBEmkb6f54pySn/+jcuM/67Z/17T73617f2w/
+8HPn4Q09xzb2QQme3owkeGHb2KXt45d3TF7dOXV91/RNSoJ7Gff2LTzYz3x4
+gPX4IPvJoXgJHhMmnliWYDKU4EX5p8vytKuK9Ou0BO9ocu5p8qAEH2IJPtEX
+PzOUPDeWvTQiCb42VyWakQTfIQnWJ0EJ2pAEP2EJpjvbMrAEP7s6s6EE3UiC
++Z7eAm9fYVSCg6X+4TL/SLkfSnC0MhCVYG1osi40VR+abgjPNIZnm8JzzZH5
+FiRBRqwEuwAbM5DTC7h9gNcP+AOrJDgKJJiBcRKcBsqZGAnORyWohRLEDIxK
+kB0dkiAXSdAMJcinJSikJYgZ6JDES1COhxnowQz0Ygb61GiQgX6agQGagUGa
+gSGagWg0AyOrGfgbBlwTeo7fXQQ4VmOQlqDND2w+JEGrFw5J0IIlaHYFzc6g
+CUkwYLT5DVaf3uLVmb06k0drdGsMLrXeqdI5lBqbXG2VqSxShUksMwqler5Y
+yxOq2TwFkyOdXxTNzPPGpxeHLDbj137DkUik5YgESaR1GJEgifTtVPTz/ynb
+8I/qzf/VsOP75t0/tO77qf3gz11Hfuk59mvfyU2DZ7YMn9saleCVqARnoARv
+rynBw7QEj0Yl+PaU+N0ZyYdz0uQLspRLsk9X5GnXsARvqrJuQwmqkQQfaPMf
+6Qoe64qeIgmWvjAgCb6CEjRVvTFXv4UStNR+wBL8aGtMgRK0N6dBCTraMp3t
+WU4sQVdXrrs7z40l6EESLPYOlEAJ+obK/MPl/pHKwGhVYKw6MF4DJRikJRiK
+l2BktQTZ8RLkDwLBEBAOA9FIvAQngGwSyKfQKAkqZ4FqDklQDSWIGbgsQRaS
+oIGNZuTQEuQBMx9J0CKgJSiiJSjBEpRiCcrwMAPdmIEezEAvzUAfZqBfiwYZ
+GKAZGKQZGIphYBgbMLrfNeB/R38rJLgmBgPADocliAYl6AmjucMWVwgOStDs
+CJiwBI1Wn8Hi02MJ6oxurcGl0TvVOodKa1eobXKVVaYwS+RGsdQgFOv4Qg2X
+r2Jx5QssyRxDMDXDHmUL5772G45EIi1HJEgircOIBEmkbyR8EPxHxS//rNv2
+XePOfzfv+bFt/08dhzZ0HdnYe/zX/lObkQTPbxu5sH3s0o7xKzsnr+2aur57
+5uae2dt75+7uY9zbv/DgAPPRwRgJHolK8PVxYeJJ0dvT4vdnJR/OS5MvSlMu
+0xK8ocy8BSWoyr6rzrlPSVBb8ARL8DmWYAKWYCKW4DtzzXsswWQrkuAnW1Mq
+lmAGLcFsV2dOjAQLPX1FtATLfEPlvuEKKEF/nATrg1MNoenG0ExTaLY5PNcS
+nm+NzLdFGO2RhQ7A7ASLXYCFGcjuBZw+wO1fQ4KiUSAeA5LxeAlOA8VMjATn
+gZpBS5AJdIu0BNkxEuQCE4+WoABLUAisIiRBmxhJ0A4lKEVzytAgA6MSxAz0
+YAZ61WiQgT6agX7MwIAeDUmQZiA1ioHhGAZGVjDwNwy4JvScv70IXhg42TLV
+ir8zWDOw6P//2bvLLqmuvO/j7+ueieIkISFGAgQLIYHgECB4cHf3xh0a2t2r
+u6rL3d31WHlV3/+9zzndVUBm5rrWSvpa0/u3vm9hP/isfQRJkMpCSIKpNIQk
+mMQSTDCFBF2IU/lYKhdL5qKJbCSeCWMJhiJcMMwGQow/SPsCKY8v6fYmnO6Y
+wxmxOcIWW9Bk8RtNHp3epdLY5ArToFTXl6Ri433syMjIhBEJkpFNwBEJkpH9
+X5j89rWa6f+8N/P9x7M+evH1lNpvp9Z9P61h/ozmBZ+0Lv60feksJMHls5EE
+V1VIcOM7JKjdtaBCgovNB5ZYDi21Hl5mO/qL/fgKx8mVzlOrsQTXuc9v8Fz4
+DSTovbzFd3UrluCOwM1dwRqQ4J7wnX3he/uxBA9FkQSPYgmeSDw7mUASPCNK
+8AKFJUg3XgEJMkiCN9jWm1zbLQ5LMN15N9N1L1MlwSe5gad5ybP84HNegoVq
+CZZECZZHJairlGDXiKl7xNwzYul9S4KDI86hEZe0QoLyEa+iQoLqMQmGdKIE
+DaioERXDDBQkaBUlaMcSdFRLEDOQ9VRJMI0ZmMEMzIoMrJJgBCcysCgykI9n
+YPk/YeD/TH9vMJCX4DsxqHF5cyM0SDBTRoEEuRKKLSYZCEkwQeXjqTxIMJbI
+RuOZSCwTjqZBgqEwGwwxgSDtD1A+X8rjTbjdcacraneEbbaQxRIwmX0Gg1ur
+dSiVFqlM36+3qcb75JGRkQkjEiQjm4AjEiQj+78w5Z3rd2a892DmB09nTwIJ
+vpozrW7u9Mb5M5sXftK65LOOpZ93/fwFL8F+kOCabwbXfju0fo5043fDm76X
+b56rBAluG5OgbvdCQYL7QYI/Wg79ZD3ys+3ocvvxX+0nVzmQBNe6zq7nJei5
+tNl7+Xcswe3+GzuxBP8I3d4bQhI8ELl/MIIkeAQkGHtyXJTgaZBgsvZc6tX5
+FEiw7hLdcFmU4PUKCd5Od9wBCaaxBDM9D7O9j7J9jyslmEcSrC3IXhWGXxfl
+dUVFfUnRUFI2llRNZXVzWdNS1mIG6tpH9B0jhs63JNg3Yu0fsQ2M2CVIgg5R
+gi7ZiHsYSdDDS1A54lMJEgxoRoJaUYL6kbChQoImJMEYSNAiStAmShAzkMIM
+pF2iBD1Ygl6c7x0SzI5KEDMwLzKwIDKwWMHAEs/ApFAVA//MgO/kHvsvKuNK
+YsUR9p0YzI7QmTKNJUhxJQpJsJRiMAaxBBOpfBxLMBbPRmOZSDQdxhIMhZhg
+kAkEaL8/5fUmPZ64yxVzOiJ2e8hqDZrNfqPRq9e5NCqbfNg4OKjpdfnt4334
+yMjI0IgEycgm4IgEycjGfcO3r96a/s+7M95/9NlHz2ZPevnN1FffTaufO6Px
+B/RoaNuSWR0/8RL8svfXr/pXfY0kuK5CgltAgvNU2+art/8wKkH9nkUGJMEl
+5gNLLYeWWY/8Yj22wiZIcI3zzDqQoOv8RveFTaIEt/mu7cAS3A0SDIoSDCMJ
+HgYJRh8fwxI8GX92CiSYeHkWS/BC6vVFkCCFJHiVbroGEmSQBG+xbTUgQU6Q
+4P1M94NRCWaxBHOS5/nBF/mhl3lRggWQoLy+KEqwJEqwrK2UYNeIsXvE1PMu
+CQ6OOIaqJSgf8SgqJKiukKCuQoJGlCBBsyDBuBVJMAEStIsSdGIJurAE3aIE
+vShgIIcZmMYMRGEGZjEDc2EUMBAVFSRYwAwsxlE8A0sVDCy/8yrwXxvwXwGw
+koHlCgZChRH2WZf+LQz6MiN0uozCEqTYEsUUUzRUSFKFZCqfSObiiVw8no3F
+MtFoOhJJh8NcKMSGgkwwQAf8lN+b9HoSblfM5Yw67GGbNWgx+81Gn1Hv1mkc
+KoVZJtUPDKh7xvv8kZGRoREJkpFNwBEJkpGN+xR3rt2e8d79mR88+fzj519O
+rv126uvvptfPm9m04JOWRZ+1/QgS/KLr59lvSnDDHJkoQcWYBBdUSHCxcf8S
+08Gl5kPLLIIEV9pPruYl6Dy3wXX+N/dFkOAW75WtXkGCu0CCgZo9WIL7sQQP
+gQQjD49iCZ6IIQmeTrw4gyV4PoklmKq7TNVfobAE6eYbTMtNBkuQRRK8y3Xe
+AwmmsQQzvY+zfU+y/U+zA89AgjlRgnlegsP1BXlDUdFYVDaVVM0ldUtJ01rW
+tIEEy7r28psS7B2x9I1Y+kesA4IE7bwEpSNO2YhruEKCyjEJ+jUjAS2SYBAk
+iBk4KsGISZSgRZSgTZBg0oEkmMISpECCbhTjQY1JEDMwHUABAzOYgVmRgTmR
+gXmRgQWRgUWRgaUkimcg3390FfhO9HFvVxYr4YpiBYzBp9UY3FfTnxlh0mUG
+SbBMsyUaS5ACCVKFFJZgMplPYAnGY5lYNBONpCNhLowlGArQQZCgL+XzJL2u
+uNsZddojDmvIZglYTD6TwWPQOrVKq0JmHJJo+twB53gfQTIyMiJBMrKJOCJB
+MrLxnQxfCN6Z8f7DTz968vmk519Nqf12Wt33MxrmgwQ/bVkMEvwcSfCX2T0r
+vuxd+XX/6m8G1nw7uG7O0IbvZL99P7xprnzLPJCgckyCCysk+KPp4E/mwz9b
+jiy3HvvVdnwVkuDptc4z60UJbvZc+t2DJLjdd20nSNB/8w8swX0gwdC9g1iC
+R7AEj0eRBE+BBONIgucSggQviRK8Rjddr5Dgbbb9jijBB+nuh+meRyDBTLUE
+c0O1eemrvOx1XlZXKcGiKMGSpq2kbS/rOsr6zrKha8TQ/S4JYga+KUE5ipeg
+VzXiU1dIUCdIMAQSNFZI0IyKYQYKErSLEnRiCbpECWIGMpiBrE+QIMdLEDMw
+gxmYDaOAgXyCBDEDCyIDiwkUz8BSBQPL/wsDvgOAb0iwVC3BAi6PexuDIEEO
+BxJkICRBCkswhSWYTOQSSILZeDQTi6SjYS4SYsNBNhRggn464Ev5PUmfO+Fx
+xlz2iNMWtluCVpPfbPAadW69yq6Wm4cHdZI+JbkWJCMb/xEJkpFNwBEJkpGN
+74bRt2Leuzfzg0efffT0i8kvvp76as70urkgwU+aF37WumRW+9LPO5aBBL/s
+WfGVIMG1b0twfrUEF2EJLjHuX2o6uMx8+BfLkRVIgidAgmvsp9c5kAQ3us5v
+cl/c4kYS3Oa9usN3fafvxm4swb0gweCdA6G7IMHDYSTBY1iCJ0GCsWdn4i/O
+YgleSL66mMQSTNVfpRquUUiCN+mWW0xrDYMlyHbc4zrvc6IE01iCmf5n2YHn
+WcmL3OBLkGBu6FVeiiSYxxIsKBoLWIJFkKBakGCJl6C+q4wk2DNi6h0x942Y
++8ckaAMJDo04MAPHJKgY8SgrJKgZ8WuRBAMgQcxAXoJhE0qQoAVJMAYStKES
+mIFVEnRXS9CHwwzkAlUSzLwhQczAfAwFDOTjGVgUGVhKoXgG8r2bgf8JANOV
+lcVKuCKuICRIMPc2Bm/1ixJksARpLEEqhSSYwhJMxnMJLMF4JB0Lp6MhLhJk
+wwEm5KeDPirgSfndCa8z7nFEXbawwxKymQJWo8+s8xg0Tq3CqpQapAPqfqff
+Md4HkYxsoo9IkIxsAo5IkIxsHCetuXpjGroQvD/zw0efffx0Npbgd9Pr585s
+/OHT5kW8BL/oWDa7WoJzBtd/N7The2mVBH9QbV+gHpPgYlGCP4sSXGk7sdp2
+ci2W4Abnud9Agi4kwa28BL3Xd2EJ7gnc2hu4vR9L8FAISfAoSDDy+ARIMPr0
+NJbgufjL8yDBBJLg5WTdFZBgCiTYeIPCEqSRBO8w7XdBgiyWIIck+Djd+yTT
+9xQkmMESzEpe5gaRBHNIgvX54Ya8vLGgaCoomwuqlqKqtahuK2raS9oOkGBJ
+lGCZl6CJl+DAiFWCGpWgAyQ4POKSo3gJelQjXjWSoI+XoE6QYBAkaKyQoBkV
+xQwUJGhHEkyABJ2olAsFEqQ8SIK0F0mQwQxkMQM5zEAUZmAGMzAbQQEDcyID
+xyQoMpCPZ2CpgoHlf3sV+G8A+C8YOCrBPC6Hy45wT6ox+LhLz5ZZLEGGRhKk
+qSKdKlDJPJTCEkzGsgkkwUw8nI6FuGiQjQSYsJ8O+aigJxVwJ33OuNcRc9si
+TkvIYQ7YjH6L3mPSuPRKu1pmGpboJD0Kci1IRjbOIxIkI5uAIxIkIxvHyW5f
+uzX9vbszPnzwyUePZ0169uWUl99Me/3djPp5nzQuAAnOal3yebUEv+lf/W2F
+BOe+JcGFmlEJ7vvRuP8nLMHlliO/Wo6tsgoSXO84sxEk6Dy/2XXxdyzB7Z6r
+O7EE/wAJ+m/twxI8GEQSPAISDD88HnkEEjyFJXg29hxJMF57MfHqkijBa6mG
+60iCTbwEb1dI8AHb9ZDrfsRhCaZ5CfY/zwy8zEpqs4OvckOvc9K6nCjBPC9B
+ZUtBlGARSbCzpOsq6bvLhh6QYNnUW66S4OCIbWjELkXxEnSCBBXVEtQIEvSD
+BPUVEjRVSNCCJBgFCdpECTpECWIGptyiBL1Ygr43JchhBqYxA1GYgdmoIMEc
+L8E4ChjIJ0hQZGCJQvEM5PuPGPgOAIoMzPCVxIq4Ai7/pgRR+2r6KzH4qEvP
+lFgsQYZCgQTpZIFK5KlELhXPpWLZZDSTwBKMh7hYkI0GmIifDnupEJag35Xw
+OWIeW9RtDTvNQbvRb9V7zVq3QeXQyS3KIYO0T93v8JGPiJKRjeeIBMnIJuCI
+BMnIxmuDNVeuTv3H7env35sJEvz48eeTn3059eW3019/P7N+Pkjws2oJftWz
+4uu3JSjbNE++ZX61BBdpdy/S7Vmi37fUsH+Z8eAvpsPLzYIE19hOruMl6Di3
+yXl+C5bgNveVHUiC13aDBH0392IJHgggCR4GCYYeHMMSPBlBEjwT5SX44gIv
+wcTrK8m6q0kswVTjTarpFtVcQ7fcppEE7zEd95EEOx9yXY+47sdcz5N077N0
+3/NM/wuQYAZLMCtKMMdLUN6UVwgSLIgSLGoFCZYMPSVjb9nYVzb1l3kJWiol
+KBtxDFdIUDniVgkS9IIEtRUSNAgSDAEDzShBglZBgjE7kmAcJOislqCnWoJ+
+FBtAAQP/TIJZzMCcyMC8yMCCyEA+noGlCgaWGdS/uQp8G4AZvn/NQCxBVA7H
+MzCDewODCocPMEiXWJBgCkISpEGCcQhJMBXNJiOZhCjBWICN+ukIlmDQnQy4
+En5H3GePeqxhlznkMAbsep9F6zapnXqFTSM1yQe0g13DXeN9IsnIJvSIBMnI
+JuCIBMnIxmv40dD37sz48N7Mjx5++vGTLyY//2pa7ZwZdXNnNsz/VJTgF+1L
+Z3cs+7Jagt9VSnAYSfCHagkurpbgCvORlZZjq60n1oIEbac32M/8Jkpwq0uQ
+4C6QoPfGHizB/X4kwUMgweC9o1iCJ8JYghFBgudjIMGXF+OvLoMEE1iCyYYb
+IMEUliDVcoduvUu33WPa7zMdSIJs12Ou+wnX85TDEkyLEsxgCWal9TlZQ264
+MTfclJc35xUteWVrQdVWULcXNB1FTSdIsDgqQUNvSZDgQNksKVsGBQnaRiUo
+FyTo4iWoRvES9OlG/HokwQBI0FglwbBFlKBNlKBDkGACSzDpRhJMgQS9KNqH
+GpMgZiAXQqXDKGBgRmRgFjMwF0fxEsxjBqJEBhZFBpZo1CgDUf/hVWCmsrcY
+mC3iCkJvMFAoM5JJj6ShN/4rQZc4LEEWS5DBEqRBgrEchSWYimSS4XQilI4H
+OSxBJuKlwx4q5E4GXYmAI+63x7zWiNsScpqCDoPPqvWY1S6D0q6TWVQSvaxH
+2Wf3kGtBMrJxG5EgGdkEHJEgGdm4THLryuUp/69m+geCBD+b9OSLKc+/5iX4
+CUiwacGs5kWft/74RftPszt+/rJr+Vc9v37Tu+rb/jVzsAS/H9owd1SCciTB
+BdUS/FG/7yfD/p+NB5ePStByYq315Hrb6Y1Ygpud5393Iglud1/ZCRL0XPsD
+S3CfDyRYcxAkGLh7BEvweIiX4OPTWILnoliCsZeX4rWX40iC15L11yskeHtU
+gjSS4EOm8xFIkBUlyGEJpgdqM5JXmcHXmaE6kGAWJChDEsyJEszzElR3FJAE
+u4q67qK+B+IlWKqQYNk6NGKVjknQARLEDByToGbEq62QoEGQYNBULUErCiQY
+tYsSxAxMuEQJeqoliBnIBAQJsu+SYEaUYHZUgpiB+eSYBAuYgXw8A1EVDCz/
+zwwoMjALlcSK1RLMi+VwWRRiIJYgSukKVkpw761+qsRhCbJJJEEGS5AGCUaz
+FJZgKpxJhtKJIBcPsDEfE/XSEQ8VdqdCrmQQS9BnjXosYbcp6DT47TqvRe0y
+KR16uVUzZFT0aQbbpZ3jfS7JyCbuiATJyCbgiATJyMZlQzVXr039J0jw7owP
+78/8+NGsyU9nT33xzfRX381EEvzhs6aFs5oXj0rwq67lX1dKUCJIcN6oBBVI
+ggvVO94pwV9NR1aZj62pkOAmx7ktDiTBbSBB15Wd7qu7eQl6kQQPgAT9dw7z
+EgwKEjwVRhI8G8ESjL64KEjw1VWQYAJLMNl4K9VUk8ISpFrv0W336fYHvAQZ
+LEEWSfA51/ci3f8SJJgWJZgZqs9KG7KiBHOiBPMqQYIFbVcBJKgDCfYWDX0l
+Yz9IsGQaKIkSLFulZZtsxD6M4iXoBAmqkATdogS9OkGCfpCgUZSgWUiQoE2U
+oAMFEoxjCSbcSIJJkKAXRflQIEEaS5DBDGQxAznMwHQEBQzMiAzMYgbmEihe
+gnmRgQWRgUUaxTOQj2cg6s8Y+LYBs6P9TxiYzeDSqAwHlTOPugyVGHzYqU8V
+OSxBNoEkyGAJ0tEcFclSWIKpUDoZ5BJ+Nu5jYl466qEiIEEnSDARsMf8tqjP
+EvGYQi5DwKHzWjVus9JpkNt0UrNqQCfrlPda3bbxPppkZBN0RIJkZBNwRIJk
+ZOMyIkEiQSJBIkEysv87IxIkI5uAIxIkIxuXXZj8/25O/+D2jA/vzvjo/icf
+P5415dmX0158MwNJcN6nFRKc3f7Tl5US7FstSHBQkOD84S0/8BJUbl+o2rEI
+S3CJds9S3b5l+v2/GA6uMI5JcJ315Abb6d9sZzbZkQS3ggSdl3a4LgsS9Fzf
+y0vQJ0owcO9Y8D5I8GQISfBM+AkvwQu8BGO1V0CC8dcgwRuJhpsgwSSWYKrl
+LkiQwhKkBQk+Ybqfsj3PWCxBTpRgWvI6M4gkmEESbMoON2flLTlFa07RllMi
+CebVHXlegtrugijBorG/aBwomSQl82DJAgkSLNuHy3b5iENRIUH1iFtTIUE9
+ipdgwCRK0IICCYaxBCN2UYKYgXGXKEFPtQQxA+lAlQRZLEEOMzCNGZiJoXgJ
+ZkUJ5jAD8ykUL8GCyMBiBQNLLIpnIN+/YeA7DIgZmOMr4PJiOVwW9YYEsxxU
+zrDlzN5bA5UYHLb7AYNYgmwcSZDBEqRBguEMxUsw8KYEw85kyJEI2uMBLEGv
+KeQ2BJw6n13jsaicJrldL7NoJAZFt0rSIukY76NJRjZBRyRIRjYBRyRIRvb3
+b/DW1StT/3lLkODHDz6d9PjzKc++mvbyW5DgJ6IEP29e/EW1BL/tXTWnUoJD
+YxJcMCpB9a7FmjcluNJ0ZLX52FqQoOXkBiuS4Gb7ud+xBLdjCe4CCbqv7cES
+3O9FEjwEEvTfPYoleCKIJHg6xEvw6fkIlmD05WWQYAxJ8Hq87kai/mYCSfB2
+svkOSDCFJUi1P6Q7HtGdj3kJMliCLEiw7yXX/4obeJ2W1KUH6zNDDRlpY0aU
+YFbOS7A9p+rIqzvzmq68ppuXYEHfWwAJGpAEi7wEzUMli7TES9CGJFh2KMoO
+pSBBFy9BLUqQoAFJ0M9L0IwSJGitkmAUSzCGJRh3V0vQVyVBOogkyGAGsmFB
+ghyWYFqUYAYzMCsysEqClBgvQQY1ysBSBQNRf8bA7LuuAnMl0YB/xkBRgrkM
+Lo3CDBzJsmUUU8688bZgEkmQwxJkY0iCDJYgDRIMZahgOhXgkn424WPiXjrm
+oaLuVMSZDDsSISTBmN8S8ZnDHmPQpfM7NB6bymVWOAwyq27IpO7VSNul3RaX
+dbwPKBnZRByRIBnZBByRIBnZ37+hmmvXp71/a/qHd2Z8dG/mxw8/nfzki6nP
+v57+8tuZogRnVUjwq46fv+5a/k23IMHv+td+L1k/l5egdEyCCysk+KN2z0+6
+fT/r9y8flaDp2Frz8fWWkxtHJWg/v82BJLjTeXmX6+ofWIL7PEiCB0GCvttH
+sASPB0CCD04FBQmeC4MEn12IvLgEEowiCV4bk2BDTbJxTIKptgcgQQpLkAYJ
+dj1lup8xPS/Y3pdsXy0vQQ5LMC1KMCNrzg4jCWZFCeZAgmokwby2J6/rLej7
+UKIEi6bBoiBBWck6XOIlaEcSLDtVkCBBN0hQhyTo5SVoFCQYAAlaBAmGQII2
+VAQzUJCga0yCCZCgFwUSTPmRBKnAOyTIYgZymIHpGAoYOCrBrCjBHGZgnkLx
+DKyUYFFkYIlDjTKQ78+vAssiACsN+D9hYI7DiQxEyR1Vn47Zc6s/gSTIYQmy
+USRBBkuQFiWY8rNJH5vwMnEPHXOlos5kBEswaIsFLFG/Oew1Bt16v1Prtavc
+FoXDNGzTD5k1AwZFp7y/sb9tvA8oGdlEHJEgGdkEHJEgGdnfv4tT/nFj2gei
+BCc9/GzKk9nTnn89A0nwe5DgZ6IEZ7f++OU7JTiwDiQ4b+i3+SBBGS/BrSDB
+RViCS0YlqNu/XH/wV8PhVcYjayokuMl2ZouNl+CFHViCu7EE97qRBA+ABL01
+h7EEj/mRBE8GBAmeDWEJhp9djDy/FEESvAoSjGEJxutvgQQTIMGmO8nme6mW
++6nWB6m2h1T7I6rjMd35lO56xnQ/BwkyWIKsKEEOSzANEpQiCWZECWZ5Cao6
+c+qunCjBvA4k2F8wDBSMEoiXYNEiLVp4CcpLdmhUguqyS1MelaBHL0jQBxI0
+jUkwaEUJErQjCUZAgk4USDDGS9AjStD3DgnSISRBJlwlQa5aghnMwGwSBQzk
+4yWYpwUJFpgxCRYrJFiqYGA5I/TnBnzrKjAP5cVyYllcRqxagihgIA2Vsg87
+jZUYvN9hiCMJcrE8F82xkRwTzjJYgnQwTSEJciDBpJdJeOi4i4o6UyDBsD0e
+ssaClmjAHPEZQx59wKX1OdRum8JpHrYbhiw6iVHdrRpqGeyKJePjfUbJyCbc
+iATJyCbgiATJyP7mDdZcuzr1fZBgzfSP7sz4+P7MSY9mTXk6JsFPsQQ/b1r0
+RfOS2a1Lv2xf9lXHL4IEe94hwR9AgsO/L5BvXajYvki5Y5Fq1xL17qWaPcu0
++37R7V+BJHiIl+A68/EN5pO/WU5tsoIEz24FCdov7HBc2oUkeGWPC0lwv+fG
+Ac+tQ1iCR313QIIn/LwEH54JYgmGnl4QJPjiSvTl1SiS4I1Y3U2QYBxLMNF0
+FySYrJLgEwpLkBYlyCAJvmYH6jhJPTfYwA02poea0tLmtKwlM9yakbdlFO1Z
+RUdW2ZkVJZgDCWqRBPP6/jxI0AASHCyYhpAEzUiCRetwESRoU5TsypIDEiXo
+0pbd2rIgQcOYBP3mNyUY4iXoqJagG0kwDhL0okCCSSzBVABJkApWSZDBEmQx
+AznMwHQcBQzkq5IgNSbBPGYgH89AlMjAUhpVycByplz+twzMF8T+AwaiONQo
+A1F0CcpSpewbLwwO2QMxQYJcJMeCBEMZJihIkPJzKV6CbiTBmDMVdSQj9kTY
+GgthCfqNIa8+4Nb6nGqPXemyDNtNUqteYtL0auVtsr5BzfB4H1Mysgk3IkEy
+sgk4IkEysr950prrWIIfggTvggQ/mfzo86lPZ0/HEvxEkOCCSgl+3fHzN528
+BFfO6RUlKAEJbuQluKBCgovHJLiXl+BKw6HVxiNrjcfWmQQJbuYlaDu/HUnw
+IpKgE0lwH0jQfeOg5yaSoBdL0CdI8HQAJPjobPDJeV6C4eeXQYIRkGDt9SiW
+YAxJ8Ha88Q5IMIElmEQSfJRqf8xLkMISpJEEa5m+VwyWIDtQz0mQBDlRgmle
+gvL2jCDBrqy6O6fpyWl6c9reHC9B/UBelGDBJC2YZYIErfKiTVEECdpVIMGS
+U11y8hLUoTz6stdQ9horJGhBCRK0CRIMYwlGQIIuVAwzsEqC/ioJUiEkQRoz
+kIlUSZB7Q4KYgdkUipdgTmRgXmRggUXxDOTjGYjKoJABMQP5/sSA/1sG5tky
+ikHlaCxBCpUdtr/5jGgsn46OSZDFEmQCadrPUT6ITXmYpJtOuKi4MxVzJKNI
+gnGQYNAUCRhDPn3Qo/W71F6H0mUddpilVsOgWdunV3UoBpskXeN9TMnIJtyI
+BMnIJuCIBMnI/uZdnvLetakf3Jz24e3pH9+dMenBp1Mefz7t6ZcgwZmiBGeJ
+EvyydelXogS/7f51Ts/K70CCfaIEBzfOHwIJbgYJLkQS3MZL8Ef17p80e37W
+7l0OEtQdXKk/tNqAJLjedHwjL0HLmd+tIMFzIMGd9ou7HJf/AAk6r+5ziRL0
+1BwBCXrvHPfdBQme8mMJBh6dCz4+H3pyIfTsEkgwjCR4LQISfHUj+hokWBPD
+EoxjCSZaHiRbHyaxBFOiBKnuF3TPS7qnlul9xfS9ZvqRBFlJA4slyPESlLWm
+hwUJZngJqrqz6p4skmBfTtef0w3wEswbB/NGQYIFy3DBIhckaFMW7aqiQ81L
+sOTSlly6kluPJOhBEiz7TCiQoL9CgkGQoB0VxgyslGAMSzAOEvShQIJJLMFU
+8B0SZLAEWcxALo5KJ1C8BDOiBLOYgTkaxUswLzIQJTKwmEZhBpZHExlYQuVQ
+f2LACgYWcmJZXEYsjeNQlQzM05DAwFwKKuZk1Ri812GI5tORHBfOcliCrChB
+GiToRRJMuenkqARtiYg1HrZEQ0iCYb8+6NX63WqvU+m2y50Wqc00aNb3G9Rd
+6uHmoR7ygCgZ2d88IkEysgk4IkEysr9zgzXXLk95/9q0D25O/+j2DCzBz6Y8
+GpXgHJDgZ6IEZ/MSbBMl2CVI8Pu+NXMrJSjdvEAmSlCxY4ly54+q3T+p9/ys
+2btcu/9X3cFV+kNrkASPIgmaTm4ygwRPgwS3gQRtogQdV/ZiCR5w3TjovnkY
+JOi5fQxL8KTvHpKg/+FZXoLBJxdDTy+FkASvhrEEI0iCt6J1NbH627GGO/HG
+u/Gm+4nmBwkswSSWYKrjGdX5nOp6QXUjCdKiBBlRgixIcKiZk7ZwWIJpeXsa
+SzCj7MqIEsyCBLVIgjm9JGcYzBuQBPMmaR4kaEYSLFgVhQoJFh2aIkjQKUiw
+5DaUeAl6QYJmkGDZbykHrHxVEgxjCUZAgm4USDDmrZZgQJBgCkuQCiMJ0piB
+TFSQIFstwTRmYCaF4iWYFSWYYwQJ5iskWBAZWEyXoTEJZqFSBQOLo73jKrDA
+9x8wsMCVCyxOkGAJRZXyPAOTuPsdVS8M3ms3RHJpkGAoywWRBNlAmkESZEGC
+lCjBhDMVdyRjtkTUGo9YYiDBIJagTxfwqH0updshd1pldvOgxdBv1PRoFa2y
+gQG1fLwPKxnZxBqRIBnZBByRIBnZ3zlZzY0rU9+/Pu1DLMFJ92ZOfvDZVCzB
+GViCnyIJzgcJflEpwXZRgt2iBPvXzZNsmD8mwS0Lh7cukgsSXKravUy95xfN
+3hUVElxnOLrBCBI8ARLcAhK0nN1mPbcDS3C3/ZIgQec1kOAhkKD71lFegl4s
+Qd/9M7wEA48vgASDIMFnV0JjErxZKcFY4z2QYBwk2PIw0foo2fY42f4UJJjq
+fJ7CEqSwBOm+1zSSYAMjaWQlTexgMzvUwklbOVkbN9yelnek5Z1phSDBDC9B
+TV9W25/lJagfzBmGckYpkqBJljcP53kJWpUFm7IAErTzEtSixiRoRHlNJZ+5
+5BuVoA0VhOzlkAPCEnSJEvSMSTAOEvSjQIJJXoKhKgnSWIKMKEEWS5ATJZge
+lSBmYJYek2AOM5BPYBmEDYjKoEqZEhhwtEoDovIFPoGB7zbguxlYrmQgioYw
+A7EE86liHhiYgAq5PdUvDEqsgXA2jSXIBdKsH0mQ8bG0KMGUi0o6Uwl7Mm5L
+xECC5ljYFAkZwgF90K8NeDU+t9LjlLvsMrtl0GrsN+p6dKp2hbRR0jPeh5WM
+bGKNSJCMbAKOSJCM7O/cpSnvX5n6AUjw1vSP74AEP5mCJPjF9GoJfl4lwZ9E
+Ca5AEuwRJTiwfr5k4w9Dv/1rCa7UHlitO7RWL0jwN5Cg6dQW8+mtvASt53fZ
+kAT3gAQdV/fzEnTxEqw55rlzAiTo5SX44Kz/0XmQYABLMAgSfH41/OJauPYG
+SDCCJRitvxNruDsqwTiS4ONE2xOQYFKUYApJ8BXV+5ruq6P76un+BmagkREl
+yIoS5IZ5CXalld1pVU9G1ZtR92ZECWZ1kqwowZxRlhMlmLco8kiCKpRdXXBo
+Cg6QoA4kWHTpi25DcVSCXpCgpeSHrKWArYQwaBcl6CyHIVc5AmEJRrEEYz4k
+wTiWYAIkGESBBFNYghQvQcxAJoYCBrKYgSjMwHRKkGBGlGBWZCCKfzaTQ/EM
+5CtmSkJZFGZgsZQTqjQgLo8qoN7NwCIff93IlfneZmCBwokMRIEE44XckD1U
+KcE/bg5gCaZFCbI+jvGytIel3QzlwhJ0jEkwao5FsASD+hBI0KfxeVRel9zl
+kDmsQ1bTgEnfo1d3quXN0oFwPDre55WMbAKNSJCMbAKOSJCM7G/bUM31i4IE
+P8ISnDwqwScgwW8+wRKcxUuwcdGXzUu+aln6ddtP34AEOyok2FshwcHffhja
+vEC6ZaHs90XD2xbLd/yo2PmTcvfPqj+Wq/eu0IxJcD1I0HD8N+OJzaaTWIJn
+tlsqJGi/zEvwoPM6SPAISNBdc9xz+4QHSfA0SNAHEnx43o8lGHh6mZdg6MX1
+8Msb4VokwUjdbZBgFEswJkjwURxLMIElmEQSfJnqrk11v6J6XlO9ggRpLEFm
+sJnBEmSlbawMSZCTd3K8BJU9aSTBvoymP6OFBAlmQYIGXoLDObMc4iWYt6ry
+NjWSoB1JsODUFZx6QYJuY9FjQvES9FlHJVgK2EtBCEswxEvQjYp6ylFvOQb5
+ynHIXwYGVkkQM5CKoECCdLUE2WoJpjEDUYiB+C8N/Ec68Qc7RyWIMJguCVVJ
+sFisYGApVyjlUW8YsFzIVZRFFbPCzSKKv2gUGVhkcQyumoGFVLEgMjCfKORB
+grFC7l71M6J32g1BQYIcliDrZRlRgpSTSjlSSXsyYUvErfEYlmAYSzCAJOj3
+qrxuhdspc9qGbJYBs6FXr+nUKFuHB3sVsvE+smRkE2hEgmRkE3BEgmRkf9uk
+NTcuTXn/6tQPb0z7qGb6JFGC07AEZ2IJfiZKcPaoBFuRBL/tWD6nc8V3SIKr
+kAT7xiS4YGhThQS3V0rwV83+VdoDa0CCusPr9Uc3Go7xEvzddHqrGUlwJ0jQ
+euEPG5LgPseV/Q4sQefNIy4sQTdI8M4pkKAXSfCcDyT46IL/8SVegsHn10CC
+ISzB8KuayOvbkbo70fq70YZ7scYHsaaH8WYkwXjrk0Tb00T7s2THi2Tny1QX
+kmAKS5Dqq6ewBGmQoKSZGWxhhgQJsrwE5V2cQpBgWt2XVvdnNAMZrSTDS1A/
+lDVIs7wETSBBRc4CCRLM2zR5XoIOJMGCy4ASJGgGCRa9lqLPWgQJ+m0okGDA
+ARIshZylkKsUhtwlhEEswSiWYMyPJBgPAAbLiWA5GUKlwigqgqKjuFiZiaPY
+BC5Z5nDpFI4qZyAaJfy8XZRgjivl+dIonoG4Im9AId6AIgNL+TzfWwzkAfi2
+Af+UgSWhUQkmkQQLCQgxEAUSjOZzf9yseka03xIIZNJ+JEFOlCDjZmhRgil7
+MgkStCAJRo1RkGBIFwpqA341kqBH4XYNOx1DNuuA2dhr0HVpVO3K4fp+8oAo
+GdnfNyJBMrIJOCJBMrK/becnv3dpygdYgh+LEpyKJTgDJPjsm09egATnzno9
+/4t6LMEmkOCPogR/QRLsWvl9z6q5SIJr5/Wvnz+wQZTgZizBrUvk25cqdi5T
+7v6Fl6B6/yrNgTXaQ+tECW4ynNhsRBLcBhI0n91pESS413Z5n/3KASzBw84b
+R1w3j7lECXruggTPerEEfY8uIgk+uRx4dhUkGEQSvBmqvQUSDGMJRpAE70ex
+BGMgwRYkwXjbs0T78wSWYLKrNoklmBIlSPU30gNNtKSZxhJkpG0MliA73Mli
+CXLKHg4kqEISTPMS1A5mdEMZXoIGWdY4nOUlaFaCBHNWVc7KS1Cbd0C6PEjQ
+CRI0ggQLblPBYy4AA3kJ+mxFPy5gLwYcRZBgEEswhCUY9pQinlLUW4r6SjHI
+XxIkGByTYBJLMAUSjKKAgaMSZColmEIBA/l4CWaYUhZiUTmIQ/EMRGWKBb6s
+UDFbKObGGjUgqgDl+P4XDCyhRAaiUlBxTILxQgEzMB/L50GCkWoM7r45gCWY
+9nGcl2M9LOtmeAnSTopCEkyBBBOWeBxLMGIIh7EEA2q/D0nQ4x52OYfstgGL
+qdeo79Kq25XyJqkkFCMPiJKR/U0jEiQjm4AjEiQj+3s2WHP9wuT3L0/54NrU
+j24iCU6+M2MKkuCsUQl+ChKsnfs5L8EGkODir5qxBNsqJNiNJDhvVIKSjQsG
+Ny0Y2rxQumWRbOuS4e1L5TuXKXb/ovxjhWrvSvX+1aIEN+iObtSDBI9vQRI8
+tc10ZgeW4G6QoPWiIEH71YMOLEEnSPDWcdftk24sQc+9s97757wPL/AS9D+5
+Enh6NfAMJHgjiCUYwhIMIwnei2AJRrEEYy2PY61PQYJxLMGEKMEkSLCnLtVb
+T/U1Uv1N1EAzLWmhB1vpoTZG2s5IOxhZJy9BFiSo6OGUvZyqj8MSTGskaUGC
+UpQowaxJkTUrsxZVzoIkmLNpciBBu46XYN5pyLuMeZcoQY8FMFjwWgtIgnYh
+kGDAWQxCrmLIXRyVYARLMIolGAuU4lCwlIBCpWQYlYqgqCguVqKheImBEig2
+ieJSOKqUhmgUMJCPl2AWMbCISqPyUKYoYDBbEBpjYL6YF8IMzFWUFV4pHDNg
+NQNLfCyOKaHodzCwmMThC0EkwRiEGIiK5HID1qoXBm+3GUQJcrwEXQzjpGkH
+RdlTKVsyZU0ksQRjxmgUSzCEJehXer0Kj2fY5ZI67BKLpc9o6NJp21XKVvlw
+1/DQeB9cMrKJMiJBMrIJOCJBMrK/Z6IEP8QSnFQhwelIgl998qYEF1ZJsJ2X
+4K9Igj1IgvP7141KcOGbEtwlSnAfSHCt5uA6LUjwyG+8BA0ntxpFCZrP7bbw
+Ery034YkeMhx7bDjxlGQoBMkWIMk6L57BiToAQk+QBL0Pb4MEvRjCQae3wi+
+uBl8eStUWxNCErwbxhKMYAlGmx/HWp6ABGNYgnEswURnbbLrdbK7LtlTn+pt
+SPU1prAEKUkLJWmlB9voIUGCzHAXI+9m5T2soocVJcipBQmmdUNpHUhQBhLM
+GIczRlGCZlXWos7yErRpc3ZdzqGHkASdIEFT3g2Z8yBBj5WXYMFnR/khR6FS
+ggiDnmLYW4xAvmLUjwIJxrAE4yEkwQSWYBJLMCVKkIojCdKYgQxmIJtC8RLk
+RAmmEQOLGRaVhTjUqARziIEFVBbFM7CQy/ONMrCYzxULKMGAFQwUSwuVODFW
+TGSgEIUDA1YwsJgoFOOiBKP5AmIgkmA+nMvdaa96YbDXHPBxaSxBzs2wogRp
+e4oSJZgwxeIgQX04AhLUBINIgj6fKEGHxGrtMxm7dboOtapFPvyyu3O8Dy4Z
+2UQZkSAZ2QQckSAZ2d+zM5PeuzD5g8tTP7w27eOb05EEbyMJTsMSnClKcBYv
+wbofkAQbsQRbQILLkAQ7KiTYu3Z+37r5/Rt+GNi4QPLbwkEkwcWyrT8Ob/9J
+vuNnxa7lij9+Ve5dqdq3Wo0kuJ6XoO7YZj1I8ASSoPH0DtPZXViCeywX91qx
+BG1XD9lBgtePOpAET4AEXbdPue+ccSMJngcJeh9e9D267MMS9D+7DhIMYAkG
+QYKv7oRe3w3X3QvX3480PIg0Poo2PY42P4m1PI21Pou1PY+3v4h31CY6XyW6
+XiewBJOiBFP9zdQAkiCFJUhLO2iQoKyLGe5mkAR7WWUfSoUkyGkkHEhQiySY
+1svShuGMQQ4SzJgUGdOYBLNWTZaXoB1JMOc05JzGHEjQJUgw77HmvdCoBB28
+BFFBVyHoLiAMvkOCqHiwGA8VE1C4mIQixWS0mIJiRQqKF2kogWKSKDaFo4oc
+RKPSEIPiJZjhBAlm04UcXwYlSjAPjTKwkIdy0CgDR58frTagyMDSf8rAIjAQ
+lUSNMhCFLwSRBCMQYmA+BGVzlRLcfWPAy6U9bNrNS5BmnTRTKUGzIMEYlmBY
+Ewyp/QEsQe+wyy11OiU2W5/J3K3Xd2jUrQp5w6AkGI2M99klI5sQIxIkI5uA
+IxIkI/sbNnDr+tlJ712c8sGVqR9dBwlOe6cEP3vx3aza7z9/NQ9JsL5Cgq3L
+5vAS7OQluFqU4HpRgpsWDm1ZLN36o2z7T8M7fpbzEtyzSrVvDS9BzaGNWpDg
+UZDg7yBBw6ntSIJnkATN50GC+0CC1ssHsQSP2EGCN5AEnUiCp10gwbtn3ffP
+e5AEL3lBgo+v+J5cAwn6sQQDL2uCtbeDWIIhLMFww0OQYARLMNryNIok+CLW
+/hIkGBclmAAJ9jQkexuTfUiCKVGCFEhwqIOWdtKyLhpLkFH0MgqQYD+rGmBB
+gmoJpxnktEMcSFAnS+uH0wZ52qjIGJEEM2ZVxqLOWDS8BLM2XdauzzoMOQeW
+oNOUc5lzbghL0GMDCeZ9dpwj74dAgi5Rgh5U2FsI+woRyF+IQiDBIAokGMcS
+TESqJJjCEqRECdJYgowoQVaUIMfwEiyk2UIG4lBZKI3iGZjL5HPYgKgcX66Q
+y/EMFDA4+g4heo0wM9q7DPivGFh8g4GlBFQoiQwsxvLFKC/BXCGMAgbmg9lc
+v6XqGdEeU5CXoIvhnDTrQBJkbCnamqQsiZQ5njTFEgYkwaguFMESDCp9fjlI
+0O2ROl0Sm73PbOk2GDo02lalskkmax+SjPfxJSObECMSJCObgCMSJCP7GyZB
+Enz/4pQPsQQn3Zw2+db0KbdnTMUSnIEl+CmS4Jw3JPh104/ftCz9Fkvwu44V
+34MEu1bN7V49r2fN/N51PyAJbuAluEiQ4DZRgruRBJX71qj2r1ULEtwEEtQd
+/10PEjwJEtxpPLPLdO4PJMEL+yy8BK8csmEJ2m8cd9w84bx10okl6Lp7zn0P
+SdCDJejFEvQ9ve5/dsP/HEkwgCUYxBIM1T8ACYaxBCOCBJ9HsQRjWILxztfx
+rrpEd31ClGASSzAlaU1J2qjBdmqogxIlSA/3MHIkQUbZz4AEVRJWPcjyEtRK
+OZ2M4yVoUKSNyrQJUmXMSIIZqxYSJGg3AAazTmOWl6DLAhLMua05jy0HEvTa
+USBBnxMkmA+4UEF3PoglGMISDGMJRgIgwUI0WIhBoUI8jEpEUMkoKhVDUXFc
+okBDyQIDpVAshaMLHMSggIF8vAQziIF5VAbFSxCXAwMKCQYcfWYUhV4mHGNg
+WqgEcXxvGRAxsCj0DgYWhOKFkshAVESUYEiQYD6Qye2u+HTMrhsDWIJpQYIU
+a3+HBOP6SEyLJBhWIQkG5B6fjJeg3dFnsXYbjB1aXatS1SiTdSvk4318ycgm
+xIgEycgm4IgEycj+hp38+J/nJr9/acqHV6d+XCnBu29J8CWW4Osfvqxf+FXD
+oq+blnzTjCXYBhJcDhKc27VSlODaH/rW/9C/YcHAxoWSTYsGtywe+n2pdNsy
+2Y5fhnetkO9eqQAJ7gUJrlMfWK8+tFFzZJMWJHgMJLhNf3K7AUlwt+nsH6bz
+e81Iggcslw9arxy2XT1iEyXouHXKWXPaKUrQff+i58ElD5LgVS+WoA9J8Jb/
+RU3g5e1A7Z3gq7vB1/dDdQ9C9UiCYSzBSPOzSMvzaOuLaNvLWHttrEOQYBxL
+MNHbmAAJ9jUn+1uSA0iCqcH2FJYgJe2iZEiCtLyXBgkq+hnlACNIcAglSpDT
+yzleggiDqrRZnQYJWkCCuowN0meQBI0opynrNGddluyoBD32nBfnc+R8zhxI
+0A8SdKOCnnzQmw9582EfKuLPRwL5P5NgAkswCRKMo4CBqCSSII0ZyFAoYCAf
+L0GOzachDpWB0qhRCWazuRwfHpbg6B3hKAMzQkUoXcFAriJWjCmW+WgcJZbC
+vc1AJMF8SWRgMZIrYgYWQtkCZiCqt/pasMsYdDFpJ5IghySYGpUgZYqnjLGk
+KMEolmAIS9Avc3uHnG6J3dlvsfUYzZ1afZtK3TQsf9XfH4iEx/sEk5H9949I
+kIxsAo5IkIzsr17/zWunPn7v3OQPLk356C0JTkcSnP0JL8Hncz5/+f0XtfNm
+vyHBFizB9uXfd/w6t3Pl3K5VogTXVUhw85IxCe4UJKjYu0a5f53qwAYkwcMg
+wS3aY7/rkAR3GE7tNJzZbRQlaL4oSNAKErx2DCRoxxJ0gARvn3XePefCEnSD
+BB9e9jxCEvQiCd70YQn6sQQDr+6BBINYgqGGR+HGJ+Gmp7wEI1iCUSzBWOfr
+GJZgvLsh0dOU6G1O9LUk+1uTA21JSXtqsCM12JkaEiRI8RKU99GKfhpLkFEN
+MmqQoBQkyGplrE6QIGdQckYVBxI0qdNmTdqiTYMErYIEM3ZjxmGCBAm6rFk3
+ZMuOStCLJYgw6Mr53bmAOxf05HgJhkCCfhRIEGEwmI+G8jEonI9DkXwiikrG
+cPF8CkrkKSiJolMohsLReRZiUBzEongJIgymc6gMKgtlcwIGc6IJ86MSzOQL
+KJGB6Yq4wr834DsYWEAlhMYYiCVYEhmIwgxEAQP9UDq3+0bV7wWxBNMOmrNT
+rC3FWJOMJUmbxySY0EXiIEF1MAISVPiCVRK02nuMlk6doU2tbRpW1A0OhWKx
+8T7EZGT//SMSJCObgCMSJCP7q9d/8zpI8PzkD7EEJ12fNvlGlQRnYgl+9vSb
+WWMSnP9l3QIkwUZRgq0/YwmuECTYvWZ+z9ofetct6NuwoH/jwoHfFkk2Lxn8
+fenQtmXS7b/Idq4Y3r1S/sdqJMF9WIIHN6oPb9IcAQlu1R3fpju5Qy9IcI/x
+3F7Thf0gQfOlQ5bLSILWa8ds14/bb5y0Ywk6QIJ3zrnuXnBhCbofXgEJeh5f
+8z657n160/fslg9L0I8lGMASDGIJhrAEw83PwliCESzBKC/BzvpYV0O8uzHe
+0xTHEkz0tyZAggPtSUlHEkmwKyXtToEEZT3UcC8lSpBWSmgsQUYjZTQyXoKs
+Xs7qFSwvQaOaM6k5kKBZm7bo0lZ92gZhCdqRBDNOc8ZpyYAEXYIEhbyOrNeZ
+rZRgAEkQFfLlQv5cGArkIkEISTCKJRjDEoxjCSZECSaxBFOiBCksQVqUICNK
+kGVzHB+XS0Np1KgEEQZHNybBDDTKQFw6X2lAzEAcO9qfMzBVEKpmYDkO5cuj
+DEQSzJVEBqIwA1EgQV8632uuuha82WJw0rwEOVuKRRJM0Oa4IEG9IMEYlmBY
+4QvJPQGZ2zfk9Ejsrn6ro8dk7dQb29S6JrmyblDaLhse70NMRvbfPyJBMrIJ
+OCJBMrK/esc++sfpj98HCV6e8jFI8BqS4JRb06feno4keB9L8LEowRcgwbmz
+X2EJ1mMJNoEEf0ISbBMkOA9JcLUowfX/WoJrFfvWKQ9sUB38jZeg5thWrSDB
+XYbTuw28BM/vN4kStFw5ykvQBhK8ecp+6wwvQSdI8N5F130kQTeWoOfJDZCg
+FyT4vMb34rb/5V1/7b3Aq/uB1w+CdQ+D9Y9DDU9CvASbn4dbXkRaX0baXkXb
+X0c76qJYgjFRgvHelkRfa6K/LSFKMAkSHOpOSXtSsl5egpS8n1IIEqRVQ7Qa
+SZDRDqN0ggRZg4rlJWjScGYtZ9FxFj3GoCFtM6btpjS6FsQSdFoBgxm3LeO2
+ZzwOKOvhJehC+d1ZvycbgECCPhRIMDQmwVw0hAvnYhFUPIpKxFDJOC6RS0HJ
+HAWlcjREoRgax+RYiM2xogQ5QYJZVCabgbIonoHZXAbiGSgEABytCHF8bxiw
+UGJQZYgWo8T+lIF5noGoUQZiCZZCOZ6BRZGBBWAg5OXyt1qr/ijRYQg4qDQv
+QUuSMSdoU5w2xihDNKWPJHXhBJZgVOWPgASHPQFplQRtnXpzm0bfpFDVDcp6
+1JrxPsRkZP/9IxIkI5uAIxIkI/tL13vz2vGP/nl60vsXJn8EErxSIcGa6dN4
+CT6c/SkvwWfffv7iuy9eYgm+xhJsWPxN04/fNvMS/OX79hVzO36d17lqXtfq
++d1rfujhJbgBJLhYsvnHwd9/Gtr6s3T7cunOX2W7Vg7/sVq+B0twP5Kg6tBm
+NUjwKEhwu+7EDt2pXfrTfxjO7DGc22cECV44YLp0yIwlaLl6zHr9BEjQhiVo
+rznruHMeJOhEErzsenDF/fCqG0vQgyXoRRK848MS9GMJBuoegQSDIMHGp6Gm
+ZyEswXBrLUgw0v46giUYBQl2Nca6m2I9SILxvtY4lmBC0pGQdCYHu5JD3Uks
+wZSsLzXcz0uQUkoopSBBWiOjNSBBOUiQ0SsYvSBB1qhheQmakQQ5qwHFS9Bu
+TjvMaacl7bSmXbaMa0yCKK8z43VlEAaxBBEGvdmgDxXyZ0OBbBgKZiMQZuAb
+EoxjCSYwA5OYgagUkiBFCRKkRQkyTJZlcVyW4xMZyMdzEIUZiMpD6RxUGGvU
+gDg2XxISDPhvGJisZiBvwAoGlqO5cgUDS6FsKShIsAgM9KdBggUvlqCHy+2q
+eEZ05/UBO5W2pTgrkiBrTjCVEtSGE5pQXB2MKZEEw8OeoNTlH3R6B+zuPquz
+x2zvMljaNYZmhaZuaPhlvyQYjY73USYj+y8fkSAZ2QQckSAZ2V86XoJnJn1w
+cVSCU5EEbwoSnIEk+MWnj7/87MnX/0qCLcu+awUJLscSXClKcO2C3vUL+jYs
+7P9t8cDmHyVbfhrc+vMQSHAHluBuJEH53vWK/RuUB7AED29RH92qObZdCxI8
+iSSoBwmeRRI0XjhouggSPGLmJXjthBVJ8LSNl+Dt8447SIJOLEEXSPDRdffj
+G54nNz1Pb3mf1XixBH1Ygn4swQCWYLDxaRBLMNTyEiQY5iXYXhfpqI92NkS7
+GqNYgjFegn1t8f72xACSYIKX4FBPUtqbxBJMyQcgSoEkSKmGKJCgGkmQ1spp
+rYLRIQkyBhVjECTImrSsWceCBC2CBDmbibObOZCgA0vQaQMMpt32tNsBYQxi
+CSIMujN+DyrgzQSwBINYgiEsQYTBUDYSzkahSDYGRbNxKJaNx7MJKJFNQsls
+CkqhKApF0zgmy/CJEmQxA7l0BpXJpPkqJJjJpbNQXgwZkBMq8rEVDGTGKtN8
+f3YVmEclcJUGrGAgChgYzvIMLPEMxBIs+ngJIgbm3Wy+y1j1jGi7PoAkmORG
+JWiIUfpoSlclwaj83RK0tmuNzUptnVT+sm8wFI+P91EmI/svH5EgGdkEHJEg
+GdlfusMf/uPER+8hCU75+NKUSVemTn5Lgp+ABB+JEnyOJVgLEvzhq7qFSIKN
+FRJsWz63fcW8jpXzOleJEly3UJDgJlGC25YP7fhVumuVbPfq4QoJKg9tVh3+
+XZTgTu3JXbpTSIL6s/sM55AEjRcPmS4dMV8+ar563AISvH7SegNJ0FZzzo4l
+6Lh7yXnvshNL0IUl6MYS9Dy77X1+x/viru/lPV/tff+rh/7XjwJ1jwP1T4IN
+T4ONz4JNL0LNL0MtteHWV+G212EswYgowWh3c6ynJdbbGsMSjA90xEGCkq7E
+YHdClGByuD85DBKUpBSSFEhQOUSppJRaRoEENUiCtE5BgwT1SIKMUcMYtQwv
+QbOetRhYKyRK0G7hHJCV4yXoEiSYdjvTHsiV9rrSIEEflqAfSRAV9GeCgUwI
+CmbCIRRIMIIlGMUSjMWqJJjAEkyKEkxhCVI0CiRIMxkGYlEsh+MZiCXIYQby
+N4TpXDrDl0dl8xyqIAQArKrSgCVaZCBVUUpoJIlLiMVxMRRmYK6SgeVwthwS
+JRjIlEQGFjEDCx4UkqCLfeNasN+aSluSnDnBmhKMEUmQ1kcpXSSlDSc1oYQq
+GOclKPOEpK7AoNM3YPf0WV09ZkeX0dauNTUrdfVS5cv+oU6FeryPMhnZf/mI
+BMnIJuCIBMnI/tIdQRJ8/+ykDy9MHpXglBvTpvISvPPJjHuzPnkgSvApluAL
+kOC8L19hCdZjCTYtndO87LuWn6sk2LXmh+61C3rWLezdsKhv45L+TUsHtiyT
+bP1lkJfgTpDgmuE/1g7vXS/ft1EBEjyIJKg6slV9bLvmuCBB3em9WIIHDOcF
+CZpAgleOm6+dsFw/BRK03jxju4UkaMcSdIAE719xPrjmenjdhSXoxhL0YAl6
+sQR9WIJ+LMFAw9NA43OQYBBLMNT6KoQlGMYSjHQ2RrqQBKM9LVEswVh/e6y/
+Iz7QGZd0xbEEE9LehLQvKUMSTMolSflgSjGYUg6lQIIqGaUepjRyCiSoVdI6
+Ja1X0QY1bRAkyJh0jFnPgAQtRpAgazOxNjMLErQLEuScds4FOVBjEnSjfJ60
+z5v2Q750AMISDGIJhrAEw2HAYCYSyUSjqFgMFY+jEglcMpOEUpkURKEoGsdk
+QII0K0iQESSY5uMyuGx6VILpHJeB8kLYgKxQEZUrMqjSaDTqTQa+YcB3MzA3
+EhUSGZjlGYgSGVjyQ4iBRS+EJQgMRBJk8p3V14LXmw2CBOOsMcbwEtRGUppw
+Ui1IMCb3RUCCQ66A5A0J6szNKn29TPVyQNql0o73USYj+y8fkSAZ2QQckSAZ
+2V83l0J+5MN/nvz4/XOTPqqU4HUkwWk106cjCX4mSPAxluCzOV+8+J6X4Nd1
+C7+pX/xtw5I5SII/IQm2/jK3bcW89l+xBFeLElxfIcHfkQQHt/86tHOVdNca
+GUhwD5bg/k2Kg5uVh0CC29RHkQQ1J3ZrsQR1Z/bpsQQNFw4bsQRNIMGrSIIW
+LEHrrXO2mvP22xftWIIOLEEnSPDRDdfjm+4nNe6ntz3P7nieIwl6ax+ABH1Y
+gv76J34swQCWYLC5NtTyKtT6OtRWF26vD3c0hLEEI7wEe1qjvW2xPiTBmCjB
++GBPfAhJMCHrT4AEh5EEk4qhJEhQKU2pZCleghoFpVVSOkhF65EEaaOWNuoE
+CZoNjMXIWCEsQZsFMMg6rKzDxoIEnWMSRHlcnMfNeSEsQR8vQT8qGECFgulQ
+KB2GwukIFElHsASjWIIxLMG4KMEElmBSlGAKSTBNMSiaxXFpho+XYAaFJSi+
+O5gTQwxkUQWUKEFmrFEDChKkxFJiyVwFA3OouFgsN8bACF+2moEZaJSBJZGB
+RcxAlIvNOxkot/N61R8lzMm0KcEZ46whxuijtC5CacMpTSipDiZUgbhCkGB4
+yBWUOP39dm+v1d1tdnYa7e16a4vKUC9T1w7InnYPjPdpJiP7Lx+RIBnZBByR
+IBnZX7fuG1exBD+olOBVXoLTxiR4//NPH87+7PFXs55+w0vwy5fzvgIJvgYJ
+LkISbPxxTtNP3zUvwxJcjiTYsXJ+5+ofutYs6F63sGf9ot6NS/o2Le3fvGzg
+918kW1dUSHCdbM/64X0b5aIElUe2qY5uV2MJak7+oeUlePaAnpfgxSPGS8dA
+gqarJ8zXTlmun7bcPAsStNact4EE71yy373suHfVgSXoxBJ0YQm6sQQ9L+55
+Xz7w1j70vXrke/3YV/fEX//M3/A80Pgi0IQkGGx5FcQSDIkSDHc2RbqaI90t
+ESzBaF97FCTY3xkb6IpJBAnGQYLS/oRsIDEsSYAE5UMYg9IkSFA1nFLLUxpF
+CiSoVYEEKb2a0mtoA5IgyqSnQYJmI8agibGaGZuFAQnasQQddsAg63LgnCzC
+IJYgwqCH83o5n5fz+zi/nwtAWIJBLMEQlmBYkGA6CsVQsTgqnkAlkrhUOglR
+6RREo3gJUqIEMQY5Jo1iM2KiBDnEQBaVR4kSZFBFFGYgnS2NRkFvGVBgIC6R
++3cMzI6EhSoZWA5kyiIDUZiBKMzAggsxMO+gc3Y6VynBHdf635IgpQ6lVMGk
+Ektw2BeV/pkE1cb6YU2tRP60WxJOJMf7QJOR/TePSJCMbAKOSJCM7K9b941r
+Rz9879THH5yd9NH5tyR4a/r025/MuCtK8NFXs55888WzObOfYwnWggQXfFO3
+6Nv6Cgm2/DK3dfm8thVYgquwBNeCBBf3bvyx77cxCUq2rxzcsWpo1xrpbizB
+vRuH92+SH9iiAAkeBgnuUB3bqeYleGqv9sw+HUjw3EH9hcMGLEHjZZDgSZCg
+GSR446zlJpKg9fZFG5agHSR4/5rjwXXnwxvOR7dAgi4sQTeS4H0PlqD31SMv
+lqAPS9CPJRhorg1gCQZb60Jt9aH2hlAHkmC4qzmMJNgW6W2P9HZE+zqj/Z1R
+LMHYYE9ssDc+1BeX9sdBgjJJYngwIR9KKKRIgkpZUjWcBAmqFSmNMqVVpUCC
+OiRByqClDDqKl6DJQJuNtMUECRK0WRk7ZGMcdgYk6HSgQIIIgy7W7WY9btbr
+YXkJ+rAEEQYDXCDIBaEQF4LCXDiCikRR0RgOSzAGEkyigIGJFJeguCQuReMY
+joJYFM3h0oIEGUGC4ldFc2J5XoJMuoASJUiPNmpAoXJqNGTA8r82IGJgFhXJ
+jjEwxJepZGDZny6LDCyJDCxiBhacTMFBgwTzdip3vbnqjxItGr8hzupjrC7K
+aCO0ZkyCCTlI0IskOOgKSRyBfruv1+rpNrs6jY52va1FbWqQa2sliqc9g1q7
+a7wPNBnZf/OIBMnIJuCIBMnI/rrte///YQl+yEvw4pTJl6dMuTp1KkjwBi/B
+mTPufvrJvc8/fSBK8CmW4AuQ4PyvX/ESXDyn4cc5jUu/awIJ/ixIsH3l/I5V
+P3SuXtC1dmH3+sU9G3/s/e2nvs3L+rf8MgAS3IYluHPN0O510j82yECC+7AE
+D/6uOLxNeQRL8Phu9ck/NCDB0/u0Zw/oQILnD+svHDFgCRqvnDRdRRI0Ywla
+bl2w1iAJ2rAE7ViCDixB5+Ma15Pbrqd33M/uup/fd7944Hn50FP7yPvqsbfu
+qa/uma/+ub/hhb/xpb+pNtD8KtCCJBhsqw9iCYY6m0KdLeGu1nB3W6QHSTDC
+S7C/KzrQHZMgCcaG+mJD/XHpQFwmifMSlEsBgwlegip5Uq1I8hJEGFSn9JqU
+XpAgZdRTJgMFEjQjCdJWM2210DYrbRMliDDowDkZFyRK0IMkiPL5WJ+f9UMB
+NhBkA1iCQSzBEJZgGEswIkiQiya4GJTk4hAwEEsQYZAWAgmmRAlSSIIsnUYx
+UAYn/l8C/2+Q4aC8EJYgzVchQSpTEsqWUhUMTIolsiOjxcViuGj2TxiYGQni
+AjwD0zwDyzwDsQRLwEAkQaboFCVop/M2KmdL5XZUPCO6/Vq/Icbpo1USVAaT
+CpCgL44lGAEJDjgCfXZfjyjBNp2tRWNukOtqB5XPeoc65OSvgmRkf+GIBMnI
+JuCIBMnI/rrtf/8fxz56/7QgwUkVEpx2Y9r0m9On18yceQckOOvTB1989ujL
+WY95CX735Yu5ggRfL/y2DiS4BEvwp++bf57b8su8VvSqYIUE1y3u2YAluOln
+XoID21ZKdqwerJCgbN+m4QNb5Ae38hJUHtulAgme+EN9cq8GJHjmgO7s/2fv
+rprrOte036/T9zPso131VnXVPnj7tHutJE6MceyYmWKI7RhjZmaZLdmSLGZm
+5jk1mZmZmQS2LPS+72fMIcu9Vu/dB3GlKh5X/b/CKPtX91OaD3WUBHOeGogE
+jfkvTQWZIEEzkaClNMdalmstz7NV5NsrC+wowWIHkaCzvszZUO5qrHQRCbqJ
+BD0gwfYGL5Ggr6vZRyToJxIM9HcEQIIDXcHB7tBQL0gwRCQY5gyGQYJcFmAw
+QiQYFXKiQm5MhBKMSQQxkKBUFJeJ43JJXCFNQEpZQiVPgATVyqRGldRC6pQO
+JZgy6FIGfYqSoMk4YjZhFiJBK0pw1G4btdtHHQ4qlCBi0DXmdo+5PWMeyDvm
+hYgEfUSC/iDBYGg8CIXHQxEsHMUiMSwaH48mxmNQEounsMQIaXQ8CY1hKWh8
+fAR6h1ESxFCC8z8xMQYMpCIMHMWmsTQGZ0aoaAmm0s1ByYl5A879dwaMfW7A
+NAMn0IALGPgx8P7jAgbOed/N0QycJQdBYOAMYeC0HQ+CKEFrarJfF1x4FuxR
++1GCkTFNeFQdHlGBBANJhT8h88Wl3hiRYFjgCPJsfo7Vyza7h4xOIkFLl0Lf
+KlY1cqVDCuaPxjBj9gXHSJAZs69wjASZMftCcyjkDxeBBBe9XPx95pLFCyVY
+8E8SrFr3cw1IcNO6hi3rG4kEW3Ztat1NJLh3a+f+rV0HtnWDBA8RCR7ZNXBs
+1+Dx3UMn97B+/4V9et/w2QOccwe5Fw7zLh3hXyYSvIYSFN08Lb59VnLnPErw
+PkpQ/uiqAiT45Kbq6S0VJcGX9zSZD7QgwdcZuuzHepBg7jPDW5SgsSDTVJhl
+LnptLkYJWogErRX5NpBgVaG9uthRU+KoLXXWlTnry51Egi4iQTdKsN5DJOjt
+bPISCfq6W/09bf7edn9fR6C/MzDQHRzsCQ71BokEQ+yB0PBgmDMU5rLCRIIR
+/nBEgBKMinhRkKBYEJMIY1JRjJKgXAoYjFMSVCkSamUCJKhRgwSTOk1Sp03q
+iQQRg4aUyZgypSU4YrGMWK0jNohI0J6W4KjTOep0jbogIkE3kaDHBxIc8/rH
+fFBgzB/EAqGxAJFgkEgwRCQYBgnGMZAgRiQYIxKMj2AgwQQtQcTg+Bj2bmwE
+eo+NQhMY/XuDo2OTo+NUUxiR4Eg6moHvZ1LvZ9NNzCaxOarEpz7Gqf7JgNGJ
+jxG68MQ/MfA9xcCPaQa+oxg4Bwz0IANnXRAycAYYiBJEBk4BAy1Q8sN/OQvq
+ouNalOCYOjSqCo4oAkk5LUGxOyqcl6DFyza5hwwgQXuvGiRoaBOrG3my6iHm
+nypmzL7gGAkyY/YVjpEgM2ZfaEOF+Q8XffMMJfgDSPA1SHDp5xJc8WPJyp/K
+Vq2qSEtwbe2mdfVEgk20BNt+2dK+QII9h3b0Ht7Zhw9EiQRP0BI8Q0vw4hHe
+5aP8K8cF104Kr59CCd5CCUruXpDevyR7ABK8psi4rnhyUwkSfHZH9eKu+uV9
+zasHmqxHWpDgm8e67Kd6IkFD3ktjPkrQRCRoLsmxlOZaylCC1soCW1WRrbrY
+XlNiry111JU56iucDZXOxipXU7WrucbdUuturfe0NXjaGz0dTd7OZm8XStBH
+S9BPJBgY7AkM9gaH+oKs/iCRYIgzFAIJctlhHjtMJBgRciNCXlTEj4oFUUqC
+UnFMJolRElTI4kp5nJKgWpXQqBNaKC3BpF6fNOiTIEEjSjBlhswpSoKIQduI
+zT5id4w4qIgEEYPuUZdn1A15Rz0+7F9IMDwWhCJYKIqFY2Ph+FgESoxFoSQW
+S2HxEdLoWAIaG0tC4xglwRQtwZH3o6MTpPTvz6MEqcanRtJ9kmCKipZg8lML
+DTgXpxkYW1B04l8Y8DMGvl/IwI++dx8/MXAcoxk4Sxg4Qxg4bYNSIMEpS3LS
+nJzs0352FiQSHAcJqkKjSpRgCiQo9cUlnrQE+Y4g1xbgWHxskwck2J+WoLFN
+omnky2uGBMFY4s/+rJkx+8uOkSAzZl/hGAkyY/aFBhJ8tOjbZz98/4KWYPbS
+pbnLluWBBJevKFzxY9GKlWkJ/ry6cu3P1evTEmwgEmzeuakFJLgHJdixb2vn
+gW1dv36SYP/RXQPHdg+e2DP0+y+sU/vYZw4MnzvIOX+YCxK8dGxegsKbp0W3
+zopRghdBgtIHV2SPrslBgo9vKp7eUoIEn99VvbyvBglmPtJkZWjfPAEJ6nKe
+6YkEDfmZxgKQ4BsTkaCZSNBSnm+tKLBWFtmqim3VKEE7kaCDSNBJJOhqqQMJ
+utsa3ESCHiJBL5Ggr6fd19vh7+vy93f7B1CCAVqCQfZgaHgoxGGFaAmG+Zyw
+ACUYEfEjIEGxMCoRRaXiKEhQJgUMxhSyGEhQqYirlHG1Kq5WEwxqEjptQkdL
+0GBIGo1JkylpIhI0W1IWa8oK2VKUBKkczhGHa8QJuUdcnhEXkaA7LUHMFxj1
+BUf9UGg0EMaCEYySYIhIMEwkGKElGCUSjNESRAyOjULJ8XSpd6T3o8DAkYl0
+RIL4K/Rjk3RpCabGp9PREkxisxhhYAKbo4qn+xcG/BenwPfpgu8/Z+A7ioEf
+P2cgkSAycNaJDJyxj87YiASRgakpYKA5MWlKfFgowS6VXxMZV9MSlPtTMl9S
+6o2LPTERSNAZ4TtCIMFhi49l8gwaXCDBHrW1S2Fqk2gb+YoallBpcfzZnzUz
+Zn/ZMRJkxuwrHCNBZsy+0IpPHM34/rtPElwCElyWu2x53vIVCyVYumpVOS3B
+mo3r6javb9i6oXE7keCuza17trT9QiS4HyXYfXBHz+Gdvb/REjy+Z+gkkeDp
+A8NnDw6fP8y5cIR76RjvynH+1ZMCkOCNMyBB0e3z4rsXJfeIBB9ek2Vcl4ME
+n6AElSDBF/fVLx+oKQm+fqIlEtTlvtC/RQkaCrKMhW9MRdmm4hxzSa6ZSNBC
+JGglErTVlNpry+x1FY76SkdDlbOx2tlU42quc7XUu1ob3G2N7vYmT0ezp7PF
+29Xq7W7zogQ7fX1dPiJBP0hwsC8w1B9goQSDw0NBkCCHHeIOh3hpCYaFvLCQ
+HxEJImJhBCQoEUelkqhMGgUJymUxhTymVMRAgiqUYFwDaRJalGBCp0/o9QmQ
+oMGYNJoIBs1JsyUJErQQCVrtKZsjZadypkCCDiJBJ0pwxO0dcftGPJB/xBvA
+QII+IkE/kWCASDAYBQyOhmKjofhoGEqMRqDkaBRKYbERLD5KIhJMjGOIwXdY
+6v0INjEyQkUYiE1CqTFoKh0tweT4DEZLMPGphQaci2EfqaJ0Ebow3UIDfmLg
+u4UM/Ogd//iJgWNzNANnKQbaR2YIA6cteBBECZoSk8bEh7zuT39E9Go+XxMe
+V4fGlMFRRSAtQYk3gRJ0RQWfJOhnmbwgwT6tAyTYCRKU6poEyhqWqEes/LM/
+a2bM/rJjJMiM2Vc4RoLMmH2h3fzmPx9/v4iS4Ksli7OWLJ2XYP7yHwuIBIt/
+/Kn0J5Rgxdqfq2gJ1hMJNu3Y1AwS3I0SxLPg/m2dB4gED6EE+47s6j+2e+D4
+nsGTvwz9vo91+gAbJHiOluBllCD/2inBjTPCm0SCd0CClyX3r0hBgo+uyzNu
+yp/cUjy9o3x2V/nivgok+OqROitDAxJ881Sb/ZySoD4v05CfZSh8YyzKNhbn
+mECCpXnmsnxLeYGlAiVoJRK0EQnaiQQdRILO5jonkaCLSNBNJOjpavUQCXpB
+gr1dvr5uX3+Pf6DXP9jnJxIMsAcD7KHgMCvIYQeJBEM8TojPDQtQgmGRICwS
+RsSiiEQcoSQok0XlsihIUKGIKZUxlSqmVscQg5q4VhvX6uKUBPWGhMGYMJow
+SoJmK2AwabElrfYkSJAKJGh3AQZTTnfK6cFc3hRI0E0k6CES9AYBgyO+0Ig/
+jAUiWDCKhWIjoTgWTmCRJBZNkUZGYtAoFh/DEuPpku9ItAQJBlMjH9IBA9Mh
+A5PYdDoiwUS6NAPj2BxVjIpI8P/XgJ9Oge/SfcbAcYqBHykGupCBczQDMcLA
+GWAgShAZOGVKEAnGPxjin50FO5Q+FS1BmT8lJRIUueNCIkGeI8yxBSkJDnwm
+QX2TQFXDFjMSZMbsy42RIDNmX+EYCTJj9oV265u/gwSfUhJcvAQk+IZI8O0y
+IsHlPxYSCZb8tKps9eqKNT9XrVtbvXFdLUhwy4aGbRsbQYI7N7fs3tL6y9Y2
+fCCKEuz6dUf3oZ14FgQJHiUSPJGWIOvMQfa5w8Pnj3AuHuNePs67Mi/Bc8Lb
+50V3LoopCT64Jn10XQYSfHxL/vSOAiT4/L7y5QMVSDAzQ531REMkqM15oSMS
+1IMEC94YCrONRTnG4lwTkaCZSNBSWWytKrFWl9pqymy1Ffa6Sns9StDRVOsg
+EnSCBFsbXW1N7vZmd0eLu7PV09Xm6e7w9nR6e7u8RIK+gV4fSHCw3z804Geh
+BAPDrABIkDMMGAwSCYYEvJCAHxaiBMNiURgkKJFEpNKITBYBCcrlUYUiqlRG
+laqYCiUY02himrQEMb0hbjDGDUSCRnPCZEmYrRglQasDMEhyJu0uzLFAgi4f
+YDDl9qc8AcwbxHyhlI9I0E8kGCASDNISDBEJhokEIykMJBilJRgjEoyPY4nx
+VOJdKgm9J02kUlS0BEcmk9AoNJWOMDCBzWBEgvHx2U/NG5AUxT5CEbowXYgu
+SPfPBvSNL2TgR3IKpBg45xydoxk4Cwy0pWYIA6fNUAIkOGWMTwID9bEP1woE
+C8+CytCYIjgqBwn6UlJvUuyhJBjjgwTtKEG2xT8EEtS7QYLdKlunwtwmNTQJ
+1TVsSUn38J/9WTNj9pcdI0FmzL7CMRJkxuxLzC6X3f72H5QEny9ePC/BHCLB
+PFqCRQskWAkS3LCudtP6ui0b6kGC2zc1URLcgxJs37etY6EEf9vVd3R3/7E9
+Ayf2Dp7cN3SKSPBsWoKcS8e5V07yrp3iXz8jAAneQgmK7l4W378iAQk+vC7N
+uCkDCT65I392VwESfPFA+fKRikhQ/fqphkhQm/tS9xYlqCcSNBAJGkvyTKX5
+prICc3mRubLYQiRoJRK01VXa6qvsDdX2xlpHU52jud7Z0uBsbXS2Nbnam11E
+gm4iQU9Ppwck2Nvt7evx9vf6Bvp8g/0+IkE/ayjAZgWG2QHOcIBIMMjjBvko
+wZBQEAIJikRhsTgskYRBglIZwaA8AhJUoASjKjWmRgnGNLqYVh9DDBriepQg
+ZjTHQYImIkGzLWGxJ6yOdCBBW1qCSYcn6YS8SZcPAwm6iQQ9RIJelCDmj2CB
+KBaMpYJxLJTAwkkskiKNpKLQaCoGjWHx8XQgQSwtwSSUgj6koySITSVGqaYx
+IsH4fMSAsXRzUJSKMDDyP2DgZ6fAcQTgPxkQSzNwlGLgnGOEYuAsYeAMMJCS
+IGHglAEkGJsECXarP/u7Me0KnyIwKvePSH0pCZGg0B0XOGN8R4SLEgyxLYEh
+o7df7+4lEuxIS1BTMywt7eH4o/E/++NmxuyvOUaCzJh9hWMkyIzZl5hdLr/z
+7T8yUII/PP9h8csFEswlEiQPRFcWrfipeOWq0tWry9esoSRYAxLcvKF+68YG
+kOCOzc27trTs2dr6C5Hg/u2dv+7oOriz+/DOHpDgkd19x/b0H987cHLf4KkD
+Q6cPss4eZp8/MnyBSPDySd5VlCD/xjnBrfPC20SC966I71+TgAQf3ZRm3JKB
+BJ/eVTy7r6Ak+CpDRSSofvNckw0SfKV9m6nLy9Lnv9EXoAQNRIJGIkETSLCi
+2FxZYqkqtVSXWWsqrLUoQRuRoJ1I0EFL0NnW7GpvcXW0ujvb3F0d7u5OT0+X
+p7fbQyTopSQ4OOAbQgn62Sw/SHB4mGCQEyASDPL5QYEgJBSGRKKQWBwSS8IS
+aVgqC8sgeUSuiCiUEYUqokxLMKrWRjW6KEgQMWiI6Y0xvSlGSdBoiZusmNkW
+BwlaaAlanQmbK2GH3AmHJ+EgEnQSCbr8gMGkO5D0BDFvKOkNJ31QJOmHiAQD
+tASDRIIhIsEwLcEIkWB0NBkdS8ag8WSc6l0yAb3HKAliyMAENomNQFNU8dFp
+ujQDY9jsfNF5Bo7PRbCPVGG6EF2QLkDy033GwDGMZuBH1+hCBs7RDJxFBqIE
+ZwgDp42UBJGBk7roB2104mr+p7PglXy+PDAm849KfSNib1LkTghdKEGeIwoS
+HLaG2ObAoNGHEtQ4u0CCcnOr1Ngk0tYOy0p7uIwEmTH7QmMkyIzZVzhGgsyY
+fYnZFfK7336TsWjR0+/TEsykJLgUJfh2GUhwZcHylYWUBFetLv95TcXatVXr
+19VsXF+7eUMdSHDbpsYdm5tAgukHotva92/vOEAkeAgl2AsSPEpL8HciwTOH
+WeeOsC8cG754gnP5JPfqKd41IsGb5wW3LwrvXBYRCYof3JBQEnx8R/b0rhwk
++PyB4uUjJUgw84kqKy1BTc4rbW6mNi9Ll/9GV5CtL8wxFOUaivOMJfnGUpSg
+iUjQTCRoIRK01lXZ6qttDTX2xjp7U72jucHR0uhoRQk6iQRdnW0uIkF3T5cb
+JNjb4+nr9fb3eQf6vUSCPtaQj8Xys9n+4WE/JUEuN8DjBYgEg0JhUCgKiVCC
+IYk0lMagPCxXhOVpCWIqTQQkqNZFNXrAYFRriOqIBBGD5pjREjNaY5QEzfa4
+xZHO6oxbXXEbkaDdQzDoTTh9mMuPuQMJN5Ggh0jQSySIGIxigVgyEE8GoQQW
+SmLhFGkkGYGAgUSCUSJBKpBg/F0i/j6RgCawJPQhHZFgHJuKj1BNY6PTsdGZ
+TwEAPzUXmW98Lvw/MGDgcwMiA8ewzxg4ijkxNCBh4BzNwFlrkmLgDDAQJYgH
+wSnCQCLByIdO1WdnwVaZT+oblXhHxJ4USFDgivOJBDk2lCCLlmAPkWC73NIq
+AQnqaoflpb28dq7sz/64mTH7a46RIDNmX+EYCTJj9iU2UJB/77tvHy1a9GSB
+BF8vXZ69dHkOkWDeAgmWrFpdRkuweuP6mk0b6rZsrN+2qWH75qadm5t341kQ
+JbgPJdj5686uQzu7D+/q+W1379E9fcf29p/YN/D7gcFTB4coCZ5PS5Bz5RT3
+2hne9XN8kOAtlKDw7hURJcGHNyUZt6QgwSd3Zc/uy0GCLx4pXmYoiQRVr5+r
+iQQ1IMG3Wdq8N7r8bF1hjp5I0EAkaCwrMpUXmypKzJWl5qoyS3WFhUjQSiRo
+a6yzNdXbmxvsRIIOkGBbi7O91dnR5upsd3V1urq73D3dbiJBT3+fByQ4MOAd
+HPQOoQR9bLYPJIgY5PhpCQb4goAAJRgUiYMiSVCMEgxJZSGpPCRDCYYVqrBC
+HaYkqNJG1LqIRh/RpCUY1ZmielMUJGggEkQM2mJme8zsiFmwuCUtwbjNHbd7
+MIc37vDFEYNEgi6UIOYJYd5wwhtJ+KBowg/FEoE4KZEIQslECEolwtAIFhkl
+jSWipNg4CRhIJLgAg/HEh3iSimIgkWBqKgaNTNOhAaPpZqkiY7PzDAx/6mOI
+7l8bcAzzkbxj/8TA0YUM/PiJgak5moGzFAPNiRnCwGnCwLQEgYGayAd1eOJq
+Pn9egm/adZQERZ6UkEiQ54hx7ShBNpHggNHXp/OABDuVdpBgC0hQqKvlKEp7
++e08RoLMmH2RMRJkxuwrHCNBZsy+xECC97/7jpLgs7QEl81LMJdIEM+CK34q
++jEtwfK1ayvXr6vagBKs3bKxbitIcFPjTnIWxAei29r2bW/fTyR4kJbgEVqC
+Jw8MnDo4eObw0NkjrPPH2BdODF8iEryKEuTduMC/dVFwGyUovHdNdP+GGCT4
+6LYk444UJPj0vuzZAzmRoOLVEyWRoOrNC3U2SlBDJKgFCRbk6Apz9UV5+uJ8
+Q0mBoazISCRoIhI0gwRrKi21VZa6amt9jbWhztZYb2tqsDc32luaHK3NjrYW
+B5Ggs7PdSSToAgn29Lh7e919fZ7+fs/AgIdI0MtieVlsH3sYMOgDCXK4fi7P
+z+P7iQQDAlFAmJYgJklLMCRThuQqGoOasEobVukiaj3BoCGiNUZAgohBc9Rg
+iRqsUaM1ChI0EQlSWZyY1RWzuWM2IkG7l8agH3MF4q5g3A2F4h4oHAcJeokE
+fUSCaQwmCAaTBIMpEpFgmJYgwWA8Oo7F3pHex+NUwEAiQVIsOZmOYiA2HYVG
+oJn5ImBAuvDoXLqxuVA6YkC6AJ1/7DMD+v6LAUfTfWLgCDDw4wIGztEMnKUZ
+OEMYOG1ABk4hA6OTwEBNGCXYoQgsPAtKfKNikKA7JXQl+c60BIdtEbYlNGQO
+DhhQgt1Egm1Ego1CfS1XVdonaOfJ/+yPmxmzv+YYCTJj9hWOkSAzZl9ig4UF
+IMGHi75/TCT4YvFSlOCS5W+WrsheihJ8u4xIcDlKsPin1aWrUYIV61CC1Rs3
+1GwGCZKzIHkg2rx7awstwY5fd3Ye3Nl1aFf34d09R/b0Htvbd3xfPyXB00SC
+546xLpxgXzo5fPkU5+oZ7jUiwZsX+bcvC+5QErwuenBT/OgWSFDy+J6USFD2
+/JGcSFCR+VSZhRJUZb9S52Sqc7M0b99o87K1RII6IkE9SLC00FBWbCwvMVaU
+mirLTFUV5ppKM5GghUjQSiRoa260tTTZW5rtrS2OtlZHe5uzo93Z2eHs6nJ1
+d7t6elxEgu7+fnf/gGdg0DM45BlCCXrZEGCQ4+NwfZQEeQI/X+gnEgwIJQGR
+NEAkGJTIg1JFkEgQU6hDIEElSjCshvRhSoJaE2AwojdH9JYISBAxaIua7JjZ
+QXJGKQla3RQGY3Yv5vDFHP6YEyISdBEJuokEPRHAYNwbjfugWNwPxeP+RDwA
+JeNBKBUPQSNYeDRdZAyjJBilJRh7H4tDE6QPsQRVWoLR5BSWmopSEkxNR1Iz
+kZH5ZqEwREswtKDg6EeqwOh/Y8DRj146D+kzA46kAwbaoRTNwOQczcBZmoFE
+grFpwkAiwcgkOQh+UIUmlMH3CyXYLPWKPSNCd0qAEkxwHTGOLTpsjbBAgiaQ
+oL8XJKh2dYAEZZZmiYmWoLCDr/izP25mzP6aYyTIjNlXOEaCzJh9iX0uwSUg
+wVdLlmXREswhEsxb/hNIsJCWYNkalGDl+vVVKEFyFiQSbNy5pQkkuGdb697t
+bft3tB/YiRg8tKvr8O7u3/b0HN3be3xf34kD/b8fHDh9ePDMkSFKghdRgsNX
+znCuneNeP88DCd66zL9zRXD3mvAeSlD08Jb4EUjwruTJfemzhyjBFxnylyhB
+RdZz5esXqjevVESC6revNSDB/BxtQa6uME9XlK8vLtATCRqIBI1EgqbqSnNN
+lbm22lJXY6mvtTbUWxsbrE2NtuYmG5GgnUjQ0dHuQAl2Oru7nd09rp5eV2+f
+qw8l6B4YdIMEB1mAQQ9icNg7zPEOc30cno/L91ES5Iv8ArEfJUhhUBagJChV
+BmWqIGJQHVJoQkptSKkLqYgE1YawxhjWmjAdkaDeChiMGG0Roz2CGHRgIEHE
+oCtqdWM2T9TmjSIGiQQRg4GYMxhzQaGYGwrHPBHMG8V8McwfJyVigSQWTJFG
+YiFoNBamGotFoHEs+o70PhajSkswCiWgyXREghFsGqMkmJoJU1EMHJkNpZuD
+gqPzEQOS/Avyjf4LA35i4Ag2b0BkYOq/MHAOGZjAaAbOEAZOEwZOEQZOEgZ+
+UIYmFMH32R36eQlezuOJiAT5riTPkeDaY8O2KNsaGTKHBk3BfiLBrrQErc1i
+U4MAJKgu6xflt7H+7I+bGbO/5hgJMmP2FY6RIDNmX2JDhYV3v/vuAZHgU0qC
+i1GCr5eueEMkmEskmA8SXLGq6KfVJSDBn9eWr11XARLcsL6afiBav31zA0hw
+19bmPdtaQIL7aAke3NV1iJbgMVqCpw4PnDkyePbY0PkTrIsn2ZeIBK+e41w/
+z71xkQcSvH1FcOea4N514X2UoOjRHXEGkeDTB9Jnj2REgvJXTxWZzxWvXyhB
+gtmZqpwsde5r9dtsTX6OpiBXSySoAwmWFOpLiw1lJYbyUmNFmZFI0EQkaK6r
+MdfXWhrqLUSCVpBgc7OtpcXW2mpva7O3tzs6OhydnY6uLpCgs6fXSSTo6htw
+9Q+6B4bcgyw3kaCHNexhowS9HJ4XJMgV+HhCH1/kAwkKJIBBv0jqBwmK5QGJ
+IiBVBkCCiEF1UKEJKrRBIsGQSh9SG0IaY4jCoM4c1lnCesgaNhAJIgYdJGfE
+7IxYXBELkaCVSBAx6Iva/VEHFIg6oWDUFYq6iATTGCQS9BIJ+uIYSPC/w2CI
+SDCclmA08i4ahd5jMWiCRCSITUYSVFPpiATDVLQEQ6nZdESCQWAgXQD7CPmp
+FhhwnoGekXRukmvkcwamMMLAj8jAtAHnLIk5moGzNANngIH66DRh4BRhIC3B
+IEqwVe5feBZsFHsErhTfiRLk2OMgQZYFJThgRAn2aL0oQYWjlUiwXqCv4YAE
+xfnt7D/742bG7K85RoLMmH2FYyTIjNmXWPGJE3e/RQlmEAk+JxLMBAkuWUHO
+gijBt8tQggUgwZWrS1atKf15bRlIcN26SiLBms0baykJ7tjSuGtr0+5tLb9s
+b923I30WPLir89DursN7uo/s7Tm2r/f4gb6TB/tBgqdpCV44ybp0in35zDBI
+8BpKkHvzMu/2FT5I8O51wf2bwge3RA/viDLuih/flzxBCUqfZ8heoATlIMGs
+F4rXr5REgioiQXVejiY/V1OQpy3M1xYX6EoKdaXF+rISfXmpoaLMUFlurKo0
+VleZaqpNtTXmulpzfZ2locHS2GhtarI2N1uJBG1EgvaODjtIsLPL0dXt7O51
+9vQ5e/udRIKugSFXGoNsN5Ggh831DPO8HL6XK/DyhF6eyMcXAwZ9IEGh1C+S
++cVyP0hQoqQwGJCpA3IiQYUOMBhU6YMqQ0htJBg0hbTmkM4S0hEJ6m1hgz1s
+hBwYSBAxiBLErJ6I1RuxQb6I3R+xEwk6iASdIYLBcNQNRaKeKOaNYb44KRH1
+Q8loAEphwREsNEoai4ahcQwkSEUwGIlORGJUHzCQICkcnwonqKYxIsFQciYd
+wWDwU3MBKiJBP5aWoI/OS7fQgO6FBkxhnzEw+fFzBqIETXFg4CzFQJQgMnCa
+MHBKgwycJAz8oAhOyAPvZf53l/M+/d2YS295IEGeM8kFCdribCtKcNCEEuzT
+pyXYTiTYBBLk66tRgpL8dubH5Zkx+yJjJMiM2Vc4RoLMmH2JFZ84eQck+B0t
+wR+WviQSzFqy4jWRYA6RYB6RYOHK1cWr1pSsXlu2Zl05/UC0GiS4ZVPdts31
+IMGdKMHmX7a37EUMkrPgLjwLEgl2H93fc/xA78mDfb8f7j99ZODMscFzJ4ZA
+ghdRguwr54avnedcBwle4t66wrt9jQ8SvHdT8OCWECT4CCUofvJA8hQlKH3x
+RPYSJShHCb5UvMlUZmcpc16rclGCaiJBDUiwqEBbXKgrKdaVlujLSvXlZYaK
+cgORoJFI0EQkaG5oMDc2WhqbLE3N1uYWa0urrbXN1tZua++wd3TaO7vsXd2O
+7h4HngX7nb0DgEEnhcFBlgskODTsZnHcRIKeYb6HI/ByUYJevtiLGJT4hFKf
+SOYTyf1ihV+ixKRpCQbk2oBCGwAJKlGCQbURAwlqzCGthWDQGtLbQgZ7yEBL
+0OgEDIZNrrDZHbZAnjBI0EokaPMTDAYiDigYcYYwVxhzRyLuaMQDxSJeKB71
+Egn6iAT9aQlGAiORIDSKhcaw8DjpXSRCBQwkEiSFYx/ogIFUU1AoAU2nIwwM
+ppuFAimqtAT9dL7Ux/m8qc8M6El9dJNcdP/VgEnKgB+tGBowzcD4HM3AWZqB
+M4SBRILhKcLASWWIYuCEjEiwRfrZWZDvTPEcSY49MWyLsazRIXNkwBTqNwR7
+9f5urbdT5QYJtkitjSJTHUhwWF02KMvv4PzZHzczZn/NMRJkxuwrHCNBZsy+
+xCgJ3v/u+0eLFj/5Pi3BV4uXZ6IEf3xDJJhLJJi/HCT4c9FPIME1pWvSD0Qr
+QYKbNtZs2VQLEty+pWHn1sZd25r2pCXYtn9n+6+7yFlwT9dvtARPEAmeOtJ/
+5tjAuROD508OXTzFuoQSZF89P3z9IudGWoK8O9f5IMH7twQP7ggf3RVl3Bc/
+fiB++kjyLEP6/In05VPZq+fyzBfyLJSggkhQmZutepujystV5+dpCvI1RIJa
+IkEdkaAeJFhZaaiqMlZXG2tqTLW1pro6U329uaHRTCRoaW6xtLRaW9usRIK2
+jk5bR5e9s9ve1ePo7nX09DnIWRAk6Owfcg6wXINs19CwCyTI4rrZPDeRoIcr
+9HBFHgqDAolXIPUKUYI+scInVvqIBP1StV+m8YMEEYO6gFIfUBoCKiJBtSmo
+MQe1FkxnDepsNAYdmNGJmVwhM4VBD4XBsNUXtkH+sD2AOYJhB5Ggk0jQFaEx
+GCPFAYMRbyLig5IRP5TCQIIBWoJBIsHQOBQOQ++wyHvSRDhK9QGLfQjFJtMB
+A9NNBxNUM1SBJDQ7nx+bw9CA8xEDkjx0/9KAyMAkZk8uYGAC+xcMjAEDZ2kG
+zuiQgdOEgVOEgZN4EAwQCfrfS33vJL7PzoL1IjeXSJBtjbEs0UGQoDHUBxLU
++bs1KME2lKANJFjL01eBBAdAgtw/++NmxuyvOUaCzJh9hWMkyIzZlxhI8PZn
+Elz2gpZg1hKUYPZSlCA5C64q+HF10U8/41mQPBAtX7e+csOGqk0bqzdvqt26
+uW77lvodlASps+CO1v072w4QDB7a0/nb3q4j+7uPHeg5cbD35OE+SoJniQQv
+nBq6dIZ1mUjw2sXhG5c4N69wb10FCfLu3uTfQwkKHt4VZtwXgQSfPBI/y5CA
+BF88lb58Lst8Ict6KX+dqXiTpch+rczJVhIJqvLfqgvy1YUFmqJCbXGxtqRE
+V1qqKyvTl5frKyv1VVWG6mpDTY2xttZYW2eqqzfVN5gbmsyNzeamFktzq6Wl
+zdrabm3rsLajBG1EgvbuXnt3n6On39E74OhLS9A5wHYODruGOC4W1wUSZPPd
+wwI3R4gY5AEGxR5+WoJeodwrUtAYVPmkap9U45dpAYN+hc6v0PtRgojBgNoU
+UJsDaQyiBIN6yB40OKgIBl0Eg+6Q2ROyQN6Q1YeBBG1EgvYghcGwM4y5Ipg7
+GnbHME8c8yYwX5KUCvuhkXAAGsWCY6TxcIiKSDD8HgpFoAks+oEuLcFgbAqL
+Q9NUAQgYmG7WT0Uk6EvOzedN9xHy0LnpXCQnnSP5TwxMfM5ANCAGBkwzMDpL
+M3CGMHCaMJBIMDipCHwgDJyQ+t4DA8Xed5fffvZAFCQ4bEMJDpmjg6ZIP0hQ
+H+jR+rs03g6QoNzZLLU1CIkE2eqyQXl+B8/lD//Z3zczZn/BMRJkxuwrHCNB
+Zsy+xG588+3tbxfd++77h4sWP/5+yTMiwZeLl78iEnxNJJgzL8EVqwtXpiVY
+ig9E11ds2FC5ESVYs3Vz7TaUIJ4Fd+NZsHnvjpZ9OxGDeBbc03kYJLgPJNh9
+/GDPycO9vx/pO32s/+yJgXMnB0GCF88MXT7LunKeDRK8fmn4xhXOravc2yDB
+G7x7t/j3iQQf3RdmPBCBBJ9miJ89kaAEn0lfvZBlvpRlZcrfZMmzXytAgrk5
+yre5qry3qnyUoLqoUFNcpCkp0ZaWasvKdOXluopKfWWVvqraUF1jqEEJGuvq
+jfUNpoYmE5GgmUjQ0tpuAQm2dVrbu2wd3bbOHlsXStDe028HCfYOOvqGHP1p
+CTqHOM4hrovFc7H5LpAgwaCbK3KDBHkSD1/qEcg8IEGCQa9Y6QUJSlCCPhmk
+9cmJBBUGwKBfZfSr0hIMaCwBrTWgtQV0tgBIUO/AEIPOoNGFmdxBsydoJhK0
+EAla/SFbALMHMUco5AiHnFAk5IKiGGKQSNBDJOilJYgYHAlho6EANBYKUo2H
+QtA7DBhIRSQYjHzAotBkOiLBADaNURKMz/ipEtCs77PmvIk0Az3p/mcGTGC2
+xEIDfrTEP4IB0wyMAQPnKAbqkYGzNANnCAOn1cjAKWRgcFIe+IAM9E9IQILe
+d2LPuyaJb+EDUY49ybYlWBaU4IAp0mcI9eoD3SBBtbdD6W4FCUps9UJTDVdf
+yVaXDoAE+YwEmTH7EmMkyIzZVzhGgsyY/eGbCIiu/+MzCT79YRk5Cy5/tXhF
+JkgQz4Irc5b+lLts1dtlq/JXrC74ER+IFq9GCZatXV++HiVYtWlT9RaUYN32
+rfX0A9HmX3bQZ8Fd7Qd3dxz6pfO3fV1HiQRPpCXYd+ZE/7mTA+dPDYIEL6EE
+WVcvsq+hBIdvXuXcvs69c4N39xbv/m3+g7uCh/dAgsLHj0RPUILi508lL55J
+Xr6QogRfyV5nyd+8lme/UeSgBJVEgqqCAnVhobqoSFNcoikp1ZaWacvKdeUV
+uooqfWW1vqrGUF1rqKkz1NYb6xqM9Y2mhmZTY4upqdXc3GZuabe0dljaOi3t
+XdaObiuRoK2rz9bdb+8ZsPcO2okEHf1sx8CwcxAl6GTxnCw+hUEXR+jiiNxc
+sZsncfOlbr7MI5ADBj0ihUek9IpVXonaK9F4pUSCMp1PrvcpIMAgStCvMvvV
+Zr/G4tdY/WkM2gN6RzqDM2BwBRCD7qDJQzDoDVp8mNWP2QJBWzCIGAzRGIyQ
+iARdMcBgyB0PeaBEyJskpUI+iJLgAgyiB8eD2LtgiOp9MAxNYDQGA5HJQHQ+
+SoJT/th0OsJAX7pZKm+CCiXoWZA78ZHKReekc5DsiX9iYBwN+ImBsXkGzpFT
+IGFg5BMDUYKhacLAKYqBcj+RoG9C4n0v9r4Ted4J3eMLJVjDd7OtiSFLbNAU
+7TeGQYI9ukC3xt+p9rYTCTaBBAWmaq6+ggUSVOR3ChgJMmP2JcZIkBmzr3CM
+BJkx+8OXlL8CCd76ZtHd775/sGhxBpEgOQsuf0kkSB6IrsymJZi3HCVYCBJc
+tbbk53WlRIIVGzZWEgnWbN1SSx6INuza1rh7e9MvO+iz4K62X3e3H/ql47d9
+nUcOdB072H3icM/vR3pPEQmeRQkOXDgzeOns0GWQ4AXWtUvs60SCt65zbt/g
+ggTv3eY9uMt/eE/wCCT4UPgkQ/T0sfjZUzGRoOTVS2nmK1lWloxIUJ6To8jN
+Vbx9q8zLV+YXqIgE1cXFIEENkaC2vEJbUamrrNZV1eira/VEggYiQWNDk5FI
+0EQkaG7pMLd2Wtq6LO3d1o4ea2evlUjQ1jNg6xm09w7Z+1h2IkHHAMcxyHUM
+8RCDbL6TLXAOowRdXLGLK3HzUIJuAQQYRAl6RCqPWO0BDEoBg1qvTOeV672I
+QYNPafQpTT4VBBgkEkQM2vxau1/nwBCDThqDbszkCZi9mMUXsBAJWokEEYMh
+zBEOOiJBJxTFXDHMHcc8CVIy6IVSQR80gvlHSWPBADSOgQSpQu8D2EQgTAUM
+pJqE/FB0ig4Z6Es3Q+WNQ7NUnnRzkDvxqf/OgPMMtMUxKx3NwI/m2CcGGqI0
+AyPAwFkwoDYMDJxRpxk4TRg4pQhMEgZ+QAb6JsTe9xQDBe7xSwseiF7M5bFA
+gubYAEjQEO7Vh3q0gS6Nv0OFEmyRORvFtjqQIAclWNIvBwmqO6792Z84M2Z/
+wTESZMbsKxwjQWbM/vCFOndeoyT4LSXBpU++XwoSfE4k+IpI8DWRYM6yVQSD
+q/NX/Fywck3RqrXFIME168vWbSgHCW7cVLV5czV5IFq3Y2v9zm0Nu7c37iEY
+3LezZf+u1gO72w7+0n54X8eRA53HDnYdP9x98kjPqWO9p0/0nT3Zfw4lOHDx
+7ODl80NXLrCuXmJdv8K+cXWYSJBz5xYXJHj/Lu/BPf6jB4KMh8LHGcKnj0XP
+noqePxO/eC55+VKS+UqalSl9/Vr25o08O1uegxJU5OWBBJUFharCIlVRsbq4
+VF1Spikt15RVaMsrtRXVusoaXVWtvrpOX1Ovr20w1DUa6puMDc3GxlZTU5up
+ud1EJGhu6zK3d1s6eiwdvdbOPmtXv7UbJWjrHbL1sux9bHv/sH2AYx/kOIYQ
+gw5WWoLOYZGTgxJ08aQYYlDuFijcQqUbJUhhUOORaj1SHY1Bg1dh9CpNXsSg
+2aey+NRWnway+UCCVIhBJ2Zw+Q1uvxHyBExEgmaUIGYNYLZgwBYK2KFwwAFF
+Ao5owAnFAi6ISNCdwECCnmTAmyKNBHzQaMAPjWGB8XTBdyRKgohBPxT+QEcY
+iE35oCg0PZ8XDEjnic2mi8+6sTkq14Kc8Y9UDjo7yRb/jIFowBgAEPt0CoxS
+DJxbwMDZNANDM/MMVFIMDEwSBn6gGUhL0DVeL/J9JkFLYhAkaIz2GcI9ulC3
+NtCpRgm2KdISrOWbqjj68iF1cR9IUCjOX/Znf+LMmP0Fx0iQGbOvcIwEmTH7
+w+cq+N9X//HtzW8W3QEJfrc4Y9HSx98vJQ9El78ACS7+MXPJytdLVr5Z+lP2
+0rQE85b/XPDjmsKf1havXleyZn0pSHD9xoqNm9JnwW1bardvrdu5rX7X9ob0
+WXBnyz5agof2dfx2oPMokeCJIz2/owR7z5zsO3eq//xplOCl84OXLwyBBK9d
+Zt24yr55ffgWSpBz9zb3HkqQ9/AB/9FDAUjwyWPh06eiZ89EL56LQYKvXkky
+M6VZr6Vv3siys2U5ufLct4q3eYq8AmV+oZJIUEUkqCYS1KAEq7SVNdqqWl11
+nY5IUE8kaGhoNjS2GBvbjE3tpuYOU0unqbXL3NZtbkcJWjr7LCDBrgFr96C1
+ByVo62Pb+odtaQxy7USCDpbAwU5L0MmROLlSJ2JQ5uLLXQKFCyQoVAEG3WK1
+W6xxS1CCmEzvkRs8ciONQbNXZfGqISJBjR0wiOkcPp3Tp4eIBBGDHr/R6zdB
+Pr/Z57f4/ZaA3woF/SBBG5EgFqExGCMYjJMSATeUDIAEPSkMJOglEsTGKAz6
+/eP+APQOC75PR0kQ++ALQ5PpIpM+gkEvNu2NUs145iMYdC/IFZujcsY/9a8N
+GPtopbPEPmdgFA34iYERmoHhzxkYBAaSg2BgijBwkjDwg8Q7IUYGvhe63wED
++c5xnnNs4QPRKq5zwBTrN0Z79SjBLk2gQ+1vV3pbFe5mqbNBhBKsHNaXEQnm
+dQrb8g9PBER/9lfOjNlfbYwEmTH7CsdIkBmzP3ZJ+Sv+3f/nyt8pCf5w/7vF
+j4gEn3y/7BmR4EsiwSxaguQsuPrt8tX5P64p+Glt0ap1xT+vL127oWz9xnLy
+QLRqy+bqrUSCO7bRZ8EdTb/sJGfB3a2//tJ2aF/7bwc6jhzsPHa468SR7t+P
+9Zw6DhLsPXuq7/zp/gtnBy6iBAevXBoCCV6/yrpxjX3rxvDtW5w7tzn37nLv
+owR5jx7yMzIEjx8Lnj4RggSfPxe9eCl++UqcmSkBCb5+I32TLcvOleW8lb/N
+k+flK/ILFQVFysJiZVGJqrhMVVKuLq1Ql1Vqyqs0FdXaylptVZ2uul5X06Cv
+bdTXNenrmw0NLYbGVmNTm7G5w0gkaGrtNrX1mNt7zR19ls5+S9eABSTYPWTt
+YVl7WVYKgwMc2wDXPsizD/HtIEGW0MEWOYbFDpBgGoMyJ1/u5CtcAiVg0CVU
+uUREgmItYNAt1bmleo8MJYgpTB6l2aO0EAxavWqbVwPZMa3DCxJEDLowg9tn
+8PiMkNdn8mFmv98cQAxagohBa8hvC2P2COaIYs6Y3xnHXAnMnSSl/B5oxO+F
+RjEfNIaBBDGUoA977wtCE1gI+kDlDU/STWGRKU9k+lOEge50s5ALilHNORfk
+oLNjHyFb7L8xYBQDA35iYATTR+bAgLowxcBZTYhi4EyagYFpwsApYKDMRyTo
+/SD2ThAGvhe43vFdyECuY+xiLm9egpVEgn0GlGC3NtQJElT52pTeFrm7Seqs
+F9pqeCjB0kF1US9IUCTOX85IkBmzP3yMBJkx+wrHSJAZsz928xK8QUvw4aIl
+GbQEn/+AEnxFJPh66U9vlq4iGFwNGMwjD0QLyQPR9FlwAzkL4gPRLTXbttZu
+30afBXc0/rKzae/O5v27Ww780npwX9vhA+1HDnYcPdx5/Leuk0e7Tx3vOU0k
+eO503/mz/RfPDVxCCQ5evTx0jUjw5g327ZvDIMG7dzj373EfPOA9fMjLyOCD
+BJ88ETx9JnwGEnwhAgm+yhRnZkmy3kjeZEuzc0CCstw8+dt8eV6hIr9IUYAS
+VBaXggRVRIJqIkENngXrtNX12poGXW2jrrZJX9esr2/RN7QaGtsMTe0Eg11G
+IkFTe6+po8/c0W/uHLB0DVq6hyw9QxaQYC/b2jds7UcJ2gZ5tkG+fUhgZwnt
+bJGdLaYw6OBKHVyZk4cSxARKJ5GgS6RxibUukKAEJeiWGTC50S03eRRmCoMe
+ldWjtnnUtAQ1DgqDXp3Lq4fcXoPHayASNBIJmvyAQZ854LMEMWsIs4V9tojP
+DkV9Dijmc0JxzJXA3ElSyueBRjDvKGnM54PGfX6qdxhIMPDeCwUnSB8wkGBo
+EvJA4akFTbsjVDNULig64yISdH5qzrEgO1VszgZF56zRj1QWuv9qwMgnAyID
+w2kGakI0A4PAwJlPDPRjhIGTNAMnkIFuYOA7nnMcGMhxjNYIvPMSvJDD7TfG
+eg3RHl24CySoDrSrfK0Kb4vM3SRx1glt1TxTBTstwbcdQkaCzJh9iTESZMbs
+KxwjQWbM/tiFOneCBC///RuQ4O1vf7hHJEjOgsueEgm+AAkuXkkeiH4mwbfL
+f06fBVevKyYSxLMgkWDVli3VW7fWbN9au2Nb3a7t9bt3NOzZ0bh3Z9O+3c0o
+wb1th/a3//Zr+9FDHcd/6zxxtOv3492nTvac+b33LEqw78K5/ksXBi6jBAev
+XR26fo0FErx1k3379jBI8N49zv37XJDgo0e8jMf8xyhBwbPnwucvhC9eiV6i
+BMUgwdfZkjc50uy30pw82dt8WV6BnEhQUViiLCpVFperSipUpZWqsip1ebW6
+okZTWaupqtdWN2hrUIK6umYdkaCeSNDQ3GFo7iQY7DG29VIYNHUiBs1dg2bE
+IMvSy7aABPs41n6udQAlaBsS2IaENgqDw2L7sMTOQQk6uHIHT+GgJChQOYVq
+p0jjTGNQ55LoXVKDCzGIEnQrzJjS4lZaaQzaMY0D0zo9WpdHRySo9xAMer1G
+yOc1+TFzwGsOei1QyIsYDNMYjBIMxkhEgk4iQVcSAwliRIIelKDXO4b5oHHM
+/470HkMMTkCeIPQhHSXB0KQ7NIWFoWkqF0QxMDLjxGbnc0SpaACSbFHKgOks
+dGaSKZLOGFnAwDCWZmCIYuAsOQUSBgYoBk6jAT9j4AdgoMg9kT4IOmkJ2kdr
++J6FD0T7DLFefaQbJKgJdqgDbUpfq9zTLHU3ip11Als111TO1pUMqAt7QIJ4
+E0zKX/3ZHzozZn+1MRJkxuwrHCNBZsz+2FESvPSf31z/R1qCD75DCWZ8v+zJ
+98ufEQm+JBLMWvLT66WrCAZXIwaX/5wHEly5tpA8EC1Zu6EUH4huqti0uXLz
+lqqtW6u3ba0BCe7cjmfBPdRZcFfz/j0tv+5tPbS/7fCv7UcOdRwjEjx5vOvU
+ye7Tv/ecPd17DiXYd/FC/+WLA1cuD15FCQ7duMG6iRJk37kzfBclyHnwkPsQ
+Jch7/IT/5Cn/6XPBM5DgS+HLTNGrLFHma3FWtuR1jiQ7FyQozc2XvS2Q5RXJ
+84vlBSWKwlJFUZmyuEJZUqkqrVKVVavLa9QVtZrKOk1Vg6a6UVvTpK1t1tW1
+6OpbdQ1t+sZ2fRNK0NDSZWjtNrYhBo3tfaaOflPngIlI0NzNMvewLb3Dlj6O
+BSTYz7MO8K2DAitgkAUYFNnYRILDUjtHZkcJUhhUOgQqh0BNY1DrFOucEr0z
+jUGjS2ZyyU0uxCBKEFPZ3Gp7Oo3DrXHSGHR79JDHY/BiRp/H6PcgBgM0BkME
+g2HMFiFFvfYY5ohjzgQp6XVBKcw9gnlG01EY9I57fNA7zA+9J014AlQf3EGq
+yXREgq50hIHhaWd45lORGQcYkM6ebs5GZ6Wz0JlJ/8KA4XkDYmDATwwMzjNw
+Bgyo8AMDpwkDpwgDJ4GBYs8HwsAJges9YeA7rmOcYx8bto2yrSMXcj49EC0f
+dvToIl3acKcm2K4KtCl8LTJPk9TVIHbUCqxVHFM5S1c8oC7oluW2400QvrI/
++0NnxuyvNkaCzJh9hWMkyIzZHzv4P2rt0X+/+J/fXPvHolvf/HD3u8X3v1vy
+kJbg0x9WPP8BJUjOgj+9XkJLcOnq3GU/v12xJn/l2oJV64pWry9es6F03cay
+DZvKNxIJbtmCEty+rXbHdvosuLNx766m/XuaD+xtObi/9fCvbUcOtR/9reP4
+0U6Q4O8nuk7/3n3mdM+5M73nz/VduNB/6WL/5csDV68OXkMJDt28ybqFEmTf
+vTd8DyXIefiI++gxL+MJ7zFKkP/sheD5S+GLTOFLlKAoK1v8Okf8JleSnSfJ
+yZfmggQLZUSCciJBRXE5SFBZWqUsq1aV16gqatWVdeqqek11g4ZIUFvXogUJ
+1rfpGtr1jR36pk59c5ehpdvQ2mMgEjS29xs7Bkydg6auIRORoLln2NzLsfRx
+Lf08ywDfksag0AoSZIltbIltWGoDCRIM2nkKO09p56MEMaHGARIU6WgMGpxS
+o1NmciIGzS6FBVNaXUqbS2WHCAZRgpjW5da63TrI49YTCRp8NAYDmDmIWUIe
+S9hjhSKYLYrZY5gj7nEkMGcSc6XSuUdIox4PNIaBBKkIBt2+924/1QQGEiS5
+ApOu4HxTkDMETX8qPONYkD08O58Nisz+fxgwzcDwnJHOEF7AwBCWZmAQDIgh
+AwOfM9BHMXAKGIgSRAZ+oBn4nmbg+LBtjG0bZVlHqnjueQmez+Z2gwQ14Q51
+sF0ZaFX4mmWeRomrXuSo4VsrOaYykGC/Or9LltMmFBcsD53/v0I3b/7Z3zoz
+Zn+pMRJkxuwrHCNBZsz+2LkK/jdI8MJ/fnOVkuC3KMEHi5Y+WrTsMZHgsx9+
+fEFLMGvJKnIWXE3Ogj/nLl+T9+Pa/J/WFa5eX7RmQ8najaXrUYIVm7ZUbqHO
+gttqdmyr3QkY3FG/Z2fDL7sa9+1pOrC3+eD+lkO/tv52qO3ob+3HjnacONZ5
+8kTXqd+7T5/qPnum59y53gvn+y6iBPuvXBm4dm3w+o2hGzeHbt1m3b7DvnOP
+fe/+8P2HnAePOA8zuBlPuI+f8p484z99wX/2UvDileBllvDVa1HmG1FWjvh1
+rjj7LUhQklsgfVsozSuW5ZfICkrlhWXyonJFcYUCMVitLKtRldeqKurUlfXq
+qgZ1daOmpllT26Kta9XWt2kb2nWNHToiQX1zt76lx9Daa2jrMxAJGjsHjZ1D
+pi6WqZttIhI093LNfVwzhcFBgWVQaB0SWVliK0tiZUspDNo4chuXSJCnAgza
+BWo7SFCodYh0DjGkd4AEJUYag2an3OJUQESCVOBBtcOldro0kMuVxqCHwqBb
+73MbfG6jHzMF3KYgZg5hlrDbQiRoJRK0EQna49hCDDpRgm7XCOYeJY25PVTj
+bi/0DgMJklz+CTpgINWkkwoYSOcITjtC883Y5wvP2CgDkqx0lvAclZnOFP5X
+BgxhunRpA35iIDEgMtA/QzMQJSj1EgZ6gIGThIEfBK4JvgsY+J7reIcMtAMD
+x1jW0SHLSCXXvfCBaLc20qkJt6uCbUp/i9zXJPU0iF11QiLBYVPpkK6oT/W2
+U5rdKhAXrICv7OPf/pZgsf7sz50Zs7/OGAkyY/YVjpEgM2Z/7D5J8O+Lbn7z
+w51vF98DCX639OGiZRnfL3/yPUrw+eKVLxf/9GrJT5lLVhEMriYYRAm+XbE2
+f+W6glXri37eUAwSXLcJz4KbNldsBgxurdq2rXo7YHB77a4ddbuJBPfuadq/
+t/lXIsHDh9qO/NZ27Gj78WMdJ090/v57F0jwzJnuc+d6zp/vvXix79Kl/stX
++q9eG7h2fRAkePPW0K07rDt32Xfvs+89GH7waPhhBufRE27GU+7jZ7ynL3jP
+XvKfvxK8yBK8fC189UaYlSN6nSt681acnS/JKZDkFkrfFknzi0GCMiJBOZGg
+orRKUVajLK9VltepKupVlQ3qqkZ1dZMaMdiqqWvT1rdrGzq0jZ26pi4dkaC+
+tVff2mdo6ze0Dxg6UILGLpaxi01h0NTLMYEE+3jmfr55ACVoGRJZhsQWlCBi
+0Doss4IEOQobV2njKW18lY2vtgs0dqEWE+nsIEGxATDokBodUpNDZnakMWh1
+KmxOJZXdqXI41RCRIGLQ7dJ6XDrI69JDPpfBjxkDbiORoIlI0BymMOi2RjFb
+jBR326GE2wElMWeKRCToGsXcoy73mMsDjZPeubxU710+qgkn5P9AR0swMOkI
+TGGUBIPT9nRoQNuCrKHZ+Sx05tAclYlkpDOQ9KEFDAzOaYOz2iDNwACWZiAa
+cAYMKPctZOCU+HMGogSd73mOd2kJEgayLCOD5pEBU+r8ggeiJSx7hzoEEmxV
++Jtl3kaJu17krBXYq3nWCpDgoK6wV5XbIXnTIvi//y16ak3mu7/9zfn993/2
+586M2V9njASZMfsKx0iQGbM/diDBmqP/fv4/vrny90U3vvnh9reL73635D4l
+wUXLH3+/4ilI8IeVL0CCi2kJLklLEM+CK9bkrVxwFlyHZ8GyjZvLN22pAAmm
+z4Lba3fuIGfBXQ179zTu39t0YH/zwV9bDh9qBQkePQISbD9xouP3k52nTnWd
+PtN99mz3ufM9Fy72XrzUBxK8cq3/2vWB6zcHiQSHbt9l3b3PuveAff/R8IOM
+4YePOUSC3CfPeU9f8p694r/IBAkKQIKZ2cKsXNHrt6I3eeKcAnFuoeRtkSSv
+WJpfIi0okxWWy4oq5MWV8pIqRWm1ogwlqKyoV1Y2qKoaVUSC6toWTV2rpr5d
+U9+hbejUNnZpm7p1zT26FpSgvq1f3zZgaB80dAwZOlmIwW62sXvY2MMx9XJN
+fTwTSLBfYB4QmgdFZpAgwaCFLbWwZdZhuZWjsHIhwCBK0MbX2AQaG2JQZxfp
+7WIDJjHaQYJSM8GgxSG3OhSQDQMJKh2IQZUTMOjUuJwat1MLeZw6r1NHJKgn
+EjQEAIMuY9BlCmHmMGaJkKIuKxRz2eKYPUFKuhxQyuWkGnG5oFEMJIihBJ3Y
+O8z7Ph0lQeyDw081mS4wZf8UMtCWbgayLsjymQHTmdJ9ZkBkYBDTYbOfDBiY
+NyBhoJ9moC/NQKl3GhnomWfgJDBQ6CIHQecEz0EfBG3jbOsYyzI6ZAYJpgZM
+yfM53HkJnnvDAQm2KYMtcn+T1NsgdtcJnTV8exXXWs42lQzqCnqUOe2S1y2C
+7Ws6QIKOf/tfor/97c/+3Jkx++uMkSAzZl/hGAkyY/bHDiV45N/P/cc3l//+
+HSXBO98uuffd0geLlj0iEnzy/Y/PUILkLLh4FcHganIW/Dl9FiQPRAtWp8+C
+Jes3lW7YXLZxy4Kz4Hb6LLir/pc9Dfv2Nh7Y3/Trr82HDrb8drj1yJG2Y8fa
+jx9vP3my4/dTnadPd51BCXafv9Bz8VLvpSt9V672X73ef+3mwI1bgzdRgkN3
+7rPuPmDde8gmEhx+9JST8Yzz+DmXSJD3PJP/4jX/5RvBq2xBVq6QSFCUnS/O
+KRTnFkneFkvySqT5pdKCcllhhayoUl5cJS+plpfWAAYV5fXKigZlZaOqqklV
+3ayqaVHXtqrr2hCDDR0aIkFtU4+2uRcwqGvt0wEG2wf07YN6gkFDF9tAJGjs
+4Rp7eaY+vqlfYBoQmmgMmockZhZK0DIsxxCDSitXZeWprXwIMKi1CXU2od4m
+0tsQg0a7xAQYtEvNdpnFLrPa5bQEFXbAoEPpcKicmNrlULsJBj1OrZdg0OfU
+Q36nIYAZg5gp5DSFnWYoglmimDWG2eKkhNMOJZ0OKIU5R0ijThc0hrmhcYyS
+oOedw/Pe4YUm0oEESXbIP0k3ZYMCVNOQNR0B4ILMwVkqE52RzkCnJ+notAFM
+E1jAQD+UNqDCBwxECcq8Cxk4JXYTBrooBn6gGfieY3+XZqB1bMgySh0E+43J
+8mHXwgei7apQqyLQLPM3Sr31Ynet0FnNt1dyrWVsU/GALr9bmd0mzmoWvDp/
+AyTI/bf/NcDcBJkx++PGSJAZs69wjASZMfsDNxEQgQSrj/yfs//xzaW/f3f9
+Hz/c+iYtwfvfLXu4aHkGkeDTH1ZSZ8GXi1e9WgIYXE0w+PMbPAuuyV2xNm/l
+uvxV6wt/3lC0ZmPxuk0l6zfPnwUrt26r2r69esf2mp07anfvqvtlT/3eXxr2
+72v89UDToYPNhw+3HDnSevRYG0jwxMn23091nDrdeeZs11mUYPeFSz0XL/de
+vtp3BSR4o//6rYGbtwdv3R28fW/oDkqQdT+D/eAx++GTYSJBzpMX3KevuM8y
+ec+zQIJ8kGBmjiDrrfB1nvBNvii7UJRbJH5bLM4rkeSXSgrKpIUV0qJKWXGV
+jEhQjhKsU1Q0KCoblZVNyqpmVXWLqqZVVdumrmtX13doGjoBgxrAYDNiUNvS
+p2vt17UN6IgE9R0sfSfb0DVs6OYYiASNvXxjH9+YxqDINCg2EQmaWTIzW2ZG
+DCosHKWFq8IQgxorX2sV6KxCCDBosImNmMRkk5pt0v+Xvbtqzivb8zxft/M2
+5qZ6qudiOmo6yk7bCWZmZmaQbTEzM7P0CB5mZmZmEpPZkmXJlHlO9Ky19t6y
+fKrmLt0Zcbx/8Y18BzvifM5/+VGSwOA4nndiwjc54UMS9E9jGJwMzsJCc5Ph
+eVhkAQYx+BwWewEDGIxjGEQSTCIJjr2FAQmOIwnCkAQnl2FTy5NT72HTK6jV
+yRmsDzAgwdmPE6C5T0SIgfOfx+e/4C18GUcYHMODDEzi/Q2UWFf82d+x/tGA
+z/4eQYWJ/tGAC5gB/46fAudxBgID4gyc/QcGfgEGtE5hDPxEMPCDfmyVYOB7
+dXxZFXunjC4pIovrJdinHuN7nnHd82znLNM+TbdOUc3jI8bkkC4GJNgt9bYJ
+HI1s07/8y/8C9f3r/yEjfzSGHLk/b6QEyZH7AUdKkBy5P3GYBE3F/9eT/9ic
+sfHn3E2/FWzeWrRlW8kWXIKVv+yqRhKsAxjEJLiVkOA2KMF2JMGu3Yd79h7p
+3X+0D0jw0PG1s+DwiVMjJ0+PnkYYBBI8f4558QKU4JUrnGvXuDducG/e4t2+
+w79zV3DvvvD+Q9HDR6JHj8WPn0qepEpT02VpmbKMLHlmjiI7V5mTr8otVOUX
+qQugBDXF5dqSCl1ppQ5JUF9ZZ6iqN1Y3GGugBE31LeaGNnNju6Wpw9rcZUUS
+tLX32jv67Z0Djq5BRzfF2TPk7B129Y26+qmuAZp7kO6mMDxDTM8wC2EQStBH
+4/uQBP1AgkxxgCUJsKVBjizIlQeRBEMCVUigDgs1YZE2jCQYkRgiUmNUZgIY
+jCrMUYhBa0xli6ntMbUjrnHGta64DgQw6EkYvAmDL2FEEjQFkuZg0hJK4hiM
+jNmiY/bYmAMUH3cmYK7kuHts3D0O84AmJryTGAYn/NOwwMxEYHYiCJqbABgM
+AQwuwCLPYNHnk9EXkzHQy8k46NVkAvQalnwzmXw7OQZanBwHLcEmQO9gk8so
+JMGpFdDENGgVNvOBCElw9uP47CfYHOgz3vyXMbzfsZILoD+wEnh/A8WffS0G
++zsoSvRfGHDh70GiwMI6Bs7/zTdPMHCOYODsH04YMODvdtD0egZ+Rgz8ZJz4
+CBk4/kE3tqpNrhAMXFZG3ymiS/LIYmr71weivaoxnucZxzXPcswybdN0yyTV
+ND5iSFJ0sT5lqEvibeXbG1hGTIIBauVf/bmTI/dPNVKC5Mj9gCMlSI7cnzhM
+giBMgjmbfsvfvLVwy7biLdtLf95R/jOUYNWvu2t+3YPOgnuJs+B+hMED6Cx4
+sGPnoc7dh7v3HunZd7T3wLG1syDl2Mmh46eGT54aOXWaevoM7exZ+vlzjAsX
+mJcusa5cYV+7xrmOJHjrNu/OXf7d+4L7D4QPoARFKU/ET1IlT9OlaRmy9CxZ
+Ro48K1eRna/MLVDmFakKStSFpZqiMk1xhba0UltWrSuv0VfU6ivrDdUNhppG
+Y22zqa7FVN9qbmg3N3VYmjstLd3W1h5rW6+tvc/WMWDvHLR3URzdQ46eYWfv
+iBNikOYaoLsHGW4K0z3E8gyzPSMcgEEvle+jCXx0oY8h8jPFfpbEz5YG2LIA
+Rx7kKoI8ZZAPJRgSakJCbVikC4v1YYk+LIUYjMhMETmUYFRpjSptURWUYEwD
+csYgBt1xnSeu98YJDCZMgYQpmMAxGE5aI0lbNIljMD7mSIw5Qckx19iYG4Yw
+OAHzTo57p8Z9U+P+6XH/zDiOwTmEwXlYeGEi/GwiAno+EQW9mIi9hMVfoV5P
+JEBvJpKgt7CxRdj4EurdxARoGTb5Hg9IELY6Po31ATbzEQ9JcAz2GTaH9SWJ
+BRiISsD+wIovYP0NFFtXFO/vEVSYKLTwnww4/3c/6qsB56ABcQbOEgyc+ZaB
+U1++MnAC9NE4/hE/CCZXtYkVTRxKUBnDGSgLL1YzA2sSfNpq5LoX2M55ln2W
+YZ2mmSdHjePD+iRFG+tVBDvFnhaevZ6BSxB8a3/1506O3D/VSAmSI/cDjpQg
+OXJ/4tYk+Pg/NqcDCf70a96mrYWboQRLft5R9vPOCiRB4iy4F2FwX+NWQoLw
+LHiwfcehjl2Hu/Yc6QYSRGfB/kPHB46cGDx6kvL1LHiGeuYs7dw5+oULjIuX
+mJevsK5eY1+/wblxkwskePsu7+59/r0HggePhA9ToAQfp4qfpElSM6RpQILZ
+ssxceXa+IgdKUJlfrCooVReWqYsrNCWV2tIqbVmNrqJWV1mnr2owVDcaapqN
+dS3G+lZTQ7upscPc1Glp7rK0QAlaoQT7bZ0DQIJ2JEFH74ijb9TZT3UO0F2D
+DBeSoBtJ0DPC9YzyAAa9NKGPLvIxxD6mxM+S+tkyP0ce4CoCXGWApwry1UGB
+JijUhkQ6GMSgISw1hoEEZeaI3BJRWCNAgko7wGBU7YgCCWpcMa07pvPEcAz6
+4gZ/3BiI4xgMJSzhhCWSwDEYS9rjSQcokQQSxDAIPTg+5p4Y84Amx7xTMN/0
+uA/D4CwsODcenB8PgRbGw6Bn45HnqBfjURDCYAxJMI4kCEMSTEIJjo8twcbf
+4U0so96PT4JWYFOgVdj0hzG8j2MzWJ9gs5+Ss5+JIAMTeL9jxedBf2DFvva3
+KFFkAS+M9/fQPF4QFZhfMyAEoG8O5p1bx0BkQMjAGYKB0zCMgcCAlkmcgUYQ
+zsAPOAMTK+r4e/wgGFkCDJSG3g5oJ9ck+KTVyHEtsB1zTNsM3TJFNU2OGMaG
+dIlBTaxHHuwQeZq5tjq6AZMgOXLk/tyREiRH7gccKUFy5P7ErUmw9vD/TNvw
+c/ZPv+Zu2lqweVsRkOCWHaU/7yz/ZVflL1CC6Cy4tw6X4L4miMED6Cx4sG3H
+P54F+w4e7z98YuDrWfD0yKkzEINnz9HOX6BfvMS4fIV55Rrr2g329Zucm7e5
+t+7y7tzj3X3Av/9I8CBF+OiJKAVKUPw0Q5KWKU2HEpRl5cmzCxS5hcq8YmV+
+iQpIsKhcXVypKanSlFVry2t1FXW6ygZ9VaO+pslQ22KsazXWt5kaOkyNnebm
+LnNLj6W119LWZ23vt3YM2DoHbV1D9u5he8+Io3fU0Ud19tMQBpkuCss1xHYP
+c9xIgh4q30MTeOlCLwPHoI/AoB9gkAcxGCAwGEQSDIkNIYkxLDWFZeawzBKW
+WzEMRlT2iMoRVTujGldU447iGPTG9L6YwR/DMRiMm0JxcziOYzCasMVg9ngC
+SNCRBBhMOsdgrnGYeyIJJIhjcBpgcMw3M+afhQXmYMH5seDCGMBg6BnEYBhJ
+EGLwJSz2ChZ/jXozngC9HU+CFmEYBscwDC6PgSbe402uoFbHprA+gJLTH4k+
+JWfwEjOfE7NYX0BxLMBAVAz2B1YUNI/1twhRmChEFEQFUP45vG8MOAtzzxIM
+hAb8AxjQgRvwd9sUYuDkF8TAz18ZOPaRYODqOgYuKyLv5OElWWhRGnwrDrxZ
+/08FOc4Fln2OYZuhWaZGTRPDhjGKLjGgjnbLAm1CdxPHWktKkBy57zNSguTI
+/YAjJUiO3J87TII0+POhP2f99GvOpq35m7cVbt5ejEnw510Vv+xGZ8E9Nb/u
+RWfBfdhZsGnbAYTBgwCD7TsPdezGz4I9+4/1Hjzed+j4wGHsLHhq6MRpiMHT
+Z0bPnKWeO0+7cIlxCUqQefU66/pN9o3bnFt3uLehBHn3HvIfpAgePhGmPBU9
+hhIUp2ZK0rKlGbmyzDxZdoE8p1CRW6zIL1EWlKkKy1VFFWogwdJqTVmtthxI
+sF4HJFjdpK9pNtS2GurbjPAs2Glq6jI3d5tbei2tfZa2fmv7gLVj0NZJsXUN
+27tH7D2j9l6qo4/m6Kc7BxjOQZaLwnYNcVzDXPcIzz3K91AFHprQQxd5GWIv
+kCBT6mPJfGy5n6Pwc5V+JMEAXxMQaINCXVCkD4oNQbExJDGFpOYQwKAcYjCs
+sIWVUIIRlTOidkVwDHqiOm9U5yMwGIgZgzEgQRyDkbglGrdG4xCD8YQ9AXMk
+E84xPIjBiaR7EmAw6ZlKekHTSd8MzD+b9CMJBuYJDD6DhZ/DIi9g0Zdj0Vew
+2GtY/A0s8Ra1OJYELcHG3uERGEzCVmCToFUYYCDex8Q01ie8mc/xr+ESjMF+
+x4qCMAbO/REhCsP+hhUiCqICRN8YcBb2jQFncANCBk4TDJz6loETiIHj6xn4
+ATFwVR1fUcXef2VgeEkaWpQE34oCb562Gdck2CWLM+1zdOsM1Tw1YpwY0o8N
+auP9qmiXNNAqcDeyrbfz/KQEyZH7HiMlSI7cDzhSguTI/bnDJGgq/renG37O
+BBL86be8TdsKNm8v2rKj5OedZUiClRCDUILoLLgPYXB/01ZCgtsOtqEHop27
+j3TtPQox+PUseHLw2EnK8VNDJ08PnzozAiR49jzt/EX6xcuMy1eZV64zr91k
+Xb/FvnmHc/se98593t2HvPsp/AePBY+eClPSRE/SxU8zxWnZkvQcKZBgVr4s
+u1CeW6TIK1HklyoLoARVxVXqkmp1aY2mvE5bUa+tbNBVNemqm/VAgnVthvp2
+Y0OnsbHL1NRtaukxt/aZ2/ot7QOWjkFrJ8XaNWTrHrYhCdqRBB0DDMcg00lh
+OYEEh7iuYZ57hO8eFbipQg9N5KGLPQyJlyn1smReltzHVvg4Sj9X5eep/XyN
+X6ANCHQBoT4gMkAMSoxBHIOWkNwaktvCCntY6QirQBgG3RGNJ6L1YhiM6v1R
+QyBqCGIYjJnCMXMkZgEBDMbitjjMnojbk3HHGAhhcDzhmoC5JxPuqYQHNJ3w
+TicgBmcxDCYD87DgAiz0LBl6ngyDXsAiL2HRV7DYa9SbZBz0NpkALcKSS6h3
+yTHQMmz8Pd7ESgK2mpjE+gCbAn2MY01/IvoMis1gfcGKgjAGzv4ewfsDFCYK
+4f0tOIsMOPu3AJEf5UN5Z9cxcOZv7pk/3DMEA6dhmAHt0IC/w38YCA34BRgQ
+MfAzYKABBBiY/IgY+GEdA98rIsvyyLs1BooDb4T+1+sl2CmLM2yzNMv0qGlq
+2DBO0SUHNPFeZaRT4m/hu+pZlu1HpwADyT8fQY7cnz5SguTI/YAjJUiO3J+7
+F5JzGAaBBDM2/pr902+58Cy4vXDLjuItO0t/3lX+C3YW3FONY3BfHZJgI47B
+g+gseKh95+GO3Uc69xzp+noWPAExeBRg8BTlxOmhk2dGTp8dPXueev4i7cJl
++qWrDCDBqzeABFk37rBv3ePcvs8FErwHJch/+FSQkip8nC56milKzRKn5Ugy
+8qSZUIKynCJ5bok8v1RRUKYsrFAWVaqKoQTVZbWa8nptRYO2EkpQV9Oir23T
+17Ub6juABI1Ags09ppZec2u/uW3A0j5o6aBYOoesXcPW7hFbD9XWS7P30e39
+DMcA0zHIclLYAIPOYZ5rhO9CEnRTRW6a2EOXeBhSDxNK0MtWeDlKH0fl46p9
+PI2fr/ULdH4CgwExlGBQYg5KLUEZlGBIYYdBDDrDKldY7Q5DCUIMRnS+iM4f
+0QcwDEaNoagpHMUxGI1ZYjFrLGaLx2yJGJAgFvTgeNw5HndNxF2TcTcISRBi
+cCbhnU34QHMJP2g+EViABZ/BQs9h4ReJ8MtEBPQqEQW9hsXewOJvUYuJBGgJ
+lnyHN7aMep8YB63AJlbiE6uwSdAHFC7BGOwTbBr0GRTFQwyc+RKB/Y4VxlsD
+ICxIFID9JwPO4Hlgf3w14PSaAf9wTEED4gyc/JaB44iBY98wEB4E46vq2Ioq
+ih0El2Xhd9LQkiS4KA68FfnfCHyvK+j+NQk+bjHQrbNU8/SIcXJIPz6oTfar
+Yj2KcIfY38xz1jEt/+d/WyQlSI7c9xgpQXLkfsCREiRH7s/dmgTrD28AEsz6
+6becTVvzNm0r3IxLkDgL7kEY3Fv76z50FtyPMHgAvRGFEmzbcbh9F8IgPAse
+6zlwHGLw8In+IycHjp0aPH4avhGFZ8Fzo+cuUi9cpl28Sr98jXHlBvMalCDr
+5l327fucOw+59x7x7kMJ8h+lClLShU8yRU+zRGk54vRcSWa+NKtQml0kyy2W
+55XK88sUBRXKwkplcZWqpEZVWqsuq9dUNGgqG7VVzbrqFl1NK5Cgvr7D0NBp
+aOw2NvUYm3tNLX0miMFBczvF0jFk6Ry2do1Yu0cRBum2Poa9n2kfYDkG2Q4K
+xznEBRh0QgwKXUiCbrrETZd6GDIPU+5hKbxsJcCgl4tj0IdhUKj3Cw1+kTEg
+NgUk5gCQoNQKMBiU24IQg46Q0hlSuUIqN4bBsNYb1vrCQIIIgxFDMGIIRXAM
+RqLmaNQSg1njMWsCwyBqLOYAjcecEzHnJMLgFMwzHffMxL2g2bhvDuafh0EM
+IgkGkQRDL3AMhhEGIxgG38Bib2EYBqEHl+Kwd/EkaBk29h5vfAVvYjUG+wCb
+BH3Eik59WtdnUGQa6wsojAcNGFpXcOYPrACRn8hH5EV5UO5pmIsIMnAKGBBn
+IHwROvk7ZkDLxBfMgJCB0ICf9BgDEx/hNTD+gWDgCn4QDL+ThZakwSVxYFHk
+fyv0vRF4X/Uox9dLkGaZHTVNDxsmKbrxAU2iVxntlofbRb4mrrOWYcaehpJ/
+SJAcuT99pATJkfsBR0qQHLk/d0ueJuJHY/4jfeOvmRt/y/5pa+7aA9EtUILl
+v+yu+GUPwCCQYM2v+9BZcD/C4IGvZ8Edh9p2Hm6HZ8GjXfuOde8/1nPweO+h
+E32HTw4cPbV2Fhw+fW7k7IXR85eoF67QLl2jX7nBuHqTef0268Zd1q377NsP
+OHcfce895j14wn+Yyk9JFzzOEAIJpuaI0nLFGfmSzAIgQWlOsSy3RJ5XJi8o
+VxRWKoqqlMXVqpJaVVmdurxBU9GoqWzSVrVoa1p1tW26ug59fae+ocvQ2GNo
+6jU29xlb+01tA6b2QXPHkLlz2NI1YuketfZQrb00Wx/dhiRoH2DbBzkOCtcx
+xHMO850jAifCoIsmdgEMMqRuhsyNMOhhKz0clZer9nI1Xp7Wx9f5BHofkqBf
+ZPKLzRgGA1JrQGYLyu1BhSOocAYJDIbUnpDGGwISRBgM6wJhfTCMYzAcMUUi
+pmjEHI1ADMYBBqPWRNSWhNnHYECCjgkMgzHXFMw9HfOAZmLeWRjEIJKgfwFg
+MB54Bgs+jwdfxEOgl/Ew6FU8AnoNi76Bxd6iFuNx0BIMSBAVSy6j3sfGsFZi
+46BVrOjEB6KP0UmsTxGsKdBnUBjvCyg0jfU7KLiuAOwPkJ/IR+RFeVDu6XUM
+nIIAXG9A+yQ0IM7ACcTA8S/fMDD56T8xcJVg4Ht5eFkWegcYKPnKwNd8z6tu
+xfj6H42hmmdGjFNDholB7Vi/Ot6jiHbJQm1CbyPHsePYzIZ/tQMJyqjkn5Ag
+R+5PHilBcuR+wJESJEfuz93az4fS7/w/qRt+zdj4W9ZPW3M2bYMPRL+eBXeX
+IwlW/bqXwCAuQXgW3HoQYnD7oVZ4FjzSsfto516EwQPHew5CCa6dBSknzgyd
+Ojd85sLIuUujF65QL16jXb5Ov3KTce02E0jw5j3W7QfsO48491K495/wHqby
+HqXxUzIET7KET7OBBEXpeeKMAklWoSS7WJpTIssrk+WXywsqFIVViqJqZUmt
+srROVVavLm9UVzRpqpo11a3amjZdbbuuDkpQ39htaOoxAAm29BtbB0xtg6Z2
+CsLgiLlr1NJNtfTQrL10ax/D1s+yIQnaKVz7EM8xzHcACY4InaMiJ1Xsoklc
+dKkLSdDNVLhZSg9b5eGoPUiCXp7Oy9f7BAaAQZ/I6EMY9EssfiBBqS0gswfk
+jgCOQVdQ5Q6qPEECgyGtP6QLhHAMhsKGcNgYCeMYjMEs8Yg1EbEmYdCDAIPj
+AINRx0TUOQlzTUVd01E3aAZi0AMwOAfzzcP8CzH/s1gA9DwWBL2IhUAvYeFX
+sfDrWAT0BhZ9C4uBFmHxJdS7GJBgYhmWXI4m38PGVohWo+OwyPgH2AToI97k
+p/DXPoNCU1hfQMGv/R4g8k/j/QMAcQNO/eEmck2tN+DvjkkIwK8GnADhBsQY
+aByDGaABPwEDQgbGEQNjawxcIRi4LA2+kwSWxP5Foe+twPuG73nNc7/iuF6s
+l+CoaWbYOEXRTQxokr2qeLc80ikJtgq8DWx7c0YxPe1cysHmJU/TX/2hkyP3
+zzZSguTI/YAjJUiO3J+7NQmaiv8tdcMv6Rt/ywQS/Glb3qbtBZt3FG3ZWfLz
+rlIgwZ/3oLPgXoRBKEF0FjyAMHiwaRvA4KGWHYexs2DHnqOd+4517T/ec+AE
+dhbsP3pq4NjpwROnKafODp2+MHz20sj5y6MXrlIvXadduUm/eotx/Q7zxj3W
+rQes2w/Zd1M4955wHzzlPUzjpWTwH2cKnmYLU6EERRkF4sxCSVaRJKdEmlsq
+zSuX5VfICyvlRdWK4hplSZ2ytF5V3qCqaFJXNmuqWjTVbdradm1dh66+S9fQ
+rW/s0Tf1Gpr7DS0DxtZBYxvF1D5k6hhGGKRaummWHrqll2HtY1oRBm2DXDuF
+Zx/i24cFjhGhA0hwVOykSpw0qYsuczHkLiRBN0vlZqs9HI2Hq/VACUIMegUG
+rxBK0Ccy+8QWv8Tql9pgMrsfYtAZULgCSncAx6A3qPEFNf4gjsFgSB8KGcIh
+HINRmDkWNsfDlkTYCkMYHIPZxyP2iYhjIuKcjDinIjgGZ2CeWZh3Luqdj/pA
+C1E/6Fk0AHoeDbyIBkEvoyHQq2gY9BoWeQOLvkUtRmOgJVgc9A6WWEZBCUZg
+K7Ax0CoMSTCM9zE8gfUphDUJ+gwK4n0BBUBTMD8wIJGPyEsEAPhfGHDyd5CD
+CGfgBAwzoGWcYCBuwH9g4EfAQHXsA2LgqjKCMfA9ZGDonYR4Fyrw4Qzkul6y
+nS8et3z90ZgWUWTIMDWoHe9XJ3sUsS5ZuF0cbOZ76ll2YEAQ+LhICZIj96eP
+lCA5cj/gSAmSI/enD5Mg+tGYX9LgWXBr9k/bcjdtz9+8o3DzzuItUILYWbDi
+l70Ag0CCNTgGDyAMHkQYPNSMzoJtu4607z7asfdY177j2Fmw9/DJviOnIAaP
+nx48CSR4fujMxeFzl0cuXB29eJ16+Qbtyi36tTuM6/eYN+8DCbLupLDvPeHc
+f8oFEnyUzkvJ5D/JFjzNEablCdPzRRmF4qwicXaJJKdUmlsmza+QFVTKC6vl
+RTWK4lpFab2yrEFV3qiqaFZXtqir2zQ17draDm1dp66+W9fQo2vs1Tf16SEG
+Bw2tFGPbkLF92NQxYuocNXfTzECCPQxLL9Pax7L2s60DHIBBG8SgwD4stI+I
+HKNiB1XioEqdNJmTLncyFACDLpbSxYYYdHM0boRBD1/v4Ru8AqNXaPKKzF6x
+BWDQJ7H6pDaf1O6XOfxyp1/h8uMY9ARU3oDaF8AxGAjqgjAcg5GQMQozxUJA
+ghgGYcmwNRm2jYVt42H7RBhicBIGMOicjrhAMxH3LMwzB/POR7wLER/oWcQP
+ev4NBoMIgyEkwfAbUCQCehuJghZhsSXUu0gcazmSAL3HCidXUKvhMawPoBBo
+/OO6PgUn1vocwJoEffGvywf7HeRdlwflJnKhnETQgBO/21FrBrSOQwNaCANC
+BiYJBiYQA+OIgTHEwOgaA1cIBi5Lgu/EgSUROgjyvW94ntdc1yuO8yXLASRo
+WJNgszBC0U8OaMb7VIluebRTGm4TBZp4nvxcNiZBetq5T8/I16HkyP3JIyVI
+jtwPOFKC5Mj96VuTYN3hDakbfk2HD0S35WzanrdpR8HmnUVbdpVs2Y0wiEuw
+6td9CIP7a9dLcOshgMGW7Ydbdx5p2320fc/Rzr3wLNh94ETPoZMQg/hZ8Czl
+1Pmh0xeHz14ePn9l5MK10Us3qJdv0a7epl+/y7hxn3nrIfP2I9bdx+x7TzkP
+0rgPoQR5j7P4T3MEqXnCtHxhRoEos0icVSzOLpXklknyyqX5lbKCKllhjRxI
+sKROUdqgLGtUljergASrWtXV7ZqaDk1tp7auS1vfo2vo1SEJ6lsGDK2DBiRB
+Y8eIsXPU1EU1IQyae5mWPpYFSdA6yLUO8mwUvo3AoB3DIE3qIDDoZCpdLJWL
+rXYBCXK0bq7OzYMS9AiMHoHJQ2DQK7Z6JVCCPpkDhmPQ7Vd6/CqvH8egP6AJ
+BLSBAMRgKKgPBw2gSNAYDRpjGAZD5gTMkoRZx0LW8RCOwcmwAzQVdoKmw64Z
+mHsWBjE4/y0Gn6NeRAKgl5Eg6FUkBHoNAxIMIwnCoATDsKVwDPQOFl8meh8G
+EkyshEBJ0CoekmAQ9hE2jvUpsNbEZ/+6fBNf1vISef6zASdgTiLHxLcGHP8d
+APCrAcdgkIFJnIHAgJCB8U/adQxUrTEwjDEQSnAdAxcF3rc8zxsufBf6ku14
+wbQ/Lx3xrkmwkOIa1E30q8d6lPEuWbRdEmoV+hu57h3HZzf8qx2T4F/9iZMj
+9084UoLkyP2AIyVIjtyfvrWfD609vOHphl/TNv6WCc+C23ORBAu37CresrsE
+SbAcx+A+hMH9xFnw4BoGm7cfbtlxpJU4C3buO9514ET3wRM9+Fnw9MDxM4Mn
+z1NOXxg6c2n43JXh89dGLt4YvXyTeuU27dpd+vX7jJsPmLceMe88Zt17wr6f
+ynmYzn2UyUvJ4j3J4T/NFaTmC9ILhBmFosxiUXaJOKdMklsuyauUQglWy4pq
+5cV18pJ6BZRgk7KiRVXZqqpqU1d3qGs7NXVdmvpubUOPtrFP19Svax7Qtwzq
+WykAg4b2EWPHqLGTauqimbrpph4GwKC5j23p51gGoAStFL51SGAbEtqGRbYR
+sX1UYqdK7TSZgy530BVOhtLJVDlZaidb4+JoXRydC2HQzTe4cQyaPSKLB0hQ
+bAMY9ErtXohBp0/u8incMByDPr/a79eAAAaDAV0Ipg8H9JGgIYphMGiKB00J
+mDkRtCSDljECgxMw+2TIPhVyTIWc0zCIQSRB9xzAYNgzH/YshL2gZ2Ef6HnY
+D3oRDoBewoKvYKHXqDfhMOhtOAJahAEJRpdCoNg71DIs/h4vsRLEWw0msT6A
+AqCxj+v65B9f67NvXV4QBkAi99f+KwOO/25H2WBfcAOOwXADJnEDQgYmEAPj
+BANjiIFRxMDItwwMLkuDy5LAO5F/CWMgHzLwNcf1io0Oggzb83ZJYk2Cj5r0
+A5qJPlWyWxHvlEbaRMEWga+R48Z+NRTEr2/+qz9xcuT+CUdKkBy5H3CkBMmR
++9O39k8FzSX//cl//Jq24beMjVvRWXBHPpDg5l1FCIOlP++BGPxlbwWQ4C9Q
+gthZcB0GD6E3oodbdh5p23W0fc+xjr3HO/dDDKKz4Km+o6f7j50ZOHFu8NQF
+yulLQ2eBBK8OX7g+cunm6OXb1Kt3aNfu0W88YAAJ3k5h3n3CupfKfpDGeZjB
+BRJ8nMN7kstPzROkFQjSC4VAglklouxScU65OK9Ckl8lLaiWFtbIiqAE5aWN
+irImRXmzsgJKUFXdrq4BGOzS1HVr6nu0Db3axn5d04CueVDXQtG3DunbhgEG
+DR1UYyfN2EU3dTNMPUxTLwtg0AwxyLMM8q0UgXVIaAUSHBbbRiS2UamdKrPT
+5Ha6wsFQOhgqB1ONYdCJY1Dv4hlcfKNbYHILzG6hBcOgR2zzSOxeqcMrdXpl
+Lq/c5YUY9PiUXp/KB4MYDPg1Qb826NeF/DooQZghGjDGAsZ4wIQFMJiEWcaC
+1nGYbSJomwzaQVNBgEEHwOAMzDUbcs2F3KD5kAe0EPKCnoV8z1EvQn7Qy1AA
+9CoUBL2Ghd6g3obCWIuhCGgJFn0XxIoto94H41groEACtIqHJOiHfcQb++gb
++7SWF4YMOP7Z87UvbiIXkZPIgbKjAABtYzArCmdgEkQYMAENaCAMCBkIDfhR
+E0UMjHxQAgaGVyEDQyuAgcCA0gBkoBgycEngXeR73vLcbziu12znKxY6CNKt
+z9rE6yWo61eP9yiTXbJYhyTcKgw28Xz1bBc9Df4fLBv+1U7+cCg5ct9jpATJ
+kfsBR0qQHLnvsW8fiP6WvnFrJpDgT9vzNu0s2LwLYXB3yZY9CINQgugsuB9h
+8ADC4EGEwUMIg4eb4VnwKHwjuvdYx77jnfAseLLn0KneI6f6jp3pP35u4OSF
+wdMXKWcuD527Onz++vDFGyOXb41euUO9do92/QH95kPGrRTmnSfMu09Z99PY
+DzI4jzK5KdncJ7m8p3n81AJ+eqEgo0iYWSLMKhUBCeZWiPMqJfnVkoIaaVGd
+rLheVtIgL22SlzUrKlqUlW3KqnZVdYeqplNd262u69HU92oa+gAGtRCDFF3L
+kL51WN82om8fBRg0dNKNXQxjN9PUwzL1ss19HHM/14wwaKEILAiD1hGxFWHQ
+RmDQTmDQwdI42FonR+fk6p1cg4tndPFNLgEIYtAtsrrFNrfY7pE4PFKQ0wMx
+6PYqPDCl1wsx6PepAz4NKOjThvzaMMCgXx/x66N+QwxmjPuhBxMwczJgHgtY
+QOMB6wTMhiQIMTgNc84EnbNBF2gu6AbNB90LQQ/oWdALeh70gV4E/aCXsMAr
+WPA16k0wBHoLCy/iRZZQUIKB6DIsBnqPByQYX/HDVv0JrA8gHygJ+ojlhX2C
+jX3ywD5juYlcsC8gJ5GDyI6yja0zYPKLBbVmQFMCGhBjIDAgzsAYYmD0o3od
+AxVrDAwCBr6X4Ax8J1rHQK7rNQcy8CXTDg+CNMuzVlF8TYIPG3V9qrFuRaJT
+Gm0Th1sEgUauNz+Xg0kQRP4jQXLkvsdICZIj9wOOlCA5ct9jaw9E0Vnwt7QN
+WzM2bsMeiOZvhhgEEizesqcESbAcx+D+qnUSRBg8hDB4uAmdBSEG9xxrh2fB
+E/CN6KGTPYdP9R493XfsbP+J8wOnLg6evkw5e3Xo3LWhCzeGL90auXxn9Opd
+6rX7tBsP6TdTGLcfM+4+Zd5LYz1IZz/M5KRkcx7ncJ/k8Z7m89IK+elFgoxi
+QVapMLtMlFMhyq0U51UBCUoKa6VF9dLiBllJI5CgvLxFUdGqqGxXVnUoqztV
+NV0qiMFedUOfprFf0zSgbR7UtlB0rcM6JEF9B1XfSTN00Q3dDGMPy9jLNvVx
+TP1cUz/PPMA3DwosFKFlSGQZhhK0jkitozIbVW6jKWx0pZ2hsjPVdqbGwdI6
+2DoHgUEnz+iEGDS7BBaX0OoS2TAMuiUON5Cg1OWRuT1ykMej8HqVPq/S71X5
+veqAVx30aUIAgz5t2KeL+HRRH47BOAx6MOE3Jf1m0JjfMu7HMTgJMBiwTQXs
+oOmAYwbmnA045wIu0HzADVoIeEDPAl7Q84D3RcAHehnwg17BAq9hwTd4obeo
+xUAYtASLgN6B/NFlovf+GNYKyBcHrRJBCXrxPmJ5kqBPWG68z651OYkcsC8g
+O8pGZE2uGfCzOQEzJdYZMA6CBtTHcANqowQDI4iBYcTA0DcMFPuXMQYKvUt8
+zyLP/ZbresNxvmY7XjHtLwED6dZnVPPCqGl+/R+S6FGOdcnjHZJoqzDUzPc3
+cDwtmaXYPxIE39Rf/XGTI/fPOVKC5Mj9gCMlSI7c99jaA1F0FtyYumFr+sZt
+WT9tz9m0I2/Tznx4FtyNYbD0570Qg7/sqwAS/GV/9a8HEAYPIgwewjGIzoIt
+O4+27j7Wtuc4dhbsOniy+9CpniOne4+d7Tt+vv/kxYFTlwbPXKEACZ6/MXTx
+5vCl2yNX7o5evU+9/oB28xH91mPGnaeMu6nM++msB5nsR1nslBzO41wukGBq
+AS+tiJ9eLMgsEWSVCbPLRTmVorwqcX61uKBWUlgnLWqQljTKSptkZS3y8lZF
+RRvEYHWnEklQVdejru9TN/RrGgc0TYOaZoq2ZUgLMTiqa6fqO2j6Trqhi2Ho
+ZhogBjnGPihB0wDfNCAwDwrNFJF5SGwZllhGpJZRmXVUbqUqrDSlja6yMdQ2
+hEE7S2uHGNQ7uAYH1+jkmZx8s1NgcRIYdIntLrHDJXECDLqlLrfM7QYSlHsB
+Bj1Kn0fp96igBGGakFcb9mojXhyDMTxD3GdMwExJn2kMYtAMMDjht4Im/bYp
+mH0a5pjxO2b9ThCBQdcCxKD7GcSg5zmOQS/CoI/AoB9i0B944w+C3sJCoEVY
+eAn1DgYwGFn2gaKg93hAgrEVL2wVFgd9AHmwAAMTH91f++Ra17cAhNmJbETW
+BMyC+mrA+GcjCjdgDDcgZGCUYCAyoCqMGBhaBQaUBxEDAzgDRT6cgYJvGciC
+DHxBt8KD4Kh5YcQ4t16C3YpkpzTWJo60CIKNPF8dy439aij5lwTJkft+IyVI
+jtwPOFKC5Mh9p60/Cz7dsDVt47bMjduzf9qRu2ln3qZd6I0oOgtu2YswuI84
+Cx5AGDz4LQYPN20/0rzjaMuuo63oLNix/0TngZNdh051Hz7dc/Rs77FzfScu
+9J+6NHD6yuDZq5Rz14cu3By6dHv48t2Rq/dGrz2g3nhEu5lCv/2EfieVcS+d
+eT+D9TCL/SibnZLLeZLHfVrATS3kpRfzM0r4mWWCrHJhToUwt0qUVy3OrxUX
+1kmK6iXFjdKSJllps6y8VV7RJq9sV1R1KKq7lDXdytoeVV2vCmJwQN04qGmi
+aJqHtC3D2tYRLcQgTddB13cy9F1MQzfL0MM2IAwaCQyaCAyaCQxaCAxacQxq
+bEytnaWzs/V2jsHONQIMOngmB9/sgBi0OoU2p8gOwjDokrpcUrdb5gEYdMu9
+boXPDSSIMOhRBz3qkEcDwjAYheljqLjXAEp4jUkMgz7zOMwy4bNM+qygKZ8N
+NO2zz/jtCIPQg3N+57zfBVrwu0HPYJ7nMO8LmO8l6pXfD3oNAxgMvPEF3vqC
+oEVYCLQEC7/Diyx78d57o1grIA8otkr0AeSOY30Eub72yZnAc3zts53IRvSN
+AeMwU3ydAWOfDLF1Box+NaAmghgY/s8MXIEM9OMMFHrfYQzkuxe5rrcc5xu2
+4zXL/oppe0m3vgAMpAIGmuaHDd9IsJrp75DEWkXhZn6ggePbeWIB+60Y8u9H
+kCP3/UZKkBy5H3CkBMmR+05bkyCo/vBPaRu2ZWzcnvXTjpxNO3M37crfDDC4
+u2jLHvRGFEoQOwtW/nLgWwxCCdZvPdy4DWFw59EWdBZs33cCYvAgwuCRMz1H
+z/Uev9B38lL/qcsDZ64Onr1OOX9z6OKtoUt3hq/cG7n6YPT6Q+qNFNotKEH6
+3TTG/Qzmg0zWw2xWSg77cR7nST7naSE3rYiXXsLLKOVnlQuyKwQ5lcLcalF+
+jaigTlxYLylqkBQ3SUubpWUtsvI2WUW7vLJDXtUJMKio6VHW9irr+lT1/SqE
+QXXTkKZ5WNMyom0d1bZRMQzqOpn6Lpa+m23o4Rh6uYY+nrGfbxwQGAeFpkGR
+iSI2DUnMw1LziMw8KrdQFRaq0kJTWelqK0NjZWptTJ2NpbMRGLRzTXae2cG3
+OARWGI5Bh1PsdEpcToRBl8zjkntdcp8LYdCtDLhVQRjEYNijiXi0EY8u6tHF
+YHoQkiDCoNc45jWBxr3mCa8FNOm1TnmtSIIIgz77rM8BmoM552GuBZ/rmc8N
+eu7zgF7AvC9hvleo1z4/6A0Mw2DgrTe4iFryhrDewcKgZQ8oAnpPBCXohq3i
+xVZdsQ/r+ugExWEO2CcsO5GNyBr/jGVBfTVgDPTJiMIZGIUARCEDRjADflTj
+BvygDCEGIgPKAhgD34t9OAMFniU+yL3I+5aBDMjA51Tzs1HTAmDgkH72UZN+
+nQR9beJoizDUxAvUsT3YNRBIEPz3r/6syZH7px0pQXLkfsCREiRH7jtt/QNR
+7CyYvnF75k87sn/amYPOgvmbdxdu3oMwuLf0530Ig/vXYfAgwuChtbNg4/Yj
+TTuONu86Bt+I7kUYPHCy6+CprsNnuo+e6zl2vvfExb6Tl/tPXx04e23w3A3K
+hVuUi3eGLt8bvnJ/5NrD0Rsp1JuPabef0u+k0e+lM+5nMh9kMR/lsFJy2Y/z
+2U8LOKlF3LRiXnopL7OMn1UhyK4U5FYJ82qE+bWignpxYYO4uFFS0iwpbZGW
+tUohBjtklZ3yqi55dbeipldR26es61fWD6gaB1VNFHXzkLplRNM6qmmjattp
+WihBhq6Lqetm67s5+h6uvpdn6OMb+gXGAaFxUGQcFJsoEtOQ1DQsM4/IzaMK
+M5AgVQUwaCEwaGXprCy9jW2wcYw2IEGuGWDQzrfYBVa7wOYQ2h0iBwzDoMTt
+lHqcMhCGQb9LEXApAy6IwZBbHXZrQBG3NooHPRgHGPToEx5D0mMcg5nGYeYJ
+j3kSYtAyhTw47bXNwOyzMMec1zHvdYIWYK5nMPdzmOcF6qXXC3rl9YFew/xv
+8IAEYYueIGgJL/QOL7zsxnsPi4BWQC7YqiuK54x+wIt9cMA+YtmJbLFPWFYi
+C5EZZSLCDRiF6aMEAyMftSjIwDBuQMjA0AdgQEUQMRAacEXqJxjo/cpAHmIg
+1/mW7XjDsr9m2l4xrC/plhdU83PIQOP8kH5uUDfzsPGrBKvovlZRpJkfauD4
+pMOZ9LRzWOTTUHLkvt9ICZIj9wOOlCA5ct9v354FN6Gz4I4shMHcTbvyNu0u
+wDG4F70R3Vf+My5BhMGDCIOHCAwebth2BGJw59EWgME9x9v2nWjffxJgsPPQ
+6a4jZ7uPnu85frH35OW+U1f6z1wbOHtj8DyQ4G3KpbtDV+4PX304cv3R6I3H
+1FtPabdTaXfT6fcyGfezGA9zmI9yWSl57CcF7KeFnNRibnoJN6OMl1nOz6rk
+51QJcquFebXC/DpRYYOoqFFc3CQpaZGUtkrL2qTl7bKKTlkllKC8pkdR26tA
+ElQ2DKoaKaqmIVXzMMCgupWqaaNp2unaDoa2k6nrYgEM6npwDOoRBg0DQgPA
+IEVspEiMCIOmEbkJYdBMVZlpagtdY2FoLUwoQSvLYGUbrAiDNq7ZxrPY+FY7
+3wYwaBfa7RCDTofY5ZC4YRCDXqfM55T7nAq/E2Iw6FKFYOqwSx1xaSIubdQF
+MRgDGHTr4m59wq1Pug2gMbcRBDA4gWHQY5mCWadhthmPbRZmn4M55mHOBZjr
+Geq5xw164fGAXsK8r1CvPT7QG48f9BYvsOiGLbmDWO9gIdCyCyv8nmjFGVlr
+FcsRBX3AsuN9tBFZv/bJQmRGmYiMKNyAERgA4FcDhnEDQgaGoAGVyICQgQHE
+QP8KMKDEhzFwGWegGzKQ61oEDOQABjpeM+3rGfhsxLgwZJij6GYHtN9IsJLm
+axGGm3hB2UhWysFm8g/KkyP3v2GkBMmR+wFHSpAcue+3b8+C/3fqhm3wLLgR
+Owvuyt20O38zwCCUYDHAIDwL7kdnQSTBXw5+i8HD9VsRBnccbd55rGX38da9
+JyAGD5zsOHi68/DZriPnuo9d6Dlxqffklb7T1/rPXh84d3Pwwm3KxbuUy/eG
+rjwYvvZo5Prj0ZtPqLdTqXfSaXcz6ECCD7IZD3OZKXmsxwWsJ4Xsp0WctBJO
+eik3o5yXVcHLruLnVAtyawT5dcKCemFho6ioSVzcLC5plZS1ScrbpRUd0spO
+WVW3rLpHXtMrr+0DGFRADFKUjUOqpmFV84iqZRRgUA0xyNB0MLWdLG0XW9vN
+0fVwdb08XS9f3yfQ9wsNAyLDoNgAJEiRGodkxmG5aURhGlWagASpajNNY6Zr
+zQwdwKCFpbdADBqtHJOVY7ZyLRgGbXybTWC3CR12odMuctrFLjvEoMch9Tpk
+IJ9D7nfKAwCDTmXQqQw5VWGnGgQwGMXTxlzauEsHSrj0SZcBBCUIM024TZNu
+M2jKbQFNu60zMNsszD4Hc8y7HQsw5zOY6znqhdsNeun2gF7BvKDXMN8b1Fu3
+H2vRFQAt4QXfES07Q1jvYWHQiuNrq47Iqh3vA8i2LmsEN6CFyExkIjJGYAaU
+HgUNGP6oReEGDH0AqVDKIAgzIGKgHzEQGvC92IsY6CEY6IIM5KBrINv+hml/
+zbC9oltf0swvRk3PAQOHDfMU3dygdqZfM71eghU0bzM/3MAJSIezsM8HYJA8
+CJIj911HSpAcuR9wpATJkfuuW5MgPAse2QQkiM6CO7N/2pWDzoL5m/cU4hjc
+V4pj8MC3GDyEMHgYYfBIw/ajTTvhG9GWPQiD+0+2HzjVcehM5+FzXUcvdB+/
+1HPicu+pq31nrvefvTlw/vbghTuDl+5RLj8Yuvpo+HrKyI0no7dSqbfTqHcy
+aPcy6fez6Q9yGI/ymCn5zMeFrCdF7NRidlopJ72Mm1nBzarkZVfzc2r4ebWC
+/HphQYOwsElU1CwqaRGXtorL2iXlHZKKTmlllxRisFdW0yev7ZfXDSjqBxUQ
+g8PKphFV86iqhapupanb6GqEQQ3EIEfbzdX2QAnqegW6PqG+X6QfEOsHJQaK
+1DAkMwzJjcMK44jCiDBooqlNBAbNTL2ZabCwjBa2ycIBQQxaeVYr32bl2zEM
+2oROm8hlE7vtIInHLvXapT67zA8w6JAHHIqgQxmCAQyqIgCDME3UqYk5taC4
+U5dwYhjUjwEMugzjLuMEzDTpMk25zKBplwU047KCZl22OTfIPg/DMOhAGHQ+
+d7lAL2DulzDPK9RrlxfrjcsHeotadPkXnbAlZwDrHSwIWnZghd4TrdixwqBV
+kI3IGv6AF/lgITJHPmKZiIyRdQYMf9SjdOF1BgyBPnw1YJAwYAAGGCj7loHA
+gCIPYqD7Hc5AJ85Alv0Ny0Yw0PKCChn4bNiwQNEDBs72a2b6VFN5/c41CWZ1
+W5t4IdlINgDgv/zL/wL/JZ+GkiP3vUdKkBy5H3CkBMmR+65b/0AUnQW3p2/c
+kblxJ8Bgzk/wLJi3aU8BxODeoi37SiAG96/D4EGEwUPfYBCdBZt2Hmvefbxl
+z4nWfQiDB093HDrbeeR817GL3ccv95y82nv6et+ZG/3nbg0ACV68N3j5PuXK
+w6FrKcPXH4/cfDp6K230djr1bibtXhbtfg79YS7jUT4jpYD5pJD1tJiVWsJO
+K+NklHMyK7lZVbycGl5uLT+vTpDfIChsFBY1CYtbRCWtotI2gEFxeaekoktS
+2S2t6pFCDPbLagfkdYPyeoqiYUiBMKhspqpaaKpWurqNoW5nqjtYmk62pouj
+QRjUAgz2QQzq+kU6hEE9RapHGDQMKwwjSuOoykhVG2kaE01routMDD2GQTPL
+aIYYNFs4FgvXagEY5EEMWgUOq9BpJTBoE3tsEq+NwKBdHoApgnYFwGAYYNCh
+isDUUZgm5tDEHTgGk049aMxpGIcZJ5zGSacJNOU0g9YwOIuaAx502eZddtCC
+ywF6BgMYdBIYdL10ukGvYJ7XqDdOL9Zbpw+0CPMvOvxLeIF3RMt2UBD0HssG
+Cq2sZQ2t4oVXLbAPIDORicgI+wgyEH01YAimDX0AaVDqIAQgbsDAVwPK/bgB
+pT70ItT7Hp0Cl4EBIQNdBAMdgIFvAQOZgIHW13TrK5rlJdX8YtT4HDBwSD8/
+qJsbAAxUT/cqp3L7HGsSzOyyNHCC+bl87GkowGBHjeSv/pTJkfsnHylBcuR+
+wJESJEfuu279A1F0FtyctmFHxsadmfhZcDd6IwowuBc7C5b8vB9h8ADC4MFK
+QoIIg4chBtFZsHHHsaZdxyEG9wIMnmw7cLr94NmOw+c7j17oOnap+8SVnlPX
+es/c6Dt7q//87YELdwcu3R+8/JBy9dHQtcfDN56O3EwduZ0+eieDejeLej+b
+9iCX/jCP8aiA8biQ+aSI9bSElVbKTi/nZFRwMqu42dXcnFpebh0/r55f0Cgo
+bBIUNQMMCkvaRKXt4rIOhMFuSWWPtKpXWt0nq+2X1Q3I6inyhiF547CiaUTR
+PKpsoSpb6ao2hqqdqWpnqTvY6k6Opour6eZpevjaXoG2T6jtE+n6xboBiW5Q
+qqfI9ENy/ZDCMKw0jKgMo2ojVQMwaKRpjQiDJqbBxDSaWCYz22zmgCxmiEGb
+hWe38B0WgEEBwKDLKnJbRR4rhkGJzyb122SggE0OJQhThu3KCEwVsaujdnXM
+jmMwAdMlHboxhx407jBMwIyTDiPCoGkaYNBpnnFaQLNOK2jOaQPNO20LTjvo
+mdMBeg5zvoABCWK5Xzlgrx0e0BuYF/QWtejwLdphS3Y/1jssW2B5XVCCVtgK
+lgUrtAoyE5lgH0BGIgORnkhHBA0Y/KBBqVGqAGj1qwH9uAFlPmBAeAqUeBED
+PTgD+S7EQOcSzkD7OgZaCAaaAAOfDekXEANn+9UzvaqpbsXkeglmdFpkI9lr
+Xw35NJQcuf8NIyVIjtwPOFKC5Mh91yXcXmPxv639b1oLcRbMgGfBXdk/7c5B
+Z8H8zXuxs2Dxlv0IgwcQBg9+i8HDCINH6rcdhRjciTC45wTE4P5TbQfOtB86
+13HkQufRS13Hr3SfvNpz6nrvmZt95273n787cPH+wKUHg1ceUa49Hrr+ZPhG
+6vCttJHbGaN3MkfvZVPv59Ae5NEf5dNTChmPi5hPipmppay0MnZ6BTuzkpNV
+zc2ugRjMq+flN/ALmviFzYKiFmFxK8Jgh6isU1zeJQYYrOqVVPdJa/qltQOy
+ukGEwWF544i8aVTRTFW00AAGlRgGO1gqhEF1F1cNMSjQ9Ao1fSJtv1hLYFBH
+kekQBvXDSj3CoIGqMQAJ0nRGut7IMBgJDJrYZhPbYuZYAQbNPJuZZzdDDDot
+ApdF6LKI3BaIQa9VAvJZpX4rkCDCoE0esinCNiVWxKaKgiAG1XG7Jm7XJuza
+pF0HGrPrx2FfMTjlMIGmHWbQDMwy67DMOaygeYcNtACzP4M5nqNeOJyglzAX
+CGLQ7n6NemP3YL21e0GLIBvIt0T0zuaHWf3LeAHQe8vXIAPNRKbg6lpGIgPs
+A0hPpCPSBgkDBj6oUQCAmAGV/lUFSo4AiBlQ6sUNKPagF6FunIE8jIEOgoG2
+dQw0Awa+HDW9GEEMpOjmB7RziIHTPYqpLvlETu86CXaYpcPZKQebsa+G1/tE
+ZfD91Z8yOXL/5CMlSI7cDzhSguTIfe/d/PfN68+CzLv/b+qGHekbd2Zu3AUw
+mPPT7txNe9AbUYDBff8/GDyEMHgYx+BWhMEdxxp3Hm/ajTC471Tr/tNtB8+2
+Hz7fceRi57HLXSeudp+83nP6Zu/ZW33n7vRfuAckOHD50eDVFMq1J0PXnw7d
+TBu+lT5yO3P0btbovRzq/Vzaw3zaowJ6ShHjSTHjaQkztYyVVs7KqGRnVnGy
+ajjZtdzcOm5eAy+/EWGwRVDUKihuE5a0CwEGy7tEFd3iyh4xxGC/pGZAWjso
+raPI6odkOAap8maaooWuaGUo25jKdpayg63q4Kg6ueounrqbryYwqIEYlGgH
+pNpBmY4i1w0pdENK3bBKP6LWj2r0VK2BpoPR9QaAQYbRyDQZWWYjwqCJYzVx
+bSau3cxzAAyaBU6zwGUWQgnCxF6L2GeR+CEGpQGrLGiVh2CKMCpiBRhUAgzG
+bGpQ3KZJwLRJm3bMpgMBDE7ADJMw4xTMNG03zdjNoFmYZQ5mnYfZFlDP7HbQ
+c7sD9ALmfIl6ZXdhvba5QW9gHtBbFJSgFbYE84HegSxY/uW1zP73sADMFFjB
+Mn5t1UCkJ9IRaYk0KDVK5Ycp/YQBfaty34ocM6AXN6DEAwwIT4EiN2KgCzEQ
+ngIRA+0EA61vCAa+opowBj4f1j+j6BYGIQNn+1QzPcqpbvlkp2w8u8e+JsGB
+hgfYn43Y8K/wpM7tevhXf8TkyP3zj5QgOXI/4EgJkiP3vVd38/7w7f/x7RvR
+LWkbdqI3othZcE8uOgsWbN5XuAVgcD/C4AGEwYMIg4e+weBvR+q2Ha3ffqxh
+57HGXQCDJ5r3nmzZd7r1wNm2Q+fbD1/sOHqp8/iVrhPXuk/d6Dlzq/fsnb7z
+9/rhWfDhwJWUwauPKdefUm6kDt1MH76dMXIna+Ru9ui9XOqDPOrDAtqjQvrj
+YvqTEsbTUmZqOTO9gpVRxc6sZmfXcnLquLn13LxGXn4Tr6AZYJBf1CYobheU
+dgjLOoUQgz2iyl5xVZ8YYVBSS5HWDUnrh2UNI7LGUQyD8haGopWpaGMp29nK
+Do6yk6vq5Km6+KpugbpHqO4VqfvEmn6Jpl+qGZBpB+VaikILJIgwqCMwqKfq
+9DS9gW4wMIwwHIMWI9tq5NiMCIMmnsPEd5r4LhPCoFnoMYu8ZjEIYtAiDcBk
+QYssZJGHYTgGozBVzKqKW9WghFWTtOIYHEdN2PSgSZthCmachplmYOZZmGUO
+NW+zghZsNtAzmP056oXNAXppc4JewVyg11bYG6sb663Vg7VowfIuEb0z+7CW
+sUwg/3ssI94KyECkx1vVEWmJNERq1FcD+gAAVxQIgNCAXpgUARAzoNiNG1Do
+egcZ6EQMdCxxMAbaCAZa1jHQuJ6B8/2aOcTAacTAiQ7JP0oQ+7MR4GPJSGP2
+ssx/9UdMjtw//0gJkiP3A46UIDly33vCrr6b/77FWPzfv30jCs+CGfAsuBvD
+YN6mveiNKMDgfoTBAwiDB7/F4GGEwSO1WxEGdwAMHocY3AMweKpl/5nWg+fa
+Dl1oP3Kp49iVzuPXuk5e7z59s+fM7d5zd/su3O+/+HDg8qOBK48Hrz2hXE+l
+3EgbupUxfDtz+E72yL2c0ft5ow/yqQ8LaSlFtMcl9CeljNQyRloFM72SlVHN
+yqphZ9dxcuo5uQ0Ag9z8Zl5BC6+wlV/cxi/pEJR2Csq6hOXdQojBPlFVv7h6
+QFwzCDAogRgckTaMyhqpsiaarJkOMChHGFS0sxUIg8pOnhJhUEVgUE1gUDMo
+1yAMaodU2mG1bkSjG9XqqDodwqCebtAzjHqGycA0G1gWGIZBjt3IdRh5DiOO
+QbdJ6IFBDPrMYr9ZAgqYpUGzDBQy4x6MWBSgqEUZs6hAcYs6YcEwCD04ZtWO
+W3WgCat+EmaYghmnUTNWE2jWagbNWS3zqAWrFfTMasN6brWDXsAcL1GvrE6s
+1xYX6A2e+y2W2b1o9mAtYZm879a1bPSt9d6wLj1sBaQD+fG0RBqQb0UNWwWp
+fCsgJQoa0LsiR+EG9BAGdBMGdMEwA/KdSzwHYqB9EZ0C37KsBAPN/8DA50O6
+Z4CBA5CBs72AgYqpLtlkh3S8XTyW1W1bk+Ct28PY3xAEH0t+j0FtCv3VHzE5
+cv/8IyVIjtwPOFKC5Mh97yXc3pv/vrnswIZv34j+z9QNO9M37srcuBtgMOen
+Pbmb9gIMwrPgf43BQwiDh6uIs2Dt1qN124/hGNx9omnPqeZ9Z1oOnGs9eL7t
+8MX2o5c7jl3tPHG969TN7tO3e87e6T1/r+/Cg75Lj/ovpwxcfTJ47eng9TTK
+zfShW5lDt7OG7+aM3MsduZ8/+rCA+qiImlJMe1xKf1pGTy1npFUyM6qYmTWs
+rFqAQXZOAye3kZPXxC1o5ha28oraeMXtAIP80i5BWbegvEdY0SuEGBwQVQ+K
+ayji2iFJ3bAEYVDaSJM10WXNDFkLU97Kkrex5e0cRQdXASTYyVd2CZTdQlWP
+SNUrVvVJ1P1Sdb9MPSDXDCo0FKUGSHBIDTCoHdFocQzqdTSDjm7U0yEG9Uyz
+nmXRs6wGts3AAdkNEINOI89l5LuMArdR4DEKvQCDJpHPJPabJAEYwKA0BIMe
+DJvlEbMiClPGzMq4GWBQlUAeTFo0YzDtuEU7YdGBJi160JTFAJq2GEEzFuOs
+xQSas5hB8xYLaAFmfYZ6brFhvbDYQS8tDtArLLPzNeqN2YX1FuZ+a3IvEi2Z
+PDAj7B3MCzN4l9fSe99j6UA+PK1vBUtDhAwI9afywpQohXedAT2g91KUxE0Y
+0AWDBnS+EzjRKdCBGGhfhAyEp8C3wIBMC8bA1zTTGgNfEAxcGNDM96sBA2d6
+FNOIgROAga2iZFaXbf1NEHwj/x97d7kk15n9e/6G5pyJGLm7/wbJFjMzl6gY
+pWLmyoKsZGZmZs4sRjEXqcSSqbuvYNZ6MndJsmyfeWU5pvYvPpfgHeFvrEdZ
+UIJueXWLJLn07M2X/ojp0fv//+gSpEdvHY4uQXr0/oLlb/g2f8MmfeH/8+kb
+0U3kjejOejwL7iZvRPe0fruXxOA+EoP7SQweIDF4kMTgISoGDw9uPjK0NRuD
+x1g7IQZPcPac4u47w9t/jn/wguBwnvDIJdGxK+IT1yQnC6Sni2RnS+TnyuQX
+yhUXK5WXqlSXb6iuVKuv1Wry6zQFDdqiRl1xs66kRV/WZihvN1Z0Gqu6TNd7
+zDd6zdV9ltp+S92AtX7I1sC0NQ5DDNpbOI5WrqONBzHo7BC6OkWuLjHEoLtH
+5umVe/oUXobSS2LQN6j1D+n8TH1g2BBgGSEGgxxzkMRgiG8LkRgMkxiMiN0R
+EoNRmS9KYjCmDMZIDMbVkTiJwYQ2ntAlkvpk0pBCVAymzKMpy1jKOp62Ygym
+7ZNpx1TaMQ0xmHHNZFyzGfdcBkqQxOCI99aI7/aIH0AM3s0J3hsN3UfhB6Ph
+h6MRQGIQe/DJWPwpSiyMJRbHkmBpLAWWx1IrY2nwbCwDVsdGwHM0+gKNvSRe
+jY2D12MT4A2afJsz9Y54PzaNRqd/RDM/UX4enf15BP2C5rJ+zeT8OzOP0jn/
+Aamsm+C/SUqCEqdkA/BDA86j8Px/QYgIzqEA4Z+lGnAGkAacRqQBSQZOkgyc
++JmcAn+CBsxl4Mg7Q+ZDBmpyGfhCHn2OGRheEQeXhYFFgW+B531SwkyulWBa
+sCv7jbRI082CyJf+fOnRWxejS5AevXU4ugTp0fsLxswvzd+wsWDDDx+XIHkj
+uqPm6511eBbcTWJwT8u3e0kM7oMYhBIkMXjg92LwMMbgFojBoxiDOyAGj7N3
+n+TsPc3dd5Z34Dz/0EXB4UvCo1dEx6+JT+RLThVKzxRLz5bKzpfLL1Qo8qqU
+l64rL1errtaor9WpC+o1hY3aoiZdcYuutFVf1m4o7zBUdhmruk3Xe003+sw1
+DEvtgKVuEGLQ2jBsa2LZmtkQg/ZWnqON72gXQAw6O8WuLomrWwox6MYYVHoY
+Km+/2jug8Q1pfUydf9jgZxkDLFOAbQ5wLEGuNcizhfj2kMAREjrDIldY7A6L
+PRGJNyL1RWT+qDwQVQSjylBMGY6pIjF1NK6JxbXxuDYBMZjQJxOGVMKQThoz
+SdMIomIwZZ1I2SZTEIN2jMG0cybtnE1nY9A9n/HczHjBrQzEoO8OxOBI4C5x
+byQI7o+EHiCMwUco+ng0+mQ0Bp6OxhdQYhEll0aTy7kYTJEYTJMYzFAxOPJi
+dBS8HB0Dr9D4a+LN6AR4iybBOzT1HoyA6R8pP43MoMzMzzmzv2SlZ39Fc1n/
+Tn3iP8n5nAQlPv/frBglSokQ2IBz/w0RuQac/Q/wE74ZqgGnETbg1K8ubMBf
+oQExAydIBo7/ZBn7iTTgWga+06XfalNvNB+ugS8UmIGrUpKBosASycCnXPfj
+kqHEb0rQJa9uESfj44++9OdLj966GF2C9Oitw9ElSI/eXzBSgt/lb/i+98A3
+n70R3Vn79a76XAzuac7G4HcfYrDzQwweJDF46EMMbj6Si8Htx4Z3HGftOsne
+c5qz9yx3/3newQv8Q3mCI5eFx66KjueLTxZKThdLzpRIz5XJzlfIL1Yq8q4r
+Lt1QXqlRXa1V5derCxo0hU3a4mZtSauutE1f1qGv6DRUdhureow3ek3VDHNN
+v7l20FI3ZGlgWhuHrU1sWzPH1sKFGLS3CRztQkeHCGLQ2SV1dctcPXJ3r8LN
+UHr6VZ4BjXdQ6x3S+Zh6H4lBP8vkJzEYIDEY5DuCAmdI6AqJ3CGxJyz2hiW+
+sNQfkQUi8kAEYlARiirDURKDMU0spsEYjOuScX0KQAwmjJmEaSRhGk2ax5KW
+cWSdSEIM2qZS9umUYzrlnElhDM4h93zaczPtuZUmMZjx3cn47+YE7mUC9zPB
++xmMwYcQgyPhRyORxyj6BMWejsQWRuJgcSSxNJrAGESpFeLZaBqsjmbA89ER
+8AKMjL4kXo2Mgdcj4+ANmnibM/mOeA8yU+DHnOmfstLTP6dnsn4BKTALfl2T
+nP13zty/Ezn/iVNilGjOfyOU8BzVgLP/Dc7+J0gCEBtwBvnQv73TVANOAdKA
+kyDbgCQDx6kMxAb80TjyHhpQv5aBydfqBGTgK2X8pSL2gmTgM3FoBTPQv8j3
+LnDdT9iuR8WflqBbUdMizTQLY7GRu1/686VHb12MLkF69Nbh6BKkR+8v2JO5
+eVKCmwo2bB7t/L8+eyOKZ8F6UoJNGIN7SQzuIzGYOwuSGDz4aQwepmLw6NA2
+EoM7T7B2nWLvOcPZd4574ALvYB7/8CXB0SvCY9dEJwpEp4rEp0skZ0ul58pl
+FyrlF6vkeTcUl6uVV2qVV+tU+Q3qgkZNUbOmuEVb0qYra9eVd+orugyVPYbr
+vcYbfabqflPNAMSguZ5paRi2NLKsTRxrM9fWwrO18kkMihwdYmenBGOwR+6C
+EuxTuhkqd78aYtCDMaj3Mg2+YaOPZfKxzH62xc+xBri2AM8eIDEYFLqCEIMi
+T4iKwTDGYDCiCEUU4agyElVFo+pYVBOPaRIxbSKmS8YwBtNxQyZuHAEQgwnz
+WMIynrBMJK2TEINJ21TSPp10zKQcGIMp11zKNZ9y30zlYvA28t0h7qb9d9OB
+e+nA/XTwQQaEHmZCjzJh8DgTAU8y0acotpCJkRiML0EPjiSWR5JgZSQFnqH0
+Kso8J16MQAyOvMyMgldo7DXxJjMO3qIJ8A5NvktPvid+TE9l/QRSYPrnj/yS
+nFnzK0iAWfBvEKfEcv4TpUQoYUqIwAac+U+AyDXg9L9BrgFJAGIDTlINOIGo
+BvzZOkZl4AiVgel3utRaBr5WxV8pY5iB8shzaXhVghm4LPQvYQZ6nrJdj3UW
+K3wLKlYZgBI0C6ta5WMt4lSzIPalv1169NbL6BKkR28dji5BevT+gpES/DZ/
+w8b8DT/0Hfj24xIELIjBr3fVfb27IReDe0kM7iMxuP/3YvAQicHDH2JwK8Tg
+MeaOE8M7T7J2n2bvPcvZf5574CLv0CX+kSuCo9cEx/OFJwtFp4rFZ0olZ8uk
+5yukFyplF6/LL1UrLtcortQpr9Wr8hvVhU3qohZNcau2tF1b1qEr79JXduur
+eg3X+4w3GMbqAVPtoKluyFw/bG5gWRrZFoxBnq2Fb2sV2NuEdoxBiaNL6uyW
+OUkMuvpUboba3a9xD2g9gzoPiUEvFYM+ttXPsfm5dj/PEeA7AwJXUOgOijxB
+kTck9oUk/pA0EJYFw/JQmMRgRBmJqKIRiEF1PKpJRLXJmC6F9OmYIRPDGByN
+m8biZoAxmLBOJqxTCdtUAmLQPpN0zCadcygbg+5bKQ+4nfLeQT5wN+W/BzAG
+Aw+gB9PBh+nQo3QYPE5HnqDo03QuBhczcbCUSYBllFxBqWfEaib9HGVe5Iy8
+TKNX6VHwGo29yRl/S7xLT6DUxHs0CX7MmfopmfMzmv45gX5ZE5/+NT6TE0P/
+BlFKhBLO+U+IEpyhGnD6334i14BTKNeAk9iAmIETVAOOA5KBYz9DA1pGsxn4
+3pj5KAOTn2ZgdC0Dn4kCK5iBvkWe5ynH9ZjleDSrPvTxFyFWKlukI83CuNwx
+9aW/XXr01svoEqRHbx2OLkF69P6arT0QLfxqs6Fww2cx+D15IwoxuOcPYvAA
+icGDJAYPfRqDRwa2HMUY3H6cuePk8K7TrD1n2fvOc/Zf4B7M4x6+zDtylX8s
+X3CiUHiyWHS6RHymTHKuXHK+UnqhSpZ3Q36pRn65VnG1XnmtQVXQpCpsVhe1
+akraNKUd2rJOXUW3rrKHxCDDUN1vrBk01g6Z6pgmjEG2pZFjaeJCDFoxBoW2
+dpG9Q2zvhBiUObrlzh6Fs1cJMejCGNS6B3TuQb1nyOBhGr3DJi/L7GVZIAZ9
+HJuPxKCfxGBA6A6QGAyKfUESgyFZMAQxKA+HFZGwMhpRxSKqeEQdj5AYjGpT
+UV06qs9gDBpGYsbRmGksZhqPmyfiFjAZt07FbdMJ+wxyzCYccwnnPMRg0nUz
+6b6V9NzO8d5Jeu9iDPogBu+jwINU8CEKPUqFHqfC4EkqAiAGF1BsEcWXUGI5
+nVhByWcotUo8T6fBC5QBL1Mj4BUafU28SY1lvUXj77KS4++TE1k/oskfE5M/
+fTD1M4jn/AJi01m/giglkvPvMCVECRIBCjbg1L99BGnAXz2TGIC5BpzABsQM
+HKcacAwb0Eo1oHmEysD0O32KysDEa3X8kwyUkQwUByEDlwWYgQsc9xOW81FI
+3/Lxt6BilbXKx5vFqSZ+lP5HgvTo/WWjS5AevXU4ugTp0ftrtvZANH/D5sKv
+thgKv/r012P+V83/7Kr9enf913tIDO4lMbiPxOB+EoMHSAwe/CQGNx2GGAT9
+m0kMbjs2tP0Ec+ep4d1nWHvOsfZdYB/I4xy6zD18hXf0Gv94geBEkfBUieh0
+qfhMufhcheR8lfTidVletQxi8Eqd4mqD8lqjsqBZVdiiLm5Tl7RrSju15V3a
+ih5dZa++qk9/o99QPWDAGGQa64ZN9SyIQXMj19LEszTzra0CaxvEoNjWIbF3
+Su0kBh09SmevytmndjE0rn6ti8Sgm8SgZ9jkYVm8LKuXbfNy7D6uw8dz+vku
+v8DtF3oCQm9A5AuI/UFJICgNBmUhiMGQPBwiMRhWxcKqeFidiGiSEW0KkRiM
+6keihtGocSxKYjBmnohZJmOWqWwMxm0zcftsnIrBhPNmwnUz4b6VcN9GHoAx
+mPTeS/ruJf33k/4HyQB4mAyCR0mIwRCJwfBTiMFUZCEVBYupGFhKxZeJlVQC
+PEslwSpKPUfpFzkQgwhjMDnyGo2+yRl7S3mXGAfvcyZ+BPGcn+KTWT/HPjb1
+S5QSQb+CMCVECVIChJ/iA5O/egkP4Z7AAHSRAHSOZxvwZ/sYNiBm4Cg2IGbg
+CHkRig34PnsK1CUxA8kp8LUq9koZfSmPvpDhNfC5JLQqDj4TYQYu8TyLHPdT
+tvPx5xl4oSPQIh1tFiaaOKGlZ2+/9IdLj956GV2C9Oitw9ElSI/eX7OPH4gW
+bNhS9NVWY9HnMbi77v9rDB5ai8FeiMEfjjA2H+nfemxg24nBHaeGdp1m7j47
+vPc8a/9F9sFLnENXuEeu8Y4W8I8XCk4WC0+VCk+Xic5WiM9VSi5cl168Ic2r
+kV2ulV+pl19tUOQ3KQtaVIWtquJ2dUmHpqxTU95NYrBPd50BMaivHjTUDBkw
+BlmmerapgQMxaG7mW1oEllahtU1kxRiU2jpl9i65vVsBMejAGNQ4GVpnv841
+oHcNGtxDRjfT5B42Qwx6qBj0khj08V0+EoN+oddPYjAgCQRIDAZl4aA8ElJE
+Q8pYSBUPkRgMa5JhTSqsTUd0GaQfiWRj0DgeNY1HzRNRM8ZgzDqNbDMxiEH7
+XNwxF3fOx503465bOe7bcfcdiMGE927Cey/hA/cT/gco8DAReJSAGAw+hh5M
+hp4kw09RZAFFF5PRpWQMLCfjYAUlnqHkKvE8mQIvUBq8RJlXCfQ6MZL1JjEK
+3mbFx95R3sfHs36MZU2An0AU/YwmUQT9AsKUUM6vQUqA4id8FGzAiV89hHvi
+F+AaxwDMNqBjjGrAUWxAzMARbEDMwAyVgblT4FtN4g05Bb5Wxl4pIAMjL2Th
+59LQWgauCHzLfO8iFzPwSUjf+vEnkBbsggzMZ0SaxekmXqyRHfrSXy09euto
+dAnSo7cOR5cgPXp/2Zj5JaQEv8+eBYs/i0Fr8T9rvoYY3ENicC/G4Lf7SAzu
+JzF4gMTgQRKDh6gYPNzzIQaP9m89PrD95ODO00O7zjL3nB/ed5G1P4998DLn
+8FXukXzesUL+iSLByRIBxOCZctHZSvH5KvGFG5KL1dJLtbLLdbIrDfJrjYr8
+ZohBZVEbicFOdVmXprxHW9GrrWLorvfrbgxADOprmIbaYYhBYz3H1Mg1NfEg
+Bs0YgyJLm9jaLrGSGLR1KezdSnuPytGrdvRpHCQGnSQGXUMmF9PsHra4h60e
+ls3Dtns4Di/X6eW5vHy3T+DxCbw+oc8v8vvFAb8kGJCGAjKAMRhURIPKWFAJ
+MZgIqZMhdSpEYjCsy4R1I2H9KMRgxDAWMY5HTBMR0yTEYNQyFbVMR60zUYhB
+22zMPhdzzCPnzZjzFnLdzsZg3HMXee/FvffjPvAg7n8IMAaxBx8nQk9Q+Cmx
+kIgsougSii0TK4k4eJZIgFWUfI5SLygvE2nwKg4yr3NG3hBv0ejb2Oi7nLH3
+WVH0Y3Q866fImgnwc5gSQr+AICVA8RM+ipfiAeO/uIlcA45hAGYb0D5KNeAI
+1YAZ0oDp98CQIi9Ck2+1CSoDY6+V0bUMfIEZGFwVBzADhZiBS1z3AmagofU3
+b6SzPxya3xdpFiSbOOH4xOMv/cnSo7eORpcgPXrrcHQJ0qP3l+3jB6L5G7YU
+frW1+Kttv/kpUWvxv2pzMbiXxOA+EoP7SQwe+G0MbsQY7M7F4BGMwS3H+red
+GNhxanDnmaHd55h7Lwzvy2MduMw+dIVz+Br3aAHvWBH/RDH/ZKngdJnwTAXE
+oOj8dfGFaklejfRSnfRyvexqo/xakyK/RVHYqixqVxV3qEq71GXdmvJeTWUf
+xKD2+oDuxqCueojEIMtQxzY2cIwYg3xTs8DcIjRjDEos7VJrh8zaKYcYtHWr
+7D1qe6/G0ad1MHSOfr1zwOAcNDpJDLpIDLpZNjeJQQ/X6SEx6BV4vCQGfSK/
+j8SgXxryS8MBWSQgjwYUMQAxGFQlgupkEGMwHdKCTIjEYFg/FjaMh43jYRKD
+EfNUxAKmIxiDs1HbXNQO5qOOmzkkBpH7Tsx9N+YB92Le+8j3IEZiMB54FA88
+jgfBk3gIPI2HwUI8vBiPgKV4FCzHY2AFxZ+hxCrxPJ4EL1AKvASx9CvidSyT
+9QaNgLfRrNF3lPcRMJb1Iwhnjf+UFUI/gyAlQPGP/5LlI7wUz/iHAHSP/eJC
+PztJADpGMQBJA2IAZhvQksk1oCnXgCQDk1QGxj/KwMhLefiPMnCR43qqs9h+
+k4FtDE62BMuGYk28eCMrGBuj/5EgPXp/3egSpEdvHY4uQXr0/srlb/gm+0AU
+YjD7RrTkH78bg3v+NAYPQgx2bDyUjcGuTYc/xODmo4wtx/u3nRzYcXpw19mh
+PeeZey8O77/EOniFfega50g+92gh93gx70QJ/1SZ4HS58Eyl8FyV6PwN8cUa
+SV6t5FK99EqD7GqT7FqzvKBVUdimLOpQlnSqSrvVZT3qCohBhqaqH2JQe2NI
+V83U1QzrIQbrOYYGrrGRZ8QYFJpaROZWsZnEoKVDbu1UWLuUEIM2EoP2Pq2d
+xKBjwOgYNDmHzE6mxcW0uoZtLpbdzXa4OU431+XhuT18j4fv9Qp8XqHfKwr4
+xEGfJOgjMeiXRfzyqB9jMB5QJgKqJIAYDGrSQU0mqB2BGAzpR0P6sZBhPGSc
+CAPTZNg8FTZPhy0zEIMR62zENofs8xHHTeIWxGDUeTvquoPcd6Pue1HPvaj3
+ftT7IAox6HsIPRjzP4oFHqPgExR6GgstxMJgEUWWUHSZWInFwLNYHKyixPOc
+5AviZTQFXqE0eE28iWZQJPMWjYB3WWEw+n5NaPRHNJb1U5ASyPnZT/FRvISH
+4iZcWaM/O0cxAHMNOPKTjbBmIABzDWhOkwZMfdyA73SJt9r4G8zA2GtV9KMM
+DL2QBp9LApiBwtyj0CUeZuCCzmL/TQZm/3lgrgQHo02cSAPT/6U/Vnr01tfo
+EqRHbx2OLkF69P7KMfOL1x6I5m/YUrBha9FX2xgHN/7mf4ypGNxLYnAficH9
+JAYPkBg8CDHY/ocxeIyx9WT/9tMDO88O7j4/tOcic1/e8IHLrINX2YfzOUcK
+OMeKuMdLeCdL+afK+acrBGerhOeui85Xiy7WiPPqJJcbpFcapVebZfkt8oI2
+RWG7orhTWdIFMagq61VX9KkxBgc01wchBrUYgyx9LVuPMcgzNPKNTQIjxqDY
+1Coxt0nN7TKIQUun0tqlsnarbT0aW6/W1qezM/T2foOdxKCDxKCTaXWSGHSx
+HS4Sg26e201i0CPweUgMesVBryTkk4R90ohPFsUYlMf8irhfmfArIQZTAXUq
+oEkHSAwGdaNB3VgwG4OGiZBxMmSaAtkYDFtmw1YwF7bNh+1ZGIPIeTvivBNx
+3Ym470bc9yIeQGIQe/Bh1Pco6gePowHwJBp8ikILxGI0DJaiEbCMoiso9oxY
+jcbBc5QAL1DyZQS9iqSyXqM0eBPOyrylvAuBkaz3IJg1+iMIfPCTn+KjeAnP
+6M9ZboprNBeA2IAjPwE7gQ2YwQa0Zn60pDEAsQFT2ICYgUlsQH2CNGD2FBh7
+o8IMfKWMvFKEMQOloReS4HNxYFXkfyb0rQi8y3zPH2agV9VQ0B9bK8FqVpQc
+BB9+6Y+VHr31NboE6dFbh6NLkB69v3JP5ubI78Zsyp4F8zdsLfxqW/FX2/sP
+bvo/xeD+34nB7w5lY7Bz4+GujRiD3ZuO9P5wrG/LCca2U/3bzwzsPDe4+8LQ
+3jzm/svDB66wDl1jHy5gHy3kHCvmHi/lnSzjnargn6kUnL0uPHdDeKFGdLFW
+nFcPMSi50iS9BjHYKitokxd1kBjsVpb2qMp7VRUMdWW/GmNwSHODqa0e1taw
+dHUcfT1XT2LQ0CQ0NouMJAZNbTJzu9zcoYAYtJAYtPZorCQGbRiDRvuAyT5o
+dgxZHENWB9PmHLY7WQ4n2+niuFxct4vncfO8br7PI/B7hAFPNgbFIa8k7CUx
+6JPFfPK4T5HIxqBflfKr0351BmIwoB0JaEcDGIPjyDARNE4GjRCD0yEzmAlZ
+ZkNWMBeyzYOw7SbEYNh+K+y4HXaCO2HXXeS+F3bfhxiMeB5EvOBhxPcI+R+j
+wJNI4GkkCBYiIbCIwksoskysRKLgGYqtojh4jhIvQDjxMpzMeoVS4DUIpd6g
+dNZbEASZd2sCmfdoBPlHflzjo3hHfgIeipviIpwUbMDMT3bChn60plGuAVNU
+AyY/bcA4OQXGSAZGX2MDRl7Jwy9zp8BPMnBlLQP1FsdvM1Dd2KmZX8tA0MiJ
+0gdBevT++tElSI/eOhxdgvTo/cUjvxuzVoJb8slZsOQffxSDe0kM7vsoBg+Q
+GDzYRmRjsIOKQTwOfn+0Z/Px3i0nGdtO9+84O7Dr/OCei0N7LzH3Xxk+eG34
+UD7rSCH7aBHnWAn3RCn3ZDnvdCX/TJXg7A3B+WrhhVrRxTrxpQbx5UbJ1Wbp
+tRZpfpussF1e1Ckv7lJgDPYqy/sgBlWVA+qqQTXG4LCmmqWtZWvrOLp6nr6B
+r28UQAwamsXGFomxVQoxaMIYVJo7VZYutaVbY+nRWnt11j69jWGw9RttJAbt
+QxY7iUHHsN1BYtBJxaCLxKBb4HdjDAY9opBHHPZIIhCDXmnUK4t5SQz6FEmf
+MuVTAYxBv2bErxn1kxgM6MYD+omAAWAMBk3TQdNM0DwTtMwGLXNBKwpZoQdv
+IvutkOM2ct4JOe+GXABjEHkehD0Pw17wKOwDj8P+JyjwFAUXiMVwCCyFw2AZ
+RVZQ9FlObJV4Ho6DFyGQAC+JV6Fk1usgSIE3WYHUW5TOeudfk3kPfB/xZn4E
+Hoqb4qI4CQfFDtI/2ohcA6aQOfUeGtCUzDWgIUEaMP5Whw34NtuA6ujrXAaG
+X8lDVAYGnov9qyLfh2sg/ttA5+9koE/d2KW52aGa+6QEWSGpcfRLf6b06K27
+0SVIj946HF2C9Oj9xaN+N+Z7EoNYggUbthV9tb3kHztMRf/80xjcT2LwAInB
+g60AY/AQxGA7xuDhTqJr05Hu74/1bD7Ru/VU3/YzjJ3nBnZdGNyTN7TvMvPA
+VSbGYAHrSBH7aDH7eCnnRBn3ZAXEIO/Mdf65asH5GuGFOmFevehSo/hyk+Rq
+i+Raq7SgXVbYISvqkhd3K0p6FGUQgwxlRT/EoKpqSH2dqSYxqKnlaOu42nqe
+DmNQqG8SQQwaMAZlxja5qV1h6lCaOlXmLrWZxKClV2fp01sZBmu/yTZgtg1a
+bINW+5DNzrTbhx0OltPBdjk5bifX4+R6XTyfi+93kRh0i4JuUchNYtAjiXqk
+MQ+JQa884VUkvcqUV5WGGPSpMz71iA9jcMyvA+N+/YTfMBkwTAWMYDpgmgmY
+wWzAMgeClvmgdT5ouxm03Qrawe2g4w5y3g0670EMhlz3Q27wIOR5iLyPkO9x
+yPck5AdPQwGwgIKLKLRELIfCYCUUAc9QFKyi2HMQjL0IxrNeogR4BQIg+Zry
+xg9S4G2WD71DaeRF74GH4qa40j9mOQkHxZ6mAjCFrIQl9R6YkxiA2IAJDEBs
+wDjVgDFsQE2UNGAEKcPkRShkYPCFNPBRBnpXBJ5lnnuJ68IMDBvaPsvApi7N
+rQ7VfAUrvZaB13qCDcxALHP/S3+m9Oitu9ElSI/eOhxdgvTo/cUjD0S/oUow
+dxbMvhEt/f0Y/B8Sg/s+j8GWj2MQj4OHSQ8e6dp0tPuH4z1bTvZuO923/Sxj
+5/n+3RcH9l4a3Hdl6MA15sH84cOFrCPFrGMl7ONlnBPl3FOV3NNVvLM3SAzW
+Ci7WC/MaRJeaxFeaxVdbJdfapAUd0sJOiEFZcY+8tFdR1qfAGBxQVg5CDKqu
+D6tvsNQ1bIhBTR1PW8/XNgh0GINifbPE0CI1kBg0tiuNHSpTp9rUpTF3a809
+OnOv3tJnsDCMEIPWAbN1AGPQNmSzkRi0kxh0cNwODsagk+dzYgwGXMKgSxhy
+icIQg25JxC2JujEG4x5ZwiNPehRJD8SgMu1VZbxqgDHo0475tOM+3bgPYlA/
+6TdM+Y3TyDTjN836zShghh6cD1jBzYDtFrLfDtjvBBwAYxC57gddD4Ju8DDo
+AY+CXvA46HuC/E9RYIFYDAbBEgoto/BKTuQZsRqMgucBEAMviJeBOPLHX6EE
+eJ3lA8k3a7zJtyiFPKl3a9w5710UJ8VB2Ck2wpqVfG8hcg2YeGckDHFowLdA
+F4MGfKONft6ArxShl/IglYH+52JfLgP5/6cM7Nbc7lTfbFPMlg+n1kqwlBGq
+Zzi/9DdKj956HF2C9Oitw9ElSI/eXz9mftHHvxsDJZi/YVvhV9uL/7Gj9B87
+P4/B8a7/zTmyhcTgfhKDB7Ix2JyLwUNtRPt3h6kYPNr1/bHuH070bDnVu+1M
+345zjF0X+vfkDey9PLj/KsbgoQLm4aJhjMFS9vFyzskKzqkq7pnrvLPV/HM1
+/At1JAYbhZebRFdaMAbz2yUYg13Som6IQVlpn7yMoSjvV2AMDimrmBCDKoxB
+jrqWCzGowRgUahtFuiaxrlmib5EZWuWGNoWBxKCRxKCpW2siMWgmMWjpN1n6
+MQatg1brkN3GdNiGnTaWy852A4hBB9frIDHoFAScgqCTxKBLHHGJoy4Sg25p
+3C1LuOVJtyLlAcq0R5XxqEa86lGvBox5teNe3YQP6Cd9himfYdpnBDM+0ywg
+STjnt8z7LTf9VnDLb7uNIAaxB+8GHPcCznsB1/2A60HADR4GPOBRwPM44AVP
+Aj7wNOAHCyiwSCwFgmA5EAIrKAyeociqPyv6nHiBYuClLyv+ivLaCxJZb4An
+560n+db9wTsXxUlxEHb0Htgo1iQVgIl3Zgo2YBwZIABjCBswSjVg5DVQhbEB
+laGPG/AFNiCeAleF3mcCzwrfvcxzLXGdi2zHQlj/exmoxQxsV861yKbz+6If
+SrCXPgjSo/dlRpcgPXrrcHQJ0qP314/63ZhPzoIFG7YXfbWj5B87IQYHDn3/
+m/95BraS//kkBrEHD+Zi8NtDrVQMkh480rnpWNf3J7o3n+rZeqZ3+7m+HRcY
+u/L691wa2HtlcP+1wQP5Q4cKmYeLh4+WsI6VsU5UsE9Wck5d5565wT1bwztf
+y79QL7jYILjUJLzcLLrSKr7WJs7vkBR0SjAGe6QlvdkYlJcPKCoGFRiDw8rr
+LNUNtgpjkKeu42vqBRqMQbG2SaJrlupaZPpWuZ7EoIHEoLFLa+zWmXr0pl6D
+qc9o7jOZGWZLv8UyYLUM2iAGrUyHlcSgjeW2sT12jtfO9Tl4fgc/4OAHHSQG
+naKwUxRxYgzGXJK4Sxp3yRIuiEF5yq1Iu5UAY9CjHvWoxzyaMQ/EoHbCq5v0
+6sGU1zDtNcx4jYj04JzPDOZ9lpvIestnve3DHrzjt9/1O8A9vxPc97seIPdD
+4pHf8xh5nyDfU2LB7weLKLCEgss5oRXimS+cteqLgOc50RfAi156Y1mvPFnx
+11lu9CYn8caF3mY5KQ70zk6xUayEhWKOIxNBGvCtIUY1IAlAbMAIacAwNqDq
+owbEDAxQGehbFXk/yUAOycA59ZHPMrC5W3unS32rXTnfKptpkUx9/I8E6/uc
+0dSdL/2B0qO3HkeXID1663B0CdKj90VG/pzEJ78bk79hW8FX24tzMbir7J+7
+xrr+1+/F4H4SgwcaCSoGD7XkYvBwG8bgkY6NRzs2He/84WT3ltM9W8/2bj/f
+t/MiY3ceY8/l/n1XByAGDxYMHSqCGGQeLR0+Vk5isIpz+gbnTDX3XC3vfB3/
+QgM/r1FwqVl4uUV4tU10rR1iUFzQJSnslmAM9klLGbKyfohBecWQopKpIDGo
+rOaoargqEoPqeqGmQaQhMahtlula5LpWhb5NqW9X6TvUhk6NgcSgsUdvhBjs
+NZpIDJr7LWYSg5Yhu4XEoHXYZSUxaON4bVyfnee38wJ2ftAuCDmEYSSKOMRR
+pzjmlMSd0oRTlnQBecqlSLsUGYhBt2rErRp1q8fcmnEP0E54dJMe3ZRHD6Y9
+hhlPrgdnvaY5ZJ73mm96LeCW13rbiz14x2e/ixz3kPO+z/nA5wIPkfsR8jz2
+eZ74vOAp8i0Qiz4/WPIFspZ9QbDiBSHwDIVXKc+9kece9AJFwUvgRq9QDLli
+r9c4428+5kBv7RQbxUqxEGbCFMsxEtCAhuhbffQNNKAu8kYbgQZ8rQlTDRgi
+DRh8CeSBXANK/c8lPioDPc8E7hW+a5nrXOI4FvVmx+cZqNCaejADb3dABspn
+W6RTNdyRj0uwttPypT9NevTW6egSpEdvHY4uQXr0vsg+/d2YbAxuy9+wvfCr
+HcVf7VyLQXPRv/4kBkkPHszGYDMVg63ZGNx4tH3jsY5NJzp/ONW15Uz3tnO9
+Oy707szr232JsedK/75rA/vzBw8WDh4qHjpSwjxaNny8gnWiknXyOhtjsIZ7
+ro57vp53sZGf1yS41CK40kpisEOU3wkxKC7skRT1SkgMSssGZOWDEIPyymFF
+FUtxnQ0xqKzhqWr5qjoBxKC6QaxplGiapBCDWhKDujaljsSgnsSgoVtn6DYY
+e4zGXpOxz2xiWEz9VvOAzTxoNw85LENOC9NlGXZbWR4r22vl+CAGbVy/jRew
+QQzyQ3ZB2C6M2EVRBxDHHJK4A2JQmnTKUk45SDsVGZdyBKlGXRCD6nG3ZsKt
+BZNu3RTST7tzPTjrMYI5j2kemW96zLc8FnDbgz14x2u767WDe17HfeR8QDz0
+usAjrxs89nrAE+R9Six4fWDR6wdLKLDsQSueYNYzTyhrFYWfu3NeoAhyRV7m
+RF85P3gNHCCW9cZOsVGsOW8thJmCARh9a0RvDISegAAkDYgBmGvA0CtswOAn
+DSjzrzXgc7F3VeR5BhnId6/wPsrA3/x3O6M8pNCae7R3uzS3O1Q32+RzLdLp
+ZvFk2VBiLQNLur3RJH0QpEfvy4wuQXr01uHoEqRH70vt8z8n8WkM7iIxuPv3
+YvBriMG6rw/Ur8Ug9uChbAy2fHuYxOARKMH2Tcc7vj/Zufl019az3dvP9+y4
+2LsLYvAyY+9Vxr5r/fsLBg4WkRgsZR4tZx6vGD5RxTp1g326mnO2loMx2EBi
+sJmPMdgmuNouxBjsEhV0QwyKi/skJQxJaT/EoLR8SFbBhBiUQwze4CiquRCD
+SoxBoapeBDGoJjGoaZZrWhTaVqW2TaVrV+s6NLpOrb5Tp+/SQwwaeowGEoNG
+EoOmAZsJYnDQYR5ymkkMWlgeC8Qg22fl+K3cgJUXtAF+yCYI2yAGhVG7KGYX
+x+0Qg5KEQ5p0yFKIxKBTMeJUjjpVYMylHndpJpB20qWdcumms9z6GbdhFhnn
+3MZ5twncdJtvIYhB7ME7Hutdj+2ux37PY7+PHA+Q8yFyPSIee9zgiccDniLv
+AvItEktuP1hGAbCCgs8oq+7Qqgs9zwm/cH7w0hl56ch5lWUH0ddZNooVvQEW
+wkwxEcZIjoHQE7rIa134tZYEoCb0Wh16BVRBbEAlNGAAG1DuJw3owwaUeLMN
+uHYKXOE5l7mOJY59Maxv/zwD+/T3e3T3ujR3OlS3SAbONIunmoXjZYPxtRIs
+7nR96Y+SHr31O7oE6dFbh6NLkB69LzVyFtz40VkwV4IFG3YUfrXzz2MQcI5s
+xRj8GmLwYCPxWQwebdt4vH3TiY4fTnVuPtO19Vz39gs9O/J6d13q3X2lb+81
+xr78/gOFAweLBw+XDB4pGzpWwTxeOXziOsQg63QN+2wd51w990Ij92ITL6+F
+f7mVjzHYIbjWKcQY7BEV9kIMijEGByRlgxCD0ophWSVLXsWWYwzyFDV8Za1A
+SWJQ1SBRN0rVTTI1iUENiUFtu1oLMdih1ZEY1Hcb9CQGDX1mA8Ni7LcaIQYH
+7KZBh4nEoHnYbYYYZHktbJ+F47dADHKDVl7Iyg9ZIQYFEZswahPFbKK4TZyw
+SxJ2adIuTdllaYhBhzzjUIw4lKMO5RjEoFM97lRPODWTSDtFTDuhB/UzLv2s
+ywDmXMZ5ZLrpMt1ymcFtt+UOst5Ftntu2323HTxwO8BDtxM8Qq7HyP2EeOr2
+gAXkXXQB31KOf5lYQQHwDDiDYJXy3Bl67kAv1tjDL9fYwq9yIsiKXgMLYaaY
+KEYQfm0g9ISOog0hDQlAdTDbgC+VAdKA/g8NKP2oAfEU6P4kA/Vm5+cvQv2a
+ll7d/R7tvW7NnU7IQMV8i3S2WTLVLJpoEox+/DSUPgjSo/cFR5cgPXrrcHQJ
+0qP3BcfML/3dsyAVg7tIDO6GGBw8tHms63//3nEQY7D+m4PZHmz6BmOwOReD
+R1s3HmvbeKJ906mOH850bjnXte189/aL3TvyenZd7t19lcRgAeNAUf/B4oHD
+pYNHykkMVjFP3hg+Vc06UwsxyD7XwMEYbIYY5F1u419p52MMdgnzu4UQg0W9
+omKGuKRfjDE4JClnQgxKK1myKo78BldOYlBRK1TWiZT1YohBVaNURWJQjTGo
+0rSpNO0abbtW26HTdup1XQZdt1HfY9L3mvV9FgPDamDYDP1244DDOOg0DblM
+TLdp2GMa9ppZPjPbZ+b4zZyAhRu08EIWftjCj1gFEaswahXGrCQGbZIkIjFo
+l2Xs8oxdMWJXYAw6VONIPeFQTzo0WVMOEoNO3YxTP4sMc07DvNMIbjpNt5D5
+tst8x2UBd11WcM9lu4/sD5DjIfHI5QSPXS7wBLmfEgtOT9ai0wuWkG85x7+S
+5fA/cwSyVoE9CJ6vsQVf2EJrXlrXhF9awq+yzBQTxUgYQq+BHr0COkILgq80
+hJpQBV4CbEA/eIEN6CMN6CUN6FkFIjdpQBc2IB8bcJljX/r8FIgZqF7LwLud
+qtvtipstsrlmyXSzaLJJMFbNSn5cgl/6c6RHb12PLkF69Nbh6BKkR+8L7tOz
+4IcSzN+w4zcxWP7PPRX/3GMu/p/fjcG6DzF4CJDj4OGW7460fHesdePxtk0n
+278/3bH5bMeWc53bLnRtz+veealn15XePdd69+b37S9kHCjuP1QycLhs4GjF
+4LHKoePXSQzWDJ+pY52tZ59v5Fxo4lxs4ea1QgzyrnTwr3byr3UJ8nuEBb3C
+oj6IQVHJgLh0UExiUFLBklaypVUcGcYgX14jgBhUkBhUNkiVjTJVk1zVrFC1
+KNWtKnWrWtOm0bRrNSQGtSQGdT0mHYlBfZ9VT2LQMOAwDDqNQy4j021kYgya
+WD4T229iByAGzdygmRcy8zAGLYKoRRCzkBi0ihNWcdIqSVmlKZs0bZNlbPIR
+pBi1K8fsynG7CkzY1ZM5mim7dhp60KGbcehmHXow5zDMI+NNh/GWwwRuO813
+kOUust5DtvtO2wOnHTxEjkfI+Zh44nQ9cbieIjdYQJ5FYsnhzVp2+MCKPcsP
+nmXZ/Ku2QNZzYM0KvgCWD14CcyjHlPPKSBiCOXpCR2iDVAAGwEs1gQ3of6kk
+AajwvZD7sAFlXtKAnk8aUOhawQx0rvAc2RehS5+fAmeUhxVaC2ag5l6XOpeB
+rZiBMyQDx5t4I6X9H/5+hDP99Et/jvTorevRJUiP3jocXYL06H3ZMfPLyFnw
++9+cBUkM7qRicPefxCDVgwfrv8YYbPgoBpu/O9ry3fHWjSdaN51q++FM++Zz
+HVvOd267SGLwcveuqz0YgwV9+4sgBhmHSvsPl5MYrBo6cWPoZDXzdC2JwQaI
+QfaFZohBTl4r93I7xCAPY7Cbn98jwBhkCIv7IQZFpUPiMqa4fBhiUFLJkV7n
+Sm/wZNV8WY1QXiuS14kV9RIFiUFlk1wJMdisVLVgDKrbNGoSg5pOvabLqO02
+aXvMuh6Lrteq67PpGXZ9v0M/4DQMutAQxqBx2Gsc9hlZGIMmThBxMQbN/IiZ
+HzULYmZh3AJECYs4aYEYxB5MW2UZq2zEKh+FGLQpxmzKcaSaICZt6imkmbZr
+Z5Bu1q6bs+vBvN0AbtqNt5DptsN0x2EGdx0WcM9hBfcdNvAA2R8SjxwO8Nju
+BE+Q6ymxYHeDReQBS8i7DGxoxebLsfqeIT9YBZac55YAMqMXWaasIHhpBIGX
+Boqe0BFaioZQ+5Eq54WSBGCuAb3PsQE90ICrQOzGBhS5SAM61xpwmWtfivze
+KRAysE/3oFf7cQbeapXNkwycahJMNPFHG7npj0vw0cpPX/pbpEdvXY8uQXr0
+1uHoEqRH78vuT86CVAzuomJwD4nBvX8Sg9iDazH4zeGmb480f3esZeOJlo0n
+WzedbvvhLMbg1gsd2/I6d1zq2nmle/e1nj35vfsKe/cX9x0sYRwq6z9cMXC0
+cuDY9UGMwRoSg/XD5xpZ55sgBtkXWzl5bZxL7dwrnbyrXTyMwV5+QZ8AY3BA
+WDIIMSjCGGSJK9gQgxKMQb60WgAxKCMxKCcxqGiUKxoVyialslmlalGrWjWq
+Nq26Xafu0Ks7DRCDmi6Tptus7bFoSQzqGHYdiUH9gEs/6NYPeQxMLxr2GVh+
+IztgZAeNnJCRGzbxQMTEj5ogBgVxszBhFoGkWZyySNIWKchYSAwixZhVMW5V
+TuSoJq2qKSuJQZtmxqYFszbdHNLPI8NNm+GWzQhuQw/aTXfs5rvIco+4b7eC
+B3YbeGgD9kfI8Zh4YnOCp8gFFpB7kViyeZasaDnHuwIsOc8sPmRGq1kmP3i+
+xoheAANFT+goWkJDqIHvhYqiJLABvS/kJABlHqoB3aQBXaQBnaQBHWCZZ8cG
+NJhcn58Csy9CsxnYDRmoutOhxAxswwycbRZNNwkhA8cauZlGdop+GkqP3t9n
+dAnSo7cOR5cgPXpffH9yFszfsJOKwd0fx2Dlv/ZZfr8HvyHHwUPZGGz89kjT
+t0ebvzsOJdiy6VTrpjMQg22bz7dvvUhi8HLXzqsQg917Cnr2FZEYLGUcKmcc
+qeg/WjVwHGKweuhk7dDpOuaZBojB4fPNrAstEIPsvHbOpQ7OlU7u1W7etR4e
+iUF+Ub+geEBQMigsZYrKhkUYgxxxJVdynSchMSitEclqxbI6iaxOKq+XyRsw
+BhVNSkWzStmiVpIYVLXrVBCDHQZ1p1FNYlDTY9H0WrV9Ni2JQV2/Uzfg0pEY
+1A959UyfnsSggRUwsIMGiEFO2MiNGHkRI8QgP2YSxE3ChEmYNJEYNIvTZknG
+LAUjFtmoRQ7GLIpxYsKiBJMW1ZQFe3DaqplB2lmrds6qA/NWPbhpNdxCxtvQ
+gzbTHZvprs0M7iHLfWC1PiAeWm3gEbI/Ro4nOc6nxILVlbVoAe4lyrLFs2xG
+KzneFZP32UdWjcCXY/A9X6MndBQteqEh1Fne5ypCSSiyPM/lBDagexVgA7qe
+AZEz14ACaEA7aUDbEse2FNb9/ilQqbH2aR/0aO53q6kMlOM1sEUy1yyebhZO
+NvHHG7kjkIGljAj9NJQevb/P6BKkR28dji5BevS++J7M3SRnwU2fnQXXYnAX
+FYN7SAzuxRj8577fPQ5OdP3f9pJvIAbrv4EePNz47dGm7441fXeieeOplk2n
+W74/2/rDubYtF9q35nVsv9Sx40rnrmtdu/O79xb27CvuPVDSe7CsD2Owsv/o
+9YHjNwZO1Ayeghishxhknm2CGBy+0MK62AYxyMYY7OJc7eZiDPbxChj8wn5+
+8aCgZEhQyhSWsUTlbBGJQfF1vuSGQFIthBiU1oiltRiDMhKD8kaFnMSggsSg
+sk2nbNer2g2qDqOq06TuMqu7Leoeq6bXpumza/ocWoZT2+/UkhjUDXp0Q14d
+xCDTrx8O6FkBPcQgO2TghA3ciIEXBUZ+zCiIGwUJI4lBkyhlEqdNkgySjphl
+o2bZmFmeNW5WTCDlpFk5ZcYenLaoZywaMGvRziHdPNLftOhvWQzgtsV422q8
+YzWBuxbTPYsZ3LdYwANkfUg8stiyHlvs4AlyPM1xLpjRotmVtYTcSyb38kdW
+jJ41zwxrvM/03tU1OorW+xxoKGpC5clREgq0KgfuVRmRa0ASgGIn1YCOTxvQ
+umQwOedUv3MKDKhbGbqHvVQGdirvdChut0EGSuebMQNnmoVTkIFN3NFGTrph
+OFHaG6JLkB69v8/oEqRHbx2OLkF69P4O++wsuO3jN6JUDO7+NAb3AXIc/Prz
+/y2343EwG4NHGr891vjd8aaNJyEGmzedafn+XOsP59u2XGzbmte+/XLHjqsk
+Bgu69xZ17yvuOVDae7C873AF40gV49j1/uPVAydqB0/VDZ5uGDrTCDHIPN8y
+fKF1+GIbK6+DfamTjTHYw7nWy83v4xb08woHIAb5GIPDgjKWsJwtrOCKKnni
+Kr74ukB8QyipFkkwBqXSOpm0Xi5rUMgalfImlbxZLW/RKFq1CojBNr2y3aAk
+MajqMqtIDKp7bepejEENw6npd2n63doBt3bQox3yaod8OqZfNxzQsYJAzw7p
+OWE9J6LnQgzGDHwQNwgSBmHSKEwZRSmjOG0UZ4wSMGKSjppkYznycZN8wqQA
+kybllEkFPThtVs2Y1TNmzaxZM2fWgnmzDtw0628hw23ijtkI7ppN4B4y30eW
+B8RDsxU8QrbHxBOzPeupyQEWkBMsZhmdS0bXmmVDlnsF6D94psvyIC1aBRqK
+mlABN1ISCkJOyFxZz6SEhAQgacAVoQMJ7MvYgDZsQO4fN+AsdQrs1dzvwVPg
+3VwGym5iBornmkXZDJxo4kEGZhpYyYahKP00lB69v9XoEqRHbx2OLkF69P4O
++/QsuPnzs+BnMbi37J97y/80BrM9WP/N4YZvjjZ8e7zxuxNNG081bTzdvOks
+xGDL5gutW/Latl1q336lY+e1jl35nXsKu/YWd+8r6TlQBjHYe7iy78h1xrEb
+/cdr+k/WDpyqhxgcPNM4dLYZYpB5oW34YvtwXgcLYvByN5vEICefATHILRzg
+FQ3xS5h8EoOCcg7EoLCSJ6riizAGReJqsbhGIqmVSkgMSkkMyppUMhKD8hat
+vFWnaNMrSAwqO01KEoOqbquqB2NQ3edQM5xqBsagZsCjGfQCiEEt068dDmiH
+IQZDOjYI6zgRHTeq58b0vLieH9dDDAqSBmHKIAJpgzhjEI9ADBqlo8SYUQbG
+jfIJpJg0KqaM0IPKaZNqBqlnkWbOpJk3acFNk+4W0t9GhjvIeJe4ZzKB+8j8
+AFkeEo9M1qzHJttjo+0JsoOnxILRgQyOxRwnWNLnLAOda80K0FI0wP0sS02o
+XDlKQkHIKVB/MuczKSEhxM4VsWNFRAjtpAFt0IBLPCtpQOPvNyBQaa0M3cNP
+MlBxp12OGdgiWcvA6Sb+ZBNvrJEz0sBKNQzFSnrogyA9en+v0SVIj946HF2C
+9Oj9TUbOghv/5CyYv2EXFYN7fhuD/9xf+a/9f9yD39Z/e6zh2xON351sxBg8
+07TpbPP351s2XyQxeLlt+9V2jMGCzj1FEINd+0u7D5T3HKroPVwFMdh3rJoB
+MXiirv9U/cDpxsEzTYNnm4fOtw5daGNiDHYOX+piXe5mXe1lX+uDGOQUDHAL
+B7lFQzyMQRa/jA0xKMAY5AurBMLrQtENkYjEoJjEoKReLmlQSBuV0kaVrEkt
+a9bKWnTyVr28zSBvNyo6TIpOs7LTouyyKrttqh67qteu6nOo+pwqhkvd71b3
+e9QDXvWgTzME/BpmQDMc1LJCWlZYyw5rIQY5UR03puPFdbyEjp/QC5J6YQqJ
+0npRRi8eMWRJRg3SMSQbN8gmDHIwaVBMGbAHp43KGaMKzBrVYM6omUfam0h3
+y6i7bdSDO8hwFxnvEfeNJvAAmcFDowU8AgbrY8oTgw08RfanevvCRxZ1jqyl
+LC1wLmdpclaAmqKiKAkFRU7ICKkDSSgQgGL7iogQ2pcFNmxAvpU0oGXxTxpw
+Vnm4X/eIoX3Yp3nQq77frbrXpbzbARkou90qzWbgLGRgE2SgADJwHDKwkZVu
+GIrXD4SvdtEHQXr0/l6jS5AevXU4ugTp0fubjJwFv/vzsyCJwd0Qg0UYg3sx
+Bv+xD2KQ9OCfxSD2YOnG+m9PNHx3qnHj6caNZ5s2nWv6/kLz5ostWy61brvS
+tuNa+878jl2FHXuKOveWdO0vIzFY2XP4eu/RG33HahjHaxkYgw39pxsHMAZb
+Bs9BDLYPXexgkhgcvtwDMci61sfO74cY5GAMMrnFw7xSFq+MzS/n8it4gkq+
+gMSgkMSgqEYiqpGKa+XiOoWkXilpUEka1dImjZTEoKxVLyMxKG83yTvMik6L
+osuq6LYpe+zKHoey15mNQRXDrer3qEgMqgf96iG/GmKQGdQMhzSssIYdAVpO
+VMuNablxLYlBHT+pE6R0wjQSZXSiEQBJqBeP6iVjeikY18smkHxSL5/SYw9O
+G5QzSDWL1HMG9bxBA24atOCWQQduI/0dZLhL3DMYwX1kegD0pod6c9YjvQU8
+RlbwhHiqs61Z0GbZF7M0aClL7chaBqqPKNGKgiInZAQGoB1J0LKYEAHbspAQ
+kADEBrSQBjT8WQOqNFZoQNCredCTzUDF3Q45ZOAtzEDxfLNotlk40yTIXgMn
+GjmjjaxMAzNRPxCp6wvSB0F69P5uo0uQHr11OLoE6dH7+4yZX/onf1EiW4JU
+DO7JxiDpwX1lGIP7MQaxBw/84XGwdKO9dFP9d6caNp6BGGzcdJ7EYF7Llsut
+265CDLbtLGjfXdSxp7hzX2nX/vKugxXdh6pIDFb3HqvpO17HOFHPwBhs6j/T
+PIAx2DZIYnAor4t5qRticPhKH+sag5Xfzy4Y5BQOcUgMckvZvDIOj8Qgv5LP
+rxQIqoSC62LhDYmwWiqqkYlq5aI6hbheKSYxKGnSSJq10hadFGKw1SBrM8pI
+DMo7LXISg4puu6LHoeh1KvtciOFWQgz2e1UDPtWgXzUUAGpmUD0cUrPCahbE
+YFTDATENN67hJbS8pJaf1ApSWkFaKwQZRHpQJx7Vicd0kjGddFwnndDJwKRO
+PoUU03qgnNErZ/UqMKdXg3m95iZxS68Ft/U6cAfp7xL39IZ7OsN9nTHrgc4E
+HhKPdOasxzoL0lqeICt4qslZQLYFNVrMUuUsqexLyo8o7MtZckJGkdqQhBAT
+IkJoXQICAhvQAg24yDWjiPZ3fhp0rQH7oQE12VPggx7V/W7lvU7MwNtt0lut
+kpvNJAObMAOnSAaON3LGGtmQgcn6gWgdI1TS5adLkB69v9voEqRHbx2OLkF6
+9P4+I39b8DdnwU/+ogQVg7vXYrD4q9/GIDkOHqjCHvzmD3pwk730e4jBho3n
+IAYbv7/YtPlS89bLLduutu7Ib9tZSGKwpGNfWSfGYCWJwRs9GIO1vcfr+jAG
+GxkYgy39Z1sHSAwOXuyEGBy61M283AsxOIwxOMAqGGQXDrGLhjnFLG4Jm1vK
+4ZZxeeU8XoWAXynkV4kgBgU3JIJqqbBGJiQxKKpXihpU4ka1GGKwSStp1kla
+9NJWg7TNKG03yTrMsk6LrNMq77LJu+3yHoe8x6nodSn63AoG8Cj7vcoBn3LA
+rxyEGAyqmCCkGg6rWBE1K6pmR9WcmBpikJvQ8JKIn9II0jnCjEY4Aj2oFY1q
+xWNIMq6VTiDZpFY2pZWDaa1iWqeY0SlnkWoOqeeJmzoNuKXT3NZpCd0dLbqr
+1YN7yHCfeKA1Zj3UmsAjoDGDx5QnakvW0ywVWlBZc5RoMUsBbGBJTpFRpMC6
+JCHEFBEhtCABWuQD8yKPBCDXtPAnDahea0B1rgFBl/JuJ54CSQaKbzaL5pqF
+s02CmSb+VBNvspGbzcCRBmaqfjBWxwjX9fjp34qhR+9vOLoE6dFbh6NLkB69
+v9X++Cz4RzG490MMYg/uJz14IBuDVf86+Ec9iElY9kPDxvMNmy40fp9HYvBK
+y7ZrrTsKWncWtu0ubt9bSmKwoutgVdeh690YgzU9GIP1vSca+k5CDDYzSAz2
+n2sfON8BMTiY1z10qWfoci/zCmP4av8wiUFWIRNikF3M4pSwOaVcbhmPW87n
+Vgh4lUJelYh/XcwnMSiokQlq5cI6pbBOJapXiRo0okatuEknbtZLWgySVqOk
+zSRtN0vbLdIOq7TTKuuyybrssm6MQXmvS97rlvd5IAYV/V5Fv08x4FcMBpSD
+QeVQUMkMKSEGhyMqVlTFjiFOXM1NqLlJNQ+k1Pw0EoCMWjgCNKJRjWhMIwbj
+GskEkk4i2ZRGPo0UM1qgnNUq55BqHqlvErc0GnAbae8QdzU6cA/pwX1keADU
+wPiQeKQ2ZT1WZZnBkyyl+WmO5akCLWTJcxaBDFiR1IIkFDEhIoTAvCgg+ATP
+tAC4RETzpw2oyTUgZiA0oBJPgV0KkoHS222SWy0kA5v+MAPj9ZCBvYHiTh99
+EKRH7284ugTp0VuHo0uQHr2/1chZ8Ns//kPzH96IQgzmb9hT8NWewq/2Yg/+
+Y1/JP/aVfhyDuR48eP1fB61/1oObGzZdbPghr3Hz5aatV5u35bdgDBa17S6B
+GGzfV95xoLITY/BG1+Hq7qM13cfqejAGG3tPNvVhDLYyzrZBDPaf7xi42AUx
+OIgx2Dd0hcG82s/MHxwuGIIYZGEMstklHHYpl1PG45AY5FYKuVUi3nUx77qE
+f0PGr5YLahSCWqWgTiWsVwtJDIqadKJmvbjFIG41iltNkjazpN0igRjssEk7
+bdIuu7TbIet2ynpcst7/l727XI8rO9e9f1AxW5JZJskCixlnMTMzM6MYLLAk
+WzIzo4zdnY6z9rvXewD7HPYeY8yapZIl2e5eSWx3Pff1/+B03LkalA+/65k1
+61LOdTnvWs27V/OetTzCoPfqiO/aiP86LnBjNHhzNHhrNHR7FHvwzljk7lj0
+Hi52v1D8wVj84Vji0VgS9Xg8hXoynn6Kyzwbzzwfz6JejOde4vKvcCOvJ0Ze
+j4+uj4++wY29Jb0bHydNvCd9GJ9EfcRN/UI3Nv0r6bexGbq/42Z/R40W+gfu
+wj9GcJ/o8rh/5udwuUL/hcoyZZjSpBQpSUpcwMVJGICz/xXF/TMy+8+bE6av
+GHAc9ZtrjDHgCG3Aj5YcZqARMTD1Rpdc1yVe6+IvdbEX2uhzbeSpNvxEE3qk
+CT5Q++6qPTdVzmtK2yrXsgoHQRjsBxxIEAYrw4EEYbAfbauZPHlGtPQsuP0z
+ogUM/o3B4C4ag7WC3RiDwj3nyHGwjsagdF/DAu/gzh48qjncrz0ySGNQX802
+nOIaT/NMZwXmGhHCoKVOasUYVNjOKxEG7c0aB8Ggs93g6jC6Ok3uLoun2+rp
+sXn7HN5+pw9j0OMf8gaGfQGWP8gOBjmhEDccIhgMC2JhQTwiTEREqag4HZVk
+YtJsTJaLyfNxxUicYDChHk9oJpLayaRuKqmbTulnUgaMwbRpLm2eT5sXMpbF
+jPUizraUtS9nHStZx6Ws83LOtZpzo9Zynit579W891redz3vv54P3BgJ3BwJ
+3hoJ3caF74yG745G7o5G75Huj8ZQD0bjD3GJR6OJx8iDY6knY6mnY2nUs7HM
+c1z2BS73ciz3aiyPej02glrHjb4hvR0bQ73Djb8nfRiboPs4NvlxdPIX3NSv
+haZ/Y/r7yAzd73R51Ow/6HK4T3RZ1AXUP1EZpjRT6sJ/oZKkxCzqn3FSjBSd
+wUVm/jkztbQ+2rDTj8TVMSMyoAcZcIwYcJQxYP4jypr7YCGnQGP6LWZgopSB
+zzYYGEAMvKf23CIMXFOYV+AgCIP9mAMJwmBlOJAgDPYDjvrbgc3fKLH1GdFT
+22KQs6uGHAdrsQf3nCtgcE8d8WC9dF+jdP/5BV7ljh4UHlsSHdceG9YdZ+mr
+OQSDfNNZoalGZK6VIAxa6uVWhMFGpa1JjTBob9E5WvXONoOzw+TqNLu6LG6M
+QbuHYNA74PYRDPqH/QEqEGAFg+xQkBMOciMhXjTERxhMhIXJsCgVEacjkkxU
+mo0SDMYUIzHlaFw1FleNJ9QTCc1kQosxmNTPJA2zKeOFlHEuZZpPmRfS5sW0
+5WLaupS2LWVsyxn7SsZxKeO8nHWuZl1rWfda1nMl57ma817L+a7nsAdv5AM3
+84Fb+eDtfAh1Jx++O0IXuTcSvY+LPRiJPRyJox6NJB6jRpNPRpNPR1OoZ6Np
+1PPRzAtc9iUu9wqXfz2aX8eNoN6MjqLe4sbekd6Pjr8fGf+Am/jI9MvIJOpX
+3BTqtzzd9N/pcrjf6bIzqH/QZQp9QqVRs4VSs/+kS6Jm/pkgxUmxmU+o6DRu
+ZvLizXHTlw3oHd9kQOfIr46RX+z5X2y5ggHNmfem9Dtj6q0+SRgYf6WLvdRG
+X2gjz7Thp9rQY02wyMDbKud1pf2KwnKJY7oEB0EY7MccSBAGK8OBBGGwH3Cr
+mRzzjOjhLz4jWpAgHetvZ9k0BncxGNxdwKCogMEGCcZgk3R/8wKvaicIoJbE
+J3Qn2Lpqjv4Uz3BaYMQYFJtqJeY6GcKgpUFhbVTZzqttzVqEQXur3tFmRBh0
+YgxaXd02N8Jgr9PT70IY9A56fEM+37DfTwX8rGCAHQpgDEaDvFiQHw8JEiGC
+wbA4HZZkItJsRJaLyvJR+UhUMRZTjsVU43H1ZFwzFddOJ3QzCf0sKmm4kDTO
+JU3zSdNCyryYslxMWZdS2IPLaftK2n4p7bicca5mXGs495Ws52rWcy3rvZ5F
+HvTfyPlv5gK3coHbueDtXOhOLnQXF76bD9/LR+7jog/y0Yf52MN8/BEu8Tif
+eJJPPhlJPh1JPcOln+MyL0YyL0eyqFe43Gtcfp30ZmQE9RaVH31XaOw96UN+
+HPURN4H6BZVDTf7K9BsqO4X6O10G9ztu+vd0oX+gUiUlpz/RJUhxUoyEATj1
+j8jUP2YmFr8AQNS1UQM24Nhv2ICjqKIBP2IDZpEBPxQNaEAMTLzRxV/rYq+0
+mIHPaQZqEAMDDzV+moF3VK4biIFKy2W58SIcBGGwH3YgQRisDAcShMF+zAUo
+HvOMKC3Bo19+RpR09jMMEg+eI8fBOoLBevHeRsm+8xKMwRbpgdYF/qEveVBS
+vSw5qT/FRxg0nBUZMQalpnMyc73c3KC0NKqs5zXWZq0NY9BgbzM6OszOTouT
+YNDV43ATDHoGPN5Br5dg0EcFfKyQnx32cyIBbjRAMBgUJILCZEiYConSYXEm
+LMmFpfmIbCQiH0UYjCrHo6qJmHoyRjAY187EdbNx/YWEATWXMM4nTAtJ82LS
+fDFpWUpal1Mo20rKfinluJx2rKada2nXWtp9JeO+mvFcy3ivZ7AHb2T9N7P+
+W9kA6nY2eAcXuosL38uF7+ciqAe5KOphLvYIF3+ciz/JJVBPc8mn+dSzfOp5
+Po16gcu8xGVfkV7nc6j1HCr/BjfylvQuN4p6jxtDfSB9zI7T/ZKdoPsVlaGb
+/A2VLvR3VIpu6ndUsqQE7h+oOClGQvqLTv4jMvl1AL4eaRgfW/COEQOOon51
+jSAD/uLIlxgwU2LAJD4F6vEpkDAw+lIbea4NP9OGnmqCmIFq/321l2bgTaX9
+qtKyqjAucQzLcBCEwX7YgQRhsDIcSBAG+zFHXh1DPyP62Vnw+E7PiNIYJB6s
+Ye+qIR5kMLi7gEHR3gbxvkbxvibJ/mbJ/lbpgTbZwfYF/mHUF6SwLD21LDtt
+OCMy1IiNBIOmOgXCoLlRbUEYbNJaW/Q2jEGTvd3swBi0ObvtCIOuXqe7z+0e
+8HgGvZ4hn3c44KWCCIM+VtjPjvg5UT83FuDFA/xEUJAMCtNBUSYkzoYIBsOy
+kbB8NKIYiyAMKieiqsmoeiqmmY5pZ2K62ZjuAvJg3DAXRxg0LiRMiwnzxQTC
+oGUZeTBpW0naLiXtl1OO1ZRzDee6knZfTbuvpT3X017UjYzvZsZ/Cxe4TbqT
+CaLuZkL3MuF72fD9bOQBLvowG32UjaEeZ+OoJ9nEU1zyGSqXep5LvcilUS+z
+qMwrXPY1aT2bQ73B5VFvcSPvSO8zo3QfMmN0H0m/ZMZ/SRf6FZVCTaB+QyU3
++nuCKT5J9zsqRoqiJn6PkKbHF9ZHvmzA+vHRee/ob55RYsARYsA8MWDuoy2L
+DWjNfLCk35vT70ypd8bkW0OCNuC6LvZaG31FngjFDNSEnmAG+h+qfYiBd1Xu
+2yrXLaX9mtK6qjAtc4zwCUEY7IceSBAGK8OBBGGwH3armey3PSP6BQzWFjFI
+joN1wj31CIOifecRBsX7WxAGJQfapQc7ZAe7gk11C/wjX1ADJqHsTKK3x1Ar
+NZ6TG+sUpnoVwqD5vMbSpLM2662tRlubydZutndYHV02R7fd2eN09bpcCIP9
+HveAzzPo9wwFPMNBLxXyssI+dsRHMOjnJfz8ZECQChAMBsXZoCQXkuZD0pGw
+bDQsHwsrxiPKiYhqMqKeimqmo5qZqBZjMKafwxnm48aFuGkxbroYNy8lLMsJ
+y0rCupIgGEzaV5OOtaQTdSXluppyX0t5ruO8N9Lem2nfrbSf7nY6cAcXvJsO
+3kuHUPfT4fuZ8INM5CEu+igTe4yLP8ElnmYSzzJJ1HNc6gUu/ZL0KpNBvcZl
+10lvMjm6t+k86h1u5H2h0Q9MH1NjdL+gkoV+RSXGi/0WZ4oV+nuUKUKaGftm
+AI78inKTXPlfsAFzqI/27EdbBhnwPTZgqsSA8VIDvtRGXmjDzzX4FPhEE3ik
+Rgz03ld7CAOdN5WO60rrmsJ0Sa6dHzReAgbCYD/yQIIwWBkOJAiD/cgreY/o
+ke0w+Nkzop9jkLULebAWe3D3OR6DQcGeeuHeRtG+JtG+ZoRB8f42hEHJwU7p
+wS5ZRY+sondBcPSpY9dXSCivWVHUGOuUxnqVqQFhUGtu0lmaDZYWoxVj0GLr
+sNo7EQYdjh6ns9fl7PO4+r2uAZ970O8mGPRQIQ8r7GVHvZyYjxv3EQz6BSm/
+MB0QZgKibFCcC0ryQelISDYaIhgMKyfCCIOqqYh6OqKZiWhno9oLUd1cVD8f
+NczHDAsx42LMdDFmXoqbl+OWlbgVdSlhu5ywryYcazjnlaTratJ1Lem+nvSg
+biS9N+lSvlsp3+2UH3UnFbibCqLupUL3ceEH6fDDdAT1KB1FPU7HnuDiT3GJ
+Z+nE83QS9QKXelko/Yr0Op15ncqsp7KoN4Vyb0nvUnm696mR98mRDxuNfkxs
+9EucKYYa+5UuyhQZ+w01MzqPWh+p//K/uNf5+vGROQzA/K9u3C8IgK7cL07c
+R0cWGfADNmCaMWCyaMA3uljRgK+0kZfacAkD/Y/UvgeYge67KhdhoB0x8IrC
+fEmuW2DrL8JzoTDYDz6QIAxWhgMJwmA/+Jjvmi89Cx77lmdESTXkOEgwuAtj
+kHiwXrCnQbD3vBBjsEW0v1W8v118oANhUHKwW4owWNknq+yXVw0sCI9/mRWo
+FWXtivKcsUFjasQYNBMMWlrNVoJBW6fd3oUx6Oh1Iww6+73OAZ9r0O8aCriH
+g24q7GFFPOyohx3zcuJebsLHS/r4Kb8g7Rdm/KJsQJwLYAyOBmVjQflYSDGB
+U06GVVNh9XRYPRPWzEa0FyK6uYhuPoI9uBA1LkaNF6OmpZh5OWZeiVlWYtZL
+cdvluG01bl+LO1BXEs6rCde1hOt6wo26kfDcxHlRt5K+2zj/naT/bjKAupcM
+3seFHiTDqIepyCNc9DEu9iQVe5qKo57hEs9JL1JJ1MtU6mUy9QqXRr3GZdZJ
+b5JZure43LsEXf4904c4U2zkY7Eo7he6CNP0yAWkv28CYP6CN/+LB5X7xU1y
+5T46szgHyZ5hDJiiDfjWmHhriGMD6pEBo8SAkVIDPtMEn2oCj9WIgd4Has89
+Fc1AB2Gg7arCfFmuW5SqZtjaBTgIwmA/+ECCMFgZDiQIg/3g+7S+TiS47TOi
+fwyDnF3nGA/W8/c0IgwK9jYLMQbbRBiDneKDXQiDkopeKcbggKxqUH5oeFF4
+YlFU/VUSPvfsX1HVpSjK1Gwwt5gQBi1tFmuHDWHQ1uWwd7vsPW5Hr8fR53X0
++5wDfudgwDUUcg2H3VTEzcIY9HDiHm7Cy0t6+SmfIO0TZv2inF+c90tGApLR
+gHQsKBsPyieCiomgcjKknAqppkPqmZBmNqy5ENbOhXXzYT3y4ELEsBgxXoyY
+lqKm5ah5JWpBXYpZL8dsqzHbWsy+FnNciTuvxp3X4i7U9bj7RiHPzbjnVtx7
+O+FD3Un47+IC93DB+4ngg0QI9TARRj1KRh7jok9wsaekZ8n4s0T8eSKBeoFL
+viS9SqRQr3Fp1Dou8yZe6G08S/cOFcuh3tNFcR/oInm6j+H8x+n8BdR6/iv6
+owF4Na8fz13w5D6i3Fmci+TMoD44Mh8QAO3pD7b0e2sKGfCdOfnOnHhrSrw1
+xt8YYusFA0aIAcPEgCFkwOeaIGGg/7Ha97DAQNcdlfOW0nFDabtGroGrcv1F
+mWoWGAiD/RQDCcJgZTiQIAz244+8Pab4XfNfeEZ0WwzW0LH+VstmMMjdXcfb
+3cDb08jf24QwKNjXKsQY7BBhDHaLD/ZIKvoklf1SjMEh2aFh+WGW4ih7UXxy
+UXzqq/pAXdI0XNI0ptkcc5vV0m6zdtqtXU5bt8vW47b3euwEg44Bv2Mw6BwK
+OYfDLiriYkXd7JibYNDDS3r4aa8g4xVmfcKcT5T3iUf8klG/dCwgGw/IJwLy
+yYBiMqicCqqmg6qZoHo2pLkQ0s6FtPMh7MGFsGExbLgYNi5FTMsR00rEvBKx
+XIpaL0etq1HbWtSOuhJ1XI05rsWc12Ku66QbMTfqZsxzC+e9HfPeiftQd+P+
+e/EA6n48iHoQDz3EhR/hIo8TkSdxVPQpLvaM9Dwep3sRT6Be4pKvULHk61iK
+bj2WpnuDy7xFRQu9Q0WydO/DTNO5mfV8HepbAIiPgAiA2Y8eoj935oOLhPTn
+TH9w4N7b0+9tKZw19c6afGehDRhnDBhlDBgmBgy90KCCxICBp5rAEzVioPeh
+2nNf5SYMdNxS2jEDFRaagUsy9QWJbAKeC4XBfoqBBGGwMhxIEAb7KUY+MFj5
+P8NgLY1B9q5z2IO767kYg+d5e5v4e1sQBgX724UYg10ijMFeMcbggKRyUIox
+SMkOs+RHOIpjXMVx/qLk9EXpmW8hIVah9vwlXVOGJ7B0Oq1dLmu329bjsfV6
+7X0+e3/AMRB0DIYcQ2HncMRJRV2smIsdd3OSbm7KzUt7+BmPIOsV5rwEgz7J
+qE865peO+2UTfvmkX4E8OBVQTgdUMwH1bFB9IaiZC2rngzrkwYWQfjFkuBgy
+LIWNy2HTStiMuhSxXI5YVyPWtYhtLWK/ErFfjTiuRh3XcM7rONeNqOtm1H0r
+6kHdjnpRd2K+uzj/vZj/fiyAehALoh7GQo9w4ce4yBPS01gU9QwXe14o/iKK
+exlNoF7hkqjXpPVoaj2CexNJ070NlzSVmb6R067nvq4/DMBc3Xh2FuXNfPBk
+PiD9udMfXLj3TpIjhbPj3tmSWH8YgIm3KGLAN8YYY8DIawLAV9rQS83nBnyq
+8T9R+x4VGOi6q3LeUSIG2m4orYSBplW5YUWmnpPKJlnqOZqBv//3//ne/x+C
+wWBfGkgQBivDgQRhsJ9lAUpAnhGlMbjtl0p8HYOMB8+xd9VxMAYbuRiDzby9
+Lfx9bQiDgv2dQozBHhHGYL8YY3BIUjUsxRhky45w5Ed5CIOKEwJltSjS3X1R
+dvaZe983qvCFv/KyvuWyocXa47H2em19flt/wD4QtA+G7ENhx3DEQUWdrJiT
+nXBxki6CQTc/4xZkPcKcR5j3ika84lGvZMwrHfdJJ3yySR/24JRfOe1XzvhV
+swH1hYBmLqCZD2APLgR1i0H9xaBhKWRcDhlXQqaVkPlS2Hw5bFkNW1FrYduV
+sO1q2E5yXIs4rkecqBsR102c+1bEfTviQd2JeO/ifPeiftT9aAD1IBp8SHoU
+DaEeR8OoJ7jI0wjuWSSKeo6LoV7g4i/pwvFX4QTqNS6JWqebSk/dyGrWc+dQ
+36g/DMDMjDf9HuUhuVGp9y6SE/fOkXxnJyEA2hJvrUR/lvhbc/wNyhQjBoyu
+6yOvCwYMMQYMEgMGiAH9T9XYgI/V3kdqzwOVmzDQcVtpv4kYqLBcU5ivKIyX
+5fplmWZeKp9iqefhuVAY7GcZSBAGK8OBBGGwn2hEglUlXze/9UsltmLw7FYM
+Eg9iDLJ3N3AwBpu4GIOtvH1t/P0dCIOCA91CjME+EcbgoJhgUFLFkhIMyo7y
+5BiDQkW1SHlSojotVZ2RXZTXLslrv5GEBRgGqi4b2y4b27NiuW0gZB8M24ci
+9uGog4o7WAknO+nkpFzctIuXcfGzbkHOLcx7RCMe8ahHPOaRjHulE14ZatIr
+n/Ippn3KGZ9y1qe64FfP+TXzOO1CQLcY0F8M6JcChuWgEbUSNF0Kmi+HzKsh
+y2rIuhayXgnZ6K6G7Ndwjushx42wE3Uz7LoVdqNuhz13cN67ON+9sO9+2I96
+EAmgHkaCqEdhVOgx6Uk4jHqKizwrFH2OCkVf4GKol6ip5ATqRlq1nv0m9206
+/6WnUZ7kW0/yHcrN5CI5SY4E6q098RbpzxZ/a8W9sSD9xXCm2Lopum6MriMD
+GiKv9eHXusIR8CUB4AtNgBjQTwzoKxrwIWag657KeVdJM9B6XWG5qjCvyWkG
+ahel8mmJZAwYCIP9RAMJwmBlOJAgDPYT7Ytvj/nDGKT+do61qx5hkL37PAdj
+sIWLMdjO29/B39+FMCg42CvEGBwQEQyKqyhxFUtymC09wpUe5cmOCeQnhPJq
+seKkRHlKqjwjV51VqGtU0f7BJWXdkvLr7zP5rJfBQ6vmjlVzZ1amysnVdlbC
+wU46OCknN+3kZZz8rEuQcwnyLuGIWzTqFo+5xeMeyYRHOuGRTXpkU175tFcx
+41XOepUXfKo5n3rOp5n3aRb82kW/7qJfv+QnHgwYVwLGSwHT5YAZtRq0rBWy
+XglarwZtqGtB+/WgA3Uj6LyJCrluhVy3Q27UnZDnLs57D+e7j/M/ID0MBVCP
+QkHUY1zoCelpMIx6RjcVH0WtZ2rXs39MzVh/2XOosdSUJ/GGzl3orYvJSUL6
+c8Tf2uNvULb4G2sMZ0FF181RrD8MwMhrlCGMAagPv9LRR8DgSwaAzzX+ZwSA
+xIDeggFVbvoUeE/luKO031baCAPNVxWmNbnhkly3JNMsShUzEsn4gHYRPh4I
+g/1EAwnCYGU4kCAM9nNtNZP74gcGt2Jwm7fHlGCwjtpVz9rdiDDI3tPMwRhs
+42IMdvL2d/EP9CAMCg72CysGhBVDosphUSXGoPgQR4IxyJceE8iOixAG5Scl
+ilMy5Wm58qxSVaNS16rV57Sael18iFpSNSyrG/+oejZ4GDqyau1Zs/XkVfoR
+lcHJzzkFeadwxCUcdYnGXOJxl2TcLZlwSyfdsim3fNojn/EoZj3KC14Vas6r
+nvdqFnyaRZ/2ok930adf8umX/YYVv/ESznTZb1r1m+nW/JYrAetVnO1awHY9
+YEfdCDhQNwPOWzjX7aDrTtCNuhv0oO4FvfdxvgeF/A9Rk+HcZAR3PSFHvc7U
+0P2Jv/2C/hITKE/stTu2TucqyRl7g4u/caBib+wkW2zdFl23RtctJHME9dqE
+9BfGGcKvDKFX+hAGoC74UosAGEARA/qxAQkAn6q9xIAexoCu+8wpEDHwltJ6
+Q2HBDJQbV+X6SzLtkky9IFVekEgnKNkUHARhsJ9rIEEYrAwHEoTBfrqtZkZK
+PjBIY7D0SyW2fuP8FzB4jtqFMNhA7W5k7W5CGGTvbeVgDHZwMQa7eQd6+Af7
+EAYFFYMIg8LKYWElJapiiQ5xxIe5kiMYg9LjItkJhEGp/JRMgTB4RqmsUalq
+NQiD6jqdpsGgaTRqz5t0TZZlzfllTdNzX8WfhuGGEMNHX0WOodacA6grrkHU
+iME2YrCPGh1u+axbMetWXvCo5jyqeY96waNZ9Gov4nRLXv2yT7/iM6Au+YyX
+fabVQuY1n/mKz4K66rNe86Ns13H2G377Tb8DdcvvvI2a8CdxgdS1qOR6TPI6
+dfZ1Gvc///t6nalFjcXHUZ7IS3fkVaHoKxfuNcrJ5Nho3U6y4V5bI68tJKQ/
+c/i1CffKGML6wwAMvtSRtAHUCwxA/wsCwOdqHzGglxjQgw2ocjMGdKLuKQun
+QMJA8zWF6YrcsCrXrcg0F2UqxMA5iXSSkk8DA2Gwn24gQRisDAcShMF+xm1+
+e8yRLd8w+EcxWE8weJ7a3cTa04IwyN7bzsEY7OJiDPbyDvbxDw7wKwYFFUMC
+jEGWsIotquKIDvPER/iSo0LJcZH0hFhWLZWdkslPKxRnlIoatbJWozqnVdXp
+1fUYg5rzZm2TRdts1bbYdK32OEewrGte1rU891f+zwG1U6+iJ17FcFe8rCte
+9qtY9as43clir+kSqFNbOv06udG/5a8wU3s1qRiLjqI8oefu0AtcGOfCvUQ5
+N3rlYLIz2ZisJEv4lRkVemUiGUMvjcGXhuBLBEB94KUu8ALpT+tn9OfDEQA+
+KwCQNqCbGND1gADwvspxT2m/q7TfUdpuK603FRbCQCNi4GUZYaBUNS+Vz0qk
+U1zhKM1A18SL7/3/EhgM9gcGEoTBynAgQRjsZxz5wOCh7V4l+ucwWEcw2Egw
+2EztaWHtbUMYZO/r5OxDGOzhIgwe6OchDB4c5FcM8SspQSVLUMUWVnGEh3ii
+I3zxUaH4mEhyQiJFGDwpl51WyM+oFGfVilqN8pwOYVBVb1A3mNSNZs15i6bJ
+qm22aVvs2laHrs2la3frOzz6Tm+SL1kxtK0Y2l8EDv37bPh9e5WuQV2Jy0fD
+ebf/iTvwlOmZO/jMhXuOcm70woEK4eyFXtqYrEwWJnMQZwpi/RkDLw2BFyh9
+4IXOj9Nu0O+52vuMiRwBPU9w7scqZEAXY0DHfSVtQBttwFsKy02F+brCdFVu
+XJPrL8u0yzL1olRJM3BaxMv2k/eFAgNhsJ9uIEEYrAwHEoTBftJ9Wn9Lvm5+
+21eJlmJwp++VKH2BzMYzotTuJoLBVmpPG2tvB8Ige183Z38P50Af90A/9+AA
+7+Agr2KYX0HxK1n8Sragiis4xBMe5osIBsXHJZJqqfSkXHpKITujkiMM1mgV
+53TKOr2y3qBqMKkazerzFnWTVdNs07TYNa1ObZtL2+7WdXh0nV59l0/f7Tf0
+BAy9IUNfOCVWrpg6L5m7UC+Ch18Ej3x3yn0T91Jn6a5EpajRQGYkmEW5PA9d
+3kekxy4f3ROU0496yvTMEShkxz2nszFZcS9QFpKZyUQyovwvDLjnev9znQ+n
+RXmfaYr08zwtiQYgMaCLGNDJGNDOGNBaNOANzEDjVblhTa67JNMsS1WLUsWc
+RDYjkUyKBSPDolFgIAz2kw4kCIOV4UCCMNjPO/J18xU7vD3mT2Bw4xlRak8L
+xuDedmpvB2tfF8Ige38vwiCHYJB7cIhbMcyroHgYgxw+waDgsEB4RCg6JhYd
+l4hPSCUEg9LTKtlZtbxGK6/VKc7pFXVGZb1J2WBWNVpU563qJpu62a5pcWpa
+XZo2t7bdo+3w6jp9ui6/vjug7wkZesOGvoihP2ociBkH46ahhGk4aaJSZiqd
+luvTCkNaabhs68PZ+1Evw8dwkWP/duslTr9K4q6ERagRb4KUdDnuuBx3UU7n
+vUKu+6QHTjfdQ6cH9chB533M9MThe2Iv9BRlY7L6ntFZmMxMJt9zOiPJQNL7
+num9z3TeZ1qSxoNi3Od+StDH0I8OA/CRykkMiI+AxIC2ggEVFsaApusK0zU5
+YqB+Vaa9JFMvSZULUvmcRDojFiMGjg6Lx4GBMNjPO5AgDFaGAwnCYD/1yAcG
+d3qV6Ld843wJBncRDO7eeEaU2tNGMNhJ7eti7eth7e9l7+9jHxjgHBjkEAxy
+KyhuJZtXyeFVcflVPP5hgeCIUHgUY1B0QiaulktOKSWnVdIzatlZraxWJz+n
+l9cZFfUmRYNZ2WhRnreqmmyqZoe6xaludanb3Jp2j6bDq+30abv8uu6griek
+7w3r+yL6/qhhIGYYjBsHE8ahpHE4ZaTSJipjYmVN7JyZkzNz82buiJk3auaP
+WQTjFsGERThhFU1mdbaszp7VO1Zdw6suKmtwZo2unMmdM3lyZjpvzuzDWXw5
+qx9n8+dtgbwtiLOHcA5UOO9ERRymazjzdZTTcsNpuem0om45bbcctts4+51C
+jrukew4n6j7KjnI9KOR+SHqE8zyyeR4Xs3qeWL04C5PZ+5TOxGRkMhTC+tN7
+n+o8OK3nqcaNK6DP9URV6DEToh/dQ5yDGNDOGNDKGNDMGNBIDGi4ItetyjQr
+MtVFqWJBIrsgkUwTBo4NSyaAgTDYTz2QIAxWhgMJwmA/+wIU/1+HwToGg03U
+nsIzotTeDoLBbopgkLW/n3VggH1gkH1wiHNwmFPB4lawuZUcbiWXV8XnHxLw
+DwsFR8XCYxLhcZmoWi4+qRSfUknOaKRntdIanaxWLztnkNeZ5PVmRYNF0WhV
+nrcpm+yqZqeqxaVudavbPOp2r6bDp+n0a7uC2u6Qries643o+qL6/ph+IG4Y
+TBgGk4ahlGE4baQyRhYqa2TnTJy8iTti4o6aeGNm/rhZgJowCyctoimLeNoi
+nrFIZq1S1AWrbM4qn8cpFmyKRZvyIk6FWrKpl3GaFZvmkk2LumzTrdpR+jWc
+4YrdeBVnuoYzX7ebb+AsN0m37FbUbZwNdQdls98l3bM56O7bnHQPrCjXQ6ZH
+VvcjC5PZ/biYicnofkJnIOmZdExaksaF6Yf153xc0qONHA9JD3D2BwwA7ymt
+2IAKC2NAEzagHBnQcFWuRwZck2kvIwZKMQPnJbJZzEDhhIiXH5ZMAgNhsJ99
+IEEYrAwHEoTBfvZ9Wn9D/e3gn8Xgme0wyHxgsOQZUWpfF41Ban8fRTDIOjDI
+OjjMPkixK1icCjYHY5DHreLzDgl4h0X8I2LBManguEx4Qi4iGBSf1kjOaCVn
+ddIavbTWIDtnktWZ5fUWeYNVft6maLIrmp3KFpey1a1q86javeoOn7rTr+kK
+arpD2p6wlmBQ1xfT9cd1Awn9YFI/lNIPpfXDaQOVMbCyBlbOyM4bOSNG7qiR
+O4Y8aOKPmwQTJsGkWThlFk2bxagZs2TWIr1gkc5ZZKh5i3zBolgspLxoVS5Z
+Vahlq3oFp7mE01626lZx+jWr/orNgLpqM6Ku2UzXSTdsZtRNlNVyq5D1NumO
+1Ya6S2ex3yvkuM/0wOJ8YMY9pDMVemRkMjDpcY9ROpKWScOkpt3neLS5h4Ww
+++juK233sf5s9BHwrtJCDGhmDGjcasBLMvWyVLkolc9LpLNi8ZRYMCbi5rj8
+EfjCCBjsLzCQIAxWhgMJwmB/gZEPDJZi8GgJBo9/MwaJB3eRt8fsLv3A4MYz
+ogSDvTQGqQMD1IEh1oFh1kGKVcFiV7DZlVxOJY9TxedWCbiHRbwjYv5RjEHB
+CYWwWik6qRKd0ojPaMVndeIavaTWIDlnktaZpfUWWYNV1miTn7fLmxyKZpei
+xa1s9SjbvKp2n6rDr+4MqrtCmu6wpiei6Y1q+2Lavri2P6EbSOoGk7qhlA57
+MKOnsnpWTs/KG9gjBs6ogYsaM/LGjfwJo2DSKJgyCadMommTeMYknjVLLuCk
+c2bZfCH5glm+aFZcxCmXUBbVskW1YlGvWDSXLJrLFi1q1aJbw+mv4AxXLYZr
+VuM1i/E6znSjkPkm6RbKbLldyHqH6a7ZhrpnorPfL2a0P8A5HhiY9I6HdDom
+LZMG9wilJmHx2VEPSyu4z/aAuI/Rn5WuCMA7CjMxoAkbUI4MaCg14Cox4IpU
+tSRVLEpkcxLJjFg0KeKPCdlZwXACGAiD/TUGEoTBynAgQRjsr7HNGDyyAwZ3
+eoHMVgzWFzC4h3xgcO+mZ0Sp/UUMDiIMUgeGKYTBgyxWBYddwWVX8tiVfA7C
+4CER94iYd1TKPybjn1AIqpWCkyrhKbXwtFZ0Ric6qxfXGMS1Rsk5s6TOIq23
+Shtsska77LxD3uSSN7sVLR5Fq1fZ5lO2+1UdAVVnSNUVVndH1D1RdW9U0xfT
+9MU1/QntQFI7mNIOpbVDGd1wVkfldKw8Ss8e0XNG9dwxA3fcwJsw8CcNxING
+4bRRNGMUz+IkF0ySOZOUbt4kW8DJF03yiyYFasmkXDapUCtm9SWc5jJOu2rW
+rpl1qCtmPeoqznCNdN1svG4y3sCZbjLdMplRt1FGlOVOIetdOoP1nsFGd1/P
+pGPS4h6gNExqJhWTcpvuK63FCP0sKES/u4qC/mgA3laYiAGNN+QGYkD9Vbnu
+imyTAZelyotS+YJEekEsnhELJ0W8ESErIxxO9qvmgYEw2F9jIEEYrAwHEoTB
+/jJbzeT+FAa3fmxw89tj6A8M0hjc9xkGBwoYPIgxSB1kUxUcVgWXRTDIrhJy
+Dok4h8XcI1LeMRnvuIJ/QsmvVglOqgWntMLTOuEZveisQVRjFNeaxXUWSb1V
+0mCTNtql5x2yJqes2S1v8chbvYo2n6Ldr+gIKDuDyi7sQVV3RNUTVfXG1H1x
+dV9C3Z/UDKQ0g2nNYEYzlNUOZ7VUTsvKa1kjOvaojjOm446j9LwJPX9SL5gy
+CKYNwhmcaNYgvlBIMmeQzBukqAWDbNGIkl80ypeMCtSyUYlaMaou4dSXjepV
+owa1ZtKirhh1qKs4/TXSdaOB7obBiLpZyHSL6bbejLpTyHKXTlfonpakYVLj
+7qNUTMpi1u2y3GMi9DPfJe5j9Gei9XdLYUQAvCmnDahnDKhdk2lWZerLMtWK
+VLksVSADLkpk8xLJBbFoWiyYEHHzQiotGIgBA2Gwv9JAgjBYGQ4kCIP9lUa+
+cb6iBINH/iAGGQ/u2u7tMYUPDJZikH5GtIhBFo1BqoJLVfJZlQJWlZBdJWIf
+lnCOSLlHZdxjCt5xJe+Ein9SzT+lEZzWCc7ohWcNwhqjqNYkOmcR11nF9TZJ
+g13S6JCcd0qbXNJmj6zFK2v1ydv88vaAoiOo6AwpusLKroiyO6rsiSl746q+
+hKovqepPqgZS6sG0ejCjHspqhnMaKq+hRjSsUS17VMsZ03LGtdwJHW9Sx5/C
+CaZ1ghmdcEYvmiVd0ItRc3rJPE66oJcu6mWoi3r5Ek6xbFCsGJSoSwYV6rJB
+vYrTrJGuGLQ4vfaqXoe6htNfZ7qhM6Bu4oyoW4VMt7WF7tBpzHR31UwqknKj
+e1+Mdh9DP9Md4j6S8RaJ6M+AuoHTEwPqNhlQWjDgEjHggkQ6J5HMikVTIv64
+kJ0TDKf4/dFAaO33//4/3/vnHQaD/csGEoTBynAgQRjsL7Z/EQZrChjcTd4e
+s4d8YHDvlzFInwWLGOQhDFKVAqpSyEIYPCRhH5Fyjso4xxTc40ruCRWvWs07
+qeGf0vFP6wVnDIKzRmGNSVhrFp6ziupsonq7uMEhbnRKzrskTR5ps1fa4pO1
++mVtAVl7UN4RkneG5Z0RRVdU0R1T9MQUvXFlb0LZl1T2p5QDadVARjWYVQ3l
+1MOovJoaUbNGNewxDWdcw5nQcCe0vEktb0rLn8YJZkizWiHqglY0pxWj5nWS
+BZx0ESe7qJMt6eSoZZ1iBae8hFNd1qlWdWq6NZzmCumqTntVi7um1aGuF9Lf
+QGlwNzUGuls44y218TadiklpvEOn+CzTl0Poo7tVyEDTj+hPT+uPBiA2oEx7
+Rab5ggEviMWzYuGUiDcmZGUFQwl+XzgQXP3eP+YwGOxfPJAgDFaGAwnCYH+9
+bcbg4S9i8AsfG9z89pgCBts2YXD/DhisYOOzYAkGqSoR65CEdVjKPiJjH5Vz
+jik5x1WcE2putYZ7Uss7peedNvDPGPlnTYJas+CcRVhnE9bbRQ0OUaNTfN4l
+bnJLmr2SFp+01S9tDUjbgtL2oKwjJOsMyzoj8q6ovDsm74nLexKK3qSiL6Xo
+TysGMkrUYFY5lFMN51XDIypqVMUaU7NR42rOhJo7ieNNqXnTOP60hj+jEczi
+hBc0wjmNaE4jnteIF3CSRY0UdVEjW9Ki5Mta+YpWgbqkVaIuk1Y1Kro1jRp1
+Bae5ilLjrqm1dNdxOtQNFe6mSl9Iqb9FpyjNgLq9Y8aSDPRvvlVwn/4mcR9J
+d51E9KdF+qMjBlSvylSXpcpLUsWyVL4kkV8kBpyXiGkDTosFkyLuqJDKCAbi
+iIGffvv/v/cPOAwG+9cPJAiDleFAgjDYX3IEg9t+tcSxP47BrW+Paaf2Md8r
+sb+n5FWig8wHBrdgsEpEVYmpKgl1SMo6LGMdkbOOKtnHVOzjak61hnNSyz2l
+55428M4YeWdN/Bozv9YiOGcT1NmF9Q5hg1PU6BKdd4ubPOJmr7jFJ2n1S1oD
+kragpD0k7QhLOyLSzqi0Kybrjst6Eih5b1Lel5L3p+X9GcVAVjGYUwzlFUMj
+yuERJTWqZI0pWeMqNmpCxZlUcemmVLxpHH9GxZ9VCVAXVMI5NUo0rxYtqMWo
+RbXkIk66hJMt4+QrOMUl0mWcclVFp1ojXcGpUVeVKM01putKLd0NBZMcpbu5
+TfpvDP3pdNcLaRH9rhXop0FdISEAYgNKSw0ouyiRLkgkxIAiZMAZsWBKxJ8Q
+skcEw2l+f4zfE/r0639/7x9tGAz2bxlIEAYrw4EEYbC/6v4UBrd89fwu8vaY
+3eQDg3u+iMEDWzFIf2CQxqCwFINUAYMK1jEV67iafULDrtZyTuo4pwzc00bu
+GRPvrJlXY+HXWvnn7II6h6DeKWxwCRvdwvMeUZNX1OwTtfjFLQFxa1DcFhK3
+hyUdEUlHVNIZlXTFpN1xaXdC2pOU9aZkfWlZX0bWn5UPZOWDOflQXj40ohge
+VVBjONa4gjWhYNNNKjhTCu6Ukjut5M3g+LNK/gWlADWnFKLmlaIFnHgRpZJc
+VEmWVFLUskq2rJStkC4p5XSXlQrUKkqBUq6RrihUdFflKDXqWiHN9c/TXpfT
+MPxCupK015kI/TTXiPsY/amvEPqtyVSrKALAbQwoFs+VGHBSxBsXsvKCoRS/
+L8rrCnz65X9/7x9qGAz27xpIEAYrw4EEYbC/9gIU/4sYLP2qwW2Pg8zbYwoY
+JG+P2fttGKz4AxhkIQye0LKrdeyTes4pI+e0iXvGzK2x8GqtvHM2Xp2DX+/k
+N7gEjW5Bo0dw3its8gmb/cKWgAjVGhS1hUTtYXF7RNwRFXfGxF1xSXdC0p2U
+9KSkvSlpX1ral5H2Z2UDOdlgXjY4IhsakQ2PyobH5BRqHMeawLEn5ewpOQc1
+LefOyHmoWTn/ggIlmMMJ5xXCBYUItagQoy4qJEtMywopakWOkl1iuiyX063K
+FKi1QsorhVRXN1Jfo5NvTfN5sm1C/wt0Vwqp1khEf8qi/lArUvmyRLYkkV6U
+SLYzIHdcyB4VUlnBQBIxkNvu+fQRGAiD/ZUHEoTBynAgQRjsLz/yVYNVDAY/
++9jgiS8+KUp7cOvbY7ZgcP9nGBzaAYMCqorx4CHkQRl1WM46omAdVbKOqVnH
+NzDIPmVAGOScMXPOWjg1Vm6tjXvOjjzIq3fxG9y4Rg//vFfQ5BM0+wXNAUFL
+UNgaEraFhe0RUXtU1BETdcZEXXFxV0LcnRT3pMS9aUlvRtKXlfRnpQM56UBe
+OjiCGxqVDo8Vosal1ISUhZqUsadwnGkZZ0bGRc3KeBdw/DmcYF4mWJAJF+TC
+RbloUSa6KBOjlgpJlkkrUindJZzsMkqGQiSk26rCDR4Wu/qViu4r/P41nHJN
+qlwlXZYqLhP6XZLKV0gEgEUDiufFojmxcFYsmBHxp0U8xoCsvGA4y+9P8Hoi
+nGb7p4//3/f+KYbBYP/egQRhsDIcSBAGK4eRrxqsKvHgt2Cw5Di4i2BwN8Hg
+nm/D4MFvxCA+DlIFDNLHwQ0MsosYPGvl1Ni4tXbuOQe3zsmtd/Ea3LwGD6/R
+yzvv4zf5+U0BfnOQ3xIStIYEbWFBW0TYHhV2xISdcWFnQtSVFHWnRD0pUW9a
+3JsR92XF/Tlxf148gBoRD46iJKihMdzwuISawLEmJawpCRs1LeHMoKTcWRzv
+gpQ3J+Wj5qUC1IJUiFpESYQXJSLUkhQlRi3jEAklJSRkVIjbUOHmi+HWlF+p
+QD/FKqEf0Z+c0Z8M6W9ZIiX6wwBcRAYUFwx44XMDUtiAgqE0vy/G6woFjROf
+Pv6v7/3zC4PB/u0DCcJgZTiQIAxWJlvNZL8Ngzu8RmYTBs8zGCTfOL+vnbxK
+9GsYrNwZg+Q4SB1Rso6q6OMg64SOXa1nnzSwTxkZD2IMcooYrHNx693cBg+3
+wctr9CEP8pr8vKYAj3iQ3xrmt0b4bVFBe0zQERd0ohLCrqSwOyXsSQt7MqLe
+rKgPlRP15wsNjIgGRkWDqDHR0DhKPDyBoybF1JSYNSVmT4vZM2IOalbMRV0Q
+8+YkKP48aUEioEMeLJIQq1AiLlXhFhjKSmC4IcQ/kqL4a6I/GaLfCqEfrb8l
+iYToT4yiAbjFgJwJIXtMSI1gAw6m+f1Jfm+U2+EP6Ea/948tDAb7Dw0kCIOV
+4UCCMFj5jGCwcgcMfvU4SGPw3JbL4HYYPPA1DFbthEEFxTwpyjqhZeHjYAGD
+7MKTorbtPdhIe7CAQV5ziN8Sxh5swx7kt8f42IMJQWdS0JUSdKPSgp6MsDeL
+68uR8sJ+1IhwYFQ4sOFB0fAEjpoUUVMi5EEW8SCbeJBDPEhISJrfrMLFDRUy
+t0IahhLxsqT0XLjxHGnJ3fCzZF9uRSJdIfQj+pMQ/YkvFvQnWsD6E87hBAiA
+F0T8GRFvWsSdKjFgTjCYwQbsi/N6Y5xWz+rMne/9AwuDwf5zAwnCYGU4kCAM
+VlYjLxTdFoM7PSl68k9hsPdzDFZ8MwYPK5jjoIZ1XFtyHDSxT5s5ZwpPinJq
+7JxaB+ccwWCdm1vv2daDvJbCcZDfFuO3xzd7ME17UNCTRREVEg/2bXhQiDxY
+ICHx4PAkQ8Lp7UnInSuqUMzHbbkV7gjDTUn+aER/4oL+xKJFrD/hPKmgPzF/
+lgCwxIAsYsAh2oApfl+C1xPldUfY5+GDgTBY2Q0kCIOV4UCCMFi5bfP3zv+h
+4+C2GDy/8ZlBGoP7v4BB9vYYPLQNBqmSJ0VZJU+KIg+yt/VgPe1BL5fG4PlA
+wYMtJR5spz2Y4Bc9WCRhdwarsODBXMGDBRKOERKOMyScJCTEJ0JEQlGRhOzZ
+ggo5FzbDcJ6B4QJu07mw9DnSryXeIdFFQr9FsZDRn2AOx6f1N8vojwbgpHCr
+AXuRAWO8rjC3IxjUj3/6AB8MhMHKbiBBGKwMBxKEwcpz5NslKv7UcbD0M4P1
+BQzuLcVgx+cYPPjZZZBNVTIerOKXYLDkHTIFD6qoo+ricZBVbWCfNNLHQfZp
+C/uMlXOWYLDGsa0HuQUPFo6D23gQkzAp6EzhCiTMFK6EvTlB6Ymwf7RIQuHW
+EyFVICGOPSP6kgo3zoVFGDItbiT8agsbCeZJiH5YfyIUj+iPO4P1x5kiTQrZ
+EzjWuHB4VDCUFwxkSwwYQQbktnrXZu997x9MGAz2fQYShMHKcCBBGKxsR75d
+4gtfPf+F4+BnGCTvkNnbRDDYuhmDPd+GQXIcPCTaDoP4OEhtYFC/owcRBmud
+nHMuDv2w6I4ejPBaoxvPi5aQkF+4EhZPhFmGhMSDfZtOhMLB8U0kHGZIuEWF
+pFnRF2C4YcNvbG5TPEQ/oj/uLKM/DEAhexLHIvqjUGOCDQOm+b1JXjdtwBCn
+1cdpcq1OwwcDYbDyHUgQBivDgQRhsHJeCQarSjD45eMgweAuhEHypfO7z22H
+wTaCwc4/j8HDmzFIjoPEgzrWCYxBVrWRfdLEPmUuepC9vQe93AYft9GPPMjd
+4kFCQsaDBRImCQlT/AIJMwUSkhOhoC8voD1YeiJEJMQqnChEq/DLMOTMMhVh
+uE2iHZvdFGeG0A/97yP9TQlZtP4maP2RC+AIBuBgDhuwjzZgnNcVRQbktvo5
+TW52gw0+GAiDlflAgjBYGQ4kCIOV+T6trwcoAfOkKI3BUg/ufBzcBoONBIPN
+22Gwl8Hg4J/H4BE1dVTDOqYt9SCr4EGCwTM29ln7Zx7kbPJggHs+WPBgM/Eg
+Q0IeImFBhQmGhClCwnSBhCUnwm1IuEmF40UV0omGGRVS09tdDAtHQ6aZz9v0
+O6dLI/Sj9TcppIj+hlFjgiECwMG8YIAAsD+zYcBOZMAwY0B7QDf+vX8GYTDY
+9x9IEAYrw4EEYTDY/93xSdGtD4t+hsHTBIM1BIN122GwnWCwi8FgH4PBIaqC
+8WAl+w9iEB8Hqa95kF1DMFjr2smDXOTBJtqD4dIrISIhry3OkDBZIGFXGlc8
+EfbkSkmI6x9FERiOMTAc33ouZJoSUrhNF0MSYd3OUZNbmiD0Gxdg/READo4I
+BjAA+f1Zfh8NwBSvp8SAbQFOs4fd6GDVWVZn4IOBMBgMDyQIg5XhQIIwGIze
+146D2z4suhMGmXfIbMJgN4PB/u0wSI6DVYwHDzEePFziwSMlT4oexRikjulY
+x/WsEwSD1SbkQdaOHnRz6jwchMGiBxsDDAlDXEzCz66EMYaEiQIJmRMhQ8Ls
+JhJuUmEBhrhtYFhqw1IeTpL/+IXGCw0VIvQbEwyO4gYwAPn9OX4fAWBvmt+T
+4nUjACZ4XciAMW47MmCQ0+xlNzpZdVZWrfnTx//9vX/oYDDYjzKQIAxWhgMJ
+wmCw0pHjYMXm4+DX3iSDMUjeIbObvENmT/12GOzYgkFyHKxgPPhnMLjhQaro
+QYTBk2bWKQv7tPULHuTU+7AHG4oe3CAhF3mwmXiwJcqQMM5rR5WcCAskzCAS
+8ruz/KIKt4XhFhtuxDxQKsCNfa3RjQboSvWX5fdm+D1pHg3ArgSvkz4CRkoM
+6EIGpGqM8HIYGAz22UCCMFgZDiQIg8G2bjUzst0X0O90HKze+NjgBgYbCAbJ
+O2T2tW7GIHlS9GDfFgwyx8EqxoOHBDtgkHmnKI3Br3jQxj5jpz3ILvVgnZch
+oZ+QkFZhkCFheDMJCydC5MHNJEzj6ENhAYbEhj10OX6pDb/Aw0IjO5en49P1
+oXI76C/G7Yhy22kAhrityIA+YkAbVWMKqEc+ffiv7/3zBYPBfriBBGGwMhxI
+EAaDbbvVTIYwsGrLF9Dv/CYZ+knR3eRJ0W0w2EYw2LkZg+Q4WMF4cCsGtz0O
+HikeB0s9qC16kEIePEE/L4o9yEIePE170LHJg+c8BRJiFfpwO5CQ2xzhFklI
+XwkLKkzyOuhShVshzcOtNtzMQ34vXZ4pt3PZTfVkmNK87hSvK8nrxADkdsS4
+7QSAbWFua4jTggDo5zQhA7pZdXaqxkydNaxO3freP1YwGOwHHUgQBivDgQRh
+MNgXtuU4+OWvHUQYJMfB3eRJ0T3kOLiXeYfMJgx2UQdoD277pOjW4+BnGJRS
+R0o8eLTEg8dKPHjcQJV68JSVhT1InhfFJHSya124c252qQrJoRCREIdI2EhI
+eL7w4ChNQm7pg6OFEvS5ENexwUNeJ922p8NvKY3i0XWlmJD+CAA74tx2AsC2
+CLc1zCkAMIABeN7DbnCx6hxUjYU6awyoMp/ef/reP00wGOzHHUgQBivDgQRh
+MNiXR46DVVseFt3Zg7vIcXD31uMgwiD52OD+9s0Y3Hoc3OlJUeLBw6XHQcaD
+BQyqim8W3d6DJ2kPWllnmBMhTUIcUWEtUuH2JOSUkrCJkBCrMFqoNcalz4Wl
+PGzflodJhodfLlmoI8EUJ/TbpD8MwIL+/JzzPnYjAqCbVe9knbOzaiysGjN1
+WrM6eeV7/xDBYLAffSBBGKwMBxKEwWDfMuY4uPXDg6UYLHpw63GwoXAc3Eee
+FN3fXjgOHqA9uO2ToowHqxgPbsIg48EjX/agrtSDFPJgtbn0RIg7Y2dtUmGR
+hLQKi8+OEhI2BBgVMiSko2HIXAxLeYhrQxV5uFmIn0dbj3CvjS5aqDXChPQX
+4jQHOU2bAVhHAFhrpc6aqTNG6oxudfLa9/7BgcFgP8dAgjBYGQ4kCIPBvn0l
+D4t+1YPVBIP0cRBh8BzzpOh5al/xSVHiwQOdhePgQcaDFbQHt8Ugcxw8XOLB
+I8WHReXU0RIPHivx4HHGg8eN1AkTtXEiJCTcpEJCwrPFQ2GBhOzNHycskhB3
+ni7EKeVh80483CzEwq+jTPRvpkPiC3OaUSEmpD8CwPN+dqOP3eBl1zMArLFR
+Zy3UGRMxoD6giH96/4/v/fMCg8F+moEEYbAyHEgQBoP9oZV8B/1OL5MpeV60
+8KQoOQ5iDNZRe8mTovuKx0HmYdEDXZs8WMEcBysZD1YxHjz0Zz14vMSDJ4wk
+TEKq2oxDKjz5+aGQddbBKiUheXaUViG7zleiwtJz4TY85DTRhXFYdkUnFv4j
+Vl5TMcI9/OcGmPxsTD+iv1IA1tqpUgCeNlCn9QFlGgwIg8H+6ECCMFgZDiQI
+g8H+xLZ48PCOXzaxixwHMQbPUnvIk6J7S4+DLdR+2oP0cZB48GDP5uMg7cFt
+MSigDpd48EiJB4+WeBBjcFsPFklYosKTRIUbh0I7fShkVLjp2VFGhaR6XzHm
+UdKtSGQ6z1hv4w/S1vOzG3xMXoI+lKdQnZt1jgHgGQRAMwNAHXVaQ51Swmth
+YDDYnxtIEAYrw4EEYTDYnx7x4AHyTfSfefAzEpLj4G7mNTKFJ0WLx8GiB9s3
+PHiwmzkOMh6sHNrhOMjf7EHJ9h48piIRDx7XkmgP6okHS1W46VBInfz82VGa
+hKzSTxQWK/KwgMQSJ9bRptsERhLzx+s8TG4WFh/KRUL0QzlYNXbqLAPA04UL
+IHVaS51SUycV8JFAGAz2PxlIEAYrw4EEYTDY/3Crmdw3ePB4yXGwZtNxcB/j
+wf0thYdFDxQ92LPJg5XMw6JVpR4sOREWPCiijpTcB4/KdvBgKQlJJ/SbSFht
+JCTcpEIK3wpLHh9FMCzYkPCQrobOVai2mBt3bnMb/y0RH/4THbizyH00/axE
+fxbqNAKgqQDAUwUAUiclAUXs0/vfv/dPAQwG+7kHEoTBynAgQRgM9i/ZDh78
+jITEg7uJB/eQ4+Be+pODpR5sLfEgfRwkHqygPTi4xYOEhEUPHhaQhCUeJCTc
+8KCCOlZCwuMaJkaFJ2gSlqiwerMKT9IqtCAVlmSjTpdmpwpUtJd85LCkmuKv
+ifjOoGy401bqtIVkZuhn2rgAntJRpzTUSRV1UkpViwLyCDwOCoPB/iUDCcJg
+ZTiQIAwG+xcOeZA8Mlqx+X0ymz246/jGw6J7ajc8uI/2IH0cJB480F7ysGjR
+gwNUZakHGRIeKnqQRx3ml3iw5ER4tOREiD1YJCGtQvUmFZ7YrMJquhIVnjRv
+iRZiadZNnd7aFvedMpIMJFp/RQDKqWpxQB4FAMJgsH/tQIIwWBkOJAiDwf7l
++7T+hvFg5Q4nwmPULubDg3vOltwH6z/34IG2wsOiBxkPVvQyD4sObpBwkwcZ
+Eh4uOREeKTkRHi2eCOXUMQUTA8PjKkJCRoUntCTdBgyr9ZtVSDpJZ9qSmTq1
+UybStu7T4k5qSOQp0GoJdUIYkIfBgDAY7N8xkCAMVoYDCcJgsH/fGA9uJSHx
+4C7iwd20B+nnRWsZDzYUnhfd1oMVPczDov1UJXMirKI9SEh4qOREeLjkRHiE
+OREepT1YvBISGB6Tb1Lh8VIVqqkTGhIDw2odIeFnESGe/Jb0JB1JSyq6T0VS
+UtVyqlpKnYCnQGEw2L99IEEYrAwHEoTBYP/uIQ8GKAHjwcrPv5V+F/3hwaIH
+ySOje88xHmwkHmxmPNhe4sFeUt9mDxZJSHuQIeHhkhPhkeKJEJGQVmEJDI/J
+CAkZGB5HKUkMDE8UVViEoZaq/oZOlkbcV62mqlUkJUlBVcuI/iTUCTF1QhCQ
+wREQBoP9JwYShMHKcCBBGAz2H9uWEyFDwl20B+n74KmCB/fWEA/WFTy4/zzx
+YAt1oBV78GAH8WAXVUGfCAkJKxkSVpWQ8BBzIjxMe5CQ8IiAJGRUKKKOiogK
+S2B4TEpUyMDweKkKCQxPfEPV21Z0nwIf/k4U6Seijguo43wAIAwG+w8PJAiD
+leFAgjAY7D+8T+vr5EWjB0tOhDQJyfOiu4sePM14kDwyuq+e8WAT48E26iBN
+ws5NJKwsknCAqhoskPBQKQk/UyFdiQ2PlsJQTB2TkEpseFz+lU58IRmJ0O84
+op8Q0Y86zqOOcQPSYEDq//T+H9/7XxEMBiu7gQRhsDIcSBAGg32vERJmAxSf
+SLCEhLuKJKym9pATYcGD54gHG6j9jcSDzdSBLSSs+IyERIVVW0lIVHiYTVRY
+tCGXOsIjldjwqJAkKnRMTJJs0/GvVqSfgDqG6Ucd41DH2NTR4YDE/endb9/7
+XwgMBivfgQRhsDIcSBAGg/0IQyRczYwwV8LKL5IQebCO8SA5ER5gSHhwKwm7
+qcoeqrL3cxIeQtEqZGB4mK6Eh0e4JMaGR1ECJuFGx7ZNwMRnIvQ7yqGOIvqx
+aP2tji1+evvL9/5nD4PBYCBBGKwcBxKEwWA/1FYzGfJxwsqSCAl3IxIep/YQ
+Eu4lJNy3mYQHtiNhBYpRYZGEVf0kWoWDRIXFhnGHKVKJDY9wSNxCR3lM3JI4
+TOySWBsdGQqI3QGRBfQHg8F+tIEEYbAyHEgQBoP9mKM/ThigeNTfDhQ+VLiL
+vFtm99EtJKwtqHB/PbWfwPAAA8ODLdRBAsOK9g0VFkjYS1X1lcTw8BDdIInw
+8DBqmInaXPGPD5U0yPxiAP06IHaB/mAw2A8+kCAMVoYDCcJgsJ9i5Nvqc+QL
+Kfj47aNIhbvJg6MFEp4mKjxL7WNguJ+B4QEGhgdpGBZVSGBYieoqqRtX1cPU
+S+qjDtH1b66vpF4S+lO6qKp2RL+AEOnv109vP3zvf3IwGAz29YEEYbAyHEgQ
+BoP9jGNgmMMw3FXJHApPUHtPUnvJrXBfqQoZGB6gYUirkIZhC1XRWlIbqZ2q
+pOsgES1i4nWT6F93kN/QEhCaAgLj6sjcp7e/fHr7EfW9/9nAYDDYHx5IEAYr
+w4EEYTDYX2PFoyFpJMAWkSTUnmPUnuPU3mosxH2nMQ/312IYHqhnatgc+YMH
+UQ2fFeAbAnx9gK+jxffpDdz7YDDYX2QgQRisDAcShMFgZbJP628LvXm3mh3H
+5VATn96836nv/ZcMg8Fg/6GBBGGwMhxIEAaDwWAwGKzMBxKEwcpwIEEYDAaD
+wWCwMh9IEAYrw4EEYTAYDAaDwcp8IEEYrAwHEoTBYDAYDAYr84EEYbAyHEgQ
+BoPBYDAYrMwHEoTBynAgQRgMBoPBYLAyH0gQBivDgQRhMBgMBoPBynwgQRis
+DAcShMFgMBgMBivzgQRhsDIcSBAGg8FgMBiszAcShMHKcCBBGAwGg8FgsDIf
+SBAGK8OBBGEwGAwGg8HKfCBBGKwMBxKEwWAwGAwGK/OBBGGwMhxIEAaDwWAw
+GKzMBxKEwcpwIEEYDAaDwWCwMh9IEAYrw4EEYTAYDAaDwcp8IEEYrAwHEoTB
+YDAYDAYr84EEYbAyHEgQBoPBYDAYrMwHEoTBynAgQRgMBoPBYLAyH0gQBivD
+gQRhMBgMBoPBynwgQRisDAcShMFgMBgMBivzgQRhsDIcSBAGg8FgMBiszAcS
+hMHKcCBBGAwGg8FgsDIfSBAGK8OBBGEwGAwGg8HKfCBBGKwMBxKEwWAwGAwG
+K/OBBGGwMhxIEAaDwWAwGKzMBxKEwcpwIEEYDAaDwWCwMh9IEAYrw4EEYTAY
+DAaDwcp8/6+9O1htI4YCKPr/H9ZdP6XYjKnNeOPpA0FpScguhMw9ZyW00vai
+J6QEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKC
+AABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQg
+JQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClB
+CFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECc
+EoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIA
+xClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQg
+AECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFI
+CQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQ
+gpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCn
+BCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAA
+cUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUI
+ABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhS
+ggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKE
+ICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQp
+QQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABA
+nBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkC
+AMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKU
+IABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQh
+SAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFK
+EIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQ
+pwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIA
+AHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAl
+CAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEI
+UoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwS
+hCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDE
+KUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAA
+QJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJ
+AgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCC
+lCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcE
+IUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABx
+ShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgA
+EKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKC
+AABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQg
+JQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClB
+CFol+BMAgDAlCDU/AABACQIAAPCGEgQAAKhRggAAADWrBG+327Ztj8fjq48D
+AADA55r0mwCcDNz3/Xq93u/3rz4RAAAAn2vSbwJwMvA4jsvlMkkoBgEAAE5s
+om/SbwLw9XpNCT6fz6lCrwUBAABObKJv0m8C8O9n9OuKcPY9GAQAADiZKb6V
+gbM4/rf215ioHgQAADiBibs1FLru/o73rDHRsW3bbwAAAL65ibtVef8Ohb5r
+3/cJxl8AAAB8c+vDiI8bEAAAAAAAADifPwPePXI=
+     "], {{0, 456.}, {599., 0}}, {0, 255},
+     ColorFunction->RGBColor,
+     ImageResolution->{144, 144}],
+    BoxForm`ImageTag["Byte", ColorSpace -> "RGB", Interleaving -> True],
+    Selectable->False],
+   DefaultBaseStyle->"ImageGraphics",
+   ImageSizeRaw->{599., 456.},
+   PlotRange->{{0, 599.}, {0, 456.}}]]], "Output",
+ TaggingRules->{
+  "Settings" :> {$CellContext`r = 75, $CellContext`ls = 
+     33.06673464102067, $CellContext`lt = 0.001}},
+ CellID->966124099,ExpressionUUID->"59abde20-a871-4db6-b5f0-a98e22762731"],
+
+Cell[BoxData[
+ PaneBox[
+  GraphicsBox[
+   TagBox[RasterBox[CompressedData["
+1:eJzs3Ql8FPXd+HFQAbWtWm+sUpV6INBWbX3ZWvsI9VGpeBavikJV8lgPfACt
+B4pCrQcWDyoUkFMUlUOECsiNgHLJIWcOIFxJSGJCDpIAovP/kt+T+Q8zs7Oz
+m2M3+X7er7x87c7+5tzV7qczu3vOfY/dmnJEo0aNeh0t/7j1L0+269nzL0//
+6QS5c1v3Xn/9n+7dHujQ/fFu/9Ot5+X3HSkT35R/fHxUo0aHblse+/fvLy0t
+/QYAAAAAUM9J3EniebvP1YB7KhUXF+8FAAAAANRzEnem8iL1YFlZmTxaUlJS
+VqkCAAAAAFDPmb6T0JPckxu+GSjBWF5enugtBQAAAADUJAk9yT1XDJqLQslA
+AAAAAGio7Bi0LxMtLCw0F4UmetMAAAAAALXFXCYqASgZuG/fPnOKMNEbBQAA
+AACoXeaDgZKBkoTFxcVcFwoAAAAADZ6knwSgZOA333yzd+/eRG8OAAAAAKAu
+SACanxqkBAEAAABACUoQAAAAALShBAEAAABAG0oQAAAAALShBAEAAABAG0oQ
+AAAAALShBAEAAABAG0oQAAAAALShBAEAAABAG0oQAAAAAJLc1krLK806nJlo
+BoRfICUIAAAAAEmOEgQAAAAAPTZU+jQcMzjMYilBAAAAAEhalCAAAAAA6GEu
++PTmXtHhvAPCXClKCQIAAABAEqIEAQAAAEAb81UwcZSgmTF44ZQgAAAAACQh
+ShAAAAAAtDE/EuFbf5GYwWbG4IVTggAAAACQhChBAAAAANCGEgQAAAAAbShB
+AAAAANCGEgQAAAAAbfjuUAAAAADQhhIEAAAAAG22VoqjBM2MwQunBAEAAAAg
+CVGCAAAAAKDThkre3PNlBodZLCUIAAAAAEmLEgQAAAAAncwFn+arYGYdzkwM
+c0WoEyUIAAAAAEmOEgQAAAAAVBMlCAAAAADaUIIAAAAAoA0lCAAAAADaUIIA
+AAAAoA0lCDQkXwAAAABffBH1fSMlCDQkif5PDgAAAJJC1PeNlCDQkJh/8S0A
+AABo9dVXX1GCgDaUIAAAgHKUIKAQJQgAAKAcJQgoRAkCAAAoRwkCClGCAAAA
+ylGCgEKUIAAAgHKUIGpEeZWysrK9lUoczBR5yB6W6O3VjhIEAABQjhJE9Tkb
+sLi4uKCgIC8vb/fu3dmV5IbclYnykLMHE73VqlGCAAAAylGCqCY7A0tKSiT3
+pPtyc3PlpSITD1aSG3JXJspDMkCGEYMJRwkCAAAoRwmiOuwMLC4uNucBi4qK
+Ir3Y5CFzflAGE4OJRQkCAAAoRwkmlYKCgp49e44ZM8bc3b59e+fOnd99993E
+blUA+2ygyUC5Hfx6kwEmBu0zg4neA6UoQQAAAOUowaQi6deoUaPbb7/d3B0x
+YoTcveiiixK7VZGYk3qlpaXywgiTgYaJQZlFZuS0YNw+DWdaJe/slCAAAIBy
+lGBScZVgXl7ec889N3PmzMRuVST2daFZWVkBF4V6yWCZxb5GNNH7US9RggAA
+AKgOSjCpuEowyZkTgvn5+dnZ2bG+8GQWmdGcFkz0ftRL3ugrruJ9yDs7JQgA
+AKAcJVhTHnnkkVatWs2bN69du3bHHHPMCy+8YKZPmDDhiiuuOP7440855ZSr
+r756/vz5zrlWrFjRpUuX008//eSTT77rrruWLVvmLMH09HRZZp8+fczdzz//
+XO4OGTLEnr2goECmPPzww/aU4cOH/+Y3vzn22GPPOuusP/3pT5s3bw7ebAmx
+3bt3b9u2bWuVLeFsriRbuHr16p07d8b6wpNZZEaZ3Swn5Eo1sJ8IeVLkqYlU
+ypQgAAAAqoMSrCk33nijRNxpp512wgkn/P73vx82bJhMHDlypEw87rjjrr32
+2ksuuURuH3300ZJ7ZhZ5q3/GGWfIxPPOO++aa66RfDv77LOdJbhu3Tq5+8AD
+D5i706ZNk7v9+vWzV5qbmytTbrjhBnN34MCBclcaUGaRIG3cuLFsT2FhYcBm
+S2tsPVzIYJF8y8jISE1NlZjds2dPrC88mUVmlNllIZSgk+vpkKfY94lzht70
+SpQgAAAAwqMEa4opwQ4dOhQVFdkTu3bt+qtf/WrVqlXmbv/+/WXMs88+a+7e
+dtttcrdXr17m7vbt25s3b16dEpR1HXnkkTt37jR3X3zxxYsvvnjWrFkBm+08
+GxhrCaanp2/atGnp0qUHDhyI9YUns8iMMrs5LVirbVW/uJ4OeYJ8nzhKEAAA
+ANVBCdYUU4LBB1OSR8Z06tTJ3G3RosUpp5ziPKTvvPNOdUrw17/+tdwdO3Zs
++A/fVb8ElyxZEl8JyoyUoFdMJVgcDSUIAAAAX5RgTTEl6L2W7/33309JSfnd
+737XunXrY489VsbceuutMj07O1tuX3XVVc7B8nRUpwSlARs3bixTTj/9dFmI
+rFpaIHizq3N1qH1OML6rQzkn6Cumq0MpQQAAAMSHEqwpviXYpUsXmXjUUUf9
+9re/7dSpkzSgXYLyJl9uX3vttc7x69evr04JVlR+Bc2jjz564YUXNqok+Wlf
+LOqrOt8YYz4nKC+hzMzMWF94MovMyOcEvWL6xhhKEAAAAPGhBGuKtwR37Ngh
+U37605/aE9esWWOXoDj55JNbtGjhXMiHH34YUIKfffaZ3O3WrZs93pSjswRt
+X3/9dfv27eXR/v3719xeHkYiRVojJycnvhKUGWV2fkUiPnx3KAAAAKqDEqwp
+3hJcvny5TLnyyivtKY8++qizBK+++mq5O3ToUHO3qKjol7/8ZUAJbtmyxXzR
+qL3A3r172yWYn59/55139ujRo6yszDw6evRo5xfU1Djze4Lyqti8ebPsePhX
+nQyWWWRGfk8wbpQgAAAAqoMSrCneEpTGOe2000zZvfjiix06dGjWrJmzBFes
+WHHsscc2bdpUBjz++ONt27Y9/vjjA0pQSAbKlDZt2kjf3XHHHWaB9jnByy+/
+XO5ed911b7311gsvvHDiiSceccQRK1eurKVdlh2U6pSAzcrKysjIKCkpCfOS
+k2EyWGaRGWV2SjA+lCAAAACqgxKsKTfffLNUWF5ennPi8uXL7Y/snXvuuZMm
+TXJ+d6iYPHnyr371K/M1L7/4xS9mzJghN+68807z6IYNG1yXg8oUCUazwNNP
+P33s2LFy46abbjKPbtu2TW5LWspEWeZFF100e/bsWt1r+7Tg1q1b09PTJUOC
+X28yQIbJYE4IVhMlCAAAgOqgBOvArl27pH0CBmRnZ2/fvj38AnNycjZv3mxf
+Beoiz1FqampBQUFsWxkXSTlZndSHJHBGRsbGjRuzsrIivdjkIRkgw2SwzCIz
+UoJx8+ZeAO/slCAAAIBylCCqyY7B/Px8Cd5169Zt2LBh27ZthYWF+yvJDbkr
+E+UhGSDDyMDqowSBpJKSkjJgwIBEb4WPqVOnmm0z0tLSEr1Fdce175GGyTHx
+Hhm5K/PKEmp/M2Mg2ylbleitiMJspJdzjHlqbMl2nAE9KEFUnx2D8grJzs7O
+yMiQ7lu5cuWySnJD7spEeUgGkIHJgBIEapa8lU3OyKoX7VAbwqecGUkJ1hSz
+kVM97AF2oZtjbt9N3CYDelGCqBEmBktLS4uKiuR1kpubK923q5LckLsyUR6S
+AWRgMqAEASWSMGfqhm/fhR9JCcYt6kZ6B5gpyfn/pQANGyWIGlRWVmZ6sKSk
+pMhB7poGjPTZRtQxShCIj/OqNnn7apeC87a5a97Wei9NDFiC652wPOScaN91
+Xn3nPKvivdDOHum6NNS1EFfvBGy8ay7nBvtunrekzDDv7kfdKq+A8fZaol4W
+6x1plmOXYKRjG982u46A6zCatTuX6X1qzJPufQ14hwU8TfaWh39VWFWvh6i9
+FrUEvQsPme1pIQQvAYALJYjaYJLQRgAmG0oQiIOdDCYQnO94Uw6/vM3ctXvH
+Hha8BNfbY9MgzhJ0BpTzrj3RlQb2FDPedTGeeefsvTYveOPtuVzncVx9590Y
+56rtKwbthftuVXBY2avz7oVziuvSRBfvSLPBpk2ce2Rf9OjdnfDb7JzFPgL2
+IXKt0fvURDrIzlW4nibXs2C/WlKq4tdscJh9iRSeLvZrxnek78lWMzHqBaIp
+0XCJKRArShBQiBIEYuX73ti+642pSGUXsIQwJegNK9dpNd+scy426ooCNt65
+dte6vBf4ud7zx7r7waeWIu27PaU2rg71HtuYttm7BO+jri3xzW3vayDgReL7
+NHlP7YXZl5jOCToFPE3ODQjZca7z1N5dBhAeJQgoRAkCsfKefHE9GtwIYZYQ
+pgSdA3wTJrgEA87IOEsw5Bt153tybzi41hVQSb5v5oNTLur21EYJOnchjm2O
+tNkBj0Y9hq4Bvs9d8NNk+b20Iu1gGPapVedZS1ehV6cEU/zOzMa6kQAMShBQ
+iBIEYhXTe/g43uvGXYJRz1t5T6D4Cq6JSHMFJ4ZrsZF2P2CrYi1BexvqpgRj
+2mbnXL6XrfruVPBB9pZgHE9TfPsSnlmU7wb77mYA7+yuU4QAYkIJAgpRgkCs
+gt+pptSrEjSnbCJ920bAxgfMVf0S9N2qgMOVDCUYcEAiMQHovITSeeR9SzCm
+c4JxPE3OjxbGtC8hOS9q9T2wkfLQy3umMuSMAHxRgoBClCAQqzooQdejtVGC
+YfoovlM2UUsw4OrQ8NUWvD3ec0+1V4JxbLOX6zthvDuVFvvVoXE8TbX9UTvX
+SzfSSz18CTqnUIJAdVCCgEKUIBAr75d1WI5vRwxTgjEtwaqdEvSd4hJ+453b
+H7IEfXc/LfJXR0bKk0jfnVKr3xjjLcGYttn3oeCOcz3pIT+MGevTFGlfXMux
+PwAYae8icRa67zaE/6yf7wueEgTiRgkCClGCQKzSqn5WwL6I0fmGNkwJBi9h
+QNWPFDgfqo0StM9DudblbNIwG59W9YN0zu13zeVaVMDu2x0Xaauibo8rN2I6
+Z+c8IFMP/z1B5zDXPsa6zfYBcY13fcov0qPeDfBuZ3xPU8C+uDY+6iG1tydg
+L+zwNAOqc0LQ4nOCQPVQgoBClCAQhzTHD7QZka7ri/TONmAJ9nt4+518LZ0T
+tPy+ISTMxntnHOD4TYEwJei7hJBb5eU6YgMO/4GDmErQueoBVT+87t34SCez
+wm+zd7y3lCM96rsBvtsZ69MUcl/MxKgl6PwIpPd5ibSFAct0zuJ9Zdb2pa1A
+w1Z/S/C55567uVJxcXGit+WQZNseIAAlCFSHOZdRG0uo/pJrZDNqY67wS4hp
++faZr+psTxzrrc68kbY55fD/ZyC+LYlvk6JuW20spwafOwDxqb8l2K5du0aV
+CgoK6nK9RUVFEyotXrw4GbYHiAMlCADJJuTZMQCoKZRgrNLT0816O3bsmAzb
+A8SBEgSAZEMJAqhjtV2C5eXl8b5XjYISBOJGCQJAsonvmzkBIG61VIJz5sy5
+7rrrzjrrrKOOOqp169Z/+ctfsrOzzUMzZ868tNKIESN69uzZsmXL0047rays
+zDy6YcOGRx555JJLLmnSpMkFF1zQuXNnKS/fVfiW16hRo2655ZaTTjqpefPm
+d9555+TJk+2H7PXKmH79+rVq1UpW0bZt24kTJzoXK8NkpT/5yU/OP//85557
+bsqUKWausWPHyqMyY5s2bcx6jzvuOJkuu+DanrVr18o2nHDCCWeeeaYsKi8v
+L8wRA+oSJQgAAKBcbZTgyJEjGzdu3Ohw5557rswuj37wwQdmytlnn20/akow
+LS1N4tE1o3TiqlWrvGvxlmD//v1d88pmvPfee+ZRe72SeK4xK1asMGMWLlzY
+rFkz56MSqubGa6+9JgMkaV2rsM8M2tsjAesc0L59+6hHDKhjlCAAAIBytVGC
+rVq1kgI6/vjjx4wZ8+mnn15xxRWmiT755JMKR5GJtm3bPv7447169TIXkf72
+t7810zt16vTRRx+lpKSYu127dvWuxVWC8+fPt0NPVjp16tSf/vSncveoo47a
+smWLa73dunXr16+fGSD+93//1yzT7r4rr7zy9ddfv+222+xZTAkuWbJk4MCB
+Zsoll1wybty4BQsWuLbnjDPOePXVV7t06XLkkUeaKbt27Qr5/hyoG5QgAACA
+crVRgllZWTt37szPzzd3J02aZILohRdeqHAU2cUXX1xUVGTPVVxc3KRJE5Ny
+paWlZmLnzp0lym688UbvWlwlKAs3dz///HMzQGLQTJFec673hhtuMAPsKTff
+fLPclW22zwPu2bPHjOnYsaOzBCtCfE5QOtQ1ZebMmVEPGlCXKEEAAADlaqME
+y8rKBg0adNddd7Vu3fqMM86wT6v16dOnwtFfvXv3ds61ePFiM13qL8xbWVcJ
+Xn/99Y0iMKf87PX27dvXLCEzM9NM+eMf/yh3p02bZu46T0G+/fbbsZZgTk6O
+mfL000+bKeZkKJA8KEEAAADlaqME//CHP5gCaty48ZlnnhmpBF966SXnXHPn
+zjXT77vvvjBvZV0leNVVV5m7P//5z39Z6aKLLpK7cuO5557zXe+uXbucJbhg
+wQJz9/bbb7fX8uqrr8ZagvbnFmW9lCCSEyUIAACgXI2X4PLly03+dOjQISsr
+S6aMGzcuTAnKwo844giZfumll9oThwwZ0rt371deecW7Ild5PfHEE+bu2rVr
+fTcsagkWFhaaDTjhhBNSU1NliizZ/qZQbwlec801AdtTQQkiiVGCAAAAytV4
+CdrXWEpe5ebmbtq06eKLLw5TgqJ169bmIWmotLS0YcOGmbs33XSTd0Wu8po4
+caK5K9MzMzOLi4v79et3YiVZju96XSUo5IaZInNJyTq/yNQuwZycHPNVMD/6
+0Y+mTJmyefNm3+2poASRxChBIDnJ//YNGDAgGX5UTjZj6tSpid4Kf8lzlBqq
+tEqxjg+eK8wYAHWsxktQOugHP/hBIwdzoi1MCS5YsODYY49tdLgmTZr4fuOK
+q7zKy8s7d+7sXWnLli13797tu15vCcpI529AyEL+9Kc/uUqw4vDPJHp/RYIS
+RPKjBIHkJG+SU1JS6vitsm9VyWbI9LrcDF++0WeOUtKGajUlQ+fKsQ3/7MvI
+lMO5nhq5m+JBDwLJoDY+JyhBZ/8cQ5s2beQ/Eeb2888/L49+9NFH5q7vNZ8z
+Zsy44oorzI/6NW7c+MILL5w9e7bvWtq3b2+WU1hYaG9k9+7dzznnHLvjbrvt
+toyMDPOod71ZWVlmipSdvdiioqJp06Y98cQTL7zwwsqVK4cPH27GvP766853
+0ZdddtnRRx8t02+99dZI2yP7a6ZMmTIl6kED6hIlCCSnhJSgb1UlTwl6D0iD
+L8FE7Z05YWfKLuSzb8abdBV29DmfMucA55ha2w8AYdVGCRrSWTt27IjvbWpx
+cfHq1avt36GI1datW9evX19SUhLrjN26dbv33nsffPBBc16vrKzMPtP35Zdf
+esfbv3YB1C+UIJCcKEEXSrAuOU/exf3sm+13zu59PZvY5LQgkHC1V4L1UZcu
+XUz3nXHGGVdfffXJJ59s7p5//vnl5eWJ3jqgxlCCQKzscyUBl8CZd7/OsyS+
+8wa8yfcNH9e8zkfNSqMu3/Wo/RlA54wDqphZzBTngDBtErwlIbfWNd65bfZm
+mxmd5eJdTvgVBR8ub4c6B7iea3sfXQt0rt3M4lyC/aj3GXHO6Npf51rsa0rt
+l5+zxVwbGeYIVOf/B4gakmZHKEEg4ShBp+zs7Lvvvtv1QcUOHTrI9ERvGlCT
+KEEgVvYb7KlVXG937Smu9/D2dOeMkarEW4L22RPfS++c1eAsI+8SfLfcXqbz
+UTOXq1O8++vLnsW5ZO8hso+Pd2tdR8O1eWakOUrOzTP76I0m11WLYWLQdcBd
+Z6/sVTsPpnOAb+O4joP36bBnibTLrj3yrtd5TOzXoet5qZsSjHqoG/YpXaB+
+oQS9tmzZMmPGjOHDh8+cOdP8EAbQwFCCQPW5GsH5Rt05zDegAtonOCtcl955
+r7LzXYLrXbc3THyvDvUtSt/NjrQu13v+SAMCoiP81aFRdyrq9lshDrgZELCF
+YUrQdx+dpwW9Gx/10Nkl6PvSqstzgt5D5FxsrE0KoFZRgoBClCAQt0hni3zf
+AIc/FWUv3LlM33md79K9dePqCN/8CVmCrhaIekWfb+84tzbuSgpTgs499V1R
+mM9gRt0F73rjLkHXN6iEKUHvhtkTa/ZEW9wlGPyCd14WyzlBIBlQgoBClCAQ
+B+dnu2xhSjD8GRBvCfoKX4K+DVLHJRgcaLVXgr6ilmDAAfddbxwlaP/fCPbC
+o5agb9E715UMJRjHJbhxbR2AGkMJAgpRgkCs7He5kd7z11IJmjV6mQGUYPCK
+Ih234F2INGONlKDvVcQNoARjOv1ds1sLIG6UIKAQJQjEKmoZ+ZZgmCsSA8YH
+V5IV7urQxJagOe0VsITaKMFYD3tMG1MjJehdb9wlGDBX3GItwfiugqYEgYSj
+BAGFKEEgVtUpwfBvql1ZEfUiupCfEwz+kpYw5w2tECXo3VpXINRxCfouNjgP
+Ix3wgDZ37ZR3g10bE/Up89143+PgHBbcVq6vIY0qoATNolyDY826WMsRQC2h
+BAGFKEEgVvbbXXOtoPdbECN9ZaLzslJ73kjvgV1v+NMcv1ngO3vUrLAcv+zg
+/L4O5/t8167Zc8Vagt6tdZ4QjLSEqKWcUvWTCmmVX67iu4/eQ2EfdtdTFlxD
+kQ6499pOs2Tvy8C1BO8Btzfe9ULyPmWuZ8T3FRh8JtG1wKgl6Npl59qda3F9
+5tF5QJycryXvExHfN9IAqFmUIKAQJQjEKs3ze+Jhzgk6H3LOG+k9ue8ZpYDZ
+w5SgVfUVJXbRpPidJbSZiXGUoHdRrj2NrwSdux/wzS3eQ+E6buHrI/j5cm2P
+d6dcAyLVk2tApGck0oze14n3mNi848PsuBF8Qtl3Ftfq4n4iANQ2ShBQiBIE
+4mOfNIl73mquOu7ZnXyToQaXX52jFLzMupw3eC7XSUDvyKgrjXtAjR/bulEb
+rwoA1UQJop4qr1JWVra3UomDmSIP2cMSvb3JhRIE9PCeHwxzegghRSpBAEh+
+lCDqI2cDFhcXFxQU5OXl7d69O7uS3JC7MlEecvZgorc6iVCCgB729Xi+H0lD
+NVGCAOovShD1jp2BJSUlknvSfbm5ufLilIkHK8kNuSsT5SEZIMOIQRdKENDD
+/m4T+2tAEr1FDUpa1ffYAEC908BKULawZ8+e7777bqI3BLXFzsDi4mJzHrCo
+qCjSy1seMucHZTAx6EQJAgAAKFevS1A2ZtasWatWrbKnbNu2rVGjRnfccUfi
+NqqGefdROftsoMlAuR38CpcBJgbtM4OJ3oOkQAkCAAAoV69LcMeOHdJ91157
+rT2l4ZWgdx81Myf1SktL5aUYJgMNE4Myi8zYYE4LfhrOtEre2SlBAAAA5SjB
+JEcJOtnXhWZlZQVcFOolg2UW+xrRRO9HDaAEAQAAUB11WYJpaWmPPPJI27Zt
+f/jDH1599dX9+/e335OvW7euVatW//jHP1555RUZ0KxZs9atW48ePTpgaX37
+9v3Zz34mlXTsscfKvKb+7BIcMmTIJZdccswxx1x22WXDhg1zzTtq1KiOHTv+
+6Ec/+sUvftGrVy9phIAVpaenP/bYY7KKH//4x7fccsuECROcj8ouyI787ne/
+O/roo2XLP/jgg379+sngjRs3yqOff/653JaNsccXFBTIlIcfftiekp2dff/9
+98u+yF7LEnr06FFaWhqwj8bw4cNvuOGGE044QQbI7MuXL7cfsg/mk08+ec45
+5zRp0iRg7+oXc0IwPz9fDlqsL3WZRWY0pwUTvR81wBt9xVW8D3lnpwQBAACU
+q7MSlPfhF1xwgUTNeeed16FDh+OPP15uS/WYRyVk5O5ZZ50lPdW+fXsZ06jS
+rFmzIi1w6NChshwZc+qpp0qgSfVUVJXgT37yk6ZNm1555ZUSVmY548ePd84o
+UyQDr732WrMiGVlSUuK7lry8vIsuukjGtGnT5g9/+IOk5RFHHDFlyhR7wPPP
+Py+PynRp2wsvvFBum3Yzn+ybNm2a3JY2tMfn5ubKFIk4+8Cef/75ZvkSpxKb
+znOavvsoBg4caK/05z//udw+5ZRTNm3a5DyYMkvjxo0lqNu1axfwvEgW7d69
+W47b1ipbktXmShLmq1ev3rlzZ6wvdZlFZpTZzXISvTcR2U+EPCny1ETqVkoQ
+AAAA1VFnJdi5c2fJkyeeeMLczc/PNwU0Y8aMiqp4adas2bx588yAPn36yJR7
+7rknYJmRrg6VAvr444/NlLffftvZVqmpqU2aNDnzzDMzMzPNlC5dusiAl19+
+2XcVf/nLX+RRyT1zd+XKlZKQkrHmtJ2UhazrpJNOkr4wAyT6THuGLMFFixZd
+fPHF3bt3N3flbbw0nRwHuRFpHzds2CA1evLJJ2dkZJgpgwcPljFXXHGFuWsf
+zOnTpwccPUNaY+vhEl1CEUm+yS7LM7hixYo9e/bE+lKXWWRGmV0WUi9K0JAX
+jO8T5wy96ZUoQaABSEtLS5IfepDNSNofR0ieo1QdaZWCBzh3M+r4OpDmEHVM
+7a29xpcMqFVnJXjOOedI4zhn/+STTyRYnn322YqqeGnfvr396Nq1a83ZuoBl
+RirBtm3b2lOysrIk1i666CJzd9SoUTJg0KBB9oDs7GyZctNNN/muomXLls2b
+N3dOefjhh2W8NIXcHjZsmNyW/1Dbj5aXl8d0TtCra9euMmDNmjWR9nHEiBEy
+5fXXX3fO9atf/app06bmzKY5mB06dIi0Cifn2cDkL0Ep7k2bNi1duvTAgQOx
+vtRlFplRZjenBRO9NxG5ng55gnyfOEoQaJAS8jPlvlVlfoy+LjfDl2/0maOU
+tKEakmx/8HPt2k0zPoF7LU9EyuFcG2O2MGCAl9lHX86Xn3kZxLRkAGHUTQnm
+5ORIm1x11VXOifIuVyZef/31FVXx8tBDDzkHSNpcfvnlAYuNVIKdOnVyDjvr
+rLOkQ83t7t27m3N2v3QwV1d6l2+qzTtYvPPOOxVVVThnzhznXLfffntMJZia
+mtq7d+9rrrnm0ksvNRVpz+67j4888oh3pffdd59MXLJkiX0wH3300YBD5zxi
+9a4EZTfjK0GZsYGVYHE0lCBQvySkBH3fVydPCXoPSMMowag/Se/aTTM+UWfE
+TIuZKjdbYorMuT3OAfaY4FeRGeZlFmUPc67LPFr3/5oADVLdlGBmZqa0yXXX
+XeecaE7GmfOAvvHSrFmz+ErQ9d2hzhI0xdS2bdvbHFq2bNm1a1fv8k2rCudg
+iUHZEfkPkb20RYsWOee65557wpegHPwTTjjBfLaxY8eO5hra4BK8//77Zcri
+xYudK/3rX/8qE821tTGVYP26OtQ+Jxjf1aH18Zxg8NWhlCDQwFCCLg24BKNK
+8t00m+c6c+caE1+yuc5+ek+GelcNID51dnVo8+bNW7Ro4Zwye/ZsCZZevXpV
+1GEJ/utf/5IBY8aMCbnZp5122nnnnRfp0TfffFOWNnToUOfEiy++2E65zz77
+TG5369bNfnT9+vXOEnzwwQddl3p26tQpuAQHDRokU1xfiPpf//VfjRs3lieo
+IsYSrF/fGGM+Jygv2szMzFhf6jKLzFiPPicY5htjKEGgzkS9Ps2cqrAOP3vi
+O2/Ae3vf8HHN63zUrDTq8l2P2p8BdM44oIqZxUxxDgiTJMFbEnJrXeOd22Zv
+tpnReTmidznhV+SaxXnOy57R3phY12Uv035hmINsH41ICzG3necEA15UAS/I
+qK+NuD90GTXH4itBs6n2XfNceJdMCQLVV2cleP311zv7paysrF27djJl3Lhx
+FfGWoDmreO6559pTopag7KwM+PWvf11YWGimSBTcfPPNzzzzjO8qzFd3mo00
+Xn311RtvvNGU2oIFC+TR888/Pz8/3zwqI50n9eSNfaPKr0u1Z+/du7ezBGVR
+cnfmzJnmrnSKOUVol6B3H5csWSJTLrzwQtN9FZW9ecQRR9ifhYypBOsXySKp
+m5ycnPhKUGaU2fkViQpKEIid/TbevoDN9TbYnmKXi10QZopzxkhV4i1B+720
+7yV5zo5zlpF3Cb5b7ryEz37UzOXsEd/99WXP4ntxoD3FPj7erXUdDdfmmZHO
+D5eZh1zR5FyX89CF/NiadwtdxzCmdbk+CmcWZfl9TtB1wL0l6Bwf8gUZ/Nqw
+Dr/wMiZhDqm9s9VZrO9C4lgyAK86K8F169addNJJTZs2ve2225588snLLrtM
+aqVjx45mgfGVoDjxxBNlxj/+8Y+DBw+uCFGCFVWn4Vq3bv23v/2tV69ep556
+asBZwrVr18oqZEvuvPPOvn37yopksDSX/ZN/d999t+mynj173nXXXcccc8zR
+Rx/tTDnzQxVt2rR59tlnZcNkUc4SfOutt+Tu2Wef/fTTT/fo0eO0004zA+zZ
+vftYUfX5xFatWslK77333uOOO07msj852LBLUI68vA6l33Nzc8O/zmWwzCIz
+8nuCBiUIVJ/rfIczB5zDfAMqoH28y3SdNnIu0HvOxXcJrrfrrk3yfT8fqSh9
+NzvSuqJ+50nUy/zCXx0adafCtIN3yfYWej8QF3Vdrm517YXryY169KJeOez7
+ggxYoHNf4i7BqAPCnIp18r4ezNFzDaMEgRpRl78sv3Dhwvbt20srSaecccYZ
+Xbp0sU/MyWbIRPvHFAxJqt/85jfByxw3blzz5s3NaT65u337drktReYc06JF
+i5YtW9p3y8rKHnvsMWlDc/JOHh05cmTAKubPn9+uXTvTd0cccYSUrP0LFGLP
+nj3SYhK58uiRRx5p/nvlTLkNGzbYP2t4+umnjx07tpHjq0rNxphjIgvv1q2b
+md3+7lDvPpq5pAHPPfdcmXjUUUf99re/nTRpkj3e92A2DBJxsu9FRUVZWVkZ
+GRklJSVhXuQyTAbLLDKjzE4JVlCCQDXY531833i7Bsf6Ztj1bt93XmeGeN8P
+u97t+75hDlmCrjfk3iyNOotra32XUFMl6NxT3xWF+Qym75hqrivSx/1cM3qP
+Q8gSjOkFGXy0w4v6wrb7t/qLDSjB+C5qBWCryxI05J3q5s2bq7kQF8mx4qof
+4AtPgm7nzp0hB0tEpKamRvoBeumLjRs3ypiKqi9vcZ7Uq6j89lTZaxnmO7sc
+VVl4QUFBwAb47uO2bduC52p47NOCW7duTU9Pl2MS/AqXATJMBjekE4IVlCCQ
+CK6PZblO9ASUYPj3q94S9BW+BH3f+ddxCQZHU+2VoK9aKsGAdYUpQd8xUUvQ
+d9V1UILhMzCOTwj6/l8f3h3hnCBQI+q+BBs83xJETZGUkxeh9E5eXl5GRoYE
+eFZWVqSXtzwkA2SYDJZZZMYGXIIBvLNTgkCs7He/kS7drKUSNGv0MgMoweAV
+RTpuMa0uzLp8n6aArbWqXYLxvSCrX4K1l4GRlkwJArWHEqxxlGBts2MwPz9/
+69at69at27Bhw7Zt2woLC/dXkhtyVybKQzJAhjWwDKygBIE6F7WMfN94h7ki
+MWB81PftYa4OTWwJmigIWEJtlGCshz14ddVcV5gStGK/OjS+F2Q1SzBkBsb3
+wcNIS450hTMlCFQfJVjjtm/fvnr16kjXkaJG2DEor8ns7OyMjAzpvpUrVy6r
+JDfkrkyUh2RAw8vA6qMEgVhVpwTDv/d2vduP+mGokJ8TDP6SljDnDa0QJejd
+Wlc41HEJ+i42uFDiLsGAdYUsQe9T6Tp6tVSCUyuFCTfva8l3j4Jf7ZFWF/D9
+M94DGN930QDwogRRT5kYLC0tLSoqkldmbm6udN+uSnJD7spEeUgGkIFelCAQ
+K/ttsLnwz/7MYPAbb8vv6sEBVT8w4eV6t29faBdp9qglaDl+m8Cw70baNXuu
+WEvQu7WuEzdxlKA9wCxz6uG/J+gc5joU9mF3PWU1XoJR1xWyBO2iNAuxn6lI
+JRjfC9J7tF1zRWJX3lQP5276DvC+Gl2ri1p2vjsbvMEAwqAEUa+VlZWZHiwp
+KSlykLumASN9S49ylCAQqzTPr36HOQXjfMg5b6Q33t4SSTv8V85ds4cpQavq
+R8btK0VT/M4S2szEOErQuyjXnsZXgs7dH1D1M4hR68zyHPaoK7LiLcHgdYUs
+Qe+eBp8T9L4g4/vuUN808/LuoM1Zgr5cJ6C9qwv4d8feWdfBiePqUwBelCAa
+BpOENgIwGCUIxMc+MRf3vNVcddyzO/mGSQ0uvzpHKXiZdT9v3a8rpiXUxqFO
+Zqp2FqgDlCCgECUI6OE9PxjmHBAAoMGjBAGFKEFAD9fVg74nBAEAClGCgEKU
+IKCH+coO+3OCnA0EABiUIKAQJQgAAKAcJQgoRAkCAAAoRwkCClGCAAAAylGC
+gEKUIAAAgHKUIKAQJQgAAKAcJQgoRAkCAAAoRwmigSmvUlZWtrdSiYOZIg/Z
+wxK9vYlBCQIAAChHCaIhcTZgcXFxQUFBXl7e7t27syvJDbkrE+UhZw8meqsT
+gBIEYpWWllb9H+NLq1RTm+RkfjSwNpYcUlqVOpsRAFBNlCAaDDsDS0pKJPek
++3Jzc+VFKxMPVpIbclcmykMyQIapjUFKEIiVpEpKSkr4YDE/5u6d6FyI75j4
+mF+Nr5FFeZec4sceYHbKKWSTumb0zmWvmk4EgNpQT0tQtqRnz57vvvtuojck
+Ntu3b+/cuXPwZo8fP152bdeuXSHHw7AzsLi42JwHLCoqivSyl4fM+UEZrDMG
+KUEgVnGUoDOX7IU4e8d3THxquwSnerhWbZ/aMzsVdWPsYeaQeuey11KDvQwA
+cKoXJSgrnTVr1qpVq+wp27Zta9So0R133FH3G1MdI0aMkM2+6KKLAsZ069ZN
+xqxduzbkeBj22UCTgXI7+JUvA0wM2mcGE70HdYoSBGJVIyUYx5iQarsEAwZ4
+j4mZJfhYeRfrmst5LW5NHSUAgFO9KMEdO3ZIEF177bX2lHpagtIdzz333MyZ
+MwPGOEswzHhUVJ0QLC0tlZdomAw0TAzKLDJjvTst+Gk40yp5Z6cEgVi5StB8
+bDDSxY3mNJY5yWWfMrOnO29HGuNau0xxXTzpvLTS9zScawt9r70M88nHqCUY
+aZbgJXs3yXWEnecEE/sRSABoqCjBZOMsQYRkXxealZUVcFGolwyWWexrRBO9
+HzGgBIE65luCJtAMZ4vZlWc/6rwG0lWCvmNca/deOWmm+K7dOvzaS/uKTVdP
+hfwInl2C4c+HhjmNGKkEvUHNpaEAUEtqqQTlv+ePPPJI27Ztf/jDH1599dX9
++/e332avW7euVatW//jHP1555RUZ0KxZs9atW48ePTrSovr27fuzn/1M4ujY
+Y4+VGU392SU4ZMiQSy655JhjjrnsssuGDRvmmnfUqFEdO3b80Y9+9Itf/KJX
+r17ynj9gm2WDZflffvnlf//3f//gBz8455xzZIGlpaW9e/du0aKFrP2KK66Y
+N29eyOXbu/nkk0/Kopo0aSIT09PTZWKfPn3sYXJYXn31VVny0UcfbY6DswS9
+47Ozs++//345IHLc5Oj16NFDttC1C/KcXn/99T/+8Y9PPfXU22+/XY5VwF43
+DOaEYH5+vhyfWP8VkFlkRnNaMNH7EQNv9BVX8T7knZ0SBGIV9epQ14kw36Dz
+fmNMpDGuia7M9GaUq5h8B3ivxgx/TjD8F8L4bp6LbwlanuAFANSq2ihBeWt9
+wQUXSM6cd955HTp0OP744+W2NIt5dPny5XL3rLPOkvZp3769jGlUadasWb5L
+Gzp0qCxEBkjX3HLLLRJWFVUl+JOf/KRp06ZXXnmlNJFZyPjx450zyhTJtGuv
+vdasRUaWlJRE2uwbb7xRxpx55pmytOuuu06WLHevueYa2U5ZwuWXXy53jzvu
+uJ07d4ZZvtlN2ebGjRtL4rVr166iMg9l4gMPPGCv9Pnnn5cpUrKSnxdeeKHc
+/ulPf2qXoGu8HPzzzz9fprRp00YKVFrPdWLU7IIc23PPPVe2XGpR7v7+978P
+eLIkf3bv3i3Hc2uVLfXN5kpSzatXr5ZnJ9Z/BWQWmVFmN8tJ9N5ssZ8IeVLk
+qYnUp5QgUMcilaB90q2OS9A1wFmCrrUEb39U9vlK++RjQOiZtUS9mpQSBIBk
+UBsl2LlzZwmQJ554wtzNz883/TJjxoyKqkSSSLHPr/Xp00em3HPPPZEWGOnq
+UImsjz/+2Ex5++23nVmUmprapEkTybrMzEwzpUuXLjLg5ZdfjrQWk1Gy8ebu
++++/b1Yxe/ZsM+XPf/6zTJk0aVKY5du7OX36dHsVrrKTAJHln3TSSRkZGWaK
+CcNIJbho0aKLL764e/fu5q685z/llFNkFXLDuQs33HBDWVmZ3M3JyZGFyxT5
+39xIey2tsfVwiS6hmEm+yQGUZ2TFihV79uyJ9V8BmUVmlNllIUlVgkZubq7v
+E+cMvemVKEGgVnlLyvfnFeqgBH2vvfSWoK8a+TmGSK1nZ2DUtVCCAJAMaqME
+zznnHCkU58hPPvlEeuTZZ5+tqEqk9u3b249K9ZgTapEWGKkE27Zta0/JysqS
+qrK/ZnPUqFEyYNCgQfaA7OxsmXLTTTdFWovJqGXLlpm7RUVF5uybPcAsU/5H
+KszyzW526NDBuQpX2Q0bNsxeoFFeXn722WdHKkGvrl27yoA1a9Y4d8F5Cevt
+t98uUwK+c8Z5NrD+lmB6evqmTZuWLl164MCBWP8VkFlkRpndnBZM9N64SzDS
+xb2UIFDHvN9nYlrGNSV5SjDNT3z77l1XpHOOIWMz5OcEAQC1qsZLMCcnR9Lj
+qquuck6UN7Qy8frrr6+oSqSHHnrIOaBp06aXX355pGVGKsFOnTo5h5111lkS
+oeZ29+7dzcm1XzrIXUnUSGsxGeU8BePakQkTJsiUf/7zn2GWb3bz0Ucfda7C
+VXYPP/yw3J0zZ45zzM033xxQgqmpqb17977mmmsuvfRS8/FJYf++htkFaVJ7
+fL9+/WSKbwvYR7LBlOCSJUviK0GZsZ6WYHE0lCBQU1wl6G2W5CnBuC8EDcm7
+hWaNYT51aPOe/gvzAUMAQA2q8RLMzMyU9LjuuuucE835MnMe0DeRmjVrFkcJ
+ur471FmC9913nzlpeJtDy5Ytu3btGmktMZVg1OWHKUGzkEWLFjnHyE5FKkF5
+pk444QTzAcmOHTuaq3C9Jejchb///e/BJdgwrg61zwnGd3VoMp8TDL46lBIE
+6oy3BH1DJtIpwrjHWI7O8t0Sw1uCvpdZOudyfmFpTFxXh/r+hoWLd13enq3B
+X1cEAIRRG1eHNm/evEWLFs4ps2fPlh7p1atXRV2V4L/+9S8ZMGbMmKhba4up
+BKMuP0wJvvnmm3LX9ZWnbdq0iVSCDz74oNx9/fXX7cGdOnWqZgk2jG+MMZ8T
+lBdzZmZmrP8KyCwyYxJ+TjDMN8ZQgkCdcfWX/QMQ5qpL+zODzp+ZSHH8joP3
+VyQijbEnmoXbS3Z9Nai9dufvEtoD7PNrri10tliYizntKzZdy7HP3Dm31itg
+Xa5954QgANS92ijB66+/3hk4ZWVl7dq1kynjxo2riKsEzSnFc889154StQRl
+p2TAr3/968LCQjNF3uTffPPNzzzzTKS1xFSCUZcfpgQXLFggdy+44AI5sGbK
+e++9F/CNMWYL7Q/9SbyYU4TVKcGGQXJJqicnJye+EpQZZXZ+RQJAgDTP7wk6
+v4nFpJArdpzf3DK16kfSo45xTTSt5Ao919p9f3fP+70xrgEhS9D1xTiuS0Bd
+WxJpdb7rcm0h3xUDAHWsNkpQ+uWkk05q2rTpbbfd9uSTT1522WUSIx07djTz
+xlGC4sQTT5S5/vjHPw4ePLgiRAlWVJ1Ba9269d/+9rdevXqdeuqpwWfxYirB
+qMsPU4Li7rvvlimtWrWSJdx1113HHHOM+dEN3xJ866235O7ZZ5/99NNP9+jR
+47TTTjO/E0EJmt8TlNen9LjsfvjXvwyWWWRGfk8QQBzCfA1L3GOizhjyS2Bq
+5LtiavY7Z7xLrvHFAgCiqqVfll+4cGH79u2layRDzjjjjC5dutjnzmSNMtH+
+KQTj6KOP/s1vfhOwwHHjxjVv3tychpO727dvl9uSTs4xLVq0aNmypX23rKzs
+sccekzY0Z9nk0ZEjRwaswnxVS15enj2l0eHfcTpx4kTnxZnBy/fdzQ0bNsjE
+bt262VP27Nlz7733mt96kHZ+6qmnzC/Lr1+/3jverNEc1SOOOEKmp6SkNHJ8
+d6h3F1588UWZMm3atIAdbwAk4uTgFBUVZWVlZWRklJSUhHnxyzAZLLPIjDI7
+JQgAAAA9aqkEDXlTunnz5hje3UYj3VRc9dt54WVmZto/B18bqr98yZDU1NSQ
+uyZPgQwuKCiozhobHvu04NatW9PT0+VgBr/yZYAMk8H18YRgBSUIAACA6qnV
+EgTqjKScvDilg/Ly8jIyMjZu3JiVlRXpZS8PyQAZJoNlFpmxAZRgAO/slCAA
+AIBylCAaDDsG8/Pzt27dum7dug0bNmzbtq2wsHB/Jbkhd2WiPCQDZFg9zcAK
+ShAAAADVQwmiIbFjUF6r2dnZGRkZ0n0rV65cVkluyF2ZKA/JgPqbgdVHCQIA
+AChHCaKBMTFYWlpaVFQkr9jc3Fzpvl2V5IbclYnykAxQm4EVlCAAAIB6lCAa
+pLKyMtODJSUlRQ5y1zSgDEj0NiYSJQgAAKAcJYiGzSShTXkA2ihBAAAA5ShB
+QCFKEAAAQDlKEFCIEgRilZaWNmDAAPlnHa+0NtaYkH1xrt0W34y1tGEAoA0l
+CChECQKxkgBJSUmp4wxJqWTflXybOnVq9Rdr9qVGFhUr2YWUw4XZDJOuwXPZ
+A0hFAAiJEgQUogSBWCWkBKdWsu/KBkjvVH+xiSpBE3TmdKSQDQjZbmbH7WFm
+RuehsA+U/LNGDhEAaEAJAgpRgkCsElKCLvW9BCNtSfBOme5zHXlzBtB51x7g
+nA4ACEAJAgpRgkCsvCXoumTRFVbm5FTwGKsqc+xHXdd/Ou/ayxlQxWyM95JR
+e9WRNtXc9s7lHOB61LnGmlUjJeg8J5gMhQsA9QIlCChECQKx8pagnW/2hY6u
+6xWdVeV7JaQ919QqroU479pLsAd7xzhHejfVXpG3BO0pZl/MXe8SarwEzaYG
+t5s58s5hvuc0zWZzaSgAhEcJAgpRgkCsXCXorS3XFG/juK6E9I0gV8sEhGHA
+xJBbYk/x3RLXYmvpnKBZdchhdg8myaWtAFDfUYKAQpQgECtXCUaNMt9rGr0D
+XEuojRL0DnCVoO+pNNfll7UhfNM5T55Gus4WABArShBQiBIEYuUtwUg/ZGBu
+Ry1B39SqpRJ0baqrBFMiCzggvqZG4D2ZGGsGOkd6L6MFAMSBEgQUogSBWNXT
+EvT9SJ23BO1fdnAJPiZekYrS99tpQp7Xi3SgauNziwCgCiUIKEQJArGq8atD
+6/KcYBxXh9aeWD/o57vXvocXABATShBQiBIEYuUqQe85KVfgRC1B79k674/r
+pfh9bYtrw7wTXav2JqfvpnrTzLV3vhd5xsr3ByxcXL8E4Xv6jxIEgOqjBAGF
+KEEgVq4StKvN9JH9Swf2+KglaFU1jv37gGYJwSWYUvVbD/bVm66J9nIibao9
+INKvSNjLcW1J9cvL+6sZ3g8SenPYuf3O5fClMQBQTZQgoBAlCMTK+3uCzp82
+sD9q53o0uAQtx6/gDaj6GfqAEnT9QLzrdyLszYj0CxeuAb6f3XMNc25JTZWg
+r4AS9J2RDASA6qMEAYUoQaCmxP3lKr5CNo53dWE2I8x21uzu1Kxk3jYAqI8o
+QUAhShBIBr6ffeNsFwCgblCCgEKUIJAMvJ8TJAMBAHWGEgQUogSBZGC+LMX5
+OcFEbxEAQBFKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAA
+QDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCI
+EgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCO
+EgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQB
+AACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQB
+hShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA
+5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFK
+EAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlK
+EFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQA
+AFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQU
+ogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACU
+owQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShB
+AAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShB
+QCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAA
+QDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCI
+EgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCO
+EgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQB
+AACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQB
+hShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA
+5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFK
+EAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlK
+EFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQA
+AFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQU
+ogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACU
+owQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShB
+AAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShB
+QCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAA
+QDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCI
+EgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCO
+EgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQB
+AACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQB
+hShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA
+5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFK
+EAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlK
+EFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQA
+AFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQU
+ogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACU
+owQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShB
+AAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShB
+QCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAA
+QDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCI
+EgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCO
+EgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQB
+AACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQB
+hShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA
+5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFK
+EAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlK
+EFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQA
+AFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQU
+ogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACU
+owQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShB
+AAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShB
+QCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAA
+QDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCI
+EgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCO
+EgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQB
+AACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQB
+hShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA
+5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFK
+EAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlK
+EFCIEgQAAFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQA
+AFCOEgQUogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQU
+ogQBAACUowQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACU
+owQBhShBAAAA5ShBQCFKEAAAQDlKEFCIEgQAAFCOEgQUogQBAACUowQBhShB
+AAAA5ShBQCFKEIASBemry3auLd+1ds/ycUUrP8qb0S9/5osFc14pnNdf/grm
+9i9ZN6VY/tZPKVo3pSI3NdHbCwB1hxIEFKIEATRUezavLtuxdudHT+2e/Gzu
+6Lt3j7or/70uhR89sGfig0UfP1Q8pXvJpz1Kpvcq/exvh/5mPVU6++nSOb1L
+5j5bMq9P8fw+RXOf+2bWM0VfvVOSPjNn5aRE7w0A1CJKEFCIEgTQwBRlrN67
+7evs8c/sHHRrztBOeSPv+ua9Lns+uL94woOlkx/d+58e5dMfr5j51L7Zz+yf
+99z+BS8cWNjv0N+iFw988dKBL185sLT/gWWv7V/22r5lr1Use6182T/3Lu1f
+9MUrhYtf3rN6TGHqzETvHwDUPEoQUIgSBNBglGxds+P9pzPfuHnn23/aPfT2
+/FF3F47tWvRht9JJD5dNeaz80177Zjy5f9YzB+b2Obig73cLX/zui5e/X/Lq
+98v+KX/Witetr960Vr1lrf7X92ve/v7rQd99Pfi7tf8+uPbfB77+9/41gyvW
+DC5b/Xbxirf2LH+j8Ov392TMS/TuAkCNoQQBhShBAA1Aztx3dwy5f8FrDy98
+45GxA156/41Xxg187cO3B3w0+M3xQwd+/cGLa8e/fGBW74Nzn/9uwd+/X/SS
+9eWr1tJ/Wsul/t6yVv3r0N+aQdbaf1vrhlob3rE2jrA2jTz0lzrKSh1tpY35
+PnX0wdTR324atX/jqPL1w0u/Hla0ekje0jeLMhcmetcBoAZQgoBClCCA+mtT
+5jcvj1na5+/D7+07LeTfSwPHT35/zORxYzfNesdaPcj6eoi1btihvw3DrY0j
+TfdZ6WOtze9ZW8ZZWz6wtsrfh5V/H8k/v9vywcHN4w5kjCtPHVu6YXTR2hF5
+X/27eMeXiT4SAFAtlCCgECUIoN4xARi+/gL+Jk/4aPLECfJnpb1rpb9nbZb6
++9DK/MjKHG9tn2htn2Tt+PjQ387JlX+fWDsmy93vt398cNuk/VsnlGd8uDf9
+g8L1Y3JXvVOwdXGiDwwAxIkSBBSiBAHUIzXYgD5V+MnkyZ98Ull/ldG3a4qV
+NdXK/vTQX860yr/p//eXPc3K+vS7XZ9+u2Pqvm2Ty7ZOKkr7MH/De1krh+dt
+XpTogwQAMaMEAYUoQQD1QpgG/Hv/d1987b3xQwZNHPbvScOHThr5zsejR0we
+M+qlgRNe+tfEGJLwP9MOtZ4U3+7PrNyZVt6syr/ZVr78zTn0J7flL3fW97tn
+HsyesX/XtPId/ynZ+klB2vicde8V7vwq0UcLAGJDCQIKUYIAklxwA/Z9adSy
+QU+sGPJ08fsP7f3osfKPH9839ekD0/scnNnv+7kvWQv6W4tft5a8ZS0fZK0c
+Yq1+Z9O89ydPmDB54qToPTj9s8nTZ1rfzLUK5h/6K1xQ+ff5//0VyN8C65sF
+Vv78g7lzD+TMrsiaWbp92p6tU/LSJm5fPaa0YEeijxwAhEUJAgpRggCS2ccL
+0n0z7fkXRy4a0GP3oM75Q7sUjupW/N7DpR/+b/nEJ/ZNefrAtEMZ+N2cygxc
+9Lr15UBr2WDrq6HW6uHW2lHW+netTeOstA+tjAmblkye/Ml/ovTgZ3Pkzypa
+fOiv+Aur+Mv//1ckf19YexZbBYsOfvP5gbwFFbvnle6atWfb9PzNU3ZtGL87
+c1mijx8AhEIJAgpRggCSljcDn+07fM6Lj2T2v2PnG3/Oebtz3pAuBSO6Fb37
+UMkH/1s24YmKyU/v/0+fb2f8/bvZL38//zVr4RvWFwOtpYOtFcOsVSOsr0db
+68daGyUDP7IyJlpbJluZU6ztn1o7p8vfpq9mTP70s4g9OGu+VbLUKl1mlS63
+9i4/9E/7r2S5VbzMKlpysPDLA98srsj9vDRnftHO2XlbPs1KnZy/c1WijyIA
+REcJAgpRggCSk+uK0Gf6vDOjz1/T/t5p6yt37Bjw5+yBnXMHd/nmnQf2jH6o
++P3H9n70ePnHT++b2ufA9H4HZ738/dzXrAVvWIsHWksGW8uHWStHWGvGWOve
+szZ8YKWOt9JNBk6tzMAZVtbMQ385s63cuVbe/MkzZk+eMce/B2d/bpWtssrl
+b/WhvzLzt8rau9Iq/er74hUHi5YfKFxanv9F6e6Fe7Lm52bO3Jk29ZvstYk+
+lgAQBSUIKEQJAkhCzrOBA598/qvHO67tfXNq306bX7pj22t37Xqzc87bXfKG
+3l8w8q9FY7uXfPh42cSnKj55bv+nfb/97KXvZvf/fv7r1sKB1peDrWXDrK9G
+WKvHWGvfs9Z/YG0ab6VNsjZ/Ym2dam2bZu34zNo1y8qec+hv93wrb4H1zSKr
+YLG158vJM+dPnrnAvwfnLLb2rbX2rTv0VyF/a63ytVbZ19beNd+Xrv62eOX+
+PSvKC5aV5H1ZmPV57vY5O9I+3ZkxP9FHFACCUIKAQpQggGTjzMA3n+izomfH
+NU/dvPH5P6W/ePvWV+/aMaBz1sB7dw++L/+d/ykc/Wjx+z1LP3qy7ONnK6b2
+3T/9H9/OfPW7ua9bnw+0Fg+2lgy1lo+wVo621rxnrfvA2jjeSp1kZXxibfmP
+lTnN2i4ZONvKnnuoAeUv93Mrf7FV8KVVuMQqWmYVr7BKV06evVD+fGJw7pfW
+/o3//2+f/G2wKtZb5eu/27v2QMmaiqJVZYVfFect/SZ7cc72+dszPtuesSDR
+xxUAIqIEAYUoQQBJxc7A/t2fmd/tv5c+dv2qJ25a1/vW1L63b37prm2v3b3z
+jXuz3+6aOzTlm5GP7Hm3R/EHf9s7oXf5Jy/s+8+LB2a8cnD2gO/mvWUtHGR9
+MdRaOtxaMdpaNdb6epy1fry1aZKV9om1+T/W1unWts+snbOtrLlWzgIrd+Gh
+v7zF1jeSgUutPcut4q+sklXW3tWHzvSVr5085wv/k4Pzllrfph/6OyB/adb+
+VGtf6vcVGw+Wbdhfuq68+OvSwlV78lfk53yZvf3zzPSZmenEIIAkRQkCClGC
+AJLHpsxvTGS9/PDTc/5y9eKH/7ii541rnrp1Q5/b0l+8c8srd28fcM+ut7rk
+DH4g752HCkY9tue9x0s+fHrvpD7lU/6+b9rLB2b+8+CcN79b8La1aIj15XBr
+2Shr5Vhr9Thr7UfWholW6mQrfaq1ZZqV+Zm1fba1c66VtcDKkQz84tBf/hKr
+YJm1Z4VVtNIqWW2VrrHK1lrl662KDYdO+e1PnTxviU8Mzl9mHdxy6O9b+dts
+Hdhs7U//riLtQPmmfXs3lpWsKy5cU5i/Mi9n2c7tC7dkzMnYNC/RxxgAfFCC
+gEKUIIDkYU4I/uPBJ2fe84fP/+e6pd1vWPnELWt7d9r0wh0Z//hzZv/OO17v
+kjXwvt1DHswf0b1gTK+icU+VjH9u78d9y6e+tG/6awdmvXFw7r+++/zf1uJh
+1pKR1vJ3rZXvW2s+stZNtDZOtlKnWhnTrC2fWdtmWzvmWrsWWNkLrd1fWHlL
+Dv19s8wqXGHtWWkVSwZ+be1dZ5VJBm609qVa+9MOnfX7NmPTlrUvjZ7vicEV
+1nfbDv0dzDz09+3W7/Zv+XZfxv7y9PK9qaUlG/YUrv0mf1VOzvLt2xZlpM3Z
+tYMvkAGQdChBQCFKEECSMBnYL+Vv/7njqnn3X7v4oeuX97hpzVN/Wv/c7an9
+7tr8cufM1+7d8UbXrLe77R76cP7IHoVj/1b0Qe+SCS/snfxi+X9e3TdjwIHZ
+bx2cN+i7z4daX4ywlo62VrxnrfrA+nqCtf5ja+P/Y+++n9rMEz3f75+xP+4P
+W7VnT+29W+d290xPO+eIc8522yJnTDDBgI0xyeScc85RIJAQSEgISaCMAso5
+SyiH7wo83cftmXPO3q17jaf0fdWnqBnbVW0/z0/v+j56NA62pwB/FuzMA9Ei
+kKCBHAuUq0C9BrTEvelJwEABpk1goQFrIAOZwM4GDg5wcoGLt3fY59nZCz2f
+KJB+f3s4yBZygF8CfBLgFfs9Iq9b6HbuOOz83V2u2cLWGxhqDVWmIO0IV1ms
+Bf426aAvNgRB0B/AEoSgIARLEIKg70Sgp2ISq4evH5l/ehaDuIiPvrKRdGMr
+7TYz6972u4eCj49FxU+lZb8qqsPVjTHa1iRDV5qpL8sylLs7lm+fKnLOlboX
+qjzoOh+2yY9rBcROsNEDqANgaxgwxgB7EmzPAD4S7KCAGA2kWCBfBco1oA5k
+IGlvegowbgITDVgYYJcJbGxg397PQD5wC4BHCLwi4BPvtZ5fOooh/50nRTFk
+4JcDn8zvlXo9Erdb7HQKbXaBZZdnNHO0BqZCvSmWkXiCFRodKRXyDvp6QxAE
+/StYghAUhGAJQhD0Pfh8INh36Zfp+6dQz8+vhF8mxF4jv75FS7/Lyr6//f6R
+oOCJqOS5tAKhqI1SN8Zr25L13emm/mzLcN7ueIF9+pNzrsKFqvGgG3wrLX58
+OyB2g40+QB0CtFHAnADsacCdA/wFIFwC4mUgXQVyPFASgTqQgeS96anASANm
+BrCwwC4b2LaBgwecfODaAW4h8IiBVwJ8UuCX7eUeUAQ2iqH8TQxSgF/p9yu8
+PrnbI3O6pTan2GoXmqx8nYmr0jGlqs0dCYnNXdnmrh30JYcgCPpXsAQhKAjB
+EoQg6HsQyKi3L5NHbx6ffXQG/erSauQVYvwNSsptesY9VvZDbt5jQcEz0aeX
+0spwRV2MqilJ256m784y9r+zjOTvjhfbpsscyCoXqs6NafKutPnwnYDYCzYG
+AXUE0MYBcwpwZgF3HggWgRADxCtAigMKAlCtAw0Z6Kh7028BIx2YmcDKBrvb
+wM4DDgFw7gCXaD8DpcAnAz458AcaUAmAan/qUczm38Qg1Q/UXr/K7VU6PQq7
+S2Z1SEw2kd4iUBu5ci1LpNjiitZp7GWxhHXQVx2CIOivYAlCUBCCJQhB0IEb
+wXDTf33dd/nIxJ1T80/PYxAhuKhr6wm3qKl36Zn3WTmPuHlPBIXPRaUIaVWU
+oj5e1Zys7UjX92QbB/LMIwXWiU+2mQoHssa52ODGtHhWOnz4bv96PyAPAeoY
+oE0C5gzgIAEXBQRoIMQC8SqQrgHFOlBtAA0F6Lb2ZqADIxOY2cC6DXZ5wC4A
+DiFwioBbAjxS4A1koAL4lcC/F4AAaPanBUA3itn6KgZHMJtev9bt0zi9Krtb
+aXXJzQ6pYVesMe8o9FyJhsWXUlkC4gZt0WBQH/S1hyAI2gNLEIKCECxBCIIO
+XKAEq+4/HLp2fOr+2YXnF5fDruBjbpCSblPT7tEzH7JzH3M/PBUUvhCVhkmr
+Y+T1iaqWVE1Hpq4n1ziQbx4pskyU7c5U2ZF1zsUmF6bNs9LpXev1rQ8C8gig
+jgPaNGDOAc4C4C4BwTIQrgAxHkiJQEECKgrQbAIdbW96JjCygXkbWHlgVwDs
+O8AhAk4JcEuBRw68CuDbz0D/5wDca0AA9PszjGJoX8XgMGbL7dc5fVq7R2N1
+q8xOhcEu01rFSuOOVMfdUTI5IgqNu0ZjEQ762kMQBO2BJQhBQQiWIARBBy7j
+1+Tui0dGb52aeXge9eIyNvzaWuxNUtIdatp9etYjdu4T7odngqJXorJISXWc
+vCFZ2ZKu6Xir631vGCwwjZRYJsp3Z2ps8w2OxRYnpt290u1Z6/etD/nJY4A6
+CWgzgIkEHBTgooEAC4Q4ICYA6TqQk4GKCjQ0oGXsTc8CRg4wc4GFD3Z3gE0E
+HBLglAKXHHgUwKsCPvVeBvp/b0ADAMb9mQIbxdADAXjuOeE//xf9/zyx95nH
+IQzN6dPbvTqrR2t2qQ0OpXZXpjKLZYYdoXqbK2PQBRskBpYroB/05YcgCIIl
+CEHBCJYgBEEHiy3U9V053nfp2Pids7OPLy6+vLISeWMt7hbp9V1q2gN61mNW
+7tPtD8/5RaHC8mhJdYKsIUXZkqHuzNH2ftAPFhpHS80TldaZ2l1ko32x1Ynp
+dK30uvEDXuKIb2PcT50CtDnAXADsJcBdBvwVIMQDMRFIN4CcApRbQE0HWube
+9Gxg5AIzH1h2wK4Q2MTAIQVOOXApgFsFvGrg0wCfDvi/akDz/iyBsUXSQAP+
+p/8EAvscg4MYms1nsHr0ZrfW4FBrbUqVVSYzikVaAU/BYYloZA5xlbx40HcA
+giAIliAEBSNYghAEHSxSR2PHhSOD105N3D039+TS0qurK5E31+LukF7fo755
+uF+Cz7bzf+UXhwvLY8XVSbKGNEVrlqrznab3o26w2DBSZpqotszU7yKbbYvt
+DkyXc6XPhR/yEEe9G5M+6oyfhgQMFGCjARcL+DiwQwDidSAlAzkVKGlAzQBa
+1t7028DIAyYBsAiBVQxsEmCXAacCuJTArQYeDfDqgE8P/IYvGtCyP+v+dgM7
+ftz7uQR/j0HqjtjqNZrcBoNTp7WrVVal3CwT6UV8FZ8tZW/yqWu01VUijEEI
+gg4YLEEICkKwBCEIOliNZ3/pvnh86NrpyfsXkM9Cll5dW4m8tRZ3l/T6PvXN
+I1rWE2buM04+glccuVMeJ6pJljaky1uzlZ3v1b0F2sFP+pEK40SNeabBimzZ
+RXXYMT2OlX4nfthNHPNsTHmps76teT9jEbAxYHsF8PFghwhEJCChAPkWUNKB
+mgk0nL3puMDAB6YdYBYBqwTYZMAuBw4lcKmBWwM8OuDVA58B+L/MwL8GIAC2
+z0Ojnb+XYGDnnhMCMUgWSExuk95l0Dp0ql2NzKwUG6R8jZAj59KEDCJrHbOB
+PuibAEFQsIMlCEFBCJYgBEEHiNDe2HruSPfFE8M3zk49uIR8dmUJcR0bKMH4
+e6TXDyhvHm1lPWXmPufkh/KKowXlCcKaFElDhqwlR9HxQdVTqBko1Y1UGiZq
+TdONZmSrFdVpQ/fasQMO3IiLMOEmTXsoc96tBR9jyc9aBturgLcGBOtARAYS
+KpDRgIIBVCyg2d6bjgcMAmAUArMYWKVgVw5sSuBQAacGuLTArQceA/Aagc8E
+/F+eA35uQHtgfuDwAUdWtuerGHzXhjN6zHqXSeMwKG06mUUtNioEWglHuUMT
+cza4m1gqTmfUHfStgCAoqMEShKAgBEsQgqADVHP6l/bzx3sunRy5eW7q4WXk
+s6tLiBvYqNv4+Hvrrx+S0x4HSpCR+ys7P5xbHMMvTxJWp4kbsqQtufKOfGVP
+sXqgTDtSpR+vN043m+baLaguK7rPhh2y40YdhEkXacZNQXo2UV462sfC+jk4
+wCMAAQkIKUC8CaR0IGcCJRuouXvT8oF+BxhFwCQBFhmwKoBNBexq4NQClw64
+DcBjBF4T8FmA3wr8XzagIzA/cPqA0wucHuDMzP7XZ0T/83/RP8mZzm3D6VwW
+jcOktBlkFq3IqBLo5ByVmC7lkQVMHGNjnUE+6FsBQVBQgyUIQUEIliAEQQcF
+21rfcPZIoAR7L58euXVhvwSvLSJuYiPv4OPuE/dK8Mlm5jN67ktWfsR2cRyv
+/PVO9RtRw1tJy3tZx0dFT4lqoFwzXKMbb9BPtRjnOswL3ZalfuvysG11zL42
+5VifdZLnXZuLbhrGw1zxsvE+LtHP39gvwS0gZQA5Cyg5QM3bm1YAdEJgEAOT
+FJjlwKoEu4ES1ACHDjj1wGUEbhPwmIHXCny7wG8DfvtvGejcz0CXF7g8wOUC
+LidwZWR//YHB7kWG2mFR2ExSq15k0vD1ym21jC7bIe9w1jhbC+srGr32oG8I
+BEHBC5YgBAUhWIIQBB0UfFtj09lj7edP9l05GyjByYchc8+vLyJuLUfexcXd
+JyQ92kh7Qs18RstFMPMj2UXx3LJkQXW6sD5b3JwnbS+Ud39S9leoh2u0Y426
+qVbDbKdxvse8NGBZHrGujtvWpuzrc46NBSd1yUVbdjNWPew17/a6j0/27VD9
+IhqQMICMDRTbQMXbm2YH6ERALwFGGTArgEUJrGpg0wK7HjgMwGkCbjPwWIDH
+Cry7wGffK0G/44sGdLuB2wXcTuB2ALcduI8c938Vg3iuTG4zS61GoUnH16s5
+GjldLqYIeYRtJnqTtEpdP+gbAkFQ8IIlCEFBCJYgBEEHper04cazxzounAqU
+4PCti5MPr8w9v4FC3MJE3l2NfRAoQVLqU0rG862cUMaHaFZRwnZZCq8qY6cu
+R9T8QdJeJOsuVfRVKodq1WNN2slW3UynYb7XuDhoxoxYVias+GkbEWnfQDko
+aOcW1kXHuVkEN4fk4ZG9gk2fkO4TM/1Stl/OBUr+3tQ7QCsCOgkwyIBJAcwq
+YNWAXR2wBUrQuFeCLgtwW4FnF3htfq/d73P4/E6f3+X1u/cz0OMCHifwOIDH
+HvhDfs8M2vvVBwazW3Eym1ViNQtNBp5ey9Yo6QopRbxD4LIxNOrUKuagbwgE
+QcELliAEBSFYghAEHQhMS33N6aNNZ090XDjde+Xc8K1LEw+vzj67sfDqNjri
+7krsg7XEx+spT8kZv27mhNE/xDCLEjmlqdzKTH5d7k5TvqitSNJVJuurUgzW
+qUab1BNt2pkuPbLPgBo0okfN2EkLbsZKQO6SUDYy2r654qDjnEyCi01ycylu
+/pZnh+4VsbwSjk/G8ykEgflVQr9G7NdJ/Xo5MCqBSQ0sWmDVgV0DsJuAw+x3
+WvyuXb/b5vPYfR6H1+v0+lwen9vtD8zj8nucfq9jLxG9u36v1e+1+Lypb31f
+fWCwfYEptlp2TCaeXs/WqGkKOUUiJvC4GAZtbp2g0moO+rZAEBSkYAlCUBCC
+JQhB0IFYbW2s3ivBk+3nT/eGnB+6dXniwdWZZzfmX91eiriHjXmIS3hMSH5K
+Sv+Vkh2+lRfLKExifUrbrszi1b4TNH4UthaLO8ulvdXygXrFSLNqvF0z3a2d
+69MtDBmWxozLk6bVGcvavHV9cXcDY6Ou2Gl4B4PoYG04t6ku3pZbwHALWR7x
+tkfK88oFe1MKvWqJTyvz6RQ+g8pnVPvMWp9F77MafTaTz27xOaw+567XZfO6
+HR6P0+Nxub3uwFw+j9Pndfi8dp/X5vft+nxWn8/i85m8XqPXe+iY/6svlcCw
+ZAKTmas3sDRamkJJlkgJfMEykzlPJi8SCQd9WyAIClKwBCEoCMEShCDoQPTH
+R9WcPtZ07lT7+TM9IReGboWM3782/fQm8uWdxfB7y9EPV+Mfr71+uv7mJTk7
+YjMvjlbwmvnpDbvi7XbNe37Dx52WEmFHubinWtrfIB9uUYx1qKa61bP92vlh
+3eKYATNlXJk14efNxCULadlKWd3dWrPRiXbmhoNDdXBpTj7DtcN2ibbdEr5b
+trM3hcijkng0Mo9W4dWrvAaN16TzmvVei9G7a/baLB671eOweZx2t8vhdjtd
+bpfL4w4EocPrDczu9dl8f81AszeQgT6j16f3+HTuPzwjGijBrGYc32TZ1huZ
+Gt2WQk2WyNYEwmUWB0mhjixjD/q2QBAUpGAJQlAQgiUIQdCBKDlxuOb08caz
+p9rOn+0OuTB4M2T0/rWpJzfnfr2DCruPjnq4EvcYn/SU+ObVxttIyvu4rY/J
+9JJ0Vnk2p/o9t76A31yy014h6q6R9DVIh1rkox2KyR7VzIAaOaxFjevQU3rs
+nAG3YCQsmdaXzeRVC3XNSlvfZZBtbKp9m2bnMR0CtkPIdYr5TulOYC65yKWU
+uFRyt0bp1qnceo3bqHObDG6z0W01u3ctbtuuy25zOewuZ4ArkIIOtycwu8dr
+8/h2PT6r12/x+s1ev8njN3r8eo9f5/ZpXL6kzK9fHbPAkLF1JobGsKnQbEgU
+awLxMpuLpNBGV/Bimfyg7wwEQcEIliAEBSFYghAEfXvIxoaSE0dqTp9sPHu6
+da8ELw7cDBm5d23y8c3ZF3cWQu8vRT5cjnu8mvRsLQ2xnhVFzo2n5ifTitMZ
+ZdmsqjxOXQG36RO/rWKnq0bU2ygZbJWOdMgnehTTA6q5EfXCuGZpWrs8p19d
+MOCXjMRl08aqmbJm2Vq30MlW5uYuh2bjMm18tn2HaxfxHRLh3mRih1zqVMqd
+aqVTo3bqtE69zmk0OE0mp9nstFqdu7tOm91hdzjsTofDZXe67S6PzeXddXut
+bp/V7be4/WaP3+T2G9xA7w5koF/j8qudPqXT95ejXz8jytKZ6WojVaFbFytx
+AgmGLUBSGWM4olSpOuibA0FQMIIlCEFBCJYgBEHfHqalseTE0erTJxvOnm45
+d67z8sW+GyHDd6+NP7o5/fwOEnEfFfEQE/N4JfE5PjWUkBlFyomnfEjeLMqg
+leYwK/PYtYXbjZ94rZWCztqdnkbRQKt4uFM61iObGlDMjijnx1WL0xrMnBa7
+oMOh9QSsYR1nJBNM1HUzjWxmbFpYdOs208rj7Aq4u0KBTSzcm0Rsl0ntCrld
+pbSr1Xat1qHTOwwGh9FkN1nsZqvdYrNb7fZdh80WKELXrsO96/BYnV6L02dx
++cwuv8nlN7qAwQX0LqB1AY0LqJ1+pcMvd/gGkF+/OqZhhrGlMlHkOqJYtcqX
+otk7c5vsURxpemXtoG8OBEHBCJYgBAUhWIIQBH1jRnJ5w+0fP504VnXqZP2Z
+M4ES7Lh0sfdayNCd62OPbk09uzP78v5C+MOl6MfLCS9WU0LXMqKI2QkbeSmU
+goytTzn0ijxmTSG7oXS7pZLXXsvvbtzpaxUNdYpHe6UTA7LpETlyQrkwrVqa
+Uy+jNKto7RpWR8TpNwgGCsm4RTbRN01MupnNNG9zLDyuVSCwCoV7E4t3pdJd
+uXxXodxVqW1qrU2rt+mMNoPJZrTYTNZds23XYt+1Oqy7TqvNbbV7LHaP2eE1
+O3wmp9/o9BucQO8EOifQOoHGCVQOoHQAud0vs/klu76fj3x9LLipNG3I9ASR
+eoUvW2IL5zY5o3jyxHidQwHfGwNB0LcGSxCCghAsQQiCvrFACeYe+eXTieOV
+p07VnTnbdO5824WL3VdDBm5fH314a+LpnZlf7yPDHqKiHqPjX2CTQ3Hp0YS3
+CevvU8gfM6jFOVvlH+jVhcz6UnZT5XZbLa+rkd/bujPQKRzpFY8PSqZGpLMT
+8vlpxeKcEoNSYdFqHFZDwGnXCToySU+lGLY2DQy6kcU0cTgmLtfMF5h3hIFZ
+RGKLWGqRyi1ypVWhtqq0VrXeqjVadSar3mI1Wi0mm8Vst1gcFqvLbHWbdz0m
+mzcwo91nsPv1dr/OAbQOoHEAtQOo7EBhD2QgkO5loF9k9fXOfH0sWDNFJ0kN
+ayINlidfZIlmN7mja5td8yuq6YcHfYsgCAo6sAQhKAjBEoQg6FtyKAir7/4p
+98ih4hPHK06dqj1ztvHs+dbzF7uuhPTfuj58/+bYkztTL+7PIh4uRD5ein2B
+SQpdSYvGZyUQ3qWS8jPJRTnU0g9blYX02lJmYyW7tXa7o5Hb08rv79wZ6hWO
+DYomRyQzE1LktAyFlC+hFMto5SpWhcepiQQNiaSlUHSbmzoaXc9gGdgcwzbX
+yBMY+cLATDtik0hqkshNUqVZrjYrtWaV3qw2mrUms85i1lvNBpvJaDeZHCaz
+y2hxG60eg9Vr2PXpd306m19r82tsQG0DKhtQ2oDCBuQ2IN0Fkl0gsvp3LD6+
+2fvnw18fCxIlBpxQu8xTLjDF01TuKIHePocVNf1XeCwIQdA3BksQgoIQLEEI
+gr4lI7k8UILvjhwuOn6i/OTpmtNnG86ebz53sSMkpPfm9cG7N0cf3Zl4fm/m
+1UNk+GNUzAt0YuhyavRqZsJaTirxQyapMIf86QO1onCrppTeUMlsrmW3N3K6
+Wrm9nfzBXsHI4M74iGhqQjw7LZlHShdRMgxajsUqcDjlGkG1TlJvUDSUTc0W
+XUtn6pgcHZur3xboecLADAKxQSg1iOQGidIoVRvlWqNCb1QZjWqTUWMx6qxG
+vc1gsBuMDoPJpTe59WaPzuLVWXxaq09j9at3/apdoNwFil0g3wWyXSC1ArEV
+iCxgx+znm3xco7dj0vvVseAwUbQi0GK4ynmGeIrCG15jtCNXN1rOwWNBCIK+
+MViCEBSEYAlCEPQtiZr+6/6Z4JGC4ydKT56uOn227sz5prMX2y6HdF+/1n/n
+5vCDO2NP7029fDgb+ng+6sVifCg6ORqbnrCanbr2PoP4MYdU/IFcVkitKt2q
+q6Q31TJbG1kdrZyeTm5/L29okD82sjM5IZyZFiHnxAsoyRJauoyVreDkeIKC
+QFKSyCrypopKV28xNXSOhsnVsgXabWFgOp5YJ5DqhHKdSKmXqPVSrV6u1yuM
+epVJr7boNVa91qbT2XV6h87g0hrdWpNHY/JqzF612aey+JUWv8IC5BYgswCp
+BUgsQGwBQnMgAwHf5OcafdsGH0vv+enQH44FU+tXsXztEkc5R5dMkHlDeGYb
+Eg9LEIKgbw+WIAQFIViCEAR9S59LMOfI0Y/H9kqw8tS5mtPnG85ebL0U0nn1
+Wu+tm4P3b488vjfx4sE04vFc5IuFuNDF19GYNwnYrBRcbsbahxxi0QdSaSG5
+spRaU7nVUEtvbmS0t7K6Otl9vduDA9yREf74uGBqemd2TjiPEqHQYjRWsoyT
+rhJk+HU5kawgbSrIdOUmU0XjqBhcNYuv5gj3xhVreFKNQK4RKrUitVai1Ur1
+WrlBqzBplRatyqpR2zQau0br0Oicar1LbXCrjB6V0as0+RQmv9zkl5mB1Awk
+ZiA2A5EJCE1AYAJ8I+Aa/By9j6XzMrSeljHPV98t2IfbWWArZ2mS8Q1+/yqj
+bZ5Iaj4XuEoHfaMgCAousAQhKAjBEoQg6JtxKAiBxll590/Zh49+OHai5MSZ
+8pPnqk9fqD9zqflCSPuVa903bvTdvT306N7YsweTLx/NhL9AxoQuJEYvpSZg
+MlJWsjNweTlrBXnEkkJSeSm5upJaV7vV1EhrbWV0djJ7etn9A5yhke3Rcd7E
+NH96TjC3sLOwJFxcFmFWxdg1CW5dukaWEjdlGzQ5hSnfZCtoXAWDr2QJ98YR
+q7hSFU+uEihVQrVapFWLdWqpQS0zqeVmldKqUu2q1HaVxqHUOpVal1LnVug9
+cr1XbvDJDD6p0S8x+sVGIDICoRHsGIHAAHgGwNUHMtDP0vkYWi9N7dlUuX/4
+xfflA6LJtStIpnJ6SzpK4vdiGa3z659LEH5UEIKgbwmWIAQFIViCEAR9M0Zy
++V4J5v5T1uGjeUdPFB0/U3ryXOWpC7VnLjWcC2m9fLXz+o2e27cHHtwdfvJg
+7MWjydDnM1GhyIRoVHLC0psUzNuMlXfZuPy8taJCYuknUmUFuaaW0tC42dJK
+a++kd/UwewdYA8Ps4fHtsSnu5BxvZoGPXBIsLO8srQoxa6KVdRGOLCZQJes0
+6QZTSmHLNrkyGl/O2NkbSyTnSBRcuYKnVAhUih2NQqRTig0KiUkhMyvkVoVi
+V6G0KVQOudop17hkGrdM65HqvIFJ9D6x3i/S+4V6sKMHAj3g6wMNCLZ1gK3z
+s7R+hsZHU3s3VR6Kwl036P7qvTGzdOUkVTJM5HcvM1qQpPX9Egxcq4O+XRAE
+BRFYghAUhGAJQhD0zXwuQdy7/55x6Oi7oycLjp8uOXGu/NSF6tOX6s5cbrp4
+te3qja5bt/vu3R18dH/k2cPxV8+nIkNn46LnkxJQaSlLmemYnOyVvDxcQeFa
+ySdCecV6Vc1GXQOlqYXa2rHV0UPr7mf0DzOHxlmjU5zx2e2pBe7sEm9+mY9a
+FaDXdpbXd1Y2hHiqiEATrTPEG2wJZVuyyZPQdgKTMkRSlkTGkcm2FTKeSsbX
+yHZ0MqFeJjLKJGaZ1CKT7crkNqnCLlU6pCqXROWWqN1ijUek8Yq0PqHWt6P1
+C7R+vtbP0wKuFnC0frbGz9T4GWofTeXdVHoDGbghcxGlzq/eG9O6yB0nSwbX
++J1oetMsKXCJYAlCEPSNwRKEoCAESxCCoG/mcwkG9uaXo7lHTuYfO110/FzZ
+yQuVpy7VnL7ccP5KS8j1jhu3eu7c6X9wf+jJw9Ffn02EI6ZjomYT4udTklHp
+6UtvszHv3mPzC1aLSvCl5YTKmvWaBlJDC7m5g9rWvdnZv9U7TB8YYwxPMcdm
+WRPz7OlFzhxme36Fu4jnoYl87IZglbqD39ohMITrLOHGtojCE20KAhPThGKG
+RMySidkKybZKwlVL+FqJQC8RGiUik0RskUisYumuWGYXyx0ihVOkdAmVbqHK
+s6PyCtSB+fhqH0/t56r9HLWfrfaz1H6myk9X+baUPqrCS5Z7SDI3UeJaEzv+
+5ec/PCCaWL08QhL34fjti/SB4VZYghAEfXuwBCEoCMEShCDom/m9BIci/yX7
+yMm8o6cLjp/7dOJC+alLVacv15690nTpetu1W5237vTcu9f/6MHw82ejoYiJ
+yMjpuLjZpNfzaW9QmW+Xct9j8j5iC0pWS8rx5dVrVfXEumZSY/tGSzelvY/a
+PbTZN0YbnKSPzDDG5pmTi6wZDHtuhbOA314kcjEkLpbCW93i4+l8AkuwztnZ
+4O1QBHvbFAppYiFDKmTKhWylkKMWcbUink4kMIh2TEKhWSiyCsW7QoltR2rf
+kTl35C6B3MVXuPkKD0/p5Sq920ofR+ljK30spZ+p9NOVPprCt6XwUeVessxD
+ku5noMiJEzoqepxfPSA6SBD1rPBaF+gLPcmwBCEI+vZgCUJQEIIlCEHQN/N7
+CeLe/XPW4ZPvjpzOP3au+MSF0pMXK05drj4dUn/hWvOVm203bnfdudf74MHA
+02fDr16NhUdMxMRNJ7yeTXmDTH+Levtu6d1HTH7xclHZSmk1rqJ+raaZUN+2
+3tRFau0jdwxSekap/RObgzO0ESR9HMWYQjNnsCwkjr1AYC+ROBjyNnZze5XO
+xTN5BA5vncvf4O+NssPfFAloUgFdLmAqBCyVgKMRbOsEPL2AbxQIzIIdi0Bo
+5YtsfLGdL3HwpE6e1MWVubcDk3s4ci9b7mXJvUy5jyH30eS+LblvU+alyLwb
+Ui9J4iGK3Wsi1+qOAyuwo3m7X71BtGaa2bnMbUJuIbtfwxKEIOjbgyUIQUEI
+liAEQd/M53eHfl76oRM5R07nHT1bePxCyYmLZScvV54KqT13reHSjZZrt9tv
+3e26d7/v8dPBF6+GQyPGomIn4pKmX6fNpmUhM98t5OQv5hWhC8qWi6tWyupW
+q5rwtW1rDZ3E5t71tkFS5wi5Z4LSP00dmtscXdgaX6JNLdNnVxnINebCOmuJ
+zMJQ2VgaZ5XBwbO3Cdvb6/y9bexwKSLupoS7JePRFTyGisdS89haHkfP4xp4
+PBOXb+YKrNydXa7Qti2yb4scHLGTI3GxJW6WxM2UehhSD13qpUm9W1LvptRL
+kXjJEu+G2LMu9hBEbrzQtSpwYvkONNe2yLH+zz95v3xAtGqS0b60XT+z+fv1
+gSUIQdC3BEsQgoIQLEEIgr6ZL0twOPKHrMOn3x09m3/sfNHxi59OXC4/GVJ1
+5mrdhRuNIbdar9/puHO/++GTvmcvB1+FD4fHjMUkTiSkTqVkzqbnIt9+WMgt
+RH0oXSqsxHyqxZY3rlS34uo68Y09hJYBYvvwetc4qXeKPDBLGV6gji5tTixv
+Ta3SZvE0JJGO2mAsURmYLSaWwVplsfAcNoG3t3UBe0PIIYs5VClnS86hKTkM
+NYep4bB0HI6Bs23kcM0cnoXNt7IFu+wdG2vHzhI6mEInQ+RiiNx0sZsm9myJ
+PZtiD1XsIYs8GyLPushDFHrWhG7cjmuF71zmBTLQvsjZnWdZHkX86wOigRKM
+LUc3L7AX+t78fn0O+l5BEBRcYAlCUBCCJQhB0Lekmn74e+xU3zyUc+Rs3tHz
+H49dLDp+qfRkSMWpq9Xnrtddutl09U7rzXsd9x93P37R9yJsIDR6OCphNC5l
+IiljKjVnJiNvLrtw/v0n1MeKpaIadGnDckULtqZjtb4b19SPbx0mdIwRuyfX
++2ZJA/Mbw4vkMQxlYoU6jd+cJWwhSVsoCm1pk46h07FMxiqHgefujcBnEneY
+JBGTLGFRZKxNBWtLxaJrWAwti6lnsQxMjom5bWZyLQzuLoNnY/DtdIGDFtiO
+c2vHtbnjogrdFKGbLHRvCN2kHTdxx00QuPECN47vWuE5l7kO9LYdxbbNM61z
+DHN+s/XLjwrGlqEb5pi/XxlYghAEfWOwBCEoCMEShCDoW/qyBPHv/0fW4bPv
+jpz/cOxiwfFLxSdCSk9eqTh9rebCjfqQ203X77bdedTx8Hn3s9C+l1ED4fHD
+McmjCenjydmTb95PZxXM5pYg88oXCqoXi+uXyprRle3LNV3Yhr7V5iFc2yi+
+Y2Kte4bQh1wfRJGG0Rtj2I0JHHmaQJldpyLJ1AXq5hJtC83YWmZvrWwHRsPx
+aGsCGlFIXxfTN6R0ipxOVdI31XSahk7X0Rl6OtNIZ5lobDONY93a3t3i2ja5
+9k2encpzUPhOMt+5wXcFts53EfkuAt+1xnPheK5VrgvLdWK2HUtsO4oVyMDd
+Wbpless0TjF89dKYhf4M+GgoBEEHBZYgBAUhWIIQBH1LXz4gun8seCT78Ln3
+Ry/kH7tUeDyk5MSV0pNXK8/eqLl4q+HqneabD1vvPet4/Kr7RWQvIm4g8vVQ
+3JuRpLfjqe8m0z9OvS2eeVc2l181X1i3UNK0WN62VNWJqe1dbhjENo+sto3j
+OqfxPXNrfQuEwSXi8PL62Or6xBppmrgxu0FGUsgLW5RFOgXNoi5z9rbC3cTx
+N/HCTYJoc12ySZJtkhWbFNUmVb25pd2k6Tbphk2Gkco0UVkWKstKYe9SODYy
+x7axbd/YdpC2HetcJ5HrJHCda1wnbtu5uu3EcpzLHAea7Vhk2ReYNiR9d5Zm
+mdo0T1CMIxu6r14ag6k+D0sQgqCDAksQgoIQLEEIgr6xr44FMw+dyzly4f3R
+Sx+PXS48fqXkxNWyU9crz9+svXyn4fqD5jtPWx+87Hga0f0ytjcsqT86bSg+
+c+R17ljah4nMoqmc0un3lbMfa5FFjfOfWlHlHYvVPUt1A5jG4eWWMWzb1Ern
+7GrPPK5vET+IWRteIYzhiBME4hRpfZZMQm6SFmgbi8wNNHtvmG0ylkdeFZDx
+QsqamEKUUtblFJKSQlZRKBoKVUve1JO3DGSacYNu3mBYSEwribm7zgrMRmTb
+CWz7GtuBZztwbMcq24FlO5ZZDjTLscS0oxj2ebptjrY7s2WZoprHycZRkn6Q
+qP3n/8f15UtjvizBg75FEAQFHViCEBSEYAlCEPSNfXUsWHXzaNbh87lHLuYd
+vfzxWEjh8aslJ66VnblRdeF27ZV7DTefNN37tfVRWMfzmC5EYk9ESn9MxmBC
+znBy3uibwvGsT5M5FVN5NTMfG2aLW5Cl7fMV3ajq/sW6oaXGUXTLBKZtZrkT
+ie1BrfShVwexuOFV/NgafmJ9bWqDMEMlzG0R5xlEFCuw9SXOOoa7vswnreyQ
+cCISXkIiyEhEBWldSSKpSWQNiaJbp+rXNw3rW0bilolIMxPoFgLdusbYxTNs
+OIZtlWFbYdqxDPsyw45m2JcY9kW6bYFmQ9J257as01TLJMU8vmEcWTcMEnR9
+ePV//5e/X4LwQBCCoG8PliAEBSFYghAEfXt/OBZ893+lHzr/9vDFd0cu5x0N
++XjsSuHxayUnr5efu1V16U7ttUf1t583PQhtfRLV/mt8Z2hyT2R6X+zbgcT3
+QykfR9JLxt6Wj+dWT36onypomilumy3tQlb2ztcMLtSNoBrHl1qm0O1zmM4F
+TM/Sch8GO7iyMoxfHSWujpNwUxT8zCZ+joZHMgNbW2CvLW6voXkEjICAFRJW
+xQSclICXEQgKAlFFWFcTSJq1Dd0aWb9GMeCpRjzVhNs047Ysq1vWlS0rlra7
+TNvF0HbRNNsSzba4ZVvY2p3f3J3btM5QrVMUy8SGeYxkHCYaBtd0fThN94rq
++jPLl68PbS2NhgeCEAQdFFiCEBSEYAlCEPTtfXUsOBz5p4xDF7IPX8o9EpJ3
+9MrHY1f3YvD0zbLztytDHtTceFZ/91XTo8iWZ3FtL193hqV1R2X1xuX2J+UP
+phYNZ5SOvK0ce1c7/qFxsqB1qqRjpqxntrJ/rmZ4vn5soXES1TKz2I5c6kSh
+e9DoPixmALc8vLY8uo4d31iZpK5Mb63OMvaGZK3Oc3AoLm6Jj0Pv4JZFOKwY
+tyrF4eQ4vAK3psIR1DiiZnVdt0rSr2wYVshGLNmEpZiXKWYM1YKmWpao1kWq
+FUW1LlCt8xTrHMU6Q7ZMky2TG+ZxkmmUaBwmGAbwur5VTTdW1YFWXH1i/tsS
+hAeCEAQdCFiCEBSEYAlCEHQg1huf/zEG/5x56FL24cv7MXj147FrhSeul5y5
+VXbhXuWVJzU3f62/F974OKb5eWIbIrUjIrMrJqcnIa8vuXAg7dNgRsVwds3I
+u4ax/ObxwvbJku6psr7pysHZmtG5uglk4/R8y9xC2wKqcwnVvbzYu7I0gEcP
+EdEjJMwYBTOxuTxF29sMY3mOjUVuYxd42EUBdmkHixZhlyVYrBS7IsfiFFi8
+CrumXiZolglaDFGPWdej1w1oknGJZFrcMKE2zAsb5vkNC3LDMrdhmSVZpknm
+yXXzBNE0RjSOrBmH8Pp+nK53RdO1rGpfUrSgpCGPTF+V4Eh97EHfFgiCghQs
+QQgKQrAEIQg6ENsbZGzuP/9NDF7OPhySe+RK3tFr+ceuF568UXL2TtmlRxXX
+XlTfDq17ENXwJL7pRXJraHp75NvO2PfdiR97kov73pQNZFYNZtcNv28ayW8d
+K+wcL+mZKBuYrByerhmbqZucbZyda5lHtqGQHej5buxC7yqqfw01uL44vLE4
+Slka39rbJH1pmomeZaPnttHzPPSCAL0oRC+J0GgJelmKxsrRKwr0qmoJp17C
+aRbx2sU1HYqgRxEMCwTDPNGIJBrniKZZommGaJommiYJpgmCaWzNOII3DOEM
+g6v6/hVdz7KmE61qW1S0LMga58Tvc+d+/m+EzyUYyMDAFrC0g74tEAQFKViC
+EBSEYAlCEHQgAiWYF/KnL0twPwZ/DsTg28NXco9cfX/02odj1wtO3S4+/6A0
+5FnFjVdVdyNrH8bWP01q/DWtOTSrNSq3Iy6/M7GoO6W0901lX2bNQE7D4PuW
+4fyOkcLu0ZK+sbKh8crRyeqJqbrp6ca5meaFmdal2Q7MXNfKXA8e2UeYHyDN
+D5EXRqh7G9tamGCgplioaQ5qloua46HmBagFIQolQi1JUGgpCiNHLSsWsMqF
+FdX8inp+VYPEaZE43RxeP4vXz+AN03jDFN4wiTeM4w1jOMMIzjC8qh9c0fdj
+db3L2m6MpmNJ1YZSNM/LGmbFqP7cz//kuCsVgR7se/0wunCWty066NsCQVCQ
+giUIQUEIliAEQQelBBGVF/Lz34vBkLeHr+Ycufbu6PUPx24UnLlXfPFJ6dWX
+5TfDK+/F1DxKqHuW0vAyoyksuyUqry2uoCOxpDOlvPtNdW9WfV9O08D7tsH8
+zqHC3uGSgZGy4dGKsfHqyYm6mYkG5GQTaqoVPd2+PN25OtO9NttLnO0nzQ1S
+9ja8OTdKQ44zkBMs5BQHOc1FzvKRcwIkUohcECFREuSidG5JNodWzGGUsxjV
+7LJ6ZlkzjQ1MO7WinVzRja/oxlZ0oyu6EaxuGKsbXNb1L2v7MNoetKZrSd2O
+UrbOK5rmZPUz4oW+3K/+1a2l0VEfpw/6hkAQFLxgCUJQEIIlCEHQQZmob0D8
+cDQv5Jevsmjt/f+dcehKIAazj1zLPXI978Sdj2cfFV1+8elaaNmtqIr7cdWP
+X9c+f1P/Kqsx/F1zdH5LXFFbUmlHSmXnm9rurMaenJa+9x39+d0DhX2DJUND
+paPDFRMj1dOjtXNj9fPjTYsTLZiJNuxkB26ya22qZ32qbyOw6QHK9NDm9Aht
+ZpQxM86ameDMTHFnpvkzM4KZOeEMUjQ9L55ekE6jZFMo+dSiYnJJObmkmkCr
+x9HqMbRmFK0ZQWuG0ZohtHYQrelHa/qWND2L6i6UqmNB2TavaJmTN85I66bE
+5I6bf5uBT3Kmpxbho6EQBB0YWIIQFIRgCUIQdFC2NzYQPxxC/HA8L+TQV3EU
+2EjUL1mHrmUfvp5z9Nb7k/c/nn9aePll8fXw0tsx5Q8SK5+k1rzIrEPk1Ifn
+NUYXNMeVtCSVt6VUt6fXd2Y1deW0db/v7P3Q01cw0F88PFA6NlgxOVQ1M1yD
+HKlfGGlcGm1eHmtdGWvHj3cSxrvXA5vo3Zjop04MbE0M0SdHmJOjrMlxzuQE
+d3KSNzElmJjZmZgVTcyJx+ck40jp2LxsbEE+uqAYRSlHUMphlGoIpRpEqQZQ
+qj6Uuhel6llQdc2rOuaVbUhFy6y8aUbWMC3tH57423/m5wwM7KDvBgRBQQ2W
+IAQFIViCEAQdoBJEBOKHY4gfTuSFHP47MRj5S+aha28P38g5dvf96ccfLrwo
+CAktuh5Vcie+7EFyxdP0qhdvaxDv6sLz66OLGuNKm5MqW1Jq2940tGe2dGS3
+d77r6vrQ11Mw2Fs80vdpvL98qr9ydqB6frAONdSAHmpaHm5ZHW7Dj3QQ9tZF
+Gukmj/ZSR/u3Rgfpo0PM0WHW6ChndIw7Os4bnRCMTu6MTglHpkUjM+LhWcnQ
+rHRoTjY4Jx9AyvuRij6kohep6EEquucUnXOKjjlF26y8ZUbePC1rnJIODE9S
+2r8+Cgzs7cfyzxkISxCCoIMFSxCCghAsQQiCDtD+seBhxA/HET+cQvxwtjvs
+63fI7B8OHso6cjv7+IPcM0/zLrzMvxJeeCOm+E7ip4epZU8zK17kVCHyaiIK
+6qJL6uPKG5Oqm1Lqmt80tWa2tmV3tL/r6cjr7/w41FU02l0y0VM23Vsx11s1
+31e72F+PHmjEDjSvDrTiAxtsIw52kAa7yEM91KHeraF++tAAY2iQNTTMGRrZ
+HhzlDY7xB8cFgxM7A5PCgUlR/5S4b0rSNy3tnZb2TMu6p2Vd07KOaVn7tKxt
+StYyJWuelDZOSOrHxaierz8VGBih+WpMCeb3DMxvJxz0rYAgKKjBEoSgIARL
+EIKgg1WCiET8cBTxw0nED6f/rRgMbDT66NsTj3POvHh/MfTDlaiPN+OL7iaX
+PHxT+jSr7EVuBSK/KryoJrq0Nq6yPqmmIaWhMa25KaOt5W1Xa25vW95Ae/5w
+R+FYR/FkZ+lMV/lcd+VCd/ViTy2mtx7b27i6t+a1vlZiXxupr4Pc10Xt797q
+76X19TH6+ll9A+y+QU7fMLdvhNc7wu8dFfSM7XSPCbvHRV3jos5xcceEuH1C
+0jYuaR2XNI9LmsbFjWPi+lERqvvvNGBgY81vMupJ0UWLv5fgCIZ70PcBgqCg
+BksQgoIQLEEIgg7W/rHg0d+OBc8gfjj34crxnvCv3yn61x6MPZl99mXuxfC8
+qzH5NxML7qYWPcwoeZL96cX7MsTHivDiquiy6riqmsTauuTG+rSWhoz2xrfd
+TTl9Le8HWz6MtBaMtxVNtpfMtJchOyoWOquWOmswnXXYwLoacF2Na13NxO5W
+UncbubuD2t252d1F6+6hd/cyu/pYXf2croHtrkFu5yCvY4jfMSxoHxa0De+0
+jggDax4RNo0IG4eFDcPCgf4xStvfeRY0MGLztdrGrow6Uno1/vcMhCUIQdCB
+gyUIQUEIliAEQQfuq2NBxA/nw368+G/F4F4Pxp8dTzr/7mp83s3X+XfTCh5m
+FT3JLX7x4dOrwrLwT+VR5ZWx1VUJddWvm2pSW+vSO+qzehqy+xvfDTXmjTTl
+jzcXTrUUz7Z8QraWoVorltqqMHurwbbVrbY34NsbCe3N6+0tG+1tlPb2zfaO
+rfZOensXo62b2dbDbuvltPZtB9bSz23u5zUN8ANrHBA0DAjqBgT9PaOU1hv/
+1l+7oaknq56SUbOeXrWWWIz+sgQP+g5AEBTsYAlCUBCCJQhB0IH746cF944F
+ET9cCP3hYsSPl3rC//JvhVVg48mXJ1Kv5N1Nz3/wtuDJu8IX+cWvikrCSksj
+K8piasrj6yuTmqtS2qrfdNZk9tS+7a/LGap7P1r/Ybzh41Rj0WxjCbKpFNVU
+vhRYcwWmuQrbXLPaXItvqSe0NK63NG20NJObW6jNrZvNbbTmdnpzB6Opk9nY
+xWrsYjd0c+oD69mu6+H2dw3/OwEY2ERTek7DZmYtOb1q/U0F/k0pNvIDEh4I
+QhD0/YAlCEFBCJYgBEHfg4n6pv1jwROfXx3zOQYRP1wM+/Fy5E8hvf9uD+6l
+Vtq1yfSbzTHRH58XFL4sLgotK46oLImuLY1rKEtsLk9ur0jrqkzvrcrqr84e
+qs4drXk/UZs/VVcwW1eErCtZCKz+01J9Gaa+AttQtdpQjW+oXWuoIzbUkxoa
+NuqbKPXN1PqWzfpWWl0rva6NUdvG6G/rX2jNJLdc/3f+VutN1xoae3PqN7Nq
+KenVG28qiW/KcGmfllMLF+GjoRAEfVdgCUJQEIIlCEHQd2L/uwWPffmM6H4M
+Xgr94XLEjyFRP13pjTi0+u5f/v0k3OuvkqNT2fench62JacWRdUVxzaWJLR8
+et1emtJV9qa3PGOgImuoIme08t1EVd5UVf5sdQFyb0UL1cWL1Z/QNWXLNeUr
+NZW4mqq1mmpCTe16TR2pun6jr7ErMHLT1cD+479D07XGhp6cus23NZSMqo03
+FetvyglppbjUYkzqR1Tc+xn4aCgEQd8VWIIQFIRgCUIQ9J3Y3iD/9ozoyd+e
+EQ3E4MVADCJ+uBz2Y0jET1ej/nyz6Malvsjj/2GL/aHLyk9O57+Y+fjrTMHL
+2ULEbFFoZ15h54firo+lXQVl3UUVeyuu7C6p7imt7SmrQ1YnIGsSyfWX99YQ
+Etj/7n+o8Sqx8WpDXXdODfVtFTmjYuNN+fqbMkLaJ3xa8UpqATrlw0Lyu5mI
+7Al4IAhB0HcFliAEBSFYghAEfT/2v2j+92dEv45BxA8hYT9dj/jz7aifH0T/
+8qQv6lRf9Jn/V0n4/9PWG64SG6421HTmVJKzKzayKjYyyklvSolpnwhpJfjU
+otXUwuWU/KXk9/Ovc6aTssbg1whCEPS9gSUIQUEIliAEQd8VxA9/+S0GT3/5
+gcHfYvAK4scbYX+6G/Hzw8hfnkUffhlzJLT47v3+uIsDCZe/Zf0R60OI9Vca
+K9sbKttzytazS9ezStczPxHTS4hpxYS04rXUIlxq4Wrqx0ADolPyUMm5c6/f
+TiWlj4SlD/9egmyh7qCvNwRB0B5YghAUhGAJQhD0XfntPaJffmDwjzH44zXE
+T7cQf7oX9vPj8F+eRxx6FXkkLPpYVOyp+PhzrxMvpQ0mXx9MuYkvPPz/cfrV
+Xg5sojKpobSpobQ5pwifXYR/W4TPKlrLLFpLL8SnFeJTC3B7+7ia8nElJX85
+JQ+d/D7QgPOvs2eTMicSU4cSXvfA50IhCPoOwRKEoCAESxCCoO/N/0YMXkf8
+6Q7izw8QPz8J/cuLsEOvwo+ERxyNjjoZH3M2Oe7im/iQzMRrOUk33yff+Vge
+kVARlTSc9XD47eOR7Ccjuc/WSk8Ryk4Ryk8Tys8QKgI7+9dVnttb1fnAxkui
+xz/F1OdX1X+sriuoyX63mP1+6W0e+m0eJitvOfPDcsYHbPoH7JsPK2kfVlI/
+rKTkYfcXqD9M8nt08rul5FzU62zk67eBBpxKfDOWkDwQH98VmtIPXxQDQdB3
+CJYgBAUhWIIQBH2HJuobv3h7zN/GYAjipxuIP91F/PwQ8ZeniF9+RRxCIA5H
+hB2NCT+REHkmOfp8WsylzNgrOfHX3yfc+ph0t+j1g9LkxxUpT6tSXtSmvmxI
+QzS/CW9Nj+xIj+5Kj+0NLCO+PyNhMCNpOCN5NDNlPDNtMvPNVEb6TEbGbEbm
+XHoWMv3tQno26k32Ylr2YmrOUkrOUnIOem+5+9v7v4uvA8sOBODC67fIpMyZ
+pPSpxLTxhJSR+MS+uNiO2PAG+FwoBEHfJ1iCEBSEYAlCEPR9+g9i8McriJ9u
+Iv58D/Hzo99iMBRxOBJxJAZxLCHsVHL42bTIC5lRl7Njrr6PvfEx7nZR/L1P
+CQ/KEx9XJT6tSXpe//plUzKiNTmsPSWic29R3SnRvSmx/anxg6kJw6lJo6mv
+x1KTJ1JSJlNSp1LSZpLfzCanz71ORyalI19nzO8tM7CF11kLgf+RlIncW8Zc
+UsZsUvpM4pvJxNSxhNfD8YkD8fE9sZGt0a9qnv92IAifC4Ug6HsDSxCCghAs
+QQiCvlv7MXjkixj8/W2iF/Zj8CriT7d+i8FniF9eIg6HIo5EIo7GBmIw9OTr
+0DNpYecywy9mR4S8j7yWH3WzMPp2Scy9stgHlXGPquOe1sU/b0z4tTnhVeve
+QtsTwjoTI7oTo3oTo/sTYwcT44YT40cSEkYTEscTkyYSX08mJk8lpkzvLTWw
+mcS03/f5VwK/O5mYMp6QPJaQNByfMBAX2xMX0xUT1hT1ovJldAvMQAiCvluw
+BCEoCMEShCDoezZR37Afg8d+e5vomS+/dB7x0zXEn27/NQZ/eYY4FIjBsP0Y
+jEEci0ccfx16KjXsbEbYhezwy+8irnyIuF4QebM48nZp1L2K6AdV0Y9qo5/U
+xzxr2tuLltiXbbGvOuJCu+LCe+IieuMi++OjB+JjBuNjh+LjRhLiRxMSxvaW
+OL63pN/2OvAzkH6j8Ykj8QnD8fGDcXH9cTE9sZGdMWEt0S/rIp+U/RrRCDMQ
+gqDvGSxBCApCsAQhCPrO/TEGT/0Wg/uHgz9e/msM/nwf8ZfHfy8GkxAnU0LP
+pIedfxt2MTf88vuIq/kR1wsjb5VE3imLulcZ9aB6rwf3kzD6aWPM8+aYX1tj
+X7bHIjpjQ7tiw7rjwnvjIvriovrjPlfh5zD8vLi/Li52MC4m8Af64qJ7YqO6
+YyM6YkJbon+tj3pWHXG/6NfQus9fHQg/GwhB0HcLliAEBSFYghAEff8m6uv3
+PzP4+5fOn/46Bv98C/HzPcRf/u7JYBLiREroqTehZzPDzmeHXXwXHvIh/GpB
+xPWiyFufAj0Yea8ysKj71VEPa6Mf10c/aYx+1hzzoiXm17aYl+0xrzp+r8LY
+8J7YiN4/LDLwsyc2vCs2vDMmLBCAbTGvWqJf1Ec9rYp8WBp+t+BZYjf8BnkI
+gr5/sAQhKAjBEoQg6B9FCSL2i48NfnE4+OOlv4nBX/c/MxiBOBqNOBaHOJ6I
+OJGMOJmGOJ0eejYr7HxO2KX34SH5+z1YHHHz095ul0XerYi8VxX1oCbqUV3U
+44b9JGwKVGH085aYF61/DcO9NvzjXrZGvwzUX1PU84aoZ3WRj6siHpSG3/74
+6mHJs/hWeBQIQdA/BFiCEBSEYAlCEPQPZKK+6YsnRU/+6ycHAzH4p6v7MXh3
+PwafIg69QBxGII6EI45GIY7FIo4nIE68RpxMQZwK9GBG6Nm3oedzAz0YFujB
+KwV7u1YUfqMk4lZpxO3yyLuVgSSMvF8T+aA26mFd1KP6QBhGPWmMevrFnu3v
+aeDXA/VXE/kwEIDlEfdKw25+DL2a++JVNWxACIL+gcAShKAgBEsQgqB/LPtP
+ih7af1L098PB/R788QLipyuIP9/Yj8GHiF+eIA49Rxx+iTgShjgaiTgWgzge
+hziRiDgZ6MFUxKk3gR5E7PVgTuiFd4GFXcoLVGHYb0kYfrM04lZZoAoj7lRE
+3K2M2AvD6r092P95vypib4FfD/xuWfjtwJ8vCrueHxqSExqSVVAxAxsQgqB/
+LLAEISgIwRKEIOgf0W9fMPHHHvzxPOKny4g/X0f8fBvxl/uIXx4hDj1FHP4V
+cQSBOBqOOBaFOB6LOBG/34PJiFOpiNP7PXgma29nsxHnc0MvvA/9LQnDrhaG
+XQv0XXH49ZL9Nvy0v5L9FYfdCCzwuwWhVz4gLuciLuUgLqSVvK446AsDQRD0
+fwKWIAQFIViCEAT94/riYdHjf32ZzI9nED/tPyn6803EX+4gfnmAOPQYcfgZ
+4shLxNHQ33owZq8HT+6fD55KQZxO21864kwG4mwgCd8izuUEqhBx4R0iEIYX
+99ow9PKH0JD8vZ97ywu99B5x6R3iYqD+shAX0hHnU0teV25vcg76ekAQBP0f
+giUIQUEIliAEQf/QJurr93vw8Bc9eBLx0znEny4j/nwN8fMtxF/uIn55iDj0
+BHH4+X4PIhDHwhHHI/d7MA5xMgFxKml/rxGnA1WYijjzBnEmHXE2UIWZiHNZ
++3uLOP95WYjzmYjzGYjzgfp7gziXjDibUJJUARsQgqB/dLAEISgIwRL8X+3d
+zW5c5QHH4ZtKIF+O4ziJSEVFFQSFViBoyNtAPiCgfuzYddP6AhC9Cu6hO4cg
+oAvfA0rkiETOJuYdTyEgUFcBi/k9j/4ajWZ1zvKn94wOsAK+7cG1J0eER86N
+o8/9rwePvzhO/H6c/OM4tTwfvDxOXxnrV8eZd8bG9bFxc7Gz746zt8bmQRie
+m1X413F+7m+LXZj7+8HnTL+/jAsfjAu3xvkbWx/8c+fOfw/71gGeAiUIQUoQ
+WCUHr6E/cXBEeJCERzYX54PPPj+OLXvw5XHy1XFqJuHrY+2NcfryWJ9J+OfF
+zlwdGzMMr42zN8bZm2Nz7t3Fzn2362Pz2th8e+v9f80A3Pn088O+V4CnRglC
+kBIEVtJMwm+fGl0bRzbG0fPjmYvj2EzCF8bxS+PES+PkK+PUH8baa2Pt9cVO
+vzHW3xzrfxpn3nqyjSsHm9/f3HrvHzt3vtz59IvDvjOAp08JQpASBFbbzvb2
+Jx99PLd19b3x7MVxdHM8c2Ec+804/ttx/HfjxKVx8sWDvTROvbzY2iuLrb+2
+dfPDrRsfzvRz/AesPCUIQUoQqJlteLDby0L85KN/z+3cvrNz+7PFtrcP+wIB
+fmlKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAl
+CAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEI
+UoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwS
+hCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDE
+KUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAA
+QJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJ
+AgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCC
+lCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcE
+IUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABx
+ShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgA
+EKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKC
+AABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQg
+JQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClB
+CFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECc
+EoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIA
+xClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQg
+AECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFI
+CQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQ
+gpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCn
+BCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAA
+cUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUI
+ABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhS
+ggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKE
+ICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQp
+QQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABA
+nBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkC
+AMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKU
+IABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQh
+SAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFK
+EIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQ
+pwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIA
+AHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAl
+CAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEI
+UoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwS
+hCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDE
+KUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAA
+QJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJ
+AgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCC
+lCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcE
+IUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABx
+ShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgA
+EKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKC
+AABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQg
+JQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClB
+CFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECc
+EoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIA
+xClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQg
+AECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFI
+CQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQ
+gpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCn
+BCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAA
+cUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUI
+ABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhS
+ggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKE
+ICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQp
+QQhSggAAcUoQgpYluA0AQJgShJr/AACAEgQAAOBHlCAAAECNEgQAAKhZluD9
++/d3d3cfPnx42JcDAADAz2um3wzAmYF7e3v37t178ODBYV8RAAAAP6+ZfjMA
+Zwbu7+/fvXt3JqEYBAAAWGEz+mb6zQB8/PjxLMFHjx7NKvRvQQAAgBU2o2+m
+3wzA715GvzwinL/7wyAAAMCKmcW3zMD5Zf+Hlr8vHxPVgwAAACtgxt3yodDl
+2d/+T1k+Jjrt7u5+DQAAwK/cjLtl5X3/odCftLe3N4PxKwAAAH7lli+M+P8N
+CAAAAAAAAKyebwD04Bfd
+     "], {{0, 456.}, {599., 0}}, {0, 255},
+     ColorFunction->RGBColor,
+     ImageResolution->{144, 144}],
+    BoxForm`ImageTag["Byte", ColorSpace -> "RGB", Interleaving -> True],
+    Selectable->False],
+   DefaultBaseStyle->"ImageGraphics",
+   ImageSizeRaw->{599., 456.},
+   PlotRange->{{0, 599.}, {0, 456.}}]]], "Output",
+ TaggingRules->{
+  "Settings" :> {$CellContext`r = 
+     25, $CellContext`ls = -1.2252211349000106`, $CellContext`lt = \
+-22.69800692218626}},
+ CellTags->"Snapshot",
+ CellID->1759672171,ExpressionUUID->"57b1cd9f-c821-4027-b186-9df09f1bddef"],
+
+Cell[BoxData[
+ PaneBox[
+  GraphicsBox[
+   TagBox[RasterBox[CompressedData["
+1:eJzs3Ql8FPXd+HFQAbWtWm+sUpV6INBWbX3ZWvsI9VERvPGqKFQlj/XAB/BG
+Uaj1wOKBQgE5RVE55KiA3Agolxxy5gDClYQkJOQgiSA6/y/5PZn/MDM7O7u5
+Nvl+3q+8fO3O/ubcrd2PM7t7zv2P35p0RIMGDXoeLf+49W9Pt+nR42/P3naC
+3Lm9W8+//0+3rg+26/ZE1//p2uPy+4+UiW/LPz47qkGDQ7ctj/379xcXF+8B
+AAAAANRxEneSeN7uczXg3nKFhYX7AAAAAAB1nMSdqbxIPVhSUiKPFhUVlZQr
+AwAAAADUcabvJPQk9+SGbwZKMJaWltb2lgIAAAAAqpKEnuSeKwbNRaFkIAAA
+AADUV3YM2peJ5ufnm4tCa3vTAAAAAADVxVwmKgEoGfjdd9+ZU4S1vVEAAAAA
+gOplPhgoGShJWFhYyHWhAAAAAFDvSfpJAEoG7tmzZ9++fbW9OQAAAACAmiAB
+aH5qkBIEAAAAACUoQQAAAADQhhIEAAAAAG0oQQAAAADQhhIEAAAAAG0oQQAA
+AADQhhIEAAAAAG0oQQAAAADQhhIEAAAAAG0oQQAAAABIcFvLLS8363BmohkQ
+foGUIAAAAAAkOEoQAAAAAPTYUO7zcMzgMIulBAEAAAAgYVGCAAAAAKCHueDT
+m3sFh/MOCHOlKCUIAAAAAAmIEgQAAAAAbcxXwcRRgmbG4IVTggAAAACQgChB
+AAAAANDG/EiEb/1FYgabGYMXTgkCAAAAQAKiBAEAAABAG0oQAAAAALShBAEA
+AABAG0oQAAAAALThu0MBAAAAQBtKEAAAAAC02VoujhI0MwYvnBIEAAAAgARE
+CQIAAACAThvKeXPPlxkcZrGUIAAAAAAkLEoQAAAAAHQyF3yar4KZdTgzMcwV
+oU6UIAAAAAAkOEoQAAAAAFBJlCAAAAAAaEMJAgAAAIA2lCAAAAAAaEMJAgAA
+AIA2lCBQn3wFAAAAfPVV1PeNlCBQn9T2v3IAAACQEKK+b6QEgfrE/A/fAgAA
+gFbffPMNJQhoQwkCAAAoRwkCClGCAAAAylGCgEKUIAAAgHKUIKAQJQgAAKAc
+JQgoRAkCAAAoRwmiSpRWKCkp2VeuyMFMkYfsYbW9vdpRggAAAMpRgqg8ZwMW
+Fhbm5eXl5OTs3r07s5zckLsyUR5y9mBtb7VqlCAAAIBylCAqyc7AoqIiyT3p
+vuzsbHmpyMSD5eSG3JWJ8pAMkGHEYK2jBAEAAJSjBFEZdgYWFhaa84AFBQWR
+XmzykDk/KIOJwdpFCQIAAChHCSaUvLy8Hj16jB492tzdvn17p06dPvjgg9rd
+qgD22UCTgXI7+PUmA0wM2mcGa3sPlKIEAQAAlKMEE4qkX4MGDe644w5zd/jw
+4XL3oosuqt2tisSc1CsuLpYXRpgMNEwMyiwyI6cF4/Z5ONPKeWenBAEAAJSj
+BBOKqwRzcnJeeOGFmTNn1u5WRWJfF5qRkRFwUaiXDJZZ7GtEa3s/6iRKEAAA
+AJVBCSYUVwkmOHNCMDc3NzMzM9YXnswiM5rTgrW9H3WSN/oKK3gf8s5OCQIA
+AChHCVaVRx99tEWLFvPmzWvTps0xxxzz0ksvmenjx4+/4oorjj/++FNOOeXq
+q6+eP3++c64VK1Z07tz59NNPP/nkk+++++5ly5Y5SzA1NVWW2bt3b3P3yy+/
+lLuDBw+2Z8/Ly5MpjzzyiD1l2LBhf/jDH4499tizzjrrtttu27x5c/BmS4jt
+3r1727ZtWytsCWdzOdnC1atX79y5M9YXnswiM8rsZjkhV6qB/UTIkyJPTaRS
+pgQBAABQGZRgVbnxxhsl4k477bQTTjjhz3/+89ChQ2XiiBEjZOJxxx137bXX
+XnLJJXL76KOPltwzs8hb/TPOOEMmnnfeeddcc43k29lnn+0swXXr1sndBx98
+0NydNm2a3O3bt6+90uzsbJlyww03mLsDBgyQu9KAMosEacOGDWV78vPzAzZb
+WmPr4UIGi+RbWlpacnKyxOzevXtjfeHJLDKjzC4LoQSdXE+HPMW+T5wz9KaX
+owQBAAAQHiVYVUwJtmvXrqCgwJ7YpUuX3/3ud6tWrTJ3+/XrJ2Oef/55c/f2
+22+Xuz179jR3t2/f3rRp08qUoKzryCOP3Llzp7n78ssvX3zxxbNmzQrYbOfZ
+wFhLMDU1ddOmTUuXLj1w4ECsLzyZRWaU2c1pwWptq7rF9XTIE+T7xFGCAAAA
+qAxKsKqYEgw+mJI8MqZjx47mbrNmzU455RTnIX3//fcrU4K///3v5e6YMWPC
+f/iu8iW4ZMmS+EpQZqQEvWIqwcJoKEEAAAD4ogSriilB77V8H330UVJS0p/+
+9KeWLVsee+yxMubWW2+V6ZmZmXL7qquucg6Wp6MyJSgN2LBhQ5ly+umny0Jk
+1dICwZtdmatD7XOC8V0dyjlBXzFdHUoJAgAAID6UYFXxLcHOnTvLxKOOOuqP
+f/xjx44dpQHtEpQ3+XL72muvdY5fv359ZUqwrPwraB577LELL7ywQTnJT/ti
+UV+V+cYY8zlBeQmlp6fH+sKTWWRGPifoFdM3xlCCAAAAiA8lWFW8Jbhjxw6Z
+8stf/tKeuGbNGrsExcknn9ysWTPnQj755JOAEvziiy/kbteuXe3xphydJWj7
+9ttv27ZtK4/269ev6vbyMBIp0hpZWVnxlaDMKLPzKxLx4btDAQAAUBmUYFXx
+luDy5ctlypVXXmlPeeyxx5wlePXVV8vdIUOGmLsFBQW//e1vA0pwy5Yt5otG
+7QX26tXLLsHc3Ny77rqre/fuJSUl5tFRo0Y5v6CmypnfE5RXxebNm2XHw7/q
+ZLDMIjPye4JxowQBAABQGZRgVfGWoDTOaaedZsru5ZdfbteuXZMmTZwluGLF
+imOPPbZx48Yy4IknnmjduvXxxx8fUIJCMlCmtGrVSvruzjvvNAu0zwlefvnl
+cve666575513XnrppRNPPPGII45YuXJlNe2y7KBUpwRsRkZGWlpaUVFRmJec
+DJPBMovMKLNTgvGhBAEAAFAZlGBVufnmm6XCcnJynBOXL19uf2Tv3HPPnThx
+ovO7Q8WkSZN+97vfma95+c1vfjNjxgy5cdddd5lHN2zY4LocVKZIMJoFnn76
+6WPGjJEbN910k3l027ZtclvSUibKMi+66KLZs2dX617bpwW3bt2ampoqGRL8
+epMBMkwGc0KwkihBAAAAVAYlWAN27dol7RMwIDMzc/v27eEXmJWVtXnzZvsq
+UBd5jpKTk/Py8mLbyrhIysnqpD4kgdPS0jZu3JiRkRHpxSYPyQAZJoNlFpmR
+EoybN/cCeGenBAEAAJSjBFFJdgzm5uZK8K5bt27Dhg3btm3Lz8/fX05uyF2Z
+KA/JABlGBlYeJQgklKSkpP79+9f2VviYOnWq2TYjJSWltreo5rj2PdIwOSbe
+IyN3ZV5ZQvVvZgxkO2WransrojAb6eUcY54aW6IdZ0APShCVZ8egvEIyMzPT
+0tKk+1auXLmsnNyQuzJRHpIBZGAioASBqiVvZRMzsupEO1SH8ClnRlKCVcVs
+5FQPe4Bd6OaY23drb5MBvShBVAkTg8XFxQUFBfI6yc7Olu7bVU5uyF2ZKA/J
+ADIwEVCCgBIJmDM1w7fvwo+kBOMWdSO9A8yUxPxvKUD9RgmiCpWUlJgeLCoq
+KnCQu6YBI322ETWMEgTi47yqTd6+2qXgvG3umre13ksTA5bgeicsDzkn2ned
+V985z6p4L7SzR7ouDXUtxNU7ARvvmsu5wb6b5y0pM8y7+1G3yitgvL2WqJfF
+ekea5dglGOnYxrfNriPgOoxm7c5lep8a86R7XwPeYQFPk73l4V8VVsXrIWqv
+RS1B78JDZntKCMFLAOBCCaI6mCS0EYCJhhIE4mAngwkE5zvepMMvbzN37d6x
+hwUvwfX22DSIswSdAeW8a090pYE9xYx3XYxn3jl7r80L3nh7Ltd5HFffeTfG
+uWr7ikF74b5bFRxW9uq8e+Gc4ro00cU70mywaRPnHtkXPXp3J/w2O2exj4B9
+iFxr9D41kQ6ycxWup8n1LNivlqSK+DUbHGZfIoWni/2a8R3pe7LVTIx6gWhS
+NFxiCsSKEgQUogSBWPm+N7bvemMqUtkFLCFMCXrDynVazTfrnIuNuqKAjXeu
+3bUu7wV+rvf8se5+8KmlSPtuT6mOq0O9xzambfYuwfuoa0t8c9v7Ggh4kfg+
+Td5Te2H2JaZzgk4BT5NzA0J2nOs8tXeXAYRHCQIKUYJArLwnX1yPBjdCmCWE
+KUHnAN+ECS7BgDMyzhIM+Ubd+Z7cGw6udQVUku+b+eCUi7o91VGCzl2IY5sj
+bXbAo1GPoWuA73MX/DRZfi+tSDsYhn1q1XnW0lXolSnBJL8zs7FuJACDEgQU
+ogSBWMX0Hj6O97pxl2DU81beEyi+gmsi0lzBieFabKTdD9iqWEvQ3oaaKcGY
+ttk5l+9lq747FXyQvSUYx9MU376EZxblu8G+uxnAO7vrFCGAmFCCgEKUIBCr
+4HeqSXWqBM0pm0jfthGw8QFzVb4Efbcq4HAlQgkGHJBITAA6L6F0HnnfEozp
+nGAcT5Pzo4Ux7UtIzotafQ9spDz08p6pDDkjAF+UIKAQJQjEqgZK0PVodZRg
+mD6K75RN1BIMuDo0fLUFb4/33FP1lWAc2+zl+k4Y706lxH51aBxPU3V/1M71
+0o30Ug9fgs4plCBQGZQgoBAlCMTK+2UdluPbEcOUYExLsKqnBH2nuITfeOf2
+hyxB391PifzVkZHyJNJ3p1TrN8Z4SzCmbfZ9KLjjXE96yA9jxvo0RdoX13Ls
+DwBG2rtInIXuuw3hP+vn+4KnBIG4UYKAQpQgEKuUip8VsC9idL6hDVOCwUvo
+X/EjBc6HqqME7fNQrnU5mzTMxqdU/CCdc/tdc7kWFbD7dsdF2qqo2+PKjZjO
+2TkPyNTDf0/QOcy1j7Fus31AXONdn/KL9Kh3A7zbGd/TFLAvro2Pekjt7QnY
+Czs8zYDKnBC0+JwgUDmUIKAQJQjEIcXxA21GpOv6Ir2zDViC/R7efidfTecE
+Lb9vCAmz8d4Z+zt+UyBMCfouIeRWebmOWP/Df+AgphJ0rrp/xQ+vezc+0sms
+8NvsHe8t5UiP+m6A73bG+jSF3BczMWoJOj8C6X1eIm1hwDKds3hfmdV9aStQ
+v9XdEnzhhRduLldYWFjb23JIom0PEIASBCrDnMuojiVUfslVshnVMVf4JcS0
+fPvMV2W2J471VmbeSNucdPh/GYhvS+LbpKjbVh3LqcLnDkB86m4JtmnTpkG5
+vLy8mlxvQUHB+HKLFy9OhO0B4kAJAkCiCXl2DACqCiUYq9TUVLPeDh06JML2
+AHGgBAEg0VCCAGpYdZdgaWlpvO9Vo6AEgbhRggCQaOL7Zk4AiFs1leCcOXOu
+u+66s84666ijjmrZsuXf/va3zMxM89DMmTMvLTd8+PAePXo0b978tNNOKykp
+MY9u2LDh0UcfveSSSxo1anTBBRd06tRJyst3Fb7lNXLkyFtuueWkk05q2rTp
+XXfdNWnSJPshe70ypm/fvi1atJBVtG7desKECc7FyjBZ6S9+8Yvzzz//hRde
+mDJliplrzJgx8qjM2KpVK7Pe4447TqbLLri2Z+3atbINJ5xwwplnnimLysnJ
+CXPEgJpECQIAAChXHSU4YsSIhg0bNjjcueeeK7PLox9//LGZcvbZZ9uPmhJM
+SUmReHTNKJ24atUq71q8JdivXz/XvLIZH374oXnUXq8knmvMihUrzJiFCxc2
+adLE+aiEqrnxxhtvyABJWtcq7DOD9vZIwDoHtG3bNuoRA2oYJQgAAKBcdZRg
+ixYtpICOP/740aNHf/7551dccYVposmTJ5c5iky0bt36iSee6Nmzp7mI9I9/
+/KOZ3rFjx08//TQpKcnc7dKli3ctrhKcP3++HXqy0qlTp/7yl7+Uu0cdddSW
+LVtc6+3atWvfvn3NAPG///u/Zpl291155ZVvvvnm7bffbs9iSnDJkiUDBgww
+Uy655JKxY8cuWLDAtT1nnHHG66+/3rlz5yOPPNJM2bVrV8j350DNoAQBAACU
+q44SzMjI2LlzZ25urrk7ceJEE0QvvfRSmaPILr744oKCAnuuwsLCRo0amZQr
+Li42Ezt16iRRduONN3rX4ipBWbi5++WXX5oBEoNmivSac7033HCDGWBPufnm
+m+WubLN9HnDv3r1mTIcOHZwlWBbic4LSoa4pM2fOjHrQgJpECQIAAChXHSVY
+UlIycODAu+++u2XLlmeccYZ9Wq13795ljv7q1auXc67Fixeb6VJ/Yd7Kukqw
+ffv2DSIwp/zs9fbp08csIT093Uy5/vrr5e60adPMXecpyPfeey/WEszKyjJT
+nn32WTPFnAwFEgclCAAAoFx1lOBf/vIXU0ANGzY888wzI5XgK6+84pxr7ty5
+Zvr9998f5q2sqwSvuuoqc/fXv/71b8tddNFFclduvPDCC77r3bVrl7MEFyxY
+YO7ecccd9lpef/31WEvQ/tyirJcSRGKiBAEAAJSr8hJcvny5yZ927dplZGTI
+lLFjx4YpQVn4EUccIdMvvfRSe+LgwYN79er12muveVfkKq8nn3zS3F27dq3v
+hkUtwfz8fLMBJ5xwQnJyskyRJdvfFOotwWuuuSZge8ooQSQwShAAAEC5Ki9B
++xpLyavs7OxNmzZdfPHFYUpQtGzZ0jwkDZWSkjJ06FBz96abbvKuyFVeEyZM
+MHdlenp6emFhYd++fU8sJ8vxXa+rBIXcMFNkLilZ5xeZ2iWYlZVlvgrmZz/7
+2ZQpUzZv3uy7PWWUIBIYJQgkJvn/vv79+yfCj8rJZkydOrW2t8Jf4hyl+ifF
+IXhMfL9+yLMGJJQqL0HpoJ/85CcNHMyJtjAluGDBgmOPPbbB4Ro1auT7jSuu
+8iotLe3UqZN3pc2bN9+9e7fver0lKCOdvwEhC7nttttcJVh2+GcSvb8iQQki
+8VGCQGKS98lJSUk1/G7Zt6pkM2R6TW6GL9/oM0cpYUO1kmqxc2W9SYfzHuQw
+YyKRkWFe3mZYfX1+gYRSHZ8TlKCzf46hVatW8i8Nc/vFF1+URz/99FNz1/ea
+zxkzZlxxxRXmR/0aNmx44YUXzp4923ctbdu2NcvJz8+3N7Jbt27nnHOO3XG3
+3357WlqaedS73oyMDDNFys5ebEFBwbRp05588smXXnpp5cqVw4YNM2PefPNN
+57voyy677Oijj5bpt956a6Ttkf01U6ZMmRL1oAE1iRIEElOtlKDvu+7EKUHv
+Aan3JVgre2fWayLUPuvn2hLvFBOGUV+x9tKiDraH1dfnF0go1VGChnTWjh07
+4nubWlhYuHr1avt3KGK1devW9evXFxUVxTpj165d77vvvoceesic1yspKbHP
+9H399dfe8favXQB1CyUIJCZK0IUSrF2ul4H3VRHyFes8hxgw2GSgqcsEOQJA
+/VZ9JVgXde7c2XTfGWeccfXVV5988snm7vnnn19aWlrbWwdUGUoQiJW5Zi/g
+oji5a94km5HOC/xc8wa8xfV9X+2a1/moWWnU5bsetT8D6JyxfwUzi316yB4Q
+5p158JaE3FrXeOe22ZttZrTPH/kuJ/yKgg+Xt0OdA1zPtb2PrgW6zqO5lmA/
+6n1GvKfkfDfMvqbUfvk5k821keG5jpu3BGO6kjP46lD7aU2oFgbqN0rQKTMz
+85577nF9ULFdu3YyvbY3DahKlCAQK/sN9tQKrnfFztMZzvfw9nTnjJHe5XpL
+0L76zvf6Omc1OMvIuwTfLbeX6XzUzOXqFO/++rJncS7Ze4js4+PdWtfRcG2e
+GWmOknPzvGeR7BkjXegYieuAu65+tFftPJjOAb6xk+R3Zs13CZF22bVH3vU6
+j4n9OnQ9L7GWoHdfIh3nuBfoZC+ZEgRqDCXotWXLlhkzZgwbNmzmzJnmhzCA
+eoYSBCrP1QjON+rOYb4BFXxaJCAr7A9z+W5DpCW43lR7w8T36lDfCvDd7Ejr
+cr2ljzQgIDDDXx0adaeibr8V4oB7wyfqU+bdNt99dJ4W9G581ENnl6DvSyum
+c4LOU7HeWewINcNiOtUYUILOk5iUIFBjKEFAIUoQiFuks0W+J0diunbO8mSF
+77zO98zeunG9i/bNn5Al6HsdYMDbft/ecW5t3JUUpgSde+q7ojCfaIu6C971
+xl2CKRVcL5KAEvRumD2xCuvJPv0d8PKzezCmlUZ6Cbn2jhIEagwlCChECQJx
+cH62yxamBMOfNPGWoK/wJejbIDVcgsGBVn0l6CtqCQYccN/1xlGC9n9GsBce
+tQR9i965ruqoJ+8ZW9fHD6Ne3xuwwQETKUGgxlCCgEKUIBAr+8RNpPf81VSC
+Zo1eZgAlGLyiSMcteBcizVglJeh7FXFilqDld1R9dz/qB0i9G+yaGAk9CFQr
+ShBQiBIEYhW1jHxLMMwViQHjo77HDnN1aO2WoHk/H7CE6ijBWA97TBtTJSXo
+XW/cJRgwV+VFDXkrlh8cibQEV3Q7/6tLHE8igPAoQUAhShCIVWVKMOT7ZMuT
+Fd4vhHEJ+TnB4C9pCXPe0ApRgt6tdZ1FquES9F1scFlEOuABbe7aKe8GuzYm
+6lPmu/G+x8E5LLgEp5YL3nffR50hH+moutYbsK6Qp8irqWoBeFGCgEKUIBAr
+O6nMeQr7c17BJWgdflmpPW+kd7muN/wpjt8s8J09alZYjl92sL8GJMnz4S/v
+KZg4StC7tc6OiLSEqKWcVPGTCuZske8+eg+FfdhdT1nUGvI94N5rO82SvS8D
+1xK8B9zeeNcLyfuUuZ4R31dg8JlE1wKD9933hepapnel3leg77piOtlHCQI1
+hhIEFKIEgVileH5PPMw5QedDznkjvQ32PaMUMHuYErQqvqLELpokv7OENjMx
+jhL0Lsq1p/GVoHP3A765xXsovB9Ai+kixuC9iPQy8A7wnkrzHRDpGYk0o/d1
+4j0mNu94L9crPNILNeqL2XddSX4CtiRgXwBUIUoQUIgSBOJjny6Je95Krjru
+2Z1832ZX4fIrc5SCl1mT80Y9b2Xf8I2sqCuNe0CVH1vf5YfZtmrdDAA1gBJE
+4iutUFJSsq9ckYOZIg/Zw2p7e+sAShDQw3t+MOrpIYQXqQQBIPFRgkhwzgYs
+LCzMy8vLycnZvXt3Zjm5IXdlojzk7MHa3upERwkCethX8fl+JA2VRAkCqLso
+QSQyOwOLiook96T7srOz5XUoEw+WkxtyVybKQzJAhhGDYVCCgB72d5sYNEvV
+Sqn4HhsAqHPqWQnKFvbo0eODDz6o7Q1BFbAzsLCw0JwHLCgoiPRKlofM+UEZ
+TAxGRQkCAAAoV6dLUDZm1qxZq1atsqds27atQYMGd955Z+1tVBXz7qMe9tlA
+k4FyO/jFLANMDNpnBmt7DxIXJQgAAKBcnS7BHTt2SPdde+219pT6V4LefVTC
+nNQrLi6WV12YDDRMDMosMmP9Pi34eTjTynlnpwQBAACUowQTnOYSNNeFZmRk
+BFwU6iWDZRb7GtHa3o/qQgkCAACgMmqyBFNSUh599NHWrVv/9Kc/vfrqq/v1
+62e/UV+3bl2LFi3++c9/vvbaazKgSZMmLVu2HDVqVMDS+vTp86tf/Uoq6dhj
+j5V5Tf3ZJTh48OBLLrnkmGOOueyyy4YOHeqad+TIkR06dPjZz372m9/8pmfP
+nhIOAStKTU19/PHHZRU///nPb7nllvHjxzsflV2QHfnTn/509NFHy5Z//PHH
+ffv2lcEbN26UR7/88ku5LRtjj8/Ly5MpjzzyiD0lMzPzgQcekH2RvZYldO/e
+vbi4OGAfjWHDht1www0nnHCCDJDZly9fbj9kH8ynn376nHPOadSoUcDeJSxz
+QjA3N1eOT6yvaplFZjSnBWt7P6qLN/oKK3gf8s5OCQIAAChXYyUob84vuOAC
+iZrzzjuvXbt2xx9/vNyW6jGPSsjI3bPOOkt6qm3btjKmQblZs2ZFWuCQIUNk
+OTLm1FNPlUCT6imrKMFf/OIXjRs3vvLKKyWszHLGjRvnnFGmSAZee+21ZkUy
+sqioyHctOTk5F110kYxp1arVX/7yF0nLI444YsqUKfaAF198UR6V6dK2F154
+odw27WY+2Tdt2jS5LW1oj8/OzpYpEnH2gT3//PPN8iVOJTad5zR991EMGDDA
+Xumvf/1ruX3KKads2rTJeTBlloYNG0pQt2nTJuB5kVbavXu3HLetFbYkgM3l
+pMFXr169c+fOWF/VMovMKLOb5dT23sTGfiLkSZGnJlLMUoIAAACojBorwU6d
+OkmePPnkk+Zubm6uKaAZM2aUVcRLkyZN5s2bZwb07t1bptx7770By4x0dagU
+0GeffWamvPfee862Sk5ObtSo0Zlnnpmenm6mdO7cWQa8+uqrvqv429/+Jo9K
+7pm7K1eulISUjDWn7SQ3ZF0nnXSSRIcZINFn2jNkCS5atOjiiy/u1q2buStv
+46Xp5DjIjUj7uGHDBqnRk08+OS0tzUwZNGiQjLniiivMXftgTp8+PeDoGdIa
+Ww9X2yV0iOSb7J08WStWrNi7d2+sr2qZRWaU2WUhdbcEDXnB+D5xztCbXo4S
+BOqBlJSUBPmhB9mMhP1xhMQ5SpWRUi54gHM3o46vMcFbYh6VF08cWxt1sYlz
+EID6ocZK8JxzzpHGcc4+efJkCZbnn3++rCJe2rZtaz+6du1ac7YuYJmRSrB1
+69b2lIyMDIm1iy66yNwdOXKkDBg4cKA9IDMzU6bcdNNNvqto3rx506ZNnVMe
+eeQRGS+hIbeHDh0qt+Vf1PajpaWlMZ0T9OrSpYsMWLNmTaR9HD58uEx58803
+nXP97ne/a9y4sTmzaQ5mu3btIq3CyXk2MKFKUOJ606ZNS5cuPXDgQKyvaplF
+ZpTZzWnB2t6b2LieDnmCfJ84ShCol2rlZ8p9q8r8GH1NboYv3+gzRylhQzUk
+2f7g59q1m2Z8Iuy1+XlK34dketLhwm9wwAGpzGIBBKiZEszKypI2ueqqq5wT
+5V2uTGzfvn1ZRbw8/PDDzgGSNpdffnnAYiOVYMeOHZ3DzjrrLOlQc7tbt27m
+nN1vHczVld7lm2rzDhbvv/9+WUUVzpkzxznXHXfcEVMJJicn9+rV65prrrn0
+0ktNRdqz++7jo48+6l3p/fffLxOXLFliH8zHHnss4NA5j1gil6DsUXwlKDNq
+KMHCaChBoG6plRL0fV+dOCXoPSD1owSj/iS9azfjPtFWVcz5OBNlvq8Nb6ua
+wVG32eyaSTzvYLNS8x8EzMiQiwUQVc2UYHp6urTJdddd55xoTsaZ84C+8dKk
+SZP4StD13aHOEjTF1Lp169sdmjdv3qVLF+/yTasK52CJQdkR+ReRvbRFixY5
+57r33nvDl6Ac/BNOOMF8trFDhw7mGtrgEnzggQdkyuLFi50r/fvf/y4TzbW1
+MZVgwl4dap8TjO/q0HpzTjD46lBKEKhnKEGXelyCUSXabtqxFum14Z0e8vXs
+PNkX5sVvFpsIr0+grquxq0ObNm3arFkz55TZs2dLsPTs2bOsBkvw3XfflQGj
+R48OudmnnXbaeeedF+nRt99+W5Y2ZMgQ58SLL77YTrkvvvhCbnft2tV+dP36
+9c4SfOihh1yXenbs2DG4BAcOHChTXF+I+l//9V8NGzaUJ6gsxhJM2G+MMZ8T
+lNdnenp6rK9qmUVmrOufEwzzjTGUIFBj7LMhka5Psy+Zc57C8J034L297ztn
+17zOR81Koy7f9aj9GUDnjP0rmFnMFOeAMEkSvCUht9Y13rlt9mabGZ1t4l1O
++BW5ZnGeorJntDcm1nXZy7RfGOYg20cj0kLMbec5wYAXVcALMuprI9YPXTpf
+J07eOovpitaol8u61pU4jQzUXTVWgu3bt3f2S0lJSZs2bWTK2LFjy+ItQXNW
+8dxzz7WnRC1B2VkZ8Pvf/z4/P99MkVK4+eabn3vuOd9VmK/uNBtpvP766zfe
+eKMptQULFsij559/fm5urnlURjpP6skb+wblX5dqz96rVy9nCcqi5O7MmTPN
+XYkXc4rQLkHvPi5ZskSmXHjhhab7ysp784gjjrA/CxlTCSYsKSAJmaysrPhK
+UGaU2fkVCUoQqCr22/ipFVzve+0pdrnYBWGmOGeM9CbWW4L2hXC+V9A5O85Z
+Rt4l+G65vUzno2YuZ4/47q8vexbnkr2HyD4+3q11HQ3X5pmR5ig5N88VTc51
+OQ9d1HawTza5ttB1DGNal3Nr7UVZfuHjOuDeEnSOD/mCDH5t2CutkhKM9CyE
+XGz4ErSPIYBKqrESXLdu3UknndS4cePbb7/96aefvuyyy6RWOnToYBYYXwmK
+E088UWa8/vrrBw0aVBaiBMsqTsO1bNnyqaee6tmz56mnnhpwlnDt2rWyCtmS
+u+66q0+fPrIiGSzNZf/k3z333GO6rEePHnffffcxxxxz9NFHO1PO/FBFq1at
+nn/+edkwWZSzBN955x25e/bZZz/77LPdu3c/7bTTzAB7du8+llV8PrFFixay
+0vvuu++4446TuexPDtabEpSDLC85SfXs7OzwL2kZLLPIjPyeICUIVCvXh5Wc
+OeAc5htQAe3jXabrtJFzgd4PTPkuwVVArk3yTaRIRem72ZHWFfU7T6Je5hf+
+6tCoOxUmH7xLtrfQdSjCrMvVra69cD25UY9e1CstfV+QAQt07kuVlKDlyE9T
+sjEtOWoJTnWcI+ZDgkCVqMlfll+4cGHbtm2llaRTzjjjjM6dO9sn5mQzZKL9
+YwqGJNUf/vCH4GWOHTu2adOm5jSf3N2+fbvcliJzjmnWrFnz5s3tuyUlJY8/
+/ri0oTl5J4+OGDEiYBXz589v06aN6bsjjjhCStb+BQqxd+9eaTGJXHn0yCOP
+NP8CdKbchg0b7J81PP3008eMGdPA8VWlZmPMMZGFd+3a1cxuf3eodx/NXNKA
+5557rkw86qij/vjHP06cONEe73sw6xyJONnNgoKCjIyMtLS0oqKiMK9nGSaD
+ZRaZUWanBClBoMpF+toK39MfMV0dZ3ne7fvO63wf7q0b17t93/wJWYK+V/oF
+vAP3bTrn1vouoapK0LmnvisK85k13zGVXFekj/u5ZvQeh5AlGNMLMvhohxRQ
+gq5zqTG9+EOWoPfMI4C41WQJGvJOdfPmzZVciIvkWGHFD/CFJ0G3c+fOkIOl
+LJKTkyP9AL1Ex8aNG2VMWcWXtzhP6pWVf3uq7LUM851djqosPC8vL2ADfPdx
+27ZtwXPVafZpwa1bt6ampsruB7+YZYAMk8H1/oRgGSUI1Ib+h38sy3WiJ6AE
+w5+/8Jagr/Al6PvOv4ZLMDiaqq8EfVVTCQasK0wJ+o6JWoK+q67FEnRNj3r1
+r0v4/7GEvFYZQFQ1X4L1nm8JIg6ScvJ6k7TJyclJS0uT1s7IyIj0SpaHZIAM
+k8Eyi8yorQQDeGenBIFY2Wf3Il26WU0laNboZQZQgsErinTcYlpdmHX5Pk0B
+W2tVugTje0FWXwn6nv5OieVLPmP6HwsfFQSqBCVY5SjBKmTHYG5u7tatW9et
+W7dhw4Zt27bl5+fvLyc35K5MlIdkgAzTkIFllCBQ46KWke8b7zBXJAaMj/ou
+OszVobVbguasUMASqqMEYz3swaur5Lqq6erQ+F6Q1V2C3uNACQKJjBKsctu3
+b1+9enWk60gRKzsG5eWXmZmZlpYm3bdy5cpl5eSG3JWJ8pAMUJKBlUcJArGq
+TAmGf+/terfv/UIYl5CfEwz+kpYw5w2tEG/UvVvrOk9UwyXou9jg0Ii7BAPW
+FbIEvU+l6+hVUwlOLRdTNfuWYKTj4Nr3gNVFeoH5TvE9pABiRQki8ZkYLC4u
+LigokBdhdna2dN+ucnJD7spEeUgGkIEhUYJArOykMhf+2Z8ZDH7jbfldPdi/
+4gcmvFzv9lMqvnYy0uxRS9By/DaB/W0brnfsrl2z54q1BL1b6zwhGGkJUUs5
+qeJ3EFLKvxfFdx+9h8I+7K6nrMpLMOq6QpagXVJmIfYzFakE43tBeo+2a67g
+g2Ovq3/FT2Z4D4tzg72vT9/VmUW5/pfiXaxzGCUIVAlKEHVFSUmJ6cGioqIC
+B7lrGjDSF/LAixIEYpXi+dXvMKdgnA855430xttbIimH/8q5a/YwJWg5vnTR
+VECS31lCm5kYRwl6F+Xa0/hK0Ln7/St+BjFqnVmewx51RVa8JRi8rpAl6N3T
+4HOC3hekK3WrvAS9++j7Sgt+qfuuzrvYJE9oBy8WQHwoQdQ5JgltBGAcKEEg
+PvZpkbjnreSq457dyTdMqnD5lTlKwcus+Xlrfl0xLaE6DnXlVdNWJebOAnUa
+JQgoRAkCevieteHtNACAEgQUogQBPVxXD/qeEAQAKEQJAgpRgoAe5ptM7M8J
+cjYQAGBQgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpR
+goBClCAAAIBylCCgECUIAACgHCWI+qS0QklJyb5yRQ5mijxkD6vt7a01lCAA
+AIBylCDqDWcDFhYW5uXl5eTk7N69O7Oc3JC7MlEecvZgbW917aAEgVilpKRU
+/sf4UspV1SY5mR8NrI4lx4QfKwSAOoQSRP1gZ2BRUZHknnRfdna2vGJl4sFy
+ckPuykR5SAbIMM0xSAkCsZLGSUpKCl865sfcvROdC/EdEx/zq/FVsqgAZvsj
+rci1d8HM8fRy9qysyEwkMAGgOtTREpQt6dGjxwcffFDbGxKb7du3d+rUKXiz
+x40bJ7u2a9eukONR5sjAwsJCcx6woKAg0mteHjLnB2Ww2hikBIFYxVGCMt67
+EGfp+I6JTw2UoNla3xI0+xVTtZnjKYuaejhnJptjVYW9DABwqhMlKCudNWvW
+qlWr7Cnbtm1r0KDBnXfeWfMbUxnDhw+Xzb7ooosCxnTt2lXGrF27NuR4lJWX
+oDkbaDJQbge/7GWAiUH7zGBt70FNowSBWFVJCcYxJqTqLkGz+5HOCTpP6sVU
+ggGDndfiVtVRAgA41YkS3LFjhwTRtddea0+poyUo6fHCCy/MnDkzYIyzBMOM
+hzmpV1xcLK/PMBlomBiUWWTGunha8PNwppXzzk4JArFylYv52GCkyxrNaSwT
+TYaZ0Ux33o40xrV2c+7MOcU+Bxcp0Fxb6P0UoXOlYfbdLKFqrw4NGOw8J5gI
+H4EEgPqHEkw0zhJEGPZ1oRkZGQEXhXrJYJnFvka0tvcjNpQgUMN8S9B5caMz
+kezKc1306Gyl4DGutbv6y16d79qdA8x31Ji7rp4KfwrPecKxykswOAZr5vOP
+AKBTNZWg/Iv90Ucfbd269U9/+tOrr766X79+9jvtdevWtWjR4p///Odrr70m
+A5o0adKyZctRo0ZFWlSfPn1+9atfSRwde+yxMqOpP7sEBw8efMkllxxzzDGX
+XXbZ0KFDXfOOHDmyQ4cOP/vZz37zm9/07NlT3vYHbLNssCz/66+//u///u+f
+/OQn55xzjiywuLi4V69ezZo1k7VfccUV8+bNC7l8ezeffvppWVSjRo1kYmpq
+qkzs3bu3PUwOy+uvvy5LPvroo81xcJagd3xmZuYDDzwgB0SOmxy97t27yxa6
+dkGe0/bt2//85z8/9dRT77jjDjlWAXtdD5gTgrm5uXJwYn39yywyozktWNv7
+ERtv9BVW8D7knZ0SBGIV5mpG17fBeIPO+40xkca4Jroy05t1rmLyHeBabMhz
+gq4Zq+8bYzjxBwA1rDpKUN5dX3DBBZIz5513Xrt27Y4//ni5Lc1iHl2+fLnc
+Peuss6R92rZtK2MalJs1a5bv0oYMGSILkQHSNbfccouEVVlFCf7iF79o3Ljx
+lVdeKU1kFjJu3DjnjDJFMu3aa681a5GRRUVFkTb7xhtvlDFnnnmmLO26666T
+Jcvda665RrZTlnD55ZfL3eOOO27nzp1hlm92U7a5YcOGknht2rQpK89Dmfjg
+gw/aK33xxRdlipSs5OeFF14ot3/5y1/aJegaLwf//PPPlymtWrWSApXWc50Y
+Nbsgx/bcc8+VLZdalLt//vOfA54sKaDdu3fL8dxaYUudsrmcJPPq1avlqYn1
+9S+zyIwyu1lObe/NIfYTIU+KPDWREpUSBGpYpBK0T7rVcAm6BjhL0LfIYv2c
+Y6RFVWEJmtOg5kbwt5ICAKpDdZRgp06dJECefPJJczc3N9f0y4wZM8oqEkki
+xT6/1rt3b5ly7733RlpgpKtDJbI+++wzM+W9995zZlFycnKjRo0k69LT082U
+zp07y4BXX3010lpMRsnGm7sfffSRWcXs2bPNlL/+9a8yZeLEiWGWb+/m9OnT
+7VW4yk4aRJZ/0kknpaWlmSkmDCOV4KJFiy6++OJu3bqZu/Ke/5RTTpFVyA3n
+Ltxwww0lJSVyNysrSxYuU+T/ZyPttbTG1sPVdgnFRvJNjp48HStWrNi7d2+s
+r3+ZRWaU2WUhiVaCRnZ2tu8T5wy96eUoQaBaeUvK9TlB18WW1VeC3rN7ll8J
++oqpBH3jsapKsMpnBwDEqjpK8JxzzpFCcY6cPHmy9Mjzzz9fVpFIbdu2tR+V
+6jEn1CItMFIJtm7d2p6SkZEhVWV/zebIkSNlwMCBA+0BmZmZMuWmm26KtBaT
+UcuWLTN3CwoKzNk3e4BZpvw/YJjlm91s166dcxWushs6dKi9QKO0tPTss8+O
+VIJeXbp0kQFr1qxx7oLzEtY77rhDpgR854zzbGAdLcHU1NRNmzYtXbr0wIED
+sb7+ZRaZUWY3pwVre28OcT0dkS7upQSBGubKIvsSTdeUxCnBFD9x7HIk3os5
+K5lyzu+lAQDUgCovwaysLEmPq666yjlR3tDKxPbt25dVJNLDDz/sHNC4cePL
+L7880jIjlWDHjh2dw8466yyJUHO7W7du5uTabx3kriRqpLWYjHKegnHtyPjx
+42XKv/71rzDLN7v52GOPOVfhKrtHHnlE7s6ZM8c55uabbw4oweTk5F69el1z
+zTWXXnqp+fiksH9fw+yCNKk9vm/fvjLFtwXsI1k/SnDJkiXxlaDMWHdLsDAa
+ShCoKq4S9DZL4pRgfBeC+vK2ZJLji2iC9y6OdVGCAFCTqrwE09PTJT2uu+46
+50RzvsycB/RNpCZNmsRRgq7vDnWW4P33329OGt7u0Lx58y5dukRaS0wlGHX5
+YUrQLGTRokXOMbJTkUpQnqkTTjjBfECyQ4cO5ipcbwk6d+Ef//hHcAnWg6tD
+7XOC8V0dmuDnBIOvDqUEgRrjLUHXRZK+lefKojjGWI4fYffdEsNbgr7XcDrn
+cv2Se0jxXR0aZl2+34QDAKg+1XF1aNOmTZs1a+acMnv2bOmRnj17ltVUCb77
+7rsyYPTo0VG31hZTCUZdfpgSfPvtt+Wu6ytPW7VqFakEH3roIbn75ptv2oM7
+duxYyRKsB98YYz4nKK/k9PT0WF//MovMmJifEwzzjTGUIFBjXP1l/wCEOTtm
+f2bQ+TMTztNnKZ5fkYg0xp5oFm4v2fXVoPbanb9LaA+wq8q1ha7vfonjFJ5v
+Cdpf/OI8Jq65vGv3bh4ZCAA1qTpKsH379s7AKSkpadOmjUwZO3ZsWVwlaE4p
+nnvuufaUqCUoOyUDfv/73+fn55sp8j7/5ptvfu655yKtJaYSjLr8MCW4YMEC
+uXvBBRfIgTVTPvzww4BvjDFbaH/oT/rFnCKsTAnWA9JKkjxZWVnxlaDMKLPz
+KxIAgqV4fk/Q+aE5E26u2HF+c4v9I+lRx7gmmk509Zdr7b6/u+f93hjXgCos
+wSQ/weuKunkAgOpWHSUo/XLSSSc1btz49ttvf/rppy+77DKJkQ4dOph54yhB
+ceKJJ8pc119//aBBg8pClGBZxRm0li1bPvXUUz179jz11FODz+LFVIJRlx+m
+BMU999wjU1q0aCFLuPvuu4855hjzoxu+JfjOO+/I3bPPPvvZZ5/t3r37aaed
+Zn4nghIsLi6WF6fEuOx7+Be/DJZZZEZ+TxBAfMJ8DUvcY6LOGPJLYOL4rpga
+4zwZCgCoYdX0y/ILFy5s27atdI1kyBlnnNG5c2f73JmsUSbaP4VgHH300X/4
+wx8CFjh27NimTZua03Byd/v27XJb0sk5plmzZs2bN7fvlpSUPP7449KG5iyb
+PDpixIiAVZivasnJybGnNDj8O04nTJjgvDgzePm+u7lhwwaZ2LVrV3vK3r17
+77vvPvNbD9LOzzzzjPll+fXr13vHmzWao3rEEUfI9KSkpAaO7w717sLLL78s
+U6ZNmxaw43WdRJwcmYKCgoyMjLS0tKKiojCvfBkmg2UWmVFmpwQBAACgSjWV
+oCFvSjdv3hzDu9topJsKK347L7z09HT75+CrQ+WXLyWSnJwcctfkKZDBeXl5
+lVljPWOfFty6dWtqaqocyeCXvQyQYTK4jp4QLKMEAQAAUDnVWoJAzZCUk1em
+RFBOTk5aWtrGjRszMjIiveblIRkgw2SwzCIz1o8SDOCdnRIEAABQjhJE/WDH
+YG5u7tatW9etW7dhw4Zt27bl5+fvLyc35K5MlIdkgAyruxlYRgkCAACgcihB
+1Bt2DMoLNTMzMy0tTbpv5cqVy8rJDbkrE+UhGVCnM7DyKEEAAADlKEHUJyYG
+i4uLCwoK5OWanZ0t3bernNyQuzJRHpIBmjOwjBIEAABQjxJE/VNSUmJ6sKio
+qMBB7poGlAG1vY21jBIEAABQjhJEPWaS0EYA2ihBAAAA5ShBQCFKEAAAQDlK
+EFCIEgRilZKS0r9/f/lnDa+0OtZYK/vi2oBq2jUAQHiUIKAQJQjESrIlKSmp
+huMlqZx9V/Jt6tSplV+s2ZcqWVQcq5a9SHJwbobZMF8yV/i1uI6bYa+XAgUA
+gxIEFKIEgVjVSglOLWffjTWIIqnFEjS7YB9G2QbnTsn0qX76lwu5Crv4nBPt
+I2mWVnU7BAB1GCUIKEQJArGqlRJ0qeslaLrPdQxNuEWdK+TW2oNdy3TmZ/Dq
+AEAPShBQiBIEYuUtQdeFjq5UMeeegsdYFeViP+q6/tN5115O/wpmY7yXjNqr
+jrSp5rZ3LucA16PONcYtvhL0vdQzePneEnSeE6yVk6EAkIAoQUAhShCIlbcE
+7Xyz08N5ws4OK1NV9l3nEuy57MsgXQtx3rWXYA/2jnGO9G6qvSJvCdpTzL6Y
+u94lVLIE7Y8Bui55DUiz8CcEnSO9JWhVBDKXhgKAjRIEFKIEgVi5StBbW64p
+3oQxS3CVne+pN/tuQBgGTAy5JfYU3y1xLbZKzgla0c6BeoU8IejaBd8SBAC4
+UIKAQpQgECtXCUaNMt8rIb0DXEuojhL0DnCVoO+ZsqgXbcbHeRo00hWzrsFR
+Twh6P/ZICQJAGJQgoBAlCMTKW4LeQnHWU9QS9E2taipB16a60ikpsoAD4sv3
+mz/NRaeWX9l5L4h17VqY60K9wyhBAAiDEgQUogSBWNXREvT9mlBvCZorP72C
+j4lXpKI064q0y94DZcXyCcGAkqUHASAAJQgoRAkCsaryq0Nr8pxgHFeHVgff
+7fc9UFboE4JW+e642HXJj8gDQABKEFCIEgRi5SpB75ks3y8tCShB79k611fK
+WJ50ivSBvuAS9Can76Z6s8u1d/ZFnnHzPf3ne6CCL++MujFcHQoAYVCCgEKU
+IBArVwna1WaSxP59BHt81BK0KsrI/n1As4TgEkyq+K0H+4SXa6K9nEibag+I
+9CsS9nJcW+J75i6OY+j8vlDfCI16XWjUjaEEASAMShBQiBIEYuX9PUHnDyIk
+VXzUzvVocAlajh+561/xM/QBJZhy+A/Eu34nwt6MSL9w4Rrg21+uYc4tqXwJ
+etfiW3xRO44SBIAqQQkCClGCQFWJ+8tVfIX8cJx3dWE2I8x2Vu3u1O5aAADB
+KEFAIUoQSAS+H44L+TUpAABUEiUIKEQJAonA+zlBMhAAUGMoQUAhShBIBOY7
+MJ2fE6ztLQIAKEIJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJ
+AgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJ
+AgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAA
+AMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBC
+lCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBy
+lCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUI
+AACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUI
+KEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAA
+KEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpR
+ggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpR
+goBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAA
+AIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCg
+ECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACg
+HCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJ
+AgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJ
+AgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAA
+AMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBC
+lCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBy
+lCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUI
+AACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUI
+KEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAA
+KEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpR
+ggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpR
+goBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAA
+AIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCg
+ECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACg
+HCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJ
+AgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJ
+AgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAA
+AMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBC
+lCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBy
+lCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUI
+AACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUI
+KEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAA
+KEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpR
+ggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpR
+goBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAA
+AIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCg
+ECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACg
+HCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJ
+AgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJ
+AgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAA
+AMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBC
+lCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBy
+lCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUI
+AACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUI
+KEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAA
+KEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpR
+ggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpR
+goBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAA
+AIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCg
+ECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACg
+HCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJ
+AgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJ
+AgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAA
+AMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBC
+lCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBy
+lCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUI
+AACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUI
+KEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAA
+KEcJAgpRggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpR
+ggAAAMpRgoBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpR
+goBClCAAAIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAA
+AIBylCCgECUIAACgHCUIKEQJAgAAKEcJAgpRggAAAMpRgoBClCAAAIBylCCg
+ECUIAACgHCUIKEQJAlAiL3V1yc61pbvW7l0+tmDlpzkz+ubOfDlvzmv58/rJ
+X97cfkXrphTK3/opBeumlGUn1/b2AkDNoQQBhShBAPXV3s2rS3as3fnpM7sn
+PZ896p7dI+/O/bBz/qcP7p3wUMFnDxdO6Vb0efei6T2Lv3jq0N+sZ4pnP1s8
+p1fR3OeL5vUunN+7YO4Le2Y9V/DN+0WpM7NWTqztvQGAakQJAgpRggDqmYK0
+1fu2fZs57rmdA2/NGtIxZ8Tdez7svPfjBwrHP1Q86bF9/+leOv2JspnPfDf7
+uf3zXti/4KUDC/se+lv08oGvXjnw9WsHlvY7sOyN/cve+G7ZG2XL3ihd9q99
+S/sVfPVa/uJX964enZ88s7b3DwCqHiUIKEQJAqg3irau2fHRs+lv3bzzvdt2
+D7kjd+Q9+WO6FHzStXjiIyVTHi/9vOd3M57eP+u5A3N7H1zQ54eFL//w1as/
+Lnn9x2X/kj9rxZvWN29bq96xVr/745r3fvx24A/fDvph7b8Prv33gW//vX/N
+oLI1g0pWv1e44p29y9/K//ajvWnzant3AaDKUIKAQpQggHoga+4HOwY/sOCN
+Rxa+9eiY/q989NZrYwe88cl7/T8d9Pa4IQO+/fjlteNePTCr18G5L/6w4B8/
+LnrF+vp1a+m/rOVSf+9Yq9499LdmoLX239a6IdaG962Nw61NIw79JY+0kkdZ
+KaN/TB51MHnU95tG7t84snT9sOJvhxasHpyz9O2C9IW1vesAUAUoQUAhShBA
+3bUpfc+ro5f2/sew+/pMC/n3yoBxkz4aPWnsmE2z3rdWD7S+HWytG3rob8Mw
+a+MI031W6hhr84fWlrHWlo+trfL3Sfnfp/LPH7Z8fHDz2ANpY0uTxxRvGFWw
+dnjON/8u3PF1bR8JAKgUShBQiBIEUOeYAAxffwF/k8Z/OmnCePmzUj6wUj+0
+Nkv9fWKlf2qlj7O2T7C2T7R2fHbob+ek8r/J1o5JcvfH7Z8d3DZx/9bxpWmf
+7Ev9OH/96OxV7+dtXVzbBwYA4kQJAgpRggDqkCpsQJ8qnDxp0uTJ5fVXHn27
+plgZU63Mzw/9ZU0r/5v+f3+Z06yMz3/Y9fn3O6Z+t21SydaJBSmf5G74MGPl
+sJzNi2r7IAFAzChBQCFKEECdEKYB/9Hvg5ff+HDc4IEThv574rAhE0e8/9mo
+4ZNGj3xlwPhX3p0QQxL+Z9qh1pPi2/2FlT3TyplV/jfbypW/OYf+5Lb8Zc/6
+cffMg5kz9u+aVrrjP0VbJ+eljMta92H+zm9q+2gBQGwoQUAhShBAggtuwD6v
+jFw28MkVg58t/OjhfZ8+XvrZE99NffbA9N4HZ/b9ce4r1oJ+1uI3rSXvWMsH
+WisHW6vf3zTvo0njx0+aMDF6D07/YtL0mdaeuVbe/EN/+QvK/778v788+Vtg
+7Vlg5c4/mD33QNbssoyZxdun7d06JSdlwvbVo4vzdtT2kQOAsChBQCFKEEAi
++2xBqm+mvfjyiEX9u+8e2Cl3SOf8kV0LP3yk+JP/LZ3w5HdTnj0w7VAG/jCn
+PAMXvWl9PcBaNsj6Zoi1epi1dqS1/gNr01gr5RMrbfymJZMmTf5PlB78Yo78
+WQWLD/0VfmUVfv3//wrk7ytr72Irb9HBPV8eyFlQtnte8a5Ze7dNz908ZdeG
+cbvTl9X28QOAUChBQCFKEEDC8mbg832GzXn50fR+d+58669Z73XKGdw5b3jX
+gg8eLvr4f0vGP1k26dn9/+n9/Yx//DD71R/nv2EtfMv6aoC1dJC1Yqi1arj1
+7Shr/Rhro2Tgp1baBGvLJCt9irX9c2vndPnb9M2MSZ9/EbEHZ823ipZaxcus
+4uXWvuWH/mn/FS23CpdZBUsO5n99YM/isuwvi7PmF+ycnbPl84zkSbk7V9X2
+UQSA6ChBQCFKEEBicl0R+lzv92f0/nvKPzpufe3OHf3/mjmgU/agznvef3Dv
+qIcLP3p836dPlH727HdTex+Y3vfgrFd/nPuGteAta/EAa8kga/lQa+Vwa81o
+a92H1oaPreRxVqrJwKnlGTjDyph56C9rtpU918qZP2nG7Ekz5vj34OwvrZJV
+Vqn8rT70V2L+Vln7VlrF3/xYuOJgwfID+UtLc78q3r1wb8b87PSZO1Om7slc
+W9vHEgCioAQBhShBAAnIeTZwwNMvfvNEh7W9bk7u03HzK3due+PuXW93ynqv
+c86QB/JG/L1gTLeiT54omfBM2eQX9n/e5/svXvlhdr8f579pLRxgfT3IWjbU
++ma4tXq0tfZDa/3H1qZxVspEa/Nka+tUa9s0a8cX1q5ZVuacQ3+751s5C6w9
+i6y8xdberyfNnD9p5gL/Hpyz2PpurfXdukN/ZfK31ipda5V8a+1b82Px6u8L
+V+7fu6I0b1lRztf5GV9mb5+zI+XznWnza/uIAkAQShBQiBIEkGicGfj2k71X
+9Oiw5pmbN754W+rLd2x9/e4d/TtlDLhv96D7c9//n/xRjxV+1KP406dLPnu+
+bGqf/dP/+f3M13+Y+6b15QBr8SBryRBr+XBr5ShrzYfWuo+tjeOs5IlW2mRr
+y3+s9GnWdsnA2Vbm3EMNKH/ZX1q5i628r638JVbBMqtwhVW8ctLshfLnE4Nz
+v7b2b/z/f9/J3warbL1Vuv6HfWsPFK0pK1hVkv9NYc7SPZmLs7bP3572xfa0
+BbV9XAEgIkoQUIgSBJBQ7Azs1+25+V3/e+nj7Vc9edO6Xrcm97lj8yt3b3vj
+np1v3Zf5XpfsIUl7Rjy694PuhR8/tW98r9LJL333n5cPzHjt4Oz+P8x7x1o4
+0PpqiLV0mLVilLVqjPXtWGv9OGvTRCtlsrX5P9bW6da2L6yds62MuVbWAit7
+4aG/nMXWHsnApdbe5VbhN1bRKmvf6kNn+krXTprzlf/JwXlLre9TD/0dkL8U
+a3+y9V3yj2UbD5Zs2F+8rrTw2+L8VXtzV+RmfZ25/cv01JnpqcQggARFCQIK
+UYIAEsem9D0msl595Nk5f7t68SPXr+hx45pnbt3Q+/bUl+/a8to92/vfu+ud
+zlmDHsx5/+G8kY/v/fCJok+e3Texd+mUf3w37dUDM/91cM7bPyx4z1o02Pp6
+mLVspLVyjLV6rLX2U2vDBCt5kpU61doyzUr/wto+29o518pYYGVJBn516C93
+iZW3zNq7wipYaRWttorXWCVrrdL1VtmGQ6f89idPmrfEJwbnL7MObjn09738
+bbYObLb2p/5QlnKgdNN3+zaWFK0rzF+Tn7syJ2vZzu0Lt6TNSds0r7aPMQD4
+oAQBhShBAInDnBD850NPz7z3L1/+z3VLu92w8slb1vbquOmlO9P++df0fp12
+vNk5Y8D9uwc/lDu8W97ongVjnyka98K+z/qUTn3lu+lvHJj11sG57/7w5b+t
+xUOtJSOs5R9YKz+y1nxqrZtgbZxkJU+10qZZW76wts22dsy1di2wMhdau7+y
+cpYc+tuzzMpfYe1daRVKBn5r7VtnlUgGbrS+S7b2pxw66/d92qYta18ZNd8T
+gyusH7Yd+juYfujv+60/7N/y/Xdp+0tTS/clFxdt2Ju/dk/uqqys5du3LUpL
+mbNrB18gAyDhUIKAQpQggARhMrBv0lP/ufOqeQ9cu/jh9su737TmmdvWv3BH
+ct+7N7/aKf2N+3a81SXjva67hzySO6J7/pinCj7uVTT+pf/H3n0/tZ0uep6f
+P2N3a7dq9+6duXemZmbrbnef06edc8Q54xxEztlgDLZxAGNyzjnnKBBICCSE
+hCRQRkgo55yznhW4m3b7nHN3a34wPqvnVZ+ibHCVbX1/etfz1VfWoTf2sQ/O
+qUL3bIl3vsK3UANwDYDQDEjtgNIF1vsAYxCwRsDGOOBNga0ZIJwDYjSQYYFi
+CaiWgWZlezoS0FOAcQ2YacASyEAmsLOBgwOcXODa3D7s82xth55PGEi/vz4c
+ZAs4wC8GPjHwivweodctcDu3HHae1co1mdk6PUOlpkrlpC3BEos1y9sg7fWL
+DUEQ9AewBCEoCMEShCDoOxHoqdikioHLB2YenMQgzuJjLqwmX1nPuM7MvrXx
+OpT//p7w4wNJ8RN5RYSqLlbTlKxvzzB2Z5v7X1mH39nHC5zTRe7Zcg+62oet
+9+OawEobWO0E1F6wPgAYw4A9BjYmAQ8JtlBAhAYSLJAtAcUyUAUykLQ9HQUY
+1oCRBswMYGUCGxvYN3YykAfcfOARAK8Q+ETbreeXDGHIf+NOUQwZ+GXAJ/V7
+JV6P2O0WOZ0Cm51vtm4aTByNnilXrYmkpE3+Io2OlAg29/r1hiAI+h0sQQgK
+QrAEIQj6Hnw+EOw+98vE7WOoR6cXI84T4i6RU67RMm+ycm5vvLnL/3BfWPhI
+UoqQV0Wr6hI0zam6jkxjT455IM868sE+8ck5XepCVXrQtb7FRj++Bax0gNVu
+QO0HtCHAHAXsCcCdBrxZIJgHogUgWQIyPFCsAFUgA8nb01GBgQZMDGBmASsb
+2DaAYxM4ecC1BdwC4BEBrxj4JMAv3c49IA9sCEP5qxikAL/C75d7fTK3R+p0
+S2xOkcUuMFp4WiNXqWVKlGtbYhKbu7jBXd7rlxyCIOh3sAQhKAjBEoQg6HsQ
+yKiXT1OHrh6eunsC/ezcUtSFlYQrlLTr9KxbrJxQbt49/oeHwk9PJWUR8upY
+ZX2ypiVD15Ft6HltHnxnHflomyh2IMtdqGo3pt672OzDt4GVLrDaB6iDgDYC
+mOOAMwW4M4A/BwQYIFoEEhyQE4CSCNRkoKVuT7cODHRgYgILG1g3gH0TOPjA
+uQVcwp0MlACfFPhkwB9oQAUAyp2phjBrfxWDVD9Qef1Kt1fh9MjtLqnFITba
+hDozX2XgyjQsoXydKyTS2AsiMWuvX3UIgqBfwRKEoCAESxCCoD03iOFmPknp
+Pn9g9MaxmQenMYgQXPQlYuI1avpN+ovbrNy73Lz7/PxHwiKEpDxaXpOgbEjV
+tGbqOnMMvXmmwQ+W0U+2yVIHstI5V+vGNHoWW334Dj+xB5D7AXUY0MYAcxJw
+kICLAnw0EGCBaAlIloGcCJSrQE0B2vXt6enAwAQmNrBsAOsmsPOBQwCcQuAW
+A48EeAMZKAd+BfBvByAA6p1pANAOYda/isFBzJrXr3H71E6v0u5WWFwyk0Oi
+t4rUpi25jitWs3gSKou/skqb0+tVe/3aQxAEbYMlCEFBCJYgBEF7LlCC5bdD
++y8dHr99cvbR2YXwC/jYK6Tk69SMW/QXoexX97hvH/DzHwuLwiUVsbKaJGVj
+urr1hbbzlaH3nWmwwDxabJ0styOrnXP1LkyzZ7HNu9zlI/YB8iCgjgDaBGBO
+A84s4M4D/gIQLAIRHkhWgJwElBSgXgNa2vZ0TGBgA9MGsGwCKx/Yt4BDCJxi
+4JYAjwx45cC3k4H+zwG43YAA6HamH8LQvorBAcy62691+jR2j9riVpqccr1d
+qrGIFIYtiZa7pWByhBQad5nGIuz1aw9BELQNliAEBSFYghAE7bmsJ6kdZw8M
+XTs2GXoa9fg8NuLSctxVUvINasZtevZd9qv73LcP+QXPhMVR4op4WW2qojFT
+3fpS2/VG3/fBOFhoHi2xTlbaZmodc41OTIt7scOz3OMj9vvJw4A6BmiTgIkE
+HBTgogEfCwQ4ICIACRHIyEBJBWoa0DC2p2MBAweYuMDMA9YtYBMChxg4JcAl
+Ax458CqBT7Wdgf7dBtQDYNiZMbAhDP2rGOzH0Jw+nd2rtXg0JpdK71BorFKl
+SSTVbwlUG1wpg85fJTGwXD59r19+CIIgWIIQFIxgCUIQtLfYAm33hcPd5w6N
+3Dg5de/s3NMLi1FXluOvkVJuUjPu0LPvsV492Hj7iFcQJiiJEVckSmvTFI1Z
+qrZcTddbXV++YajINFpmmayyIuvsc01OTJtrscuN7/WuDPpWR/zUcUCbBsxZ
+wJ4H3AXAWwQCPBCtAMkqkFGAYh2o6EDD3J6ODQxcYOIB8xawCoBNBBwS4JQB
+lxy4lcCrAj418GmB/6sGNO3MHBhbKPkqBvswNJtPb/HoTG6N3qHS2BRKi1Rq
+EAk1/E05hyWkkTkrS+S5vb4CEARBsAQhKBjBEoQgaG+RWutazxzou3Rs9Oap
+6fvn5p9dXIy6uhx/g5Ryi/o8dKcEH268e8L7GCEoiRNVJEtrM+RN2cq21+qu
+99q+j/rBYuNohXmyxopssM21ODDtzsVuF77fszLkXR3zUSf9NCRgoAAbDbhY
+wMOBLQIQEYGEDGRUoKABFQNoWNvTbQDDJjDygVkALCJgEwO7FDjlwKUAbhXw
+qIFXC3w64Nd/0YDmnVl2Zg2MLZR+FYPULZHFazC69XqnVmNXKS0KmUkq1Al5
+Sh5bwl7jUZdpS0srMAYhCNpjsAQhKAjBEoQgaG/Vnfyl4+zh/kvHx26fQT4M
+mX92aTHq2nL8TVLKberzu7Ts+8xXDznvEJsfo7ZK4oWVqZLaTFlTjqLtjarr
+g6bvk26w1DBaaZqstSAbrahWO6bTsdjjxA+4V4Y9q+Ne6pRvfcbPmANsDNhY
+BDw82FoBQhIQU4BsHSjoQMUEas72tFyg5wHjFjAJgUUMbFJglwGHArhUwK0G
+Hi3w6oBPD/xfZuCvAQiA7fP8wMYUyr6KQTJfbHQbdS69xqFVWtVSk0Kkl/DU
+Ao6MSxMwVlhEzCp6ry8CBEHBDpYgBAUhWIIQBO0hQktd06kDHWePDFw5OX7n
+HPLhhXnEZWygBBNukVLuUJ7fXc9+wHz1iPMubPNjDL8kUVCZJq7Nkjbmylvf
+Kjvz1b1F2sEy/WiVcaLOhGyyoNps6C47tteBG3QRRt2kCQ9l2rs+62PM+1kL
+YGMJbC4DPhEIyUBMBVIakDOAkgXUG9vTbgI9HxgEwCQCFgmwyoBNARxK4FQD
+lwa4dcCjB14D8BmB/8tzwM8NaA/MDxw+4PACRz+G9WUJvm7GGTwmncuodugV
+Nq3UrBIZ5HyNmKPYook4q9w1LBWnNWj3+lJAEBTUYAlCUBCCJQhB0B6qPP5L
+y+nDneeODl49NR56Hvnw4jziCjb6Oj7hFjEllJxxL1CCjFdP2O8iuB9jeSXJ
+gooMUW22pPGVrPWdovOjqrdYM1iuG6kxTDQYp1vMqHYLutuG7bfjhhyEMRdp
+0k1BetZQXjrax8L6OTiwSQB8EhBQgGgNSOhAxgQKNlBxt6fhAd0WMAiBUQzM
+UmCRA5sS2FXAqQEuLXDrgccAvEbgMwO/Bfi/bEBHYH7g9AGnFzg9wOkCzr4/
+xuCrZpzWZVY7jAqbXmrWCA1KvlbGUYrokk0yn4ljrBIZ5L2+FBAEBTVYghAU
+hGAJQhC0V7BNNbUnDwRKsOv88cFrZ3ZK8NIc4io26gY+/vbKdgneX3vxkP7q
+Ketd5MbH+M2SlK2K58Lal+LGN9LW9/LOQmVviXqgUjtSqxtvNEy3mmY7zPM9
+loUB29KwfXncQZxykmdca3NuGsbDXPSy8T7uip+3ulOC60DCADIWUHCAanN7
+Gj7QCoBeBIwSYJIBiwJYAyWoBg4tcOqAywDcRuAxAa8F+KzAbwN++28Z6NzJ
+QJcXuDzA5QIuJ3A5gKsXw/4yBjvmGCqHWW4zSiw6oVHN0yk2VFK6dIu8xVnm
+rM8SF9U6zV5fEAiCghcsQQgKQrAEIQjaK/jmuvqTh1pOH+2+cDJQgmOhIdOP
+Ls8hri1E3cTF3yYk313NuE998ZD2CsF8F8UuSOAWp/IrMgU1OaKGPElLvqzj
+k6KnVDVQqRmu04436afaDDOdpvle88KgZWnEtjxuJ047Vmed1HkXbcHNWPKw
+l70bRB+P7Nui+oU0IGYAKRvIN4Byc3vqLaAVAp0YGKTAJAdmBbCogE0D7Drg
+0AOnEbhNwGMGHgvwWoHPvl2CfscXDeh2A7cLuJ3A7QBuO3Bb/a7XzfgvYxDP
+lcpsJonFIDBqeToVRy2jy0QUwSZhg4leIy1RiXt9QSAICl6wBCEoCMEShCBo
+r5Qf31938lDrmWOBEhy4dnYs9ML0oysoxDVM1M2luDuBEiSlP6BkPVrPDWO8
+jWEVJG4Up22WZ21V5wob3opbCqQdRfLuMkV/lWq4XjPWpJ1s0890Geb6TJhB
+8+KoBT9hW0HaV1EOCtq5jnXRcW4Wwc0heTbJXv6aT0D3iZh+Cdsv4wIFb3uq
+LaARAq0Y6KXAKAcmJbCogVULbIESNGyXoMsM3BbgsQKvze+1+30On9/p87u8
+fvdOBnpcwOMEHgfw2AN/yO+x+D2rW6ovSzCnCSe1WcQWk8Co39Rp2GoFXS6h
+iLYIXDaGRh1fwuz1BYEgKHjBEoSgIARLEIKgPYFprKk8frD+5JHWM8e7Lpwa
+uHZuNPTi1MMrs8+uoyNvLsbdWU66R0x7QM56spYbTn8byyxI4hSlc8te8Kpf
+bdW/EzYXiNuLpd3l8r5q5VC9arRZM9muQ3brUX0G9JAJO2bGTVoISCsJZSOj
+7WuLDjrOySS42CQ3l+LmrXu26F4hyyvm+KSbPjk/ML9S4FeL/FqJXycDBgUw
+qoBZAyxaYNUDuxE4TH6n2e+y+t02n8fu8zi8XqfX5/L43G5/YB6X3+P0ex3b
+iei1+r0Wv9fs8xp9HiL/DzHYMssUWcxbRuOmTsdWq2hyGUUsImxyMQzaNJGg
+1Kj3+rJAEBSkYAlCUBCCJQhB0J5Yaqqr2C7Boy2nj3eFnO6/dn70zsXJh1dm
+nl2fj7yFjQ3FJd4jpD4gZT6h5ESs58Ux8pNZnzI2yrI3q17z694Lmj6K2kok
+XRWy3hr5YINypEU90aGZ7tbO9uvnhw0LY8alSfPyjIU4Z13F2KiLdhrewVhx
+sFadG1TX5rqbz3ALWB7Rhkey6ZXxt6cQeFVin0bq08p9eqXPoPKZND6zzmcx
++GxGn93sc1h8TqvXZfO6HR6P0+Nxub3uwFw+j9Pndfi8dp/X5vdZfT6Lz2f2
++Yxer8Hr1Xk8HfOcL2MQw5LyjSauTs9Sa2hyBVksIfD4C0zmDJk8t0LY68sC
+QVCQgiUIQUEIliAEQXuiJyG68vih+lPHWk6f6Aw5038tZOT2pYkHV5FPb8xF
+3FqICV1KuLec8oD4/Ck5J3ItL572IYX56Tm79OVG5Rte7futxkJBa4mos0LS
+UysbaJQPtyrHO1RTPZqZAe3csB4zblicMuJnTCvzZtKChbJkXV+20VfszFUH
+h+rg0pw8hmuL7RJuuMU8t3Rre3KhRyn2qKUejdyrU3r1aq9R6zXpvGaD12ry
+2sweu8XjsHmcdrfL4XY7XW6Xy+MOBKHD6w3M7vXZfL9moMkbyECfwevTeXxa
+t1ft8uQ2/f6GwewGHM9o3tAZmGrtulxFFkuX+YIFFgdJoQ4uYPf6skAQFKRg
+CUJQEIIlCEHQnig8sr/y+OG6k8eaT5/sCDnTdzVk6Pal8ftXp5/cQIXfRkeH
+Lsbfwyc/WHn+bPVlFOVN/Pr7VHphJqskh1PxhlvzgddQuNVSKuyoFHfXSvob
+ZUOt8rFO5WSvCjmgQY1o0eM67LQeN2sgzBuJCybykpm6bKERrQyyjU21b9Ds
+m0wHn+0QcJ0inlOyFZhLJnQpxC6lzK1WuLVKt07tNmjdRr3bZHBbTG6r2W2z
+uuw2l8Pucga4AinocHsCs3u8No/P6vFZvH6z12/y+o0ev8Hj13n8WrdP7fIp
+Xd4lrvrLY8FZhpStNTLU+jW5elUsX+aLFthcJIU2tIgXSWV7fWUgCApGsAQh
+KAjBEoQg6NtD1tUWHjlQefxo3cnjTdsleLb3asjgrUtj965OPb4xG3Z7Pip0
+If7eUvLD5QwEMTua/CqB+i6V9jGTUZzDKs/jVH/g1n/iNZdutVcKu+rEfU2S
+wVbZaKd8olc5PaiaHVHPT2gWpnVLs3r8vGFlwbi6ZKIsm9eJZjrZwlyzcmg2
+LtPGY9u3uHYhzyEWbE8qcsgkToXMqVI41SqnVuPUaZ0GvdNodJpMTovFabU6
+bXaH3eGwOx0Ol93ptrs8NpfX6vZa3D6L2292+00ev9Ht17uBzh3IQL/a5Vc5
+fQqnT+bwvmxc/jIGWVoTXWWgyrVEkQLHF2PYfCSVMYxbkSiUe31xIAgKRrAE
+ISgIwRKEIOjbwzTWFR45WHH8aO3J442nTrWdP9t9JWTg5qWRu1cnHt1AIm6j
+IkMxsfcWkx7h08MIL6JJuQmUt6lrBVm0olxmWR67Kn+j7tNmUxm/rWqrs07Y
+2yQaaJMMd0rHe+VTg4qZEeXchBozrcHOanFoHQGrJ+IMZIKRSjTRyCbGmplF
+t2wwLZscK59rFfBtIsH2xCK7VGKXy+xKhV2lsms0Dq3Oodc7DEa70Ww3Wexm
+m91it1sdNlugCF1Wh9vq8FicXrPTZ3b5TC6/0eU3uIDeBXQuoHEBtQuonH6F
+wy9z+CR2L4b9h2PB2knGutJIkWlXRMolngTN3ppeYw/hSBOLy3t9cSAICkaw
+BCEoCMEShCDoGzOQS2qv//jpyKHyY0drTpwIlGDrubNdl0L6b1wevntt/OGN
+qae3ZyNC52PuLSQ+XkoLW86KXslJXM1Lo3zIWv+USy/NY1bms2uLNhrLNluq
+eB11W91Nwv420VCXZLQ3MZSddG9DMTuhnJ9WLaDUS2jNMla7gtOtEvQUkmGd
+bKSvGZl0E5tp2uCYN7kWPt8iEGxPJLJKJFaZzCpXWJUqm0pj0+hsWoNNb7QZ
+zDajxWqyWc12q8VhsTotNrfF7jHbPSaH1+TwGZ1+g9OvdwKdE2idQOMEaidQ
+OoDCAWR2v9TmF1t9Qou3ceYPj45ZUxhXpTqCULXIk86zBdNrnCE8eXSk2iGH
+z42BIOhbgyUIQUEIliAEQd9YoARfHfjl05HDZceOVZ84WX/qdPOZsx0XQ3qv
+Xx4KvTb64Mbkk9vI8FBU9D10wmNsahguM4bwMpH4Jo38Pov6MXe95C29Ip9Z
+U8SuL9tortpsr+N1NW31tgkGuxJuM//DfwCB9X8kyOemFRiUEotW4bBqAk5D
+JGjJJB2Vol9f0zPoBhbTyOEYuVwTj2/aEgRmForMIolZIjPLFBa5yqLUWFQ6
+i8Zg0RotOrPFYDEbbWaT3Wx2mC0uk8VtsnqMNm9gBrtPb/fr7H6tA2gcQO0A
+KgdQ2oHcHshAINnOQL/Q4tsye3kmz4uG3x8dUzlOJ0n0y0I1dlM2xxJOrXGH
+ltfaZxaVE6F7fYkgCAo6sAQhKAjBEoQg6FtyyAlLr//11YF9H48cLj12rOrE
+ybqTp5tOn22/ENJz7fLA7avD92+MP749hQidjbo3H/cYkxy2mBGDz04kvE4n
+vXtBLsilFr1dL8unVxUx68rYTVUbrXXcziZeT9tWf9fnDAws8R5XikLK5lHy
+BbRiCavE41QrBDWJpKFQtGtrWhpdx2Dp2Rz9BtewyTfwBIEZt0RGocQolhkl
+CpNMZVJoTEqdSWUwaYwmrdmks5j0NqPBbjQ6jCaXwew2WDx6i1dv9emsPq3N
+r7H51TagsgGlDShsQG4DMhuQWIHYCoQW/5bZxzN5uQZP3fQfjgVXxHqcQLOw
+qZhliiao3CECvWUaK6z/Z3gsCEHQNwZLEIKCECxBCIK+JQO5JFCCrw/sLzh8
+pOTo8crjJ2tPnm44dbY1JKTr6uW+m1eH7t4YfXRr8lkoMuIeKvYxOilsIT1m
+6UXicm76ytsXpPxc8qe31NL89coiem0Zs6GK3VLHaW/idrXF3qDvlmDCXa54
+BimZQ0kxaBkWK8fhFMsEJZGkWqWoKWvqdbqGztQyOVo2V7fB120KAtPzRXqB
+RC+U6cUKg0RlkGkMcp1BaTCojAa12aC1GHQ2vd6uNzj0RpfO6NaZPFqzV2v2
+aSw+tcWvsvqVVqCwArkVyKxAagUSCxBZgNAMtkx+ntHHNXg5eg9L5/6yBAdW
+hIt8DYarmGGIximbA8uMFuTSauMpeCwIQdA3BksQgoIQLEEIgr4lYf0/75wJ
+Hvhw+EjR0ePlx09Wnzhdf/Js8/mQjsuXem5cHbhzY/jBrfGnoVNh92aiH88l
+hKFTY7CZiUs56ctvslbe55I+viUX51PLi9ary+j1VcymOlZrE6ezLeb67yUo
+mJwQIqdFsyjxPFqygJUu4mR4gpxAUpDISvKakkpXrTPVdI6aydWw+ZoNQWDa
+TZGWL9EKZFqhQidW6SQanUynkxt0SqNOZdapLTqNTau1a3UOrd6lMbg1Ro/a
+6FWbvCqTT2n2K8x+uRnIzEBqBhIzEJuByAwEpkAGAp7RzzX4NvQ+ls7D0Lir
+J9i7JZhes4TlaeY5imm6eJS82Y9nNiPxsAQhCPr2YAlCUBCCJQhB0Lf0uQRz
+Dxx8f2i7BMuOnao8frr25NmmcyFtFy91Xbvad/v64L1bo4/vTCDuTUc9no0P
+m0uJwTxPxGan4V5lLb/NXSl4SyrKJ5cVUSvL1mur6A11jJYmVnvbbgbG3ubw
+xye2pqYFMyghCi1CY8ULOMkSQYonylbIctKanExXrDGVNI6SwVWxeCqOYHtc
+kXpToubL1AKFRqjSiDUaiU4j02vkRo3CrFFa1CqbWm1XaxxqrVOlc6n0bqXB
+ozR4FUaf3OiXGf1SE5CYgNgERCYgNAKBEfCNgGcAXL2fo/OxtF6GxkNTu9eU
+zi+PBbtxW7NsxRRNPLLK61liNM+skBpOBV6lvb5QEAQFF1iCEBSEYAlCEPTN
+OOSEQOMsvv7XnP0H3x46UnjkRMnRUxXHz9ScONdwJqTlwqWOK1e6b17vv3tr
++OGdsad3JyMeI2PDZpNi5tMTMVlpizlZuLzc5Q95K4X5pJIickUZtbpqvb6O
+1tTEaPu9BGNucTZHJ3gT0/zp2a3ZecHcghCzJMIui3FEyTJZsrImXaXJKEzZ
+GltO48oZPAVLsD2OSMmVKDdlSr5CKVCphBqVSKuS6FVSo0pmUiosSqVVqbIr
+1Q6FxqnQuBRat1znkem8Mr1PqvdJDH6xwS8yAKEBCAxgywD4erCpB1xdIAP9
+LK2PofHSVJ41pZssd2bU4nZLMLVqEclUTKxLhki8LiyjaYb4uQThWwUhCPqW
+YAlCUBCCJQhB0DdjIJdsl+Crf83efzDv4JGCwyeKjp4qO3am6sS52lMhTecv
+tl2+0nn9eu+dmwP37ww/vjsW9mgyOgyZGINKTZx/noZ5mbX4Ogf3Lm+5IH+l
+6BOprJRcWUWprVtrbIq4vL5bguyBkY3hce7Y9ObkLA85z59d2JpfEmCWhYtE
+IY4sIlDFRJpklSmhsKVrXCmNJ2NsbY8llHHEcq5MvqmQ85XyLbVcqFWI9HKx
+US41yWUWudwqV9jkSodM5ZSpXVK1W6rxSLTewMQ6n0jnF+r8Ah3Y0gG+DvB0
+gQYEG1rA1vpZGj9D7aOpvGtKD0XuJkmdg0T5l8eCU3TFGFU8sMLrWGA0IknE
+nRIMvFZ7fbkgCAoisAQhKAjBEoQg6Jv5XIK41/85a9/B1wePfjh8vPDIqZJj
+ZyqOn6s+cb7+7MXmi1far13vvnWz7+7twYehI88ejUeFTcXHzCQnojLS5l9k
+YnJzFvPycB/ylws/EUpKieWVq9W1lPrG8Eu/lyCzf4Q1NM4ZmdoYn+VOzW/O
+LPBQS3z08tYCcWtxVYCnCgk0IZEhWmWLKRvitU0xbSswCUMoYYmlHKl0Qy7d
+VEp5aumWVirQSYUGqdgklZilUqtUZpPI7RKFQ6J0iZVuscotUnuEaq9Q4xNo
+fFsaP1/j52n8mxrA1QCOxs9W+5lqP0Ploym9awpvIANXpa4ViRMvsn9Zgk1z
+3BGyuG+Z14am10+RAi8RLEEIgr4xWIIQFIRgCUIQ9M18LsHAnv9y8NWBo+8O
+HS84fKr46JmyY+cqj5+vPX2hMeRy65VrnTdu9Ny53X8/dOjJw9EIxERs9FRi
+wkxaKiozc/5lDub1G+y7D0sFhfiiEkJZJbGyllTbuJuBEddY9N5hxsA4c3iK
+NTrDnpjjTGM2Zha5c/hN9AoPu8pfom7h17cIDAGRJVjdEFI2hWv8wEQ0gYgh
+FrGkIrZcvKEUc1VinkbM14kFBrHQKBaZxWKLSGIVSe0imUModwoVLoHCLVB6
+tpReviowH0/l21T5uSo/R+Vnq/wslZ+p9NOVvnWFjyr3kmUektS9InYtixxL
+Alta9e83iCZVLAySRN04XsscvXegCZYgBEHfHixBCApCsAQhCPpmdkuwP+rf
+cg4czTt4/MPhU5+OnCk5dq78+Pmqkxfqz11uvnSt7dqNzlu3eu7eGXj0cCgM
+MRoVNREfP5WcMpPxHPXi5fyrN5i899gPhUuFJfiSiuXympXqht0SDL/KWuse
+pvWN0QcnGcMzzLE51iSGPb3ImcVvzK1wMSQulrK5tM7D03kEFp/I2Vrd3KLw
+t7cmENBEAoZEwJQJ2AoBRyXkaoSbWiFfL9wyCgQmgdAiEFkFYtuWxL4ldW7J
+XHyZiyd38+SeTYWXq/BuKHwchY+t8LEUfqbCT1f4aHLfutxHlXnJUg9JspOB
+QidO4MDybV1Lki+PBfsIws7FzaZZ+mxnKixBCIK+PViCEBSEYAlCEPTN7JYg
+7vV/yd5/9PWB4+8Onfp45EzR0bOlx85XHA+pOXOp4cLV5ivX22/c6rpzp/fB
+w4Fnz4YjIkdj4ycSU6bSniMzX6Jevp5//R7z7uNCQfFiUQWutObpOcpuCdY+
+x1A6h6g9o2t9k7RBJH0ExRhHMyexLCSOPUtgz5M4GPIGdm1jic7FMzcJnE0i
+l7fK2x5li7cm5NMkfLqMz5TzWUo+R83f0PI3dXyegc838bfMfIGFJ7TxRHae
+2LEpcW5KXFypeyMwmYcj87JlXpbMy5T5GDIfTeZbl/nWpF6K1Lsq8ZLEnhWR
+e1noWtoKZKAdvWlFccxflmDlBLNtgVuPXEd2pMAShCDo24MlCEFBCJYgBEHf
+zOdnh35e5r4juQeO5x08mX/4TOGRs8VHz5cdC6k6dan23JXGS9dbrt1sv3W7
++96DvsfPBsIih6PjRuOTJ1IypjKykS9ez+a+m8srQH8oXvhYvlhc/fjs7yVI
+bO4jtQ2SO0cpPRPU/um1odn1kXna+AJ9aomBXGbOElnzZBaGysbSOEsMDp69
+QdjYIPK2t7rFpQi5a2LuunSTLt9kKDdZqk22ZpOj2+TqNzeNXJ6Jy7dwt6xc
+gW1DaN8QOjgiJ0fsYovdLLGbKfEwJB66xEuTeNcl3jWJlyL2ksXeVZGHKPIQ
+hG68wLXEd2J5DjTXNsexzLBMyZWLuyVYPsZomd+omVzbfX1gCUIQ9C3BEoSg
+IARLEIKgb+bLEhyI+iF7//HXB0++O3S64PDZT0fOlxwNKT9xsfrMlbqQa02X
+b7TeuN0Rer/74dO+ZxEDEbHDsUmjienjaS+mMl8hX76dfZWPels0n1+G+VT1
+b/8s/5yB//e/qAiNvSstA8T2EVLXOLl3ijIwSx2aXxtdWB9fok3hacgVOmqV
+MU9lYNaZWAZricXCc9iEze0R+exVAYcs4lAlnHUZh6bgMFQcpprD0nI4es6G
+gcM1cTbNbJ6Fzbeyt2ysLTtL4GAKnAyhiyF000VumsizLvKsiTxUkYcs9KwK
+PUShZ0XgWRa4cVuuRZ5zYTOQgfY5jnWGZZ5iGJvmBLslGFeCbphlz3Y/3319
+9vpaQRAUXGAJQlAQgiUIQdC3pJwI3Y2diqv7cg+czDt4+v2hswWHzxUdDSk9
+drHi1OXqc1frL95ounqr9fa9jnuPux+H94bFDEQnDsWnjSZnjafnTmblTefk
+z7z5hHpfOl9QuXsg+DiEhqvvwTcNEFqHVzrGiN1TpN6Z1YE58jCGMrpIncCv
+TRHWkaR1FIU2v0bH0OlYJmOJw8Bzt0fgMVe2mCQhkyxmUaSsNTlrXcmiq1kM
+DYupY7H0TI6RuWFics0MrpWxaWPw7HS+gxbYlnN9y7W25aIK3BSBmyxwrwrc
+pC33ypabwHfj+W4cz7W46VzgOtAbdhTbNsO0TDNM4+uG+tmt30uwGF07zdx9
+ZWAJQhD0jcEShKAgBEsQgqBv6csSxL/5r9n7T74+cPrtobMfDp/7eCSk6OiF
+0uOXKs9cqQm5Xn/5ZvONu62hjzoehnU/je6NSBiITR1KzBxJzRl7/mYi+8PU
+q0JkXsnsh4rdEnx0joat7V5q6Mc1D+FbR5c7JgndSGIfijSAXh3Gro7iyBME
+yhSRiiRTZ6lr87R1NGN9gb2+uBEYDbdJW+bTVgR0ooi+KqFTZHSqgr6motPU
+dLqWztDRmQY6y0hjm2gcy/qGdZ1rW+Pa1zbt1E0Hheck85yrPFdgRJ5rheci
+8FzLmy7cpmuJ68JynZgNxzzbjmIFMtA6RTdPrBtHKPpBkubLtwrO9mTBW0Mh
+CNorsAQhKAjBEoQg6Fv68gbRnWPBAzn7T705eObdoXP5h0MKj1woOnqx7OSV
+yrPXai/eaLga2nTrYeu9Zx2Po7oQ8b1RKf3xzweTX46kvx7LfD/+8uPk6+K7
+x4m7JThf3oap6lqo7cM2DC41j+DaJvCd08vds4S++ZWBBeLwEnF0mTSxsjq1
+SkZSyLPrlDk6Bc2iLnC2t8hdw/HW8II1gnCNKF4jSdfI8jWKco2qWlvXrNG0
+a3T9GsNAZRqpLDOVZaGwrRSOjcyxrW7YVzccpA0Hketc4ToJXOcy14nbcC5t
+OLEc5wLHgWY75lj2WaYNSbdO0czja6ZRimFwVdu3ovqyBDEVp2EJQhC0V2AJ
+QlAQgiUIQdA39tWx4It9p3IPnHlz8Nz7Q+fzD18oPHKx+NjlstNXq87fqL18
+p+HGg6Y7T1sfRHY8jesKT+6JyehPeDGY8mo44+3oi4Lx3KLQoyu7JYgqaZ2r
+6Jyv7sXUDSw0DmObxxfbppY6Z3Ddc/g+zPLAImEYtzJKWBknEafIJOQaaZa2
+OsdcRbO3h9kgYzfJS3wyXkBZFlFWJBSijEJSUMhKCkVNoWrIazryup5MM6zS
+TasMM4lpITGtRFZgthW2ncC2L7MdeLYDx3YssR1YtmOB5UCzHPNMO4phn6Hb
+pmnWyXXzONU0QjYMkXR9K5puvDK+dOFvluBeXyIIgoIOLEEICkKwBCEI+sa+
+OhYsv3owe//pVwfO5h08//5QSP7hi4VHLhWfuFJ+5nrVhVu1V+/X33rSdDe8
+9VFsOyKpMzKtJzarLzF3IDVv6Hn+SPanO0d+LcH//n8qkEUtM6UdqIqeuer+
++bohdOMopnlyoQ2J7UQtdqOX+rC4gSX88DJ+lLg8vkqYpBKm11dmGCsoVmDE
+eQ4RwyUu8EiLWySckIQXkwhS0oqcRFSQSCoSWU2iaIlUHXFNT1w3rKwbV2gm
+At1MoFuWGVY8w4Zj2JYYtkWmHcuwLzDsaIZ9nmGfo9tmaTYkzTq9bpmgmsco
+ppFVwyBR30fQduNVHYvyuJK/UYLwQBCCoG8PliAEBSFYghAEfXt/OBZ8/d8y
+951+uf/s6wPn8w6GvD90If/wpcKjl0tOXSs/d6Pq0t2a64/q74Q13Y9ueZLQ
+FpbaGZXZHfeyN+lNf9r7wczC//q/Sz+X4J0TlMmPzVNF7ciyrpnKvtnqQVTd
+yHzjOLplGtM2i+mcX+jGYPsWFwfwS0MrSyMk3DgFP7mGn6bhkczAlmfZy3Mb
+y+hNAoZPwAoISyICTkLASwkEOWFFSSCqCCT18qp2maxbpujxVAOeasStmXDr
+5qV1y+K6BUuzLtCsGJoVTbPN02xz67bZdevMmnV6zTJJtYxTzKOrpmGSYWBF
+37es7capOxaVLWhpdhNptwSbimLggSAEQXsFliAEBSFYghAEfXtfHQsORP0p
+a9+ZnP3nXh0IyTt44f2hi9sxePxq8enrZSF3Kq88rLn5rP5uVOPD+OanKW3h
+GR3R2V3xr3qS3/WlF+zeGnr7GHnsQ9N4YetkcedUWc905cBMzfBs3RiqcXKu
+BTnfhkJ3otHdWEwvbmFgeWGIiB1ZXRyjLk6sL00xtodkLc1wcCgubp6HQ2/h
+FoQ4rAi3JMHhZDi8HLesxBFUuBX1ElG7RNItruoXyQYs2YilmBYoJgzVjKaa
+56mWOaoFRbXMUi0zFMs0xTJJNk+QzWOrphGScWjFMEDQ9+K13UvqDqyyFS1v
+RImzGohflSA8EIQgaE/AEoSgIARLEIKgPUGse/THGPzzi33ncvaf34nBi+8P
+Xco/crnwxLXiM7fKLtyvvPqk5lZE3b3YhkdJzYj01sgX7bG5nYl53an5uyX4
++vHY8LuGkfyWscKO8eLuibK+qcqh6epRZN3ETOP0bPMsqm0e1bEw17U434tH
+96+gB0mYYQpmdG1hnLa9ScbCNBuL3MDObmLn+Nj5LSxaiF0QY7ES7KIMi5Nj
+8UrssmqBoF4gaDArOgxRhybq0STDPMk4t2pErZpmV00zq2bkqnl61TxFMk+Q
+TGNE0+iKcXjFMLhs6MfrenDarkV1+4KyZT6QgZLaaWFda/uXJThYE7fXlwWC
+oCAFSxCCghAsQQiC9sTGKhn76r/8VQyez9kf8urAhbyDl94dupx/9ErhyRvF
+5+6WXnpccT2s+k507f2E+sepTWGZLVEv2+LeZN3o3C3BnIejA2/qB981Dee3
+jRR2jhb3jpUNTFQOT1aPTdVNTTfOIJtRyFb0TAd2tmsJ1bOM6iPODazODVHm
+R9a3N0afn2Cip9jo6Q30zCZ6lo+eE6DnhWi0GL0gQWNl6EU5ekk5j1PN49Rz
+eM3cshZF0KEI+lmCfmbFgFwxTK8Yp1aMkyvGiRXjGME4SjAOLxsG8fp+nL5v
+SdezqO1cULehlc1z8sZZad20CNWT+/k/jqk4HcjAwGaxtL2+LBAEBSlYghAU
+hGAJQhC0JwIlmBfypy9LcCcGfw7E4Mv9F14duPjm4KW3hy5/OHb94+k7RSEP
+S688K78ZVRUaV/Mgue5JRkNYdlP0q8s/L+6WYPeLyt7c2r43jQPvWgfzO4YK
+u4eL+0fKhsYqRserJybqpicbZieb5qdaMdPti9OdeGQ3YaaXNNNPnh2kbm94
+fXaUgRpnoSY4qCkuanoTNcNHzQpQKCFqXoxCS1AYGWpBPotVzC4qZxZVM0tq
+JE6DxGmn8bopvG4Sr5/A68fx+jG8fgSvH8bpB3H6gSVd36KuB6vtWtB0YNSt
+88pmlLxhRlo7FcjAV90poV/+32PypzY3hHt9WSAIClKwBCEoCMEShCBorxQi
+ovNCfv5bMRjycv/F3AOXXh+8/PbQlQ8nbn08e7/o4tOSqxFlt2Ir7yZWP0yr
+fZpVH55z8U/Y3RLseF7RlV3TnVvf+6a5711bf37XQGHvYPHAUOnwSMXYaPXk
+aC1yrB413oSeaFmYaFua7Fie6lqZ6iFN91G2N7A2PURDjjCQoyzkOAc5wUVO
+8ZDTfCRSgJwVIlFi5Jxkel46jZZPYxRTGOXUgmpyQT2BDUwzvqgZW9SOLGqH
+F7VDi9pBrHYAq+1b0PYsaLoxmk60un1e1YJSNM3I66elNZOi17nTgQyMv1Aa
+2Of/dVNRTPT7ib2+IBAEBS9YghAUhGAJQhC0V0ZrahE/HMwL+eWrGFx+89+z
+9l0IxGDOgUuvDlzOO3Lj/cm7Becff7oUVnwtuvR2fMW9lKpHz2ueZV/4aeFz
+Bv7r/yZpTStre17VkV3XmdvY/aa1511Hb353X2F/f9HQQOnoYMXEUNX0cM3M
+SP3caCNmtBk71ooba18e7ySOd68GNtFLmehfmxikTQ4xJkdYk6OcyXHu5ARv
+cpI/OS2YRAonZkQTs5IJlHQcJRufk4/NK8bmlaNo1QhaNYxWD6HVg2j1AFrd
+j9b0odU9aHX3vLpzTtWOUrbOKppn5I3TsrpJSfW4iNx6NRCAn//ZP/8L4XMG
+3s+dGJ+Dt4ZCELRnYAlCUBCCJQhB0F7ZWF1F/LAP8cPhvJB9X8VgYIPRv2Tv
+u5Sz/3LuwWtvjt5+f/pB/vmnHy9HFF2PLbmTVHY/vfLxi//0vwg/J9W//K+S
+xuSS5rSKlsyatuz69tzmjjdtXW87uz/09nwc6C0a7isd6y+fHKhEDtbMDtbN
+DzUsDDctDrfgR9oIIx3EwEa7Vkd7qKO966P99LFB5tgQa2yEMzbKHRvbHB3n
+j05ujU4JR6dFI9PiEaRkeEY6PCsbmpUPoRSDKMUAStmPUvahlL0oZTdK1YVS
+ds4q22eUrTOKZqS8cUpWPymtnZD0DIzu3hEaaMDAP3s3AwPb66sBQVBQgyUI
+QUEIliAEQXuoEBGJ+OEQ4ocjeSH7/0YMRv3yYt+ll/uv5B66+eb4vbdnHn8I
+CSu4HF14I6H4Tmrpg8z/+D8LPpdgyJ9xdfFFDclljWlVzc9rW140tua0tL1u
+b3/b3fmhr+vjYPenkZ6S8Z6yqd6Kmb5qVH8tur9+YaBxaaAZP9hK2F47abCD
+PNRFHepZH+qjD/UzhwZYQ0OcoWHu0Mjm0Ch/aGxraFwwOCEcnBQNTIn7pyT9
+09K+aVkvUtaDlHcj5V1IeSdS3jEtb5uWt07Lm6dkjZOyhglp3bikd2CM0vL7
+UWCgBz/fHfryfcnus0P3+lJAEBTUYAlCUBCCJQhB0B7aORbcj/jhMOKHY4gf
+TnaEf/0MmZ3DwX3ZB67nHL7z6sSDvDNP312IyL8S+/FG0qfQ9H/+n34twXM/
+LVXHFNbEl9QlV9SnVTc8r2960dSc09ryurM1r6ftfX97wVBH4Whn8URX6XRX
++Ux31VxPDbq3DtvbsNTbhA+sr3mlr5XU107u76T2d63399D7exn9faz+AU7/
+4Ebf0GbfMK9vhN83utU7JugdE/aMi7rHxd0Tkq4JSeeEtGNC2j4hbZ2QtkxI
+m8eljePShjFJ3ai4ZkSE6tx+OMznQ8DdEiQ0XIwtxOxm4LsWwl5fCgiCghos
+QQgKQrAEIQjaW4WIKMQPBxE/HEX8cPzvxWBgQzEHXx65l3vi8ZuzYW8vRL+/
+mlBwM3W3rc78sFgeUVAZU1QVX1aTXFmbVluX0VCf1dz4sr3pVVdzXm/Lu4HW
+/OHWj2NtRZPtJdMdZbMdFXOdVZiuGmxX3dL2Gpa7m1a6m0ndreTudmpPx3pP
+F627m9Hdw+ruZXf3cboHuN2Dm12DvK4hfufwVsewoGNE2D4ibBsRtY6KWkbF
+zSPiphFxw4i4fkRUNyyqGRK+yUYGAjCwz0+G+fxPDfxiuOF5Vg0ppmButwQH
+Mdy9vg4QBAU1WIIQFIRgCUIQtLd2jgUP/nYseALxw6m3Fw53Rnz9TNFfezDu
+aM7Jp6/ORuRdjH13NWm3BE/9G7YY8b404mN5THFFfHllUlV1al1NRmNtVkvd
+y4763O7GN32NbwebPow0F4y1FE62FCNbS2fbyufbKjFt1djA2mtx7XXL7Q0r
+HU2kjmZyRyu1o22to53W0Unv6GK2d7PaezjtvRvtfdy2vs3Wfl7rAL9lgN88
+sNU0KAisYVBQPyioGxDUDgh6e4YrM/K/PAT8HICB79y+OFdV155VTcqswO9m
+ICxBCIL2HCxBCApCsAQhCNpzXx0LIn44Hf7j2b8Xg9s9mHByJPn064sJu511
+8v9a+Pj47adn+cURn0qiS8riKsoTqytS6ivTm6ozW2uyO2tzeupe99flDda/
+G2nIH2/8ONX4CdlUjGoqnW8ux2yvEttcvdRSi2+pI7Q0EFsaV1uaKS0tay2t
+6y1t9JZ2RnMHs7mT3dzFaereCKyxh9vQs1nfywusrpdf28uv7uX3dA5Vpn+I
+v1D6+W2AX5Xg4xR+dg0lq5KYWb6c9BH9ZQnu9RWAICjYwRKEoCAESxCCoD33
+x3cLbh8LIn44E/bD2cgfz3VG/OXv9eDu/ZaBHf9v6A/3X+c/fvfxWUFheFFR
+VGlxbGVJQk1ZckN5WnPF87bKF51VL3uqc/ur3wzVvB2pfT9eVzBVV4isL0LV
+l8wH1lCKaSjHNlQuNVThG2sIjXXExvrVxgZyQyO1oWmtoZnW0EJvaGXUtzHr
+2ll17ezaDk5NYJ0b1Z3cnvYBStOVrw4Bd98bGPj6PGU0t3btRRU5s5z4vBT/
+vAgb9RYJDwQhCPp+wBKEoCAESxCCoO/BaE39zrHgkc+Pjvkcg4gfzob/eD7q
+p5Cuv9ODu9l1+0D3WObVhtiY948+5D/9WBBW/DGyrDCmqii+tjipoSS1pTSj
+vSyzqzy7pyKnv+LVUOWb0ap349UfpqoLkNWFs4HVfJqvKcbUlGJry5dqK/C1
+Vcu11Su1NaTa2tWaekpNA7Wmca2miVbdRK9uZlQ1M3qae16nj1ekvdt9J2Ag
+/b46BPynf7E+Tubn1qxlV1EyK1afl608L8ZlfFpIz5+Dt4ZCEPRdgSUIQUEI
+liAEQd+Jnc8WPPTlPaI7MXgu7IfzkT+GRP90oSty39Lrf/ubJfj5t58fzEIs
+PDiec3s8N7Q5Nb0guvpjXF1hYuOnlJaitPbi510lWb2l2f2luUNlr0fL88bL
+301VfEBur2C24uNcxSd0ZfFCZcliZRmusny5soJQWUWsrCZV1Kx217UHVpHy
+NrC/7r7P/4bdz4u/c2GurrYzt3rtZSUlq3z1eSnxeQkhowiX/hGT/h4V/2YS
+3hoKQdB3BZYgBAUhWIIQBH0nNlbJv90jevS3e0QDMXg2EIOIH86H/xgS+dPF
+6D9fLbhyrjvq8G76fb4PczcDP//i868/v1lvuw1Ljr54WJ39qCb7cd1UPmKq
+IKwtL7/t7cf290XtH4o7Ckq397Gso7Cis6iqs7gaWZGYG9dbkfg6sHvnZyqS
+3nz1MRCf/9Ivfxv4aeA7//SfrCXJb2urO3IrqS/LyVmlq89LiM+LCRmf8Bkf
+F9M/oNPezqa+nozMGYUHghAEfVdgCUJQEIIlCEHQ92Png+Z37xH9OgYRP4SE
+/3Q58s/Xo3++E/PL/e7oY90xJz4X35clGIiy3RPDz9/86uEtn7//Vdn9+z/6
+d0ow8P1/+o+WkqS82sq23DJyTulqdulqVgnpedFKxidCRiE+vWApPX8h7d18
+6puZlNyJ5Oxh+DGCEAR9b2AJQlAQgiUIQdB3BfHDX36LweNfvmHwtxi8gPjx
+Svifbkb+HBr1y8OY/U9jD4R9vHm7J/5s4rnXX94j+lUSftV6f7MB/50/8FUe
+Bn5bkvgmsCfR7NqyltxiYk4RMbuI+OLTSmbhSsZHQsbH5fQCXHr+Uvr7QAOi
+0/JQqa+mU16OJ2cOhmcO7JYgW6Dd69cbgiBoGyxBCApCsAQhCPqu/PYc0S/f
+MPjHGPzxEuKna4g/3Qr/+V7EL48i9z2LOhAecyg67lhCwqmUpHMZfamXky59
+wOfv704J3T0u/OpOzr93IPg3S/BzUf4f/2QsiX/9PLqvtqi+tqghtwCfU4B/
+WYDPLlh+UbCcmY/PyMenf8Bt7/1S2vvFtHcLaXno1DeBBpxJyZlKfjGalN6f
+mNIJ7wuFIOg7BEsQgoIQLEEIgr43/x9i8DLiTzcQf76D+Pl+2F8eh+97FnEg
+IvJgTPTRhNiTqfFnnyeEvEi6lJt89U3qjfclkYml0ckD2aEpt8pSb1ekhlbe
+PDJMKD5269jIrWOjt46P/bbxWycCm7h1cqI45mUGoj0jrKPmXXnN+4rqD5U5
+r+dy3sy/zEO/zMNk5y28eLuQ9Rab+Rb7/O1ixtvF9LeLaXnYnQXqD5P6Bp36
+ej71FSolB5nyMtCA40nPhxNTexMS2sPSeuCDYiAI+g7BEoSgIARLEIKg79Bo
+Td0XT4/56xgMQfx0BfGnm4ifQxF/eYD45QliHwKxPzL8YGzEkcSoE6kxpzNi
+z72Iu5CbcPlN4rX3yTcLUu4Upd4rTXtQnva4Kv1pbQai4XlEU2ZUa2ZMe2Zc
+V2BZCT1ZiX1ZyQNZqUMv0kZeZIy9eD6elTmZlTWV9WI6MxuZ+XI2Mwf1PGcu
+I2cuPXc+LXc+NRe9vVc72/7tXEpgOYEAnE15iUx+MZmcOZ6UMZKYNpiQ1B0f
+1xoXUQvvC4Ug6PsESxCCghAsQQiCvk//LzH44wXET1cRf76F+PnubzEYhtgf
+hTgQiziUGH4sNeJkRtSZF9Hnc2Ivvom78j7+ekHCrU+Jd0qS7pUnPahMflST
+8rQ+FdGUGt6SFtm2veiOtJiutLie9IS+9MSB9OSh9JTh9NTRtLSxtPTxtIzJ
+1OdTqZnTKZnI5ExkStbM9l4ENpuSPRv4RfIL5PayppOzppIzJ5OejyWlDyem
+DCQk9SYkdMZFNcU8q3z024EgvC8UgqDvDSxBCApCsAQhCPpu7cTggS9icPdp
+omd2YvAi4k/XfovBh4hfniL2hyEORCEOxgViMOxoStiJjPBTLyLO5kSGvIm6
+9C76an7M9cLYW8Vxd8ri71bEP6hOeFSX+KQh8VnT9sJaEsPbkiI7kqK7kmJ6
+kuL6kuIHkhIGExOHEpNGkpJHk1LGklLHk9Imtpce2GRSxu4+fyfw07GktJHE
+1OHE5IGExN74uM742PbY8Prox2VPYxphBkIQ9N2CJQhBQQiWIARB37PRmtqd
+GDz029NET3z5ofOIny4h/nT91xj85SFiXyAGw3diMBZxKAFxOCXsWHr4yazw
+MzkR519HXngbeflD1NWPUdeLom+Vxtwpj7lbFXO/JvZh/fYeN8Y9bY571hof
+1h4f0Rkf2RUf1ZMQ05sQ25cQ158QP5iYMJSYOLy9pJHtJf+2lMDXQPoNJSQN
+JiQOJCT0xcf3xMd2xkW1xYY3xjytjrpf/CSyDmYgBEHfM1iCEBSEYAlCEPSd
++2MMHvstBncOB388/2sM/nwb8Zd7fysGkxFH08JOZIaffhl+9lXE+TeRF99F
+Xs6PulYYdaM4+lZZ9J2K7R7cScKYB3WxjxpinzTFPW2JQ7TFhbXHhXfER3TF
+R3bHR/fEf67Cz2H4efG/Lj6uLz428Ae642M646I74iJbY8MaY57URD+siLxd
+8CSs+vNHB8L3BkIQ9N2CJQhBQQiWIARB37/Rmpqd9wzufuj88a9j8M/XED/f
+Qvzlb54MJiOOpIUdex528kX46Zzws68jQt5GXPwQebkg6tqnQA9G3SoLLPp2
+RXRoVcy9mpj7dTEPG2IfN8Y+aY592hL7rHW3CuMiOuMiu/6wqMDXzriI9riI
+ttjwQAA2xz5rjHlcE/2gPCq0KOLmh4dJHfAT5CEI+v7BEoSgIARLEIKgfxSF
+iLgv3jb4xeHgj+f+Kgaf7LxnMBJxMAZxKB5xOAlxJBVxNANxPDPsZHb46dzw
+c28iQt7t9ODHyKuftne9OOpmadSt8ug7ldF3q6Pv1e4kYX2gCmMeNcY+bvo1
+DLfb8I972hTzNFB/9dGPaqMfVkfdK4+8UxRx/f2z0MKHCU3wKBCCoH8IsAQh
+KAjBEoQg6B/IaE39F3eKHv39nYOBGPzTxZ0YvLkTgw8Q+x4j9iMQByIQB6MR
+h+IQhxMRR1IQR9MQxwI9mBV28mXY6VeBHgwP9OCFD9u7VBBxpTDyWlHk9ZKo
+m2WBJIy6XRl1pyo6tDr6bk0gDKPv10U/+GIPd/Yg8P1A/VVGhQYCsCTyVlH4
+1fdhF189flYBGxCCoH8gsAQhKAjBEoQg6B/Lzp2i+3buFN09HNzpwR/PIH66
+gPjzlZ0YDEX8ch+x7xFi/1PEgXDEwSjEoVjE4XjEkSTE0UAPpiOOPQ/0IGK7
+B3PDzrwOLPxcXqAKw39LwoirRZHXigNVGHmjNPJmWeR2GFZs787O19vlkdsL
+fD/w0+KI64E/XxB++V1YSG5YSPaH0knYgBAE/WOBJQhBQQiWIARB/4h++4CJ
+P/bgj6cRP51H/Pky4ufriL/cRvxyF7HvAWL/E8QBBOJgBOJQNOJwHOJIwk4P
+piKOpSOO7/TgieztncxBnH4VduZN2G9JGH4xP/xSoO8+Rlwu3GnDTzsr3NnH
+8CuBBX76IezCW8T5V4hzuYgzGYUppXv9wkAQBP2PgCUIQUEIliAEQf+4vrhZ
+9PCvD5P58QTip507RX++ivjLDcQvdxD77iH2P0QceIo4GPZbD8Zu9+DRnfPB
+Y2mI4xk7y0ScyEKcDCThS8Sp3EAVIs68RgTC8Ox2G4adfxsW8m776/byws69
+QZx7jTgbqL9sxJlMxOn0wpSyjTXOXr8eEARB/4NgCUJQEIIlCEHQP7TRmpqd
+Htz/RQ8eRfx0CvGn84g/X0L8fA3xl5uIX0IR++4j9j/a6UEE4lAE4nDUTg/G
+I44mIo4l7ywFcTxQhemIE88RJzIRJwNV+AJxKntnLxGnPy8bcfoF4nQW4nSg
+/p4jTqUiTiYWJpfCBoQg6B8dLEEICkKwBCEI+v+B33rwwO9HhD8eR/x0+tce
+/MtVxC83EftCEfs/nw8+QRx8hjgUjjgciTgSjTgSu72jcYijCYhjO2H4/7R3
+LytyVQEYRl9KzbVNYpuGiKIoCSokeN1GNBoVL7PMnGg/gOhT5B2cdYx4GfQ7
+SEIHEzqTtLu6MCqKo8TG+tbipyhqdM7wY5/iPDmr8JNxeu7TxTbmPtv/nOn3
+8dj4aGx8ME5f2vzoi+3rPx/0rQM8AEoQgpQgsEr2X0N/dP+IcD8JH1lfnA8e
+enocXvbguXHspXF8JuGFsfbKePz1cWIm4VuLnbw4Ts0wfGc8cWk88d5Yn3t/
+sSfv792x/s5Yf3vzwy9nAG5/98NB3yvAA6MEIUgJAitpJuHvT42ujUdOjUdP
+j8fOjMMzCZ8dR54fR8+OYy+O4y+PtfNj7cJij78yTrw6Trw2Tr7xx069ub/5
+/dXNy59vX/9p+7sfD/rOAB48JQhBShBYbdtbW1e/+npu8+LlcejMeHR9PLYx
+Dj81jjwzjjw3jj4/jr2wv7Pj+LnF1l5c7MT5zfeubF66MtPP8R+w8pQgBClB
+oGa24f6uLQvx6lffzG1fu7597fvFtrYO+gIB/mtKEIKUIABAnBKEICUIABCn
+BCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAA
+cUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUI
+ABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhS
+ggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKE
+ICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQp
+QQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABA
+nBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkC
+AMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKU
+IABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQh
+SAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFK
+EIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQ
+pwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIA
+AHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAl
+CAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEI
+UoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwS
+hCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDE
+KUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAA
+QJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJ
+AgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCC
+lCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcE
+IUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABx
+ShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgA
+EKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKC
+AABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQg
+JQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClB
+CFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECc
+EoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIA
+xClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQg
+AECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFI
+CQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQ
+gpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCn
+BCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAA
+cUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUI
+ABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhS
+ggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKE
+ICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQp
+QQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKUIABA
+nBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQhSAkC
+AMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFKEIKU
+IABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQpwQh
+SAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIAAHFK
+EIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAlCAAQ
+pwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEIUoIA
+AHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwShCAl
+CAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDEKUEI
+UoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAAQJwS
+hCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJAgDE
+KUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCClCAA
+QJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcEIUgJ
+AgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABxShCC
+lCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgAEKcE
+IUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKCAABx
+ShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpQgAECcEoQgJQgA
+EKcEIUgJAgDEKUEIUoIAAHFKEIKUIABAnBKEICUIABCnBCFICQIAxClBCFKC
+AABxShCClCAAQJwShCAlCAAQpwQhSAkCAMQpQQhSggAAcUoQgpYluAUAQJgS
+hJpvAQBACQIAAPA3ShAAAKBGCQIAANQsS/DWrVs7Ozt37tw56MsBAADg4Zrp
+NwNwZuDu7u7Nmzdv37590FcEAADAwzXTbwbgzMC9vb0bN27MJBSDAAAAK2xG
+30y/GYD37t2bJXj37t1Zhf4tCAAAsMJm9M30mwF4/2X0yyPC+bs/DAIAAKyY
+WXzLDJxf9v5q+fvyMVE9CAAAsAJm3C0fCl2e/e39k+VjotPOzs6vAAAA/M/N
+uFtW3p8fCv1Hu7u7Mxh/AQAA4H9u+cKIf29AAAAAAAAAYPX8Buk5W8c=
+     "], {{0, 456.}, {599., 0}}, {0, 255},
+     ColorFunction->RGBColor,
+     ImageResolution->{144, 144}],
+    BoxForm`ImageTag["Byte", ColorSpace -> "RGB", Interleaving -> True],
+    Selectable->False],
+   DefaultBaseStyle->"ImageGraphics",
+   ImageSizeRaw->{599., 456.},
+   PlotRange->{{0, 599.}, {0, 456.}}]]], "Output",
+ TaggingRules->{
+  "Settings" :> {$CellContext`r = 
+     25, $CellContext`ls = -38.13893481458008, $CellContext`lt = \
+-18.126989611213105`}},
+ CellTags->"Snapshot",
+ CellID->1812875160,ExpressionUUID->"b037802b-902b-433d-b439-a0c8bb8414ac"],
+
+Cell[BoxData[
+ PaneBox[
+  GraphicsBox[
+   TagBox[RasterBox[CompressedData["
+1:eJzs3Ql4FPXdwHFQAbWtWm+sUpV6INBW2/rYWvsK9RUpeLSCR0VBLXnbqlhA
+tIqCUu8WizcigojigYigiIACAsolhyCQAxKuJCQxNyGC6Lw/82/+HWZmZyeb
+a5Pf9/PkeZ/d2Tn+M7v03a8zu3vSDbf+IWW/Fi1aDD5Q/s8frr+jy6BB1995
++WFyp/eAwX/5vwH9/9R9wG39/6//oHNu2F8mjpL/89YBLVp8e9vx2b17d3l5
++RcAAAAAgCZO4k4Sz999ngYsrlJaWroTAAAAANDESdyZyovVgxUVFfJoWVlZ
+RZVKAAAAAEATZ/pOQk9yT24EZqAE465duxp7pAAAAACAuiShJ7nniUFzUSgZ
+CAAAAADNlY1Be5loUVGRuSi0sYcGAAAAAKgv5jJRCUDJwC+//NKcImzsQQEA
+AAAA6pf5YKBkoCRhaWkp14UCAAAAQLMn6ScBKBn4xRdf7Ny5s7GHAwAAAABo
+CBKA5qcGKUEAAAAAUIISBAAAAABtKEEAAAAA0IYSBAAAAABtKEEAAAAA0IYS
+BAAAAABtKEEAAAAA0IYSBAAAAABtKEEAAAAA0IYSBAAAAIAkl1llWZXZ+zIT
+zQzRV0gJAgAAAECSowQBAAAAQI91Vd6NxswcZbWUIAAAAAAkLUoQAAAAAPQw
+F3z6c69kX/4ZolwpSgkCAAAAQBKiBAEAAABAG/NVMAmUoFkwfOWUIAAAAAAk
+IUoQAAAAALQxPxIRWH+xmJnNguErpwQBAAAAIAlRggAAAACgDSUIAAAAANpQ
+ggAAAACgDSUIAAAAANrw3aEAAAAAoA0lCAAAAADaZFZJoATNguErpwQBAAAA
+IAlRggAAAACg07oq/twLZGaOslpKEAAAAACSFiUIAAAAADqZCz7NV8HM3peZ
+GOWKUDdKEAAAAACSHCUIAAAAAKglShAAAAAAtKEEAQAAAEAbShAAAAAAtKEE
+AQAAAEAbShBoTj4GAAAAPv447vtGShBoThr7f3IAAACQFOK+b6QEgebE/MN3
+AAAAoNWnn35KCQLaUIIAAADKUYKAQpQgAACAcpQgoBAlCAAAoBwlCChECQIA
+AChHCQIKUYIAAADKUYKovV3VKioqdlYpczFT5CE7W2OPF5QgAACAdpQgasnd
+gKWlpYWFhfn5+Tt27MipIjfkrkyUh9w92Nij1o4SBAAAUI4SRG3YDCwrK5Pc
+k+7Ly8uT14lM3FtFbshdmSgPyQwyGzGYDChBAAAA5ShBJMxmYGlpqTkPWFJS
+EuuVJg+Z84MyMzHY6ChBAAAA5SjBpFJYWDho0KAJEyaYu1u2bOnTp89LL73U
+uKOKxZ4NNBkot8NfbDKDiUF7ZrCx90AvShAAAEA5SjCpSPq1aNHiiiuuMHdf
+eOEFuXvGGWc07qgCmZN65eXl8qqIkoGGiUFZRBbktGBtvBvNjCr+xSlBAAAA
+5SjBpOIpwfz8/HvuuWfWrFmNO6pA9rrQ7OzskItC/WRmWcReI9rY+9FUUYIA
+AACoDUowqXhKMJmZE4IFBQU5OTk1fdXJIrKgOS3Y2PvRVPmjr7Sa/yH/4pQg
+AACAcpRgXbn55ps7dOgwd+7cLl26HHTQQffee6+ZPnny5HPPPffQQw896qij
+Lrjggnnz5rmXWr58ed++fY899tgjjzzy6quvXrp0qbsE09PTZZ3Dhg0zdz/6
+6CO5O3r0aLt4YWGhTLnpppvslLFjx/7yl788+OCDTzjhhMsvv3zjxo3hw5YW
+27Fjx+bNmzOrbYpgYxUZ3qpVq7Zt21bTV50sIgvK4mY9Ubaoh30i5EmRpyZW
+LFOCAAAAqA1KsK5ccsklEnHHHHPMYYcd9pvf/GbMmDEycdy4cTLxkEMO6dat
+21lnnSW3DzzwQMk9s4i81T/uuONk4imnnHLhhRdKvp144onuEly7dq3c/dOf
+/mTuzpgxQ+6OGDHCbjQvL0+mXHzxxebuE088IXelAWURCdKWLVvKeIqKikKG
+La2Rua8otSL5lpGRkZqaKiVbXFxc01edLCILyuKyEkrQw/N0yFMc+MS5Q++9
+KpQgAAAAoqME64opwe7du5eUlNiJ/fr1+/nPf75y5Upz99FHH5V57r77bnO3
+d+/ecnfw4MHm7pYtW9q2bVubEpRt7b///tu2bTN377///jPPPHP27Nkhw3af
+DaxRCaanp2/YsGHJkiV79uyp6atOFpEFZXFzWrC+26pp8Twd8gQFPnGUIAAA
+AGqDEqwrpgTDD6ZUj8zTq1cvc7ddu3ZHHXWU+5A+//zztSnBX/ziF3J34sSJ
+0T9/V8sSXLx4cWIlKAtSgoFqVIKl8VCCAAAACEQJ1hVTgv5r+V555ZWUlJRf
+//rXHTt2PPjgg2WeP/zhDzI9JydHbp9//vnumeXpqE0JSgO2bNlSphx77LGy
+Etm0tED4sBO+OtSeE0zs6lDOCcZSo6tDKUEAAAAkhhKsK4El2LdvX5l4wAEH
+/OpXv+rVq5c0oC1BeZMvt7t16+ae//PPP69NCVZWfQXNLbfccvrpp7eoIvlp
+LxYNlPA3xpjPCcrrJysrq6avOllEFuRzgoFq9I0xlCAAAAASQwnWFX8Jbt26
+Vab88Ic/tBNXr15tS1AceeSR7dq1c6/ktddeCynB999/X+7279/fzm/K0V2C
+1meffda1a1d59NFHH627vfwvKRQJjdzc3MRKUBaUxfkViYTx3aEAAACoDUqw
+rvhLcNmyZTLlvPPOs1NuueUWdwlecMEFcve5554zd0tKSn7605+GlOCmTZvM
+F43aFQ4dOtSWYEFBwVVXXTVw4MCKigrz6Isvvuj+gpq6ZX5PUF4SGzdulL2O
+/pKTmWURWZDfE6wNShAAAAC1QQnWFX8JSuYcc8wxpuzuv//+7t27t2nTxl2C
+y5cvP/jgg1u3bi0z3HbbbZ07dz700ENDSlBIBsqUTp06Sd9deeWVZoX2nOA5
+55wjdy+66KLHH3/83nvvPfzww/fbb78VK1bUx/7K3klySr1mZ2dnZGSUlZVF
+eb3JbDKzLCILyuKUYMIoQQAAANQGJVhXLrvsMqmw/Px898Rly5bZj+ydfPLJ
+U6ZMcX93qJg6derPf/5z8zUvP/nJT2bOnCk3rrrqKvPounXrPJeDyhQJRrPC
+Y489duLEiXLj0ksvNY9u3rxZbktaykRZ5xlnnDFnzpz622V7WjAzMzM9PV0a
+JPzFJjPIbDIzJwRrjxIEAABAbVCCDWD79u2SPyEz5OTkbNmyJfoKc3NzN27c
+aK8C9ZDnKDU1tbCwsGajrDlJOdmWpIf0b0ZGxvr167Ozs2O90uQhmUFmk5ll
+EVmQEqwNf+6F8C9OCQIAAChHCaI2bAwWFBRI7a5du3bdunWbN28uKiraXUVu
+yF2ZKA/JDDIbGVgnKEGgvo0cOTIlJaWxRxEspcrIKtOnT2/s4TQc2Vm74yLW
+bPJQWlqaZ6JZsJ4HWGNmj/yjTVoyVPPy80w3O+JW01dmrENh/iUmvFoAIShB
+1JKNQXl55OTkZGRkSPetWLFiaRW5IXdlojwkM5CBSYISBOKaXqWxRxGgybVD
+HYpYc4G9QAnWns1ATwmavXAf85rulw1JzyJ2zWlVmtbhApIfJYjaMzFYXl5e
+UlIiL5K8vDzpvu1V5IbclYnykMxABiYJShBoupL5ZGV9i3hKiBKsJ/ZsrOcV
+GPiajH7A7ale/6HwP5Xhp4MB1AgliLpSUVFherCsrKzERe6aBoz1wUY0PEoQ
+sOSdp/vyM/u2U26433Dau2Z+9/WHIWvwvIk1c3oWtGc63Iu71+k/1RJ4aahn
+DO531CGDNw8FXnoXMrwoBzD8oVg82wo8yJ5diDUYz0WkZop/SJ71JDDmkHWa
+w+uZwfPUmCnhGw15muwm7JNrH4242ogdanMveglGf8bNQQs8OP4STInXzmkR
+xB0YoAEliDpnktAiAJMQJQgY9mTE9Gr2Tabnza25a/+vff8cvgbPyQvzXtf9
+Rt0dLO7Kc68zxXVuxRaBeci+obWZ4w636IM3S3nOT8Uanv+9euDu28Xdowo/
+m+MZj3tz7jV49t1zhP1DsofIHl73aN1Dqv2YPfHizlL7qPsYup/0wBniPk32
+0ZR94zfKvtjXUsgOurcS+E/DPQbPlLhrdv+LiFWCgdeLhqec+78nxBJ3lwEN
+KEFAIUoQcGK8WbXvMANL0DNz3DVEKUHPSTR/CASOxD8M/4Y8+xJl8O4x+4fn
++C75C3m3H3dUgfMnvDnPUv7Z/AfW8Z1gqumYAxdxfK8i9+I20NyL+18DITM4
++z5N7k707K/n5edvKPMfFuIe0sC8DZzHzBYxMAP/OcQtwcCXZciw3VMiLgjo
+QQkCClGCgBPjPbwVt7+irCFKCcZ9Ax93JLHCx64n+uDdEwOH52+QWG+tY40q
+ejk6vpKqZQn6z+55WqOmY3binVaLddmk5xiGvAbiPk3Rcyl6Q/m35V4q5OXk
+PhkXd0OefyB1XoKecUY5mQhoQwkCClGCgBPvq1eilGDcNTRACaa5vs7RI7wE
+7YWLfu7LO+OWYOC+RxlV4Hg8E6OUml9iJRgy5pCNupdyX4waslPuiXFLMORp
+CllDyOWRNS1B/yKxzkq7T63GPS0Y5fRryK4l8DII/+82gE6UIKAQJQg4zasE
+p1d/zb5H3MGHLBW3BEN2P8qoAsfjmdjwJVijMbvX4062KEc+cAf9Q437NIWf
+OEtgXzxiFaV7kIEHPPxfR/hH+dJcn2NNCyrBKHtBCQJxUYKAQpQg4DRICQae
+9aiPq0NjnWhLePCxhuc/Jxj4njxt3w+7RZEkJVijMft5vjul9leHxn2aQkqw
+ptEXyB+S7jh1Yh+3KC8wN3uyLy30v0VEDDr/YfH/lxkAlCCgECUIOLE/cJQW
++7tDa7MGx3dhW12VoOfDdH4JDD7W8Nxvp8PTKe6ooozHnCFy341Ygv5RxS1B
+J0K8BA7bM8W9krivgbglGPdpitXjUarW9FdNgzHif4vwPHdxtxXxn4NntdEH
+SQkCfpQgoBAlCBj200yekx1OtBIMX4N9D28etVcP1nkJplV/VM19NeBI13dC
+xh28Z/whw/O8nfbsvnuRuKOKeDDd80csQc967LJxSzCxMbsPoCf0PEd4ZPVv
+PcQaQOBQw5+mWCVoL790LzVy368Yjftpvli7HPc/cfjXHPfzfSFnAENeEoEC
+t5VA5gPNHiUIKEQJApbn80qxrsoLeRsZaw2eh0ZW/yRfnZeg4/odPffmopzq
+8n9cy3M2KrwE4+6++9NznlFFGY//FGGUbLFBZ9hl45ZgAmP2H0D3CG25BB6f
+wAEEDtV/kKNcoxvy5HqGF2vvAoVcxxvy3CVWgv41xx1trFPVsc6uApo13RK8
+5557LqtSWlra2GP5VrKNBwhBCQIe7pNHdb6G2q+8ToYRd6naDDJ88ZquvE6O
+WL3uUcT5PedYEx6MexMJP7+13Hr0DdXHthryHxGgR9MtwS5durSoUlhY2JDb
+LSkpmVxl0aJFyTAeIAGUIAA0AK5IBJDMKMGaSk9PN9vt2bNnMowHSAAlCAAN
+gBIEkMzquwR37dqV6HvVOChBIGGUIAA0APM1L409CgAIVk8l+MEHH1x00UUn
+nHDCAQcc0LFjx+uvvz4nJ8c8NGvWrJ9VeeGFFwYNGtS+fftjjjmmoqLCPLpu
+3bqbb775rLPOatWq1WmnndanTx8pr8BNBJbX+PHjf//73x9xxBFt27a96qqr
+pk6dah+y25V5RowY0aFDB9lE586d33zzTfdqZTbZ6A9+8INTTz31nnvumTZt
+mllq4sSJ8qgs2KlTJ7PdQw45RKbLLnjGs2bNGhnDYYcddvzxx8uq8vPzoxwx
+oCFRggAAAMrVRwmOGzeuZcuWLfZ18skny+Ly6KuvvmqmnHjiifZRU4JpaWkS
+j54FpRNXrlzp34q/BB999FHPsjKMl19+2TxqtyuJ55ln+fLlZp4FCxa0adPG
+/aiEqrnxz3/+U2aQpPVswp4ZtOORgHXP0LVr17hHDGhglCAAAIBy9VGCHTp0
+kAI69NBDJ0yY8O6775577rmmid5+++1KV5GJzp0733bbbYMHDzYXkf7qV78y
+03v16vX666+npKSYu/369fNvxVOC8+bNs6EnG50+ffoPf/hDuXvAAQds2rTJ
+s93+/fuPGDHCzCD+9re/mXXa7jvvvPMee+yx3r1720VMCS5evPiJJ54wU846
+66xJkybNnz/fM57jjjvukUce6du37/7772+mbN++PeL7c6BhUIIAAADK1UcJ
+Zmdnb9u2raCgwNydMmWKCaJ777230lVkZ555ZklJiV2qtLS0VatWJuXKy8vN
+xD59+kiUXXLJJf6teEpQVm7ufvTRR2YGiUEzRXrNvd2LL77YzGCnXHbZZXJX
+xmzPAxYXF5t5evbs6S7BygifE5QO9UyZNWtW3IMGNCRKEAAAQLn6KMGKioqn
+n3766quv7tix43HHHWdPqw0bNqzS1V9Dhw51L7Vo0SIzXeovyltZTwn26NGj
+RQzmlJ/d7n333WfWkJWVZab87ne/k7szZswwd92nIJ966qmalmBubq6Zcued
+d5op5mQokDwoQQAAAOXqowR/+9vfmgJq2bLl8ccfH6sEH3zwQfdSH374oZl+
+ww03RHkr6ynB888/39z98Y9//NMqZ5xxhtyVG/fcc0/gdrdv3+4uwfnz55u7
+V1xxhd3KI488UtMStJ9blO1SgkhOlCAAAIBydV6Cy5YtM/nTvXv37OxsmTJp
+0qQoJSgr32+//WT6z372Mztx9OjRQ4cOffjhh/0b8pTXkCFDzN01a9YEDixu
+CRYVFZkBHHbYYampqTJF1my/KdRfghdeeGHIeCopQSQxShAAAEC5Oi9Be42l
+5FVeXt6GDRvOPPPMKCUoOnbsaB6ShkpLSxszZoy5e+mll/o35CmvN99809yV
+6VlZWaWlpSNGjDi8iqwncLueEhRyw0yRpaRk3V9kakswNzfXfBXM9773vWnT
+pm3cuDFwPJWUIJIYJQg0pJEjR8r/U2vsUXz723YyksYeRUwyNn56r56kucSd
+J4GV18k8ABpenZegdNB3vvOdFi7mRFuUEpw/f/7BBx/cYl+tWrUK/MYVT3nt
+2rWrT58+/o22b99+x44dgdv1l6DM6f4NCFnJ5Zdf7inByn0/k+j/FQlKEMmP
+EgQaUkpKSgM3TuAPmktqyUgachixBKaxjC2ZQ7WWGqtzZaMp+/IffLnrmadG
+4Rb35W3GkOAOAKhP9fE5QQk6+3MMnTp1kv/NMbeHDx8uj77++uvmbuA1nzNn
+zjz33HPNj/q1bNny9NNPnzNnTuBWunbtatZTVFRkBzlgwICTTjrJdlzv3r0z
+MjLMo/7tZmdnmylSdna1JSUlM2bMGDJkyL333rtixYqxY8eaeR577DH3u+iz
+zz77wAMPlOl/+MMfYo1H9tdMmTZtWtyDBjQkShBoSA1fgiOr+CcmyRvywAPS
+vEuwsfbOvBLs+T4TZZ6RuPPQlmPcNZsVmhdV4MvbPUOSvPAAeNRHCRrSWVu3
+bk3sbWppaemqVavs71DUVGZm5ueff15WVlbTBfv373/dddf9+c9/Nuf1Kioq
+7Jm+Tz75xD+//bULoGmhBIGGRAl6UIINxn92z/MyMOnnfjrMKcK4pwVt4sV6
+eXtOR9ZiJwDUl/orwaaob9++pvuOO+64Cy644MgjjzR3Tz311F27djX26IA6
+QwkChvvdrHlD634DbM5o2FMb7gv83Cc7zIIhred/q2w+shf4Rto8ZE/fxHqn
+7XnUnX52zSOrmZ0y0/0jj3uUPNsKPETuPQpZp3vrdnj2KJlVudfjv46xpoN3
+Qo+25ZnBfQml3Uf/OmNtwrOVWM9I3D2yLzn7FNsFPYOMzlOCgf99IKUm3Rr3
+iUie/wQBwIMSdMvJybnmmms8H1Ts3r27TG/soQF1iRIEDPOOd3o1827c/S7d
+vkV3Z4udbpcNf+fsbz1bPXZx9zt89+b8o3LP4xm5fdRes+dOVHeP+JeKxTPa
+8EMU92i4L1D0DC/uesy2bJvHPexRjrb7yNjteq54NNv1N1rKvmfW3HvkOdFm
+j5tnlwPH5t6QfSWYG+6Rh1yWGfdo+DfhmS3wnHIslCDQdFGCfps2bZo5c+bY
+sWNnzZplfggDaGYoQSCQ5z2/Oz3cswXWRMjZGX8U+LPCvvH2z2CHEThIuwbP
+iZ5YV4d6zuj5d8S/p55t+Qfj2Vbcd/6B7eAPXs+Ap/u+eCSx8XsOTqx9rFEJ
++nm2EhhccVcbeKLQDntk5G+hcZ959ByuWCUYvd0oQaDpogQBhShBwM3zfRrh
+CeDU/HN//hL0zOB+qxyYme636yFntdx3o7y9j7WDVshozQASq6RYR9UzZs+e
+JvBcBI7fMzHwxGhiJRjyxSyx9s6zWk/bRjnpGYW9vNkfg5QgoBklCChECQLG
+9H0/3hXlssC49eTnnt/zaTI3O6TA0Bu578cAPZuopxIM3JZ7hIFrCOwvtwRK
+0P9LB1bc8Qeyv50XmEI1LUHPx/3syyni3rnX495WXZVgyMgpQUAzShBQiBIE
+nH0/pWUnNkAJjnR9q7+be1SUYKwNhRy6WOMPX6ROStDWpXuG5CxB/5nWwN2n
+BAENKEFAIUoQcGJ/a2KUEqzR+/MU3znBkJkjlmDDXB2abCVY0yyK0iC1L8Eo
+n0b0byXwQ46eVdVfCYa/IGv03zooQaDpogQBhShBwIlQRrFCKdZnxGJtKMo6
+o58T9DeRvXIyfIQJlGDgDO5tJVyCgfEVftYsgaCIe7SdoLIOfBl4xhb3o52e
+EvS3eeBq/Z9hjFWC5tOIIa+6WDyb8Adp4HcWhWyLEgSaLkoQUIgSBBzXO15z
+uaD9nFeUakup/tEBu2zIuRvPSuynEe2ViglkhRmqmZ5SLdaupbl+T9C/I1He
+xnuOUvghiluCnnXaoxRegjZ4PYcu4vg9u+A5CHYe/8sg1kHw5LDn9eDZHf+T
+7sR4Bbq3G1KC/pn97LMTsgnH9Q2lZh7Pa8mJcdLT7kiK66c9AmfwXKMbMmAA
+DYwSBBSiBAFjuus308272Sgl6FnQVkCsrcRqJffi9g1/lBJ0XD81PtL1a+yx
+NlGbEvSP1nO2KIEStLnhjo64JWj32nPo4saFZ/yxNhTrZeAfsB1GyCHyPGVp
++36lTNq+p4ADj23gMbEilqB/32P9l42QQxrr8tcUH/+5xfAjD6BxUYKAQpQg
+YNXyVEXtl62TsySxTkrW4SmYOj+h08CHPe7R9pygDCym8I1GGVXgDPV9sizK
+K41zdoBClCCail3VKioqdlYpczFT5CE7W2OPN6lRgkCTFuWUDWqD4wlAA0oQ
+TYK7AUtLSwsLC/Pz83fs2JFTRW7IXZkoD7l7sLFHnbwoQaBJsx9Ds58T5KK7
+ukUJAtCAEkTysxlYVlYmuSfdl5eXJ69Gmbi3ityQuzJRHpIZZDZiMBwlCDRp
+9rtN7OcEG3tEzU1iX8sJAE1LMytBGeGgQYNeeumlxh4I6ozNwNLSUnMesKSk
+JNbrWR4y5wdlZmIwBCUIAACgXJMuQRnM7NmzV65caads3ry5RYsWV155ZeMN
+qo7591EbezbQZKDcDn9JywwmBu2Zwcbeg2RECQIAACjXpEtw69at0n3dunWz
+U5pfCfr3URVzUq+8vFxee1Ey0DAxKIvIgs31tOC70cyo4l+cEgQAAFCOEkxy
+lKC5LjQ7OzvkolA/mVkWsdeINvZ+1D1KEAAAALXRkCWYlpZ28803d+7c+bvf
+/e4FF1zw6KOP2rfoa9eu7dChwwMPPPDwww/LDG3atOnYseOLL74Ysrb77rvv
+Rz/6kVTSwQcfLMua+rMlOHr06LPOOuuggw46++yzx4wZ41l2/PjxPXv2/N73
+vveTn/xk8ODBkgwhG0pPT7/11ltlE9///vd///vfT5482f2o7ILsyK9//esD
+DzxQRv7qq6+OGDFCZl6/fr08+tFHH8ltGYydv7CwUKbcdNNNdkpOTs6NN94o
++yJ7LWsYOHBgeXl5yD4aY8eOvfjiiw877DCZQRZftmyZfcgezDvuuOOkk05q
+1apVyN4lOXNCsKCgQI5STV/bsogsaE4LNvZ+1D1/9JVW8z/kX5wSBAAAUK7B
+SlDelp922mkSNaecckr37t0PPfRQuS3VYx6VkJG7J5xwgvRU165dZZ4WVWbP
+nh1rhc8995ysR+Y5+uijJdCkeiqrS/AHP/hB69atzzvvPAkrs5433njDvaBM
+kQzs1q2b2ZDMWVZWFriV/Pz8M844Q+bp1KnTb3/7W0nL/fbbb9q0aXaG4cOH
+y6MyXdr29NNPl9um3cwn+2bMmCG3pQ3t/Hl5eTJFIs4e2FNPPdWsX+JUYtN9
+TjNwH8UTTzxhN/rjH/9Ybh911FEbNmxwH0xZpGXLlhLUXbp0CXlepJJ27Ngh
+xy2z2qaksbGKlPiqVau2bdtW09e2LCILyuJmPY29N1HZJ0KeFHlqYmUsJQgA
+AIDaaLAS7NOnj+TJkCFDzN2CggJTQDNnzqysjpc2bdrMnTvXzDBs2DCZcu21
+14asM9bVoVJAb731lpny1FNPudsqNTW1VatWxx9/fFZWlpnSt29fmeGhhx4K
+3MT1118vj0rumbsrVqyQhJSMNaftJDRkW0cccYTkhplBos+0Z8QSXLhw4Zln
+njlgwABzV97GS9PJcZAbsfZx3bp1UqNHHnlkRkaGmfLMM8/IPOeee665aw/m
+e++9F3L0DGmNzH01dgn9l+Sb7KM8ZcuXLy8uLq7pa1sWkQVlcVlJUyxBQ14w
+gU+cO/Teq0IJAkkrSX7owfzwRGOPIiYZWzP4Cb+4T7RnN9Oq1POg4khziTtP
+YmuOO1uNVgugrjRYCZ500knSOO7F3377bQmWu+++u7I6Xrp27WofXbNmjTlb
+F7LOWCXYuXNnOyU7O1ti7YwzzjB3x48fLzM8/fTTdoacnByZcumllwZuon37
+9m3btnVPuemmm2R+SQy5PWbMGLkt/6tuH921a1eNzgn69evXT2ZYvXp1rH18
+4YUXZMpjjz3mXurnP/9569atzZlNczC7d+8eaxNu7rOBSViCktgbNmxYsmTJ
+nj17avralkVkQVncnBZs7L2JyvN0yBMU+MRRgkAT0vA/U25+cNAz0fwGfUMO
+I5bANJaxJXOoRiE7Ffe59uxm4+61DDVlX/6nxj9PlBezORRusXLPrL9u9gdA
+DTVMCebm5kqbnH/++e6J8i5XJvbo0aOyOl7++te/umeQtDnnnHNCVhurBHv1
+6uWe7YQTTpAONbcHDBhgztn91MVcXelfv6k2/8zi+eefr6yuwg8++MC91BVX
+XFGjEkxNTR06dOiFF174s5/9zFSkXTxwH2+++Wb/Rm+44QaZuHjxYnswb7nl
+lpBD5z5iyV+Csl+JlaAs2LxLsDQeShBIBg1fguYX5/0Tk+Qtd+ABaR4lGPcn
+6T272bg/YW9eJ/bMnYkyz/A8T5aZEnfM7qi0LemewWzRvCaT5GUJKNQwJZiV
+lSVtctFFF7knmpNx5jxgYLy0adMmsRL0fHeouwRNMXXu3Lm3S/v27fv16+df
+v2lV4Z5ZYlB2RP5nza5t4cKF7qWuvfba6CUoB/+www4zn23s2bOnuYY2vARv
+vPFGmbJo0SL3Rv/yl7/IRHNtbY1KMMmvDrXnBBO7OrQZnBMMvzqUEgSaBErQ
+o7mWYBRJtZv+oPO8SAJfM3F3wd+P5hShe3OeU42J7wOAWmiwq0Pbtm3brl07
+95Q5c+ZIsAwePLiyAUvwySeflBkmTJgQcdjHHHPMKaecEuvRUaNGydqee+45
+98QzzzzTptz7778vt/v3728f/fzzz90l+Oc//9lzqWevXr3CS/Dpp5+WKZ4v
+RP2f//mfli1byhNUWcMSTPJvjDGfE5RXaVZWVk1f27KILNh0PycY5RtjKEGg
+luwpCXvZm/vNqjlnYU9euD/h5T6dYRYMaT1/+JiP7AVebmcesidoYl2P53nU
+nX52zSOrmZ0y0/0jj3uUPNsKPETuPQpZp3vrdnj2KJlVudfjSZUEBu9+Bt1L
+eSb6z3OFb8s+4/a1YVcYcnWl/6Sb52OD/hekp6civjYS/mhqxBIMP/I16sfk
++Q8UgEINVoI9evRw90tFRUWXLl1kyqRJkyoTLUFzVvHkk0+2U+KWoOyszPCL
+X/yiqKjITJFGuOyyy+66667ATZiv7jSDNB555JFLLrnElNr8+fPl0VNPPbWg
+oMA8KnO6T+rJG/sWVV+XahcfOnSouwRlVXJ31qxZ5q5kizlFaEvQv4+LFy+W
+Kaeffrrpvsqq3txvv/3sZyFrVIJJTjpIciY3NzexEpQFZXF+RcK/OCUIGObd
+6fRqniJwf9bJnS12ul021rtcuxX/9XX2Lb3ncjv7qG1Pf6fYeTwjt4+ad9f2
+UTPdnWD+pWLxjDb8EMU9Gu5LED3Di7sesy3bXHEPe/hqa7kt+wTZtZk5Yz3X
+7mcq5HOCNXpB2nk8XWaf/fAj4+dfm3/AgVv0CHxeAs9TO5Qg0KgarATXrl17
+xBFHtG7dunfv3nfcccfZZ58ttdKzZ0+zwsRKUBx++OGy4O9+97tnnnmmMkIJ
+VlafhuvYsePtt98+ePDgo48+OuQs4Zo1a2QTMpKrrrrqvvvukw3JzNJc9if/
+rrnmGtNlgwYNuvrqqw866KADDzzQnXLmhyo6dep09913y8BkVe4SfPzxx+Xu
+iSeeeOeddw4cOPCYY44xM9jF/ftYWf35xA4dOshGr7vuukMOOUSWsp8cbGYl
+KIdaXngS7Hl5edFf2DKzLCIL8nuClCAQneedvDsH3LN52s3OHGu17nXGeutu
+3yT7Z7DDCBykXYPnVE7gW3HPsP3X7HkEjtY/GM+24r63D0wJf/B6Bjzd99Ui
+ccfvBFWJ3VBtthVYW56nJu7RCxxeyAoDn3r/Gsx/Cohegu6zn/6DaYPU/V8Y
+wlcYqwQDXxWUINCIGvKX5RcsWNC1a1dpJemU4447rm/fvvbEnAxDJtofUzAk
+qX75y1+Gr3PSpElt27Y1p/nk7pYtW+S2FJl7nnbt2rVv397eraiouPXWW6UN
+zck7eXTcuHEhm5g3b16XLl1M3+23335SsvYXKERxcbG0mESuPLr//vub/7V0
+p9y6devszxoee+yxEydObOH6qlIzGHNMZOX9+/c3i9vvDvXvo1lKGvDkk0+W
+iQcccMCvfvWrKVOm2PkDD2YTJREnO1tSUpKdnZ2RkVFWVhblVS2zycyyiCwo
+i1OC/sUpQcDN840Z4W+8nZp/7s9fB54Z3G+GAzPT/dY6cIboJeieEve7LkNG
+awYQJUv9Yh1Vf9G49zSx5yLi8Gq6rcAjHFiC4bsZGE01ekHWvqTsBa6BMWjH
+YE9HUoJAs9GQJWjIO9WNGzfWciUekmOl1T/AF50E3bZt2yLOLE2Rmpoa6wfo
+JTfWr18v81RWf3mL+6ReZdW3p8pey2yBi8tRlZUXFhaGDCBwHzdv3hy+VDNg
+TwtmZmamp6fLQQh/ScsMMpvM3IxPCFZSgkAdmb7v5/U8pzwC33jHrSc/T0Gk
+xGCHFBh69q114DvneirBuNEUuIbAAnJLoATTfL9KEDFMEijBkG25n4W4JRgY
+ROElmMALsm5LyrM2z6sx4mlBShBoKhq+BJu9wBJEwiTl5FUngZOfn5+RkSHF
+nZ2dHev1LA/JDDKbzCyLyIJ6SjCEf3FKEHD2/QScndgAJTjS9b39bu5RUYKx
+NhRy6CJuK/pOhWyrPkowsRdk3ZZUlHOjUc75xt3x6GsDUH8owTpHCdY5G4MF
+BQWZmZlr165dt27d5s2bi4qKdleRG3JXJspDMoPM1rwzsJISBOpC4FvQiCUY
+8tkuvxTfOcGQmSOWYMNcHZpsJVijwx5rWxF3KnxbUUow1gssVgkm9oKsjxKc
+Xv21qDU6uxc+Q6xXGiUINCJKsM5t2bJl1apVsa4jRWJsDMqLMCcnJyMjQ7pv
+xYoVS6vIDbkrE+UhmaHZZ2DtUYKAE6GMYoVS4HvXkDNTUdYZ/Zyg//25vZox
+fIQJlGDgDO5tJVyCUc4ZeQ5FYsmQQAk6MXLbs5KIJZgW+yOfTrwSjPKCDFxq
+eqI/WO957mI9U+55/Jvzv4YDvzwn1vgBNBhKEE2FicHy8vKSkhJ5Kebl5Un3
+ba8iN+SuTJSHZAYyMC5KEHBc707NVX/281lRqi2l+mv87bIhp5A8K7GftLIX
+HLrfDMctQbuGlOofm0ipFmvX0ly/J+jfkfArXT2jjfLJtbgl6FmnPUrhJWiD
+13Po6uMbY+JuK0oJelbiftbcw/NcHVrTF6R/d6J8lM+9tlhPruMruCjz2P1y
+74vn9em4vhXH9rL7xQCgYVCCaFoqKipMD5aVlZW4yF3TgLG+lgdulCBguL8R
+0Xw+K0oJeha0VRhrK7Fayb24JwfCS9Cp/u4Ow9OS/k3UpgT9o3XPn1gJ2jRw
+B0LcErR77Tl04fmQWAk61b8dH2tbUUrQCTp0ISXoJPSCrE0JeoYXuFTceQJL
+0PMU+58m/2r9LwAA9Y0SRBNlktAiAGuEEgSsWp6MqP2ydXIeJNZJyTo8yVLn
+p2wa67A3/LZqtIaGPzsWZYuJjYozfUCSowQBhShBoEkLPL0S9xwQAABulCCg
+ECUINGnm8j97dSiX1QEAEkAJAgpRgkCTZj7C5v6cYGOPCADQ9FCCgEKUIAAA
+gHKUIKAQJQgAAKAcJQgoRAkCAAAoRwkCClGCAAAAylGCgEKUIAAAgHKUIKAQ
+JQgAAKAcJYhmb1e1ioqKnVXKXMwUecjO1tjjbQiUIAAAgHKUIJo3dwOWlpYW
+Fhbm5+fv2LEjp4rckLsyUR5y92Bjj7reUYKAUSc/xldPP+dnfjGw/n4rMK1a
+Leepq6UAAA2MEkQzZjOwrKxMck+6Ly8vT17GMnFvFbkhd2WiPCQzyGxKYpAS
+BIyUlBQJrogzS9r400zuulcSOE9iZJ2y5nrqKRlkiov/IJj9cosykrhLmZ2q
+0WEHANSTJlqCMpJBgwa99NJLjT2QmtmyZUufPn3Ch/3GG2/Irm3fvj3i/IjF
+ZmBpaak5D1hSUhLrH4I8ZM4PyswaYpASBIyalqA/beSurMFO9IRhbdRfCZoM
+NGs24/ePWabYpLX5FnfN4UtNr2LHwElDAGhcTaIEZaOzZ89euXKlnbJ58+YW
+LVpceeWVDT+Y2njhhRdk2GeccUbIPP3795d51qxZE3F+xGLPBpoMlNvh/xZk
+BhOD9sxgY+9BPaIEAaP2JRg4TzKXYGD3mTYMmSfKvsddihIEgKTSJEpw69at
+EkTdunWzU5poCUpl3HPPPbNmzQqZx12CUeZHIHNSr7y8XF60UTLQMDEoi8iC
+SX5a8N1oZlTxL04JAoanXPzXTLorxjw6sppZ0H05qJ3HzuafxzIzu6eY2ezW
+3WfuAmfw92aUjxaaXvNM9CSbJwztsfIM2CPuUvY4mM2FrAoA0AAowWTjLkEk
+zF4Xmp2dHXJRqJ/MLIvYa0Qbez9iogSBOuHpKZMt06u5P+lmr6K0M9jpdiXh
+83gCLfA0XKyt25XYkrLz+9cZfkYysNc8pzIDo8+0bfjBjLuUaVVOCAJAMqin
+EpT/hb/55ps7d+783e9+94ILLnj00Uftm+q1a9d26NDhgQceePjhh2WGNm3a
+dOzY8cUXX4y1qvvuu+9HP/qRxNHBBx8sC5r6syU4evTos84666CDDjr77LPH
+jBnjWXb8+PE9e/b83ve+95Of/GTw4MHyDj9kzDJgWf8nn3zyv//7v9/5zndO
+OukkWWF5efnQoUPbtWsnWz/33HPnzp0bcf12N++44w5ZVatWrWRienq6TBw2
+bJidTQ7LI488Ims+8MADzXFwl6B//pycnBtvvFEOiBw3OXoDBw6UEXp2QZ7T
+Hj16fP/73z/66KOvuOIKOVYhe91cmROCBQUFcsRq+o9CFpEFzWnBxt6PmPzR
+V1rN/5B/cUoQMMK7yVNwsT4nmLLvN8b41xmlBP0fxPNcHeo/l+dfremsKCUY
+vhexmi78RF5iSwEAGkt9lKC8kT7ttNMkZ0455ZTu3bsfeuihcluaxTy6bNky
+uXvCCSdI+3Tt2lXmaVFl9uzZgWt77rnnZCUyg3TN73//ewmryuoS/MEPftC6
+devzzjtPmsis5I033nAvKFMk07p162a2InOWlZXFGvYll1wi8xx//PGytosu
+ukjWLHcvvPBCGaes4ZxzzpG7hxxyyLZt26Ks3+ymjLlly5aSeF26dKmsykOZ
++Kc//cludPjw4TJFSlby8/TTT5fbP/zhD20JeuaXg3/qqafKlE6dOkmBSut5
+ToyaXZBje/LJJ8vIpRbl7m9+85uQJ0tiZ8eOHXI8M6ttavo2VpGOXrVqlTxf
+Nf1HIYvIgrK4WU8DD94+EfKkyFMTq0YpQaBOBJag/REEzym2+ivBwM/ueUow
+cKgJfCbRfr2nOWUZuKeUIABoUB8l2KdPHwmQIUOGmLsFBQWmX2bOnFlZnUgS
+Kfb82rBhw2TKtddeG2uFsa4Olch66623zJSnnnrKnUWpqamtWrWSrMvKyjJT
++vbtKzM89NBDsbZiMkoGb+6+8sorZhNz5swxU/74xz/KlClTpkRZv93N9957
+z27CU3aSG7L+I444IiMjw0wxYRirBBcuXHjmmWcOGDDA3JX3/EcddZRsQm64
+d+Hiiy+uqKiQu7m5ubJymSL/Xz7WXktrZO6rgcOnPki+ySGV52j58uXFxcU1
+/Uchi8iCsrispBFL0MjLywt84tyh914VShBIgKek7DWZ7k/qNVgJBv7ggvv6
+0kAJfDuNf22UIAAoVB8leNJJJ0mhuOd8++23pUfuvvvuyupE6tq1q31Uqsec
+UIu1wlgl2LlzZzslOztbqsp+zeb48eNlhqefftrOkJOTI1MuvfTSWFsxGbV0
+6VJzt6SkxJx9szOYdcr/U4uyfrOb3bt3d2/CU3ZjxoyxKzR27dp14oknxipB
+v379+skMq1evdu+C+xLWK664QqaEfOeM+2xgcyrB9PT0DRs2LFmyZM+ePTX9
+RyGLyIKyuDkt2MCD9zwdsS7upQSBOuHOH/vJu1g/CdHoJeg+i+eW2L67F/ef
+f/Q3nf/6Vf8MgUuFf7oQANBY6rwEc3NzJT3OP/9890R5QysTe/ToUVmdSH/9
+61/dM7Ru3fqcc86Jtc5YJdirVy/3bCeccIJEqLk9YMAAc3Ltpy5yVxI11lZM
+RrlPwXh2ZPLkyTLlX//6V5T1m9285ZZb3JvwlN1NN90kdz/44AP3PJdddllI
+Caampg4dOvTCCy/82c9+Zj4+Kezva5hdkCa1848YMUKmBLaAPZLNuAQXL16c
+WAnKgk2iBEvjoQSBcO5q85+9qtsSDPnhhsA1+0uw/pLKU3mxvgU0ge+iSeys
+JQCgAdR5CWZlZUl6XHTRRe6J5nyZOQ8YmEht2rRJoAQ93x3qLsEbbrjBnDTs
+7dK+fft+/frF2kqNSjDu+qOUoFnJwoUL3fPITsUqQXmmDjvsMPMByZ49e5qr
+cP0l6N6Ff/zjH+El2FyvDrXnBBO7OjR5zgmGXx1KCQK15ClBT2p5Pr4XpfJC
+5vGs3B1fgTN4ztNFucwybd+fuY8oyq8HBs7j2Zb/zGbg5x8BAEmiPq4Obdu2
+bbt27dxT5syZIz0yePDgyoYqwSeffFJmmDBhQtzRWjUqwbjrj1KCo0aNkrue
+rzzt1KlTrBL885//LHcfe+wxO3OvXr1qWYLN9RtjzOcE5eWdlZVV038Usogs
+2OifE4zyjTGUIFBL/qtD7RWY9pf7An9mwnSQE5R+dik7j+P6fYe0fX8T0C7l
+nsE9j+dSVc81op5vCo3yKxKOK+L83xUTuBd20+4ZAisv7lIAgORRHyXYo0cP
+d+BUVFR06dJFpkyaNKkyoRI0pxRPPvlkOyVuCcpOyQy/+MUvioqKzBR5S3/Z
+ZZfdddddsbZSoxKMu/4oJTh//ny5e9ppp8mBNVNefvnlkG+MMSO0H/qTVDGn
+CGtTgs2VBJR0UG5ubmIlKAvK4vyKBNDseVrG/Y0xJrLCZ3CCStA/j+P7khb7
+G/TuwQRuPc33IxHu9Xh+mC9iCfo35J/HM2D/LwAGlmDcpQAAyaM+SlD65Ygj
+jmjdunXv3r3vuOOOs88+W2KkZ8+eZtkESlAcfvjhstTvfve7Z555pjJCCVZW
+n0Hr2LHj7bffPnjw4KOPPjr8LF6NSjDu+qOUoLjmmmtkSocOHWQNV1999UEH
+HWR+dCOwBB9//HG5e+KJJ955550DBw485phjzO9EUIJ+5vcE5RUrhS4HJPq/
+CJlZFpEF+T1BQKcoX8MS5XtaAueJuObEVl4jNdpQTbdVy6+yAQA0jHr6ZfkF
+CxZ07dpVukYy5Ljjjuvbt689dyZblIn2pxCMAw888Je//GXICidNmtS2bVtz
+Gk7ubtmyRW5LOrnnadeuXfv27e3dioqKW2+9VdrQnGWTR8eNGxeyCfNVLfn5
++XZKi32/4/TNN990X5wZvv7A3Vy3bp1M7N+/v51SXFx83XXXmd96kHb++9//
+bn5Z/vPPP/fPb7Zojup+++0n01NSUlq4vjvUvwv333+/TJkxY0bIjjdLEnFy
+uEpKSrKzszMyMsrKyqL8c5DZZGZZRBaUxSlBAAAANFf1VIKGvCnduHFjDd7d
+xiPdVFr923nRZWVl2Z+Drw+1X79ER2pqasRdk6dAZi4sLKzNFjWwpwUzMzPT
+09Pl8Ib/W5AZZDaZOflPCFZSggAAAKidei1BoBFJysnLVcooPz8/IyNj/fr1
+2dnZsf4hyEMyg8wmM8sismCTK8EQ/sUpQQAAAOUoQTRjNgYLCgoyMzPXrl27
+bt26zZs3FxUV7a4iN+SuTJSHZAaZrUlkYCUlCAAAgNqhBNG82RiUV29OTk5G
+RoZ034oVK5ZWkRtyVybKQzJDU8nA2qMEAQAAlKME0eyZGCwvLy8pKZHXcF5e
+nnTf9ipyQ+7KRHlIZlCSgZWUIAAAgHqUIJSoqKgwPVhWVlbiIndNA8oMjT3G
+hkMJAgAAKEcJQhuThJaqALQoQQAAAOUoQUAhShAAAEA5ShBQiBIEjJEjR6al
+pTXkFtOq1MeaZV+mT59eH2uuQzXd9zSXehoSAKhFCQIKUYKAkZKS0sD1JL0m
+G7VdI1uXKXWyZlltXa0qOtmRlBgCD2z0A26OTPg65W7ItgAA4ShBQCFKEDAa
+PiKmV7F3TezUyZobqwSnB/EcWHNSz+xsjUrQnhC00eeOaLuqhj+3CwDNACUI
+KEQJAkajn05q6iUYyF+C7rN7CR9wc/7RLk4JAkAtUYKAQpQgYIRccGgecveF
+Oatlzk/ZtPF3jT35ZYysEng5qN3WyGpmtsBLRv2x4xmqvwQ9I/HvaT0FVEju
+1aYEPYFpnw5TiAmOFQAUowQBhShBwPCEie2pwMsR3Z+JM1/P4j/5Zdfgvk7S
+c02jzRZblHZmM1vgicIoG3KXoHtf7O74z9PV+SlR/4ZC9iI6032e1DUHkBOC
+AJAYShBQiBIEDM/Vhv5Pt7nzynN1ouHJE/+JObPawBJ0YkRf3BIMrC3PpgOH
+6l6tyag6L8Hw1kugBG0vJ8m1rwDQbFCCgEKUIGD488ozg7ueYpWg+xxfrMtN
+66ME/TN4rjv1zGDGX6+nzwK365ZwCdbTGUwA0IwSBBSiBAHDHReB/eXuuIgl
+GPhpvrotwVgz+D+B6JfAL/r5vxrU/W0tnj0Nj7U6/JwgAKCWKEFAIUoQMJpu
+CfovlXSXoP3VQr/wA+Ln/1E/+0lJz5xxTwg6tf6yVq4RBYA6RAkCClGCgBGx
+BM3tuCUYePllI54TbMjvUYl4wo4SBIDkQQkCClGCgOEOk8COi/KNMZ4SdKeK
+/R2HGpWgv+M8m/asM9ZQ/dHkWef0fX8mozbMicIoswWWoH8w/oFxdSgA1C1K
+EFCIEgQMT1nYryUxF1J6vqUkbgk6vp8I9H86z1OCdp3uqzdtx5np/t8utL9n
+4ZnB/ysS9scp7Gz+na39YYzbaHbvUlw/bBG+BnMAPYOPEpsAgIgoQUAhShAw
+/P3i+a6VkBNzhv+knv2uS/fvEnrWH2uLnm8HtX3n37RnnNODflne/70x7hnq
+sATjNlrghw3dx9ZfgoGD53cDAaAOUYKAQpQgEC6xL1cJFOV7VJygiyGjDCPK
+OBP+rpgk0dTHDwBJixIEFKIEgXriCZbA04gAACQDShBQiBIE6on/c4J81yUA
+IDlRgoBClCBQT8wHA92fE2zsEQEAEIwSBBSiBAEAAJSjBAGFKEEAAADlKEFA
+IUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABA
+OUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgS
+BAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4S
+BBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEA
+AJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGF
+KEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADl
+KEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQ
+AABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQ
+UIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAA
+UI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSi
+BAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSj
+BAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEA
+AADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFA
+IUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABA
+OUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgS
+BAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4S
+BBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEA
+AJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGF
+KEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADl
+KEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQ
+AABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQ
+UIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAA
+UI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSi
+BAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSj
+BAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEA
+AADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFA
+IUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABA
+OUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgS
+BAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4S
+BBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEA
+AJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGF
+KEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADl
+KEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQ
+AABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQ
+UIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAA
+UI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSi
+BAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSj
+BAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEA
+AADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFA
+IUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABA
+OUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgS
+BAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4S
+BBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEA
+AJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGF
+KEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADl
+KEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQ
+AABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQ
+UIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAA
+UI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSi
+BAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSj
+BAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEA
+AADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFA
+IUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABA
+OUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgS
+BAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4S
+BBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEA
+AJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGF
+KEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADl
+KEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQ
+AABAOUoQUIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQ
+UIgSBAAAUI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAA
+UI4SBBSiBAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSi
+BAEAAJSjBAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAEAAJSj
+BAGFKEEAAADlKEFAIUoQAABAOUoQUIgSBAAAUI4SBBSiBAGoVbF9jfztyl5r
+/hp7OADQaChBQCFKEECzV5i+ate2NblTh+ZPv6dw5ogdE68tePWGwjf/r+it
+vxa9fXPxO7d++/fuwOIZg4reG1z43uCSecPLPx1blvpe6Yb3yrZRiACaP0oQ
+UIgSBNAslWxclfXy7blvDs19/qrcsb3zJ/QpnHR98ev9S6f8pWzagJ3vDqyY
+OWTX7L9XfjC0cu6wb//mD//yo/sqF4yoXHj/rkX3Vyy6f+fHD5YveqB0wf0l
+Cx8oWTm+NH32zh2pjb1bAFAvKEFAIUoQQHNSumlV5oQh2a8P3fbU5bnP9c4f
+d3XRxL7Fr/6pbPJfdr49YNc7gypn3v7l7Dt3f3j3nnnDv1owYu+iB/Z+8pD8
+fb3k0a+X/uvr5SO//vTfe1eM2rvyia9WPrFn5RNfrni8csXjFZ8+XrbssZKl
+IwsWPlyy8cPG3ksAqGOUIKAQJQigeSjbtHrzS3dkjrxs6xOX546+ouCFq4sm
+9C2Z9KfyyX+tmHpr5TuDd8+8Y8/soV99OPzr+SO+Wfig88kjzpJ/Ossecz4d
+9e3fyiec1U87a5511o52Pn/O+XyMs+55Z/3Yb9a/8PX6sV+tG7v78+e/XPt8
+xWejS1c+XbjsibLNC4sy5jb2TgNA3aAEAYUoQQBN3YasL16eMGXYP8YOf+CF
+6+6bEevvwVGvvTVh7NSXxk19+UVnyUhn+ShnxRPOqqedz5799m+tpN9YZ/04
+J3W8kzbBSX/JyZjoZLzsbHzF/H2T8crXGS9/lT5xd9pLFevHl619oXj1mKLV
+zxdlLmjsAwAAtUUJAgpRggCaIqk/+XtowpKQ9Iv7N/X1V6dOfv3b+vs2AF90
+0l6qSr9JzqZXnczXnaw3nM2TnS1vVv1N+c/f5je/zpr8VebkLze+VpE+qWzD
+xC8+e6Fw7YSCjPmNfUgAIHGUIKAQJQigaal9ALr/ftIlvdv1S+TvwdHTpk6d
+6mRK/VV139a3nG1vO9unOdnTnex3nBz5e/fbv+x3v727/Z2vt03fs+Xtyqwp
+OzdOLkmdVLD2pS828r+lAJoqShBQiBIE0FTUbQOaDGzRwjF//z1ROP2dqe9U
+FV/uDCf3PWfH+06e/M1y8mf/5y9v9rd3d8z6Jvf9vdnv7d727q4t08s2TSlM
+fS13zcTCrcsa+zgBQI1RgoBClCCAJiGkAe97aPyIh19c/tydK8YO2/nG3yqn
+Dtn9zl1fzRz+9Zx/OHMfchb80/n4386SJzfMGjf1tVenvv76g8+8bRa0GSh/
+3a73rn/qjPed/DlOwYfOF3OdQvmbV/U3v+pvnvPFPKdgrpP/4d68D/bkzK7c
+PrN88ztFG6fuWP96cfbKxj5aAFAzlCCgECUIIMltyPoiMACH3z9u4ciBn4wa
+VDCmX/GLKaWv3LTz9b/teuv2L6cP/eq94Xtn3//N3Iedj/7lfDzKWfKUs/xZ
+Z+XzzmfjnLUTnPUvO6mvPvvYgvAS/E8Pvj/HKV7gFC90ShZV/X3837/iRU7R
+QqdwwdcF8/fkz6vM/bB826zirBn5GVO3rnk1Z+MnjX3kACAqShBQiBIEkMze
+mp/ur7N7Rrww7+Fbt4/6Y+5TffKf61s4rn/JxJvKXxtY8ebtX04bumfG8L2z
+7v/mw4ed+f9yFo5yFj/lLBvtrHjeWT3eWfuSs+4VJ/U1J33yvbducJfg1Hfe
+C/tumdlznbIlTvnSqr9lVX9LnbKqv9IlTvHir4s+3vPFwsq8j8pz5hZvnZ23
+8Z3tG97asZkrRQE0DZQgoBAlCCBpeTLwrmHPPzf8H2n/6JX5yJVbH/tjzhN9
+8p7t+8XY/sUTbiqb9Ledk4dUTr1r9zvDv5p5/9dzHv5m3r+cBaOcj59ylo52
+Ph3rrBrvrKnKwA2vO+lvOhvfOv+cL0wDnv/LIvlzcuc4Oz6c+t7sqTPnBMfg
+nI82pC52KlY4FSv3+du5win/1Cldvrdk2Z6ixbsKFpXv+Kh4+9y8zJlbN7xd
+kP1ZYx9FAIiPEgQUogQBJCd3Bv797jHT7khZc9dlqff12vjQlZv/+cfto/rs
+eLpvwZg/FY3/a8nLt5a/PqRiyl2V04btmfGPr2Y9/PWH/3I+GuUsespZPNpZ
+9ryzcrzz2UvO2knO+tedtDedjKlO5nR7NvDewZny5+yY6+TPd75Y4BQucoo/
+mTprXnAPfrDQqVyzz9+uNU7FZ87O1d+Ur9pbumJ38fJdXywpy/u4MHv+js1z
+tqS+k5+9prGPJQDEQQkCClGCAJKQOwNH3TZs2cAeq/9+6frhl6fff0XmI1dv
+faxPzpN985698Yuxfy6eMKB00m07J9+5a+qwL98ZsWfmQ3vn/PObef92Fjzl
+fPKss/R559PxzqqXnDWTnHWvO6lvOulTnU3T5726xJbgvCmr5M/J+8gpWOgU
+fuwUL3ZKljqly53yFVPnLAjuwQ8/cXav/8/fl/K3zqn83Nm19uuda/aUrf6y
+ZGVF0ael+Uu+yFmYu2Xu5rT38rPXNvYRBYAwlCCgECUIINnYDLztjmcn3dRv
+8YAeK4dcunboH1Lvu2LjQ1dv/uc120ddl/vU9flj/q9w/C3FEweVvXbHzin3
+VE67b/eMB7+a9ejeD//9zfwnnUXPOoufd5aNc1a85Kx+xVn7urP+TSdtqpMx
+3cmcce/fNtoSdPIWfPuXv8j54hOnaIlTsswp/dQpX+nsXP3tyb5da6d+8HFA
+DM5d7HyV/u3fnrRv/3anOl+mflO5fm/Fut3la3eVflZetLK4YHlBzifZW+Zn
+pr2/YzsxCCB5UYKAQpQggGRjUmvQkGc/uP6CRX/tvnzQJav//vt1w3qn339V
+5sPXbBl5bfbj/XY8279g7E2FL/6t5JXby94YWvHWvZXTH9j93iNfzR65d+4T
+33z0jPPxGGfJOGf5BGflK85nrzmfT3Y2THXSpzsbZzhZ7987cNN/PiT4qxIn
+b9G3fwWLncKlTvFyp3SFU7bKKf/MqVjj7PrcqVznfLlh6oeL/TH44IvznL2b
+/vP31UZnz0Znd/rXX6Z9tSv1y53rK8rWlhatLiz4NC93ybbNH21Km5P6+ZzG
+PrQAEIwSBBSiBAEkFXNCcOBtz8zs0/WjlIsWD+i5Yshla4b22nDvlRkP/DHr
+0Wu3PtY3+8kbd4z+S8G4W4teuq3k1TvLJw+rmPqPyncf3v3+v76aM2rvvKe+
+WfCc88lYZ+mLzqcvO6teddZMdta95aROc9LfdTbNdLJm//dDgrdtdfIXf/v3
+xVKnaLlTstIprcrAnWudXeucyvXOl6nO7jRnT4a03tR5SwNODs5b7ny92dmb
+9e3fV5nf7Nn01Zcbd+9K31WRWl62rrhoTUHBytycZZuzFqSlzt66eXVjH2AA
+CEAJAgpRggCSh8nAWwc/Pa33b+be2G3hX3osG3jpqjsu//yeK1JHXL3xoT6b
+/3ndtn/3y3k6JW/MzV+MH1T08h0lr91d/uZ9FdMerJzx6O73//3VB0/unf/s
+Nwufdz4Z7yyb6KyY5Kx+w1k7xVn/tpP6rpMx08mc7Wz+8L8lOGSbU7D027/C
+T53/Z+++n9rKGz3P/yU7M/fODbt3587MbuduB2ycc86xbR+ywWCSMTZgGxsw
+Juecc84555wEEggJRZRQRFk6K6CbdvfzzN2p3anGzz2fV30eF7b5wehUdT3v
++h4dbUySimlSNUuq58lNGqldJPV00sDYOuwzMUnzqq31FlcX/koMdo+TVi5p
+4ZDmNauJbTayjPpVnW5Fo2EoVYuyjXmReIrHH2Wu9i3MNyvkwr1+mQEA/ggl
+CEBBKEEA+HLshFX5hf3Nd490PTk56Hpu/PmlGf+rC69u0N/cZn64y/74gBvz
+WJDoLEpzl2Z7bxS8UJS8Vle83az5oGuINLTEGDsSzd2p1v5MciiHHC0gJ0rI
+6XJyroqk1ZH0RnK5hVxtD/Jg/fa4mKpFUjK+NdkkKZ8mlbOkap7U0MjNJVJH
+J/XLpIFJGldJE4s0s0nLGmnl2KKvqnviL2JwgrTySSvPauGZTVyjcU2vZ29q
+V1WaZbmSLpEtCETTa9xR+krvwmLnXr/MAAB/hBIEoCCUIAB8IXYOBEMI37rr
+h9seHO91PDPsfmHC+/JswHVa0E3G2zvMsPvsyIfcWAdBspso3VOa47dRGKgo
+DVFVhmpqI7SNUfrWeGNHsrkn3dKfTQ7nk2NF5GQZOVNJzteSiw0kvZlcaSNX
+O4OesT97XMwYKZnYmmyalM+SynlSTSM1S6SWQepWSL0tA1mkiU2a10gLl7Tw
+tnKPFNhW1T35FzE4RZJCq1VosQhMZr7eyNXq19RalkLNlCoY69IFrnB6lTO2
+sNS9xBje6xcbAOB3UIIAFIQSBIAvhK0EAx97V16ya7x1tPPRqX7ncyMelyZ9
+rs6+vEELus14d5cZ9mAt6jE33lmQ7C7K8JbkvtgofK0oe6uqCtPURWqbYvWt
+icbOVFNPpmUg1zpcSI6VkJMV5Ew1OV9PLjaR9FZypYNkddt9r/j1cTEqUjxB
+Sqe2tjFLyudJJY1UL5EaBqldIXVM0sAijWukiUOabRnIJ622BhSS5Pr2RIts
+5h+fIZPTayVFFqvIZFnXmwRaA0+t5yo22TIVUyRn8CU0tmCazhqZXuhisef3
++vUGAPgNShCAglCCAPCFsJVU4al91VcOt9w70UWcGXC9MOp5ecrv+lzgLVrw
+HUbofWb4Q3aUAzfBTZDiKcr0k+QGyoqCFWWhqqoITV30ZlO8ri3Z0Jlu7M02
+D+RbhovJsTJysoqcqSXnG8jFFpLRTq50kayezx4XIyDFtgyc2drGHCmnkcol
+Us0gNSuklknqWKRhjTRySBOPNPNJi4C0bgUgSYq3JyFJ6SJ7NTSn7/cx2Gcm
+JSarWG8WaU1CtUGg1PFkmjWxclUgY6yJaMucqfmV4eGJFplsfa9fcgCAX6AE
+ASgIJQgAX4LKbsarx74lZw/WXT/a+uBUt8O5QbdLY15Xp/xuzAXeXgy5ywh9
+wIx4xI524ia4C1K917NeiPNey4reyss+KKsj1XUxm02JurZUfWemsTfXNFBo
+GS6xjlWQk9XkTD0530QutpKMDnKlm2T1fVaCQlI8TUrntraxQMoXSSWdVC+T
+GiapZZG6NdLAIY080sQnzULSsk5aRbsNSJIyktzYWWhO/x9i0GiV6S1SrVms
+NoqUeuGGlidWrwnkqxwJgylYWGRNTC8NTs3jv70A8KVACQJQEEoQAL4ECYHv
+807uq7h4uOHW8baHZ3qcLgy6Xx57fm3K/+bcqzu0kHvbJUiwY1y5ic/4qb7r
+WS/FecHS4tCN8nBFdZSqPk7TlKxtS9d1Zht6840DRebhMstYpXWylpxpIOdb
+yMV2kt5FrvR2Fc3/9riYimVSNEtK5rcmWyTldFK5TKqZpIZFatdIHYc08Eij
+gDQJSfM6aRGT1s8bUL49xfaUf4jBdzn9euuG1ixTmyRKg2hDJ5Ro+ELlGle2
+uiqi07lzsytjIzPdYrFgr194AIAtKEEACkIJAsCX4NVjv8JTB6qvHG28fbL9
+0dle54uD7lfGnl+f8r819+ouLeQ+PfTnlY+OrJinnEQvXpq/MOuVKP+NpPi9
+rPyjvDpaWZ+gbkrZbMvQduboewsMAyWm4QrzWLVlsp6caSLnW8nFDpLeTa70
+Bblzf3tcjHCGFM2REtrWZEuknEEqV0jVKqlhk1oOqeORej5pFJImEWkWkxYJ
+aZX+2oC/BCBJqnZX1T3/eQyWdc9tWuRq04bCKN3QiSWbQqGKz5OvscRMhmBp
+nj0zRhuaWhjd6xceAGALShCAglCCALDnOjJSsk/sLzl7qObasaa7pzsen+91
+vjTofnXs+Y0p/9uzr+7RQh7Q3z9e+ejMivFYS/Tmpb0QZAWt57+VFIfJyj/J
+q2MVdUmqpjRNW9ZmZ56up0g/UGocrjSN1ZonG6wzzeRcG0nrIum95HL/70tw
+lhQtkJLFrcnopHyZVKySKhapWSM3uaSOT+qFpGGdNIpJs4S0yEjrBmmV/74B
+1SSp2V1ozsDnMVjaNac2KxTGDZleKtaKhWohT8FjSdnL68s0Lm2SMTE0OyDC
+sSAAfAFQggAUhBIEgD03lpued/Jg6Tn72usnmu+d7Xh8odf58qDHtTHvm5P+
+d2wluBDycOk9sfzRdTXmGTvRl5v2kp8VLMwLFRdHSMujNqri5XXJyqZ0dWu2
+pjNf21Os6y83DFUZR+tME43m6RbLXIeV1k0u9ZHLg3bfqX55cOgPGlIwR67T
+SPHS1qQMcoNJKlikao1Uc8lNHqkVkPp10iAmjRLSJCPNG6RFTlp3M3C3ATe3
+p7WSWjOpfff7GCzumlcYFTKDXKyVCjVinlLI3uAui1g0HmN6dW5ofmRsDseC
+ALD3UIIAFIQSBIC9NZCVknZsX/5Ju7ILR+tunmq+f67jycVe5yuDHtdHvW9N
++N+ZCbw/H/Lz4ntHxsenzBgvVqIfJ+0VLytEkPdeVPRRUhYjrUrYqEtRNGao
+WnPUHQWbPSXa/gr9ULVhtN440WSabjPPdVoWeqxL/SRj6LfHxXiKSME8ub5I
+iulbky6TG6uknE0qOaSaR2oEpFZI6kSkXkIapKRpgzTLSYuCtCpJq/rXDNwK
+wO3prKTOQupMpM5I6t7lDH4eg2NMrtSgEOvkwk0pVyVibwhWJJxFAXOGvTi6
+NNU13rMuEu71RQAAqkMJAlAQShAA9tZwTlrm8YP5Jw+XXzxWe/P0dgle6nG5
+OuBxY+T57Qn/u9OBD+ZCHtPeO9E/uq/EeLMSX6ylvuZmveXnhQmLIkVlsZKq
+RFltqrwxS9Gap+oo1HSXbvZVagdr9CMNhvFm41S7abbLvNBrWRywMoZ/V4L8
+BVK4RIoYW5OskDIWKV8jFVxSxSc1QnJzndSKSb2UNMhIo5w0KUizkrSoSauG
+tG7+moG67QzUW0i9mdQbSb2B1M+whX/4nEGpQSXSKQWbG1yVhCVfX5HyF4Xs
+mTXG2PJ8z/TI0AyOBQFgj6EEASgIJQgAeyvx6L6s43YFp+zLL52ovXmm6f75
+9ieXe5yvDbjfGH5+e9z/3lTgg9mQJwvvXZY+eizH+DATA9ipQZzMd7zccEFh
+1HppnLgySVqbttGQLW/JV7YXqbrKNH1Vm4O12pFG3XiLYbLDONNtmu8zLw52
+5C3+9uDQUhbJo5ECOrm+vDUxk5SyyA0OqeCRSgGpFpIaEamVkDoZqd8gDQrS
+qCRNKtKsJi2bpFW7tV8a0GAmDSbSYCSNBtKoJ41a0jDFXv+8BIOzBtZ1Kv6m
+gqOSseTiZalwcZ07w10dYy72L0w1D3Xv9UUAAKpDCQJQEEoQAPZQb2ZKytED
+WScOFZ4+Wn7pZM3Ns033L9hKsNv5Wr/7zWGvO2N+9yZfPpgJJuZDXRcjPBnR
+visJL1kpwWuZodzcCH5htLA0XlSRLK5JlzZkbzTny9uLlV3lqt5qzUDd5nCT
+dqxVN9mhn+4xzPUbaUOvXPm7JWhdm7fyFrdLcGVr4lVSwiZlHFLOIxUCUrVO
+qsXkppTUykidfLsEVaRJTZo1pHmTtGitVp3VupuBxu0MNOlJk440bZJGjdVY
+3LX4eQzmtS/wNlUctXxVIV2Wimjr/Fkee3yVMbA41z4+JJJK9vpSAACloQQB
+KAglCAB7qOSZc8rRg1knDhecPlr2SwlebHt8pcvpet/Tm0Ned0Z970+8/Hk6
+2HEu1I0W4bUU7bccH8hMCWFlvOfkfOQVRPNLEoQVKaLqDEl9jrSpYKOtRN5Z
+oeypUfXXq4eaNKNt2olO3XSPfrbfsDAU+FkJmtcWLNwlC59hFTK3JmKR4jVS
+yiU3+KRCSCpFpFpCaqTk5gapU5B6JWlQbxWeadNq1lrMOotFb7YYTFajbUbS
+tJOBWlslWs22b1JZTUqLKST7d28Y7F3iramUq4oNhkxCEwlneNxxFnNgidYx
+PdEzgRtEAWAvoQQBKAglCAB7KNZ+X8pRu+wT9gWnj5VdOlV981zDvYutj690
+Ol3vfXprwPPOiM/98YBHU0FOs6Hu8+HPF6P86XGvVpLfrKZ/YGdHcvJjeMWJ
+gvLU9epMUV2upLFQ2lq60VEp765R9DWoBpvVI+2a8a7NqV7tzIBufvilyy8l
+ePA7jYlNM3GWzLxls4Bpm2WdZRFxLBKeVSawytetCrFVJbGqZVaN3KpVWHUq
+i15tMWxajFqzSWc26U1mg8liNFqMBotJbzXrbH1o3clAs8piVlrMcrN5w2T6
+vARfZw6wVSqmQkGXyRZEohk+f5zNHqDTO2ama/t7BaL1vb4aAEBdKEEACkIJ
+AsBeYU2Ox9jvTzl6KOvEkfzTx0svna6+cb7+3qWWR1c7HG/0uN3qf3Z3yPv+
+2IvHk0HO0+885sK9aZ9eLMW9ZiS9ZaaFsbIi2XmxnKJEXlmaoCprvTZP1Fgk
+aSmVtldudNXKexsUAy3K4XbVWJd6slczPbA5N3zgm18+QiLwqdjAohnX6Ebu
+som/ujUh27TOMYt5ZqnAvLFulovNSqlZtWFWy82bSrNWZdZpzPpNk0FrMuqN
+RoPRZDSYjXpbE5rNOotZa7FsWiwai0VlsSjNFrnZsmEyS03moRXx5zHYReMt
+y5VL0o15kWSaLxhjcwYYK52zcw3DI0KJeK8vCABQF0oQgIJQggCwV/qy0mPt
+D6QeO5x5/GjeKVsJnqm6fr7u7qXmn6+2O97ocr3d53F38Pn9kRePx1+7TL31
+mA3zno8MoMUG0RPfLaeGMTM/sXJj1wqTuKVpvMosQU3eekORqLlM0lYl7ayV
+9TRu9LcohjqUo92qiT711KBmdmT31tCXT8U65qKeRTdwVgy81a3x2UYhxyji
+GyVCk1Rk2pCY5FKTcsOkUpjUSuOm2qjVGHVao15nMOgNtv8ZjTqTSWcya03m
+TbNFY7aozVaV2ao0W+Vm64bJKjVZJEaLyGAOyhr6PAYZctWiVD4nkk7x10fZ
+3IHl1c45WuPoeMvg4F5fEACgLpQgAAWhBAFgr1R4ecTaH0w5ar9dgidKLp6p
+uH6+9s6lxodXWx1udLrc7nG/2+91f9j/ydgrl4k3z6Y/+Mx+DFiICV5MeEdP
+CV/O+MTMiWMVJK2VpHPLs3nV+YK6YmFTmai1StxRJ+lulPW1bgx2yEe6FWN9
+yslB1cxvJRjgJtauLGpXGTr2io6zapuet6YXcPXrfINYaJCIDDKJYUNmUMgN
+SoVBpTKo1XrNpl6r1Wtt/+HU6/QGrcGoNZg2jWaN0aI2WVQmq9JkVZiscpN1
+w2iVGq0Sg1VksAj15j7G744F05vnaRLF7Lpski8eYfP7l1mdC/T60cmuiem9
+viAAQF0oQQAKQgkCwJ7QCYbD7PbF2tslH7XPOH4s99TJogtnyq+dr7l9ueHh
+tZYnN9qdb3c/vdvn9WDQjxgJdB0PeTb53mcm4uVcdPBCfOhScjgjPWolO241
+P5lVnL5Wls2tyufVFgsayoUtVevtdeKuJklvq3SgQzbUvTHaL58Yqk/77SMk
+GvPYmuVFDZOxyVrZXGPZpuWuaflcrZCvWxfqxCKdRKKTyXQbcp1CoVOqdCqN
+Tr2p1Wi1Wzlo2NQZN/Umjd6sNphVBovKYFUarQojKTeSMiMpNZASAynSW4V6
+q0Bn4WnN2W1Ln8dg0zRnZn1jgicZZgn6GGudC8v1YzPlPYO212SvLwsAUBRK
+EICCUIIAsCdoDQlhdvtj7Q8lHT2SfuxY9smThefPlF29UHXrct39a02Pb7Q5
+3u50u9vr+bDf12HopetosOf4O9+p8JczUcHzcaG0pIiltChGVvxKXjKzMJ1V
+mr1Wkc+pKebVl/ObqoWtdesdTaLuVnFfp2SwRzrSLxsbqvusBJWLCyrGknqF
+oV5latisrXHWNFzuJp+/KVzfFIk3xZJNqWxTJt/cUG4qVJtKzaZqc1Nt+39B
+es2mQa01qrUmlc6s1FmUeotCb5XrrRt6UqYnpXpSrLdlICnUkQKdlae1cDYt
+bLX5VcZvzxENSOufEsrHuNIhlrCXwWmfX6kfmyvtHpqp89/rywIAFIUSBKAg
+lCAA/PnkEzGVrv8aZncg+vChxCNH0o4dzzp+Mv/cmZIrFypvXa69d63h0Y0W
+h9vtrne7nz3s83EYCHAbfu059tZ3IixwOjJ4NiZ0PjGClhq9lBnPyEleKchg
+luSwyvPZVcWcunJuYzW/pU7Q3iTsal3v7RQN9IiH+iWjQz7Ebx8hIactKJaW
+lAyGcoWpWmVtjb2m4nDVPIGav64WitUiqVosU0vlaplSvaFSyzVq5aZapVOp
+9Cq1QakxKjdNik2zQmuRa60bOqtMR0p1pERHinXkuo4Uakm+luRtWjkaK1tt
+WVWZOxZ+d49o7cTaKEc6uLreTee2zTHrxxdKe0amck7iWBAA9gRKEICCUIIA
+8OfbLsH/GmZ3MOrw4YQjR1OPHc88fjL3zJmiSxfKb1yuvnut/uGNJuJ2m/Pd
+TveHPc8d+v3dBl95jrzxG3sfOPkxZDo6dDY+Yj45mpYev5SdzMjLWC7KYZYV
+sCpL2DXla/XV3OZ6XlsTv7NV0N0p7OtZH+wXDQ95f1aCsvmFjcUlOZ0hX2Yq
+mKytsdYUbJ6SI1Dy1pUCsVIoVYpkSrFcKVEqZSrlhkYp31QqdAqlXqEyyNVG
+udq0oTFvbFpkm1bpplWiJcVaUqQl17WkcJPkb9oykORoSLbaylJZVpRmhsIU
+mP7bseCL1P7hNVn/qqiLzmuZW60bXyzpHmsveLrecHuvLw4AUBFKEICCUIIA
+8Odjp/9DwuWvPxw8+OnQ4Xj7o8lHj6cfO5lz+kzhxQul1y5X3r5a++BGw+Nb
+LU53258+7PJy6PVz6w/0HArxGwkNHA8PmfwUOh0XMZsUPZ8WT8tMXsrNoBfk
+LJcUMMtLVqvLWXXVa431nJYmbnsrr6uT39Mj6O8XDg39+H//8hESP32tkcwt
+SBeWZIsMGZ25sczaGnNtg8WVrwnknHU5TywXSOVCmVwkl4uVcolKLtXIZZvy
+Dd2GXL+hMMiURpnKJFWZpWqLRG0Va6wiDbmuIYUaUqAh+RqSqyE5apKtIldV
+VqbSsqwwL22YmmdFnx8Llg+zelfEnUv85llWzdhiSe9kWVmi7ZXZ64sDAFSE
+EgSgIJQgAPzJ5BMxtt6Jv/x16MGDkYfs4+yPJR09kXbsVNapM/kXLhRfvVR+
+62r1vRv1j241OdxtdX3Y8cyhy8etN8BzIMhv6G3gaFjIeGToZEzEdEL0bEr8
+fEYyLTtjMT+HXlTAKCteqSxn1lSz6uvYTU1rra2cjk5udw+vr58/8FsJejuK
+RDML4rklMY0hWWJKGCzbpCtrUiZXxhLI1tZlHLGMJ5XxZTKhXLaulIlUMolG
+Jt2UynTSDb1UbpDIjRKFSaw0i5QWkcq6rrIKVaRATfLVJE9FclXkmopkK8lV
+JbmisC7LLfQNM01mmpcYA9J+Oxb0S+nrWRa3L/IbZ1jVo/SiHlsJJtleGdwg
+CgB/PpQgAAWhBAHgT7ZTggmXv3l34ODHQ/Yxh48lHDmRcvRU5skzuefOF16+
+VHrjauXdG7UPbzUQd5qdH7Z5OHR6u3W/8Ox75TfwJnDoffBoROh4dMRkfPR0
+UvxsWvJcVvpCbvZiYf5SSTGjvHy5qnqlrm61sYnV0spu61jr7OH09HP7hnZv
+DfVyEAmnF9Znl9bnGSLaimiJZZuYsSZe4YqZfAlLKFkTSTgSCU8m4cslAqVk
+XSURaSRbT5HRiaV6scwg2jCK5KZ1uVmosAgVVoHCyleSPCXJVZIc5VYDshTk
+qoJckZOMDeuSzLIoNc9LTLMiY92k8PNjwU66uHWBXz/FrhyhF3ZPlZYl214Z
+2+uz15cIACgHJQhAQShBAPiTrTfc3i7Bb98csAu3s486fCzO/kTS0VNpx89k
+nzmff/FS8bWr5bevVz24Vfv4TqPTw5anDm1ebp1+nt0vffuCXw68Cx4KDx39
+FDEeGzWZGD+VkjyTkT6Xnb2Qn08rKl4qK6dXVjFq6lbqm5hNrautHaz2bnZX
+31rvbyXoSYj4kwuC6UXBLEM4vyKksWxbX1pbZ3DXV/jrTKGIJRKxJSKOTMSV
+i/gKkUAlEqrX1zfXRdp1sV4oMQilRoHMJJCZ+RsWnm1yK1du5cjJNTnJkpOr
+cpIpJ5c3SIbMloFWmtQyLzHPikzT68YJgf7zEizoZTbP8esm2eVDS/ld08Wl
+WyWItwoCwJ8PJQhAQShBAPiT2WLHtgqX/x6y3y7Mzv7ToWOx9icSj5xKOXom
+49T53AsXC69cKb15veLezeqfb9c5PGx0dWh55tbu49kZ4Nvz+mXfm+CBD6FD
+HyNGoqPG4uMmkpKn0tJnsrJnc/PnC4oXSsoWy6uWqurotY3LDa0rzR3Mtu7V
+jj5W9+BuCZYmM7nj89zJRd40nTe7wp9f3RqNLVjiChh8wYpQwBQJWBIhWybk
+bAi5CgFPJeCrBYJNwbpWsK7ji/R8sZEnMfGkJq7UzJFZ1mRWtszKkllXZSRT
+Rq7IyGUZSZeSS1IrTWKdF1tmRebpddOkwDDG0/unDOyWoHdib+Msv2aCXTKw
+lNMxVVSSvPPi7PUlAgDKQQkCUBBKEAD+ZDuxE3vp26B9du8PHvl46Fj04RPx
+9qeSjp5JO3Eu69zFvMtXim5cL7tzs/LB7ZonD+qdiSYP19bnnu3+vp2BL3uC
+g/tC3w2Ehw99ihqJjRtLSJpISZvMyJ7Ozp/JL5orKpsvraJV1C5WNy7VtdAb
+2xkt3cttfQVR87slWJzIZI/Or40vcibpnOll7uzq1ubZXBqHt8TjMQS85XUe
+U8xblfLYG7w1BY+j5HHVPL6GJ9ByhTquUM9ZN3BExjWxaU1sZkssLIllVWJl
+SqwrEuuyhGRIyCWJdVFsXRBb50WW2XXztNCWgcYxnmGEoysf5n9+LFg3za8c
+Yxf1LWW3TbcWeKEEAWBPoAQBKAglCAB/sp3YGXjzL6/22b07YB9ud+zToROx
+9qcSjpxJPnYu4/TFnIuXC65eK751o+ze7apHD2odiXo31ybPZ62+Pu0BAZ1B
+QT1v3/V9CB/4+GkoOnY4Lmk0KW08LWsyM28qp2imoGy2uHKurHahsoFW07JY
+377U1EVv6c2P/K0EmYMzq8NzrFEaa5zOnlxmTzNtW5tlr81z1mi8tSUBh77O
+WRZzVqScVRmHJeewlZw11RpXs8bbXONr2Xw9W2BgCY2sddPquokpMjNFlhWR
+ZVlkZYisdJF1UWSliawL69a5dcuM0DIlME/wTWM84whHP8jW9a1ufl6C6W1L
+5SOsgt6ljJaplnxPlCAA7AmUIAAFoQQB4E+2EzvbbxX84c1++/cHj308dCL6
+8Kk4+zOJR86mnryQdf5y7uWrhTdulNy5Vf7wfhXxpNbFpcHDo+m5d6t/QPur
+oM6Qd92hYb3hn/o/xQ7GJA4npI6mZI2l505kFU7mlU4XVs6U1MyWN8xVNS/U
+ttEauhabel3vcnZLcLl/emVwbmV4gTm6xBxnrE4ytzbNYs2usea5LBqftShk
+0UUshoS1ImMx5axVBYulYrHVLM7mKke7ytWt8vRMvmFFYFwRmJYFZobQTBda
+loSWRaGFJrQsCC1zQsuswDItsEzxzRM80xjXOLJmGGTr+1e1PSsan6T+3RL0
+jO8pGVzN615MbZzYfWX2+hIBAOWgBAEoCCUIAH+y3d6Jv/xD8H77dweOhdud
++HToVMzhM/FHziYfP59+9lLWxat5V68X3rpVev9+xeMnVU7OtU/dGzy9m3xf
+tAS8bg962/n2Q/eHyN6PMX1RiQNxqUNJmSOpuaMZhePZJRP5FZNFNdOl9TMV
+TbPVbXO1nfMNPS53fivBpZ5pev8sY3CBMby4PMpYHl+xbWVydWV6bWWWy5zj
+MxeEzEURc0nCpEuZyxvMFQWTqWSuqldYmhX25sqadpmjW+bqGVwDnWek80xL
+fNMi30zjmxf4lnm+ZZZvmeFZpnjmSa55nGsa5ZiG2cZBlqF/VdezstnJUOf3
+cnZL8Flcd2E/M7tzsa3YDyUIAHsFJQhAQShBAPiT7Tw71LbBt//nq332bw4c
+/XDwRITdqajDp2PtzyYcPZ9y6lLGuSvZl6/lX79ZdPde6c+PKxycqlzcaz2e
+13v7N/m/agl80xb8oePdx66wmJ7IhL6YlP74jMHknOG0gpHMktGc8vGC6oni
+usmypqmK1pnqjtm6bufbazsZ+M1/U9G6phZ7Zxf755cGF5eG6fTR5a2NrzIm
+2YwpDmOGx5gTMObXl2ni5UXpMl3GYMgZywrGiorBVNNXNXSWls7WLbH1i2uG
+RY6BxjEucEzzXNMc1zzLNc9wzdNc8yTHPMExj62ZRtmmYZZxcNXQx9T3LGu7
+GJvti6qWBcXnN4jG1sxmtNFaC313XhY8OxQA/nwoQQAKQgkCwJ9stwS3jwV/
+Ct5/NPTAiTC7kx8PnY4+fDbO/lziiYupZy5nXriWc/VG/q27RfcflT52qnB6
+WvXUq9bTr973VWNASPPr961vItrfR3dGxHd/Su6NTe9LyB5IyR9MLx7OKh/J
+rRorqBsvbpwoa5msbJ+q6f76XxW7JTjXMTnfNbPQM7fQT6MNLtGGl21bHGUu
+jrEWJ9aWprhLM/ylWeHSvGhpQbJEky4tbSzRFYsM5eKyanFFQ2Nu0la1C6u6
+BZZ+nmWYYxtm2UbbZtimabZpkm2aYJvG2aZRlmmEZRxaNQ4wDX0r+h6GrpNu
+y0BNy4KqcU7uldC3W4LRVbPlNcW7rwk+TxAA/nwoQQAKQgkCwJ9MJxjerZ7B
+t//l1b6jbw6ceH/wZLjd6chDZ6MPn4s/eiHp1OW0c1czL13PvXEn/+7PRT87
+lBJuFS6eVR6+tc8D6/2CGwNDm4PCW99GtX+I6/yY1BWd1hOX1ZuY159aNJBR
+NpRdOZxXO1LYMFrSPFbePl7Z9dV/+aUEv/6vqpm2iZmO6dmu2bmehbm+xfkB
+xtaGVuZHVhfG2AsTnIVJ3sK0YGFmfWFOvDAvXViQLdDkC0uKBbpynqGeZ2jm
+ljfnVrSzTN0MU2/b9KphatU4uWqcWDWOrxpHV40jTOMQ0zi4YuhfMfQu67vp
+us4lbTvNloHqxjll3fSGZ/xvJfgqc6itOAAlCAB7CCUIQEEoQQD4k31egtvH
+gvuC9h9/e+Dkh4OnI+zOfDp0Lubw+fjjl5LPXEm7cD3r6u2cWw/z7xNFj11L
+nZ6Vu/lUeb6s8Qmqe/Gu4VVYU8inltDYtvDE9sjUzujMrvjcnqTC3tTS/syK
+gZyawbz6ocKmkZK20fLO3RJ0uM2fbB6fapua6pid7pqf7lmc6aNvbWB5dog5
+O8yaHV2bHefOTvDnpoRz06K5WcnsnHR2fmN2QT5LU84sqmaW1DN0zTR9c4qh
+nVrWTS7rJpb14yv6sRXD6IphZMUwvGwYXDYMMAx9DH0PXd+1pOtY1LYtaFrm
+1Y2ztgyUV0/IUpqZuyXoFtX5+Quy19cHAKgIJQhAQShBAPjzfX6D6Pax4PGQ
+/SffHTj14eCZCLtznw6djzlyMeHk5ZRz19Iv3cq6fj/nzpP8h85FhEeJi3e5
++4tKr9fVfm9rX36ofx3Z+Cam+X1Ca3hK26eMjpiczoSC7uSSnrTy3szqvpy6
+gfzGwaLWoZKO3cfFPLnFG2scG2+eHG+dmWifm+yiTXYvba2XMdW/MjXImhpm
+T49wpsd40+OC6cn16Snx9LRkakY2NbcxNS+fWlBOLqgmaeqJRc3E0ub4knZs
+STtK143QdcN0/RBdP0jXD9D1fUv63iV996Kuk6ZtX9C2zmua59SNM6q6KUX1
+xEbFqCSxcXm3BF9/iMGBIADsLZQgAAWhBAHgz/cXx4IHXu87EbL/VOjBM2F2
+ZyPszn86dCH22KWE01dTzt9Iv3Iv8+bjnHtO+Y/cCx2fl7j6l3m8qvAOqfJ/
+XxMYURcc3fA2vulDcnNEemtUdltsfkdCUWdKWVd6VU9mbW9OQ19+c39R+24J
+Pr7JHa4bHWmcGG2eGm2dHWufH+tctG28mz7euzzex5wYYE0MrU0McydG+RNj
+wolx0cSkeGJKOj4tG5/ZGJ9VjM0px+ZVo/Pq0QXNyIJmmLY5RNMO0rQDNF0/
+TddH0/XSdN00XdeCtmNe2za32TqraZpRN0yraicV1eO2DJSWDonj6xifPzQG
+JQgAewslCEBBKEEA2BO/OxZ8868vfzoRtO/UmwOnQw+eDbM7F2F34ZP9xdgT
+VxLOXE++eDft+s+ZdxxzHrjlPfEqdPIrfvqy1DO43Ce08kV49auo2pC4+ndJ
+DWFpTR+zWqLyWuMK2xJLO1IqOtNrurLqu3OaevJbd0vw0XXuQM3IYN34UMPk
+UNPMcMvccBvNtpGOpZEuxkjPymjv6mg/e3SQMzrEGx0WjI4KR8dEo+Pi0Qnp
+yKRsZGpjeFoxPKMcmlXZNjinHpjT9M9p+uY3e+c3e+Y3u+e0XXObHXOb7bOb
+rTOa5hlN47S6flJVO6GoGpOXj8hKhySF/eu5Pfy/WoJ7fVkAgKJQggAUhBIE
+gD3xh2PBCpdvA386Gbz/9NsDZ0MPnguzO2+Lwaijl2NPXk04dzv58sO0m0Tm
+Pdfsn5/lOfgUuAQUuQeVeL0t8w2rCIiseh1TE5JQG5pSH5bRGJnTFF3QHFfS
+mljellLVnl7XkdUY5T+2W4KxwfO9lcN91aP9tRP9DdMDTbMDLfO2DbYuDrbT
+BzuXh7qZQz2sob61oX7u0CBvaEgwNLw+NCIaGpMMjksHJ2QDExsDk/L+KUX/
+lLJvWtU7re6ZVnfPaLpmNJ0zmo4ZTfu0pnVa0zKlbppUN0yq6iaUNWOKyhF5
++bCsZNCWgaK8HkFWB+cvSxAHggCwV1CCABSEEgSAvWILn9/H4Hev9p0O3n/m
+zVYMng87eOHj4UtRx67Enr6ZcOF+8tUnabecM+57ZD32znX0z3d9Vejxpvj5
++1K/j+Uvoytfx1e9Sa4JTa8Nz66PzG+ILmqKK2tOrGxJqWlNb/joO7pbglGv
+57rKBrsrRnqqx3tqJ3vrZ3ob52zra17oa13qa2P0d6z0d632d7P6e9f6+7j9
+/fz+AUH/0Hr/sKhvRNI3Ku0dlfWObfSMy3vGFd0Tiq4JZeekqmNS1T6paptU
+t06qWybUTROqhnFV/ZiydlRRPaKoHN4oG5QV90sKe0V53cKsDl5aC/sPJYgM
+BIA9hBIEoCCUIADsFfr4eG/Iv3weg5Wuthg8E7T/7JsD50IPXvhw8GKE/eVP
+J67HnL0bf+lR0nXH1DtP0x94ZT3xy3EKzHMLLngWWuQdXuL/qfRlbHlQYuWb
+1Kr3mTXhubWRhXXRJQ1xFY2J1U0pdeHew7slGBk401480FE63Fkx2lU10VUz
+1VU3a1t3w3x3E627eamnldHTvtLTsdrTxe7p5vT0cHv6+D39gu6B9e5BUfeQ
+uGtY0jUs7RyRdY5udIzK20cVbWOK1jFly5iyeUzZNKZsGFXWjyprRxTVw/LK
+IXn54EbpgLS4T1LQI8rtEma189NbOCXV1VlRbra9/hCzU4Iry5y9viAAQF0o
+QQAKQgkCwB4qC3b4vAS3YtDl+1c/nQnad+7N/vPvDlz4YHcp4sjVT6dux5x/
+GH/FIfGma8rdZ2kPfTKIgGzn17lP3+Z7hhX6RBb5x5QEJpQFpZS/zah8n10V
+nl8dWVwbXVYXV1mfWPvB67cSbMnraSnoay0abCsdaSsfa6+cbK+etq2jdraj
+fqGjYbGzid7ZstzZyuxsX+3sYHd2cjq7uZ09/I5eQUefsKNf1D4gbh+QtA1K
+WwdlrUOylqGN5uGNpmF547C8YVheNySvHZJXD8qrBjcqBjbK+mUlfdKiHkl+
+lyinQ5jZxk9r4ZRW1+z8sMXet22z9WBlisdeXwoAoDSUIAAFoQQBYA9FEi55
+jv/XX8Zg4E9ng/adf7P/wrsDF98fuhxx7OanM/ejLz6Ju+qccMs9+d7z1J/9
+0x1eZbqEZLu/z/WKyPeJKnwRVxSYVBKcVvo2q/x9bkV4YWVkSVV0RU1c9c3T
+9N0SbMjuasztbcrvby4aai4ZbSkbb6mY3FrVTGvNXGvtQmv9Ylsjva1pua2F
+2dbKamtjt3VwWju5rV381m5BS4+wpWe9uVfU3Cdu6pM09kttq++X1fXLavtl
+Nf2y6n5ZZb+sok9W1ist6ZEWdUsKusR5nevZ7cKMVl5qE6e9JMT2M3qci939
+eW0l2Na/sNeXAgAoDSUIQEEoQQDYQ/TxceKrfXmOX/0hBitcfgj86ZwtBkP2
+X3hri8HD18NP3I089yjqkmPsNbf4255J931THr1McwzKcHmX5R6W7RWZ6xOT
+/yKhMDClKDij5G1O6fv8svDi8siyiujKG6d+K8HajI66rO76nL76/IGGwuGG
+4tHG0omtlU81Vcw0Vc011dCa6hab6ulNjctNTcymZlZTC7upba2pndvUwWvs
+5Dd2Chq6hPXd6/XdoroecW2PuKZHUt0jqeqRVPZIynskZd2Skm5JcZe4sFOU
+37Ge2y7MahVkNPNSGzlvg1tsDWj7Z9h+/f6fh3cy8F5wQ1Nd715fCgCgNJQg
+AAWhBAFgb0USrsRXdn8Zg0Nv/1vgT+df77sQvP/im4NXQo/cCjv18OM54tNl
+l5jrHnF3vBMevEh+/CrF8U2a6/sM94gsr6hs37jcF0n5r9IKgrMK3+YWvy8s
+CS8p/Vh+7cTSbglWpbZXp3dWZ/bUZPfX5g3WFozUFY1trXiirnS6vny2vnK+
+vopWX7NUX0uvr1+ub2DWN67WN7HrmtfqWjh1rdzaNn5tu6CmXVDdIazuWK/q
+XK/sFJV3iso6RaUdopIOUXGHqLBdlN+2ntsqzG4RZDbz0xt5ZZV1k7mXd04D
+d/4lO/eF2jLwyduGvb4IAEB1KEEACkIJAsDeiiSciK8OEF8dynP8+g8xuP0M
+mR9f7bsQtP9SiN2Nd8fufTj1KPy8Y+Tlp1E3vGLv+sU/fJn4JDjZ8V2qa1ia
+R2SGV0yWb0L2i5TcwIy8oOz8N/kFoUVFYWVXji3ulmBZYmt5SkdFWldlRm9l
+Vn9VzlBV3sjWCsaqiyarS6arS2dryudrKmk1VYs11fSa2uXqupXq+tXqBlZ1
+I7uqaa2qmVvZzKtosY1f3iooaxWUtgpLWoXFrcLCVmFBqzC/RZjbLMhuEmQ2
+8tMbeKn1nPaiN7buszXgzk2h3//zsO2LnQy0rbKbsdcXAQCoDiUIQEEoQQDY
+Wzs3iBJf2RFf2b87u/+vxKDLj1WuP73efy3k8J23xx6+P02EXXCJuOLx6aZ3
+9N0XsQ9fxz95k+j0Ptk1IsUjKs0rLsM3KfNFWlZgZk5Qbu6bgrzQ4ktHaDsZ
++C//ICuOay5JaCtJ6ihN7S5L7y3LHCjPHtpa7kh5/nhFwWRF0XRFyWxF6XxF
+Oa2iYrGikl5RxaioWSmvZZbXrZbXscrq2aUNa6UNnJJGbnEjr7iJV9jEL2ji
+5zfy8xr5OY387AZeZj0vvY6bWsspLa9NfBG+k36fvz0w9FPi7kdIoAQBYM+h
+BAEoCCUIAHtu91iQ+OoI8dWxAsdv/9rh4L5XB24GHb735vijd2ecPlx4Gn7V
+K/Km36e7L6MfBsU+eRfvGJboGpnsEZPilZDmk5Lun57xMjvzdV5WSOFF+4Wd
+Evw//rM0P6qxILa5ML6tMLGzKKW7OK2vOH1ga5lDJdmjJbnjJfmTpQXTpUWz
+pcVzpSULJWWLJeVLJRWMksrlkqqV4mpmUc1qUQ2rsJZdULtWULeWX8fJq+Pk
+1HGy6zhZtZyMWk56DSe1Zq20rMbWgDvngDt3hO48KXQ443xgytiT0JbdElxk
+Sff6CgAA1aEEASgIJQgAe277WHD/zrEg8dVR4qvjBY7f/WUMbvXgU7tqD/vg
+E8TbMy6hFz3CrnpH3Hzx8e6rTw9Doh+HxjpGxLtGJbjHJXkmJvukpvhnpL3M
+SX+df/7Q/E4J/u9/L835WJ/zqTE3uiUvrj0/oTM/qSc/pc+2grSBgoyhgszR
+wuzxwtzJwrzpwoKZwsK5wqKFwmJaQcliQRm9oJyRX76cX7GSV8HMrVzNrWTl
+VLGyq9hZVezMKnZ6FTutkp1ayS4tqU703zoH3L0ldbcE/byrXyaPByQMfv6x
+8nv98gMAoAQBqAglCABfgkjC+fNjQeKrE05fnyp0+v6v9qBt1Z7HQs4+fXfR
+6/1V3w83A8LvBn188PbT4w/Rjh9jXaLj3OPjPZMSvdOS/DKTA3L/6T+Jdors
+n/9ekvGhJjO8PiuyKSuqJTumPTuuKyehZ2tJfTkpA7lpQ7npI7mZY7nZE7k5
+U7m5M7l5s7n587mFCzlFtJzipexienYJI6t02bbM0pWMMmZ6GTOtjJlaxiwt
+qnoWJEj0D9t5LuhuBu6UYIx3aFJa/suksYD4Idewtt0MfJ8zvNevPQAAShCA
+ilCCAPCF2H634MHdY0FbDDp+farA6fsipx/+Rz1Y432q1vfMu6v+oTcDP9wN
+Dn/w7uPj8E+On6JcYqKfJsQ+S457nh7vm/WP/3F9p8j+6e/EKW+rUkNr08Lq
+0yKa0iNbM6LaM2I6txbXk5nQl5k0kJkylJU6kpU+lpUxkZk5mZk1nZkzk5k7
+l5k3n5G/kJFPSy9YTCtcSiukpxbSU4oYyUWMkvyKRL+wP9Tf7m9vnu9ISSsM
+TJ4MSBh9ETf4Irrv8wNBvEkQAL4EKEEACkIJAsAXojYldfse0UPbMXhsOwZP
+El+dcvr6TKHTD/9GD9o2Ev5jbcClDFeXDw/ehz+OiHCI+ugc+8ktMcojJdor
+4x//g3Anyv7xP4kTgsoT31QlvatNft+QHN6U8rE1JbJ9a1GdqTHdqXG9qQn9
+aYmDacnDaSmjqanjqekTqRlTqZnTqVkzKdlzKdnzyTnzSbkLJTmlib4fEnw/
+2Ipv54Ewn2fgzjngzXMdqWmFr5OnXiZOBMSNvIgZ9P/U6xfRgVtDAeBLgxIE
+oCCUIAB8OSIJl+1jwcO794hux+Bpx6/POH9z1haDxc4//Rs9uLPRyP31QTfq
+g29l+/hGuCZ9dE/9h//tlxL8h/8oinlZGvu6PC64Kv5NbXxoQ8KHpoSwFtsS
+I9oTIzsTo7oTY3qTYvuT4geTEoaSEkcSk0cTU8YTUydK0vKL0wsSvENt+8vu
+2+nB3a9jvENTUwteJ00FJtgacOxFzLB/1ID/xx6/sHbnN404EASALw1KEICC
+UIIA8OX47BMlDu/eI0p8dcoWg8RXZ5y+PufyzQXX764UuRz8f+3Bz7fbaP/5
+P6w3hRN5b8Ly3oXnh37MD4sqCI8uiIi1rfBjfOGnhMKopMKY5MLY1NbE5yEe
+ZQleb+6eaUvwevuXb/37y3cC2vZ3/6R59GwlJGkqKGEyMG78RczYi+gR/6gh
+/8h+v/Au3/dtPm8anV7X4KmhAPClQQkCUBBKEAC+KLUpaX94juhnMXjW4atz
+Tt9cdP7umusPtyMuXyh2O9L/7pv/+RLcXbH37Z1TvL/cX/3+v3oIuPvFzTPt
+aYn5qYl5QXETr2PHA7cCcNT/07B/5KD/x36/iF7fD50+b1u9gxueB1bhQBAA
+vkAoQQAKQgkCwJdm+x7Rz58j+ssbBndikPjqnMM3lx2/u+H8wx3Xnx667Xvi
+fsCpxP1k6bPT/5MluPsBf391O5/692+X4NZ7AE+3xXi+TY3PCYkeC44efR01
+Ghg1GvBp5EXksP/HIb+IQb/wfr+wXt/3Xb7vOnxCmr1f13kFVDgGVOAdggDw
+BUIJAlAQShAAvjTb94j+tP2Gwb8ag2eIry8Q31wlvrvp+MM9px9/dtlHuB5w
+enroqcdRT8+TvqXeF8p8Lg2G79stwT+U3V99wMvnJfiHv7V9v+0P/+7vFTHP
+3rxwLUuNykiJygiKGHwdMfgqYigwYuhlxOCL8EG/MNsG/ML6/T70+b7v8X3X
+5fO23Sek1Tuo6fnLWi+/MjffEhwIAsCXCSUIQEEoQQD4An0Wg4f/+sngN5eI
+b68T390mfrjv8OMjx30OTvudXezc3Y54uZ/we3Y6wPP86+eX3nhffR/j9CzW
+5XnFq9veN+J8bsYf+Gri+qHq4Wj7G/Y1N+xrbxyp+3X1N47WR7u+inZ7bZs/
+ke/vUPDwwVjKh4TksMSgN51Bb7tev+t+9a478F3Py9DegNDeF6G9/qF9fqF9
+vu96t2erv26ft10+bzp9Qtq9g1q9Xzc9D6z3elHl6V3y7Fke8bwQnyEIAF8m
+lCAABaEEAeDL9OvTY/4HMfj1OeKby8R3N4jv7xA/PCB+fEz85Oiw38XxoLuz
+/XPXY75uJwPcz772uPDG83Ko17Xw5zc/ed+J8bkf7/swye9Rqj+R/sIx64VL
+boBbfoB70dY8Sl56lr18XvHSpyrQtybQv+7li/qXAY0vXzYFBLYEvGoNeN32
+IqjdP6jDL6jDN6jTJ9i2rq2FdG1/3ekd3OEdZAvANu9XLc8DG58H1Hv513j6
+VjzzKvJ4mrObgbgvFAC+QChBAApCCQLAF2v7EwZ3HyX6lzF4nvj2CvHdTeL7
+u7/E4D5HYr8rccDD4ZCX4xFf5+MBLqdfu50LeXox1ONKuMf1yGc3oz3vxHnd
+S3z+MMX7UZoPkenjmO3jnGebr0uBr1uRr3uJr0eZn2eF3/MqX+8aX59aX986
+H78GH/9GnxdN3i+anwe02Ob9snVrgb/seWDL85e22f626XlAg5d/nZdvtae3
+rQFLPTwK3J0z3Z4k4HmhAPAlQwkCUBBKEAC+ZL9+3PzuyeDu00S3PmeQ+OYC
+8e3VX2Lwx4fET0+IfU7EfjdbDBJ2Xg72vo7HAhxPvnY6E+JyPtT1UpjrlY9u
+16Oe3ox1v5PgcS/52YPUZz9nPHucZZsnkePpmOfpXODpUuTlVuL1tMzTo8Lz
+WaWnZ5WnV43X81ov7zovn3ovX9savPx21ujl37j9Rb2XX52Xb62nT42nd/Uz
+r/Jnz0o83As93PKeOqS6Pox96FuKDASALxlKEICCUIIA8IX79WRw9wEyR3/7
+0PmvzxDfXNyKwe9vEj98HoNbJ4PEQS/ikI/DkReOJ145nQ5xOvvO+cIHl0sR
+Llc+uV6Pcb0Z73Yn0e1eytMHaVt7mOH+KMv9SY67Q56HY4GHc5GHS/Ez19Jn
+bmXP3Muf7VahZ7Wn1697XrM929dVzzwrn3naArDMw73Ew63A3SX3qUOG26Mk
+lzufHjkkIgMB4AuHEgSgIJQgAHz5alNSPotB+19jcPtwcCcGv7PF4C3ih3vE
+jz9/FoPuxEFPws7bwd7f4Vig48kgp9NvnM6FOl8Ic7700eVqlOv1WFsPut5O
+tM3tborbfVsSZjz9Ocv9cY77k1x3h3x3WxI6FW5XYYmHa6mHW6nH0zLbntnm
+/ss8ntr+3FZ/Re6uhe4u+e5OOU+JDLefk10fxDtd//AzkYhHxADAlw8lCEBB
+KEEA+Juw/QCZg9ufM2j3xztFf4vBX08G9z0h9jsSB1yJg+6E3VYMEof9HI4E
+OBx/5Xgy2PHMW6dz750vhDtfjrT1oMv1WNtcb8S73kp0vZPsdi/V7UH604eZ
+tiR8+ij76WNb2eXtVOHWnAo/W8HWHPOfOuY+dbB9W5bb4wzXh8ku9+Kdb39y
+uvz2gVc+PjACAP4moAQBKAglCAB/Q2pT0rffNrgTg/a/PkZmOwa/vUB8d+WX
+GPzJFoOPif0OxAEX4uBTwu4Zceg5cciXOPzC4Wigw/Egx5MhjmfeOZ3/4HQh
+wvlS5NauRLlci3G5HudyM8H1dpLrnRRXWxLeT7NVodvDDLefM90eZbk9yv5l
+j23L2tqjTLefbfWX5vrA9v2JLnfinG9EOl4OfXwjbOcoEHeEAsDfBJQgAAWh
+BAHgb8vv3zZ4+Ld3Dn59+tcYvEH8cIf48QGx7xGxnyAOOBMH3Qi7rWfIEIe2
+DgcJ+xfEka0edDj5xvH0O8ez721zOh/mdPGj86VPzleina/FbiXhjXhbFbrc
+SnS5nex6J9n17lYb/rqU7SW73LX9bbzzrVjnG9FO1yMdL74jzr7++UksGhAA
+/ragBAEoCCUIAH9zalNSIgmX7TtFd985uN2DX58kvj1HfHeZ+P468cNt4sd7
+xE8/b90pesCROOj66+GgF3HYh7D3I44E2HqQOPba4UTI1k69dTwd6nj2g+P5
+cKcLH50uRTpd/uR0Jcr5qi0MY5yv21ov7pfZvt6a7Q+jna7avuej48UPDuff
+EadfR/okh8XUoAEB4G8OShCAglCCAPA3avtw8Kc/9uDXJ4hvzhDfXSS+v0r8
+cJP48Q7x087hoMP24aArYedOHHpGHH6+3YP+Wz14NHB7r4hjQYQtCU++dTgd
+6nDm/VYVnguzhaHjBdsiHC/aii9iaxd2/iTM4Zzt294Qp4KIU6+cLr+tzane
+65cEAOD/I5QgAAWhBAHgb1ptStqvPWj3y/2iXx8lvjlNfHee+P4y8cM14sdb
+xE93iX0Pif2PiQMOxEEnws7Wg0+3e9CLsPcm7H23dsSfOPqCOPqSOGZLwtfE
+8SDieDBxwrYQ4qQt937dSdtvg4mTQcTJV8TJl8QJP6eLIbU5NXv9MgAA/P+C
+EgSgIJQgAPw7sN2D+349H9x+nsw3x4lvd3vwOvHTbWLffWL/Tg8S2z3oQhyy
+9aAHcfjZ1uy3q/CID3HEjzi6XYXHArZ2/OVns/32BXHcnzjuSxx7Thx1r82p
+3esfHQDgfwGUIAAFoQQB4N+N7fcPuv6WhF/bE9+c+KUHf7hM/GjrwVvEvjvb
+SfgzceAxcdCBsNtOwq0qdCUOPyUOuxP2tir0JI54bc+We7vzIo4+s9WfbZGe
+kfSphb3+cQEA/pdBCQJQEEoQAP6dGanOrU1J3U7C/VtJ+LUd8c1R4tuTxPfn
+iB8uET9eJX66TuyzJeFdYv994sBD4uCj7T0h7AjCzpE45Ly1w5/N3varE3GY
+iHwWHunxlj45u9c/IgDA/2IoQQAKQgkCwL9jtiTcunH0m8NbB4W2X789Tnx3
+ivj+LPHDBeLHS8RPV4l9tiq8ubX9t4j9d4gD94iDD7Z3f3t3Iz3eRboH0yfn
+EIAA8O8YShCAglCCAEAR9PHxnTCMdHCNdPSIdHpOfH+C+OHMziJd/LbmGmBb
+bXqerfvokzN7/U8GAPiToAQBKAglCAAAAEBxKEEACkIJAgAAAFAcShCAglCC
+AAAAABSHEgSgIJQgAAAAAMWhBAEoCCUIAAAAQHEoQQAKQgkCAAAAUBxKEICC
+UIIAAAAAFIcSBKAglCAAAAAAxaEEASgIJQgAAABAcShBAApCCQIAAABQHEoQ
+gIJQggAAAAAUhxIEoCCUIAAAAADFoQQBKAglCAAAAEBxKEEACkIJAgAAAFAc
+ShCAglCCAAAAABSHEgSgIJQgAAAAAMWhBAEoCCUIAAAAQHEoQQAKQgkCAAAA
+UBxKEICCUIIAAAAAFIcSBKAglCAAAAAAxaEEASgIJQgAAABAcShBAApCCQIA
+AABQHEoQgIJQggAAAAAUhxIEoCCUIAAAAADFoQQBKAglCAAAAEBxKEEACkIJ
+AgAAAFAcShCAglCCAAAAABSHEgSgIJQgAAAAAMWhBAEoCCUIAAAAQHEoQQAK
+QgkCAAAAUBxKEICCUIIAAAAAFIcSBKAglCAAAAAAxaEEASgIJQgAAABAcShB
+AApCCQIAAABQHEoQgIJQggAAAAAUhxIEoCCUIAAAAADFoQQBKAglCAAAAEBx
+KEEACkIJAgAAAFAcShCAglCCAAAAABSHEgSgIJQgAAAAAMWhBAEoCCUIAAAA
+QHEoQQAKQgkCAAAAUBxKEICCUIIAAAAAFIcSBKAglCAAAAAAxaEEASgIJQgA
+AABAcShBAApCCQIAAABQHEoQgIJQggAAAAAUhxIEoCCUIAAAAADFoQQBKAgl
+CAAAAEBxKEEACkIJAgAAAFAcShCAglCCAAAAABSHEgSgIJQgAAAAAMWhBAEo
+CCUIAAAAQHEoQQAKQgkCAAAAUBxKEICCUIIAAAAAFIcSBKAglCAAAAAAxaEE
+ASgIJQgAAABAcShBAApCCQIAAABQHEoQgIJQggAAAAAUhxIEoCCUIAAAAADF
+oQQBKAglCAAAAEBxKEEACkIJAgAAAFAcShCAglCCAAAAABSHEgSgIJQgAAAA
+AMWhBAEoCCUIAAAAQHEoQQAKQgkCAAAAUBxKEICCUIIAAAAAFIcSBKAglCAA
+AAAAxaEEASgIJQgAAABAcShBAApCCQIAAABQHEoQgIJQggAAAAAUhxIEoCCU
+IAAAAMD/094drLYRQwEU/f8P666fUmzG1Ga88fSBoLQkZBdC5p6zElppe9ET
+ilOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA4pQgBClB
+AIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQACBOCUKQ
+EgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA4pQg
+BClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQACBO
+CUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA
+4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQ
+ACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCk
+BAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUI
+QUoQACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhT
+ghCkBAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCA
+OCUIQUoQACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIE
+AIhTghCkBAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQp
+QQCAOCUIQUoQACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglC
+kBIEAIhTghCkBAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKU
+IAQpQQCAOCUIQUoQACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAg
+TglCkBIEAIhTghCkBAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQB
+AOKUIAQpQQCAOCUIQUoQACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFK
+EAAgTglCkBIEAIhTghCkBAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQ
+pAQBAOKUIAQpQQCAOCUIQUoQACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDgl
+CEFKEAAgTglCkBIEAIhTghCkBAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACI
+U4IQpAQBAOKUIAQpQQCAOCUIQUoQACBOCUKQEgQAiFOCEKQEAQDilCAEKUEA
+gDglCEFKEAAgTglCkBIEAIhTghCkBAEA4pQgBClBAIA4JQhBShAAIE4JQpAS
+BACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQACBOCUKQEgQAiFOCEKQEAQDilCAE
+KUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA4pQgBClBAIA4JQhBShAAIE4J
+QpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQACBOCUKQEgQAiFOCEKQEAQDi
+lCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA4pQgBClBAIA4JQhBShAA
+IE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQACBOCUKQEgQAiFOCEKQE
+AQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA4pQgBClBAIA4JQhB
+ShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQACBOCUKQEgQAiFOC
+EKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA4pQgBClBAIA4
+JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQACBOCUKQEgQA
+iFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA4pQgBClB
+AIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQACBOCUKQ
+EgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA4pQg
+BClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQACBO
+CUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCkBAEA
+4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUIQUoQ
+ACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhTghCk
+BAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCAOCUI
+QUoQACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIEAIhT
+ghCkBAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQpQQCA
+OCUIQUoQACBOCUKQEgQAiFOCEKQEAQDilCAEKUEAgDglCEFKEAAgTglCkBIE
+AIhTghCkBAEA4pQgBClBAIA4JQhBShAAIE4JQpASBACIU4IQpAQBAOKUIAQp
+QQCAOCUIQasEfwIAEKYEoeYHAAAoQQAAAN5QggAAADVKEAAAoGaV4O1227bt
+8Xh89XEAAAD4XJN+E4CTgfu+X6/X+/3+1ScCAADgc036TQBOBh7HcblcJgnF
+IAAAwIlN9E36TQC+Xq8pwefzOVXotSAAAMCJTfRN+k0A/v2Mfl0Rzr4HgwAA
+ACczxbcycBbH/9b+GhPVgwAAACcwcbeGQtfd3/GeNSY6tm37DQAAwDc3cbcq
+79+h0Hft+z7B+AsAAIBvbn0Y8XEDAgAAAAAAAOfzB9lwggs=
+     "], {{0, 456.}, {599., 0}}, {0, 255},
+     ColorFunction->RGBColor,
+     ImageResolution->{144, 144}],
+    BoxForm`ImageTag["Byte", ColorSpace -> "RGB", Interleaving -> True],
+    Selectable->False],
+   DefaultBaseStyle->"ImageGraphics",
+   ImageSizeRaw->{599., 456.},
+   PlotRange->{{0, 599.}, {0, 456.}}]]], "Output",
+ TaggingRules->{
+  "Settings" :> {$CellContext`r = 
+     24.200000000000003`, $CellContext`ls = -30.106510717881708`, \
+$CellContext`lt = -38.0132711084365}},
+ CellTags->"Snapshot",
+ CellID->494830484,ExpressionUUID->"6623e441-b1ca-4f02-a6d3-c7831a396c1b"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell["Source & Additional Information", "Section",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "Source & Additional Information"},
+ CellTags->"SourceInformationGroup",
+ CellID->62407265,ExpressionUUID->"e67b7ac9-7ce5-4e24-a422-e84cd737770a"],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Contributed By",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"AuthorNames", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{
+          "'John Smith' for single authors; 'John Smith, Robert Ford, and \
+Jane Doe' for multiple authors. To credit people other than Demonstrations \
+authors, please see the 'Details & Citations' section."}], "MoreInfoText"], 
+        Background -> GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> 
+        GrayLevel[0.9], RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoAuthorNames"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "ad3910df-bd12-48d3-8791-35477149ca06"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "AuthorNames"},
+ DefaultNewCellStyle->"Item",
+ CellTags->{"AuthorNames", "Contributed By", "TemplateCellGroup"},
+ CellID->255368948,ExpressionUUID->"65396ff6-955e-4046-8d9f-2280747f913c"],
+
+Cell["Bernard Vuilleumier", "Text",
+ TaggingRules->{},
+ CellID->161482345,ExpressionUUID->"5a18061c-5dd7-4ddc-899f-51bd0203baac"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Details & Citations",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"DetailCells", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{
+          "This optional section is for a more detailed description of the \
+Demonstration than the caption, but it should still be as concise as \
+possible. This section may also include numbered snapshot captions (e.g., \
+Snapshot 1: phrase or sentence without an initial capital and without a \
+period, unless more than one sentence is used) and explanations of the ", 
+           StyleBox["Manipulate", "MRbig"], 
+           " control labels. Define any symbols undefined so far. Include \
+only text in this section \[LongDash] no code, graphics, etc. Do not change \
+the cell style or copy cells from other sections. \n\nA book reference uses \
+this format: \n   L. D. Schmidt, ", 
+           StyleBox[
+           "The Engineering of Chemical Reactions", FontSlant -> "Italic"], 
+           ", New York: Oxford University Press, 1998. \n\nAn article \
+reference uses this format: \n   D. Pearson, \"A Polynomial-Time Algorithm \
+for the Change-Making Problem,\" ", 
+           StyleBox["Operations Research Letters", FontSlant -> "Italic"], 
+           ", ", 
+           StyleBox["33", FontWeight -> "Bold"], 
+           "(3), 2005 pp. 231\[Dash]234."}], "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoDetailCells"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "6926aa10-521c-44b2-ba9b-fc1f53337f68"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "DetailCells"},
+ DefaultNewCellStyle->"Text",
+ CellTags->{
+  "AuthorNotes", "DetailCells", "Details & Citations", "TemplateCellGroup"},
+ CellID->441931514,ExpressionUUID->"c6e8eb5c-33d4-4a2b-930c-b905e32940af"],
+
+Cell["Details, references or citation information", "Text",
+ TaggingRules->{},
+ CellEventActions->{Inherited, {"KeyDown", "\t"} :> Replace[SelectionMove[
+       SelectedNotebook[], After, Cell]; NotebookFind[
+       SelectedNotebook[], "TabNext", Next, CellTags, AutoScroll -> True, 
+       WrapAround -> True], Blank[NotebookSelection] :> SelectionMove[
+       SelectedNotebook[], All, CellContents, AutoScroll -> True]], 
+   PassEventsDown -> False, PassEventsUp -> False},
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->111711384,ExpressionUUID->"a44ba792-9b26-497a-92e4-5a60c079de85"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "References",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"ReferenceCells", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{
+          "This optional section is for a more detailed description of the \
+Demonstration than the caption, but it should still be as concise as \
+possible. This section may also include numbered snapshot captions (e.g., \
+Snapshot 1: phrase or sentence without an initial capital and without a \
+period, unless more than one sentence is used) and explanations of the ", 
+           StyleBox["Manipulate", "MRbig"], 
+           " control labels. Define any symbols undefined so far. Include \
+only text in this section \[LongDash] no code, graphics, etc. Do not change \
+the cell style or copy cells from other sections. \n\nA book reference uses \
+this format: \n   L. D. Schmidt, ", 
+           StyleBox[
+           "The Engineering of Chemical Reactions", FontSlant -> "Italic"], 
+           ", New York: Oxford University Press, 1998. \n\nAn article \
+reference uses this format: \n   D. Pearson, \"A Polynomial-Time Algorithm \
+for the Change-Making Problem,\" ", 
+           StyleBox["Operations Research Letters", FontSlant -> "Italic"], 
+           ", ", 
+           StyleBox["33", FontWeight -> "Bold"], 
+           "(3), 2005 pp. 231\[Dash]234."}], "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoReferenceCells"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "db13300b-1eb0-4905-bcdd-d9593ec6976e"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "ReferenceCells"},
+ DefaultNewCellStyle->"Text",
+ CellTags->{"ReferenceCells", "References", "TemplateCellGroup"},
+ CellID->592881655,ExpressionUUID->"2a8f96e3-65d2-4fe8-8c67-f9391216f923"],
+
+Cell["References for demonstration.", "Text",
+ TaggingRules->{},
+ CellEventActions->{Inherited, {"KeyDown", "\t"} :> Replace[SelectionMove[
+       SelectedNotebook[], After, Cell]; NotebookFind[
+       SelectedNotebook[], "TabNext", Next, CellTags, AutoScroll -> True, 
+       WrapAround -> True], Blank[NotebookSelection] :> SelectionMove[
+       SelectedNotebook[], All, CellContents, AutoScroll -> True]], 
+   PassEventsDown -> False, PassEventsUp -> False},
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->423796343,ExpressionUUID->"ce89f651-625f-4b84-b2b4-17029aac56e2"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Submission Notes",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"SubmissionNotes", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{
+          "Enter any additional information that you would like to \
+communicate to the reviewer here. This section will not be included in the \
+published resource.", 
+           StyleBox["\n", FontSize -> 4]}], "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoSubmissionNotes"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "5cd7c771-f1ee-493f-a595-1ec293b6821e"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "SubmissionNotes"},
+ DefaultNewCellStyle->"Text",
+ CellTags->{"Submission Notes", "SubmissionNotes", "TemplateCellGroup"},
+ CellID->797097429,ExpressionUUID->"6b3b01e9-6ca1-487e-ab6c-2312fc9df879"],
+
+Cell["Additional information for the reviewer.", "Text",
+ TaggingRules->{},
+ CellEventActions->{Inherited, {"KeyDown", "\t"} :> Replace[SelectionMove[
+       SelectedNotebook[], After, Cell]; NotebookFind[
+       SelectedNotebook[], "TabNext", Next, CellTags, AutoScroll -> True, 
+       WrapAround -> True], Blank[NotebookSelection] :> SelectionMove[
+       SelectedNotebook[], All, CellContents, AutoScroll -> True]], 
+   PassEventsDown -> False, PassEventsUp -> False},
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->820829112,ExpressionUUID->"53319a44-3896-4fc6-bf9f-f08f087e1424"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Keywords",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"Keywords", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+        "List relevant terms (e.g. functional areas, algorithm names, related \
+concepts) that should be used to include the demonstration in search \
+results.", "MoreInfoText"], Background -> GrayLevel[0.95], FrameMargins -> 20,
+         FrameStyle -> GrayLevel[0.9], RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoKeywords"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "a20e2457-e42a-4186-a396-a1acf6b3c9d1"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "Keywords"},
+ DefaultNewCellStyle->"Item",
+ CellTags->{"Keywords", "TemplateCellGroup"},
+ CellID->938146184,ExpressionUUID->"6074178a-3ee1-448f-bdda-18641673cfd6"],
+
+Cell["arc length", "Item",
+ TaggingRules->{},
+ CellID->386963008,ExpressionUUID->"d3daeb29-3afc-4e72-9375-237d18747143"],
+
+Cell["equator", "Item",
+ TaggingRules->{},
+ CellID->247815498,ExpressionUUID->"12e333bb-320f-46c0-9bd7-920a201d0301"],
+
+Cell["meridian", "Item",
+ TaggingRules->{},
+ CellID->96860228,ExpressionUUID->"da60c26f-0b44-4a4e-bb98-8f28ae70e49f"],
+
+Cell["latitude", "Item",
+ TaggingRules->{},
+ CellID->639559915,ExpressionUUID->"f35ff1e7-5347-4258-a1ee-276bc633483b"],
+
+Cell["longitude", "Item",
+ TaggingRules->{},
+ CellID->19443273,ExpressionUUID->"c2812707-1d48-4d75-b610-2e7bf70ce128"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Categories",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"Categories", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+        "Choose categories that best represent your demonstration. These \
+choices determine which pages your demonstration will appear on when \
+published to the repository.", "MoreInfoText"], Background -> GrayLevel[0.95],
+         FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], RoundingRadius -> 
+        5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoCategories"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "31b22a67-6bd1-446d-a7bb-1f8cc5c0b6e1"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "Categories"},
+ CellTags->{"Categories", "DemoCategories", "TemplateCellGroup"},
+ CellID->845692503,ExpressionUUID->"53143ca2-f91a-4c84-a16e-14dccff6475c"],
+
+Cell[BoxData[
+ TagBox[GridBox[{
+    {
+     TagBox[GridBox[{
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Mathematics"}], "\" \"", 
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "School Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"School Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"School Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Elementary School K-2 Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Elementary School K-2 Mathematics\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Elementary School 3-5 Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Elementary School 3-5 Mathematics\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Middle School Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Middle School Mathematics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"High School Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}, GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"High School Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Algebra I"}], 
+                    "\" \"", 
+                    StyleBox["\"High School Algebra I\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    "High School Geometry", {False, "High School Geometry"}], 
+                    "\" \"", 
+                    StyleBox["\"High School Geometry\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, 
+                    "High School Algebra II and Trigonometry"}], "\" \"", 
+                    StyleBox[
+                    "\"High School Algebra II and Trigonometry\"", FontSize -> 
+                    12, Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Precalculus"}], 
+                    "\" \"", 
+                    StyleBox["\"High School Precalculus\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, 
+                    "High School Calculus and Analytic Geometry"}], "\" \"", 
+                    StyleBox[
+                    "\"High School Calculus and Analytic Geometry\"", 
+                    FontSize -> 12, Editable -> False, StripOnInput -> 
+                    False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, 
+                    "High School Advanced Calculus and Linear Algebra"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Advanced Calculus and Linear Algebra\"", 
+                    FontSize -> 12, Editable -> False, StripOnInput -> 
+                    False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "High School Finite Mathematics"}], 
+                    "\" \"", 
+                    StyleBox["\"High School Finite Mathematics\"", FontSize -> 
+                    12, Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Statistics"}], 
+                    "\" \"", 
+                    StyleBox["\"High School Statistics\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}}, GridBoxAlignment -> {"Columns" -> {{
+                    Left}}}, DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, GridBoxAlignment -> {
+                    "Columns" -> {{Left}}}, AutoDelete -> False, 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}, GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Area"}], "\" \"", 
+                    StyleBox[
+                    "\"Area\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Equations"}], "\" \"", 
+                    StyleBox[
+                    "\"Equations\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Exponential Functions"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Exponential Functions\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Exponents and Logarithms"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Exponents and Logarithms\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Hyperbolic Functions"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Hyperbolic Functions\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Identities"}], "\" \"", 
+                    StyleBox[
+                    "\"Identities\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Inequalities"}], "\" \"", 
+                    StyleBox[
+                    "\"Inequalities\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Integers"}], "\" \"", 
+                    StyleBox[
+                    "\"Integers\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Irrational Numbers"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Irrational Numbers\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Number Bases"}], "\" \"", 
+                    StyleBox[
+                    "\"Number Bases\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Parametric Equations"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Parametric Equations\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Perimeter"}], "\" \"", 
+                    StyleBox[
+                    "\"Perimeter\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Pi"}], "\" \"", 
+                    StyleBox[
+                    "\"Pi\"", FontSize -> 12, Editable -> False, StripOnInput -> 
+                    False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Polynomials"}], "\" \"", 
+                    StyleBox[
+                    "\"Polynomials\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Pre-Algebra"}], "\" \"", 
+                    StyleBox[
+                    "\"Pre-Algebra\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Prime Numbers"}], "\" \"", 
+                    StyleBox[
+                    "\"Prime Numbers\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Rational Numbers"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Rational Numbers\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Real Numbers"}], "\" \"", 
+                    StyleBox[
+                    "\"Real Numbers\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Trigonometric Functions"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Trigonometric Functions\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Volume"}], "\" \"", 
+                    StyleBox[
+                    "\"Volume\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Algebra"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Algebra\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Algebra\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Algebra I"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Algebra I\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, 
+                    "High School Algebra II and Trigonometry"}], "\" \"", 
+                    StyleBox[
+                    "\"High School Algebra II and Trigonometry\"", FontSize -> 
+                    12, Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Precalculus"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Precalculus\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Complex Numbers"}], "\" \"", 
+                    StyleBox[
+                    "\"Complex Numbers\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Linear Algebra"}], "\" \"", 
+                    StyleBox[
+                    "\"Linear Algebra\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Polynomials"}], "\" \"", 
+                    StyleBox[
+                    "\"Polynomials\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Quadratic Forms"}], "\" \"", 
+                    StyleBox[
+                    "\"Quadratic Forms\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Rational Functions"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Rational Functions\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Vector Algebra"}], "\" \"", 
+                    StyleBox[
+                    "\"Vector Algebra\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Applied Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Applied Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Applied Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Approximation Methods"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Approximation Methods\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Linear Algebra"}], "\" \"", 
+                    StyleBox[
+                    "\"Linear Algebra\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Numerical Analysis"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Numerical Analysis\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Operations Research"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Operations Research\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Optimization"}], "\" \"", 
+                    StyleBox[
+                    "\"Optimization\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Special Functions"}], "\" \"", 
+                    StyleBox[
+                    "\"Special Functions\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Wavelets"}], "\" \"", 
+                    StyleBox[
+                    "\"Wavelets\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Calculus & Analysis"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Calculus & Analysis\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Calculus & Analysis\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, 
+                    "High School Calculus and Analytic Geometry"}], "\" \"", 
+                    StyleBox[
+                    "\"High School Calculus and Analytic Geometry\"", 
+                    FontSize -> 12, Editable -> False, StripOnInput -> 
+                    False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, 
+                    "High School Advanced Calculus and Linear Algebra"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Advanced Calculus and Linear Algebra\"", 
+                    FontSize -> 12, Editable -> False, StripOnInput -> 
+                    False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Calculus"}], "\" \"", 
+                    StyleBox[
+                    "\"Calculus\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Complex Analysis"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Complex Analysis\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Derivatives"}], "\" \"", 
+                    StyleBox[
+                    "\"Derivatives\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Differential Equations"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Differential Equations\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Harmonic Analysis"}], "\" \"", 
+                    StyleBox[
+                    "\"Harmonic Analysis\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Integrals"}], "\" \"", 
+                    StyleBox[
+                    "\"Integrals\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Multivariable Calculus"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Multivariable Calculus\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Real Analysis"}], "\" \"", 
+                    StyleBox[
+                    "\"Real Analysis\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Related Rates"}], "\" \"", 
+                    StyleBox[
+                    "\"Related Rates\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Riemann Surfaces"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Riemann Surfaces\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Series"}], "\" \"", 
+                    StyleBox[
+                    "\"Series\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Special Functions"}], "\" \"", 
+                    StyleBox[
+                    "\"Special Functions\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Vector Fields"}], "\" \"", 
+                    StyleBox[
+                    "\"Vector Fields\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Discrete Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Discrete Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Discrete Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "High School Finite Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Finite Mathematics\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Coding Theory"}], "\" \"", 
+                    StyleBox[
+                    "\"Coding Theory\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Combinatorics"}], "\" \"", 
+                    StyleBox[
+                    "\"Combinatorics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Graph Theory"}], "\" \"", 
+                    StyleBox[
+                    "\"Graph Theory\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Networks"}], "\" \"", 
+                    StyleBox[
+                    "\"Networks\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Sequences"}], "\" \"", 
+                    StyleBox[
+                    "\"Sequences\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Tiling"}], "\" \"", 
+                    StyleBox[
+                    "\"Tiling\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Trees"}], "\" \"", 
+                    StyleBox[
+                    "\"Trees\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Experimental Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Experimental Mathematics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Geometry"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Geometry\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Geometry\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    "High School Geometry", {False, "High School Geometry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Algebraic Curves"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Algebraic Curves\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Algebraic Geometry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Algebraic Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Algebraic Surfaces"}], 
+                    "\" \"", 
+                    StyleBox["\"Algebraic Surfaces\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Analytic Geometry"}], "\" \"", 
+                    StyleBox[
+                    "\"Analytic Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Conic Sections"}], "\" \"", 
+                    StyleBox[
+                    "\"Conic Sections\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Curves"}], "\" \"", 
+                    StyleBox[
+                    "\"Curves\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Differential Geometry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Differential Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Ellipses"}], "\" \"", 
+                    StyleBox[
+                    "\"Ellipses\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Geometric Transformations"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Geometric Transformations\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Higher-Dimensional Geometry"}], "\" \"", 
+                    StyleBox[
+                    "\"Higher-Dimensional Geometry\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Hyperbolic Geometry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Hyperbolic Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Nested Patterns"}], "\" \"", 
+                    StyleBox[
+                    "\"Nested Patterns\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Plane Geometry"}], "\" \"", 
+                    StyleBox[
+                    "\"Plane Geometry\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Polygons"}], "\" \"", 
+                    StyleBox[
+                    "\"Polygons\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Polyhedra"}], "\" \"", 
+                    StyleBox[
+                    "\"Polyhedra\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Projective Geometry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Projective Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Reflections"}], "\" \"", 
+                    StyleBox[
+                    "\"Reflections\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Solid Geometry"}], "\" \"", 
+                    StyleBox[
+                    "\"Solid Geometry\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Surfaces"}], "\" \"", 
+                    StyleBox["\"Surfaces\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Triangles"}], "\" \"", 
+                    StyleBox[
+                    "\"Triangles\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Historical Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Historical Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Historical Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Euclid's Elements"}], "\" \"", 
+                    StyleBox[
+                    "\"Euclid's Elements\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Foundations of Mathematics"}],
+                     "\" \"", 
+                    StyleBox[
+                    "\"Foundations of Mathematics\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Greek Mathematics"}], "\" \"", 
+                    StyleBox[
+                    "\"Greek Mathematics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Unsolved Problems"}], "\" \"", 
+                    StyleBox[
+                    "\"Unsolved Problems\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Number Theory"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Number Theory\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Number Theory\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Number Bases"}], "\" \"", 
+                    StyleBox[
+                    "\"Number Bases\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Prime Numbers"}], "\" \"", 
+                    StyleBox[
+                    "\"Prime Numbers\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Representations of Numbers"}],
+                     "\" \"", 
+                    StyleBox[
+                    "\"Representations of Numbers\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}}, GridBoxAlignment -> {
+                    "Columns" -> {{Left}}}, DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Pure Mathematics"}], "\" \"", 
+                    
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Pure Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Pure Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Algebraic Geometry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Algebraic Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Complex Analysis"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Complex Analysis\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Differential Geometry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Differential Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Dynamical Systems Theory"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Dynamical Systems Theory\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Group Theory"}], "\" \"", 
+                    StyleBox[
+                    "\"Group Theory\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Knot Theory"}], "\" \"", 
+                    StyleBox[
+                    "\"Knot Theory\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Mathematical Logic"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Mathematical Logic\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Theorem Proving"}], "\" \"", 
+                    StyleBox[
+                    "\"Theorem Proving\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Topology"}], "\" \"", 
+                    StyleBox[
+                    "\"Topology\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Recreational Mathematics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Recreational Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Recreational Mathematics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Golden Ratio"}], "\" \"", 
+                    StyleBox[
+                    "\"Golden Ratio\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Mathematics Problems"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Mathematics Problems\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Unsolved Problems"}], "\" \"", 
+                    StyleBox[
+                    "\"Unsolved Problems\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Statistics"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Statistics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Statistics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Statistics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Statistics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Data Analysis"}], "\" \"", 
+                    StyleBox[
+                    "\"Data Analysis\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Probability"}], "\" \"", 
+                    StyleBox[
+                    "\"Probability\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Random Processes"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Random Processes\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, 
+                    StripOnInput -> False], DynamicModuleValues :> {}], 
+                    FontSize -> 12, Editable -> False, StripOnInput -> 
+                    False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]},
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Life Sciences"}], "\" \"", 
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Life Sciences\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Life Sciences\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Biology"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Biology\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Biology\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Biology"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Biology\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Developmental Biology"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Developmental Biology\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Growth Processes"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Growth Processes\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Molecular Biology"}], "\" \"", 
+                    StyleBox[
+                    "\"Molecular Biology\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Natural Forms"}], "\" \"", 
+                    StyleBox["\"Natural Forms\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Plant Biology"}], "\" \"", 
+                    StyleBox[
+                    "\"Plant Biology\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Zoology"}], "\" \"", 
+                    StyleBox[
+                    "\"Zoology\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Cognitive Science"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Cognitive Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Cognitive Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Perception"}], "\" \"", 
+                    StyleBox[
+                    "\"Perception\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Psychology"}], "\" \"", 
+                    StyleBox[
+                    "\"Psychology\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Psychophysics"}], "\" \"", 
+                    StyleBox[
+                    "\"Psychophysics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Ecology"}], "\" \"", 
+                    StyleBox[
+                    "\"Ecology\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Medicine"}], "\" \"", 
+                    StyleBox[
+                    "\"Medicine\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]},
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Engineering & Technology"}], "\" \"", 
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Engineering & Technology\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Engineering & Technology\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "School Applied Sciences"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"School Applied Sciences\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Chemical Engineering"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Chemical Engineering\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Civil Engineering"}], "\" \"", 
+                    StyleBox[
+                    "\"Civil Engineering\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Control Theory"}], "\" \"", 
+                    StyleBox[
+                    "\"Control Theory\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Electrical Engineering"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Electrical Engineering\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Electrical Engineering\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Circuit Design"}], "\" \"", 
+                    StyleBox[
+                    "\"Circuit Design\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Signal Processing"}], "\" \"", 
+                    StyleBox[
+                    "\"Signal Processing\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Fluid Mechanics"}], "\" \"", 
+                    StyleBox[
+                    "\"Fluid Mechanics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Image Processing"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Image Processing\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Machines"}], "\" \"", 
+                    StyleBox[
+                    "\"Machines\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Mechanical Engineering"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Mechanical Engineering\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Nanotechnology"}], "\" \"", 
+                    StyleBox[
+                    "\"Nanotechnology\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Robotics"}], "\" \"", 
+                    StyleBox[
+                    "\"Robotics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Signal Processing"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Signal Processing\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Signal Processing\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Audio"}], "\" \"", 
+                    StyleBox[
+                    "\"Audio\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Wavelets"}], "\" \"", 
+                    StyleBox[
+                    "\"Wavelets\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]},
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Kids & Fun"}], "\" \"", 
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Kids & Fun\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Kids & Fun\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "School Puzzles and Recreations"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"School Puzzles and Recreations\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"School Puzzles and Recreations\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Puzzles and Recreations: Elementary"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Puzzles and Recreations: Elementary\"", FontSize -> 12,
+                     Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Puzzles and Recreations: Intermediate"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Puzzles and Recreations: Intermediate\"", FontSize -> 
+                    12, Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Puzzles and Recreations: Advanced"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Puzzles and Recreations: Advanced\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}}, GridBoxAlignment -> {
+                    "Columns" -> {{Left}}}, DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Everyday Life"}], "\" \"", 
+                    StyleBox[
+                    "\"Everyday Life\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "For Kids"}], "\" \"", 
+                    StyleBox[
+                    "\"For Kids\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Optical Illusions"}], "\" \"", 
+                    StyleBox[
+                    "\"Optical Illusions\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Puzzles"}], "\" \"", 
+                    StyleBox[
+                    "\"Puzzles\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Recreation"}], "\" \"", 
+                    StyleBox[
+                    "\"Recreation\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]}
+       },
+       DefaultBaseStyle->"Column",
+       GridBoxAlignment->{"Columns" -> {{Left}}},
+       GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}],
+      "Column"], 
+     TagBox[GridBox[{
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Computation"}], "\" \"", 
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Computation\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Computation\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Algorithms"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Algorithms\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Algorithms\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Automatic Reasoning"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Automatic Reasoning\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Coding Theory"}], "\" \"", 
+                    StyleBox[
+                    "\"Coding Theory\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Computational Geometry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Computational Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Computer Algebra"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Computer Algebra\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Computer Graphics"}], "\" \"", 
+                    StyleBox[
+                    "\"Computer Graphics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Cryptography"}], "\" \"", 
+                    StyleBox[
+                    "\"Cryptography\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Data Compression"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Data Compression\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Image Processing"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Image Processing\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Numerical Analysis"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Numerical Analysis\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Computer Science"}], "\" \"", 
+                    
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Computer Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Computer Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "High School Computer Science"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"High School Computer Science\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Computational Geometry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Computational Geometry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Computer Graphics"}], "\" \"", 
+                    StyleBox[
+                    "\"Computer Graphics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Data Structures"}], "\" \"", 
+                    StyleBox[
+                    "\"Data Structures\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Finite State Machines"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Finite State Machines\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Recursion"}], "\" \"", 
+                    StyleBox[
+                    "\"Recursion\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Theory of Computation"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Theory of Computation\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Computer Systems"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Computer Systems\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "NKS / Wolfram Science"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"NKS / Wolfram Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"NKS / Wolfram Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Cellular Automata"}], "\" \"", 
+                    StyleBox[
+                    "\"Cellular Automata\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Fractals"}], "\" \"", 
+                    StyleBox[
+                    "\"Fractals\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Nested Patterns"}], "\" \"", 
+                    StyleBox[
+                    "\"Nested Patterns\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Simple Computational Systems"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Simple Computational Systems\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Substitution Systems"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Substitution Systems\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]},
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Business & Social Systems"}], "\" \"", 
+           
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Business & Social Systems\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Business & Social Systems\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Actuarial Science"}], "\" \"", 
+                    StyleBox[
+                    "\"Actuarial Science\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Business"}], "\" \"", 
+                    StyleBox[
+                    "\"Business\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Economics"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Economics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Economics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "High School Economics and Finance"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Economics and Finance\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Macroeconomics"}], "\" \"", 
+                    StyleBox[
+                    "\"Macroeconomics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Microeconomics"}], "\" \"", 
+                    StyleBox[
+                    "\"Microeconomics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Finance"}], "\" \"", 
+                    StyleBox[
+                    "\"Finance\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Law"}], "\" \"", 
+                    StyleBox[
+                    "\"Law\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Political Science"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Political Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Political Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "International Relations"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"International Relations\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Social Sciences"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Social Sciences\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Social Sciences\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    "School Social Studies", {False, 
+                    "School Social Studies"}], "\" \"", 
+                    StyleBox[
+                    "\"School Social Studies\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Linguistics"}], "\" \"", 
+                    StyleBox[
+                    "\"Linguistics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]},
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Our World"}], "\" \"", 
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Our World\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Our World\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Elementary School K-2 Science"}], "\" \"", 
+                    StyleBox[
+                    "\"Elementary School K-2 Science\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Elementary School 3-5 Science"}], "\" \"", 
+                    StyleBox[
+                    "\"Elementary School 3-5 Science\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Middle School Science"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Middle School Science\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Everyday Life"}], "\" \"", 
+                    StyleBox[
+                    "\"Everyday Life\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox["Geography", {False, "Geography"}], "\" \"", 
+                    StyleBox[
+                    "\"Geography\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Geometric Models"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Geometric Models\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "History"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"History\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"History\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Classic Science Experiments"}], "\" \"", 
+                    StyleBox[
+                    "\"Classic Science Experiments\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Euclid's Elements"}], "\" \"", 
+                    StyleBox[
+                    "\"Euclid's Elements\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Greek Mathematics"}], "\" \"", 
+                    StyleBox[
+                    "\"Greek Mathematics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "International Relations"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"International Relations\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Linguistics"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Linguistics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Linguistics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "School Language Arts"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"School Language Arts\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Textual Analysis"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Textual Analysis\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Machines"}], "\" \"", 
+                    StyleBox[
+                    "\"Machines\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Natural Forms"}], "\" \"", 
+                    StyleBox[
+                    "\"Natural Forms\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox["Navigation", {False, "Navigation"}], "\" \"", 
+                    StyleBox[
+                    "\"Navigation\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Solar System"}], "\" \"", 
+                    StyleBox[
+                    "\"Solar System\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]},
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Programming Functionality"}], "\" \"", 
+           
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Programming Functionality\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Programming Functionality\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox["3D Graphics", {False, "3D Graphics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"3D Graphics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Version 7 Features"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Version 7 Features\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Short Programs"}], "\" \"", 
+                    StyleBox[
+                    "\"Short Programs\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]}
+       },
+       DefaultBaseStyle->"Column",
+       GridBoxAlignment->{"Columns" -> {{Left}}},
+       GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}],
+      "Column"], 
+     TagBox[GridBox[{
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Physical Sciences"}], "\" \"", 
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Physical Sciences\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Physical Sciences\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Astronomy"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Astronomy\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Astronomy\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Astronomy"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Astronomy\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Solar System"}], "\" \"", 
+                    StyleBox[
+                    "\"Solar System\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Chemistry"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Chemistry\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Chemistry\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Chemistry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Chemistry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Chemical Kinetics"}], "\" \"", 
+                    StyleBox[
+                    "\"Chemical Kinetics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "General Chemistry"}], "\" \"", 
+                    StyleBox[
+                    "\"General Chemistry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Inorganic Chemistry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Inorganic Chemistry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Organic Chemistry"}], "\" \"", 
+                    StyleBox[
+                    "\"Organic Chemistry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Physical Chemistry"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Physical Chemistry\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Earth Science"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Earth Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Earth Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, 
+                    "High School Earth and Environmental Sciences"}], "\" \"", 
+                    StyleBox[
+                    "\"High School Earth and Environmental Sciences\"", 
+                    FontSize -> 12, Editable -> False, StripOnInput -> 
+                    False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Meteorology"}], "\" \"", 
+                    StyleBox[
+                    "\"Meteorology\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "History of Science"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"History of Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"History of Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[
+                    False, {False, "Classic Science Experiments"}], "\" \"", 
+                    StyleBox[
+                    "\"Classic Science Experiments\"", FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Classic Scientific Images"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Classic Scientific Images\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Materials Science"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Materials Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Materials Science\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Crystallography"}], "\" \"", 
+                    StyleBox[
+                    "\"Crystallography\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Physics"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Physics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Physics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "High School Physics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"High School Physics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Acoustics"}], "\" \"", 
+                    StyleBox[
+                    "\"Acoustics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Astrophysics"}], "\" \"", 
+                    StyleBox[
+                    "\"Astrophysics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "College Physics"}], "\" \"", 
+                    StyleBox[
+                    "\"College Physics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Electromagnetism"}], "\" \"", 
+                    
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Electromagnetism\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}, GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Electromagnetism\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Electrostatics"}], "\" \"", 
+                    StyleBox[
+                    "\"Electrostatics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}, GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", BaselinePosition -> {1, 
+                    1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Fluid Mechanics"}], "\" \"", 
+                    StyleBox[
+                    "\"Fluid Mechanics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Gravitation Theory"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Gravitation Theory\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Mechanics"}], "\" \"", 
+                    StyleBox[
+                    "\"Mechanics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Optics"}], "\" \"", 
+                    StyleBox[
+                    "\"Optics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Particle Physics"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Particle Physics\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Quantum Physics"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Quantum Physics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}, GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Quantum Physics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Quantum Mechanics"}], "\" \"", 
+                    StyleBox[
+                    "\"Quantum Mechanics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}, GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Statistical Mechanics"}], 
+                    "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Statistical Mechanics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}, GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Statistical Mechanics\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Chemical Kinetics"}], "\" \"", 
+                    StyleBox[
+                    "\"Chemical Kinetics\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Thermodynamics"}], "\" \"", 
+                    StyleBox[
+                    "\"Thermodynamics\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}, GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Waves"}], "\" \"", 
+                    StyleBox[
+                    "\"Waves\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]},
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Systems, Models & Methods"}], "\" \"", 
+           
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Systems, Models & Methods\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Systems, Models & Methods\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Cellular Automata"}], "\" \"", 
+                    StyleBox[
+                    "\"Cellular Automata\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Chaos Theory"}], "\" \"", 
+                    StyleBox[
+                    "\"Chaos Theory\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Discrete Models"}], "\" \"", 
+                    StyleBox[
+                    "\"Discrete Models\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Experimental Methods"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Experimental Methods\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Fractals"}], "\" \"", 
+                    StyleBox[
+                    "\"Fractals\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Game Theory"}], "\" \"", 
+                    StyleBox[
+                    "\"Game Theory\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Generation of Form"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Generation of Form\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Multi-agent Modeling"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Multi-agent Modeling\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Networks"}], "\" \"", 
+                    StyleBox[
+                    "\"Networks\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Random Processes"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Random Processes\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Substitution Systems"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Substitution Systems\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Trees"}], "\" \"", 
+                    StyleBox[
+                    "\"Trees\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]},
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, "Creative Arts"}], "\" \"", 
+           StyleBox[
+            DynamicModuleBox[{Typeset`var$$ = False}, 
+             StyleBox[
+              PaneSelectorBox[{False -> TagBox[
+                  GridBox[{{"\"Creative Arts\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                  GridBox[{{"\"Creative Arts\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "School Art and Design"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"School Art and Design\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Visual Patterns"}], "\" \"", 
+                    StyleBox[
+                    "\"Visual Patterns\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Architecture"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Architecture\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Architecture\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Geometric Models"}], "\" \"", 
+                    
+                    StyleBox[
+                    "\"Geometric Models\"", FontSize -> 12, Editable -> False,
+                     StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Art"}], "\" \"", 
+                    StyleBox[
+                    "\"Art\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Color"}], "\" \"", 
+                    StyleBox[
+                    "\"Color\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Generation of Form"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Generation of Form\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Graphic Design"}], "\" \"", 
+                    StyleBox[
+                    "\"Graphic Design\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Iconography & Typography"}], 
+                    "\" \"", 
+                    StyleBox[
+                    "\"Iconography & Typography\"", FontSize -> 12, Editable -> 
+                    False, StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Music"}], "\" \"", 
+                    StyleBox[
+                    DynamicModuleBox[{Typeset`var$$ = False}, 
+                    StyleBox[
+                    PaneSelectorBox[{False -> TagBox[
+                    GridBox[{{"\"Music\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"], True -> TagBox[
+                    GridBox[{{"\"Music\"", 
+                    OpenerBox[
+                    Dynamic[Typeset`var$$]]}, {
+                    PaneBox[
+                    TagBox[
+                    GridBox[{{
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "School Music"}], "\" \"", 
+                    StyleBox[
+                    "\"School Music\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Audio"}], "\" \"", 
+                    StyleBox[
+                    "\"Audio\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Music Theory"}], "\" \"", 
+                    StyleBox[
+                    "\"Music Theory\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {"Columns" -> {{Automatic}}, 
+                    "Rows" -> {{Automatic}}}], "Column"], ImageMargins -> 0], 
+                    "\[SpanFromLeft]"}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                    DefaultBaseStyle -> "OpenerView", 
+                    BaselinePosition -> {1, 1}], "Grid"]}, 
+                    Dynamic[Typeset`var$$], Alignment -> Automatic, 
+                    BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, 
+                    ImageSize -> Automatic], Deployed -> False, StripOnInput -> 
+                    False], DynamicModuleValues :> {}], FontSize -> 12, 
+                    Editable -> False, StripOnInput -> False]}, 
+                    "RowDefault"]}, {
+                    TemplateBox[{
+                    CheckboxBox[False, {False, "Patterns"}], "\" \"", 
+                    StyleBox[
+                    "\"Patterns\"", FontSize -> 12, Editable -> False, 
+                    StripOnInput -> False]}, "RowDefault"]}}, 
+                    GridBoxAlignment -> {"Columns" -> {{Left}}}, 
+                    DefaultBaseStyle -> "Column", 
+                    GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                    "Column"], ImageMargins -> 0], "\[SpanFromLeft]"}}, 
+                   GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> 
+                   False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.2}}, "Rows" -> {{0.5}}}, 
+                   DefaultBaseStyle -> "OpenerView", 
+                   BaselinePosition -> {1, 1}], "Grid"]}, 
+               Dynamic[Typeset`var$$], Alignment -> Automatic, 
+               BaseStyle -> {}, BaselinePosition -> Baseline, 
+               DefaultBaseStyle -> "OpenerView", ImageMargins -> 0, ImageSize -> 
+               Automatic], Deployed -> False, StripOnInput -> False], 
+             DynamicModuleValues :> {}], FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]},
+        {"\<\"\"\>"}
+       },
+       DefaultBaseStyle->"Column",
+       GridBoxAlignment->{"Columns" -> {{Left}}},
+       GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}],
+      "Column"]}
+   },
+   AutoDelete->False,
+   BaseStyle->{"ControlStyle", ShowStringCharacters -> False},
+   GridBoxAlignment->{"Columns" -> {{Left}}, "Rows" -> {{Top}}},
+   GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}},
+   GridBoxSpacings->{"Columns" -> {{2}}}],
+  "Grid"]], "Output",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{
+  "CheckboxData" -> 
+   "OEM6eJy9Wetv28gRby+xJdmW/HaSu+\
+uBQdE7oDjhih6KAv3GyI8I8UM1fTmg39bkStrLkssul0qUv74zfIhDLiWnH9pPtvYxOzvzm9/\
+MLN3dobflmaXk3vZdauLUDL3OaM79DzyYbiXPr0VivN2fz50rzeK58BOvd8XVDH8svZO3YjZ3PH+\
+ulHRgOORGL72dW7YQM2aEirzTYtJTvmDwx6SB4AkcOTY8TFw4fPeGmTkPYbmfuHtD76jYQYdfDr3XF\
+5KHPDJML8sD3w3/SldNf5dr27r25+Hf2te+uhFBILljn1qteUGvSfXqDr1TOufKGX/\
+UzBlXe1tNVE3/0Lp97LAocB60mKmouaOmzERzn0k/lSlR9890xaiYziS6EZNL0LxFkb/\
+UFAkWLPJ5UN99LSLOdKlltfU7uvVSRMLwdjue0YWegdmkvuC5qzkR3Lv4d5rBiCw5vfgUqwici3C6T\
+CO/Mf+ynC90VjOmhZmHCXXJMub6UUkwRIuEnXGA4g3gtBrcG0cclJGN4e44MnzGNRk6GmudKQ363ab\
+hY21yLx9x3rCEijmZMM3QIaBRy517E64FTHNdjX01EdWP3YmSS0AK2CSho5oPLW/\
+1JyjLVu3gfr3W97xt+AUBaLspt98rmYa8GugU6ri9pyPnfxEa+yMVxpJ/si8zWIfudtvu/\
+zNlAfoZ7q00RdfRyo4tBhm8575RLaccu3EsBUQcpZcOGAnGtfokwkyoc8PNXAVfovYR3BBQAybIoz4\
+RZNfxHQRAjjLnnicgwJ8Td9/FRoTic7agGj70Yu6vibrur2zBJTf0jBV3fL/SwN3//\
+7NTd2Sh4KBEgW2Z3XMw2gJuvqDxeXYuplOuC9ZpidDDt0yHKgLdbZG9jCN0DT5nN6mEM4Ca2CMkH1v\
+FfhZytjAYl8zA3QFlvBa9AlATRY6X6inz6dS2B1eiA5sc2S8Aeim4pDg7OReJr3md2TH/\
+fTH590cqENHMeZhzRV0L4+GjiBicWlu/\
+lxUc1vLuLTcflf5ADewBNfOofukHIeG0amDrQXO6APNExqpQJqxJ+90Sh+\
+7pk3n8oMAdIGCU6hp4jqopex+ZtD13uCEiBqMMbh63OLd5/\
+mkNvLak7oWUIq7lo1fFKjjgQTOQDhTXhPw3aBCuh+dowyRnPFv4Mcm19uz+\
+LU8QzBNmILnViHIiWcTbtEU6njXSIwzNeVDj04lWv6FtFm1Cdu/\
+5VFqWG3igZtB2pu2aHmQgFs1kjSXewh+Vcy6NkufgyYvUB9k/JE5RmpJtX1+\
+qNAoKNlbTdiweXgF8P6yZ+yVKlFygHbUCOqHZqF8UHHkYuc/\
+WliDryoKv73msIUVEptLQrh0mqa4zQ+8J3G+g4Kfw+vJ8GbEws7K3TLCNsEgCuEOlsTW8+\
+y5Sxho9qvQGkVAwCp8gNFvNQzTtokYo3QcVK6lmVLN7DhxZpn9qDrT7lZJQWDpZeUCIlSxr8d8m3+\
+5UJTRi7Mnqun/ODGvLeSiaPQJhGuqhe8iqKrs4IL+GlV10XpoDAk/eAU+rvMpGxx+\
+7qVHZjaC4YAnwFLXbujxwRoS2+v0gX8BbcvzhaqrsUgkWRnoZm6JjJdIyY+A+\
+QHdSK3QOxiGb8fLiNeU3VlWVgp4vMB9hAfdtrdxpLPgvbr/\
+pivvZXTyjU99AINJYKjIywgED1J9DlURpDBCb6vr1T3PPYKATpVqvmYcf2Xr7znN+\
+cn5Vcgr9zMoMW6g+\
+lzKVWKDl4KAV2qVmvqmX12sTw7eeQOJw6vayNDnx0keAv0mzstmaPpzMwXcZheQ6Ju42WMNNjMa2Yu\
+l+1exPyhkCLEgXrDQCMekIwhn+A7bdbghZzVC34hgq8g480+R8HkGZ3rrveBwpPWNYArRJvVs/\
+d7S6estk/4JpM185DqzwI71APovV9kW0EGCQonwqjUgoAjoVQFGDII/yDJlhi5zxzUgyCDS/\
+HHOq2owWJbVVRkzh3yxSqcmATWEnYGkl//\
+fY9WlwEpPSYoFObozE7WOpQrvHfJy41fVV2iDUvQwVcXMpNJlScmSQ5szBBVYdGvA/\
+Q2cnIWo3KAYT08jr+5cyhXrkhvtzdCYtKYEDFiJHv0WkvZYN29jS1TSZgCuFL1uUxNY2MmlYzqCOh+\
+VYi+zTVa7BpFfOo183gXsAakPLFOS5nExsYStJs9a1mPIqTCHddN6IDFdIrzWnFeO0lODQlqq4gKk1\
+fwB1wkdAdEuOO7xR4JaMsaxt/VsGPIsNVL3172PRauz1nX+pxgiw+\
+QyIGavTEqdQIuxMuPZ5XKfbnUmyhOs1NMgHLeh1LvzGyu4ND4QP5ieB9CZNMA1gZ16+y+\
+YEiRY9dCGJYGMq7SzVLXcStMGJ+DqSFzmva2xRzmSMAZmI1YQNIB1pxctFdEK0T3QsGc+\
+u2UfK6gof6AitI3ZfYP+tozJVZA10vfDfL61QggzZv/\
+XhmhDcNRQGabPEelUY8kfnRgVcooWLJxt82t6UBPdGc6bsSna/\
+6rszgSTD1RvY5sNQS1LdvWJQ4Vvlb55lMioBWkZI0+oU3ymGQLKA60yDeg1sN+\
+MbysYncrLdoUczABvcEarF750HYJYoj3sw5YsyLxfPZnYGOlmRD5FDI1AsxJo57K2BkKVdo+\
+ZU3ZSKeBmMhPZTYZxznohZ7dkMfjLZWk6uZ/\
+gNNWjXLuPOSgnrbju4ZdD6rCxIhN2rR9UoOyyF8X5bLgQA6VtaXvx6d6mG2k/LAD30h/\
+YPNhantKzDjzXWutP6hxprvn+x4HoZsKWDCYNotfpcRXl/9b7RDKtOUaJgovmyumRTb7+pbX+\
+alyjHoA9OirtfMxhGeLiaHnbwwD8Bdbe1Ji2YWZfEyNe7J2vd/\
+ihrdxe5Ju5ORZvwO2P9ZjTsvxcJqmgX9nuuBhUBo9jCIG9vcNIzEE+IA+otRT6NbGS0QdE+\
+WZq9HGPCyZGCdLOMLdhs3UD687NmvvwYiANkQSNI9rJ5+\
+w3Tvv3OOxFgtrhMI2wbvivL0PTzZ8nzBFo9LmSp9o9r5v7hVAFVyf/T2tUZCkMoEqByrta/Xru+\
+fH1/OvK6YHkH70UbkzjPz2NIhEkd7Z3iSGKU6mCSYoGXwDFhiGmhfMHGD3PZ6xb9Uk0Q8Z5nTa7zd+\
+eSs0aPPPDmCtBaiKVBA0MQ72bpbT+oGASCjndZdZYkvdUbB34ux69cjcFBZtcYUnf+\
+IbznRkvMfxzjegSdhArHEXSwydYlJGleDWJSTJ7fqohnH94SlUJNCGjkXv+\
+ch3C2yaFdfMyCRjwozh89+w+cjdPx"},
+ CellTags->{"CheckboxCell", "Topics", "Topics-Checkboxes"},
+ CellID->375137771,ExpressionUUID->"ea774907-334f-403a-8e2e-013c07972c0d"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Related Demonstrations",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"RelatedDemonstrations", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{
+          "Enter any additional information that you would like to \
+communicate to the reviewer here.", 
+           StyleBox["\n", FontSize -> 4]}], "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoRelatedDemonstrations"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "061ad2ea-a278-4a12-9019-50064550fb7e"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "RelatedDemonstrations"},
+ DefaultNewCellStyle->"Text",
+ CellTags->{
+  "Related Demonstrations", "RelatedDemonstrations", "TemplateCellGroup"},
+ CellID->1132753,ExpressionUUID->"53eefeb9-f7fb-49cc-a999-6f677ead9d51"],
+
+Cell["Link to a related demonstration", "Item",
+ TaggingRules->{},
+ CellEventActions->{Inherited, {"KeyDown", "\t"} :> Replace[SelectionMove[
+       SelectedNotebook[], After, Cell]; NotebookFind[
+       SelectedNotebook[], "TabNext", Next, CellTags, AutoScroll -> True, 
+       WrapAround -> True], Blank[NotebookSelection] :> SelectionMove[
+       SelectedNotebook[], All, CellContents, AutoScroll -> True]], 
+   PassEventsDown -> False, PassEventsUp -> False},
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->904163252,ExpressionUUID->"0d6e2845-dbfa-4e1c-b780-969415c4146e"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "External Links",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"ExternalLinks", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{
+          "Provide hyperlinks (not just bare URLs) to any relevant \
+resources.wolfram.com pages, with the page title as the linked text. Links to \
+", 
+           ButtonBox[
+           "NKS | Online", 
+            BaseStyle -> {"Hyperlink", FontColor -> RGBColor[0.4, 0.45, 0.5]},
+             ButtonData -> {
+              URL["http://www.wolframscience.com/nks"], None}], 
+           " should use the section title, not a page number. Links to \
+non-Wolfram sites go in the Details section.", 
+           StyleBox["\n", FontSize -> 4]}], "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoExternalLinks"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "b041bf6e-a504-4372-9f34-5e2827791a99"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "ExternalLinks"},
+ DefaultNewCellStyle->"Item",
+ CellTags->{"External Links", "ExternalLinks", "TemplateCellGroup"},
+ CellID->843468725,ExpressionUUID->"c7e61a88-e056-4fd4-92f6-d76c81bf19d6"],
+
+Cell["Link to external information", "Item",
+ TaggingRules->{},
+ CellEventActions->{Inherited, {"KeyDown", "\t"} :> Replace[SelectionMove[
+       SelectedNotebook[], After, Cell]; NotebookFind[
+       SelectedNotebook[], "TabNext", Next, CellTags, AutoScroll -> True, 
+       WrapAround -> True], Blank[NotebookSelection] :> SelectionMove[
+       SelectedNotebook[], All, CellContents, AutoScroll -> True]], 
+   PassEventsDown -> False, PassEventsUp -> False},
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->180966586,ExpressionUUID->"c3717123-fab8-49ef-bb07-872904b07f43"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Related Symbols",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"RelatedSymbols", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{
+          "List the names of published resource objects from any Wolfram \
+repository that are related to this function.", 
+           StyleBox["\n", FontSize -> 4]}], "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoRelatedSymbols"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "72313f5a-84c8-4264-8311-79a029b6860b"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "RelatedSymbols"},
+ DefaultNewCellStyle->"Item",
+ CellTags->{"Related Symbols", "RelatedSymbols", "TemplateCellGroup"},
+ CellID->899564547,ExpressionUUID->"39801c7c-0114-4a4e-9bdc-d1e59d88d289"],
+
+Cell["SymbolName (documented Wolfram Language symbol)", "Item",
+ TaggingRules->{},
+ CellEventActions->{Inherited, {"KeyDown", "\t"} :> Replace[SelectionMove[
+       SelectedNotebook[], After, Cell]; NotebookFind[
+       SelectedNotebook[], "TabNext", Next, CellTags, AutoScroll -> True, 
+       WrapAround -> True], Blank[NotebookSelection] :> SelectionMove[
+       SelectedNotebook[], All, CellContents, AutoScroll -> True]], 
+   PassEventsDown -> False, PassEventsUp -> False},
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->159321921,ExpressionUUID->"6519833f-75b7-4b82-8ac9-a1c215acba33"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Published Date",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"PublishedDate", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+         TextData[{"If known, the date Demonstration was published."}], 
+         "MoreInfoText"], Background -> GrayLevel[0.95], FrameMargins -> 20, 
+        FrameStyle -> GrayLevel[0.9], RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoPublishedDate"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "4eef56de-063c-4235-84c5-447313d9834f"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "PublishedDate"},
+ DefaultNewCellStyle->"Text",
+ CellTags->{"Published Date", "PublishedDate", "TemplateCellGroup"},
+ CellID->364555554,ExpressionUUID->"96c4ac55-b088-49f7-9ebd-b94233dc8a81"],
+
+Cell["2011-03-07", "Text",
+ TaggingRules->{},
+ CellID->15904391,ExpressionUUID->"37c281de-8208-45f7-96b3-8db2ef28ad4c"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Compatibility",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"Compatibility", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+        "Specify any known compatibilities for your demonstration to ensure \
+it is discoverable on the correct platforms.", "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoCompatibility"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "15bbf13c-3637-41c1-b437-b217f08d079a"]
+}], "Subsection",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{"TemplateGroupName" -> "Compatibility"},
+ CellTags->{"Compatibility", "TemplateCellGroup"},
+ CellID->618273920,ExpressionUUID->"0d510131-c801-4515-915b-232ee417072a"],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "AR Support",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"CompatibilityARSupport", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+        "Specify whether your demonstration is expected to be supported \
+through AR (Augmented Reality).", "MoreInfoText"], Background -> 
+        GrayLevel[0.95], FrameMargins -> 20, FrameStyle -> GrayLevel[0.9], 
+        RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoCompatibilityARSupport"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "a7a1dfb4-c10d-4e2d-be48-d9657b639384"]
+}], "Subsubsection",
+ Editable->False,
+ Deletable->False,
+ CellMargins->{{Inherited, Inherited}, {4, 6}},
+ TaggingRules->{"TemplateGroupName" -> "CompatibilityARSupport"},
+ DefaultNewCellStyle->"Text",
+ FontSize->16,
+ CellID->855747700,ExpressionUUID->"00faa4f7-afe3-48ea-8c73-56a7a3482e4d"],
+
+Cell[BoxData[
+ TagBox[GridBox[{
+    {
+     TagBox[GridBox[{
+        {
+         TemplateBox[{
+           CheckboxBox[False, {False, False}], "\" \"", 
+           StyleBox[
+           "\"Supported in ARPublish (Augmented Reality)\"", FontSize -> 12, 
+            Editable -> False, StripOnInput -> False]},
+          "RowDefault"]}
+       },
+       DefaultBaseStyle->"Column",
+       GridBoxAlignment->{"Columns" -> {{Left}}},
+       GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}],
+      "Column"]}
+   },
+   AutoDelete->False,
+   BaseStyle->{"ControlStyle", ShowStringCharacters -> False},
+   GridBoxAlignment->{"Columns" -> {{Left}}, "Rows" -> {{Top}}},
+   GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}},
+   GridBoxSpacings->{"Columns" -> {{2}}}],
+  "Grid"]], "Output",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{
+  "CheckboxData" -> 
+   "OEM6eJw9j8tOwzAQRSlKKOW1ZJ0lVPJHmCCkSIhWGX7ATSfUwvZYnvEif4/\
+NazlH9zFXXyloQRaHcLHLErMoWPcnnD7xOJ9x82q5kHYQ9Dyvfu75nJsxF8cWcoyUBI+dDZ0e9/\
+ngLJ+6B50/PIbKRzTOyvLI7YtxjAou94kiJlngvicfjdiDrQo9/oaV/l0US4F5o7OQL5KpPkUu+\
+8D9SsHdULJTTCimCmH9ROTQBAXXfeZiGUIZ8l/5B+\
+sGbt4oFHYzIlNOE74vEeH2GX0plPSd9wX8smDe"},
+ CellTags->{
+  "CheckboxCell", "CompatibilityARSupport", 
+   "CompatibilityARSupport-Checkboxes"},
+ CellID->678130364,ExpressionUUID->"f61c5465-ffa4-4001-926f-6007a866f625"]
+}, Closed]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Wolfram Language Version",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"CompatibilityWolframLanguageVersionRequired", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+        "Enter required Wolfram Language Version (e.g. 12.1+).", 
+         "MoreInfoText"], Background -> GrayLevel[0.95], FrameMargins -> 20, 
+        FrameStyle -> GrayLevel[0.9], RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {
+       "SectionMoreInfoCompatibilityWolframLanguageVersionRequired"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "8152e657-4f09-45c4-845f-7116d418d1a7"]
+}], "Subsubsection",
+ Editable->False,
+ Deletable->False,
+ CellMargins->{{Inherited, Inherited}, {4, 6}},
+ TaggingRules->{
+  "TemplateGroupName" -> "CompatibilityWolframLanguageVersionRequired"},
+ DefaultNewCellStyle->"Text",
+ FontSize->16,
+ CellID->96439972,ExpressionUUID->"7024026e-3452-4886-8db9-20f5fe0c495b"],
+
+Cell["6", "Text",
+ TaggingRules->{},
+ CellTags->"ScrapeDefault",
+ CellID->642025685,ExpressionUUID->"e5eea8d6-cf7e-442f-a42d-5ba0c0bc21c0"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[{
+ "Cloud Support",
+ Cell[BoxData[
+  PaneSelectorBox[{True->
+   TemplateBox[{"CompatibilityCloudSupport", 
+     Cell[
+      BoxData[
+       FrameBox[
+        Cell[
+        "Specify whether your demonstration is expected to work in the public \
+cloud.", "MoreInfoText"], Background -> GrayLevel[0.95], FrameMargins -> 20, 
+        FrameStyle -> GrayLevel[0.9], RoundingRadius -> 5, ImageSize -> {
+          Scaled[0.65], Automatic}]], "MoreInfoText", Deletable -> True, 
+      CellTags -> {"SectionMoreInfoCompatibilityCloudSupport"}, 
+      CellMargins -> {{66, 66}, {15, 15}}]},
+    "MoreInfoOpenerButtonTemplate"]}, Dynamic[
+    CurrentValue[
+     EvaluationNotebook[], {TaggingRules, "ResourceCreateNotebook"}]],
+   ImageSize->Automatic]],ExpressionUUID->
+  "7025ad79-a6bb-4eed-9ae2-9212cf11d6b5"]
+}], "Subsubsection",
+ Editable->False,
+ Deletable->False,
+ CellMargins->{{Inherited, Inherited}, {4, 6}},
+ TaggingRules->{"TemplateGroupName" -> "CompatibilityCloudSupport"},
+ DefaultNewCellStyle->"Text",
+ FontSize->16,
+ CellID->122353723,ExpressionUUID->"afc79548-0ab3-464e-b662-10499fc58080"],
+
+Cell[BoxData[
+ TagBox[GridBox[{
+    {
+     TagBox[GridBox[{
+        {
+         TemplateBox[{
+           CheckboxBox[True, {False, True}], "\" \"", 
+           StyleBox[
+           "\"Supported in cloud\"", FontSize -> 12, Editable -> False, 
+            StripOnInput -> False]},
+          "RowDefault"]}
+       },
+       DefaultBaseStyle->"Column",
+       GridBoxAlignment->{"Columns" -> {{Left}}},
+       GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}],
+      "Column"]}
+   },
+   AutoDelete->False,
+   BaseStyle->{"ControlStyle", ShowStringCharacters -> False},
+   GridBoxAlignment->{"Columns" -> {{Left}}, "Rows" -> {{Top}}},
+   GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}},
+   GridBoxSpacings->{"Columns" -> {{2}}}],
+  "Grid"]], "Output",
+ Editable->False,
+ Deletable->False,
+ TaggingRules->{
+  "CheckboxData" -> 
+   "OEM6eJxFjkuOwjAQRAUKf4bF7NhxgRwCjJAioQHRXCAkjbCw3Za7e5Hb4yDQbEvvVdV2XsIIpH\
+MI45NKVClhYh7YPLG9D7g4WhYurkkxc5Wg5296H3Jx0ez9gsZISbDd2LBpHGn7NabnRBGTdLA25GMt\
+9madlc700EfLe6colgLzbKtCPlNNf4Kc+sBmUMKqCoIpJpS6B2GyI3JYhxIWRjkrVcjHeXSoHeN/\
+2L/l4o9CzpYXZNLU4LWLCD979HlQ0rvvBXKCW6E="},
+ CellTags->{
+  "CheckboxCell", "CompatibilityCloudSupport", 
+   "CompatibilityCloudSupport-Checkboxes"},
+ CellID->291004391,ExpressionUUID->"34b1d8c5-5c2d-42a1-a08f-8d44bc1c0e10"]
+}, Closed]]
+}, Open  ]]
+}, Closed]]
+}, Open  ]]
+},
+TaggingRules->{
+ "ResourceType" -> "Demonstration", "ResourceCreateNotebook" -> True, 
+  "TemplateVersion" -> "2024.05.27", "CreationTimestamp" -> 
+  3.927380838423746`16.346678006041895*^9, "UpdatedTimestamp" -> 
+  3.927380838423816`16.3466780060419*^9, "CompatibilityTest" -> HoldComplete[
+    BinaryDeserialize[
+     BaseDecode[
+     "OEM6eJzVWFtv2zYUri+\
+5IPEyNECB9a0PeciCbR2GAduaXerJSeohSZPQ6XNo6UgRTJMqSaXxv98hJTm2I7mS7WCdHxJapL7z8\
+dz40X5N7TpiGImYe0f3kQSlQsH9mlq7jEPQfj13uq7qXR//\
+Ntrcw39rRx9jytTO3geQZv48HvZBSt9+9t+aFYQO4RIHLSeWErj+QFkM/\
+jO1e3SHI6rNW0JDX4gBrmqehkqrVo8GQciDq5iBIq0rUCKWLvRGEZBmh2qKNJvvuQuFLNf+\
+ZsIdmGUJ4J4juIZ7fUH1rd8o2vk5gKfIfmaPjJSGocNCpH3TAT/\
+k4STdm4dXXhlS2Wt5S1XzPGYMif3weDI1cAUBUgWJTP0wiKV1zXi7f5UldQWRUKEWcpQAJjgqBWrY+\
+NXU5jENWSwxMjX11QV1GeguV5oyRr4pYuivL+Lshdza6ompyGwRLTEf/hGhsdc4o5HdQ8xd86a/\
+llgmLwuda8lRZdJ6O8EiEQu1eUyY0E6N1G5I/c0fEw/qh1uWPOavIt+WJX/\
+gNwu81CBg7G11xCdui0Cp38qiZoP3scYwgmcKagsjzagLbcyrFcJum6LrAKMj8BB3+\
+51gHgYSE5OrP8sCX8jwDgFv7pK2cCIBv0m1cc1V2g5yvNGpik6jCLh3zW8p9xh4DjCm5jpmVRbm+\
+Ai/VvaSi7DY8VIE8rwHQ9yABmPuRIo4Wh4Ua7fVZmaE7eAOE/\
+qFg4sCIUNQ3zu34A764h4f7zw8NtZJK5uz33bQHo2ZtvXNdQ5T8nX2iEBSm7mhLt3NxoFQg564jjwc\
+p32/OMorAJ8KcAMfbGQlsHnCRJ+\
+ym1tzpE16VP1S1uwJ6Heh5wFPGlH5cj2m3B05tyJ0oRNSJoJJYq2UmNR4SuL5ik2Z8kEedYqzz+\
+2sOZMIfIwBd012Uw8wLzN4icfFeL/\
+TBibAsiNlrSdjW9pLdokqh102yJIulSHqp6oUeL9KjaVSZtbqlIcyf57Dp7E/\
+c32cFIg6q0p5L1ZwCgF1R92AC5l0pyzWqmmikV98h2Ut5eDOFN68MlzSzLweW1frp/\
+imbYzHVf0WgM7a2LTFlZUSlsQ2Mgfsi1SBegq6hdWIEtqq5nWzutsxdWn5qY0u9uwAM3Wzy62x0Wec\
+3BizLth4Cly672U7UuOT4RFs/8HbY/MTNmvqqPIxSLngoUvZhRQRoLesnluU8wTR/\
+EtEPW2GrbZSwg2t9r5U7cq1HaVsyQjpj4YmhzbbVoz0xGrgbJqQHWKBzkBTz9wP0hsY2XRCnVxAXiY\
+rXl+BD9Jk96ts6qG7rCYqE0ZnaCW3p/EdKrmCNk/R54+uns/s5+\
+At3gmWuazMuUlU0PcHhSjVBH01nHkK/udCJLwEDmgAxMWAVNPt14WYyWmXlweJsYWF/JOZnK/\
+sS3qvjJ5fCOoLU/EXy0ehgqx/CmuL6Pz9Qh6zwr64bP8nSn6hboEAP362X81KZ2fp4FoF/\
+7oQ5ikkezHpKfcsLNS/K8RfTplXxS0rxX8v54//VoAvRfILkt2/\
+Fu6DuJJG2H9mK2QZ3X1Y8rjKVdsLU11Qbnfn/Mae/TiO1RZHs2bny+6Vwq5Sfi8TnHKi+1+K4NOh"]\
+]], "DefinitionNotebookFramework" -> "DefinitionNotebookClient", 
+  "RuntimeConfiguration" -> {
+   "Contexts" -> {
+     "DemonstrationResource`", "DemonstrationResource`DefinitionNotebook`"}, 
+    "DefaultContentMethod" -> "Tagged", "HintPods" -> True, "LoadingMethod" -> 
+    "Paclet", "PacletName" -> "DemonstrationResource"}, "ToolsOpen" -> True, 
+  "SubmissionReviewData" -> {"Review" -> False}},
+CreateCellID->True,
+FrontEndVersion->"14.1 for Mac OS X x86 (64-bit) (June 13, 2024)",
+StyleDefinitions->Notebook[{
+   Cell[
+    CellGroupData[{
+      Cell[
+       StyleData[StyleDefinitions -> "Default.nb"]], 
+      Cell[
+       StyleData[All, "Working"], WindowToolbars -> {}, DockedCells -> {
+         Cell[
+          BoxData[
+           TemplateBox[{}, "MainGridTemplate"]], "DockedCell", 
+          CellMargins -> {{-10, -10}, {-8, -8}}, CellFrame -> 0, Background -> 
+          RGBColor[0.7508, 0.17868, 0.085283], CellTags -> {"MainDockedCell"},
+           CacheGraphics -> False], 
+         Cell[
+          BoxData[
+           TemplateBox[{}, "ToolsGridTemplate"]], "DockedCell", 
+          TaggingRules -> {"Tools" -> True}, 
+          CellTags -> {"ToolbarDockedCell"}, 
+          CellFrameMargins -> {{0, 0}, {2, 2}}, CellFrame -> {{0, 0}, {1, 0}},
+           CacheGraphics -> False, CellOpen -> Dynamic[
+            CurrentValue[
+             EvaluationNotebook[], {TaggingRules, "ToolsOpen"}, True]]]}, 
+       PrivateNotebookOptions -> {
+        "FileOutlineCache" -> False, "SafeFileOpen" -> "IgnoreCache"}, 
+       CellLabelAutoDelete -> False, 
+       CodeAssistOptions -> {"AutoDetectHyperlinks" -> False}, 
+       AutoQuoteCharacters -> {}, PasteAutoQuoteCharacters -> {}]}, Open]], 
+   Cell["Hint Styles", "Section"], 
+   Cell[
+    StyleData["MoreInfoText", StyleDefinitions -> StyleData["Text"]], 
+    FontColor -> GrayLevel[0.25]], 
+   Cell[
+    StyleData["ErrorText", StyleDefinitions -> StyleData["Text"]], 
+    ShowCellBracket -> False, CellMargins -> {{66, Inherited}, {10, 10}}, 
+    CellElementSpacings -> {"CellMinHeight" -> 0, "ClosedCellHeight" -> 0}, 
+    FontWeight -> Bold, FontColor -> RGBColor[1, 0, 0]], 
+   Cell[
+    StyleData["WarningText", StyleDefinitions -> StyleData["Text"]], 
+    ShowCellBracket -> False, CellMargins -> {{66, 35}, {0, 0}}, FontSize -> 
+    14, GridBoxOptions -> {BaseStyle -> {}}], 
+   Cell["Template Boxes", "Section"], 
+   Cell[
+    StyleData["MoreInfoOpenerIconTemplate"], 
+    TemplateBoxOptions -> {
+     DisplayFunction -> (PaneSelectorBox[{False -> GraphicsBox[{
+            Thickness[0.090909], 
+            StyleBox[{
+              
+              JoinedCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1,
+                3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGJJIGYC4oSnF5RuVyo58OlumvteXcIBxj//Pfjx0tky
+Dp8u+SYJzFB0kGQJ49MtUnBYIKV/V4UNRis5GHKskYl6AlOnDNUHM0cFaq4I
+nD/niMKGogx+OB+oO8X6Phtcf/+hrxox/Qxw80HKftZ9sYfZ/7BKZJ37w1f2
+MPfB+DD3w/h+SQIRlluE4foh9vDBzYfQHHD7izMmvq2xZ4K7r9CW6/rigr/2
+MPfD+DD/wfgw/8P0w8IHZj4s/GD2w8IX5j708AcA2Xetpg==
+               "], CurveClosed -> {1}]}, {
+              JoinForm[{"Miter", 3.25}], 
+              Thickness[0.045818], 
+              RGBColor[0.62744, 0.62744, 0.62744, 1.]}, StripOnInput -> 
+             False], 
+            StyleBox[{
+              
+              FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1,
+                 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{0, 2, 0}, {0, 1, 
+                0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {1,
+                 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 
+                0}}}, {CompressedData["
+1:eJxTTMoPSmViYGCQBGIQ3b48/JRRi4jD3qBpin2m8g5n6j32194VhvNZnvdo
+vPUVdoh2sntxM0feQfiT4/m0q0IOQNnSwtvyDmxCIvbHYoQcMhnyG1lUFRyk
+eR/oTlAAym/iKVyTjeAf2aiXt/gggt+odqhtubgiXP+k00CLYxXh5mdrf5t+
+d7Ii3P5LDPeYOE8pwt33vfTBHMGnig4w98P4j5fOPqJgIArn539oPRlyUBSu
+/9OGgOxZ5mJw88sKgS5aKwa3XzOm/9DXF2Jw98H4MPfD+DD/wfTD/A8zHxY+
+MPth4QdzHyx80cMfAIsMpwk=
+                "], CompressedData["
+1:eJxTTMoPSmViYGCQB2IQXTFnkfJOGwmHsNp125Lq+R1g/G8aMf2HvvI4KP39
+VvrgjgAGH6b+c19wicp0IQeBKrPVduICcL6EWjDr4ksCqPLTBeH8211/U7+n
+CMH5S+7v45tjLAznX773gHvySwS/qdhtyrc2ETj/04aA7FnfReH8RxHi2y8e
+EIPzNUHOzRCH8x8vnX1E4QOCP+/98mPe5RJw/o9goAoWSTj/6vMs7W/TJR0O
+X9ZOlVwk4PB2no3OlVsI/jKgcRs+STlonhY4vstCzCFoh1zr64syDkBXssXP
+EHO4WvFSzbADwa9JNAo1yJKA82H+gfFh/oXxA29JA7Ug+GY2e4OmJQrB+f83
+VX/aMEEQzrerjFhhelYAzofFB3r8AgApYdcE
+                "]}]}, {
+              FaceForm[
+               RGBColor[0.62744, 0.62744, 0.62744, 1.]]}, StripOnInput -> 
+             False]}, ImageSize -> {11., 11.}, 
+           PlotRange -> {{0., 11.}, {0., 11.}}, AspectRatio -> Automatic], 
+         True -> GraphicsBox[{
+            Thickness[0.090909], 
+            StyleBox[{
+              
+              JoinedCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1,
+                3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGJJIGYC4oSnF5RuVyo58OlumvteXcIBxj//Pfjx0tky
+Dp8u+SYJzFB0kGQJ49MtUnBYIKV/V4UNRis5GHKskYl6AlOnDNUHM0cFaq4I
+nD/niMKGogx+OB+oO8X6Phtcf/+hrxox/Qxw80HKftZ9sYfZ/7BKZJ37w1f2
+MPfB+DD3w/h+SQIRlluE4foh9vDBzYfQHHD7izMmvq2xZ4K7r9CW6/rigr/2
+MPfD+DD/wfgw/8P0w8IHZj4s/GD2w8IX5j708AcA2Xetpg==
+               "], CurveClosed -> {1}]}, {
+              JoinForm[{"Miter", 3.25}], 
+              Thickness[0.045818], 
+              RGBColor[0.5, 0.5, 0.5, 1.]}, StripOnInput -> False], 
+            StyleBox[{
+              
+              FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1,
+                3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGJJIGYC4oSnF5RuVyo58OlumvteXcIBxj//Pfjx0tky
+Dp8u+SYJzFB0kGQJ49MtUnBYIKV/V4UNRis5GHKskYl6AlOnDNUHM0cFaq4I
+nD/niMKGogx+OB+oO8X6Phtcf/+hrxox/Qxw80HKftZ9sYfZ/7BKZJ37w1f2
+MPfB+DD3w/h+SQIRlluE4foh9vDBzYfQHHD7izMmvq2xZ4K7r9CW6/rigr/2
+MPfD+DD/wfgw/8P0w8IHZj4s/GD2w8IX5j708AcA2Xetpg==
+               "]]}, {
+              FaceForm[
+               RGBColor[0.5, 0.5, 0.5, 1.]]}, StripOnInput -> False], 
+            StyleBox[{
+              
+              FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1,
+                 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{0, 2, 0}, {0, 1, 
+                0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {1,
+                 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 
+                0}}}, {CompressedData["
+1:eJxTTMoPSmViYGCQBGIQ3b48/JRRi4jD3qBpin2m8g5n6j32194VhvNZnvdo
+vPUVdoh2sntxM0feQfiT4/m0q0IOQNnSwtvyDmxCIvbHYoQcMhnyG1lUFRyk
+eR/oTlAAym/iKVyTjeAf2aiXt/gggt+odqhtubgiXP+k00CLYxXh5mdrf5t+
+d7Ii3P5LDPeYOE8pwt33vfTBHMGnig4w98P4j5fOPqJgIArn539oPRlyUBSu
+/9OGgOxZ5mJw88sKgS5aKwa3XzOm/9DXF2Jw98H4MPfD+DD/wfTD/A8zHxY+
+MPth4QdzHyx80cMfAIsMpwk=
+                "], CompressedData["
+1:eJxTTMoPSmViYGCQB2IQXTFnkfJOGwmHsNp125Lq+R1g/G8aMf2HvvI4KP39
+VvrgjgAGH6b+c19wicp0IQeBKrPVduICcL6EWjDr4ksCqPLTBeH8211/U7+n
+CMH5S+7v45tjLAznX773gHvySwS/qdhtyrc2ETj/04aA7FnfReH8RxHi2y8e
+EIPzNUHOzRCH8x8vnX1E4QOCP+/98mPe5RJw/o9goAoWSTj/6vMs7W/TJR0O
+X9ZOlVwk4PB2no3OlVsI/jKgcRs+STlonhY4vstCzCFoh1zr64syDkBXssXP
+EHO4WvFSzbADwa9JNAo1yJKA82H+gfFh/oXxA29JA7Ug+GY2e4OmJQrB+f83
+VX/aMEEQzrerjFhhelYAzofFB3r8AgApYdcE
+                "]}]}, {
+              FaceForm[
+               RGBColor[0.99998, 0.99998, 0.99998, 1.]]}, StripOnInput -> 
+             False]}, ImageSize -> {11., 11.}, 
+           PlotRange -> {{0., 11.}, {0., 11.}}, AspectRatio -> Automatic]}, 
+        Dynamic[
+         CurrentValue["MouseOver"]], ImageSize -> Automatic, FrameMargins -> 
+        0]& )}], 
+   Cell[
+    StyleData["MoreInfoOpenerButtonTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (AdjustmentBox[
+        DynamicModuleBox[{
+         RSNB`mPosRegion$$, RSNB`attachPos$$, RSNB`offsetPos$$, 
+          RSNB`horizontalRegion$$, RSNB`verticalRegion$$, 
+          RSNB`chooseAttachLocation$$}, 
+         TagBox[
+          TemplateBox[{
+            TemplateBox[{}, "MoreInfoOpenerIconTemplate"], 
+            "\"Click for more information\""}, "PrettyTooltipTemplate"], 
+          EventHandlerTag[{"MouseDown" :> AttachCell[
+              ParentBox[
+               EvaluationBox[]], #2, 
+              RSNB`chooseAttachLocation$$[], 
+              RemovalConditions -> {"EvaluatorQuit", "MouseClickOutside"}], 
+            Method -> "Preemptive", PassEventsDown -> Automatic, PassEventsUp -> 
+            True}]], 
+         DynamicModuleValues :> {{DownValues[RSNB`mPosRegion$$] = {HoldPattern[
+                RSNB`mPosRegion$$[]] :> RSNB`mPosRegion$$[
+                Ceiling[MousePosition["WindowScaled"] 3]], HoldPattern[
+                RSNB`mPosRegion$$[
+                 Pattern[RSNB`reg, {
+                   Blank[Integer], 
+                   Blank[Integer]}]]] :> RSNB`reg, HoldPattern[
+                RSNB`mPosRegion$$[
+                 BlankNullSequence[]]] :> None}}, {
+           DownValues[RSNB`attachPos$$] = {HoldPattern[
+                RSNB`attachPos$$[{
+                  Pattern[RSNB`h$, 
+                   Blank[Integer]], 
+                  Pattern[RSNB`v$, 
+                   Blank[Integer]]}]] :> {
+                RSNB`horizontalRegion$$[RSNB`h$], 
+                RSNB`verticalRegion$$[RSNB`v$]}}}, {
+           DownValues[RSNB`offsetPos$$] = {HoldPattern[
+                RSNB`offsetPos$$[{
+                  Pattern[RSNB`h$, 
+                   Blank[Integer]], 
+                  Pattern[RSNB`v$, 
+                   Blank[Integer]]}]] :> {
+                RSNB`horizontalRegion$$[4 - RSNB`h$], 
+                RSNB`verticalRegion$$[4 - RSNB`v$]}}}, {
+           DownValues[RSNB`horizontalRegion$$] = {HoldPattern[
+                RSNB`horizontalRegion$$[1]] :> Left, HoldPattern[
+                RSNB`horizontalRegion$$[2]] :> Center, HoldPattern[
+                RSNB`horizontalRegion$$[3]] :> Right}}, {
+           DownValues[RSNB`verticalRegion$$] = {HoldPattern[
+                RSNB`verticalRegion$$[1]] :> Top, HoldPattern[
+                RSNB`verticalRegion$$[2]] :> Top, HoldPattern[
+                RSNB`verticalRegion$$[3]] :> Top}}, {
+           DownValues[RSNB`chooseAttachLocation$$] = {HoldPattern[
+                RSNB`chooseAttachLocation$$[]] :> 
+              With[{RSNB`p$ = RSNB`mPosRegion$$[]}, 
+                Apply[Sequence, {
+                  RSNB`offsetPos$$[RSNB`p$], {-30, 30}, 
+                  RSNB`attachPos$$[RSNB`p$]}]]}}}], BoxBaselineShift -> -0.5, 
+        BoxMargins -> 0.2]& )}], 
+   Cell[
+    StyleData["InlineMoreInfoOpenerButtonTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (AdjustmentBox[
+        DynamicModuleBox[{
+         RSNB`mPosRegion$$, RSNB`attachPos$$, RSNB`offsetPos$$, 
+          RSNB`horizontalRegion$$, RSNB`verticalRegion$$, 
+          RSNB`chooseAttachLocation$$}, 
+         TagBox[
+          TemplateBox[{
+            TemplateBox[{}, "MoreInfoOpenerIconTemplate"], #4}, 
+           "PrettyTooltipTemplate"], 
+          EventHandlerTag[{"MouseDown" :> AttachCell[
+              ParentBox[
+               EvaluationBox[]], #2, 
+              RSNB`chooseAttachLocation$$[], 
+              RemovalConditions -> {"EvaluatorQuit", "MouseClickOutside"}], 
+            Method -> "Preemptive", PassEventsDown -> Automatic, PassEventsUp -> 
+            True}]], 
+         DynamicModuleValues :> {{DownValues[RSNB`mPosRegion$$] = {HoldPattern[
+                RSNB`mPosRegion$$[]] :> RSNB`mPosRegion$$[
+                Ceiling[MousePosition["WindowScaled"] 3]], HoldPattern[
+                RSNB`mPosRegion$$[
+                 Pattern[RSNB`reg, {
+                   Blank[Integer], 
+                   Blank[Integer]}]]] :> RSNB`reg, HoldPattern[
+                RSNB`mPosRegion$$[
+                 BlankNullSequence[]]] :> None}}, {
+           DownValues[RSNB`attachPos$$] = {HoldPattern[
+                RSNB`attachPos$$[{
+                  Pattern[RSNB`h$, 
+                   Blank[Integer]], 
+                  Pattern[RSNB`v$, 
+                   Blank[Integer]]}]] :> {
+                RSNB`horizontalRegion$$[RSNB`h$], 
+                RSNB`verticalRegion$$[RSNB`v$]}}}, {
+           DownValues[RSNB`offsetPos$$] = {HoldPattern[
+                RSNB`offsetPos$$[{
+                  Pattern[RSNB`h$, 
+                   Blank[Integer]], 
+                  Pattern[RSNB`v$, 
+                   Blank[Integer]]}]] :> {
+                RSNB`horizontalRegion$$[4 - RSNB`h$], 
+                RSNB`verticalRegion$$[4 - RSNB`v$]}}}, {
+           DownValues[RSNB`horizontalRegion$$] = {HoldPattern[
+                RSNB`horizontalRegion$$[1]] :> Left, HoldPattern[
+                RSNB`horizontalRegion$$[2]] :> Center, HoldPattern[
+                RSNB`horizontalRegion$$[3]] :> Right}}, {
+           DownValues[RSNB`verticalRegion$$] = {HoldPattern[
+                RSNB`verticalRegion$$[1]] :> Top, HoldPattern[
+                RSNB`verticalRegion$$[2]] :> Top, HoldPattern[
+                RSNB`verticalRegion$$[3]] :> Top}}, {
+           DownValues[RSNB`chooseAttachLocation$$] = {HoldPattern[
+                RSNB`chooseAttachLocation$$[]] :> 
+              With[{RSNB`p$ = RSNB`mPosRegion$$[]}, 
+                Apply[Sequence, {
+                  RSNB`offsetPos$$[RSNB`p$], {-30, 30}, 
+                  RSNB`attachPos$$[RSNB`p$]}]]}}}], BoxBaselineShift -> -0.5, 
+        BoxMargins -> 0.2]& )}], 
+   Cell[
+    StyleData["ClickToCopyTemplate"], 
+    TemplateBoxOptions -> {
+     DisplayFunction -> (PaneSelectorBox[{False -> TagBox[
+           GridBox[{{#, 
+              ButtonBox[
+               GraphicsBox[{
+                 GrayLevel[0.85], 
+                 Thickness[
+                  NCache[2/45, 0.044444]], 
+                 
+                 FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                   0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 
+                   0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                   0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 
+                   0}, {0, 1, 0}, {0, 1, 0}}}, {{{10.5, 18.75}, {10.5, 18.}, {
+                   9., 18.}, {9., 15.75}, {13.5, 15.75}, {13.5, 18.}, {12., 
+                   18.}, {12., 18.75}}, {{6., 18.}, {6., 4.5}, {16.5, 4.5}, {
+                   16.5, 18.}, {14.25, 18.}, {14.25, 17.25}, {15.75, 17.25}, {
+                   15.75, 5.25}, {6.75, 5.25}, {6.75, 17.25}, {8.25, 17.25}, {
+                   8.25, 18.}}, {{9.75, 17.25}, {12.75, 17.25}, {12.75, 
+                   16.5}, {9.75, 16.5}}}], 
+                 
+                 FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 
+                  0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                  0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{8.25, 14.25}, {
+                  14.25, 14.25}, {14.25, 13.5}, {8.25, 13.5}}, {{8.25, 12.}, {
+                  14.25, 12.}, {14.25, 11.25}, {8.25, 11.25}}, {{8.25, 
+                  9.75}, {14.25, 9.75}, {14.25, 9.}, {8.25, 9.}}, {{8.25, 
+                  7.5}, {14.25, 7.5}, {14.25, 6.75}, {8.25, 6.75}}}]}, 
+                ImageSize -> 12], ButtonFunction :> Null, 
+               Appearance -> {
+                "Default" -> None, "Hover" -> None, "Pressed" -> None}, 
+               Evaluator -> Automatic, Method -> "Preemptive"]}}, 
+            GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Center}}},
+             AutoDelete -> False, 
+            GridBoxItemSize -> {
+             "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+            GridBoxSpacings -> {"Columns" -> {{0.4}}}], "Grid"], True -> 
+         DynamicModuleBox[{RSNB`clickTime$$ = 0., RSNB`timeout$$ = 3.}, 
+           TagBox[
+            GridBox[{{#, 
+               TagBox[
+                ButtonBox[
+                 DynamicBox[
+                  ToBoxes[
+                   Refresh[
+                    If[AbsoluteTime[] - RSNB`clickTime$$ > RSNB`timeout$$, 
+                    RawBoxes[
+                    TemplateBox[{
+                    PaneSelectorBox[{False -> GraphicsBox[{
+                    GrayLevel[0.65], 
+                    Thickness[
+                    NCache[2/45, 0.044444]], 
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                    0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 
+                    0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                    0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 
+                    0}, {0, 1, 0}, {0, 1, 0}}}, {{{10.5, 18.75}, {10.5, 
+                    18.}, {9., 18.}, {9., 15.75}, {13.5, 15.75}, {13.5, 
+                    18.}, {12., 18.}, {12., 18.75}}, {{6., 18.}, {6., 4.5}, {
+                    16.5, 4.5}, {16.5, 18.}, {14.25, 18.}, {14.25, 17.25}, {
+                    15.75, 17.25}, {15.75, 5.25}, {6.75, 5.25}, {6.75, 
+                    17.25}, {8.25, 17.25}, {8.25, 18.}}, {{9.75, 17.25}, {
+                    12.75, 17.25}, {12.75, 16.5}, {9.75, 16.5}}}], 
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
+                     0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                    0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{8.25, 
+                    14.25}, {14.25, 14.25}, {14.25, 13.5}, {8.25, 13.5}}, {{
+                    8.25, 12.}, {14.25, 12.}, {14.25, 11.25}, {8.25, 
+                    11.25}}, {{8.25, 9.75}, {14.25, 9.75}, {14.25, 9.}, {8.25,
+                     9.}}, {{8.25, 7.5}, {14.25, 7.5}, {14.25, 6.75}, {8.25, 
+                    6.75}}}]}, ImageSize -> 12], True -> GraphicsBox[{
+                    RGBColor[0.98824, 0.41961, 0.20392], 
+                    Thickness[
+                    NCache[2/45, 0.044444]], 
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                    0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 
+                    0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                    0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 
+                    0}, {0, 1, 0}, {0, 1, 0}}}, {{{10.5, 18.75}, {10.5, 
+                    18.}, {9., 18.}, {9., 15.75}, {13.5, 15.75}, {13.5, 
+                    18.}, {12., 18.}, {12., 18.75}}, {{6., 18.}, {6., 4.5}, {
+                    16.5, 4.5}, {16.5, 18.}, {14.25, 18.}, {14.25, 17.25}, {
+                    15.75, 17.25}, {15.75, 5.25}, {6.75, 5.25}, {6.75, 
+                    17.25}, {8.25, 17.25}, {8.25, 18.}}, {{9.75, 17.25}, {
+                    12.75, 17.25}, {12.75, 16.5}, {9.75, 16.5}}}], 
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
+                     0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                    0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{8.25, 
+                    14.25}, {14.25, 14.25}, {14.25, 13.5}, {8.25, 13.5}}, {{
+                    8.25, 12.}, {14.25, 12.}, {14.25, 11.25}, {8.25, 
+                    11.25}}, {{8.25, 9.75}, {14.25, 9.75}, {14.25, 9.}, {8.25,
+                     9.}}, {{8.25, 7.5}, {14.25, 7.5}, {14.25, 6.75}, {8.25, 
+                    6.75}}}]}, ImageSize -> 12]}, 
+                    Dynamic[
+                    CurrentValue["MouseOver"]], ImageSize -> Automatic, 
+                    FrameMargins -> 0], "\"Click to copy to the clipboard\""},
+                     "PrettyTooltipTemplate"]], 
+                    RawBoxes[
+                    TemplateBox[{
+                    GraphicsBox[{
+                    RGBColor[0, 
+                    NCache[2/3, 0.66667], 0], 
+                    Thickness[
+                    NCache[2/45, 0.044444]], 
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                    0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 
+                    0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+                    0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 
+                    0}, {0, 1, 0}, {0, 1, 0}}}, {{{10.5, 18.75}, {10.5, 
+                    18.}, {9., 18.}, {9., 15.75}, {13.5, 15.75}, {13.5, 
+                    18.}, {12., 18.}, {12., 18.75}}, {{6., 18.}, {6., 4.5}, {
+                    16.5, 4.5}, {16.5, 18.}, {14.25, 18.}, {14.25, 17.25}, {
+                    15.75, 17.25}, {15.75, 5.25}, {6.75, 5.25}, {6.75, 
+                    17.25}, {8.25, 17.25}, {8.25, 18.}}, {{9.75, 17.25}, {
+                    12.75, 17.25}, {12.75, 16.5}, {9.75, 16.5}}}], 
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
+                     0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                    0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}}, {{{8.25, 
+                    14.25}, {14.25, 14.25}, {14.25, 13.5}, {8.25, 13.5}}, {{
+                    8.25, 12.}, {14.25, 12.}, {14.25, 11.25}, {8.25, 
+                    11.25}}, {{8.25, 9.75}, {14.25, 9.75}, {14.25, 9.}, {8.25,
+                     9.}}, {{8.25, 7.5}, {14.25, 7.5}, {14.25, 6.75}, {8.25, 
+                    6.75}}}]}, ImageSize -> 12], "\"Copied\""}, 
+                    "PrettyTooltipTemplate"]]], UpdateInterval -> 1, 
+                    TrackedSymbols :> {RSNB`clickTime$$}], StandardForm], 
+                  Evaluator -> "System"], 
+                 ButtonFunction :> (RSNB`clickTime$$ = AbsoluteTime[]; 
+                  CopyToClipboard[
+                    BinaryDeserialize[
+                    BaseDecode[#2], Defer]]), 
+                 Appearance -> {
+                  "Default" -> None, "Hover" -> None, "Pressed" -> None}, 
+                 Method -> "Queued", Evaluator -> "System"], 
+                MouseAppearanceTag["LinkHand"]]}}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Center}}}, AutoDelete -> 
+             False, GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{0.4}}}], "Grid"], 
+           DynamicModuleValues :> {}]}, 
+        Dynamic[
+         CurrentValue["MouseOver"]], ImageSize -> Automatic, FrameMargins -> 
+        0]& )}], 
+   Cell[
+    StyleData["PrettyTooltipTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (TagBox[
+        TooltipBox[#, 
+         FrameBox[
+          
+          StyleBox[#2, "Text", FontColor -> 
+           RGBColor[0.53725, 0.53725, 0.53725], FontSize -> 12, FontWeight -> 
+           "Plain", FontTracking -> "Plain", StripOnInput -> False], 
+          Background -> RGBColor[0.96078, 0.96078, 0.96078], FrameStyle -> 
+          RGBColor[0.89804, 0.89804, 0.89804], FrameMargins -> 8, 
+          StripOnInput -> False], TooltipDelay -> 0.1, 
+         TooltipStyle -> {Background -> None, CellFrame -> 0}], 
+        Annotation[#, 
+         Framed[
+          Style[
+          RSNB`$$tooltip, "Text", FontColor -> 
+           RGBColor[0.53725, 0.53725, 0.53725], FontSize -> 12, FontWeight -> 
+           "Plain", FontTracking -> "Plain"], Background -> 
+          RGBColor[0.96078, 0.96078, 0.96078], FrameStyle -> 
+          RGBColor[0.89804, 0.89804, 0.89804], FrameMargins -> 8], 
+         "Tooltip"]& ]& )}], 
+   Cell[
+    StyleData["ToolsGridTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (StyleBox[
+        TagBox[
+         GridBox[{{
+            FrameBox[
+             ButtonBox[
+              StyleBox[
+              "\"Add Snapshot\"", "Text", FontFamily -> "Source Sans Pro", 
+               FontSize -> 11, StripOnInput -> False], ButtonFunction :> 
+              With[{RSNB`nb$ = ButtonNotebook[], RSNB`$cp$ = $ContextPath}, 
+                Quiet[
+                 
+                 Block[{$ContextPath = RSNB`$cp$, 
+                   ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                   DefinitionNotebookClient`$ButtonCodeID = None}, 
+                  Internal`WithLocalSettings[
+                   DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    1953907064413444837; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = 
+                    HoldForm[
+                    DefinitionNotebookClient`$ClickedButton = "AddSnapshot"; (
+                    Needs["DemonstrationResource`DefinitionNotebook`" -> 
+                    None]; DemonstrationResource`DefinitionNotebook`\
+AddManipulateSnapshot[
+                    ButtonNotebook[]])]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    1953907064413444837]], 
+                    DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+                  Null]]], FrameMargins -> {{4, 4}, {0, 0}}, BaseStyle -> 
+              Dynamic[
+                FEPrivate`If[
+                 CurrentValue[Enabled], 
+                 FEPrivate`If[
+                  CurrentValue["MouseOver"], {
+                  FontColor -> GrayLevel[1], 
+                   TaggingRules -> {"ButtonHovering" -> True}}, {
+                  FontColor -> RGBColor[0.5489, 0.092317, 0.067842], 
+                   TaggingRules -> {"ButtonHovering" -> False}}], {
+                 FontColor -> RGBColor[0.88722, 0.77308, 0.76696], 
+                  TaggingRules -> {"ButtonHovering" -> False}}], Evaluator -> 
+                "System"], Appearance -> {"Default" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3Ixe3bNuZmzrI0hiAgGyhCvCF3L11cERnS
+IyGIiYDiQFmChtw4dnSaoRZQ/URl2UOtjS8unIcgIBsoAhQHygLV4DHkwc0b
+M0z0gCqX+Xp8efkCLfyBIkBxoCxQDVAlLkPWpSUB1Sz2cPr9/TvWeASKA2WB
+aoAqsRpy48TxXinhPlmx9w/u40kPQFmgGqBKoHpMQ3bWVwOt2FGYSzBdAdUA
+VQLVYxqywM0BKHVv726ChgDVAFUC1UM0QpI0hD1FWxUohRmemACoBqgSqB5u
+CBBQbghVXELdMKFK7FAlnVAlxVIr7zyjRi6GAMrLEzigsGQjFVDREPyAmHoH
+APEDg3E=
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True], "Hover" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I9T2bD1Ykb/TUgiAgGyhCvCEPrlzYnea7
+XJsNEwHFgbIEDblz8vA6R0Wg+tV6HOc9pV/HaUEQkA0UAYoDZYFq8Bjy6Nb1
+9S4qQJW7LAW+pOj/yTZBRkARoDhQFqgGqBKXIfuKooFqdljw/8wwQjMBgoDi
+QFmgGqBKrIbcOXV0uS7HCh32D0m6WE2AIKAsUA1QJVA9piHHOsqAVpxwFsdj
+AgQB1QBVAtVjGrI1xAIo9SRCnaAhQDVAlUD1EI2QJA1hr7GRBkphhicmAqoB
+qgSqhxsCBJQbQhWXUDdMqBI7VEknVEmx1Mo7z6iRiyGA8vIEDigs2UgFVDQE
+PyCm3gEAQ+/Dcg==
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True], "Pressed" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I69evv3z58gsGgGygCPGGvHjx4vv371g9
+DhQHyhI05OXLl79//wYK/vz8+cTEvsVuDhAEZANFgOJAWaAaPIY8f/4cYsKT
+k8en6ar3SAgiI6AIUBxiDlAlLkO+fv0K5D4/d7ZfXgLNBAgCigNlgWqAKrEa
+AnTkv3///vz8OdvMAKsJEASUBaoBqoR7CtmQT58+AdmXli7CYwIEAdUAVQLV
+Yxry8+dPIHtNZAhBQ4BqQCH/8ydEIyRJQ9h//vwBsjHDExMB1QBVAtXDDQEC
+yg2hikuoGyZUiR2qpBOqpFhq5Z1n1MjFEEB5eQIHFJZspAIqGoIfEFPvAACe
+kBKf
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True]}, Background -> GrayLevel[0.9], 
+              Method -> "Queued", ImageSize -> {All, 20}, Evaluator -> 
+              Automatic], FrameStyle -> Directive[
+               GrayLevel[0.9], 
+               AbsoluteThickness[2]], FrameMargins -> -1, ContentPadding -> 
+             False, StripOnInput -> False], 
+            FrameBox[
+             ButtonBox[
+              TemplateBox[{
+                StyleBox[
+                "\"Template Input\"", "Text", FontFamily -> "Source Sans Pro",
+                  FontSize -> 11, StripOnInput -> False], 
+                "\"Format selection automatically using appropriate \
+documentation styles\""}, "PrettyTooltipTemplate"], ButtonFunction :> 
+              With[{RSNB`nb$ = ButtonNotebook[], RSNB`$cp$ = $ContextPath}, 
+                Quiet[
+                 
+                 Block[{$ContextPath = RSNB`$cp$, 
+                   ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                   DefinitionNotebookClient`$ButtonCodeID = None}, 
+                  Internal`WithLocalSettings[
+                   DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    7071186616034202283; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = 
+                    HoldForm[
+                    DefinitionNotebookClient`$ClickedButton = 
+                    "Template Input"; 
+                    DefinitionNotebookClient`TemplateInput[]]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    7071186616034202283]], 
+                    DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+                  Null]]], FrameMargins -> {{4, 4}, {0, 0}}, BaseStyle -> 
+              Dynamic[
+                FEPrivate`If[
+                 CurrentValue[Enabled], 
+                 FEPrivate`If[
+                  CurrentValue["MouseOver"], {
+                  FontColor -> GrayLevel[1], 
+                   TaggingRules -> {"ButtonHovering" -> True}}, {
+                  FontColor -> RGBColor[0.5489, 0.092317, 0.067842], 
+                   TaggingRules -> {"ButtonHovering" -> False}}], {
+                 FontColor -> RGBColor[0.88722, 0.77308, 0.76696], 
+                  TaggingRules -> {"ButtonHovering" -> False}}], Evaluator -> 
+                "System"], Appearance -> {"Default" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3Ixe3bNuZmzrI0hiAgGyhCvCF3L11cERnS
+IyGIiYDiQFmChtw4dnSaoRZQ/URl2UOtjS8unIcgIBsoAhQHygLV4DHkwc0b
+M0z0gCqX+Xp8efkCLfyBIkBxoCxQDVAlLkPWpSUB1Sz2cPr9/TvWeASKA2WB
+aoAqsRpy48TxXinhPlmx9w/u40kPQFmgGqBKoHpMQ3bWVwOt2FGYSzBdAdUA
+VQLVYxqywM0BKHVv726ChgDVAFUC1UM0QpI0hD1FWxUohRmemACoBqgSqB5u
+CBBQbghVXELdMKFK7FAlnVAlxVIr7zyjRi6GAMrLEzigsGQjFVDREPyAmHoH
+APEDg3E=
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True], "Hover" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I9T2bD1Ykb/TUgiAgGyhCvCEPrlzYnea7
+XJsNEwHFgbIEDblz8vA6R0Wg+tV6HOc9pV/HaUEQkA0UAYoDZYFq8Bjy6Nb1
+9S4qQJW7LAW+pOj/yTZBRkARoDhQFqgGqBKXIfuKooFqdljw/8wwQjMBgoDi
+QFmgGqBKrIbcOXV0uS7HCh32D0m6WE2AIKAsUA1QJVA9piHHOsqAVpxwFsdj
+AgQB1QBVAtVjGrI1xAIo9SRCnaAhQDVAlUD1EI2QJA1hr7GRBkphhicmAqoB
+qgSqhxsCBJQbQhWXUDdMqBI7VEknVEmx1Mo7z6iRiyGA8vIEDigs2UgFVDQE
+PyCm3gEAQ+/Dcg==
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True], "Pressed" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I69evv3z58gsGgGygCPGGvHjx4vv371g9
+DhQHyhI05OXLl79//wYK/vz8+cTEvsVuDhAEZANFgOJAWaAaPIY8f/4cYsKT
+k8en6ar3SAgiI6AIUBxiDlAlLkO+fv0K5D4/d7ZfXgLNBAgCigNlgWqAKrEa
+AnTkv3///vz8OdvMAKsJEASUBaoBqoR7CtmQT58+AdmXli7CYwIEAdUAVQLV
+Yxry8+dPIHtNZAhBQ4BqQCH/8ydEIyRJQ9h//vwBsjHDExMB1QBVAtXDDQEC
+yg2hikuoGyZUiR2qpBOqpFhq5Z1n1MjFEEB5eQIHFJZspAIqGoIfEFPvAACe
+kBKf
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True]}, Background -> GrayLevel[0.9], 
+              Method -> "Queued", ImageSize -> {All, 20}, Evaluator -> 
+              Automatic], FrameStyle -> Directive[
+               GrayLevel[0.9], 
+               AbsoluteThickness[2]], FrameMargins -> -1, ContentPadding -> 
+             False, StripOnInput -> False], 
+            FrameBox[
+             ButtonBox[
+              TemplateBox[{
+                StyleBox[
+                "\"Literal Input\"", "Text", FontFamily -> "Source Sans Pro", 
+                 FontSize -> 11, StripOnInput -> False], 
+                "\"Format selection as literal Wolfram Language code\""}, 
+               "PrettyTooltipTemplate"], ButtonFunction :> 
+              With[{RSNB`nb$ = ButtonNotebook[], RSNB`$cp$ = $ContextPath}, 
+                Quiet[
+                 
+                 Block[{$ContextPath = RSNB`$cp$, 
+                   ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                   DefinitionNotebookClient`$ButtonCodeID = None}, 
+                  Internal`WithLocalSettings[
+                   DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    4937992391498864149; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = 
+                    HoldForm[
+                    DefinitionNotebookClient`$ClickedButton = "Literal Input"; 
+                    DefinitionNotebookClient`LiteralInput[]]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    4937992391498864149]], 
+                    DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+                  Null]]], FrameMargins -> {{4, 4}, {0, 0}}, BaseStyle -> 
+              Dynamic[
+                FEPrivate`If[
+                 CurrentValue[Enabled], 
+                 FEPrivate`If[
+                  CurrentValue["MouseOver"], {
+                  FontColor -> GrayLevel[1], 
+                   TaggingRules -> {"ButtonHovering" -> True}}, {
+                  FontColor -> RGBColor[0.5489, 0.092317, 0.067842], 
+                   TaggingRules -> {"ButtonHovering" -> False}}], {
+                 FontColor -> RGBColor[0.88722, 0.77308, 0.76696], 
+                  TaggingRules -> {"ButtonHovering" -> False}}], Evaluator -> 
+                "System"], Appearance -> {"Default" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3Ixe3bNuZmzrI0hiAgGyhCvCF3L11cERnS
+IyGIiYDiQFmChtw4dnSaoRZQ/URl2UOtjS8unIcgIBsoAhQHygLV4DHkwc0b
+M0z0gCqX+Xp8efkCLfyBIkBxoCxQDVAlLkPWpSUB1Sz2cPr9/TvWeASKA2WB
+aoAqsRpy48TxXinhPlmx9w/u40kPQFmgGqBKoHpMQ3bWVwOt2FGYSzBdAdUA
+VQLVYxqywM0BKHVv726ChgDVAFUC1UM0QpI0hD1FWxUohRmemACoBqgSqB5u
+CBBQbghVXELdMKFK7FAlnVAlxVIr7zyjRi6GAMrLEzigsGQjFVDREPyAmHoH
+APEDg3E=
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True], "Hover" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I9T2bD1Ykb/TUgiAgGyhCvCEPrlzYnea7
+XJsNEwHFgbIEDblz8vA6R0Wg+tV6HOc9pV/HaUEQkA0UAYoDZYFq8Bjy6Nb1
+9S4qQJW7LAW+pOj/yTZBRkARoDhQFqgGqBKXIfuKooFqdljw/8wwQjMBgoDi
+QFmgGqBKrIbcOXV0uS7HCh32D0m6WE2AIKAsUA1QJVA9piHHOsqAVpxwFsdj
+AgQB1QBVAtVjGrI1xAIo9SRCnaAhQDVAlUD1EI2QJA1hr7GRBkphhicmAqoB
+qgSqhxsCBJQbQhWXUDdMqBI7VEknVEmx1Mo7z6iRiyGA8vIEDigs2UgFVDQE
+PyCm3gEAQ+/Dcg==
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True], "Pressed" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I69evv3z58gsGgGygCPGGvHjx4vv371g9
+DhQHyhI05OXLl79//wYK/vz8+cTEvsVuDhAEZANFgOJAWaAaPIY8f/4cYsKT
+k8en6ar3SAgiI6AIUBxiDlAlLkO+fv0K5D4/d7ZfXgLNBAgCigNlgWqAKrEa
+AnTkv3///vz8OdvMAKsJEASUBaoBqoR7CtmQT58+AdmXli7CYwIEAdUAVQLV
+Yxry8+dPIHtNZAhBQ4BqQCH/8ydEIyRJQ9h//vwBsjHDExMB1QBVAtXDDQEC
+yg2hikuoGyZUiR2qpBOqpFhq5Z1n1MjFEEB5eQIHFJZspAIqGoIfEFPvAACe
+kBKf
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True]}, Background -> GrayLevel[0.9], 
+              Method -> "Queued", ImageSize -> {All, 20}, Evaluator -> 
+              Automatic], FrameStyle -> Directive[
+               GrayLevel[0.9], 
+               AbsoluteThickness[2]], FrameMargins -> -1, ContentPadding -> 
+             False, StripOnInput -> False], 
+            FrameBox[
+             ButtonBox[
+              TemplateBox[{
+                StyleBox[
+                "\"Subscripted Variable\"", "Text", FontFamily -> 
+                 "Source Sans Pro", FontSize -> 11, StripOnInput -> False], 
+                "\"Insert subscripted variable placeholder\""}, 
+               "PrettyTooltipTemplate"], ButtonFunction :> 
+              With[{RSNB`nb$ = ButtonNotebook[], RSNB`$cp$ = $ContextPath}, 
+                Quiet[
+                 
+                 Block[{$ContextPath = RSNB`$cp$, 
+                   ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                   DefinitionNotebookClient`$ButtonCodeID = None}, 
+                  Internal`WithLocalSettings[
+                   DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    168721804526114855; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = 
+                    HoldForm[
+                    DefinitionNotebookClient`$ClickedButton = 
+                    "Subscripted Variable"; 
+                    DefinitionNotebookClient`SubscriptInsert[]]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    168721804526114855]], 
+                    DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+                  Null]]], FrameMargins -> {{4, 4}, {0, 0}}, BaseStyle -> 
+              Dynamic[
+                FEPrivate`If[
+                 CurrentValue[Enabled], 
+                 FEPrivate`If[
+                  CurrentValue["MouseOver"], {
+                  FontColor -> GrayLevel[1], 
+                   TaggingRules -> {"ButtonHovering" -> True}}, {
+                  FontColor -> RGBColor[0.5489, 0.092317, 0.067842], 
+                   TaggingRules -> {"ButtonHovering" -> False}}], {
+                 FontColor -> RGBColor[0.88722, 0.77308, 0.76696], 
+                  TaggingRules -> {"ButtonHovering" -> False}}], Evaluator -> 
+                "System"], Appearance -> {"Default" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3Ixe3bNuZmzrI0hiAgGyhCvCF3L11cERnS
+IyGIiYDiQFmChtw4dnSaoRZQ/URl2UOtjS8unIcgIBsoAhQHygLV4DHkwc0b
+M0z0gCqX+Xp8efkCLfyBIkBxoCxQDVAlLkPWpSUB1Sz2cPr9/TvWeASKA2WB
+aoAqsRpy48TxXinhPlmx9w/u40kPQFmgGqBKoHpMQ3bWVwOt2FGYSzBdAdUA
+VQLVYxqywM0BKHVv726ChgDVAFUC1UM0QpI0hD1FWxUohRmemACoBqgSqB5u
+CBBQbghVXELdMKFK7FAlnVAlxVIr7zyjRi6GAMrLEzigsGQjFVDREPyAmHoH
+APEDg3E=
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True], "Hover" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I9T2bD1Ykb/TUgiAgGyhCvCEPrlzYnea7
+XJsNEwHFgbIEDblz8vA6R0Wg+tV6HOc9pV/HaUEQkA0UAYoDZYFq8Bjy6Nb1
+9S4qQJW7LAW+pOj/yTZBRkARoDhQFqgGqBKXIfuKooFqdljw/8wwQjMBgoDi
+QFmgGqBKrIbcOXV0uS7HCh32D0m6WE2AIKAsUA1QJVA9piHHOsqAVpxwFsdj
+AgQB1QBVAtVjGrI1xAIo9SRCnaAhQDVAlUD1EI2QJA1hr7GRBkphhicmAqoB
+qgSqhxsCBJQbQhWXUDdMqBI7VEknVEmx1Mo7z6iRiyGA8vIEDigs2UgFVDQE
+PyCm3gEAQ+/Dcg==
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True], "Pressed" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I69evv3z58gsGgGygCPGGvHjx4vv371g9
+DhQHyhI05OXLl79//wYK/vz8+cTEvsVuDhAEZANFgOJAWaAaPIY8f/4cYsKT
+k8en6ar3SAgiI6AIUBxiDlAlLkO+fv0K5D4/d7ZfXgLNBAgCigNlgWqAKrEa
+AnTkv3///vz8OdvMAKsJEASUBaoBqoR7CtmQT58+AdmXli7CYwIEAdUAVQLV
+Yxry8+dPIHtNZAhBQ4BqQCH/8ydEIyRJQ9h//vwBsjHDExMB1QBVAtXDDQEC
+yg2hikuoGyZUiR2qpBOqpFhq5Z1n1MjFEEB5eQIHFJZspAIqGoIfEFPvAACe
+kBKf
+                  "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                  Interleaving -> True]}, Background -> GrayLevel[0.9], 
+              Method -> "Queued", ImageSize -> {All, 20}, Evaluator -> 
+              Automatic], FrameStyle -> Directive[
+               GrayLevel[0.9], 
+               AbsoluteThickness[2]], FrameMargins -> -1, ContentPadding -> 
+             False, StripOnInput -> False], 
+            ActionMenuBox[
+             FrameBox[
+              ButtonBox[
+               StyleBox[
+                
+                TemplateBox[{
+                 "\"Cells\"", 
+                  "\"\[ThinSpace]\[ThinSpace]\[ThinSpace]\[FilledDownTriangle]\
+\""}, "RowDefault"], "Text", FontFamily -> "Source Sans Pro", FontSize -> 11, 
+                StripOnInput -> False], ButtonFunction :> 
+               With[{RSNB`nb$ = ButtonNotebook[], RSNB`$cp$ = $ContextPath}, 
+                 Quiet[
+                  
+                  Block[{$ContextPath = RSNB`$cp$, 
+                    ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                    DefinitionNotebookClient`$ButtonCodeID = None}, 
+                   Internal`WithLocalSettings[
+                    DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    4246462567992284997; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = HoldForm[Null]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    4246462567992284997]], 
+                    DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+                   Null]]], FrameMargins -> {{4, 4}, {0, 0}}, BaseStyle -> 
+               Dynamic[
+                 FEPrivate`If[
+                  CurrentValue[Enabled], 
+                  FEPrivate`If[
+                   CurrentValue["MouseOver"], {
+                   FontColor -> GrayLevel[1], 
+                    TaggingRules -> {"ButtonHovering" -> True}}, {
+                   FontColor -> RGBColor[0.5489, 0.092317, 0.067842], 
+                    TaggingRules -> {"ButtonHovering" -> False}}], {
+                  FontColor -> RGBColor[0.88722, 0.77308, 0.76696], 
+                   TaggingRules -> {"ButtonHovering" -> False}}], Evaluator -> 
+                 "System"], Appearance -> {"Default" -> Image[CompressedData["
+
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3Ixe3bNuZmzrI0hiAgGyhCvCF3L11cERnS
+IyGIiYDiQFmChtw4dnSaoRZQ/URl2UOtjS8unIcgIBsoAhQHygLV4DHkwc0b
+M0z0gCqX+Xp8efkCLfyBIkBxoCxQDVAlLkPWpSUB1Sz2cPr9/TvWeASKA2WB
+aoAqsRpy48TxXinhPlmx9w/u40kPQFmgGqBKoHpMQ3bWVwOt2FGYSzBdAdUA
+VQLVYxqywM0BKHVv726ChgDVAFUC1UM0QpI0hD1FWxUohRmemACoBqgSqB5u
+CBBQbghVXELdMKFK7FAlnVAlxVIr7zyjRi6GAMrLEzigsGQjFVDREPyAmHoH
+APEDg3E=
+                   "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                   Interleaving -> True], "Hover" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I9T2bD1Ykb/TUgiAgGyhCvCEPrlzYnea7
+XJsNEwHFgbIEDblz8vA6R0Wg+tV6HOc9pV/HaUEQkA0UAYoDZYFq8Bjy6Nb1
+9S4qQJW7LAW+pOj/yTZBRkARoDhQFqgGqBKXIfuKooFqdljw/8wwQjMBgoDi
+QFmgGqBKrIbcOXV0uS7HCh32D0m6WE2AIKAsUA1QJVA9piHHOsqAVpxwFsdj
+AgQB1QBVAtVjGrI1xAIo9SRCnaAhQDVAlUD1EI2QJA1hr7GRBkphhicmAqoB
+qgSqhxsCBJQbQhWXUDdMqBI7VEknVEmx1Mo7z6iRiyGA8vIEDigs2UgFVDQE
+PyCm3gEAQ+/Dcg==
+                   "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                   Interleaving -> True], "Pressed" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYInlEGaG3I69evv3z58gsGgGygCPGGvHjx4vv371g9
+DhQHyhI05OXLl79//wYK/vz8+cTEvsVuDhAEZANFgOJAWaAaPIY8f/4cYsKT
+k8en6ar3SAgiI6AIUBxiDlAlLkO+fv0K5D4/d7ZfXgLNBAgCigNlgWqAKrEa
+AnTkv3///vz8OdvMAKsJEASUBaoBqoR7CtmQT58+AdmXli7CYwIEAdUAVQLV
+Yxry8+dPIHtNZAhBQ4BqQCH/8ydEIyRJQ9h//vwBsjHDExMB1QBVAtXDDQEC
+yg2hikuoGyZUiR2qpBOqpFhq5Z1n1MjFEEB5eQIHFJZspAIqGoIfEFPvAACe
+kBKf
+                   "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+                   Interleaving -> True]}, Background -> GrayLevel[0.9], 
+               Method -> "Queued", ImageSize -> {All, 20}, Evaluator -> 
+               Automatic], FrameStyle -> Directive[
+                GrayLevel[0.9], 
+                AbsoluteThickness[2]], FrameMargins -> -1, ContentPadding -> 
+              False, StripOnInput -> False], {
+             "\"Insert comment for reviewer\"" :> 
+              With[{RSNB`nb$ = InputNotebook[], RSNB`$cp$ = $ContextPath}, 
+                Quiet[
+                 
+                 Block[{$ContextPath = RSNB`$cp$, 
+                   ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                   DefinitionNotebookClient`$ButtonCodeID = None}, 
+                  Internal`WithLocalSettings[
+                   DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    7544339529118446740; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = 
+                    HoldForm[
+                    DefinitionNotebookClient`$ClickedButton = "Cells"; 
+                    DefinitionNotebookClient`$ClickedAction = 
+                    "Insert comment for reviewer"; 
+                    DefinitionNotebookClient`CommentInsert[]]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    7544339529118446740]], 
+                    DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+                  Null]]], "\"Mark/unmark selected cells as comments\"" :> 
+              With[{RSNB`nb$ = InputNotebook[], RSNB`$cp$ = $ContextPath}, 
+                Quiet[
+                 
+                 Block[{$ContextPath = RSNB`$cp$, 
+                   ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                   DefinitionNotebookClient`$ButtonCodeID = None}, 
+                  Internal`WithLocalSettings[
+                   DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    1923617830619908649; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = 
+                    HoldForm[
+                    DefinitionNotebookClient`$ClickedButton = "Cells"; 
+                    DefinitionNotebookClient`$ClickedAction = 
+                    "Mark/unmark selected cells as comments"; 
+                    DefinitionNotebookClient`CommentToggle[]]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    1923617830619908649]], 
+                    DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+                  Null]]], "\"Mark/unmark selected cells as excluded\"" :> 
+              With[{RSNB`nb$ = InputNotebook[], RSNB`$cp$ = $ContextPath}, 
+                Quiet[
+                 
+                 Block[{$ContextPath = RSNB`$cp$, 
+                   ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                   DefinitionNotebookClient`$ButtonCodeID = None}, 
+                  Internal`WithLocalSettings[
+                   DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    1439263868824766472; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = 
+                    HoldForm[
+                    DefinitionNotebookClient`$ClickedButton = "Cells"; 
+                    DefinitionNotebookClient`$ClickedAction = 
+                    "Mark/unmark selected cells as excluded"; 
+                    DefinitionNotebookClient`ExclusionToggle[]]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    1439263868824766472]], 
+                    DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+                  Null]]]}, Appearance -> None, Method -> "Queued"]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Center}}}, 
+          AutoDelete -> False, 
+          GridBoxBackground -> {"Columns" -> {{None}}, "Rows" -> {
+              GrayLevel[0.9]}}, 
+          GridBoxFrame -> {
+           "Columns" -> False, "RowsIndexed" -> {1 -> GrayLevel[0.9]}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          GridBoxSpacings -> {
+           "Columns" -> {5, {0.5}, 5}, "Rows" -> {{Automatic}}}, FrameStyle -> 
+          GrayLevel[0.75]], "Grid"], ButtonBoxOptions -> {Enabled -> Dynamic[
+            Not[
+             TrueQ[DefinitionNotebookClient`$ButtonsDisabled]], 
+            TrackedSymbols :> {DefinitionNotebookClient`$ButtonsDisabled}]}, 
+        StripOnInput -> False]& )}], 
+   Cell[
+    StyleData["MainGridTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (StyleBox[
+        TagBox[
+         GridBox[{{
+            TagBox[
+             GridBox[{{
+                GraphicsBox[
+                 RasterBox[CompressedData["
+1:eJztnXvQFlUdx0ktEbIsMsnKUWqaLkOYKWNNiHSbQUrtRdLUerm8L+AlbJBE
+ur7gIFlmzeQ4iOIlanTGCyT4RzPZWDKKt1E0TSP6OcZomhI5mpFmnc/s7rTv
+tufsue3zHHj44+Mg7HMu39095/wu5+xhs8/pm7vXiBEjzh2p/tM3a/GUhQtn
+LZl+gPqfGQvOPWPegsGBqQsWDc4bXHj07L3VXw4oZir2Ucj7dmlOyel2O3qR
+0YptOaMTaE+vsULxn5wLE2hPL/Fexc6S/jvzv+t2u3qFW0vaF2xIoF29wLQa
+7QumJdC+3Zl9FVsM+m/Jr+l2O3dXlhi0Lzg/gXbujrxT8ZKF/i/l13a7vZ1m
+kuKNLZZ/vYX2Bde12I79FZMT0LvKKsUOxQ8Vh0Yue7KD9gXHRG7DOMWPFC8o
+Lk9A7yrLSn3/t+JmifOc7KPY7KH/5vy3ofVPUaxTvFYqeygBvavM1+jwgGKm
++K9LzvbQvuAszzpHKmYb7vu8BPSucnyDFs8qlirGOpR5oOJvAfpvV7zNob6D
+FRco/tpQ7ucS0LvKREtN/qVYo/ioRZmrArQvsBmrafvP87bZlHlEAnpXeYeH
+NhsVM6R+nD5Sho+5vrym0Ys6v6i406NMl3e4U+wt2bzro9GTivMUb83Lep3i
+rgjaF9yVlzkirwMb7c+eZb2q2CsBvet4OlAnbKeVim9F1L6AMhmL/hFYzlMJ
+6KzjvhZ0S417EtBZx4YE9GmbWxLQWcflCejTNisT0FnHUAL6tM13EtBZx9wu
+acIak3nxMcWjir/I8PhkTAYS0FnHcR3S+znFz3Itxku9b4P15nsUp0tm7/09
+Ut1TE9BZxxEtar4z1/yzktkarm0bpRhU/DGwHYcnoLOOsS3o/rxkfqO3R2oj
+du85kvmRfdpzUAI668AufDWS7ujzbWkvpsPYdI9jm16R/9nRqfJUJP1/L1kc
+63uKryg+rHh95La+QbIxzbZN2xLQt4m7I+lfx4uS5f4wfsSK8fI8f9+y/rsT
+0LeJdS3qX4Y1568VJ4nffFzlEos61yWgb5U3KT6t+KZivcRb57nwJ8WXJcwv
+yW9vaqiHvuFjwZfHOuzNHdaa52yCZPG31ZLZOjF89LHA/xeyPmSuf8yhPvrO
+PHW1ZPHXj0icmHMB8bg+xUWK28Uu/6bbsEbBv++7TpmQl+FbPxrdofiBZGPj
+uyzrxT4hh+frihslm+u7rWUIN+Z98rkHyyO3hTUh+SCLFcfK8DU1efTkKMRa
+t8fiGcUmyfy9NyjWijn3sw7mZ5+9GfwmNJZkgjghuRWsrXnmX05Ab3xm+HbJ
+oyjbuqzR50gWn/y84gDJ7GzyUh61KPdXeRmu9+CslvtLHO4TeV194h+7DeUh
+yfZw1WlE+74rWWy/TiPWLP3SnC+y2kN/xq7nWuozWn+hUp8uf6otyFWcLfo1
+I+vJGZZacX/uaKjvdI97cHFLfZ+rqW9ZS/VVuVfxbkO/eaY/6agV788thjrJ
+43L1nR3eQt+HDPWxZlvdsvZotJ+hDeRbnuCoUwFxgI2Guq/yKPOJiH1fZVEf
+Ntb6lrS/TcxzIbb0Ek/tC7BZdPMBazzXfXpXROr7WrH3kzD3+OSFmdgq2drF
+VO+i/B6E6A/9hnZc5ljWnAh93yjutsgYyWzrGNoz3x/dUB+5tnV5xYwpX1Jc
+I5lv4MW8THJreUbIl/1A5TeMow9o2vKCoxZHBfb9EcVbHLUvOETi2ME2ORus
+t8u2EjngrPlt1oDMrdiRh5V+f5rh+j4HDcYE9BvtbP0POohvh/g0se1s1h2L
+S3/mmXO1dZk3iO+enJcxSvR2pas94OMP4pn4UKD2Bezl+aen/jbjLXt7Tsr/
+3G/oL/PnhlzrMyQ7d+B3+b8xLmE3f1yxIC9L509+3LH/Oxz7XLZtYzFd/Gxk
+m1z5WZLNzfMM5RCrfX/pN325juVriv0uvLO8C18zlGdaA4foX2fbxuJMR+23
+WpZb+HZ09xc/XHnO1I3t15auIT7yY0PbXMYGF//Y/Ja0L3CxkS+1LBNf+fOa
+MtiTMq50LTEn3fNYjQ+eZ2jbpyzbNtqhv0tb1h5cbORTLcu831DGmsq1A4Zr
+q/PqDMO1J1q2bbxlX6/sgPYFV1q2abxleQ8byqj64K4yXFvNzVwTQf9TLfvK
+ve9EbtBSy/aAbezjQUMZiyvX6vIrGJPK8XDGLN1+OuaZKZZtu9Shv8ta1t7F
+R/2yQ7mbDOUwh36mdO21mutOK10zylAmMXPWxOW1lImtDn2GM1vS3jVGs8Oh
+7BsM5ZBrxVqyGMuqcanHZbg9i66mvELshq+KXS6dTz4xGk2PrL1PjNJF/xWG
+cm7Kr+E+YFthYxU+IHwr2GC8l9hk2Ga6ODZjUX9e1iLLdl3moT9gq8Y6f4J1
+ss8e9Fcc6phuKIf7XthK+BYGxe4coDL47SbmZeADrs4pdYyVsLg4Phvb9YcO
+fEch/rcxlvVwRoApj6u8jsXHxvti80zguyMXaGTp98TVmnyxsDKg3wVod4in
+9vhMHwms/yiH+kzxBnzJ1bUdPucL8t9tz68j94n54KeSvSsja+pZXlNWlY9J
+vHwEfPi2z2EB6wdTHM+WOQ51mnw/0O/Yhzo+KMPXSXXgh3Jd8zRxp9jHHBgf
+10aq9woHbYh7mfxcxBQPDtCeZ548SlOOLrHR2yJrX7Be7OKPMc4cKXjCUaOh
+hvJ4J33PEWJdbvK5Mceb8idi0GQjN/XfB5d8ZOzlpnMx0Mg1nw3fqmlNTi7M
+vS1rX6Czkdvau3uxo1ZN5zjBb8X+DBj2Lp2s+TfGIuYo1/hKKFUfNfGCtvIP
+WQO6xDrgJxblMh/0i348Z38Sz1rdWpP3h5zHhzqsewFaFzY7cbLQM1macD2H
+DX1+aVk2Objk4vI+sHZhrMHvPyjDxynsZvK6OKPimS7pXgbbDr8COdCbpd38
+W3K5XfPAWQ/9xqOuP0i2fsOnxJpjUyJ6l8FHgk2zotRf9gQcK5ltzl6BWPtI
+C5Y76g+smdtek3QC7GD2g7C3ZZLY2wL4H8hLID5IfnHI/iP8QRM87gHrNfZh
+p7Y/RAca3S6ZrcEYH2KzVGFvGXvMmL+vlsy2dtl/hx/Mdz875/Hpctq6BX3H
+R8O6Hvud5yvGXlgXiDmRa8CeTPy/Tbla+JN994nyu5mS7Tftht70jTnlG5Lt
+uY2Rqxqbmy36cUlgHbyHvNv4Cjq5byfF/ddVbM8fYM9/jHg168r5+X1v2ocU
+yq5w/oBLvICzL3z2xpkgv5/cBvz+rPV/If+fJ+dLymdPAs+za64qsdpxkeqv
+wlzP2sn3rJ8qKZ+9Cgd59gt9yJmNtXefMYk8GV1OXQgpnj1cELpfjbPB8Bv4
+7Ftn3cc6jDGtrbP3IMWztwumRuoj6zxy19gzSry3bp4mDkB8eyDXvK29ulWO
+S0BnHabczBB4ntkfj68NG455sFvnruj27qZAG+dmp8ZQAjrriJGzkTopfnun
+YHfwVTaR8ncmXc9z3BW5LwGddYTGDIjD8X639f0FxsfQM7yeTkDnOkLOXiXn
+AX9B+fsjMfffV78/QnzySc+y8Pd12sdsg8/Zw2jMN3Dq7F7snFjf3zmypnzq
+ZG+NT56f7jyibmKbK08eON96sskNjfE9B5szR/gW1hqx//7URIsyO03T2fP4
+hsmXdYnHkRe9vaFcE+RIH+hQH+8wfqNnG8o9PgG9q+jyt8it4JyrulxkG0LO
+YTvbs058GzNFH+9se4+vD0Ol9jHm4ne33eNmotvf35wsWWynHGdre5+dD4zV
++JH5Rmtsf/4xHvpPjtyGQyX7ti65ijZzSqehv/u3WP51Dtpf32I7iOlMSkDv
+TkM+Z7HvzkSvfn+8E5xvoX/o+XF70MO6xHQu0xbx35+xBzumGfSflkD7eoG6
+70zemkC7egVyfMox9p3ifq7nHsK4sKT/ii7U3+uwn2Nbjs8Z/3sI55ScbrfD
+m/8Cm+a3ew==
+                  "], {{0, 0}, {96, 100}}, {0, 255}, ColorFunction -> 
+                  RGBColor], {
+                 ImageSize -> {Automatic, 32}, 
+                  ImagePadding -> {{5, 0}, {0, 0}}, BaselinePosition -> 
+                  Scaled[0.25], PlotRange -> {{0, 96}, {0, 100}}, 
+                  ImageSizeRaw -> {96., 100.}}], 
+                StyleBox[
+                 TagBox[
+                  GridBox[{{
+                    StyleBox[
+                    "\"Demonstration Resource\"", FontFamily -> 
+                    "Source Sans Pro", FontWeight -> "SemiBold", StripOnInput -> 
+                    False], 
+                    StyleBox[
+                    "\"DEFINITION NOTEBOOK\"", FontFamily -> 
+                    "Source Sans Pro", FontTracking -> "SemiCondensed", 
+                    FontVariations -> {"CapsType" -> "AllSmallCaps"}, 
+                    StripOnInput -> False]}}, 
+                   GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Baseline}}}, 
+                   AutoDelete -> False, 
+                   GridBoxDividers -> {
+                    "ColumnsIndexed" -> {2 -> GrayLevel[1]}, 
+                    "Rows" -> {{None}}}, 
+                   GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], 
+                  "Grid"], FontSize -> 24, FontColor -> GrayLevel[1], 
+                 StripOnInput -> False]}}, 
+              GridBoxAlignment -> {
+               "Columns" -> {{Left}}, "Rows" -> {{Baseline}}}, AutoDelete -> 
+              False, GridBoxItemSize -> {
+               "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], "Grid"],
+             "\[SpanFromLeft]", "\[SpanFromLeft]", "\[SpanFromLeft]", 
+            "\[SpanFromLeft]", "\[SpanFromLeft]", "\[SpanFromLeft]", 
+            TemplateBox[{
+              StyleBox[
+               
+               TemplateBox[{
+                "\"Demonstration Repository\"", "\" \[RightGuillemet]  \""}, 
+                "RowDefault"], "Text", FontColor -> GrayLevel[1], 
+               StripOnInput -> False], 
+              "https://resources.wolframcloud.com/DemonstrationRepository"}, 
+             "HyperlinkURL"]}, {
+            TemplateBox[{
+              
+              TemplateBox[{
+               "\"Open Sample\"", 
+                "\"View a completed sample definition notebook\""}, 
+               "PrettyTooltipTemplate"], Annotation[
+              DefinitionNotebookClient`$ButtonCodeID = 1953775238739395670; (
+                DefinitionNotebookClient`$ClickedButton = "Open Sample"; 
+                DefinitionNotebookClient`ViewExampleNotebook[
+                  ButtonNotebook[]]), 
+               DefinitionNotebookClient`ButtonCodeID[1953775238739395670]]& , 
+              "\"View a completed sample definition notebook\"", False}, 
+             "OrangeButtonTemplate"], 
+            TemplateBox[{
+              
+              TemplateBox[{
+               "\"Style Guidelines\"", 
+                "\"View general guidelines for authoring resources\""}, 
+               "PrettyTooltipTemplate"], Annotation[
+              DefinitionNotebookClient`$ButtonCodeID = 6116318327813659236; (
+                DefinitionNotebookClient`$ClickedButton = "Style Guidelines"; 
+                SystemOpen[
+                 "https://demonstrations.wolfram.com/guidelines.php"]), 
+               DefinitionNotebookClient`ButtonCodeID[6116318327813659236]]& , 
+              "\"View general guidelines for authoring resources\"", False}, 
+             "OrangeButtonTemplate"], 
+            TemplateBox[{
+              TemplateBox[{
+                TagBox[
+                 GridBox[{{"\"Tools\"", 
+                    PaneSelectorBox[{False -> GraphicsBox[{
+                    GrayLevel[1], 
+                    AbsoluteThickness[1.], 
+                    LineBox[{{0, 0}, {0, 10}, {10, 10}, {10, 0}, {0, 0}}], 
+                    LineBox[{{5, 2.5}, {5, 7.5}}], 
+                    LineBox[{{2.5, 5}, {7.5, 5}}]}, ImageSize -> 12, 
+                    PlotRangePadding -> 1.5], True -> GraphicsBox[{
+                    GrayLevel[1], 
+                    AbsoluteThickness[1.], 
+                    LineBox[{{0, 0}, {0, 10}, {10, 10}, {10, 0}, {0, 0}}], 
+                    LineBox[{{2.5, 5}, {7.5, 5}}]}, ImageSize -> 12, 
+                    PlotRangePadding -> 1.5]}, 
+                    Dynamic[
+                    CurrentValue[
+                    EvaluationNotebook[], {TaggingRules, "ToolsOpen"}, True]],
+                     BaselinePosition -> Scaled[0.05]]}}, 
+                  GridBoxAlignment -> {
+                   "Columns" -> {{Automatic}}, "Rows" -> {{Baseline}}}, 
+                  AutoDelete -> False, 
+                  GridBoxItemSize -> {
+                   "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                  GridBoxSpacings -> {"Columns" -> {{0.35}}}], "Grid"], 
+                "\"Toggle documentation toolbar\""}, "PrettyTooltipTemplate"],
+               Annotation[
+              DefinitionNotebookClient`$ButtonCodeID = 1908941340027841465; (
+                DefinitionNotebookClient`$ClickedButton = "Tools"; 
+                DefinitionNotebookClient`ToggleToolbar[
+                  ButtonNotebook[]]), 
+               DefinitionNotebookClient`ButtonCodeID[1908941340027841465]]& , 
+              "\"Toggle documentation toolbar\"", False}, 
+             "OrangeButtonTemplate"], 
+            TagBox[
+             
+             GridBox[{{"\"\"", "\"\""}}, 
+              GridBoxAlignment -> {
+               "Columns" -> {{Left}}, "Rows" -> {{Center}}}, AutoDelete -> 
+              False, GridBoxDividers -> {
+               "ColumnsIndexed" -> {2 -> True}, "Rows" -> {{False}}}, 
+              GridBoxItemSize -> {
+               "Columns" -> {{Automatic}}, "Rows" -> {{2}}}, 
+              GridBoxSpacings -> {"Columns" -> {{0.5}}}, FrameStyle -> 
+              RGBColor[0.57555, 0.57556, 0.57554]], "Grid"], 
+            TemplateBox[{
+              
+              TemplateBox[{
+               "\"Check\"", "\"Check notebook for potential errors\""}, 
+               "PrettyTooltipTemplate"], Annotation[
+              DefinitionNotebookClient`$ButtonCodeID = 3941141659801008137; (
+                DefinitionNotebookClient`$ClickedButton = "Check"; 
+                DefinitionNotebookClient`CheckDefinitionNotebook[
+                  ButtonNotebook[]]), 
+               DefinitionNotebookClient`ButtonCodeID[3941141659801008137]]& , 
+              "\"Check notebook for potential errors\"", False}, 
+             "OrangeButtonTemplate"], 
+            ActionMenuBox[
+             TemplateBox[{
+               TemplateBox[{"\"Deploy\"", 
+                 TemplateBox[{5}, "Spacer1"], "\"\[FilledDownTriangle]\""}, 
+                "RowDefault"], Annotation[
+               DefinitionNotebookClient`$ButtonCodeID = 6058522267645278627; 
+                Null, 
+                DefinitionNotebookClient`ButtonCodeID[6058522267645278627]]& ,
+                "\"\"", True}, "OrangeButtonTemplate"], {
+             "\"To my cloud account\"" :> 
+              With[{RSNB`nb$ = InputNotebook[], RSNB`$cp$ = $ContextPath}, 
+                Quiet[
+                 
+                 Block[{$ContextPath = RSNB`$cp$, 
+                   ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                   DefinitionNotebookClient`$SuppressDynamicEvents = True, 
+                   DefinitionNotebookClient`$ButtonCodeID = None}, 
+                  Internal`WithLocalSettings[
+                   DefinitionNotebookClient`$ButtonsDisabled = True; 
+                    CurrentValue[RSNB`nb$, {TaggingRules, "StatusMessage"}] = 
+                    ProgressIndicator[Appearance -> "Necklace"]; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    8267267753343341396; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = 
+                    HoldForm[
+                    DefinitionNotebookClient`$ClickedButton = "DeployCustom"; 
+                    DefinitionNotebookClient`$ClickedAction = 
+                    "To my cloud account"; 
+                    DefinitionNotebookClient`DisplayStripe[
+                    ButtonNotebook[], 
+                    DefinitionNotebookClient`DeployResource["Demonstration", 
+                    ButtonNotebook[], "CloudPrivate"], "ShowProgress" -> 
+                    True]]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    8267267753343341396]], 
+                    CurrentValue[RSNB`nb$, {TaggingRules, "StatusMessage"}] = 
+                    ""; DefinitionNotebookClient`$ButtonsDisabled = False; 
+                    Null]; Null]]], "\"Publicly in the cloud\"" :> 
+              With[{RSNB`nb$ = InputNotebook[], RSNB`$cp$ = $ContextPath}, 
+                Quiet[
+                 
+                 Block[{$ContextPath = RSNB`$cp$, 
+                   ResourceSystemClient`$\
+AsyncronousResourceInformationUpdates = False, 
+                   DefinitionNotebookClient`$SuppressDynamicEvents = True, 
+                   DefinitionNotebookClient`$ButtonCodeID = None}, 
+                  Internal`WithLocalSettings[
+                   DefinitionNotebookClient`$ButtonsDisabled = True; 
+                    CurrentValue[RSNB`nb$, {TaggingRules, "StatusMessage"}] = 
+                    ProgressIndicator[Appearance -> "Necklace"]; Once[
+                    ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                    "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                    Annotation[
+                    DefinitionNotebookClient`$ButtonCodeID = 
+                    1628664177886538591; 
+                    DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = 
+                    HoldForm[
+                    DefinitionNotebookClient`$ClickedButton = "DeployCustom"; 
+                    DefinitionNotebookClient`$ClickedAction = 
+                    "Publicly in the cloud"; 
+                    DefinitionNotebookClient`DisplayStripe[
+                    ButtonNotebook[], 
+                    DefinitionNotebookClient`DeployResource["Demonstration", 
+                    ButtonNotebook[], "CloudPublic"], "ShowProgress" -> 
+                    True]]]], 
+                    DefinitionNotebookClient`ButtonCodeID[
+                    1628664177886538591]], 
+                    CurrentValue[RSNB`nb$, {TaggingRules, "StatusMessage"}] = 
+                    ""; DefinitionNotebookClient`$ButtonsDisabled = False; 
+                    Null]; Null]]]}, Appearance -> None, Method -> "Queued"], 
+            
+            ItemBox[
+             StyleBox[
+              DynamicBox[
+               ToBoxes[
+                CurrentValue[
+                 EvaluationNotebook[], {TaggingRules, "StatusMessage"}, ""], 
+                StandardForm], Initialization :> (CurrentValue[
+                  EvaluationNotebook[], {TaggingRules, "StatusMessage"}] = 
+                "")], "Text", 
+              GrayLevel[1], StripOnInput -> False], ItemSize -> Fit, 
+             Alignment -> Right, StripOnInput -> False], 
+            DynamicBox[
+             ToBoxes[
+              If[
+               CurrentValue[
+                EvaluationNotebook[], {
+                TaggingRules, "SubmissionReviewData", "Review"}, False], 
+               RawBoxes[
+                TemplateBox[{
+                  TemplateBox[{
+                    TagBox[
+                    GridBox[{{
+                    GraphicsBox[{
+                    Thickness[0.06349], 
+                    StyleBox[{
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
+                     0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                    0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1,
+                     0}, {0, 1, 0}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBWIWIGZigIEX9mCqQd8Bwv+Bnc/A54CiHs5HV6/ngJUP
+p2HmwdTp4FCHTvOhqYfZrw2lhdDk0fno6tHcD1PPwOSAnY+uns8BAE8cGz4=
+
+                    "]]}, {
+                    FaceForm[
+                    GrayLevel[1]]}, StripOnInput -> False], 
+                    StyleBox[{
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
+                     0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                    0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1,
+                     0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 
+                    2, 0}, {0, 1, 0}, {0, 1, 0}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgB2IWIGZigAEJBwjNB6EblHHwX9ijqofxoeoYhKC0Bg4+
+Hw4apk4Uap8aDr4QDhqqDu4uVRx8URw0TJ001D5lHHwJHDRUHYMclFbCwZfG
+QUPVNSjgp+HmIWgAG/wcEg==
+                    "]], 
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
+                     0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                    0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1,
+                     0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 
+                    2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 
+                    1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0,
+                     1, 0}, {0, 1, 0}}}, CompressedData["
+1:eJx10EEKgCAQhWGpFtEyEAYGggQj6RKeoSMErbuCR0/IWfTgCcPwy7fR9XrO
+u3fOTXWGOp2zM+ZvH2170nv+e2sFH0ijt45/XxJp9NgRPHYAb63kHhu9tf2H
+eU8aPfbS9kxawAvxnrSCx3c3XzbS6JX4RFrAS34B53ckaw==
+                    "]]}, {
+                    FaceForm[
+                    GrayLevel[1]]}, StripOnInput -> False]}, ImageSize -> 15, 
+                    PlotRange -> {{0., 15.75}, {0., 16.5}}, AspectRatio -> 
+                    1.15], "\"Submit Update\""}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Center}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0}}, "ColumnsIndexed" -> {2 -> 0.5}, 
+                    "Rows" -> {{0}}}], "Grid"], 
+                    "\"Submit changes to update your demonstration submission\
+\""}, "PrettyTooltipTemplate"], Annotation[
+                  DefinitionNotebookClient`$ButtonCodeID = 
+                    2169377100431483360; (
+                    DefinitionNotebookClient`$ClickedButton = "SubmitUpdate"; 
+                    With[{RSNB`nb = ButtonNotebook[]}, 
+                    DefinitionNotebookClient`DisplayStripe[RSNB`nb, 
+                    DefinitionNotebookClient`SubmitRepositoryUpdate[RSNB`nb], 
+                    "ShowProgress" -> True]]), 
+                   DefinitionNotebookClient`ButtonCodeID[
+                   2169377100431483360]]& , 
+                  "\"Submit changes to update your demonstration \
+submission\"", True}, "OrangeButtonTemplate"]], 
+               RawBoxes[
+                TemplateBox[{
+                  TemplateBox[{
+                    TagBox[
+                    GridBox[{{
+                    GraphicsBox[{
+                    Thickness[0.06349], 
+                    StyleBox[{
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
+                     0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                    0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1,
+                     0}, {0, 1, 0}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBWIWIGZigIEX9mCqQd8Bwv+Bnc/A54CiHs5HV6/ngJUP
+p2HmwdTp4FCHTvOhqYfZrw2lhdDk0fno6tHcD1PPwOSAnY+uns8BAE8cGz4=
+
+                    "]]}, {
+                    FaceForm[
+                    GrayLevel[1]]}, StripOnInput -> False], 
+                    StyleBox[{
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
+                     0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                    0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1,
+                     0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 
+                    2, 0}, {0, 1, 0}, {0, 1, 0}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgB2IWIGZigAEJBwjNB6EblHHwX9ijqofxoeoYhKC0Bg4+
+Hw4apk4Uap8aDr4QDhqqDu4uVRx8URw0TJ001D5lHHwJHDRUHYMclFbCwZfG
+QUPVNSjgp+HmIWgAG/wcEg==
+                    "]], 
+                    
+                    FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2,
+                     0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 
+                    0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1,
+                     0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 
+                    2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 
+                    1, 0}}, {{0, 2, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0,
+                     1, 0}, {0, 1, 0}}}, CompressedData["
+1:eJx10EEKgCAQhWGpFtEyEAYGggQj6RKeoSMErbuCR0/IWfTgCcPwy7fR9XrO
+u3fOTXWGOp2zM+ZvH2170nv+e2sFH0ijt45/XxJp9NgRPHYAb63kHhu9tf2H
+eU8aPfbS9kxawAvxnrSCx3c3XzbS6JX4RFrAS34B53ckaw==
+                    "]]}, {
+                    FaceForm[
+                    GrayLevel[1]]}, StripOnInput -> False]}, ImageSize -> 15, 
+                    PlotRange -> {{0., 15.75}, {0., 16.5}}, AspectRatio -> 
+                    1.15], "\"Submit to Repository\""}}, 
+                    GridBoxAlignment -> {
+                    "Columns" -> {{Left}}, "Rows" -> {{Center}}}, AutoDelete -> 
+                    False, GridBoxItemSize -> {
+                    "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                    GridBoxSpacings -> {
+                    "Columns" -> {{0}}, "ColumnsIndexed" -> {2 -> 0.5}, 
+                    "Rows" -> {{0}}}], "Grid"], 
+                    "\"Submit your demonstration to the Wolfram Demonstration \
+Repository\""}, "PrettyTooltipTemplate"], Annotation[
+                  DefinitionNotebookClient`$ButtonCodeID = 
+                    850153740503147579; (
+                    DefinitionNotebookClient`$ClickedButton = "Submit"; 
+                    With[{RSNB`nb = ButtonNotebook[]}, 
+                    DefinitionNotebookClient`DisplayStripe[RSNB`nb, 
+                    DefinitionNotebookClient`SubmitRepository[RSNB`nb], 
+                    "ShowProgress" -> True]]), 
+                   DefinitionNotebookClient`ButtonCodeID[
+                   850153740503147579]]& , 
+                  "\"Submit your demonstration to the Wolfram Demonstration \
+Repository\"", True}, "OrangeButtonTemplate"]]], StandardForm], Evaluator -> 
+             "System", SingleEvaluation -> True]}}, 
+          GridBoxAlignment -> {
+           "Columns" -> {{Left}}, "ColumnsIndexed" -> {-1 -> Right}, 
+            "Rows" -> {{Center}}}, AutoDelete -> False, 
+          GridBoxBackground -> {"Columns" -> {{None}}, "Rows" -> {
+              RGBColor[0.1511, 0.15112, 0.15108], 
+              RGBColor[0.7508, 0.17868, 0.085283]}}, 
+          GridBoxFrame -> {
+           "Columns" -> False, 
+            "RowsIndexed" -> {
+             1 -> RGBColor[0.1511, 0.15112, 0.15108], 2 -> 
+              RGBColor[0.7508, 0.17868, 0.085283]}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          GridBoxSpacings -> {
+           "Columns" -> {5, {0.9}, 5}, 
+            "RowsIndexed" -> {1 -> 1.1, 2 -> 1.3, 3 -> 0.25}}, FrameStyle -> 
+          RGBColor[0.1511, 0.15112, 0.15108]], "Grid"], 
+        ButtonBoxOptions -> {Enabled -> Dynamic[
+            Not[
+             TrueQ[DefinitionNotebookClient`$ButtonsDisabled]], 
+            TrackedSymbols :> {DefinitionNotebookClient`$ButtonsDisabled}]}, 
+        StripOnInput -> False]& )}], 
+   Cell[
+    StyleData["ReviewerCommentLabelTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (TagBox[
+        GridBox[{{#, 
+           TemplateBox[{
+             GraphicsBox[
+              RasterBox[CompressedData["
+1:eJztnXvQFlUdx0ktEbIsMsnKUWqaLkOYKWNNiHSbQUrtRdLUerm8L+AlbJBE
+ur7gIFlmzeQ4iOIlanTGCyT4RzPZWDKKt1E0TSP6OcZomhI5mpFmnc/s7rTv
+tufsue3zHHj44+Mg7HMu39095/wu5+xhs8/pm7vXiBEjzh2p/tM3a/GUhQtn
+LZl+gPqfGQvOPWPegsGBqQsWDc4bXHj07L3VXw4oZir2Ucj7dmlOyel2O3qR
+0YptOaMTaE+vsULxn5wLE2hPL/Fexc6S/jvzv+t2u3qFW0vaF2xIoF29wLQa
+7QumJdC+3Zl9FVsM+m/Jr+l2O3dXlhi0Lzg/gXbujrxT8ZKF/i/l13a7vZ1m
+kuKNLZZ/vYX2Bde12I79FZMT0LvKKsUOxQ8Vh0Yue7KD9gXHRG7DOMWPFC8o
+Lk9A7yrLSn3/t+JmifOc7KPY7KH/5vy3ofVPUaxTvFYqeygBvavM1+jwgGKm
++K9LzvbQvuAszzpHKmYb7vu8BPSucnyDFs8qlirGOpR5oOJvAfpvV7zNob6D
+FRco/tpQ7ucS0LvKREtN/qVYo/ioRZmrArQvsBmrafvP87bZlHlEAnpXeYeH
+NhsVM6R+nD5Sho+5vrym0Ys6v6i406NMl3e4U+wt2bzro9GTivMUb83Lep3i
+rgjaF9yVlzkirwMb7c+eZb2q2CsBvet4OlAnbKeVim9F1L6AMhmL/hFYzlMJ
+6KzjvhZ0S417EtBZx4YE9GmbWxLQWcflCejTNisT0FnHUAL6tM13EtBZx9wu
+acIak3nxMcWjir/I8PhkTAYS0FnHcR3S+znFz3Itxku9b4P15nsUp0tm7/09
+Ut1TE9BZxxEtar4z1/yzktkarm0bpRhU/DGwHYcnoLOOsS3o/rxkfqO3R2oj
+du85kvmRfdpzUAI668AufDWS7ujzbWkvpsPYdI9jm16R/9nRqfJUJP1/L1kc
+63uKryg+rHh95La+QbIxzbZN2xLQt4m7I+lfx4uS5f4wfsSK8fI8f9+y/rsT
+0LeJdS3qX4Y1568VJ4nffFzlEos61yWgb5U3KT6t+KZivcRb57nwJ8WXJcwv
+yW9vaqiHvuFjwZfHOuzNHdaa52yCZPG31ZLZOjF89LHA/xeyPmSuf8yhPvrO
+PHW1ZPHXj0icmHMB8bg+xUWK28Uu/6bbsEbBv++7TpmQl+FbPxrdofiBZGPj
+uyzrxT4hh+frihslm+u7rWUIN+Z98rkHyyO3hTUh+SCLFcfK8DU1efTkKMRa
+t8fiGcUmyfy9NyjWijn3sw7mZ5+9GfwmNJZkgjghuRWsrXnmX05Ab3xm+HbJ
+oyjbuqzR50gWn/y84gDJ7GzyUh61KPdXeRmu9+CslvtLHO4TeV194h+7DeUh
+yfZw1WlE+74rWWy/TiPWLP3SnC+y2kN/xq7nWuozWn+hUp8uf6otyFWcLfo1
+I+vJGZZacX/uaKjvdI97cHFLfZ+rqW9ZS/VVuVfxbkO/eaY/6agV788thjrJ
+43L1nR3eQt+HDPWxZlvdsvZotJ+hDeRbnuCoUwFxgI2Guq/yKPOJiH1fZVEf
+Ntb6lrS/TcxzIbb0Ek/tC7BZdPMBazzXfXpXROr7WrH3kzD3+OSFmdgq2drF
+VO+i/B6E6A/9hnZc5ljWnAh93yjutsgYyWzrGNoz3x/dUB+5tnV5xYwpX1Jc
+I5lv4MW8THJreUbIl/1A5TeMow9o2vKCoxZHBfb9EcVbHLUvOETi2ME2ORus
+t8u2EjngrPlt1oDMrdiRh5V+f5rh+j4HDcYE9BvtbP0POohvh/g0se1s1h2L
+S3/mmXO1dZk3iO+enJcxSvR2pas94OMP4pn4UKD2Bezl+aen/jbjLXt7Tsr/
+3G/oL/PnhlzrMyQ7d+B3+b8xLmE3f1yxIC9L509+3LH/Oxz7XLZtYzFd/Gxk
+m1z5WZLNzfMM5RCrfX/pN325juVriv0uvLO8C18zlGdaA4foX2fbxuJMR+23
+WpZb+HZ09xc/XHnO1I3t15auIT7yY0PbXMYGF//Y/Ja0L3CxkS+1LBNf+fOa
+MtiTMq50LTEn3fNYjQ+eZ2jbpyzbNtqhv0tb1h5cbORTLcu831DGmsq1A4Zr
+q/PqDMO1J1q2bbxlX6/sgPYFV1q2abxleQ8byqj64K4yXFvNzVwTQf9TLfvK
+ve9EbtBSy/aAbezjQUMZiyvX6vIrGJPK8XDGLN1+OuaZKZZtu9Shv8ta1t7F
+R/2yQ7mbDOUwh36mdO21mutOK10zylAmMXPWxOW1lImtDn2GM1vS3jVGs8Oh
+7BsM5ZBrxVqyGMuqcanHZbg9i66mvELshq+KXS6dTz4xGk2PrL1PjNJF/xWG
+cm7Kr+E+YFthYxU+IHwr2GC8l9hk2Ga6ODZjUX9e1iLLdl3moT9gq8Y6f4J1
+ss8e9Fcc6phuKIf7XthK+BYGxe4coDL47SbmZeADrs4pdYyVsLg4Phvb9YcO
+fEch/rcxlvVwRoApj6u8jsXHxvti80zguyMXaGTp98TVmnyxsDKg3wVod4in
+9vhMHwms/yiH+kzxBnzJ1bUdPucL8t9tz68j94n54KeSvSsja+pZXlNWlY9J
+vHwEfPi2z2EB6wdTHM+WOQ51mnw/0O/Yhzo+KMPXSXXgh3Jd8zRxp9jHHBgf
+10aq9woHbYh7mfxcxBQPDtCeZ548SlOOLrHR2yJrX7Be7OKPMc4cKXjCUaOh
+hvJ4J33PEWJdbvK5Mceb8idi0GQjN/XfB5d8ZOzlpnMx0Mg1nw3fqmlNTi7M
+vS1rX6Czkdvau3uxo1ZN5zjBb8X+DBj2Lp2s+TfGIuYo1/hKKFUfNfGCtvIP
+WQO6xDrgJxblMh/0i348Z38Sz1rdWpP3h5zHhzqsewFaFzY7cbLQM1macD2H
+DX1+aVk2Objk4vI+sHZhrMHvPyjDxynsZvK6OKPimS7pXgbbDr8COdCbpd38
+W3K5XfPAWQ/9xqOuP0i2fsOnxJpjUyJ6l8FHgk2zotRf9gQcK5ltzl6BWPtI
+C5Y76g+smdtek3QC7GD2g7C3ZZLY2wL4H8hLID5IfnHI/iP8QRM87gHrNfZh
+p7Y/RAca3S6ZrcEYH2KzVGFvGXvMmL+vlsy2dtl/hx/Mdz875/Hpctq6BX3H
+R8O6Hvud5yvGXlgXiDmRa8CeTPy/Tbla+JN994nyu5mS7Tftht70jTnlG5Lt
+uY2Rqxqbmy36cUlgHbyHvNv4Cjq5byfF/ddVbM8fYM9/jHg168r5+X1v2ocU
+yq5w/oBLvICzL3z2xpkgv5/cBvz+rPV/If+fJ+dLymdPAs+za64qsdpxkeqv
+wlzP2sn3rJ8qKZ+9Cgd59gt9yJmNtXefMYk8GV1OXQgpnj1cELpfjbPB8Bv4
+7Ftn3cc6jDGtrbP3IMWztwumRuoj6zxy19gzSry3bp4mDkB8eyDXvK29ulWO
+S0BnHabczBB4ntkfj68NG455sFvnruj27qZAG+dmp8ZQAjrriJGzkTopfnun
+YHfwVTaR8ncmXc9z3BW5LwGddYTGDIjD8X639f0FxsfQM7yeTkDnOkLOXiXn
+AX9B+fsjMfffV78/QnzySc+y8Pd12sdsg8/Zw2jMN3Dq7F7snFjf3zmypnzq
+ZG+NT56f7jyibmKbK08eON96sskNjfE9B5szR/gW1hqx//7URIsyO03T2fP4
+hsmXdYnHkRe9vaFcE+RIH+hQH+8wfqNnG8o9PgG9q+jyt8it4JyrulxkG0LO
+YTvbs058GzNFH+9se4+vD0Ol9jHm4ne33eNmotvf35wsWWynHGdre5+dD4zV
++JH5Rmtsf/4xHvpPjtyGQyX7ti65ijZzSqehv/u3WP51Dtpf32I7iOlMSkDv
+TkM+Z7HvzkSvfn+8E5xvoX/o+XF70MO6xHQu0xbx35+xBzumGfSflkD7eoG6
+70zemkC7egVyfMox9p3ifq7nHsK4sKT/ii7U3+uwn2Nbjs8Z/3sI55ScbrfD
+m/8Cm+a3ew==
+               "], {{0, 0}, {96, 100}}, {0, 255}, ColorFunction -> 
+               RGBColor], {
+              ImageSize -> {Automatic, 12}, ImagePadding -> {{5, 0}, {0, 0}}, 
+               BaselinePosition -> Scaled[0.25], 
+               PlotRange -> {{0, 96}, {0, 100}}, 
+               ImageSizeRaw -> {96., 100.}}], 
+             "Wolfram Demonstration Repository Reviewer"}, 
+            "PrettyTooltipTemplate"]}}, 
+         GridBoxAlignment -> {
+          "Columns" -> {{Automatic}}, "Rows" -> {{Center}}}, AutoDelete -> 
+         False, GridBoxItemSize -> {
+          "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+         GridBoxSpacings -> {"Columns" -> {{0.25}}}], "Grid"]& )}], 
+   Cell[
+    StyleData["CommentReplyIcon"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         Thickness[0.076923], 
+         FaceForm[{#, 
+           Opacity[1.]}], 
+         FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}}}, {{{1.5, 7.5}, {6.5, 11.5}, {
+          6.5, 3.5}}}], 
+         FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+          0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+          3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+          3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+          0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}}}, CompressedData["
+1:eJw9U2tIVEEUvq5iVkttZmdfuo/ZbQukJGKVqPBLUTGJ0h9hVLIJRYhUVJj2
+AjGRWCKiF0llZWRCSEnZExEJ06CotaiQyH7EIrthT3u6NXPn3jswnDlzzzlz
+vu8711u9vWJzsqIoSXwv5tuk6IsgrQvOnLf+1CRC5ZKbg3WJAIJV90rNJoJF
+XOR6sebI6W3pyXq8DxccIoGwa+uxj/v/McxNbTxZOJ3w4Rkb+ZVgWGk2ZbcQ
+Yfm0V+07Jhm6St7vzVhI2JfBT78ZCkI8cj2hqe/xxaIJJm0PoWEssCgtzvCc
+lzlYYwXP5iUYHpXlHV4xasXLeh4wyKCWX2fDqcJwbfQ+w4F83vGQDT1fJ1/U
+dzJ842bsih1XB3hiI0NzrPyOq9mBPb1tjpyNDBXci5U7MVQnLhji4nMsE+9W
+c6ARL3i3XSWbXNiiLi8EzPxbbqydsaD73LgHJ2wp/OiFoKVJ8Ui+Chha6M3T
+H8NZUMPm+XB9p8h0QtATjvtxqUh0SBgV76QHZN+lszReA5pNQ66o1+8HV6O3
+rdWCBIcTuKHxHJ4NQdO1sx4Nxxy4VYBug2dVt4lMnB/vGCi7TSgWz/504Etk
+VbXlNSGkCmWHqFYbJXziYXlT7VKXEdLq2DDMwyvvksTZZ5W4OgiCjmCVFTUP
+dh+3HSKJ8y9hqUogIfqn83PkCUndQoTLQsZ2gpperL3fQJLXIMEn5F5GaD3D
+l50g2O3OIkhiCUf7v8/fMJOMuRPTmT2FjLlU+0ghY471+dV93epzr/sPPaJz
+u3Ev65sNX/8//gP5Ei2u
+          "]]}, AspectRatio -> Automatic, ImageSize -> {13., 13.}, 
+        PlotRange -> {{0., 13.}, {0., 13.}}]& )}], 
+   Cell[
+    StyleData["CommentCellLabelTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (StyleBox[
+        TagBox[
+         GridBox[{{
+            StyleBox[#, FontSize -> 11], "\[SpanFromLeft]"}, {
+            StyleBox[
+             DynamicBox[
+              ToBoxes[
+               DateString[
+                TimeZoneConvert[
+                 DateObject[#2, TimeZone -> 0]], {
+                "Month", "/", "Day", "/", "Year", " ", "Hour24", ":", 
+                 "Minute"}], StandardForm], SingleEvaluation -> True], 
+             FontSize -> 9], 
+            ItemBox[
+             ButtonBox[
+              TagBox[
+               StyleBox[
+                TemplateBox[{"\"Reply \[RightGuillemet]\"", 
+                  StyleBox["\"Reply \[RightGuillemet]\"", "HyperlinkActive"], 
+                  BaseStyle -> "Hyperlink"}, "MouseoverTemplate"], FontSize -> 
+                9], 
+               MouseAppearanceTag["LinkHand"]], BaseStyle -> "Hyperlink", 
+              ButtonFunction :> (SelectionMove[
+                 ParentCell[
+                  EvaluationCell[]], After, Cell]; 
+               DefinitionNotebookClient`CommentInsert[]), Evaluator -> 
+              Automatic, Method -> "Queued"], Alignment -> Right]}}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}}, AutoDelete -> False, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+          GridBoxSpacings -> {"Columns" -> {{Automatic}}, "Rows" -> {{0}}}], 
+         "Grid"], "CommentLabel", ShowStringCharacters -> False]& )}], 
+   Cell[
+    StyleData["OrangeButtonTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (FrameBox[
+        ButtonBox[
+         StyleBox[#, "Text", FontFamily -> "Source Sans Pro", FontWeight -> 
+          "SemiBold", FontTracking -> "Condensed", FontSize -> 13, FontColor -> 
+          Dynamic[
+            FEPrivate`If[
+             CurrentValue[Enabled], 
+             GrayLevel[1], 
+             RGBColor[0.88722, 0.77308, 0.76696]], Evaluator -> "System"], 
+          StripOnInput -> False], ButtonFunction :> 
+         With[{RSNB`nb$ = ButtonNotebook[]}, 
+           If[#4, CurrentValue[RSNB`nb$, {TaggingRules, "StatusMessage"}] = 
+             ProgressIndicator[Appearance -> "Necklace"]]; 
+           With[{RSNB`$cp$ = $ContextPath}, 
+             Quiet[
+              
+              Block[{$ContextPath = RSNB`$cp$, 
+                ResourceSystemClient`$AsyncronousResourceInformationUpdates = 
+                False, DefinitionNotebookClient`$ButtonCodeID = None}, 
+               Internal`WithLocalSettings[
+                DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                   ReleaseHold[
+                    CurrentValue[
+                    RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                   "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                 Annotation[
+                 DefinitionNotebookClient`$ButtonCodeID = 2045406886999866622; 
+                  DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                    ReleaseHold[
+                    DefinitionNotebookClient`$ButtonCode = HoldForm[
+                    #2[]]]], 
+                  DefinitionNotebookClient`ButtonCodeID[2045406886999866622]],
+                  DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+               Null]]]; 
+           CurrentValue[RSNB`nb$, {TaggingRules, "StatusMessage"}] = ""; 
+           Null], FrameMargins -> {{5, 5}, {0, 0}}, 
+         Appearance -> {"Default" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYI9uuJUYJobchmTZGFisJTpAUhCMgGihBvyC5t0Tly
+Qj0SgpgIKA6UJWjIdi3RSVJYtMMRUBaoBo8hu3VEJ0vjMwGCgGqAKnEZMl8B
+uy8wEVAlVkOAjiTSBAiCewrZkKXKwiQZAlSPach0GWL9AkFA9RCNkCQNYU/A
+GymYCKgebggQUG4IVVxC3TChSuxQJZ1QJcVSK+9QJRdTqzyhVslGKqKiIfgB
+MfUOAGAkpIY=
+             "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+             Interleaving -> True], "Hover" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYI9uuJUYJobchOXaENOjyrtDkgCMgGihBvyB5dkXXa
+3Mu12TARUBwoS9CQ3brCK7XZsZoAQUBZoBo8huzVFQW6HI8JEARUA1SJyxCg
+xwmaAEFAlVgNATqSSBMgCO4pZEM26/CRZAhQPaYha7Q5STIEqB6iEZKkIWz8
+kYI1muCGAAHlhlDFJdQNE6rEDlXSCVVSLLXyDlVyMbXKE2qVbKQiKhqCHxBT
+7wAAuk3GZQ==
+             "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+             Interleaving -> True], "Pressed" -> Image[CompressedData["
+1:eJxTTMoPSmNiYGAo5gASQYnljkVFiZXBAkBOaF5xZnpeaopnXklqemqRRRIz
+UFASiMWBGMT+TwgQowYI9uuJUYJobcjZGK8nK+Z9uXsTgoBsoAjxhhx11H61
+ZwtWjwPFgbIEDTnha/n96SOg4K8vn67O6tgRag5BQDZQBCgOlAWqwWPIYWuV
+b4/ug2w8e3S9nexybTZkBBQBigNlgWqAKnEZ8mz9MiD3zaXTKw150UyAIKA4
+UBaoBqgSqyEnfMz//fnz59fPTe7qWE2AIKAsUA1QJVA9piH3pnUB2XfWzMNj
+AgQB1QBVAtVjGvLhwikQO82HoCFANUCVQPUQjZAkDWH/eP0SyMYMT0wEVANU
+CVQPNwQIKDeEKi6hbphQJXaokk6okmKplXeokoupVZ5Qq2QjFVHREPyAmHoH
+AG0Lmsg=
+             "], "Byte", ColorSpace -> "RGB", ImageResolution -> 144, 
+             Interleaving -> True]}, Background -> 
+         RGBColor[0.7508, 0.17868, 0.085283], Method -> "Queued", 
+         ImageSize -> {All, 23}, Evaluator -> Automatic], FrameStyle -> 
+        Directive[
+          RGBColor[0.7508, 0.17868, 0.085283], 
+          AbsoluteThickness[2]], FrameMargins -> -1, ContentPadding -> False, 
+        StripOnInput -> False]& )}], 
+   Cell[
+    StyleData["SuggestionGridTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (StyleBox[
+        FrameBox[
+         AdjustmentBox[
+          TagBox[
+           GridBox[{{
+              
+              TemplateBox[{#2, #3, {16., 16.}, {{1., 17.}, {1., 17.}}}, 
+               "SuggestionIconTemplate"], 
+              
+              PaneBox[#, ImageSizeAction -> "ShrinkToFit", BaselinePosition -> 
+               Baseline, ImageSize -> Full], 
+              RowBox[{
+                AdjustmentBox[
+                 TemplateBox[{
+                   ActionMenuBox[
+                    TagBox[
+                    PaneSelectorBox[{False -> GraphicsBox[{
+                    EdgeForm[
+                    Directive[
+                    GrayLevel[1, 0], 
+                    Thickness[0.025]]], 
+                    FaceForm[#4], 
+                    
+                    RectangleBox[{-1.75, -2}, {1.75, 2}, RoundingRadius -> 
+                    0.2], 
+                    Thickness[0.15], #5, 
+                    LineBox[{{-0.5, -1.}, {0.5, 0.}, {-0.5, 1.}}]}, 
+                    ImageSize -> {Automatic, 15}, ImageMargins -> 0], True -> 
+                    GraphicsBox[{
+                    EdgeForm[
+                    Directive[#5, 
+                    Thickness[0.025]]], 
+                    FaceForm[#2], 
+                    
+                    RectangleBox[{-1.75, -2}, {1.75, 2}, RoundingRadius -> 
+                    0.2], 
+                    Thickness[0.15], 
+                    GrayLevel[1], 
+                    LineBox[{{-0.5, -1.}, {0.5, 0.}, {-0.5, 1.}}]}, 
+                    ImageSize -> {Automatic, 15}, ImageMargins -> 0]}, 
+                    Dynamic[
+                    CurrentValue["MouseOver"]], ImageSize -> Automatic, 
+                    FrameMargins -> 0], 
+                    MouseAppearanceTag["LinkHand"]], #6, Appearance -> None, 
+                    Method -> "Queued"], "\"View suggestions\""}, 
+                  "PrettyTooltipTemplate"], BoxBaselineShift -> -0.5], 
+                " "}]}}, 
+            GridBoxAlignment -> {
+             "Columns" -> {{Left}}, "Rows" -> {{Baseline}}}, AutoDelete -> 
+            False, GridBoxItemSize -> {
+             "Columns" -> {Automatic, Automatic, Fit}, 
+              "Rows" -> {{Automatic}}}, 
+            GridBoxSpacings -> {"Columns" -> {{0.4}}}], "Grid"], 
+          BoxMargins -> {{0.25, -0.5}, {0.15, -0.15}}], 
+         RoundingRadius -> {13, 75}, Background -> #4, FrameStyle -> None, 
+         FrameMargins -> {{0, 8}, {0, 0}}, ImageMargins -> {{0, 0}, {5, 5}}, 
+         StripOnInput -> False], "Text", FontColor -> #5, FontSize -> 14, 
+        FontFamily -> "Source Sans Pro", FontWeight -> "SemiBold", 
+        FontTracking -> "Plain", 
+        PrivateFontOptions -> {"OperatorSubstitution" -> False}, 
+        LineBreakWithin -> False]& )}], 
+   Cell[
+    StyleData["SuggestionIconTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         Thickness[0.055556], 
+         StyleBox[{
+           
+           FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3,
+             3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGJJIGZigIIGAwcIQ8kBxk94ekHp9k9Vh8qXaoYcOfoO
+m+a+X37stKZDTP+hrxpzdOA0TBymDqYPl7n2pnG7PHlk4Pw5RxQ2FGWIwPWD
+jI3p54WbLxuVYn3fnwluD8S8H/Yo9gD5KPYA+TB7YPph9sDMh9EwcZg6FPdh
+MRfdXpi7YPph7oaZD/MXzB5c4QCzBwA/Dn+d
+            "]]}, 
+          FaceForm[#]], 
+         StyleBox[{
+           
+           FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1,
+              0}, {0, 1, 0}}, {{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1,
+              3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}}, {{{8.1753, 7.4169}, {
+             7.7969, 11.308}, {7.7969, 13.38}, {10.12, 13.38}, {10.12, 
+             11.308}, {9.7415, 7.4169}, {8.1753, 7.4169}}, CompressedData["
+1:eJxTTMoPSmViYGCQBGIQDQFKDg+rRNa5P+RzKPOXE8vSVYTz8z+0ngxpVHCA
+qBNwmPd++THv7/IO8q2vA3fICTpUvlQz5Hgj52DLdX1xga2QQxoYyDmcYLed
+HTpfGM6/k8GQ3+giCue7M1dwq7wQg+vnmbyyKdBTAm6+tsTUK5wZknD7Pec2
+qB1qk4K772Y8iCXtAHM/jP/bquBcxyUEfyJ/ldnqOmW4/qw9JZMlWFTg5tfa
+m8bt6lSB23/2DAiowN0H48PcD+PD/AfTD/M/zHxY+MDsh4UfzH2w8EUPfwD5
+N5G6
+             "]}]}, 
+          FaceForm[#2]]}, ImageSize -> #3, PlotRange -> #4, AspectRatio -> 
+        Automatic, BaselinePosition -> Scaled[0.1]]& )}], 
+   Cell[
+    StyleData["FormEditValuesButtonTemplate"], 
+    TemplateBoxOptions -> {DisplayFunction -> (TemplateBox[{
+         TagBox[
+          PaneBox[
+           PaneSelectorBox[{False -> GraphicsBox[{
+                Thickness[0.066667], 
+                FaceForm[{
+                  GrayLevel[0.75], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+                  3}}, {{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{0, 2, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3,
+                   3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3,
+                   3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}}, {{0, 2, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1,
+                   0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3,
+                   3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1,
+                   0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3,
+                   3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}}}, {{{7.5, 
+                  5.6426}, {6.475, 5.6426}, {5.643, 6.4746}, {5.643, 
+                  7.4996}, {5.643, 8.5256}, {6.475, 9.3576}, {7.5, 9.3576}, {
+                  8.525, 9.3576}, {9.357, 8.5256}, {9.357, 7.4996}, {9.357, 
+                  6.4746}, {8.525, 5.6426}, {7.5, 5.6426}}, {{7.5, 10.287}, {
+                  5.962, 10.287}, {4.714, 9.0386}, {4.714, 7.4996}, {4.714, 
+                  5.9616}, {5.962, 4.7136}, {7.5, 4.7136}, {9.038, 4.7136}, {
+                  10.286, 5.9616}, {10.286, 7.4996}, {10.284, 9.0386}, {9.038,
+                   10.285}, {7.5, 10.287}}, CompressedData["
+1:eJxTTMoPSmViYGAwBGIQHdN/6KvGHQ2Hu1tbai4YCzn4mHc6JqSqOZhLHYhW
+cBR2sNxyomxfvIrD+5OHndZm8jncPPc9+PFTFYfHx2fsnjaBxSENBNSUHRKN
+Qg20VjI62JvG7fLsUXZYuveguFowk8PZMyCg6LCZp3BN9+1/9tb3/Xun5yk4
+mDRsd2h6xO4AtO3pBSVpOB9sXpoEXH3jVOfunOcicPOMQWCzKNw+vySBCEsT
+Ibh7gIYLNTsIw917Uen2z7osPrh/QN6N6WeB+9cFaPpvoDmH2paHn9ok6tAu
+BvIhk4PAy+3rmYH2lu+bL6V/95/91523uv6mSjg8rBJZ5/6Q3cH4yEa9PGVp
+OJ+Zs0s+GegvmHqlvtJC6bOKcPOmfGOLnwEMF5h9u9X5ubcCww3mHrC3n6nA
+3QsLd5h/wOEOjBeYf2HxBgsP/bsqbI1TNR1g4QWMBR6mbE14eIKdpaIFD28P
+kMPZNRxg8QHjw+ILph4WnyjmAd0Nsw+WHmDugbkb5l5YeoKJw9TB/AszBxYe
+MHtg4WXIsUYmCugOWHjC3AkLbxgfFh8w9bD4gpkHi0+YfbD4Rk//AAQ8Rd0=
+
+                  "], CompressedData["
+1:eJxdVA1IU1EYHStG2VxrxByaa073dFtRkiYheW9/EmhkGaWW/WjaEs1ICxEJ
+zX6sCCuzX7USSiLRKHEWESWSaVFWhpkWlaiZWk5Lnab19p7nCj0Yb/fx3e/n
+nPMdj5jk9XFSiUSyg/853r/GGtO6ODO1z+yylme70ePLtrc3fDXSwkyu+qi3
+Oztn8ceSJi1FvC72R9TyIB3Nyl9xMrHTTJcHfWsufaCjT+qvr6pcNI+evjbs
+21HmQbfkVv/2aTVTF+tryadDevp2TYwy4r6ZDsm2XQx9p6fH1M0vh96aqER4
+DDSpc/SW7axJvFdgoNNK50TtDDTRthtXanR7OSqXmo+pI40TdTlapT3SvS7N
+hxb9LHkaYuVoe4O+xT7OiX3Gc9SzxX4w4Q9HjY6EFo7GC89knDJiScWzSo4G
+Vw7wN3zEex2TdVD3vKNc4GRfIwcTHqbmmeiroXA+xIs+58ceGDPRsFMX9qiy
+9eL3FjOtO/Doqmu5B8PlRwbx38rjpJh/t/Anj5twb+kEjt5m2v+GB+i9lrrw
+sIS3GcU4ngecHVU1h91YvEHm+OfK8iWrsh/XX9ewetuFQdWsnxhhYBXrd/WX
+9NlltUo2T4rlTG8GUbB5fQUC5AwPfpoFH72cGV4ingqG5/48zdSNCjnDW+h3
+qpzxMZenq0orY3yJ+EkZn2L+cQLcC2p0d/ZZRglwrw0J4CVpJ9CL0K5/P4Ge
+xPw2Ar0NO9LX9BDoUTz3EehVxGOQQM8OuTxMlTC944x9QDz2BfkqIn/f/3DC
+ldXT5DdOtxRrWD9OFn1i2oia9et7yaTJ36Bm8+SGp3pd+DuLzWuLfREd8kzJ
+8Hia5JdppQqG19ryc3E5sXKGZ2vwlLQZPC/A+7CzI0LB+EhffDto02YF4ysn
+Npq/Imd8Lp3XeLnDXcb41o8N7v9cIGV6GOntfrzEc5xAL02q/mWv4kcJ9BT2
+R5PSpBom0NvC0JtOwQYbgR5X7k7uO1LXQ6BXv+KKgOHqPgI9F201PlfWDhLo
+3X5t173vKRK2DzhjXxCPfUI+7BvqYR/RD/YV/UJXmAe6w7zwA+ABvwBe8BPg
+Cb8B3tgL8AG/Al/YK/AJvwPf8EPoAX4JvcBPoSf4LfQGH4Ae4dfQ6//+/w8B
+rcVF
+                  "]}]}, AspectRatio -> Automatic, ImageSize -> {15., 15.}, 
+               PlotRange -> {{0., 15.}, {0., 15.}}], True -> GraphicsBox[{
+                Thickness[0.066667], 
+                FaceForm[{
+                  GrayLevel[0.25], 
+                  Opacity[1.]}], 
+                
+                FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+                  3}}, {{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{0, 2, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3,
+                   3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3,
+                   3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}}, {{0, 2, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1,
+                   0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3,
+                   3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1,
+                   0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+                  0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {
+                  1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3,
+                   3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}}}, {{{7.5, 
+                  5.6426}, {6.475, 5.6426}, {5.643, 6.4746}, {5.643, 
+                  7.4996}, {5.643, 8.5256}, {6.475, 9.3576}, {7.5, 9.3576}, {
+                  8.525, 9.3576}, {9.357, 8.5256}, {9.357, 7.4996}, {9.357, 
+                  6.4746}, {8.525, 5.6426}, {7.5, 5.6426}}, {{7.5, 10.287}, {
+                  5.962, 10.287}, {4.714, 9.0386}, {4.714, 7.4996}, {4.714, 
+                  5.9616}, {5.962, 4.7136}, {7.5, 4.7136}, {9.038, 4.7136}, {
+                  10.286, 5.9616}, {10.286, 7.4996}, {10.284, 9.0386}, {9.038,
+                   10.285}, {7.5, 10.287}}, CompressedData["
+1:eJxTTMoPSmViYGAwBGIQHdN/6KvGHQ2Hu1tbai4YCzn4mHc6JqSqOZhLHYhW
+cBR2sNxyomxfvIrD+5OHndZm8jncPPc9+PFTFYfHx2fsnjaBxSENBNSUHRKN
+Qg20VjI62JvG7fLsUXZYuveguFowk8PZMyCg6LCZp3BN9+1/9tb3/Xun5yk4
+mDRsd2h6xO4AtO3pBSVpOB9sXpoEXH3jVOfunOcicPOMQWCzKNw+vySBCEsT
+Ibh7gIYLNTsIw917Uen2z7osPrh/QN6N6WeB+9cFaPpvoDmH2paHn9ok6tAu
+BvIhk4PAy+3rmYH2lu+bL6V/95/91523uv6mSjg8rBJZ5/6Q3cH4yEa9PGVp
+OJ+Zs0s+GegvmHqlvtJC6bOKcPOmfGOLnwEMF5h9u9X5ubcCww3mHrC3n6nA
+3QsLd5h/wOEOjBeYf2HxBgsP/bsqbI1TNR1g4QWMBR6mbE14eIKdpaIFD28P
+kMPZNRxg8QHjw+ILph4WnyjmAd0Nsw+WHmDugbkb5l5YeoKJw9TB/AszBxYe
+MHtg4WXIsUYmCugOWHjC3AkLbxgfFh8w9bD4gpkHi0+YfbD4Rk//AAQ8Rd0=
+
+                  "], CompressedData["
+1:eJxdVA1IU1EYHStG2VxrxByaa073dFtRkiYheW9/EmhkGaWW/WjaEs1ICxEJ
+zX6sCCuzX7USSiLRKHEWESWSaVFWhpkWlaiZWk5Lnab19p7nCj0Yb/fx3e/n
+nPMdj5jk9XFSiUSyg/853r/GGtO6ODO1z+yylme70ePLtrc3fDXSwkyu+qi3
+Oztn8ceSJi1FvC72R9TyIB3Nyl9xMrHTTJcHfWsufaCjT+qvr6pcNI+evjbs
+21HmQbfkVv/2aTVTF+tryadDevp2TYwy4r6ZDsm2XQx9p6fH1M0vh96aqER4
+DDSpc/SW7axJvFdgoNNK50TtDDTRthtXanR7OSqXmo+pI40TdTlapT3SvS7N
+hxb9LHkaYuVoe4O+xT7OiX3Gc9SzxX4w4Q9HjY6EFo7GC89knDJiScWzSo4G
+Vw7wN3zEex2TdVD3vKNc4GRfIwcTHqbmmeiroXA+xIs+58ceGDPRsFMX9qiy
+9eL3FjOtO/Doqmu5B8PlRwbx38rjpJh/t/Anj5twb+kEjt5m2v+GB+i9lrrw
+sIS3GcU4ngecHVU1h91YvEHm+OfK8iWrsh/XX9ewetuFQdWsnxhhYBXrd/WX
+9NlltUo2T4rlTG8GUbB5fQUC5AwPfpoFH72cGV4ingqG5/48zdSNCjnDW+h3
+qpzxMZenq0orY3yJ+EkZn2L+cQLcC2p0d/ZZRglwrw0J4CVpJ9CL0K5/P4Ge
+xPw2Ar0NO9LX9BDoUTz3EehVxGOQQM8OuTxMlTC944x9QDz2BfkqIn/f/3DC
+ldXT5DdOtxRrWD9OFn1i2oia9et7yaTJ36Bm8+SGp3pd+DuLzWuLfREd8kzJ
+8Hia5JdppQqG19ryc3E5sXKGZ2vwlLQZPC/A+7CzI0LB+EhffDto02YF4ysn
+Npq/Imd8Lp3XeLnDXcb41o8N7v9cIGV6GOntfrzEc5xAL02q/mWv4kcJ9BT2
+R5PSpBom0NvC0JtOwQYbgR5X7k7uO1LXQ6BXv+KKgOHqPgI9F201PlfWDhLo
+3X5t173vKRK2DzhjXxCPfUI+7BvqYR/RD/YV/UJXmAe6w7zwA+ABvwBe8BPg
+Cb8B3tgL8AG/Al/YK/AJvwPf8EPoAX4JvcBPoSf4LfQGH4Ae4dfQ6//+/w8B
+rcVF
+                  "]}]}, AspectRatio -> Automatic, ImageSize -> {15., 15.}, 
+               PlotRange -> {{0., 15.}, {0., 15.}}]}, 
+            Dynamic[
+             CurrentValue["MouseOver"]], ImageSize -> Automatic, FrameMargins -> 
+            0], ImageSize -> {Automatic, 15}, ImageSizeAction -> 
+           "ResizeToFit"], 
+          MouseAppearanceTag["LinkHand"]], "\"Edit values\""}, 
+        "PrettyTooltipTemplate"]& )}], 
+   Cell[
+    StyleData["HintPodTitleBar"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         GrayLevel[0.97], 
+         FilledCurveBox[
+          BezierCurve[{
+            Offset[{0, -3}, {1, 1}], 
+            Offset[{0, -1.3443}, {1, 1}], 
+            Offset[{-1.3443, 0}, {1, 1}], 
+            Offset[{-3, 0}, {1, 1}], 
+            Offset[{-3, 0}, {1, 1}], 
+            Offset[{3, 0}, {-1, 1}], 
+            Offset[{3, 0}, {-1, 1}], 
+            Offset[{1.3443, 0}, {-1, 1}], 
+            Offset[{0, -1.3443}, {-1, 1}], 
+            Offset[{0, -3}, {-1, 1}], 
+            Offset[{0, -3}, {-1, 1}], {-1, -1}, {-1, -1}, {-1, -1}, {1, -1}, {
+            1, -1}}]], 
+         InsetBox[
+          FormBox[
+           StyleBox[
+           "\"Notebook Analysis\"", FontColor -> GrayLevel[0.4], FontColor -> 
+            GrayLevel[0.4], FontFamily -> "Source Sans Pro", FontWeight -> 
+            Plain, FontSize -> 13, StripOnInput -> False], TraditionalForm], 
+          Offset[{8, 0}, {-1, 0}], 
+          NCache[
+           ImageScaled[{0, 1/2}], 
+           ImageScaled[{0, 0.5}]]], 
+         TagBox[
+          TagBox[
+           TooltipBox[{
+             GrayLevel[0.6], 
+             DiskBox[
+              Offset[{-13, -10}, {1, 1}], 
+              Offset[6]], 
+             GrayLevel[0.97], 
+             AbsoluteThickness[1.5], 
+             CapForm["Round"], 
+             LineBox[{{
+                Offset[{-15, -8}, {1, 1}], 
+                Offset[{-11, -12}, {1, 1}]}, {
+                Offset[{-15, -12}, {1, 1}], 
+                Offset[{-11, -8}, {1, 1}]}}]}, 
+            FrameBox[
+             StyleBox[
+             "\"Close analysis pod\"", "Text", FontColor -> 
+              RGBColor[0.53725, 0.53725, 0.53725], FontSize -> 12, FontWeight -> 
+              "Plain", FontTracking -> "Plain", StripOnInput -> False], 
+             Background -> RGBColor[0.96078, 0.96078, 0.96078], FrameStyle -> 
+             RGBColor[0.89804, 0.89804, 0.89804], FrameMargins -> 8, 
+             StripOnInput -> False], TooltipDelay -> 0.1, 
+            TooltipStyle -> {Background -> None, CellFrame -> 0}], 
+           Annotation[#, "Close analysis pod", "Tooltip"]& ], 
+          EventHandlerTag[{"MouseClicked" :> NotebookDelete[
+              EvaluationCell[]], Method -> "Preemptive", PassEventsDown -> 
+            Automatic, PassEventsUp -> True}]]}, AspectRatio -> Full, 
+        ImageSize -> {Full, 20}, PlotRange -> {{-1, 1}, {-1, 1}}, 
+        ImageMargins -> {{0, 0}, {0, 0}}, 
+        ImagePadding -> {{0, 0}, {0, 0}}]& )}], 
+   Cell[
+    StyleData["HintPodDelimiterTop"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         AbsoluteThickness[1], 
+         GrayLevel[0.85], 
+         CapForm["Round"], 
+         LineBox[{{-1, 0}, {1, 0}}]}, AspectRatio -> Full, 
+        PlotRange -> {{-1, 1}, {-1, 1}}, ImagePadding -> {{0, 0}, {0, 0}}, 
+        ImageSize -> {Full, 2}, BaselinePosition -> Scaled[0.1], 
+        ImageMargins -> {{0, 0}, {4, 0}}]& )}], 
+   Cell[
+    StyleData["HintPodDelimiterBottom"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         AbsoluteThickness[1], 
+         GrayLevel[0.85], 
+         CapForm["Round"], 
+         LineBox[{{-1, 0}, {1, 0}}]}, AspectRatio -> Full, 
+        PlotRange -> {{-1, 1}, {-1, 1}}, ImagePadding -> {{0, 0}, {0, 0}}, 
+        ImageSize -> {Full, 2}, BaselinePosition -> Scaled[0.1], 
+        ImageMargins -> {{0, 0}, {0, 4}}]& )}], 
+   Cell[
+    StyleData["HintPodFooter"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         GrayLevel[0.97], 
+         FilledCurveBox[
+          BezierCurve[{{-1, 1}, {-1, 1}, 
+            Offset[{0, 3}, {-1, -1}], 
+            Offset[{0, 3}, {-1, -1}], 
+            Offset[{0, 1.3443}, {-1, -1}], 
+            Offset[{1.3443, 0}, {-1, -1}], 
+            Offset[{3, 0}, {-1, -1}], 
+            Offset[{3, 0}, {-1, -1}], 
+            Offset[{-3, 0}, {1, -1}], 
+            Offset[{-3, 0}, {1, -1}], 
+            Offset[{-1.3443, 0}, {1, -1}], 
+            Offset[{0, 1.3443}, {1, -1}], 
+            Offset[{0, 3}, {1, -1}], 
+            Offset[{0, 3}, {1, -1}], {1, 1}, {1, 1}}]], 
+         InsetBox[
+          BoxData[
+           FormBox[
+            TemplateBox[{
+              StyleBox[
+               TemplateBox[{3}, "Spacer1"], FontColor -> GrayLevel[0.4], 
+               FontFamily -> "Source Sans Pro", FontWeight -> Plain, FontSize -> 
+               12, StripOnInput -> False], 
+              
+              StyleBox[#, FontColor -> GrayLevel[0.4], FontFamily -> 
+               "Source Sans Pro", FontWeight -> Plain, FontSize -> 12, 
+               StripOnInput -> False], 
+              StyleBox[
+               TemplateBox[{5}, "Spacer1"], FontColor -> GrayLevel[0.4], 
+               FontFamily -> "Source Sans Pro", FontWeight -> Plain, FontSize -> 
+               12, StripOnInput -> False]}, "RowDefault"], TraditionalForm]], 
+          
+          Offset[{5, 2.5}, {-1, 0}], {-1, 0}]}, AspectRatio -> Full, 
+        ImageSize -> {Full, 21}, PlotRange -> {{-1, 1}, {-1, 1}}, 
+        ImageMargins -> {{0, 0}, {0, 3}}, 
+        ImagePadding -> {{0, 0}, {0, 0}}]& )}], 
+   Cell[
+    StyleData["HintPodMenuItems"], 
+    TemplateBoxOptions -> {
+     DisplayFunction -> (
+       TemplateBox[{#, FrameMargins -> 3, Background -> GrayLevel[1], 
+         RoundingRadius -> 0, FrameStyle -> Directive[
+           AbsoluteThickness[1], 
+           RGBColor[0.75686, 0.82745, 0.88235]], ImageMargins -> #2}, 
+        "Highlighted"]& )}], 
+   Cell[
+    StyleData["HintPodActionMenuItem"], 
+    TemplateBoxOptions -> {DisplayFunction -> (ButtonBox[
+        TemplateBox[{
+          TagBox[
+           GridBox[{{#, 
+              TemplateBox[{7}, "Spacer1"], #2}}, 
+            GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+            AutoDelete -> False, 
+            GridBoxItemSize -> {
+             "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+            GridBoxSpacings -> {"Columns" -> {{0}}}], "Grid"], FrameStyle -> 
+          None, RoundingRadius -> 0, FrameMargins -> {{5, 2}, {2, 2}}, 
+          ImageSize -> Full, ImageMargins -> {{0, 0}, {0, 0}}, Background -> 
+          Dynamic[
+            If[
+             CurrentValue["MouseOver"], 
+             GrayLevel[0.96], 
+             GrayLevel[1.]]]}, "Highlighted"], ButtonFunction :> 
+        ReleaseHold[#3], 
+        Appearance -> {
+         "Default" -> 
+          Image[RawArray["UnsignedInteger8",{{{255, 255, 255, 255}, {0, 0, 0, 
+             255}, {255, 255, 255, 255}}, {{0, 0, 0, 255}, {0, 0, 0, 0}, {0, 
+             0, 0, 255}}, {{255, 255, 255, 255}, {0, 0, 0, 255}, {255, 255, 
+             255, 255}}}], "Byte", ColorSpace -> "RGB", 
+            ImageResolution -> {72, 72}, Interleaving -> True], "Hover" -> 
+          Image[RawArray["UnsignedInteger8",{{{255, 255, 255, 255}, {0, 0, 0, 
+             255}, {255, 255, 255, 255}}, {{0, 0, 0, 255}, {0, 0, 0, 0}, {0, 
+             0, 0, 255}}, {{255, 255, 255, 255}, {0, 0, 0, 255}, {255, 255, 
+             255, 255}}}], "Byte", ColorSpace -> "RGB", 
+            ImageResolution -> {72, 72}, Interleaving -> True], "Pressed" -> 
+          Image[RawArray["UnsignedInteger8",{{{255, 255, 255, 255}, {0, 0, 0, 
+             255}, {255, 255, 255, 255}}, {{0, 0, 0, 255}, {0, 0, 0, 0}, {0, 
+             0, 0, 255}}, {{255, 255, 255, 255}, {0, 0, 0, 255}, {255, 255, 
+             255, 255}}}], "Byte", ColorSpace -> "RGB", 
+            ImageResolution -> {72, 72}, Interleaving -> True]}, Method -> 
+        "Queued", Evaluator -> Automatic]& )}], 
+   Cell[
+    StyleData["HintPodDisabledMenuItem"], 
+    TemplateBoxOptions -> {DisplayFunction -> (ButtonBox[
+        TemplateBox[{
+          TagBox[
+           GridBox[{{#, 
+              TemplateBox[{7}, "Spacer1"], 
+              StyleBox[#2, FontOpacity -> 0.4]}}, 
+            GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+            AutoDelete -> False, 
+            GridBoxItemSize -> {
+             "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+            GridBoxSpacings -> {"Columns" -> {{0}}}], "Grid"], FrameStyle -> 
+          None, RoundingRadius -> 0, FrameMargins -> {{5, 2}, {2, 2}}, 
+          ImageSize -> Full, ImageMargins -> {{0, 0}, {0, 0}}, Background -> 
+          GrayLevel[1.]}, "Highlighted"], ButtonFunction :> Null, 
+        Appearance -> {
+         "Default" -> 
+          Image[RawArray["UnsignedInteger8",{{{255, 255, 255, 255}, {0, 0, 0, 
+             255}, {255, 255, 255, 255}}, {{0, 0, 0, 255}, {0, 0, 0, 0}, {0, 
+             0, 0, 255}}, {{255, 255, 255, 255}, {0, 0, 0, 255}, {255, 255, 
+             255, 255}}}], "Byte", ColorSpace -> "RGB", 
+            ImageResolution -> {72, 72}, Interleaving -> True], "Hover" -> 
+          Image[RawArray["UnsignedInteger8",{{{255, 255, 255, 255}, {0, 0, 0, 
+             255}, {255, 255, 255, 255}}, {{0, 0, 0, 255}, {0, 0, 0, 0}, {0, 
+             0, 0, 255}}, {{255, 255, 255, 255}, {0, 0, 0, 255}, {255, 255, 
+             255, 255}}}], "Byte", ColorSpace -> "RGB", 
+            ImageResolution -> {72, 72}, Interleaving -> True], "Pressed" -> 
+          Image[RawArray["UnsignedInteger8",{{{255, 255, 255, 255}, {0, 0, 0, 
+             255}, {255, 255, 255, 255}}, {{0, 0, 0, 255}, {0, 0, 0, 0}, {0, 
+             0, 0, 255}}, {{255, 255, 255, 255}, {0, 0, 0, 255}, {255, 255, 
+             255, 255}}}], "Byte", ColorSpace -> "RGB", 
+            ImageResolution -> {72, 72}, Interleaving -> True]}, Method -> 
+        "Queued", Evaluator -> Automatic, Enabled -> False]& )}], 
+   Cell[
+    StyleData["HintPodActionLabel"], 
+    TemplateBoxOptions -> {DisplayFunction -> (PaneBox[
+        StyleBox[#, FontColor -> GrayLevel[0.2], FontFamily -> 
+         "Source Sans Pro", FontWeight -> Plain, FontSize -> 13, LineIndent -> 
+         0, StripOnInput -> False], FrameMargins -> 0, ImageMargins -> 0, 
+        BaselinePosition -> Baseline, ImageSize -> Full]& )}], 
+   Cell[
+    StyleData["HintPodMenuDelimiter"], 
+    TemplateBoxOptions -> {DisplayFunction -> (PaneBox[
+        StyleBox[
+         GraphicsBox[{
+           CapForm["Round"], 
+           GrayLevel[0.9], 
+           AbsoluteThickness[1], 
+           LineBox[{{-1, 0}, {1, 0}}]}, AspectRatio -> Full, 
+          PlotRange -> {{-1, 1}, {-1, 1}}, ImageMargins -> {{0, 0}, {2, 2}}, 
+          ImagePadding -> {{5, 5}, {0, 0}}, ImageSize -> {Full, 2}], 
+         LineIndent -> 0, StripOnInput -> False], FrameMargins -> 0, 
+        ImageMargins -> 0, BaselinePosition -> Baseline, ImageSize -> 
+        Full]& )}], 
+   Cell[
+    StyleData["HintPodIconChevron"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         GrayLevel[0.2], 
+         AbsoluteThickness[1.8], 
+         CapForm["Round"], 
+         JoinForm["Miter"], 
+         LineBox[{{-0.5, 1}, {0.5, 0}, {-0.5, -1}}]}, AspectRatio -> Full, 
+        BaselinePosition -> Bottom, ImageMargins -> {{0, 4}, {0, 0}}, 
+        ImageSize -> {5.6, 7.7}]& )}], 
+   Cell[
+    StyleData["HintPodIconPopOut"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         FaceForm[
+          GrayLevel[0.4]], 
+         FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {1, 3, 
+          3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 
+          0}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGIlIGYC4h1yra8Dd6g4rHN/WCWip+KwRiYqxXq+isNk
+CZYwvlwEDROHqYPpKwUrUHFgAIEDKg5nzwDBG2VU/hlluPogMEMCzm9kOdpv
+aC6OJi/mINR84NRCVwQfIq8M519wufHhi5Yymn4lNPOVHNLAQBHO/6YR03/o
+K5eDB9Ab69wFHJoeHZ+xexqng8r0/xPqfvM5cG9dVnl8JacD0FO6m+byOPxL
+/f4kUZHbQZr3ge4EBW6HD2IeAX9m8Dhkzyqfs2gxp8ONxmK3Kd/4HOYsUt75
+p50Tbi6YesgF9b8ShJ+oCOfD3Anjw/zx9JP8pXx7hD9h4QfjqxtyAKNCBU0e
+EY4wPqr5iHh4/nvlx0tnVRyYObvkk98pOwA9+X75MRUHWWD03udHxCssngGf
+XO7X
+          "]]}, AspectRatio -> Automatic, ImageSize -> {14., 14.}, 
+        PlotRange -> {{0., 13.62}, {0., 13.62}}]& )}], 
+   Cell[
+    StyleData["HintPodIconWrench"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         GrayLevel[0.4], 
+         AbsoluteThickness[1], 
+         Opacity[1.], 
+         JoinedCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+          0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+          0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 
+          3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGJRIGYCYmWv6mZ9n3/2cmJZvp/5BBzci37yv9wu6/Au
+ysnuhaQynG8at8uT55AGXJwBDHQdPl3yTRKIUIfzo1Ks7/vzajiosjVOdfbW
+ccjaUzJZokUFrv8ySLmlqoPbts9/r1iowsVh6mD6zp4BAh4NnPbA3AHTr+ss
+8/rRNoS7YXyYv2D+7H/ySf5SPrdD7D/nX29ff7H/6hXZZnGNGc6HqYPRMPED
+b+bZ6FxBqAPpOprL7YAefgCtVISU
+          "], CurveClosed -> {1}]}, AspectRatio -> Automatic, 
+        BaselinePosition -> Scaled[0.2], ImagePadding -> 0.5, 
+        ImageSize -> {16., 16.}, PlotRange -> {{0., 16.}, {0., 16.}}]& )}], 
+   Cell[
+    StyleData["HintPodIconInfo"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         FaceForm[
+          GrayLevel[0.4]], 
+         FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{1, 4,
+            3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+           3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{1, 4, 3}, {0, 1, 0}, {1, 3,
+            3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}}}, {{{6.81, 13.}, {
+           3.3914, 13.}, {0.62, 10.229}, {0.62, 6.81}, {0.62, 3.3914}, {
+           3.3914, 0.62}, {6.81, 0.62}, {10.229, 0.62}, {13., 3.3914}, {13., 
+           6.81}, {13., 10.229}, {10.229, 13.}, {6.81, 13.}}, CompressedData["
+
+1:eJxTTMoPSmViYGCQB2IQbct1fXGBrbRD6+vAHXKtvA7r3B9WiayTdoCI8zgc
+/qoR039IHkoLOjCAgYKDB0iZu4CDPFijgsOsmSDAC1UnCzWPE0rLQMXZHV6x
+mAia1Ug56E1Y8MMwjdXh685bXX9VJRx4Jq9sCvRkcTh7BgREHfoPgTSwOAQB
+db8OFHYAO4eLFeo+IQcRMIMLzoe4h9dBW2LqFc4MYYd4zdMCx38JOviYdzom
+pIo4PJgjuHSvo6jDkgKQz0QdCsEelHDQjAHZJAa1VxIqLwH3Jzofok8S4i9W
+RQews67LQsJhnoKDMRjIQ9Q3wMJJwQFMJULDSRJmrhzUPKh6Blmof+QcwM6K
+kXb4Bgq2rzJQcXFovMhA5UUdciqqluo0SztsKMqY+NZG2OHV1E08hTrSDquA
+oTmXQdABPX4BaWq/EA==
+           "], {{8.81, 9.79}, {8.8101, 9.5122}, {8.5878, 9.2854}, {8.31, 
+           9.28}, {7.51, 9.28}, {7.2283, 9.28}, {7., 9.5083}, {7., 9.79}, {7.,
+            10.62}, {7.0054, 10.898}, {7.2322, 11.12}, {7.51, 11.12}, {8.35, 
+           11.12}, {8.6239, 11.115}, {8.8447, 10.894}, {8.85, 10.62}}}]}, 
+        AspectRatio -> Automatic, ImagePadding -> 0.5, 
+        ImageSize -> {14., 14.}, 
+        PlotRange -> {{0., 13.62}, {0., 13.62}}]& )}], 
+   Cell[
+    StyleData["HintPodIconNone"], 
+    TemplateBoxOptions -> {
+     DisplayFunction -> (
+       GraphicsBox[{}, AspectRatio -> Automatic, ImageSize -> {16., 16.}, 
+        PlotRange -> {{0., 16.}, {0., 16.}}, BaselinePosition -> Scaled[0.2], 
+        ImagePadding -> 0.5]& )}], 
+   Cell[
+    StyleData["HintPodIconIgnoreAlways"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         EdgeForm[None], 
+         FaceForm[
+          GrayLevel[0.4]], 
+         FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+          3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+          3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {0, 1, 
+          0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+          3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGJTIGYCYpF17g+rROQcbLmuLy6wlXaoBguoOvQf+qoR
+w6/i8CZwh1zralWH4oyJb2vsVRx0N819v/yYqoO0/l0VtkYEv/U1UOFRBP/D
+8mPe5pyqcP0z8oSaD3ipws2H0famcbs8fVQd2BqnOnevUXUAa+dWdUgSiLDc
+ckLVwQPounXHVeB8kK1TmxH8gN7peULOKnD9EP+owM2H+QvmzyUFIBEeuHxC
+mb+c2CtuuP75NjpXZj3jgpsP0s11nRPO5+feuqzyOAec73dxYsy/w+xw/WDr
+uNjh5n9MPhPr7cEG93+V2Wq78Nus8PCB8WHhB+PDwhemHxb+MPNh8ZMGBhJw
+f8Lkv2nEAJXwOGyu/rQh4DWrwwrTs9Z+F7kdvHiYtNunsTrYgrwpy+XQteHh
+y6lGbA6HxNWCWRdzOJwKObhiyTk2B3fmCm4VDXaouRwOEaeMjmzUY4OHhybI
+eA02eHgt/GH4bJ0qm4PT+bSrz4Hh+Z0tfobPVDZ4eIOVx7DD3QlzNwMYIPx1
+smzffCl9FUg4u7M5hPEBU1S+isPs0Pmr195gdTAGgc0qUHewOswDJhfv7yoO
+/g7CiYcvszoAU9vrQAtVh6V+QAFnNqg9iHj5dMk3SWAGIt78wBGJiFcYH+ZP
+GB/mT5h+WLqBmQ/zJwC4F0s3
+          "]]}, AspectRatio -> Automatic, ImageMargins -> {{0, 0}, {0, 2}}, 
+        ImageSize -> {14., 14.}, 
+        PlotRange -> {{-0.5, 13.62}, {-0.5, 13.62}}]& )}], 
+   Cell[
+    StyleData["HintPodIconIgnoreInCell"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         EdgeForm[None], 
+         FaceForm[
+          GrayLevel[0.4]], 
+         FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+           0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}}, {{0, 2, 0}, {0, 1,
+            0}}}, {{{11.69, 13.37}, {7.57, 13.37}, {7.57, 12.37}, {7.76, 
+           12.37}, {11.19, 8.93}, {11.19, 1.25}, {7.57, 1.25}, {7.57, 0.25}, {
+           12.19, 0.25}, {12.19, 13.37}}, {{9.17, 12.37}, {11.17, 12.37}, {
+           11.17, 10.37}}}], 
+         FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {0, 1, 
+          0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {0, 1, 
+          0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {0, 1, 
+          0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGIjIGYCYo+HVSLr3EUdbLmuLy6wlXZYUgBiyTlAxJUc
+kt9FOdllyDuU6yrKf1mD4LM879F466sMV28MApuVHX7yv9y+3lkOQj9WdngU
+Ib794gFZh/Dojfvf/FN22CHX+jrQAsHvf/JJ/tJ6GTgfbI+ODFz/2TMgIA03
+vxroqodVQg5gSkQO6m4mVPubGR1E7I/d2fpE2cHy2tFckwYGB2n9uypsjCoO
+YG89/GcP4wd5zm1QO/QHzr9wNeyN/u5f9jD9kHD4aQ8zX+z36XcnD3+3v8fE
+2SXfrOygvqBzw8OX3+yDQAxHBB/srr9KcL7mW959BjuV4PrnCi7de7BcCW4+
+LLwhND88PmDyEHcLOjg2PTo+Y/d3+/21shbpLYIOTglPLyjd/mZ//wH35JVM
+CD4knATgfL0JC34YPuOH688Nq1237REf3HzNmP5DXzX4HLhVNOp6dv6yP3xZ
+O1UyiRcePrlH/22q/sQDD79vGiANPA5yy1946NUzOOy61fU39TuPw5GNenmL
+GxkdwPal8cLjB2Y+LP7SwEDCgQEMZODyf7+VPpgTKOOw9ldM7tE6XgfmCqCL
+9sk43PfvnZ4nxAuJZ2NZB5j9UV933uraK+swf/XaG/HfeCDudZJzuA1yTgov
+PH3CzBcAJg/mdHmHVElQyuSH851lXj8ykxKEq4eFNwCKHGBr
+          "]]}, AspectRatio -> Automatic, ImageMargins -> {{0, 0}, {0, 2}}, 
+        ImageSize -> {14., 14.}, 
+        PlotRange -> {{-0.5, 13.62}, {-0.5, 13.62}}]& )}], 
+   Cell[
+    StyleData["HintPodIconIgnoreInNotebook"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         FaceForm[
+          GrayLevel[0.4]], 
+         FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+          3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+          3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+          3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+          3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGJTIGYC4qAdcq2vAwUcbLmuLy6wFXdYUgBiSTp4PKwS
+Weeu4GCgtVL4AouUw1zBpXsPlis4vDlgqexlLeWg+ZZ3n8FOBB+s/y+CH6S+
+oHODoyJc/z0mzi75ZkW4+cYgsFnRoanYbco3N0kHEftjd7Y+UXRYeM3kvcVR
+CYeQx0tnH2FQgroLwb9pWxmxYqs4nP9zQfrmV8bicP0g1VzXxeDmf9OI6T/0
+lcsB6Bmgj6QcGMDggz1MvoTnRNz7f2/sf/K/3L7+saLDzmCriP/PX9iHR2/c
+/+YfzL1P4Pz+Xoc96+IfwPkrVqZm1068AdcPtAxo4yW4+ccenln/jOGkPcz/
+MjWJRqEGh+xh4QPjw8IPxoeFL0w/LPxh5sPiB0KzwuNPHhibO+Su2h8GKTvE
+7aAYeYAl7+5Z+/rfVgXnOLgdPu6qO5h345j9voPiasGsXHA+JJw44Hy9CQt+
+GD5jh+vPDatdt+0RG9x8TZByDTYH/uky5V7st+21JaZe4cxgdZgp5PnFqOuh
+vQY/99ZlP1kcIO54CjWfxeFeX0HUh0Uv7bdEft15i4vVoa2/Q3Oiy1t77Xax
+m+fKWeHxAzMfFn9pYCACj1+YfMeX29cbgfF/+LJ2qmQSKzx95B79t6n6Ews8
+/cDsB3O5JB1Upv+fUPebxeHIRr28xQeB6e+Cy40PX1gdnjTPO7uKX8qh/8kn
++Uv57A4sYXy6m2KlHDjBCY3DwV9OLMvXGJjeda7MejaXC56eYeENAPSkchE=
+
+          "]], 
+         FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+          0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 
+          0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}, {1, 3, 
+          3}, {0, 1, 0}, {1, 3, 3}, {0, 1, 0}, {1, 3, 3}, {1, 3, 
+          3}}}, CompressedData["
+1:eJxTTMoPSmVmYGBgBGJdIGYC4qAdcq2vL6o52HJdX1ywVwtC24rB+YdTViWE
+XBKE86tF1rk/rOJxMAaBzxpwPkReDY2vCDVPCMpXhvPB+jerwfnPf6/8eOms
+ukPDdoemR+wiUHkNuHtgfJh7YXy2xqnO3W/U0eQ14ObB+DD7YHzNmP5DXzWY
+4PzY3KP/NlX/toeZBxYP/GIPsw/GBzuHSxrOX7TF/MchFSkH9g9iHgF/Ptmb
+vrdwdTeSdNjZywYU+WQPcb8E1B+f7H8EP146m0XcYeE1E6DKT/Z9IGUXRB02
+V3/aEJD92R5s7A4Rh1kzQeCr/YQFPwyfvRN2+Put9MEcwe/2894vP+ZtLuxw
+3793ep7QT3uIOiEHkC651t/2YH8a80LtY3NA5TPB+RPrflsVnPtkL/8lJ6xW
+T8jhTSDYo1DzxOB8BjBQh/O/aQADzlQTTV4bbh6MD7MPxoeFfwDI2czaDmfP
+gAA0nCdqOTglPL2gdFvDweNhlci645oO8iAPzdOEmPNXw+EPMDp9k7Qc4nZ5
+8jC9VncAG39KywE9/QIAH6UuJw==
+          "]], 
+         FilledCurveBox[{{{0, 2, 0}, {1, 3, 3}, {0, 1, 0}, {0, 1, 0}}}, {{{
+          5.63, 11.05}, {5.63, 10.44}, {6.0569, 10.539}, {6.5048, 10.49}, {
+          6.9, 10.3}, {9.53, 10.3}, {9.53, 11.05}}}], 
+         FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {0, 1, 0}}}, {{{7.92, 3.73}, {
+          8.0396, 3.4994}, {8.0784, 3.2353}, {8.03, 2.98}, {9.41, 2.98}, {
+          9.41, 3.73}}}], 
+         FilledCurveBox[{{{0, 2, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 0}, {0, 1, 
+          0}}}, {{{6.73, 6.21}, {6.2, 5.82}, {6.67, 5.46}, {11.22, 5.46}, {
+          11.22, 6.21}, {6.73, 6.21}}}], 
+         FilledCurveBox[{{{1, 4, 3}, {0, 1, 0}, {0, 1, 0}}}, {{{8., 8.7}, {
+          8.0514, 8.4458}, {8.0162, 8.1818}, {7.9, 7.95}, {10.25, 7.95}, {
+          10.25, 8.7}}}]}, AspectRatio -> Automatic, ImagePadding -> 0.75, 
+        ImageSize -> {15., 15.}, 
+        PlotRange -> {{0., 13.62}, {0., 13.62}}]& )}], 
+   Cell[
+    StyleData["HintPodIconHint"], 
+    TemplateBoxOptions -> {DisplayFunction -> (GraphicsBox[{
+         EdgeForm[None], 
+         FaceForm[#], 
+         FilledCurveBox[{{{1, 4, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}}, {{1, 4,
+            3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+           3}, {1, 3, 3}}, {{0, 2, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3,
+            3}, {0, 1, 0}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 3}, {1, 3, 
+           3}, {1, 3, 3}}}, {{{9.015, 17.37}, {4.4559, 17.37}, {0.76, 
+           13.645}, {0.76, 9.05}, {0.76, 4.455}, {4.4559, 0.73}, {9.015, 
+           0.73}, {13.574, 0.73}, {17.27, 4.455}, {17.27, 9.05}, {17.27, 
+           13.645}, {13.574, 17.37}, {9.015, 17.37}}, CompressedData["
+1:eJxTTMoPSmViYGCQBGIQbcixRiYqRcVh3bak+pu23A5rf8XkHt2n7OC/fkpq
+x2MOB8+5DWqHnik5nP8e/HjpbHYHj4dVIuvYlRyAiisjVrA78Bau6b6toegQ
+ApQ9soDdQepAtIJjoILDJ8fzaVefczgs6Nzw8GWoPNx84yMb9fIeyzr831T9
+acMFXod1N+LL/OVkHV5uX8/8/IyAw7Fck4btDrIOZQ/mCC7dK+TAXMGtomEn
+6/DP+dfb1w0iDkIi9sfufJV1ePRy6iYeQzGHac7dOc+t5R3SwEDcwe7FzTW/
+bBQc9kybwF+1TcLh7TwbnStSig7Hd+3oZSuQdDjab1iuy6jk0MIL8qGkg8f+
+WlmL50oO9uHRG/fnSDr4fu4LLjmi7HDw1ELXbZslHGDhAzO//9BXjRh+VQeG
+iXW/rQzEHKzv+/dOz1N1uFfY1fekSMRhzhGFDUUZqhB/LhaCmFOs6sC0h1VI
+ZL+Ag8g6d2AIqjqYCJrZ7L3E64Ae/gDrrapT
+           "], CompressedData["
+1:eJxTTMoPSmViYGBQBGIQ/emSb5KAhJoDAwg0aDhYbjlRtu++isNudX7urWpK
+DrX2pnG7Tqo4TFPsKy2sVnRQvv2zLqtGBULfUXAI6J2eJ8Ss4mDSsN2hKUnB
+Ia0jOfZOmrKD/l0Vtsar8g5Gz9apPlms5GDgs4zLLVXeweLHoZRVDxQdnNdm
+3ivskneQW/7CQ09e0aHEbco3tnh5h+jLex6LxCo4FErzPtC9IO+wVfT36Xed
+8nDzH5tJHYheIOeQBxJ4pOCgu2nu++Vscg75Qs0HTjUqOjDkN7IcPS/rcObd
+ycNOukoObqqlTLM4ZOD+O7JRL2/xQWkHHibtdrFITYeb8WX+ctOkHQ6eWui6
+zVjLQfD4rh29bdIO/Ye+asTwazuAnJswRdohaIdc6+uL2g6qbI1TnbtlHGy5
+ri8uqNVxEIgAhtg3WYj5B3QcgKEkzcsAdOfS2UcUDHQdEp5eULotqehw89z3
+4Mepug63pGsSjUyVHMr3zZfSj9V1uKKdKvkoQtmhOGPi25p6XQeQ8p91KhB9
+lroOIGH7UlWH+qw9JZNn6EDs54bGF4OOA9AVtlzhag6KG4oyJupqO4CCYaGr
+mgM4XiO0HK5WvFQz9FBzuAzi7tR0cNv2+e8VCzUHJ5AF0poO6PEPAFdvzZk=
+
+           "]}]}, AspectRatio -> Automatic, BaselinePosition -> Scaled[0.1], 
+        ImagePadding -> 0.5, ImageSize -> {14., 14.778}, 
+        PlotRange -> {{0.76, 17.27}, {0.73, 17.37}}]& )}], 
+   Cell["Documentation", "Section"], 
+   Cell["Usage", "Subsection"], 
+   Cell[
+    StyleData["UsageInputs", StyleDefinitions -> StyleData["Input"]], 
+    CellMargins -> {{66, 10}, {0, 8}}, 
+    StyleKeyMapping -> {"Tab" -> "UsageDescription"}, Evaluatable -> False, 
+    CellEventActions -> {"ReturnKeyDown" :> With[{RSNB`nb$ = Notebooks[
+           EvaluationCell[]]}, SelectionMove[
+          EvaluationCell[], After, Cell]; NotebookWrite[RSNB`nb$, 
+          Cell["", "UsageDescription"], All]; 
+        SelectionMove[RSNB`nb$, Before, CellContents]], {"KeyDown", "\t"} :> 
+      Replace[SelectionMove[
+          SelectedNotebook[], After, Cell]; NotebookFind[
+          SelectedNotebook[], "TabNext", Next, CellTags, AutoScroll -> True, 
+          WrapAround -> True], Blank[NotebookSelection] :> SelectionMove[
+          SelectedNotebook[], All, CellContents, AutoScroll -> True]]}, 
+    ShowAutoStyles -> False, ShowCodeAssist -> False, 
+    CodeAssistOptions -> {"DynamicHighlighting" -> False}, 
+    LineSpacing -> {1, 3}, TabSpacings -> {2.5}, CounterIncrements -> "Text", 
+    FontFamily -> "Source Sans Pro", FontSize -> 15, FontWeight -> "Plain"], 
+   Cell[
+    StyleData["UsageDescription", StyleDefinitions -> StyleData["Text"]], 
+    CellMargins -> {{86, 10}, {7, 0}}, 
+    StyleKeyMapping -> {"Backspace" -> "UsageInputs"}, CellGroupingRules -> 
+    "OutputGrouping", 
+    CellEventActions -> {"ReturnKeyDown" :> With[{RSNB`nb$ = Notebooks[
+           EvaluationCell[]]}, SelectionMove[
+          EvaluationCell[], After, Cell]; NotebookWrite[RSNB`nb$, 
+          Cell[
+           BoxData[""], "UsageInputs", FontFamily -> "Source Sans Pro"], All]; 
+        SelectionMove[RSNB`nb$, Before, CellContents]], {"KeyDown", "\t"} :> 
+      Replace[SelectionMove[
+          SelectedNotebook[], After, Cell]; NotebookFind[
+          SelectedNotebook[], "TabNext", Next, CellTags, AutoScroll -> True, 
+          WrapAround -> True], Blank[NotebookSelection] :> SelectionMove[
+          SelectedNotebook[], All, CellContents, AutoScroll -> True]]}, 
+    ShowAutoSpellCheck -> False], 
+   Cell["Details & Options", "Subsection"], 
+   Cell[
+    StyleData["Notes", StyleDefinitions -> StyleData["Item"]], CellDingbat -> 
+    StyleBox["\[FilledVerySmallSquare]", FontColor -> GrayLevel[0.6]], 
+    CellMargins -> {{66, 24}, {9, 7}}, ReturnCreatesNewCell -> False, 
+    StyleKeyMapping -> {}, DefaultNewCellStyle -> "Notes", ShowAutoSpellCheck -> 
+    False, GridBoxOptions -> {BaseStyle -> "TableNotes"}], 
+   Cell[
+    StyleData["TableNotes", StyleDefinitions -> StyleData["Notes"]], 
+    CellDingbat -> None, CellFrameColor -> RGBColor[0.749, 0.694, 0.553], 
+    StyleMenuListing -> None, 
+    ButtonBoxOptions -> {Appearance -> {Automatic, None}}, 
+    GridBoxOptions -> {
+     FrameStyle -> GrayLevel[0.906], 
+      GridBoxAlignment -> {
+       "Columns" -> {{Left}}, "ColumnsIndexed" -> {}, "Rows" -> {{Baseline}}, 
+        "RowsIndexed" -> {}}, 
+      GridBoxDividers -> {"Columns" -> {{None}}, "Rows" -> {{True}}}, 
+      GridDefaultElement -> Cell["\[Placeholder]", "TableText"]}], 
+   Cell[
+    StyleData["TableText"], DefaultInlineFormatType -> 
+    "DefaultInputInlineFormatType", AutoQuoteCharacters -> {}, 
+    PasteAutoQuoteCharacters -> {}, StyleMenuListing -> None], 
+   Cell["Examples", "Subsection"], 
+   Cell[
+    StyleData["ExampleDelimiter"], Selectable -> False, ShowCellBracket -> 
+    Automatic, CellMargins -> {{66, 14}, {5, 10}}, Evaluatable -> True, 
+    CellGroupingRules -> {"SectionGrouping", 58}, 
+    CellEvaluationFunction -> (($Line = 0; Null)& ), ShowCellLabel -> False, 
+    CellLabelAutoDelete -> True, TabFilling -> 
+    "\[LongDash]\[NegativeThickSpace]", TabSpacings -> {100}, 
+    StyleMenuListing -> None, FontFamily -> "Verdana", FontWeight -> Bold, 
+    FontSlant -> "Plain", FontColor -> GrayLevel[0.906]], 
+   Cell[
+    StyleData["ExampleText", StyleDefinitions -> StyleData["Text"]]], 
+   Cell[
+    StyleData["PageBreak", StyleDefinitions -> StyleData["ExampleDelimiter"]],
+     Selectable -> False, CellFrame -> {{0, 0}, {1, 0}}, 
+    CellMargins -> {{66, 14}, {15, -5}}, 
+    CellElementSpacings -> {"CellMinHeight" -> 1}, Evaluatable -> True, 
+    CellEvaluationFunction -> (($Line = 0; Null)& ), CellFrameColor -> 
+    GrayLevel[
+      Rational[77, 85]]], 
+   Cell[
+    StyleData["Subsection"], Evaluatable -> True, 
+    CellEvaluationFunction -> (($Line = 0; Null)& ), ShowCellLabel -> False], 
+   
+   Cell[
+    StyleData["Subsubsection"], Evaluatable -> True, 
+    CellEvaluationFunction -> (($Line = 0; Null)& ), ShowCellLabel -> False], 
+   
+   Cell[
+    StyleData["ExampleImage"], PageWidth :> 650, 
+    CellMargins -> {{66, 66}, {16, 5}}, Evaluatable -> False, ShowCellLabel -> 
+    False, MenuSortingValue -> 10000, 
+    RasterBoxOptions -> {ImageEditMode -> False}], 
+   Cell["Links", "Section"], 
+   Cell[
+    StyleData["Link"], FontFamily -> "Source Sans Pro", FontColor -> Dynamic[
+      If[
+       CurrentValue["MouseOver"], 
+       RGBColor[0.855, 0.396, 0.145], 
+       RGBColor[0.02, 0.286, 0.651]]]], 
+   Cell[
+    StyleData["StringTypeLink", StyleDefinitions -> StyleData["Link"]], 
+    FontColor -> Dynamic[
+      If[
+       CurrentValue["MouseOver"], 
+       RGBColor[0.969, 0.467, 0.], 
+       GrayLevel[0.467]]]], 
+   Cell[
+    StyleData["CharactersRefLink"], ShowSpecialCharacters -> False], 
+   Cell["Annotation", "Section"], 
+   Cell[
+    StyleData["Excluded"], 
+    CellBracketOptions -> {
+     "Color" -> RGBColor[0.9, 0.4, 0.4], "Thickness" -> 2}, 
+    GeneratedCellStyles -> {
+     "Graphics" -> {"Graphics", "Excluded"}, 
+      "Message" -> {"Message", "MSG", "Excluded"}, 
+      "Output" -> {"Output", "Excluded"}, "Print" -> {"Print", "Excluded"}, 
+      "PrintTemporary" -> {"PrintTemporary", "Excluded"}}, CellFrameMargins -> 
+    4, CellFrameLabels -> {{None, 
+       Cell[
+        BoxData[
+         TemplateBox[{
+           StyleBox[
+           "\"excluded\"", "ExcludedCellLabel", StripOnInput -> False], 
+           "\"Excluded cells will not appear anywhere in the published \
+resource except for the definition notebook\""}, "PrettyTooltipTemplate"]], 
+        "ExcludedCellLabel"]}, {None, None}}, StyleMenuListing -> None, 
+    Background -> RGBColor[1, 0.95, 0.95]], 
+   Cell[
+    StyleData["ExcludedCellLabel", StyleDefinitions -> StyleData["Text"]], 
+    ShowStringCharacters -> False, FontFamily -> "Source Sans Pro", FontSize -> 
+    9, FontWeight -> Plain, FontSlant -> Italic, FontColor -> 
+    RGBColor[0.9, 0.4, 0.4, 0.5], Background -> None], 
+   Cell[
+    StyleData["HiddenMaterial"], 
+    CellBracketOptions -> {
+     "Color" -> RGBColor[0.3, 0.7, 0.6], "Thickness" -> 2}, CellFrameMargins -> 
+    4, CellFrameLabels -> {{None, 
+       Cell[
+        BoxData[
+         TemplateBox[{
+           StyleBox[
+           "\"hidden\"", "HiddenMaterialCellLabel", StripOnInput -> False], 
+           "\"Hidden input cells will be closed on the published web page but \
+will remain open in the downloadable example notebook\""}, 
+          "PrettyTooltipTemplate"]], "HiddenMaterialCellLabel"]}, {
+      None, None}}, StyleMenuListing -> None, Background -> 
+    RGBColor[0.8, 1., 0.9]], 
+   Cell[
+    StyleData[
+    "HiddenMaterialCellLabel", StyleDefinitions -> StyleData["Text"]], 
+    ShowStringCharacters -> False, FontFamily -> "Source Sans Pro", FontSize -> 
+    9, FontWeight -> Plain, FontSlant -> Italic, FontColor -> 
+    RGBColor[0.3, 0.7, 0.6, 0.5], Background -> None], 
+   Cell[
+    StyleData["Comment", StyleDefinitions -> StyleData["Text"]], 
+    CellFrame -> {{3, 0}, {0, 0}}, CellMargins -> {{66, 0}, {1, 0}}, 
+    CellElementSpacings -> {"ClosedCellHeight" -> 0}, 
+    GeneratedCellStyles -> {
+     "Graphics" -> {"Graphics", "Comment"}, 
+      "Message" -> {"Message", "MSG", "Comment"}, 
+      "Output" -> {"Output", "Comment"}, "Print" -> {"Print", "Comment"}, 
+      "PrintTemporary" -> {"PrintTemporary", "Comment"}}, CellFrameColor -> 
+    RGBColor[0.88072, 0.61104, 0.14205], 
+    CellFrameLabelMargins -> {{0, 10}, {0, 0}}, FontColor -> GrayLevel[0.25], 
+    Background -> RGBColor[0.982, 0.942, 0.871]], 
+   Cell[
+    StyleData["AuthorComment", StyleDefinitions -> StyleData["Comment"]], 
+    GeneratedCellStyles -> {
+     "Graphics" -> {"Graphics", "AuthorComment"}, 
+      "Message" -> {"Message", "MSG", "AuthorComment"}, 
+      "Output" -> {"Output", "AuthorComment"}, 
+      "Print" -> {"Print", "AuthorComment"}, 
+      "PrintTemporary" -> {"PrintTemporary", "AuthorComment"}}, 
+    CellFrameColor -> RGBColor[0.36842, 0.50678, 0.7098], Background -> 
+    RGBColor[0.905, 0.926, 0.956]], 
+   Cell[
+    StyleData["ReviewerComment", StyleDefinitions -> StyleData["Comment"]], 
+    GeneratedCellStyles -> {
+     "Graphics" -> {"Graphics", "ReviewerComment"}, 
+      "Message" -> {"Message", "MSG", "ReviewerComment"}, 
+      "Output" -> {"Output", "ReviewerComment"}, 
+      "Print" -> {"Print", "ReviewerComment"}, 
+      "PrintTemporary" -> {"PrintTemporary", "ReviewerComment"}}, 
+    CellFrameColor -> RGBColor[0.56018, 0.69157, 0.19488], Background -> 
+    RGBColor[0.934, 0.954, 0.879]], 
+   Cell[
+    StyleData["CommentLabel", StyleDefinitions -> StyleData["Text"]], 
+    ShowStringCharacters -> False, FontSlant -> "Italic", 
+    PrivateFontOptions -> {"OperatorSubstitution" -> False}, FontColor -> 
+    GrayLevel[0.5]], 
+   Cell["Special Input", "Section"], 
+   Cell[
+    StyleData["FormObjectCell"], CellMargins -> {{66, 66}, {16, 5}}], 
+   Cell[
+    StyleData["LocalFileInput", StyleDefinitions -> StyleData["Input"]], 
+    CellFrameLabels -> {{None, 
+       Cell[
+        BoxData[
+         ButtonBox[
+         "\"Choose\"", FrameMargins -> {{5, 5}, {0, 0}}, 
+          BaseStyle -> {"Panel", FontSize -> 12}, Evaluator -> Automatic, 
+          Method -> "Queued", ButtonFunction :> 
+          With[{RSNB`nb$ = ButtonNotebook[], RSNB`$cp$ = $ContextPath}, 
+            Quiet[
+             
+             Block[{$ContextPath = RSNB`$cp$, 
+               ResourceSystemClient`$AsyncronousResourceInformationUpdates = 
+               False, DefinitionNotebookClient`$ButtonCodeID = None}, 
+              Internal`WithLocalSettings[
+               DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                  ReleaseHold[
+                   CurrentValue[
+                   RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                  "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                Annotation[
+                DefinitionNotebookClient`$ButtonCodeID = 8263526385974082686; 
+                 DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                   ReleaseHold[DefinitionNotebookClient`$ButtonCode = HoldForm[
+                    If[$VersionNumber >= 13., 
+                    DefinitionNotebookClient`LocalFileInputDialog[
+                    "Demonstration", 
+                    ParentCell[
+                    EvaluationCell[]], "Type" -> "FileOpen"], 
+                    MessageDialog[
+                    "This feature requires Wolfram Language version 13 or \
+later."]]]]], 
+                 DefinitionNotebookClient`ButtonCodeID[8263526385974082686]], 
+                DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+              Null]]], Appearance :> 
+          FEPrivate`FrontEndResource[
+           "FEExpressions", "GrayButtonNinePatchAppearance"]]]]}, {
+      None, None}}], 
+   Cell[
+    StyleData["LocalDirectoryInput", StyleDefinitions -> StyleData["Input"]], 
+    CellFrameLabels -> {{None, 
+       Cell[
+        BoxData[
+         ButtonBox[
+         "\"Choose\"", FrameMargins -> {{5, 5}, {0, 0}}, 
+          BaseStyle -> {"Panel", FontSize -> 12}, Evaluator -> Automatic, 
+          Method -> "Queued", ButtonFunction :> 
+          With[{RSNB`nb$ = ButtonNotebook[], RSNB`$cp$ = $ContextPath}, 
+            Quiet[
+             
+             Block[{$ContextPath = RSNB`$cp$, 
+               ResourceSystemClient`$AsyncronousResourceInformationUpdates = 
+               False, DefinitionNotebookClient`$ButtonCodeID = None}, 
+              Internal`WithLocalSettings[
+               DefinitionNotebookClient`$ButtonsDisabled = True; Once[
+                  ReleaseHold[
+                   CurrentValue[
+                   RSNB`nb$, {TaggingRules, "CompatibilityTest"}]], 
+                  "KernelSession"]; Needs["DefinitionNotebookClient`"], 
+                Annotation[
+                DefinitionNotebookClient`$ButtonCodeID = 5263076252613204070; 
+                 DefinitionNotebookClient`CheckForUpdates[RSNB`nb$, 
+                   ReleaseHold[DefinitionNotebookClient`$ButtonCode = HoldForm[
+                    If[$VersionNumber >= 13., 
+                    DefinitionNotebookClient`LocalFileInputDialog[
+                    "Demonstration", 
+                    ParentCell[
+                    EvaluationCell[]], "Type" -> "Directory"], 
+                    MessageDialog[
+                    "This feature requires Wolfram Language version 13 or \
+later."]]]]], 
+                 DefinitionNotebookClient`ButtonCodeID[5263076252613204070]], 
+                DefinitionNotebookClient`$ButtonsDisabled = False; Null]; 
+              Null]]], Appearance :> 
+          FEPrivate`FrontEndResource[
+           "FEExpressions", "GrayButtonNinePatchAppearance"]]]]}, {
+      None, None}}], 
+   Cell["Misc", "Section"], 
+   Cell[
+    StyleData["Item"], DefaultNewCellStyle -> "Item"], 
+   Cell[
+    StyleData["RelatedSymbol", StyleDefinitions -> StyleData["Item"]], 
+    DefaultNewCellStyle -> {"RelatedSymbol", FontFamily -> "Source Sans Pro"},
+     DefaultFormatType -> DefaultInputFormatType, FormatType -> InputForm], 
+   Cell[
+    StyleData["ButtonText"], FontFamily -> "Sans Serif", FontSize -> 11, 
+    FontWeight -> Bold, FontColor -> RGBColor[0.459, 0.459, 0.459]], 
+   Cell[
+    StyleData["InlineFormula"], 
+    HyphenationOptions -> {"HyphenationCharacter" -> "\[Continuation]"}, 
+    LanguageCategory -> "Formula", AutoSpacing -> True, ScriptLevel -> 1, 
+    SingleLetterItalics -> False, SpanMaxSize -> 1, StyleMenuListing -> None, 
+    FontFamily -> "Source Sans Pro", FontSize -> 1. Inherited, 
+    ButtonBoxOptions -> {Appearance -> {Automatic, None}}, 
+    FractionBoxOptions -> {BaseStyle -> {SpanMaxSize -> Automatic}}, 
+    GridBoxOptions -> {
+     GridBoxItemSize -> {
+       "Columns" -> {{Automatic}}, "ColumnsIndexed" -> {}, "Rows" -> {{1.}}, 
+        "RowsIndexed" -> {}}}], 
+   Cell[
+    StyleData["DockedCell"], CellFrameColor -> GrayLevel[0.75], Background -> 
+    GrayLevel[0.9]]}, Visible -> False, FrontEndVersion -> 
+  "14.1 for Mac OS X x86 (64-bit) (June 13, 2024)", StyleDefinitions -> 
+  "PrivateStylesheetFormatting.nb"],
+ExpressionUUID->"ec9b0036-47fa-45da-819c-eadf7b5148bc"
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{
+ "Name"->{
+  Cell[580, 22, 326, 6, 70, "Title",ExpressionUUID->"866c1904-16e4-44ee-9184-9bb11f640e2e",
+   CellTags->{"Name", "Title"},
+   CellID->806361579]},
+ "Title"->{
+  Cell[580, 22, 326, 6, 70, "Title",ExpressionUUID->"866c1904-16e4-44ee-9184-9bb11f640e2e",
+   CellTags->{"Name", "Title"},
+   CellID->806361579]},
+ "Caption"->{
+  Cell[931, 32, 1495, 33, 70, "Section",ExpressionUUID->"41890601-af97-484b-af98-bab485770a0e",
+   CellTags->{"Caption", "CaptionCells", "TemplateCellGroup"},
+   CellID->138150581]},
+ "CaptionCells"->{
+  Cell[931, 32, 1495, 33, 70, "Section",ExpressionUUID->"41890601-af97-484b-af98-bab485770a0e",
+   CellTags->{"Caption", "CaptionCells", "TemplateCellGroup"},
+   CellID->138150581]},
+ "TemplateCellGroup"->{
+  Cell[931, 32, 1495, 33, 70, "Section",ExpressionUUID->"41890601-af97-484b-af98-bab485770a0e",
+   CellTags->{"Caption", "CaptionCells", "TemplateCellGroup"},
+   CellID->138150581],
+  Cell[3366, 87, 2246, 48, 70, "Section",ExpressionUUID->"35eef4e2-7bed-4ff3-a9a3-53c85af9a2b3",
+   CellTags->{"Initialization Code", "InitializationCode", "TemplateCellGroup"},
+   CellID->447669593],
+  Cell[6403, 158, 1944, 40, 70, "Section",ExpressionUUID->"751f4140-0594-4598-9de8-56db0cbc4bfd",
+   CellTags->{"Manipulate", "ManipulateGroup", "TemplateCellGroup"},
+   CellID->791025314],
+  Cell[23895, 576, 1302, 31, 70, "Section",ExpressionUUID->"21d2b916-5354-4bd6-b138-bd27b92b77b3",
+   CellTags->{"SnapshotGroup", "Snapshots", "TemplateCellGroup"},
+   CellID->98938448],
+  Cell[374375, 6373, 1221, 29, 70, "Subsection",ExpressionUUID->"65396ff6-955e-4046-8d9f-2280747f913c",
+   CellTags->{"AuthorNames", "Contributed By", "TemplateCellGroup"},
+   CellID->255368948],
+  Cell[375765, 6411, 2197, 46, 70, "Subsection",ExpressionUUID->"c6e8eb5c-33d4-4a2b-930c-b905e32940af",
+   CellTags->{"AuthorNotes", "DetailCells", "Details & Citations", "TemplateCellGroup"},
+   CellID->441931514],
+  Cell[378594, 6473, 2173, 45, 70, "Subsection",ExpressionUUID->"2a8f96e3-65d2-4fe8-8c67-f9391216f923",
+   CellTags->{"ReferenceCells", "References", "TemplateCellGroup"},
+   CellID->592881655],
+  Cell[381385, 6534, 1242, 30, 70, "Subsection",ExpressionUUID->"6b3b01e9-6ca1-487e-ab6c-2312fc9df879",
+   CellTags->{"Submission Notes", "SubmissionNotes", "TemplateCellGroup"},
+   CellID->797097429],
+  Cell[383256, 6580, 1106, 27, 70, "Subsection",ExpressionUUID->"6074178a-3ee1-448f-bdda-18641673cfd6",
+   CellTags->{"Keywords", "TemplateCellGroup"},
+   CellID->938146184],
+  Cell[385004, 6632, 1128, 27, 70, "Subsection",ExpressionUUID->"53143ca2-f91a-4c84-a16e-14dccff6475c",
+   CellTags->{"Categories", "DemoCategories", "TemplateCellGroup"},
+   CellID->845692503],
+  Cell[571955, 10101, 1216, 30, 70, "Subsection",ExpressionUUID->"53eefeb9-f7fb-49cc-a999-6f677ead9d51",
+   CellTags->{"Related Demonstrations", "RelatedDemonstrations", "TemplateCellGroup"},
+   CellID->1132753],
+  Cell[573791, 10147, 1558, 37, 70, "Subsection",ExpressionUUID->"c7e61a88-e056-4fd4-92f6-d76c81bf19d6",
+   CellTags->{"External Links", "ExternalLinks", "TemplateCellGroup"},
+   CellID->843468725],
+  Cell[575966, 10200, 1191, 29, 70, "Subsection",ExpressionUUID->"39801c7c-0114-4a4e-9bdc-d1e59d88d289",
+   CellTags->{"Related Symbols", "RelatedSymbols", "TemplateCellGroup"},
+   CellID->899564547],
+  Cell[577793, 10245, 1070, 26, 70, "Subsection",ExpressionUUID->"96c4ac55-b088-49f7-9ebd-b94233dc8a81",
+   CellTags->{"Published Date", "PublishedDate", "TemplateCellGroup"},
+   CellID->364555554],
+  Cell[579022, 10280, 1073, 26, 70, "Subsection",ExpressionUUID->"0d510131-c801-4515-915b-232ee417072a",
+   CellTags->{"Compatibility", "TemplateCellGroup"},
+   CellID->618273920]},
+ "Initialization Code"->{
+  Cell[3366, 87, 2246, 48, 70, "Section",ExpressionUUID->"35eef4e2-7bed-4ff3-a9a3-53c85af9a2b3",
+   CellTags->{"Initialization Code", "InitializationCode", "TemplateCellGroup"},
+   CellID->447669593]},
+ "InitializationCode"->{
+  Cell[3366, 87, 2246, 48, 70, "Section",ExpressionUUID->"35eef4e2-7bed-4ff3-a9a3-53c85af9a2b3",
+   CellTags->{"Initialization Code", "InitializationCode", "TemplateCellGroup"},
+   CellID->447669593]},
+ "DefaultContent"->{
+  Cell[5615, 137, 751, 16, 70, "CodeText",ExpressionUUID->"7e3e6cd8-09c5-4dd4-b1ac-7bd5c6cc93f2",
+   CellTags->{"DefaultContent", "samplecell", "TabNext"},
+   CellID->687519280],
+  Cell[377965, 6459, 592, 9, 70, "Text",ExpressionUUID->"a44ba792-9b26-497a-92e4-5a60c079de85",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->111711384],
+  Cell[380770, 6520, 578, 9, 70, "Text",ExpressionUUID->"ce89f651-625f-4b84-b2b4-17029aac56e2",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->423796343],
+  Cell[382630, 6566, 589, 9, 70, "Text",ExpressionUUID->"53319a44-3896-4fc6-bf9f-f08f087e1424",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->820829112],
+  Cell[573174, 10133, 580, 9, 70, "Item",ExpressionUUID->"0d6e2845-dbfa-4e1c-b780-969415c4146e",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->904163252],
+  Cell[575352, 10186, 577, 9, 70, "Item",ExpressionUUID->"c3717123-fab8-49ef-bb07-872904b07f43",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->180966586],
+  Cell[577160, 10231, 596, 9, 70, "Item",ExpressionUUID->"6519833f-75b7-4b82-8ac9-a1c215acba33",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->159321921]},
+ "samplecell"->{
+  Cell[5615, 137, 751, 16, 70, "CodeText",ExpressionUUID->"7e3e6cd8-09c5-4dd4-b1ac-7bd5c6cc93f2",
+   CellTags->{"DefaultContent", "samplecell", "TabNext"},
+   CellID->687519280]},
+ "TabNext"->{
+  Cell[5615, 137, 751, 16, 70, "CodeText",ExpressionUUID->"7e3e6cd8-09c5-4dd4-b1ac-7bd5c6cc93f2",
+   CellTags->{"DefaultContent", "samplecell", "TabNext"},
+   CellID->687519280],
+  Cell[377965, 6459, 592, 9, 70, "Text",ExpressionUUID->"a44ba792-9b26-497a-92e4-5a60c079de85",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->111711384],
+  Cell[380770, 6520, 578, 9, 70, "Text",ExpressionUUID->"ce89f651-625f-4b84-b2b4-17029aac56e2",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->423796343],
+  Cell[382630, 6566, 589, 9, 70, "Text",ExpressionUUID->"53319a44-3896-4fc6-bf9f-f08f087e1424",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->820829112],
+  Cell[573174, 10133, 580, 9, 70, "Item",ExpressionUUID->"0d6e2845-dbfa-4e1c-b780-969415c4146e",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->904163252],
+  Cell[575352, 10186, 577, 9, 70, "Item",ExpressionUUID->"c3717123-fab8-49ef-bb07-872904b07f43",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->180966586],
+  Cell[577160, 10231, 596, 9, 70, "Item",ExpressionUUID->"6519833f-75b7-4b82-8ac9-a1c215acba33",
+   CellTags->{"DefaultContent", "TabNext"},
+   CellID->159321921]},
+ "Manipulate"->{
+  Cell[6403, 158, 1944, 40, 70, "Section",ExpressionUUID->"751f4140-0594-4598-9de8-56db0cbc4bfd",
+   CellTags->{"Manipulate", "ManipulateGroup", "TemplateCellGroup"},
+   CellID->791025314]},
+ "ManipulateGroup"->{
+  Cell[6403, 158, 1944, 40, 70, "Section",ExpressionUUID->"751f4140-0594-4598-9de8-56db0cbc4bfd",
+   CellTags->{"Manipulate", "ManipulateGroup", "TemplateCellGroup"},
+   CellID->791025314]},
+ "SnapshotGroup"->{
+  Cell[23895, 576, 1302, 31, 70, "Section",ExpressionUUID->"21d2b916-5354-4bd6-b138-bd27b92b77b3",
+   CellTags->{"SnapshotGroup", "Snapshots", "TemplateCellGroup"},
+   CellID->98938448]},
+ "Snapshots"->{
+  Cell[23895, 576, 1302, 31, 70, "Section",ExpressionUUID->"21d2b916-5354-4bd6-b138-bd27b92b77b3",
+   CellTags->{"SnapshotGroup", "Snapshots", "TemplateCellGroup"},
+   CellID->98938448]},
+ "Snapshot"->{
+  Cell[208114, 3615, 55504, 917, 70, "Output",ExpressionUUID->"57b1cd9f-c821-4027-b186-9df09f1bddef",
+   CellTags->"Snapshot",
+   CellID->1759672171],
+  Cell[263621, 4534, 55662, 919, 70, "Output",ExpressionUUID->"b037802b-902b-433d-b439-a0c8bb8414ac",
+   CellTags->"Snapshot",
+   CellID->1812875160],
+  Cell[319286, 5455, 54754, 904, 70, "Output",ExpressionUUID->"6623e441-b1ca-4f02-a6d3-c7831a396c1b",
+   CellTags->"Snapshot",
+   CellID->494830484]},
+ "SourceInformationGroup"->{
+  Cell[374077, 6364, 273, 5, 70, "Section",ExpressionUUID->"e67b7ac9-7ce5-4e24-a422-e84cd737770a",
+   CellTags->"SourceInformationGroup",
+   CellID->62407265]},
+ "AuthorNames"->{
+  Cell[374375, 6373, 1221, 29, 70, "Subsection",ExpressionUUID->"65396ff6-955e-4046-8d9f-2280747f913c",
+   CellTags->{"AuthorNames", "Contributed By", "TemplateCellGroup"},
+   CellID->255368948]},
+ "Contributed By"->{
+  Cell[374375, 6373, 1221, 29, 70, "Subsection",ExpressionUUID->"65396ff6-955e-4046-8d9f-2280747f913c",
+   CellTags->{"AuthorNames", "Contributed By", "TemplateCellGroup"},
+   CellID->255368948]},
+ "AuthorNotes"->{
+  Cell[375765, 6411, 2197, 46, 70, "Subsection",ExpressionUUID->"c6e8eb5c-33d4-4a2b-930c-b905e32940af",
+   CellTags->{"AuthorNotes", "DetailCells", "Details & Citations", "TemplateCellGroup"},
+   CellID->441931514]},
+ "DetailCells"->{
+  Cell[375765, 6411, 2197, 46, 70, "Subsection",ExpressionUUID->"c6e8eb5c-33d4-4a2b-930c-b905e32940af",
+   CellTags->{"AuthorNotes", "DetailCells", "Details & Citations", "TemplateCellGroup"},
+   CellID->441931514]},
+ "Details & Citations"->{
+  Cell[375765, 6411, 2197, 46, 70, "Subsection",ExpressionUUID->"c6e8eb5c-33d4-4a2b-930c-b905e32940af",
+   CellTags->{"AuthorNotes", "DetailCells", "Details & Citations", "TemplateCellGroup"},
+   CellID->441931514]},
+ "ReferenceCells"->{
+  Cell[378594, 6473, 2173, 45, 70, "Subsection",ExpressionUUID->"2a8f96e3-65d2-4fe8-8c67-f9391216f923",
+   CellTags->{"ReferenceCells", "References", "TemplateCellGroup"},
+   CellID->592881655]},
+ "References"->{
+  Cell[378594, 6473, 2173, 45, 70, "Subsection",ExpressionUUID->"2a8f96e3-65d2-4fe8-8c67-f9391216f923",
+   CellTags->{"ReferenceCells", "References", "TemplateCellGroup"},
+   CellID->592881655]},
+ "Submission Notes"->{
+  Cell[381385, 6534, 1242, 30, 70, "Subsection",ExpressionUUID->"6b3b01e9-6ca1-487e-ab6c-2312fc9df879",
+   CellTags->{"Submission Notes", "SubmissionNotes", "TemplateCellGroup"},
+   CellID->797097429]},
+ "SubmissionNotes"->{
+  Cell[381385, 6534, 1242, 30, 70, "Subsection",ExpressionUUID->"6b3b01e9-6ca1-487e-ab6c-2312fc9df879",
+   CellTags->{"Submission Notes", "SubmissionNotes", "TemplateCellGroup"},
+   CellID->797097429]},
+ "Keywords"->{
+  Cell[383256, 6580, 1106, 27, 70, "Subsection",ExpressionUUID->"6074178a-3ee1-448f-bdda-18641673cfd6",
+   CellTags->{"Keywords", "TemplateCellGroup"},
+   CellID->938146184]},
+ "Categories"->{
+  Cell[385004, 6632, 1128, 27, 70, "Subsection",ExpressionUUID->"53143ca2-f91a-4c84-a16e-14dccff6475c",
+   CellTags->{"Categories", "DemoCategories", "TemplateCellGroup"},
+   CellID->845692503]},
+ "DemoCategories"->{
+  Cell[385004, 6632, 1128, 27, 70, "Subsection",ExpressionUUID->"53143ca2-f91a-4c84-a16e-14dccff6475c",
+   CellTags->{"Categories", "DemoCategories", "TemplateCellGroup"},
+   CellID->845692503]},
+ "CheckboxCell"->{
+  Cell[386135, 6661, 185783, 3435, 70, "Output",ExpressionUUID->"ea774907-334f-403a-8e2e-013c07972c0d",
+   CellTags->{"CheckboxCell", "Topics", "Topics-Checkboxes"},
+   CellID->375137771],
+  Cell[581248, 10340, 1370, 35, 70, "Output",ExpressionUUID->"f61c5465-ffa4-4001-926f-6007a866f625",
+   CellTags->{"CheckboxCell", "CompatibilityARSupport", "CompatibilityARSupport-Checkboxes"},
+   CellID->678130364],
+  Cell[585116, 10448, 1328, 34, 70, "Output",ExpressionUUID->"34b1d8c5-5c2d-42a1-a08f-8d44bc1c0e10",
+   CellTags->{"CheckboxCell", "CompatibilityCloudSupport", "CompatibilityCloudSupport-Checkboxes"},
+   CellID->291004391]},
+ "Topics"->{
+  Cell[386135, 6661, 185783, 3435, 70, "Output",ExpressionUUID->"ea774907-334f-403a-8e2e-013c07972c0d",
+   CellTags->{"CheckboxCell", "Topics", "Topics-Checkboxes"},
+   CellID->375137771]},
+ "Topics-Checkboxes"->{
+  Cell[386135, 6661, 185783, 3435, 70, "Output",ExpressionUUID->"ea774907-334f-403a-8e2e-013c07972c0d",
+   CellTags->{"CheckboxCell", "Topics", "Topics-Checkboxes"},
+   CellID->375137771]},
+ "Related Demonstrations"->{
+  Cell[571955, 10101, 1216, 30, 70, "Subsection",ExpressionUUID->"53eefeb9-f7fb-49cc-a999-6f677ead9d51",
+   CellTags->{"Related Demonstrations", "RelatedDemonstrations", "TemplateCellGroup"},
+   CellID->1132753]},
+ "RelatedDemonstrations"->{
+  Cell[571955, 10101, 1216, 30, 70, "Subsection",ExpressionUUID->"53eefeb9-f7fb-49cc-a999-6f677ead9d51",
+   CellTags->{"Related Demonstrations", "RelatedDemonstrations", "TemplateCellGroup"},
+   CellID->1132753]},
+ "External Links"->{
+  Cell[573791, 10147, 1558, 37, 70, "Subsection",ExpressionUUID->"c7e61a88-e056-4fd4-92f6-d76c81bf19d6",
+   CellTags->{"External Links", "ExternalLinks", "TemplateCellGroup"},
+   CellID->843468725]},
+ "ExternalLinks"->{
+  Cell[573791, 10147, 1558, 37, 70, "Subsection",ExpressionUUID->"c7e61a88-e056-4fd4-92f6-d76c81bf19d6",
+   CellTags->{"External Links", "ExternalLinks", "TemplateCellGroup"},
+   CellID->843468725]},
+ "Related Symbols"->{
+  Cell[575966, 10200, 1191, 29, 70, "Subsection",ExpressionUUID->"39801c7c-0114-4a4e-9bdc-d1e59d88d289",
+   CellTags->{"Related Symbols", "RelatedSymbols", "TemplateCellGroup"},
+   CellID->899564547]},
+ "RelatedSymbols"->{
+  Cell[575966, 10200, 1191, 29, 70, "Subsection",ExpressionUUID->"39801c7c-0114-4a4e-9bdc-d1e59d88d289",
+   CellTags->{"Related Symbols", "RelatedSymbols", "TemplateCellGroup"},
+   CellID->899564547]},
+ "Published Date"->{
+  Cell[577793, 10245, 1070, 26, 70, "Subsection",ExpressionUUID->"96c4ac55-b088-49f7-9ebd-b94233dc8a81",
+   CellTags->{"Published Date", "PublishedDate", "TemplateCellGroup"},
+   CellID->364555554]},
+ "PublishedDate"->{
+  Cell[577793, 10245, 1070, 26, 70, "Subsection",ExpressionUUID->"96c4ac55-b088-49f7-9ebd-b94233dc8a81",
+   CellTags->{"Published Date", "PublishedDate", "TemplateCellGroup"},
+   CellID->364555554]},
+ "Compatibility"->{
+  Cell[579022, 10280, 1073, 26, 70, "Subsection",ExpressionUUID->"0d510131-c801-4515-915b-232ee417072a",
+   CellTags->{"Compatibility", "TemplateCellGroup"},
+   CellID->618273920]},
+ "CompatibilityARSupport"->{
+  Cell[581248, 10340, 1370, 35, 70, "Output",ExpressionUUID->"f61c5465-ffa4-4001-926f-6007a866f625",
+   CellTags->{"CheckboxCell", "CompatibilityARSupport", "CompatibilityARSupport-Checkboxes"},
+   CellID->678130364]},
+ "CompatibilityARSupport-Checkboxes"->{
+  Cell[581248, 10340, 1370, 35, 70, "Output",ExpressionUUID->"f61c5465-ffa4-4001-926f-6007a866f625",
+   CellTags->{"CheckboxCell", "CompatibilityARSupport", "CompatibilityARSupport-Checkboxes"},
+   CellID->678130364]},
+ "ScrapeDefault"->{
+  Cell[583828, 10411, 139, 3, 70, "Text",ExpressionUUID->"e5eea8d6-cf7e-442f-a42d-5ba0c0bc21c0",
+   CellTags->"ScrapeDefault",
+   CellID->642025685]},
+ "CompatibilityCloudSupport"->{
+  Cell[585116, 10448, 1328, 34, 70, "Output",ExpressionUUID->"34b1d8c5-5c2d-42a1-a08f-8d44bc1c0e10",
+   CellTags->{"CheckboxCell", "CompatibilityCloudSupport", "CompatibilityCloudSupport-Checkboxes"},
+   CellID->291004391]},
+ "CompatibilityCloudSupport-Checkboxes"->{
+  Cell[585116, 10448, 1328, 34, 70, "Output",ExpressionUUID->"34b1d8c5-5c2d-42a1-a08f-8d44bc1c0e10",
+   CellTags->{"CheckboxCell", "CompatibilityCloudSupport", "CompatibilityCloudSupport-Checkboxes"},
+   CellID->291004391]}
+ }
+*)
+(*CellTagsIndex
+CellTagsIndex->{
+ {"Name", 727440, 13151},
+ {"Title", 727600, 13155},
+ {"Caption", 727762, 13159},
+ {"CaptionCells", 727964, 13163},
+ {"TemplateCellGroup", 728171, 13167},
+ {"Initialization Code", 731130, 13213},
+ {"InitializationCode", 731357, 13217},
+ {"DefaultContent", 731580, 13221},
+ {"samplecell", 732758, 13243},
+ {"TabNext", 732952, 13247},
+ {"Manipulate", 734130, 13269},
+ {"ManipulateGroup", 734343, 13273},
+ {"SnapshotGroup", 734554, 13277},
+ {"Snapshots", 734758, 13281},
+ {"Snapshot", 734961, 13285},
+ {"SourceInformationGroup", 735443, 13295},
+ {"AuthorNames", 735622, 13299},
+ {"Contributed By", 735840, 13303},
+ {"AuthorNotes", 736055, 13307},
+ {"DetailCells", 736290, 13311},
+ {"Details & Citations", 736533, 13315},
+ {"ReferenceCells", 736771, 13319},
+ {"References", 736984, 13323},
+ {"Submission Notes", 737203, 13327},
+ {"SubmissionNotes", 737428, 13331},
+ {"Keywords", 737646, 13335},
+ {"Categories", 737839, 13339},
+ {"DemoCategories", 738056, 13343},
+ {"CheckboxCell", 738271, 13347},
+ {"Topics", 738916, 13357},
+ {"Topics-Checkboxes", 739130, 13361},
+ {"Related Demonstrations", 739349, 13365},
+ {"RelatedDemonstrations", 739591, 13369},
+ {"External Links", 739826, 13373},
+ {"ExternalLinks", 740046, 13377},
+ {"Related Symbols", 740268, 13381},
+ {"RelatedSymbols", 740491, 13385},
+ {"Published Date", 740714, 13389},
+ {"PublishedDate", 740934, 13393},
+ {"Compatibility", 741154, 13397},
+ {"CompatibilityARSupport", 741365, 13401},
+ {"CompatibilityARSupport-Checkboxes", 741624, 13405},
+ {"ScrapeDefault", 741863, 13409},
+ {"CompatibilityCloudSupport", 742046, 13413},
+ {"CompatibilityCloudSupport-Checkboxes", 742314, 13417}
+ }
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[CellGroupData[{
+Cell[580, 22, 326, 6, 70, "Title",ExpressionUUID->"866c1904-16e4-44ee-9184-9bb11f640e2e",
+ CellTags->{"Name", "Title"},
+ CellID->806361579],
+Cell[CellGroupData[{
+Cell[931, 32, 1495, 33, 70, "Section",ExpressionUUID->"41890601-af97-484b-af98-bab485770a0e",
+ CellTags->{"Caption", "CaptionCells", "TemplateCellGroup"},
+ CellID->138150581],
+Cell[2429, 67, 900, 15, 70, "Text",ExpressionUUID->"95086f4e-5220-4cc7-aa34-540a667c952b",
+ CellID->171705253]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[3366, 87, 2246, 48, 70, "Section",ExpressionUUID->"35eef4e2-7bed-4ff3-a9a3-53c85af9a2b3",
+ CellTags->{"Initialization Code", "InitializationCode", "TemplateCellGroup"},
+ CellID->447669593],
+Cell[5615, 137, 751, 16, 70, "CodeText",ExpressionUUID->"7e3e6cd8-09c5-4dd4-b1ac-7bd5c6cc93f2",
+ CellTags->{"DefaultContent", "samplecell", "TabNext"},
+ CellID->687519280]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[6403, 158, 1944, 40, 70, "Section",ExpressionUUID->"751f4140-0594-4598-9de8-56db0cbc4bfd",
+ CellTags->{"Manipulate", "ManipulateGroup", "TemplateCellGroup"},
+ CellID->791025314],
+Cell[CellGroupData[{
+Cell[8372, 202, 9917, 253, 70, "Input",ExpressionUUID->"64c4fb47-7afb-4e9e-9c7c-dfa4218eebfb",
+ CellID->913152983],
+Cell[18292, 457, 5554, 113, 70, "Output",ExpressionUUID->"42f7e86c-24c1-43e9-835b-de103ad72916",
+ CellID->1394899794]
+}, Open  ]]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[23895, 576, 1302, 31, 70, "Section",ExpressionUUID->"21d2b916-5354-4bd6-b138-bd27b92b77b3",
+ CellTags->{"SnapshotGroup", "Snapshots", "TemplateCellGroup"},
+ CellID->98938448],
+Cell[25200, 609, 182911, 3004, 70, "Output",ExpressionUUID->"59abde20-a871-4db6-b5f0-a98e22762731",
+ CellID->966124099],
+Cell[208114, 3615, 55504, 917, 70, "Output",ExpressionUUID->"57b1cd9f-c821-4027-b186-9df09f1bddef",
+ CellTags->"Snapshot",
+ CellID->1759672171],
+Cell[263621, 4534, 55662, 919, 70, "Output",ExpressionUUID->"b037802b-902b-433d-b439-a0c8bb8414ac",
+ CellTags->"Snapshot",
+ CellID->1812875160],
+Cell[319286, 5455, 54754, 904, 70, "Output",ExpressionUUID->"6623e441-b1ca-4f02-a6d3-c7831a396c1b",
+ CellTags->"Snapshot",
+ CellID->494830484]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[374077, 6364, 273, 5, 70, "Section",ExpressionUUID->"e67b7ac9-7ce5-4e24-a422-e84cd737770a",
+ CellTags->"SourceInformationGroup",
+ CellID->62407265],
+Cell[CellGroupData[{
+Cell[374375, 6373, 1221, 29, 70, "Subsection",ExpressionUUID->"65396ff6-955e-4046-8d9f-2280747f913c",
+ CellTags->{"AuthorNames", "Contributed By", "TemplateCellGroup"},
+ CellID->255368948],
+Cell[375599, 6404, 129, 2, 70, "Text",ExpressionUUID->"5a18061c-5dd7-4ddc-899f-51bd0203baac",
+ CellID->161482345]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[375765, 6411, 2197, 46, 70, "Subsection",ExpressionUUID->"c6e8eb5c-33d4-4a2b-930c-b905e32940af",
+ CellTags->{"AuthorNotes", "DetailCells", "Details & Citations", "TemplateCellGroup"},
+ CellID->441931514],
+Cell[377965, 6459, 592, 9, 70, "Text",ExpressionUUID->"a44ba792-9b26-497a-92e4-5a60c079de85",
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->111711384]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[378594, 6473, 2173, 45, 70, "Subsection",ExpressionUUID->"2a8f96e3-65d2-4fe8-8c67-f9391216f923",
+ CellTags->{"ReferenceCells", "References", "TemplateCellGroup"},
+ CellID->592881655],
+Cell[380770, 6520, 578, 9, 70, "Text",ExpressionUUID->"ce89f651-625f-4b84-b2b4-17029aac56e2",
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->423796343]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[381385, 6534, 1242, 30, 70, "Subsection",ExpressionUUID->"6b3b01e9-6ca1-487e-ab6c-2312fc9df879",
+ CellTags->{"Submission Notes", "SubmissionNotes", "TemplateCellGroup"},
+ CellID->797097429],
+Cell[382630, 6566, 589, 9, 70, "Text",ExpressionUUID->"53319a44-3896-4fc6-bf9f-f08f087e1424",
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->820829112]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[383256, 6580, 1106, 27, 70, "Subsection",ExpressionUUID->"6074178a-3ee1-448f-bdda-18641673cfd6",
+ CellTags->{"Keywords", "TemplateCellGroup"},
+ CellID->938146184],
+Cell[384365, 6609, 120, 2, 70, "Item",ExpressionUUID->"d3daeb29-3afc-4e72-9375-237d18747143",
+ CellID->386963008],
+Cell[384488, 6613, 117, 2, 70, "Item",ExpressionUUID->"12e333bb-320f-46c0-9bd7-920a201d0301",
+ CellID->247815498],
+Cell[384608, 6617, 117, 2, 70, "Item",ExpressionUUID->"da60c26f-0b44-4a4e-bb98-8f28ae70e49f",
+ CellID->96860228],
+Cell[384728, 6621, 118, 2, 70, "Item",ExpressionUUID->"f35ff1e7-5347-4258-a1ee-276bc633483b",
+ CellID->639559915],
+Cell[384849, 6625, 118, 2, 70, "Item",ExpressionUUID->"c2812707-1d48-4d75-b610-2e7bf70ce128",
+ CellID->19443273]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[385004, 6632, 1128, 27, 70, "Subsection",ExpressionUUID->"53143ca2-f91a-4c84-a16e-14dccff6475c",
+ CellTags->{"Categories", "DemoCategories", "TemplateCellGroup"},
+ CellID->845692503],
+Cell[386135, 6661, 185783, 3435, 70, "Output",ExpressionUUID->"ea774907-334f-403a-8e2e-013c07972c0d",
+ CellTags->{"CheckboxCell", "Topics", "Topics-Checkboxes"},
+ CellID->375137771]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[571955, 10101, 1216, 30, 70, "Subsection",ExpressionUUID->"53eefeb9-f7fb-49cc-a999-6f677ead9d51",
+ CellTags->{"Related Demonstrations", "RelatedDemonstrations", "TemplateCellGroup"},
+ CellID->1132753],
+Cell[573174, 10133, 580, 9, 70, "Item",ExpressionUUID->"0d6e2845-dbfa-4e1c-b780-969415c4146e",
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->904163252]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[573791, 10147, 1558, 37, 70, "Subsection",ExpressionUUID->"c7e61a88-e056-4fd4-92f6-d76c81bf19d6",
+ CellTags->{"External Links", "ExternalLinks", "TemplateCellGroup"},
+ CellID->843468725],
+Cell[575352, 10186, 577, 9, 70, "Item",ExpressionUUID->"c3717123-fab8-49ef-bb07-872904b07f43",
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->180966586]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[575966, 10200, 1191, 29, 70, "Subsection",ExpressionUUID->"39801c7c-0114-4a4e-9bdc-d1e59d88d289",
+ CellTags->{"Related Symbols", "RelatedSymbols", "TemplateCellGroup"},
+ CellID->899564547],
+Cell[577160, 10231, 596, 9, 70, "Item",ExpressionUUID->"6519833f-75b7-4b82-8ac9-a1c215acba33",
+ CellTags->{"DefaultContent", "TabNext"},
+ CellID->159321921]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[577793, 10245, 1070, 26, 70, "Subsection",ExpressionUUID->"96c4ac55-b088-49f7-9ebd-b94233dc8a81",
+ CellTags->{"Published Date", "PublishedDate", "TemplateCellGroup"},
+ CellID->364555554],
+Cell[578866, 10273, 119, 2, 70, "Text",ExpressionUUID->"37c281de-8208-45f7-96b3-8db2ef28ad4c",
+ CellID->15904391]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[579022, 10280, 1073, 26, 70, "Subsection",ExpressionUUID->"0d510131-c801-4515-915b-232ee417072a",
+ CellTags->{"Compatibility", "TemplateCellGroup"},
+ CellID->618273920],
+Cell[CellGroupData[{
+Cell[580120, 10310, 1125, 28, 70, "Subsubsection",ExpressionUUID->"00faa4f7-afe3-48ea-8c73-56a7a3482e4d",
+ CellID->855747700],
+Cell[581248, 10340, 1370, 35, 70, "Output",ExpressionUUID->"f61c5465-ffa4-4001-926f-6007a866f625",
+ CellTags->{"CheckboxCell", "CompatibilityARSupport", "CompatibilityARSupport-Checkboxes"},
+ CellID->678130364]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[582655, 10380, 1170, 29, 70, "Subsubsection",ExpressionUUID->"7024026e-3452-4886-8db9-20f5fe0c495b",
+ CellID->96439972],
+Cell[583828, 10411, 139, 3, 70, "Text",ExpressionUUID->"e5eea8d6-cf7e-442f-a42d-5ba0c0bc21c0",
+ CellTags->"ScrapeDefault",
+ CellID->642025685]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[584004, 10419, 1109, 27, 70, "Subsubsection",ExpressionUUID->"afc79548-0ab3-464e-b662-10499fc58080",
+ CellID->122353723],
+Cell[585116, 10448, 1328, 34, 70, "Output",ExpressionUUID->"34b1d8c5-5c2d-42a1-a08f-8d44bc1c0e10",
+ CellTags->{"CheckboxCell", "CompatibilityCloudSupport", "CompatibilityCloudSupport-Checkboxes"},
+ CellID->291004391]
+}, Closed]]
+}, Open  ]]
+}, Closed]]
+}, Open  ]]
+}
+]
+*)
+
+(* End of internal cache information *)


### PR DESCRIPTION
## Summary

- Woxi Studio was tested against the Wolfram Demonstration ["Latitude and Longitude of a Point on a Sphere"](https://demonstrations.wolfram.com/LatitudeAndLongitudeOfAPointOnASphere/) (`tests/notebooks/latitude_longitude_sphere.nb`, added by this PR).
- Its `Manipulate` builds `Show[Graphics3D[...], ParametricPlot3D[...], ..., PlotLabel -> Style[Column[{...}], "Label"], ...]` — a multi-line caption of computed values, a common Demonstrations pattern. Woxi Studio rendered this `PlotLabel` as a single line of raw `Column[{...}]` syntax instead of stacking each row, because the 3-D `PlotLabel` renderer only ever called the single-line `expr_to_svg_markup`, unlike the 2-D chart renderers (`Plot`/`BarChart`/`PieChart`), which already stack `Grid`/`Column` titles via `StyledLabel`.
- Routed the 3-D `PlotLabel` renderer through the same `StyledLabel`/`parse_styled_label` machinery the 2-D renderers use, and taught `parse_styled_label` to look through a `Style[...]` wrapper around a `Grid`/`Column` so the stacking survives being wrapped that way (`Style[Column[{...}], "Label"]`, exactly as this Demonstration writes it).
- Along the way, found and fixed a related pre-existing gap: `parse_style_directive_args` didn't recognize the `FontSize -> value` / `FontColor -> value` / `FontSlant -> Italic` / `FontWeight -> Bold` rule syntax for style directives (only bare values like `Style[expr, 18, Blue]` were recognized), unlike `expr_to_svg_markup`'s own `Style` handling. Fixed to keep the two in sync.

## Test plan

- [x] Added `graphics3d_plot_label_grid_stacks_lines` and `graphics3d_plot_label_style_wrapped_column_stacks_lines` regression tests in `tests/interpreter_tests/graphics.rs`.
- [x] `make test` — all 27,269 tests pass.
- [x] `make format`.
- [x] Verified with `cargo run -p woxi-studio --example dump_manipulate -- tests/notebooks/latitude_longitude_sphere.nb` that the Demonstration's `Manipulate` now builds its widget and renders the stacked `PlotLabel` correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NanwaRTnDGEnK5grkbjmSi)_