### PR TITLE
Implement BlockRandom for localized random state

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -1146,7 +1146,7 @@ ListCorrelate,Discrete cross-correlation of two lists with optional overhang cyc
 After,,🚫,,3.0,1130
 IntegerLength,Returns the number of digits in an integer,✅,pure,6.0,1132
 StirlingS2,Returns the Stirling number of the second kind,✅,pure,1.0,1133
-BlockRandom,,🚫,,6.0,1134
+BlockRandom,Evaluates an expression with the random number generator localized so any SeedRandom inside does not affect the outer random sequence,✅,pure,6.0,1134
 Correlation,Pearson correlation of two lists; of one data matrix gives the correlation matrix of its columns; of a multivariate distribution gives its normalized covariance matrix,✅,pure,6.0,1135
 SwatchLegend,Inert legend description with color swatches consumed by Legended (produced by PeriodicTablePlot property coloring),✅,pure,9.0,1136
 TreeForm,Display an expression as a tree structure,✅,pure,1.0,1138

--- a/src/evaluator/attributes.rs
+++ b/src/evaluator/attributes.rs
@@ -555,7 +555,8 @@ pub fn get_builtin_attributes(name: &str) -> Vec<&'static str> {
 
     // HoldAll + Protected
     "Hold" | "HoldForm" | "HoldPattern" | "Table" | "Do" | "While" | "For"
-    | "Module" | "DynamicModule" | "Block" | "With" | "Assuming" | "Trace"
+    | "Module" | "DynamicModule" | "Block" | "BlockRandom" | "With"
+    | "Assuming" | "Trace"
     | "TraceScan" | "TracePrint"
     | "Defer" | "Compile" | "CompiledFunction" | "Which"
     | "Clear" | "ClearAll" | "Condition" | "Off" | "On"

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -2367,6 +2367,7 @@ pub fn evaluate_expr_to_expr_inner(
         || name == "ParallelDo"
         || name == "With"
         || name == "Block"
+        || name == "BlockRandom"
         || name == "Function"
         || name == "For"
         || name == "While"

--- a/src/evaluator/dispatch/structural.rs
+++ b/src/evaluator/dispatch/structural.rs
@@ -91,6 +91,7 @@ pub fn dispatch_structural(
     // display path (a Grid, a Graphics, a Column) renders it as itself.
     "Module" | "DynamicModule" => return Some(module_ast(args)),
     "Block" => return Some(block_ast(args)),
+    "BlockRandom" => return Some(block_random_ast(args)),
     "Assuming" if args.len() == 2 => return Some(assuming_ast(args)),
     "With" if args.len() >= 2 => return Some(with_ast(args)),
     "Set" if args.len() == 2 => {

--- a/src/evaluator/scoping.rs
+++ b/src/evaluator/scoping.rs
@@ -313,6 +313,24 @@ pub fn block_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   result
 }
 
+/// `BlockRandom[expr]` (also accepts the 2-arg `BlockRandom[expr, seedspec]`
+/// form, ignoring `seedspec`): evaluates `expr` with the global random
+/// generator state localized, so a `SeedRandom[…]` call inside `expr` does
+/// not affect the random sequence seen after `BlockRandom` returns.
+pub fn block_random_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  if args.is_empty() || args.len() > 2 {
+    return Err(InterpreterError::EvaluationError(format!(
+      "BlockRandom expects 1 or 2 arguments; {} given",
+      args.len()
+    )));
+  }
+
+  let saved = crate::snapshot_rng_state();
+  let result = evaluate_expr_to_expr(&args[0]);
+  crate::restore_rng_state(saved);
+  result
+}
+
 /// Valid domain names for Element[]
 const VALID_DOMAINS: &[&str] = &[
   "Primes",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,19 @@ pub fn unseed_rng() {
   });
 }
 
+/// Snapshot the current RNG state (used by `BlockRandom` to localize any
+/// `SeedRandom` calls made inside its body).
+pub fn snapshot_rng_state() -> Option<ChaCha8Rng> {
+  SEEDED_RNG.with(|rng| rng.borrow().clone())
+}
+
+/// Restore a previously snapshotted RNG state (see [`snapshot_rng_state`]).
+pub fn restore_rng_state(state: Option<ChaCha8Rng>) {
+  SEEDED_RNG.with(|rng| {
+    *rng.borrow_mut() = state;
+  });
+}
+
 /// Execute a closure with a mutable reference to the current RNG.
 /// Uses the seeded RNG if set, otherwise falls back to thread_rng().
 pub fn with_rng<F, R>(f: F) -> R

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -7073,6 +7073,62 @@ mod seed_random {
   }
 }
 
+mod block_random {
+  use super::*;
+
+  #[test]
+  fn localizes_seed_random() {
+    // A `SeedRandom` inside `BlockRandom` must not affect the outer random
+    // sequence: the draw right after `BlockRandom` returns should match the
+    // draw that would have come next had `BlockRandom` never run.
+    woxi::clear_state();
+    let _ = interpret("SeedRandom[42]");
+    let a = interpret("RandomInteger[1000]").unwrap();
+    let b = interpret("RandomInteger[1000]").unwrap();
+
+    woxi::clear_state();
+    let _ = interpret("SeedRandom[42]");
+    let a2 = interpret("RandomInteger[1000]").unwrap();
+    assert_eq!(a, a2);
+    let _ = interpret("BlockRandom[SeedRandom[1]; RandomInteger[1000]]");
+    let b2 = interpret("RandomInteger[1000]").unwrap();
+    assert_eq!(b, b2);
+  }
+
+  #[test]
+  fn deterministic_inside() {
+    woxi::clear_state();
+    let a =
+      interpret("BlockRandom[SeedRandom[7]; RandomInteger[1000]]").unwrap();
+    let b =
+      interpret("BlockRandom[SeedRandom[7]; RandomInteger[1000]]").unwrap();
+    assert_eq!(a, b);
+  }
+
+  #[test]
+  fn returns_body_value() {
+    woxi::clear_state();
+    assert_eq!(interpret("BlockRandom[1 + 1]").unwrap(), "2");
+  }
+
+  #[test]
+  fn two_arg_form_ignores_method_spec() {
+    woxi::clear_state();
+    let result =
+      interpret("BlockRandom[SeedRandom[7]; RandomInteger[1000], Method]");
+    assert!(result.is_ok());
+  }
+
+  #[test]
+  fn attributes_hold_all() {
+    woxi::clear_state();
+    assert_eq!(
+      interpret("Attributes[BlockRandom]").unwrap(),
+      "{HoldAll, Protected}"
+    );
+  }
+}
+
 mod select {
   use super::*;
 


### PR DESCRIPTION
## Summary

As part of the periodic Wolfram Demonstrations compatibility check, a random Demonstration was downloaded ("Circle Images", by Roman E. Maeder and A. Odlyzko) and tested against Woxi Studio's Manipulate rendering pipeline.

Its body wraps `SeedRandom` in `BlockRandom`:

```
Manipulate[
  BlockRandom[SeedRandom[rand]; ParametricPlot[...]],
  {{n, 10, "degree"}, 1, 100, 1, Appearance -> "Labeled"},
  {{rand, 0, ""}, Button["randomize", rand = RandomInteger[2^64 - 1]]&},
  ...
]
```

`BlockRandom` was unimplemented, so evaluating the widget's body emitted an "unimplemented" warning and skipped the seeded-random behavior the Demonstration depends on for a reproducible plot per `rand` value.

- `BlockRandom[expr]` (and the 2-arg `BlockRandom[expr, method]` form) now evaluates `expr` with the random generator state saved beforehand and restored afterward, so a `SeedRandom` call inside `expr` only affects the random sequence during that call and does not leak into the surrounding random stream — matching Wolfram's semantics.
- Given `HoldAll`, consistent with `Block`/`Module`/`With`.
- `functions.csv` updated to mark `BlockRandom` as implemented with a description.

With this fix, Woxi Studio's `dump_manipulate` diagnostic tool builds and renders the Circle Images widget (controls + `ParametricPlot`) with no warnings or errors.

## Test plan

- [x] Added `tests/interpreter_tests/list.rs::block_random` covering: localizing an inner `SeedRandom` from the outer sequence, determinism inside `BlockRandom`, the plain return-value form, the 2-arg form, and `Attributes[BlockRandom]`.
- [x] `cargo test` — full suite passes (25234 unit tests, 576 script snapshot tests, 44 CLI tests).
- [x] `make format`
- [x] Verified via `woxi-studio`'s `dump_manipulate` example that the Circle Images notebook's Manipulate widget now builds its controls and renders its `ParametricPlot` graphic with no unimplemented-function warnings.


---
_Generated by [Claude Code](https://claude.ai/code/session_012GmEeBiZfVPt42BupVwjYy)_