### PR TITLE
Prefer BigInt to num_bigint::BigInt throughout Woxi

### DIFF
--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -36,8 +36,7 @@ fn exact_integer_ord(a: &Expr, b: &Expr) -> Option<std::cmp::Ordering> {
   // included so a value too small for an f64 still compares correctly: without
   // this `10^-400 > 0` went through the f64 path, underflowed to 0.0 and
   // answered False.
-  fn as_fraction(e: &Expr) -> Option<(num_bigint::BigInt, num_bigint::BigInt)> {
-    use num_bigint::BigInt;
+  fn as_fraction(e: &Expr) -> Option<(BigInt, BigInt)> {
     match e {
       Expr::Integer(n) => Some((BigInt::from(*n), BigInt::from(1))),
       Expr::BigInteger(n) => Some((n.clone(), BigInt::from(1))),

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -3565,7 +3565,7 @@ pub fn expr_to_box_form(expr: &Expr) -> Expr {
           if let Expr::FunctionCall { name: tn, args: ta } = arg
             && tn == "Times"
             && ta.len() >= 2
-            && matches!(&ta[0], Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus)
+            && matches!(&ta[0], Expr::BigInteger(n) if n.sign() == Sign::Minus)
           {
             parts.push(Expr::String("-".to_string()));
             let mut pos_args = ta.clone();
@@ -4830,7 +4830,7 @@ fn tf_negated_term(term: &Expr) -> Option<Expr> {
     match e {
       Expr::Integer(n) if *n < 0 => Some(Expr::Integer(-n)),
       Expr::Real(f) if *f < 0.0 => Some(Expr::Real(-f)),
-      Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
+      Expr::BigInteger(n) if n.sign() == Sign::Minus => {
         Some(Expr::BigInteger(-n.clone()))
       }
       _ => None,
@@ -11653,26 +11653,26 @@ fn rat_div(a: (i128, i128), b: (i128, i128)) -> Option<(i128, i128)> {
 /// overflows (and panics) on inputs with large coordinates.
 #[derive(Clone, PartialEq, Eq)]
 struct BigRat {
-  num: num_bigint::BigInt,
-  den: num_bigint::BigInt,
+  num: BigInt,
+  den: BigInt,
 }
 
 impl BigRat {
-  fn new(num: num_bigint::BigInt, den: num_bigint::BigInt) -> Self {
+  fn new(num: BigInt, den: BigInt) -> Self {
     use num_traits::Zero;
     if den.is_zero() {
       return Self {
-        num: num_bigint::BigInt::zero(),
-        den: num_bigint::BigInt::from(1),
+        num: BigInt::zero(),
+        den: BigInt::from(1),
       };
     }
     // Euclid's algorithm; num-integer is not a dependency.
-    let mut a = if num < num_bigint::BigInt::zero() {
+    let mut a = if num < BigInt::zero() {
       -num.clone()
     } else {
       num.clone()
     };
-    let mut b = if den < num_bigint::BigInt::zero() {
+    let mut b = if den < BigInt::zero() {
       -den.clone()
     } else {
       den.clone()
@@ -11682,16 +11682,8 @@ impl BigRat {
       a = b;
       b = r;
     }
-    let g = if a.is_zero() {
-      num_bigint::BigInt::from(1)
-    } else {
-      a
-    };
-    let sign = if den < num_bigint::BigInt::zero() {
-      -1
-    } else {
-      1
-    };
+    let g = if a.is_zero() { BigInt::from(1) } else { a };
+    let sign = if den < BigInt::zero() { -1 } else { 1 };
     Self {
       num: num * sign / &g,
       den: den * sign / &g,
@@ -11700,13 +11692,13 @@ impl BigRat {
 
   fn zero() -> Self {
     Self {
-      num: num_bigint::BigInt::from(0),
-      den: num_bigint::BigInt::from(1),
+      num: BigInt::from(0),
+      den: BigInt::from(1),
     }
   }
 
   fn from_pair((n, d): (i128, i128)) -> Self {
-    Self::new(num_bigint::BigInt::from(n), num_bigint::BigInt::from(d))
+    Self::new(BigInt::from(n), BigInt::from(d))
   }
 
   fn is_zero(&self) -> bool {
@@ -11737,11 +11729,11 @@ impl BigRat {
   /// otherwise the reduced rational (built by evaluating `n/d`, which keeps
   /// big numerators and denominators exact).
   fn to_expr(&self) -> Result<Expr, InterpreterError> {
-    let int = |v: &num_bigint::BigInt| match i128::try_from(v.clone()) {
+    let int = |v: &BigInt| match i128::try_from(v.clone()) {
       Ok(i) => Expr::Integer(i),
       Err(_) => Expr::BigInteger(v.clone()),
     };
-    if self.den == num_bigint::BigInt::from(1) {
+    if self.den == BigInt::from(1) {
       return Ok(int(&self.num));
     }
     crate::evaluator::evaluate_expr_to_expr(&call(

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -2467,7 +2467,7 @@ fn evaluate_function_call_ast_inner(
       if args.len() == 1 {
         let invalid = match &args[0] {
           Expr::Integer(v) => *v < 0,
-          Expr::BigInteger(v) => v.sign() == num_bigint::Sign::Minus,
+          Expr::BigInteger(v) => v.sign() == Sign::Minus,
           Expr::Real(_) | Expr::BigFloat(..) => true,
           Expr::FunctionCall { name: dn, args: da }
             if dn == "DirectedInfinity" =>

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -2748,7 +2748,6 @@ pub fn dispatch_math_functions(
     }
     // BitGet[n, k] — bit k of n, using two's complement for negative n
     "BitGet" if args.len() == 2 => {
-      use num_bigint::BigInt;
       use num_traits::{One, Signed, Zero};
       let n: Option<BigInt> = match &args[0] {
         Expr::Integer(v) => Some(BigInt::from(*v)),
@@ -4470,13 +4469,11 @@ pub fn dispatch_math_functions(
         }
         let n = n as u64;
         // Compute iteratively: af(0) = 0, af(k) = k! - af(k-1)
-        let mut factorials: Vec<num_bigint::BigInt> =
-          vec![num_bigint::BigInt::from(1u64)];
+        let mut factorials: Vec<BigInt> = vec![BigInt::from(1u64)];
         for k in 1..=n {
-          factorials
-            .push(factorials.last().unwrap() * num_bigint::BigInt::from(k));
+          factorials.push(factorials.last().unwrap() * BigInt::from(k));
         }
-        let mut af = num_bigint::BigInt::from(0);
+        let mut af = BigInt::from(0);
         for k in 1..=n {
           af = &factorials[k as usize] - &af;
         }

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -562,7 +562,7 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
         .collect();
       let suffix = "4741994566655706294890138869165136649510315974360597429933393392703942354819024473254400806573416326";
       let digits = format!("{prefix}{suffix}");
-      let big = num_bigint::BigInt::parse_bytes(digits.as_bytes(), 10)?;
+      let big = BigInt::parse_bytes(digits.as_bytes(), 10)?;
       Some(Expr::BigInteger(big))
     }
     // Default to "UTF8" like wolframscript on any modern terminal. The

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -6,6 +6,7 @@ use crate::syntax::{
   unevaluated,
 };
 use crate::{ENV, InterpreterError, PART_DEPTH, StoredValue, interpret};
+use num_bigint::{BigInt, Sign};
 
 pub(crate) mod assignment;
 mod attributes;

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -3881,7 +3881,7 @@ fn match_pattern_impl(
       if let Expr::BigInteger(m) = expr {
         if m == n { Some(vec![]) } else { None }
       } else if let Expr::Integer(m) = expr {
-        if num_bigint::BigInt::from(*m) == *n {
+        if BigInt::from(*m) == *n {
           Some(vec![])
         } else {
           None

--- a/src/evaluator/type_helpers.rs
+++ b/src/evaluator/type_helpers.rs
@@ -38,7 +38,7 @@ pub fn contains_i(expr: &Expr) -> bool {
 /// Apply a binary operation when at least one operand is a BigInteger or large Integer
 pub fn bigint_binary_op<F>(left: &Expr, right: &Expr, op: F) -> Option<Expr>
 where
-  F: FnOnce(num_bigint::BigInt, num_bigint::BigInt) -> num_bigint::BigInt,
+  F: FnOnce(BigInt, BigInt) -> BigInt,
 {
   if !needs_bigint(left) && !needs_bigint(right) {
     return None;

--- a/src/functions/count_roots_ast.rs
+++ b/src/functions/count_roots_ast.rs
@@ -15,7 +15,6 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::functions::math_ast::rat_reduce_bigint;
-use num_bigint::BigInt;
 use num_traits::{One, Signed, Zero};
 
 // ---------------------------------------------------------------------------

--- a/src/functions/country_data.rs
+++ b/src/functions/country_data.rs
@@ -333,7 +333,7 @@ fn interpret_scalar(ty: &str, val: &Expr) -> Option<Expr> {
     let t = s.trim();
     match t.parse::<i128>() {
       Ok(n) => Some(Expr::Integer(n)),
-      Err(_) => match t.parse::<num_bigint::BigInt>() {
+      Err(_) => match t.parse::<BigInt>() {
         Ok(n) => Some(Expr::BigInteger(n)),
         Err(_) => None,
       },

--- a/src/functions/dirichlet_ast.rs
+++ b/src/functions/dirichlet_ast.rs
@@ -342,7 +342,6 @@ fn total_rotation(factors: &[Factor], exps: &[i128], a: i128) -> (i128, i128) {
 ///   Principal characters (k > 1), s >= 2, non-integer s, and characters
 ///   with higher-order values stay unevaluated.
 pub fn dirichlet_l_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  use num_bigint::BigInt;
   let unevaluated = |args: &[Expr]| unevaluated("DirichletL", args);
   if args.len() != 3 {
     return Ok(unevaluated(args));

--- a/src/functions/geometric_test_ast.rs
+++ b/src/functions/geometric_test_ast.rs
@@ -575,7 +575,7 @@ fn expr_is_zero(e: &Expr) -> Option<bool> {
   let v = crate::evaluator::evaluate_expr_to_expr(e).ok()?;
   match &v {
     Expr::Integer(n) => Some(*n == 0),
-    Expr::BigInteger(n) => Some(*n == num_bigint::BigInt::from(0)),
+    Expr::BigInteger(n) => Some(*n == BigInt::from(0)),
     Expr::Real(r) => Some(*r == 0.0),
     _ => super::math_ast::try_eval_to_f64(&v).map(|f| f == 0.0),
   }

--- a/src/functions/linear_algebra_ast.rs
+++ b/src/functions/linear_algebra_ast.rs
@@ -99,7 +99,7 @@ pub fn pseudo_inverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     row.iter().all(|e| {
       matches!(e, Expr::Integer(0))
         || matches!(e, Expr::Real(x) if *x == 0.0)
-        || matches!(e, Expr::BigInteger(n) if *n == num_bigint::BigInt::from(0))
+        || matches!(e, Expr::BigInteger(n) if *n == BigInt::from(0))
     })
   });
   if is_zero {
@@ -1506,7 +1506,7 @@ pub fn inverse_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Try integer matrix inverse via adjugate method
   let det = determinant(&matrix);
   let det_is_zero = matches!(&det, Expr::Integer(0))
-    || matches!(&det, Expr::BigInteger(n) if n == &num_bigint::BigInt::from(0));
+    || matches!(&det, Expr::BigInteger(n) if n == &BigInt::from(0));
   if det_is_zero {
     // Matches wolframscript: emit Inverse::sing and return unevaluated.
     crate::emit_message(&format!(
@@ -1713,7 +1713,7 @@ pub fn identity_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::BigInteger(n) => {
         use num_traits::ToPrimitive;
         use num_traits::Zero;
-        if *n >= num_bigint::BigInt::zero() {
+        if *n >= BigInt::zero() {
           n.to_usize()
         } else {
           None
@@ -2773,10 +2773,7 @@ fn char_poly_coefficients(a: &[Vec<i128>]) -> Vec<i128> {
 
 /// BigInt Faddeev–LeVerrier: ascending coefficients of the monic
 /// characteristic polynomial det(x I - A). O(n^3), exact for any size.
-fn char_poly_coefficients_big(
-  a: &[Vec<num_bigint::BigInt>],
-) -> Vec<num_bigint::BigInt> {
-  use num_bigint::BigInt;
+fn char_poly_coefficients_big(a: &[Vec<BigInt>]) -> Vec<BigInt> {
   let n = a.len();
   let mut coeffs = vec![BigInt::from(0); n + 1];
   coeffs[n] = BigInt::from(1);
@@ -2816,7 +2813,6 @@ pub fn characteristic_polynomial_int(
   rows: &[Expr],
   var: &Expr,
 ) -> Option<Result<Expr, InterpreterError>> {
-  use num_bigint::BigInt;
   let n = rows.len();
   let mut a: Vec<Vec<BigInt>> = Vec::with_capacity(n);
   for r in rows {
@@ -5091,14 +5087,14 @@ fn row_reduce_impl(matrix: &[Vec<Expr>]) -> Vec<Vec<Expr>> {
 fn is_zero_expr(e: &Expr) -> bool {
   matches!(e, Expr::Integer(0))
     || matches!(e, Expr::Real(x) if *x == 0.0)
-    || matches!(e, Expr::BigInteger(n) if n == &num_bigint::BigInt::from(0))
+    || matches!(e, Expr::BigInteger(n) if n == &BigInt::from(0))
 }
 
 /// Check if an expression is one
 fn is_one_expr(e: &Expr) -> bool {
   matches!(e, Expr::Integer(1))
     || matches!(e, Expr::Real(x) if *x == 1.0)
-    || matches!(e, Expr::BigInteger(n) if n == &num_bigint::BigInt::from(1))
+    || matches!(e, Expr::BigInteger(n) if n == &BigInt::from(1))
 }
 
 /// MatrixRank[matrix] - rank of a matrix

--- a/src/functions/list_helpers_ast/combinatorics.rs
+++ b/src/functions/list_helpers_ast/combinatorics.rs
@@ -144,7 +144,6 @@ pub fn permutations_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 pub fn combinatorica_unrank_permutation_ast(
   args: &[Expr],
 ) -> Result<Expr, InterpreterError> {
-  use num_bigint::{BigInt, Sign};
   use num_traits::ToPrimitive;
 
   let original = || unevaluated("Combinatorica`UnrankPermutation", args);

--- a/src/functions/list_helpers_ast/mod.rs
+++ b/src/functions/list_helpers_ast/mod.rs
@@ -10,6 +10,7 @@ use crate::helpers::{
 use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, unevaluated,
 };
+use num_bigint::{BigInt, Sign};
 
 mod aggregation;
 mod combinatorics;

--- a/src/functions/list_helpers_ast/sorting.rs
+++ b/src/functions/list_helpers_ast/sorting.rs
@@ -146,7 +146,6 @@ fn is_infinity_expr(e: &Expr) -> Option<i8> {
 /// denominators). Returns None unless both arguments are exact real numbers,
 /// so Reals, complex values, and symbolic terms fall through unchanged.
 fn exact_real_cmp(a: &Expr, b: &Expr) -> Option<std::cmp::Ordering> {
-  use num_bigint::{BigInt, Sign};
   fn as_ratio(e: &Expr) -> Option<(BigInt, BigInt)> {
     match e {
       Expr::Integer(n) => Some((BigInt::from(*n), BigInt::from(1))),

--- a/src/functions/list_helpers_ast/summation.rs
+++ b/src/functions/list_helpers_ast/summation.rs
@@ -2083,18 +2083,18 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           && min >= 0
           && max >= min
         {
-          let mut fact = num_bigint::BigInt::from(1);
+          let mut fact = BigInt::from(1);
           for k in 2..=min {
-            fact *= num_bigint::BigInt::from(k);
+            fact *= BigInt::from(k);
           }
-          let mut sum = num_bigint::BigInt::from(0);
+          let mut sum = BigInt::from(0);
           let mut i = min;
           while i <= max {
             sum += &fact;
             for s in 1..=step {
               let next = i + s;
               if next >= 2 {
-                fact *= num_bigint::BigInt::from(next);
+                fact *= BigInt::from(next);
               }
             }
             i += step;
@@ -2259,9 +2259,9 @@ pub fn sum_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
         // Sum[k, {k, a, b, c}] = n_terms * (first + last) / 2.
         if matches!(body, Expr::Identifier(name) if name == &var_name) {
           let last = min + step * (n - 1);
-          let sum_num = num_bigint::BigInt::from(n)
-            * (num_bigint::BigInt::from(min) + num_bigint::BigInt::from(last));
-          let sum = sum_num / num_bigint::BigInt::from(2);
+          let sum_num =
+            BigInt::from(n) * (BigInt::from(min) + BigInt::from(last));
+          let sum = sum_num / BigInt::from(2);
           return Ok(crate::functions::math_ast::bigint_to_expr(sum));
         }
       }
@@ -4902,7 +4902,7 @@ fn get_integer(expr: &Expr) -> Option<i128> {
 
 fn is_one(expr: &Expr) -> bool {
   matches!(expr, Expr::Integer(1))
-    || matches!(expr, Expr::BigInteger(n) if *n == num_bigint::BigInt::from(1))
+    || matches!(expr, Expr::BigInteger(n) if *n == BigInt::from(1))
 }
 
 /// Compute ζ(2k) = |B_{2k}| * (2π)^{2k} / (2 * (2k)!) as a symbolic expression.

--- a/src/functions/math_ast/arithmetic.rs
+++ b/src/functions/math_ast/arithmetic.rs
@@ -1,8 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
 use contains_inexact_real as contains_real;
-use num_bigint::BigInt;
-use num_bigint::Sign;
 
 /// Combine `SeriesData[var, x0, coeffs, nmin, nmax, denom]` summands that
 /// share the same `(var, x0, denom)` into a single SeriesData. The result

--- a/src/functions/math_ast/complex.rs
+++ b/src/functions/math_ast/complex.rs
@@ -1456,7 +1456,7 @@ pub fn rationalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     // N[999999/1000003], N[1/2^40], and N[1000001/2^30] do not
     // (differential fuzzer, seed 15336548261066338105).
     match rationalize_machine_default(x) {
-      Some((n, d)) if d == num_bigint::BigInt::from(1) => Ok(bigint_to_expr(n)),
+      Some((n, d)) if d == BigInt::from(1) => Ok(bigint_to_expr(n)),
       Some((n, d)) => {
         Ok(call("Rational", vec![bigint_to_expr(n), bigint_to_expr(d)]))
       }
@@ -1466,8 +1466,7 @@ pub fn rationalize_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 }
 
 /// The exact binary fraction of a finite double: `x = n/d` with `d > 0`.
-fn f64_exact_ratio(x: f64) -> Option<(num_bigint::BigInt, num_bigint::BigInt)> {
-  use num_bigint::BigInt;
+fn f64_exact_ratio(x: f64) -> Option<(BigInt, BigInt)> {
   if !x.is_finite() {
     return None;
   }
@@ -1505,10 +1504,7 @@ fn f64_exact_ratio(x: f64) -> Option<(num_bigint::BigInt, num_bigint::BigInt)> {
 /// third — closer than 10^-5 but NOT machine-close, like 0.333333 or
 /// 0.499999 — is ambiguous and stays Real (0.142857, one step further
 /// from any t ≤ 3 fraction, still rationalizes to 142857/1000000).
-fn rationalize_machine_default(
-  x: f64,
-) -> Option<(num_bigint::BigInt, num_bigint::BigInt)> {
-  use num_bigint::BigInt;
+fn rationalize_machine_default(x: f64) -> Option<(BigInt, BigInt)> {
   use num_traits::{Signed, Zero};
   let (num, den) = f64_exact_ratio(x)?;
 

--- a/src/functions/math_ast/digits.rs
+++ b/src/functions/math_ast/digits.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use num_bigint::BigInt;
 use num_traits::{Signed, Zero};
 
 /// DigitCount[n] - counts of each digit 1-9,0 in base 10

--- a/src/functions/math_ast/elementary.rs
+++ b/src/functions/math_ast/elementary.rs
@@ -1,8 +1,6 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::syntax::ExprForm;
-use num_bigint::BigInt;
-use num_bigint::Sign;
 
 /// Check if an expression is known to be non-negative without assumptions.
 /// Used for simplifications like Sqrt[x^2] → x (only valid when x >= 0).

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use num_bigint::BigInt;
 
 /// Pochhammer[a, n] - Rising factorial (Pochhammer symbol): a * (a+1) * ... * (a+n-1)
 pub fn pochhammer_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/src/functions/math_ast/hypergeometric.rs
+++ b/src/functions/math_ast/hypergeometric.rs
@@ -1068,7 +1068,6 @@ fn is_half(expr: &Expr) -> bool {
 }
 
 pub fn hypergeometric1f1_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  use num_bigint::BigInt;
   if args.len() != 3 {
     return Err(InterpreterError::EvaluationError(
       "Hypergeometric1F1 expects exactly 3 arguments".into(),

--- a/src/functions/math_ast/misc_special.rs
+++ b/src/functions/math_ast/misc_special.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use num_bigint::BigInt;
 
 /// QPochhammer[a, q, n] — q-Pochhammer symbol.
 /// Computes Product[(1 - a*q^k), {k, 0, n-1}] for non-negative integer n.

--- a/src/functions/math_ast/mod.rs
+++ b/src/functions/math_ast/mod.rs
@@ -10,6 +10,7 @@ use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
   expr_to_string, unevaluated,
 };
+use num_bigint::{BigInt, Sign};
 
 mod airy;
 mod arithmetic;

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use num_bigint::BigInt;
 use num_traits::{Signed, Zero};
 use std::cell::RefCell;
 

--- a/src/functions/math_ast/numeric_utils.rs
+++ b/src/functions/math_ast/numeric_utils.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use num_bigint::BigInt;
 use num_traits::{Signed, Zero};
 
 /// Helper - constants are kept symbolic, no direct f64 conversion in expr_to_num.

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -72,7 +72,7 @@ fn n_eval_arbitrary_precision_form(
 ) -> Result<Expr, InterpreterError> {
   let is_exact_zero = match expr {
     Expr::Integer(n) => *n == 0,
-    Expr::BigInteger(n) => n.sign() == num_bigint::Sign::NoSign,
+    Expr::BigInteger(n) => n.sign() == Sign::NoSign,
     _ => false,
   };
   if is_exact_zero {
@@ -1197,7 +1197,7 @@ fn n_eval_arbitrary_partial(
   // An exact zero stays exact under `N[expr, p]` (Head Integer, Precision
   // Infinity), just like at the top level — `N[x == 0, 10]` is `x == 0`.
   if matches!(expr, Expr::Integer(0))
-    || matches!(expr, Expr::BigInteger(n) if n.sign() == num_bigint::Sign::NoSign)
+    || matches!(expr, Expr::BigInteger(n) if n.sign() == Sign::NoSign)
   {
     return Ok(Expr::Integer(0));
   }
@@ -5208,7 +5208,6 @@ fn compute_khinchin(
 /// exactly: enough base-b digits accumulate into a big integer M so that
 /// M/b^K determines the requested decimal digits, then long-divided.
 fn champernowne_decimal_digits(base: i128, decimal_digits: usize) -> String {
-  use num_bigint::BigInt;
   let k_needed = ((decimal_digits as f64 + 2.0) * std::f64::consts::LN_10
     / (base as f64).ln())
   .ceil() as usize

--- a/src/functions/math_ast/orthogonal_polynomials.rs
+++ b/src/functions/math_ast/orthogonal_polynomials.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use super::*;
-use num_bigint::BigInt;
 
 /// Visit every additive term of a polynomial expression, flattening nested and
 /// n-ary `Plus`. Anything that is not a `Plus` is a single term.

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -1119,11 +1119,11 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       // Try all-integer exact path (Integer and BigInteger). Computed in
       // BigInt so the squared deviations don't overflow i128.
       let mut all_int = true;
-      let mut int_vals: Vec<num_bigint::BigInt> = Vec::new();
+      let mut int_vals: Vec<BigInt> = Vec::new();
       let mut has_real = false;
       for item in items {
         match item {
-          Expr::Integer(n) => int_vals.push(num_bigint::BigInt::from(*n)),
+          Expr::Integer(n) => int_vals.push(BigInt::from(*n)),
           Expr::BigInteger(n) => int_vals.push(n.clone()),
           Expr::Real(_) => {
             all_int = false;
@@ -1139,7 +1139,6 @@ pub fn variance_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if all_int && !int_vals.is_empty() {
         // Exact: Variance = Sum[(xi - mean)^2] / (n-1)
         // = (n * Sum[xi^2] - (Sum[xi])^2) / (n * (n-1))
-        use num_bigint::BigInt;
         let n = BigInt::from(int_vals.len() as i128);
         let sum: BigInt = int_vals.iter().sum();
         let sum_sq: BigInt = int_vals.iter().map(|x| x * x).sum();

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -6,6 +6,7 @@ use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_output,
   expr_to_string, unevaluated,
 };
+use num_bigint::BigInt;
 
 // Functions are organized by categories
 pub mod assessment_ast;

--- a/src/functions/polynomial_ast/expand.rs
+++ b/src/functions/polynomial_ast/expand.rs
@@ -905,9 +905,7 @@ fn multiply_terms(a: &Expr, b: &Expr) -> Expr {
     // Promote to BigInteger on i128 overflow instead of panicking.
     (Expr::Integer(x), Expr::Integer(y)) => match x.checked_mul(*y) {
       Some(p) => Expr::Integer(p),
-      None => Expr::BigInteger(
-        num_bigint::BigInt::from(*x) * num_bigint::BigInt::from(*y),
-      ),
+      None => Expr::BigInteger(BigInt::from(*x) * BigInt::from(*y)),
     },
     (Expr::Real(x), Expr::Real(y)) => Expr::Real(x * y),
     (Expr::Integer(x), Expr::Real(y)) | (Expr::Real(y), Expr::Integer(x)) => {

--- a/src/functions/polynomial_ast/linear_programming.rs
+++ b/src/functions/polynomial_ast/linear_programming.rs
@@ -21,7 +21,6 @@
 
 #[allow(unused_imports)]
 use super::*;
-use num_bigint::BigInt;
 use num_traits::{One, Signed, Zero};
 
 /// An exact rational number with a `BigInt` numerator/denominator, kept in

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -3,7 +3,6 @@ use super::*;
 use crate::functions::math_ast::{
   expr_to_f64, expr_to_i128, expr_to_rational, gcd_bigint,
 };
-use num_bigint::BigInt;
 
 /// MinimalPolynomial[α, x] - Computes the minimal polynomial of an algebraic number α
 /// in the variable x.
@@ -2257,7 +2256,6 @@ pub fn algebraic_number_denominator_ast(
 /// chain over exact big-integer arithmetic (pseudo-remainders scaled by
 /// positive constants so the sign structure is preserved).
 fn sturm_real_root_count(coeffs: &[i128]) -> usize {
-  use num_bigint::BigInt;
   use num_traits::{Signed, Zero};
 
   fn trim(mut v: Vec<BigInt>) -> Vec<BigInt> {

--- a/src/functions/polynomial_ast/mod.rs
+++ b/src/functions/polynomial_ast/mod.rs
@@ -13,6 +13,7 @@ use crate::syntax::{
   BinaryOperator, ComparisonOp, Expr, UnaryOperator, expr_to_string,
   unevaluated,
 };
+use num_bigint::BigInt;
 
 mod apart;
 mod cancel;

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -345,7 +345,7 @@ fn is_zero_constant(expr: &Expr) -> bool {
 fn is_nonnegative_constant(expr: &Expr) -> bool {
   match expr {
     Expr::Integer(n) => *n >= 0,
-    Expr::BigInteger(n) => *n >= num_bigint::BigInt::from(0),
+    Expr::BigInteger(n) => *n >= BigInt::from(0),
     Expr::Real(f) => *f >= 0.0,
     Expr::FunctionCall { name, args }
       if name == "Rational" && args.len() == 2 =>
@@ -365,7 +365,7 @@ fn is_nonnegative_constant(expr: &Expr) -> bool {
 fn is_nonpositive_constant(expr: &Expr) -> bool {
   match expr {
     Expr::Integer(n) => *n <= 0,
-    Expr::BigInteger(n) => *n <= num_bigint::BigInt::from(0),
+    Expr::BigInteger(n) => *n <= BigInt::from(0),
     Expr::Real(f) => *f <= 0.0,
     Expr::FunctionCall { name, args }
       if name == "Rational" && args.len() == 2 =>
@@ -591,7 +591,7 @@ fn extract_element_vars(expr: &Expr) -> Vec<String> {
 fn is_positive_constant(expr: &Expr) -> bool {
   match expr {
     Expr::Integer(n) => *n > 0,
-    Expr::BigInteger(n) => *n > num_bigint::BigInt::from(0),
+    Expr::BigInteger(n) => *n > BigInt::from(0),
     Expr::Real(f) => *f > 0.0,
     Expr::FunctionCall { name, args }
       if name == "Rational" && args.len() == 2 =>
@@ -4380,7 +4380,6 @@ fn simplify_for_leaf_count(expr: &Expr) -> Expr {
 /// `n*Log[m]` (with positive integers `n`, `m`) → `Log[m^n]` if the
 /// power evaluates to a finite integer literal.
 fn log_collapse_candidate(expr: &Expr) -> Option<Expr> {
-  use num_bigint::BigInt;
   use num_traits::ToPrimitive;
   let pair_opt = match expr {
     Expr::FunctionCall { name, args } if name == "Times" && args.len() == 2 => {
@@ -5435,7 +5434,7 @@ fn simplify_cost_key(e: &Expr) -> (usize, usize) {
   fn negative_ints(e: &Expr) -> usize {
     match e {
       Expr::Integer(n) => usize::from(*n < 0),
-      Expr::BigInteger(n) => usize::from(n < &num_bigint::BigInt::from(0)),
+      Expr::BigInteger(n) => usize::from(n < &BigInt::from(0)),
       Expr::BinaryOp { left, right, .. } => {
         negative_ints(left) + negative_ints(right)
       }
@@ -9390,8 +9389,7 @@ fn complexity_digits(expr: &Expr) -> usize {
 /// Parse a summand of the form `c*Log[n]` with an integer coefficient `c` and a
 /// positive integer base `n >= 2`, returning `(c, n)`. Symbolic/rational bases
 /// and non-integer coefficients are not recognised (they are left un-merged).
-fn parse_log_term(term: &Expr) -> Option<(i64, num_bigint::BigInt)> {
-  use num_bigint::BigInt;
+fn parse_log_term(term: &Expr) -> Option<(i64, BigInt)> {
   let as_log = |e: &Expr| -> Option<BigInt> {
     if let Expr::FunctionCall { name, args } = e
       && name == "Log"
@@ -9459,7 +9457,6 @@ fn parse_log_term(term: &Expr) -> Option<(i64, num_bigint::BigInt)> {
 /// Returns `None` when no merge beats the original (or the base cannot exceed
 /// a sanity bound on the coefficient magnitude).
 fn try_merge_logs(expr: &Expr) -> Option<Expr> {
-  use num_bigint::BigInt;
   use num_traits::One;
 
   // Flatten the additive structure (both FunctionCall and BinaryOp forms),

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -1761,7 +1761,7 @@ pub fn together_expr(expr: &Expr) -> Expr {
     // Accumulate in a BigInt: pathological intermediates (e.g. Simplify
     // iterating on complex-radical quotients) can carry integer factors
     // whose product overflows i128, which previously panicked here.
-    let mut int_prod = num_bigint::BigInt::from(1);
+    let mut int_prod = BigInt::from(1);
     let mut split_dens: Vec<Expr> = Vec::new();
     for f in canonical_dens.drain(..) {
       match f {
@@ -1799,7 +1799,7 @@ pub fn together_expr(expr: &Expr) -> Expr {
       }
     }
     canonical_dens = split_dens;
-    if int_prod != num_bigint::BigInt::from(1) {
+    if int_prod != BigInt::from(1) {
       let folded = match i128::try_from(&int_prod) {
         Ok(n) => Expr::Integer(n),
         Err(_) => Expr::BigInteger(int_prod),

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -441,7 +441,7 @@ pub fn even_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(n) => n % 2 == 0,
     Expr::BigInteger(n) => {
       use num_traits::Zero;
-      (n % num_bigint::BigInt::from(2)).is_zero()
+      (n % BigInt::from(2)).is_zero()
     }
     _ => return Ok(bool_expr(false)),
   };
@@ -461,7 +461,7 @@ pub fn odd_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(n) => n % 2 != 0,
     Expr::BigInteger(n) => {
       use num_traits::Zero;
-      !(n % num_bigint::BigInt::from(2)).is_zero()
+      !(n % BigInt::from(2)).is_zero()
     }
     _ => return Ok(bool_expr(false)),
   };
@@ -760,7 +760,7 @@ fn expr_has_real_or_i(expr: &Expr) -> bool {
 fn is_known_positive(expr: &Expr) -> Option<bool> {
   match expr {
     Expr::Integer(n) => Some(*n > 0),
-    Expr::BigInteger(n) => Some(*n > num_bigint::BigInt::from(0)),
+    Expr::BigInteger(n) => Some(*n > BigInt::from(0)),
     Expr::Real(f) => Some(*f > 0.0),
     // Rational[n, d]: positive when n and d have the same sign
     Expr::FunctionCall { name, args }
@@ -825,7 +825,7 @@ fn is_known_positive(expr: &Expr) -> Option<bool> {
 fn is_known_negative(expr: &Expr) -> Option<bool> {
   match expr {
     Expr::Integer(n) => Some(*n < 0),
-    Expr::BigInteger(n) => Some(*n < num_bigint::BigInt::from(0)),
+    Expr::BigInteger(n) => Some(*n < BigInt::from(0)),
     Expr::Real(f) => Some(*f < 0.0),
     // Rational[n, d]: negative when n and d have opposite signs
     Expr::FunctionCall { name, args }
@@ -1059,7 +1059,6 @@ fn is_zero(expr: &Expr) -> bool {
 /// otherwise (both parts nonzero) the norm `re^2 + im^2` must be a rational
 /// prime.
 fn is_gaussian_prime(re: i128, im: i128) -> bool {
-  use num_bigint::BigInt;
   let is_p =
     |n: i128| crate::functions::math_ast::is_prime_bigint(&BigInt::from(n));
   if re == 0 && im == 0 {
@@ -1121,7 +1120,7 @@ pub fn prime_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       Expr::BigInteger(n) => {
         use num_traits::Signed;
         let abs_n = n.abs();
-        let is_three_mod_four = (&abs_n % 4u8) == num_bigint::BigInt::from(3);
+        let is_three_mod_four = (&abs_n % 4u8) == BigInt::from(3);
         return Ok(bool_expr(
           is_three_mod_four
             && crate::functions::math_ast::is_prime_bigint(&abs_n),
@@ -1183,7 +1182,7 @@ pub fn composite_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Integer(n) => return Ok(bool_expr(n.abs() > 1)),
     Expr::BigInteger(n) => {
       use num_traits::Signed;
-      return Ok(bool_expr(n.abs() > num_bigint::BigInt::from(1)));
+      return Ok(bool_expr(n.abs() > BigInt::from(1)));
     }
     _ => {}
   }
@@ -1708,7 +1707,7 @@ pub fn square_free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
     Expr::Real(_) => Ok(bool_expr(false)),
     Expr::BigInteger(n) => {
       use num_traits::Zero;
-      let mut num = if n < &num_bigint::BigInt::from(0) {
+      let mut num = if n < &BigInt::from(0) {
         -n.clone()
       } else {
         n.clone()
@@ -1716,19 +1715,19 @@ pub fn square_free_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       if num.is_zero() {
         return Ok(bool_expr(false));
       }
-      let two = num_bigint::BigInt::from(2);
+      let two = BigInt::from(2);
       let mut count = 0;
-      while &num % &two == num_bigint::BigInt::from(0) {
+      while &num % &two == BigInt::from(0) {
         count += 1;
         num /= &two;
         if count > 1 {
           return Ok(bool_expr(false));
         }
       }
-      let mut i = num_bigint::BigInt::from(3);
+      let mut i = BigInt::from(3);
       while &i * &i <= num {
         count = 0;
-        while &num % &i == num_bigint::BigInt::from(0) {
+        while &num % &i == BigInt::from(0) {
           count += 1;
           num /= &i;
           if count > 1 {
@@ -1784,7 +1783,6 @@ pub fn palindrome_q_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 /// Divisible[n, m] - Tests if n is divisible by m
 /// Returns unevaluated if arguments are not exact numbers (non-integer Reals)
 pub fn divisible_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
-  use num_bigint::BigInt;
   use num_traits::Zero;
 
   if args.len() != 2 {

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -5,6 +5,7 @@
 #[allow(unused_imports)]
 use super::*;
 use crate::syntax::pair_to_expr;
+use num_bigint::Sign;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -4445,7 +4446,6 @@ fn decimal_string_to_base_string(
   base: i128,
   decimal_digits: f64,
 ) -> Option<String> {
-  use num_bigint::BigInt;
   use num_traits::{Signed, Zero};
 
   const DIGITS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
@@ -9335,22 +9335,19 @@ fn integer_to_base64_string(n: &Expr) -> Result<String, InterpreterError> {
   const ALPHABET: &[u8] =
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   let abs_big = match n {
-    Expr::BigInteger(b) => {
-      use num_bigint::Sign;
-      match b.sign() {
-        Sign::Minus => -b,
-        _ => b.clone(),
-      }
-    }
-    _ => num_bigint::BigInt::from(expr_to_int(n)?.unsigned_abs()),
+    Expr::BigInteger(b) => match b.sign() {
+      Sign::Minus => -b,
+      _ => b.clone(),
+    },
+    _ => BigInt::from(expr_to_int(n)?.unsigned_abs()),
   };
-  if abs_big == num_bigint::BigInt::from(0) {
+  if abs_big == BigInt::from(0) {
     return Ok("A".to_string());
   }
   let mut val = abs_big;
-  let base = num_bigint::BigInt::from(64);
+  let base = BigInt::from(64);
   let mut digits: Vec<u8> = Vec::new();
-  while val > num_bigint::BigInt::from(0) {
+  while val > BigInt::from(0) {
     let rem = &val % &base;
     let d = rem
       .to_string()
@@ -9481,7 +9478,6 @@ pub fn integer_string_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // directly via num-bigint's to_str_radix; fall back to i128 for
   // smaller integers.
   let mut result = if let Expr::BigInteger(n) = &args[0] {
-    use num_bigint::Sign;
     match n.sign() {
       Sign::Minus => (-n).to_str_radix(base),
       _ => n.to_str_radix(base),
@@ -12088,17 +12084,17 @@ pub fn format_digest(hex_string: &str, format: &str) -> Option<Expr> {
     // The integer, zero-padded to the fixed width of the digest size — the
     // number of decimal digits of 256^nbytes (matching wolframscript).
     "DecimalString" => {
-      let n = num_bigint::BigInt::parse_bytes(hex_string.as_bytes(), 16)
-        .unwrap_or_default();
-      let width = num_bigint::BigInt::from(256u32)
+      let n =
+        BigInt::parse_bytes(hex_string.as_bytes(), 16).unwrap_or_default();
+      let width = BigInt::from(256u32)
         .pow(bytes.len() as u32)
         .to_string()
         .len();
       Some(Expr::String(format!("{n:0>width$}")))
     }
     "Integer" => {
-      let n = num_bigint::BigInt::parse_bytes(hex_string.as_bytes(), 16)
-        .unwrap_or_default();
+      let n =
+        BigInt::parse_bytes(hex_string.as_bytes(), 16).unwrap_or_default();
       use num_traits::ToPrimitive;
       Some(match n.to_i128() {
         Some(i) => Expr::Integer(i),

--- a/src/functions/txt_ast.rs
+++ b/src/functions/txt_ast.rs
@@ -41,7 +41,7 @@ fn token_to_expr(tok: &str) -> Expr {
   // the Carl-Gauss `prime.txt` round-trip as Integer.
   if !tok.contains('.') && !tok.contains('e') && !tok.contains('E') {
     use std::str::FromStr;
-    if let Ok(big) = num_bigint::BigInt::from_str(tok) {
+    if let Ok(big) = BigInt::from_str(tok) {
       return Expr::BigInteger(big);
     }
   }

--- a/src/functions/wl_serialize.rs
+++ b/src/functions/wl_serialize.rs
@@ -134,7 +134,7 @@ fn build_normal(head: &Expr, args: Vec<Expr>) -> Expr {
 fn parse_integer(s: &str) -> Expr {
   if let Ok(i) = s.parse::<i128>() {
     Expr::Integer(i)
-  } else if let Ok(big) = s.parse::<num_bigint::BigInt>() {
+  } else if let Ok(big) = s.parse::<BigInt>() {
     Expr::BigInteger(big)
   } else {
     Expr::Integer(0)

--- a/src/functions/wxf_ast.rs
+++ b/src/functions/wxf_ast.rs
@@ -476,7 +476,7 @@ fn read_expr(bytes: &[u8], pos: &mut usize) -> Option<Expr> {
     T_BIGINT => {
       let len = read_varint(bytes, pos)?;
       let digits = std::str::from_utf8(read_exact(bytes, pos, len)?).ok()?;
-      let big = num_bigint::BigInt::parse_bytes(digits.as_bytes(), 10)?;
+      let big = BigInt::parse_bytes(digits.as_bytes(), 10)?;
       use num_traits::ToPrimitive;
       Some(match big.to_i128() {
         Some(i) => Expr::Integer(i),

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,3 +1,5 @@
+use num_bigint::{BigInt, Sign};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImageType {
   Bit,
@@ -14,7 +16,7 @@ pub enum Expr {
   /// Integer literal
   Integer(i128),
   /// Big integer (exceeds i128 range)
-  BigInteger(num_bigint::BigInt),
+  BigInteger(BigInt),
   /// Real/float literal
   Real(f64),
   /// Arbitrary-precision real: (formatted_digits, precision_in_decimal_digits)
@@ -2251,7 +2253,7 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
         Ok(n) => Expr::Integer(n),
         Err(_) => {
           // Overflows i128 — use BigInteger
-          match s.parse::<num_bigint::BigInt>() {
+          match s.parse::<BigInt>() {
             Ok(n) => Expr::BigInteger(n),
             Err(_) => Expr::Integer(0),
           }
@@ -2273,8 +2275,8 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
           Expr::Integer(n)
         } else {
           // Overflow: use BigInteger
-          let m = num_bigint::BigInt::from(mantissa);
-          let f = num_bigint::BigInt::from(10).pow(exponent as u32);
+          let m = BigInt::from(mantissa);
+          let f = BigInt::from(10).pow(exponent as u32);
           Expr::BigInteger(m * f)
         }
       } else {
@@ -2296,9 +2298,9 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
           // Overflow: keep the value exact with big integers, the way the
           // positive branch does. `1*^-300` is the rational 1/10^300 in
           // Wolfram, not a machine real.
-          let m = num_bigint::BigInt::from(mantissa);
-          let d = num_bigint::BigInt::from(10).pow(abs_exp);
-          let zero = num_bigint::BigInt::from(0);
+          let m = BigInt::from(mantissa);
+          let d = BigInt::from(10).pow(abs_exp);
+          let zero = BigInt::from(0);
           let (mut a, mut b) =
             (if m < zero { -m.clone() } else { m.clone() }, d.clone());
           while b != zero {
@@ -2307,7 +2309,7 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
             b = r;
           }
           let (num, den) = (m / &a, d / &a);
-          if den == num_bigint::BigInt::from(1) {
+          if den == BigInt::from(1) {
             Expr::BigInteger(num)
           } else {
             Expr::FunctionCall {
@@ -2464,7 +2466,7 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
         } else if let Ok(v) = i128::from_str_radix(int_part, base) {
           v as f64
         } else {
-          use num_bigint::BigInt;
+          use BigInt;
           use num_traits::{Num, ToPrimitive};
           BigInt::from_str_radix(int_part, base)
             .ok()
@@ -2483,7 +2485,7 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
         Expr::Integer(val)
       } else {
         // Overflows i128 — try BigInteger
-        use num_bigint::BigInt;
+        use BigInt;
         use num_traits::Num;
         match BigInt::from_str_radix(&lower, base) {
           Ok(n) => Expr::BigInteger(n),
@@ -6862,13 +6864,11 @@ fn negate_leading_negative_in_times(expr: &Expr) -> Option<Expr> {
           })
         }
       }
-      Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
-        Some(Expr::BinaryOp {
-          op: BinaryOperator::Times,
-          left: Box::new(Expr::BigInteger(-n)),
-          right: right.clone(),
-        })
-      }
+      Expr::BigInteger(n) if n.sign() == Sign::Minus => Some(Expr::BinaryOp {
+        op: BinaryOperator::Times,
+        left: Box::new(Expr::BigInteger(-n)),
+        right: right.clone(),
+      }),
       Expr::FunctionCall { name, args }
         if name == "Rational"
           && args.len() == 2
@@ -6926,7 +6926,7 @@ fn negate_leading_negative_in_times(expr: &Expr) -> Option<Expr> {
             })
           }
         }
-        Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
+        Expr::BigInteger(n) if n.sign() == Sign::Minus => {
           let mut new_args = vec![Expr::BigInteger(-n)];
           new_args.extend_from_slice(&args[1..]);
           Some(if new_args.len() == 1 {
@@ -9928,9 +9928,7 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
             // Find a numeric factor whose negation flips the term's sign.
             let neg_idx = factor_refs.iter().position(|f| match f {
               Expr::Integer(n) if *n < 0 => true,
-              Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
-                true
-              }
+              Expr::BigInteger(n) if n.sign() == Sign::Minus => true,
               Expr::Real(v) if *v < 0.0 => true,
               Expr::FunctionCall { name, args }
                 if name == "Rational"
@@ -10039,7 +10037,7 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
                 } else {
                   Some(Expr::Integer(-n))
                 }),
-                Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
+                Expr::BigInteger(n) if n.sign() == Sign::Minus => {
                   Some(Some(Expr::BigInteger(-n)))
                 }
                 Expr::Real(r) if *r < 0.0 => Some(Some(Expr::Real(-r))),
@@ -10125,7 +10123,7 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
               result.push_str(&fmt(arg));
             }
           } else if let Expr::BigInteger(n) = arg {
-            if n.sign() == num_bigint::Sign::Minus {
+            if n.sign() == Sign::Minus {
               result.push_str(" - ");
               result.push_str(&fmt(&Expr::BigInteger(-n)));
             } else {
@@ -11783,7 +11781,7 @@ fn ring_operand_needs_parens(e: &Expr) -> bool {
 fn negate_neg_numeric_coeff(e: &Expr) -> Option<Expr> {
   match e {
     Expr::Real(r) if *r < 0.0 => Some(Expr::Real(-r)),
-    Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
+    Expr::BigInteger(n) if n.sign() == Sign::Minus => {
       Some(Expr::BigInteger(-n))
     }
     Expr::FunctionCall { name, args }
@@ -12749,7 +12747,7 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
             } else {
               Some(Expr::Integer(-n))
             }),
-            Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
+            Expr::BigInteger(n) if n.sign() == Sign::Minus => {
               Some(Some(Expr::BigInteger(-n)))
             }
             Expr::Real(r) if *r < 0.0 => Some(Some(Expr::Real(-r))),
@@ -12815,7 +12813,7 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
             result.push_str(&expr_to_input_form(arg));
           }
         } else if let Expr::BigInteger(n) = arg {
-          if n.sign() == num_bigint::Sign::Minus {
+          if n.sign() == Sign::Minus {
             result.push_str(" - ");
             result.push_str(&expr_to_input_form(&Expr::BigInteger(-n)));
           } else {
@@ -13105,7 +13103,7 @@ pub fn string_to_expr(s: &str) -> Result<Expr, crate::InterpreterError> {
     let digits = raw.strip_prefix('-').unwrap_or(raw);
     if !digits.is_empty()
       && digits.chars().all(|c| c.is_ascii_digit())
-      && let Ok(n) = trimmed.parse::<num_bigint::BigInt>()
+      && let Ok(n) = trimmed.parse::<BigInt>()
     {
       return Ok(Expr::BigInteger(n));
     }
@@ -15320,7 +15318,7 @@ fn extract_sign_for_plus(expr: &Expr) -> (&'static str, Expr) {
         right: right.clone(),
       },
     ),
-    Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus => {
+    Expr::BigInteger(n) if n.sign() == Sign::Minus => {
       (" - ", Expr::BigInteger(-n))
     }
     Expr::BinaryOp {
@@ -15350,7 +15348,7 @@ fn extract_sign_for_plus(expr: &Expr) -> (&'static str, Expr) {
       op: BinaryOperator::Times,
       left,
       right,
-    } if matches!(left.as_ref(), Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus) => {
+    } if matches!(left.as_ref(), Expr::BigInteger(n) if n.sign() == Sign::Minus) => {
       if let Expr::BigInteger(n) = left.as_ref() {
         (
           " - ",
@@ -15367,7 +15365,7 @@ fn extract_sign_for_plus(expr: &Expr) -> (&'static str, Expr) {
     Expr::FunctionCall { name, args }
       if name == "Times"
         && !args.is_empty()
-        && matches!(&args[0], Expr::BigInteger(n) if n.sign() == num_bigint::Sign::Minus) =>
+        && matches!(&args[0], Expr::BigInteger(n) if n.sign() == Sign::Minus) =>
     {
       if let Expr::BigInteger(n) = &args[0] {
         let mut new_args = vec![Expr::BigInteger(-n)];


### PR DESCRIPTION
Several earlier PRs reduced the use of num_bigint::BigInt in the source files to improve readability. This PR completes that work, plus some cases of num_bigint::Sign.