### PR TITLE
Support VertexLabeling -> False in TreeForm

### DIFF
--- a/src/functions/tree_form.rs
+++ b/src/functions/tree_form.rs
@@ -220,6 +220,27 @@ pub fn tree_form_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
   let font_size_int = (font_size.round() as i128).max(8);
 
+  // `VertexLabeling -> False` displays each vertex as a plain point instead
+  // of a labeled box; any other setting (including the default) keeps the
+  // labeled-box rendering.
+  let vertex_labeling = args[1..]
+    .iter()
+    .find_map(|a| match a {
+      Expr::Rule {
+        pattern,
+        replacement,
+      } if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "VertexLabeling") =>
+      {
+        match replacement.as_ref() {
+          Expr::Identifier(s) if s == "False" => Some(false),
+          Expr::Identifier(s) if s == "True" => Some(true),
+          _ => None,
+        }
+      }
+      _ => None,
+    })
+    .unwrap_or(true);
+
   // Generate Graphics primitives: Lines for edges, then boxes and text
   let mut primitives: Vec<Expr> = Vec::new();
 
@@ -247,89 +268,110 @@ pub fn tree_form_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     }
   }
 
-  // First pass: rectangular boxes for every node (drawn on top of edges)
-  for node in &layout {
-    let is_leaf = node.children_indices.is_empty();
-    let hw = box_half_width(&node.label);
-    let hh = box_half_height;
+  if vertex_labeling {
+    // First pass: rectangular boxes for every node (drawn on top of edges)
+    for node in &layout {
+      let is_leaf = node.children_indices.is_empty();
+      let hw = box_half_width(&node.label);
+      let hh = box_half_height;
 
-    if is_leaf {
-      // Leaf nodes: white fill, black border
-      primitives.push(call(
-        "EdgeForm",
-        vec![call(
+      if is_leaf {
+        // Leaf nodes: white fill, black border
+        primitives.push(call(
+          "EdgeForm",
+          vec![call(
+            "RGBColor",
+            vec![Expr::Real(0.0), Expr::Real(0.0), Expr::Real(0.0)],
+          )],
+        ));
+        primitives.push(call(
+          "RGBColor",
+          vec![Expr::Real(1.0), Expr::Real(1.0), Expr::Real(1.0)],
+        ));
+      } else {
+        // Internal nodes: light orange fill, orange border
+        primitives.push(call(
+          "EdgeForm",
+          vec![call(
+            "RGBColor",
+            vec![Expr::Real(0.84), Expr::Real(0.48), Expr::Real(0.0)],
+          )],
+        ));
+        primitives.push(call(
+          "RGBColor",
+          vec![Expr::Real(1.0), Expr::Real(0.95), Expr::Real(0.85)],
+        ));
+      }
+
+      primitives.push(Expr::FunctionCall {
+        name: "Rectangle".to_string(),
+        args: vec![
+          Expr::List(
+            vec![Expr::Real(node.x - hw), Expr::Real(node.y - hh)].into(),
+          ),
+          Expr::List(
+            vec![Expr::Real(node.x + hw), Expr::Real(node.y + hh)].into(),
+          ),
+        ]
+        .into(),
+      });
+    }
+
+    // Second pass: text labels for all nodes (on top of boxes)
+    primitives.push(call0("EdgeForm"));
+
+    for node in &layout {
+      let is_leaf = node.children_indices.is_empty();
+
+      if is_leaf {
+        // Leaf nodes: black text
+        primitives.push(call(
           "RGBColor",
           vec![Expr::Real(0.0), Expr::Real(0.0), Expr::Real(0.0)],
-        )],
-      ));
-      primitives.push(call(
-        "RGBColor",
-        vec![Expr::Real(1.0), Expr::Real(1.0), Expr::Real(1.0)],
-      ));
-    } else {
-      // Internal nodes: light orange fill, orange border
-      primitives.push(call(
-        "EdgeForm",
-        vec![call(
+        ));
+      } else {
+        // Internal nodes: dark orange text
+        primitives.push(call(
           "RGBColor",
           vec![Expr::Real(0.84), Expr::Real(0.48), Expr::Real(0.0)],
-        )],
-      ));
-      primitives.push(call(
-        "RGBColor",
-        vec![Expr::Real(1.0), Expr::Real(0.95), Expr::Real(0.85)],
-      ));
+        ));
+      }
+
+      primitives.push(Expr::FunctionCall {
+        name: "Text".to_string(),
+        args: vec![
+          Expr::FunctionCall {
+            name: "Style".to_string(),
+            args: vec![
+              Expr::String(node.label.clone()),
+              Expr::Integer(font_size_int),
+            ]
+            .into(),
+          },
+          Expr::List(vec![Expr::Real(node.x), Expr::Real(node.y)].into()),
+        ]
+        .into(),
+      });
     }
-
-    primitives.push(Expr::FunctionCall {
-      name: "Rectangle".to_string(),
-      args: vec![
-        Expr::List(
-          vec![Expr::Real(node.x - hw), Expr::Real(node.y - hh)].into(),
-        ),
-        Expr::List(
-          vec![Expr::Real(node.x + hw), Expr::Real(node.y + hh)].into(),
-        ),
-      ]
-      .into(),
-    });
-  }
-
-  // Second pass: text labels for all nodes (on top of boxes)
-  primitives.push(call0("EdgeForm"));
-
-  for node in &layout {
-    let is_leaf = node.children_indices.is_empty();
-
-    if is_leaf {
-      // Leaf nodes: black text
-      primitives.push(call(
-        "RGBColor",
-        vec![Expr::Real(0.0), Expr::Real(0.0), Expr::Real(0.0)],
-      ));
-    } else {
-      // Internal nodes: dark orange text
-      primitives.push(call(
-        "RGBColor",
-        vec![Expr::Real(0.84), Expr::Real(0.48), Expr::Real(0.0)],
-      ));
+  } else {
+    // VertexLabeling -> False: display each vertex as a plain black point
+    // instead of a labeled box.
+    let dot_radius = box_half_height * 0.35;
+    primitives.push(call0("EdgeForm"));
+    primitives.push(call(
+      "RGBColor",
+      vec![Expr::Real(0.0), Expr::Real(0.0), Expr::Real(0.0)],
+    ));
+    for node in &layout {
+      primitives.push(Expr::FunctionCall {
+        name: "Disk".to_string(),
+        args: vec![
+          Expr::List(vec![Expr::Real(node.x), Expr::Real(node.y)].into()),
+          Expr::Real(dot_radius),
+        ]
+        .into(),
+      });
     }
-
-    primitives.push(Expr::FunctionCall {
-      name: "Text".to_string(),
-      args: vec![
-        Expr::FunctionCall {
-          name: "Style".to_string(),
-          args: vec![
-            Expr::String(node.label.clone()),
-            Expr::Integer(font_size_int),
-          ]
-          .into(),
-        },
-        Expr::List(vec![Expr::Real(node.x), Expr::Real(node.y)].into()),
-      ]
-      .into(),
-    });
   }
 
   // Build Graphics[{primitives...}, ImageSize -> width]

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -12745,6 +12745,63 @@ mod tree_form_graphics {
     assert!(result.contains("Plus"), "Expected Plus node in tree");
     assert!(result.contains("Power"), "Expected Power node in tree");
   }
+
+  #[test]
+  fn tree_form_vertex_labeling_true_shows_node_labels() {
+    // VertexLabeling -> True (also the default) keeps the labeled-box
+    // rendering: every node's head/atom text appears in the SVG.
+    clear_state();
+    let result = interpret(
+      "ExportString[TreeForm[a + b*c, VertexLabeling -> True], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(result.contains("<svg"), "Expected SVG output");
+    assert!(result.contains("Plus"), "Expected Plus node label in tree");
+    assert!(
+      result.contains("Times"),
+      "Expected Times node label in tree"
+    );
+  }
+
+  #[test]
+  fn tree_form_vertex_labeling_false_hides_node_labels() {
+    // VertexLabeling -> False displays each vertex as a plain point instead
+    // of a labeled box, so none of the node text should appear.
+    clear_state();
+    let result = interpret(
+      "ExportString[TreeForm[a + b*c, VertexLabeling -> False], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(result.contains("<svg"), "Expected SVG output");
+    assert!(
+      !result.contains("Plus"),
+      "VertexLabeling -> False should not show the Plus node label"
+    );
+    assert!(
+      !result.contains("Times"),
+      "VertexLabeling -> False should not show the Times node label"
+    );
+  }
+
+  #[test]
+  fn tree_form_vertex_labeling_false_still_renders_edges() {
+    // Hiding vertex labels should not remove the tree's edges: the SVG must
+    // still contain line segments connecting the (now unlabeled) nodes.
+    clear_state();
+    let result = interpret(
+      "ExportString[TreeForm[f[g[x], h[y]], VertexLabeling -> False], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(result.contains("<svg"), "Expected SVG output");
+    assert!(
+      result.contains("<polyline") || result.contains("<line"),
+      "Expected edge lines connecting the tree nodes"
+    );
+    assert!(
+      result.contains("<ellipse") || result.contains("<circle"),
+      "Expected a plain point/dot for each vertex"
+    );
+  }
 }
 
 mod graphics_row {


### PR DESCRIPTION
## Summary

- A randomly sampled Wolfram Demonstration notebook ("Expression Trees for Integrals") drives a `TreeForm[..., VertexLabeling -> se, ...]` call where `se` toggles between `True`/`False` via a "label subexpressions" checkbox.
- Woxi's `TreeForm` rendering ignored the `VertexLabeling` option entirely, so both settings produced an identical labeled-box tree — the toggle had no visible effect in Woxi Studio.
- Per the Wolfram documentation, `VertexLabeling -> False` should display each vertex as a plain point. This PR implements that: when `VertexLabeling -> False` is passed, `TreeForm` now renders each node as an unlabeled dot instead of a labeled box, while `True` (and the default, unset case) keeps the existing labeled-box rendering.

## Test plan

- [x] Added unit tests in `tests/interpreter_tests/graphics.rs` covering `VertexLabeling -> True` (labels present), `VertexLabeling -> False` (labels absent, edges/dots still present), matching the documented option semantics.
- [x] `make test` — all 27277 tests pass.
- [x] `make format`
- [x] Manually verified the downloaded Demonstration notebook still parses and evaluates via `woxi run` with no errors, and that toggling `VertexLabeling` now produces visibly different SVG output.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WSde8ziR89QMKcsHCJXwWH)_