### PR TITLE
Fix implicit multiplication before an indexed function's trailing derivative

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -4235,17 +4235,10 @@ fn parse_function_call(pair: Pair<Rule>) -> Expr {
   let name_pair = &inner_pairs[0];
   // Leading vs. trailing DerivativePrime: a leading prime applies to
   // the head (`f'[x]` → `Derivative[1][f][x]`); a trailing prime wraps
-  // the entire call (`h[1]'` → `Derivative[1][h[1]]`).
+  // the entire call, and may itself be applied to further bracket args:
+  // `h[1]'` → `Derivative[1][h[1]]`, `x[i]''[t]` → `Derivative[2][x[i]][t]`.
   let first_bracket_idx_fc =
     inner_pairs.iter().enumerate().find_map(|(i, p)| {
-      if matches!(p.as_rule(), Rule::BracketArgs) {
-        Some(i)
-      } else {
-        None
-      }
-    });
-  let last_bracket_idx_fc =
-    inner_pairs.iter().enumerate().rev().find_map(|(i, p)| {
       if matches!(p.as_rule(), Rule::BracketArgs) {
         Some(i)
       } else {
@@ -4258,16 +4251,38 @@ fn parse_function_call(pair: Pair<Rule>) -> Expr {
       .find(|p| matches!(p.as_rule(), Rule::DerivativePrime))
       .map(|p| p.as_str().len())
   });
-  let trailing_prime_order_fc = last_bracket_idx_fc.and_then(|lb| {
-    inner_pairs[lb + 1..]
+  let trailing_prime_idx = first_bracket_idx_fc.and_then(|fb| {
+    inner_pairs[fb..]
       .iter()
-      .find(|p| matches!(p.as_rule(), Rule::DerivativePrime))
-      .map(|p| p.as_str().len())
+      .position(|p| matches!(p.as_rule(), Rule::DerivativePrime))
+      .map(|offset| fb + offset)
   });
-  // Collect bracket sequences separately for proper chained call handling
+  let trailing_prime_order_fc =
+    trailing_prime_idx.map(|i| inner_pairs[i].as_str().len());
+  let post_prime_bracket_args: Vec<Vec<Expr>> = trailing_prime_idx
+    .map(|i| {
+      inner_pairs[i + 1..]
+        .iter()
+        .take_while(|p| matches!(p.as_rule(), Rule::BracketArgs))
+        .map(|bracket| {
+          bracket
+            .clone()
+            .into_inner()
+            .filter(|p| {
+              p.as_str() != "[" && p.as_str() != "]" && p.as_str() != ","
+            })
+            .map(pair_to_expr)
+            .collect()
+        })
+        .collect()
+    })
+    .unwrap_or_default();
+  // Collect bracket sequences before the trailing prime for proper chained call handling
   let bracket_sequences: Vec<Vec<Expr>> = inner_pairs
     .iter()
-    .filter(|p| matches!(p.as_rule(), Rule::BracketArgs))
+    .skip(1)
+    .skip_while(|p| matches!(p.as_rule(), Rule::DerivativePrime))
+    .take_while(|p| matches!(p.as_rule(), Rule::BracketArgs))
     .map(|bracket| {
       bracket
         .clone()
@@ -4278,7 +4293,7 @@ fn parse_function_call(pair: Pair<Rule>) -> Expr {
     })
     .collect();
   // Check if the function head is an anonymous function
-  if matches!(name_pair.as_rule(), Rule::SimpleAnonymousFunction) {
+  let result = if matches!(name_pair.as_rule(), Rule::SimpleAnonymousFunction) {
     let anon_expr = pair_to_expr(name_pair.clone());
     // Build curried calls: (#&)[1] or (#^2&)[{1,2,3}]
     let mut result = Expr::CurriedCall {
@@ -4312,7 +4327,7 @@ fn parse_function_call(pair: Pair<Rule>) -> Expr {
   } else {
     let name = resolve_head_name(name_pair);
     // Build chained calls: f[a][b] becomes Apply(f[a], b)
-    let result = if bracket_sequences.len() == 1 {
+    if bracket_sequences.len() == 1 {
       Expr::FunctionCall {
         name,
         args: bracket_sequences.into_iter().next().unwrap().into(),
@@ -4332,20 +4347,29 @@ fn parse_function_call(pair: Pair<Rule>) -> Expr {
         };
       }
       result
-    };
-    // Trailing DerivativePrime wraps the entire call:
-    // `h[1]'` → `Derivative[1][h[1]]`.
-    if let Some(order) = trailing_prime_order_fc {
-      Expr::CurriedCall {
-        func: Box::new(Expr::FunctionCall {
-          name: "Derivative".to_string(),
-          args: vec![Expr::Integer(order as i128)].into(),
-        }),
-        args: vec![result],
-      }
-    } else {
-      result
     }
+  };
+
+  // Trailing DerivativePrime wraps the entire call, and may itself be
+  // applied to further bracket args: `h[1]'` → `Derivative[1][h[1]]`,
+  // `x[i]''[t]` → `Derivative[2][x[i]][t]`.
+  if let Some(order) = trailing_prime_order_fc {
+    let mut wrapped = Expr::CurriedCall {
+      func: Box::new(Expr::FunctionCall {
+        name: "Derivative".to_string(),
+        args: vec![Expr::Integer(order as i128)].into(),
+      }),
+      args: vec![result],
+    };
+    for args in &post_prime_bracket_args {
+      wrapped = Expr::CurriedCall {
+        func: Box::new(wrapped),
+        args: args.clone(),
+      };
+    }
+    wrapped
+  } else {
+    result
   }
 }
 

--- a/src/wolfram.pest
+++ b/src/wolfram.pest
@@ -940,7 +940,11 @@ FunctionArg = _{ &HasRuleOperator ~ FunctionArgRule | &HasSemicolon ~ CompoundEx
 FunctionArgOrOmitted = _{ FunctionArg | OmittedArg }
 FunctionArgOrOmittedLast = _{ FunctionArg | OmittedArg | OmittedTrailingArg }
 BracketArgs = { "[" ~ (FunctionArgOrOmitted ~ ("," ~ FunctionArgOrOmittedLast)*)? ~ "]" }
-FunctionCall = { (Identifier | NamedCharIdentifier | SimpleAnonymousFunction) ~ DerivativePrime? ~ BracketArgs+ ~ DerivativePrime? }
+// A trailing prime may itself be applied to further bracket args, same as
+// FunctionCallExtended: `x[i]''[t]` -> `Derivative[2][x[i]][t]`. This matters
+// inside implicit multiplication (`m x[i]''[t]`), where SimpleTerm uses this
+// rule rather than FunctionCallExtended.
+FunctionCall = { (Identifier | NamedCharIdentifier | SimpleAnonymousFunction) ~ DerivativePrime? ~ BracketArgs+ ~ (DerivativePrime ~ BracketArgs*)? }
 
 // FunctionDefinition supports multiple pattern arguments: f[a_, b_] := ...
 // `PatternOptionalNamedBlank` (`x:_:v`) and `PatternOptionalAnonBlank`

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7532,6 +7532,31 @@ mod ndsolve {
   }
 
   #[test]
+  fn ndsolve_implicit_coefficient_times_indexed_double_derivative() {
+    // Regression: a coefficient placed via implicit multiplication directly
+    // before an indexed function's double derivative (`mu pos[1]''[t]`, no
+    // `*`) used to fail to parse — this is exactly the shape of the
+    // equations of motion in a lattice/chain ODE (e.g. coupled oscillators),
+    // where each particle's acceleration is written as `mass x[k]''[t]`.
+    // With mass canceling out, `mu pos[1]''[t] == -2 mu pos[1][t]` reduces
+    // to `pos1'' = -2 pos1`, so with pos1(0) = 1, pos1'(0) = 0 the solution
+    // is `pos1(t) = Cos[Sqrt[2] t]`.
+    let result = interpret(
+      "mu = 2; \
+       sol = NDSolve[{mu pos[1]''[t] == -2 mu pos[1][t], \
+       pos[1][0] == 1, pos[1]'[0] == 0}, pos[1], {t, 0, 2}]; \
+       (pos[1] /. sol[[1]])[1.0]",
+    )
+    .unwrap();
+    let val: f64 = result.parse().expect("should be a number");
+    let expected = (2.0_f64.sqrt()).cos();
+    assert!(
+      (val - expected).abs() < 0.01,
+      "Expected {expected}, got {val}"
+    );
+  }
+
+  #[test]
   fn interior_initial_point_integrates_both_directions() {
     // The initial condition sits inside the domain: y' = y, y(1) = 1 on
     // {t, 0, 2} → y(t) = E^(t-1) on both sides of t = 1.

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -9356,6 +9356,42 @@ mod cases {
     assert_case(r#"OutputForm[f'[x]]"#, r#"OutputForm[Derivative[1][f][x]]"#);
   }
   #[test]
+  fn implicit_times_indexed_double_derivative_then_call() {
+    // Regression: inside implicit multiplication (`mass y[k]''[t]`), the
+    // grammar's SimpleTerm only allowed a bare FunctionCall with a single
+    // *trailing* prime and no further bracket args after it, so the `[t]`
+    // following the prime was left unconsumed and the whole expression
+    // failed to parse. `y[k]''[t]` -> `Derivative[2][y[k]][t]`, same as it
+    // already did outside of implicit multiplication.
+    assert_case(
+      r#"Hold[mass y[k]''[t]]"#,
+      r#"Hold[mass*Derivative[2][y[k]][t]]"#,
+    );
+  }
+  #[test]
+  fn implicit_times_indexed_single_derivative_then_call() {
+    assert_case(
+      r#"Hold[mass y[k]'[t]]"#,
+      r#"Hold[mass*Derivative[1][y[k]][t]]"#,
+    );
+  }
+  #[test]
+  fn implicit_times_indexed_triple_derivative_then_call() {
+    assert_case(
+      r#"Hold[mass y[k]'''[t]]"#,
+      r#"Hold[mass*Derivative[3][y[k]][t]]"#,
+    );
+  }
+  #[test]
+  fn implicit_times_trailing_prime_then_multiple_bracket_calls() {
+    // `g[1]''[2][3]` -> `Derivative[2][g[1]][2][3]`, chained curried calls
+    // after the derivative, still under implicit multiplication.
+    assert_case(
+      r#"Hold[2 g[1]''[2][3]]"#,
+      r#"Hold[2*Derivative[2][g[1]][2][3]]"#,
+    );
+  }
+  #[test]
   fn sequence_form() {
     assert_case(r#"SequenceForm["[", "x = ", 56, "]"]"#, r#""[""x = "56"]""#);
   }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6665,6 +6665,77 @@ mod tests {
     );
   }
 
+  /// A lattice of masses coupled by `NDSolve`, with a discrete `view`
+  /// control switching between `Plot` and `ListPlot3D` of the same
+  /// solution, a `SeedRandom`+`Module` compound body, styled `Tiny`
+  /// labeled sliders, a Greek-letter coefficient, and a label-less
+  /// `{seed, default}` slider spec. This mirrors the general construct
+  /// category used by many coupled-oscillator/lattice Wolfram
+  /// Demonstrations Project notebooks (independently written, not copied
+  /// from any specific one).
+  #[test]
+  fn manipulate_lattice_ode_which_view_switch_and_greek_slider() {
+    let code = r#"Manipulate[
+      SeedRandom[seed];
+      Module[{sol = NDSolve[
+          Flatten[{
+            Table[mass pos[k]''[time] == pos[k + 1][time] - 2 pos[k][time] + pos[k - 1][time] - β Derivative[1][pos[k]][time],
+              {k, count}] /. {pos[0][time] :> 0, pos[count + 1][time] :> 0},
+            Table[{pos[k][0] == k, Derivative[1][pos[k]][0] == 0}, {k, count}]
+          }],
+          Table[pos[k], {k, count}], {time, 0, span}]},
+        Pane[Which[
+          view == "plot", Plot[Evaluate[Table[pos[k][time], {k, count}] /. sol], {time, 0, span}],
+          view == "3D plot", ListPlot3D[Evaluate[Table[pos[k][time], {k, count}, {time, 0, span, 0.5}] /. sol[[1]]]]
+        ], ImageSize -> 300]
+      ],
+      {{view, "plot"}, {"plot", "3D plot"}, ControlPlacement -> Top},
+      {{count, 4, Style["particles", Italic]}, 2, 12, 1, ImageSize -> Tiny, Appearance -> "Labeled"},
+      {{span, 10., Style["duration", Italic]}, 1, 40, ImageSize -> Tiny, Appearance -> "Labeled"},
+      {{mass, 1., Style["mass", Italic]}, 0.1, 5, ImageSize -> Tiny, Appearance -> "Labeled"},
+      {{β, 1, Style["damping", Italic]}, 0, 5, ImageSize -> Tiny, Appearance -> "Labeled"},
+      {{seed, 12345}, 1, 999999, 1, ImageSize -> Tiny},
+      ControlPlacement -> Left,
+      SynchronousUpdating -> False
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr).expect(
+      "a view popup + four labeled sliders + a label-less slider should build a ManipulateState",
+    );
+
+    assert_eq!(state.controls.len(), 6, "view, count, span, mass, β, seed");
+    assert!(
+      matches!(
+        &state.controls[0],
+        manipulate::ControlState::Discrete { name, value_labels, .. }
+          if name == "view" && value_labels == &["plot", "3D plot"]
+      ),
+      "the view/plot-choices spec should build a two-choice discrete control: {:?}",
+      state.controls[0]
+    );
+    for (i, label) in ["count", "span", "mass", "β", "seed"].iter().enumerate()
+    {
+      assert!(
+        matches!(
+          &state.controls[i + 1],
+          manipulate::ControlState::Continuous { name, .. } if name == label
+        ),
+        "control {i} should be the continuous slider {label:?}: {:?}",
+        state.controls[i + 1]
+      );
+    }
+    assert!(
+      state.error.is_none(),
+      "body should evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "Plot of the NDSolve lattice solution should render a graphic"
+    );
+  }
+
   /// A discrete `SetterBar`-style term-count picker (`{{n, 2, "terms"},
   /// {2, 3, 4}}`) that `Take`s that many sliders and folds them through a
   /// recursive, pattern-matched, `Module`-based extended-GCD helper (mixing


### PR DESCRIPTION
## Summary

- A random Wolfram Demonstrations Project notebook ("The Fermi-Pasta-Ulam Experiment") downloaded via the resource system API failed to open correctly: its `Manipulate[...]` cell — a lattice ODE with `mass x[i]''[t]`-style equations of motion — didn't parse.
- Root cause: `m x[i]''[t]` (a coefficient via *implicit* multiplication directly preceding a trailing-prime derivative that is itself applied to further bracket args) failed to parse. The `SimpleTerm` grammar rule used inside implicit multiplication only allowed `FunctionCall` with a single trailing `DerivativePrime` and no bracket args after it — unlike `FunctionCallExtended`, used at the top-level `Term` position, which already supported this shape (`x[i]''[t]` on its own parsed fine).
- Fixed `FunctionCall`'s grammar to accept `(DerivativePrime ~ BracketArgs*)?` like `FunctionCallExtended` does, and updated `parse_function_call` to build the corresponding `Derivative[...]` call chain, mirroring the existing logic in `parse_function_call_extended`.
- This pattern (`mass * x[i]''[t]` written without an explicit `*`) is common in lattice/coupled-oscillator equations of motion, so this was blocking Woxi Studio from opening real-world Demonstrations notebooks built around such ODEs.

## Test plan

- [x] Added parser-level regression tests (`Hold[...]` round-trips) in `tests/interpreter_tests/syntax.rs` covering single/double/triple trailing derivatives under implicit multiplication, plus chained bracket calls after the derivative.
- [x] Added an end-to-end `NDSolve` regression test in `tests/interpreter_tests/calculus.rs` using the exact previously-failing syntax (`mu pos[1]''[t]`), checked against the closed-form solution.
- [x] Added a Woxi Studio test in `woxi-studio/src/main.rs` building a full interactive `ManipulateState` from a freshly-written lattice-ODE `Manipulate[...]` (independently written, not copied from the Demonstration notebook, per repo convention) with a `SeedRandom`+`Module`+`NDSolve` body, a `Which`-driven `Plot`/`ListPlot3D` view switch, styled `Tiny` labeled sliders, and a Greek-letter coefficient — confirming Woxi Studio now builds all 6 controls and renders the graphic.
- [x] `make test` (27309 tests) and `make test-studio` (167 tests) both pass.
- [x] `make format` run.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iPZ1wJihe3nBH4YDaVw7n)_