### PR TITLE
Pad arbitrary-precision reals to their full precision on display

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -4267,9 +4267,9 @@ fn trim_bigfloat_to_precision_for_output(expr: &Expr) -> Expr {
   match expr {
     Expr::BigFloat(digits, prec) => {
       // OutputForm shows exactly `prec` significant digits:
-      // truncate when the stored digits exceed it, pad with
+      // round when the stored digits exceed it, pad with
       // trailing zeros when they fall short. Examples:
-      //   BigFloat("3.142", 3) → "3.14"     (truncate)
+      //   BigFloat("3.142", 3) → "3.14"     (round)
       //   BigFloat("3.14",  5) → "3.1400"   (pad)
       let prec_target = prec.round().max(1.0) as usize;
       let (sign, rest) = if let Some(r) = digits.strip_prefix('-') {
@@ -4277,33 +4277,13 @@ fn trim_bigfloat_to_precision_for_output(expr: &Expr) -> Expr {
       } else {
         ("", digits.as_str())
       };
-      let (int_part, frac_part) = match rest.find('.') {
-        Some(dp) => (&rest[..dp], &rest[dp + 1..]),
-        None => (rest, ""),
-      };
-      let int_sig = if int_part == "0" {
-        0
-      } else {
-        int_part.trim_start_matches('0').len()
-      };
-      let frac_needed = prec_target.saturating_sub(int_sig);
-      let formatted = if frac_needed == 0 {
-        format!("{sign}{int_part}.")
-      } else if frac_part.len() >= frac_needed {
-        format!("{}{}.{}", sign, int_part, &frac_part[..frac_needed])
-      } else {
-        format!(
-          "{}{}.{}{}",
-          sign,
-          int_part,
-          frac_part,
-          "0".repeat(frac_needed - frac_part.len())
-        )
-      };
       // OutputForm uses `Raw` so the rendered text is the exact
-      // padded/truncated decimal — bypasses `format_real`'s
+      // padded/rounded decimal — bypasses `format_real`'s
       // default trimming.
-      Expr::Raw(formatted)
+      Expr::Raw(format!(
+        "{sign}{}",
+        crate::round_significant(rest, prec_target)
+      ))
     }
     Expr::FunctionCall { name, args } => Expr::FunctionCall {
       name: name.clone(),

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -798,7 +798,7 @@ fn band_color(
   bounds.push(v_min);
   bounds.extend_from_slice(levels);
   bounds.push(v_max);
-  let mid = 0.5 * (bounds[band] + bounds[band + 1]);
+  let mid = f64::midpoint(bounds[band], bounds[band + 1]);
   scaled_color(scale_value(mid, v_min, v_max), color_function)
 }
 

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -5239,51 +5239,19 @@ fn render_grid_lines(
   }
 }
 
-/// Truncate a BigFloat digit string to `prec` significant digits for graphical display.
-/// E.g. digits="0.84147098480789650665" with prec=3 → "0.841"
-fn truncate_bigfloat_digits(digits: &str, prec: usize) -> String {
+/// Render a BigFloat digit string at `prec` significant digits for graphical
+/// display, e.g. digits="0.84147098480789650665" with prec=3 → "0.841".
+/// Delegates to the canonical rounder, so a label shows exactly the figures
+/// its precision claims (`N[28, 6]` → `28.0000`).
+fn bigfloat_digits_at_precision(digits: &str, prec: usize) -> String {
   if prec == 0 {
     return digits.to_string();
   }
-  let negative = digits.starts_with('-');
-  let d = if negative { &digits[1..] } else { digits };
-
-  // Count leading zeros after decimal point (they are not significant)
-  // e.g. "0.00123" has 2 leading zeros
-  let mut sig_seen = 0;
-  let mut cut_pos = d.len();
-  let mut past_dot = false;
-  let mut leading_zeros = true;
-  for (i, ch) in d.char_indices() {
-    if ch == '.' {
-      past_dot = true;
-      continue;
-    }
-    if !ch.is_ascii_digit() {
-      cut_pos = i;
-      break;
-    }
-    if leading_zeros && past_dot && ch == '0' {
-      continue; // leading fractional zeros are not significant
-    }
-    if ch != '0' || !leading_zeros {
-      leading_zeros = false;
-      sig_seen += 1;
-      if sig_seen == prec {
-        cut_pos = i + ch.len_utf8();
-        break;
-      }
-    }
-  }
-
-  let truncated = &d[..cut_pos];
-  // Remove trailing dot if nothing follows
-  let truncated = truncated.strip_suffix('.').unwrap_or(truncated);
-  if negative {
-    format!("-{truncated}")
-  } else {
-    truncated.to_string()
-  }
+  let (sign, mantissa) = match digits.strip_prefix('-') {
+    Some(rest) => ("-", rest),
+    None => ("", digits),
+  };
+  format!("{sign}{}", crate::round_significant(mantissa, prec))
 }
 
 /// Information about how a BigFloat should be displayed graphically.
@@ -5369,7 +5337,10 @@ fn bigfloat_display_parts(digits: &str, prec: f64) -> BigFloatDisplay {
 
   // Normal range — just truncate
   BigFloatDisplay {
-    mantissa: truncate_bigfloat_digits(digits, (prec.ceil() as usize).max(1)),
+    mantissa: bigfloat_digits_at_precision(
+      digits,
+      (prec.ceil() as usize).max(1),
+    ),
     exponent: None,
   }
 }

--- a/src/functions/image_ast.rs
+++ b/src/functions/image_ast.rs
@@ -8789,7 +8789,7 @@ fn ciede2000_distance(lab1: (f64, f64, f64), lab2: (f64, f64, f64)) -> f64 {
 
   let c1 = (a1 * a1 + b1 * b1).sqrt();
   let c2 = (a2 * a2 + b2 * b2).sqrt();
-  let avg_c = 0.5 * (c1 + c2);
+  let avg_c = f64::midpoint(c1, c2);
   let avg_c7 = avg_c.powi(7);
   let g = 0.5 * (1.0 - (avg_c7 / (avg_c7 + 25f64.powi(7))).sqrt());
 
@@ -8797,7 +8797,7 @@ fn ciede2000_distance(lab1: (f64, f64, f64), lab2: (f64, f64, f64)) -> f64 {
   let a2p = a2 * (1.0 + g);
   let c1p = (a1p * a1p + b1 * b1).sqrt();
   let c2p = (a2p * a2p + b2 * b2).sqrt();
-  let avg_cp = 0.5 * (c1p + c2p);
+  let avg_cp = f64::midpoint(c1p, c2p);
 
   let to_deg = 180.0 / std::f64::consts::PI;
   let h1p = {
@@ -8827,11 +8827,11 @@ fn ciede2000_distance(lab1: (f64, f64, f64), lab2: (f64, f64, f64)) -> f64 {
   let delta_hp_rad = delta_hp_deg / to_deg;
   let delta_h_big = 2.0 * cprod.sqrt() * (delta_hp_rad / 2.0).sin();
 
-  let avg_lp = 0.5 * (l1 + l2);
+  let avg_lp = f64::midpoint(l1, l2);
   let avg_hp_deg = if cprod == 0.0 {
     h1p + h2p
   } else if (h1p - h2p).abs() <= 180.0 {
-    0.5 * (h1p + h2p)
+    f64::midpoint(h1p, h2p)
   } else if h1p + h2p < 360.0 {
     0.5 * (h1p + h2p + 360.0)
   } else {

--- a/src/functions/math_ast/carlson.rs
+++ b/src/functions/math_ast/carlson.rs
@@ -267,10 +267,11 @@ fn carlson_rg(x: f64, y: f64, z: f64) -> f64 {
   if c == 0.0 {
     return 0.0;
   }
-  0.5
-    * (c * carlson_rf(a, b, c)
-      - (1.0 / 3.0) * (a - c) * (b - c) * carlson_rd(a, b, c)
-      + (a * b / c).sqrt())
+  f64::midpoint(
+    c * carlson_rf(a, b, c)
+      - (1.0 / 3.0) * (a - c) * (b - c) * carlson_rd(a, b, c),
+    (a * b / c).sqrt(),
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/src/functions/math_ast/distributions.rs
+++ b/src/functions/math_ast/distributions.rs
@@ -1127,7 +1127,7 @@ pub fn quantile_distribution_numeric(
   let mut lo_b = lo;
   // Bisection: ~50 iterations gives ≈1e-15 precision for any sane support.
   for _ in 0..80 {
-    let mid = 0.5 * (lo_b + hi);
+    let mid = f64::midpoint(lo_b, hi);
     let Some(c) = cdf_at(mid) else {
       return Ok(None);
     };
@@ -1140,7 +1140,7 @@ pub fn quantile_distribution_numeric(
       break;
     }
   }
-  Ok(Some(Expr::Real(0.5 * (lo_b + hi))))
+  Ok(Some(Expr::Real(f64::midpoint(lo_b, hi))))
 }
 
 /// PDF[ProbabilityDistribution[pdf_expr, {var, lo, hi}], t] substitutes `t`
@@ -9568,8 +9568,8 @@ fn cdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
     return uneval(x);
   };
   let mut terms: Vec<Expr> = vec![int(1)];
-  let default;
-  if distinct {
+
+  let default = if distinct {
     let coeffs = coxian_distinct_coefficients(&alphas, &rates)?;
     let mut order: Vec<usize> = (0..rates.len()).collect();
     let val = |i: usize| try_eval_to_f64(&rates[i]).unwrap();
@@ -9578,7 +9578,7 @@ fn cdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       let c = eval(&times2(int(-1), coeffs[i].clone()))?;
       terms.push(coxian_exp_term(c, None, &rates[i], &x));
     }
-    default = int(0);
+    int(0)
   } else {
     // Survival of the equal-rate mixture: Σ_j (Σ_{k>j} w_k) λ^j x^j
     // e^(-λ x)/j! subtracted from 1.
@@ -9604,8 +9604,8 @@ fn cdf_coxian(dargs: &[Expr], x: Expr) -> Result<Expr, InterpreterError> {
       };
       terms.push(coxian_exp_term(c, xpow, lam, &x));
     }
-    default = int(1);
-  }
+    int(1)
+  };
   let value = call("Plus", terms);
   let cond = comparison(x, ComparisonOp::GreaterEqual, int(0));
   eval(&piecewise(vec![(value, cond)], default))
@@ -17208,8 +17208,7 @@ pub fn truncated_distribution_value(
       // Below the interval nothing has accumulated; above it, everything has.
       Some(false) => {
         let below = eval("Less", vec![x.clone(), lo.clone()])
-          .ok()
-          .is_some_and(|r| matches!(&r, Expr::Identifier(b) if b == "True"));
+          .is_ok_and(|r| matches!(&r, Expr::Identifier(b) if b == "True"));
         Ok(Some(Expr::Integer(i128::from(!below))))
       }
       None => Ok(None),

--- a/src/functions/math_ast/elliptic.rs
+++ b/src/functions/math_ast/elliptic.rs
@@ -156,14 +156,14 @@ fn inverse_elliptic_nome_q_numeric(q: f64) -> f64 {
   let mut lo = 0.0_f64;
   let mut hi = 1.0_f64;
   for _ in 0..200 {
-    let mid = 0.5 * (lo + hi);
+    let mid = f64::midpoint(lo, hi);
     if nome(mid) < q {
       lo = mid;
     } else {
       hi = mid;
     }
   }
-  0.5 * (lo + hi)
+  f64::midpoint(lo, hi)
 }
 
 /// InverseEllipticNomeQ[q] - inverse elliptic nome: the parameter m with

--- a/src/functions/math_ast/gamma.rs
+++ b/src/functions/math_ast/gamma.rs
@@ -1440,14 +1440,14 @@ fn inverse_beta_regularized_numeric(s: f64, a: f64, b: f64) -> f64 {
   let mut lo = 0.0_f64;
   let mut hi = 1.0_f64;
   for _ in 0..200 {
-    let mid = 0.5 * (lo + hi);
+    let mid = f64::midpoint(lo, hi);
     if beta_regularized_numeric(mid, a, b) < s {
       lo = mid;
     } else {
       hi = mid;
     }
   }
-  0.5 * (lo + hi)
+  f64::midpoint(lo, hi)
 }
 
 /// InverseBetaRegularized[s, a, b] - inverse of the regularized incomplete beta
@@ -1932,14 +1932,14 @@ fn inverse_gamma_regularized_numeric(a: f64, q: f64) -> f64 {
     guard += 1;
   }
   for _ in 0..200 {
-    let mid = 0.5 * (lo + hi);
+    let mid = f64::midpoint(lo, hi);
     if gamma_regularized_numeric(a, mid) > q {
       lo = mid;
     } else {
       hi = mid;
     }
   }
-  0.5 * (lo + hi)
+  f64::midpoint(lo, hi)
 }
 
 /// InverseGammaRegularized[a, q] - inverse of the upper regularized incomplete

--- a/src/functions/math_ast/statistics.rs
+++ b/src/functions/math_ast/statistics.rs
@@ -4964,65 +4964,72 @@ pub fn pearson_chi_square_test_ast(
   };
 
   // Determine the null distribution and number of estimated parameters
-  let (dist_cdf, estimated_params): (Box<dyn Fn(f64) -> f64>, usize) = if args
-    .len()
-    >= 2
-  {
-    match &args[1] {
-      Expr::Identifier(s) if s == "Automatic" => {
-        // Normal with estimated mean and variance
-        let n = data.len() as f64;
-        let mean = data.iter().sum::<f64>() / n;
-        let var =
-          data.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (n - 1.0);
-        let sd = var.sqrt();
-        (
-          Box::new(move |x: f64| {
-            0.5 * (1.0 + erf_f64((x - mean) / (sd * std::f64::consts::SQRT_2)))
-          }),
-          2, // estimated mean and variance
-        )
-      }
-      Expr::FunctionCall { name, args: dargs } => match name.as_str() {
-        "NormalDistribution" => {
-          let (mu, sigma) = match dargs.len() {
-            0 => (0.0, 1.0),
-            2 => {
-              let mu = try_eval_to_f64(&dargs[0]).unwrap_or(0.0);
-              let sigma = try_eval_to_f64(&dargs[1]).unwrap_or(1.0);
-              (mu, sigma)
-            }
-            _ => (0.0, 1.0),
-          };
+  let (dist_cdf, estimated_params): (Box<dyn Fn(f64) -> f64>, usize) =
+    if args.len() >= 2 {
+      match &args[1] {
+        Expr::Identifier(s) if s == "Automatic" => {
+          // Normal with estimated mean and variance
+          let n = data.len() as f64;
+          let mean = data.iter().sum::<f64>() / n;
+          let var =
+            data.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (n - 1.0);
+          let sd = var.sqrt();
           (
             Box::new(move |x: f64| {
-              0.5
-                * (1.0 + erf_f64((x - mu) / (sigma * std::f64::consts::SQRT_2)))
+              f64::midpoint(
+                1.0,
+                erf_f64((x - mean) / (sd * std::f64::consts::SQRT_2)),
+              )
             }),
-            0,
+            2, // estimated mean and variance
           )
         }
+        Expr::FunctionCall { name, args: dargs } => match name.as_str() {
+          "NormalDistribution" => {
+            let (mu, sigma) = match dargs.len() {
+              0 => (0.0, 1.0),
+              2 => {
+                let mu = try_eval_to_f64(&dargs[0]).unwrap_or(0.0);
+                let sigma = try_eval_to_f64(&dargs[1]).unwrap_or(1.0);
+                (mu, sigma)
+              }
+              _ => (0.0, 1.0),
+            };
+            (
+              Box::new(move |x: f64| {
+                f64::midpoint(
+                  1.0,
+                  erf_f64((x - mu) / (sigma * std::f64::consts::SQRT_2)),
+                )
+              }),
+              0,
+            )
+          }
+          _ => {
+            return Ok(unevaluated("PearsonChiSquareTest", args));
+          }
+        },
         _ => {
           return Ok(unevaluated("PearsonChiSquareTest", args));
         }
-      },
-      _ => {
-        return Ok(unevaluated("PearsonChiSquareTest", args));
       }
-    }
-  } else {
-    // Default: Normal with estimated parameters
-    let n = data.len() as f64;
-    let mean = data.iter().sum::<f64>() / n;
-    let var = data.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (n - 1.0);
-    let sd = var.sqrt();
-    (
-      Box::new(move |x: f64| {
-        0.5 * (1.0 + erf_f64((x - mean) / (sd * std::f64::consts::SQRT_2)))
-      }),
-      2,
-    )
-  };
+    } else {
+      // Default: Normal with estimated parameters
+      let n = data.len() as f64;
+      let mean = data.iter().sum::<f64>() / n;
+      let var =
+        data.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (n - 1.0);
+      let sd = var.sqrt();
+      (
+        Box::new(move |x: f64| {
+          f64::midpoint(
+            1.0,
+            erf_f64((x - mean) / (sd * std::f64::consts::SQRT_2)),
+          )
+        }),
+        2,
+      )
+    };
 
   // Parse property
   let property = if args.len() == 3 {

--- a/src/functions/math_ast/zeta_functions.rs
+++ b/src/functions/math_ast/zeta_functions.rs
@@ -1398,7 +1398,7 @@ fn gauss_legendre_integrate_lerch<F: Fn(f64) -> f64>(
 ) -> f64 {
   let nodes = lerch_gl_nodes();
   let half = (hi - lo) * 0.5;
-  let mid = (lo + hi) * 0.5;
+  let mid = f64::midpoint(lo, hi);
   let mut sum = 0.0;
   for (t, w) in nodes {
     let x = mid + half * t;

--- a/src/functions/plot3d.rs
+++ b/src/functions/plot3d.rs
@@ -977,7 +977,7 @@ fn generate_svg(
       for s in 0..EDGE_SUBDIVISIONS {
         let t0 = s as f64 / EDGE_SUBDIVISIONS as f64;
         let t1 = (s + 1) as f64 / EDGE_SUBDIVISIONS as f64;
-        let tm = (t0 + t1) * 0.5;
+        let tm = f64::midpoint(t0, t1);
         let lerp = |t: f64| Point3D {
           x: a.x + (b.x - a.x) * t,
           y: a.y + (b.y - a.y) * t,
@@ -1274,7 +1274,7 @@ fn draw_axes_on_box(
       let (dx, dy) = (sx1 - sx0, sy1 - sy0);
       let len = (dx * dx + dy * dy).sqrt();
       if len > 1.0 {
-        let (mid_x, mid_y) = ((sx0 + sx1) * 0.5, (sy0 + sy1) * 0.5);
+        let (mid_x, mid_y) = (f64::midpoint(sx0, sx1), f64::midpoint(sy0, sy1));
         let (perpx, perpy) = (-dy / len, dx / len);
         let sign = if perpx * (cx - mid_x) + perpy * (cy - mid_y) > 0.0 {
           -1.0
@@ -1342,8 +1342,8 @@ fn draw_axes_on_box(
                 ));
 
         // Place label on the outward side (away from box center)
-        let mid_x = (sx0 + sx1) * 0.5;
-        let mid_y = (sy0 + sy1) * 0.5;
+        let mid_x = f64::midpoint(sx0, sx1);
+        let mid_y = f64::midpoint(sy0, sy1);
         let to_center_x = cx - mid_x;
         let to_center_y = cy - mid_y;
         let sign = if perpx * to_center_x + perpy * to_center_y > 0.0 {
@@ -1720,7 +1720,7 @@ pub fn vector_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       for s in 0..EDGE_SUBDIVISIONS {
         let t0 = s as f64 / EDGE_SUBDIVISIONS as f64;
         let t1 = (s + 1) as f64 / EDGE_SUBDIVISIONS as f64;
-        let tm = (t0 + t1) * 0.5;
+        let tm = f64::midpoint(t0, t1);
         let lerp = |t: f64| Point3D {
           x: a.x + (b.x - a.x) * t,
           y: a.y + (b.y - a.y) * t,
@@ -5549,7 +5549,7 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       for s in 0..EDGE_SUBDIVISIONS {
         let t0 = s as f64 / EDGE_SUBDIVISIONS as f64;
         let t1 = (s + 1) as f64 / EDGE_SUBDIVISIONS as f64;
-        let tm = (t0 + t1) * 0.5;
+        let tm = f64::midpoint(t0, t1);
         let lerp = |t: f64| Point3D {
           x: a.x + (b.x - a.x) * t,
           y: a.y + (b.y - a.y) * t,
@@ -5590,7 +5590,7 @@ pub fn graphics3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
           for s in 0..LINE_SUBDIVISIONS {
             let t0 = s as f64 / LINE_SUBDIVISIONS as f64;
             let t1 = (s + 1) as f64 / LINE_SUBDIVISIONS as f64;
-            let tm = (t0 + t1) * 0.5;
+            let tm = f64::midpoint(t0, t1);
             let lerp = |t: f64| Point3D {
               x: a.x + (b.x - a.x) * t,
               y: a.y + (b.y - a.y) * t,
@@ -7950,7 +7950,7 @@ fn generate_scatter_svg(
     for s in 0..EDGE_SUBDIVISIONS {
       let t0 = s as f64 / EDGE_SUBDIVISIONS as f64;
       let t1 = (s + 1) as f64 / EDGE_SUBDIVISIONS as f64;
-      let tm = (t0 + t1) * 0.5;
+      let tm = f64::midpoint(t0, t1);
       let lerp = |t: f64| Point3D {
         x: a.x + (b.x - a.x) * t,
         y: a.y + (b.y - a.y) * t,
@@ -8205,9 +8205,9 @@ pub fn list_line_plot3d_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
       let (ax, ay) = project(a, &camera);
       let (bx, by) = project(b, &camera);
       let mid = Point3D {
-        x: (a.x + b.x) * 0.5,
-        y: (a.y + b.y) * 0.5,
-        z: (a.z + b.z) * 0.5,
+        x: f64::midpoint(a.x, b.x),
+        y: f64::midpoint(a.y, b.y),
+        z: f64::midpoint(a.z, b.z),
       };
       segments.push(LineSeg3D {
         x0: ax,
@@ -8357,7 +8357,7 @@ fn generate_line3d_svg(
     for s in 0..EDGE_SUBDIVISIONS {
       let t0 = s as f64 / EDGE_SUBDIVISIONS as f64;
       let t1 = (s + 1) as f64 / EDGE_SUBDIVISIONS as f64;
-      let tm = (t0 + t1) * 0.5;
+      let tm = f64::midpoint(t0, t1);
       let lerp = |t: f64| Point3D {
         x: a.x + (b.x - a.x) * t,
         y: a.y + (b.y - a.y) * t,

--- a/src/functions/polynomial_ast/simplify.rs
+++ b/src/functions/polynomial_ast/simplify.rs
@@ -8493,30 +8493,28 @@ fn simplify_quotient_select(
   // the quotient instead ((1+2n+n^2)/n^2 → (1+n)^2/n^2 via the Factor
   // pipeline), so the split only competes for irreducible numerators.
   let num_factors_nontrivially = || {
-    super::factor::factor_ast(std::slice::from_ref(num))
-      .ok()
-      .is_some_and(|f| {
-        let factors =
-          super::together::flatten_times_args(std::slice::from_ref(&f));
-        let non_constant = factors
-          .iter()
-          .filter(|f| {
-            let mut vars = std::collections::HashSet::new();
-            collect_variables(f, &mut vars);
-            !vars.is_empty()
-          })
-          .count();
-        non_constant >= 2
-          || factors.iter().any(|f| {
-            matches!(
-              f,
-              Expr::BinaryOp {
-                op: BinaryOperator::Power,
-                ..
-              }
-            ) || matches!(f, Expr::FunctionCall { name, .. } if name == "Power")
-          })
-      })
+    super::factor::factor_ast(std::slice::from_ref(num)).is_ok_and(|f| {
+      let factors =
+        super::together::flatten_times_args(std::slice::from_ref(&f));
+      let non_constant = factors
+        .iter()
+        .filter(|f| {
+          let mut vars = std::collections::HashSet::new();
+          collect_variables(f, &mut vars);
+          !vars.is_empty()
+        })
+        .count();
+      non_constant >= 2
+        || factors.iter().any(|f| {
+          matches!(
+            f,
+            Expr::BinaryOp {
+              op: BinaryOperator::Power,
+              ..
+            }
+          ) || matches!(f, Expr::FunctionCall { name, .. } if name == "Power")
+        })
+    })
   };
   if den_is_mono && n_terms.len() > 1 && !num_factors_nontrivially() {
     let split_cost = 1

--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -5686,42 +5686,22 @@ fn box_ast_to_tex(expr: &Expr) -> String {
   }
 }
 
-/// Pad a BigFloat digit string with trailing zeros so the total
-/// number of significant digits equals `prec`. Used by TeX/C/
-/// Fortran rendering where the precision-tag suffix isn't shown
-/// but the digit count should still reflect the stored precision.
-/// `digits` is e.g. `-14.` or `3.14`; `prec` is the significant-
-/// digit count. Returns `-14.0` for `("-14.", 3.0)`.
+/// Render a BigFloat digit string at exactly `prec` significant digits. Used
+/// by TeX/C/Fortran rendering where the precision-tag suffix isn't shown but
+/// the digit count should still reflect the stored precision. `digits` is
+/// e.g. `-14.` or `3.14`; `prec` is the significant-digit count. Returns
+/// `-14.0` for `("-14.", 3.0)`.
 fn pad_bigfloat_to_precision(digits: &str, prec: f64) -> String {
   let prec_target = prec.round().max(0.0) as usize;
+  if prec_target == 0 {
+    return digits.to_string();
+  }
   let (sign, rest) = if let Some(r) = digits.strip_prefix('-') {
     ("-", r)
   } else {
     ("", digits)
   };
-  // Split into integer and fractional parts around the decimal
-  // point (if any).
-  let (int_part, frac_part) = match rest.find('.') {
-    Some(dp) => (&rest[..dp], &rest[dp + 1..]),
-    None => (rest, ""),
-  };
-  // Significant digits in the integer part: skip leading zeros
-  // unless the integer is just "0".
-  let int_sig = if int_part == "0" {
-    0
-  } else {
-    int_part.trim_start_matches('0').len()
-  };
-  let current_sig = int_sig + frac_part.len();
-  if current_sig >= prec_target {
-    return digits.to_string();
-  }
-  let pad = prec_target - current_sig;
-  if rest.contains('.') {
-    format!("{}{}.{}{}", sign, int_part, frac_part, "0".repeat(pad))
-  } else {
-    format!("{}{}.{}", sign, int_part, "0".repeat(pad))
-  }
+  format!("{sign}{}", crate::round_significant(rest, prec_target))
 }
 
 /// The rows of `items` when it is a matrix for TeX purposes: every element is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4093,8 +4093,9 @@ fn precision_number_display(token: &str) -> Option<String> {
 /// with placeholder zeros in the integer part (`314.159` → 2 sig figs →
 /// `310.`), rounding carries propagate (`9.99` → 2 sig figs → `10.`), and a
 /// trailing decimal point is always kept so an approximate real still reads as
-/// `3.` rather than `3`. When `prec` exceeds the digits available, every
-/// stored digit is shown unrounded.
+/// `3.` rather than `3`. When `prec` exceeds the digits available the result is
+/// padded with trailing zeros, because an arbitrary-precision real shows every
+/// figure its precision claims (`N[28, 6]` → `28.0000`, `3.14`5` → `3.1400`).
 pub(crate) fn round_significant(mantissa: &str, prec: usize) -> String {
   let prec = prec.max(1);
   let (int_s, frac_s) = match mantissa.find('.') {
@@ -4141,6 +4142,10 @@ pub(crate) fn round_significant(mantissa: &str, prec: usize) -> String {
       }
     }
   }
+
+  // Show every figure the precision claims, padding when the stored digits
+  // run out (`28.` at 6 significant figures displays as `28.0000`).
+  kept.resize(prec, 0);
 
   let m = kept.len() as isize;
   let tail_exp = lead_exp - (m - 1);

--- a/tests/interpreter_tests/calculus.rs
+++ b/tests/interpreter_tests/calculus.rs
@@ -7287,7 +7287,7 @@ mod ndsolve {
     .unwrap()
     .parse()
     .expect("should be a number");
-    let expected = 0.5 * (1.0 + (-2.0f64).exp());
+    let expected = f64::midpoint(1.0, (-2.0f64).exp());
     assert!(
       (value - expected).abs() < 1e-6,
       "expected {expected}, got {value}"

--- a/tests/miscellaneous_tests/precision_display.rs
+++ b/tests/miscellaneous_tests/precision_display.rs
@@ -203,9 +203,39 @@ mod tests {
   }
 
   #[test]
-  fn precision_beyond_available_digits_shows_all_digits() {
-    // When the requested precision exceeds the stored significant digits,
-    // every available digit is shown (no padding beyond the mantissa).
-    assert_eq!(truncate_precision_reals("3.14`8."), "3.14");
+  fn precision_beyond_available_digits_pads_with_trailing_zeros() {
+    // An arbitrary-precision real shows every figure its precision claims, so
+    // a mantissa with fewer stored digits is padded rather than left short.
+    // Matches the TeX rendering of the same values (`3.14`5 // TeXForm` →
+    // `3.1400`, `-14.`3 // TeXForm` → `-14.0`), which Woxi already got right
+    // through a separate code path.
+    assert_eq!(truncate_precision_reals("3.14`8."), "3.1400000");
+    assert_eq!(truncate_precision_reals("3.14`5."), "3.1400");
+    assert_eq!(truncate_precision_reals("-14.`3."), "-14.0");
+    // A value that lands exactly on an integer still shows its full precision
+    // (`N[28, 6]` → `28.0000`), which is what a Demonstration's `N[…, 6]`
+    // readout produces whenever the quantity happens to come out exact.
+    assert_eq!(truncate_precision_reals("28.`6."), "28.0000");
+    assert_eq!(truncate_precision_reals("0.5`6."), "0.500000");
+  }
+
+  /// Padding is a display concern for *arbitrary*-precision reals only: a
+  /// machine real (bare backtick) still drops its trailing zeros.
+  #[test]
+  fn machine_precision_reals_still_drop_trailing_zeros() {
+    assert_eq!(truncate_precision_reals("2.`"), "2.");
+    assert_eq!(truncate_precision_reals("0.3`"), "0.3");
+    assert_eq!(truncate_precision_reals("100.`"), "100.");
+  }
+
+  /// The graphical (SVG) label path shows the same padded figures, so a
+  /// `Text[N[area, 6], …]` readout inside a `Graphics` reads `28.0000` rather
+  /// than the bare `28.` it used to.
+  #[test]
+  fn graphics_labels_pad_arbitrary_precision_reals() {
+    assert_eq!(output_text("N[28, 6]"), "28.0000");
+    assert_eq!(output_text("N[Sqrt[784], 6]"), "28.0000");
+    // Digits beyond the precision are still rounded away.
+    assert_eq!(output_text("N[Pi, 6]"), "3.14159");
   }
 }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -19563,4 +19563,172 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`nmax$$ = 10}, DynamicBox[\[Ellipsis
       "dropping the spoke count from 11 to 5 must change the rendered wheel"
     );
   }
+
+  /// Checked a randomly-sampled Wolfram Demonstrations Project notebook: a
+  /// triangle whose three vertices are draggable `Locator` controls, with
+  /// toggles that overlay its perimeter and its area as `N[…, 6]` readouts.
+  /// Independently written, not copied from any specific Demonstration: the
+  /// area here comes from the shoelace determinant rather than Heron's
+  /// formula, and the readout row is a `Rectangle` plate instead of a
+  /// five-point `Polygon`.
+  ///
+  /// Two things are worth pinning down. First, a `Locator` control whose
+  /// value is a *single* point (`{{v1, {-4, 3}, "…"}, {-10, -10}, {10, 8},
+  /// Locator, Appearance -> None}`) must become a 2D control binding `v1` to
+  /// a bare `{x, y}` pair, not to a one-element list of points — the body
+  /// reads `v1[[1]]`/`v1[[2]]` and would break otherwise. Second, an exact
+  /// `N[…, 6]` readout must show all six figures: a lattice triangle's area
+  /// is always a multiple of `1/2`, so this label lands on an exact value
+  /// constantly, and it has to read `28.0000`, not `28.`.
+  #[test]
+  fn demonstration_triangle_locators_report_perimeter_and_area() {
+    let code = "Manipulate[\
+      With[{ax = v1[[1]], ay = v1[[2]], bx = v2[[1]], by = v2[[2]], \
+            cx = v3[[1]], cy = v3[[2]]}, \
+        With[{peri = N[Sqrt[(ax - bx)^2 + (ay - by)^2] \
+                     + Sqrt[(bx - cx)^2 + (by - cy)^2] \
+                     + Sqrt[(cx - ax)^2 + (cy - ay)^2], 6], \
+              area = N[Abs[(bx - ax) (cy - ay) - (cx - ax) (by - ay)]/2, 6]}, \
+          Graphics[{\
+            Tooltip[Locator[v1], v1], Tooltip[Locator[v2], v2], \
+            Tooltip[Locator[v3], v3], \
+            Style[Line[{v1, v2, v3, v1}], Blue, Thickness[.005]], \
+            If[showPerimeter, {\
+              Style[Rectangle[{1, 9}, {10, 10}], White], \
+              Style[Text[\"perimeter =\", {6, 9.5}, {Right, Center}], Red], \
+              Style[Text[peri, {8, 9.5}], Red]}, {}], \
+            If[showArea, {\
+              Style[Rectangle[{1, 8}, {10, 9}], White], \
+              Style[Text[\"area =\", {6, 8.5}, {Right, Center}], Blue], \
+              Style[Polygon[{v1, v2, v3}], Blue, Opacity[.5]], \
+              Style[Text[area, {8, 8.5}], Blue]}, {}]}, \
+            Axes -> True, AxesLabel -> {x, y}, PlotRange -> 10, \
+            BaseStyle -> {Medium, 14}, \
+            GridLines -> {Table[{n, RGBColor[0, 0.6, 1.]}, {n, -10, 10, 1}], \
+                          Table[{n, RGBColor[0, 0.6, 1.]}, {n, -10, 10, 1}]}, \
+            ImageSize -> {400, 400}]]], \
+      {{v1, {-4, 3}, \"x1/y1\"}, {-10, -10}, {10, 8}, Locator, \
+        Appearance -> None}, \
+      {{v2, {5, -2}, \"x2/y2\"}, {-10, -10}, {10, 8}, Locator, \
+        Appearance -> None}, \
+      {{v3, {-2, -5}, \"x3/y3\"}, {-10, -10}, {10, 8}, Locator, \
+        Appearance -> None}, \
+      {{showPerimeter, False, \"show perimeter\"}, {True, False}}, \
+      {{showArea, False, \"show area\"}, {True, False}}, \
+      ControlPlacement -> Left\
+    ]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the triangle Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some(), "the triangle must render");
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the triangle must render")
+    };
+    let plain = render(&state);
+    assert!(
+      !plain.contains("perimeter =") && !plain.contains("area ="),
+      "both readouts start switched off"
+    );
+
+    // Each single-point Locator binds a bare `{x, y}` pair, so `v1[[1]]` is a
+    // coordinate rather than a point.
+    match &mut state.controls[..] {
+      [
+        manipulate::ControlState::Slider2D {
+          name: n1,
+          x: x1,
+          y: y1,
+          x_min,
+          x_max,
+          y_min,
+          y_max,
+          ..
+        },
+        manipulate::ControlState::Slider2D { name: n2, .. },
+        manipulate::ControlState::Slider2D { name: n3, .. },
+        manipulate::ControlState::Discrete {
+          name: n4,
+          values: peri_values,
+          current_index: peri_index,
+          ..
+        },
+        manipulate::ControlState::Discrete {
+          name: n5,
+          current_index: area_index,
+          ..
+        },
+      ] => {
+        assert_eq!(
+          [
+            n1.as_str(),
+            n2.as_str(),
+            n3.as_str(),
+            n4.as_str(),
+            n5.as_str()
+          ],
+          ["v1", "v2", "v3", "showPerimeter", "showArea"]
+        );
+        // The two corner points bound the draggable region.
+        assert_eq!((*x_min, *y_min), (-10.0, -10.0));
+        assert_eq!((*x_max, *y_max), (10.0, 8.0));
+        assert_eq!((*x1, *y1), (-4.0, 3.0));
+        assert_eq!(peri_values, &["True".to_string(), "False".to_string()]);
+        // Both toggles default to False — the second choice.
+        assert_eq!((*peri_index, *area_index), (1, 1));
+        *peri_index = 0;
+        *area_index = 0;
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    let labelled = render(&state);
+    assert!(
+      labelled.contains("perimeter =") && labelled.contains("area ="),
+      "switching both toggles on must draw the two readout rows"
+    );
+    // Vertices (-4, 3), (5, -2), (-2, -5): the shoelace determinant is
+    // |9*(-8) - 2*(-5)| / 2 = 31, an exact value that must still print all
+    // six figures its precision claims.
+    assert!(
+      labelled.contains("31.0000"),
+      "an exact area must show its full precision, got: {labelled}"
+    );
+
+    // Dragging a vertex changes both the outline and the readouts.
+    if let manipulate::ControlState::Slider2D { x, y, .. } =
+      &mut state.controls[0]
+    {
+      *x = 6.0;
+      *y = 7.0;
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    let dragged = render(&state);
+    assert_ne!(
+      labelled, dragged,
+      "moving a locator must change the rendered triangle"
+    );
+    assert!(
+      !dragged.contains("31.0000"),
+      "the area readout must follow the moved vertex"
+    );
+  }
 }


### PR DESCRIPTION
Sampled a random Wolfram Demonstrations Project notebook — a triangle whose three vertices are draggable `Locator` controls, with toggles overlaying its perimeter and area as `N[…, 6]` readouts.

Woxi Studio already builds the widget, binds all five controls, and re-renders correctly as the vertices are dragged. One thing printed wrong: an exact readout came out short. A lattice triangle's area is always a multiple of `1/2`, so `N[area, 6]` constantly lands on an exact value — and the label read `28.` where Wolfram shows `28.0000`.

Two commits, reviewable independently.

## 1. Pad arbitrary-precision reals to their full precision

Four separate implementations of "render a `BigFloat` at its precision" had drifted apart:

| path | rounds past precision? | pads short digits? |
| --- | --- | --- |
| TeX / C / Fortran (`pad_bigfloat_to_precision`) | no | yes |
| `OutputForm` (`trim_bigfloat_to_precision_for_output`) | truncates | yes |
| graphics labels (`truncate_bigfloat_digits`) | truncates | **no** |
| notebook display (`round_significant`) | rounds | **no** |

Only the first two matched Wolfram, and the repo's own tests had inherited both sides of the split: `tests/interpreter_tests/string.rs` asserts the wolframscript-verified `3.14`5 // TeXForm` → `3.1400`, while `tests/miscellaneous_tests/precision_display.rs` asserted the contradictory `3.14`8.` → `3.14`.

Folded all four onto `round_significant`, which now pads with trailing zeros — the behaviour its own call site already documented ("keeping trailing zeros (an arbitrary-precision real shows every requested figure)") but which the function never implemented. The graphics, `OutputForm`, and TeX paths now agree, and digits past the precision round rather than truncate.

```
N[28, 6]     28.       →  28.0000
N[1/2, 6]    0.5       →  0.500000
3.14`5       3.14      →  3.1400
-14.`3       -14.      →  -14.0
```

Machine-precision reals are unaffected — they still drop trailing zeros (`0.1 + 0.2` → `0.3`), and `N[Pi, 6]` → `3.14159` still rounds away the excess.

### Tests

- Corrected `precision_beyond_available_digits_*` to the padded form and extended it to the cases the TeXForm tests already pinned down.
- Added `machine_precision_reals_still_drop_trailing_zeros` so the two display modes can't be conflated again.
- Added `graphics_labels_pad_arbitrary_precision_reals` covering the SVG label path the Demonstration actually hits.
- Added an independently-written Studio regression test for the notebook's shape. Its load-bearing assertion: a `Locator` control whose value is a *single* point must become a 2D control binding the variable to a bare `{x, y}` pair, not to a one-element list of points — the body reads `v1[[1]]`/`v1[[2]]` and would break otherwise. It also checks that toggling both readouts on draws them, that an exact area shows all six figures, and that dragging a vertex moves both the outline and the numbers.

No code was copied from the sampled notebook; the test computes area from the shoelace determinant rather than Heron's formula and uses its own layout.

## 2. Fix clippy lints from the stable toolchain bump

Unrelated to the change above, but it blocks CI. The workflows use `dtolnay/rust-toolchain@stable` and nothing pins the version, so stable moved 1.94 → 1.98 and brought new lints that fire on pre-existing code: 31 `manual_midpoint`, 2 `manual_is_variant_and`, 1 `needless_late_init`, across ten files this PR does not otherwise touch.

**These reproduce identically on an untouched `origin/main` worktree under 1.98** — `main` is red as of now, independent of this PR; its last green run predates the bump. Worth considering a `rust-toolchain.toml` so this doesn't recur on the next unrelated PR.

All fixes are mechanical (`cargo clippy --fix`). `f64::midpoint` is not bit-identical to `0.5 * (a + b)` (it is correctly rounded and cannot overflow), so the full suite was re-run rather than assumed safe.

---

`make test` 27364 passed · `make test-studio` 169 passed · `cargo clippy --all-targets -- -D warnings` clean under both 1.94 and 1.98 · `make format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HV5zWLwDxQTuMS5ErZxmNz