### PR TITLE
More rational code simplifications

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -11644,7 +11644,7 @@ fn rat_div(a: (i128, i128), b: (i128, i128)) -> Option<(i128, i128)> {
   if b.0 == 0 {
     return None;
   }
-  Some(rat_mul(a, (b.1, b.0)))
+  Some(rat_reduce(a.0 * b.1, a.1 * b.0))
 }
 
 /// An exact rational over big integers, kept reduced with a positive

--- a/src/evaluator/dispatch/math_functions.rs
+++ b/src/evaluator/dispatch/math_functions.rs
@@ -5320,7 +5320,7 @@ fn rat_mul(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
 }
 
 fn rat_sub(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  rat_add(a, (-b.0, b.1))
+  rat_reduce(a.0 * b.1 - b.0 * a.1, a.1 * b.1)
 }
 
 fn rat_div(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {

--- a/src/functions/calculus_ast.rs
+++ b/src/functions/calculus_ast.rs
@@ -13586,11 +13586,7 @@ fn rat_mul(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
 }
 
 fn rat_div(a: (i128, i128), b: (i128, i128)) -> (i128, i128) {
-  if b.0 < 0 {
-    rat_reduce(-a.0 * b.1, a.1 * -b.0)
-  } else {
-    rat_reduce(a.0 * b.1, a.1 * b.0)
-  }
+  rat_reduce(a.0 * b.1, a.1 * b.0)
 }
 
 fn rat_to_expr(r: (i128, i128)) -> Expr {

--- a/src/functions/math_ast/number_theory.rs
+++ b/src/functions/math_ast/number_theory.rs
@@ -1192,9 +1192,7 @@ fn euler_polynomial(n: usize, z: &Expr) -> Result<Expr, InterpreterError> {
     let mut result = (0i128, 1i128);
     for k in (0..=n).rev() {
       // result = result * z + coeffs[k]
-      let rn = result.0 * z_num;
-      let rd = result.1 * z_den;
-      let (rn, rd) = rat_reduce(rn, rd);
+      let (rn, rd) = rat_reduce(result.0 * z_num, result.1 * z_den);
       result = rat_add((rn, rd), coeffs[k]);
     }
     return Ok(make_rational(result.0, result.1));

--- a/src/functions/polynomial_ast/decompose.rs
+++ b/src/functions/polynomial_ast/decompose.rs
@@ -52,30 +52,20 @@ pub fn decompose_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
 
 type Rat = (i128, i128); // (numerator, denominator), always reduced
 
-fn rat_reduce(n: i128, d: i128) -> Rat {
-  let g = gcd_i128(n, d).max(1);
-  let (n, d) = (n / g, d / g);
-  if d < 0 { (-n, -d) } else { (n, d) }
-}
-
 fn rat_add(a: Rat, b: Rat) -> Rat {
-  let num = a.0 * b.1 + b.0 * a.1;
-  let den = a.1 * b.1;
-  rat_reduce(num, den)
+  rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
 }
 
 fn rat_sub(a: Rat, b: Rat) -> Rat {
-  rat_add(a, (-b.0, b.1))
+  rat_reduce(a.0 * b.1 - b.0 * a.1, a.1 * b.1)
 }
 
 fn rat_mul(a: Rat, b: Rat) -> Rat {
-  let num = a.0 * b.0;
-  let den = a.1 * b.1;
-  rat_reduce(num, den)
+  rat_reduce(a.0 * b.0, a.1 * b.1)
 }
 
 fn rat_div(a: Rat, b: Rat) -> Rat {
-  rat_mul(a, (b.1, b.0))
+  rat_reduce(a.0 * b.1, a.1 * b.0)
 }
 
 fn rat_is_zero(a: Rat) -> bool {

--- a/src/functions/polynomial_ast/minimal_polynomial.rs
+++ b/src/functions/polynomial_ast/minimal_polynomial.rs
@@ -1169,12 +1169,6 @@ fn poly_primitive_big(coeffs: &[BigInt]) -> Vec<BigInt> {
 /// Exact rational as a normalized (numerator, positive denominator) pair.
 type Rat = (i128, i128);
 
-fn rat_reduce(n: i128, d: i128) -> Rat {
-  let g = gcd_i128(n, d).max(1);
-  let (n, d) = (n / g, d / g);
-  if d < 0 { (-n, -d) } else { (n, d) }
-}
-
 fn rat_add(a: Rat, b: Rat) -> Rat {
   rat_reduce(a.0 * b.1 + b.0 * a.1, a.1 * b.1)
 }

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -3250,33 +3250,24 @@ impl Rat {
   }
 }
 
-fn rat_reduce(n: i128, d: i128) -> Rat {
-  if d == 0 {
-    return Rat { num: n, den: d };
-  }
-  let (n, d) = crate::functions::math_ast::rat_reduce(n, d);
+fn reduce_q(n: i128, d: i128) -> Rat {
+  let (n, d) = rat_reduce(n, d);
   Rat { num: n, den: d }
 }
 
 fn mul_q(a: &Rat, b: &Rat) -> Rat {
-  rat_reduce(a.num * b.num, a.den * b.den)
+  reduce_q(a.num * b.num, a.den * b.den)
 }
 
 fn sub_q(a: &Rat, b: &Rat) -> Rat {
-  rat_reduce(a.num * b.den - b.num * a.den, a.den * b.den)
+  reduce_q(a.num * b.den - b.num * a.den, a.den * b.den)
 }
 
 fn inv_q(a: &Rat) -> Option<Rat> {
   if a.num == 0 {
     return None;
   }
-  let mut n = a.den;
-  let mut d = a.num;
-  if d < 0 {
-    n = -n;
-    d = -d;
-  }
-  Some(Rat { num: n, den: d })
+  Some(reduce_q(a.den, a.num))
 }
 
 fn rational_to_expr(r: &Rat) -> Expr {
@@ -3297,7 +3288,7 @@ fn simplify_to_rational(e: &Expr) -> Option<Rat> {
         if *d == 0 {
           None
         } else {
-          Some(rat_reduce(*n, *d))
+          Some(reduce_q(*n, *d))
         }
       } else {
         None
@@ -3315,7 +3306,7 @@ fn simplify_to_rational(e: &Expr) -> Option<Rat> {
       let mut acc = Rat::from_int(0);
       for arg in args {
         let r = simplify_to_rational(arg)?;
-        acc = rat_reduce(acc.num * r.den + r.num * acc.den, acc.den * r.den);
+        acc = reduce_q(acc.num * r.den + r.num * acc.den, acc.den * r.den);
       }
       Some(acc)
     }

--- a/src/functions/rsolve_ast.rs
+++ b/src/functions/rsolve_ast.rs
@@ -836,12 +836,12 @@ fn fib_lucas_at(k: i128) -> Option<(i128, i128)> {
 }
 
 /// Reduce a rational to lowest terms with a positive denominator.
-fn rat_reduce(n: i128, d: i128) -> Option<(i128, i128)> {
+/// Reject +/-Infinity.
+fn rat_reduce_inf(n: i128, d: i128) -> Option<(i128, i128)> {
   if d == 0 {
     return None;
   }
-  let (n, d) = crate::functions::math_ast::rat_reduce(n, d);
-  Some((n, d))
+  Some(rat_reduce(n, d))
 }
 
 /// Solve the golden-ratio recurrence (characteristic polynomial r^2 - r - 1,
@@ -857,7 +857,7 @@ fn solve_fibonacci_lucas(ics: &[(i128, Expr)], var_name: &str) -> Option<Expr> {
     let evaled =
       crate::evaluator::evaluate_expr_to_expr(e).unwrap_or_else(|_| e.clone());
     crate::functions::math_ast::expr_to_rational(&evaled)
-      .and_then(|(n, d)| rat_reduce(n, d))
+      .and_then(|(n, d)| rat_reduce_inf(n, d))
   };
 
   match ics {
@@ -870,8 +870,8 @@ fn solve_fibonacci_lucas(ics: &[(i128, Expr)], var_name: &str) -> Option<Expr> {
       // never 0 for integer k, so the elimination is always valid.)
       let (vn, vd) = ic_value(v_expr)?;
       let (fk, lk) = fib_lucas_at(*k)?;
-      let beta_const = rat_reduce(vn, vd.checked_mul(lk)?)?;
-      let beta_c1 = rat_reduce(-fk, lk)?;
+      let beta_const = rat_reduce_inf(vn, vd.checked_mul(lk)?)?;
+      let beta_c1 = rat_reduce_inf(-fk, lk)?;
       build_fib_lucas_combination(
         (0, 1),
         (1, 1),
@@ -904,8 +904,8 @@ fn solve_fibonacci_lucas(ics: &[(i128, Expr)], var_name: &str) -> Option<Expr> {
         .checked_mul(f1)?
         .checked_sub(v1n.checked_mul(v2d)?.checked_mul(f2)?)?;
       let denom = v1d.checked_mul(v2d)?.checked_mul(det)?;
-      let alpha = rat_reduce(alpha_num, denom)?;
-      let beta = rat_reduce(beta_num, denom)?;
+      let alpha = rat_reduce_inf(alpha_num, denom)?;
+      let beta = rat_reduce_inf(beta_num, denom)?;
       build_fib_lucas_combination(alpha, (0, 1), beta, (0, 1), 1, var_name)
     }
     _ => None, // over-determined — leave unevaluated
@@ -1532,7 +1532,7 @@ fn solve_initial_conditions(
         let (lhs_n, lhs_d) = (an * fd * pn * bd, ad * fd * pn * bd);
         let rhs_n = fn_ * pd * bn * ad;
         let (new_n, new_d) = (lhs_n - rhs_n, lhs_d);
-        let (nn, nd) = crate::functions::math_ast::rat_reduce(new_n, new_d);
+        let (nn, nd) = rat_reduce(new_n, new_d);
         aug[row][j] = (nn, nd);
       }
     }
@@ -1546,18 +1546,14 @@ fn solve_initial_conditions(
       // sn/sd -= aug[i][j] * solution[j]
       let (an, ad) = aug[i][j];
       let (cn, cd) = solution[j];
-      let sub_n = an * cn;
-      let sub_d = ad * cd;
+      let (sub_n, sub_d) = (an * cn, ad * cd);
       // sn/sd - sub_n/sub_d
-      sn = sn * sub_d - sub_n * sd;
-      sd *= sub_d;
-      (sn, sd) = crate::functions::math_ast::rat_reduce(sn, sd);
+      (sn, sd) = (sn * sub_d - sub_n * sd, sd * sub_d);
+      (sn, sd) = rat_reduce(sn, sd);
     }
     // solution[i] = (sn/sd) / aug[i][i]
     let (pn, pd) = aug[i][i];
-    sn *= pd;
-    sd *= pn;
-    (sn, sd) = crate::functions::math_ast::rat_reduce(sn, sd);
+    (sn, sd) = rat_reduce(sn * pd, sd * pn);
     solution[i] = (sn, sd);
   }
 


### PR DESCRIPTION
This PR simplifies some more code associated with rational numbers.

- Removed unneeded copies of rat_reduce from decompose.rs and minimal_polynomial.rs.
- Renamed rat_reduce to reduce_q in reduce.rs, rat_reduce_inf in rsolve_ast.rs to eliminate name collisions with the global rat_reduce. Change reduce_q to reduce (+/-n, 0) to (+/-1, 0) like rat_reduce.
- Adjusted various copies of rat_add, rat_sub, rat_mul, rat_div to be more alike. Ideally there should only be one implementation of these.
- Two versions of rat_div(a, b) handled negative b separately, but rat_reduce already will handle swapping the signs if the final denominator is negative. Similarly inv_q in reduce.rs can delegate normalization to rat_reduce.