### PR TITLE
Recognize a variable-bound Pi/E/Degree in arbitrary-precision evaluation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 # Unreleased
 
+- A variable holding `Pi`, `E`, or `Degree` now reaches arbitrary-precision
+    evaluation the same way the literal constant does. Assignment substitutes
+    the constant in as an `Identifier`, not the `Constant` node a literal
+    `Pi` token parses to, and the arbitrary-precision conversion only
+    recognized the latter — so `c = Pi; N[c, 30]` and
+    `c = Pi; RealDigits[c, 10, 20]` silently returned `c`/`RealDigits[Pi, …]`
+    unevaluated instead of computing digits. This is the pattern a
+    `Manipulate` control commonly uses (binding one of several symbolic
+    constants to a control variable, then computing its digits), which is
+    how the bug surfaced.
 - A `FractionBox` in a prose cell keeps its grouping when Woxi Studio
     flattens it onto one line. A two-dimensional fraction says how it groups
     by being two-dimensional, so a compound numerator or denominator now

--- a/src/functions/math_ast/numerical.rs
+++ b/src/functions/math_ast/numerical.rs
@@ -1442,21 +1442,30 @@ pub fn expr_to_bigfloat(
       rm,
       cc,
     )),
-    Expr::Constant(name) => match name.as_str() {
-      "Pi" | "-Pi" => {
-        let pi = cc.pi(bits, rm);
-        if name == "-Pi" { Ok(pi.neg()) } else { Ok(pi) }
+    // A variable holding `Pi`/`E`/`Degree` substitutes in as `Identifier`
+    // rather than `Constant` (unlike a literal `Pi` token), so both variants
+    // are accepted here — matching how GoldenRatio, EulerGamma, etc. below
+    // already handle their `Identifier` form.
+    Expr::Constant(name) | Expr::Identifier(name)
+      if matches!(name.as_str(), "Pi" | "-Pi" | "E" | "Degree") =>
+    {
+      match name.as_str() {
+        "Pi" | "-Pi" => {
+          let pi = cc.pi(bits, rm);
+          if name == "-Pi" { Ok(pi.neg()) } else { Ok(pi) }
+        }
+        "E" => Ok(cc.e(bits, rm)),
+        "Degree" => {
+          let pi = cc.pi(bits, rm);
+          let d180 = BigFloat::from_i32(180, bits);
+          Ok(pi.div(&d180, bits, rm))
+        }
+        _ => unreachable!(),
       }
-      "E" => Ok(cc.e(bits, rm)),
-      "Degree" => {
-        let pi = cc.pi(bits, rm);
-        let d180 = BigFloat::from_i32(180, bits);
-        Ok(pi.div(&d180, bits, rm))
-      }
-      _ => Err(InterpreterError::EvaluationError(format!(
-        "N: cannot evaluate constant {name} to arbitrary precision"
-      ))),
-    },
+    }
+    Expr::Constant(name) => Err(InterpreterError::EvaluationError(format!(
+      "N: cannot evaluate constant {name} to arbitrary precision"
+    ))),
     Expr::Identifier(name) if name == "GoldenRatio" => {
       // GoldenRatio = (1 + Sqrt[5]) / 2
       let five = BigFloat::from_i32(5, bits);

--- a/tests/interpreter_tests.rs
+++ b/tests/interpreter_tests.rs
@@ -2276,6 +2276,42 @@ mod interpreter_tests {
   }
 
   #[test]
+  fn arbitrary_precision_constant_through_variable() {
+    // Regression: a variable bound to Pi/E/Degree must reach the
+    // arbitrary-precision path the same way the literal constant does.
+    // Assignment substitutes the constant in as `Identifier`, not the
+    // `Constant` node a literal `Pi` token parses to, and `N[_, digits]`
+    // and `RealDigits` only recognized the latter — so `c = Pi; N[c, 30]`
+    // silently returned `c` unevaluated instead of computing digits.
+    assert_eq!(
+      interpret("c = Pi; N[c, 30]").unwrap(),
+      interpret("N[Pi, 30]").unwrap()
+    );
+    assert_eq!(
+      interpret("c = E; N[c, 30]").unwrap(),
+      interpret("N[E, 30]").unwrap()
+    );
+    assert_eq!(
+      interpret("c = Degree; N[c, 30]").unwrap(),
+      interpret("N[Degree, 30]").unwrap()
+    );
+    assert_eq!(
+      interpret("c = Pi; RealDigits[c, 10, 10]").unwrap(),
+      "{{3, 1, 4, 1, 5, 9, 2, 6, 5, 3}, 1}"
+    );
+    assert_eq!(
+      interpret("c = E; RealDigits[c, 10, 10]").unwrap(),
+      "{{2, 7, 1, 8, 2, 8, 1, 8, 2, 8}, 1}"
+    );
+    // GoldenRatio already worked through a variable; keep it covered
+    // alongside Pi/E/Degree so a future regression here is caught too.
+    assert_eq!(
+      interpret("c = GoldenRatio; RealDigits[c, 10, 10]").unwrap(),
+      "{{1, 6, 1, 8, 0, 3, 3, 9, 8, 8}, 1}"
+    );
+  }
+
+  #[test]
   fn notation_wrappers_stay_symbolic_without_warning() {
     // Notation/display wrapper heads stay unevaluated as their canonical form
     // in wolframscript and must NOT emit a spurious "not yet implemented"

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -6626,6 +6626,52 @@ mod tests {
       "Graphics of translated/rotated pieces should render"
     );
   }
+  /// A digit-inspector Manipulate picking among symbolic constants (Pi, E,
+  /// GoldenRatio) and rendering the chosen constant's leading digits via
+  /// `RealDigits`. Independently written, not copied from any specific
+  /// Wolfram Demonstration; it targets the general "constant bound to a
+  /// Manipulate control variable, then passed to RealDigits/N" pattern that
+  /// several digit- and constant-themed Demonstrations use.
+  #[test]
+  fn manipulate_constant_picker_feeds_real_digits() {
+    let code = r#"Manipulate[
+      Text[Row[First[RealDigits[constant, base, digits]]]],
+      {{constant, Pi}, {Pi, E, GoldenRatio}},
+      {{base, 10}, 2, 16, 1, ImageSize -> Tiny},
+      {{digits, 12}, 2, 30, 1, ImageSize -> Tiny}
+    ]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("a discrete constant picker plus two sliders should build a ManipulateState");
+
+    assert_eq!(state.controls.len(), 3, "constant, base, digits");
+    assert!(
+      matches!(
+        &state.controls[0],
+        manipulate::ControlState::Discrete { name, values, .. }
+          if name == "constant" && values == &["Pi", "E", "GoldenRatio"]
+      ),
+      "the {{Pi, E, GoldenRatio}} domain builds a discrete control: {:?}",
+      state.controls[0]
+    );
+    assert!(
+      state.error.is_none(),
+      "RealDigits[constant, base, digits] must evaluate cleanly even though \
+       `constant` substitutes a Manipulate-bound Pi/E, not a literal token: {:?}",
+      state.error
+    );
+    // A top-level `Text[Row[…]]` body renders as a graphic (like every other
+    // typeset body in this test file), not as `text_output` — the point
+    // under test is that `error` stayed `None`, i.e. `RealDigits` actually
+    // computed the digits instead of returning unevaluated.
+    assert!(
+      state.graphics_handle.is_some(),
+      "expected a rendered graphic, got text_output={:?}",
+      state.text_output
+    );
+  }
+
   #[test]
   fn manipulate_2d_angle_slider_combines_initialization_surfaces() {
     let code = r#"Manipulate[


### PR DESCRIPTION
## Summary

- Tested Woxi Studio against a randomly picked Wolfram Demonstration
  ("Math Songs" by Hector Zenil), whose `Manipulate` binds one of several
  symbolic constants (`Pi`, `E`, `GoldenRatio`, ...) to a control variable
  and then computes its digits with `RealDigits`.
- That exposed a real bug: a variable assigned a literal `Pi`/`E`/`Degree`
  substitutes in as an `Identifier` during evaluation, not the `Constant`
  node a literal `Pi` token parses to, and `expr_to_bigfloat` (the
  arbitrary-precision conversion backing `N[…, digits]` and `RealDigits`)
  only matched the latter. So `c = Pi; N[c, 30]` and
  `c = Pi; RealDigits[c, 10, 20]` silently returned the input unevaluated
  instead of computing digits — while `GoldenRatio`/`EulerGamma`/etc.
  already worked through a variable, since their `Identifier` form was
  already handled in the same match.
- Fixes it by accepting both `Constant` and `Identifier` for
  `Pi`/`-Pi`/`E`/`Degree`, matching how the other constants are already
  handled.
- No source code from the Demonstration notebook is included; the added
  tests independently reconstruct the general pattern (a constant-picker
  control feeding `RealDigits`).

## Test plan

- [x] Added a unit test (`arbitrary_precision_constant_through_variable`)
      covering `N[_, digits]` and `RealDigits` for a variable bound to
      `Pi`, `E`, `Degree`, and (as a non-regression check) `GoldenRatio`.
- [x] Added a Woxi Studio test
      (`manipulate_constant_picker_feeds_real_digits`) building a
      `ManipulateState` for a constant-picker + `RealDigits` body and
      asserting it evaluates without error.
- [x] `make test` — 27,387 tests passed.
- [x] `make test-studio` — 172 tests passed.
- [x] `make format`.


---
_Generated by [Claude Code](https://claude.ai/code/session_013atat6Ja8Y965jP3BUYtrf)_