### PR TITLE
Honor Manipulate's ControlPlacement option in Woxi Studio

### DIFF
--- a/src/functions/graphics.rs
+++ b/src/functions/graphics.rs
@@ -16893,6 +16893,37 @@ pub struct ManipulateSpec {
   /// choices, TrackingFunction -> (a = #; t = 0; &)}`). Controls with no
   /// `TrackingFunction` option do not appear here.
   pub tracking: Vec<(String, String)>,
+  /// `ControlPlacement -> Top | Bottom | Left | Right`: which side of the
+  /// output the control panel sits on. Wolfram's default is `Top`; a
+  /// Demonstration with a large square graphic and several short sliders
+  /// usually asks for `Left` so the controls run down beside the picture
+  /// instead of pushing it off screen.
+  pub control_placement: ControlPlacement,
+}
+
+/// Where a Manipulate's control panel sits relative to its output, from the
+/// widget-level `ControlPlacement` option. A `ControlPlacement` given inside
+/// an individual control spec places just that control in Wolfram; Woxi keeps
+/// one panel, so those are ignored and only the widget-level option applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ControlPlacement {
+  #[default]
+  Top,
+  Bottom,
+  Left,
+  Right,
+}
+
+impl ControlPlacement {
+  fn from_symbol(name: &str) -> Option<Self> {
+    match name {
+      "Top" => Some(Self::Top),
+      "Bottom" => Some(Self::Bottom),
+      "Left" => Some(Self::Left),
+      "Right" => Some(Self::Right),
+      _ => None,
+    }
+  }
 }
 
 /// Result of parsing a single list-shaped Manipulate argument.
@@ -17070,6 +17101,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
   let mut fixed: Vec<(String, String)> = Vec::new();
   let mut appearance_none = false;
   let mut tracked_symbols: Option<Vec<String>> = None;
+  let mut control_placement = ControlPlacement::default();
   // Compound (non-symbol) control variables such as `Subscript[signal, 1]`
   // cannot be bound by name; each is renamed to a synthesized plain symbol,
   // and every occurrence in the body (and related code fragments) is
@@ -17197,6 +17229,14 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
         && matches!(replacement.as_ref(), Expr::Identifier(s) if s == "None")
       {
         appearance_none = true;
+      }
+      // `ControlPlacement -> Left` runs the control panel down the side of
+      // the output instead of above it.
+      if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "ControlPlacement")
+        && let Expr::Identifier(side) = replacement.as_ref()
+        && let Some(placement) = ControlPlacement::from_symbol(side)
+      {
+        control_placement = placement;
       }
       // `AnimationRunning -> False` builds the widget paused.
       if matches!(pattern.as_ref(), Expr::Identifier(s) if s == "AnimationRunning")
@@ -17636,6 +17676,7 @@ pub fn extract_manipulate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     appearance_none,
     tracked_symbols,
     tracking,
+    control_placement,
   })
 }
 
@@ -18803,6 +18844,7 @@ pub fn extract_list_animate_spec(expr: &Expr) -> Option<ManipulateSpec> {
     appearance_none: false,
     tracked_symbols: None,
     tracking: Vec::new(),
+    control_placement: ControlPlacement::default(),
   })
 }
 
@@ -18885,6 +18927,7 @@ pub fn extract_animator_spec(expr: &Expr) -> Option<ManipulateSpec> {
     appearance_none: false,
     tracked_symbols: None,
     tracking: Vec::new(),
+    control_placement: ControlPlacement::default(),
   })
 }
 
@@ -18961,6 +19004,7 @@ pub fn extract_locator_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     appearance_none: false,
     tracked_symbols: None,
     tracking: Vec::new(),
+    control_placement: ControlPlacement::default(),
   })
 }
 
@@ -19013,6 +19057,7 @@ pub fn extract_click_pane_spec(expr: &Expr) -> Option<ManipulateSpec> {
     appearance_none: false,
     tracked_symbols: None,
     tracking: Vec::new(),
+    control_placement: ControlPlacement::default(),
   })
 }
 
@@ -19076,6 +19121,7 @@ pub fn extract_control_spec(expr: &Expr) -> Option<ManipulateSpec> {
     appearance_none: false,
     tracked_symbols: None,
     tracking: Vec::new(),
+    control_placement: ControlPlacement::default(),
   })
 }
 
@@ -23184,5 +23230,80 @@ mod manipulate_reversed_range_tests {
     assert_eq!(min, 0.01);
     assert_eq!(max, 2.0);
     assert_eq!(initial, 1.3);
+  }
+}
+
+#[cfg(test)]
+mod manipulate_control_placement_tests {
+  use super::*;
+
+  fn placement(code: &str) -> ControlPlacement {
+    let expr = crate::parse_to_expr(code).expect("parse");
+    extract_manipulate_spec(&expr)
+      .expect("extract spec")
+      .control_placement
+  }
+
+  /// Wolfram's default is `Top`, so a Manipulate that says nothing about
+  /// placement keeps its controls above the output.
+  #[test]
+  fn placement_defaults_to_top() {
+    assert_eq!(
+      placement("Manipulate[Plot[Sin[a x], {x, 0, 6}], {{a, 1}, 1, 5}]"),
+      ControlPlacement::Top
+    );
+  }
+
+  /// Every side Wolfram accepts is recorded, not just the `Left` the
+  /// square-graphic Demonstrations ask for.
+  #[test]
+  fn every_placement_side_is_recorded() {
+    for (side, expected) in [
+      ("Top", ControlPlacement::Top),
+      ("Bottom", ControlPlacement::Bottom),
+      ("Left", ControlPlacement::Left),
+      ("Right", ControlPlacement::Right),
+    ] {
+      let code = format!(
+        "Manipulate[Plot[Sin[a x], {{x, 0, 6}}], {{{{a, 1}}, 1, 5}}, \
+         ControlPlacement -> {side}]"
+      );
+      assert_eq!(placement(&code), expected, "ControlPlacement -> {side}");
+    }
+  }
+
+  /// A `ControlPlacement` naming something Wolfram does not accept leaves
+  /// the default standing rather than failing the whole extraction.
+  #[test]
+  fn unknown_placement_keeps_the_default() {
+    assert_eq!(
+      placement(
+        "Manipulate[Plot[Sin[a x], {x, 0, 6}], {{a, 1}, 1, 5}, \
+         ControlPlacement -> Sideways]"
+      ),
+      ControlPlacement::Top
+    );
+  }
+
+  /// `ControlPlacement` written inside a single control spec is Wolfram's
+  /// per-control form. Woxi keeps one panel, so that spec is still a
+  /// perfectly good slider and the widget keeps the default placement.
+  #[test]
+  fn per_control_placement_leaves_the_widget_default() {
+    let expr = crate::parse_to_expr(
+      "Manipulate[Plot[Sin[a x], {x, 0, 6}], \
+       {a, 1, 5, ControlPlacement -> Bottom}]",
+    )
+    .expect("parse");
+    let spec = extract_manipulate_spec(&expr).expect("extract spec");
+    assert_eq!(
+      spec
+        .controls
+        .iter()
+        .map(ManipulateControl::name)
+        .collect::<Vec<_>>(),
+      vec!["a"]
+    );
+    assert_eq!(spec.control_placement, ControlPlacement::Top);
   }
 }

--- a/woxi-studio/src/main.rs
+++ b/woxi-studio/src/main.rs
@@ -3760,6 +3760,13 @@ const SETTER_BAR_MAX_COMPACT_CHOICES: usize = 10;
 /// to sit in a long SetterBar.
 const SETTER_BAR_COMPACT_LABEL_CHARS: usize = 3;
 
+/// Width, on top of the label column, reserved for a control panel placed
+/// beside the output by `ControlPlacement -> Left`/`Right`. The rows inside
+/// it are `Fill`, so without a fixed width the panel would claim half the
+/// cell and squeeze the graphic; this leaves room for a draggable slider
+/// plus its value readout.
+const SIDE_PANEL_CONTROL_WIDTH: f32 = 230.0;
+
 /// Whether a discrete control's choices render as a segmented SetterBar (a row
 /// of toggle buttons) rather than a dropdown.
 ///
@@ -4409,7 +4416,9 @@ fn render_manipulate_widget<'a>(
   // AnimationRunning -> True). It stays visible under Appearance -> None so
   // the animation can still be paused. A Trigger control renders its own
   // toggle in its row, so the widget-level one would be redundant.
-  if state.animated && !(show_controls && state.has_trigger()) {
+  let show_play_toggle =
+    state.animated && !(show_controls && state.has_trigger());
+  if show_play_toggle {
     let symbol = if state.playing { "❚❚" } else { "▶" };
     let play_btn = button(text(symbol).size(11))
       .padding([3, 10])
@@ -4452,13 +4461,48 @@ fn render_manipulate_widget<'a>(
 
   // Extra display elements (e.g. a Checkbox grid) sit above the rendered
   // body output; each interactive checkbox emits a write-back on toggle.
-  let mut widget_col = column![controls_col].spacing(6);
+  let mut body_col = Column::new().spacing(6).width(Fill);
   for tree in &state.display_trees {
-    widget_col = widget_col.push(render_display_node(cell_idx, tree));
+    body_col = body_col.push(render_display_node(cell_idx, tree));
   }
-  widget_col = widget_col.push(output_col);
+  body_col = body_col.push(output_col);
 
-  container(widget_col).padding(6).width(Fill).into()
+  // `ControlPlacement` decides which side the panel sits on. A widget that
+  // ended up with no panel rows at all (`Appearance -> None` with nothing to
+  // play) stacks instead, so a side placement cannot reserve an empty gutter
+  // next to the graphic.
+  let panel_is_empty = !show_play_toggle
+    && !visible_controls
+      .iter()
+      .enumerate()
+      .any(|(i, _)| state.control_is_visible.get(i).copied().unwrap_or(true));
+  let placement = if panel_is_empty {
+    manipulate::ControlPlacement::Top
+  } else {
+    state.control_placement
+  };
+  let side_width =
+    iced::Length::Fixed(label_col_width + SIDE_PANEL_CONTROL_WIDTH);
+  let widget: Element<Message> = match placement {
+    manipulate::ControlPlacement::Top => {
+      column![controls_col, body_col].spacing(6).into()
+    }
+    manipulate::ControlPlacement::Bottom => {
+      column![body_col, controls_col].spacing(6).into()
+    }
+    manipulate::ControlPlacement::Left => {
+      row![controls_col.width(side_width), body_col]
+        .spacing(12)
+        .into()
+    }
+    manipulate::ControlPlacement::Right => {
+      row![body_col, controls_col.width(side_width)]
+        .spacing(12)
+        .into()
+    }
+  };
+
+  container(widget).padding(6).width(Fill).into()
 }
 
 /// Recursively render a Manipulate display-element widget tree into iced.
@@ -20447,5 +20491,116 @@ Cell[BoxData["DynamicModuleBox[{$CellContext`nmax$$ = 10}, DynamicBox[\[Ellipsis
       fourth_ring.contains(">81<") && fourth_ring.contains(">32<"),
       "the recomputed panel must show the ring-4 numbers"
     );
+  }
+
+  /// A rotationally symmetric emblem Manipulate: a filled disk with a white
+  /// disk punched out of it (leaving a ring) and an n-pointed star inside,
+  /// driven by five `ImageSize -> Tiny` sliders with the control panel asked
+  /// to sit beside the square graphic. Two things the category depends on:
+  /// the orientation slider's upper bound is `Dynamic[…]` over the point
+  /// count, so widening the star narrows the rotation range, and the body
+  /// opens by clamping that same control back inside the new range — a write
+  /// to one of the widget's own variables. This mirrors the general
+  /// construct category used by parameterized-logo Wolfram Demonstrations
+  /// Project notebooks (independently written, not copied from any specific
+  /// one).
+  #[test]
+  fn manipulate_emblem_dynamic_bound_clamps_and_places_controls_left() {
+    let code = r#"Manipulate[
+      If[rot > 360/pts, rot = 360/pts];
+      Graphics[{
+        {Disk[], White, Disk[{0, 0}, ring]},
+        Polygon[Table[
+          With[{a = (rot + 90 + j 180/pts + If[OddQ[j], skew, 0]) Degree},
+            If[EvenQ[j], 1, waist] ring {Cos[a], Sin[a]}],
+          {j, 0, 2 pts - 1}]]
+      }, ImageSize -> {400, 400}],
+      {{pts, 3, "points"}, 3, 24, 1, ImageSize -> Tiny},
+      {{waist, 0.14, "sharpness"}, 0, 1, ImageSize -> Tiny},
+      {{skew, 0, "twist"}, 0, 360, ImageSize -> Tiny},
+      {{ring, 0.94, "thickness"}, 0, 1, ImageSize -> Tiny},
+      {{rot, 0, "orientation"}, 0, Dynamic[360/pts], ImageSize -> Tiny},
+      ControlPlacement -> Left,
+      AutorunSequencing -> {1, 2, 3, 4}]"#;
+    let expr =
+      woxi::interpret_to_expr(code).expect("Manipulate should parse and hold");
+    let mut state = manipulate::ManipulateState::from_expr(&expr)
+      .expect("five Tiny sliders should build a ManipulateState");
+
+    assert_eq!(
+      state.control_placement,
+      manipulate::ControlPlacement::Left,
+      "ControlPlacement -> Left must survive into the widget state"
+    );
+    let names: Vec<&str> = state.controls.iter().map(|c| c.name()).collect();
+    assert_eq!(names, ["pts", "waist", "skew", "ring", "rot"]);
+
+    // The orientation slider's range is one full sector at the starting
+    // three points: 360/3.
+    let bounds = |s: &manipulate::ManipulateState| match &s.controls[4] {
+      manipulate::ControlState::Continuous {
+        min, max, current, ..
+      } => (*min, *max, *current),
+      other => panic!("orientation should be a slider: {other:?}"),
+    };
+    assert_eq!(bounds(&state), (0.0, 120.0, 0.0));
+
+    let ring_3 = star_points(&state);
+    // Three points, so six polygon vertices alternating long and short.
+    assert_eq!(
+      ring_3.matches(',').count(),
+      6,
+      "star should have 6 vertices: {ring_3}"
+    );
+
+    // Rotate all the way round the sector, then raise the point count: the
+    // bound follows `pts` down to 360/24 and the body's clamp pulls the
+    // orientation in with it.
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[4]
+    {
+      *current = 120.0;
+    }
+    if let manipulate::ControlState::Continuous { current, .. } =
+      &mut state.controls[0]
+    {
+      *current = 24.0;
+    }
+    state.reevaluate();
+    assert!(state.error.is_none(), "re-render failed: {:?}", state.error);
+    assert_eq!(
+      bounds(&state),
+      (0.0, 15.0, 15.0),
+      "the Dynamic bound must follow the point count and clamp the value"
+    );
+
+    let ring_24 = star_points(&state);
+    assert_eq!(
+      ring_24.matches(',').count(),
+      48,
+      "24 points should give 48 vertices: {ring_24}"
+    );
+  }
+
+  /// The `points="…"` attribute of the polygon a Manipulate's body draws at
+  /// its current control values.
+  fn star_points(state: &manipulate::ManipulateState) -> String {
+    let bindings: Vec<(String, String)> = state
+      .controls
+      .iter()
+      .filter(|c| c.binds_variable())
+      .map(|c| (c.name().to_string(), c.current_code()))
+      .collect();
+    let svg = woxi::with_scoped_globals(&bindings, || {
+      woxi::interpret_with_stdout(&state.body)
+    })
+    .expect("body evaluates")
+    .graphics
+    .expect("body should render a graphic");
+    svg
+      .split_once("<polygon points=\"")
+      .and_then(|(_, r)| r.split_once('"'))
+      .map(|(pts, _)| pts.to_string())
+      .unwrap_or_else(|| panic!("no polygon in rendered SVG: {svg}"))
   }
 }

--- a/woxi-studio/src/manipulate.rs
+++ b/woxi-studio/src/manipulate.rs
@@ -8,6 +8,7 @@
 //! that free control variables are substituted.
 
 use iced::widget::svg;
+pub use woxi::functions::graphics::ControlPlacement;
 use woxi::functions::graphics::{
   DisplayNode, LabelRun, ManipulateControl, ManipulateSpec,
   apply_manipulate_mutations, build_manipulate_display, extract_animator_spec,
@@ -332,6 +333,9 @@ pub struct ManipulateState {
   /// `Appearance -> None`: hide the control rows (the animation just runs);
   /// the play/pause toggle stays visible for animated widgets.
   pub appearance_none: bool,
+  /// `ControlPlacement -> …`: which side of the output the control panel
+  /// sits on. `Top` (Wolfram's default) stacks the controls above it.
+  pub control_placement: ControlPlacement,
   /// `TrackedSymbols :> {…}`: the variables whose change re-runs the body.
   /// A control bound to any other variable still moves, but the rendering
   /// waits for a tracked variable to change. `None` tracks everything.
@@ -440,6 +444,7 @@ impl ManipulateState {
       // unless the spec was built paused (`AnimationRunning -> False`).
       playing: spec.animated && spec.animation_running,
       appearance_none: spec.appearance_none,
+      control_placement: spec.control_placement,
       tracked_symbols: spec.tracked_symbols,
       animation_var: spec.animation_var,
       tracking: spec.tracking,


### PR DESCRIPTION
Checked a random Wolfram Demonstration notebook against Woxi Studio and fixed the one thing it did not support.

## What was wrong

`ControlPlacement -> Left` (and `Bottom` / `Right`) was accepted as a Manipulate option and then dropped, so every widget rendered its control panel stacked above the output. Demonstrations with a large square graphic and a column of short sliders ask for `Left` precisely so the controls run down beside the picture instead of pushing it off screen.

Everything else the notebook needs already worked: the five `ImageSize -> Tiny` sliders, the orientation slider's `Dynamic[…]` upper bound following the point count, and the body's opening clamp writing back to that same control.

## What changed

- `ManipulateSpec` gains a `control_placement` field and a `ControlPlacement` enum (`Top` / `Bottom` / `Left` / `Right`), parsed from the widget-level option. An unrecognized value leaves the default standing rather than failing the extraction.
- `ManipulateState` carries it through to the studio.
- `render_manipulate_widget` lays the panel out on the requested side. Beside the output the panel takes a fixed width, since its rows are `Fill` and would otherwise claim half the cell and squeeze the graphic.
- A widget that ends up with no panel rows at all (`Appearance -> None` with nothing to play) keeps stacking, so a side placement cannot reserve an empty gutter next to the graphic.
- `ControlPlacement` written inside a single control spec is Wolfram's per-control form. Woxi keeps one panel, so those stay ignored and the widget keeps the default `Top`.

## Tests

- `src/functions/graphics.rs` — four cases: the default is `Top`, all four sides are recorded, an unknown value keeps the default, and a per-control `ControlPlacement` still yields a working slider at the default placement.
- `woxi-studio/src/main.rs` — an emblem Manipulate in the same construct category as the notebook (ring plus n-pointed star, five `Tiny` sliders, a `Dynamic` bound over another control, a body clamping its own variable, `ControlPlacement -> Left`). It asserts the placement survives into the widget state, that raising the point count narrows the orientation range and pulls the value in with it, and that the rendered star gains the matching vertices. Written independently, not copied from the notebook.

Full suite green: 27,409 tests in the main crate, 177 in `woxi-studio`. `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings` clean for both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QC2RD1qbwnRGKLBXwU1Ceb

---
_Generated by [Claude Code](https://claude.ai/code/session_01QC2RD1qbwnRGKLBXwU1Ceb)_