### PR TITLE
Fix TraditionalForm box escape mangling Manipulate bodies

### DIFF
--- a/src/functions/string_ast.rs
+++ b/src/functions/string_ast.rs
@@ -8233,12 +8233,12 @@ pub fn expr_to_boxes(expr: &Expr) -> String {
 
     // Lists
     Expr::List(items) => {
-      let mut parts = vec!["\"{{\"".to_string()];
+      let mut parts = vec!["\"{\"".to_string()];
       if !items.is_empty() {
         let inner: Vec<String> = items.iter().map(expr_to_boxes).collect();
         parts.push(format!("RowBox[{{{}}}]", inner.join(", \",\", ")));
       }
-      parts.push("\"}}\"".to_string());
+      parts.push("\"}\"".to_string());
       format!("RowBox[{{{}}}]", parts.join(", "))
     }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1724,6 +1724,35 @@ fn box_escape_to_expr(box_src: &str) -> Option<Expr> {
   string_to_expr(&text).ok()
 }
 
+/// Is every `"` in this box source backslash-escaped?
+///
+/// That is the spelling `escape_string_for_input_form` produces when a box
+/// escape is itself written out as the InputForm of a *string* — there the
+/// box delimiters are escaped along with everything else. Box data as a real
+/// `.nb` file writes it always leaves those delimiters bare and uses `\"`
+/// only *inside* a box, to mark it as a string literal (`"\"a, b\""`) rather
+/// than source text (`"a + b"`). So one bare `"` settles it: the text needs
+/// no unescaping, and unescaping it anyway would strip that marking off every
+/// string in the expression.
+fn box_source_is_double_escaped(s: &str) -> bool {
+  let mut saw_quote = false;
+  let mut backslashes = 0usize;
+  for c in s.chars() {
+    match c {
+      '\\' => backslashes += 1,
+      '"' => {
+        if backslashes.is_multiple_of(2) {
+          return false;
+        }
+        saw_quote = true;
+        backslashes = 0;
+      }
+      _ => backslashes = 0,
+    }
+  }
+  saw_quote
+}
+
 /// Undo `escape_string_for_input_form`'s `\"`/`\\` escaping of a `\!\(\*
 /// boxes\)` escape's content. Named-character escapes (`\[Name]`) are left
 /// untouched — they're valid box-source syntax on their own, not part of
@@ -2724,19 +2753,24 @@ fn pair_to_expr_inner(pair: Pair<Rule>) -> Expr {
         }
         // `\!\(\*boxes\)` — the FrontEnd's "interpret these boxes" escape,
         // which is what `InputForm` writes for a typeset expression, in
-        // either delimiter spelling (`\*` or the `BOX_SEP` marker). The
-        // backslash spelling carries `\"`-escaped string literals — that is
-        // what makes the whole `\!\(…\)` token survive being re-tokenized as
-        // source — so undo that before handing the text to the box-source
-        // readers, which expect the bare `"` delimiters real `.nb` box data
-        // and the marker spelling both use.
+        // either delimiter spelling (`\*` or the `BOX_SEP` marker). Writing
+        // the segment out as the InputForm of a *string* escapes its quotes a
+        // second time, so undo that layer — but only when it is really there
+        // (see `box_source_is_double_escaped`): ordinarily the text is box
+        // data as a real `.nb` file writes it, where a `\"` marks a *string
+        // literal* box (`"\"a, b\""`) apart from one holding source text
+        // (`"a + b"`), and unescaping would turn every string in the
+        // expression into unparsed source.
         let trimmed = inner.trim_start();
         if let Some(box_src) = trimmed.strip_prefix("\\*").or_else(|| {
           trimmed.strip_prefix(crate::functions::string_ast::BOX_SEP)
-        }) && let Some(expr) =
-          box_escape_to_expr(&unescape_box_source(box_src))
-        {
-          return expr;
+        }) {
+          let unescaped = box_source_is_double_escaped(box_src)
+            .then(|| unescape_box_source(box_src));
+          let box_src = unescaped.as_deref().unwrap_or(box_src);
+          if let Some(expr) = box_escape_to_expr(box_src) {
+            return expr;
+          }
         }
         // Fallback: surface the raw source as HoldComplete.
         return Expr::FunctionCall {

--- a/tests/interpreter_tests/syntax.rs
+++ b/tests/interpreter_tests/syntax.rs
@@ -462,6 +462,86 @@ mod implicit_times_with_strings {
       r#"Hold[StringJoin["z = ", ToString[z]]]"#
     );
   }
+
+  // `TraditionalForm[expr]` serializes into InputForm as a `\!\(\*boxes\)`
+  // escape, so the boxes have to read back as the very expression they were
+  // built from — Woxi Studio re-evaluates a Manipulate body from that text on
+  // every control change. Two ways they did not: a list's boxes doubled its
+  // braces, so `{1, 2}` came back as `{{1, 2}}`; and a string-literal box was
+  // unescaped a second time, so `"For each such pair, "` came back as bare
+  // source that re-parsed as the product `each*For*pair*such` and a lone
+  // `","` came back as `Null`. (Regressions from the "Twin Pythagorean
+  // Triples" Demonstration, whose whole body is one
+  // `Text@TraditionalForm@Column[…]` of styled `Row`s.)
+  #[test]
+  fn traditional_form_box_escape_reparses_to_the_same_expression() {
+    for src in [
+      "{1, 2}",
+      "{{1, 2}, {3, 4}}",
+      r#"Column[{Row[{"a", 1}], Row[{"b", 2}]}]"#,
+      r#"Row[{"For each such pair, ", 1}]"#,
+      r#"Row[{"x", ","}]"#,
+      r#"Row[{Style["sum: ", 12, RGBColor[0.25, 0.43, 0.82], Bold], 1 + 2}]"#,
+      "ArcTan[N[4/3]]*180/Pi",
+    ] {
+      let printed = interpret(&format!(
+        "ToString[Hold[TraditionalForm[{src}]], InputForm]"
+      ))
+      .unwrap();
+      // The escape yields the expression the boxes typeset, with the
+      // display-only `TraditionalForm` wrapper gone — so the target is the
+      // bare expression, held.
+      let same = interpret(&format!("{printed} === Hold[{src}]")).unwrap();
+      assert_eq!(
+        same, "True",
+        "box escape of `{src}` re-parses differently: `{printed}`"
+      );
+    }
+  }
+
+  // A list's box form uses single braces. The doubled-brace spelling that
+  // used to come out (`"{{"` … `"}}"`, a `format!` escape written into a
+  // plain string literal) re-read as one extra level of nesting.
+  #[test]
+  fn list_box_form_uses_single_braces() {
+    assert_eq!(
+      interpret("ToString[Hold[TraditionalForm[{1, 2}]], InputForm]").unwrap(),
+      r#"Hold[\!\(\*FormBox[RowBox[{"{", RowBox[{"1", ",", "2"}], "}"}], TraditionalForm]\)]"#
+    );
+  }
+
+  // A string-literal box keeps its `\"` quoting in the escape, which is what
+  // marks it as content rather than source text.
+  #[test]
+  fn string_box_in_escape_keeps_its_quoting() {
+    assert_eq!(
+      interpret(r#"ToString[Hold[TraditionalForm[Row[{"a, b"}]]], InputForm]"#)
+        .unwrap(),
+      r#"Hold[\!\(\*FormBox[RowBox[{"Row[", RowBox[{"{", RowBox[{"\"a, b\""}], "}"}], "]"}], TraditionalForm]\)]"#
+    );
+  }
+
+  // Writing the escape out as the InputForm of a *string* escapes its quotes
+  // a second time (the box delimiters included). Both spellings have to read
+  // the string literal back as a string — the outer layer is undone, the box
+  // one is not.
+  #[test]
+  fn string_box_reads_back_from_either_escaping_depth() {
+    assert_eq!(
+      interpret(
+        r#"ToExpression[ToString[InputForm[TraditionalForm[Row[{"a, b", 1}]]]]]"#
+      )
+      .unwrap(),
+      "a, b1"
+    );
+    assert_eq!(
+      interpret(
+        r#"ToExpression[StringTrim[ToString[ToString[InputForm[TraditionalForm[Row[{"a, b", 1}]]]], InputForm], "\""]]"#
+      )
+      .unwrap(),
+      "a, b1"
+    );
+  }
 }
 
 mod operator_shorthand_parens {

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -19563,4 +19563,146 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`nmax$$ = 10}, DynamicBox[\[Ellipsis
       "dropping the spoke count from 11 to 5 must change the rendered wheel"
     );
   }
+
+  /// Checked a randomly-sampled Wolfram Demonstrations Project notebook whose
+  /// whole body is one `Pane[Text@TraditionalForm@Column[…]]` of styled
+  /// `Row`s — a prose panel rather than a picture. Independently written, not
+  /// copied from any specific Demonstration: this one walks the odd squares
+  /// ring by ring, where that Demonstration walked Pythagorean triples.
+  ///
+  /// The body is stored as InputForm and re-evaluated on every control
+  /// change, and `TraditionalForm[…]` serializes into a `\!\(\*boxes\)`
+  /// escape — so this pins down that the escape reads back as the very
+  /// expression it was built from. It used to come back mangled three ways:
+  /// the `Column`'s list gained a level of nesting (doubled braces in the box
+  /// form), which flattened the whole panel onto one line; a string holding a
+  /// comma was re-read as bare source, so `"Odd squares, ring by ring "` came
+  /// back as a product of its words in alphabetical order; and a lone `","`
+  /// came back as `Null`.
+  #[test]
+  fn demonstration_prose_panel_manipulate_keeps_its_column_and_strings() {
+    let code = "Manipulate[\
+      Pane[\
+        Text@TraditionalForm@Column[{\
+          sqSide = 2 ringIdx + 1; sqArea = sqSide^2; \
+            sqRing = sqArea - (2 ringIdx - 1)^2; \
+            Row[{Style[\"Odd squares, ring by ring \", 12, \
+              RGBColor[0.2, 0.4, 0.8], Bold]}], \
+          \" \", \
+          Row[{Style[\"This square has side and area: \", 12, \
+              RGBColor[0.9, 0.6, 0.2], Bold], \
+            Style[{sqSide, sqArea}, Bold], \",\"}], \
+          Row[{Style[\"and the ring it adds is: \", 12, \
+              RGBColor[0.9, 0.6, 0.2], Bold], \
+            sqArea, \" - \", (2 ringIdx - 1)^2, \" = \", sqRing, \".\"}], \
+          Row[{Style[\"Its half-diagonal leans by \", 12, \
+              RGBColor[0.2, 0.4, 0.8], Bold], \
+            \" \\!\\(\\*SubscriptBox[\\(\\[Theta]\\), \\(1\\)]\\) = \", \
+            ArcTan[N[sqSide/(sqSide + 2)]], \" rad. = \", \
+            ArcTan[N[sqSide/(sqSide + 2)]]*180/Pi, \"\\[Degree]\", \".\"}]\
+        }], \
+        {600, 240}\
+      ], \
+      {{ringIdx, 1, \"ring index\"}, 1, 5000, 1, ImageSize -> Medium, \
+        Appearance -> \"Labeled\"}, \
+      TrackedSymbols -> True\
+    ]";
+    let mut state = instantiate_stored_manipulate(code, "")
+      .expect("the prose-panel Manipulate must build a widget");
+    assert!(
+      state.error.is_none(),
+      "body must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert!(
+      state.graphics_handle.is_some(),
+      "the typeset panel must render"
+    );
+
+    let render = |w: &manipulate::ManipulateState| {
+      let bindings: Vec<(String, String)> = w
+        .controls
+        .iter()
+        .filter(|c| c.binds_variable())
+        .map(|c| (c.name().to_string(), c.current_code()))
+        .collect();
+      woxi::with_scoped_globals(&bindings, || {
+        woxi::interpret_with_stdout(&w.body)
+      })
+      .expect("body evaluates")
+      .graphics
+      .expect("the panel must render")
+    };
+    let first_ring = render(&state);
+
+    // A string carrying a comma stays one string rather than being re-read
+    // as source (which reordered its words), and a lone comma stays a comma
+    // rather than becoming `Null`.
+    assert!(
+      first_ring.contains("Odd squares, ring by ring"),
+      "the heading string must survive the box round trip verbatim"
+    );
+    assert!(
+      !first_ring.contains("Null"),
+      "the lone \",\" item must stay a comma, not become Null"
+    );
+    // `\!\(\*SubscriptBox[…]\)` inside a string still typesets as a subscript.
+    assert!(
+      first_ring.contains("baseline-shift=\"sub\""),
+      "the inline SubscriptBox must typeset as a subscript"
+    );
+    // The `Column` lays its items out stacked. Flattened onto one line the
+    // panel came out ~20px tall and many hundreds wide.
+    let dims = |svg: &str| {
+      let num = |attr: &str| {
+        svg
+          .split_once(attr)
+          .and_then(|(_, r)| r.split_once('"'))
+          .and_then(|(v, _)| v.parse::<f64>().ok())
+          .unwrap_or_default()
+      };
+      (num("width=\""), num("height=\""))
+    };
+    let (width, height) = dims(&first_ring);
+    assert!(
+      height > 80.0 && height < width,
+      "the Column must stack its rows, got {width}x{height}"
+    );
+
+    match &mut state.controls[..] {
+      [
+        manipulate::ControlState::Continuous {
+          name,
+          label,
+          min,
+          max,
+          step,
+          current,
+          ..
+        },
+      ] => {
+        assert_eq!(name.as_str(), "ringIdx");
+        assert_eq!(label.as_str(), "ring index");
+        assert_eq!(*min, 1.0);
+        assert_eq!(*max, 5000.0);
+        assert_eq!(*step, 1.0);
+        assert_eq!(*current, 1.0);
+        *current = 4.0;
+      }
+      other => panic!("unexpected controls: {other:?}"),
+    }
+
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    let fourth_ring = render(&state);
+    assert_ne!(
+      first_ring, fourth_ring,
+      "moving the slider must recompute the panel"
+    );
+    // Ring 4: side 9, area 81, and the ring it adds over the 7x7 square is 32.
+    assert!(
+      fourth_ring.contains(">81<") && fourth_ring.contains(">32<"),
+      "the recomputed panel must show the ring-4 numbers"
+    );
+  }
 }


### PR DESCRIPTION
Sampled a random Wolfram Demonstrations Project notebook whose whole body is one `Pane[Text@TraditionalForm@Column[…]]` of styled `Row`s — a prose panel rather than a picture. Woxi Studio built the widget and computed the right numbers, but drew the panel as a single 6900px-wide line of literal list syntax, with two of its strings destroyed.

## Root causes

Woxi Studio stores a Manipulate body as InputForm and re-evaluates it on every control change, and `TraditionalForm[…]` serializes into a `\!\(\*boxes\)` escape — so the escape has to read back as the very expression it was built from. It did not, two ways:

**1. `expr_to_boxes` doubled a list's braces.** It wrote `RowBox[{"{{", …, "}}"}]`. The `{{`/`}}` are `format!` escapes, but they sat in a plain string literal (`vec["\"{{\"".to_string()]`), so the doubled braces reached the output verbatim and re-read as an extra level of nesting. That collapsed the `Column` into a one-line list.

**2. The read side unescaped `\"` in every box escape.** Only the spelling produced by writing the segment out as the InputForm of a *string* carries that second layer. Ordinary box data — the marker spelling Studio stores, and what a real `.nb` file holds — uses `\"` to mark a *string literal* box (`"\"a, b\""`) apart from one holding source text (`"a + b"`), so unescaping it turned strings into bare source:

- `"For each such pair, "` came back as the product of its words, which `Times` then sorted → `each For pair such`
- a lone `","` came back as `Null`

The two spellings are now told apart by whether any `"` is left bare (`box_source_is_double_escaped`), so the existing doubly-escaped round trip keeps working.

## Result

The sampled notebook now renders as a 912×352 stacked column with every string intact, correct arithmetic at each slider position, the `Style` colors and weights applied, and the inline `\!\(\*SubscriptBox[…]\)` typeset as a subscript.

## Tests

- `tests/interpreter_tests/syntax.rs`: box-escape round trips for lists, nested lists, columns, styled rows, strings holding commas, a lone comma, and both escaping depths; plus the exact box spelling for a list and for a string literal.
- `woxi-studio/src/main.rs`: an independently-written regression test for a prose-panel Manipulate (odd squares ring by ring — not the sampled notebook's triples), asserting the column stacks, the strings survive verbatim, the subscript typesets, and moving the slider recomputes the panel. It fails on `main` and passes here.

`cargo test` is green across the workspace (25296 + 1258 + 576 + 209 + 44 lib/integration tests, and 172 in `woxi-studio`), and `make format` was run. `main` has been merged in — both sides had appended a Demonstration regression test to the same `woxi-studio` test module.