### PR TITLE
Honor PointSize in PlotStyle for scatter plots

### DIFF
--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -1652,6 +1652,7 @@ fn contour_plot_equations(
           fill_opacity: None,
           marker: None,
           thickness: series_thickness,
+          point_size: None,
         });
       }
     }

--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -30,7 +30,7 @@ fn point_radius(point_size: f64, svg_w: f64) -> f64 {
 
 /// A named point size. `Small`/`Medium`/… name absolute sizes, like the
 /// named dash lengths do.
-fn symbolic_point_size(expr: &Expr) -> Option<f64> {
+pub(crate) fn symbolic_point_size(expr: &Expr) -> Option<f64> {
   let Expr::Identifier(s) = expr else {
     return None;
   };
@@ -10430,7 +10430,11 @@ pub fn plot_source_primitives(ps: &crate::syntax::PlotSource) -> Vec<Expr> {
       ],
     ));
     if sd.is_scatter {
-      series_prims.push(call1("PointSize", Expr::Real(0.012)));
+      series_prims.push(match sd.point_size {
+        Some(p) if p < 0.0 => call1("AbsolutePointSize", Expr::Real(-p)),
+        Some(f) => call1("PointSize", Expr::Real(f)),
+        None => call1("PointSize", Expr::Real(0.012)),
+      });
       let coords: Vec<Expr> = sd
         .points
         .iter()

--- a/src/functions/plot.rs
+++ b/src/functions/plot.rs
@@ -1762,6 +1762,10 @@ pub(crate) struct SeriesStyle {
   /// Line thickness in display pixels (e.g. 1.5 = default, 2.0 = Thick).
   /// None means use the default (1.5px).
   pub thickness: Option<f64>,
+  /// Scatter dot size: a fraction of the image width for `PointSize[…]`,
+  /// stored negative for the absolute printer's points of
+  /// `AbsolutePointSize[…]`. None means the default dot.
+  pub point_size: Option<f64>,
   /// Dash pattern in display pixels. None = solid line.
   pub dashing: Option<Vec<f64>>,
   /// DropShadowing[...] directive: draw the curve with a drop shadow.
@@ -3753,10 +3757,11 @@ pub(crate) fn build_plot_source(
     .enumerate()
     .map(|(i, points)| {
       let color = series_color(plot_style, i);
-      let thickness = if plot_style.is_empty() {
-        None
+      let (thickness, point_size) = if plot_style.is_empty() {
+        (None, None)
       } else {
-        plot_style[i % plot_style.len()].thickness
+        let style = &plot_style[i % plot_style.len()];
+        (style.thickness, style.point_size)
       };
       crate::syntax::PlotSeriesData {
         points: points.clone(),
@@ -3767,6 +3772,7 @@ pub(crate) fn build_plot_source(
         fill_opacity,
         marker: None,
         thickness,
+        point_size,
       }
     })
     .collect();
@@ -3809,6 +3815,9 @@ pub(crate) fn collapse_style_for_single_series(
     if style.thickness.is_some() {
       merged.thickness = style.thickness;
     }
+    if style.point_size.is_some() {
+      merged.point_size = style.point_size;
+    }
     if style.dashing.is_some() {
       merged.dashing.clone_from(&style.dashing);
     }
@@ -3849,6 +3858,26 @@ fn series_thickness(plot_style: &[SeriesStyle], idx: usize) -> u32 {
     (t * RESOLUTION_SCALE as f64).round() as u32
   } else {
     default_thickness
+  }
+}
+
+/// The radius, in render-space units, of the dots of a scatter series.
+/// `PointSize[f]` gives the dot a diameter of the fraction `f` of the image
+/// width; `AbsolutePointSize[p]` (stored negative) is p printer's points
+/// whatever the image size. Without either, the 3px default dot.
+fn series_point_radius(
+  plot_style: &[SeriesStyle],
+  idx: usize,
+  render_width: u32,
+) -> u32 {
+  let default_radius = 3 * RESOLUTION_SCALE;
+  if plot_style.is_empty() {
+    return default_radius;
+  }
+  match plot_style[idx % plot_style.len()].point_size {
+    Some(f) if f > 0.0 => (f * render_width as f64 * 0.5).round() as u32,
+    Some(p) => (-p * 0.5 * RESOLUTION_SCALE as f64).round() as u32,
+    None => default_radius,
   }
 }
 
@@ -4161,8 +4190,9 @@ pub(crate) fn generate_scatter_svg_with_options(
     }
 
     // Draw scatter points using plotters Circle markers
-    let marker_size = 3 * RESOLUTION_SCALE;
     for (series_idx, points) in all_series.iter().enumerate() {
+      let marker_size =
+        series_point_radius(&opts.plot_style, series_idx, render_width);
       let (r, g, b) = series_color(&opts.plot_style, series_idx);
       let color = RGBColor(r, g, b);
       let finite_pts: Vec<(f64, f64)> = points
@@ -4450,6 +4480,7 @@ pub(crate) fn render_merged_plot_source(
         s.color.2 as f64 / 255.0,
       )),
       thickness: s.thickness,
+      point_size: s.point_size,
       ..SeriesStyle::default()
     })
     .collect();
@@ -4574,7 +4605,11 @@ fn scatter_overlay_primitives(
     }
     return prims;
   }
-  prims.push(call1("AbsolutePointSize", Expr::Real(6.0)));
+  prims.push(match series.point_size {
+    Some(f) if f > 0.0 => call1("PointSize", Expr::Real(f)),
+    Some(p) => call1("AbsolutePointSize", Expr::Real(-p)),
+    None => call1("AbsolutePointSize", Expr::Real(6.0)),
+  });
   prims.push(Expr::FunctionCall {
     name: "Point".to_string(),
     args: vec![Expr::List(
@@ -6589,6 +6624,7 @@ pub(crate) fn histogram_plot_source(
       fill_opacity: None,
       marker: None,
       thickness: None,
+      point_size: None,
     });
   }
 
@@ -7494,6 +7530,24 @@ fn apply_style_directive(expr: &Expr, style: &mut SeriesStyle) {
           style.thickness = Some(t);
         }
       }
+      "PointSize" if args.len() == 1 => {
+        if let Some(s) =
+          crate::functions::graphics::symbolic_point_size(&args[0])
+        {
+          style.point_size = Some(s);
+        } else if let Some(s) = try_eval_to_f64(&args[0]) {
+          style.point_size = Some(s);
+        }
+      }
+      "AbsolutePointSize" if args.len() == 1 => {
+        if let Some(s) =
+          crate::functions::graphics::symbolic_point_size(&args[0])
+        {
+          style.point_size = Some(s);
+        } else if let Some(s) = try_eval_to_f64(&args[0]) {
+          style.point_size = Some(-s);
+        }
+      }
       "Dashing" if !args.is_empty() => {
         if let Expr::List(items) = &args[0] {
           let dashes: Vec<f64> = items
@@ -7674,6 +7728,7 @@ pub(crate) fn parse_plot_style(replacement: &Expr) -> Vec<SeriesStyle> {
     let style = parse_one_series_style(&val);
     if style.color.is_some()
       || style.thickness.is_some()
+      || style.point_size.is_some()
       || style.dashing.is_some()
       || style.shadow.is_some()
     {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -203,6 +203,11 @@ pub struct PlotSeriesData {
   /// …); `None` = the 1.5px default. Travels with the series so a curve keeps
   /// its weight when `Show` merges it into another graphic.
   pub thickness: Option<f64>,
+  /// Dot size of a scatter series from `PlotStyle` — a fraction of the image
+  /// width for `PointSize[…]`, stored negative for the absolute printer's
+  /// points of `AbsolutePointSize[…]`, the same sign convention the graphics
+  /// primitives use. `None` = the default dot.
+  pub point_size: Option<f64>,
 }
 
 /// Convert a Wolfram named character name (e.g. "Pi", "Alpha", "Sum") to its

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -4655,6 +4655,81 @@ mod plot3d {
       assert!(two.contains("#FF0000") && two.contains("#00FF00"));
     }
 
+    /// A `PointSize` in `PlotStyle` has to resize the dots, not just get
+    /// parsed and dropped: `PointSize[f]` is the fraction `f` of the image
+    /// width the dot's *diameter* spans, so at the 500px-wide image below
+    /// `PointSize[0.015]` is a 3.75px radius — 38 render-space units at the
+    /// 10x resolution scale. `AbsolutePointSize[p]` is p printer's points
+    /// across whatever the image size.
+    #[test]
+    fn plot_style_point_size_resizes_scatter_dots() {
+      let radius = |code: &str| -> f64 {
+        let svg = export_svg(code);
+        let at = svg.find(" r=\"").expect("a dot must be drawn");
+        let rest = &svg[at + 4..];
+        rest[..rest.find('"').unwrap()].parse().unwrap()
+      };
+      let plain =
+        radius(r#"ListPlot[{{0, 0}, {1, 1}}, ImageSize -> {500, 350}]"#);
+      assert_eq!(plain, 30.0, "the default dot is a 3px radius");
+      // A bare directive, a list and a Directive[…] all reach the dots.
+      for style in [
+        "PointSize[0.015]",
+        "{PointSize[0.015], Red}",
+        "Directive[PointSize[0.015], Red]",
+      ] {
+        assert_eq!(
+          radius(&format!(
+            "ListPlot[{{{{0, 0}}, {{1, 1}}}}, PlotStyle -> {style}, \
+             ImageSize -> {{500, 350}}]"
+          )),
+          38.0,
+          "PointSize[0.015] must widen the dots ({style})"
+        );
+      }
+      // Half the image width, so the fraction — not a fixed pixel count.
+      assert_eq!(
+        radius(
+          r#"ListPlot[{{0, 0}, {1, 1}}, PlotStyle -> PointSize[0.015],
+               ImageSize -> {250, 175}]"#
+        ),
+        19.0
+      );
+      // Absolute sizes and the named ones stay put at any image size.
+      for size in ["{500, 350}", "{250, 175}"] {
+        assert_eq!(
+          radius(&format!(
+            "ListPlot[{{{{0, 0}}, {{1, 1}}}}, \
+             PlotStyle -> AbsolutePointSize[12], ImageSize -> {size}]"
+          )),
+          60.0
+        );
+        assert_eq!(
+          radius(&format!(
+            "ListPlot[{{{{0, 0}}, {{1, 1}}}}, PlotStyle -> PointSize[Large], \
+             ImageSize -> {size}]"
+          )),
+          35.0
+        );
+      }
+      // The size travels with the series through a `Show` merge, where the
+      // scatter layer is drawn over the curve instead of as the chart.
+      let merged = |style: &str| {
+        radius(&format!(
+          "Show[Plot[x^2, {{x, -2, 2}}], \
+           ListPlot[{{{{0, 1}}, {{1, 2}}}}{style}], ImageSize -> {{500, 350}}]"
+        ))
+      };
+      let big = merged(", PlotStyle -> PointSize[0.05]");
+      let small = merged(", PlotStyle -> PointSize[0.01]");
+      assert!(
+        (big / small - 5.0).abs() < 0.01,
+        "a five-times PointSize must give five-times dots after a Show, \
+         got {big} vs {small}"
+      );
+      assert_ne!(big, merged(""), "the default must not swallow the size");
+    }
+
     #[test]
     fn plot_label_expression_is_typeset() {
       // A PlotLabel is drawn, not printed: `Subscript[p, 0]` becomes a

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -19731,4 +19731,122 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`nmax$$ = 10}, DynamicBox[\[Ellipsis
       "the area readout must follow the moved vertex"
     );
   }
+
+  /// Checked a randomly-sampled Wolfram Demonstrations Project notebook that
+  /// sweeps a line through a fixed point on a parabola and marks where the
+  /// two meet. Independently written, not copied from any specific
+  /// Demonstration: a downward parabola pivoting about `(2, 1)` rather than
+  /// an upward one about `(1, -2)`.
+  ///
+  /// Two things make the shape worth pinning down. `Solve` is called with
+  /// the variable list *omitted*, so the intersection abscissas have to come
+  /// out of a bare equation list and land in the `{x, f[x]}` point template
+  /// a `ReplaceAll` builds. And the marks carry
+  /// `PlotStyle -> PointSize[…]`, which used to be parsed and then dropped —
+  /// the dots came out at the default size however the notebook asked for
+  /// them.
+  #[test]
+  fn demonstration_secant_manipulate_sizes_its_intersection_marks() {
+    let code = "Manipulate[\
+      Show[\
+        Plot[{2 - x^2/4, k (x - 2) + 1}, {x, -7, 7}], \
+        ListPlot[{x, 2 - x^2/4} /. Solve[{2 - x^2/4 == k (x - 2) + 1}], \
+          PlotStyle -> PointSize[0.03]], \
+        PlotRange -> {{-7, 7}, {-8, 3}}, ImageSize -> {440, 300}], \
+      {k, -1.5, 1, 0.05, Appearance -> \"Labeled\"}\
+    ]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the secant Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(state.graphics_handle.is_some(), "the plot must render");
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the parabola and its secant must render")
+    };
+    // The dots the marks are drawn as, biggest first.
+    let mark_radii = |svg: &str| {
+      let mut radii: Vec<f64> = svg
+        .match_indices("<circle")
+        .filter_map(|(at, _)| {
+          let tag = &svg[at..svg[at..].find("/>")? + at];
+          let r = tag.find(" r=\"")? + 4;
+          tag[r..][..tag[r..].find('"')?].parse().ok()
+        })
+        .collect();
+      radii.sort_by(|a, b| b.partial_cmp(a).unwrap());
+      radii
+    };
+
+    match &state.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name,
+          min,
+          max,
+          step,
+          current,
+          ..
+        },
+      ] => {
+        assert_eq!(name.as_str(), "k");
+        assert_eq!((*min, *max, *step), (-1.5, 1.0, 0.05));
+        assert_eq!(*current, -1.5, "a slider with no initial starts at min");
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    // `Solve` without a variable list still finds both intersections, so
+    // both marks are drawn — at the size `PlotStyle` asked for, not the
+    // default dot the same picture draws without it.
+    let secant_svg = render(&state);
+    let secant = mark_radii(&secant_svg);
+    assert_eq!(secant.len(), 2, "both intersections must be marked");
+    assert_eq!(secant[0], secant[1], "both marks are the same size");
+    let plain = code.replace(", PlotStyle -> PointSize[0.03]", "");
+    let default_state =
+      instantiate_stored_manipulate(&plain, "").expect("widget");
+    let default_dot = mark_radii(&render(&default_state))[0];
+    assert!(
+      secant[0] > 1.5 * default_dot,
+      "PointSize[0.03] must draw a bigger mark than the default {default_dot}, \
+       got {}",
+      secant[0]
+    );
+
+    // Sliding to the tangency at k = -1 collapses the two intersections
+    // onto the single point the line touches.
+    match &mut state.controls[..] {
+      [manipulate::ControlState::Continuous { current, .. }] => {
+        *current = -1.0;
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    let tangent = render(&state);
+    assert_eq!(
+      mark_radii(&tangent).len(),
+      2,
+      "the double root still yields two coincident marks"
+    );
+    assert_ne!(
+      tangent, secant_svg,
+      "moving the slider must redraw the picture"
+    );
+  }
 }


### PR DESCRIPTION
Sampled a random Wolfram Demonstrations Project notebook — a line pivoting
about a fixed point on a parabola, with the intersections marked by a
`ListPlot` of the `Solve` solutions substituted into a `{x, f[x]}` point
template.

Woxi Studio already parsed the notebook, built the `Manipulate` widget from
the stored `DynamicModuleBox` dump, decoded the `RasterBox` snapshots, and
evaluated the body at every slider position — including the `Solve[{eqn}]`
call with the variable list omitted. The one thing it got wrong was the
marks: `PlotStyle -> PointSize[…]` was parsed into the series style and then
dropped, so the dots always came out at the default size, however large the
notebook asked for them.

## Changes

- `PointSize[f]` / `AbsolutePointSize[p]` (and the named `Tiny`…`Large`
  sizes) now set a `point_size` on `SeriesStyle`, the way `Thickness` already
  set `thickness`. Accepted as a bare directive, inside a `{…}` list and
  inside `Directive[…]`.
- The size travels on `PlotSeriesData`, so a scatter series keeps it when
  `Show` merges it over a curve and it is drawn as an overlay instead of as
  the chart itself.
- The scatter renderer computes each series' dot radius from its own style
  rather than using one hard-coded default for the whole picture.

## Tests

- `plot_style_point_size_resizes_scatter_dots` covers the three spellings, a
  fraction scaling with the image width, absolute and named sizes staying
  fixed across image sizes, and the size surviving a `Show` merge.
- `demonstration_secant_manipulate_sizes_its_intersection_marks` pins down
  the notebook's shape end to end in Woxi Studio: the labeled slider's range
  and step, both intersections found by a variable-less `Solve`, marks drawn
  larger than the default dot, and the two marks collapsing onto the
  tangency point when the slider reaches it. Independently written, not
  copied from the Demonstration.

Full suite green (27,548 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEXQzJhV4HJ3LTYCMKQdej

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEXQzJhV4HJ3LTYCMKQdej)_