### PR TITLE
Support RotationTransform[theta, axis, point] (3D rotation through a point)

### DIFF
--- a/src/evaluator/dispatch/arg_count.rs
+++ b/src/evaluator/dispatch/arg_count.rs
@@ -1254,7 +1254,7 @@ pub fn get_arg_count_range(name: &str) -> Option<(usize, usize)> {
     "RotateLeft" => Some((1, 2)),
     "RotateRight" => Some((1, 2)),
     "RotationMatrix" => Some((1, 2)),
-    "RotationTransform" => Some((1, 2)),
+    "RotationTransform" => Some((1, 3)),
     "Round" => Some((1, 2)),
     "RowReduce" => Some((1, 2)),
     "RankDecomposition" => Some((1, 1)),

--- a/src/evaluator/dispatch/linear_algebra_functions.rs
+++ b/src/evaluator/dispatch/linear_algebra_functions.rs
@@ -1328,7 +1328,7 @@ pub fn dispatch_linear_algebra_functions(
         && axis.len() == 3
         && axis.iter().all(|e| !matches!(e, Expr::List(_)))
       {
-        match rotation_transform_3d_axis(&args[0], axis) {
+        match rotation_transform_3d_axis(&args[0], axis, None) {
           Some(Ok(tf)) => {
             if let Expr::FunctionCall {
               name: tf_name,
@@ -1529,7 +1529,11 @@ pub fn dispatch_linear_algebra_functions(
     }
     // RotationTransform[angle] → TransformationFunction[2D rotation matrix in homogeneous coords]
     // RotationTransform[angle, {cx, cy}] → rotation about point {cx, cy}
-    "RotationTransform" if args.len() == 1 || args.len() == 2 => {
+    // RotationTransform[angle, {x, y, z}, {px, py, pz}] → 3D rotation about
+    // the axis {x,y,z} through the point {px,py,pz}
+    "RotationTransform"
+      if args.len() == 1 || args.len() == 2 || args.len() == 3 =>
+    {
       // Two-vector form RotationTransform[{u, v}] (2D): the rotation taking the
       // direction of u to the direction of v. Build it directly from the
       // normalized dot/cross products so the angle is never materialized.
@@ -1582,9 +1586,28 @@ pub fn dispatch_linear_algebra_functions(
         && let Expr::List(axis) = &args[1]
         && axis.len() == 3
       {
-        if let Some(result) = rotation_transform_3d_axis(&args[0], axis) {
+        if let Some(result) = rotation_transform_3d_axis(&args[0], axis, None) {
           return Some(result);
         }
+        return Some(Ok(unevaluated("RotationTransform", args)));
+      }
+      // Three-dimensional axis-through-point form
+      // RotationTransform[theta, {x, y, z}, {px, py, pz}]: rotation by theta
+      // about the axis through `point`, parallel to `axis`.
+      if args.len() == 3
+        && let Expr::List(axis) = &args[1]
+        && axis.len() == 3
+        && let Expr::List(point) = &args[2]
+        && point.len() == 3
+      {
+        if let Some(result) =
+          rotation_transform_3d_axis(&args[0], axis, Some(point))
+        {
+          return Some(result);
+        }
+        return Some(Ok(unevaluated("RotationTransform", args)));
+      }
+      if args.len() == 3 {
         return Some(Ok(unevaluated("RotationTransform", args)));
       }
       let theta = &args[0];
@@ -4202,22 +4225,27 @@ fn roll_pitch_yaw_matrix_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   euler_matrix_ast(&euler_args)
 }
 
-/// RotationTransform[theta, {x, y, z}] for a numeric 3D axis.
+/// RotationTransform[theta, {x, y, z}] and RotationTransform[theta, {x, y,
+/// z}, point] for a numeric 3D axis.
 ///
 /// Builds the 4×4 homogeneous TransformationFunction whose top-left 3×3 block
 /// is the rotation by `theta` about the axis through the origin, via
 /// Rodrigues' formula
 ///   R = cos(θ) I + (1 - cos(θ)) u uᵀ + sin(θ) [u]ₓ
-/// with u the normalized axis. Each entry is run through `Together` so the
-/// radical form matches wolframscript (e.g. `1/3 - 1/Sqrt[3]` → `(1 -
-/// Sqrt[3])/3`). Returns `None` for a non-numeric axis so the caller can leave
-/// the expression unevaluated.
+/// with u the normalized axis. When `point` is given, the axis instead passes
+/// through it: the translation column is `point - R.point`, i.e. translate
+/// `point` to the origin, rotate, then translate back. Each entry is run
+/// through `Together` so the radical form matches wolframscript (e.g. `1/3 -
+/// 1/Sqrt[3]` → `(1 - Sqrt[3])/3`). Returns `None` for a non-numeric axis or
+/// point so the caller can leave the expression unevaluated.
 fn rotation_transform_3d_axis(
   theta: &Expr,
   axis: &[Expr],
+  point: Option<&[Expr]>,
 ) -> Option<Result<Expr, InterpreterError>> {
   if axis
     .iter()
+    .chain(point.into_iter().flatten())
     .any(crate::evaluator::core_eval::has_free_symbols)
   {
     return None;
@@ -4248,18 +4276,42 @@ fn rotation_transform_3d_axis(
     _ => int(0),
   };
 
+  // Raw (un-simplified) rotation-matrix entries R[i][j], reused below both
+  // to fill the matrix and — when a pivot `point` is given — to derive the
+  // translation column t = point - R.point (rotating about the axis through
+  // `point` is: translate `point` to the origin, rotate, translate back).
+  let r: Vec<Vec<Expr>> = (0..3)
+    .map(|i| {
+      (0..3)
+        .map(|j| {
+          let diag = if i == j { cos.clone() } else { int(0) };
+          let outer =
+            times(one_minus_cos.clone(), times(u[i].clone(), u[j].clone()));
+          let cr = times(sin.clone(), cross(i, j));
+          plus(vec![diag, outer, cr])
+        })
+        .collect()
+    })
+    .collect();
+
   let mut rows = Vec::with_capacity(4);
-  for i in 0..3 {
-    let mut row = Vec::with_capacity(4);
-    for j in 0..3 {
-      let diag = if i == j { cos.clone() } else { int(0) };
-      let outer =
-        times(one_minus_cos.clone(), times(u[i].clone(), u[j].clone()));
-      let cr = times(sin.clone(), cross(i, j));
-      let entry = plus(vec![diag, outer, cr]);
-      row.push(call1("Together", entry));
-    }
-    row.push(int(0));
+  for (i, r_row) in r.iter().enumerate() {
+    let mut row: Vec<Expr> =
+      r_row.iter().map(|e| call1("Together", e.clone())).collect();
+    let translation = match point {
+      Some(p) => {
+        let r_dot_p: Vec<Expr> = (0..3)
+          .map(|j| times(r_row[j].clone(), p[j].clone()))
+          .collect();
+        plus(
+          std::iter::once(p[i].clone())
+            .chain(r_dot_p.into_iter().map(&neg))
+            .collect(),
+        )
+      }
+      None => int(0),
+    };
+    row.push(call1("Together", translation));
     rows.push(Expr::List(row.into()));
   }
   rows.push(Expr::List(vec![int(0), int(0), int(0), int(1)].into()));

--- a/tests/interpreter_tests/linear_algebra.rs
+++ b/tests/interpreter_tests/linear_algebra.rs
@@ -4059,6 +4059,65 @@ mod transformation_function_apply {
       "{{1/Sqrt[2], -(1/Sqrt[2]), 0}, {1/Sqrt[2], 1/Sqrt[2], 0}, {0, 0, 1}}"
     );
   }
+
+  // Three-dimensional axis form RotationTransform[theta, axis]: rotation by
+  // theta about the axis through the origin.
+  #[test]
+  fn rotation_3d_axis_through_origin() {
+    assert_eq!(
+      interpret("RotationTransform[Pi/2, {0, 0, 1}][{1, 0, 0}]").unwrap(),
+      "{0, 1, 0}"
+    );
+  }
+
+  // Three-dimensional axis-through-point form
+  // RotationTransform[theta, axis, point]: rotation by theta about the axis
+  // through `point`, parallel to `axis`. A half turn around the z-axis
+  // through {1, 0, 0} maps {2, 0, 0} to the point directly opposite it
+  // across the pivot, {0, 0, 0}.
+  #[test]
+  fn rotation_3d_axis_through_point_half_turn() {
+    assert_eq!(
+      interpret("RotationTransform[Pi, {0, 0, 1}, {1, 0, 0}][{2, 0, 0}]")
+        .unwrap(),
+      "{0, 0, 0}"
+    );
+  }
+
+  // A quarter turn around the z-axis through {1, 1, 0}: translate the
+  // pivot to the origin, rotate {1, 0, 0} -> {0, 1, 0}, translate back.
+  #[test]
+  fn rotation_3d_axis_through_point_quarter_turn() {
+    assert_eq!(
+      interpret("RotationTransform[Pi/2, {0, 0, 1}, {1, 1, 0}][{2, 1, 0}]")
+        .unwrap(),
+      "{1, 2, 0}"
+    );
+  }
+
+  // Rotating about an axis through the origin ({0, 0, 0}) matches the
+  // two-argument form.
+  #[test]
+  fn rotation_3d_axis_through_origin_point_matches_two_arg_form() {
+    assert_eq!(
+      interpret(
+        "RotationTransform[Pi/2, {0, 0, 1}, {0, 0, 0}][{1, 0, 0}] == \
+         RotationTransform[Pi/2, {0, 0, 1}][{1, 0, 0}]"
+      )
+      .unwrap(),
+      "True"
+    );
+  }
+
+  // A symbolic axis has no closed form (matching the two-argument case), so
+  // the expression is left unevaluated rather than producing wrong results.
+  #[test]
+  fn rotation_3d_axis_through_point_symbolic_axis_unevaluated() {
+    assert_eq!(
+      interpret("RotationTransform[Pi, {0, 0, x}, {1, 0, 0}]").unwrap(),
+      "RotationTransform[Pi, {0, 0, x}, {1, 0, 0}]"
+    );
+  }
 }
 
 // TransformationMatrix extracts the homogeneous matrix from a


### PR DESCRIPTION
## Summary

- Downloaded a real Wolfram Demonstrations Project notebook ("Pulsars", by Jeff Bryant) and checked whether Woxi Studio fully supports it.
- Parsing, cell extraction, and round-trip serialization all already worked (50/50 cells preserved). Evaluating the notebook's `Manipulate[Graphics3D[...]]` body, however, raised `RotationTransform::argt: RotationTransform called with 3 arguments; 1 or 2 arguments are expected.` — the three-argument form `RotationTransform[theta, axis, point]` (rotate about an axis anchored at a point other than the origin) was not implemented, only the one- and two-argument forms.
- Extended `rotation_transform_3d_axis` to optionally take a pivot point and derive the translation column as `point - R.point` (translate the point to the origin, rotate, translate back), matching how Mathematica defines this form. Updated the `RotationTransform` dispatch arm and its `arg_count` entry accordingly.
- No code from the copyrighted notebook was copied into the repo; the added tests use independently authored geometry (rotations of axis-aligned points around chosen pivots) to verify the new code path.

## Test plan

- [x] `cargo build --release` succeeds
- [x] New unit tests in `tests/interpreter_tests/linear_algebra.rs` (3D axis-through-origin, half/quarter turns about an off-origin pivot, agreement with the two-argument form at the origin, and graceful fallback to unevaluated for a symbolic axis) all pass
- [x] `make test` — all 27,310 tests pass
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114AVtxa3GjUM6GNJ6c79j1

---
_Generated by [Claude Code](https://claude.ai/code/session_0114AVtxa3GjUM6GNJ6c79j1)_