### PR TITLE
Rename RatExp, Ratio to Rat for consistency

### DIFF
--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -945,14 +945,14 @@ pub fn bernoulli_b_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // Represent each Bernoulli number as a reduced (numerator, denominator)
   // pair in BigInt, so large numerators (e.g. BernoulliB[60]) don't overflow
   // i128.
-  fn rat_reduce(num: &BigInt, den: &BigInt) -> (BigInt, BigInt) {
+  fn reduce(num: &BigInt, den: &BigInt) -> (BigInt, BigInt) {
     rat_reduce_bigint(num, den)
   }
   fn rat_add(a: &(BigInt, BigInt), b: &(BigInt, BigInt)) -> (BigInt, BigInt) {
-    rat_reduce(&(&a.0 * &b.1 + &b.0 * &a.1), &(&a.1 * &b.1))
+    reduce(&(&a.0 * &b.1 + &b.0 * &a.1), &(&a.1 * &b.1))
   }
   fn rat_mul(a: &(BigInt, BigInt), b: &(BigInt, BigInt)) -> (BigInt, BigInt) {
-    rat_reduce(&(&a.0 * &b.0), &(&a.1 * &b.1))
+    reduce(&(&a.0 * &b.0), &(&a.1 * &b.1))
   }
 
   let mut b: Vec<(BigInt, BigInt)> = Vec::with_capacity(n + 1);

--- a/src/functions/music_ast.rs
+++ b/src/functions/music_ast.rs
@@ -1814,32 +1814,32 @@ pub fn music_rest(args: &[Expr]) -> Option<Expr> {
 
 /// A rational number as a reduced `(numerator, denominator)` pair with a
 /// positive denominator.
-type Ratio = (i128, i128);
+type Rat = (i128, i128);
 
 /// Reduce a `(numerator, denominator)` pair.
-fn ratio_mul((an, ad): Ratio, (bn, bd): Ratio) -> Ratio {
-  rat_reduce(an * bn, ad * bd)
+fn rat_mul(a: Rat, b: Rat) -> Rat {
+  rat_reduce(a.0 * b.0, a.1 * b.1)
 }
 
-fn ratio_add((an, ad): Ratio, (bn, bd): Ratio) -> Ratio {
-  rat_reduce(an * bd + bn * ad, ad * bd)
+fn rat_add(a: Rat, b: Rat) -> Rat {
+  rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
 }
 
-fn ratio_sub((an, ad): Ratio, (bn, bd): Ratio) -> Ratio {
-  rat_reduce(an * bd - bn * ad, ad * bd)
+fn rat_sub(a: Rat, b: Rat) -> Rat {
+  rat_reduce(a.0 * b.1 - b.0 * a.1, a.1 * b.1)
 }
 
-fn ratio_cmp((an, ad): Ratio, (bn, bd): Ratio) -> std::cmp::Ordering {
-  (an * bd).cmp(&(bn * ad))
+fn rat_cmp(a: Rat, b: Rat) -> std::cmp::Ordering {
+  (a.0 * b.1).cmp(&(b.0 * a.1))
 }
 
-/// Render a `Ratio` as the `Expr` the Wolfram Language prints for it.
-fn ratio_expr((n, d): Ratio) -> Expr {
-  make_rational(n, d)
+/// Render a `Rat` as the `Expr` the Wolfram Language prints for it.
+fn rat_expr(r: Rat) -> Expr {
+  make_rational(r.0, r.1)
 }
 
-/// Parse a bare rhythmic value (`Integer` or `Rational`) into a `Ratio`.
-fn duration_ratio(expr: &Expr) -> Option<Ratio> {
+/// Parse a bare rhythmic value (`Integer` or `Rational`) into a `Rat`.
+fn duration_ratio(expr: &Expr) -> Option<Rat> {
   match expr {
     Expr::Integer(n) => Some((*n, 1)),
     Expr::FunctionCall { name, args } if name == "Rational" => {
@@ -1854,8 +1854,8 @@ fn duration_ratio(expr: &Expr) -> Option<Ratio> {
   }
 }
 
-/// The rhythmic value of a `MusicDuration[…]` object as a `Ratio`.
-fn music_duration_ratio(expr: &Expr) -> Option<Ratio> {
+/// The rhythmic value of a `MusicDuration[…]` object as a `Rat`.
+fn music_duration_ratio(expr: &Expr) -> Option<Rat> {
   match expr {
     Expr::FunctionCall { name, args } if name == "MusicDuration" => {
       match args.first()? {
@@ -1895,8 +1895,8 @@ fn time_signature_parts(expr: &Expr) -> Option<(i128, i128)> {
 /// with its explicit rhythmic value if one was given (`None` for the default
 /// one-beat duration).
 enum MeasureEvent {
-  Note(Expr, Option<Ratio>),
-  Rest(Option<Ratio>),
+  Note(Expr, Option<Rat>),
+  Rest(Option<Rat>),
 }
 
 impl MeasureEvent {
@@ -1910,7 +1910,7 @@ impl MeasureEvent {
 /// Extract an explicit rhythmic value from a canonical note/rest association,
 /// distinguishing "no duration key" (`Some(None)` — a default event) from a
 /// present-but-unparsable duration (`None` — bail out).
-fn explicit_duration(pairs: &[(Expr, Expr)]) -> Option<Option<Ratio>> {
+fn explicit_duration(pairs: &[(Expr, Expr)]) -> Option<Option<Rat>> {
   match assoc_get(pairs, "Duration") {
     None => Some(None),
     Some(dur) => music_duration_ratio(dur).map(Some),
@@ -1943,24 +1943,24 @@ fn parse_measure_event(expr: &Expr) -> Option<MeasureEvent> {
 /// stored `"Duration"` key is kept only for events that were given an explicit
 /// value; every event gains `"BeatDuration"` and `"Beats"`.
 fn beat_annotated_duration(
-  explicit: Option<Ratio>,
-  beat_duration: Ratio,
-  beats: Ratio,
+  explicit: Option<Rat>,
+  beat_duration: Rat,
+  beats: Rat,
 ) -> Expr {
   let mut pairs = Vec::new();
   if let Some(value) = explicit {
-    pairs.push(("Duration", ratio_expr(value)));
+    pairs.push(("Duration", rat_expr(value)));
   }
-  pairs.push(("BeatDuration", ratio_expr(beat_duration)));
-  pairs.push(("Beats", ratio_expr(beats)));
+  pairs.push(("BeatDuration", rat_expr(beat_duration)));
+  pairs.push(("Beats", rat_expr(beats)));
   music_assoc("MusicDuration", pairs)
 }
 
 /// Rebuild a measure event as its beat-annotated canonical object.
 fn annotate_event(
   event: &MeasureEvent,
-  beat_duration: Ratio,
-  beats: Ratio,
+  beat_duration: Rat,
+  beats: Rat,
 ) -> Expr {
   match event {
     MeasureEvent::Note(pitch, explicit) => music_assoc(
@@ -2017,12 +2017,12 @@ pub fn music_measure(args: &[Expr]) -> Option<Expr> {
 
   // Simple vs. compound meter fixes the beat unit and the beats per measure.
   let compound = numer % 3 == 0 && (numer >= 6 || denom >= 8);
-  let beat_duration: Ratio = if compound {
+  let beat_duration: Rat = if compound {
     rat_reduce(3, denom)
   } else {
     rat_reduce(1, denom)
   };
-  let capacity: Ratio = if compound {
+  let capacity: Rat = if compound {
     rat_reduce(numer, 3)
   } else {
     (numer, 1)
@@ -2044,8 +2044,8 @@ pub fn music_measure(args: &[Expr]) -> Option<Expr> {
         music_assoc(
           "MusicDuration",
           vec![
-            ("Beats", ratio_expr(capacity)),
-            ("BeatDuration", ratio_expr(beat_duration)),
+            ("Beats", rat_expr(capacity)),
+            ("BeatDuration", rat_expr(beat_duration)),
           ],
         ),
       )],
@@ -2066,19 +2066,19 @@ pub fn music_measure(args: &[Expr]) -> Option<Expr> {
 
   // Nominal beats: an explicit duration measures `duration / beatDuration`
   // beats; a default event is one beat.
-  let nominal: Vec<Ratio> = events
+  let nominal: Vec<Rat> = events
     .iter()
     .map(|e| match e {
       MeasureEvent::Note(_, Some(v)) | MeasureEvent::Rest(Some(v)) => {
-        ratio_mul(*v, (beat_duration.1, beat_duration.0))
+        rat_mul(*v, (beat_duration.1, beat_duration.0))
       }
       _ => (1, 1),
     })
     .collect();
-  let total = nominal.iter().fold((0, 1), |acc, &b| ratio_add(acc, b));
+  let total = nominal.iter().fold((0, 1), |acc, &b| rat_add(acc, b));
 
   // Overfull: warn and return the non-associated form unchanged.
-  if ratio_cmp(total, capacity) == std::cmp::Ordering::Greater {
+  if rat_cmp(total, capacity) == std::cmp::Ordering::Greater {
     crate::emit_message_to_stdout(&format!(
       "MusicMeasure::measdur: The total duration of beats {} exceeds the \
        allowed number of beats per measure {}.",
@@ -2092,14 +2092,14 @@ pub fn music_measure(args: &[Expr]) -> Option<Expr> {
   }
 
   // Fill the measure to exactly `capacity` beats.
-  let deficit = ratio_sub(capacity, total);
+  let deficit = rat_sub(capacity, total);
   let last = events.len() - 1;
   let last_is_elastic = !events[last].is_explicit();
 
   let mut note_list: Vec<Expr> = Vec::with_capacity(events.len() + 1);
   for (i, event) in events.iter().enumerate() {
     let beats = if i == last && last_is_elastic {
-      ratio_add(nominal[i], deficit)
+      rat_add(nominal[i], deficit)
     } else {
       nominal[i]
     };
@@ -2107,7 +2107,7 @@ pub fn music_measure(args: &[Expr]) -> Option<Expr> {
   }
   // A rigid final event cannot stretch, so pad the remainder with a rest.
   if deficit != (0, 1) && !last_is_elastic {
-    let pad = MeasureEvent::Rest(Some(ratio_mul(deficit, beat_duration)));
+    let pad = MeasureEvent::Rest(Some(rat_mul(deficit, beat_duration)));
     note_list.push(annotate_event(&pad, beat_duration, deficit));
   }
 
@@ -2287,7 +2287,7 @@ pub fn emit_music_plot_message(arg: &Expr) {
 
 /// Render a beat count the way the Wolfram Language prints it in the
 /// `MusicMeasure::measdur` message (an integer, or `n/d` for a fraction).
-fn format_ratio((n, d): Ratio) -> String {
+fn format_ratio((n, d): Rat) -> String {
   if d == 1 {
     n.to_string()
   } else {

--- a/src/functions/polynomial_ast/cancel.rs
+++ b/src/functions/polynomial_ast/cancel.rs
@@ -595,10 +595,10 @@ fn cancel_expr_impl(expr: &Expr, canonicalize_sign: bool) -> Expr {
 /// Supports rational exponents: a^(3/2)/a^(1/2) → a
 pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
   // Rational exponent as (numerator, denominator) pair
-  type RatExp = (i128, i128);
+  type Rat = (i128, i128);
 
   // Extract base string and rational exponent from a factor
-  fn base_and_exp(f: &Expr) -> (String, RatExp) {
+  fn base_and_exp(f: &Expr) -> (String, Rat) {
     match f {
       Expr::BinaryOp {
         op: BinaryOperator::Power,
@@ -705,7 +705,7 @@ pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
   }
 
   // Reconstruct a factor from base expr and rational exponent
-  fn make_factor(base: &Expr, exp: RatExp) -> Option<Expr> {
+  fn make_factor(base: &Expr, exp: Rat) -> Option<Expr> {
     let (n, d) = exp;
     if n == 0 {
       None
@@ -730,17 +730,17 @@ pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
   }
 
   // Subtract two rational exponents: (a/b) - (c/d)
-  fn rat_sub(a: RatExp, b: RatExp) -> RatExp {
+  fn rat_sub(a: Rat, b: Rat) -> Rat {
     rat_reduce(a.0 * b.1 - b.0 * a.1, a.1 * b.1)
   }
 
   // Check if rational exponent is positive
-  fn rat_positive(r: RatExp) -> bool {
+  fn rat_positive(r: Rat) -> bool {
     (r.0 > 0 && r.1 > 0) || (r.0 < 0 && r.1 < 0)
   }
 
   // Minimum of two positive rational exponents
-  fn rat_min(a: RatExp, b: RatExp) -> RatExp {
+  fn rat_min(a: Rat, b: Rat) -> Rat {
     // Compare a/b with c/d: a*d vs c*b
     let lhs = a.0 * b.1;
     let rhs = b.0 * a.1;
@@ -781,7 +781,7 @@ pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
   }
 
   // Build maps of base → (original_expr, base_str, exponent) for numerator and denominator
-  let mut num_map: Vec<(Expr, String, RatExp)> = num_factors
+  let mut num_map: Vec<(Expr, String, Rat)> = num_factors
     .iter()
     .map(|f| {
       let (base_str, exp) = base_and_exp(f);
@@ -790,7 +790,7 @@ pub fn cancel_symbolic_factors(num: &Expr, den: &Expr) -> Expr {
     })
     .collect();
 
-  let mut den_map: Vec<(Expr, String, RatExp)> = den_factors
+  let mut den_map: Vec<(Expr, String, Rat)> = den_factors
     .iter()
     .map(|f| {
       let (base_str, exp) = base_and_exp(f);

--- a/src/functions/polynomial_ast/function_expand.rs
+++ b/src/functions/polynomial_ast/function_expand.rs
@@ -229,23 +229,14 @@ fn negate_if_negative(t: &Expr) -> Option<Expr> {
 }
 
 /// A positive rational as a normalised `(numerator, denominator)` pair.
-type Ratio = (i128, i128);
+type Rat = (i128, i128);
 
-fn gcd_i128(a: i128, b: i128) -> i128 {
-  if b == 0 { a.abs() } else { gcd_i128(b, a % b) }
+fn rat_mul(a: Rat, b: Rat) -> Rat {
+  rat_reduce(a.0 * b.0, a.1 * b.1)
 }
 
-fn ratio(n: i128, d: i128) -> Ratio {
-  let g = gcd_i128(n, d).max(1);
-  (n / g, d / g)
-}
-
-fn ratio_times(a: Ratio, b: Ratio) -> Ratio {
-  ratio(a.0 * b.0, a.1 * b.1)
-}
-
-fn ratio_over(a: Ratio, b: Ratio) -> Ratio {
-  ratio(a.0 * b.1, a.1 * b.0)
+fn rat_div(a: Rat, b: Rat) -> Rat {
+  rat_reduce(a.0 * b.1, a.1 * b.0)
 }
 
 /// The exact square root of a non-negative integer, if it has one.
@@ -265,7 +256,7 @@ fn integer_sqrt(n: i128) -> Option<i128> {
 }
 
 /// The exact square root of a positive rational, if it has one.
-fn ratio_sqrt(r: Ratio) -> Option<Ratio> {
+fn rat_sqrt(r: Rat) -> Option<Rat> {
   Some((integer_sqrt(r.0)?, integer_sqrt(r.1)?))
 }
 
@@ -289,7 +280,7 @@ fn squarefree_kernel(mut n: i128) -> i128 {
 }
 
 /// The positive rational value of `e`, when it is one written exactly.
-fn as_positive_ratio(e: &Expr) -> Option<Ratio> {
+fn as_positive_ratio(e: &Expr) -> Option<Rat> {
   match e {
     Expr::Integer(n) if *n > 0 => Some((*n, 1)),
     Expr::FunctionCall { name, args }
@@ -297,7 +288,7 @@ fn as_positive_ratio(e: &Expr) -> Option<Ratio> {
     {
       match (&args[0], &args[1]) {
         (Expr::Integer(p), Expr::Integer(q)) if *p > 0 && *q > 0 => {
-          Some(ratio(*p, *q))
+          Some(rat_reduce(*p, *q))
         }
         _ => None,
       }
@@ -342,12 +333,12 @@ fn as_even_power(e: &Expr) -> Option<(i128, Expr)> {
 
 /// A negated term of the form `c u^2` or `c u^4`, split into the positive
 /// rational `c` and the square root `u` (or `u^2`) of the power.
-fn as_scaled_square(e: &Expr) -> Option<(Ratio, Expr)> {
-  let mut coefficient: Ratio = (1, 1);
+fn as_scaled_square(e: &Expr) -> Option<(Rat, Expr)> {
+  let mut coefficient: Rat = (1, 1);
   let mut power: Option<(i128, Expr)> = None;
   for factor in as_times_factors(e) {
     if let Some(r) = as_positive_ratio(&factor) {
-      coefficient = ratio_times(coefficient, r);
+      coefficient = rat_mul(coefficient, r);
     } else if power.is_none() {
       power = Some(as_even_power(&factor)?);
     } else {
@@ -425,17 +416,17 @@ fn split_sqrt_of_square_difference(radicand: &Expr) -> Option<Expr> {
 
   // `prefactor` is pulled out of the radical as `Sqrt[prefactor]`; `a` and
   // `b` are the two sides of the rescaled difference of squares.
-  let (prefactor, a, b): (Ratio, Expr, Expr) = if let Some(ca) = ca
+  let (prefactor, a, b): (Rat, Expr, Expr) = if let Some(ca) = ca
     && ca != (1, 1)
-    && ratio_over(cb, ca).1 == 1
-    && integer_sqrt(ratio_over(cb, ca).0).is_some()
+    && rat_div(cb, ca).1 == 1
+    && integer_sqrt(rat_div(cb, ca).0).is_some()
   {
     // The whole constant divides out and leaves a perfect square behind:
     // `Sqrt[3 - 12 x^2]` → `Sqrt[3] Sqrt[1 - 2 x] Sqrt[1 + 2 x]`.
-    let scale = integer_sqrt(ratio_over(cb, ca).0)?;
+    let scale = integer_sqrt(rat_div(cb, ca).0)?;
     (ca, mk_int(1), mk_times(mk_int(scale), base))
   } else if let Some(ca) = ca
-    && let (Some(ra), Some(rb)) = (ratio_sqrt(ca), ratio_sqrt(cb))
+    && let (Some(ra), Some(rb)) = (rat_sqrt(ca), rat_sqrt(cb))
   {
     // Both coefficients are already squares: `Sqrt[4 - 9 x^2]` →
     // `Sqrt[2 - 3 x] Sqrt[2 + 3 x]`.
@@ -448,9 +439,9 @@ fn split_sqrt_of_square_difference(radicand: &Expr) -> Option<Expr> {
     // Scale the radicand so the negated coefficient becomes a square, and
     // divide the result by the square root of that scale.
     let scale = squarefree_kernel(cb.0 * cb.1);
-    let scaled_b = ratio_sqrt(ratio_times(cb, (scale, 1)))?;
+    let scaled_b = rat_sqrt(rat_mul(cb, (scale, 1)))?;
     let scaled_a = match ca {
-      Some(ca) => call1("Sqrt", mk_exact_ratio(ratio_times(ca, (scale, 1)))),
+      Some(ca) => call1("Sqrt", mk_exact_ratio(rat_mul(ca, (scale, 1)))),
       None if scale == 1 => call1("Sqrt", a_sq.clone()),
       None => call1("Sqrt", mk_times(mk_int(scale), a_sq.clone())),
     };
@@ -476,7 +467,7 @@ fn split_sqrt_of_square_difference(radicand: &Expr) -> Option<Expr> {
 }
 
 /// A positive rational as an `Integer` or `Rational[…]` expression.
-fn mk_exact_ratio(r: Ratio) -> Expr {
+fn mk_exact_ratio(r: Rat) -> Expr {
   if r.1 == 1 {
     mk_int(r.0)
   } else {

--- a/src/functions/polynomial_ast/together.rs
+++ b/src/functions/polynomial_ast/together.rs
@@ -1669,7 +1669,7 @@ pub fn together_expr(expr: &Expr) -> Expr {
 
   // Compute the common denominator (LCM of all denominators)
   // Decompose each denominator into base^exp pairs and take max exp for each base
-  let mut base_exp_map: Vec<(String, Expr, RatExp)> = Vec::new();
+  let mut base_exp_map: Vec<(String, Expr, Rat)> = Vec::new();
   let mut fractional_int_exponent = false;
   for (_, den) in &fractions {
     if matches!(den, Expr::Integer(1)) {
@@ -2154,9 +2154,9 @@ fn factor_common_monomial_from_terms(num: &Expr) -> Expr {
 }
 
 /// A rational exponent represented as (numerator, denominator) with denominator > 0.
-type RatExp = (i128, i128);
+type Rat = (i128, i128);
 
-fn rat_exp_from_expr(exp: &Expr) -> RatExp {
+fn rat_exp_from_expr(exp: &Expr) -> Rat {
   match exp {
     Expr::Integer(n) => (*n, 1),
     Expr::FunctionCall { name, args }
@@ -2172,7 +2172,7 @@ fn rat_exp_from_expr(exp: &Expr) -> RatExp {
   }
 }
 
-fn rat_exp_to_expr((n, d): RatExp) -> Expr {
+fn rat_exp_to_expr((n, d): Rat) -> Expr {
   if d == 1 {
     Expr::Integer(n)
   } else {
@@ -2181,23 +2181,23 @@ fn rat_exp_to_expr((n, d): RatExp) -> Expr {
 }
 
 /// Compare two rational exponents: returns a > b
-fn rat_gt((an, ad): RatExp, (bn, bd): RatExp) -> bool {
-  an * bd > bn * ad
+fn rat_gt(a: Rat, b: Rat) -> bool {
+  a.0 * b.1 > b.0 * a.1
 }
 
 /// Compute max of two rational exponents
-fn rat_max(a: RatExp, b: RatExp) -> RatExp {
+fn rat_max(a: Rat, b: Rat) -> Rat {
   if rat_gt(a, b) { a } else { b }
 }
 
 /// Subtract two rational exponents: a - b
-fn rat_sub((an, ad): RatExp, (bn, bd): RatExp) -> RatExp {
-  rat_reduce(an * bd - bn * ad, ad * bd)
+fn rat_sub(a: Rat, b: Rat) -> Rat {
+  rat_reduce(a.0 * b.1 - b.0 * a.1, a.1 * b.1)
 }
 
 /// Extract base and exponent from a denominator expression.
 /// Returns (base, exponent) pairs with rational exponents.
-fn extract_den_factors(den: &Expr) -> Vec<(Expr, RatExp)> {
+fn extract_den_factors(den: &Expr) -> Vec<(Expr, Rat)> {
   match den {
     Expr::Integer(1) => vec![],
     Expr::BinaryOp {
@@ -2226,10 +2226,10 @@ fn extract_den_factors(den: &Expr) -> Vec<(Expr, RatExp)> {
 /// denominator. For each base in the LCM, compute base^(lcm_exp - den_exp).
 fn compute_missing_factor(
   den: &Expr,
-  base_exp_map: &[(String, Expr, RatExp)],
+  base_exp_map: &[(String, Expr, Rat)],
 ) -> Expr {
   let den_factors = extract_den_factors(den);
-  let mut den_map: Vec<(String, RatExp)> = Vec::new();
+  let mut den_map: Vec<(String, Rat)> = Vec::new();
   for (base, exp) in &den_factors {
     let key = expr_to_string(base);
     if let Some(entry) = den_map.iter_mut().find(|(k, _)| *k == key) {


### PR DESCRIPTION
Rationals are usually represented as (i128, i128) tuples in Woxi, although in some places a struct or a type alias is used. This PR makes the naming consistent for the type aliases by always using `Rat`.  Some function names were adjusted as well to reflect the consistent naming.

Also eliminates an overlooked recursive fn gcd_i128 in function_expand.rs.