### PR TITLE
Typeset StringForm placeholders in graphics labels

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -8562,6 +8562,26 @@ pub fn expr_to_svg_markup_lines(expr: &Expr) -> Vec<String> {
 }
 
 pub fn expr_to_svg_markup(expr: &Expr) -> String {
+  // `StringForm["template", args…]` substitutes its placeholders wherever
+  // it is *typeset* — a graphic's label is exactly that (unlike
+  // `Print`/OutputForm in a script, which show the literal wrapper because
+  // there is no front end to apply the Format rule). A Demonstration's
+  // `PlotLabel -> StringForm["Distance = ``", d]` idiom depends on this.
+  if let Expr::FunctionCall { name, args } = expr
+    && name == "StringForm"
+    && let Some(Expr::String(template)) = args.first()
+  {
+    // Escape the template's literal text up front — the placeholders
+    // (`` `` `` / `` `n` ``) contain no XML-special characters, so this
+    // cannot corrupt them — and substitute each argument through the same
+    // markup renderer used for the rest of the label, so a `NumberForm`,
+    // `Power`, etc. argument typesets instead of leaking its FullForm text.
+    return crate::functions::string_ast::format_string_form_with(
+      &svg_escape(template),
+      &args[1..],
+      expr_to_svg_markup,
+    );
+  }
   // A unit-fraction power is a radical, not a superscript: `Sqrt[2]`
   // (which is `2^(1/2)`) typesets as √2 under its vinculum, and a cube
   // root carries its index in the hook.

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -8375,7 +8375,20 @@ fn box_function_call(name: &str, args: &[Expr]) -> String {
 /// `` `` `` placeholders are replaced sequentially, `` `n` `` with the nth argument.
 /// Out-of-range indices leave the placeholder literal in the output and
 /// emit a StringForm::sfr warning, matching wolframscript.
-fn format_string_form(template: &str, values: &[Expr]) -> String {
+pub(crate) fn format_string_form(template: &str, values: &[Expr]) -> String {
+  format_string_form_with(template, values, crate::syntax::expr_to_output)
+}
+
+/// `format_string_form`, rendering each substituted value with `fmt` instead
+/// of always using `OutputForm` text. A graphic's `PlotLabel ->
+/// StringForm["…", args]` typesets its arguments the same as everything
+/// else in the label (so `NumberForm`/`Power`/etc. render properly), unlike
+/// `Print`/`ToString`'s plain OutputForm text.
+pub(crate) fn format_string_form_with(
+  template: &str,
+  values: &[Expr],
+  fmt: impl Fn(&Expr) -> String,
+) -> String {
   let mut result = String::new();
   let chars: Vec<char> = template.chars().collect();
   let len = chars.len();
@@ -8390,9 +8403,7 @@ fn format_string_form(template: &str, values: &[Expr]) -> String {
       if i + 1 < len && chars[i + 1] == '`' {
         let idx = last_index + 1;
         if idx >= 1 && (idx as usize) <= values.len() {
-          result.push_str(&crate::syntax::expr_to_output(
-            &values[(idx - 1) as usize],
-          ));
+          result.push_str(&fmt(&values[(idx - 1) as usize]));
         } else {
           // Out of range — keep the `` literal and warn.
           result.push('`');
@@ -8428,7 +8439,7 @@ fn format_string_form(template: &str, values: &[Expr]) -> String {
           .unwrap_or(0);
         if signed >= 1 && (signed as usize) <= values.len() {
           let idx = signed as usize;
-          result.push_str(&crate::syntax::expr_to_output(&values[idx - 1]));
+          result.push_str(&fmt(&values[idx - 1]));
         } else {
           // Out of range — keep the `n` placeholder literal and warn.
           result.push('`');

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -909,6 +909,91 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_graphics_plotlabel_stringform_substitutes_placeholders() {
+    // Regression: `PlotLabel -> StringForm["…", args]` (the "Paths inside a
+    // Polygon" Demonstration's `PlotLabel -> StringForm["Path distance =
+    // ``", …]` idiom) leaked the literal `StringForm[…]` wrapper into the
+    // graphic instead of substituting its placeholders. `Print`/`ToString`
+    // are unaffected — wolframscript itself only substitutes `StringForm`
+    // when it is explicitly typeset (a front end, or `ToString`), and a
+    // graphic's label is exactly that.
+    clear_state();
+    let svg = interpret_with_stdout(
+      "Graphics[{Circle[]}, PlotLabel -> StringForm[\"d = ``\", 3.14]]",
+    )
+    .unwrap()
+    .graphics
+    .expect("Graphics should produce an SVG");
+    assert!(
+      svg.contains(">d = 3.14<"),
+      "PlotLabel must substitute the StringForm placeholder:\n{svg}"
+    );
+    assert!(
+      !svg.contains("StringForm["),
+      "PlotLabel must not leak the literal StringForm wrapper:\n{svg}"
+    );
+
+    // A substituted argument still typesets through the label's own
+    // renderer — a NumberForm argument rounds/pads, and a symbolic power
+    // still becomes a superscript tspan — instead of dropping to FullForm
+    // text.
+    clear_state();
+    let svg_numberform = interpret_with_stdout(
+      "Graphics[{Circle[]}, PlotLabel -> \
+       StringForm[\"Path distance = ``\", NumberForm[3.14159, {9, 3}]]]",
+    )
+    .unwrap()
+    .graphics
+    .expect("Graphics should produce an SVG");
+    assert!(
+      svg_numberform.contains(">Path distance = 3.142<"),
+      "NumberForm argument must render its rounded form, not FullForm text:\n{svg_numberform}"
+    );
+
+    clear_state();
+    let svg_power = interpret_with_stdout(
+      "Graphics[{Circle[]}, PlotLabel -> StringForm[\"area = ``\", x^2]]",
+    )
+    .unwrap()
+    .graphics
+    .expect("Graphics should produce an SVG");
+    assert!(
+      svg_power.contains("area = x<tspan baseline-shift=\"super\""),
+      "Power argument must typeset as a superscript:\n{svg_power}"
+    );
+
+    // The template's own literal text still gets XML-escaped.
+    clear_state();
+    let svg_escaped = interpret_with_stdout(
+      "Graphics[{Circle[]}, PlotLabel -> StringForm[\"a < b: ``\", 5]]",
+    )
+    .unwrap()
+    .graphics
+    .expect("Graphics should produce an SVG");
+    assert!(
+      svg_escaped.contains("a &lt; b: 5"),
+      "PlotLabel template text must stay XML-escaped:\n{svg_escaped}"
+    );
+
+    // `Print`/`ToString` are unrelated call sites and must keep their
+    // existing (wolframscript-verified) behavior.
+    clear_state();
+    let printed = interpret_with_stdout("Print[StringForm[\"Value: ``\", 5]]")
+      .unwrap()
+      .stdout;
+    assert_eq!(
+      printed.trim(),
+      "StringForm[Value: ``, 5]",
+      "Print must keep showing the literal StringForm wrapper"
+    );
+    clear_state();
+    assert_eq!(
+      interpret("ToString[StringForm[\"Value: ``\", 5]]").unwrap(),
+      "Value: 5"
+    );
+  }
+
+  #[test]
   fn test_plot3d_framed_plotlabel_typesets_content() {
     // Regression: Plot3D[…, PlotLabel -> Style[Framed[TraditionalForm[expr]],
     // …]] (the pattern the "Complex Exponential and Logarithm Functions"

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -7348,6 +7348,47 @@ mod tests {
   }
 
   #[test]
+  fn locator_default_bound_to_initialization_functions_resolves_before_layout()
+  {
+    // The "Paths inside a Polygon" Demonstration pattern: a Locator's
+    // default is a pair of points looked up from helper functions the
+    // `Initialization` option defines (`{{pt, {A[mode], B[mode]}}, Locator}`),
+    // with `Initialization` written *after* the Locator spec in the argument
+    // list — how a Demonstration picks each mode's starting endpoints.
+    // Control specs used to be parsed before `Initialization` ran (only a
+    // `ButtonBar` got it early), so the helper functions were still
+    // undefined when the Locator's default was evaluated and it fell back
+    // to a fixed, non-interactive point pair instead of a draggable one.
+    let expr = woxi::interpret_to_expr(
+      "Manipulate[Graphics[{Line[pt]}, PlotRange -> {{-5, 5}, {-5, 5}}], \
+       {{mode, 1, \"layout\"}, {1 -> \"vertical\", 2 -> \"horizontal\"}}, \
+       {{pt, {Endpoint[mode, 1], Endpoint[mode, 2]}}, Locator}, \
+       Initialization :> (\
+         Endpoint[1, 1] = {0, -3}; Endpoint[1, 2] = {0, 3}; \
+         Endpoint[2, 1] = {-3, 0}; Endpoint[2, 2] = {3, 0})]",
+    )
+    .unwrap();
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("the Manipulate must build a widget");
+    match &state.controls[1] {
+      manipulate::ControlState::Locator { points, .. } => {
+        assert_eq!(
+          points,
+          &[(0.0, -3.0), (0.0, 3.0)],
+          "the locator must start at the initialization-defined endpoints, \
+           not fall back to a fixed symbolic value"
+        );
+      }
+      other => panic!("expected a locator control, got {other:?}"),
+    }
+    assert!(
+      state.graphics_handle.is_some(),
+      "initial frame should render: {:?}",
+      state.error
+    );
+  }
+
+  #[test]
   fn stale_animation_ticks_are_dropped() {
     // While a blocking animation advance runs, the timer keeps queueing
     // ticks. Ticks generated before the advance finished are backlog and


### PR DESCRIPTION
## Summary

While checking whether Woxi Studio fully supports a randomly-sampled Wolfram Demonstration ("Paths inside a Polygon"), I found that its `PlotLabel -> StringForm["Path distance = ``", ...]` idiom printed the literal `StringForm[...]` wrapper into the graphic instead of substituting the placeholder.

- `PlotLabel -> StringForm["...", args]` now substitutes its placeholders when rendered into an SVG label, the way a real front end typesets `StringForm`. `Print`/`ToString` are unaffected — matching wolframscript, which only substitutes `StringForm` when it is actually typeset (a front end, or an explicit `ToString`), not in plain script output.
- Each substituted argument renders through the same label markup renderer as the rest of the graphic, so a `NumberForm` or `Power` argument typesets properly (rounds/superscripts) instead of leaking `FullForm` text.
- Added coverage for a `Locator` control whose default point pair is looked up from `Initialization`-defined helper functions referenced via another control's variable, with `Initialization` declared *after* the `Locator` in the argument list — also this Demonstration's shape (this already worked correctly; the test documents it).

No code from the Demonstration itself is reproduced — all test fixtures are original.

## Test plan

- [x] `make test` — 27302/27302 passing
- [x] `make test-studio` — 166/166 passing
- [x] `make format`
- [x] New regression test `test_graphics_plotlabel_stringform_substitutes_placeholders` in `tests/interpreter_tests.rs`
- [x] New coverage test `locator_default_bound_to_initialization_functions_resolves_before_layout` in `woxi-studio/src/main.rs`


---
_Generated by [Claude Code](https://claude.ai/code/session_01MzF4LCLqnGrSPa96TZDjpp)_