### PR TITLE
Do not accept unknown attributes on symbols

### DIFF
--- a/src/evaluator/assignment.rs
+++ b/src/evaluator/assignment.rs
@@ -864,37 +864,50 @@ fn reorder_orderless_pattern_args(pattern: Expr) -> Expr {
   pattern
 }
 
-/// Helper for Attributes[f] = value / Attributes[f] := value
-/// Extracts attribute symbols from value, validates, and sets them on the symbol.
-fn set_attributes_from_value(
-  sym_name: &str,
-  rhs_value: &Expr,
-) -> crate::syntax::Expr {
-  // Check if symbol is locked
-  let is_locked = crate::FUNC_ATTRS.with(|m| {
-    m.borrow()
-      .get(sym_name)
-      .is_some_and(|attrs| attrs.contains(&"Locked".to_string()))
-  });
-  if is_locked {
-    crate::emit_message(&format!(
-      "Attributes::locked: Symbol {sym_name} is locked."
-    ));
-    return rhs_value.clone();
-  }
+fn is_known_attribute(name: &str) -> bool {
+  matches!(
+    name,
+    "Constant"
+      | "Flat"
+      | "HoldAll"
+      | "HoldAllComplete"
+      | "HoldFirst"
+      | "HoldRest"
+      | "Listable"
+      | "Locked"
+      | "NHoldAll"
+      | "NHoldFirst"
+      | "NHoldRest"
+      | "NonThreadable"
+      | "NumericFunction"
+      | "OneIdentity"
+      | "Orderless"
+      | "Protected"
+      | "ReadProtected"
+      | "SequenceHold"
+  )
+}
 
+pub fn get_attributes(expr: &Expr) -> Option<Vec<String>> {
   // Extract attribute names from the value
-  let attr_exprs = match rhs_value {
+  let attr_exprs = match expr {
     Expr::List(items) => items.clone(),
-    Expr::Identifier(_) => vec![rhs_value.clone()].into(),
-    _ => vec![rhs_value.clone()].into(),
+    _ => vec![expr.clone()].into(),
   };
 
   let mut valid_attrs = Vec::new();
   let mut has_error = false;
   for attr_expr in &attr_exprs {
     if let Expr::Identifier(attr_name) = attr_expr {
-      valid_attrs.push(attr_name.clone());
+      if is_known_attribute(attr_name) {
+        valid_attrs.push(attr_name.clone());
+      } else {
+        // Unknown attribute — emit warning
+        crate::emit_message(&format!(
+          "Attributes::attnf: {attr_name} is not a known attribute."
+        ));
+        has_error = true;
+      }
     } else {
       // Non-symbol attribute — emit warning
       let attr_str = expr_to_string(attr_expr);
@@ -906,8 +919,29 @@ fn set_attributes_from_value(
   }
 
   if has_error {
-    return Expr::Identifier("$Failed".to_string());
+    return None;
   }
+  Some(valid_attrs)
+}
+
+/// Helper for Attributes[f] = value / Attributes[f] := value
+/// Extracts attribute symbols from value, validates, and sets them on the symbol.
+fn set_attributes_from_value(
+  sym_name: &str,
+  rhs_value: &Expr,
+) -> crate::syntax::Expr {
+  // Check if symbol is locked
+  let is_locked = crate::func_attrs_contains(sym_name, "Locked");
+  if is_locked {
+    crate::emit_message(&format!(
+      "Attributes::locked: Symbol {sym_name} is locked."
+    ));
+    return rhs_value.clone();
+  }
+
+  let Some(valid_attrs) = get_attributes(rhs_value) else {
+    return Expr::Identifier("$Failed".to_string());
+  };
 
   // Replace all user-defined attributes for this symbol
   crate::FUNC_ATTRS.with(|m| {
@@ -1158,21 +1192,13 @@ fn is_downvalue_head_protected(name: &str) -> bool {
   if is_value_redirect_head(name) {
     return false;
   }
-  let was_unprotected = crate::FUNC_ATTRS_REMOVED.with(|m| {
-    m.borrow()
-      .get(name)
-      .is_some_and(|attrs| attrs.iter().any(|a| a == "Protected"))
-  });
+  let was_unprotected = crate::func_attrs_removed_contains(name, "Protected");
   if was_unprotected {
     return false;
   }
   crate::evaluator::attributes::get_builtin_attributes(name)
     .contains(&"Protected")
-    || crate::FUNC_ATTRS.with(|m| {
-      m.borrow()
-        .get(name)
-        .is_some_and(|attrs| attrs.iter().any(|a| a == "Protected"))
-    })
+    || crate::func_attrs_contains(name, "Protected")
 }
 
 /// Flatten a left-associative chain of `BinaryOp { op: Times, .. }` into

--- a/src/evaluator/attributes.rs
+++ b/src/evaluator/attributes.rs
@@ -807,20 +807,10 @@ pub fn dispatch_attributes(
         Expr::List(items) => items.iter().filter_map(symbol_name).collect(),
         _ => symbol_name(&args[0]).map(|n| vec![n]).unwrap_or_default(),
       };
-      let attr: Vec<String> = match &args[1] {
-        Expr::Identifier(a) => vec![a.clone()],
-        Expr::List(items) => items
-          .iter()
-          .filter_map(|item| {
-            if let Expr::Identifier(a) = item {
-              Some(a.clone())
-            } else {
-              None
-            }
-          })
-          .collect(),
-        _ => vec![],
+      let Some(attr) = get_attributes(&args[1]) else {
+        return Some(Ok(Expr::Identifier("Null".to_string())));
       };
+
       if !func_names.is_empty() {
         let mut locked = false;
         crate::FUNC_ATTRS.with(|m| {

--- a/src/evaluator/core_eval.rs
+++ b/src/evaluator/core_eval.rs
@@ -187,11 +187,7 @@ pub fn expand_arith_shorthand(
 /// Check if a function has a specific Hold attribute (built-in or user-defined).
 fn has_hold_attribute(name: &str, attr: &str) -> bool {
   get_builtin_attributes(name).contains(&attr)
-    || crate::FUNC_ATTRS.with(|m| {
-      m.borrow()
-        .get(name)
-        .is_some_and(|attrs| attrs.contains(&attr.to_string()))
-    })
+    || crate::func_attrs_contains(name, attr)
 }
 
 /// Whether `expr`'s head suppresses evaluation of the arguments it holds.

--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -1060,11 +1060,7 @@ pub fn dispatch_complex_and_special(
         {
           let has_flat =
             crate::evaluator::listable::is_builtin_flat(&expr_head)
-              || crate::FUNC_ATTRS.with(|m| {
-                m.borrow()
-                  .get(expr_head.as_str())
-                  .is_some_and(|attrs| attrs.contains(&"Flat".to_string()))
-              });
+              || crate::func_attrs_contains(&expr_head, "Flat");
           if has_flat {
             let all_bindings =
               crate::evaluator::pattern_matching::enumerate_flat_partition_matches(

--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -495,12 +495,8 @@ fn evaluate_function_call_ast_inner(
   };
 
   // Thread Listable functions over list arguments
-  let is_listable = is_builtin_listable(name)
-    || crate::FUNC_ATTRS.with(|m| {
-      m.borrow()
-        .get(name)
-        .is_some_and(|attrs| attrs.contains(&"Listable".to_string()))
-    });
+  let is_listable =
+    is_builtin_listable(name) || crate::func_attrs_contains(name, "Listable");
   if is_listable && let Some(result) = thread_listable(name, args)? {
     return Ok(result);
   }
@@ -524,12 +520,8 @@ fn evaluate_function_call_ast_inner(
   }
 
   // Apply Flat attribute: flatten nested calls of the same function
-  let has_flat = is_builtin_flat(name)
-    || crate::FUNC_ATTRS.with(|m| {
-      m.borrow()
-        .get(name)
-        .is_some_and(|attrs| attrs.contains(&"Flat".to_string()))
-    });
+  let has_flat =
+    is_builtin_flat(name) || crate::func_attrs_contains(name, "Flat");
   let args_after_flat;
   let args = if has_flat {
     let mut flat_args: Vec<Expr> = Vec::new();
@@ -580,11 +572,7 @@ fn evaluate_function_call_ast_inner(
   let has_orderless = name != "Plus"
     && name != "Times"
     && (is_builtin_orderless(name)
-      || crate::FUNC_ATTRS.with(|m| {
-        m.borrow()
-          .get(name)
-          .is_some_and(|attrs| attrs.contains(&"Orderless".to_string()))
-      }));
+      || crate::func_attrs_contains(name, "Orderless"));
   let args_after_sort;
   let args = if has_orderless {
     let mut sorted_args = args.to_vec();
@@ -713,12 +701,9 @@ fn evaluate_function_call_ast_inner(
   // stores upvalues in FUNC_DEFS too (their params start with `_up`), so
   // when the head carries HoldAllComplete we drop those entries before
   // dispatch — DownValues for the same head are still tried as usual.
-  let head_has_hold_all_complete = crate::FUNC_ATTRS.with(|m| {
-    m.borrow()
-      .get(name)
-      .is_some_and(|attrs| attrs.contains(&"HoldAllComplete".to_string()))
-  }) || get_builtin_attributes(name)
-    .contains(&"HoldAllComplete");
+  let head_has_hold_all_complete =
+    crate::func_attrs_contains(name, "HoldAllComplete")
+      || get_builtin_attributes(name).contains(&"HoldAllComplete");
   let overloads = crate::FUNC_DEFS.with(|m| {
     let defs = m.borrow();
     let raw = defs.get(name).cloned();

--- a/src/evaluator/listable.rs
+++ b/src/evaluator/listable.rs
@@ -1425,21 +1425,11 @@ pub fn get_system_variable(name: &str) -> Option<Expr> {
 /// SequenceHold semantics (Wolfram Language: HoldAllComplete = HoldAll
 /// + SequenceHold + ... ).
 pub(crate) fn has_sequence_hold(name: &str) -> bool {
-  matches!(
-    name,
-    "Set"
-      | "SetDelayed"
-      | "Rule"
-      | "RuleDelayed"
-      | "HoldComplete"
-      | "MakeBoxes"
-  ) || crate::FUNC_ATTRS.with(|m| {
-    m.borrow().get(name).is_some_and(|attrs| {
-      attrs.contains(&"SequenceHold".to_string())
-        || attrs.contains(&"HoldAllComplete".to_string())
-    })
-  }) || crate::evaluator::attributes::get_builtin_attributes(name)
-    .contains(&"HoldAllComplete")
+  let builtin = crate::evaluator::attributes::get_builtin_attributes(name);
+  builtin.contains(&"SequenceHold")
+    || crate::func_attrs_contains(name, "SequenceHold")
+    || crate::func_attrs_contains(name, "HoldAllComplete")
+    || builtin.contains(&"HoldAllComplete")
 }
 
 pub fn flatten_sequences<'a>(

--- a/src/evaluator/pattern_matching.rs
+++ b/src/evaluator/pattern_matching.rs
@@ -692,19 +692,11 @@ pub fn is_symbol_protected(name: &str) -> bool {
   let builtin_protected = builtin.contains(&"Protected");
   // `Unprotect` records the removal in FUNC_ATTRS_REMOVED so the builtin's
   // baseline can be temporarily overridden without losing it.
-  let removed = crate::FUNC_ATTRS_REMOVED.with(|m| {
-    m.borrow()
-      .get(name)
-      .is_some_and(|attrs| attrs.iter().any(|a| a == "Protected"))
-  });
+  let removed = crate::func_attrs_removed_contains(name, "Protected");
   if builtin_protected && !removed {
     return true;
   }
-  crate::FUNC_ATTRS.with(|m| {
-    m.borrow()
-      .get(name)
-      .is_some_and(|attrs| attrs.contains(&"Protected".to_string()))
-  })
+  crate::func_attrs_contains(name, "Protected")
 }
 
 fn has_one_identity(name: &str) -> bool {
@@ -712,11 +704,7 @@ fn has_one_identity(name: &str) -> bool {
   if builtin.contains(&"OneIdentity") {
     return true;
   }
-  crate::FUNC_ATTRS.with(|m| {
-    m.borrow()
-      .get(name)
-      .is_some_and(|attrs| attrs.contains(&"OneIdentity".to_string()))
-  })
+  crate::func_attrs_contains(name, "OneIdentity")
 }
 
 /// Look up a user-defined `Default[f, position]` (or position-less
@@ -1368,11 +1356,7 @@ fn try_flat_partition_match(
 ) -> Option<Vec<(String, Expr)>> {
   let has_orderless =
     crate::evaluator::listable::is_builtin_orderless(pat_name)
-      || crate::FUNC_ATTRS.with(|m| {
-        m.borrow()
-          .get(pat_name)
-          .is_some_and(|attrs| attrs.contains(&"Orderless".to_string()))
-      });
+      || crate::func_attrs_contains(pat_name, "Orderless");
   let n = expr_args.len();
   let k = pat_args.len();
   if has_orderless {
@@ -2131,12 +2115,8 @@ fn try_flat_replace_all(
 ) -> Result<Option<Expr>, InterpreterError> {
   match expr {
     Expr::FunctionCall { name, args } => {
-      let has_flat = is_builtin_flat(name)
-        || crate::FUNC_ATTRS.with(|m| {
-          m.borrow()
-            .get(name.as_str())
-            .is_some_and(|attrs| attrs.contains(&"Flat".to_string()))
-        });
+      let has_flat =
+        is_builtin_flat(name) || crate::func_attrs_contains(name, "Flat");
       if has_flat
         && let Expr::FunctionCall {
           name: pat_name,
@@ -2146,12 +2126,7 @@ fn try_flat_replace_all(
         && pat_args.len() < args.len()
       {
         let has_orderless = is_builtin_orderless(name)
-          || crate::FUNC_ATTRS.with(|m| {
-            m.borrow()
-              .get(name.as_str())
-              .is_some_and(|attrs| attrs.contains(&"Orderless".to_string()))
-          });
-
+          || crate::func_attrs_contains(name, "Orderless");
         if has_orderless {
           // For Flat+Orderless: try all combinations of sub_len args
           let sub_len = pat_args.len();
@@ -2185,11 +2160,8 @@ fn try_flat_replace_all(
           // -> rp[x]` → `r[a, rp[r[b]], c]`. The literal form is the
           // fallback so plain literal patterns like `f[a, b, c] /.
           // f[a, b] -> d` still match.
-          let has_one_identity = crate::FUNC_ATTRS.with(|m| {
-            m.borrow()
-              .get(name.as_str())
-              .is_some_and(|attrs| attrs.contains(&"OneIdentity".to_string()))
-          });
+          let has_one_identity =
+            crate::func_attrs_contains(name, "OneIdentity");
           let sub_len = pat_args.len();
           for start in 0..=(args.len() - sub_len) {
             let try_match =
@@ -4170,11 +4142,7 @@ fn match_pattern_impl(
           // `Plus[n_Integer, s__Symbol, rest_]`.
           let is_orderless =
             crate::evaluator::listable::is_builtin_orderless(pat_name)
-              || crate::FUNC_ATTRS.with(|m| {
-                m.borrow()
-                  .get(pat_name.as_str())
-                  .is_some_and(|attrs| attrs.contains(&"Orderless".to_string()))
-              });
+              || crate::func_attrs_contains(pat_name, "Orderless");
           if is_orderless && expr_args.len() >= 2 {
             for perm in permutations(expr_args) {
               if let Some(b) = match_args_with_sequences(&perm, pat_args) {
@@ -4228,11 +4196,7 @@ fn match_pattern_impl(
             if pat_args.len() < expr_args.len() && !pat_args.is_empty() {
               let has_flat =
                 crate::evaluator::listable::is_builtin_flat(pat_name)
-                  || crate::FUNC_ATTRS.with(|m| {
-                    m.borrow()
-                      .get(pat_name)
-                      .is_some_and(|attrs| attrs.contains(&"Flat".to_string()))
-                  });
+                  || crate::func_attrs_contains(pat_name, "Flat");
               if has_flat
                 && let Some(b) =
                   try_flat_partition_match(pat_name, pat_args, expr_args)
@@ -4245,11 +4209,7 @@ fn match_pattern_impl(
           // For Orderless functions (Times, Plus), try all permutations
           let is_orderless =
             crate::evaluator::listable::is_builtin_orderless(pat_name)
-              || crate::FUNC_ATTRS.with(|m| {
-                m.borrow()
-                  .get(pat_name)
-                  .is_some_and(|attrs| attrs.contains(&"Orderless".to_string()))
-              });
+              || crate::func_attrs_contains(pat_name, "Orderless");
           if is_orderless && pat_args.len() >= 2 {
             // Try all permutations of expression args against pattern args.
             // When Optional patterns are present, prefer matches where more

--- a/src/functions/polynomial_ast/reduce.rs
+++ b/src/functions/polynomial_ast/reduce.rs
@@ -530,11 +530,7 @@ fn extract_reduce_vars(expr: &Expr) -> Vec<String> {
   match expr {
     Expr::Identifier(name) => {
       // Check it's not a constant
-      let is_constant = crate::FUNC_ATTRS.with(|m| {
-        m.borrow()
-          .get(name.as_str())
-          .is_some_and(|attrs| attrs.contains(&"Constant".to_string()))
-      });
+      let is_constant = crate::func_attrs_contains(name, "Constant");
       if is_constant
         || matches!(
           name.as_str(),

--- a/src/functions/polynomial_ast/solve.rs
+++ b/src/functions/polynomial_ast/solve.rs
@@ -2411,11 +2411,7 @@ fn solve_core(args: &[Expr]) -> Result<Expr, InterpreterError> {
   };
 
   // Check if variable has Constant attribute (user-defined constants)
-  let is_constant = crate::FUNC_ATTRS.with(|m| {
-    m.borrow()
-      .get(var)
-      .is_some_and(|attrs| attrs.contains(&"Constant".to_string()))
-  });
+  let is_constant = crate::func_attrs_contains(var, "Constant");
   if is_constant {
     crate::emit_message(&format!(
       "Solve::ivar: {var} is not a valid variable."

--- a/src/functions/predicate_ast.rs
+++ b/src/functions/predicate_ast.rs
@@ -695,11 +695,7 @@ fn is_numeric_function(name: &str) -> bool {
       | "BernoulliB"
       | "Zeta"
       | "N"
-  ) || crate::FUNC_ATTRS.with(|m| {
-    m.borrow()
-      .get(name)
-      .is_some_and(|attrs| attrs.contains(&"NumericFunction".to_string()))
-  })
+  ) || crate::func_attrs_contains(name, "NumericFunction")
 }
 
 /// Numerically evaluate a NumericQ expression (e.g. Sin[11]) and apply

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5282,6 +5282,22 @@ pub fn interpret_expr_with_stdout(
   })
 }
 
+pub fn func_attrs_contains(func_name: &str, attr_name: &str) -> bool {
+  FUNC_ATTRS.with(|m| {
+    m.borrow()
+      .get(func_name)
+      .is_some_and(|attrs| attrs.contains(&attr_name.to_string()))
+  })
+}
+
+pub fn func_attrs_removed_contains(func_name: &str, attr_name: &str) -> bool {
+  FUNC_ATTRS_REMOVED.with(|m| {
+    m.borrow()
+      .get(func_name)
+      .is_some_and(|attrs| attrs.contains(&attr_name.to_string()))
+  })
+}
+
 fn store_function_definition(
   pair: Pair<Rule>,
 ) -> Result<Option<String>, InterpreterError> {
@@ -5311,19 +5327,11 @@ fn store_function_definition(
     "N" | "MessageName" | "Format" | "Default" | "Options"
   );
   let is_n_value_assignment = allows_redirected_rule;
-  let was_unprotected = FUNC_ATTRS_REMOVED.with(|m| {
-    m.borrow()
-      .get(func_name.as_str())
-      .is_some_and(|attrs| attrs.contains(&"Protected".to_string()))
-  });
+  let was_unprotected = func_attrs_removed_contains(&func_name, "Protected");
   let is_builtin_protected = !is_n_value_assignment
     && !was_unprotected
     && evaluator::get_builtin_attributes(&func_name).contains(&"Protected");
-  let is_user_protected = FUNC_ATTRS.with(|m| {
-    m.borrow()
-      .get(func_name.as_str())
-      .is_some_and(|attrs| attrs.contains(&"Protected".to_string()))
-  });
+  let is_user_protected = func_attrs_contains(&func_name, "Protected");
   if is_builtin_protected || is_user_protected {
     let (tag, ret) = if is_builtin_protected && !is_user_protected {
       ("SetDelayed::write", Some("$Failed".to_string()))

--- a/tests/interpreter_tests/attributes.rs
+++ b/tests/interpreter_tests/attributes.rs
@@ -4,6 +4,25 @@ mod set_attributes {
   use super::*;
 
   #[test]
+  fn unknown_attributes() {
+    clear_state();
+    let result = interpret_with_stdout("Attributes[f] = Foo").unwrap();
+    assert!(
+      result.warnings[0]
+        .contains("Attributes::attnf: Foo is not a known attribute."),
+      "unexpected warnings: {:?}",
+      result.warnings
+    );
+    let result = interpret_with_stdout("SetAttributes[f, Foo]").unwrap();
+    assert!(
+      result.warnings[0]
+        .contains("Attributes::attnf: Foo is not a known attribute."),
+      "unexpected warnings: {:?}",
+      result.warnings
+    );
+  }
+
+  #[test]
   fn listable_threads_over_list() {
     clear_state();
     assert_eq!(


### PR DESCRIPTION
Currently Woxi allows you to set any identifier as an attribute on a symbol. Instead, it should raise an error, typically "attnf: ... is not a known attribute.".

This PR implements this as fn get_attributes, used by both SetAttributes[] and Attributes[symbol] =.

Note that attributes are currently stored as Vec<String>, but long term should be a bitmask to restrict the values. To this end, this PR includes some helper functions (fn func_attrs_contains and fn func_attrs_removed_contains) to begin to isolate usage of FUNC_ATTRS and FUNC_ATTRS_REMOVED.

I also fixed some bugs I noticed with attributes.
- fn has_sequence_hold returned false for TagSet and UpSet.
- fn is_builtin_flat returned false for GCD, LCM, Composition, NonCommutativeMultiply, Join, StringJoin, Union and Intersection.
- fn is_builtin_orderless returned false for Multinomial.

I'm sure there are other missed cases in fn is_builtin_listable which I didn't investigate further. The long term fix here is to only have one source of truth for builtin attributes.  Functions should refer to the attribute bitmask and not duplicate the list of attribute names that match a certain condition.