### PR TITLE
Fix delayed compound-expression bodies losing statements on reprint

### DIFF
--- a/src/evaluator/dispatch/complex_and_special.rs
+++ b/src/evaluator/dispatch/complex_and_special.rs
@@ -15009,6 +15009,20 @@ fn number_list(values: &[f64], source: &Expr) -> Expr {
   )
 }
 
+/// Render a rule's right-hand side for a hand-assembled `lhs := rhs` /
+/// `lhs = rhs` / `lhs ^:= rhs` display line, parenthesizing a `;`-sequence
+/// body (`CompoundExpression` has the lowest precedence of any operator, so
+/// printing it unparenthesized after `:=` would re-parse as separate
+/// top-level statements instead of one delayed definition).
+fn format_assignment_rhs(body: &Expr) -> String {
+  let s = expr_to_string(body);
+  if crate::syntax::assignment_rhs_needs_parens(body) {
+    format!("({s})")
+  } else {
+    s
+  }
+}
+
 /// The text `Definition[sym]` displays: attributes, defaults, options and
 /// the symbol's own rules, one per paragraph. `None` when the symbol
 /// carries nothing at all (wolframscript shows a blank panel then).
@@ -15097,7 +15111,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
       lines.push(format!(
         "{} ^:= {}",
         expr_to_string(orig_lhs),
-        expr_to_string(orig_body)
+        format_assignment_rhs(orig_body)
       ));
     }
   }
@@ -15152,7 +15166,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
           "{}[{}] := {}",
           printed,
           params_str,
-          expr_to_string(&display_body)
+          format_assignment_rhs(&display_body)
         ));
         continue;
       }
@@ -15189,7 +15203,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
           "{}[{}] = {}",
           printed,
           args_strs.join(", "),
-          expr_to_string(body)
+          format_assignment_rhs(body)
         ));
       } else {
         // Reconstruct f[x_, y_Integer] := body
@@ -15210,7 +15224,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
           "{}[{}] := {}",
           printed,
           params_str.join(", "),
-          expr_to_string(body)
+          format_assignment_rhs(body)
         ));
       }
     }
@@ -15228,7 +15242,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
       lines.push(format!(
         "{} := {}",
         expr_to_string(lhs),
-        expr_to_string(rhs)
+        format_assignment_rhs(rhs)
       ));
     }
   }
@@ -15293,7 +15307,7 @@ pub fn definition_text(sym: &str) -> Option<String> {
       "{} /: Default[{}] := {}",
       printed,
       default_args.join(", "),
-      expr_to_string(body)
+      format_assignment_rhs(body)
     ));
   }
 
@@ -15497,7 +15511,7 @@ pub fn full_definition_text(sym: &str) -> Option<String> {
             "{}[{}] = {}",
             sym,
             args_strs.join(", "),
-            expr_to_string(body)
+            format_assignment_rhs(body)
           ));
         } else {
           let params_str: Vec<String> = params
@@ -15515,7 +15529,7 @@ pub fn full_definition_text(sym: &str) -> Option<String> {
             "{}[{}] := {}",
             sym,
             params_str.join(", "),
-            expr_to_string(body)
+            format_assignment_rhs(body)
           ));
         }
       }

--- a/src/functions/field_plot.rs
+++ b/src/functions/field_plot.rs
@@ -154,6 +154,31 @@ fn parse_field_options(args: &[Expr], start: usize) -> (u32, u32, bool) {
   (svg_width, svg_height, full_width)
 }
 
+/// `Epilog -> …` primitives for `VectorPlot`, drawn over the finished field
+/// with `plot_epilog::render_epilog_svg` — the same mechanism `DensityPlot`/
+/// `ContourPlot` already use via `DensityContourOptions`. Evaluated eagerly
+/// so primitives that reference a Manipulate's current control values (e.g.
+/// `Disk[place1]`) resolve to numeric coordinates.
+fn parse_vector_plot_epilog(args: &[Expr], start: usize) -> Vec<Expr> {
+  for opt in &args[start..] {
+    if let Expr::Rule {
+      pattern,
+      replacement,
+    } = opt
+      && matches!(pattern.as_ref(), Expr::Identifier(name) if name == "Epilog")
+    {
+      let val = evaluate_expr_to_expr(replacement)
+        .unwrap_or_else(|_| (**replacement).clone());
+      return match val {
+        Expr::List(ref items) => items.to_vec(),
+        Expr::Identifier(ref s) if s == "None" => Vec::new(),
+        other => vec![other],
+      };
+    }
+  }
+  Vec::new()
+}
+
 /// Contour level specification from the Contours option.
 enum ContourSpec {
   /// Contours -> n: n equally spaced levels
@@ -1880,6 +1905,7 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   );
   let body = resolved.as_ref().unwrap_or(&args[0]);
   let (svg_width, svg_height, full_width) = parse_field_options(args, 3);
+  let epilog = parse_vector_plot_epilog(args, 3);
 
   let x_step = (x_max - x_min) / VECTOR_GRID as f64;
   let y_step = (y_max - y_min) / VECTOR_GRID as f64;
@@ -1920,6 +1946,24 @@ pub fn vector_plot_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
   // primitives a surrounding `Graphics[{…}]` can redraw.
   let primitives =
     render_vector_arrows(&vectors, max_mag, cell_size, &area, &mut svg);
+
+  if !epilog.is_empty() {
+    let epilog_area = crate::functions::plot_epilog::PlotArea {
+      x0: area.plot_x0,
+      y0: area.plot_y0,
+      w: area.plot_w,
+      h: area.plot_h,
+      x_min: area.x_min,
+      x_max: area.x_max,
+      y_min: area.y_min,
+      y_max: area.y_max,
+      scale: f64::from(RESOLUTION_SCALE),
+    };
+    svg.push_str(&crate::functions::plot_epilog::render_epilog_svg(
+      &epilog,
+      &epilog_area,
+    ));
+  }
 
   svg.push_str("</svg>");
   Ok(crate::graphics_result_with_structure(

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -7958,6 +7958,17 @@ fn format_map_apply_shorthand(
   format!("{func_display} {op} {list_display}")
 }
 
+/// Parenthesize an assignment's already-formatted RHS if the RHS is a
+/// `;`-sequence: `CompoundExpression` has the lowest precedence of any
+/// operator, so printing `lhs := a; b; c` without parens re-parses as
+/// `(lhs := a); b; c`, silently dropping `b` and `c` from the delayed
+/// definition — the Demonstrations idiom `f[x_] := (a = x; b = f[a]; b)`
+/// for a multi-statement body would lose everything after the first
+/// statement. Applies equally to `=`, `:=`, `^=` and `^:=`.
+pub(crate) fn assignment_rhs_needs_parens(rhs: &Expr) -> bool {
+  matches!(rhs, Expr::CompoundExpr(_))
+}
+
 fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
   let fmt = |e: &Expr| -> String { format_expr(e, form) };
   let fmt_fn: fn(&Expr) -> String = match form {
@@ -8536,16 +8547,40 @@ fn format_expr_impl(expr: &Expr, form: ExprForm) -> String {
         return format!("{} :> {}", fmt(&args[0]), rhs_final);
       }
       if name == "Set" && args.len() == 2 {
-        return format!("{} = {}", fmt(&args[0]), fmt(&args[1]));
+        let rhs = fmt(&args[1]);
+        let rhs = if assignment_rhs_needs_parens(&args[1]) {
+          format!("({rhs})")
+        } else {
+          rhs
+        };
+        return format!("{} = {}", fmt(&args[0]), rhs);
       }
       if name == "SetDelayed" && args.len() == 2 {
-        return format!("{} := {}", fmt(&args[0]), fmt(&args[1]));
+        let rhs = fmt(&args[1]);
+        let rhs = if assignment_rhs_needs_parens(&args[1]) {
+          format!("({rhs})")
+        } else {
+          rhs
+        };
+        return format!("{} := {}", fmt(&args[0]), rhs);
       }
       if name == "UpSet" && args.len() == 2 {
-        return format!("{} ^= {}", fmt(&args[0]), fmt(&args[1]));
+        let rhs = fmt(&args[1]);
+        let rhs = if assignment_rhs_needs_parens(&args[1]) {
+          format!("({rhs})")
+        } else {
+          rhs
+        };
+        return format!("{} ^= {}", fmt(&args[0]), rhs);
       }
       if name == "UpSetDelayed" && args.len() == 2 {
-        return format!("{} ^:= {}", fmt(&args[0]), fmt(&args[1]));
+        let rhs = fmt(&args[1]);
+        let rhs = if assignment_rhs_needs_parens(&args[1]) {
+          format!("({rhs})")
+        } else {
+          rhs
+        };
+        return format!("{} ^:= {}", fmt(&args[0]), rhs);
       }
       if name == "AddTo" && args.len() == 2 {
         return format!("{} += {}", fmt(&args[0]), fmt(&args[1]));
@@ -12014,11 +12049,13 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
       }
     }
     Expr::FunctionCall { name, args } if name == "Set" && args.len() == 2 => {
-      format!(
-        "{} = {}",
-        expr_to_input_form(&args[0]),
-        expr_to_input_form(&args[1])
-      )
+      let rhs = expr_to_input_form(&args[1]);
+      let rhs = if assignment_rhs_needs_parens(&args[1]) {
+        format!("({rhs})")
+      } else {
+        rhs
+      };
+      format!("{} = {}", expr_to_input_form(&args[0]), rhs)
     }
     // `Out[-k]` for k > 0 renders as `%` shorthand (`%`, `%%`, `%%%`, …)
     // when held; matches expr_to_string/format_expr behavior.
@@ -12036,27 +12073,33 @@ fn expr_to_input_form_impl(expr: &Expr) -> String {
     Expr::FunctionCall { name, args }
       if name == "SetDelayed" && args.len() == 2 =>
     {
-      format!(
-        "{} := {}",
-        expr_to_input_form(&args[0]),
-        expr_to_input_form(&args[1])
-      )
+      let rhs = expr_to_input_form(&args[1]);
+      let rhs = if assignment_rhs_needs_parens(&args[1]) {
+        format!("({rhs})")
+      } else {
+        rhs
+      };
+      format!("{} := {}", expr_to_input_form(&args[0]), rhs)
     }
     Expr::FunctionCall { name, args } if name == "UpSet" && args.len() == 2 => {
-      format!(
-        "{} ^= {}",
-        expr_to_input_form(&args[0]),
-        expr_to_input_form(&args[1])
-      )
+      let rhs = expr_to_input_form(&args[1]);
+      let rhs = if assignment_rhs_needs_parens(&args[1]) {
+        format!("({rhs})")
+      } else {
+        rhs
+      };
+      format!("{} ^= {}", expr_to_input_form(&args[0]), rhs)
     }
     Expr::FunctionCall { name, args }
       if name == "UpSetDelayed" && args.len() == 2 =>
     {
-      format!(
-        "{} ^:= {}",
-        expr_to_input_form(&args[0]),
-        expr_to_input_form(&args[1])
-      )
+      let rhs = expr_to_input_form(&args[1]);
+      let rhs = if assignment_rhs_needs_parens(&args[1]) {
+        format!("({rhs})")
+      } else {
+        rhs
+      };
+      format!("{} ^:= {}", expr_to_input_form(&args[0]), rhs)
     }
     Expr::FunctionCall { name, args } if name == "AddTo" && args.len() == 2 => {
       format!(

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -1509,6 +1509,25 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn test_vector_plot_epilog_draws_extra_primitives() {
+    // Regression: VectorPlot silently dropped its Epilog option entirely,
+    // so markers a Wolfram Demonstration draws over the field (e.g. the
+    // source charges in an electric-field trajectory plot) went missing
+    // from the render. Mirrors DensityPlot/ContourPlot, which already
+    // draw Epilog via plot_epilog::render_epilog_svg.
+    clear_state();
+    let svg = interpret(
+      "ExportString[VectorPlot[{y, -x}, {x, -2, 2}, {y, -2, 2}, \
+       Epilog -> {Red, Disk[{0, 0}, 0.3]}], \"SVG\"]",
+    )
+    .unwrap();
+    assert!(
+      svg.contains("<ellipse") || svg.contains("<path"),
+      "Epilog Disk not drawn: {svg}"
+    );
+  }
+
+  #[test]
   fn test_graphics_text_renders_inline_box_notation() {
     // A notebook `Text[…]` label can carry its typeset content as inline
     // `\!\(\*…\)` box notation — the front end's linear-syntax form for a
@@ -1806,6 +1825,98 @@ mod interpreter_tests {
     // The circumflex must stay literal inside string content.
     clear_state();
     assert_eq!(interpret("\"aˆb\"").unwrap(), "aˆb");
+  }
+
+  #[test]
+  fn test_set_delayed_compound_expression_rhs_keeps_parens_in_input_form() {
+    // Regression: printing `lhs := (a; b; c)` back to InputForm must keep
+    // the parentheses around the `;`-sequence body. CompoundExpression has
+    // the lowest precedence of any operator, so dropping them would
+    // re-parse as `(lhs := a); b; c` — silently losing every statement
+    // after the first. Same for `=`, `^:=`, and `^=`.
+    clear_state();
+    assert_eq!(
+      interpret("ToString[Hold[f[x_] := (a = x; a + 1)], InputForm]").unwrap(),
+      "Hold[f[x_] := (a = x; a + 1)]"
+    );
+    clear_state();
+    assert_eq!(
+      interpret("ToString[Hold[f[x_] = (a = x; a + 1)], InputForm]").unwrap(),
+      "Hold[f[x_] = (a = x; a + 1)]"
+    );
+    clear_state();
+    assert_eq!(
+      interpret("ToString[Hold[f[x_] ^:= (a = x; a + 1)], InputForm]").unwrap(),
+      "Hold[f[x_] ^:= (a = x; a + 1)]"
+    );
+    clear_state();
+    assert_eq!(
+      interpret("ToString[Hold[f[x_] ^= (a = x; a + 1)], InputForm]").unwrap(),
+      "Hold[f[x_] ^= (a = x; a + 1)]"
+    );
+  }
+
+  #[test]
+  fn test_definition_of_compound_expression_body_keeps_parens() {
+    // Same regression, surfaced through Definition[] (which formats
+    // DownValues by hand rather than through expr_to_input_form): a
+    // Demonstrations-style multi-statement delayed body must print with
+    // its grouping parentheses so Definition[f]'s own text remains valid
+    // input.
+    clear_state();
+    interpret("f[x_] := (a = x; b = a + 1; b)").unwrap();
+    assert_eq!(
+      interpret("Definition[f]").unwrap(),
+      "f[x_] := (a = x; b = a + 1; b)"
+    );
+  }
+
+  #[test]
+  fn test_definition_of_compound_expression_body_round_trips() {
+    // The real-world failure mode: re-parsing a printed Definition must
+    // reproduce the exact same function, not one that only runs its first
+    // statement. This is the mechanism Woxi Studio's Manipulate rendering
+    // relies on: a Demonstration's body is parsed to an AST and printed
+    // back to source before evaluation, so any statement dropped here
+    // silently breaks the Manipulate at render time.
+    clear_state();
+    interpret("f[x_] := (a = x; b = a + 1; b)").unwrap();
+    let def_text = interpret("ToString[Definition[f], InputForm]").unwrap();
+    clear_state();
+    interpret(&def_text).unwrap();
+    assert_eq!(interpret("f[5]").unwrap(), "6");
+  }
+
+  #[test]
+  fn test_while_with_parenthesized_compound_body_survives_reprint() {
+    // The exact shape that broke a real Wolfram Demonstration in Woxi
+    // Studio: a recursive downvalue whose base case is set from inside a
+    // `While` loop, with the whole delayed body parenthesized as a
+    // `;`-sequence. Printing the parsed body back to source (as the
+    // Manipulate renderer does) and re-running it must still terminate
+    // with the right answer instead of raising
+    // "While: test must evaluate to True or False" from a statement that
+    // silently escaped the delayed definition.
+    clear_state();
+    interpret("step[n_] := step[n - 1] + 1;").unwrap();
+    interpret(
+      "run[start_] := (step[0] = start; \
+         k = 1; \
+         While[k <= 3, k++]; \
+         step[3]);",
+    )
+    .unwrap();
+    let printed = interpret("ToString[Definition[run], InputForm]").unwrap();
+    assert!(
+      printed.starts_with("run[start_] := ("),
+      "lost the grouping parens: {printed}"
+    );
+    // Re-define `run` from nothing but its own printed definition (`step`'s
+    // definition is untouched) and confirm it still runs as one delayed
+    // multi-statement body instead of leaking its later statements out as
+    // immediate top-level code.
+    interpret(&printed).unwrap();
+    assert_eq!(interpret("run[10]").unwrap(), "13");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Found via the daily Woxi Studio Demonstration check: `RandomResourcePage` served [Trajectory of a Test Charge in an Electric Field](https://demonstrations.wolfram.com/TrajectoryOfATestChargeInAnElectricField/), whose `Manipulate` failed to render in Woxi Studio with `While: test must evaluate to True or False`.

Root cause: `expr_to_input_form` and the general expression formatter printed a `CompoundExpression` (`;`-sequence) RHS of `Set`/`SetDelayed`/`UpSet`/`UpSetDelayed` **without** the parentheses needed to keep it grouped. `CompoundExpression` has the lowest precedence of any operator, so `f[x_] := (a = x; b = a + 1; b)` printed back without its parens re-parses as `(f[x_] := a = x); b = a + 1; b` — the delayed body silently loses every statement after the first. `Definition[]`/`FullDefinition[]` build the same `"lhs := rhs"` lines by hand and had the identical bug.

This broke Woxi Studio's `Manipulate` support broadly, not just for this one notebook: a Demonstration's body is parsed to an AST and printed back to source before each re-evaluation, so any multi-statement helper function (a common pattern for recursive path-tracing / simulation code) would silently stop working after the first render, surfacing as an unrelated evaluation error far from the real cause.

- `src/syntax.rs`: added a shared `assignment_rhs_needs_parens` helper and applied it at all 8 `Set`/`SetDelayed`/`UpSet`/`UpSetDelayed` formatting sites (both the general formatter and `expr_to_input_form`).
- `src/evaluator/dispatch/complex_and_special.rs`: `Definition[]`/`FullDefinition[]` assemble their display lines by hand rather than through the formatter above, so they had the same bug independently — fixed via a small `format_assignment_rhs` wrapper that delegates to the same helper.
- `src/functions/field_plot.rs`: while diagnosing the notebook, found `VectorPlot` silently ignored its `Epilog` option entirely (the field's source-charge markers and the computed trajectory line were missing from the render). Wired it through the same `plot_epilog::render_epilog_svg` helper `DensityPlot`/`ContourPlot` already use.
- `tests/interpreter_tests.rs`: regression tests for the reprint bug (`Set`/`SetDelayed`/`UpSet`/`UpSetDelayed`, `Definition[]` round-trip, and a synthetic recursive-downvalue-in-a-`While`-loop shape matching the real failure) plus a test for `VectorPlot`'s `Epilog`.

No code from the (copyrighted) Demonstration notebook is included — all tests use original, synthetic examples that exercise the same language constructs.

## Test plan

- [x] `make test` — 27391 tests passed
- [x] `make format`
- [x] Verified the downloaded Demonstration notebook now renders in Woxi Studio (`cargo run -p woxi-studio --example dump_manipulate`) with `graphics=true error=None`, and visually confirmed the two charge markers and trajectory line now draw correctly via the exported SVG

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YgTj7nZ5kTq7zsx8tPDY)_