### PR TITLE
Fix Manipulate widgets that one unsupported control spec silently killed

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -17304,9 +17304,17 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
           manipulate_post_body_bindings(args.first(), &initial_bindings)
         })
         .clone();
-      crate::with_scoped_globals(&after_body, || {
+      let Some(parsed) = crate::with_scoped_globals(&after_body, || {
         parse_manipulate_control(&spec, &sibling_names)
-      })?
+      }) else {
+        // A spec neither the leading-assignment probe nor a full body run
+        // can make sense of is skipped rather than failing the whole
+        // Manipulate — one unrecognised control row must not take every
+        // other, already-understood row down with it (see the comment
+        // above the loop on `Initialization`/`TrackedSymbols`).
+        continue;
+      };
+      parsed
     };
     match parsed {
       ParsedControl::Visible {
@@ -20618,6 +20626,27 @@ fn parse_manipulate_control(
     }
     let value = crate::syntax::expr_to_input_form(bounds[0]);
     return Some(ParsedControl::Fixed { name, value });
+  }
+
+  // No domain at all — `{u, uinit}` or `{{u, uinit, ulbl}, opts…}` with
+  // nothing but options (`FieldSize -> n`, `Enabled -> cond`, …) after the
+  // head. Wolfram's default widget for a bare variable with no min/max and
+  // no choice list is an `InputField`; the Demonstrations idiom pairs one
+  // with `Enabled -> False` to show a value driven entirely by another
+  // control's `EventHandler` (a read-only status field next to a grid of
+  // clickable cells). Woxi has no dedicated InputField widget, but the same
+  // live-value display a `TogglerBar[Dynamic[v], …]` gets above renders the
+  // current value as text and updates it every re-evaluation, which is
+  // enough to keep the variable both mutable and visible.
+  if bounds.is_empty() {
+    let value = explicit_initial
+      .as_ref()
+      .map_or_else(|| "Null".to_string(), manipulate_value_to_input_form);
+    return Some(ParsedControl::StateWithDisplay {
+      name: name.clone(),
+      value,
+      display: format!("Dynamic[{name}]"),
+    });
   }
 
   // Continuous form: {u, umin, umax} or {u, umin, umax, du}

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -11086,10 +11086,14 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
         }
         _ => fmt(pattern),
       };
-      // Parenthesize RHS if it's a pure function (& has low precedence)
+      // Parenthesize RHS if it's a pure function (& has low precedence) or a
+      // `;`-sequence (CompoundExpression binds looser than every operator,
+      // including `->`, so `a -> b; c` is `(a -> b); c` without parens —
+      // dropping them would silently turn `key -> (v1; v2)` into two
+      // top-level statements instead of one rule).
       let rhs_str = fmt(replacement);
       let rhs_final = match replacement.as_ref() {
-        Expr::Function { .. } => format!("({rhs_str})"),
+        Expr::Function { .. } | Expr::CompoundExpr(_) => format!("({rhs_str})"),
         _ => rhs_str,
       };
       format!("{lhs} -> {rhs_final}")
@@ -11109,7 +11113,12 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
         _ => fmt(pattern),
       };
       // Parenthesize RHS if it's an assignment so the := operator is
-      // correctly disambiguated from the :> operator visually.
+      // correctly disambiguated from the :> operator visually, or if it's a
+      // `;`-sequence — CompoundExpression has the lowest precedence of any
+      // operator, so `cond :> a = 1; b = 2` is `(cond :> a = 1); b = 2`
+      // without parens (the Demonstrations idiom `"event" :> (a = 1; b =
+      // 2)` for a multi-statement event handler action would silently lose
+      // its later statements from the rule).
       let rhs_str = fmt(replacement);
       let rhs_final = match replacement.as_ref() {
         Expr::FunctionCall { name: n, args: a }
@@ -11120,6 +11129,7 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
         {
           format!("({rhs_str})")
         }
+        Expr::CompoundExpr(_) => format!("({rhs_str})"),
         _ => rhs_str,
       };
       format!("{lhs} :> {rhs_final}")
@@ -11585,10 +11595,16 @@ fn input_form_rule_lhs(e: &Expr) -> String {
 }
 
 /// Parenthesize a rule's RHS when it is a pure function, since `&` binds
-/// looser than `->`/`:>` (`x -> (#1 & )`), matching wolframscript.
+/// looser than `->`/`:>` (`x -> (#1 & )`), matching wolframscript. A
+/// `;`-sequence is parenthesized too: `CompoundExpression` has the lowest
+/// precedence of any operator, so `x -> a; b` is `(x -> a); b` without
+/// parens — printing `x -> (a; b)` bare would silently split one rule into
+/// a rule plus a stray top-level statement once re-parsed.
 fn input_form_rule_rhs(e: &Expr) -> String {
   match e {
-    Expr::Function { .. } => format!("({})", expr_to_input_form(e)),
+    Expr::Function { .. } | Expr::CompoundExpr(_) => {
+      format!("({})", expr_to_input_form(e))
+    }
     _ => expr_to_input_form(e),
   }
 }
@@ -11819,7 +11835,12 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
       // Parenthesize RHS if it's an assignment (Set/SetDelayed/Up*), so
       // that e.g. `Initialization :> (d[t_] := ...)` renders with the
       // parentheses required to disambiguate operator precedence. A pure
-      // function on the RHS is also parenthesised (`&` binds looser than `:>`).
+      // function on the RHS is also parenthesised (`&` binds looser than
+      // `:>`), and so is a `;`-sequence — `CompoundExpression` has the
+      // lowest precedence of any operator, so `cond :> a = 1; b = 2` is
+      // `(cond :> a = 1); b = 2` without parens (the Demonstrations idiom
+      // `"event" :> (a = 1; b = 2)` for a multi-statement action would
+      // silently lose its later statements once re-parsed).
       let rhs_str = expr_to_input_form(replacement);
       let rhs_final = match replacement.as_ref() {
         Expr::FunctionCall { name: n, args: a }
@@ -11830,7 +11851,7 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
         {
           format!("({rhs_str})")
         }
-        Expr::Function { .. } => format!("({rhs_str})"),
+        Expr::Function { .. } | Expr::CompoundExpr(_) => format!("({rhs_str})"),
         _ => rhs_str,
       };
       format!("{} :> {}", input_form_rule_lhs(pattern), rhs_final)
@@ -11848,7 +11869,7 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
         {
           format!("({rhs_str})")
         }
-        Expr::Function { .. } => format!("({rhs_str})"),
+        Expr::Function { .. } | Expr::CompoundExpr(_) => format!("({rhs_str})"),
         _ => rhs_str,
       };
       format!("{} :> {}", input_form_rule_lhs(&args[0]), rhs_final)

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -1473,6 +1473,29 @@ mod rule_display {
     assert_eq!(interpret("f[a, b] /. Rule[a, 1]").unwrap(), "f[1, b]");
   }
 
+  // Same CompoundExpression-precedence guard as RuleDelayed (see
+  // `rule_delayed_compound_expression_rhs_keeps_parens`), checked through
+  // `Hold` since a bare `->` evaluates its RHS immediately and would
+  // collapse `(a = 1; b = 2)` to `2` before there was anything to print.
+  #[test]
+  fn rule_compound_expression_rhs_keeps_parens() {
+    assert_eq!(
+      interpret("ToString[Hold[x -> (a = 1; b = 2)], InputForm]").unwrap(),
+      "Hold[x -> (a = 1; b = 2)]"
+    );
+    assert_eq!(
+      interpret(
+        "Clear[a, b]; \
+         printed = ToString[Hold[x -> (a = 1; b = 2)], InputForm]; \
+         held = ToExpression[printed]; \
+         held[[1, 2]]; \
+         {a, b}"
+      )
+      .unwrap(),
+      "{1, 2}"
+    );
+  }
+
   #[test]
   fn replace_all_function_form_reevaluates_result() {
     // ReplaceAll[...] (function-call form) should re-evaluate the result
@@ -1824,6 +1847,38 @@ mod rule_delayed {
   fn rule_delayed_holds_rhs() {
     // RuleDelayed should not evaluate the RHS prematurely
     assert_eq!(interpret("RuleDelayed[x, 1 + 1]").unwrap(), "x :> 1 + 1");
+  }
+
+  // CompoundExpression has the lowest precedence of any operator, so a
+  // `;`-sequence on the right of `:>` needs explicit parentheses to stay one
+  // replacement: `cond :> a = 1; b = 2` is `(cond :> a = 1); b = 2` without
+  // them. Regression for a Wolfram Demonstrations idiom — an EventHandler
+  // action with more than one statement, `"event" :> (a = 1; b = 2)` — whose
+  // printed InputForm silently dropped the parens and lost every statement
+  // after the first once re-parsed.
+  #[test]
+  fn rule_delayed_compound_expression_rhs_keeps_parens() {
+    assert_eq!(
+      interpret("x :> (a = 1; b = 2)").unwrap(),
+      "x :> (a = 1; b = 2)"
+    );
+  }
+
+  #[test]
+  fn rule_delayed_compound_expression_rhs_round_trips_through_input_form() {
+    // Print the rule, re-parse the text, then run the replacement pulled
+    // back out with Part -- both statements must still fire.
+    assert_eq!(
+      interpret(
+        "Clear[a, b]; \
+         printed = ToString[Hold[x :> (a = 1; b = 2)], InputForm]; \
+         held = ToExpression[printed]; \
+         held[[1, 2]]; \
+         {a, b}"
+      )
+      .unwrap(),
+      "{1, 2}"
+    );
   }
 }
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -19239,4 +19239,109 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`nmax$$ = 10}, DynamicBox[\[Ellipsis
       "the DynamicModule local must stay put across an unrelated re-render"
     );
   }
+
+  /// The Demonstrations shape of a status field that only ever changes from
+  /// an `EventHandler` elsewhere in the body: `Control[{{var, init, ""},
+  /// FieldSize -> n, Enabled -> False}]` grouped in a `Row[…]` next to a
+  /// real control. That field spec has no bounds and no choice list — the
+  /// domain Wolfram's own default renders as an `InputField` — and one
+  /// spec `extract_manipulate_spec` could not place used to abort the
+  /// *whole* Manipulate instead of just that row, so the entire widget
+  /// (setter bar included) silently failed to build. The field also gets
+  /// written by a multi-statement `EventHandler` action, which exercises
+  /// the paired regression in `expr_to_input_form`: a `RuleDelayed` whose
+  /// replacement is a `;`-sequence must keep its parentheses when the body
+  /// is reconstructed, or only the first statement of the click handler
+  /// would survive.
+  #[test]
+  fn manipulate_row_of_status_field_and_setter_bar_builds() {
+    let code = r#"Manipulate[
+      Grid[{{EventHandler[Style[label, Bold],
+        {"MouseClicked" :> (hits = hits + 1; last = op)}]}}],
+      {{op, "ping", ""}, {"ping", "pong"}, ControlType -> SetterBar},
+      Row[{Control[{{last, "", ""}, FieldSize -> 6, Enabled -> False}],
+        " last click"}],
+      {{hits, 0}, ControlType -> None}
+    ]"#;
+    woxi::clear_state();
+    let expr = woxi::interpret_to_expr(code).expect("the spec must parse");
+    let widget = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a Row-embedded status field must not sink the whole widget");
+    assert!(
+      widget.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      widget.error
+    );
+
+    // The setter bar survives as a real, named control...
+    let setter = widget
+      .controls
+      .iter()
+      .find_map(|c| match c {
+        manipulate::ControlState::Discrete { name, values, .. }
+          if name == "op" =>
+        {
+          Some(values.clone())
+        }
+        _ => None,
+      })
+      .expect("the SetterBar control must still build");
+    assert_eq!(setter, ["\"ping\"", "\"pong\""]);
+
+    // ...and the bounds-less field becomes live, mutable state with a
+    // display that shows its current value, rather than vanishing.
+    assert!(
+      widget.state.iter().any(|(n, v)| n == "last" && v == "\"\""),
+      "the status field's variable must stay bound: {:?}",
+      widget.state
+    );
+    assert!(
+      widget.state.iter().any(|(n, _)| n == "hits"),
+      "the ControlType -> None counter must also stay bound: {:?}",
+      widget.state
+    );
+    assert!(
+      widget.displays.iter().any(|d| d == "Dynamic[last]"),
+      "the field's value must be shown live: {:?}",
+      widget.displays
+    );
+
+    // The click handler's action is a `;`-sequence held by `:>` — printed
+    // without its parentheses, only `hits = hits + 1` would remain part of
+    // the rule and `last = op` would leak out as a stray top-level
+    // statement next to it.
+    assert!(
+      widget.body.contains("(hits = hits + 1; last = op)"),
+      "the multi-statement click action must keep its parens: {}",
+      widget.body
+    );
+
+    // Simulate what that EventHandler rule does when it fires: apply it to
+    // the live bindings and check both statements ran, not just the first.
+    let op_value = widget
+      .controls
+      .iter()
+      .find_map(|c| match c {
+        manipulate::ControlState::Discrete {
+          name,
+          values,
+          current_index,
+          ..
+        } if name == "op" => Some(values[*current_index].clone()),
+        _ => None,
+      })
+      .expect("op must have a current value");
+    let preamble: String = widget
+      .state
+      .iter()
+      .map(|(n, v)| format!("{n} = {v};\n"))
+      .chain(std::iter::once(format!("op = {op_value};\n")))
+      .collect();
+    let ran = woxi::interpret_with_stdout(&format!(
+      "{preamble}hits = hits + 1; last = op; {{hits, last}}"
+    ))
+    .expect("the click action must evaluate")
+    .result;
+    assert_eq!(ran, "{1, ping}", "both statements of the action must fire");
+  }
 }


### PR DESCRIPTION
## Summary

- Fixed a Manipulate-widget robustness bug in Woxi Studio: if one control spec still couldn't be parsed after the body-run retry, `extract_manipulate_spec` aborted the *whole* widget via `?` instead of just skipping that row — one unrecognized control took every other, already-understood control down with it. It now skips the unparseable spec and keeps the rest.
- Added support for the bounds-less Demonstrations control shape `{{var, init, ""}, FieldSize -> n, Enabled -> False}` (a status field written only by an `EventHandler` elsewhere in the body, Wolfram's default `InputField` domain). It's now built as live, mutable state with a `Dynamic[var]` display instead of failing to parse.
- Fixed `expr_to_input_form` (used to reconstruct a Manipulate's body when a notebook is opened) dropping the parentheses around a `CompoundExpression` on the right of `->`/`:>`. `CompoundExpression` has the lowest precedence of any operator, so printing `"event" :> (a = 1; b = 2)` without its parens and re-parsing it silently truncated the rule to `a = 1`, with `b = 2` leaking out as a stray top-level statement.

Found while checking whether Woxi Studio can fully open a random Wolfram Demonstrations Project notebook ("Exploring the Times Table"), whose Manipulate combines both patterns: a `Row` of read-only status fields next to a `SetterBar`, all driven by multi-statement `EventHandler` actions. No code from that notebook is included here — the regression test uses an original, small example exercising the same control shapes.

## Test plan

- [x] `make test` (27287 tests, all passing)
- [x] `make test-studio` (165 tests, all passing)
- [x] `make format`
- [x] New unit tests:
  - `tests/interpreter_tests/syntax.rs`: `rule_delayed_compound_expression_rhs_keeps_parens`, `rule_delayed_compound_expression_rhs_round_trips_through_input_form`, `rule_compound_expression_rhs_keeps_parens`
  - `woxi-studio/src/main.rs`: `manipulate_row_of_status_field_and_setter_bar_builds`


---
_Generated by [Claude Code](https://claude.ai/code/session_012yhmGu2TYRhf33nJzskpMT)_