### PR TITLE
Fix Sinh/Cosh complex-float evaluation and ContourPlot PlotLabel support

### DIFF
--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -185,6 +185,9 @@ struct DensityContourOptions {
   /// `Epilog -> {…}`: graphics primitives drawn over the finished plot,
   /// in data coordinates.
   epilog: Vec<Expr>,
+  /// `PlotLabel -> …`: the caption drawn above the plot, already typeset
+  /// as SVG markup, alongside the font size its outer `Style` asked for.
+  plot_label: Option<(String, Option<f64>)>,
 }
 
 /// Parse ImageSize, ColorFunction, Contours, ContourShading, Mesh,
@@ -302,6 +305,7 @@ fn parse_density_contour_options(
     contour_style,
     frame_labels,
     epilog,
+    plot_label: parse_field_plot_label(args, start),
   }
 }
 
@@ -341,9 +345,17 @@ fn field_plot_axes(
   y_range: (f64, f64),
   opts: &DensityContourOptions,
 ) -> Result<crate::functions::plot::PlotArea, InterpreterError> {
-  let margins = opts.has_outer_frame_labels().then_some({
+  let needs_margins =
+    opts.has_outer_frame_labels() || opts.plot_label.is_some();
+  let margins = needs_margins.then_some({
+    let top_margin = match &opts.plot_label {
+      Some((_, size)) => {
+        ((size.unwrap_or(14.0) * 2.0).round() as u32) * RESOLUTION_SCALE
+      }
+      None => 10 * RESOLUTION_SCALE,
+    };
     crate::functions::plot::MarginOverrides {
-      top_margin: 10 * RESOLUTION_SCALE,
+      top_margin,
       x_label_area: (40 + 24) * RESOLUTION_SCALE,
       y_label_area: (65 + 20) * RESOLUTION_SCALE,
     }
@@ -367,6 +379,9 @@ fn push_field_plot_overlays(
   area: &crate::functions::plot::PlotArea,
   opts: &DensityContourOptions,
 ) {
+  if let Some(label) = &opts.plot_label {
+    inject_field_plot_label(svg, area, label);
+  }
   if !opts.epilog.is_empty() {
     let epilog_area = crate::functions::plot_epilog::PlotArea {
       x0: area.plot_x0,

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -9077,6 +9077,15 @@ pub fn expr_to_svg_markup(expr: &Expr) -> String {
           format!("<tspan style=\"letter-spacing:{pts:.2}px\"> </tspan>")
         }
 
+        // Framed[content, …] / Highlighted[content, …] set inline text —
+        // a `PlotLabel`/`AxesLabel` markup line has no room to draw the
+        // frame's border or highlight fill around it, so just typeset the
+        // content (matching `Tooltip`, whose hover-only chrome the same
+        // static context can't show either).
+        "Framed" | "Highlighted" if !args.is_empty() => {
+          expr_to_svg_markup(&args[0])
+        }
+
         // Row[{a, b, …}] concatenates its parts; Row[{…}, sep] joins
         // them with the separator.
         "Row" if !args.is_empty() => match &args[0] {

--- a/src/functions/math_ast/trigonometric.rs
+++ b/src/functions/math_ast/trigonometric.rs
@@ -4253,6 +4253,15 @@ pub fn sinh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Real(f) => return Ok(Expr::Real(f.sinh())),
     _ => {}
   }
+  // Complex float: sinh(a+bi) = sinh(a)*cos(b) + i*cosh(a)*sin(b)
+  if contains_float(&args[0])
+    && let Some((re, im)) = try_extract_complex_float(&args[0])
+    && im != 0.0
+  {
+    let sinh_re = re.sinh() * im.cos();
+    let cosh_re = re.cosh() * im.sin();
+    return build_complex_float_result(sinh_re, cosh_re);
+  }
   // Sinh[Log[u]] = (u^2 - 1)/(2 u)
   if let Some(res) = hyperbolic_of_log("Sinh", &args[0]) {
     return res;
@@ -4307,6 +4316,15 @@ pub fn cosh_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(0) => return Ok(Expr::Integer(1)),
     Expr::Real(f) => return Ok(Expr::Real(f.cosh())),
     _ => {}
+  }
+  // Complex float: cosh(a+bi) = cosh(a)*cos(b) + i*sinh(a)*sin(b)
+  if contains_float(&args[0])
+    && let Some((re, im)) = try_extract_complex_float(&args[0])
+    && im != 0.0
+  {
+    let cosh_re = re.cosh() * im.cos();
+    let sinh_re = re.sinh() * im.sin();
+    return build_complex_float_result(cosh_re, sinh_re);
   }
   // Cosh[Log[u]] = (u^2 + 1)/(2 u)
   if let Some(res) = hyperbolic_of_log("Cosh", &args[0]) {

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -909,6 +909,32 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_plot3d_framed_plotlabel_typesets_content() {
+    // Regression: Plot3D[…, PlotLabel -> Style[Framed[TraditionalForm[expr]],
+    // …]] (the pattern the "Complex Exponential and Logarithm Functions"
+    // Demonstration's Manipulate uses) printed the literal `Framed[…]`
+    // wrapper text instead of typesetting the boxed content. SVG text
+    // markup has no room to draw the frame's border, so the fix typesets
+    // the content plain rather than leaking the head.
+    clear_state();
+    let svg = interpret_with_stdout(
+      "Plot3D[x + y, {x, -1, 1}, {y, -1, 1}, \
+       PlotLabel -> Style[Framed[TraditionalForm[Re[Exp[z]]]], Blue]]",
+    )
+    .unwrap()
+    .graphics
+    .expect("Plot3D should produce a graphics SVG");
+    assert!(
+      !svg.contains("Framed["),
+      "Framed PlotLabel must not leak its literal head:\n{svg}"
+    );
+    assert!(
+      svg.contains("Re(") || svg.contains("Re["),
+      "Framed PlotLabel should still typeset its content:\n{svg}"
+    );
+  }
+
+  #[test]
   fn test_column_with_nested_tableform_renders_as_graphics() {
     // In visual mode (playground / woxi-studio), a Column containing a
     // TableForm must pre-render the table as a sub-SVG instead of falling

--- a/tests/interpreter_tests/arithmetic.rs
+++ b/tests/interpreter_tests/arithmetic.rs
@@ -4554,6 +4554,37 @@ mod expand_threading {
     );
   }
 
+  // Regression: Sinh/Cosh of a complex float with both real and imaginary
+  // parts nonzero used to stay unevaluated (only the pure-imaginary case
+  // reduced, via Sinh[I*x] = I*Sin[x] / Cosh[I*x] = Cos[x]), which made
+  // Plot3D[Abs[Cosh[x + I*y]], ...] over a range spanning nonzero x report
+  // "function produced no finite values in the given range".
+  #[test]
+  fn sinh_complex_float() {
+    assert_eq!(
+      interpret("Sinh[1.0 + I]").unwrap(),
+      "0.6349639147847361 + 1.2984575814159773*I"
+    );
+  }
+
+  #[test]
+  fn cosh_complex_float() {
+    assert_eq!(
+      interpret("Cosh[1.0 + I]").unwrap(),
+      "0.8337300251311491 + 0.9888977057628651*I"
+    );
+  }
+
+  #[test]
+  fn abs_cosh_complex_float_is_finite() {
+    let result = interpret("N[Abs[Cosh[5.0 + 8.0*I]]]").unwrap();
+    let v: f64 = result.parse().expect("expected a finite real number");
+    assert!(
+      v.is_finite(),
+      "Abs[Cosh[5+8I]] should be finite, got {result}"
+    );
+  }
+
   #[test]
   fn conjugate_real_constants() {
     assert_eq!(interpret("Conjugate[Pi]").unwrap(), "Pi");

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -9969,6 +9969,35 @@ ParametricPlot[f[t], {t, 0, 1}]]",
       );
     }
 
+    /// Regression: `ContourPlot` used to ignore `PlotLabel` entirely (no
+    /// text drawn, no headroom reserved), unlike `Plot`/`Plot3D`/`PieChart`.
+    /// A `Framed[…]` label must also typeset its content rather than
+    /// printing the literal `Framed[…]` wrapper — SVG text markup has no
+    /// room to draw the frame's border, so it typesets the content plain.
+    #[test]
+    fn contour_plot_honors_plot_label() {
+      let svg = export_svg(
+        "ContourPlot[x + y, {x, 0, 4}, {y, 0, 4}, PlotLabel -> \"caption\"]",
+      );
+      assert!(
+        svg.contains(">caption</text>"),
+        "missing PlotLabel in:\n{svg}"
+      );
+
+      let framed_svg = export_svg(
+        "ContourPlot[x + y, {x, 0, 4}, {y, 0, 4}, \
+         PlotLabel -> Style[Framed[\"boxed\"], Blue]]",
+      );
+      assert!(
+        framed_svg.contains(">boxed<"),
+        "Framed PlotLabel content missing:\n{framed_svg}"
+      );
+      assert!(
+        !framed_svg.contains("Framed["),
+        "Framed PlotLabel must not leak its literal head:\n{framed_svg}"
+      );
+    }
+
     /// A `DensityPlot` takes the same labels and epilog — the option
     /// parsing is shared across the whole density/contour family.
     #[test]


### PR DESCRIPTION
## Summary

Found while checking whether Woxi Studio fully supports a random Wolfram Demonstration — "Complex Exponential and Logarithm Functions" (a `Manipulate` over `Plot3D`/`ContourPlot` of `Exp`/`Log`/`Cos`/`Sin`/`Cosh`/`Sinh`, with a `Framed`, `TraditionalForm`-styled `PlotLabel`). Testing it through `woxi-studio`'s headless `dump_manipulate`/`test_notebook` example harnesses (which exercise the exact pipeline Woxi Studio uses for interactive cells) surfaced three real bugs, not specific to this one notebook:

- **`Sinh`/`Cosh` never evaluated a complex float argument with both real and imaginary parts nonzero** (only the pure-real and pure-imaginary special cases reduced). `Sin`/`Cos`/`Exp`/`Log` already had this complex-float branch; `Sinh`/`Cosh` didn't. This made `Plot3D[Abs[Cosh[x + I*y]], ...]` over a range spanning nonzero `x` report "function produced no finite values in the given range" instead of drawing the surface.
- **`ContourPlot` silently ignored `PlotLabel` entirely**, unlike `Plot`/`Plot3D`/`PieChart`. Wired the density/contour family's existing `PlotLabel` parsing/rendering (already used by other field-style plots) into `ContourPlot`/`DensityPlot`/`ListContourPlot`/`ListDensityPlot` via their one shared implementation, rather than duplicating it.
- **A `Framed[...]` label printed its literal head** (`Framed[Re[ⅇ^z]]`) instead of typesetting its content, because inline SVG text markup (used for `PlotLabel`/`AxesLabel`/etc.) has no room to draw an actual frame border — it fell through to the generic `name[args...]` fallback. Now it typesets the content, matching how `Tooltip`'s hover-only chrome is already dropped in this same static context.

## Test plan

- [x] Added `sinh_complex_float` / `cosh_complex_float` / `abs_cosh_complex_float_is_finite` unit tests in `tests/interpreter_tests/arithmetic.rs`
- [x] Added `contour_plot_honors_plot_label` in `tests/interpreter_tests/graphics.rs`
- [x] Added `test_plot3d_framed_plotlabel_typesets_content` in `tests/interpreter_tests.rs`
- [x] `make test` — full suite (27,279 tests) passes
- [x] `make format`
- [x] Re-verified the original Demonstration's `Manipulate` renders correctly across all `{plottype, part, func}` combinations (`Plot3D`/`ContourPlot` × `Re`/`Im`/`Abs` × `Exp`/`Log`/`Cos`/`Sin`/`Cosh`/`Sinh`) via `cargo run -p woxi-studio --example dump_manipulate`, with no errors and no literal-text leaks


---
_Generated by [Claude Code](https://claude.ai/code/session_015nFxyyq16pgd2XwxoBKFct)_