### PR TITLE
Splice Sequence into pure-function args and add Developer`ToPackedArray

### DIFF
--- a/functions.csv
+++ b/functions.csv
@@ -6300,3 +6300,4 @@ SetProperty,Graph with an annotation set for one of its vertices or edges,✅,pu
 Evaluated,Option for whether to evaluate a plot's function once symbolically,✅,pure,6.0,
 ParallelSelect,Parallel version of Select (evaluated sequentially),✅,pure,14.2,
 ParallelCases,Parallel version of Cases (evaluated sequentially),✅,pure,14.2,
+Developer`ToPackedArray,Packs a full rectangular array of machine numbers into one numeric type (integers become reals when the array mixes both); leaves anything unpackable unchanged,✅,pure,4.0,

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -3994,6 +3994,11 @@ pub fn evaluate_expr_to_expr_inner(
           prepared.push(evaluate_expr_to_expr(a)?);
         }
       }
+      // An argument that evaluated to `Sequence[…]` splices into the
+      // argument list, exactly as it does for a named head — this is what
+      // makes `Function[{a, b}, …][Sequence @@ {1, 2}]` bind both params.
+      let prepared =
+        crate::evaluator::listable::flatten_sequences("Function", &prepared);
       apply_curried_call(&evaluated_func, &prepared)
     }
   }

--- a/src/evaluator/dispatch/list_operations.rs
+++ b/src/evaluator/dispatch/list_operations.rs
@@ -4846,6 +4846,9 @@ pub fn dispatch_list_operations(
       let target = numeric_array_payload(&args[0]).unwrap_or(&args[0]);
       return Some(list_helpers_ast::array_depth_ast(target));
     }
+    "Developer`ToPackedArray" if args.len() == 1 || args.len() == 2 => {
+      return Some(list_helpers_ast::to_packed_array_ast(args));
+    }
     "ArrayComponents" if !args.is_empty() && args.len() <= 3 => {
       return Some(list_helpers_ast::array_components_ast(args));
     }

--- a/src/functions/list_helpers_ast/properties.rs
+++ b/src/functions/list_helpers_ast/properties.rs
@@ -820,6 +820,78 @@ pub fn list_depth(expr: &Expr) -> usize {
   }
 }
 
+/// `` Developer`ToPackedArray[expr] `` — pack a full rectangular array of
+/// machine numbers into a single numeric type.
+///
+/// Woxi has no packed representation, so the only observable effect is the
+/// type unification a real pack performs: an array that mixes integers and
+/// reals comes back as all reals. Anything unpackable (ragged nesting,
+/// rationals, symbols, strings) is returned unchanged, as in Wolfram.
+/// A second argument restricts the target type to `Integer` or `Real`.
+pub fn to_packed_array_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  let expr = &args[0];
+  let target = match args.get(1) {
+    None => None,
+    Some(Expr::Identifier(t)) if t == "Integer" => Some(LeafType::Integer),
+    Some(Expr::Identifier(t)) if t == "Real" => Some(LeafType::Real),
+    Some(_) => return Ok(expr.clone()),
+  };
+  let Some(found) = packable_leaf_type(expr) else {
+    return Ok(expr.clone());
+  };
+  let target = match target {
+    // Reals cannot be demoted to an integer array.
+    Some(LeafType::Integer) if found == LeafType::Real => {
+      return Ok(expr.clone());
+    }
+    Some(t) => t,
+    None => found,
+  };
+  Ok(convert_leaves(expr, target))
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LeafType {
+  Integer,
+  Real,
+}
+
+/// The common machine type of a full rectangular numeric array, or `None`
+/// when the expression cannot be packed.
+fn packable_leaf_type(expr: &Expr) -> Option<LeafType> {
+  if !matches!(expr, Expr::List(_))
+    || !matches!(array_q_ast(expr), Ok(Expr::Identifier(ref b)) if b == "True")
+  {
+    return None;
+  }
+  fn walk(expr: &Expr, found: &mut Option<LeafType>) -> bool {
+    match expr {
+      Expr::List(items) => items.iter().all(|item| walk(item, found)),
+      Expr::Integer(_) => {
+        found.get_or_insert(LeafType::Integer);
+        true
+      }
+      Expr::Real(_) => {
+        *found = Some(LeafType::Real);
+        true
+      }
+      _ => false,
+    }
+  }
+  let mut found = None;
+  if walk(expr, &mut found) { found } else { None }
+}
+
+fn convert_leaves(expr: &Expr, target: LeafType) -> Expr {
+  match expr {
+    Expr::List(items) => {
+      Expr::List(items.iter().map(|i| convert_leaves(i, target)).collect())
+    }
+    Expr::Integer(n) if target == LeafType::Real => Expr::Real(*n as f64),
+    other => other.clone(),
+  }
+}
+
 /// Dimensions[list] - Returns the dimensions of a nested list.
 /// Dimensions[list, n] - Limits the analysis to at most n levels.
 pub fn dimensions_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {

--- a/tests/SUMMARY.md
+++ b/tests/SUMMARY.md
@@ -1120,6 +1120,7 @@
     - [`TimeConstrained`](functions/TimeConstrained.md)
     - [`TimeRemaining`](functions/TimeRemaining.md)
     - [`TimesBy`](functions/TimesBy.md)
+    - [`` Developer`ToPackedArray ``](functions/ToPackedArray.md)
     - [`UniformDistribution`](functions/UniformDistribution.md)
     - [`ValueQ`](functions/ValueQ.md)
     - [`WeibullDistribution`](functions/WeibullDistribution.md)

--- a/tests/cli/functions.md
+++ b/tests/cli/functions.md
@@ -82,6 +82,7 @@ icon: lucide/square-function
 - [`Through`](functions/Through.md)
 - [`Throw`](functions/Throw.md)
 - [`TimesBy`](functions/TimesBy.md)
+- [`` Developer`ToPackedArray ``](functions/ToPackedArray.md)
 - [`UniformDistribution`](functions/UniformDistribution.md)
 - [`ValueQ`](functions/ValueQ.md)
 - [`WeibullDistribution`](functions/WeibullDistribution.md)

--- a/tests/cli/functions/ToPackedArray.md
+++ b/tests/cli/functions/ToPackedArray.md
@@ -1,0 +1,35 @@
+# `` Developer`ToPackedArray ``
+
+Packs a full rectangular array of machine numbers into a single numeric type.
+Woxi keeps no packed representation, so the only visible effect is that type
+unification: an array mixing integers and reals comes back as all reals.
+
+```scrut
+$ wo 'Developer`ToPackedArray[{1, 2, 3}]'
+{1, 2, 3}
+```
+
+```scrut
+$ wo 'Developer`ToPackedArray[{1, 2.5}]'
+{1., 2.5}
+```
+
+A second argument asks for a specific type.
+
+```scrut
+$ wo 'Developer`ToPackedArray[{1, 2}, Real]'
+{1., 2.}
+```
+
+Anything that cannot be packed — ragged nesting, rationals, symbols — is
+returned unchanged.
+
+```scrut
+$ wo 'Developer`ToPackedArray[{1, {2, 3}}]'
+{1, {2, 3}}
+```
+
+```scrut
+$ wo 'Developer`ToPackedArray[{1/2, 1}]'
+{1/2, 1}
+```

--- a/tests/interpreter_tests/function_application.rs
+++ b/tests/interpreter_tests/function_application.rs
@@ -1155,6 +1155,44 @@ mod named_function_arity_check {
   fn single_param_single_arg_works() {
     assert_eq!(interpret("Function[{x}, x^2][3]").unwrap(), "9");
   }
+
+  #[test]
+  fn sequence_argument_splices_into_parameters() {
+    assert_eq!(
+      interpret("Function[{x, y}, {x, y}][Sequence @@ {1, 2}]").unwrap(),
+      "{1, 2}"
+    );
+  }
+
+  #[test]
+  fn literal_sequence_argument_splices_into_parameters() {
+    assert_eq!(
+      interpret("Function[{x, y}, x + y][Sequence[1, 2]]").unwrap(),
+      "3"
+    );
+  }
+
+  #[test]
+  fn sequence_argument_splices_into_slots() {
+    assert_eq!(
+      interpret("Function[{#1, #2}][Sequence @@ {1, 2}]").unwrap(),
+      "{1, 2}"
+    );
+  }
+
+  /// The Demonstrations `Initialization` idiom: a factory closes over
+  /// several packed arrays that are handed to it in one list.
+  #[test]
+  fn factory_applied_to_packed_arrays_from_one_list() {
+    assert_eq!(
+      interpret(
+        "parts = Developer`ToPackedArray /@ {{1, 2}, {3, 4.}}; \
+         Function[{u, v}, u + v][Sequence @@ parts]"
+      )
+      .unwrap(),
+      "{4., 6.}"
+    );
+  }
 }
 
 mod slot_zero_self_reference {

--- a/tests/interpreter_tests/list.rs
+++ b/tests/interpreter_tests/list.rs
@@ -21093,3 +21093,83 @@ mod part_bracket_groups {
     );
   }
 }
+
+/// `` Developer`ToPackedArray `` — Woxi keeps no packed representation, so
+/// the visible effect is the numeric type unification that packing performs.
+mod to_packed_array {
+  use super::*;
+
+  #[test]
+  fn integer_array_keeps_integers() {
+    assert_eq!(
+      interpret("Developer`ToPackedArray[{1, 2, 3}]").unwrap(),
+      "{1, 2, 3}"
+    );
+  }
+
+  #[test]
+  fn mixed_array_becomes_reals() {
+    assert_eq!(
+      interpret("Developer`ToPackedArray[{1, 2.5}]").unwrap(),
+      "{1., 2.5}"
+    );
+  }
+
+  #[test]
+  fn nested_array_is_packed_elementwise() {
+    assert_eq!(
+      interpret("Developer`ToPackedArray[{{1, 2}, {3, 4.}}]").unwrap(),
+      "{{1., 2.}, {3., 4.}}"
+    );
+  }
+
+  #[test]
+  fn ragged_list_is_left_alone() {
+    assert_eq!(
+      interpret("Developer`ToPackedArray[{1, {2, 3}}]").unwrap(),
+      "{1, {2, 3}}"
+    );
+  }
+
+  #[test]
+  fn non_machine_numbers_are_left_alone() {
+    assert_eq!(
+      interpret("Developer`ToPackedArray[{1/2, 1}]").unwrap(),
+      "{1/2, 1}"
+    );
+    assert_eq!(
+      interpret("Developer`ToPackedArray[{1, x}]").unwrap(),
+      "{1, x}"
+    );
+  }
+
+  #[test]
+  fn scalar_is_left_alone() {
+    assert_eq!(interpret("Developer`ToPackedArray[5]").unwrap(), "5");
+  }
+
+  #[test]
+  fn explicit_real_type_promotes_integers() {
+    assert_eq!(
+      interpret("Developer`ToPackedArray[{1, 2}, Real]").unwrap(),
+      "{1., 2.}"
+    );
+  }
+
+  #[test]
+  fn explicit_integer_type_does_not_demote_reals() {
+    assert_eq!(
+      interpret("Developer`ToPackedArray[{1.5, 2}, Integer]").unwrap(),
+      "{1.5, 2}"
+    );
+  }
+
+  #[test]
+  fn packed_array_stays_a_list_for_downstream_functions() {
+    assert_eq!(
+      interpret("Length[Developer`ToPackedArray[N[{{1, 0}, {0, 1}}]]]")
+        .unwrap(),
+      "2"
+    );
+  }
+}

--- a/tests/zensical.toml
+++ b/tests/zensical.toml
@@ -1205,6 +1205,7 @@ nav = [
       { "TimeConstrained" = "functions/TimeConstrained.md" },
       { "TimeRemaining" = "functions/TimeRemaining.md" },
       { "TimesBy" = "functions/TimesBy.md" },
+      { "Developer`ToPackedArray" = "functions/ToPackedArray.md" },
       { "UniformDistribution" = "functions/UniformDistribution.md" },
       { "ValueQ" = "functions/ValueQ.md" },
       { "WeibullDistribution" = "functions/WeibullDistribution.md" },


### PR DESCRIPTION
Checking a random Wolfram Demonstration notebook ("The 26-Sided Unilluminable Room") against Woxi Studio surfaced two interpreter bugs. Its `Initialization` section builds compiled helpers with the idiom `Function[{a, b}, …][Sequence @@ packedData]`, which failed on two counts:

- **`Sequence` did not splice into a pure function's arguments.** An argument that evaluated to `Sequence[…]` spliced only when the head was a named symbol, so a two-parameter factory saw a single argument and reported `Function::fpct`. The curried-call path in `core_eval` now runs the same `flatten_sequences` step named heads already use.
- **`` Developer`ToPackedArray `` had no implementation**, so it stayed unevaluated and every list built through it was an opaque expression rather than an array (`Partition`, `Length`, arithmetic all went wrong downstream). Woxi keeps no packed representation, so the implementation performs the one observable part of packing — numeric type unification, where an array mixing integers and reals comes back as all reals — and leaves anything unpackable (ragged nesting, rationals, symbols) unchanged, as Wolfram does. A second argument restricts the target type to `Integer` or `Real`.

With both fixed, the notebook's `Manipulate` runs its initialization without messages, builds all of its controls, and renders graphics through the Studio's widget pipeline (verified with `woxi-studio/examples/dump_manipulate`), instead of erroring during initialization.

## Tests

- `tests/interpreter_tests/function_application.rs`: `Sequence` splicing into named parameters and slots, plus a regression test for the factory-applied-to-packed-arrays idiom.
- `tests/interpreter_tests/list.rs`: a `to_packed_array` module covering type unification, explicit type arguments, and the unpackable cases.
- `tests/cli/functions/ToPackedArray.md` documents the new function; `functions.csv`, `tests/SUMMARY.md`, `tests/cli/functions.md` and `tests/zensical.toml` are updated to match.

Full suite passes (`cargo test --tests`, 27 375 tests) and `make format` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153LFcrWtvGD2yLU96c9yje

---
_Generated by [Claude Code](https://claude.ai/code/session_0153LFcrWtvGD2yLU96c9yje)_