### PR TITLE
Support Part[expr, i] = v as a Part-assignment target

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -1073,6 +1073,9 @@ fn assignment_target_symbol(lhs: &Expr) -> Option<&str> {
   match lhs {
     Expr::Identifier(name) | Expr::Constant(name) => Some(name),
     Expr::Part { expr, .. } => assignment_target_symbol(expr),
+    Expr::FunctionCall { name, args } if name == "Part" && !args.is_empty() => {
+      assignment_target_symbol(&args[0])
+    }
     Expr::FunctionCall { name, .. } => Some(name),
     _ => None,
   }
@@ -1261,7 +1264,9 @@ pub fn set_ast(lhs: &Expr, rhs: &Expr) -> Result<Expr, InterpreterError> {
   }
 
   // Handle Part assignment: var[[indices]] = value
-  if let Expr::Part { .. } = lhs {
+  if matches!(lhs, Expr::Part { .. })
+    || matches!(lhs, Expr::FunctionCall { name, args } if name == "Part" && args.len() >= 2)
+  {
     // Flatten nested Part to get base variable and list of indices. A
     // bracket group followed by another parses as the `Part[base, …]` call
     // form (see `apply_part_group`), so `m[[1]][[2]] = v` reaches here with

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -4318,6 +4318,26 @@ mod part_extraction {
   }
 
   #[test]
+  fn part_function_call_assignment_updates_element() {
+    // Part[x, i] = v is the same operation as x[[i]] = v — Part[...] is
+    // just the function-call spelling of the [[...]] bracket syntax.
+    // Wolfram notebooks' saved-definitions boxes commonly spell it this
+    // way, so both forms must reach the same Part-assignment code path.
+    assert_eq!(
+      interpret("x = {1, 2, 3}; Part[x, 2] = 99; x").unwrap(),
+      "{1, 99, 3}"
+    );
+  }
+
+  #[test]
+  fn part_function_call_assignment_updates_matrix_cell() {
+    assert_eq!(
+      interpret("A = {{1, 2}, {3, 4}}; Part[A, 1, 2] = 5; A").unwrap(),
+      "{{1, 5}, {3, 4}}"
+    );
+  }
+
+  #[test]
   fn part_assignment_on_undefined_symbol_returns_rhs() {
     // Matches Mathematica: Part assignment on a symbol with no immediate
     // value emits a 'Set::noval' warning and returns the RHS unchanged.


### PR DESCRIPTION
Found while checking a random Wolfram Demonstration notebook ("Magic Cube") against Woxi Studio.

## The bug

`Part[x, 2] = 99` is the function-call spelling of `x[[2]] = 99`, but only the bracket form reached the Part-assignment path in `set_ast`. The call form fell through to the generic function-assignment branch and was rejected:

```
Set::write: Tag Part in x[[2]] is Protected.
```

…silently leaving the list unchanged.

```wolfram
(* before *)
x = {1, 2, 3}; Part[x, 2] = 99; x
(* Set::write: Tag Part in x[[2]] is Protected. *)
(* {1, 2, 3}   <- write lost *)

(* after *)
{1, 99, 3}
```

## Why it matters for Woxi Studio

Wolfram writes the `Part[...]` call form into a notebook's stored `Initialization` / saved-definitions boxes, even when the author typed `[[...]]` in the source. So any Demonstration whose setup code builds a table by assigning into it lost *every one of those writes* when Woxi Studio replayed the stored definitions — the arrays kept their placeholder fill values, and the widget rendered from wrong data.

The Magic Cube notebook hit this on its face-colour table: three `Set::write` messages plus a `General::stop` suppressing the rest, on every load.

## Changes

- `set_ast` now recognizes `Part[expr, i, …]` in function-call form as a Part-assignment target alongside `Expr::Part`. The existing flattening loop already handled both spellings, so only the entry condition needed widening.
- `assignment_target_symbol` looks through a `Part[...]` call to the symbol underneath, so the target resolves to `x` rather than to `Part`.

## Tests

Two regression tests in `tests/interpreter_tests/list.rs` covering the flat and matrix-cell cases:

- `part_function_call_assignment_updates_element`
- `part_function_call_assignment_updates_matrix_cell`

`make test`: 27303 passed, 0 failed. `make format` clean.

Verified against the notebook end to end: the `Set::write` messages are gone, the Manipulate widget still builds, and the rendered 3D cube is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAmYuR4QM45JD884nXVosJ)_