### PR TITLE
Accept a bare adjacency matrix in GraphPlot

### DIFF
--- a/src/evaluator/dispatch/evaluate_functions.rs
+++ b/src/evaluator/dispatch/evaluate_functions.rs
@@ -4264,6 +4264,19 @@ fn evaluate_function_call_ast_inner(
           replacement: Box::new(Expr::List(spec.into())),
         });
       }
+      // `GraphPlot[m]` also accepts a bare adjacency matrix directly (unlike
+      // plain `Graph[…]`, which needs `AdjacencyGraph[m]`): a list whose
+      // entries are themselves lists, rather than edges (Rules or
+      // Directed/UndirectedEdge), is unambiguously that matrix form.
+      let matrix_graph = match &args[0] {
+        Expr::List(rows)
+          if !rows.is_empty()
+            && rows.iter().all(|r| matches!(r, Expr::List(_))) =>
+        {
+          crate::functions::graph::adjacency_matrix_to_graph(None, rows)
+        }
+        _ => None,
+      };
       let graph_expr = if let Expr::FunctionCall {
         name: gn,
         args: gargs,
@@ -4271,6 +4284,11 @@ fn evaluate_function_call_ast_inner(
         && gn == "Graph"
       {
         // The plot's own options apply on top of the graph's.
+        let mut merged: Vec<Expr> = gargs.iter().cloned().collect();
+        merged.extend(forwarded[1..].iter().cloned());
+        call("Graph", merged)
+      } else if let Some(Expr::FunctionCall { args: gargs, .. }) = &matrix_graph
+      {
         let mut merged: Vec<Expr> = gargs.iter().cloned().collect();
         merged.extend(forwarded[1..].iter().cloned());
         call("Graph", merged)
@@ -9667,74 +9685,7 @@ fn evaluate_function_call_ast_inner(
 
   // AdjacencyGraph[matrix] or AdjacencyGraph[vertices, matrix] — create graph from adjacency matrix
   if name == "AdjacencyGraph" && (args.len() == 1 || args.len() == 2) {
-    let (vertices, matrix) = if args.len() == 2 {
-      if let Expr::List(verts) = &args[0] {
-        (Some(verts.clone()), &args[1])
-      } else {
-        return Ok(unevaluated(name, args));
-      }
-    } else {
-      (None, &args[0])
-    };
-
-    if let Expr::List(rows) = matrix {
-      let n = rows.len();
-      let verts: Vec<Expr> = vertices
-        .unwrap_or_else(|| (1..=n).map(|i| Expr::Integer(i as i128)).collect())
-        .to_vec();
-
-      // Check if symmetric (undirected)
-      let mut is_symmetric = true;
-      let mut matrix_vals: Vec<Vec<i128>> = Vec::new();
-      for row in rows {
-        if let Expr::List(cols) = row {
-          let vals: Vec<i128> = cols
-            .iter()
-            .map(|c| match c {
-              Expr::Integer(v) => *v,
-              _ => 0,
-            })
-            .collect();
-          matrix_vals.push(vals);
-        }
-      }
-      for i in 0..n {
-        for j in 0..n {
-          if i < matrix_vals.len()
-            && j < matrix_vals[i].len()
-            && j < matrix_vals.len()
-            && i < matrix_vals[j].len()
-            && matrix_vals[i][j] != matrix_vals[j][i]
-          {
-            is_symmetric = false;
-          }
-        }
-      }
-
-      let mut edges = Vec::new();
-      let edge_name = if is_symmetric {
-        "UndirectedEdge"
-      } else {
-        "DirectedEdge"
-      };
-      for i in 0..n {
-        let start = if is_symmetric { i + 1 } else { 0 };
-        for j in start..n {
-          if i < matrix_vals.len()
-            && j < matrix_vals[i].len()
-            && matrix_vals[i][j] != 0
-          {
-            edges
-              .push(call(edge_name, vec![verts[i].clone(), verts[j].clone()]));
-          }
-        }
-      }
-
-      return Ok(call(
-        "Graph",
-        vec![Expr::List(verts.into()), Expr::List(edges.into())],
-      ));
-    }
+    return crate::functions::graph::adjacency_graph_ast(args);
   }
 
   // MovingAverage[list, r] — simple moving average with window size r.

--- a/src/functions/graph.rs
+++ b/src/functions/graph.rs
@@ -4277,6 +4277,78 @@ pub fn weighted_adjacency_graph_ast(
   })
 }
 
+/// AdjacencyGraph[matrix] / AdjacencyGraph[vertices, matrix] — graph from
+/// a 0/1 adjacency matrix. Symmetric matrices give undirected edges
+/// (upper triangle, row-major); anything else gives directed edges in
+/// row-major order.
+pub fn adjacency_graph_ast(args: &[Expr]) -> Result<Expr, InterpreterError> {
+  let unevaluated = |args: &[Expr]| unevaluated("AdjacencyGraph", args);
+  let (vertices, matrix) = match args {
+    [Expr::List(m)] => (None, m),
+    [Expr::List(v), Expr::List(m)] => (Some(v.clone()), m),
+    _ => return Ok(unevaluated(args)),
+  };
+  let Some(graph) = adjacency_matrix_to_graph(vertices.as_deref(), matrix)
+  else {
+    return Ok(unevaluated(args));
+  };
+  Ok(graph)
+}
+
+/// Shared conversion from a square adjacency matrix (list of rows) into a
+/// `Graph[{vertices}, {edges}]` expression. Returns `None` when `matrix`
+/// isn't a square list of lists, or `vertices` (when given) doesn't match
+/// its dimension. Used by `AdjacencyGraph` and by `GraphPlot[m]`, which
+/// accepts a bare adjacency matrix directly.
+pub fn adjacency_matrix_to_graph(
+  vertices: Option<&[Expr]>,
+  matrix: &[Expr],
+) -> Option<Expr> {
+  let n = matrix.len();
+  let rows: Option<Vec<&[Expr]>> = matrix
+    .iter()
+    .map(|row| match row {
+      Expr::List(cells) if cells.len() == n => Some(cells.as_slice()),
+      _ => None,
+    })
+    .collect();
+  let rows = rows?;
+  let verts: Vec<Expr> = match vertices {
+    Some(v) if v.len() == n => v.to_vec(),
+    Some(_) => return None,
+    None => (1..=n as i128).map(Expr::Integer).collect(),
+  };
+  let is_edge = |e: &Expr| {
+    crate::functions::math_ast::try_eval_to_f64(e).is_some_and(|v| v != 0.0)
+  };
+  let symmetric = (0..n)
+    .all(|i| (0..n).all(|j| is_edge(&rows[i][j]) == is_edge(&rows[j][i])));
+
+  let mut edges: Vec<Expr> = Vec::new();
+  for i in 0..n {
+    let j_start = if symmetric { i } else { 0 };
+    for j in j_start..n {
+      if symmetric && i == j {
+        continue;
+      }
+      if is_edge(&rows[i][j]) {
+        edges.push(Expr::FunctionCall {
+          name: if symmetric {
+            "UndirectedEdge".to_string()
+          } else {
+            "DirectedEdge".to_string()
+          },
+          args: vec![verts[i].clone(), verts[j].clone()].into(),
+        });
+      }
+    }
+  }
+  Some(Expr::FunctionCall {
+    name: "Graph".to_string(),
+    args: vec![Expr::List(verts.into()), Expr::List(edges.into())].into(),
+  })
+}
+
 /// FindMinimumCostFlow[cmat, s, t] - minimum total cost of a maximum
 /// flow from s to t where each nonzero cost-matrix entry is an arc of
 /// capacity one (wolframscript's default). No path at all stays

--- a/tests/cli/plotting/GraphPlot.md
+++ b/tests/cli/plotting/GraphPlot.md
@@ -7,6 +7,19 @@ $ wo 'Head[GraphPlot[{1 -> 2, 2 -> 3, 3 -> 1}]]'
 Graphics
 ```
 
+A square matrix is taken directly as an adjacency matrix — symmetric
+matrices give undirected edges, anything else gives directed edges:
+
+```scrut
+$ wo 'Head[GraphPlot[{{0, 1, 0}, {1, 0, 1}, {0, 1, 0}}]]'
+Graphics
+```
+
+```scrut
+$ wo 'Head[GraphPlot[{{0, 1, 0}, {0, 0, 1}, {1, 0, 0}}]]'
+Graphics
+```
+
 `Method` names the embedding to lay the vertices out with —
 `"CircularEmbedding"` puts all of them on one circle, even when the graph
 falls apart into separate pieces:

--- a/tests/interpreter_tests/graph_theory.rs
+++ b/tests/interpreter_tests/graph_theory.rs
@@ -592,6 +592,68 @@ mod adjacency_graph_from_matrix {
   }
 }
 
+/// Regression: `GraphPlot[m]` takes a bare adjacency matrix directly
+/// (documented for GraphPlot, unlike plain `Graph[m]` which needs
+/// `AdjacencyGraph[m]`). It used to stay unevaluated because the matrix
+/// was forwarded straight to `Graph[m]`, which only understands an edge
+/// list or an already-split `{vertices}, {edges}` pair.
+mod graph_plot_from_matrix {
+  use super::*;
+
+  #[test]
+  fn renders_graphics() {
+    assert_eq!(
+      interpret("Head[GraphPlot[{{0, 1, 1}, {1, 0, 0}, {1, 0, 0}}]]").unwrap(),
+      "Graphics"
+    );
+  }
+
+  #[test]
+  fn undirected_symmetric_vertex_and_edge_count() {
+    let svg = interpret(
+      "ExportString[GraphPlot[{{0, 1, 1}, {1, 0, 0}, {1, 0, 0}}], \"SVG\"]",
+    )
+    .unwrap();
+    assert_eq!(svg.matches("<ellipse").count(), 3, "SVG: {svg}");
+    assert_eq!(svg.matches("<polyline").count(), 2, "SVG: {svg}");
+  }
+
+  #[test]
+  fn directed_asymmetric_vertex_and_edge_count() {
+    let svg = interpret(
+      "ExportString[GraphPlot[{{0, 1, 0}, {0, 0, 1}, {1, 0, 0}}], \"SVG\"]",
+    )
+    .unwrap();
+    assert_eq!(svg.matches("<ellipse").count(), 3, "SVG: {svg}");
+    assert_eq!(svg.matches("<polyline").count(), 3, "SVG: {svg}");
+  }
+
+  /// GraphPlot's own options (e.g. SelfLoopStyle, VertexLabeling,
+  /// DirectedEdges) still apply when the argument is a matrix rather than
+  /// an edge list.
+  #[test]
+  fn accepts_graphplot_options() {
+    assert_eq!(
+      interpret(
+        "Head[GraphPlot[{{0, 1, 0}, {1, 0, 1}, {0, 1, 0}}, SelfLoopStyle -> True, VertexLabeling -> True, DirectedEdges -> True]]"
+      )
+      .unwrap(),
+      "Graphics"
+    );
+  }
+
+  /// AdjacencyGraph itself must keep working after the shared matrix
+  /// conversion was factored out for reuse by GraphPlot.
+  #[test]
+  fn adjacency_graph_still_works() {
+    assert_eq!(
+      interpret("EdgeList[AdjacencyGraph[{{0, 1, 0}, {0, 0, 1}, {1, 0, 0}}]]")
+        .unwrap(),
+      "{1  2, 2  3, 3  1}"
+    );
+  }
+}
+
 mod path_graph {
   use super::*;
 


### PR DESCRIPTION
## Summary

- `GraphPlot[m]` is documented to accept `m` as a matrix directly specifying the graph, but Woxi's `GraphPlot` forwarded any list argument straight to `Graph[…]`, which only understands an edge list or an already-split `{vertices}, {edges}` pair — so a bare adjacency matrix stayed unevaluated instead of rendering as `Graphics`.
- Found while checking a random Wolfram Demonstration notebook ("N-Step Transition Matrices for Markov Chains") against Woxi Studio: its `Manipulate` calls `GraphPlot` on a matrix built live from an interactive checkbox grid, so the graph view of that Demonstration never rendered.
- Factored the matrix→`Graph[…]` conversion already used by `AdjacencyGraph` into a shared helper (`adjacency_matrix_to_graph`) in `src/functions/graph.rs`, and reused it in `GraphPlot`'s dispatch for list-of-lists arguments that aren't edges (Rules / `Directed`/`UndirectedEdge`).
- No code from the Demonstration notebook itself is included — the added tests use independently written matrices.

## Test plan

- [x] Added unit tests in `tests/interpreter_tests/graph_theory.rs` (`graph_plot_from_matrix` module): `GraphPlot[m]` renders `Graphics` for symmetric/asymmetric matrices with the right vertex/edge counts, GraphPlot options still apply, and `AdjacencyGraph` keeps working after the refactor.
- [x] Added CLI doc examples in `tests/cli/plotting/GraphPlot.md`.
- [x] `make test` (27391 tests) — all passing.
- [x] `make format`.
- [x] Verified via Woxi Studio's `dump_manipulate` diagnostic that the Demonstration's `Manipulate` now renders graphics (`render: graphics=true`) instead of falling back to text output.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DJXGHDpGfKrWo3cDTka9g9)_