### PR TITLE
Add interactive ColorSlider/ColorSetter Manipulate control; fix LocatorAutoCreate integer form

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -150,6 +150,33 @@ const BLACK: Color = Color {
   a: 1.0,
 };
 
+/// The RGB color (each channel `0.0..=1.0`) of `Hue[h]` at full saturation
+/// and brightness — the same HSB→RGB conversion `Hue[…]` itself evaluates
+/// with. Exposed so a frontend can *paint* a hue value (e.g. Woxi Studio's
+/// ColorSlider/ColorSetter gradient bar and drag handle) without
+/// re-implementing the conversion as a second copy.
+pub fn hue_to_rgb01(h: f64) -> (f64, f64, f64) {
+  let c = Color::from_hue(h, 1.0, 1.0);
+  (c.r, c.g, c.b)
+}
+
+/// Resolve a color expression's InputForm code to an `(r, g, b)` triple in
+/// `0.0..=1.0`, falling back to black for anything that isn't a recognized
+/// color head (`RGBColor`, `Hue`, `GrayLevel`, `CMYKColor`, a named color,
+/// …). Used by a frontend to paint a Manipulate color control's current
+/// value (e.g. Woxi Studio's ColorSlider/ColorSetter handle).
+pub fn manipulate_color_to_rgb(code: &str) -> (f64, f64, f64) {
+  // `interpret_to_expr` already fully evaluates its input (see its own
+  // doc comment), so `parse_color` runs directly on the result.
+  let Ok(expr) = crate::interpret_to_expr(code) else {
+    return (0.0, 0.0, 0.0);
+  };
+  match parse_color(&expr) {
+    Some(c) => (c.r, c.g, c.b),
+    None => (0.0, 0.0, 0.0),
+  }
+}
+
 // ── Theme colors for light/dark mode ────────────────────────────────────
 
 pub struct ThemeColors {
@@ -16740,6 +16767,22 @@ pub enum ManipulateControl {
   /// A `Delimiter` argument: a horizontal separator row between control
   /// groups. Binds no variable.
   Divider,
+  /// A `ControlType -> ColorSlider` (or `-> ColorSetter`) control: a
+  /// hue-gradient bar whose handle position (`0..1`) maps to `Hue[position]`
+  /// at full saturation/value. Wolfram draws `ColorSetter` identically to
+  /// `ColorSlider` (a click/tap-to-set variant of the same idea), so both
+  /// dispatch here rather than duplicating the control.
+  Color {
+    name: String,
+    /// The spec's literal initial color, as InputForm (e.g.
+    /// `RGBColor[0, 0, 0]`). Kept exactly as the bound variable's value on
+    /// the first frame even though it is usually not *on* the hue gradient
+    /// — mirrors how `Continuous::initial` keeps an off-grid literal (see
+    /// `woxi-studio/src/manipulate.rs`'s `ControlState::Color`).
+    initial: String,
+    label: String,
+    label_runs: Vec<LabelRun>,
+  },
 }
 
 impl ManipulateControl {
@@ -16752,7 +16795,8 @@ impl ManipulateControl {
       | Self::Slider2D { name, .. }
       | Self::IntervalSlider { name, .. }
       | Self::Trigger { name, .. }
-      | Self::Locator { name, .. } => name,
+      | Self::Locator { name, .. }
+      | Self::Color { name, .. } => name,
       Self::Button { .. } | Self::Heading { .. } | Self::Divider => "",
     }
   }
@@ -18692,6 +18736,14 @@ fn patch_default_label(
         *label = pretty;
       }
     }
+    ManipulateControl::Color {
+      label, label_runs, ..
+    } => {
+      if label == synth {
+        *label = pretty;
+        *label_runs = pretty_runs;
+      }
+    }
     ManipulateControl::Button { .. }
     | ManipulateControl::Heading { .. }
     | ManipulateControl::Divider => {}
@@ -20187,6 +20239,9 @@ fn parse_manipulate_control(
               // the user may add; any such range still means "adding is
               // allowed".
               Expr::List(bounds) => !bounds.is_empty(),
+              // `LocatorAutoCreate -> n`: a bare positive integer caps how
+              // many locators may be added (0/negative disables it).
+              Expr::Integer(n) => *n > 0,
               _ => false,
             }
       )
@@ -20438,6 +20493,35 @@ fn parse_manipulate_control(
     });
   }
 
+  // Color control: `ControlType -> ColorSlider` (or `-> ColorSetter`), also
+  // given as a bare marker after the head (`{{bg, RGBColor[0, 0, 0],
+  // "background"}, ColorSlider}`). Wolfram draws `ColorSetter` identically
+  // to `ColorSlider` — a click/tap-to-set variant of the same hue-gradient
+  // widget — so both dispatch through the same control here rather than
+  // duplicating it. The bound variable keeps the spec's literal initial
+  // color exactly (see `ManipulateControl::Color::initial`); there is no
+  // numeric domain to fall back on the way a range spec gives a slider one.
+  if matches!(control_type.as_deref(), Some("ColorSlider" | "ColorSetter")) {
+    let initial = explicit_initial.as_ref().map_or_else(
+      || "RGBColor[0, 0, 0]".to_string(),
+      manipulate_value_to_input_form,
+    );
+    return Some(ParsedControl::Visible {
+      control: ManipulateControl::Color {
+        name,
+        initial,
+        label,
+        label_runs,
+      },
+      enabled,
+      min_code: None,
+      max_code: None,
+      values_code: None,
+      animate: None,
+      tracking: tracking.clone(),
+    });
+  }
+
   // Discrete form: `{u, {u1, u2, …}}` or `{{u, uinit, …}, {u1, u2, …}}`,
   // possibly with trailing options (`{{u, uinit, ""}, {u1, …},
   // ControlType -> PopupMenu}`) — hence matched on the option-free `bounds`.
@@ -20631,8 +20715,11 @@ fn parse_manipulate_control(
   // alternate(s), matching the Demonstrations idiom of toggling between a
   // couple of fixed colours. With an explicit initial colour that differs
   // from `colour`, the two form a real 2-swatch choice; without one there is
-  // only a single possible value, so the variable stays fixed at it (there
-  // is nothing to pick between).
+  // only a single possible value to alternate with, and wolframscript draws
+  // a full `ColorSlider` over the whole hue gradient instead (the same
+  // widget the explicit `ColorSlider`/`ColorSetter` marker produces above) —
+  // there being nothing to swatch-toggle between is exactly what makes the
+  // domain "any colour" rather than "one of these two".
   if bounds.len() == 1
     && crate::functions::graphics::parse_color(bounds[0]).is_some()
   {
@@ -20668,8 +20755,32 @@ fn parse_manipulate_control(
         tracking: tracking.clone(),
       });
     }
-    let value = crate::syntax::expr_to_input_form(bounds[0]);
-    return Some(ParsedControl::Fixed { name, value });
+    // With no explicit initial at all — the bare `{u, colour}` form, not the
+    // labelled triple — there is only the one literal value `colour` ever
+    // named in the spec: it is baked into the body as a fixed constant, the
+    // same as any other single-valued domain, rather than promoted to a
+    // widget.
+    let Some(init) = explicit_initial.as_ref() else {
+      return Some(ParsedControl::Fixed {
+        name,
+        value: alt_code,
+      });
+    };
+    let initial = manipulate_value_to_input_form(init);
+    return Some(ParsedControl::Visible {
+      control: ManipulateControl::Color {
+        name,
+        initial,
+        label,
+        label_runs,
+      },
+      enabled,
+      min_code: None,
+      max_code: None,
+      values_code: None,
+      animate: None,
+      tracking: tracking.clone(),
+    });
   }
 
   // No domain at all — `{u, uinit}` or `{{u, uinit, ulbl}, opts…}` with
@@ -21015,6 +21126,9 @@ pub fn manipulate_initial_bindings(
       )),
       ManipulateControl::Locator { name, points, .. } => {
         Some((name.clone(), format_point_list_input(points)))
+      }
+      ManipulateControl::Color { name, initial, .. } => {
+        Some((name.clone(), initial.clone()))
       }
     })
     // Mutable `ControlType -> None` state variables travel in the binding
@@ -21656,6 +21770,20 @@ pub fn manipulate_spec_to_json(spec: &ManipulateSpec) -> String {
       }
       ManipulateControl::Divider => {
         ctrl_parts.push(r#"{"kind":"delimiter"}"#.to_string());
+      }
+      ManipulateControl::Color {
+        name,
+        initial,
+        label,
+        label_runs,
+      } => {
+        ctrl_parts.push(format!(
+          r#"{{"kind":"color","name":"{}","label":"{}","labelRuns":{},"initial":"{}"}}"#,
+          json_escape_manipulate(name),
+          json_escape_manipulate(label),
+          label_runs_to_json(label_runs),
+          json_escape_manipulate(initial),
+        ));
       }
     }
   }
@@ -22876,6 +23004,84 @@ mod manipulate_dynamic_control_list_tests {
         assert!(popup, "ControlType -> PopupMenu must render as a dropdown");
       }
       other => panic!("expected a Discrete control, got {other:?}"),
+    }
+  }
+
+  /// `LocatorAutoCreate -> n` for a bare positive integer allows adding
+  /// locators the same as `-> True`/`-> Automatic` — a Demonstration caps
+  /// how many extra points a click may add this way (e.g. `-> 2`), and the
+  /// integer form must not be mistaken for "no auto-create" the way an
+  /// unrecognized value would be.
+  #[test]
+  fn locator_auto_create_bare_integer_enables_adding_points() {
+    let s = spec(
+      "Manipulate[pts, {{pts, {{0, 0}, {1, 1}}}, Locator, \
+       LocatorAutoCreate -> 2}]",
+    );
+    match &s.controls[0] {
+      ManipulateControl::Locator { auto_create, .. } => {
+        assert!(
+          *auto_create,
+          "LocatorAutoCreate -> 2 must enable adding locators"
+        );
+      }
+      other => panic!("expected a Locator control, got {other:?}"),
+    }
+  }
+
+  /// `{{bg, RGBColor[0, 0, 0], "background"}, ColorSlider}` — a color
+  /// control bound to `bg` — parses into a `Color` control rather than
+  /// being silently dropped or misread as a hidden/discrete spec. The
+  /// bound variable keeps the spec's *literal* initial color exactly (not
+  /// snapped to whatever the hue gradient's own position 0 would give),
+  /// mirroring how a `Continuous` control keeps an off-grid literal
+  /// initial value.
+  #[test]
+  fn color_slider_parses_and_keeps_literal_initial() {
+    let s = spec(
+      r#"Manipulate[Graphics[{bg}], \
+         {{bg, RGBColor[0, 0, 0], "background"}, ColorSlider}]"#,
+    );
+    assert_eq!(names(&s), vec!["bg"]);
+    match &s.controls[0] {
+      ManipulateControl::Color { initial, label, .. } => {
+        assert_eq!(initial, "RGBColor[0, 0, 0]");
+        assert_eq!(label, "background");
+      }
+      other => panic!("expected a Color control, got {other:?}"),
+    }
+  }
+
+  /// `ColorSetter` is Wolfram's click/tap-to-set variant of the same
+  /// hue-gradient widget as `ColorSlider` — it must parse to the same
+  /// `Color` control rather than a second, duplicate implementation.
+  #[test]
+  fn color_setter_parses_the_same_as_color_slider() {
+    let s = spec(
+      r#"Manipulate[Graphics[{bg}], \
+         {{bg, RGBColor[1, 0, 0], "background"}, ColorSetter}]"#,
+    );
+    match &s.controls[0] {
+      ManipulateControl::Color { initial, .. } => {
+        assert_eq!(initial, "RGBColor[1, 0, 0]");
+      }
+      other => panic!("expected a Color control, got {other:?}"),
+    }
+  }
+
+  /// `ControlType -> ColorSlider` (the option-rule spelling, rather than
+  /// the bare marker) must parse identically.
+  #[test]
+  fn control_type_color_slider_option_parses_the_same() {
+    let s = spec(
+      r#"Manipulate[Graphics[{bg}], \
+         {{bg, RGBColor[0, 1, 0]}, ControlType -> ColorSlider}]"#,
+    );
+    match &s.controls[0] {
+      ManipulateControl::Color { initial, .. } => {
+        assert_eq!(initial, "RGBColor[0, 1, 0]");
+      }
+      other => panic!("expected a Color control, got {other:?}"),
     }
   }
 }

--- a/tests/cli/comparison/mathematica/conformance_gaps.md
+++ b/tests/cli/comparison/mathematica/conformance_gaps.md
@@ -2301,9 +2301,6 @@ against the rendered picture.
 
 ### `Manipulate` control gaps
 
-- A colour control (`{{u, colour, label}, colour}`) binds at its initial colour
-  and renders identically to WL on the first frame, but is invisible and
-  non-interactive; WL renders a `ColorSlider`.
 - A `TabView` of controls is flattened — every tab's controls are shown at
   once, since Woxi's control panel is one flat list.
 - One unrecognised control spec makes the **entire** `Manipulate` give up, so a

--- a/tests/interpreter_tests/graphics.rs
+++ b/tests/interpreter_tests/graphics.rs
@@ -21766,28 +21766,58 @@ mod manipulate {
   }
 
   // `{{u, colour, label}, colour}` is a colour control — wolframscript
-  // renders a `ColorSlider`. Woxi has no colour widget yet, so the variable
-  // is bound to its initial colour; the point of the test is that the rest
-  // of the Manipulate still builds. Regression: the unrecognised spec made
-  // `extract_manipulate_spec` give up, taking every other control with it.
+  // renders a full-gradient `ColorSlider` over it (there being only one
+  // possible value to alternate with is what makes the domain "any
+  // colour" rather than "one of these two" — see the 2-swatch case in
+  // `parse_manipulate_control`'s "Colour form" branch for the alternative).
+  // Regression: this shape used to make `extract_manipulate_spec` give up
+  // on the whole control (dropping every other control with it) and, once
+  // that was fixed, to silently bind the variable without ever building a
+  // widget for it.
   #[test]
-  fn colour_control_binds_without_killing_the_widget() {
+  fn colour_control_renders_a_color_slider() {
     let expr = woxi::interpret_to_expr(
       "Manipulate[{col, Disk[]}, {{n, 3, \"division\"}, 2, 20, 1}, \
        Control@{{col, Red, \"color\"}, Red}]",
     )
     .unwrap();
     let spec = extract_manipulate_spec(&expr).expect("well-formed manipulate");
-    // The visible controls survive…
+    // Both the division slider and the colour control survive…
     match &spec.controls[..] {
-      [ManipulateControl::Continuous { name, .. }] => assert_eq!(name, "n"),
-      other => panic!("expected just the division slider, got {other:?}"),
+      [
+        ManipulateControl::Continuous { name: n, .. },
+        ManipulateControl::Color {
+          name: col, initial, ..
+        },
+      ] => {
+        assert_eq!(n, "n");
+        assert_eq!(col, "col");
+        // `Red` is itself `RGBColor[1, 0, 0]` once evaluated (see
+        // `manipulate_value_to_input_form`'s evaluate-then-format
+        // convention, shared by every other control kind's initial value).
+        assert_eq!(initial, "RGBColor[1, 0, 0]");
+      }
+      other => {
+        panic!("expected a slider and a colour control, got {other:?}")
+      }
     }
-    // …and the colour is in scope for the body at its initial value.
+    // …and the colour is in scope for the body at its initial value. A
+    // visible widget's initial value travels via `manipulate_initial_bindings`
+    // (installed at evaluation time through `with_scoped_globals`), unlike a
+    // `Fixed` control's value, which is baked directly into `body_code` as a
+    // `Block[...]` wrapper — there is no such wrapper here since `col` is a
+    // real widget, not a fixed constant.
+    let bindings = manipulate_initial_bindings(&spec);
+    assert!(
+      bindings
+        .iter()
+        .any(|(name, value)| name == "col" && value == "RGBColor[1, 0, 0]"),
+      "the colour binding is missing: {bindings:?}"
+    );
     let json = manipulate_spec_to_json(&spec);
     assert!(
-      json.contains("Block[{col = Red}"),
-      "the colour binding is missing: {json}"
+      json.contains(r#""kind":"color""#),
+      "the colour control must render as a widget: {json}"
     );
   }
 

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -319,6 +319,9 @@ enum Message {
   /// Remove a point from a `LocatorAutoCreate` locator.
   /// (cell_idx, ctrl_idx, point_idx)
   ManipulateLocatorRemoved(usize, usize, usize),
+  /// A ColorSlider/ColorSetter handle was dragged to a new hue position
+  /// (`0.0..=1.0`). (cell_idx, ctrl_idx, position)
+  ManipulateColorChanged(usize, usize, f64),
   /// A checkbox in a Manipulate display element was toggled.
   /// (cell_idx, write-back assignment, e.g. `data[[3, 5]] = 1`)
   ManipulateDisplayToggled(usize, String),
@@ -1804,6 +1807,23 @@ impl WoxiStudio {
           && point_idx < points.len()
         {
           points.remove(point_idx);
+          state.apply_tracking(ctrl_idx);
+          if state.request_reeval(ctrl_idx) {
+            return manipulate_reeval_task(cell_idx);
+          }
+        }
+        Task::none()
+      }
+
+      Message::ManipulateColorChanged(cell_idx, ctrl_idx, position) => {
+        if let Some(editor) = self.cell_editors.get_mut(cell_idx)
+          && let Some(state) = editor.manipulate_state.as_mut()
+          && matches!(
+            state.controls.get(ctrl_idx),
+            Some(manipulate::ControlState::Color { .. })
+          )
+        {
+          state.color_change(ctrl_idx, position);
           state.apply_tracking(ctrl_idx);
           if state.request_reeval(ctrl_idx) {
             return manipulate_reeval_task(cell_idx);
@@ -3689,7 +3709,8 @@ fn manipulate_label_char_count(ctrl: &manipulate::ControlState) -> usize {
     | manipulate::ControlState::Slider2D { label, .. }
     | manipulate::ControlState::IntervalSlider { label, .. }
     | manipulate::ControlState::Trigger { label, .. }
-    | manipulate::ControlState::Locator { label, .. } => label,
+    | manipulate::ControlState::Locator { label, .. }
+    | manipulate::ControlState::Color { label, .. } => label,
     // Heading/divider rows span the full row instead of sitting in the
     // label column, so they don't widen it; a button carries its label
     // inside the button itself.
@@ -4154,6 +4175,59 @@ fn render_manipulate_widget<'a>(
         ]
         .align_y(Center)
         .spacing(8);
+        controls_col = controls_col.push(control_row);
+      }
+      manipulate::ControlState::Color {
+        name: _,
+        label,
+        label_runs,
+        current,
+        position,
+      } => {
+        // A fixed rainbow bar (the standard look of Wolfram's ColorSlider/
+        // ColorSetter) with a draggable handle layered on top, painted in
+        // the color it would currently set. The bar is drawn as a plain
+        // container underneath rather than as the slider's own rail — see
+        // `color_gradient_container_style` for why the built-in rail can't
+        // show a fixed gradient on its own.
+        let bar = container(
+          space::Space::new()
+            .width(Fill)
+            .height(iced::Length::Fixed(14.0)),
+        )
+        .width(Fill)
+        .style(color_gradient_container_style);
+        let handle_color = manipulate_color(current);
+        let picker = slider(0.0..=1.0, *position, move |v| {
+          if enabled {
+            Message::ManipulateColorChanged(cell_idx, ctrl_idx, v)
+          } else {
+            Message::Noop
+          }
+        })
+        .step(0.001)
+        .width(Fill)
+        .style(color_slider_overlay_style(handle_color, enabled));
+        let swatch = container(
+          space::Space::new()
+            .width(iced::Length::Fixed(20.0))
+            .height(iced::Length::Fixed(20.0)),
+        )
+        .style(move |_theme: &Theme| container::Style {
+          background: Some(Background::Color(handle_color)),
+          border: Border {
+            radius: 4.0.into(),
+            width: 1.0,
+            color: Color::from_rgba(0.0, 0.0, 0.0, 0.3),
+          },
+          ..container::Style::default()
+        });
+        let label_widget =
+          manipulate_label_widget(label_runs, label, label_col_width, enabled);
+        let control_row =
+          row![label_widget, stack![bar, picker].width(Fill), swatch]
+            .align_y(Center)
+            .spacing(8);
         controls_col = controls_col.push(control_row);
       }
       manipulate::ControlState::Locator {
@@ -4639,6 +4713,25 @@ fn format_manipulate_number(v: f64) -> String {
   } else {
     trimmed.to_string()
   }
+}
+
+/// Convert a hue fraction (`0.0..=1.0`) to an `iced::Color` at full
+/// saturation and brightness — matching Wolfram's `Hue[h]`. Delegates to
+/// the interpreter's own `Hue[…]` conversion (`hue_to_rgb01`) rather than
+/// re-implementing HSB→RGB a second time; only the `f64`-triple → `iced::
+/// Color` wrapping happens here.
+fn hue_to_rgb(h: f64) -> Color {
+  let (r, g, b) = woxi::functions::graphics::hue_to_rgb01(h);
+  Color::from_rgb(r as f32, g as f32, b as f32)
+}
+
+/// Resolve a Manipulate color control's current InputForm value (e.g.
+/// `RGBColor[0, 0, 0]` or `Hue[0.3]`) to an `iced::Color`, for painting its
+/// drag handle. Delegates to the interpreter's own color parsing
+/// (`manipulate_color_to_rgb`) rather than a second copy.
+fn manipulate_color(code: &str) -> Color {
+  let (r, g, b) = woxi::functions::graphics::manipulate_color_to_rgb(code);
+  Color::from_rgb(r as f32, g as f32, b as f32)
 }
 
 /// Build a display-only editor for a stored Output cell the interpreter
@@ -5374,6 +5467,70 @@ fn disabled_slider_style(
       border_color: Color::TRANSPARENT,
       border_width: 0.0,
     },
+  }
+}
+
+/// Background for the fixed rainbow bar behind a ColorSlider/ColorSetter's
+/// drag handle: a full-width `Hue[0]..Hue[1]` gradient, the standard look
+/// of Wolfram's color control. Drawn as a plain container underneath the
+/// interactive slider (see `color_slider_overlay_style`) rather than as the
+/// slider's own rail, since the built-in slider widget paints its rail as
+/// two separate quads split at the handle — a gradient given to either half
+/// would restretch across just that half instead of staying fixed to the
+/// full bar as the handle moves.
+fn color_gradient_container_style(_theme: &Theme) -> container::Style {
+  use iced::gradient::Linear;
+  let mut gradient = Linear::new(iced::Radians(0.0));
+  const STOPS: usize = 7;
+  for i in 0..STOPS {
+    let t = i as f32 / (STOPS - 1) as f32;
+    gradient = gradient.add_stop(t, hue_to_rgb(t as f64));
+  }
+  container::Style {
+    background: Some(Background::Gradient(gradient.into())),
+    border: Border {
+      radius: 4.0.into(),
+      width: 0.0,
+      color: Color::TRANSPARENT,
+    },
+    ..container::Style::default()
+  }
+}
+
+/// Style for the interactive slider layered on top of the rainbow bar: a
+/// fully transparent rail (the bar underneath already shows through) and a
+/// handle painted in the color it would currently set, so dragging previews
+/// the picked hue right under the cursor.
+fn color_slider_overlay_style(
+  current: Color,
+  enabled: bool,
+) -> impl Fn(&Theme, iced::widget::slider::Status) -> iced::widget::slider::Style
+{
+  move |theme, _status| {
+    use iced::widget::slider::{Handle, HandleShape, Rail, Style};
+    let palette = theme.extended_palette();
+    let handle_color = if enabled {
+      current
+    } else {
+      palette.background.strong.color
+    };
+    Style {
+      rail: Rail {
+        backgrounds: (Color::TRANSPARENT.into(), Color::TRANSPARENT.into()),
+        width: 14.0,
+        border: Border {
+          radius: 0.0.into(),
+          width: 0.0,
+          color: Color::TRANSPARENT,
+        },
+      },
+      handle: Handle {
+        shape: HandleShape::Circle { radius: 8.0 },
+        background: handle_color.into(),
+        border_color: palette.background.base.color,
+        border_width: 2.0,
+      },
+    }
   }
 }
 
@@ -6626,6 +6783,132 @@ mod tests {
       "Graphics of translated/rotated pieces should render"
     );
   }
+
+  /// `{{bg, RGBColor[0, 0, 0], "background"}, ColorSlider}` builds a real
+  /// `Color` control rather than being dropped or misread as a hidden
+  /// binding, and on the first frame the bound variable is the spec's
+  /// exact literal initial color — not snapped to whatever the hue
+  /// gradient's own position 0 would give (mirroring `Continuous`'s
+  /// off-grid literal `initial`).
+  #[test]
+  fn color_slider_builds_and_keeps_literal_initial_on_first_frame() {
+    let expr = woxi::interpret_to_expr(
+      r#"Manipulate[bg, {{bg, RGBColor[0, 0, 0], "background"}, ColorSlider}]"#,
+    )
+    .expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a ColorSlider control should build a ManipulateState");
+    assert_eq!(state.controls.len(), 1);
+    match &state.controls[0] {
+      manipulate::ControlState::Color {
+        name,
+        label,
+        current,
+        position,
+        ..
+      } => {
+        assert_eq!(name, "bg");
+        assert_eq!(label, "background");
+        assert_eq!(current, "RGBColor[0, 0, 0]");
+        assert_eq!(
+          *position, 0.0,
+          "the handle defaults to position 0 even though black isn't on the gradient"
+        );
+      }
+      other => panic!("expected a Color control, got {other:?}"),
+    }
+    assert!(
+      state.error.is_none(),
+      "the literal initial color must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert_eq!(
+      state.text_output.as_deref(),
+      Some("RGBColor[0, 0, 0]"),
+      "the bound variable must be exactly the spec's literal initial color \
+       on the first frame"
+    );
+  }
+
+  /// `ColorSetter` is Wolfram's click/tap-to-set variant of the same
+  /// hue-gradient widget as `ColorSlider` — it must build the same `Color`
+  /// control rather than a second, duplicate implementation.
+  #[test]
+  fn color_setter_builds_the_same_control_as_color_slider() {
+    let expr = woxi::interpret_to_expr(
+      r#"Manipulate[bg, {{bg, RGBColor[1, 0, 0], "background"}, ColorSetter}]"#,
+    )
+    .expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a ColorSetter control should build a ManipulateState");
+    match &state.controls[0] {
+      manipulate::ControlState::Color { current, .. } => {
+        assert_eq!(current, "RGBColor[1, 0, 0]");
+      }
+      other => panic!("expected a Color control, got {other:?}"),
+    }
+  }
+
+  /// Dragging a ColorSlider's handle to a new hue position rewrites the
+  /// bound variable to `Hue[position]` and goes through the same
+  /// tracking/re-evaluation path every other control uses.
+  #[test]
+  fn color_slider_drag_rebinds_to_hue_and_reevaluates() {
+    let expr = woxi::interpret_to_expr(
+      r#"Manipulate[bg, {{bg, RGBColor[0, 0, 0], "background"}, ColorSlider}]"#,
+    )
+    .expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a ColorSlider control should build a ManipulateState");
+
+    state.color_change(0, 0.25);
+    match &state.controls[0] {
+      manipulate::ControlState::Color {
+        current, position, ..
+      } => {
+        assert_eq!(current, "Hue[0.25]");
+        assert_eq!(*position, 0.25);
+      }
+      other => panic!("expected a Color control, got {other:?}"),
+    }
+    state.apply_tracking(0);
+    assert!(
+      state.request_reeval(0),
+      "the first change after a drag should arm the throttle timer"
+    );
+    state.run_scheduled_reeval();
+    assert!(
+      state.error.is_none(),
+      "Hue[0.25] must evaluate cleanly: {:?}",
+      state.error
+    );
+    assert_eq!(state.text_output.as_deref(), Some("Hue[0.25]"));
+  }
+
+  /// `color_change` on any other control kind (e.g. a plain slider at index
+  /// 0) is a no-op rather than corrupting that control's state — mirroring
+  /// how `slider2d_change` only acts when the control at `ctrl_idx` is
+  /// actually a `Slider2D`.
+  #[test]
+  fn color_change_on_a_non_color_control_is_a_noop() {
+    let expr = woxi::interpret_to_expr("Manipulate[x, {x, 0, 1}]")
+      .expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a plain slider should build a ManipulateState");
+    state.color_change(0, 0.5);
+    match &state.controls[0] {
+      manipulate::ControlState::Continuous { current, .. } => {
+        assert_eq!(
+          *current, 0.0,
+          "an unrelated Continuous control must be untouched"
+        );
+      }
+      other => {
+        panic!("expected the original Continuous control, got {other:?}")
+      }
+    }
+  }
+
   #[test]
   fn manipulate_2d_angle_slider_combines_initialization_surfaces() {
     let code = r#"Manipulate[
@@ -8727,18 +9010,22 @@ Cell[BoxData[
     );
     assert!(state.graphics_handle.is_some(), "the net must render");
 
-    // The division slider and the net/surface setter both survive the
-    // colour control they share a `Row` with.
+    // The division slider and the net/surface setter both survive sharing
+    // a `Row` with the colour control — which is itself now a real
+    // `ColorSlider` widget (`{{col, Red, "color"}, Red}` has one possible
+    // value with an explicit initial matching it, so it renders a full hue
+    // gradient rather than being baked into the body as a fixed constant).
     let names: Vec<&str> = state
       .controls
       .iter()
       .map(|c| match c {
         manipulate::ControlState::Continuous { name, .. }
-        | manipulate::ControlState::Discrete { name, .. } => name.as_str(),
+        | manipulate::ControlState::Discrete { name, .. }
+        | manipulate::ControlState::Color { name, .. } => name.as_str(),
         other => panic!("unexpected control {other:?}"),
       })
       .collect();
-    assert_eq!(names, vec!["n", "nt"]);
+    assert_eq!(names, vec!["n", "nt", "col"]);
   }
 
   /// The shape a whole family of solid-geometry Demonstrations is built

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -134,6 +134,26 @@ pub enum ControlState {
   },
   /// A `Delimiter` argument: a horizontal separator row. Binds no variable.
   Divider,
+  /// A `ControlType -> ColorSlider`/`ColorSetter` control: a hue-gradient
+  /// bar whose handle position (`0..1`) maps to `Hue[position]` at full
+  /// saturation/value. `ColorSetter` renders and behaves identically —
+  /// Wolfram draws it as the same widget, just click/tap-to-set — so both
+  /// spec forms produce this one control rather than a duplicate.
+  Color {
+    name: String,
+    label: String,
+    label_runs: Vec<LabelRun>,
+    /// The bound variable's current value, as InputForm. Starts as the
+    /// spec's literal initial color (kept exactly even when it isn't on
+    /// the hue gradient at all, e.g. `RGBColor[0, 0, 0]`); dragging the
+    /// slider overwrites it with `Hue[<position>]`.
+    current: String,
+    /// The slider handle's on-screen position in `0.0..=1.0` (the hue
+    /// fraction it was last dragged to). Purely cosmetic — defaults to
+    /// `0.0`, since the spec's initial color is usually not on the
+    /// gradient at all, without affecting `current`.
+    position: f64,
+  },
 }
 
 impl ControlState {
@@ -145,6 +165,7 @@ impl ControlState {
       ControlState::IntervalSlider { name, .. } => name,
       ControlState::Trigger { name, .. } => name,
       ControlState::Locator { name, .. } => name,
+      ControlState::Color { name, .. } => name,
       ControlState::Button { .. }
       | ControlState::Heading { .. }
       | ControlState::Divider => "",
@@ -194,6 +215,7 @@ impl ControlState {
       ControlState::Locator { points, .. } => {
         woxi::functions::graphics::format_point_list_input(points)
       }
+      ControlState::Color { current, .. } => current.clone(),
       // Annotation and button rows bind no variable; never substituted.
       ControlState::Button { .. }
       | ControlState::Heading { .. }
@@ -260,6 +282,9 @@ impl ControlState {
         {
           *points = new_points;
         }
+      }
+      ControlState::Color { current, .. } => {
+        *current = woxi::syntax::expr_to_input_form(&expr);
       }
       ControlState::Button { .. }
       | ControlState::Heading { .. }
@@ -619,6 +644,23 @@ impl ManipulateState {
     {
       *x = accepted.0;
       *y = accepted.1;
+    }
+  }
+
+  /// Move a ColorSlider/ColorSetter handle to a new hue `position`
+  /// (`0.0..=1.0`): updates the cosmetic handle position and rewrites the
+  /// bound variable to `Hue[position]` — the InputForm Wolfram's own color
+  /// control would bind after a drag (full saturation/value). No-op for
+  /// any other control kind at `ctrl_idx`.
+  pub fn color_change(&mut self, ctrl_idx: usize, position: f64) {
+    if let Some(ControlState::Color {
+      current,
+      position: pos,
+      ..
+    }) = self.controls.get_mut(ctrl_idx)
+    {
+      *pos = position;
+      *current = format!("Hue[{}]", format_f64(position));
     }
   }
 
@@ -1145,6 +1187,18 @@ fn controls_from_spec(spec: &ManipulateSpec) -> Vec<ControlState> {
         }
       }
       ManipulateControl::Divider => ControlState::Divider,
+      ManipulateControl::Color {
+        name,
+        initial,
+        label,
+        label_runs,
+      } => ControlState::Color {
+        name: name.clone(),
+        label: label.clone(),
+        label_runs: label_runs.clone(),
+        current: initial.clone(),
+        position: 0.0,
+      },
     })
     .collect()
 }


### PR DESCRIPTION
## Summary

While auditing whether Woxi Studio fully supports a random Wolfram Demonstration notebook ("Orbits of the Hopalong Map"), two real gaps in `Manipulate` support surfaced:

- `LocatorAutoCreate -> n` for a bare positive integer (not just `True`/`Automatic`/a list) failed to enable adding locators — the notebook uses `LocatorAutoCreate -> 2`.
- A colour control (`ControlType -> ColorSlider`/`ColorSetter`, or the equivalent `{{u, colour, label}, colour}` shorthand) rendered identically to Wolfram on the first frame but was otherwise invisible and non-interactive — a gap already documented in `conformance_gaps.md`. The notebook's background-colour picker uses this exact shape.

This adds a real, interactive `Color` control: a hue-gradient bar with a draggable handle in Woxi Studio, wired through the same tracking/re-evaluation path every other control already uses, while keeping the spec's literal first-frame value exactly (mirroring how `Continuous` already keeps an off-grid literal initial value). The bare `{u, colour}` form with no explicit initial still bakes its single value into the body as a fixed constant, unchanged from before — only the labelled-triple form with an explicit initial (or the explicit `ColorSlider`/`ColorSetter` marker) becomes a widget.

## Test plan

- [x] `cargo test --lib` — 220/220 passed
- [x] `cargo test --test interpreter_tests` — 25292/25292 passed
- [x] `cargo test -p woxi-studio` — 175/175 passed
- [x] Added unit tests for the `LocatorAutoCreate -> <integer>` fix, the `Color` control's spec extraction (both explicit `ColorSlider`/`ColorSetter` and the single-colour-domain shorthand), and its interactive drag/re-evaluation behavior in Woxi Studio
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WR1rkYV3myvYp3yEZgkgCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR1rkYV3myvYp3yEZgkgCm)_